### PR TITLE
Made frontpage news on english frontpage be in english

### DIFF
--- a/apps/web/components/LatestNewsSection/LatestNewsSection.tsx
+++ b/apps/web/components/LatestNewsSection/LatestNewsSection.tsx
@@ -45,7 +45,7 @@ const LatestNewsSection: React.FC<LatestNewsProps> = ({
         <GridColumn span="6/12" hideBelow="md">
           <Box display="flex" justifyContent="flexEnd" paddingBottom={4}>
             <Typography variant="h3" as="p" paddingBottom={4}>
-              <ArrowLink href="/frett" arrowHeight={16}>
+              <ArrowLink href={makePath('news')} arrowHeight={16}>
                 {n('seeMore')}
               </ArrowLink>
             </Typography>

--- a/apps/web/pages/en/news/index.tsx
+++ b/apps/web/pages/en/news/index.tsx
@@ -1,5 +1,5 @@
 import withApollo from '@island.is/web/graphql/withApollo'
 import { withLocale } from '@island.is/web/i18n'
-import newsListScreen from '@island.is/web/screens/NewsItem'
+import newsListScreen from '@island.is/web/screens/NewsList'
 
 export default withApollo(withLocale('en')(newsListScreen))

--- a/apps/web/screens/Home.tsx
+++ b/apps/web/screens/Home.tsx
@@ -35,7 +35,6 @@ import {
   LatestNewsSection,
 } from '@island.is/web/components'
 import { withMainLayout } from '@island.is/web/layouts/main'
-import { Sleeve, ContentBlock } from '@island.is/island-ui/core'
 import { GlobalNamespaceContext } from '@island.is/web/context'
 
 interface HomeProps {
@@ -174,6 +173,7 @@ Home.getInitialProps = async ({ apolloClient, locale }) => {
       variables: {
         input: {
           perPage: 3,
+          lang: locale as ContentLanguage,
         },
       },
     }),

--- a/libs/api/domains/cms/src/lib/cms.contentful.service.ts
+++ b/libs/api/domains/cms/src/lib/cms.contentful.service.ts
@@ -281,9 +281,11 @@ export class CmsContentfulService {
       .getLocalizedEntries<types.INewsFields>(lang, params)
       .catch(errorHandler('getNewsList'))
 
+    const mappedNews = result.items.map(mapNews)
+
     return {
-      page: makePage(page, perPage, result.total),
-      news: result.items.map(mapNews),
+      page: makePage(page, perPage, mappedNews.length),
+      news: mappedNews.filter((news) => news.title && news.slug), // we consider news "empty" that dont pass this check
     }
   }
 

--- a/libs/api/domains/cms/src/lib/cms.contentful.service.ts
+++ b/libs/api/domains/cms/src/lib/cms.contentful.service.ts
@@ -435,7 +435,6 @@ export class CmsContentfulService {
         include: 1,
       })
       .catch(errorHandler('getUrl'))
-    logger.info('url', { result })
     return result.items.map(mapUrl)[0] ?? null
   }
 

--- a/libs/api/domains/cms/src/lib/models/image.model.ts
+++ b/libs/api/domains/cms/src/lib/models/image.model.ts
@@ -26,8 +26,10 @@ export class Image {
   height: number
 }
 
-export const mapImage = ({ fields, sys }: Asset): Image =>
-  new Image({
+export const mapImage = (entry: Asset): Image => {
+  const fields = entry?.fields
+  const sys = entry?.sys
+  return new Image({
     id: sys?.id ?? '',
     url: fields?.file?.url ?? '',
     title: fields?.title ?? '',
@@ -35,3 +37,4 @@ export const mapImage = ({ fields, sys }: Asset): Image =>
     width: fields?.file?.details?.image?.width ?? 0,
     height: fields?.file?.details?.image?.height ?? 0,
   })
+}

--- a/libs/api/domains/cms/src/lib/models/news.model.ts
+++ b/libs/api/domains/cms/src/lib/models/news.model.ts
@@ -33,11 +33,11 @@ export class News {
 
 export const mapNews = ({ fields, sys }: INews): News => ({
   id: sys.id,
-  slug: fields.slug,
-  title: fields.title,
-  subtitle: fields.subtitle,
-  intro: fields.intro,
-  image: fields.image?.fields?.file ? mapImage(fields.image) : null,
-  date: fields.date,
+  slug: fields?.slug ?? '',
+  title: fields?.title ?? '',
+  subtitle: fields?.subtitle ?? '',
+  intro: fields?.intro ?? '',
+  image: mapImage(fields.image),
+  date: fields?.date ?? '',
   content: JSON.stringify(fields.content),
 })


### PR DESCRIPTION
# English news on english page

Made a quick fix for the english news on the frontpage.
Will itterate by mergeing the latest news endpoint into the getNews endpoint

## What

- Made news qeujry use locale
- Made news mapper handle empty news items
- Added empty condition to api

## Screenshots / Gifs

<img width="1418" alt="Screenshot 2020-09-21 at 08 51 15" src="https://user-images.githubusercontent.com/6640435/93751550-c8ec3b80-fbec-11ea-9716-7662968a04c5.png">
<img width="1651" alt="Screenshot 2020-09-21 at 11 14 52" src="https://user-images.githubusercontent.com/6640435/93760527-b3cad900-fbfb-11ea-83af-6df128a006fb.png">



## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
