### PR TITLE
Remove swiping and fix mobile button

### DIFF
--- a/apps/web/components/FrontpageTabs/FrontpageTabs.tsx
+++ b/apps/web/components/FrontpageTabs/FrontpageTabs.tsx
@@ -220,74 +220,6 @@ export const FrontpageTabs: FC<FrontpageTabsProps> = ({
     }
   }
 
-  const getDirection = (absX: number, absY: number, deltaX, deltaY) => {
-    if (absX > absY) {
-      if (deltaX > 0) {
-        return LEFT
-      }
-      return RIGHT
-    } else if (deltaY > 0) {
-      return UP
-    }
-    return DOWN
-  }
-
-  const isMouseEvent = <T extends HTMLElement>(
-    event: React.MouseEvent<T, MouseEvent> | React.TouchEvent<T>,
-  ): event is React.MouseEvent<T, MouseEvent> => {
-    return event.nativeEvent instanceof MouseEvent
-  }
-
-  const handleTouchStart = (
-    e:
-      | React.MouseEvent<HTMLElement, MouseEvent>
-      | React.TouchEvent<HTMLElement>,
-  ) => {
-    const x = isMouseEvent(e) ? e.clientX : e.targetTouches[0].pageX
-    const y = isMouseEvent(e) ? e.clientY : e.targetTouches[0].pageY
-    setInitialClientX(x)
-  }
-
-  const handleTouchMove = (
-    e:
-      | React.MouseEvent<HTMLElement, MouseEvent>
-      | React.TouchEvent<HTMLElement>,
-  ) => {
-    const x = isMouseEvent(e) ? e.clientX : e.targetTouches[0].pageX
-    const y = isMouseEvent(e) ? e.clientY : e.targetTouches[0].pageY
-
-    setFinalClientX(x)
-    setFinalClientY(y)
-  }
-
-  const handleTouchEnd = (
-    e:
-      | React.MouseEvent<HTMLElement, MouseEvent>
-      | React.TouchEvent<HTMLElement>,
-  ) => {
-    if (e.cancelable) {
-      e.preventDefault()
-      e.stopPropagation()
-    }
-
-    const deltaX = finalClientX - initialClientX
-    const deltaY = finalClientY - initialClientX
-    const absX = Math.abs(deltaX)
-    const absY = Math.abs(deltaY)
-
-    if (finalClientX > 10) {
-      if (getDirection(absX, absY, deltaX, deltaY) === LEFT) {
-        goTo('prev')
-      }
-      if (getDirection(absX, absY, deltaX, deltaY) === RIGHT) {
-        goTo('next')
-      }
-    }
-
-    setFinalClientX(0)
-    setInitialClientX(0)
-  }
-
   const generateUrls = (link: string): LinkUrls => {
     if (link) {
       const linkData = JSON.parse(link)
@@ -368,15 +300,6 @@ export const FrontpageTabs: FC<FrontpageTabsProps> = ({
                         paddingY={3}
                         ref={(el) => (itemsRef.current[index] = el)}
                         style={{ minHeight: `${minHeight}px` }}
-                        onTouchStart={(e) =>
-                          isTabletOrMobile ? handleTouchStart(e) : null
-                        }
-                        onTouchEnd={(e) =>
-                          isTabletOrMobile ? handleTouchEnd(e) : null
-                        }
-                        onTouchMove={(e) =>
-                          isTabletOrMobile ? handleTouchMove(e) : null
-                        }
                       >
                         <Stack space={3}>
                           <Typography


### PR DESCRIPTION
# Fix mobile button

## What
* Remove swiping effect in frontpage tabs

## Why
* They were causing bug in mobile, unable to click button
* Swiping was not working nicely
* Should do this more elegantly

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
