### PR TITLE
Add array merge customizer in answer action

### DIFF
--- a/libs/application/form/src/reducer/ApplicationFormReducer.ts
+++ b/libs/application/form/src/reducer/ApplicationFormReducer.ts
@@ -5,7 +5,8 @@ import {
 } from '@island.is/application/schema'
 import { Action, ActionTypes, ApplicationUIState } from './ReducerTypes'
 import { applyConditionsToFormFields, moveToScreen } from './reducerUtils'
-import { mergeWith, isArray } from 'lodash'
+import mergeWith from 'lodash/mergeWith'
+import isArray from 'lodash/isArray'
 
 /* 
   Makes it so that lodash merge only uses the newer array.


### PR DESCRIPTION
This PR fixes a bug where updated checkbox answers end up incorrect.

### Repro:
1. Answer a checkbox question with three choices so that the answer looks like this: `[ 'VW', 'Audi', 'Porsche' ]`
2. Go back to the question and change your answer to just `['Tesla']`

Result: `[ 'Tesla', 'Audi', 'Porsche' ]`
Expected: `[ 'Tesla']`