### PR TITLE
Fix further outstanding issues with SideMenu

### DIFF
--- a/apps/web/components/SideMenu/SideMenu.treat.ts
+++ b/apps/web/components/SideMenu/SideMenu.treat.ts
@@ -8,7 +8,9 @@ export const root = style({
   display: 'none',
   height: '100%',
   left: 0,
-  padding: theme.spacing[3],
+  paddingTop: theme.spacing[3],
+  paddingLeft: theme.spacing[3],
+  paddingRight: theme.spacing[3],
   position: 'fixed',
   right: 0,
   top: 0,
@@ -20,13 +22,15 @@ export const root = style({
       position: 'absolute',
       top: theme.spacing[3],
       right: theme.spacing[3],
+      paddingBottom: theme.spacing[3],
       width: SIDE_MENU_WIDTH,
     },
   },
 })
 
 export const isVisible = style({
-  display: 'block',
+  display: 'flex',
+  flexDirection: 'column',
 })
 
 export const tabHeader = style({
@@ -49,12 +53,13 @@ export const tabActive = style({
 })
 
 export const content = style({
-  overflowY: 'scroll',
-  maxHeight: 450,
-  paddingBottom: theme.spacing[4],
+  flex: 1,
+  overflow: 'auto',
+  paddingBottom: theme.spacing[2],
+  // for Firefox
+  minHeight: 0,
   '@media': {
     [`screen and (min-width: ${theme.breakpoints.md}px)`]: {
-      maxHeight: 'none',
       paddingBottom: 0,
     },
   },

--- a/apps/web/components/SideMenu/SideMenu.tsx
+++ b/apps/web/components/SideMenu/SideMenu.tsx
@@ -2,8 +2,7 @@ import React, { FC, useState, useRef, useEffect } from 'react'
 import Link from 'next/link'
 import FocusLock from 'react-focus-lock'
 import { RemoveScroll } from 'react-remove-scroll'
-
-import { useKey, useClickAway, useWindowSize } from 'react-use'
+import { useKey, useWindowSize } from 'react-use'
 import cn from 'classnames'
 import {
   Typography,
@@ -47,14 +46,12 @@ interface Props {
 
 export const SideMenu: FC<Props> = ({ tabs, isVisible, handleClose }) => {
   const [activeTab, setActiveTab] = useState(0)
-  const ref = useRef(null)
   const buttonsRef = useRef([])
   const { activeLocale, t } = useI18n()
   const { width } = useWindowSize()
   const isMobile = width < theme.breakpoints.md
 
   useKey('Escape', handleClose)
-  useClickAway(ref, handleClose)
 
   useEffect(() => {
     if (buttonsRef.current && buttonsRef.current[activeTab]) {
@@ -65,10 +62,7 @@ export const SideMenu: FC<Props> = ({ tabs, isVisible, handleClose }) => {
   return isVisible ? (
     <RemoveScroll enabled={isMobile}>
       <FocusLock>
-        <div
-          className={cn(styles.root, { [styles.isVisible]: isVisible })}
-          ref={ref}
-        >
+        <div className={cn(styles.root, { [styles.isVisible]: isVisible })}>
           <div className={styles.tabHeader}>
             <button onClick={handleClose} tabIndex={-1}>
               <Icon type="close" />

--- a/apps/web/components/SideMenu/components/LinkBox/LinkBox.treat.ts
+++ b/apps/web/components/SideMenu/components/LinkBox/LinkBox.treat.ts
@@ -16,16 +16,6 @@ export const root = style({
   },
 })
 
-export const anchorWrap = style({
-  display: 'flex',
-  flexDirection: 'column',
-  selectors: {
-    [`${root}:hover &`]: {
-      textDecoration: 'none',
-    },
-  },
-})
-
 export const linkBox = style({
   alignItems: 'center',
   background: theme.color.blue100,

--- a/apps/web/components/SideMenu/components/LinkBox/LinkBox.tsx
+++ b/apps/web/components/SideMenu/components/LinkBox/LinkBox.tsx
@@ -1,25 +1,23 @@
 import React from 'react'
 import * as styles from './LinkBox.treat'
-import { Typography, Icon } from '@island.is/island-ui/core'
+import { Typography, Icon, Link } from '@island.is/island-ui/core'
 
 export const LinkBox = ({ title, url, icon }) => {
   const firstLetter = title[0]
 
   return (
     <li className={styles.root}>
-      <a href={url} className={styles.anchorWrap}>
+      <Link href={url}>
         <div className={styles.linkBox}>
           <div className={styles.hoverIcon}>
             <Icon type="external" height={16} />
           </div>
-          <div className={styles.iconWrap}>
-            {icon || <div className={styles.letterIcon}>{firstLetter}</div>}
-          </div>
+          <div className={styles.iconWrap}>{icon || firstLetter}</div>
           <Typography variant="eyebrow" color="blue400">
             {title}
           </Typography>
         </div>
-      </a>
+      </Link>
     </li>
   )
 }


### PR DESCRIPTION
- Fix scrollbar being visible on desktop. Content does not scroll on desktop, users should scroll the whole page.

- Allow vertical scrolling inside content on mobile.
![image](https://user-images.githubusercontent.com/8494120/92023518-68d04b00-ed4c-11ea-97ed-b95ad5302f00.png)

- Don't close the SideMenu on `click outside` as users will accidentally close it when using the main scrollbar.