### PR TITLE
article call to action button is back

### DIFF
--- a/apps/web/screens/Article.tsx
+++ b/apps/web/screens/Article.tsx
@@ -129,6 +129,28 @@ const RelatedArticles: FC<{
   )
 }
 
+const ActionButton: FC<{ content: Slice[]; defaultText: string }> = ({
+  content,
+  defaultText,
+}) => {
+  const processEntries = content.filter((slice): slice is ProcessEntry => {
+    return slice.__typename === 'ProcessEntry' && Boolean(slice.processLink)
+  })
+
+  // we'll only show the button if there is exactly one process entry on the page
+  if (processEntries.length !== 1) return null
+
+  const { buttonText, processLink } = processEntries[0]
+
+  return (
+    <SidebarBox>
+      <Button href={processLink} width="fluid">
+        {buttonText || defaultText}
+      </Button>
+    </SidebarBox>
+  )
+}
+
 const SubArticleNavigation: FC<{
   title: string
   article: Article
@@ -278,6 +300,10 @@ const ArticleSidebar: FC<ArticleSidebarProps> = ({
 }) => {
   return (
     <Stack space={3}>
+      <ActionButton
+        content={article.body}
+        defaultText={n('processLinkButtonText')}
+      />
       {article.subArticles.length === 0 ? (
         <ArticleNavigation title="Efnisyfirlit" article={article} />
       ) : (


### PR DESCRIPTION
# \<Description\>

## Screenshots / Gifs

Button in upper right corner

![Screenshot 2020-09-18 at 14 13 53](https://user-images.githubusercontent.com/15398/93607739-416ab680-f9b9-11ea-98f8-06d263397d20.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
