### PR TITLE
Use unique key prop on category page

### DIFF
--- a/apps/web/screens/Category/Category.tsx
+++ b/apps/web/screens/Category/Category.tsx
@@ -112,7 +112,7 @@ const Category: Screen<CategoryProps> = ({
 
                 return (
                   <AccordionCard
-                    key={index}
+                    key={groupSlug}
                     id={`accordion-${index}`}
                     label={title}
                     visibleContent={


### PR DESCRIPTION
otherwise, because page component is not unmounted/mounted when
selecting another cateogy, using index as a key the accordion instance
gets re-used and open/closed state maintained between pages


![Screen Recording 2020-08-13 at 13 15 44 mov](https://user-images.githubusercontent.com/15398/90139547-0ea12300-dd68-11ea-9300-24236a72bc33.gif)
