### PR TITLE
Store cooperation for airlines

### DIFF
--- a/apps/air-discount-scheme/api.graphql
+++ b/apps/air-discount-scheme/api.graphql
@@ -16,6 +16,16 @@ type Link {
   url: String!
 }
 
+type Html {
+  id: ID!
+  document: JSON!
+}
+
+"""
+The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+"""
+scalar JSON @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
+
 type TimelineEvent {
   id: ID!
   title: String!
@@ -23,7 +33,7 @@ type TimelineEvent {
   numerator: Int
   denominator: Int
   label: String!
-  body: String
+  body: Html
   tags: [String!]
   link: String!
 }
@@ -73,16 +83,6 @@ type Statistic {
   value: String!
   label: String!
 }
-
-type Html {
-  id: ID!
-  document: JSON!
-}
-
-"""
-The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
-"""
-scalar JSON @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
 
 type QuestionAndAnswer {
   id: ID!
@@ -238,8 +238,8 @@ type Article {
   contentStatus: String!
   title: String!
   slug: String!
-  shortTitle: String!
-  intro: String!
+  shortTitle: String
+  intro: String
   containsApplicationForm: Boolean
   importance: Float
   body: [Slice!]!
@@ -322,7 +322,6 @@ type FrontpageSlider {
   title: String!
   subtitle: String!
   content: String!
-  image: Image
   link: String
   animationJson: String
 }
@@ -349,6 +348,7 @@ type Namespace {
 }
 
 type AboutPage {
+  id: ID!
   title: String!
   seoDescription: String!
   theme: String!
@@ -404,7 +404,7 @@ type LifeEventPage {
   title: String!
   slug: String!
   intro: String!
-  image: Image!
+  image: Image
   thumbnail: Image
   content: [Slice!]!
   category: ArticleCategory
@@ -451,6 +451,7 @@ type Flight {
 type FlightLeg {
   id: ID!
   airline: String!
+  cooperation: String
   financialState: String!
   travel: String!
   originalPrice: Float!
@@ -636,6 +637,7 @@ input GetUrlInput {
 
 input FlightLegsInput {
   airline: String
+  cooperation: String
   flightLeg: Travel
   period: Period
   state: [String!]

--- a/apps/air-discount-scheme/api/src/app/modules/flightLeg/dto/flightLeg.input.ts
+++ b/apps/air-discount-scheme/api/src/app/modules/flightLeg/dto/flightLeg.input.ts
@@ -39,6 +39,9 @@ export class FlightLegsInput implements TFlightLegsInput {
   @Field((_) => String, { nullable: true })
   airline: string
 
+  @Field((_) => String, { nullable: true })
+  cooperation: string
+
   @Field((_) => Travel, { nullable: true })
   flightLeg: Travel
 

--- a/apps/air-discount-scheme/api/src/app/modules/flightLeg/flightLeg.model.ts
+++ b/apps/air-discount-scheme/api/src/app/modules/flightLeg/flightLeg.model.ts
@@ -10,6 +10,9 @@ export class FlightLeg {
   @Field()
   airline: string
 
+  @Field({ nullable: true })
+  cooperation: string
+
   @Field()
   financialState: string
 

--- a/apps/air-discount-scheme/backend/migrations/20200921084928-store-cooperation.js
+++ b/apps/air-discount-scheme/backend/migrations/20200921084928-store-cooperation.js
@@ -1,0 +1,30 @@
+'use strict'
+
+module.exports = {
+  up: (queryInterface) => {
+    return queryInterface.sequelize.query(`
+      BEGIN;
+
+        /* add nullable cooperation column to flight_leg */
+        ALTER TABLE flight_leg ADD COLUMN cooperation VARCHAR;
+
+        /* set cooperation where appropriate */
+        UPDATE flight_leg
+        SET cooperation = 'norlandair'
+        WHERE airline = 'norlandair';
+
+        /* set airline as icelandair where appropriate */
+        UPDATE flight_leg
+        SET airline = 'icelandair'
+        WHERE airline = 'norlandair';
+
+      COMMIT;
+    `)
+  },
+
+  down: (queryInterface) => {
+    return queryInterface.sequelize.query(`
+        ALTER TABLE flight DROP COLUMN cooperation;
+    `)
+  },
+}

--- a/apps/air-discount-scheme/backend/src/app/modules/flight/dto/body.dto.ts
+++ b/apps/air-discount-scheme/backend/src/app/modules/flight/dto/body.dto.ts
@@ -60,6 +60,10 @@ export class GetFlightLegsBody implements FlightLegsInput {
   airline: string
 
   @IsOptional()
+  @IsEnum(Object.keys(Airlines))
+  cooperation: string
+
+  @IsOptional()
   @IsObject()
   flightLeg: Travel
 

--- a/apps/air-discount-scheme/backend/src/app/modules/flight/flight.model.ts
+++ b/apps/air-discount-scheme/backend/src/app/modules/flight/flight.model.ts
@@ -68,6 +68,13 @@ export class FlightLeg extends Model<FlightLeg> implements TFlightLeg {
   @ApiProperty()
   airline: string
 
+  @Column({
+    type: DataType.ENUM,
+    values: Object.values(Airlines),
+  })
+  @ApiProperty()
+  cooperation: string
+
   // eslint-disable-next-line
   @BelongsTo(() => Flight)
   flight

--- a/apps/air-discount-scheme/backend/src/app/modules/flight/test/integration/flight.service.spec.ts
+++ b/apps/air-discount-scheme/backend/src/app/modules/flight/test/integration/flight.service.spec.ts
@@ -58,15 +58,19 @@ describe('create', () => {
     city: 'string',
   }
 
-  it('should set the airline as norlandair for first 3 legs, and icelandair for last', async () => {
+  it('should set the cooperation as norlandair for first 3 legs, and null for last', async () => {
     const airline = 'icelandair'
     const result = await flightService.create(flightDto, user, airline)
 
     expect(result.flightLegs.length).toEqual(4)
-    expect(result.flightLegs[0].airline).toEqual('norlandair')
-    expect(result.flightLegs[1].airline).toEqual('norlandair')
-    expect(result.flightLegs[2].airline).toEqual('norlandair')
+    expect(result.flightLegs[0].airline).toEqual(airline)
+    expect(result.flightLegs[1].airline).toEqual(airline)
+    expect(result.flightLegs[2].airline).toEqual(airline)
     expect(result.flightLegs[3].airline).toEqual(airline)
+    expect(result.flightLegs[0].cooperation).toEqual('norlandair')
+    expect(result.flightLegs[1].cooperation).toEqual('norlandair')
+    expect(result.flightLegs[2].cooperation).toEqual('norlandair')
+    expect(result.flightLegs[3].cooperation).toEqual(null)
   })
 
   it('should set the airline as ernir', async () => {
@@ -78,5 +82,9 @@ describe('create', () => {
     expect(result.flightLegs[1].airline).toEqual(airline)
     expect(result.flightLegs[2].airline).toEqual(airline)
     expect(result.flightLegs[3].airline).toEqual(airline)
+    expect(result.flightLegs[0].cooperation).toEqual(null)
+    expect(result.flightLegs[1].cooperation).toEqual(null)
+    expect(result.flightLegs[2].cooperation).toEqual(null)
+    expect(result.flightLegs[3].cooperation).toEqual(null)
   })
 })

--- a/apps/air-discount-scheme/web/graphql/possibleTypes.json
+++ b/apps/air-discount-scheme/web/graphql/possibleTypes.json
@@ -19,6 +19,7 @@
       "SectionWithImage"
     ],
     "BulletEntry": ["IconBullet", "NumberBulletGroup"],
-    "AdgerdirSlice": ["AdgerdirGroupSlice", "AdgerdirFeaturedNewsSlice"]
+    "AdgerdirSlice": ["AdgerdirGroupSlice", "AdgerdirFeaturedNewsSlice"],
+    "UrlPage": ["Article", "ArticleCategory", "News", "LifeEventPage"]
   }
 }

--- a/apps/air-discount-scheme/web/graphql/schema.tsx
+++ b/apps/air-discount-scheme/web/graphql/schema.tsx
@@ -34,6 +34,12 @@ export type Link = {
   url: Scalars['String']
 }
 
+export type Html = {
+  __typename?: 'Html'
+  id: Scalars['ID']
+  document: Scalars['JSON']
+}
+
 export type TimelineEvent = {
   __typename?: 'TimelineEvent'
   id: Scalars['ID']
@@ -42,8 +48,8 @@ export type TimelineEvent = {
   numerator?: Maybe<Scalars['Int']>
   denominator?: Maybe<Scalars['Int']>
   label: Scalars['String']
-  body?: Maybe<Scalars['String']>
-  tags: Array<Scalars['String']>
+  body?: Maybe<Html>
+  tags?: Maybe<Array<Scalars['String']>>
   link: Scalars['String']
 }
 
@@ -99,17 +105,11 @@ export type Statistic = {
   label: Scalars['String']
 }
 
-export type Html = {
-  __typename?: 'Html'
-  id: Scalars['ID']
-  document: Scalars['JSON']
-}
-
 export type QuestionAndAnswer = {
   __typename?: 'QuestionAndAnswer'
   id: Scalars['ID']
   question: Scalars['String']
-  answer: Html
+  answer?: Maybe<Html>
 }
 
 export type ArticleCategory = {
@@ -129,8 +129,8 @@ export type ArticleGroup = {
 export type ArticleSubgroup = {
   __typename?: 'ArticleSubgroup'
   title: Scalars['String']
+  importance?: Maybe<Scalars['Float']>
   slug: Scalars['String']
-  importance?: Maybe<Scalars['Int']>
 }
 
 export type OrganizationTag = {
@@ -264,13 +264,8 @@ export type Statistics = {
 export type ProcessEntry = {
   __typename?: 'ProcessEntry'
   id: Scalars['ID']
-  title: Scalars['String']
-  subtitle?: Maybe<Scalars['String']>
-  details?: Maybe<Html>
   type: Scalars['String']
   processTitle: Scalars['String']
-  processDescription?: Maybe<Scalars['String']>
-  processInfo?: Maybe<Html>
   processLink: Scalars['String']
   buttonText: Scalars['String']
 }
@@ -303,15 +298,17 @@ export type Article = {
   contentStatus: Scalars['String']
   title: Scalars['String']
   slug: Scalars['String']
-  shortTitle: Scalars['String']
-  intro: Scalars['String']
+  shortTitle?: Maybe<Scalars['String']>
+  intro?: Maybe<Scalars['String']>
+  containsApplicationForm?: Maybe<Scalars['Boolean']>
+  importance?: Maybe<Scalars['Float']>
   body: Array<Slice>
   category?: Maybe<ArticleCategory>
   group?: Maybe<ArticleGroup>
   subgroup?: Maybe<ArticleSubgroup>
-  organization: Array<Organization>
+  organization?: Maybe<Array<Organization>>
   subArticles: Array<SubArticle>
-  relatedArticles: Array<Article>
+  relatedArticles?: Maybe<Array<Article>>
 }
 
 export type AdgerdirTag = {
@@ -389,18 +386,18 @@ export type AdgerdirFeaturedNewsSlice = {
   featured: Array<AdgerdirNews>
 }
 
-export type FrontpageSlide = {
-  __typename?: 'FrontpageSlide'
+export type FrontpageSlider = {
+  __typename?: 'FrontpageSlider'
   title: Scalars['String']
   subtitle: Scalars['String']
   content: Scalars['String']
-  image?: Maybe<Image>
   link?: Maybe<Scalars['String']>
+  animationJson?: Maybe<Scalars['String']>
 }
 
 export type FrontpageSliderList = {
   __typename?: 'FrontpageSliderList'
-  items: Array<FrontpageSlide>
+  items: Array<FrontpageSlider>
 }
 
 export type Pagination = {
@@ -425,6 +422,7 @@ export type Namespace = {
 
 export type AboutPage = {
   __typename?: 'AboutPage'
+  id: Scalars['ID']
   title: Scalars['String']
   seoDescription: Scalars['String']
   theme: Scalars['String']
@@ -448,6 +446,18 @@ export type LandingPage = {
   content: Array<Slice>
 }
 
+export type AlertBanner = {
+  __typename?: 'AlertBanner'
+  id: Scalars['ID']
+  showAlertBanner: Scalars['Boolean']
+  bannerVariant: Scalars['String']
+  title?: Maybe<Scalars['String']>
+  description?: Maybe<Scalars['String']>
+  link?: Maybe<Link>
+  isDismissable: Scalars['Boolean']
+  dismissedForDays: Scalars['Int']
+}
+
 export type GenericPage = {
   __typename?: 'GenericPage'
   title: Scalars['String']
@@ -464,19 +474,21 @@ export type Menu = {
   links: Array<Link>
 }
 
-export type LifeEventPage = {
-  __typename?: 'LifeEventPage'
-  title: Scalars['String']
-  slug: Scalars['String']
-  intro: Scalars['String']
-  image: Image
-  thumbnail?: Maybe<Image>
-  content: Array<Slice>
-}
-
 export type AdgerdirTags = {
   __typename?: 'AdgerdirTags'
   items: Array<AdgerdirTag>
+}
+
+export type LifeEventPage = {
+  __typename?: 'LifeEventPage'
+  id: Scalars['ID']
+  title: Scalars['String']
+  slug: Scalars['String']
+  intro: Scalars['String']
+  image?: Maybe<Image>
+  thumbnail?: Maybe<Image>
+  content: Array<Slice>
+  category?: Maybe<ArticleCategory>
 }
 
 export type PaginatedAdgerdirNews = {
@@ -489,6 +501,16 @@ export type OrganizationTags = {
   __typename?: 'OrganizationTags'
   items: Array<OrganizationTag>
 }
+
+export type Url = {
+  __typename?: 'Url'
+  id: Scalars['ID']
+  title?: Maybe<Scalars['String']>
+  page: UrlPage
+  urlsList: Array<Scalars['String']>
+}
+
+export type UrlPage = Article | ArticleCategory | News | LifeEventPage
 
 export type Fund = {
   __typename?: 'Fund'
@@ -517,6 +539,7 @@ export type FlightLeg = {
   __typename?: 'FlightLeg'
   id: Scalars['ID']
   airline: Scalars['String']
+  cooperation: Scalars['String']
   financialState: Scalars['String']
   travel: Scalars['String']
   originalPrice: Scalars['Float']
@@ -546,12 +569,12 @@ export type Discount = {
 export type Query = {
   __typename?: 'Query'
   getArticle?: Maybe<Article>
-  getNews?: Maybe<News>
   getNewsList: PaginatedNews
   getAdgerdirNewsList: PaginatedAdgerdirNews
   getNamespace?: Maybe<Namespace>
   getAboutPage: AboutPage
   getLandingPage?: Maybe<LandingPage>
+  getAlertBanner?: Maybe<AlertBanner>
   getGenericPage?: Maybe<GenericPage>
   getAdgerdirPage?: Maybe<AdgerdirPage>
   getOrganization?: Maybe<Organization>
@@ -565,6 +588,11 @@ export type Query = {
   getMenu?: Maybe<Menu>
   getLifeEventPage?: Maybe<LifeEventPage>
   getLifeEvents: Array<LifeEventPage>
+  getLifeEventsInCategory: Array<LifeEventPage>
+  getArticleCategories: Array<ArticleCategory>
+  getArticles: Array<Article>
+  getSingleNews?: Maybe<News>
+  getUrl?: Maybe<Url>
   flightLegs: Array<FlightLeg>
   user?: Maybe<User>
   discounts?: Maybe<Array<Discount>>
@@ -572,10 +600,6 @@ export type Query = {
 
 export type QueryGetArticleArgs = {
   input: GetArticleInput
-}
-
-export type QueryGetNewsArgs = {
-  input: GetNewsInput
 }
 
 export type QueryGetNewsListArgs = {
@@ -596,6 +620,10 @@ export type QueryGetAboutPageArgs = {
 
 export type QueryGetLandingPageArgs = {
   input: GetLandingPageInput
+}
+
+export type QueryGetAlertBannerArgs = {
+  input: GetAlertBannerInput
 }
 
 export type QueryGetGenericPageArgs = {
@@ -650,6 +678,26 @@ export type QueryGetLifeEventsArgs = {
   input: GetLifeEventsInput
 }
 
+export type QueryGetLifeEventsInCategoryArgs = {
+  input: GetLifeEventsInCategoryInput
+}
+
+export type QueryGetArticleCategoriesArgs = {
+  input: GetArticleCategoriesInput
+}
+
+export type QueryGetArticlesArgs = {
+  input: GetArticlesInput
+}
+
+export type QueryGetSingleNewsArgs = {
+  input: GetSingleNewsInput
+}
+
+export type QueryGetUrlArgs = {
+  input: GetUrlInput
+}
+
 export type QueryFlightLegsArgs = {
   input: FlightLegsInput
 }
@@ -657,11 +705,6 @@ export type QueryFlightLegsArgs = {
 export type GetArticleInput = {
   slug?: Maybe<Scalars['String']>
   lang: Scalars['String']
-}
-
-export type GetNewsInput = {
-  slug: Scalars['String']
-  lang?: Maybe<Scalars['String']>
 }
 
 export type GetNewsListInput = {
@@ -693,6 +736,11 @@ export type GetAboutPageInput = {
 
 export type GetLandingPageInput = {
   slug: Scalars['String']
+  lang: Scalars['String']
+}
+
+export type GetAlertBannerInput = {
+  id: Scalars['String']
   lang: Scalars['String']
 }
 
@@ -756,8 +804,35 @@ export type GetLifeEventsInput = {
   lang: Scalars['String']
 }
 
+export type GetLifeEventsInCategoryInput = {
+  slug: Scalars['String']
+  lang: Scalars['String']
+}
+
+export type GetArticleCategoriesInput = {
+  lang: Scalars['String']
+  size?: Maybe<Scalars['Int']>
+}
+
+export type GetArticlesInput = {
+  lang: Scalars['String']
+  category: Scalars['String']
+  size?: Maybe<Scalars['Int']>
+}
+
+export type GetSingleNewsInput = {
+  slug: Scalars['String']
+  lang?: Maybe<Scalars['String']>
+}
+
+export type GetUrlInput = {
+  slug: Scalars['String']
+  lang: Scalars['String']
+}
+
 export type FlightLegsInput = {
   airline?: Maybe<Scalars['String']>
+  cooperation?: Maybe<Scalars['String']>
   flightLeg?: Maybe<Travel>
   period?: Maybe<Period>
   state?: Maybe<Array<Scalars['String']>>
@@ -823,6 +898,7 @@ export type FlightLegsQueryQuery = { __typename?: 'Query' } & {
       | 'id'
       | 'travel'
       | 'airline'
+      | 'cooperation'
       | 'originalPrice'
       | 'discountPrice'
       | 'financialState'
@@ -1087,6 +1163,7 @@ export const FlightLegsQueryDocument = gql`
       id
       travel
       airline
+      cooperation
       originalPrice
       discountPrice
       financialState

--- a/apps/air-discount-scheme/web/screens/Admin/Admin.tsx
+++ b/apps/air-discount-scheme/web/screens/Admin/Admin.tsx
@@ -27,6 +27,7 @@ const FlightLegsQuery = gql`
       id
       travel
       airline
+      cooperation
       originalPrice
       discountPrice
       financialState
@@ -61,8 +62,12 @@ const Admin: Screen = ({}) => {
         ...filters,
         airline:
           filters.airline?.value === Airlines.norlandair
-            ? [Airlines.icelandair, Airlines.norlandair]
+            ? Airlines.icelandair
             : filters.airline?.value,
+        cooperation:
+          filters.airline?.value === Airlines.norlandair
+            ? Airlines.norlandair
+            : undefined,
         gender:
           filters.gender?.length === 2 ? undefined : (filters.gender || [])[0],
         age: {

--- a/apps/air-discount-scheme/web/screens/Admin/components/Panel/Panel.tsx
+++ b/apps/air-discount-scheme/web/screens/Admin/components/Panel/Panel.tsx
@@ -70,7 +70,10 @@ function Panel({ filters, flightLegs }: PropTypes) {
                   </Typography>
                   <Typography color="dark300" variant="pSmall">
                     <span className={styles.capitalize}>
-                      {flightLeg.airline}
+                      {flightLeg.airline}{' '}
+                      {flightLeg.cooperation
+                        ? `+ ${flightLeg.cooperation}`
+                        : ''}
                     </span>
                   </Typography>
                 </Box>

--- a/apps/air-discount-scheme/web/screens/Admin/components/Summary/Summary.tsx
+++ b/apps/air-discount-scheme/web/screens/Admin/components/Summary/Summary.tsx
@@ -18,8 +18,36 @@ function Summary({ flightLegs, airline: filteredAirline }: PropTypes) {
     arr.reduce((acc, item) => acc + item[key], 0)
 
   const airlines = Object.values(Airlines).filter(
-    (airline) => !filteredAirline || airline === filteredAirline,
+    (airline) =>
+      airline !== Airlines.norlandair &&
+      (!filteredAirline ||
+        airline ===
+          (filteredAirline === Airlines.norlandair
+            ? Airlines.icelandair
+            : filteredAirline)),
   )
+
+  const getFlightLegs = (airline) => {
+    if (filteredAirline === Airlines.norlandair) {
+      return flightLegs.filter(
+        (flightLeg) =>
+          flightLeg.airline === airline &&
+          flightLeg.cooperation === filteredAirline,
+      )
+    }
+
+    return flightLegs.filter(
+      (flightLeg) =>
+        flightLeg.airline === airline || flightLeg.cooperation === airline,
+    )
+  }
+
+  const getAirline = (airline) => {
+    if (airline === Airlines.icelandair) {
+      return 'Icelandair + Norlandair'
+    }
+    return airline
+  }
 
   return (
     <Box marginBottom={6}>
@@ -32,9 +60,7 @@ function Summary({ flightLegs, airline: filteredAirline }: PropTypes) {
         </Typography>
         <Stack space={6}>
           {airlines.map((airline) => {
-            const legs = flightLegs.filter(
-              (flightLeg) => flightLeg.airline === airline,
-            )
+            const legs = getFlightLegs(airline)
             const awaitingCredit = legs.filter(
               (leg) => leg.financialState === States.awaitingCredit,
             )
@@ -66,7 +92,9 @@ function Summary({ flightLegs, airline: filteredAirline }: PropTypes) {
             return (
               <Stack space={2} key={airline}>
                 <Typography variant="h3">
-                  <span className={styles.capitalize}>{airline}</span>
+                  <span className={styles.capitalize}>
+                    {getAirline(airline)}
+                  </span>
                 </Typography>
                 <Stack space={1}>
                   <Box background="blue100" borderRadius="standard" padding={2}>


### PR DESCRIPTION
#  Store the cooperation in the flightLeg

## What

Store cooperation in flight_leg and show in Admin UI.

## Why

Before, the cooperation was overwriting the airline column in the flight_leg table,
which is incorrect. By moving it to the cooperation column, we can better explain
the airlines relationships in the Admin UI

## Screenshots / Gifs
![coop](https://user-images.githubusercontent.com/5694851/93753172-3ef1a200-fbef-11ea-8b6a-2e6c60cfa167.gif)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
