### PR TITLE
Website / Tighten SideMenu layout on mobile

### DIFF
--- a/apps/web/components/Header/Header.tsx
+++ b/apps/web/components/Header/Header.tsx
@@ -144,10 +144,12 @@ export const Header: FC<HeaderProps> = ({ showSearchInHeader = true }) => {
           </Columns>
         </GridColumn>
       </GridRow>
-      <SideMenu
-        isVisible={sideMenuOpen}
-        handleClose={() => setSideMenuOpen(false)}
-      />
+      <ColorSchemeContext.Provider value={{ colorScheme: 'blue' }}>
+        <SideMenu
+          isVisible={sideMenuOpen}
+          handleClose={() => setSideMenuOpen(false)}
+        />
+      </ColorSchemeContext.Provider>
     </GridContainer>
   )
 }

--- a/apps/web/components/SideMenu/SideMenu.tsx
+++ b/apps/web/components/SideMenu/SideMenu.tsx
@@ -21,14 +21,13 @@ import {
   Box,
   FocusableBox,
   Logo,
-  ColorSchemeContext,
 } from '@island.is/island-ui/core'
 import { theme } from '@island.is/island-ui/theme'
 import { MenuTabsContext } from '@island.is/web/context/MenuTabsContext/MenuTabsContext'
 import { useI18n } from '@island.is/web/i18n'
-import * as styles from './SideMenu.treat'
 import { SearchInput } from '../SearchInput/SearchInput'
 import { LanguageToggler } from '../LanguageToggler'
+import * as styles from './SideMenu.treat'
 
 interface TabLink {
   title: string
@@ -56,7 +55,6 @@ export const SideMenu: FC<Props> = ({ tabs = [], isVisible, handleClose }) => {
   const tabRefs = useRef<Array<HTMLElement | null>>([])
   const isMobile = width < theme.breakpoints.md
   const { menuTabs } = useContext(MenuTabsContext)
-  const { colorScheme } = useContext(ColorSchemeContext)
 
   const tabList = menuTabs || tabs
 
@@ -88,180 +86,176 @@ export const SideMenu: FC<Props> = ({ tabs = [], isVisible, handleClose }) => {
   }, [isVisible, ref, handleClickOutside])
 
   return (
-    <ColorSchemeContext.Provider
-      value={{ colorScheme: isMobile ? null : 'white' }}
-    >
-      <RemoveScroll ref={ref} enabled={isMobile && isVisible}>
-        <FocusLock>
+    <RemoveScroll ref={ref} enabled={isMobile && isVisible}>
+      <FocusLock>
+        <Box
+          className={cn(styles.root, {
+            [styles.isVisible]: isVisible,
+          })}
+          background="white"
+          borderRadius="large"
+          height="full"
+        >
           <Box
-            className={cn(styles.root, {
-              [styles.isVisible]: isVisible,
-            })}
-            background="white"
-            borderRadius="large"
-            height="full"
+            display="flex"
+            alignItems="center"
+            paddingBottom={3}
+            justifyContent="spaceBetween"
           >
-            <Box
-              display="flex"
-              alignItems="center"
-              paddingBottom={3}
-              justifyContent="spaceBetween"
-            >
-              <Logo width={isMobile ? 30 : 40} iconOnly id="sideMenuLogo" />
-              <Box display="flex" alignItems="center">
-                <FocusableBox
-                  component="button"
-                  onClick={handleClose}
-                  tabIndex={-1}
-                  padding={1}
-                >
-                  <Icon type="close" />
-                </FocusableBox>
-              </Box>
+            <Logo width={isMobile ? 30 : 40} iconOnly id="sideMenuLogo" />
+            <Box display="flex" alignItems="center">
+              <FocusableBox
+                component="button"
+                onClick={handleClose}
+                tabIndex={-1}
+                padding={1}
+              >
+                <Icon type="close" />
+              </FocusableBox>
             </Box>
-            <Hidden above="sm">
-              <GridContainer>
-                <GridRow>
-                  <GridColumn span="12/12">
-                    <SearchInput
-                      id="search_input_side_menu"
-                      activeLocale={activeLocale}
-                      placeholder={t.searchPlaceholder}
-                      size="medium"
-                    />
-                  </GridColumn>
-                </GridRow>
-                <GridRow>
-                  <GridColumn
-                    span="8/12"
-                    paddingTop={[2, 2, 3]}
-                    paddingBottom={[2, 2, 3]}
-                  >
-                    <Button
-                      href="https://minarsidur.island.is/"
-                      variant="menu"
-                      leftIcon="user"
-                      width="fluid"
-                    >
-                      {t.login}
-                    </Button>
-                  </GridColumn>
-                  <GridColumn
-                    span="4/12"
-                    paddingTop={[2, 2, 3]}
-                    paddingBottom={[2, 2, 3]}
-                  >
-                    <LanguageToggler />
-                  </GridColumn>
-                </GridRow>
-              </GridContainer>
-            </Hidden>
-
-            <div className={styles.tabBar}>
-              {tabList.map((tab, index) => (
-                <div key={index} className={styles.tabContainer}>
-                  <FocusableBox
-                    ref={(el) => (tabRefs.current[index] = el)}
-                    component="button"
-                    role="tab"
-                    aria-controls={`tab-content-${index}`}
-                    aria-selected={activeTab === index}
-                    onClick={() => setActiveTab(index)}
-                    className={styles.tabButton}
-                  >
-                    {({ isFocused }) => (
-                      <div
-                        className={cn(styles.tab, {
-                          [styles.tabActive]: activeTab === index,
-                          [styles.tabFocused]: isFocused,
-                        })}
-                      >
-                        <Typography
-                          variant="menuTab"
-                          fontWeight={activeTab === index ? 'medium' : 'light'}
-                          color="blue400"
-                        >
-                          {tab.title}
-                        </Typography>
-                      </div>
-                    )}
-                  </FocusableBox>
-                </div>
-              ))}
-            </div>
-            {tabList.map((tab, index) => {
-              const hasExternalLinks =
-                tab.externalLinks && tab.externalLinks.length
-              return (
-                <div
-                  key={index}
-                  aria-labelledby={`tab${index}`}
-                  role="tabpanel"
-                  className={styles.content}
-                  hidden={activeTab !== index}
+          </Box>
+          <Hidden above="sm">
+            <GridContainer>
+              <GridRow>
+                <GridColumn span="12/12">
+                  <SearchInput
+                    id="search_input_side_menu"
+                    activeLocale={activeLocale}
+                    placeholder={t.searchPlaceholder}
+                    size="medium"
+                  />
+                </GridColumn>
+              </GridRow>
+              <GridRow>
+                <GridColumn
+                  span="8/12"
+                  paddingTop={[2, 2, 3]}
+                  paddingBottom={[2, 2, 3]}
                 >
-                  <div className={styles.linksContent}>
-                    {tab.links.map((link, index) => {
-                      const props = {
-                        ...(link.href && { href: link.href }),
-                        ...(link.as && { as: link.as }),
-                      }
+                  <Button
+                    href="https://minarsidur.island.is/"
+                    variant="menu"
+                    leftIcon="user"
+                    width="fluid"
+                  >
+                    {t.login}
+                  </Button>
+                </GridColumn>
+                <GridColumn
+                  span="4/12"
+                  paddingTop={[2, 2, 3]}
+                  paddingBottom={[2, 2, 3]}
+                >
+                  <LanguageToggler />
+                </GridColumn>
+              </GridRow>
+            </GridContainer>
+          </Hidden>
 
-                      return (
+          <div className={styles.tabBar}>
+            {tabList.map((tab, index) => (
+              <div key={index} className={styles.tabContainer}>
+                <FocusableBox
+                  ref={(el) => (tabRefs.current[index] = el)}
+                  component="button"
+                  role="tab"
+                  aria-controls={`tab-content-${index}`}
+                  aria-selected={activeTab === index}
+                  onClick={() => setActiveTab(index)}
+                  className={styles.tabButton}
+                >
+                  {({ isFocused }) => (
+                    <div
+                      className={cn(styles.tab, {
+                        [styles.tabActive]: activeTab === index,
+                        [styles.tabFocused]: isFocused,
+                      })}
+                    >
+                      <Typography
+                        variant="menuTab"
+                        fontWeight={activeTab === index ? 'medium' : 'light'}
+                        color="blue400"
+                      >
+                        {tab.title}
+                      </Typography>
+                    </div>
+                  )}
+                </FocusableBox>
+              </div>
+            ))}
+          </div>
+          {tabList.map((tab, index) => {
+            const hasExternalLinks =
+              tab.externalLinks && tab.externalLinks.length
+            return (
+              <div
+                key={index}
+                aria-labelledby={`tab${index}`}
+                role="tabpanel"
+                className={styles.content}
+                hidden={activeTab !== index}
+              >
+                <div className={styles.linksContent}>
+                  {tab.links.map((link, index) => {
+                    const props = {
+                      ...(link.href && { href: link.href }),
+                      ...(link.as && { as: link.as }),
+                    }
+
+                    return (
+                      <Typography
+                        key={index}
+                        variant="sideMenu"
+                        color="blue400"
+                        paddingBottom={index + 1 === tab.links.length ? 0 : 2}
+                      >
+                        <Box
+                          component="span"
+                          display="inlineBlock"
+                          width="full"
+                          onClick={handleClose}
+                        >
+                          <FocusableBox {...props}>{link.title}</FocusableBox>
+                        </Box>
+                      </Typography>
+                    )
+                  })}
+                </div>
+                {hasExternalLinks && (
+                  <Box
+                    display="flex"
+                    alignItems="center"
+                    flexDirection="column"
+                  >
+                    <Typography
+                      variant="menuTab"
+                      color="blue400"
+                      paddingTop={3}
+                      paddingBottom={3}
+                    >
+                      {tab.externalLinksHeading}
+                    </Typography>
+                    <div className={styles.linksContent}>
+                      {tab.externalLinks.map((link, index) => (
                         <Typography
                           key={index}
                           variant="sideMenu"
                           color="blue400"
-                          paddingBottom={index + 1 === tab.links.length ? 0 : 2}
+                          paddingBottom={2}
                         >
-                          <Box
-                            component="span"
-                            display="inlineBlock"
-                            width="full"
-                            onClick={handleClose}
-                          >
-                            <FocusableBox {...props}>{link.title}</FocusableBox>
-                          </Box>
+                          <FocusableBox href={link.href}>
+                            {link.title}
+                          </FocusableBox>
                         </Typography>
-                      )
-                    })}
-                  </div>
-                  {hasExternalLinks && (
-                    <Box
-                      display="flex"
-                      alignItems="center"
-                      flexDirection="column"
-                    >
-                      <Typography
-                        variant="menuTab"
-                        color="blue400"
-                        paddingTop={3}
-                        paddingBottom={3}
-                      >
-                        {tab.externalLinksHeading}
-                      </Typography>
-                      <div className={styles.linksContent}>
-                        {tab.externalLinks.map((link, index) => (
-                          <Typography
-                            key={index}
-                            variant="sideMenu"
-                            color="blue400"
-                            paddingBottom={2}
-                          >
-                            <FocusableBox href={link.href}>
-                              {link.title}
-                            </FocusableBox>
-                          </Typography>
-                        ))}
-                      </div>
-                    </Box>
-                  )}
-                </div>
-              )
-            })}
-          </Box>
-        </FocusLock>
-      </RemoveScroll>
-    </ColorSchemeContext.Provider>
+                      ))}
+                    </div>
+                  </Box>
+                )}
+              </div>
+            )
+          })}
+        </Box>
+      </FocusLock>
+    </RemoveScroll>
   )
 }

--- a/apps/web/components/SideMenu/SideMenu.tsx
+++ b/apps/web/components/SideMenu/SideMenu.tsx
@@ -21,6 +21,7 @@ import {
   Box,
   FocusableBox,
   Logo,
+  ColorSchemeContext,
 } from '@island.is/island-ui/core'
 import { theme } from '@island.is/island-ui/theme'
 import { MenuTabsContext } from '@island.is/web/context/MenuTabsContext/MenuTabsContext'
@@ -55,6 +56,7 @@ export const SideMenu: FC<Props> = ({ tabs = [], isVisible, handleClose }) => {
   const tabRefs = useRef<Array<HTMLElement | null>>([])
   const isMobile = width < theme.breakpoints.md
   const { menuTabs } = useContext(MenuTabsContext)
+  const { colorScheme } = useContext(ColorSchemeContext)
 
   const tabList = menuTabs || tabs
 
@@ -86,174 +88,180 @@ export const SideMenu: FC<Props> = ({ tabs = [], isVisible, handleClose }) => {
   }, [isVisible, ref, handleClickOutside])
 
   return (
-    <RemoveScroll ref={ref} enabled={isMobile && isVisible}>
-      <FocusLock>
-        <Box
-          className={cn(styles.root, { [styles.isVisible]: isVisible })}
-          background="white"
-          borderRadius="large"
-          height="full"
-        >
+    <ColorSchemeContext.Provider
+      value={{ colorScheme: isMobile ? null : 'white' }}
+    >
+      <RemoveScroll ref={ref} enabled={isMobile && isVisible}>
+        <FocusLock>
           <Box
-            display="flex"
-            alignItems="center"
-            paddingBottom={3}
-            justifyContent="spaceBetween"
+            className={cn(styles.root, {
+              [styles.isVisible]: isVisible,
+            })}
+            background="white"
+            borderRadius="large"
+            height="full"
           >
-            <Logo width={isMobile ? 30 : 40} iconOnly id="sideMenuLogo" />
-            <Box display="flex" alignItems="center">
-              <FocusableBox
-                component="button"
-                onClick={handleClose}
-                tabIndex={-1}
-                padding={1}
-              >
-                <Icon type="close" />
-              </FocusableBox>
-            </Box>
-          </Box>
-          <Hidden above="sm">
-            <GridContainer>
-              <GridRow>
-                <GridColumn span="12/12">
-                  <SearchInput
-                    id="search_input_side_menu"
-                    activeLocale={activeLocale}
-                    placeholder={t.searchPlaceholder}
-                    size="medium"
-                  />
-                </GridColumn>
-              </GridRow>
-              <GridRow>
-                <GridColumn
-                  span="8/12"
-                  paddingTop={[2, 2, 3]}
-                  paddingBottom={[2, 2, 3]}
-                >
-                  <Button
-                    href="https://minarsidur.island.is/"
-                    variant="menu"
-                    leftIcon="user"
-                    width="fluid"
-                  >
-                    {t.login}
-                  </Button>
-                </GridColumn>
-                <GridColumn
-                  span="4/12"
-                  paddingTop={[2, 2, 3]}
-                  paddingBottom={[2, 2, 3]}
-                >
-                  <LanguageToggler />
-                </GridColumn>
-              </GridRow>
-            </GridContainer>
-          </Hidden>
-
-          <div className={styles.tabBar}>
-            {tabList.map((tab, index) => (
-              <div key={index} className={styles.tabContainer}>
+            <Box
+              display="flex"
+              alignItems="center"
+              paddingBottom={3}
+              justifyContent="spaceBetween"
+            >
+              <Logo width={isMobile ? 30 : 40} iconOnly id="sideMenuLogo" />
+              <Box display="flex" alignItems="center">
                 <FocusableBox
-                  ref={(el) => (tabRefs.current[index] = el)}
                   component="button"
-                  role="tab"
-                  aria-controls={`tab-content-${index}`}
-                  aria-selected={activeTab === index}
-                  onClick={() => setActiveTab(index)}
-                  className={styles.tabButton}
+                  onClick={handleClose}
+                  tabIndex={-1}
+                  padding={1}
                 >
-                  {({ isFocused }) => (
-                    <div
-                      className={cn(styles.tab, {
-                        [styles.tabActive]: activeTab === index,
-                        [styles.tabFocused]: isFocused,
-                      })}
-                    >
-                      <Typography
-                        variant="menuTab"
-                        fontWeight={activeTab === index ? 'medium' : 'light'}
-                        color="blue400"
-                      >
-                        {tab.title}
-                      </Typography>
-                    </div>
-                  )}
+                  <Icon type="close" />
                 </FocusableBox>
-              </div>
-            ))}
-          </div>
-          {tabList.map((tab, index) => {
-            const hasExternalLinks =
-              tab.externalLinks && tab.externalLinks.length
-            return (
-              <div
-                key={index}
-                aria-labelledby={`tab${index}`}
-                role="tabpanel"
-                className={styles.content}
-                hidden={activeTab !== index}
-              >
-                <div className={styles.linksContent}>
-                  {tab.links.map((link, index) => {
-                    const props = {
-                      ...(link.href && { href: link.href }),
-                      ...(link.as && { as: link.as }),
-                    }
-
-                    return (
-                      <Typography
-                        key={index}
-                        variant="sideMenu"
-                        color="blue400"
-                        paddingBottom={index + 1 === tab.links.length ? 0 : 2}
-                      >
-                        <Box
-                          component="span"
-                          display="inlineBlock"
-                          width="full"
-                          onClick={handleClose}
-                        >
-                          <FocusableBox {...props}>{link.title}</FocusableBox>
-                        </Box>
-                      </Typography>
-                    )
-                  })}
-                </div>
-                {hasExternalLinks && (
-                  <Box
-                    display="flex"
-                    alignItems="center"
-                    flexDirection="column"
+              </Box>
+            </Box>
+            <Hidden above="sm">
+              <GridContainer>
+                <GridRow>
+                  <GridColumn span="12/12">
+                    <SearchInput
+                      id="search_input_side_menu"
+                      activeLocale={activeLocale}
+                      placeholder={t.searchPlaceholder}
+                      size="medium"
+                    />
+                  </GridColumn>
+                </GridRow>
+                <GridRow>
+                  <GridColumn
+                    span="8/12"
+                    paddingTop={[2, 2, 3]}
+                    paddingBottom={[2, 2, 3]}
                   >
-                    <Typography
-                      variant="menuTab"
-                      color="blue400"
-                      paddingTop={3}
-                      paddingBottom={3}
+                    <Button
+                      href="https://minarsidur.island.is/"
+                      variant="menu"
+                      leftIcon="user"
+                      width="fluid"
                     >
-                      {tab.externalLinksHeading}
-                    </Typography>
-                    <div className={styles.linksContent}>
-                      {tab.externalLinks.map((link, index) => (
+                      {t.login}
+                    </Button>
+                  </GridColumn>
+                  <GridColumn
+                    span="4/12"
+                    paddingTop={[2, 2, 3]}
+                    paddingBottom={[2, 2, 3]}
+                  >
+                    <LanguageToggler />
+                  </GridColumn>
+                </GridRow>
+              </GridContainer>
+            </Hidden>
+
+            <div className={styles.tabBar}>
+              {tabList.map((tab, index) => (
+                <div key={index} className={styles.tabContainer}>
+                  <FocusableBox
+                    ref={(el) => (tabRefs.current[index] = el)}
+                    component="button"
+                    role="tab"
+                    aria-controls={`tab-content-${index}`}
+                    aria-selected={activeTab === index}
+                    onClick={() => setActiveTab(index)}
+                    className={styles.tabButton}
+                  >
+                    {({ isFocused }) => (
+                      <div
+                        className={cn(styles.tab, {
+                          [styles.tabActive]: activeTab === index,
+                          [styles.tabFocused]: isFocused,
+                        })}
+                      >
+                        <Typography
+                          variant="menuTab"
+                          fontWeight={activeTab === index ? 'medium' : 'light'}
+                          color="blue400"
+                        >
+                          {tab.title}
+                        </Typography>
+                      </div>
+                    )}
+                  </FocusableBox>
+                </div>
+              ))}
+            </div>
+            {tabList.map((tab, index) => {
+              const hasExternalLinks =
+                tab.externalLinks && tab.externalLinks.length
+              return (
+                <div
+                  key={index}
+                  aria-labelledby={`tab${index}`}
+                  role="tabpanel"
+                  className={styles.content}
+                  hidden={activeTab !== index}
+                >
+                  <div className={styles.linksContent}>
+                    {tab.links.map((link, index) => {
+                      const props = {
+                        ...(link.href && { href: link.href }),
+                        ...(link.as && { as: link.as }),
+                      }
+
+                      return (
                         <Typography
                           key={index}
                           variant="sideMenu"
                           color="blue400"
-                          paddingBottom={2}
+                          paddingBottom={index + 1 === tab.links.length ? 0 : 2}
                         >
-                          <FocusableBox href={link.href}>
-                            {link.title}
-                          </FocusableBox>
+                          <Box
+                            component="span"
+                            display="inlineBlock"
+                            width="full"
+                            onClick={handleClose}
+                          >
+                            <FocusableBox {...props}>{link.title}</FocusableBox>
+                          </Box>
                         </Typography>
-                      ))}
-                    </div>
-                  </Box>
-                )}
-              </div>
-            )
-          })}
-        </Box>
-      </FocusLock>
-    </RemoveScroll>
+                      )
+                    })}
+                  </div>
+                  {hasExternalLinks && (
+                    <Box
+                      display="flex"
+                      alignItems="center"
+                      flexDirection="column"
+                    >
+                      <Typography
+                        variant="menuTab"
+                        color="blue400"
+                        paddingTop={3}
+                        paddingBottom={3}
+                      >
+                        {tab.externalLinksHeading}
+                      </Typography>
+                      <div className={styles.linksContent}>
+                        {tab.externalLinks.map((link, index) => (
+                          <Typography
+                            key={index}
+                            variant="sideMenu"
+                            color="blue400"
+                            paddingBottom={2}
+                          >
+                            <FocusableBox href={link.href}>
+                              {link.title}
+                            </FocusableBox>
+                          </Typography>
+                        ))}
+                      </div>
+                    </Box>
+                  )}
+                </div>
+              )
+            })}
+          </Box>
+        </FocusLock>
+      </RemoveScroll>
+    </ColorSchemeContext.Provider>
   )
 }

--- a/apps/web/components/SideMenu/SideMenu.tsx
+++ b/apps/web/components/SideMenu/SideMenu.tsx
@@ -6,7 +6,6 @@ import React, {
   useCallback,
   useContext,
 } from 'react'
-import Link from 'next/link'
 import FocusLock from 'react-focus-lock'
 import { RemoveScroll } from 'react-remove-scroll'
 import { useKey, useWindowSize } from 'react-use'
@@ -77,7 +76,7 @@ export const SideMenu: FC<Props> = ({ tabs = [], isVisible, handleClose }) => {
   useEffect(() => {
     document.addEventListener('click', handleClickOutside, true)
 
-    if (tabRefs.current) {
+    if (tabRefs.current && !isMobile) {
       tabRefs.current[0] && tabRefs.current[0].focus()
     }
 
@@ -95,8 +94,13 @@ export const SideMenu: FC<Props> = ({ tabs = [], isVisible, handleClose }) => {
           borderRadius="large"
           height="full"
         >
-          <Box display="flex" paddingBottom={3} justifyContent="spaceBetween">
-            <Logo iconOnly id="sideMenuLogo" />
+          <Box
+            display="flex"
+            alignItems="center"
+            paddingBottom={3}
+            justifyContent="spaceBetween"
+          >
+            <Logo width={isMobile ? 30 : 40} iconOnly id="sideMenuLogo" />
             <Box display="flex" alignItems="center">
               <FocusableBox
                 component="button"
@@ -121,7 +125,11 @@ export const SideMenu: FC<Props> = ({ tabs = [], isVisible, handleClose }) => {
                 </GridColumn>
               </GridRow>
               <GridRow>
-                <GridColumn span="8/12" paddingTop={3} paddingBottom={3}>
+                <GridColumn
+                  span="8/12"
+                  paddingTop={[2, 2, 3]}
+                  paddingBottom={[2, 2, 3]}
+                >
                   <Button
                     href="https://minarsidur.island.is/"
                     variant="menu"
@@ -131,7 +139,11 @@ export const SideMenu: FC<Props> = ({ tabs = [], isVisible, handleClose }) => {
                     {t.login}
                   </Button>
                 </GridColumn>
-                <GridColumn span="4/12" paddingTop={3} paddingBottom={3}>
+                <GridColumn
+                  span="4/12"
+                  paddingTop={[2, 2, 3]}
+                  paddingBottom={[2, 2, 3]}
+                >
                   <LanguageToggler />
                 </GridColumn>
               </GridRow>


### PR DESCRIPTION
# Tighten up mobile

## Screenshots / Gifs

**Tighten up**

Before:
![image](https://user-images.githubusercontent.com/8494120/94126010-9fc6e780-fe46-11ea-8692-a93dbf808280.png)

After:
![image](https://user-images.githubusercontent.com/8494120/94125973-93db2580-fe46-11ea-935e-36cb0f90a2b3.png)

**Fix mobile SideMenu colorscheme bug.**

Before:
![image](https://user-images.githubusercontent.com/8494120/94128509-c76b7f00-fe49-11ea-96b6-57c9f253b7f7.png)

After:
![image](https://user-images.githubusercontent.com/8494120/94128586-da7e4f00-fe49-11ea-8e02-83a72fd63724.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
