### PR TITLE
Fixing typescript errors in message-queue and infra-express-server libs

### DIFF
--- a/libs/infra-express-server/src/lib/infra-express-server.ts
+++ b/libs/infra-express-server/src/lib/infra-express-server.ts
@@ -1,7 +1,7 @@
 // This needs to be the first import in the app to hook into the modules system correctly
 import { initTracing } from '@island.is/infra-tracing'
 
-import express, { Router } from 'express'
+import express, { Router, Request, Response, NextFunction } from 'express'
 import { collectDefaultMetrics, Histogram } from 'prom-client'
 import { metricsApp } from './metrics-publisher'
 import { logger } from '@island.is/logging'
@@ -68,7 +68,12 @@ export const runServer = ({
   // secured
   app.use('/', routes)
 
-  app.use(function errorHandler(err, req, res, next) {
+  app.use(function errorHandler(
+    err: any, // eslint-disable-line  @typescript-eslint/no-explicit-any
+    req: Request,
+    res: Response,
+    next: NextFunction, // eslint-disable-line
+  ) {
     logger.error(`Status code: ${err.status}, msg: ${err.message}`)
     res.status(err.status || 500)
     res.send(err.message)

--- a/libs/infra-express-server/tsconfig.json
+++ b/libs/infra-express-server/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "types": ["node", "jest"],
-    "strict": false
+    "types": ["node", "jest"]
   },
   "include": ["**/*.ts"]
 }

--- a/libs/message-queue/tsconfig.json
+++ b/libs/message-queue/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "types": ["node", "jest"],
-    "strict": false
+    "types": ["node", "jest"]
   },
   "include": ["**/*.ts"]
 }


### PR DESCRIPTION
Reduces work on: #253
 
This PR fixes typescript errors in:
* message-queue
* infra-next-server

## What

Kill all typescript errors that come due to strict setting being enabled

## Why

So all code in monorepo can be strict

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
