### PR TITLE
Website/ Always sort 'other' subgroup key to bottom.

### DIFF
--- a/apps/web/screens/Category/Category.tsx
+++ b/apps/web/screens/Category/Category.tsx
@@ -177,7 +177,9 @@ const Category: Screen<CategoryProps> = ({
   const sortSubgroups = (articlesBySubgroup: Record<string, Articles>) =>
     Object.keys(articlesBySubgroup).sort((a, b) => {
       // 'undefined' is a valid subgroup key but we'll sort it to the bottom
-      if (a === 'undefined' || b === 'undefined') {
+      if (a === 'undefined') {
+        return 1
+      } else if (b === 'undefined') {
         return -1
       }
 

--- a/apps/web/screens/Category/Category.tsx
+++ b/apps/web/screens/Category/Category.tsx
@@ -176,6 +176,11 @@ const Category: Screen<CategoryProps> = ({
 
   const sortSubgroups = (articlesBySubgroup: Record<string, Articles>) =>
     Object.keys(articlesBySubgroup).sort((a, b) => {
+      // 'undefined' is a valid subgroup key but we'll sort it to the bottom
+      if (a === 'undefined' || b === 'undefined') {
+        return -1
+      }
+
       // Look up the subgroups being sorted and find+compare their importance.
       // If their importance is equal we sort alphabetically.
       const foundA = availableSubgroups.find((subgroup) => subgroup.title === a)


### PR DESCRIPTION
# Fix category subgroup sorting bug


## What

Always sort 'other' subgroup key to bottom.

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/8494120/93914585-464fa300-fcf6-11ea-9678-3ccfec4cd1be.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
