### PR TITLE
Show intro text (description) on search results

### DIFF
--- a/apps/api/src/api.graphql
+++ b/apps/api/src/api.graphql
@@ -459,7 +459,7 @@ type LifeEventPage {
   id: ID!
   title: String!
   slug: String!
-  intro: String!
+  intro: String
   image: Image
   thumbnail: Image
   content: [Slice!]!

--- a/apps/web/components/SearchInput/SearchInput.tsx
+++ b/apps/web/components/SearchInput/SearchInput.tsx
@@ -36,6 +36,7 @@ import {
   AutocompleteTermResultsQuery,
   Article,
   SearchableContentTypes,
+  LifeEventPage,
 } from '@island.is/web/graphql/schema'
 
 const DEBOUNCE_TIMER = 150
@@ -377,7 +378,7 @@ const Results: FC<{
               <Typography variant="eyebrow" color="purple400">
                 Beint að efninu
               </Typography>
-              {(search.results.items as Article[])
+              {(search.results.items as Article[] & LifeEventPage[])
                 .slice(0, 5)
                 .map(({ id, title, slug }) => (
                   <div key={id} {...getItemProps({ item: '' })}>

--- a/apps/web/graphql/schema.ts
+++ b/apps/web/graphql/schema.ts
@@ -545,7 +545,7 @@ export type LifeEventPage = {
   id: Scalars['ID']
   title: Scalars['String']
   slug: Scalars['String']
-  intro: Scalars['String']
+  intro?: Maybe<Scalars['String']>
   image?: Maybe<Image>
   thumbnail?: Maybe<Image>
   content: Array<Slice>
@@ -1731,7 +1731,7 @@ export type GetSearchResultsQuery = { __typename?: 'Query' } & {
       items: Array<
         | ({ __typename?: 'Article' } & Pick<
             Article,
-            'id' | 'title' | 'slug' | 'containsApplicationForm'
+            'id' | 'title' | 'slug' | 'intro' | 'containsApplicationForm'
           > & {
               group?: Maybe<
                 { __typename?: 'ArticleGroup' } & Pick<ArticleGroup, 'title'>
@@ -1814,7 +1814,7 @@ export type GetSearchResultsDetailedQuery = { __typename?: 'Query' } & {
       items: Array<
         | ({ __typename?: 'Article' } & Pick<
             Article,
-            'id' | 'title' | 'slug' | 'containsApplicationForm'
+            'id' | 'title' | 'slug' | 'intro' | 'containsApplicationForm'
           > & {
               group?: Maybe<
                 { __typename?: 'ArticleGroup' } & Pick<ArticleGroup, 'title'>

--- a/apps/web/screens/queries/Search.tsx
+++ b/apps/web/screens/queries/Search.tsx
@@ -9,6 +9,7 @@ export const GET_SEARCH_RESULTS_QUERY = gql`
           id
           title
           slug
+          intro
           containsApplicationForm
           group {
             title
@@ -81,6 +82,7 @@ export const GET_SEARCH_RESULTS_QUERY_DETAILED = gql`
           id
           title
           slug
+          intro
           containsApplicationForm
           group {
             title

--- a/libs/api/domains/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/api/domains/cms/src/lib/generated/contentfulTypes.d.ts
@@ -345,6 +345,39 @@ export interface ICardSection extends Entry<ICardSectionFields> {
 export interface IContactUsFields {
   /** Title */
   title?: string | undefined
+
+  /** Required */
+  required: string
+
+  /** Invalid Phone */
+  invalidPhone: string
+
+  /** Invalid Email */
+  invalidEmail: string
+
+  /** Label Name */
+  labelName: string
+
+  /** Label Phone */
+  labelPhone: string
+
+  /** Label Email */
+  labelEmail: string
+
+  /** Label Subject */
+  labelSubject: string
+
+  /** Label Message */
+  labelMessage: string
+
+  /** Submit button text */
+  submitButtonText: string
+
+  /** Success message */
+  successMessage: string
+
+  /** Error message */
+  errorMessage: string
 }
 
 export interface IContactUs extends Entry<IContactUsFields> {
@@ -641,7 +674,7 @@ export interface ILifeEventPageFields {
   slug: string
 
   /** intro */
-  intro: string
+  intro?: string | undefined
 
   /** image */
   image?: Asset | undefined

--- a/libs/api/domains/cms/src/lib/models/lifeEventPage.model.ts
+++ b/libs/api/domains/cms/src/lib/models/lifeEventPage.model.ts
@@ -17,8 +17,8 @@ export class LifeEventPage {
   @Field()
   slug: string
 
-  @Field()
-  intro: string
+  @Field({ nullable: true })
+  intro?: string
 
   @Field({ nullable: true })
   image?: Image

--- a/libs/api/schema/src/lib/schema.d.ts
+++ b/libs/api/schema/src/lib/schema.d.ts
@@ -556,7 +556,7 @@ export type LifeEventPage = {
   id: Scalars['ID']
   title: Scalars['String']
   slug: Scalars['String']
-  intro: Scalars['String']
+  intro?: Maybe<Scalars['String']>
   image?: Maybe<Image>
   thumbnail?: Maybe<Image>
   content: Array<Slice>
@@ -2575,7 +2575,7 @@ export type LifeEventPageResolvers<
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>
   title?: Resolver<ResolversTypes['String'], ParentType, ContextType>
   slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>
-  intro?: Resolver<ResolversTypes['String'], ParentType, ContextType>
+  intro?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   image?: Resolver<Maybe<ResolversTypes['Image']>, ParentType, ContextType>
   thumbnail?: Resolver<Maybe<ResolversTypes['Image']>, ParentType, ContextType>
   content?: Resolver<Array<ResolversTypes['Slice']>, ParentType, ContextType>


### PR DESCRIPTION
## What

Show the intro text/description if it exists, on search result cards...

## Why

It was missing.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
