### PR TITLE
Removed empty life events

### DIFF
--- a/apps/web/components/LifeEventsCardsSection/LifeEventsCardsSection.tsx
+++ b/apps/web/components/LifeEventsCardsSection/LifeEventsCardsSection.tsx
@@ -48,7 +48,9 @@ export const LifeEventsCardsSection: React.FC<LifeEventsSectionProps> = ({
         </GridColumn>
       </GridRow>
       <GridRow>
-        {lifeEvents.map((lifeEvent) => (
+        {lifeEvents
+          .filter((lifeEvent) => lifeEvent.title && lifeEvent.slug) // life event can be empty in some locales
+          .map((lifeEvent) => (
           <GridColumn
             span={['12/12', '12/12', '6/12', '6/12', '4/12']}
             paddingBottom={3}

--- a/apps/web/components/LifeEventsCardsSection/LifeEventsCardsSection.tsx
+++ b/apps/web/components/LifeEventsCardsSection/LifeEventsCardsSection.tsx
@@ -51,14 +51,14 @@ export const LifeEventsCardsSection: React.FC<LifeEventsSectionProps> = ({
         {lifeEvents
           .filter((lifeEvent) => lifeEvent.title && lifeEvent.slug) // life event can be empty in some locales
           .map((lifeEvent) => (
-          <GridColumn
-            span={['12/12', '12/12', '6/12', '6/12', '4/12']}
-            paddingBottom={3}
-            key={lifeEvent.title}
-          >
-            {renderLifeEventCard(lifeEvent)}
-          </GridColumn>
-        ))}
+            <GridColumn
+              span={['12/12', '12/12', '6/12', '6/12', '4/12']}
+              paddingBottom={3}
+              key={lifeEvent.title}
+            >
+              {renderLifeEventCard(lifeEvent)}
+            </GridColumn>
+          ))}
       </GridRow>
     </GridContainer>
   )


### PR DESCRIPTION
# Hide empty life events

## What

Hide empty life events on frontpage

## Why

Contentful returns all published content even if it is empty we have to filter out the empty content

## Screenshots / Gifs

![Screenshot 2020-09-19 at 09 33 59](https://user-images.githubusercontent.com/6640435/93664016-454f1500-fa5b-11ea-851d-ed84d46ba2cb.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
