### PR TITLE
Bring back page links in front page sliders

### DIFF
--- a/apps/web/components/FrontpageTabs/FrontpageTabs.tsx
+++ b/apps/web/components/FrontpageTabs/FrontpageTabs.tsx
@@ -295,7 +295,7 @@ export const FrontpageTabs: FC<FrontpageTabsProps> = ({
 
       const slug = linkData.fields?.slug
 
-      if (slug && ['article', 'category', 'news'].includes(contentId)) {
+      if (slug && ['article', 'category', 'news', 'page'].includes(contentId)) {
         return {
           href: makePath(contentId, '/[slug]'),
           as: makePath(contentId, slug),


### PR DESCRIPTION
# Bring back front page sliders

Attach a link to issue if relevant

## What
Links in frontpage sliders disappeared in some merge, bringing them back

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/70899104/94045104-824e3b00-fdbe-11ea-8fed-c82dde91644e.png)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against master before asking for a review
