### PR TITLE
Make success check run always

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -478,7 +478,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-  trigger-deployments:
+  deploy:
     runs-on: ubuntu-20.04
     needs: [retag-unaffected, prepare]
     env:
@@ -488,6 +488,8 @@ jobs:
     strategy:
       matrix:
         service: [islandis, gjafakort, air-discount-scheme]
+    outputs:
+      TRIGGER_FINISHED: ${{ steps.finished.outputs.TRIGGER_FINISHED }}
     steps:
       - uses: actions/checkout@v2
       - name: Trigger Deployment for service
@@ -503,11 +505,18 @@ jobs:
           "parameters": { "docker_tag": "$DOCKER_TAG" }
           }
           BODY
+      - id: finished
+        run: echo "::set-output name=TRIGGER_FINISHED::yes"
 
   success:
     runs-on: ubuntu-20.04
-    needs: trigger-deployments
+    if: always()
+    needs: deploy
+    env:
+      TRIGGER_FINISHED: ${{ needs.deploy.outputs.TRIGGER_FINISHED }}
     steps:
+      - name: Check success
+        run: '[[ $TRIGGER_FINISHED == "yes" ]] || exit 1'
       - name: Announce success
         run: echo "Build is successful"
 
@@ -522,7 +531,7 @@ jobs:
         prepare,
         linting,
         formatting,
-        trigger-deployments,
+        deploy,
       ]
     env:
       PUBLISH: ${{ needs.prepare.outputs.PUBLISH}}


### PR DESCRIPTION
Currently, success is skipped if previous checks don't run. This will
allow developers to merge red pull requests.

This closes #1070

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have rebased against master before asking for a review
