### PR TITLE
Fix for "undefined" in search results

### DIFF
--- a/apps/services/search-indexer/src/app/indexing.service.ts
+++ b/apps/services/search-indexer/src/app/indexing.service.ts
@@ -123,8 +123,8 @@ export class IndexingService {
         }
         if (doc.data && doc.data.target) {
           if (doc.data.target.sys.contentType.sys.id === 'processEntry') {
-            response += doc.data.target.fields.processTitle + '\n'
-            response += doc.data.target.fields.processDescription + '\n'
+            response += (doc.data.target.fields.processTitle ?? '') + '\n'
+            response += (doc.data.target.fields.processDescription ?? '') + '\n'
           } else {
             //todo implement more types
           }


### PR DESCRIPTION
Prevent undefined field becoming part of 'reducedContent' for ES document