### PR TITLE
Fix bug where Box component ignores zero values props

### DIFF
--- a/libs/island-ui/core/src/lib/Box/useBoxStyles.ts
+++ b/libs/island-ui/core/src/lib/Box/useBoxStyles.ts
@@ -111,15 +111,15 @@ export const useBoxStyles = ({
     ...styleRefs,
   }
 
-  const resolvedPaddingTop = paddingTop || paddingY || padding
-  const resolvedPaddingBottom = paddingBottom || paddingY || padding
-  const resolvedPaddingLeft = paddingLeft || paddingX || padding
-  const resolvedPaddingRight = paddingRight || paddingX || padding
+  const resolvedPaddingTop = paddingTop ?? paddingY ?? padding
+  const resolvedPaddingBottom = paddingBottom ?? paddingY ?? padding
+  const resolvedPaddingLeft = paddingLeft ?? paddingX ?? padding
+  const resolvedPaddingRight = paddingRight ?? paddingX ?? padding
 
-  const resolvedMarginTop = marginTop || marginY || margin
-  const resolvedMarginBottom = marginBottom || marginY || margin
-  const resolvedMarginLeft = marginLeft || marginX || margin
-  const resolvedMarginRight = marginRight || marginX || margin
+  const resolvedMarginTop = marginTop ?? marginY ?? margin
+  const resolvedMarginBottom = marginBottom ?? marginY ?? margin
+  const resolvedMarginLeft = marginLeft ?? marginX ?? margin
+  const resolvedMarginRight = marginRight ?? marginX ?? margin
 
   return classnames(
     component !== null && resetStyles.base,


### PR DESCRIPTION
Fix bug where e.g. `<Box padding={5} paddingBottom={0} />` results in non-zero
bottom padding