### PR TITLE
Article source elasticsearch

### DIFF
--- a/apps/api/src/api.graphql
+++ b/apps/api/src/api.graphql
@@ -7,6 +7,7 @@ type HelloWorld {
 }
 
 type Image {
+  typename: String!
   id: ID!
   url: String!
   title: String!
@@ -21,6 +22,7 @@ type Link {
 }
 
 type Html {
+  typename: String!
   id: ID!
   document: JSON!
 }
@@ -43,6 +45,7 @@ type TimelineEvent {
 }
 
 type TimelineSlice {
+  typename: String!
   id: ID!
   title: String!
   events: [TimelineEvent!]!
@@ -132,9 +135,10 @@ type SubArticle {
   body: [Slice!]!
 }
 
-union Slice = PageHeaderSlice | TimelineSlice | HeadingSlice | StorySlice | LinkCardSlice | LatestNewsSlice | MailingListSignupSlice | LogoListSlice | BulletListSlice | Html | Image | Statistics | ProcessEntry | FaqList | EmbeddedVideo | SectionWithImage
+union Slice = PageHeaderSlice | TimelineSlice | MailingListSignupSlice | HeadingSlice | LinkCardSlice | StorySlice | LogoListSlice | LatestNewsSlice | BulletListSlice | Statistics | ProcessEntry | FaqList | EmbeddedVideo | SectionWithImage | Html | Image
 
 type PageHeaderSlice {
+  typename: String!
   id: ID!
   title: String!
   introduction: String!
@@ -143,31 +147,8 @@ type PageHeaderSlice {
   slices: [TimelineSlice!]!
 }
 
-type HeadingSlice {
-  id: ID!
-  title: String!
-  body: String!
-}
-
-type StorySlice {
-  id: ID!
-  readMoreText: String!
-  stories: [Story!]!
-}
-
-type LinkCardSlice {
-  id: ID!
-  title: String!
-  cards: [LinkCard!]!
-}
-
-type LatestNewsSlice {
-  id: ID!
-  title: String!
-  news: [News!]!
-}
-
 type MailingListSignupSlice {
+  typename: String!
   id: ID!
   title: String!
   description: String
@@ -175,14 +156,44 @@ type MailingListSignupSlice {
   buttonText: String!
 }
 
+type HeadingSlice {
+  typename: String!
+  id: ID!
+  title: String!
+  body: String!
+}
+
+type LinkCardSlice {
+  typename: String!
+  id: ID!
+  title: String!
+  cards: [LinkCard!]!
+}
+
+type StorySlice {
+  typename: String!
+  id: ID!
+  readMoreText: String!
+  stories: [Story!]!
+}
+
 type LogoListSlice {
+  typename: String!
   id: ID!
   title: String!
   body: String!
   images: [Image!]!
 }
 
+type LatestNewsSlice {
+  typename: String!
+  id: ID!
+  title: String!
+  news: [News!]!
+}
+
 type BulletListSlice {
+  typename: String!
   id: ID!
   bullets: [BulletEntry!]!
 }
@@ -205,12 +216,14 @@ type NumberBulletGroup {
 }
 
 type Statistics {
+  typename: String!
   id: ID!
   title: String!
   statistics: [Statistic!]!
 }
 
 type ProcessEntry {
+  typename: String!
   id: ID!
   type: String!
   processTitle: String!
@@ -219,18 +232,21 @@ type ProcessEntry {
 }
 
 type FaqList {
+  typename: String!
   id: ID!
   title: String!
   questions: [QuestionAndAnswer!]!
 }
 
 type EmbeddedVideo {
+  typename: String!
   id: ID!
   title: String!
   url: String!
 }
 
 type SectionWithImage {
+  typename: String!
   id: ID!
   title: String!
   image: Image
@@ -521,7 +537,6 @@ type DocumentCategory {
 
 type Query {
   helloWorld(input: HelloWorldInput!): HelloWorld!
-  getArticle(input: GetArticleInput!): Article
   getNewsList(input: GetNewsListInput!): PaginatedNews!
   getAdgerdirNewsList(input: GetAdgerdirNewsListInput!): PaginatedAdgerdirNews!
   getNamespace(input: GetNamespaceInput!): Namespace
@@ -543,6 +558,7 @@ type Query {
   getLifeEvents(input: GetLifeEventsInput!): [LifeEventPage!]!
   getLifeEventsInCategory(input: GetLifeEventsInCategoryInput!): [LifeEventPage!]!
   getArticleCategories(input: GetArticleCategoriesInput!): [ArticleCategory!]!
+  getSingleArticle(input: GetSingleArticleInput!): Article
   getArticles(input: GetArticlesInput!): [Article!]!
   getSingleNews(input: GetSingleNewsInput!): News
   getUrl(input: GetUrlInput!): Url
@@ -559,11 +575,6 @@ type Query {
 
 input HelloWorldInput {
   name: String = "World"
-}
-
-input GetArticleInput {
-  slug: String
-  lang: String!
 }
 
 input GetNewsListInput {
@@ -671,6 +682,11 @@ input GetLifeEventsInCategoryInput {
 input GetArticleCategoriesInput {
   lang: String!
   size: Int
+}
+
+input GetSingleArticleInput {
+  slug: String!
+  lang: String!
 }
 
 input GetArticlesInput {

--- a/apps/web/graphql/schema.ts
+++ b/apps/web/graphql/schema.ts
@@ -607,7 +607,6 @@ export type DocumentCategory = {
 export type Query = {
   __typename?: 'Query'
   helloWorld: HelloWorld
-  getArticle?: Maybe<Article>
   getNewsList: PaginatedNews
   getAdgerdirNewsList: PaginatedAdgerdirNews
   getNamespace?: Maybe<Namespace>
@@ -629,6 +628,7 @@ export type Query = {
   getLifeEvents: Array<LifeEventPage>
   getLifeEventsInCategory: Array<LifeEventPage>
   getArticleCategories: Array<ArticleCategory>
+  getSingleArticle?: Maybe<Article>
   getArticles: Array<Article>
   getSingleNews?: Maybe<News>
   getUrl?: Maybe<Url>
@@ -645,10 +645,6 @@ export type Query = {
 
 export type QueryHelloWorldArgs = {
   input: HelloWorldInput
-}
-
-export type QueryGetArticleArgs = {
-  input: GetArticleInput
 }
 
 export type QueryGetNewsListArgs = {
@@ -735,6 +731,10 @@ export type QueryGetArticleCategoriesArgs = {
   input: GetArticleCategoriesInput
 }
 
+export type QueryGetSingleArticleArgs = {
+  input: GetSingleArticleInput
+}
+
 export type QueryGetArticlesArgs = {
   input: GetArticlesInput
 }
@@ -781,11 +781,6 @@ export type QueryGetTranslationsArgs = {
 
 export type HelloWorldInput = {
   name?: Maybe<Scalars['String']>
-}
-
-export type GetArticleInput = {
-  slug?: Maybe<Scalars['String']>
-  lang: Scalars['String']
 }
 
 export type GetNewsListInput = {
@@ -893,6 +888,11 @@ export type GetLifeEventsInCategoryInput = {
 export type GetArticleCategoriesInput = {
   lang: Scalars['String']
   size?: Maybe<Scalars['Int']>
+}
+
+export type GetSingleArticleInput = {
+  slug: Scalars['String']
+  lang: Scalars['String']
 }
 
 export type GetArticlesInput = {
@@ -1130,12 +1130,12 @@ export type GetAlertBannerQuery = { __typename?: 'Query' } & {
   >
 }
 
-export type GetArticleQueryVariables = Exact<{
-  input: GetArticleInput
+export type GetSingleArticleQueryVariables = Exact<{
+  input: GetSingleArticleInput
 }>
 
-export type GetArticleQuery = { __typename?: 'Query' } & {
-  getArticle?: Maybe<
+export type GetSingleArticleQuery = { __typename?: 'Query' } & {
+  getSingleArticle?: Maybe<
     { __typename?: 'Article' } & Pick<
       Article,
       | 'id'

--- a/apps/web/screens/Article.tsx
+++ b/apps/web/screens/Article.tsx
@@ -36,12 +36,12 @@ import { CustomNextError } from '@island.is/web/units/errors'
 import {
   QueryGetNamespaceArgs,
   GetNamespaceQuery,
-  QueryGetArticleArgs,
-  GetArticleQuery,
   Article,
   SubArticle,
   Slice,
   ProcessEntry,
+  GetSingleArticleQuery,
+  QueryGetSingleArticleArgs,
 } from '@island.is/web/graphql/schema'
 import { createNavigation } from '@island.is/web/utils/navigation'
 import useScrollSpy from '@island.is/web/hooks/useScrollSpy'
@@ -480,7 +480,7 @@ ArticleScreen.getInitialProps = async ({ apolloClient, query, locale }) => {
 
   const [article, namespace] = await Promise.all([
     apolloClient
-      .query<GetArticleQuery, QueryGetArticleArgs>({
+      .query<GetSingleArticleQuery, QueryGetSingleArticleArgs>({
         query: GET_ARTICLE_QUERY,
         variables: {
           input: {
@@ -489,7 +489,7 @@ ArticleScreen.getInitialProps = async ({ apolloClient, query, locale }) => {
           },
         },
       })
-      .then((r) => r.data.getArticle),
+      .then((response) => response.data.getSingleArticle),
     apolloClient
       .query<GetNamespaceQuery, QueryGetNamespaceArgs>({
         query: GET_NAMESPACE_QUERY,

--- a/apps/web/screens/queries/Article.tsx
+++ b/apps/web/screens/queries/Article.tsx
@@ -2,8 +2,8 @@ import gql from 'graphql-tag'
 import { slices } from './fragments'
 
 export const GET_ARTICLE_QUERY = gql`
-  query GetArticle($input: GetArticleInput!) {
-    getArticle(input: $input) {
+  query GetSingleArticle($input: GetSingleArticleInput!) {
+    getSingleArticle(input: $input) {
       id
       slug
       title

--- a/libs/api/domains/cms/src/lib/cms.elasticsearch.service.ts
+++ b/libs/api/domains/cms/src/lib/cms.elasticsearch.service.ts
@@ -9,7 +9,7 @@ import { Article } from './models/article.model'
 
 @Injectable()
 export class CmsElasticsearchService {
-  constructor(private elasticService: ElasticService) { }
+  constructor(private elasticService: ElasticService) {}
 
   async getArticleCategories(
     index: SearchIndexes,
@@ -49,7 +49,10 @@ export class CmsElasticsearchService {
     )
   }
 
-  async getSingleDocumentTypeBySlug<RequestedType>(index: SearchIndexes, { type, slug }: { type: string, slug: string }): Promise<RequestedType | null> {
+  async getSingleDocumentTypeBySlug<RequestedType>(
+    index: SearchIndexes,
+    { type, slug }: { type: string; slug: string },
+  ): Promise<RequestedType | null> {
     // return a single news item by slug
     const query = { types: [type], tags: [{ type: 'slug', key: slug }] }
     const newsResponse = await this.elasticService.getDocumentsByMetaData(

--- a/libs/api/domains/cms/src/lib/cms.elasticsearch.service.ts
+++ b/libs/api/domains/cms/src/lib/cms.elasticsearch.service.ts
@@ -9,7 +9,7 @@ import { Article } from './models/article.model'
 
 @Injectable()
 export class CmsElasticsearchService {
-  constructor(private elasticService: ElasticService) {}
+  constructor(private elasticService: ElasticService) { }
 
   async getArticleCategories(
     index: SearchIndexes,
@@ -49,9 +49,9 @@ export class CmsElasticsearchService {
     )
   }
 
-  async getNews(index: SearchIndexes, { slug }: { slug: string }) {
+  async getSingleDocumentTypeBySlug<RequestedType>(index: SearchIndexes, { type, slug }: { type: string, slug: string }): Promise<RequestedType | null> {
     // return a single news item by slug
-    const query = { types: ['webNews'], tags: [{ type: 'slug', key: slug }] }
+    const query = { types: [type], tags: [{ type: 'slug', key: slug }] }
     const newsResponse = await this.elasticService.getDocumentsByMetaData(
       index,
       query,

--- a/libs/api/domains/cms/src/lib/cms.resolver.ts
+++ b/libs/api/domains/cms/src/lib/cms.resolver.ts
@@ -69,7 +69,7 @@ export class CmsResolver {
   constructor(
     private readonly cmsContentfulService: CmsContentfulService,
     private readonly cmsElasticsearchService: CmsElasticsearchService,
-  ) { }
+  ) {}
 
   @Directive(cacheControlDirective())
   @Query(() => PaginatedNews)
@@ -262,10 +262,12 @@ export class CmsResolver {
 
   @Directive(cacheControlDirective())
   @Query(() => Article, { nullable: true })
-  getSingleArticle(@Args('input') { lang, slug }: GetSingleArticleInput): Promise<Article | null> {
+  getSingleArticle(
+    @Args('input') { lang, slug }: GetSingleArticleInput,
+  ): Promise<Article | null> {
     return this.cmsElasticsearchService.getSingleDocumentTypeBySlug<Article>(
       SearchIndexes[lang],
-      { type: 'webArticle', slug }
+      { type: 'webArticle', slug },
     )
   }
 
@@ -284,7 +286,7 @@ export class CmsResolver {
   ): Promise<News | null> {
     return this.cmsElasticsearchService.getSingleDocumentTypeBySlug<News>(
       SearchIndexes[lang],
-      { type: 'webNews', slug }
+      { type: 'webNews', slug },
     )
   }
 
@@ -300,7 +302,7 @@ export class CmsResolver {
 
 @Resolver(() => LatestNewsSlice)
 export class LatestNewsSliceResolver {
-  constructor(private cmsContentfulService: CmsContentfulService) { }
+  constructor(private cmsContentfulService: CmsContentfulService) {}
 
   @ResolveField(() => [News])
   async news() {
@@ -314,7 +316,7 @@ export class LatestNewsSliceResolver {
 
 @Resolver(() => Article)
 export class ArticleResolver {
-  constructor(private cmsContentfulService: CmsContentfulService) { }
+  constructor(private cmsContentfulService: CmsContentfulService) {}
 
   @ResolveField(() => [Article])
   async relatedArticles(@Parent() article: Article) {

--- a/libs/api/domains/cms/src/lib/dto/getSingleArticle.input.ts
+++ b/libs/api/domains/cms/src/lib/dto/getSingleArticle.input.ts
@@ -1,0 +1,13 @@
+import { Field, InputType } from '@nestjs/graphql'
+import { IsString } from 'class-validator'
+
+@InputType()
+export class GetSingleArticleInput {
+  @Field()
+  @IsString()
+  slug: string
+
+  @Field()
+  @IsString()
+  lang: string
+}

--- a/libs/api/domains/cms/src/lib/models/bulletListSlice.model.ts
+++ b/libs/api/domains/cms/src/lib/models/bulletListSlice.model.ts
@@ -6,9 +6,8 @@ import { BulletEntry, mapBulletEntry } from './bulletEntry.model'
 
 @ObjectType()
 export class BulletListSlice {
-  constructor(initializer: BulletListSlice) {
-    Object.assign(this, initializer)
-  }
+  @Field()
+  typename: string
 
   @Field(() => ID)
   id: string
@@ -20,8 +19,8 @@ export class BulletListSlice {
 export const mapBulletListSlice = ({
   fields,
   sys,
-}: IBigBulletList): BulletListSlice =>
-  new BulletListSlice({
-    id: sys.id,
-    bullets: fields.bullets.map(mapBulletEntry),
-  })
+}: IBigBulletList): BulletListSlice => ({
+  typename: 'BulletListSlice',
+  id: sys.id,
+  bullets: fields.bullets.map(mapBulletEntry),
+})

--- a/libs/api/domains/cms/src/lib/models/embeddedVideo.model.ts
+++ b/libs/api/domains/cms/src/lib/models/embeddedVideo.model.ts
@@ -4,9 +4,8 @@ import { IEmbeddedVideo } from '../generated/contentfulTypes'
 
 @ObjectType()
 export class EmbeddedVideo {
-  constructor(initializer: EmbeddedVideo) {
-    Object.assign(this, initializer)
-  }
+  @Field()
+  typename: string
 
   @Field(() => ID)
   id: string
@@ -21,8 +20,8 @@ export class EmbeddedVideo {
 export const mapEmbeddedVideo = ({
   fields,
   sys,
-}: IEmbeddedVideo): EmbeddedVideo =>
-  new EmbeddedVideo({
-    id: sys.id,
-    ...fields,
-  })
+}: IEmbeddedVideo): EmbeddedVideo => ({
+  typename: 'EmbeddedVideo',
+  id: sys.id,
+  ...fields,
+})

--- a/libs/api/domains/cms/src/lib/models/faqList.model.ts
+++ b/libs/api/domains/cms/src/lib/models/faqList.model.ts
@@ -9,9 +9,8 @@ import {
 
 @ObjectType()
 export class FaqList {
-  constructor(initializer: FaqList) {
-    Object.assign(this, initializer)
-  }
+  @Field()
+  typename: string
 
   @Field(() => ID)
   id: string
@@ -23,9 +22,9 @@ export class FaqList {
   questions: QuestionAndAnswer[]
 }
 
-export const mapFaqList = ({ fields, sys }: IFaqList): FaqList =>
-  new FaqList({
-    id: sys.id,
-    title: fields.title,
-    questions: (fields.questions ?? []).map(mapQuestionAndAnswer),
-  })
+export const mapFaqList = ({ fields, sys }: IFaqList): FaqList => ({
+  typename: 'FaqList',
+  id: sys.id,
+  title: fields.title,
+  questions: (fields.questions ?? []).map(mapQuestionAndAnswer),
+})

--- a/libs/api/domains/cms/src/lib/models/headingSlice.model.ts
+++ b/libs/api/domains/cms/src/lib/models/headingSlice.model.ts
@@ -4,9 +4,8 @@ import { ISectionHeading } from '../generated/contentfulTypes'
 
 @ObjectType()
 export class HeadingSlice {
-  constructor(initializer: HeadingSlice) {
-    Object.assign(this, initializer)
-  }
+  @Field()
+  typename: string
 
   @Field(() => ID)
   id: string
@@ -21,9 +20,9 @@ export class HeadingSlice {
 export const mapHeadingSlice = ({
   fields,
   sys,
-}: ISectionHeading): HeadingSlice =>
-  new HeadingSlice({
-    id: sys.id,
-    title: fields.title ?? '',
-    body: fields.body ?? '',
-  })
+}: ISectionHeading): HeadingSlice => ({
+  typename: 'HeadingSlice',
+  id: sys.id,
+  title: fields.title ?? '',
+  body: fields.body ?? '',
+})

--- a/libs/api/domains/cms/src/lib/models/html.model.ts
+++ b/libs/api/domains/cms/src/lib/models/html.model.ts
@@ -46,6 +46,9 @@ export class Html {
     Object.assign(this, initializer)
   }
 
+  @Field()
+  typename: string
+
   @Field(() => ID)
   id: string
 
@@ -59,12 +62,14 @@ export const mapHtml = (html: Document | TopLevelBlock, id: string): Html => {
   switch (newHtml.nodeType) {
     case BLOCKS.DOCUMENT:
       return new Html({
+        typename: 'Html',
         id: String(id),
         document: newHtml as Document,
       })
 
     default:
       return new Html({
+        typename: 'Html',
         id: String(id),
         document: {
           nodeType: BLOCKS.DOCUMENT,

--- a/libs/api/domains/cms/src/lib/models/image.model.ts
+++ b/libs/api/domains/cms/src/lib/models/image.model.ts
@@ -3,9 +3,8 @@ import { Asset } from 'contentful'
 
 @ObjectType()
 export class Image {
-  constructor(initializer: Image) {
-    Object.assign(this, initializer)
-  }
+  @Field()
+  typename: string
 
   @Field(() => ID)
   id: string
@@ -29,12 +28,13 @@ export class Image {
 export const mapImage = (entry: Asset): Image => {
   const fields = entry?.fields
   const sys = entry?.sys
-  return new Image({
+  return {
+    typename: 'Image',
     id: sys?.id ?? '',
     url: fields?.file?.url ?? '',
     title: fields?.title ?? '',
     contentType: fields?.file?.contentType ?? '',
     width: fields?.file?.details?.image?.width ?? 0,
     height: fields?.file?.details?.image?.height ?? 0,
-  })
+  }
 }

--- a/libs/api/domains/cms/src/lib/models/latestNewsSlice.model.ts
+++ b/libs/api/domains/cms/src/lib/models/latestNewsSlice.model.ts
@@ -6,9 +6,8 @@ import { News } from './news.model'
 
 @ObjectType()
 export class LatestNewsSlice {
-  constructor(initializer: LatestNewsSlice) {
-    Object.assign(this, initializer)
-  }
+  @Field()
+  typename: string
 
   @Field(() => ID)
   id: string
@@ -23,9 +22,9 @@ export class LatestNewsSlice {
 export const mapLatestNewsSlice = ({
   fields,
   sys,
-}: ILatestNewsSlice): LatestNewsSlice =>
-  new LatestNewsSlice({
-    id: sys.id,
-    title: fields.title ?? '',
-    news: [], // populated by resolver
-  })
+}: ILatestNewsSlice): LatestNewsSlice => ({
+  typename: 'LatestNewsSlice',
+  id: sys.id,
+  title: fields.title ?? '',
+  news: [], // populated by resolver
+})

--- a/libs/api/domains/cms/src/lib/models/linkCardSlice.model.ts
+++ b/libs/api/domains/cms/src/lib/models/linkCardSlice.model.ts
@@ -6,9 +6,8 @@ import { LinkCard, mapLinkCard } from './linkCard.model'
 
 @ObjectType()
 export class LinkCardSlice {
-  constructor(initializer: LinkCardSlice) {
-    Object.assign(this, initializer)
-  }
+  @Field()
+  typename: string
 
   @Field(() => ID)
   id: string
@@ -23,9 +22,9 @@ export class LinkCardSlice {
 export const mapLinkCardSlice = ({
   fields,
   sys,
-}: ICardSection): LinkCardSlice =>
-  new LinkCardSlice({
-    id: sys.id,
-    title: fields?.title ?? '',
-    cards: fields.cards.map(mapLinkCard),
-  })
+}: ICardSection): LinkCardSlice => ({
+  typename: 'LinkCardSlice',
+  id: sys.id,
+  title: fields?.title ?? '',
+  cards: fields.cards.map(mapLinkCard),
+})

--- a/libs/api/domains/cms/src/lib/models/logoListSlice.model.ts
+++ b/libs/api/domains/cms/src/lib/models/logoListSlice.model.ts
@@ -6,9 +6,8 @@ import { Image, mapImage } from './image.model'
 
 @ObjectType()
 export class LogoListSlice {
-  constructor(initializer: LogoListSlice) {
-    Object.assign(this, initializer)
-  }
+  @Field()
+  typename: string
 
   @Field(() => ID)
   id: string
@@ -26,10 +25,10 @@ export class LogoListSlice {
 export const mapLogoListSlice = ({
   fields,
   sys,
-}: ILogoListSlice): LogoListSlice =>
-  new LogoListSlice({
-    id: sys.id,
-    title: fields.title ?? '',
-    body: fields.body ?? '',
-    images: (fields.images ?? []).map(mapImage),
-  })
+}: ILogoListSlice): LogoListSlice => ({
+  typename: 'LogoListSlice',
+  id: sys.id,
+  title: fields.title ?? '',
+  body: fields.body ?? '',
+  images: (fields.images ?? []).map(mapImage),
+})

--- a/libs/api/domains/cms/src/lib/models/mailingListSignupSlice.model.ts
+++ b/libs/api/domains/cms/src/lib/models/mailingListSignupSlice.model.ts
@@ -4,9 +4,8 @@ import { IMailingListSignup } from '../generated/contentfulTypes'
 
 @ObjectType()
 export class MailingListSignupSlice {
-  constructor(initializer: MailingListSignupSlice) {
-    Object.assign(this, initializer)
-  }
+  @Field()
+  typename: string
 
   @Field(() => ID)
   id: string
@@ -27,11 +26,11 @@ export class MailingListSignupSlice {
 export const mapMailingListSignup = ({
   fields,
   sys,
-}: IMailingListSignup): MailingListSignupSlice =>
-  new MailingListSignupSlice({
-    id: sys.id,
-    title: fields.title,
-    description: fields.description,
-    inputLabel: fields.inputLabel,
-    buttonText: fields.buttonText,
-  })
+}: IMailingListSignup): MailingListSignupSlice => ({
+  typename: 'MailingListSignupSlice',
+  id: sys.id,
+  title: fields.title,
+  description: fields.description,
+  inputLabel: fields.inputLabel,
+  buttonText: fields.buttonText,
+})

--- a/libs/api/domains/cms/src/lib/models/pageHeaderSlice.model.ts
+++ b/libs/api/domains/cms/src/lib/models/pageHeaderSlice.model.ts
@@ -1,15 +1,12 @@
 import { Field, ID, ObjectType } from '@nestjs/graphql'
-
 import { IPageHeader } from '../generated/contentfulTypes'
-
 import { Link, mapLink } from './link.model'
 import { TimelineSlice, mapTimelineSlice } from './timelineSlice.model'
 
 @ObjectType()
 export class PageHeaderSlice {
-  constructor(initializer: PageHeaderSlice) {
-    Object.assign(this, initializer)
-  }
+  @Field()
+  typename: string
 
   @Field(() => ID)
   id: string
@@ -33,12 +30,12 @@ export class PageHeaderSlice {
 export const mapPageHeaderSlice = ({
   fields,
   sys,
-}: IPageHeader): PageHeaderSlice =>
-  new PageHeaderSlice({
-    id: sys.id,
-    title: fields.title,
-    introduction: fields.introduction,
-    navigationText: fields.navigationText,
-    links: (fields.links ?? []).map(mapLink),
-    slices: fields.slices.map(mapTimelineSlice),
-  })
+}: IPageHeader): PageHeaderSlice => ({
+  typename: 'PageHeaderSlice',
+  id: sys.id,
+  title: fields.title,
+  introduction: fields.introduction,
+  navigationText: fields.navigationText,
+  links: (fields.links ?? []).map(mapLink),
+  slices: fields.slices.map(mapTimelineSlice),
+})

--- a/libs/api/domains/cms/src/lib/models/processEntry.model.ts
+++ b/libs/api/domains/cms/src/lib/models/processEntry.model.ts
@@ -23,7 +23,10 @@ export class ProcessEntry {
   buttonText: string
 }
 
-export const mapProcessEntry = ({ fields, sys }: IProcessEntry): ProcessEntry => ({
+export const mapProcessEntry = ({
+  fields,
+  sys,
+}: IProcessEntry): ProcessEntry => ({
   typename: 'ProcessEntry',
   id: sys.id,
   type: fields?.type ?? '',

--- a/libs/api/domains/cms/src/lib/models/processEntry.model.ts
+++ b/libs/api/domains/cms/src/lib/models/processEntry.model.ts
@@ -4,9 +4,8 @@ import { IProcessEntry } from '../generated/contentfulTypes'
 
 @ObjectType()
 export class ProcessEntry {
-  constructor(initializer: ProcessEntry) {
-    Object.assign(this, initializer)
-  }
+  @Field()
+  typename: string
 
   @Field(() => ID)
   id: string
@@ -24,11 +23,11 @@ export class ProcessEntry {
   buttonText: string
 }
 
-export const mapProcessEntry = ({ fields, sys }: IProcessEntry): ProcessEntry =>
-  new ProcessEntry({
-    id: sys.id,
-    type: fields.type,
-    processTitle: fields.processTitle,
-    processLink: fields.processLink,
-    buttonText: fields.buttonText ?? '',
-  })
+export const mapProcessEntry = ({ fields, sys }: IProcessEntry): ProcessEntry => ({
+  typename: 'ProcessEntry',
+  id: sys.id,
+  type: fields?.type ?? '',
+  processTitle: fields?.processTitle ?? '',
+  processLink: fields?.processLink ?? '',
+  buttonText: fields?.buttonText ?? '',
+})

--- a/libs/api/domains/cms/src/lib/models/sectionWithImage.model.ts
+++ b/libs/api/domains/cms/src/lib/models/sectionWithImage.model.ts
@@ -6,9 +6,8 @@ import { Html, mapHtml } from './html.model'
 
 @ObjectType()
 export class SectionWithImage {
-  constructor(initializer: SectionWithImage) {
-    Object.assign(this, initializer)
-  }
+  @Field()
+  typename: string
 
   @Field(() => ID)
   id: string
@@ -26,10 +25,10 @@ export class SectionWithImage {
 export const mapSectionWithImage = ({
   fields,
   sys,
-}: ISectionWithImage): SectionWithImage =>
-  new SectionWithImage({
-    id: sys.id,
-    title: fields.title ?? '',
-    image: fields.image?.fields?.file ? mapImage(fields.image) : null,
-    html: mapHtml(fields.body, sys.id + ':html'),
-  })
+}: ISectionWithImage): SectionWithImage => ({
+  typename: 'SectionWithImage',
+  id: sys.id,
+  title: fields.title ?? '',
+  image: fields.image?.fields?.file ? mapImage(fields.image) : null,
+  html: mapHtml(fields.body, sys.id + ':html'),
+})

--- a/libs/api/domains/cms/src/lib/models/slice.model.ts
+++ b/libs/api/domains/cms/src/lib/models/slice.model.ts
@@ -74,9 +74,9 @@ export const Slice = createUnionType({
     EmbeddedVideo,
     SectionWithImage,
     Html,
-    Image
+    Image,
   ],
-  resolveType: (document) => document.typename,// typename is appended to request on indexing
+  resolveType: (document) => document.typename, // typename is appended to request on indexing
 })
 
 export const mapSlice = (slice: SliceTypes): typeof Slice => {

--- a/libs/api/domains/cms/src/lib/models/slice.model.ts
+++ b/libs/api/domains/cms/src/lib/models/slice.model.ts
@@ -61,21 +61,22 @@ export const Slice = createUnionType({
   types: () => [
     PageHeaderSlice,
     TimelineSlice,
-    HeadingSlice,
-    StorySlice,
-    LinkCardSlice,
-    LatestNewsSlice,
     MailingListSignupSlice,
+    HeadingSlice,
+    LinkCardSlice,
+    StorySlice,
     LogoListSlice,
+    LatestNewsSlice,
     BulletListSlice,
-    Html,
-    Image,
     Statistics,
     ProcessEntry,
     FaqList,
     EmbeddedVideo,
     SectionWithImage,
+    Html,
+    Image
   ],
+  resolveType: (document) => document.typename,// typename is appended to request on indexing
 })
 
 export const mapSlice = (slice: SliceTypes): typeof Slice => {

--- a/libs/api/domains/cms/src/lib/models/statistics.model.ts
+++ b/libs/api/domains/cms/src/lib/models/statistics.model.ts
@@ -6,9 +6,8 @@ import { Statistic, mapStatistic } from './statistic.model'
 
 @ObjectType()
 export class Statistics {
-  constructor(initializer: Statistics) {
-    Object.assign(this, initializer)
-  }
+  @Field()
+  typename: string
 
   @Field(() => ID)
   id: string
@@ -20,9 +19,9 @@ export class Statistics {
   statistics: Statistic[]
 }
 
-export const mapStatistics = ({ fields, sys }: IStatistics): Statistics =>
-  new Statistics({
-    id: sys.id,
-    title: fields.title ?? '',
-    statistics: fields.statistics.map(mapStatistic),
-  })
+export const mapStatistics = ({ fields, sys }: IStatistics): Statistics => ({
+  typename: 'Statistics',
+  id: sys.id,
+  title: fields.title ?? '',
+  statistics: fields.statistics.map(mapStatistic),
+})

--- a/libs/api/domains/cms/src/lib/models/storySlice.model.ts
+++ b/libs/api/domains/cms/src/lib/models/storySlice.model.ts
@@ -6,9 +6,8 @@ import { Story, mapStory } from './story.model'
 
 @ObjectType()
 export class StorySlice {
-  constructor(initializer: StorySlice) {
-    Object.assign(this, initializer)
-  }
+  @Field()
+  typename: string
 
   @Field(() => ID)
   id: string
@@ -20,9 +19,9 @@ export class StorySlice {
   stories: Story[]
 }
 
-export const mapStorySlice = ({ fields, sys }: IStorySection): StorySlice =>
-  new StorySlice({
-    id: sys.id,
-    readMoreText: fields.readMoreText ?? '',
-    stories: fields.stories.map(mapStory),
-  })
+export const mapStorySlice = ({ fields, sys }: IStorySection): StorySlice => ({
+  typename: 'StorySlice',
+  id: sys.id,
+  readMoreText: fields.readMoreText ?? '',
+  stories: fields.stories.map(mapStory),
+})

--- a/libs/api/domains/cms/src/lib/models/timelineSlice.model.ts
+++ b/libs/api/domains/cms/src/lib/models/timelineSlice.model.ts
@@ -19,7 +19,10 @@ export class TimelineSlice {
   events: TimelineEvent[]
 }
 
-export const mapTimelineSlice = ({ fields, sys }: ITimeline): TimelineSlice => ({
+export const mapTimelineSlice = ({
+  fields,
+  sys,
+}: ITimeline): TimelineSlice => ({
   typename: 'TimelineSlice',
   id: sys.id,
   title: fields.title ?? '',

--- a/libs/api/domains/cms/src/lib/models/timelineSlice.model.ts
+++ b/libs/api/domains/cms/src/lib/models/timelineSlice.model.ts
@@ -6,9 +6,8 @@ import { TimelineEvent, mapTimelineEvent } from './timelineEvent.model'
 
 @ObjectType()
 export class TimelineSlice {
-  constructor(initializer: TimelineSlice) {
-    Object.assign(this, initializer)
-  }
+  @Field()
+  typename: string
 
   @Field(() => ID)
   id: string
@@ -20,9 +19,9 @@ export class TimelineSlice {
   events: TimelineEvent[]
 }
 
-export const mapTimelineSlice = ({ fields, sys }: ITimeline): TimelineSlice =>
-  new TimelineSlice({
-    id: sys.id,
-    title: fields.title ?? '',
-    events: fields.events.map(mapTimelineEvent),
-  })
+export const mapTimelineSlice = ({ fields, sys }: ITimeline): TimelineSlice => ({
+  typename: 'TimelineSlice',
+  id: sys.id,
+  title: fields.title ?? '',
+  events: fields.events.map(mapTimelineEvent),
+})

--- a/libs/api/schema/src/lib/schema.d.ts
+++ b/libs/api/schema/src/lib/schema.d.ts
@@ -618,7 +618,6 @@ export type DocumentCategory = {
 export type Query = {
   __typename?: 'Query'
   helloWorld: HelloWorld
-  getArticle?: Maybe<Article>
   getNewsList: PaginatedNews
   getAdgerdirNewsList: PaginatedAdgerdirNews
   getNamespace?: Maybe<Namespace>
@@ -640,6 +639,7 @@ export type Query = {
   getLifeEvents: Array<LifeEventPage>
   getLifeEventsInCategory: Array<LifeEventPage>
   getArticleCategories: Array<ArticleCategory>
+  getSingleArticle?: Maybe<Article>
   getArticles: Array<Article>
   getSingleNews?: Maybe<News>
   getUrl?: Maybe<Url>
@@ -656,10 +656,6 @@ export type Query = {
 
 export type QueryHelloWorldArgs = {
   input: HelloWorldInput
-}
-
-export type QueryGetArticleArgs = {
-  input: GetArticleInput
 }
 
 export type QueryGetNewsListArgs = {
@@ -746,6 +742,10 @@ export type QueryGetArticleCategoriesArgs = {
   input: GetArticleCategoriesInput
 }
 
+export type QueryGetSingleArticleArgs = {
+  input: GetSingleArticleInput
+}
+
 export type QueryGetArticlesArgs = {
   input: GetArticlesInput
 }
@@ -792,11 +792,6 @@ export type QueryGetTranslationsArgs = {
 
 export type HelloWorldInput = {
   name?: Maybe<Scalars['String']>
-}
-
-export type GetArticleInput = {
-  slug?: Maybe<Scalars['String']>
-  lang: Scalars['String']
 }
 
 export type GetNewsListInput = {
@@ -904,6 +899,11 @@ export type GetLifeEventsInCategoryInput = {
 export type GetArticleCategoriesInput = {
   lang: Scalars['String']
   size?: Maybe<Scalars['Int']>
+}
+
+export type GetSingleArticleInput = {
+  slug: Scalars['String']
+  lang: Scalars['String']
 }
 
 export type GetArticlesInput = {
@@ -1329,7 +1329,6 @@ export type ResolversTypes = {
   DocumentCategory: ResolverTypeWrapper<DocumentCategory>
   Query: ResolverTypeWrapper<{}>
   HelloWorldInput: HelloWorldInput
-  GetArticleInput: GetArticleInput
   GetNewsListInput: GetNewsListInput
   GetAdgerdirNewsListInput: GetAdgerdirNewsListInput
   GetNamespaceInput: GetNamespaceInput
@@ -1351,6 +1350,7 @@ export type ResolversTypes = {
   GetLifeEventsInput: GetLifeEventsInput
   GetLifeEventsInCategoryInput: GetLifeEventsInCategoryInput
   GetArticleCategoriesInput: GetArticleCategoriesInput
+  GetSingleArticleInput: GetSingleArticleInput
   GetArticlesInput: GetArticlesInput
   GetSingleNewsInput: GetSingleNewsInput
   GetUrlInput: GetUrlInput
@@ -1503,7 +1503,6 @@ export type ResolversParentTypes = {
   DocumentCategory: DocumentCategory
   Query: {}
   HelloWorldInput: HelloWorldInput
-  GetArticleInput: GetArticleInput
   GetNewsListInput: GetNewsListInput
   GetAdgerdirNewsListInput: GetAdgerdirNewsListInput
   GetNamespaceInput: GetNamespaceInput
@@ -1525,6 +1524,7 @@ export type ResolversParentTypes = {
   GetLifeEventsInput: GetLifeEventsInput
   GetLifeEventsInCategoryInput: GetLifeEventsInCategoryInput
   GetArticleCategoriesInput: GetArticleCategoriesInput
+  GetSingleArticleInput: GetSingleArticleInput
   GetArticlesInput: GetArticlesInput
   GetSingleNewsInput: GetSingleNewsInput
   GetUrlInput: GetUrlInput
@@ -2595,12 +2595,6 @@ export type QueryResolvers<
     ContextType,
     RequireFields<QueryHelloWorldArgs, 'input'>
   >
-  getArticle?: Resolver<
-    Maybe<ResolversTypes['Article']>,
-    ParentType,
-    ContextType,
-    RequireFields<QueryGetArticleArgs, 'input'>
-  >
   getNewsList?: Resolver<
     ResolversTypes['PaginatedNews'],
     ParentType,
@@ -2726,6 +2720,12 @@ export type QueryResolvers<
     ParentType,
     ContextType,
     RequireFields<QueryGetArticleCategoriesArgs, 'input'>
+  >
+  getSingleArticle?: Resolver<
+    Maybe<ResolversTypes['Article']>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryGetSingleArticleArgs, 'input'>
   >
   getArticles?: Resolver<
     Array<ResolversTypes['Article']>,


### PR DESCRIPTION
# Get articles from elasticsearch

To reduce risk of article being found in search engine and not accessible through contentful we are using the search engine to display the article. 

## What

- Got source data from elastic instead of Contentful
- Added type resolvers to mapping logic

## Why

- Increase stability of website
- To keep search results and content in sync

## Screenshots / Gifs

<img width="1411" alt="Screenshot 2020-09-21 at 17 37 21" src="https://user-images.githubusercontent.com/6640435/93801324-58b3d900-fc31-11ea-8016-93e27d82e35c.png">

<img width="1482" alt="Screenshot 2020-09-21 at 17 38 50" src="https://user-images.githubusercontent.com/6640435/93801331-5c476000-fc31-11ea-85b2-b317b5593e85.png">

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
