### PR TITLE
Slack notifications failing builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -260,3 +260,12 @@ jobs:
             ]
           }
           BODY
+
+      - uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took # selectable (default: repo,message)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # optional
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+        if: failure() && env.PUBLISH == 'true'


### PR DESCRIPTION
Notifying about build failures only for branches that should be published(master for now).
The slack channel is called `dev-builds`.
Already provisioned the SLACK_WEBHOOK_URL secrets.

Fixes island-is/infrastructure#57
