### PR TITLE
fix invalid alignItems property

### DIFF
--- a/apps/gjafakort/web/components/Toast/Toast.tsx
+++ b/apps/gjafakort/web/components/Toast/Toast.tsx
@@ -100,7 +100,6 @@ function Toast() {
           </Column>
           <Column width="content">
             <Box
-              alignItems="flexEnd"
               marginLeft={2}
               display="flex"
               cursor="pointer"


### PR DESCRIPTION
"right" is not a valid value for "alignItems" and is causing the build in gjafakort-web to fail.

This is causing failed checks on pull requests unrelated to gjafakort-web, like #326 