### PR TITLE
Adding winston transport to log errors to sentry

### DIFF
--- a/libs/logging/src/lib/logging.ts
+++ b/libs/logging/src/lib/logging.ts
@@ -1,4 +1,5 @@
 import { createLogger, format, transports } from 'winston'
+import { SentryTransport } from './transports'
 
 // Default log settings for debug mode
 let logLevel = 'debug'
@@ -13,5 +14,5 @@ if (process.env.NODE_ENV === 'production') {
 export const logger = createLogger({
   level: logLevel,
   format: logFormat,
-  transports: [new transports.Console()],
+  transports: [new transports.Console(), new SentryTransport()],
 })

--- a/libs/logging/src/lib/transports.ts
+++ b/libs/logging/src/lib/transports.ts
@@ -1,0 +1,17 @@
+import * as Sentry from '@sentry/node'
+import * as Transport from 'winston-transport'
+
+export class SentryTransport extends Transport {
+  constructor() {
+    super({ level: 'error' })
+  }
+
+  log(info, callback) {
+    // Checks whether sentry has been initialized
+    // https://github.com/getsentry/sentry-go/issues/9
+    if (Sentry.getCurrentHub()?.getClient()) {
+      Sentry.captureMessage(info.message)
+    }
+    callback()
+  }
+}

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "treat": "1.4.1",
     "uuidv4": "6.0.8",
     "winston": "3.2.1",
+    "winston-transport": "4.4.0",
     "xstate": "4.10.0",
     "yup": "0.29.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -16226,7 +16226,7 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.0, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.3, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.0, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@^2.3.7, readable-stream@~2.3.3, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -19663,6 +19663,14 @@ widest-line@^3.1.0:
   integrity sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==
   dependencies:
     string-width "^4.0.0"
+
+winston-transport@4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.4.0.tgz#17af518daa690d5b2ecccaa7acf7b20ca7925e59"
+  integrity sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==
+  dependencies:
+    readable-stream "^2.3.7"
+    triple-beam "^1.2.0"
 
 winston-transport@^4.3.0:
   version "4.3.0"


### PR DESCRIPTION
This means that if Sentry is configured in your project and you do `logger.error('whoops this is bad')`, it will propagate to Sentry.

https://sentry.io/organizations/island_is/issues/1762054318/?project=5274533&query=&statsPeriod=14d