### PR TITLE
Temporarily remove fallback codeowners rule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,10 @@
 # Fallback. If there is no owner, assign to core maintainers.
-*                               @island-is/core
+# Remove fallback rule while graphql files are in the way.
+# *                               @island-is/core
+
+/*                              @island-is/core
+/.github/                       @island-is/core
+
 
 # Project folders are usually owned by the team assigned.
 # Add new projects here.
@@ -25,6 +30,7 @@ service-portal*/                @island-is/sendiradid
 /apps/services/search-indexer/  @island-is/stefna
 content-search/                 @island-is/stefna
 
+/.storybook/                    @island-is/island-ui
 /libs/island-ui/                @island-is/island-ui
 
 /apps/reference-backend/        @island-is/devops


### PR DESCRIPTION
# Temporarily remove fallback codeowners rule

## What

Changed the core maintainer rule to only focus on root files and the .github directory.

Will re-enable the fallback rule when we've found a way to remove codegen schemas from git. 

## Why

This is to unblock the web team while they're working on the island.is launch.

Any change that touches the graphql schema causes changes in multiple generated schema files. This unneccessarily triggers code reviews for multiple codeowners, which slows down development.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
