### PR TITLE
Added rose colored variant to tag

### DIFF
--- a/libs/island-ui/core/src/lib/Tag/Tag.stories.tsx
+++ b/libs/island-ui/core/src/lib/Tag/Tag.stories.tsx
@@ -22,6 +22,7 @@ export const Basic = () => (
         <Tag variant="white" label>
           Færnimat
         </Tag>
+        <Tag variant="rose">Færnimat</Tag>
         <Tag variant="red" attention>
           Mikilvægt
         </Tag>

--- a/libs/island-ui/core/src/lib/Tag/Tag.treat.ts
+++ b/libs/island-ui/core/src/lib/Tag/Tag.treat.ts
@@ -62,6 +62,10 @@ export const variants = styleMap({
     color: theme.color.dark400,
     backgroundColor: theme.color.mint200,
   },
+  rose: {
+    color: theme.color.roseTinted400,
+    backgroundColor: theme.color.roseTinted100,
+  },
   label: {},
 })
 

--- a/libs/island-ui/core/src/lib/Tag/Tag.tsx
+++ b/libs/island-ui/core/src/lib/Tag/Tag.tsx
@@ -12,6 +12,7 @@ export type TagVariant =
   | 'red'
   | 'mint'
   | 'darkerMint'
+  | 'rose'
 
 export interface TagProps {
   onClick?: () => void


### PR DESCRIPTION
# Added rose colored variant to tag

## What

Added a rose variant to tags

## Why

This is needed in the skilavottord project

## Screenshots / Gifs

<img width="104" alt="Screenshot 2020-09-23 at 13 21 46" src="https://user-images.githubusercontent.com/64913954/94006178-bcf4ab00-fd9f-11ea-99bc-6399feb04d4b.png">

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
