### PR TITLE
Website / About page spacing tweaks for mobile

### DIFF
--- a/apps/web/components/AboutLatestNews/AboutLatestNews.tsx
+++ b/apps/web/components/AboutLatestNews/AboutLatestNews.tsx
@@ -52,7 +52,7 @@ export const AboutLatestNews: FC<LatestNewsProps> = ({
     <>
       <div className={styles.indent}>
         {Boolean(title) && (
-          <Box paddingBottom={8}>
+          <Box paddingBottom={[4, 4, 8]}>
             <Typography variant="h1" as="h2">
               {title}
             </Typography>
@@ -69,7 +69,11 @@ export const AboutLatestNews: FC<LatestNewsProps> = ({
       </div>
       <GridRow>
         {rest.map((newsItem, index) => (
-          <GridColumn key={index} span={['1/1', '1/1', '1/2']} paddingTop={15}>
+          <GridColumn
+            key={index}
+            span={['1/1', '1/1', '1/2']}
+            paddingTop={[7, 7, 15]}
+          >
             <NewsCard
               key={index}
               title={newsItem.title}

--- a/apps/web/components/AboutLatestNews/AboutLatestNews.tsx
+++ b/apps/web/components/AboutLatestNews/AboutLatestNews.tsx
@@ -16,7 +16,6 @@ import { useNamespace } from '@island.is/web/hooks'
 import routeNames from '@island.is/web/i18n/routeNames'
 import { useI18n } from '@island.is/web/i18n'
 import { GetNamespaceQuery } from '@island.is/web/graphql/schema'
-import Link from 'next/link'
 
 // This component is used to display latest news on the About page only.
 // It's not how we display the latest news on the front page.

--- a/apps/web/components/Timeline/Timeline.tsx
+++ b/apps/web/components/Timeline/Timeline.tsx
@@ -33,7 +33,7 @@ export const Timeline: FC<TimelineProps> = ({ title, events }) => {
     <>
       <GridRow>
         <GridColumn offset={[null, null, null, '1/9']}>
-          <Box paddingTop={2} paddingBottom={5}>
+          <Box paddingTop={2} paddingBottom={[0, 0, 5]}>
             <Typography variant="p" as="p" color="white">
               {title}
             </Typography>

--- a/apps/web/screens/AboutPage/AboutPage.tsx
+++ b/apps/web/screens/AboutPage/AboutPage.tsx
@@ -28,6 +28,7 @@ import {
   GridRow,
   SpanType,
   Tabs,
+  Hidden,
 } from '@island.is/island-ui/core'
 import { withMainLayout } from '@island.is/web/layouts/main'
 import Sidebar, { SidebarProps } from './Sidebar'
@@ -159,7 +160,7 @@ const PageHeader: FC<PageHeaderProps> = ({ page }) => {
   return (
     <Background id={slice.id} theme={page.theme}>
       {!!mobileNavigation.length && (
-        <Box display={['block', 'block', 'block', 'none']} paddingBottom={4}>
+        <Hidden above="md">
           <DrawerMenu
             categories={[
               {
@@ -168,11 +169,11 @@ const PageHeader: FC<PageHeaderProps> = ({ page }) => {
               },
             ]}
           />
-        </Box>
+        </Hidden>
       )}
       <GridContainer position="none">
         <ColorSchemeContext.Provider value={{ colorScheme: 'white' }}>
-          <Box marginBottom={[8, 8, 8, 15]}>
+          <Box marginBottom={[0, 0, 8, 15]}>
             <Header />
           </Box>
         </ColorSchemeContext.Provider>

--- a/apps/web/screens/AboutPage/AboutPage.tsx
+++ b/apps/web/screens/AboutPage/AboutPage.tsx
@@ -17,7 +17,6 @@ import {
 } from '@island.is/web/components'
 import {
   Typography,
-  Divider,
   Box,
   BoxProps,
   Breadcrumbs,
@@ -205,7 +204,6 @@ const PageHeader: FC<PageHeaderProps> = ({ page }) => {
                 const [navigationTitle, ...navigationList] = navigation
                 return (
                   <>
-                    {}
                     <Box
                       component="a"
                       ref={
@@ -301,7 +299,7 @@ const Section: FC<SectionProps> = ({ slice, namespace }) => {
       return (
         <div key={slice.id} id={slice.id}>
           <Layout indent={mainContentIndent} width={mainContentSpanWithIndent}>
-            <Box paddingTop={15} paddingBottom={10}>
+            <Box paddingTop={[6, 6, 15]} paddingBottom={[5, 5, 10]}>
               <Heading {...slice} />
             </Box>
           </Layout>
@@ -311,7 +309,7 @@ const Section: FC<SectionProps> = ({ slice, namespace }) => {
       return (
         <Box key={slice.id} id={slice.id} background="dotted">
           <Layout width={mainContentSpan}>
-            <Box paddingTop={8} paddingBottom={10}>
+            <Box paddingTop={8} paddingBottom={[5, 5, 10]}>
               <LinkCardList {...slice} />
             </Box>
           </Layout>
@@ -321,7 +319,7 @@ const Section: FC<SectionProps> = ({ slice, namespace }) => {
       return (
         <Box key={slice.id} id={slice.id} background="blue100">
           <Layout width={mainContentSpanWithIndent} indent={mainContentIndent}>
-            <Box paddingTop={10} paddingBottom={7}>
+            <Box paddingTop={[4, 4, 10]} paddingBottom={[3, 3, 7]}>
               <RenderForm
                 namespace={namespace}
                 heading={slice.title}
@@ -337,7 +335,7 @@ const Section: FC<SectionProps> = ({ slice, namespace }) => {
       return (
         <div key={slice.id} id={slice.id} className={styles.gradient}>
           <Layout width={mainContentSpan}>
-            <Box paddingTop={12} paddingBottom={10}>
+            <Box paddingTop={[8, 8, 12]} paddingBottom={[8, 8, 10]}>
               <StoryList
                 {...slice}
                 stories={(slice.stories as any[]).map((story) => ({
@@ -353,7 +351,7 @@ const Section: FC<SectionProps> = ({ slice, namespace }) => {
       return (
         <div key={slice.id} id={slice.id}>
           <Layout width={mainContentSpan}>
-            <Box paddingTop={15} paddingBottom={12}>
+            <Box paddingTop={[8, 8, 15]} paddingBottom={[6, 6, 12]}>
               <AboutLatestNews {...slice} namespace={namespace} />
             </Box>
           </Layout>
@@ -363,7 +361,7 @@ const Section: FC<SectionProps> = ({ slice, namespace }) => {
       return (
         <div key={slice.id} id={slice.id} className={styles.gradient}>
           <Layout width={mainContentSpan}>
-            <Box paddingTop={12} paddingBottom={5}>
+            <Box paddingTop={[8, 8, 12]} paddingBottom={5}>
               <LogoList
                 {...slice}
                 images={slice.images.map((img) => img.url)}
@@ -376,7 +374,7 @@ const Section: FC<SectionProps> = ({ slice, namespace }) => {
       return (
         <div id={slice.id} key={slice.id}>
           <Layout width={mainContentSpan}>
-            <Box paddingBottom={10}>
+            <Box paddingBottom={[5, 5, 10]}>
               <BulletList
                 bullets={slice.bullets.map((bullet) => {
                   switch (bullet.__typename) {
@@ -401,7 +399,7 @@ const Section: FC<SectionProps> = ({ slice, namespace }) => {
       return (
         <Box key={slice.id} id={slice.id} background="dotted">
           <Layout width={mainContentSpan}>
-            <Box paddingTop={8} paddingBottom={10}>
+            <Box paddingTop={8} paddingBottom={[5, 5, 10]}>
               <Tabs
                 label={slice?.title}
                 tabs={slice?.tabs.map((tab) => ({
@@ -412,7 +410,7 @@ const Section: FC<SectionProps> = ({ slice, namespace }) => {
                         span={['9/9', '9/9', '9/9', '7/9']}
                         offset={[null, null, null, '1/9']}
                       >
-                        <Box paddingY={9}>
+                        <Box paddingTop={[4, 4, 9]} paddingBottom={[0, 0, 9]}>
                           <Typography variant="h2" as="h2" marginBottom={3}>
                             {tab.contentTitle}
                           </Typography>

--- a/libs/island-ui/core/src/lib/Timeline/Timeline.treat.ts
+++ b/libs/island-ui/core/src/lib/Timeline/Timeline.treat.ts
@@ -4,6 +4,14 @@ import { themeUtils, theme } from '@island.is/island-ui/theme'
 export const container = style({
   position: 'relative',
   display: 'flex',
+
+  '@media': {
+    [`screen and (max-width: ${theme.breakpoints.md}px)`]: {
+      // Escape grid
+      marginLeft: -theme.grid.gutter.mobile * 2,
+      marginRight: -theme.grid.gutter.mobile * 2,
+    },
+  },
 })
 
 export const innerContainer = style({
@@ -13,7 +21,6 @@ export const innerContainer = style({
   height: 'auto',
   flexDirection: 'row',
   transition: `transform 300ms ease`,
-  // border: '5px solid lime',
   ':before': {
     content: '""',
     position: 'absolute',
@@ -30,7 +37,6 @@ export const innerContainer = style({
   ...themeUtils.responsiveStyle({
     lg: {
       minWidth: '100%',
-      // padding: '40px 0',
       flexDirection: 'column',
       ':before': {
         background: `linear-gradient(359.09deg, #0161FD 15.89%, #3F46D2 33.21%, #812EA4 51.23%, #C21578 69.24%, #FD0050 85.18%)`,

--- a/libs/island-ui/core/src/lib/Typography/Typography.treat.ts
+++ b/libs/island-ui/core/src/lib/Typography/Typography.treat.ts
@@ -144,7 +144,7 @@ export const variants: Variants = {
       xs: 12,
       md: 14,
     },
-    lineHeight: 1.142857,
+    lineHeight: { xs: 1.5, md: 1.142857 },
   },
   menuTab: {
     fontSize: {

--- a/libs/island-ui/core/src/lib/Typography/Typography.tsx
+++ b/libs/island-ui/core/src/lib/Typography/Typography.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import cn from 'classnames'
-import { resolveResponsiveProp } from '../../utils/responsiveProp'
 
 import styles, {
   VariantTypes,


### PR DESCRIPTION
# About page spacing tweaks for mobile
https://app.asana.com/0/1183498341031105/1195547281923255

## What

- AboutPage mobile spacing tweaks
- Make Timeline escape grid on mobile 
- Give eyebrow bigger line-height on mobile.
- General improvements

## Screenshots

Before:
![image](https://user-images.githubusercontent.com/8494120/94135253-b83cff00-fe52-11ea-852a-de272ea28b17.png)

After:
![image](https://user-images.githubusercontent.com/8494120/94135215-a4919880-fe52-11ea-8a2d-638eaed74978.png)

Before:
![image](https://user-images.githubusercontent.com/8494120/94135282-c7bc4800-fe52-11ea-987d-a5d97ae2037b.png)

After:
![image](https://user-images.githubusercontent.com/8494120/94135372-e7537080-fe52-11ea-9529-30b2040f1dce.png)

Etc...


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
