### PR TITLE
Always serve index.html as fallback content

### DIFF
--- a/scripts/dockerfile-config/static-nginx.conf
+++ b/scripts/dockerfile-config/static-nginx.conf
@@ -6,6 +6,7 @@ server {
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
+        # The following is necessary for React router based apps
         try_files $uri $uri/ /index.html =404;
     }
 

--- a/scripts/dockerfile-config/static-nginx.conf
+++ b/scripts/dockerfile-config/static-nginx.conf
@@ -6,6 +6,7 @@ server {
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
+        try_files $uri $uri/ /index.html =404;
     }
 
     error_page   500 502 503 504  /50x.html;


### PR DESCRIPTION
# React router gets to route

Fixes #962 

## What

See issue

## Why

The React-based static apps don't work.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
