### PR TITLE
Add workflow dispatch trigger in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     branches:
       - master
+  workflow_dispatch: {}
 
 env:
   DOCKER_REGISTRY: 821090935708.dkr.ecr.eu-west-1.amazonaws.com/


### PR DESCRIPTION
## What

Maybe this allows us to trigger builds that for some reason are not
running (see discussions on #804)

## Why

We want to be able to run CI manually

## Info

https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
