### PR TITLE
Added prev/next arrow buttons to frontpage tabs

### DIFF
--- a/apps/web/components/FrontpageTabs/FrontpageTabs.treat.ts
+++ b/apps/web/components/FrontpageTabs/FrontpageTabs.treat.ts
@@ -1,17 +1,27 @@
 import { style } from 'treat'
-import { theme, themeUtils } from '@island.is/island-ui/theme'
+import { ThemeOrAny } from 'treat/theme'
+import { ThemedStyle, Style } from 'treat/lib/types/types'
+import { theme } from '@island.is/island-ui/theme'
 
-export const container = style({
-  width: '100%',
-  margin: '0 auto',
-  maxWidth: '1120px',
-  display: 'block',
+const whenMobile = (style: ThemedStyle<Style, ThemeOrAny>) => ({
+  '@media': {
+    [`screen and (max-width: ${theme.breakpoints.md - 1}px)`]: {
+      ...style,
+    },
+  },
 })
 
 export const link = style({
   ':hover': {
     textDecoration: 'none',
   },
+})
+
+export const removeMobileSpacing = style({
+  ...whenMobile({
+    paddingLeft: theme.grid.gutter.mobile / 2,
+    paddingRight: theme.grid.gutter.mobile / 2,
+  }),
 })
 
 export const tabWrapper = style({
@@ -34,12 +44,12 @@ export const tabPanel = style({
   right: 0,
   opacity: 0,
   pointerEvents: 'none',
-  outline: 0,
   transition: `opacity 300ms ease 0ms`,
 })
 
 export const tabPanelVisible = style({
   opacity: 1,
+  outline: 0,
   position: 'relative',
   display: 'inline-block',
   width: '100%',
@@ -99,17 +109,35 @@ export const imageContainer = style({
   width: '100%',
   alignItems: 'center',
   justifyContent: 'center',
-  ...themeUtils.responsiveStyle({
-    xs: {
-      display: 'none',
-      maxWidth: '220px',
-    },
-    lg: {
-      display: 'flex',
-      maxWidth: '300px',
-    },
-    xl: {
-      maxWidth: '440px',
-    },
+})
+
+export const arrowButton = style({
+  position: 'relative',
+  display: 'flex',
+  zIndex: 1,
+  justifyContent: 'center',
+  alignItems: 'center',
+  borderRadius: '50%',
+  width: 40,
+  height: 40,
+  backgroundColor: theme.color.red100,
+  opacity: 1,
+  transition: 'all 150ms ease',
+  outline: 0,
+  ':focus': {
+    backgroundColor: theme.color.red200,
+  },
+  ':hover': {
+    backgroundColor: theme.color.red200,
+  },
+})
+
+export const arrowButtonDisabled = style({
+  opacity: 0.5,
+})
+
+export const searchContentContainer = style({
+  ...whenMobile({
+    borderRadius: 0,
   }),
 })

--- a/apps/web/components/FrontpageTabs/FrontpageTabs.tsx
+++ b/apps/web/components/FrontpageTabs/FrontpageTabs.tsx
@@ -18,12 +18,13 @@ import {
   GridContainer,
   GridRow,
   GridColumn,
+  Icon,
+  Hidden,
 } from '@island.is/island-ui/core'
 import { Locale } from '@island.is/web/i18n/I18n'
 import { useRouteNames } from '@island.is/web/i18n/useRouteNames'
 import { useI18n } from '../../i18n'
-import Dots from './Dots'
-import HeartSvg from './HeartSvg'
+
 import * as styles from './FrontpageTabs.treat'
 
 const AUTOPLAY_TIMER = 8000
@@ -69,8 +70,10 @@ export const FrontpageTabs: FC<FrontpageTabsProps> = ({
   searchContent,
   autoplay = true,
 }) => {
+  const contentRef = useRef(null)
   const timer = useRef(null)
   const [minHeight, setMinHeight] = useState<number>(0)
+  const [maxContainerHeight, setMaxContainerHeight] = useState<number>(0)
   const [autoplayOn, setAutoplayOn] = useState<boolean>(autoplay)
   const itemsRef = useRef<Array<HTMLElement | null>>([])
   const [selectedIndex, setSelectedIndex] = useState<number>(0)
@@ -89,6 +92,7 @@ export const FrontpageTabs: FC<FrontpageTabsProps> = ({
 
   const onResize = useCallback(() => {
     setMinHeight(0)
+    setMaxContainerHeight(0)
 
     let height = 0
 
@@ -97,13 +101,18 @@ export const FrontpageTabs: FC<FrontpageTabsProps> = ({
     })
 
     setMinHeight(height)
-  }, [itemsRef])
+
+    if (contentRef.current) {
+      setMaxContainerHeight(contentRef.current.offsetHeight)
+    }
+  }, [itemsRef, contentRef])
 
   const nextSlide = useCallback(() => {
-    const index = tab.items.findIndex((x) => x.id === tab.currentId)
-    const nextIndex = (index + 1) % tab.items.length
+    tab.next()
+  }, [tab])
 
-    tab.move(tab.items[nextIndex].id)
+  const prevSlide = useCallback(() => {
+    tab.previous()
   }, [tab])
 
   useEffect(() => {
@@ -117,13 +126,14 @@ export const FrontpageTabs: FC<FrontpageTabsProps> = ({
   }, [autoplayOn, nextSlide])
 
   useEffect(() => {
-    onResize()
+    setTimeout(onResize, 0)
     window.addEventListener('resize', onResize, { passive: true })
     return () => window.removeEventListener('resize', onResize)
   }, [onResize])
 
   useEffect(() => {
-    setSelectedIndex(tab.items.findIndex((x) => x.id === tab.currentId))
+    const newSelectedIndex = tab.items.findIndex((x) => x.id === tab.currentId)
+    setSelectedIndex(newSelectedIndex)
     setAutoplayOn(false)
   }, [tab])
 
@@ -151,116 +161,217 @@ export const FrontpageTabs: FC<FrontpageTabsProps> = ({
     }
   }, [selectedIndex, updateImage])
 
+  const goTo = (direction: string) => {
+    switch (direction) {
+      case 'prev':
+        prevSlide()
+        break
+      case 'next':
+        nextSlide()
+        break
+      default:
+        break
+    }
+  }
+
   return (
-    <GridContainer>
+    <GridContainer className={styles.removeMobileSpacing}>
       <GridRow>
-        <GridColumn span="6/12" offset="1/12">
-          <TabList {...tab} aria-label="My tabs" className={styles.tabWrapper}>
-            {tabs.map(({ subtitle = '' }, index) => {
-              return (
-                <Tab key={index} {...tab} className={cn(styles.tabContainer)}>
-                  <TabBullet selected={selectedIndex === index} />
-                  <span className={styles.srOnly}>{subtitle}</span>
-                </Tab>
-              )
-            })}
-          </TabList>
-        </GridColumn>
-      </GridRow>
-      <GridRow>
-        <GridColumn span="6/12" offset="1/12">
-          <div className={styles.tabPanelWrapper}>
-            {tabs.map(({ title, subtitle, content, link }, index) => {
-              let href = null
-              let as = null
-
-              const currentIndex = tab.items.findIndex(
-                (x) => x.id === tab.currentId,
-              )
-
-              const visible = currentIndex === index
-
-              if (link) {
-                const linkData = JSON.parse(link)
-                const contentId = linkData.sys?.contentType?.sys?.id
-
-                const slug = linkData.fields?.slug
-
-                if (slug && ['article', 'category'].includes(contentId)) {
-                  href = `${makePath(contentId)}/[slug]`
-                  as = makePath(contentId, slug)
-                }
-              }
-
-              return (
-                <TabPanel
-                  key={index}
-                  {...tab}
-                  style={{
-                    display: 'inline-block',
-                  }}
-                  className={cn(styles.tabPanel, {
-                    [styles.tabPanelVisible]: visible,
-                  })}
-                >
-                  <Box
-                    paddingY={3}
-                    ref={(el) => (itemsRef.current[index] = el)}
-                    style={{ minHeight: `${minHeight}px` }}
-                  >
-                    <Stack space={3}>
-                      <Typography variant="eyebrow" as="h2" color="purple400">
-                        <span className={styles.textItem}>{subtitle}</span>
-                      </Typography>
-                      <Typography variant="h1" as="h1">
-                        <span className={styles.textItem}>{title}</span>
-                      </Typography>
-                      <Typography variant="p" as="p">
-                        <span className={styles.textItem}>
-                          {content}
-                          {href ? (
-                            <>
-                              {` `}
-                              <Link as={as} href={href} passHref>
-                                <a className={styles.link}>
-                                  <Button variant="text" icon="arrowRight">
-                                    Sjá nánar
-                                  </Button>
-                                </a>
-                              </Link>
-                            </>
-                          ) : null}
-                        </span>
-                      </Typography>
-                    </Stack>
-                  </Box>
-                </TabPanel>
-              )
-            })}
-          </div>
-
+        <GridColumn span={[null, null, null, '1/12']}>
           <Box
-            display="inlineFlex"
-            alignItems="center"
+            display="flex"
+            height="full"
             width="full"
-            borderRadius="large"
-            background="blue100"
-            paddingX={[1, 1, 3]}
-            paddingY={[1, 1, 4]}
+            justifyContent="center"
+            alignItems="center"
           >
-            {searchContent}
+            <Hidden below="lg">
+              <button
+                onClick={() => goTo('prev')}
+                className={cn(styles.arrowButton, {
+                  [styles.arrowButtonDisabled]: false,
+                })}
+              >
+                <Icon color="red400" width="18" height="18" type="arrowLeft" />
+              </button>
+            </Hidden>
           </Box>
         </GridColumn>
-        <GridColumn span="5/12">
-          <div className={styles.imageContainer}>
-            <div className={styles.dots}>
-              <Dots />
-            </div>
-            {image ? <img src={image.url} alt={image.title} /> : <HeartSvg />}
+        <GridColumn span={['12/12', '12/12', '12/12', '6/12']}>
+          <div ref={contentRef}>
+            <Hidden above="md">
+              <Box
+                display="flex"
+                height="full"
+                width="full"
+                marginBottom={2}
+                justifyContent="center"
+                alignItems="center"
+                overflow="hidden"
+                style={{ maxHeight: 220 }}
+              >
+                <Image image={image} />
+              </Box>
+            </Hidden>
+            <Box paddingX={[3, 3, 0]}>
+              <TabList
+                {...tab}
+                aria-label="My tabs"
+                className={styles.tabWrapper}
+              >
+                {tabs.map(({ subtitle = '' }, index) => {
+                  return (
+                    <Tab
+                      key={index}
+                      {...tab}
+                      className={cn(styles.tabContainer)}
+                    >
+                      <TabBullet selected={selectedIndex === index} />
+                      <span className={styles.srOnly}>{subtitle}</span>
+                    </Tab>
+                  )
+                })}
+              </TabList>
+              <div className={styles.tabPanelWrapper}>
+                {tabs.map(({ title, subtitle, content, link }, index) => {
+                  let href = null
+                  let as = null
+
+                  const currentIndex = tab.items.findIndex(
+                    (x) => x.id === tab.currentId,
+                  )
+
+                  const visible = currentIndex === index
+
+                  if (link) {
+                    const linkData = JSON.parse(link)
+                    const contentId = linkData.sys?.contentType?.sys?.id
+
+                    const slug = linkData.fields?.slug
+
+                    if (slug && ['article', 'category'].includes(contentId)) {
+                      href = `${makePath(contentId)}/[slug]`
+                      as = makePath(contentId, slug)
+                    }
+                  }
+
+                  return (
+                    <TabPanel
+                      key={index}
+                      {...tab}
+                      style={{
+                        display: 'inline-block',
+                      }}
+                      tabIndex={visible ? 0 : -1}
+                      className={cn(styles.tabPanel, {
+                        [styles.tabPanelVisible]: visible,
+                      })}
+                    >
+                      <Box
+                        paddingY={3}
+                        ref={(el) => (itemsRef.current[index] = el)}
+                        style={{ minHeight: `${minHeight}px` }}
+                      >
+                        <Stack space={3}>
+                          <Typography
+                            variant="eyebrow"
+                            as="h2"
+                            color="purple400"
+                          >
+                            <span className={styles.textItem}>{subtitle}</span>
+                          </Typography>
+                          <Typography variant="h1" as="h1">
+                            <span className={styles.textItem}>{title}</span>
+                          </Typography>
+                          <Typography variant="p" as="p">
+                            <span className={styles.textItem}>{content}</span>
+                          </Typography>
+                          {href ? (
+                            <Link as={as} href={href} passHref>
+                              <Button
+                                variant="text"
+                                icon="arrowRight"
+                                tabIndex={visible ? 0 : -1}
+                              >
+                                Sjá nánar
+                              </Button>
+                            </Link>
+                          ) : null}
+                        </Stack>
+                      </Box>
+                    </TabPanel>
+                  )
+                })}
+              </div>
+            </Box>
+            <Box
+              display="inlineFlex"
+              alignItems="center"
+              width="full"
+              background="blue100"
+              padding={3}
+              borderRadius="large"
+              className={styles.searchContentContainer}
+            >
+              {searchContent}
+            </Box>
           </div>
+        </GridColumn>
+        <GridColumn span={['12/12', '12/12', '12/12', '4/12']}>
+          <Box
+            display="flex"
+            height="full"
+            width="full"
+            justifyContent="center"
+            alignItems="center"
+            overflow="hidden"
+            style={{ maxHeight: `${maxContainerHeight}px` }}
+          >
+            <Hidden below="lg">
+              <Image image={image} />
+            </Hidden>
+          </Box>
+        </GridColumn>
+        <GridColumn span={[null, null, null, '1/12']}>
+          <Box
+            display="flex"
+            height="full"
+            width="full"
+            justifyContent="center"
+            alignItems="center"
+          >
+            <Hidden below="lg">
+              <button
+                onClick={() => goTo('next')}
+                className={cn(styles.arrowButton, {
+                  [styles.arrowButtonDisabled]: false,
+                })}
+              >
+                <Icon color="red400" width="18" height="18" type="arrowRight" />
+              </button>
+            </Hidden>
+          </Box>
         </GridColumn>
       </GridRow>
     </GridContainer>
+  )
+}
+
+const Image = ({ image = null }: { image?: ImageProps }) => {
+  if (!image) {
+    return null
+  }
+
+  return (
+    <Box
+      display="flex"
+      height="full"
+      width="full"
+      justifyContent="center"
+      alignItems="center"
+    >
+      <img src={image.url} alt={image.title} />
+    </Box>
   )
 }
 

--- a/apps/web/screens/Home.tsx
+++ b/apps/web/screens/Home.tsx
@@ -87,7 +87,7 @@ const Home: Screen<HomeProps> = ({
 
   return (
     <>
-      <Section paddingY={[2, 2, 3, 3, 6]}>
+      <Section paddingY={[0, 0, 3, 3, 6]}>
         <FrontpageTabs tabs={frontpageSlides} searchContent={searchContent} />
       </Section>
       <Section background="purple100" paddingY={[4, 4, 4, 6]}>

--- a/libs/island-ui/core/src/lib/Button/Button.tsx
+++ b/libs/island-ui/core/src/lib/Button/Button.tsx
@@ -33,6 +33,7 @@ export interface ButtonProps {
   noWrap?: boolean
   target?: string
   white?: boolean
+  tabIndex?: number
 }
 
 const isLinkExternal = (href: string): boolean => href.indexOf('://') > 0
@@ -58,6 +59,7 @@ export const Button = forwardRef<
       noWrap,
       target = '_blank',
       white,
+      tabIndex,
     },
     ref,
   ) => {
@@ -82,6 +84,7 @@ export const Button = forwardRef<
     }
 
     const sharedProps = {
+      tabIndex,
       className,
       onClick,
     }


### PR DESCRIPTION
This was made with a tabs functionality in mind and these arrows (prev/next) only act as moving to previous or next tab and are automatically giving the selected tab focus.

### Mobile (no arrow buttons on mobile)
![image](https://user-images.githubusercontent.com/8450096/92396843-3e4c0c80-f115-11ea-841d-4c19d6cbc57b.png)

### Desktop
![image](https://user-images.githubusercontent.com/8450096/92391329-f83e7b00-f10b-11ea-8866-c953451f8b4e.png)
