### PR TITLE
Judicial system user endpoint

### DIFF
--- a/apps/judicial-system/api/README.md
+++ b/apps/judicial-system/api/README.md
@@ -14,7 +14,13 @@ Then run the migrations:
 
 You can serve this service locally by running:
 
-`yarn nx serve judicial-system-api`
+`yarn nx serve judicial-system-api --ssl`
+
+To skip authentication at innskraning.island.is run:
+
+`AUTH_USER=<national id> yarn nx serve judicial-system-api`
+
+where `<national id>` is the national id of a known user.
 
 ## Graphql - not yet implemented
 

--- a/apps/judicial-system/api/src/app/modules/auth/auth.guard.ts
+++ b/apps/judicial-system/api/src/app/modules/auth/auth.guard.ts
@@ -4,6 +4,7 @@ import {
   UnauthorizedException,
 } from '@nestjs/common'
 import { AuthGuard } from '@nestjs/passport'
+
 import { AuthUser } from './auth.types'
 
 @Injectable()

--- a/apps/judicial-system/api/src/app/modules/auth/auth.service.spec.ts
+++ b/apps/judicial-system/api/src/app/modules/auth/auth.service.spec.ts
@@ -23,10 +23,10 @@ describe('AuthService', () => {
   describe('validateUser', () => {
     it('should be an unknown user', async () => {
       // Arrange & Act
-      const role = await authService.validateUser(user)
+      const found = await authService.validateUser(user)
 
       // Assert
-      expect(role).toBeNull()
+      expect(found).toBeFalsy()
     })
   })
 })

--- a/apps/judicial-system/api/src/app/modules/auth/auth.service.ts
+++ b/apps/judicial-system/api/src/app/modules/auth/auth.service.ts
@@ -1,19 +1,15 @@
 import { Injectable } from '@nestjs/common'
 
-import { User, UserService } from '../user'
+import { UserService } from '../user'
 import { AuthUser } from './auth.types'
 
 @Injectable()
 export class AuthService {
   constructor(private userService: UserService) {}
 
-  async validateUser(authUser: AuthUser): Promise<User> {
-    const user = await this.userService.findOne(authUser.nationalId)
+  async validateUser(authUser: AuthUser): Promise<boolean> {
+    const user = await this.userService.findByNationalId(authUser.nationalId)
 
-    if (user) {
-      return user
-    }
-
-    return null
+    return !!user
   }
 }

--- a/apps/judicial-system/api/src/app/modules/auth/jwt.strategy.ts
+++ b/apps/judicial-system/api/src/app/modules/auth/jwt.strategy.ts
@@ -3,8 +3,8 @@ import { Strategy } from 'passport-jwt'
 import { Injectable, Inject } from '@nestjs/common'
 import { PassportStrategy } from '@nestjs/passport'
 
-import { ACCESS_TOKEN_COOKIE_NAME } from '@island.is/judicial-system/consts'
 import { Logger, LOGGER_PROVIDER } from '@island.is/logging'
+import { ACCESS_TOKEN_COOKIE_NAME } from '@island.is/judicial-system/consts'
 
 import { environment } from '../../../environments'
 import { Credentials } from './auth.types'

--- a/apps/judicial-system/api/src/app/modules/case/case.controller.ts
+++ b/apps/judicial-system/api/src/app/modules/case/case.controller.ts
@@ -74,7 +74,7 @@ export class CaseController {
     )
 
     if (numberOfAffectedRows === 0) {
-      throw new NotFoundException(`An case with the id ${id} does not exist`)
+      throw new NotFoundException(`A case with the id ${id} does not exist`)
     }
 
     return updatedCase

--- a/apps/judicial-system/api/src/app/modules/case/case.model.ts
+++ b/apps/judicial-system/api/src/app/modules/case/case.model.ts
@@ -1,5 +1,4 @@
 import {
-  AllowNull,
   Column,
   CreatedAt,
   DataType,

--- a/apps/judicial-system/api/src/app/modules/case/e2e/case.spec.ts
+++ b/apps/judicial-system/api/src/app/modules/case/e2e/case.spec.ts
@@ -16,6 +16,11 @@ describe('Application', () => {
       .send({
         policeCaseNumber: 'Case Number',
         suspectNationalId: '0101010000',
+        suspectName: 'Suspect Name',
+        suspectAddress: 'Suspect Address',
+        court: 'Court',
+        arrestDate: '2020-09-08T08:00:00.000Z',
+        requestedCourtDate: '2020-09-08T11:30:00.000Z',
       })
       .expect(201)
 

--- a/apps/judicial-system/api/src/app/modules/case/e2e/case.spec.ts
+++ b/apps/judicial-system/api/src/app/modules/case/e2e/case.spec.ts
@@ -2,6 +2,7 @@ import * as request from 'supertest'
 import { INestApplication } from '@nestjs/common'
 
 import { setup } from '../../../../../test/setup'
+import { CaseState, Case } from '../case.model'
 
 let app: INestApplication
 
@@ -9,21 +10,189 @@ beforeAll(async () => {
   app = await setup()
 })
 
-describe('Application', () => {
-  it(`POST /case should create a case`, async () => {
-    const response = await request(app.getHttpServer())
+describe('Case', () => {
+  it('POST /case should create a case', async () => {
+    const data = {
+      policeCaseNumber: 'Case Number',
+      suspectNationalId: '0101010000',
+      suspectName: 'Suspect Name',
+      suspectAddress: 'Suspect Address',
+      court: 'Court',
+      arrestDate: '2020-09-08T08:00:00.000Z',
+      requestedCourtDate: '2020-09-08T11:30:00.000Z',
+    }
+
+    await request(app.getHttpServer())
       .post('/api/case')
-      .send({
-        policeCaseNumber: 'Case Number',
-        suspectNationalId: '0101010000',
+      .send(data)
+      .expect(201)
+      .then(async (response) => {
+        // Check the response
+        expect(response.body.id).toBeTruthy()
+        expect(response.body.created).toBeTruthy()
+        expect(response.body.modified).toBeTruthy()
+        expect(response.body.state).toBe(CaseState.DRAFT)
+        expect(response.body.policeCaseNumber).toBe(data.policeCaseNumber)
+        expect(response.body.suspectNationalId).toBe(data.suspectNationalId)
+        expect(response.body.suspectName).toBe(data.suspectName)
+        expect(response.body.suspectAddress).toBe(data.suspectAddress)
+        expect(response.body.court).toBe(data.court)
+        expect(response.body.arrestDate).toBe(data.arrestDate)
+        expect(response.body.requestedCourtDate).toBe(data.requestedCourtDate)
+
+        // Check the data in the database
+        await Case.findOne({ where: { id: response.body.id } }).then(
+          (value) => {
+            expect(value.id).toBe(response.body.id)
+            expect(value.created.toISOString()).toBe(response.body.created)
+            expect(value.modified.toISOString()).toBe(response.body.modified)
+            expect(value.state).toBe(response.body.state)
+            expect(value.policeCaseNumber).toBe(data.policeCaseNumber)
+            expect(value.suspectNationalId).toBe(data.suspectNationalId)
+            expect(value.suspectName).toBe(data.suspectName)
+            expect(value.suspectAddress).toBe(data.suspectAddress)
+            expect(value.court).toBe(data.court)
+            expect(value.arrestDate.toISOString()).toBe(data.arrestDate)
+            expect(value.requestedCourtDate.toISOString()).toBe(
+              data.requestedCourtDate,
+            )
+          },
+        )
+      })
+  })
+
+  it('POST /case with required fields should create a case', async () => {
+    const data = {
+      policeCaseNumber: 'Case Number',
+      suspectNationalId: '0101010000',
+    }
+
+    await request(app.getHttpServer())
+      .post('/api/case')
+      .send(data)
+      .expect(201)
+      .then(async (response) => {
+        // Check the response
+        expect(response.body.id).toBeTruthy()
+        expect(response.body.created).toBeTruthy()
+        expect(response.body.modified).toBeTruthy()
+        expect(response.body.state).toBe(CaseState.DRAFT)
+        expect(response.body.policeCaseNumber).toBe(data.policeCaseNumber)
+        expect(response.body.suspectNationalId).toBe(data.suspectNationalId)
+        expect(response.body.suspectName).toBeNull()
+        expect(response.body.suspectAddress).toBeNull()
+        expect(response.body.court).toBeNull()
+        expect(response.body.arrestDate).toBeNull()
+        expect(response.body.requestedCourtDate).toBeNull()
+
+        // Check the data in the database
+        await Case.findOne({ where: { id: response.body.id } }).then(
+          (value) => {
+            expect(value.id).toBe(response.body.id)
+            expect(value.created.toISOString()).toBe(response.body.created)
+            expect(value.modified.toISOString()).toBe(response.body.modified)
+            expect(value.state).toBe(response.body.state)
+            expect(value.policeCaseNumber).toBe(data.policeCaseNumber)
+            expect(value.suspectNationalId).toBe(data.suspectNationalId)
+            expect(value.suspectName).toBeNull()
+            expect(value.suspectAddress).toBeNull()
+            expect(value.court).toBeNull()
+            expect(value.arrestDate).toBeNull()
+            expect(value.requestedCourtDate).toBeNull()
+          },
+        )
+      })
+  })
+
+  it('GET /case/:id should get a case by id', async () => {
+    await Case.create({
+      state: CaseState.SUBMITTED,
+      policeCaseNumber: 'Case Number',
+      suspectNationalId: '0101010000',
+      suspectName: 'Suspect Name',
+      suspectAddress: 'Suspect Address',
+      court: 'Court',
+      arrestDate: '2020-09-08T08:00:00.000Z',
+      requestedCourtDate: '2020-09-08T11:30:00.000Z',
+    }).then(async (value) => {
+      await request(app.getHttpServer())
+        .get(`/api/case/${value.id}`)
+        .send()
+        .expect(200)
+        .then((response) => {
+          // Check the response
+          expect(response.body.id).toBe(value.id)
+          expect(response.body.created).toBe(value.created.toISOString())
+          expect(response.body.modified).toBe(value.modified.toISOString())
+          expect(response.body.state).toBe(value.state)
+          expect(response.body.policeCaseNumber).toBe(value.policeCaseNumber)
+          expect(response.body.suspectNationalId).toBe(value.suspectNationalId)
+          expect(response.body.suspectName).toBe(value.suspectName)
+          expect(response.body.suspectAddress).toBe(value.suspectAddress)
+          expect(response.body.court).toBe(value.court)
+          expect(response.body.arrestDate).toBe(value.arrestDate.toISOString())
+          expect(response.body.requestedCourtDate).toBe(
+            value.requestedCourtDate.toISOString(),
+          )
+        })
+    })
+  })
+
+  it('PUT /case/:id should update a case by id', async () => {
+    await Case.create({
+      policeCaseNumber: 'Case Number',
+      suspectNationalId: '0101010000',
+    }).then(async (value) => {
+      const data = {
+        state: CaseState.ACTIVE,
+        policeCaseNumber: 'New Case Number',
+        suspectNationalId: '0101010009',
         suspectName: 'Suspect Name',
         suspectAddress: 'Suspect Address',
         court: 'Court',
         arrestDate: '2020-09-08T08:00:00.000Z',
         requestedCourtDate: '2020-09-08T11:30:00.000Z',
-      })
-      .expect(201)
+      }
 
-    expect(response.body.id).toBeTruthy()
+      await request(app.getHttpServer())
+        .put(`/api/case/${value.id}`)
+        .send(data)
+        .expect(200)
+        .then(async (response) => {
+          // Check the response
+          expect(response.body.id).toBe(value.id)
+          expect(response.body.created).toBe(value.created.toISOString())
+          expect(response.body.modified).not.toBe(value.modified.toISOString())
+          expect(response.body.state).toBe(data.state)
+          expect(response.body.policeCaseNumber).toBe(data.policeCaseNumber)
+          expect(response.body.suspectNationalId).toBe(data.suspectNationalId)
+          expect(response.body.suspectName).toBe(data.suspectName)
+          expect(response.body.suspectAddress).toBe(data.suspectAddress)
+          expect(response.body.court).toBe(data.court)
+          expect(response.body.arrestDate).toBe(data.arrestDate)
+          expect(response.body.requestedCourtDate).toBe(data.requestedCourtDate)
+
+          // Check the data in the database
+          await Case.findOne({ where: { id: response.body.id } }).then(
+            (newValue) => {
+              expect(newValue.id).toBe(value.id)
+              expect(newValue.created).toStrictEqual(value.created)
+              expect(newValue.modified.toISOString()).toBe(
+                response.body.modified,
+              )
+              expect(newValue.state).toBe(data.state)
+              expect(newValue.policeCaseNumber).toBe(data.policeCaseNumber)
+              expect(newValue.suspectNationalId).toBe(data.suspectNationalId)
+              expect(newValue.suspectName).toBe(data.suspectName)
+              expect(newValue.suspectAddress).toBe(data.suspectAddress)
+              expect(newValue.court).toBe(data.court)
+              expect(newValue.arrestDate.toISOString()).toBe(data.arrestDate)
+              expect(newValue.requestedCourtDate.toISOString()).toBe(
+                data.requestedCourtDate,
+              )
+            },
+          )
+        })
+    })
   })
 })

--- a/apps/judicial-system/api/src/app/modules/case/e2e/case.spec.ts
+++ b/apps/judicial-system/api/src/app/modules/case/e2e/case.spec.ts
@@ -11,16 +11,14 @@ beforeAll(async () => {
 
 describe('Application', () => {
   it(`POST /case should create a case`, async () => {
-    // Act
     const response = await request(app.getHttpServer())
       .post('/api/case')
       .send({
         policeCaseNumber: 'Case Number',
         suspectNationalId: '0101010000',
       })
-      .expect(401)
+      .expect(201)
 
-    // Assert
-    // expect(response.body.id).toBeTruthy()
+    expect(response.body.id).toBeTruthy()
   })
 })

--- a/apps/judicial-system/api/src/app/modules/user/user.controller.spec.ts
+++ b/apps/judicial-system/api/src/app/modules/user/user.controller.spec.ts
@@ -1,0 +1,28 @@
+import { mock } from 'jest-mock-extended'
+
+import { Test, TestingModule } from '@nestjs/testing'
+
+import { LOGGER_PROVIDER, Logger } from '@island.is/logging'
+
+import { UserController } from './user.controller'
+import { UserService } from './user.service'
+
+describe('User Controller', () => {
+  let controller: UserController
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UserController],
+      providers: [
+        UserService,
+        { provide: LOGGER_PROVIDER, useValue: mock<Logger>() },
+      ],
+    }).compile()
+
+    controller = module.get<UserController>(UserController)
+  })
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined()
+  })
+})

--- a/apps/judicial-system/api/src/app/modules/user/user.controller.spec.ts
+++ b/apps/judicial-system/api/src/app/modules/user/user.controller.spec.ts
@@ -6,6 +6,7 @@ import { LOGGER_PROVIDER, Logger } from '@island.is/logging'
 
 import { UserController } from './user.controller'
 import { UserService } from './user.service'
+import { UserRole } from './user.types'
 
 describe('User Controller', () => {
   let controller: UserController
@@ -22,7 +23,16 @@ describe('User Controller', () => {
     controller = module.get<UserController>(UserController)
   })
 
-  it('should be defined', () => {
-    expect(controller).toBeDefined()
+  it('should get user', async () => {
+    const user = await controller.getCurrentUser({
+      user: { nationalId: '2510654469' },
+    })
+
+    expect(user).toBeDefined()
+    expect(user.nationalId).toBe('2510654469')
+    expect(user.roles).toBeDefined()
+    expect(user.roles.length).toBe(2)
+    expect(user.roles).toContain(UserRole.PROCECUTOR)
+    expect(user.roles).toContain(UserRole.JUDGE)
   })
 })

--- a/apps/judicial-system/api/src/app/modules/user/user.controller.ts
+++ b/apps/judicial-system/api/src/app/modules/user/user.controller.ts
@@ -27,7 +27,7 @@ export class UserController {
 
   @Get('user')
   @ApiOkResponse({ type: User })
-  async getAll(@Req() req) {
+  async getCurrentUser(@Req() req) {
     this.logger.debug('Received request from user', {
       extra: { user: req.user },
     })

--- a/apps/judicial-system/api/src/app/modules/user/user.controller.ts
+++ b/apps/judicial-system/api/src/app/modules/user/user.controller.ts
@@ -1,0 +1,51 @@
+import {
+  Controller,
+  UseGuards,
+  Get,
+  Req,
+  Inject,
+  NotFoundException,
+} from '@nestjs/common'
+import { ApiTags, ApiOkResponse } from '@nestjs/swagger'
+
+import { LOGGER_PROVIDER, Logger } from '@island.is/logging'
+
+import { AuthUser } from '../auth/auth.types'
+import { JwtAuthGuard } from '../auth/auth.guard'
+import { User } from './user.types'
+import { UserService } from './user.service'
+
+@UseGuards(JwtAuthGuard)
+@Controller('api')
+@ApiTags('users')
+export class UserController {
+  constructor(
+    private readonly userService: UserService,
+    @Inject(LOGGER_PROVIDER)
+    private logger: Logger,
+  ) {}
+
+  @Get('user')
+  @ApiOkResponse()
+  async getAll(@Req() req) {
+    this.logger.debug('Received request from user', {
+      extra: { user: req.user },
+    })
+
+    const authUser: AuthUser = req.user
+
+    let user: User
+
+    if (authUser) {
+      user = await this.userService.findByNationalId(authUser.nationalId)
+    }
+
+    if (user) {
+      return user
+    }
+
+    throw new NotFoundException(
+      `User ${authUser && authUser.nationalId} not found`,
+    )
+  }
+}

--- a/apps/judicial-system/api/src/app/modules/user/user.controller.ts
+++ b/apps/judicial-system/api/src/app/modules/user/user.controller.ts
@@ -26,7 +26,7 @@ export class UserController {
   ) {}
 
   @Get('user')
-  @ApiOkResponse()
+  @ApiOkResponse({ type: User })
   async getAll(@Req() req) {
     this.logger.debug('Received request from user', {
       extra: { user: req.user },

--- a/apps/judicial-system/api/src/app/modules/user/user.module.ts
+++ b/apps/judicial-system/api/src/app/modules/user/user.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common'
 
 import { UserService } from './user.service'
+import { UserController } from './user.controller'
 
 @Module({
   providers: [UserService],
   exports: [UserService],
+  controllers: [UserController],
 })
 export class UserModule {}

--- a/apps/judicial-system/api/src/app/modules/user/user.service.spec.ts
+++ b/apps/judicial-system/api/src/app/modules/user/user.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing'
+
 import { UserService } from './user.service'
 
 describe('UserService', () => {

--- a/apps/judicial-system/api/src/app/modules/user/user.service.ts
+++ b/apps/judicial-system/api/src/app/modules/user/user.service.ts
@@ -10,11 +10,11 @@ export class UserService {
     this.users = [
       {
         nationalId: '2510654469',
-        roles: [UserRole.PROCECUTOR, UserRole.PROCECUTOR],
+        roles: [UserRole.PROCECUTOR, UserRole.JUDGE],
       },
       {
         nationalId: '1112902539',
-        roles: [UserRole.PROCECUTOR, UserRole.PROCECUTOR],
+        roles: [UserRole.PROCECUTOR, UserRole.JUDGE],
       },
     ]
   }

--- a/apps/judicial-system/api/src/app/modules/user/user.service.ts
+++ b/apps/judicial-system/api/src/app/modules/user/user.service.ts
@@ -17,7 +17,7 @@ export class UserService {
     ]
   }
 
-  async findOne(nationalId: string): Promise<User | undefined> {
+  async findByNationalId(nationalId: string): Promise<User | undefined> {
     return this.users.find((user) => user.nationalId === nationalId)
   }
 }

--- a/apps/judicial-system/api/src/app/modules/user/user.service.ts
+++ b/apps/judicial-system/api/src/app/modules/user/user.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common'
 
-import { User } from './user.types'
+import { User, UserRole } from './user.types'
 
 @Injectable()
 export class UserService {
@@ -10,9 +10,11 @@ export class UserService {
     this.users = [
       {
         nationalId: '2510654469',
+        roles: [UserRole.PROCECUTOR, UserRole.PROCECUTOR],
       },
       {
         nationalId: '1112902539',
+        roles: [UserRole.PROCECUTOR, UserRole.PROCECUTOR],
       },
     ]
   }

--- a/apps/judicial-system/api/src/app/modules/user/user.types.ts
+++ b/apps/judicial-system/api/src/app/modules/user/user.types.ts
@@ -1,1 +1,14 @@
-export type User = { nationalId: string }
+import { ApiProperty } from '@nestjs/swagger'
+
+export enum UserRole {
+  PROCECUTOR = 'PROCECUTOR',
+  JUDGE = 'JUDGE',
+}
+
+export class User {
+  @ApiProperty()
+  nationalId: string
+
+  @ApiProperty()
+  roles: UserRole[]
+}

--- a/apps/judicial-system/api/src/openapi.yaml
+++ b/apps/judicial-system/api/src/openapi.yaml
@@ -24,6 +24,18 @@ components:
           type: string
       required:
         - version
+    User:
+      type: object
+      properties:
+        nationalId:
+          type: string
+        roles:
+          type: array
+          items:
+            type: string
+      required:
+        - nationalId
+        - roles
     Case:
       type: object
       properties:
@@ -173,6 +185,10 @@ paths:
       responses:
         '200':
           description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
       tags:
         - users
   /api/cases:

--- a/apps/judicial-system/api/src/openapi.yaml
+++ b/apps/judicial-system/api/src/openapi.yaml
@@ -139,6 +139,42 @@ paths:
                 $ref: '#/components/schemas/Version'
       tags:
         - internal
+  /api/auth/callback:
+    post:
+      operationId: AuthController_callback
+      parameters: []
+      responses:
+        '201':
+          description: ''
+      tags:
+        - api/auth
+  /api/auth/login:
+    get:
+      operationId: AuthController_login
+      parameters: []
+      responses:
+        '200':
+          description: ''
+      tags:
+        - api/auth
+  /api/auth/logout:
+    get:
+      operationId: AuthController_logout
+      parameters: []
+      responses:
+        '200':
+          description: ''
+      tags:
+        - api/auth
+  /api/user:
+    get:
+      operationId: UserController_getAll
+      parameters: []
+      responses:
+        '200':
+          description: ''
+      tags:
+        - users
   /api/cases:
     get:
       operationId: CaseController_getAll
@@ -214,30 +250,3 @@ paths:
                 $ref: '#/components/schemas/Case'
       tags:
         - cases
-  /api/auth/callback:
-    post:
-      operationId: AuthController_callback
-      parameters: []
-      responses:
-        '201':
-          description: ''
-      tags:
-        - api/auth
-  /api/auth/login:
-    get:
-      operationId: AuthController_login
-      parameters: []
-      responses:
-        '200':
-          description: ''
-      tags:
-        - api/auth
-  /api/auth/logout:
-    get:
-      operationId: AuthController_logout
-      parameters: []
-      responses:
-        '200':
-          description: ''
-      tags:
-        - api/auth

--- a/apps/judicial-system/api/src/openapi.yaml
+++ b/apps/judicial-system/api/src/openapi.yaml
@@ -180,7 +180,7 @@ paths:
         - api/auth
   /api/user:
     get:
-      operationId: UserController_getAll
+      operationId: UserController_getCurrentUser
       parameters: []
       responses:
         '200':

--- a/apps/judicial-system/api/test/setup.ts
+++ b/apps/judicial-system/api/test/setup.ts
@@ -1,13 +1,16 @@
 import { Sequelize } from 'sequelize-typescript'
 
 import { getConnectionToken } from '@nestjs/sequelize'
-import { INestApplication, Type } from '@nestjs/common'
+import { INestApplication, Type, CanActivate } from '@nestjs/common'
 
 import { testServer, TestServerOptions } from '@island.is/infra-nest-server'
 
-import { AppModule } from '../src/app/app.module'
+import { JwtAuthGuard } from '../src/app/modules/auth'
+import { AppModule } from '../src/app'
 
-export let app: INestApplication
+const noGuard: CanActivate = { canActivate: jest.fn(() => true) }
+
+let app: INestApplication
 let sequelize: Sequelize
 
 export const truncate = () => {
@@ -34,6 +37,8 @@ export const truncate = () => {
 export const setup = async (options?: Partial<TestServerOptions>) => {
   app = await testServer({
     appModule: AppModule,
+    override: (builder) =>
+      builder.overrideGuard(JwtAuthGuard).useValue(noGuard),
     ...options,
   })
   sequelize = await app.resolve(getConnectionToken() as Type<Sequelize>)

--- a/apps/judicial-system/api/test/setup.ts
+++ b/apps/judicial-system/api/test/setup.ts
@@ -51,7 +51,7 @@ export const setup = async (options?: Partial<TestServerOptions>) => {
   return app
 }
 
-beforeEach(() => truncate())
+beforeAll(() => truncate())
 
 afterAll(async () => {
   if (app && sequelize) {

--- a/apps/judicial-system/api/test/setup.ts
+++ b/apps/judicial-system/api/test/setup.ts
@@ -1,4 +1,5 @@
 import { Sequelize } from 'sequelize-typescript'
+import { execSync } from 'child_process'
 
 import { getConnectionToken } from '@nestjs/sequelize'
 import { INestApplication, Type, CanActivate } from '@nestjs/common'
@@ -43,7 +44,9 @@ export const setup = async (options?: Partial<TestServerOptions>) => {
   })
   sequelize = await app.resolve(getConnectionToken() as Type<Sequelize>)
 
-  await sequelize.sync()
+  // Need to use sequelize-cli becuase sequelize.sync does not work for our models
+  execSync('yarn nx run judicial-system-api:migrate')
+  // await sequelize.sync()
 
   return app
 }

--- a/apps/judicial-system/web/src/routes/Login/Login.tsx
+++ b/apps/judicial-system/web/src/routes/Login/Login.tsx
@@ -39,7 +39,7 @@ export const Login = () => {
       </div>
       <div className={styles.buttonContainer}>
         <Button
-          href={`${apiUrl}/api/auth/login?returnUrl=gaesluvardhaldskrofur`}
+          href={`${apiUrl}/api/auth/login?returnUrl=/gaesluvardhaldskrofur`}
           width="fluid"
         >
           Innskráning


### PR DESCRIPTION
Adds an api endpoint to get the current user.

Makes it possible to skip island.is authentication during local development (see Readme).