### PR TITLE
Fix Swiper for iOS

### DIFF
--- a/libs/island-ui/core/src/lib/Swiper/Swiper.tsx
+++ b/libs/island-ui/core/src/lib/Swiper/Swiper.tsx
@@ -1,17 +1,24 @@
-import React from 'react'
+import React, { FC, useEffect, useRef, useState } from 'react'
 import cn from 'classnames'
 import * as styles from './Swiper.treat'
-import { useMeasure } from 'react-use'
 
-const Swiper = ({ children }) => {
-  const [ref, { width }] = useMeasure()
+const Swiper: FC = ({ children }) => {
+  const [width, setWidth] = useState<number>(0)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (ref?.current) {
+      const w = ref?.current?.offsetWidth as number
+      setWidth(~~(w * 0.77))
+    }
+  }, [ref.current])
 
   return (
     <div className={styles.root}>
       <div className={cn(styles.container)} ref={ref}>
         <div className={styles.slides}>
           {React.Children.map(children, (child) => (
-            <div className={styles.slide} style={{ width: ~~(width * 0.77) }}>
+            <div className={styles.slide} style={{ width }}>
               {child}
             </div>
           ))}

--- a/libs/island-ui/core/src/lib/Swiper/Swiper.tsx
+++ b/libs/island-ui/core/src/lib/Swiper/Swiper.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useRef, useState } from 'react'
+import React, { FC, useCallback, useEffect, useRef, useState } from 'react'
 import cn from 'classnames'
 import * as styles from './Swiper.treat'
 
@@ -6,12 +6,18 @@ const Swiper: FC = ({ children }) => {
   const [width, setWidth] = useState<number>(0)
   const ref = useRef<HTMLDivElement>(null)
 
-  useEffect(() => {
+  const onResize = useCallback(() => {
     if (ref?.current) {
       const w = ref?.current?.offsetWidth as number
       setWidth(~~(w * 0.77))
     }
-  }, [ref.current])
+  }, [ref])
+
+  useEffect(() => {
+    onResize()
+    window.addEventListener('resize', onResize, { passive: true })
+    return () => window.removeEventListener('resize', onResize)
+  }, [onResize])
 
   return (
     <div className={styles.root}>


### PR DESCRIPTION
## What

For whatever reason that I could not fix, useMeasure was not returning the width of the ref element in iOS. I replaced it with a manual check for offsetWidth on the ref.

## Why

To make Swiper work correctly for iOS (or at least some versions of iOS, was happening in Chrome/Safari).

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
