### PR TITLE
Fixing ingress problems in ads

### DIFF
--- a/helm/air-discount-scheme/values.dev.yaml
+++ b/helm/air-discount-scheme/values.dev.yaml
@@ -15,6 +15,7 @@ air-discount-scheme-api:
 
   ingress:
     annotations:
+      kubernetes.io/ingress.class: 'nginx-external'
       cert-manager.io/cluster-issuer: 'devland-is-letsencrypt-dns01'
     hosts:
       - host: 'ads.dev01.devland.is'
@@ -27,6 +28,7 @@ air-discount-scheme-api:
 air-discount-scheme-web:
   ingress:
     annotations:
+      kubernetes.io/ingress.class: 'nginx-external'
       cert-manager.io/cluster-issuer: 'devland-is-letsencrypt-dns01'
     hosts:
       - host: 'ads.dev01.devland.is'
@@ -50,12 +52,14 @@ air-discount-scheme-backend:
 
   ingress:
     annotations:
+      kubernetes.io/ingress.class: 'nginx-external'
       cert-manager.io/cluster-issuer: 'devland-is-letsencrypt-dns01'
+      nginx.ingress.kubernetes.io/rewrite-target: /$1$2
+      nginx.ingress.kubernetes.io/enable-global-auth: "false"
     hosts:
       - host: 'ads.dev01.devland.is'
         paths:
-          - '/api/swagger'
-          - '/api/public'
+          - '/api/(swagger|public)(.*)'
     tls:
       - hosts: ['ads.dev01.devland.is']
         secretName: 'air-discount-scheme-web-tls'

--- a/helm/air-discount-scheme/values.prod.yaml
+++ b/helm/air-discount-scheme/values.prod.yaml
@@ -13,13 +13,14 @@ air-discount-scheme-api:
 
   ingress:
     annotations:
-      cert-manager.io/cluster-issuer: 'air-discount-scheme-island-is-letsencrypt-dns01'
+      kubernetes.io/ingress.class: 'nginx-external'
+      cert-manager.io/cluster-issuer: 'devland-is-letsencrypt-dns01'
     hosts:
-      - host: 'ads.island.is'
+      - host: 'ads.devland.is'
         paths:
           - '/api'
     tls:
-      - hosts: ['ads.island.is']
+      - hosts: ['ads.devland.is']
         secretName: 'air-discount-scheme-web-tls'
 
 air-discount-scheme-web:
@@ -27,13 +28,14 @@ air-discount-scheme-web:
 
   ingress:
     annotations:
-      cert-manager.io/cluster-issuer: 'air-discount-scheme-island-is-letsencrypt-dns01'
+      kubernetes.io/ingress.class: 'nginx-external'
+      cert-manager.io/cluster-issuer: 'devland-is-letsencrypt-dns01'
     hosts:
-      - host: 'ads.island.is'
+      - host: 'ads.devland.is'
         paths:
           - '/'
     tls:
-      - hosts: ['ads.island.is']
+      - hosts: ['ads.devland.is']
         secretName: 'air-discount-scheme-web-tls'
 
 air-discount-scheme-backend:
@@ -49,4 +51,14 @@ air-discount-scheme-backend:
       DB_USER: 'air_discount_scheme_backend'
 
   ingress:
-    enabled: false
+    annotations:
+      kubernetes.io/ingress.class: 'nginx-external'
+      cert-manager.io/cluster-issuer: 'devland-is-letsencrypt-dns01'
+      nginx.ingress.kubernetes.io/rewrite-target: /$1$2
+    hosts:
+      - host: 'ads.devland.is'
+        paths:
+          - '/api/(swagger|public)(.*)'
+    tls:
+      - hosts: ['ads.devland.is']
+        secretName: 'air-discount-scheme-web-tls'


### PR DESCRIPTION
* Disabled github auth for backend ingress so the airline companies can access the endpoints
* Opened only for /api/swagger and /api/public on the ingress, /api/private will be unauthenticated and not opened on the ingress (I will add authentication to the /api/public later)