### PR TITLE
Make sure SideMenu uses default blue scheme in Header

### DIFF
--- a/apps/web/components/Header/Header.tsx
+++ b/apps/web/components/Header/Header.tsx
@@ -144,10 +144,12 @@ export const Header: FC<HeaderProps> = ({ showSearchInHeader = true }) => {
           </Columns>
         </GridColumn>
       </GridRow>
-      <SideMenu
-        isVisible={sideMenuOpen}
-        handleClose={() => setSideMenuOpen(false)}
-      />
+      <ColorSchemeContext.Provider value={{ colorScheme: 'blue' }}>
+        <SideMenu
+          isVisible={sideMenuOpen}
+          handleClose={() => setSideMenuOpen(false)}
+        />
+      </ColorSchemeContext.Provider>
     </GridContainer>
   )
 }


### PR DESCRIPTION
## What

Make SideMenu inputs visible on about page.

## Why

Was invisible on the about page.

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/8450096/94128867-2f21ca00-fe4a-11ea-9e70-14f5f0477370.png)

![image](https://user-images.githubusercontent.com/8450096/94128513-c9354280-fe49-11ea-8bf7-17ed4baab628.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
