### PR TITLE
island-ui - Textarea support for inputs

### DIFF
--- a/libs/island-ui/core/src/lib/Input/Input.mixins.ts
+++ b/libs/island-ui/core/src/lib/Input/Input.mixins.ts
@@ -41,6 +41,10 @@ export const input = {
   boxShadow: 'none',
 }
 
+export const textarea = {
+  resize: 'vertical',
+}
+
 export const inputPlaceholder = {
   color: theme.color.dark300,
   fontWeight: theme.typography.light,

--- a/libs/island-ui/core/src/lib/Input/Input.mixins.ts
+++ b/libs/island-ui/core/src/lib/Input/Input.mixins.ts
@@ -41,10 +41,6 @@ export const input = {
   boxShadow: 'none',
 }
 
-export const textarea = {
-  resize: 'vertical',
-}
-
 export const inputPlaceholder = {
   color: theme.color.dark300,
   fontWeight: theme.typography.light,

--- a/libs/island-ui/core/src/lib/Input/Input.stories.tsx
+++ b/libs/island-ui/core/src/lib/Input/Input.stories.tsx
@@ -20,6 +20,19 @@ export const Default = () => (
   </ContentBlock>
 )
 
+export const Tooltip = () => (
+  <ContentBlock>
+    <Box padding={['gutter', 2, 3, 4]}>
+      <Input
+        label="This is the label"
+        placeholder="This is the placeholder"
+        name="Test"
+        tooltip="Bacon ipsum dolor amet ball tip leberkas pork belly pork chop, meatloaf swine jerky doner andouille tenderloin"
+      />
+    </Box>
+  </ContentBlock>
+)
+
 export const Error = () => (
   <ContentBlock>
     <Box padding={['gutter', 2, 3, 4]}>
@@ -42,6 +55,65 @@ export const Required = () => (
         placeholder="This is the placeholder"
         name="Test"
         required
+      />
+    </Box>
+  </ContentBlock>
+)
+
+export const Textarea = () => (
+  <ContentBlock>
+    <Box padding={['gutter', 2, 3, 4]}>
+      <Input
+        label="Textarea label"
+        placeholder="This is the placeholder"
+        name="Test"
+        textarea
+        rows={4}
+      />
+    </Box>
+  </ContentBlock>
+)
+
+export const Textarea10Rows = () => (
+  <ContentBlock>
+    <Box padding={['gutter', 2, 3, 4]}>
+      <Input
+        label="Textarea label"
+        placeholder="This is the placeholder"
+        name="Test"
+        textarea
+        rows={10}
+      />
+    </Box>
+  </ContentBlock>
+)
+
+export const TextareaError = () => (
+  <ContentBlock>
+    <Box padding={['gutter', 2, 3, 4]}>
+      <Input
+        label="Textarea label"
+        placeholder="This is the placeholder"
+        name="Test"
+        hasError
+        errorMessage="This is the error message"
+        textarea
+        rows={4}
+      />
+    </Box>
+  </ContentBlock>
+)
+
+export const TextareaRequired = () => (
+  <ContentBlock>
+    <Box padding={['gutter', 2, 3, 4]}>
+      <Input
+        label="Textarea label"
+        placeholder="This is the placeholder"
+        name="Test"
+        required
+        textarea
+        rows={4}
       />
     </Box>
   </ContentBlock>

--- a/libs/island-ui/core/src/lib/Input/Input.stories.tsx
+++ b/libs/island-ui/core/src/lib/Input/Input.stories.tsx
@@ -14,7 +14,7 @@ export const Default = () => (
       <Input
         label="This is the label"
         placeholder="This is the placeholder"
-        name="Test"
+        name="Test1"
       />
     </Box>
   </ContentBlock>
@@ -26,7 +26,7 @@ export const Tooltip = () => (
       <Input
         label="This is the label"
         placeholder="This is the placeholder"
-        name="Test"
+        name="Test2"
         tooltip="Bacon ipsum dolor amet ball tip leberkas pork belly pork chop, meatloaf swine jerky doner andouille tenderloin"
       />
     </Box>
@@ -39,7 +39,7 @@ export const Error = () => (
       <Input
         label="This is the label"
         placeholder="This is the placeholder"
-        name="Test"
+        name="Test3"
         hasError
         errorMessage="This is the error message"
       />
@@ -53,7 +53,7 @@ export const Required = () => (
       <Input
         label="This is the label"
         placeholder="This is the placeholder"
-        name="Test"
+        name="Test4"
         required
       />
     </Box>
@@ -66,7 +66,7 @@ export const Textarea = () => (
       <Input
         label="Textarea label"
         placeholder="This is the placeholder"
-        name="Test"
+        name="Test5"
         textarea
         rows={4}
       />
@@ -80,7 +80,7 @@ export const Textarea10Rows = () => (
       <Input
         label="Textarea label"
         placeholder="This is the placeholder"
-        name="Test"
+        name="Test6"
         textarea
         rows={10}
       />
@@ -94,7 +94,7 @@ export const TextareaError = () => (
       <Input
         label="Textarea label"
         placeholder="This is the placeholder"
-        name="Test"
+        name="Test7"
         hasError
         errorMessage="This is the error message"
         textarea
@@ -110,7 +110,7 @@ export const TextareaRequired = () => (
       <Input
         label="Textarea label"
         placeholder="This is the placeholder"
-        name="Test"
+        name="Test8"
         required
         textarea
         rows={4}

--- a/libs/island-ui/core/src/lib/Input/Input.treat.ts
+++ b/libs/island-ui/core/src/lib/Input/Input.treat.ts
@@ -29,6 +29,10 @@ export const input = style({
   ':disabled': mixins.inputDisabled,
 })
 
+export const textarea = style({
+  ...mixins.textarea,
+})
+
 export const errorMessage = style(mixins.errorMessage)
 
 export const hasError = style({

--- a/libs/island-ui/core/src/lib/Input/Input.treat.ts
+++ b/libs/island-ui/core/src/lib/Input/Input.treat.ts
@@ -30,7 +30,7 @@ export const input = style({
 })
 
 export const textarea = style({
-  ...mixins.textarea,
+  resize: 'vertical',
 })
 
 export const errorMessage = style(mixins.errorMessage)

--- a/libs/island-ui/core/src/lib/Input/Input.tsx
+++ b/libs/island-ui/core/src/lib/Input/Input.tsx
@@ -48,8 +48,12 @@ function useMergeRefs<ForwardRef, LocalRef extends ForwardRef>(
   )
 }
 
-const InputHOC = (props) => <input {...props} />
-const TextareaHOC = (props) => <textarea {...props} />
+const InputHOC = forwardRef((props, ref: React.Ref<HTMLInputElement>) => (
+  <input ref={ref} {...props} />
+))
+const TextareaHOC = forwardRef((props, ref: React.Ref<HTMLTextAreaElement>) => (
+  <textarea ref={ref} {...props} />
+))
 
 export const Input = forwardRef(
   (

--- a/libs/island-ui/core/src/lib/Input/Input.tsx
+++ b/libs/island-ui/core/src/lib/Input/Input.tsx
@@ -22,6 +22,8 @@ interface InputProps {
   onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void
   onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
+  textarea?: boolean
+  rows?: number
 }
 
 function setRefs<T>(ref: React.Ref<T>, value: T) {
@@ -46,8 +48,14 @@ function useMergeRefs<ForwardRef, LocalRef extends ForwardRef>(
   )
 }
 
+const InputHOC = (props) => <input {...props} />
+const TextareaHOC = (props) => <textarea {...props} />
+
 export const Input = forwardRef(
-  (props: InputProps, ref?: React.Ref<HTMLInputElement>) => {
+  (
+    props: InputProps,
+    ref?: React.Ref<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
     const {
       name,
       label,
@@ -62,10 +70,11 @@ export const Input = forwardRef(
       backgroundColor = 'white',
       onFocus,
       onBlur,
+      textarea,
       ...inputProps
     } = props
     const [hasFocus, setHasFocus] = useState(false)
-    const inputRef = useRef<HTMLInputElement>(null)
+    const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null)
     const ariaError = hasError
       ? {
           'aria-invalid': true,
@@ -73,6 +82,8 @@ export const Input = forwardRef(
         }
       : {}
     const mergedRefs = useMergeRefs(inputRef, ref || null)
+
+    const InputComponent = textarea ? TextareaHOC : InputHOC
 
     return (
       <div>
@@ -107,8 +118,10 @@ export const Input = forwardRef(
               </Box>
             )}
           </label>
-          <input
-            className={styles.input}
+          <InputComponent
+            className={cn(styles.input, {
+              [styles.textarea]: textarea,
+            })}
             id={id}
             disabled={disabled}
             name={name}

--- a/libs/island-ui/core/src/lib/Input/Input.tsx
+++ b/libs/island-ui/core/src/lib/Input/Input.tsx
@@ -6,24 +6,34 @@ import Tooltip from '../Tooltip/Tooltip'
 
 type InputBackgroundColor = 'white' | 'blue'
 
-interface InputProps {
+interface InputComponentProps {
   name: string
-  label?: string
-  hasError?: boolean
   value?: string | number
-  errorMessage?: string
   id?: string
+  className?: string
   disabled?: boolean
   required?: boolean
   placeholder?: string
+  autoFocus?: boolean
+  onFocus?: (
+    event: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => void
+  onBlur?: (
+    event: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => void
+  onChange?: (
+    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => void
+  rows?: number
+}
+
+interface InputProps extends InputComponentProps {
+  label?: string
+  hasError?: boolean
+  errorMessage?: string
   tooltip?: string
   backgroundColor?: InputBackgroundColor
-  autoFocus?: boolean
-  onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void
-  onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void
-  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
   textarea?: boolean
-  rows?: number
 }
 
 function setRefs<T>(ref: React.Ref<T>, value: T) {
@@ -48,12 +58,16 @@ function useMergeRefs<ForwardRef, LocalRef extends ForwardRef>(
   )
 }
 
-const InputHOC = forwardRef((props, ref: React.Ref<HTMLInputElement>) => (
-  <input ref={ref} {...props} />
-))
-const TextareaHOC = forwardRef((props, ref: React.Ref<HTMLTextAreaElement>) => (
-  <textarea ref={ref} {...props} />
-))
+const InputHOC = forwardRef(
+  (props: InputComponentProps, ref: React.Ref<HTMLInputElement>) => (
+    <input ref={ref} {...props} />
+  ),
+)
+const TextareaHOC = forwardRef(
+  (props: InputComponentProps, ref: React.Ref<HTMLTextAreaElement>) => (
+    <textarea ref={ref} {...props} />
+  ),
+)
 
 export const Input = forwardRef(
   (


### PR DESCRIPTION
resolves #764

Use native textarea behavior and lock resize to only work vertically, component width should be block (100%) and controlled by parent, so there should be no need to resize horizontally

![textarea](https://user-images.githubusercontent.com/5655741/92814191-4b395c00-f3b2-11ea-99af-aff8a3e71a60.gif)
