### PR TITLE
Improve the quality of search results

### DIFF
--- a/apps/services/search-indexer/config/template-is.json
+++ b/apps/services/search-indexer/config/template-is.json
@@ -43,7 +43,7 @@
             "icelandicStemmer"
           ]
         },
-        "compound": {
+        "compoundIcelandic": {
           "type": "custom",
           "tokenizer": "standard",
           "filter": [
@@ -80,7 +80,7 @@
           },
           "compound": {
             "type": "text",
-            "analyzer": "compound"
+            "analyzer": "compoundIcelandic"
           }
         }
       },

--- a/apps/services/search-indexer/config/template-is.json
+++ b/apps/services/search-indexer/config/template-is.json
@@ -1,6 +1,6 @@
 {
   "order": 0,
-  "version": 9,
+  "version": 10,
   "index_patterns": ["island-is-v*"],
   "settings": {
     "analysis": {
@@ -40,6 +40,17 @@
             "icelandicSynonym",
             "icelandicStop",
             "icelandicKeyword",
+            "icelandicStemmer"
+          ]
+        },
+        "compound": {
+          "type": "custom",
+          "tokenizer": "standard",
+          "filter": [
+            "lowercase",
+            "icelandicSynonym",
+            "icelandicStop",
+            "icelandicKeyword",
             "icelandicDeCompounded",
             "icelandicStemmer"
           ]
@@ -47,7 +58,7 @@
         "termIcelandic": {
           "type": "custom",
           "tokenizer": "standard",
-          "filter": ["lowercase", "icelandicSynonym"]
+          "filter": ["lowercase", "icelandicSynonym", "icelandicStop"]
         }
       }
     }
@@ -66,6 +77,10 @@
           "stemmed": {
             "type": "text",
             "analyzer": "baseIcelandic"
+          },
+          "compound": {
+            "type": "text",
+            "analyzer": "compound"
           }
         }
       },

--- a/libs/api/content-search/src/queries/search.ts
+++ b/libs/api/content-search/src/queries/search.ts
@@ -66,7 +66,7 @@ export const searchQuery = ({
       // eslint-disable-next-line @typescript-eslint/camelcase
       analyze_wildcard: true,
       // eslint-disable-next-line @typescript-eslint/camelcase
-      default_operator: "and",
+      default_operator: 'and',
     },
   })
 

--- a/libs/api/content-search/src/queries/search.ts
+++ b/libs/api/content-search/src/queries/search.ts
@@ -62,9 +62,11 @@ export const searchQuery = ({
     // eslint-disable-next-line @typescript-eslint/camelcase
     simple_query_string: {
       query: queryString,
-      fields: ['title^20', 'title.stemmed^10', 'content.stemmed^2'],
+      fields: ['title.stemmed^20', 'title.compound^3', 'content.stemmed^10'],
       // eslint-disable-next-line @typescript-eslint/camelcase
       analyze_wildcard: true,
+      // eslint-disable-next-line @typescript-eslint/camelcase
+      default_operator: "and",
     },
   })
 


### PR DESCRIPTION
# Improve the quality of search results

- Vastly improve the quality of search results
- Added stopwords filter for autocomplete

## What

Removed hyphenation compound filter from content field in ES.
Because hyphenation compound filter does not produce good results against a large body of text

## Why

Prevent non relevant search results being displayed to the user

## Screenshots / Gifs

![Screenshot 2020-09-23 at 12 52 16](https://user-images.githubusercontent.com/7864222/94014989-cf6ce580-fd9b-11ea-8bc4-b12531abbaa2.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
