### PR TITLE
Making the news list in next.js be translatable

### DIFF
--- a/apps/web/screens/NewsList.tsx
+++ b/apps/web/screens/NewsList.tsx
@@ -23,10 +23,7 @@ import {
   GridColumn,
 } from '@island.is/island-ui/core'
 import { withMainLayout } from '@island.is/web/layouts/main'
-import {
-  GET_NEWS_LIST_QUERY,
-  GET_NAMESPACE_QUERY,
-} from './queries'
+import { GET_NEWS_LIST_QUERY, GET_NAMESPACE_QUERY } from './queries'
 import { NewsListLayout } from './Layouts/Layouts'
 import { CustomNextError } from '../units/errors'
 import {
@@ -57,7 +54,7 @@ const NewsList: Screen<NewsListProps> = ({
   namespace,
 }) => {
   const Router = useRouter()
-  const { activeLocale,  } = useI18n()
+  const { activeLocale } = useI18n()
   const { makePath } = routeNames(activeLocale)
   const { format } = useDateUtils()
   const n = useNamespace(namespace)
@@ -152,7 +149,9 @@ const NewsList: Screen<NewsListProps> = ({
         <Stack space={[3, 3, 4]}>
           <Breadcrumbs>
             <Link href={makePath()}>Ísland.is</Link>
-            <Link href={makePath('news')}>{n('newsTitle', 'Fréttir og tilkynningar')}</Link>
+            <Link href={makePath('news')}>
+              {n('newsTitle', 'Fréttir og tilkynningar')}
+            </Link>
           </Breadcrumbs>
           {selectedYear && (
             <Hidden below="lg">


### PR DESCRIPTION
# News list in next.js translatable

https://app.asana.com/0/1183498341031105/1195074272522333/f

## What

Make it so the news list page is in english as well

## Why

So non-native speakers can understand it

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/61151/93894453-45127c00-fcde-11ea-824e-b3d463419a80.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
