### PR TITLE
Adds integration with document signing service from dokobit

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,6 +24,7 @@ gjafakort/                      @island-is/vice-versa
 /apps/judicial-system/          @island-is/kolibri
 /libs/judicial-system/          @island-is/kolibri
 /libs/nova-sms/                 @island-is/kolibri
+/libs/dokobit-signing           @island-is/kolibri
 
 service-portal*/                @island-is/sendiradid
 /libs/api/domains/documents/    @island-is/sendiradid

--- a/libs/dokobit-signing/.eslintrc
+++ b/libs/dokobit-signing/.eslintrc
@@ -1,0 +1,1 @@
+{ "extends": "../../.eslintrc", "rules": {}, "ignorePatterns": ["!**/*"] }

--- a/libs/dokobit-signing/README.md
+++ b/libs/dokobit-signing/README.md
@@ -1,0 +1,34 @@
+# Getting started
+
+This library defines dokobit-signing, a service that is derived from Apollo's RESTDataSource.
+The service allows its users to request individuals to sign PDF documents using their mobile electronic ids via Dokobit.
+
+### NestJS GraphQLModule
+
+Add the service to your GraphQLModule datasources:
+
+To be done.
+
+### NestJS Standalone - not recommended
+
+Assuming `environment.signingOptions` implements `SigningServiceOptions`, add the service to your Module providers:
+
+```typescript
+@Module({
+  providers: [
+    {
+      provide: 'SIGNING_OPTIONS',
+      useValue: environment.signingOptions
+    },
+    {
+      provide: SigningService,
+      useFactory: (options: SigningServiceOptions, logger: Logger) => {
+        const signingService = new SigningService(options, logger)
+        signingService.initialize({} as DataSourceConfig<{}>)
+        return signingService
+      },
+      inject: ['SIGNING_OPTIONS', LOGGER_PROVIDER],
+    },
+  ],
+})
+```

--- a/libs/dokobit-signing/jest.config.js
+++ b/libs/dokobit-signing/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  name: 'dokobit-signing',
+  preset: '../../jest.config.js',
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html'],
+  coverageDirectory: '../../coverage/libs/dokobit-signing',
+}

--- a/libs/dokobit-signing/src/index.ts
+++ b/libs/dokobit-signing/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/signing.service'

--- a/libs/dokobit-signing/src/lib/signing.service.spec.ts
+++ b/libs/dokobit-signing/src/lib/signing.service.spec.ts
@@ -22,7 +22,7 @@ const testDocumentContent = 'Test Document Content'
 const testSignPath = `sign.json?access_token=${testOptions.accessToken}`
 const testSignResponse = {
   status: 'ok',
-  control_code: 'Test Control Code',
+  control_code: 'Test Control Code', // eslint-disable-line @typescript-eslint/camelcase
   token: 'Test Document Token',
 }
 const testStatusPath = `sign/status/${testSignResponse.token}.json?access_token=${testOptions.accessToken}`
@@ -39,8 +39,8 @@ const testStatusResponse = {
 }
 const postMock = jest.fn(function(
   path: string,
-  body?: Body,
-  init?: RequestInit,
+  body?: Body, // eslint-disable-line @typescript-eslint/no-unused-vars
+  init?: RequestInit, // eslint-disable-line @typescript-eslint/no-unused-vars
 ) {
   switch (path) {
     case testSignPath:

--- a/libs/dokobit-signing/src/lib/signing.service.spec.ts
+++ b/libs/dokobit-signing/src/lib/signing.service.spec.ts
@@ -1,0 +1,133 @@
+import { mock } from 'jest-mock-extended'
+import { Base64 } from 'js-base64'
+import { createHash } from 'crypto'
+
+import { Test, TestingModule } from '@nestjs/testing'
+
+import { Logger, LOGGER_PROVIDER } from '@island.is/logging'
+
+import { SigningService } from './signing.service'
+
+const testOptions = {
+  url: 'Test Url',
+  accessToken: 'Test Access Token',
+}
+const testMobileNumber = '1111111'
+const testMessage = 'Test Message'
+const testContact = 'Test Contact'
+const testLocation = 'Test Location'
+const testDocumentName = 'Test Document Name'
+const testDocumentContent = 'Test Document Content'
+
+const testSignPath = `sign.json?access_token=${testOptions.accessToken}`
+const testSignResponse = {
+  status: 'ok',
+  control_code: 'Test Control Code',
+  token: 'Test Document Token',
+}
+const testStatusPath = `sign/status/${testSignResponse.token}.json?access_token=${testOptions.accessToken}`
+const testSignedDocumentContent = 'Test Content'
+const testStatusResponse = {
+  status: 'ok',
+  file: {
+    name: testDocumentName,
+    digest: createHash('sha256')
+      .update(testSignedDocumentContent)
+      .digest('hex'),
+    content: testSignedDocumentContent,
+  },
+}
+const postMock = jest.fn(function(
+  path: string,
+  body?: Body,
+  init?: RequestInit,
+) {
+  switch (path) {
+    case testSignPath:
+      return testSignResponse
+    case testStatusPath:
+      return testStatusResponse
+    default:
+      throw new Error()
+  }
+})
+jest.mock('apollo-datasource-rest', function() {
+  return {
+    RESTDataSource: function() {
+      this.post = postMock
+      return this
+    },
+  }
+})
+
+describe('SigningService', () => {
+  let signingService: SigningService
+
+  beforeEach(async () => {
+    postMock.mockClear()
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        {
+          provide: LOGGER_PROVIDER,
+          useValue: mock<Logger>(),
+        },
+        {
+          provide: 'SIGNING_OPTIONS',
+          useValue: testOptions,
+        },
+        SigningService,
+      ],
+    }).compile()
+
+    signingService = module.get<SigningService>(SigningService)
+  })
+
+  it('should sign a document', async () => {
+    const res = await signingService.requestSignature(
+      testMobileNumber,
+      testMessage,
+      testContact,
+      testLocation,
+      testDocumentName,
+      testDocumentContent,
+    )
+
+    // Verify response
+    expect(res.controlCode).toBe(testSignResponse.control_code)
+    expect(res.documentToken).toBe(testSignResponse.token)
+
+    // Verify sign
+    const base64 = Base64.encode(testDocumentContent)
+    const digest = createHash('sha256')
+      .update(base64)
+      .digest('hex')
+
+    const body = new FormData()
+    body.append('phone', testMobileNumber)
+    body.append('message', `${testMessage} `)
+    body.append('timestamp', 'true')
+    body.append('language', 'IS')
+    body.append('pdf[contact]', testContact)
+    body.append('pdf[location]', testLocation)
+    body.append('type', 'pdf')
+    body.append('pdf[files][0][name]', testDocumentName)
+    body.append('pdf[files][0][content]', base64)
+    body.append('pdf[files][0][digest]', digest)
+
+    expect(postMock).toHaveBeenCalledWith(testSignPath, body)
+  })
+
+  it('should get a signed document', async () => {
+    const res = await signingService.getDocument(
+      testDocumentName,
+      testSignResponse.token,
+    )
+
+    // Verify response
+    expect(res).toBe(Base64.atob(testStatusResponse.file.content))
+
+    // Verify sign status
+    expect(postMock).toHaveBeenCalledWith(testStatusPath)
+  })
+})

--- a/libs/dokobit-signing/src/lib/signing.service.ts
+++ b/libs/dokobit-signing/src/lib/signing.service.ts
@@ -21,6 +21,7 @@ export class SigningServiceError extends Error {
     super()
 
     this.name = 'DokobitError'
+    this.message = `${code}: ${message}`
   }
 }
 

--- a/libs/dokobit-signing/src/lib/signing.service.ts
+++ b/libs/dokobit-signing/src/lib/signing.service.ts
@@ -1,0 +1,158 @@
+import { RESTDataSource, RequestOptions } from 'apollo-datasource-rest'
+import { Base64 } from 'js-base64'
+import { createHash } from 'crypto'
+
+import { Injectable, Inject } from '@nestjs/common'
+
+import { Logger, LOGGER_PROVIDER } from '@island.is/logging'
+
+export interface SigningServiceOptions {
+  url: string
+  accessToken: string
+}
+
+export class SigningServiceResponse {
+  controlCode: string
+  documentToken: string
+}
+
+export class SigningServiceError extends Error {
+  constructor(code: number, message: string) {
+    super()
+
+    this.name = 'DokobitError'
+  }
+}
+
+interface DokobitSignResponse {
+  status: string
+  control_code: string
+  token: string
+  error_code: number
+  message: string
+}
+
+interface DokobitStatusResponse {
+  status: string
+  file: {
+    name: string
+    digest: string
+    content: string
+  }
+  signature_id: string
+  error_code: number
+  message: string
+}
+
+@Injectable()
+export class SigningService extends RESTDataSource {
+  constructor(
+    @Inject('SIGNING_OPTIONS') private options: SigningServiceOptions,
+    @Inject(LOGGER_PROVIDER)
+    private logger: Logger,
+  ) {
+    super()
+
+    this.baseURL = `${this.options.url}/mobile/`
+  }
+
+  willSendRequest(request: RequestOptions) {
+    request.headers.set('Content-Type', 'multipart/form-data')
+  }
+
+  async requestSignature(
+    mobileNumber: string,
+    message: string,
+    contact: string,
+    location: string,
+    documentName: string,
+    documentContent: string,
+  ): Promise<SigningServiceResponse> {
+    this.logger.debug(
+      `${contact} ${location} is requesting ${mobileNumber} to sign ${documentName} with message ${message}`,
+    )
+
+    const base64 = Base64.encode(documentContent)
+    const digest = createHash('sha256')
+      .update(base64)
+      .digest('hex')
+
+    const body = new FormData()
+    body.append('phone', mobileNumber)
+    body.append('message', `${message} `)
+    body.append('timestamp', 'true')
+    body.append('language', 'IS')
+    body.append('pdf[contact]', contact)
+    body.append('pdf[location]', location)
+    body.append('type', 'pdf')
+    body.append('pdf[files][0][name]', documentName)
+    body.append('pdf[files][0][content]', base64)
+    body.append('pdf[files][0][digest]', digest)
+
+    const resSign: DokobitSignResponse = await this.post(
+      `sign.json?access_token=${this.options.accessToken}`,
+      body,
+    )
+
+    if (resSign.status !== 'ok') {
+      throw new SigningServiceError(resSign.error_code, resSign.message)
+    }
+
+    return {
+      controlCode: resSign.control_code,
+      documentToken: resSign.token,
+    }
+  }
+
+  async getDocument(
+    documentName: string,
+    documentToken: string,
+  ): Promise<string> {
+    let resStatus: DokobitStatusResponse
+
+    // Try to retrieve the signed document
+    // Need to try longer than the mobile signature timeout, but not too long
+    for (let i = 1; i < 120; i++) {
+      resStatus = await this.post(
+        `sign/status/${documentToken}.json?access_token=${this.options.accessToken}`,
+      )
+
+      if (resStatus.status === 'ok') {
+        return this.getVerifiedDocument(documentName, resStatus)
+      }
+
+      if (resStatus.status !== 'waiting') {
+        throw new SigningServiceError(resStatus.error_code, resStatus.message)
+      }
+
+      // Wait a second
+      await this.delay(1000)
+    }
+
+    throw new SigningServiceError(99999, 'Timeout while retrieving document')
+  }
+
+  private getVerifiedDocument(
+    documentName: string,
+    resStatus: DokobitStatusResponse,
+  ) {
+    if (resStatus.file.name !== documentName) {
+      throw new SigningServiceError(99999, 'File name verification failed')
+    }
+
+    const base64 = resStatus.file.content
+    const digest = createHash('sha256')
+      .update(base64)
+      .digest('hex')
+
+    if (digest !== resStatus.file.digest) {
+      throw new SigningServiceError(99999, 'Checksum verification failed')
+    }
+
+    return Base64.atob(base64)
+  }
+
+  private delay(ms: number) {
+    return new Promise((resolve) => setTimeout(resolve, ms))
+  }
+}

--- a/libs/dokobit-signing/tsconfig.json
+++ b/libs/dokobit-signing/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "jest"]
+  },
+  "include": ["**/*.ts"]
+}

--- a/libs/dokobit-signing/tsconfig.lib.json
+++ b/libs/dokobit-signing/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "rootDir": "./src",
+    "types": ["node"]
+  },
+  "exclude": ["**/*.spec.ts"],
+  "include": ["**/*.ts"]
+}

--- a/libs/dokobit-signing/tsconfig.spec.json
+++ b/libs/dokobit-signing/tsconfig.spec.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.spec.js",
+    "**/*.spec.jsx",
+    "**/*.d.ts"
+  ]
+}

--- a/libs/nova-sms/README.md
+++ b/libs/nova-sms/README.md
@@ -1,6 +1,7 @@
 # Getting started
 
-This library defines a service that is derived from Apollo's RESTDataSource.
+This library defines nova-sms, a service that is derived from Apollo's RESTDataSource.
+The service allows its users to send sms messages on behalf of Island.is via Nova.
 
 ### NestJS GraphQLModule
 

--- a/libs/nova-sms/src/lib/sms.service.spec.ts
+++ b/libs/nova-sms/src/lib/sms.service.spec.ts
@@ -12,8 +12,8 @@ const testSendSms = 'SendSms'
 const testCode = '0'
 const postMock = jest.fn(function(
   path: string,
-  body?: Body,
-  init?: RequestInit,
+  body?: Body, // eslint-disable-line @typescript-eslint/no-unused-vars
+  init?: RequestInit, // eslint-disable-line @typescript-eslint/no-unused-vars
 ) {
   switch (path) {
     case testLogin:

--- a/libs/nova-sms/src/lib/sms.service.ts
+++ b/libs/nova-sms/src/lib/sms.service.ts
@@ -57,7 +57,7 @@ export class SmsService extends RESTDataSource {
     request.headers.set('Content-Type', 'application/json')
   }
 
-  async login(): Promise<string> {
+  private async login(): Promise<string> {
     try {
       const res: NovaAuthResponse = await this.post('Login', undefined, {
         headers: {

--- a/nx.json
+++ b/nx.json
@@ -245,6 +245,9 @@
     },
     "service-portal-assets": {
       "tags": []
+    },
+    "dokobit-signing": {
+      "tags": []
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@sentry/react": "^5.22.3",
     "@sentry/tracing": "^5.22.3",
     "@sindresorhus/slugify": "1.0.0",
+    "@types/js-base64": "^3.0.0",
     "@types/react-datepicker": "^3.1.1",
     "@xstate/react": "0.8.1",
     "amazon-s3-uri": "^0.0.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -122,7 +122,8 @@
       "@island.is/nova-sms": ["libs/nova-sms/src/index.ts"],
       "@island.is/service-portal/assets": [
         "libs/service-portal/assets/src/index.ts"
-      ]
+      ],
+      "@island.is/dokobit-signing": ["libs/dokobit-signing/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]

--- a/workspace.json
+++ b/workspace.json
@@ -3192,6 +3192,32 @@
           }
         }
       }
+    },
+    "dokobit-signing": {
+      "root": "libs/dokobit-signing",
+      "sourceRoot": "libs/dokobit-signing/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@angular-devkit/build-angular:tslint",
+          "options": {
+            "tsConfig": [
+              "libs/dokobit-signing/tsconfig.lib.json",
+              "libs/dokobit-signing/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**", "!libs/dokobit-signing/**"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/dokobit-signing/jest.config.js",
+            "tsConfig": "libs/dokobit-signing/tsconfig.spec.json",
+            "passWithNoTests": true
+          }
+        }
+      }
     }
   },
   "cli": {

--- a/workspace.json
+++ b/workspace.json
@@ -3200,8 +3200,10 @@
       "schematics": {},
       "architect": {
         "lint": {
-          "builder": "@angular-devkit/build-angular:tslint",
+          "builder": "@nrwl/linter:lint",
           "options": {
+            "linter": "eslint",
+            "config": "libs/dokobit-signing/.eslintrc",
             "tsConfig": [
               "libs/dokobit-signing/tsconfig.lib.json",
               "libs/dokobit-signing/tsconfig.spec.json"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4682,6 +4682,11 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
+"@types/js-base64@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/js-base64/-/js-base64-3.0.0.tgz#b7b4c130facefefd5c57ba82664c41e2995f91be"
+  integrity sha512-BnEyOcDE4H6bkg8m84xhdbkYoAoCg8sYERmAvE4Ff50U8jTfbmOinRdJpauBn1P9XsCCQgCLuSiyz3PM4WHYOA==
+
 "@types/js-cookie@2.2.6", "@types/js-cookie@^2.2.6":
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-2.2.6.tgz#f1a1cb35aff47bc5cfb05cb0c441ca91e914c26f"


### PR DESCRIPTION
# Wraps Dokobit's document signing API

## What

A service for signing PDF documents using Dokobit's API. The service can be extended later to include other types of documents and/or other capabilities supported by Dokobit's API.

## Why

This service will first be used to sign verdicts in detention request cases.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
