### PR TITLE
handle embedded non-image assets in contentful editor

### DIFF
--- a/apps/api/src/api.graphql
+++ b/apps/api/src/api.graphql
@@ -143,7 +143,7 @@ type SubArticle {
   body: [Slice!]!
 }
 
-union Slice = TimelineSlice | MailingListSignupSlice | HeadingSlice | LinkCardSlice | StorySlice | LogoListSlice | LatestNewsSlice | BulletListSlice | Statistics | ProcessEntry | FaqList | EmbeddedVideo | SectionWithImage | TabSection | TeamList | Html | Image
+union Slice = TimelineSlice | MailingListSignupSlice | HeadingSlice | LinkCardSlice | StorySlice | LogoListSlice | LatestNewsSlice | BulletListSlice | Statistics | ProcessEntry | FaqList | EmbeddedVideo | SectionWithImage | TabSection | TeamList | Html | Image | Asset
 
 type MailingListSignupSlice {
   typename: String!
@@ -262,6 +262,14 @@ type TeamList {
   typename: String!
   id: ID!
   teamMembers: [TeamMember!]!
+}
+
+type Asset {
+  typename: String!
+  id: ID!
+  url: String!
+  title: String!
+  contentType: String!
 }
 
 type Article {

--- a/apps/web/graphql/fragmentTypes.json
+++ b/apps/web/graphql/fragmentTypes.json
@@ -55,6 +55,9 @@
           },
           {
             "name": "Image"
+          },
+          {
+            "name": "Asset"
           }
         ]
       },

--- a/apps/web/graphql/schema.ts
+++ b/apps/web/graphql/schema.ts
@@ -1903,7 +1903,7 @@ export type ImageFieldsFragment = { __typename: 'Image' } & Pick<
 
 export type AssetFieldsFragment = { __typename: 'Asset' } & Pick<
   Asset,
-  'id' | 'title' | 'url' | 'contentType'
+  'typename' | 'id' | 'title' | 'url' | 'contentType'
 >
 
 export type TimelineFieldsFragment = { __typename: 'TimelineSlice' } & Pick<

--- a/apps/web/graphql/schema.ts
+++ b/apps/web/graphql/schema.ts
@@ -188,6 +188,7 @@ export type Slice =
   | TeamList
   | Html
   | Image
+  | Asset
 
 export type MailingListSignupSlice = {
   __typename?: 'MailingListSignupSlice'
@@ -322,6 +323,15 @@ export type TeamList = {
   typename: Scalars['String']
   id: Scalars['ID']
   teamMembers: Array<TeamMember>
+}
+
+export type Asset = {
+  __typename?: 'Asset'
+  typename: Scalars['String']
+  id: Scalars['ID']
+  url: Scalars['String']
+  title: Scalars['String']
+  contentType: Scalars['String']
 }
 
 export type Article = {
@@ -1202,6 +1212,7 @@ export type GetAboutPageQuery = { __typename?: 'Query' } & {
         | ({ __typename?: 'TeamList' } & AllSlicesTeamListFragment)
         | ({ __typename?: 'Html' } & AllSlicesHtmlFragment)
         | ({ __typename?: 'Image' } & AllSlicesImageFragment)
+        | ({ __typename?: 'Asset' } & AllSlicesAssetFragment)
       >
     }
 }
@@ -1255,6 +1266,7 @@ export type GetAboutSubPageQuery = { __typename?: 'Query' } & {
           | ({ __typename?: 'TeamList' } & AllSlicesTeamListFragment)
           | ({ __typename?: 'Html' } & AllSlicesHtmlFragment)
           | ({ __typename?: 'Image' } & AllSlicesImageFragment)
+          | ({ __typename?: 'Asset' } & AllSlicesAssetFragment)
         >
       }
   >
@@ -1320,6 +1332,7 @@ export type GetSingleArticleQuery = { __typename?: 'Query' } & {
           | ({ __typename?: 'TeamList' } & AllSlicesTeamListFragment)
           | ({ __typename?: 'Html' } & AllSlicesHtmlFragment)
           | ({ __typename?: 'Image' } & AllSlicesImageFragment)
+          | ({ __typename?: 'Asset' } & AllSlicesAssetFragment)
         >
         group?: Maybe<
           { __typename?: 'ArticleGroup' } & Pick<
@@ -1376,6 +1389,7 @@ export type GetSingleArticleQuery = { __typename?: 'Query' } & {
                 | ({ __typename?: 'TeamList' } & AllSlicesTeamListFragment)
                 | ({ __typename?: 'Html' } & AllSlicesHtmlFragment)
                 | ({ __typename?: 'Image' } & AllSlicesImageFragment)
+                | ({ __typename?: 'Asset' } & AllSlicesAssetFragment)
               >
             }
         >
@@ -1487,6 +1501,7 @@ export type GetLandingPageQuery = { __typename?: 'Query' } & {
           | ({ __typename?: 'TeamList' } & AllSlicesTeamListFragment)
           | ({ __typename?: 'Html' } & AllSlicesHtmlFragment)
           | ({ __typename?: 'Image' } & AllSlicesImageFragment)
+          | ({ __typename?: 'Asset' } & AllSlicesAssetFragment)
         >
       }
   >
@@ -1529,6 +1544,7 @@ export type GetLifeEventQuery = { __typename?: 'Query' } & {
           | ({ __typename?: 'TeamList' } & AllSlicesTeamListFragment)
           | ({ __typename?: 'Html' } & AllSlicesHtmlFragment)
           | ({ __typename?: 'Image' } & AllSlicesImageFragment)
+          | ({ __typename?: 'Asset' } & AllSlicesAssetFragment)
         >
       }
   >
@@ -1885,6 +1901,11 @@ export type ImageFieldsFragment = { __typename: 'Image' } & Pick<
   'typename' | 'id' | 'title' | 'url' | 'contentType' | 'width' | 'height'
 >
 
+export type AssetFieldsFragment = { __typename: 'Asset' } & Pick<
+  Asset,
+  'id' | 'title' | 'url' | 'contentType'
+>
+
 export type TimelineFieldsFragment = { __typename: 'TimelineSlice' } & Pick<
   TimelineSlice,
   'typename' | 'id' | 'title'
@@ -2114,6 +2135,10 @@ export type AllSlicesImageFragment = {
   __typename?: 'Image'
 } & ImageFieldsFragment
 
+export type AllSlicesAssetFragment = {
+  __typename?: 'Asset'
+} & AssetFieldsFragment
+
 export type AllSlicesFragment =
   | AllSlicesTimelineSliceFragment
   | AllSlicesMailingListSignupSliceFragment
@@ -2132,3 +2157,4 @@ export type AllSlicesFragment =
   | AllSlicesTeamListFragment
   | AllSlicesHtmlFragment
   | AllSlicesImageFragment
+  | AllSlicesAssetFragment

--- a/apps/web/screens/queries/fragments.ts
+++ b/apps/web/screens/queries/fragments.ts
@@ -12,6 +12,14 @@ export const slices = gql`
     height
   }
 
+  fragment AssetFields on Asset {
+    __typename
+    id
+    title
+    url
+    contentType
+  }
+
   fragment TimelineFields on TimelineSlice {
     __typename
     typename
@@ -248,6 +256,7 @@ export const slices = gql`
     ...ProcessEntryFields
     ...HtmlFields
     ...ImageFields
+    ...AssetFields
     ...EmbeddedVideoFields
     ...SectionWithImageFields
     ...TabSectionFields

--- a/apps/web/screens/queries/fragments.ts
+++ b/apps/web/screens/queries/fragments.ts
@@ -14,6 +14,7 @@ export const slices = gql`
 
   fragment AssetFields on Asset {
     __typename
+    typename
     id
     title
     url

--- a/libs/api/domains/cms/src/lib/models/asset.model.ts
+++ b/libs/api/domains/cms/src/lib/models/asset.model.ts
@@ -1,0 +1,28 @@
+import { Field, Int, ObjectType, ID } from '@nestjs/graphql'
+import { Asset as ContentfulAsset } from 'contentful'
+
+@ObjectType()
+export class Asset {
+  @Field()
+  typename: string
+
+  @Field(() => ID)
+  id: string
+
+  @Field()
+  url: string
+
+  @Field()
+  title: string
+
+  @Field()
+  contentType: string
+}
+
+export const mapAsset = ({ sys, fields }: ContentfulAsset): Asset => ({
+  typename: 'Asset',
+  id: sys.id,
+  title: fields.title ?? '',
+  url: fields.file?.url ?? '',
+  contentType: fields.file?.contentType ?? '',
+})

--- a/libs/api/domains/cms/src/lib/models/slice.model.ts
+++ b/libs/api/domains/cms/src/lib/models/slice.model.ts
@@ -3,7 +3,6 @@ import { ApolloError } from 'apollo-server-express'
 import { Document, BLOCKS, Block } from '@contentful/rich-text-types'
 
 import {
-  IPageHeader,
   ITimeline,
   IMailingListSignup,
   ISectionHeading,
@@ -22,6 +21,7 @@ import {
 } from '../generated/contentfulTypes'
 
 import { Image, mapImage } from './image.model'
+import { Asset, mapAsset } from './asset.model'
 import {
   MailingListSignupSlice,
   mapMailingListSignup,
@@ -80,6 +80,7 @@ export const Slice = createUnionType({
     TeamList,
     Html,
     Image,
+    Asset,
   ],
   resolveType: (document) => document.typename, // typename is appended to request on indexing
 })
@@ -156,7 +157,11 @@ export const mapDocument = (
         slices.push(safelyMapSlices(block.data.target))
         break
       case BLOCKS.EMBEDDED_ASSET:
-        slices.push(mapImage(block.data.target))
+        if (block.data.target.fields.file) {
+          block.data.target.fields.file.details?.image
+            ? slices.push(mapImage(block.data.target))
+            : slices.push(mapAsset(block.data.target))
+        }
         break
       default: {
         // ignore last empty paragraph because of this annoying bug:

--- a/libs/api/schema/src/lib/schema.d.ts
+++ b/libs/api/schema/src/lib/schema.d.ts
@@ -199,6 +199,7 @@ export type Slice =
   | TeamList
   | Html
   | Image
+  | Asset
 
 export type MailingListSignupSlice = {
   __typename?: 'MailingListSignupSlice'
@@ -333,6 +334,15 @@ export type TeamList = {
   typename: Scalars['String']
   id: Scalars['ID']
   teamMembers: Array<TeamMember>
+}
+
+export type Asset = {
+  __typename?: 'Asset'
+  typename: Scalars['String']
+  id: Scalars['ID']
+  url: Scalars['String']
+  title: Scalars['String']
+  contentType: Scalars['String']
 }
 
 export type Article = {
@@ -1328,6 +1338,7 @@ export type ResolversTypes = {
     | ResolversTypes['TeamList']
     | ResolversTypes['Html']
     | ResolversTypes['Image']
+    | ResolversTypes['Asset']
   MailingListSignupSlice: ResolverTypeWrapper<MailingListSignupSlice>
   HeadingSlice: ResolverTypeWrapper<HeadingSlice>
   LinkCardSlice: ResolverTypeWrapper<LinkCardSlice>
@@ -1351,6 +1362,7 @@ export type ResolversTypes = {
   SectionWithImage: ResolverTypeWrapper<SectionWithImage>
   TabSection: ResolverTypeWrapper<TabSection>
   TeamList: ResolverTypeWrapper<TeamList>
+  Asset: ResolverTypeWrapper<Asset>
   Article: ResolverTypeWrapper<
     Omit<Article, 'body'> & { body: Array<ResolversTypes['Slice']> }
   >
@@ -1521,6 +1533,7 @@ export type ResolversParentTypes = {
     | ResolversParentTypes['TeamList']
     | ResolversParentTypes['Html']
     | ResolversParentTypes['Image']
+    | ResolversParentTypes['Asset']
   MailingListSignupSlice: MailingListSignupSlice
   HeadingSlice: HeadingSlice
   LinkCardSlice: LinkCardSlice
@@ -1542,6 +1555,7 @@ export type ResolversParentTypes = {
   SectionWithImage: SectionWithImage
   TabSection: TabSection
   TeamList: TeamList
+  Asset: Asset
   Article: Omit<Article, 'body'> & {
     body: Array<ResolversParentTypes['Slice']>
   }
@@ -1921,7 +1935,8 @@ export type SliceResolvers<
     | 'TabSection'
     | 'TeamList'
     | 'Html'
-    | 'Image',
+    | 'Image'
+    | 'Asset',
     ParentType,
     ContextType
   >
@@ -2140,6 +2155,18 @@ export type TeamListResolvers<
     ParentType,
     ContextType
   >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
+
+export type AssetResolvers<
+  ContextType = Context,
+  ParentType extends ResolversParentTypes['Asset'] = ResolversParentTypes['Asset']
+> = {
+  typename?: Resolver<ResolversTypes['String'], ParentType, ContextType>
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>
+  url?: Resolver<ResolversTypes['String'], ParentType, ContextType>
+  title?: Resolver<ResolversTypes['String'], ParentType, ContextType>
+  contentType?: Resolver<ResolversTypes['String'], ParentType, ContextType>
   __isTypeOf?: IsTypeOfResolverFn<ParentType>
 }
 
@@ -3097,6 +3124,7 @@ export type Resolvers<ContextType = Context> = {
   SectionWithImage?: SectionWithImageResolvers<ContextType>
   TabSection?: TabSectionResolvers<ContextType>
   TeamList?: TeamListResolvers<ContextType>
+  Asset?: AssetResolvers<ContextType>
   Article?: ArticleResolvers<ContextType>
   AdgerdirTag?: AdgerdirTagResolvers<ContextType>
   AdgerdirPage?: AdgerdirPageResolvers<ContextType>
@@ -3216,6 +3244,9 @@ const result: IntrospectionResultData = {
           },
           {
             name: 'Image',
+          },
+          {
+            name: 'Asset',
           },
         ],
       },

--- a/libs/island-ui/contentful/src/lib/AssetLink/AssetLink.tsx
+++ b/libs/island-ui/contentful/src/lib/AssetLink/AssetLink.tsx
@@ -1,0 +1,21 @@
+import React, { FC } from 'react'
+import { FocusableBox, LinkCard } from '@island.is/island-ui/core'
+
+interface AssetLinkProps {
+  url: string
+}
+
+export const AssetLink: FC<AssetLinkProps> = ({ url, children }) => {
+  const parts = url.split('.')
+  const extension = parts[parts.length - 1].toUpperCase()
+
+  return (
+    <FocusableBox href={url} border="standard" borderRadius="large">
+      <LinkCard background="white" tag={extension}>
+        {children}
+      </LinkCard>
+    </FocusableBox>
+  )
+}
+
+export default AssetLink

--- a/libs/island-ui/contentful/src/lib/FaqList/FaqList.tsx
+++ b/libs/island-ui/contentful/src/lib/FaqList/FaqList.tsx
@@ -14,7 +14,7 @@ export interface FaqListProps {
   questions: {
     id: string
     question: string
-    answer: Html
+    answer?: Html
   }[]
 }
 

--- a/libs/island-ui/contentful/src/lib/richTextRendering.tsx
+++ b/libs/island-ui/contentful/src/lib/richTextRendering.tsx
@@ -5,13 +5,16 @@ import {
   Inline,
   BLOCKS,
   INLINES,
+  AssetHyperlink,
 } from '@contentful/rich-text-types'
+import { Asset } from 'contentful'
 import { documentToReactComponents } from '@contentful/rich-text-react-renderer'
 import Image from './Image/Image'
 import FaqList from './FaqList/FaqList'
 import { Slice } from '@island.is/api/schema'
 import { Statistics } from './Statistics/Statistics'
 import Hyperlink from './Hyperlink/Hyperlink'
+import AssetLink from './AssetLink/AssetLink'
 import {
   Typography,
   Blockquote,
@@ -31,7 +34,12 @@ export interface RenderNode {
 }
 
 type SliceType = Slice['__typename']
-type Ordered = 'ordered' | 'unordered'
+
+export interface PaddingConfig {
+  sorted?: boolean
+  space: ResponsiveSpace
+  types: [SliceType, SliceType]
+}
 
 export interface RenderConfig {
   renderComponent: (slice: Slice, config: RenderConfig) => ReactNode
@@ -39,7 +47,7 @@ export interface RenderConfig {
   renderNode: RenderNode
   htmlClassName?: string
   defaultPadding: ResponsiveSpace
-  padding: Readonly<Array<[SliceType, SliceType, ResponsiveSpace, Ordered?]>>
+  padding: Readonly<Array<PaddingConfig>>
 }
 
 export const defaultRenderComponent = (
@@ -61,6 +69,9 @@ export const defaultRenderComponent = (
 
     case 'Image':
       return <Image type="apiImage" image={slice} />
+
+    case 'Asset':
+      return <AssetLink {...slice}>{slice.title}</AssetLink>
 
     case 'ProcessEntry':
       return <ProcessEntry {...slice} />
@@ -108,6 +119,15 @@ export const defaultRenderNode: Readonly<RenderNode> = {
   [INLINES.HYPERLINK]: (node: Inline, children: ReactNode): ReactNode => (
     <Hyperlink href={node.data.uri}>{children}</Hyperlink>
   ),
+  [INLINES.ASSET_HYPERLINK]: (
+    node: AssetHyperlink,
+    children: ReactNode,
+  ): ReactNode => {
+    const asset = (node.data.target as unknown) as Asset
+    return asset.fields.file?.url ? (
+      <Hyperlink href={asset.fields.file.url}>{children}</Hyperlink>
+    ) : null
+  },
 }
 
 export const renderHtml = (
@@ -127,17 +147,19 @@ export const renderHtml = (
   )
 }
 
-const matches = (name: string, type: string) => name === '*' || name === type
-
 export const defaultRenderPadding = (
   { __typename: above }: Slice,
   { __typename: below }: Slice,
   config: RenderConfig,
 ): ReactNode => {
-  for (const [a, b, space, order = 'unordered'] of config.padding) {
+  for (const {
+    sorted = false,
+    space,
+    types: [a, b],
+  } of config.padding) {
     if (
-      (matches(a, above) && matches(b, below)) ||
-      (order === 'unordered' && matches(a, below) && matches(b, above))
+      (a === above && b === below) ||
+      (!sorted && a === below && b === above)
     ) {
       return <Box paddingTop={space} />
     }

--- a/libs/island-ui/core/src/lib/LinkCard/LinkCard.tsx
+++ b/libs/island-ui/core/src/lib/LinkCard/LinkCard.tsx
@@ -1,13 +1,13 @@
-import React, { forwardRef } from 'react'
+import React, { forwardRef, ComponentPropsWithRef } from 'react'
 import cn from 'classnames'
-import { Box } from '../Box/Box'
+import { Box, BoxProps } from '../Box/Box'
 import { Typography } from '../Typography/Typography'
 import { Tag, TagVariant, TagProps } from '../Tag/Tag'
 import * as styles from './LinkCard.treat'
 
-export interface LinkCardProps {
+export interface LinkCardProps extends ComponentPropsWithRef<'div'> {
   onClick?: () => void
-  children: string
+  background?: BoxProps['background']
   tag?: string
   tagVariant?: TagVariant
   tagProps?: Omit<TagProps, 'children'>
@@ -19,6 +19,7 @@ export const LinkCard = forwardRef<HTMLAnchorElement, LinkCardProps>(
     {
       onClick,
       children,
+      background = 'blue100',
       tag,
       tagVariant = 'darkerBlue',
       tagProps = {
@@ -30,7 +31,7 @@ export const LinkCard = forwardRef<HTMLAnchorElement, LinkCardProps>(
   ) => {
     return (
       <Box
-        background="blue100"
+        background={background}
         borderRadius="large"
         position="relative"
         display="flex"


### PR DESCRIPTION
# \<Description\>

Specify what you're trying to achieve

support embedding non-image assets in contentful which was broken before

Specify why you need to achieve this

So content editors can embed e.g. pdf files in contentful editor

## Screenshots / Gifs

![Screenshot 2020-09-16 at 15 15 06](https://user-images.githubusercontent.com/15398/94000649-fcfb6400-fd86-11ea-8a33-5f0e6a79b518.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
