### PR TITLE
Ads/removing zero and O from discount code because users tend to mix them up

### DIFF
--- a/apps/air-discount-scheme/backend/src/app/modules/discount/discount.service.ts
+++ b/apps/air-discount-scheme/backend/src/app/modules/discount/discount.service.ts
@@ -27,16 +27,21 @@ export class DiscountService {
   ) {}
 
   private getRandomRange(min: number, max: number): number {
-    return Math.random() * (max - min) + min
+    return Math.random() * (max + 1 - min) + min
   }
 
   private generateDiscountCode(): string {
     return [...Array(DISCOUNT_CODE_LENGTH)]
       .map(() => {
-        const rand = Math.round(Math.random())
-        const digits = this.getRandomRange(48, 57)
-        const upperLetters = this.getRandomRange(65, 90)
-        return String.fromCharCode(rand > 0.5 ? upperLetters : digits)
+        // We are excluding 0 and O because users mix them up
+        const charCodes = [
+          this.getRandomRange(49, 57), // 1 - 9
+          this.getRandomRange(65, 78), // A - N
+          this.getRandomRange(80, 90), // P - Z
+        ]
+        const randomCharCode =
+          charCodes[Math.floor(Math.random() * charCodes.length)]
+        return String.fromCharCode(randomCharCode)
       })
       .join('')
   }


### PR DESCRIPTION
## What

Removing zero and O from discount code

## Why

Because users tend to mix them up

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against master before asking for a review
