### PR TITLE
Web: Only enable default prefetching for links with 'as'

### DIFF
--- a/libs/island-ui/core/src/lib/Link/Link.tsx
+++ b/libs/island-ui/core/src/lib/Link/Link.tsx
@@ -43,6 +43,10 @@ const Link: React.FC<Props> = ({
     },
   )
 
+  // In next 9.5.3 and later, this will be unnecessary, since the as parameter will be
+  // optiona - but as things stand, as is needed if you have a dynamic href
+  const prefetchDefault = !as ? false : prefetch
+
   if (isInternal) {
     return (
       <NextLink
@@ -51,7 +55,7 @@ const Link: React.FC<Props> = ({
         shallow={shallow}
         scroll={scroll}
         passHref={passHref}
-        prefetch={prefetch}
+        prefetch={prefetchDefault}
       >
         <a className={classNames} {...linkProps}>
           {children}


### PR DESCRIPTION
# Description

Only enabling default prefetching of JS bundles, when the target bundle is known (when the 'as' prop is set on the Link component)

Note: This (along with most Link references) will have to updated anyways after next >= 9.5.3

## What

Changes the NextLink generic component in the ui-core (which is probably not the right place for the component in the first place)

## Why

The console spits out a bunch of 404 not founds for links defined using <Link>, but without specifying an 'as' prop (to know what kind of component it is supposed to link to)

## Screenshots / Gifs

N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
