### PR TITLE
Set default size limit to 1000 for articlesInCategory

### DIFF
--- a/libs/api/content-search/src/services/elastic.service.ts
+++ b/libs/api/content-search/src/services/elastic.service.ts
@@ -113,9 +113,11 @@ export class ElasticService {
   }
 
   async fetchItems(index: SearchIndexes, input) {
-    const requestBody = new RequestBodySearch().query(
-      esb.boolQuery().must([esb.matchQuery('category_slug', input.slug)]),
-    ).size(1000)
+    const requestBody = new RequestBodySearch()
+      .query(
+        esb.boolQuery().must([esb.matchQuery('category_slug', input.slug)]),
+      )
+      .size(1000)
 
     return this.findByQuery(index, requestBody)
   }


### PR DESCRIPTION
default limit from 10 to 1000 for articlesInCategory, otherwise articles in /flokkur/[slug] would be limited to 10.