### PR TITLE
fix: SideMenu zIndex issue

### DIFF
--- a/apps/web/components/SideMenu/SideMenu.treat.ts
+++ b/apps/web/components/SideMenu/SideMenu.treat.ts
@@ -12,7 +12,7 @@ export const root = style({
   position: 'fixed',
   right: 0,
   top: 0,
-  zIndex: 1,
+  zIndex: 10,
   '@media': {
     [`screen and (min-width: ${theme.breakpoints.md}px)`]: {
       height: 'auto',


### PR DESCRIPTION
Fix Hero's arrow buttons having higher zIndex than SideMenu
![image](https://user-images.githubusercontent.com/8494120/92485788-ea0b6000-f1da-11ea-9a55-489c4bd101d2.png)
