### PR TITLE
Contentful sync

### DIFF
--- a/apps/services/search-indexer/src/app/indexing.service.ts
+++ b/apps/services/search-indexer/src/app/indexing.service.ts
@@ -39,44 +39,53 @@ export class IndexingService {
   async continueSync(syncToken: string, index: SearchIndexes) {
     await this.needConnection()
     logger.info('Start continue sync')
-    const result = await this.contentFulSyncer.getSyncEntries({
+    const {
+      items,
+      token,
+      deletedItems,
+    } = await this.contentFulSyncer.getSyncEntries({
       nextSyncToken: syncToken,
       // eslint-disable-next-line @typescript-eslint/camelcase
-      content_type: 'article',
       resolveLinks: true,
     })
+
     logger.info('Continue sync found results', {
-      numItems: result.items.length,
+      numItems: items.length,
     })
-    for (const item of result.items) {
+
+    for (const item of items) {
       // one at a time please, else ES will be unhappy
-      await this.transformAndIndexEntry(index, result.token, item)
+      await this.transformAndIndexEntry(index, token, item)
     }
+
+    // delete content that has been unpublished from contentful
+    await this.elasticService.deleteByIds(index, deletedItems)
+
     logger.info('Continue sync done')
   }
 
   async initialSync(index: SearchIndexes) {
     await this.needConnection()
     logger.info('Start initial sync')
-    const result = await this.contentFulSyncer.getSyncEntries({
+    const { items, token } = await this.contentFulSyncer.getSyncEntries({
       initial: true,
       // eslint-disable-next-line @typescript-eslint/camelcase
-      content_type: 'article',
       resolveLinks: true,
     })
     logger.info('Initial sync found result', {
-      numItems: result.items.length,
+      numItems: items.length,
     })
 
-    for (const item of result.items) {
+    // TODO: Use es client batch here
+    for (const item of items) {
       // one at a time please, else ES will be unhappy
-      await this.transformAndIndexEntry(index, result.token, item)
+      await this.transformAndIndexEntry(index, token, item)
     }
 
     // delete everything in ES, except for synced content, to ensure no stale data in index
     await this.elasticService.deleteAllExcept(
       index,
-      result.items.map((entry) => entry.sys.id),
+      items.map((entry) => entry.sys.id),
     )
 
     logger.info('Initial sync done')
@@ -129,7 +138,7 @@ export class IndexingService {
             response += (doc.data.target.fields.processTitle ?? '') + '\n'
             response += (doc.data.target.fields.processDescription ?? '') + '\n'
           } else {
-            //todo implement more types
+            //todo implement more typesz
           }
         }
       })
@@ -138,10 +147,13 @@ export class IndexingService {
 
     // TODO: Fix this when improving mapping
     // related articles has a recursive nesting problem, we prune it for now
-    if(entry.fields?.relatedArticles?.[0]) {
-      logger.info('Removing related articles from related articles')
+    if (entry.fields?.relatedArticles?.[0]?.fields) {
+      logger.info('Removing nested related articles from related articles')
       // remove related articles from nested articles
-      const {relatedArticles, ...prunedRelatedArticlesFields} = entry.fields.relatedArticles[0].fields
+      const {
+        relatedArticles,
+        ...prunedRelatedArticlesFields
+      } = entry.fields.relatedArticles[0].fields
       entry.fields.relatedArticles[0].fields = prunedRelatedArticlesFields
     }
 
@@ -169,6 +181,7 @@ export class IndexingService {
       url: '',
       _id: entry.sys.id,
     }
+
     if (syncToken) {
       document.nextSyncToken = syncToken
     }
@@ -182,3 +195,5 @@ export class IndexingService {
     })
   }
 }
+
+// TODO: Setup cron to cleanup the dev environment

--- a/apps/services/search-indexer/src/app/indexing.service.ts
+++ b/apps/services/search-indexer/src/app/indexing.service.ts
@@ -138,7 +138,7 @@ export class IndexingService {
             response += (doc.data.target.fields.processTitle ?? '') + '\n'
             response += (doc.data.target.fields.processDescription ?? '') + '\n'
           } else {
-            //todo implement more typesz
+            //todo implement more types
           }
         }
       })
@@ -195,5 +195,3 @@ export class IndexingService {
     })
   }
 }
-
-// TODO: Setup cron to cleanup the dev environment

--- a/apps/services/search-indexer/src/app/indexing.service.ts
+++ b/apps/services/search-indexer/src/app/indexing.service.ts
@@ -49,8 +49,8 @@ export class IndexingService {
       resolveLinks: true,
     })
 
-    logger.info('Continue sync found results', {
-      numItems: items.length,
+    logger.info('Continue sync is importing', {
+      itemCount: items.length,
     })
 
     for (const item of items) {
@@ -72,8 +72,8 @@ export class IndexingService {
       // eslint-disable-next-line @typescript-eslint/camelcase
       resolveLinks: true,
     })
-    logger.info('Initial sync found result', {
-      numItems: items.length,
+    logger.info('Initial sync is importing', {
+      itemCount: items.length,
     })
 
     // TODO: Use es client batch here

--- a/apps/services/search-indexer/src/contentful/syncer.ts
+++ b/apps/services/search-indexer/src/contentful/syncer.ts
@@ -45,8 +45,6 @@ export class Syncer {
   async getSyncEntries(opts): Promise<SyncerResult> {
     const collection: SyncCollection = await this.contentFulClient.sync(opts)
 
-    logger.info('Entire collection', { collection: collection })
-    logger.info('Deleted entries', { deleted: collection.deletedEntries })
     const idChunks = chunk(
       collection.entries.map((entry) => entry.sys.id),
       30,

--- a/apps/services/search-indexer/src/contentful/syncer.ts
+++ b/apps/services/search-indexer/src/contentful/syncer.ts
@@ -44,12 +44,16 @@ export class Syncer {
 
   async getSyncEntries(opts): Promise<SyncerResult> {
     const collection: SyncCollection = await this.contentFulClient.sync(opts)
+
+    logger.info('Entire collection', { collection: collection })
+    logger.info('Deleted entries', { deleted: collection.deletedEntries })
     const idChunks = chunk(
       collection.entries.map((entry) => entry.sys.id),
       30,
     )
     const result = {
       items: [],
+      deletedItems: [],
       token: collection.nextSyncToken,
     }
     for (const ids of idChunks) {

--- a/apps/services/search-indexer/src/environments/environment.prod.ts
+++ b/apps/services/search-indexer/src/environments/environment.prod.ts
@@ -6,4 +6,5 @@ export const environment = {
     environment: process.env.CONTENTFUL_ENVIRONMENT,
     host: process.env.CONTENTFUL_HOST,
   },
+  indexableTypes: ['article'],
 }

--- a/apps/services/search-indexer/src/environments/environment.ts
+++ b/apps/services/search-indexer/src/environments/environment.ts
@@ -6,4 +6,5 @@ export const environment = {
     environment: process.env.CONTENTFUL_ENVIRONMENT || 'master',
     host: process.env.CONTENTFUL_HOST || 'preview.contentful.com',
   },
+  indexableTypes: ['article'],
 }

--- a/libs/api/content-search/src/services/elastic.service.ts
+++ b/libs/api/content-search/src/services/elastic.service.ts
@@ -1,6 +1,6 @@
 import { Client } from '@elastic/elasticsearch'
 import { Document, SearchIndexes } from '../types'
-import esb, { RequestBodySearch, TermsAggregation } from 'elastic-builder'
+import esb, {RequestBodySearch, Sort, TermsAggregation} from 'elastic-builder'
 import { logger } from '@island.is/logging'
 import merge from 'lodash/merge'
 import { environment } from '../environments/environment'
@@ -123,26 +123,39 @@ export class ElasticService {
     return this.findByQuery(index, requestBody)
   }
 
-  async deleteAllExcept(index: SearchIndexes, excludeIds: Array<string>) {
-    const body = {
-      query: {
-        bool: {
-          // eslint-disable-next-line @typescript-eslint/camelcase
-          must_not: excludeIds.map((id) => ({ match: { _id: id } })),
-        },
-      },
+  async deleteByIds(index: SearchIndexes, ids: Array<string>) {
+    // In case we get an empty list, ES will match that to all records... which we don't want to delete
+    if (!ids.length) {
+      return
     }
     const client = await this.getClient()
-    return client
-      .delete_by_query({
-        index: index,
-        body: body,
-      })
-      .catch((error) => {
-        // TODO: Improve this cleaning function so it handles no index exists case
-        // we dont want to take down the indexer if there is no index to delete from
-        logger.error('Failed to delete all except', error)
-      })
+    return client.delete_by_query({
+      index: index,
+      body: {
+        query: {
+          bool: {
+            // eslint-disable-next-line @typescript-eslint/camelcase
+            must: ids.map((id) => ({ match: { _id: id } })),
+          },
+        },
+      },
+    })
+  }
+
+  async deleteAllExcept(index: SearchIndexes, excludeIds: Array<string>) {
+    const client = await this.getClient()
+
+    return client.delete_by_query({
+      index: index,
+      body: {
+        query: {
+          bool: {
+            // eslint-disable-next-line @typescript-eslint/camelcase
+            must_not: excludeIds.map((id) => ({ match: { _id: id } })),
+          },
+        },
+      },
+    })
   }
 
   async deleteAll(index: SearchIndexes) {

--- a/libs/api/content-search/src/services/elastic.service.ts
+++ b/libs/api/content-search/src/services/elastic.service.ts
@@ -123,25 +123,6 @@ export class ElasticService {
     return this.findByQuery(index, requestBody)
   }
 
-  async deleteByIds(index: SearchIndexes, ids: Array<string>) {
-    // In case we get an empty list, ES will match that to all records... which we don't want to delete
-    if (!ids.length) {
-      return
-    }
-    const client = await this.getClient()
-    return client.delete_by_query({
-      index: index,
-      body: {
-        query: {
-          bool: {
-            // eslint-disable-next-line @typescript-eslint/camelcase
-            must: ids.map((id) => ({ match: { _id: id } })),
-          },
-        },
-      },
-    })
-  }
-
   async deleteAllExcept(index: SearchIndexes, excludeIds: Array<string>) {
     const client = await this.getClient()
 
@@ -155,15 +136,6 @@ export class ElasticService {
           },
         },
       },
-    })
-  }
-
-  async deleteAll(index: SearchIndexes) {
-    const client = await this.getClient()
-    return client.delete_by_query({
-      index: index,
-      // eslint-disable-next-line @typescript-eslint/camelcase
-      body: { query: { match_all: {} } },
     })
   }
 


### PR DESCRIPTION
The `sync` was not deleting entries when doing normal sync.
Parameters passes to contentful sync caused `deletedEntries` to be allways empty.
We have an upcoming task to expand the sync to support locale and multiple content type search from contentful,
we will fix ts types and optimize during that process

- `sync` now deletes entries from the ES index
- Made sync mapping not fail when encountering nested relatedArticles
- `content_type` argument caused sync endpoint to not return deleted entries
- Added `deleteByIds`
- Added comments
- Added TODO comments as reminders