### PR TITLE
Safe slice types

### DIFF
--- a/libs/api/domains/cms/src/lib/models/aboutPage.model.ts
+++ b/libs/api/domains/cms/src/lib/models/aboutPage.model.ts
@@ -1,8 +1,6 @@
 import { Field, ID, ObjectType } from '@nestjs/graphql'
-
 import * as types from '../generated/contentfulTypes'
-
-import { Slice, mapSlice } from './slice.model'
+import { Slice, safelyMapSlices } from './slice.model'
 
 @ObjectType()
 export class AboutPage {
@@ -24,8 +22,8 @@ export class AboutPage {
 
 export const mapAboutPage = ({ fields, sys }: types.IPage): AboutPage => ({
   id: sys.id,
-  slices: fields.slices.map(mapSlice),
-  title: fields.title,
-  theme: fields.theme.toLowerCase(),
-  seoDescription: fields.seoDescription ?? '',
+  slices: fields?.slices?.map(safelyMapSlices).filter(Boolean), // filter out empty slices that failed mapping
+  title: fields?.title ?? '',
+  theme: fields?.theme?.toLowerCase() ?? '',
+  seoDescription: fields?.seoDescription ?? '',
 })

--- a/libs/api/domains/cms/src/lib/models/slice.model.ts
+++ b/libs/api/domains/cms/src/lib/models/slice.model.ts
@@ -130,7 +130,7 @@ export const safelyMapSlices = (data) => {
   try {
     return mapSlice(data)
   } catch (error) {
-    logger.error('Failed to map slice in about page', error)
+    logger.error('Failed to map slice', error)
     return null
   }
 }

--- a/libs/api/domains/cms/src/lib/models/slice.model.ts
+++ b/libs/api/domains/cms/src/lib/models/slice.model.ts
@@ -38,6 +38,7 @@ import { ProcessEntry, mapProcessEntry } from './processEntry.model'
 import { FaqList, mapFaqList } from './faqList.model'
 import { EmbeddedVideo, mapEmbeddedVideo } from './embeddedVideo.model'
 import { SectionWithImage, mapSectionWithImage } from './sectionWithImage.model'
+import { logger } from '@island.is/logging'
 
 type SliceTypes =
   | IPageHeader
@@ -120,6 +121,20 @@ const isEmptyNode = (node: Block): boolean => {
   })
 }
 
+/*
+if we add a slice that is not in mapper mapSlices fails for that slice.
+we dont want a single slice to cause errors on a whole page so we fail them gracefully
+this can e.g. happen when a developer is creating a new slice type and an editor publishes it by accident on a page
+*/
+export const safelyMapSlices = (data) => {
+  try {
+    return mapSlice(data)
+  } catch (error) {
+    logger.error('Failed to map slice in about page', error)
+    return null
+  }
+}
+
 export const mapDocument = (
   document: Document,
   idPrefix: string,
@@ -130,7 +145,7 @@ export const mapDocument = (
   docs.forEach((block, index) => {
     switch (block.nodeType) {
       case BLOCKS.EMBEDDED_ENTRY:
-        slices.push(mapSlice(block.data.target))
+        slices.push(safelyMapSlices(block.data.target))
         break
       case BLOCKS.EMBEDDED_ASSET:
         slices.push(mapImage(block.data.target))
@@ -151,5 +166,5 @@ export const mapDocument = (
     }
   })
 
-  return slices
+  return slices.filter(Boolean) // filter out empty slices that failed mapping
 }


### PR DESCRIPTION
# Safe slice types

New slice types are causing issues on live and dev sites in development

## What

- Made slice types not in mapping logic be ignored

## Why

- To make environments more stable

## Screenshots / Gifs

<img width="1300" alt="Screenshot 2020-09-21 at 11 57 23" src="https://user-images.githubusercontent.com/6640435/93763901-c1835d00-fc01-11ea-96af-2ab41bf282f8.png">
<img width="1488" alt="Screenshot 2020-09-21 at 11 58 11" src="https://user-images.githubusercontent.com/6640435/93763920-c47e4d80-fc01-11ea-9212-4f1f2c9ff9be.png">


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
