### PR TITLE
Ignoring Helm folder when calculating 'affected' projects

### DIFF
--- a/.nxignore
+++ b/.nxignore
@@ -1,3 +1,5 @@
+# helm
+/helm
 # gjafakort
 apps/gjafakort/bin
 apps/gjafakort/codegen.yml


### PR DESCRIPTION
That has only to do with deployments so no need to test, lint, etc.