### PR TITLE
Added translatable strings in category and life events

### DIFF
--- a/apps/web/screens/Category/Category.tsx
+++ b/apps/web/screens/Category/Category.tsx
@@ -28,7 +28,6 @@ import {
   GET_LIFE_EVENTS_IN_CATEGORY_QUERY,
 } from '../queries'
 import { CategoryLayout } from '../Layouts/Layouts'
-import { LifeEventCard } from '../../components/LifeEventsCardsSection/components/LifeEventCard'
 import LifeEventInCategory from './LifeEventInCategory'
 
 import { useNamespace } from '@island.is/web/hooks'
@@ -336,6 +335,7 @@ const Category: Screen<CategoryProps> = ({
                         ? lifeEvent.thumbnail.url
                         : lifeEvent.image.url
                     }
+                    categoryTag={n('categoryTag', 'Lífsviðburður')}
                   />
                 )
               })}

--- a/apps/web/screens/Category/LifeEventInCategory.tsx
+++ b/apps/web/screens/Category/LifeEventInCategory.tsx
@@ -20,6 +20,7 @@ export interface LifeEventInCategoryProps {
   slug: string
   intro: string
   image: string
+  categoryTag: string
 }
 
 const LifeEventInCategory: FC<LifeEventInCategoryProps> = ({
@@ -27,6 +28,7 @@ const LifeEventInCategory: FC<LifeEventInCategoryProps> = ({
   slug,
   intro,
   image,
+  categoryTag,
 }) => {
   const { activeLocale } = useI18n()
   const { makePath } = routeNames(activeLocale)
@@ -54,7 +56,7 @@ const LifeEventInCategory: FC<LifeEventInCategoryProps> = ({
                 {intro}
               </Typography>
               <div className={styles.pushDown}>
-                <Tag>{'Lífsviðburður'}</Tag>
+                <Tag>{categoryTag}</Tag>
               </div>
             </GridRow>
           </GridColumn>

--- a/apps/web/screens/LifeEvent/LifeEvent.tsx
+++ b/apps/web/screens/LifeEvent/LifeEvent.tsx
@@ -77,7 +77,7 @@ export const LifeEvent: Screen<LifeEventProps> = ({
       <ArticleLayout
         sidebar={
           <SidebarNavigation
-            title="Efnisyfirlit"
+            title={n('categoryOverview', 'Efnisyfirlit')}
             navigation={navigation}
             position="right"
           />
@@ -101,7 +101,7 @@ export const LifeEvent: Screen<LifeEventProps> = ({
               <Breadcrumbs>
                 <Link href={makePath()}>Ísland.is</Link>
                 <Tag variant="blue" label>
-                  Lífsviðburður
+                  {n('lifeEventTitle', 'Lífsviðburður')}
                 </Tag>
               </Breadcrumbs>
             </GridColumn>


### PR DESCRIPTION
# More translatable strings - catagory and life events

https://app.asana.com/0/1183498341031105/1195074272522333/f

## What

Translating more UI elements

## Why

So non-native speakers can understand

## Screenshots / Gifs

Because of contentful rate limiting, i was never able to see this change

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against master before asking for a review
