### PR TITLE
fix bug in apps/web graphql stack

### DIFF
--- a/libs/api/domains/cms/src/lib/models/article.model.ts
+++ b/libs/api/domains/cms/src/lib/models/article.model.ts
@@ -58,7 +58,7 @@ export const mapArticle = ({ fields, sys }: IArticle): Article => ({
   shortTitle: fields.shortTitle ?? '',
   slug: fields.slug,
   intro: fields.intro ?? '',
-  body: fields.content ? mapDocument(fields.content) : [],
+  body: fields.content ? mapDocument(fields.content, sys.id + ':body') : [],
   category: fields.category?.fields,
   group: fields.group?.fields,
   subgroup: fields.subgroup?.fields,

--- a/libs/api/domains/cms/src/lib/models/html.model.ts
+++ b/libs/api/domains/cms/src/lib/models/html.model.ts
@@ -19,7 +19,7 @@ export class Html {
 
 export const mapHtml = (
   html: Document | TopLevelBlock,
-  id: number | string = -1,
+  id: string,
 ): Html => {
   switch (html.nodeType) {
     case BLOCKS.DOCUMENT:

--- a/libs/api/domains/cms/src/lib/models/html.model.ts
+++ b/libs/api/domains/cms/src/lib/models/html.model.ts
@@ -17,10 +17,7 @@ export class Html {
   document: Document
 }
 
-export const mapHtml = (
-  html: Document | TopLevelBlock,
-  id: string,
-): Html => {
+export const mapHtml = (html: Document | TopLevelBlock, id: string): Html => {
   switch (html.nodeType) {
     case BLOCKS.DOCUMENT:
       return new Html({

--- a/libs/api/domains/cms/src/lib/models/landingPage.model.ts
+++ b/libs/api/domains/cms/src/lib/models/landingPage.model.ts
@@ -31,10 +31,10 @@ export class LandingPage {
   content: Array<typeof Slice>
 }
 
-export const mapLandingPage = ({ fields }: ILandingPage): LandingPage => ({
+export const mapLandingPage = ({ sys, fields }: ILandingPage): LandingPage => ({
   ...fields,
   image: fields.image && mapImage(fields.image),
   actionButton: fields.actionButton && mapLink(fields.actionButton),
   links: fields.links && mapLinkList(fields.links),
-  content: fields.content && mapDocument(fields.content),
+  content: fields.content && mapDocument(fields.content, sys.id + ':content'),
 })

--- a/libs/api/domains/cms/src/lib/models/lifeEventPage.model.ts
+++ b/libs/api/domains/cms/src/lib/models/lifeEventPage.model.ts
@@ -28,11 +28,12 @@ export class LifeEventPage {
 
 export const mapLifeEventPage = ({
   fields,
+  sys,
 }: ILifeEventPage): LifeEventPage => ({
   title: fields.title,
   slug: fields.slug,
   intro: fields.intro,
   image: mapImage(fields.image),
   thumbnail: fields.thumbnail && mapImage(fields.thumbnail),
-  content: mapDocument(fields.content),
+  content: mapDocument(fields.content, sys.id + ':content'),
 })

--- a/libs/api/domains/cms/src/lib/models/processEntry.model.ts
+++ b/libs/api/domains/cms/src/lib/models/processEntry.model.ts
@@ -46,11 +46,13 @@ export const mapProcessEntry = ({ fields, sys }: IProcessEntry): ProcessEntry =>
     id: sys.id,
     title: fields.title,
     subtitle: fields.subtitle,
-    details: fields.details && mapHtml(fields.details),
+    details: fields.details && mapHtml(fields.details, sys.id + ':details'),
     type: fields.type,
     processTitle: fields.processTitle,
     processDescription: fields.processDescription,
-    processInfo: fields.processInfo && mapHtml(fields.processInfo),
+    processInfo:
+      fields.processInfo &&
+      mapHtml(fields.processInfo, sys.id + ':processInfo'),
     processLink: fields.processLink,
     buttonText: fields.buttonText ?? '',
   })

--- a/libs/api/domains/cms/src/lib/models/questionAndAnswer.model.ts
+++ b/libs/api/domains/cms/src/lib/models/questionAndAnswer.model.ts
@@ -22,5 +22,5 @@ export const mapQuestionAndAnswer = ({
 }: IQuestionAndAnswer): QuestionAndAnswer => ({
   id: sys.id,
   question: fields.question,
-  answer: fields.answer && mapHtml(fields.answer),
+  answer: fields.answer && mapHtml(fields.answer, sys.id + ':answer'),
 })

--- a/libs/api/domains/cms/src/lib/models/sectionWithImage.model.ts
+++ b/libs/api/domains/cms/src/lib/models/sectionWithImage.model.ts
@@ -31,5 +31,5 @@ export const mapSectionWithImage = ({
     id: sys.id,
     title: fields.title ?? '',
     image: fields.image && mapImage(fields.image),
-    html: mapHtml(fields.body),
+    html: mapHtml(fields.body, sys.id + ':html'),
   })

--- a/libs/api/domains/cms/src/lib/models/slice.model.ts
+++ b/libs/api/domains/cms/src/lib/models/slice.model.ts
@@ -120,7 +120,10 @@ const isEmptyNode = (node: Block): boolean => {
   })
 }
 
-export const mapDocument = (document: Document, idPrefix: string): Array<typeof Slice> => {
+export const mapDocument = (
+  document: Document,
+  idPrefix: string,
+): Array<typeof Slice> => {
   const slices: Array<typeof Slice> = []
 
   document.content.forEach((block, index) => {

--- a/libs/api/domains/cms/src/lib/models/slice.model.ts
+++ b/libs/api/domains/cms/src/lib/models/slice.model.ts
@@ -120,7 +120,7 @@ const isEmptyNode = (node: Block): boolean => {
   })
 }
 
-export const mapDocument = (document: Document): Array<typeof Slice> => {
+export const mapDocument = (document: Document, idPrefix: string): Array<typeof Slice> => {
   const slices: Array<typeof Slice> = []
 
   document.content.forEach((block, index) => {
@@ -141,7 +141,7 @@ export const mapDocument = (document: Document): Array<typeof Slice> => {
         if (prev instanceof Html) {
           prev.document.content.push(block)
         } else {
-          slices.push(mapHtml(block, index))
+          slices.push(mapHtml(block, `${idPrefix}:${index}`))
         }
       }
     }

--- a/libs/api/domains/cms/src/lib/models/subArticle.model.ts
+++ b/libs/api/domains/cms/src/lib/models/subArticle.model.ts
@@ -16,8 +16,8 @@ export class SubArticle {
   body: Array<typeof Slice>
 }
 
-export const mapSubArticle = ({ fields }: ISubArticle): SubArticle => ({
+export const mapSubArticle = ({ sys, fields }: ISubArticle): SubArticle => ({
   title: fields.title,
   slug: fields.slug,
-  body: mapDocument(fields.content),
+  body: mapDocument(fields.content, sys.id + ':body'),
 })


### PR DESCRIPTION
apollo in-memory-cache needs the [__typename, id] combination to be
unique for each slice. It the id is not unique, the cache might
return incorrect data, resulting in incorrect content to be shown
to the user