### PR TITLE
Adds authorisation header to api calls

### DIFF
--- a/apps/judicial-system/api/src/app/modules/auth/jwt.strategy.ts
+++ b/apps/judicial-system/api/src/app/modules/auth/jwt.strategy.ts
@@ -27,10 +27,10 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   validate(req: Request, { csrfToken, user }: Credentials) {
-    // if (csrfToken && `Bearer ${csrfToken}` !== req.headers['authorization']) {
-    //   this.logger.error('invalid csrf token')
-    //   return null
-    // }
+    if (csrfToken && `Bearer ${csrfToken}` !== req.headers['authorization']) {
+      this.logger.error('invalid csrf token')
+      return null
+    }
 
     return user
   }

--- a/apps/judicial-system/web/src/routes/Login/Login.treat.ts
+++ b/apps/judicial-system/web/src/routes/Login/Login.treat.ts
@@ -4,7 +4,7 @@ export const loginContainer = style({
   display: 'grid',
   gridColumnGap: 24,
   gridTemplateColumns: 'repeat(12, 1fr)',
-  gridTemplateRows: 'repeat(5, auto)',
+  gridTemplateRows: 'repeat(6, auto)',
   margin: '168px 48px 0',
 })
 
@@ -14,14 +14,19 @@ export const logoContainer = style({
   marginBottom: 72,
 })
 
-export const titleContainer = style({
+export const errorMessage = style({
   gridRow: '2',
+  gridColumn: '2 / span 4',
+})
+
+export const titleContainer = style({
+  gridRow: '3',
   gridColumn: '2 / span 6',
   marginBottom: 24,
 })
 
 export const subTitleContainer = style({
-  gridRow: '3',
+  gridRow: '4',
   gridColumn: '2 / span 6',
   marginBottom: 40,
 })

--- a/apps/judicial-system/web/src/routes/Login/Login.tsx
+++ b/apps/judicial-system/web/src/routes/Login/Login.tsx
@@ -1,16 +1,29 @@
 import React from 'react'
 
 import { Logo } from '@island.is/judicial-system-web/src/shared-components/Logo/Logo'
-import { Typography, Input, Button, Box } from '@island.is/island-ui/core'
+import { Typography, Button, Box, Alert } from '@island.is/island-ui/core'
 import { apiUrl } from '../../api'
 import * as styles from './Login.treat'
 
 export const Login = () => {
+  const urlParams = new URLSearchParams(window.location.search)
+
   return (
     <div className={styles.loginContainer}>
       <div className={styles.logoContainer}>
         <Logo />
       </div>
+      {urlParams.has('error') && (
+        <div className={styles.errorMessage}>
+          <Box marginBottom={6}>
+            <Alert
+              type="info"
+              title="Innskráning ógild"
+              message="Innskráning ekki lengur gild. Vinsamlegast reynið aftur."
+            />
+          </Box>
+        </div>
+      )}
       <div className={styles.titleContainer}>
         <Box>
           <Typography as="h1" variant="h1">

--- a/apps/judicial-system/web/src/utils/cookies.ts
+++ b/apps/judicial-system/web/src/utils/cookies.ts
@@ -1,0 +1,20 @@
+/*
+Credit: https://gist.github.com/hunan-rostomyan/28e8702c1cecff41f7fe64345b76f2ca
+
+Given a cookie key `name`, returns the value of
+the cookie or `null`, if the key is not found.
+*/
+export const getCookie = (name: string): string => {
+  const nameLenPlus = name.length + 1
+  return (
+    document.cookie
+      .split(';')
+      .map((c) => c.trim())
+      .filter((cookie) => {
+        return cookie.substring(0, nameLenPlus) === `${name}=`
+      })
+      .map((cookie) => {
+        return decodeURIComponent(cookie.substring(nameLenPlus))
+      })[0] || null
+  )
+}


### PR DESCRIPTION
Reads csrfToken from cookie sent from server and uses that as an authentication agains API. If the API is called without this token, it returns 401 and you are redirected to the login page with an error message saying that the login is no longer valid.