### PR TITLE
Unset tooltip "as" attribute.

### DIFF
--- a/libs/application/form/src/fields/CheckboxFormField.tsx
+++ b/libs/application/form/src/fields/CheckboxFormField.tsx
@@ -63,7 +63,6 @@ const CheckboxFormField: FC<Props> = ({ showFieldName = false, field }) => {
                         <Tooltip
                           colored={true}
                           placement="top"
-                          as="button"
                           text={option.tooltip}
                         />
                       </Box>

--- a/libs/application/form/src/fields/RadioFormField.tsx
+++ b/libs/application/form/src/fields/RadioFormField.tsx
@@ -44,7 +44,6 @@ const RadioFormField: FC<Props> = ({ showFieldName = false, field }) => {
                         <Tooltip
                           colored={true}
                           placement="top"
-                          as="button"
                           text={option.tooltip}
                         />
                       </Box>


### PR DESCRIPTION
Unset tooltip `as="button"` so it defaults to span.