### PR TITLE
Solve SideMenu active-tab focus indicator issue

### DIFF
--- a/apps/web/components/SideMenu/SideMenu.treat.ts
+++ b/apps/web/components/SideMenu/SideMenu.treat.ts
@@ -36,12 +36,21 @@ export const tabBar = style({
 })
 
 export const tab = style({
-  borderBottom: `2px solid transparent`,
+  border: `2px solid transparent`,
   flex: 1,
   padding: theme.spacing[2],
+  outline: 0,
+  ':focus': {
+    borderColor: theme.color.mint400,
+  },
 })
+
 export const tabActive = style({
-  borderColor: theme.color.blue400,
+  borderBottomColor: theme.color.blue400,
+  ':focus': {
+    borderColor: 'transparent',
+    borderBottomColor: theme.color.blue400,
+  },
 })
 
 export const content = style({


### PR DESCRIPTION
Initial tab focus:
![image](https://user-images.githubusercontent.com/8494120/92639313-24542a80-f2cb-11ea-9ea6-16b625d3e713.png)

Inactive tab focus:
![image](https://user-images.githubusercontent.com/8494120/92639344-2d44fc00-f2cb-11ea-8881-413edad0641e.png)

