### PR TITLE
Ads - using map instead of flatMap

### DIFF
--- a/apps/air-discount-scheme/web/components/Content/Content.tsx
+++ b/apps/air-discount-scheme/web/components/Content/Content.tsx
@@ -123,7 +123,7 @@ const embeddedNodes = () => ({
 
 const options = (type) => ({
   renderText: (text) =>
-    text.split('\n').flatMap((text, i) => [i > 0 && <br key={i} />, text]),
+    text.split('\n').map((text, i) => [i > 0 && <br key={i} />, text]),
   renderNode: {
     [BLOCKS.PARAGRAPH]: (node, children) => {
       return (


### PR DESCRIPTION
First solution was based on this comment https://github.com/contentful/rich-text/issues/96#issuecomment-511100434

React should be able to render arrays if you provide all elements with keys, so there should be no need to flatten the array