### PR TITLE
Add readiness/liveness probes to skilavottord-web

### DIFF
--- a/apps/skilavottord/web/next-modules/withHealthcheckConfig.js
+++ b/apps/skilavottord/web/next-modules/withHealthcheckConfig.js
@@ -1,0 +1,20 @@
+module.exports = (nextConfig = {}) => {
+  return {
+    ...nextConfig,
+    webpack: (config, options) => {
+      // Fixes dependency on 'dns' module in frontend
+      if (!options.isServer) {
+        config.node = {
+          dns: 'empty',
+        }
+      }
+
+      // Overload the Webpack config if it was already overloaded
+      if (typeof nextConfig.webpack === 'function') {
+        return nextConfig.webpack(config, options)
+      }
+
+      return config
+    },
+  }
+}

--- a/apps/skilavottord/web/next.config.js
+++ b/apps/skilavottord/web/next.config.js
@@ -1,23 +1,26 @@
 const withTreat = require('next-treat')()
+const withHealthcheckConfig = require('./next-modules/withHealthcheckConfig')
 
 const {
   API_URL = 'http://localhost:3333/api',
   WEB_PUBLIC_URL = 'http://localhost:4200',
 } = process.env
 
-module.exports = withTreat({
-  webpack: (config, options) => {
-    if (!options.isServer) {
-      config.resolve.alias['@sentry/node'] = '@sentry/browser'
-    }
-    return config
-  },
-  serverRuntimeConfig: {
-    // Will only be available on the server side
-    apiUrl: API_URL,
-  },
-  publicRuntimeConfig: {
-    // Will be available on both server and client
-    apiUrl: `${WEB_PUBLIC_URL}/api`,
-  },
-})
+module.exports = withTreat(
+  withHealthcheckConfig({
+    webpack: (config, options) => {
+      if (!options.isServer) {
+        config.resolve.alias['@sentry/node'] = '@sentry/browser'
+      }
+      return config
+    },
+    serverRuntimeConfig: {
+      // Will only be available on the server side
+      apiUrl: API_URL,
+    },
+    publicRuntimeConfig: {
+      // Will be available on both server and client
+      apiUrl: `${WEB_PUBLIC_URL}/api`,
+    },
+  }),
+)

--- a/apps/skilavottord/web/pages/_app.tsx
+++ b/apps/skilavottord/web/pages/_app.tsx
@@ -5,6 +5,7 @@ import App from 'next/app'
 import { AppProps } from 'next/app'
 import { ApolloProvider } from '@apollo/client'
 
+import { withHealthchecks } from '../units/Healthchecks/withHealthchecks'
 import { client as initApollo } from '../graphql'
 import { AppLayout } from '../components/Layouts'
 import { appWithTranslation } from '../i18n'
@@ -39,4 +40,9 @@ class SupportApplication extends App<AppProps> {
   }
 }
 
-export default appWithTranslation(SupportApplication)
+// TODO: Add api endpoint? Other external dependencies?
+const externalEndpointDependencies = []
+
+export default appWithTranslation(
+  withHealthchecks(externalEndpointDependencies)(SupportApplication),
+)

--- a/apps/skilavottord/web/units/Healthchecks/withHealthchecks.tsx
+++ b/apps/skilavottord/web/units/Healthchecks/withHealthchecks.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import dns from 'dns'
+
+const checkExternalDependency = (url: string) =>
+  new Promise((resolve, reject) => {
+    dns.lookup(url, (err) => {
+      if (err) reject(false)
+      resolve(true)
+    })
+  })
+
+export const withHealthchecks = (externalEndpointDependencies: string[]) => (
+  Component,
+) => {
+  const NewComponent = (props) => <Component {...props} />
+
+  NewComponent.getInitialProps = async (context) => {
+    const ctx = context.ctx ?? context
+    /*
+    Readiness should return 200 if it can resolve hostnames of external dependencies.
+    Apps should inform the cluster of their own state not the state of other services.
+    If we make this app depend on external service we risk it going down with those external dependecies.
+    e.g the web app should render the error page for users if the api goes offline the web app should not go offline
+    */
+    if (ctx.req?.url === '/readiness') {
+      // check if we can resolve the provided url hostnames in DNS
+      const externalDnsRequests = externalEndpointDependencies.map(
+        (externalUrl) => {
+          const url = new URL(externalUrl)
+          return checkExternalDependency(url.hostname)
+        },
+      )
+
+      // we dotn care about the error, error means no resolve so we return 500
+      const status = await Promise.all(externalDnsRequests)
+        .then(() => 200)
+        .catch(() => 500)
+
+      // forward the api status code as readiness status code
+      ctx.res.statusCode = status
+      ctx.res.end('')
+      return null
+    }
+
+    // tels the cluster this instance is alive
+    if (ctx.req?.url === '/liveness') {
+      ctx.res.statusCode = 200
+      ctx.res.end('')
+      return null
+    }
+    return Component.getInitialProps(context)
+  }
+
+  return NewComponent
+}

--- a/apps/skilavottord/web/units/errors.ts
+++ b/apps/skilavottord/web/units/errors.ts
@@ -1,0 +1,9 @@
+export class CustomNextError extends Error {
+  statusCode: number
+  title: string
+  constructor(statusCode: number, title?: string, message?: string) {
+    super(message ?? title)
+    this.statusCode = statusCode
+    this.title = title
+  }
+}


### PR DESCRIPTION
## What

Listen to /liveness and /readiness

## Why

Because we want to conform to standards

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
