### PR TITLE
Setting opacity to 0 on blurred thumbnail after image has been loaded

### DIFF
--- a/libs/island-ui/contentful/src/lib/Image/Image.treat.ts
+++ b/libs/island-ui/contentful/src/lib/Image/Image.treat.ts
@@ -3,7 +3,6 @@ import { theme } from '@island.is/island-ui/theme'
 
 export const container = style({
   position: 'relative',
-  background: theme.color.dark100,
   overflow: 'hidden',
 })
 
@@ -25,4 +24,8 @@ export const thumbnail = style({
 
 export const show = style({
   opacity: 1,
+})
+
+export const hide = style({
+  opacity: 0,
 })

--- a/libs/island-ui/contentful/src/lib/Image/Image.tsx
+++ b/libs/island-ui/contentful/src/lib/Image/Image.tsx
@@ -65,7 +65,7 @@ export const Image: FC<AnyImageType> = (image) => {
         src={thumbnail}
         alt=""
         className={cn(styles.image, styles.thumbnail, {
-          [styles.show]: thumbLoaded && !imageLoaded,
+          [styles.hide]: imageLoaded,
         })}
       />
       <img


### PR DESCRIPTION
* Remove grey background color
* Set opacity to 0 on blurred thumbnail after image has been loaded

Before:
![image](https://user-images.githubusercontent.com/70899104/93266799-266e2b80-f79a-11ea-8ec7-b7906b4a32fd.png)

After:
![image](https://user-images.githubusercontent.com/70899104/93266759-148c8880-f79a-11ea-96cb-53a893fff2e1.png)
