### PR TITLE
Display "Lausagæsla" in overview if there are no custody restrictions

### DIFF
--- a/apps/judicial-system/web/src/api/index.ts
+++ b/apps/judicial-system/web/src/api/index.ts
@@ -34,7 +34,6 @@ export const getCases: () => Promise<DetentionRequest[]> = async () => {
     }
   } catch (ex) {
     // TODO: Log error
-    console.log(ex)
   }
 }
 

--- a/apps/judicial-system/web/src/routes/CourtRecord/CourtRecord.tsx
+++ b/apps/judicial-system/web/src/routes/CourtRecord/CourtRecord.tsx
@@ -10,7 +10,7 @@ import { format, isValid, parseISO, setHours, setMinutes } from 'date-fns'
 import React, { useEffect, useState } from 'react'
 import CourtDocument from '../../shared-components/CourtDocument/CourtDocument'
 import { FormFooter } from '../../shared-components/FormFooter'
-import { Logo } from '../../shared-components/Logo/Logo'
+import { JudgeLogo } from '../../shared-components/Logos'
 import { GetCaseByIdResponse } from '../../types'
 import useWorkingCase from '../../utils/hooks/useWorkingCase'
 import { autoSave } from '../../utils/stepHelper'
@@ -44,7 +44,7 @@ export const CourtRecord: React.FC = () => {
       <GridContainer>
         <GridRow>
           <GridColumn span={'3/12'}>
-            <Logo />
+            <JudgeLogo />
           </GridColumn>
           <GridColumn span={'8/12'} offset={'1/12'}>
             <Box marginBottom={10}>

--- a/apps/judicial-system/web/src/routes/DetentionRequests/DetentionRequests.spec.tsx
+++ b/apps/judicial-system/web/src/routes/DetentionRequests/DetentionRequests.spec.tsx
@@ -50,7 +50,7 @@ describe('Detention requests route', () => {
 
     const { getAllByTestId } = render(
       <Router history={history}>
-        <DetentionRequests onGetUser={() => console.log('get user cb')} />
+        <DetentionRequests onGetUser={() => undefined} />
       </Router>,
     )
 
@@ -71,7 +71,7 @@ describe('Detention requests route', () => {
         value={{ user: { nationalId: '0123456789', roles: [UserRole.JUDGE] } }}
       >
         <Router history={history}>
-          <DetentionRequests onGetUser={() => console.log('get user cb')} />
+          <DetentionRequests onGetUser={() => undefined} />
         </Router>
       </userContext.Provider>,
     )
@@ -91,7 +91,7 @@ describe('Detention requests route', () => {
         }}
       >
         <Router history={history}>
-          <DetentionRequests onGetUser={() => console.log('get user cb')} />
+          <DetentionRequests onGetUser={() => undefined} />
         </Router>
       </userContext.Provider>,
     )
@@ -115,7 +115,7 @@ describe('Detention requests route', () => {
 
     const { getAllByTestId } = render(
       <Router history={history}>
-        <DetentionRequests onGetUser={() => console.log('get user cb')} />
+        <DetentionRequests onGetUser={() => undefined} />
       </Router>,
     )
 
@@ -133,7 +133,7 @@ describe('Detention requests route', () => {
 
     const { getByTestId, queryByTestId } = render(
       <Router history={history}>
-        <DetentionRequests onGetUser={() => console.log('get user cb')} />
+        <DetentionRequests onGetUser={() => undefined} />
       </Router>,
     )
     await waitFor(() => getByTestId('detention-requests-error'))

--- a/apps/judicial-system/web/src/routes/Judge/Overview.spec.tsx
+++ b/apps/judicial-system/web/src/routes/Judge/Overview.spec.tsx
@@ -1,0 +1,108 @@
+import { createMemoryHistory } from 'history'
+import React from 'react'
+import { cleanup, render, waitFor } from '@testing-library/react'
+import { Route, Router } from 'react-router-dom'
+import fetchMock from 'fetch-mock'
+import * as Constants from '../../utils/constants'
+import JudgeOverview from './Overview'
+import { CustodyRestrictions } from '../../types'
+
+describe(`${Constants.JUDGE_SINGLE_REQUEST_BASE_ROUTE}/:id`, () => {
+  test('should display the string lausagæsla in custody restrictions if there are no custody restrictions', async () => {
+    // Arrange
+    const history = createMemoryHistory()
+
+    // Ensure our route has an ID
+    const route = `${Constants.JUDGE_SINGLE_REQUEST_BASE_ROUTE}/test_id`
+    history.push(route)
+
+    // Mock API call to getCaseById
+    fetchMock.mock('/api/case/test_id', {
+      id: 'b5041539-27c0-426a-961d-0f268fe45165',
+      created: '2020-09-16T19:50:08.033Z',
+      modified: '2020-09-16T19:51:39.466Z',
+      state: 'SUBMITTED',
+      court: 'string',
+      comments: 'string',
+      policeCaseNumber: 'string',
+      suspectNationalId: 'string',
+      suspectName: 'string',
+      suspectAddress: 'string',
+      arrestDate: '2020-09-16T19:51:28.224Z',
+      requestedCourtDate: '2020-09-16T19:51:28.224Z',
+      requestedCustodyEndDate: '2020-09-16T19:51:28.224Z',
+      lawsBroken: 'string',
+      custodyProvisions: ['_95_1_A'],
+      custodyRestrictions: [],
+      caseFacts: 'string',
+      witnessAccounts: 'string',
+      investigationProgress: 'string',
+      legalArguments: 'string',
+    })
+
+    // Act
+    const { getByText } = render(
+      <Router history={history}>
+        <Route path={`${Constants.JUDGE_SINGLE_REQUEST_BASE_ROUTE}/:id`}>
+          <JudgeOverview />
+        </Route>
+      </Router>,
+    )
+
+    // Assert
+    await waitFor(() => getByText('Lausagæsla'))
+    expect(getByText('Lausagæsla')).toBeTruthy()
+    cleanup()
+  })
+
+  test('should display the approprieate custody restriction if there are any', async () => {
+    // Arrange
+    const history = createMemoryHistory()
+
+    // Ensure our route has an ID
+    const route = `${Constants.JUDGE_SINGLE_REQUEST_BASE_ROUTE}/test_id`
+    history.push(route)
+
+    // Mock API call to getCaseById
+    fetchMock.mock(
+      '/api/case/test_id',
+      {
+        id: 'b5041539-27c0-426a-961d-0f268fe45165',
+        created: '2020-09-16T19:50:08.033Z',
+        modified: '2020-09-16T19:51:39.466Z',
+        state: 'SUBMITTED',
+        court: 'string',
+        comments: 'string',
+        policeCaseNumber: 'string',
+        suspectNationalId: 'string',
+        suspectName: 'string',
+        suspectAddress: 'string',
+        arrestDate: '2020-09-16T19:51:28.224Z',
+        requestedCourtDate: '2020-09-16T19:51:28.224Z',
+        requestedCustodyEndDate: '2020-09-16T19:51:28.224Z',
+        lawsBroken: 'string',
+        custodyProvisions: ['_95_1_A'],
+        custodyRestrictions: ['ISOLATION', 'MEDIA'],
+        caseFacts: 'string',
+        witnessAccounts: 'string',
+        investigationProgress: 'string',
+        legalArguments: 'string',
+      },
+      { overwriteRoutes: true },
+    )
+
+    // Act
+    const { getByText } = render(
+      <Router history={history}>
+        <Route path={`${Constants.JUDGE_SINGLE_REQUEST_BASE_ROUTE}/:id`}>
+          <JudgeOverview />
+        </Route>
+      </Router>,
+    )
+
+    // Assert
+    await waitFor(() => getByText('B - Einangrun, E - Fjölmiðlabann'))
+    expect(getByText('B - Einangrun, E - Fjölmiðlabann')).toBeTruthy()
+    cleanup()
+  })
+})

--- a/apps/judicial-system/web/src/routes/Judge/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Judge/Overview.tsx
@@ -13,7 +13,7 @@ import { JudgeLogo } from '../../shared-components/Logos'
 import { formatDate, capitalize } from '../../utils/formatters'
 import is from 'date-fns/locale/is'
 import { autoSave, getRestrictionByValue } from '../../utils/stepHelper'
-import { Case, CustodyRestrictions } from '../../types'
+import { CustodyRestrictions } from '../../types'
 import { FormFooter } from '../../shared-components/FormFooter'
 import { useParams } from 'react-router-dom'
 import * as api from '../../api'
@@ -38,16 +38,25 @@ export const JudgeOverview: React.FC = () => {
   const [workingCase, setWorkingCase] = useWorkingCase()
 
   useEffect(() => {
+    let mounted = true
+
     const getCurrentCase = async () => {
       const currentCase = await api.getCaseById(id)
       window.localStorage.setItem('workingCase', JSON.stringify(currentCase))
-      setWorkingCase(currentCase.case)
+
+      if (mounted) {
+        setWorkingCase(currentCase.case)
+      }
     }
 
     if (id) {
       getCurrentCase()
     }
-  }, [])
+
+    return () => {
+      mounted = false
+    }
+  }, [id])
 
   return workingCase ? (
     <Box marginTop={7} marginBottom={30}>
@@ -207,14 +216,14 @@ export const JudgeOverview: React.FC = () => {
                   onToggle={() => setAccordionItemThreeExpanded(false)}
                 >
                   <Typography variant="p" as="p">
-                    {workingCase?.custodyRestrictions?.length > 0 &&
-                      workingCase?.custodyRestrictions
-                        .map(
-                          (restriction: CustodyRestrictions) =>
-                            `${getRestrictionByValue(restriction)}`,
-                        )
-                        .toString()
-                        .replace(',', ', ')}
+                    {workingCase?.custodyRestrictions?.length > 0
+                      ? workingCase?.custodyRestrictions
+                          .map((restriction: CustodyRestrictions) =>
+                            getRestrictionByValue(restriction),
+                          )
+                          .toString()
+                          .replace(',', ', ')
+                      : 'Lausagæsla'}
                   </Typography>
                 </AccordionItem>
                 <AccordionItem

--- a/apps/judicial-system/web/src/routes/Judge/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Judge/Overview.tsx
@@ -12,7 +12,11 @@ import {
 import { JudgeLogo } from '../../shared-components/Logos'
 import { formatDate, capitalize } from '../../utils/formatters'
 import is from 'date-fns/locale/is'
-import { autoSave, getRestrictionByValue } from '../../utils/stepHelper'
+import {
+  autoSave,
+  getRestrictionByValue,
+  renderRestrictons,
+} from '../../utils/stepHelper'
 import { CustodyRestrictions } from '../../types'
 import { FormFooter } from '../../shared-components/FormFooter'
 import { useParams } from 'react-router-dom'
@@ -216,14 +220,7 @@ export const JudgeOverview: React.FC = () => {
                   onToggle={() => setAccordionItemThreeExpanded(false)}
                 >
                   <Typography variant="p" as="p">
-                    {workingCase?.custodyRestrictions?.length > 0
-                      ? workingCase?.custodyRestrictions
-                          .map((restriction: CustodyRestrictions) =>
-                            getRestrictionByValue(restriction),
-                          )
-                          .toString()
-                          .replace(',', ', ')
-                      : 'Lausagæsla'}
+                    {renderRestrictons(workingCase.custodyRestrictions)}
                   </Typography>
                 </AccordionItem>
                 <AccordionItem

--- a/apps/judicial-system/web/src/routes/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Overview/Overview.tsx
@@ -14,7 +14,10 @@ import { ProsecutorLogo } from '../../shared-components/Logos'
 import Modal from '../../shared-components/Modal/Modal'
 import { formatDate, capitalize } from '../../utils/formatters'
 import is from 'date-fns/locale/is'
-import { getRestrictionByValue } from '../../utils/stepHelper'
+import {
+  getRestrictionByValue,
+  renderRestrictons,
+} from '../../utils/stepHelper'
 import { CustodyRestrictions } from '../../types'
 import { FormFooter } from '../../shared-components/FormFooter'
 import * as Constants from '../../utils/constants'
@@ -166,15 +169,7 @@ export const Overview: React.FC = () => {
                   </AccordionItem>
                   <AccordionItem id="id_3" label="Takmarkanir á gæslu">
                     <Typography variant="p" as="p">
-                      {caseDraftJSON.custodyRestrictions?.length > 0
-                        ? caseDraftJSON.custodyRestrictions
-                            .map(
-                              (restriction: CustodyRestrictions) =>
-                                `${getRestrictionByValue(restriction)}`,
-                            )
-                            .toString()
-                            .replace(',', ', ')
-                        : 'Lausagæsla'}
+                      {renderRestrictons(caseDraftJSON.custodyRestrictions)}
                     </Typography>
                   </AccordionItem>
                   <AccordionItem

--- a/apps/judicial-system/web/src/routes/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Overview/Overview.tsx
@@ -166,13 +166,15 @@ export const Overview: React.FC = () => {
                   </AccordionItem>
                   <AccordionItem id="id_3" label="Takmarkanir á gæslu">
                     <Typography variant="p" as="p">
-                      {caseDraftJSON.custodyRestrictions
-                        .map(
-                          (restriction: CustodyRestrictions) =>
-                            `${getRestrictionByValue(restriction)}`,
-                        )
-                        .toString()
-                        .replace(',', ', ')}
+                      {caseDraftJSON.custodyRestrictions?.length > 0
+                        ? caseDraftJSON.custodyRestrictions
+                            .map(
+                              (restriction: CustodyRestrictions) =>
+                                `${getRestrictionByValue(restriction)}`,
+                            )
+                            .toString()
+                            .replace(',', ', ')
+                        : 'Lausagæsla'}
                     </Typography>
                   </AccordionItem>
                   <AccordionItem

--- a/apps/judicial-system/web/src/utils/stepHelper.ts
+++ b/apps/judicial-system/web/src/utils/stepHelper.ts
@@ -55,3 +55,12 @@ export const getRestrictionByValue = (value: CustodyRestrictions) => {
       return 'C - Heimsóknarbann'
   }
 }
+
+export const renderRestrictons = (restrictions: CustodyRestrictions[]) => {
+  return restrictions && restrictions.length > 0
+    ? restrictions
+        .map((restriction) => getRestrictionByValue(restriction))
+        .toString()
+        .replace(',', ', ')
+    : 'Lausagæsla'
+}

--- a/apps/judicial-system/web/src/utils/utils.spec.ts
+++ b/apps/judicial-system/web/src/utils/utils.spec.ts
@@ -1,6 +1,8 @@
 import { UserRole, hasRole } from './authenticate'
 import { formatDate, parseArray, parseString } from './formatters'
 import * as Constants from './constants'
+import { renderRestrictons } from './stepHelper'
+import { CustodyRestrictions } from '../types'
 
 describe('Authenticate utils', () => {
   describe('HasRole util', () => {
@@ -81,6 +83,35 @@ describe('Formatters utils', () => {
       // Assert
       expect(time).toEqual('09:36')
       expect(time2).toEqual('23:36')
+    })
+  })
+})
+
+describe('Step helper', () => {
+  describe('renderRestrictions', () => {
+    test('should return a comma separated list of restrictions', () => {
+      // Arrange
+      const restrictions: CustodyRestrictions[] = [
+        CustodyRestrictions.ISOLATION,
+        CustodyRestrictions.COMMUNICATION,
+      ]
+
+      // Act
+      const r = renderRestrictons(restrictions)
+
+      // Assert
+      expect(r).toEqual('B - Einangrun, D - Bréfskoðun, símabann')
+    })
+
+    test('should return "Lausgæsla" if no custody restriction is supplyed', () => {
+      // Arrange
+      const restrictions: CustodyRestrictions[] = []
+
+      // Act
+      const r = renderRestrictons(restrictions)
+
+      // Assert
+      expect(r).toEqual('Lausagæsla')
     })
   })
 })


### PR DESCRIPTION
# Display "Lausagæsla" in overview if there are no custody restrictions

https://app.asana.com/0/1189271618154957/1195315258966996

## What

If there are custody restrictions then they should be listed in a comma separated list (B - Einangrun, E - Fjölmiðlabann). If there are no custody restrictions then "Lausagæsla" should be displayed.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
