### PR TITLE
Removed hypen from ES analyzers name

### DIFF
--- a/apps/services/search-indexer/config/template-is.json
+++ b/apps/services/search-indexer/config/template-is.json
@@ -1,6 +1,6 @@
 {
   "order": 0,
-  "version": 7,
+  "version": 8,
   "index_patterns": ["island-is-v*"],
   "settings": {
     "analysis": {
@@ -25,8 +25,8 @@
         },
         "icelandicDeCompounded": {
           "type": "hyphenation_decompounder",
-          "word_list_path": "analyzers/{HYPHEN-WHITELIST}",
-          "hyphenation_patterns_path": "analyzers/{HYPHEN-PATTERNS}",
+          "word_list_path": "analyzers/{HYPHENWHITELIST}",
+          "hyphenation_patterns_path": "analyzers/{HYPHENPATTERNS}",
           "max_subword_size": 18,
           "min_subword_size": 4
         }

--- a/apps/services/search-indexer/src/migrate/dictionary.ts
+++ b/apps/services/search-indexer/src/migrate/dictionary.ts
@@ -10,8 +10,8 @@ const analyzers = [
   'keywords',
   'synonyms',
   'stopwords',
-  'hyphen-patterns',
-  'hyphen-whitelist',
+  'hyphenpatterns',
+  'hyphenwhitelist',
 ]
 
 const getDictUrl = (type: string, lang: string): string => {


### PR DESCRIPTION
# Fix analyzer names

Attach a link to issue if relevant

## What

Removed hypen from ES analyzers name

## Why

This was causing issues in AWS ES migrate script

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review

## Warnings / Errors

Our elasticsearch dictionaries are in a separate repo, because of that changes to references of dictionary items can issues if/while the dictionaries are out of sync