### PR TITLE
Ads/Start setting new cache keys to prepare for reactivate discount

### DIFF
--- a/apps/air-discount-scheme/backend/src/app/modules/discount/test/unit/discount.service.spec.ts
+++ b/apps/air-discount-scheme/backend/src/app/modules/discount/test/unit/discount.service.spec.ts
@@ -35,7 +35,7 @@ describe('DiscountService', () => {
 
       const result = await discountService.createDiscountCode(nationalId)
 
-      expect(cacheManagerSpy).toHaveBeenCalledTimes(2)
+      expect(cacheManagerSpy).toHaveBeenCalledTimes(5)
       expect(result.discountCode).toHaveLength(DISCOUNT_CODE_LENGTH)
     })
   })


### PR DESCRIPTION
This is for preparation for this PR https://github.com/island-is/island.is/pull/824

We need to start setting the cache 24 hours before we start using it.