### PR TITLE
Tweaks to frontpage slider

### DIFF
--- a/apps/web/components/FrontpageTabs/FrontpageTabs.treat.ts
+++ b/apps/web/components/FrontpageTabs/FrontpageTabs.treat.ts
@@ -4,14 +4,19 @@ import { ThemedStyle, Style } from 'treat/lib/types/types'
 import { theme } from '@island.is/island-ui/theme'
 
 export const animationContainer = style({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
   opacity: 1,
-  transform: `translateX(0)`,
+  // transform: `translateX(0)`,
   transition: `opacity 400ms ease, transform 400ms ease`,
 })
 
 export const animationContainerHidden = style({
   opacity: 0,
-  transform: `translateX(25px)`,
+  // transform: `translateX(25px)`,
 })
 
 const whenMobile = (style: ThemedStyle<Style, ThemeOrAny>) => ({
@@ -26,13 +31,6 @@ export const link = style({
   ':hover': {
     textDecoration: 'none',
   },
-})
-
-export const removeMobileSpacing = style({
-  ...whenMobile({
-    paddingLeft: theme.grid.gutter.mobile / 2,
-    paddingRight: theme.grid.gutter.mobile / 2,
-  }),
 })
 
 export const tabWrapper = style({
@@ -115,8 +113,10 @@ export const dots = style({
 
 export const imageContainer = style({
   position: 'relative',
+  outline: '1px solid red',
   display: 'flex',
   overflow: 'hidden',
+  height: '100%',
   width: '100%',
   alignItems: 'center',
   justifyContent: 'center',
@@ -148,7 +148,10 @@ export const arrowButtonDisabled = style({
 })
 
 export const searchContentContainer = style({
+  borderRadius: theme.border.radius.large,
   ...whenMobile({
     borderRadius: 0,
+    width: 'calc(100% + 60px)',
+    marginLeft: -30,
   }),
 })

--- a/apps/web/components/FrontpageTabs/FrontpageTabs.treat.ts
+++ b/apps/web/components/FrontpageTabs/FrontpageTabs.treat.ts
@@ -149,7 +149,8 @@ export const searchContentContainer = style({
   borderRadius: theme.border.radius.large,
   ...whenMobile({
     borderRadius: 0,
-    width: 'calc(100% + 60px)',
-    marginLeft: -30,
+    marginLeft: -24,
+    marginRight: -24,
+    width: `calc(100% + ${24 * 2}px)`,
   }),
 })

--- a/apps/web/components/FrontpageTabs/FrontpageTabs.treat.ts
+++ b/apps/web/components/FrontpageTabs/FrontpageTabs.treat.ts
@@ -5,6 +5,7 @@ import { theme } from '@island.is/island-ui/theme'
 
 export const animationContainer = style({
   position: 'absolute',
+  display: 'inline-block',
   top: 0,
   left: 0,
   right: 0,
@@ -111,13 +112,10 @@ export const dots = style({
 
 export const imageContainer = style({
   position: 'relative',
-  outline: '1px solid red',
-  display: 'flex',
+  display: 'inline-block',
   overflow: 'hidden',
   height: '100%',
   width: '100%',
-  alignItems: 'center',
-  justifyContent: 'center',
 })
 
 export const arrowButton = style({

--- a/apps/web/components/FrontpageTabs/FrontpageTabs.treat.ts
+++ b/apps/web/components/FrontpageTabs/FrontpageTabs.treat.ts
@@ -10,13 +10,11 @@ export const animationContainer = style({
   right: 0,
   bottom: 0,
   opacity: 1,
-  // transform: `translateX(0)`,
-  transition: `opacity 400ms ease, transform 400ms ease`,
+  transition: `opacity 400ms ease`,
 })
 
 export const animationContainerHidden = style({
   opacity: 0,
-  // transform: `translateX(25px)`,
 })
 
 const whenMobile = (style: ThemedStyle<Style, ThemeOrAny>) => ({

--- a/apps/web/components/FrontpageTabs/FrontpageTabs.tsx
+++ b/apps/web/components/FrontpageTabs/FrontpageTabs.tsx
@@ -102,7 +102,7 @@ export const FrontpageTabs: FC<FrontpageTabsProps> = ({
 
   useEffect(() => {
     if (animationContainerRefs.current?.length) {
-      let newAnimations = []
+      const newAnimations = []
 
       animationContainerRefs.current.forEach((x, i) => {
         newAnimations.push(

--- a/apps/web/components/FrontpageTabs/FrontpageTabs.tsx
+++ b/apps/web/components/FrontpageTabs/FrontpageTabs.tsx
@@ -340,7 +340,7 @@ export const FrontpageTabs: FC<FrontpageTabsProps> = ({
               background="blue100"
               paddingTop={[4, 4, 5]}
               paddingBottom={4}
-              paddingX={4}
+              paddingX={[3, 3, 4]}
               className={styles.searchContentContainer}
             >
               {searchContent}

--- a/apps/web/components/FrontpageTabs/FrontpageTabs.tsx
+++ b/apps/web/components/FrontpageTabs/FrontpageTabs.tsx
@@ -20,7 +20,6 @@ import {
   GridRow,
   GridColumn,
   Icon,
-  Hidden,
 } from '@island.is/island-ui/core'
 import { Locale } from '@island.is/web/i18n/I18n'
 import routeNames from '@island.is/web/i18n/routeNames'
@@ -28,19 +27,10 @@ import { useI18n } from '../../i18n'
 
 import * as styles from './FrontpageTabs.treat'
 
-type ImageProps = {
-  title: string
-  url: string
-  contentType: string
-  width: number
-  height: number
-}
-
 type TabsProps = {
   subtitle?: string
   title?: string
   content?: string
-  image?: ImageProps
   link?: string
   animationJson?: string
 }
@@ -74,21 +64,13 @@ export const FrontpageTabs: FC<FrontpageTabsProps> = ({
   const [animations, setAnimations] = useState([])
   const animationDataLoaded = useRef(null)
   const [minHeight, setMinHeight] = useState<number>(0)
-  const [maxContainerHeight, setMaxContainerHeight] = useState<number>(0)
   const itemsRef = useRef<Array<HTMLElement | null>>([])
   const [selectedIndex, setSelectedIndex] = useState<number>(0)
-  const [image, setImage] = useState<ImageProps | null>(null)
   const tab = useTabState({
     baseId: 'frontpage-tab',
   })
   const { activeLocale } = useI18n()
   const { makePath } = routeNames(activeLocale as Locale)
-
-  const updateImage = useCallback(() => {
-    if (selectedIndex >= 0) {
-      setImage(tabs[selectedIndex].image)
-    }
-  }, [selectedIndex, tabs])
 
   useEffect(() => {
     if (!animationDataLoaded.current) {
@@ -121,7 +103,6 @@ export const FrontpageTabs: FC<FrontpageTabsProps> = ({
 
   const onResize = useCallback(() => {
     setMinHeight(0)
-    setMaxContainerHeight(0)
 
     let height = 0
 
@@ -132,10 +113,6 @@ export const FrontpageTabs: FC<FrontpageTabsProps> = ({
     })
 
     setMinHeight(height)
-
-    if (contentRef.current) {
-      setMaxContainerHeight(contentRef.current.offsetHeight)
-    }
   }, [itemsRef, contentRef])
 
   const nextSlide = useCallback(() => {
@@ -188,10 +165,8 @@ export const FrontpageTabs: FC<FrontpageTabsProps> = ({
         const ms = index * 100
         span.style.transitionDelay = `${ms}ms`
       })
-
-      updateImage()
     }
-  }, [selectedIndex, updateImage, animations])
+  }, [selectedIndex, animations])
 
   const goTo = (direction: string) => {
     switch (direction) {
@@ -211,34 +186,18 @@ export const FrontpageTabs: FC<FrontpageTabsProps> = ({
       <GridRow>
         <GridColumn hiddenBelow="lg" span="1/12">
           <Box display="flex" height="full" width="full" alignItems="center">
-            <Hidden below="lg">
-              <button
-                onClick={() => goTo('prev')}
-                className={cn(styles.arrowButton, {
-                  [styles.arrowButtonDisabled]: false,
-                })}
-              >
-                <Icon color="red400" width="18" height="18" type="arrowLeft" />
-              </button>
-            </Hidden>
+            <button
+              onClick={() => goTo('prev')}
+              className={cn(styles.arrowButton, {
+                [styles.arrowButtonDisabled]: false,
+              })}
+            >
+              <Icon color="red400" width="18" height="18" type="arrowLeft" />
+            </button>
           </Box>
         </GridColumn>
         <GridColumn span={['12/12', '12/12', '12/12', '6/12']}>
           <Box ref={contentRef}>
-            <Hidden above="md">
-              <Box
-                display="flex"
-                height="full"
-                width="full"
-                marginBottom={2}
-                justifyContent="center"
-                alignItems="center"
-                overflow="hidden"
-                style={{ maxHeight: 220 }}
-              >
-                <Image image={image} />
-              </Box>
-            </Hidden>
             <Box>
               <TabList
                 {...tab}
@@ -347,34 +306,20 @@ export const FrontpageTabs: FC<FrontpageTabsProps> = ({
             </Box>
           </Box>
         </GridColumn>
-        <GridColumn span={['12/12', '12/12', '12/12', '4/12']}>
-          <Box
-            display="flex"
-            height="full"
-            width="full"
-            justifyContent="center"
-            alignItems="center"
-            overflow="hidden"
-            style={{ maxHeight: `${maxContainerHeight}px` }}
-          >
-            <div className={styles.imageContainer}>
-              <Hidden below="lg">
-                {animationData.map((_, index) => {
-                  const visible = index === selectedIndex
+        <GridColumn hiddenBelow="lg" span={['0', '0', '0', '4/12']}>
+          {animationData.map((_, index) => {
+            const visible = index === selectedIndex
 
-                  return (
-                    <div
-                      key={index}
-                      ref={(el) => (animationContainerRefs.current[index] = el)}
-                      className={cn(styles.animationContainer, {
-                        [styles.animationContainerHidden]: !visible,
-                      })}
-                    />
-                  )
+            return (
+              <div
+                key={index}
+                ref={(el) => (animationContainerRefs.current[index] = el)}
+                className={cn(styles.animationContainer, {
+                  [styles.animationContainerHidden]: !visible,
                 })}
-              </Hidden>
-            </div>
-          </Box>
+              />
+            )
+          })}
         </GridColumn>
         <GridColumn hiddenBelow="lg" span="1/12">
           <Box
@@ -384,38 +329,18 @@ export const FrontpageTabs: FC<FrontpageTabsProps> = ({
             justifyContent="flexEnd"
             alignItems="center"
           >
-            <Hidden below="lg">
-              <button
-                onClick={() => goTo('next')}
-                className={cn(styles.arrowButton, {
-                  [styles.arrowButtonDisabled]: false,
-                })}
-              >
-                <Icon color="red400" width="18" height="18" type="arrowRight" />
-              </button>
-            </Hidden>
+            <button
+              onClick={() => goTo('next')}
+              className={cn(styles.arrowButton, {
+                [styles.arrowButtonDisabled]: false,
+              })}
+            >
+              <Icon color="red400" width="18" height="18" type="arrowRight" />
+            </button>
           </Box>
         </GridColumn>
       </GridRow>
     </GridContainer>
-  )
-}
-
-const Image = ({ image = null }: { image?: ImageProps }) => {
-  if (!image) {
-    return null
-  }
-
-  return (
-    <Box
-      display="flex"
-      height="full"
-      width="full"
-      justifyContent="center"
-      alignItems="center"
-    >
-      <img src={image.url} alt={image.title} />
-    </Box>
   )
 }
 

--- a/apps/web/screens/Home.tsx
+++ b/apps/web/screens/Home.tsx
@@ -77,7 +77,7 @@ const Home: Screen<HomeProps> = ({
 
   const searchContent = (
     <Box display="flex" flexDirection="column" width="full">
-      <Stack space={[1, 1, 3]}>
+      <Stack space={4}>
         <Box display="inlineFlex" alignItems="center" width="full">
           <SearchInput
             id="search_input_home"
@@ -88,7 +88,7 @@ const Home: Screen<HomeProps> = ({
             placeholder={n('heroSearchPlaceholder')}
           />
         </Box>
-        <Inline space={1}>
+        <Inline space={2}>
           {featuredArticles.map(({ title, url }, index) => {
             const isLatest = index + 1 === featuredArticles.length
             return (
@@ -114,7 +114,7 @@ const Home: Screen<HomeProps> = ({
 
   return (
     <>
-      <Section paddingY={[0, 0, 3, 3, 6]}>
+      <Section paddingY={[0, 0, 4, 4, 6]}>
         <FrontpageTabs tabs={frontpageSlides} searchContent={searchContent} />
       </Section>
       <Section


### PR DESCRIPTION
## What

Better transitions without destroying and reloading animations, now they fade into each other and each animation restarts.

Also fixed padding to be correct according to design for blue search container.

## Why

Looks better according to the designer.

## Screenshots / Gifs

![Sep-22-2020 10-31-48](https://user-images.githubusercontent.com/8450096/93871884-e1c52180-fcbe-11ea-881e-5a158e94021f.gif)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
