### PR TITLE
User role judge can see submitted cases

### DIFF
--- a/apps/judicial-system/web/src/routes/CreateDetentionRequest/StepTwo/StepTwo.tsx
+++ b/apps/judicial-system/web/src/routes/CreateDetentionRequest/StepTwo/StepTwo.tsx
@@ -174,7 +174,7 @@ export const StepTwo: React.FC = () => {
   useEffect(() => {
     api.saveCase(
       window.localStorage.getItem('caseId'),
-      parseString('status', CaseState.SUBMITTED),
+      parseString('state', CaseState.SUBMITTED),
     )
     updateState(
       workingCase,

--- a/apps/judicial-system/web/src/routes/CreateDetentionRequest/StepTwo/StepTwo.tsx
+++ b/apps/judicial-system/web/src/routes/CreateDetentionRequest/StepTwo/StepTwo.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 
 import { Logo } from '@island.is/judicial-system-web/src/shared-components/Logo/Logo'
 import {
@@ -15,6 +15,7 @@ import {
   CaseCustodyProvisions,
   CaseCustodyRestrictions,
   CreateDetentionReqStepOneCase,
+  CaseState,
 } from '@island.is/judicial-system-web/src/types'
 import { updateState, autoSave } from '../../../utils/stepHelper'
 import { validate } from '@island.is/judicial-system-web/src/utils/validate'
@@ -22,7 +23,10 @@ import { setHours, setMinutes, isValid, parseISO } from 'date-fns'
 import { isNull } from 'lodash'
 import { FormFooter } from '../../../shared-components/FormFooter'
 import * as api from '../../../api'
-import { parseArray } from '@island.is/judicial-system-web/src/utils/formatters'
+import {
+  parseArray,
+  parseString,
+} from '@island.is/judicial-system-web/src/utils/formatters'
 
 export const StepTwo: React.FC = () => {
   const caseDraft = window.localStorage.getItem('workingCase')
@@ -166,6 +170,19 @@ export const StepTwo: React.FC = () => {
         'Gæslufangar mega lesa dagblöð og bækur, svo og fylgjast með hljóðvarpi og sjónvarpi. Þó getur sá sem rannsókn stýrir takmarkað aðgang gæslufanga að fjölmiðlum ef nauðsyn ber til í þágu rannsóknar.',
     },
   ]
+
+  useEffect(() => {
+    api.saveCase(
+      window.localStorage.getItem('caseId'),
+      parseString('status', CaseState.SUBMITTED),
+    )
+    updateState(
+      workingCase,
+      'id',
+      window.localStorage.getItem('caseId'),
+      setWorkingCase,
+    )
+  }, [])
 
   return (
     <Box marginTop={7} marginBottom={30}>

--- a/apps/judicial-system/web/src/routes/DetentionRequests/DetentionRequests.tsx
+++ b/apps/judicial-system/web/src/routes/DetentionRequests/DetentionRequests.tsx
@@ -52,18 +52,20 @@ export const DetentionRequests: React.FC = () => {
     }
   }, [])
 
-  const mapCaseStateToTagVariant = (state: string): TagVariant => {
+  const mapCaseStateToTagVariant = (
+    state: CaseState,
+  ): { color: TagVariant; text: string } => {
     switch (state) {
-      case 'DRAFT':
-        return 'red'
-      case 'SUBMITTED':
-        return 'purple'
-      case 'ACTIVE':
-        return 'darkerMint'
-      case 'COMPLETED':
-        return 'blue'
+      case CaseState.DRAFT:
+        return { color: 'red', text: 'Drög' }
+      case CaseState.SUBMITTED:
+        return { color: 'purple', text: 'Krafa staðfest' }
+      case CaseState.ACTIVE:
+        return { color: 'darkerMint', text: 'Gæsluvarðhald virkt' }
+      case CaseState.COMPLETED:
+        return { color: 'blue', text: 'Gæsluvarðhaldi lokið' }
       default:
-        return 'white'
+        return { color: 'white', text: 'Óþekkt' }
     }
   }
 
@@ -109,8 +111,8 @@ export const DetentionRequests: React.FC = () => {
                   {format(parseISO(c.created), 'PP', { locale: localeIS })}
                 </td>
                 <td>
-                  <Tag variant={mapCaseStateToTagVariant(c.state)} label>
-                    {CaseState[c.state]}
+                  <Tag variant={mapCaseStateToTagVariant(c.state).color} label>
+                    {mapCaseStateToTagVariant(c.state).text}
                   </Tag>
                 </td>
                 <td>

--- a/apps/judicial-system/web/src/types.ts
+++ b/apps/judicial-system/web/src/types.ts
@@ -15,11 +15,11 @@ export enum CaseCustodyRestrictions {
 }
 
 export enum CaseState {
-  UNKNOWN = 'Óþekkt',
-  DRAFT = 'Drög',
-  SUBMITTED = 'Krafa staðfest',
-  ACTIVE = 'Gæsluvarðhald virkt',
-  COMPLETED = 'Gæsluvarðhaldi lokið',
+  UNKNOWN = 'UNKNOWN',
+  DRAFT = 'DRAFT',
+  SUBMITTED = 'SUBMITTED',
+  ACTIVE = 'ACTIVE',
+  COMPLETED = 'COMPLETED',
 }
 
 export interface Case {


### PR DESCRIPTION
This PR sets a case as SUBMITTED when you enter the second step of the flow. Ideally this would happen when you actually submit the case but that PR is still being worked on and we will move the code to its right place when it's merged(#875). If you now login with my ssn (1112902539) You'll only see the cases marked as SUBMITTED. 