### PR TITLE
WIP: Fixed an issue with malformed yaml and values in search-indexer

### DIFF
--- a/helm/islandis/charts/search-indexer-service/templates/deployment.yaml
+++ b/helm/islandis/charts/search-indexer-service/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
-    containers:
+      containers:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -65,15 +65,15 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-      {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
+        {{- with .Values.nodeSelector }}
+        nodeSelector:
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.affinity }}
+        affinity:
+          {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- with .Values.tolerations }}
+        tolerations:
+          {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/islandis/values.dev.yaml
+++ b/helm/islandis/values.dev.yaml
@@ -4,10 +4,23 @@
 web:
   env:
     API_URL: "http://web-api"
+
 search-indexer-service:
+  namespace: search-indexer
   serviceAccount:
+    create: true
+    name: 'search-indexer'
     annotations:
       eks.amazonaws.com/role-arn: 'arn:aws:iam::013313053092:role/search-indexer'
-  environment:
+  secrets:
+    CONTENTFUL_ACCESS_TOKEN: "/k8s/search-indexer/CONTENTFUL_ACCESS_TOKEN"
+  env:
+    APPLICATION_URL: "http://search-indexer-service"
+    ELASTIC_NODE: "https://vpc-search-njkekqydiegezhr4vqpkfnw5la.eu-west-1.es.amazonaws.com"
+    ELASTIC_INDEX: "island-is"
+    CONTENTFUL_SPACE: "8k0h54kbe6bj"
+    CONTENTFUL_ENVIRONMENT: "master"
+    CONTENTFUL_HOST: "preview.contentful.com"
     S3_BUCKET: "dev-es-custom-packages"
-    ELASTIC_NODE: 'https://vpc-search-njkekqydiegezhr4vqpkfnw5la.eu-west-1.es.amazonaws.com'
+
+  migration_script: /webapp/bin/migrate.js


### PR DESCRIPTION
values.dev.yaml hadn't been updated to fit with the search-indexer
chart.  This fixes:
  * an indentation error
  * mis-named variable `env` in values.dev.yaml

Keep in mind that `values.yaml` does not have an IAM Role linked to the ServiceAccount, so if any AWS privileges are required they will not work in production.