### PR TITLE
Added a required prop to input

### DIFF
--- a/libs/island-ui/core/src/lib/Input/Input.stories.tsx
+++ b/libs/island-ui/core/src/lib/Input/Input.stories.tsx
@@ -33,3 +33,16 @@ export const Error = () => (
     </Box>
   </ContentBlock>
 )
+
+export const Required = () => (
+  <ContentBlock>
+    <Box padding={['gutter', 2, 3, 4]}>
+      <Input
+        label="This is the label"
+        placeholder="This is the placeholder"
+        name="Test"
+        required
+      />
+    </Box>
+  </ContentBlock>
+)

--- a/libs/island-ui/core/src/lib/Input/Input.treat.ts
+++ b/libs/island-ui/core/src/lib/Input/Input.treat.ts
@@ -41,7 +41,12 @@ export const label = style({
     [`${hasError} &`]: mixins.labelErrorState,
   },
 })
+
 export const labelDisabledEmptyInput = style(mixins.labelDisabledEmptyInput)
+
+export const isRequiredStar = style({
+  color: theme.color.red400,
+})
 
 export const hasFocus = style({
   selectors: {

--- a/libs/island-ui/core/src/lib/Input/Input.tsx
+++ b/libs/island-ui/core/src/lib/Input/Input.tsx
@@ -7,17 +7,18 @@ import Tooltip from '../Tooltip/Tooltip'
 type InputBackgroundColor = 'white' | 'blue'
 
 interface InputProps {
-  autoFocus?: boolean
   name: string
   label?: string
-  id?: string
-  value?: string | number
-  disabled?: boolean
   hasError?: boolean
+  value?: string | number
   errorMessage?: string
+  id?: string
+  disabled?: boolean
+  required?: boolean
   placeholder?: string
   tooltip?: string
   backgroundColor?: InputBackgroundColor
+  autoFocus?: boolean
   onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void
   onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
@@ -38,18 +39,19 @@ function mergeRefs(refs) {
 export const Input = forwardRef(
   (props: InputProps, ref?: React.Ref<HTMLInputElement>) => {
     const {
-      label,
       name,
+      label,
       hasError = false,
       value,
       errorMessage = '',
       id = name,
       disabled,
-      onFocus,
-      onBlur,
+      required,
       placeholder,
       tooltip,
       backgroundColor = 'white',
+      onFocus,
+      onBlur,
       ...inputProps
     } = props
     const [hasFocus, setHasFocus] = useState(false)
@@ -87,6 +89,7 @@ export const Input = forwardRef(
             })}
           >
             {label}
+            {required && <span className={styles.isRequiredStar}> *</span>}
             {tooltip && (
               <Box marginLeft={1} display="inlineBlock">
                 <Tooltip text={tooltip} />


### PR DESCRIPTION
If the `required` prop is set on input fields, a red star is added to the label. It doesn't add any kind of validation, that's still the consumers job.

![Screenshot 2020-09-02 at 09 54 34](https://user-images.githubusercontent.com/3789875/91967459-cc358b00-ed02-11ea-8353-820975c60152.png)
