### PR TITLE
Mapper not handling unpublished content fix

### DIFF
--- a/apps/services/search-indexer/src/app/indexing.service.ts
+++ b/apps/services/search-indexer/src/app/indexing.service.ts
@@ -122,7 +122,10 @@ export class IndexingService {
           response += reduceContent(doc.content)
         }
         if (doc.data && doc.data.target) {
-          if (doc.data.target.sys.contentType && doc.data.target.sys.contentType.sys.id === 'processEntry') {
+          if (
+            doc.data.target.sys.contentType &&
+            doc.data.target.sys.contentType.sys.id === 'processEntry'
+          ) {
             response += (doc.data.target.fields.processTitle ?? '') + '\n'
             response += (doc.data.target.fields.processDescription ?? '') + '\n'
           } else {

--- a/apps/services/search-indexer/src/app/indexing.service.ts
+++ b/apps/services/search-indexer/src/app/indexing.service.ts
@@ -122,7 +122,7 @@ export class IndexingService {
           response += reduceContent(doc.content)
         }
         if (doc.data && doc.data.target) {
-          if (doc.data.target.sys.contentType.sys.id === 'processEntry') {
+          if (doc.data.target.sys.contentType && doc.data.target.sys.contentType.sys.id === 'processEntry') {
             response += (doc.data.target.fields.processTitle ?? '') + '\n'
             response += (doc.data.target.fields.processDescription ?? '') + '\n'
           } else {
@@ -135,12 +135,12 @@ export class IndexingService {
 
     /* eslint-disable @typescript-eslint/camelcase */
     const document: Document = {
-      category: entry.fields?.category?.fields.title,
-      category_slug: entry.fields?.category?.fields.slug,
-      category_description: entry.fields?.category?.fields.description,
-      group: entry.fields?.group?.fields.title,
-      group_slug: entry.fields?.group?.fields.slug,
-      group_description: entry.fields?.group?.fields.description,
+      category: entry.fields?.category?.fields?.title,
+      category_slug: entry.fields?.category?.fields?.slug,
+      category_description: entry.fields?.category?.fields?.description,
+      group: entry.fields?.group?.fields?.title,
+      group_slug: entry.fields?.group?.fields?.slug,
+      group_description: entry.fields?.group?.fields?.description,
       content: reduceContent(entry.fields.content?.content),
       content_blob: JSON.stringify(entry.fields),
       content_id: entry.sys.id,

--- a/libs/api/content-search/src/services/elastic.service.ts
+++ b/libs/api/content-search/src/services/elastic.service.ts
@@ -133,14 +133,16 @@ export class ElasticService {
       },
     }
     const client = await this.getClient()
-    return client.delete_by_query({
-      index: index,
-      body: body,
-    }).catch(error => {
-      // TODO: Improve this cleaning function so it handles no index exists case
-      // we dont want to take down the indexer if there is no index to delete from
-      logger.error('Failed to delete all except', error)
-    })
+    return client
+      .delete_by_query({
+        index: index,
+        body: body,
+      })
+      .catch((error) => {
+        // TODO: Improve this cleaning function so it handles no index exists case
+        // we dont want to take down the indexer if there is no index to delete from
+        logger.error('Failed to delete all except', error)
+      })
   }
 
   async deleteAll(index: SearchIndexes) {

--- a/libs/api/content-search/src/services/elastic.service.ts
+++ b/libs/api/content-search/src/services/elastic.service.ts
@@ -136,6 +136,10 @@ export class ElasticService {
     return client.delete_by_query({
       index: index,
       body: body,
+    }).catch(error => {
+      // TODO: Improve this cleaning function so it handles no index exists case
+      // we dont want to take down the indexer if there is no index to delete from
+      logger.error('Failed to delete all except', error)
     })
   }
 


### PR DESCRIPTION
The indexer goes down when trying to map articles that have unpublished content.
Added this as a quick fix, this will be handled properly when we tackle indexing of multiple content types
- Made indexer not go down due to unpublished content