### PR TITLE
Make life event header image span all container

### DIFF
--- a/apps/web/screens/LifeEvent/LifeEvent.tsx
+++ b/apps/web/screens/LifeEvent/LifeEvent.tsx
@@ -86,8 +86,7 @@ export const LifeEvent: Screen<LifeEventProps> = ({
         <>
           <GridRow>
             <GridColumn
-              offset={['0', '0', '0', '0', '1/9']}
-              span={['9/9', '9/9', '9/9', '9/9', '7/9']}
+              span={'9/9'}
               paddingBottom={2}
             >
               <Box marginBottom={2} display="inlineBlock" width="full">
@@ -98,12 +97,6 @@ export const LifeEvent: Screen<LifeEventProps> = ({
                   image={image}
                 />
               </Box>
-              <Breadcrumbs>
-                <Link href={makePath()}>Ísland.is</Link>
-                <Tag variant="blue" label>
-                  {n('lifeEventTitle', 'Lífsviðburður')}
-                </Tag>
-              </Breadcrumbs>
             </GridColumn>
           </GridRow>
           {!!mobileNavigation.length && (
@@ -127,6 +120,12 @@ export const LifeEvent: Screen<LifeEventProps> = ({
               offset={['0', '0', '0', '0', '1/9']}
               span={['9/9', '9/9', '9/9', '9/9', '7/9']}
             >
+              <Breadcrumbs>
+                <Link href={makePath()}>Ísland.is</Link>
+                <Tag variant="blue" label>
+                  {n('lifeEventTitle', 'Lífsviðburður')}
+                </Tag>
+              </Breadcrumbs>
               <Typography variant="h1" as="h1">
                 <span id={slugify(title)}>{title}</span>
               </Typography>

--- a/apps/web/screens/LifeEvent/LifeEvent.tsx
+++ b/apps/web/screens/LifeEvent/LifeEvent.tsx
@@ -85,10 +85,7 @@ export const LifeEvent: Screen<LifeEventProps> = ({
       >
         <>
           <GridRow>
-            <GridColumn
-              span={'9/9'}
-              paddingBottom={2}
-            >
+            <GridColumn span={'9/9'} paddingBottom={2}>
               <Box marginBottom={2} display="inlineBlock" width="full">
                 <BackgroundImage
                   ratio="12:4"


### PR DESCRIPTION
#Lif Event Header Image

## What
Life event header image should span all gridcontainer

## Why
Follow design

## Screenshots / Gifs

Before:
![image](https://user-images.githubusercontent.com/70899104/94034835-f7ffda00-fdb1-11ea-9f86-11e721915c46.png)

After:
![image](https://user-images.githubusercontent.com/70899104/94034775-e9b1be00-fdb1-11ea-9371-9fcc3513a58b.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
