### PR TITLE
Fix layout issues on articles

### DIFF
--- a/apps/web/components/RichText/RichText.tsx
+++ b/apps/web/components/RichText/RichText.tsx
@@ -54,7 +54,6 @@ export const RichText: FC<{
   body: Slice[]
   config?: Partial<RenderConfig>
 }> = memo(({ body, config = {} }) => {
-  console.log('body', body)
   return <>{renderSlices(body, { renderComponent, ...config })}</>
 })
 

--- a/apps/web/components/RichText/RichText.tsx
+++ b/apps/web/components/RichText/RichText.tsx
@@ -31,7 +31,7 @@ const renderComponent = (slice: Slice, config: RenderConfig) => {
         <GridRow>
           <GridColumn
             offset={['0', '0', '0', '0', '1/9']}
-            span={['0', '0', '0', '0', '7/9']}
+            span={['9/9', '9/9', '9/9', '9/9', '7/9']}
           >
             {children}
           </GridColumn>
@@ -54,6 +54,7 @@ export const RichText: FC<{
   body: Slice[]
   config?: Partial<RenderConfig>
 }> = memo(({ body, config = {} }) => {
+  console.log('body', body)
   return <>{renderSlices(body, { renderComponent, ...config })}</>
 })
 

--- a/libs/island-ui/contentful/src/lib/ProcessEntry/ProcessEntry.tsx
+++ b/libs/island-ui/contentful/src/lib/ProcessEntry/ProcessEntry.tsx
@@ -46,7 +46,7 @@ export const ProcessEntry: FC<ProcessEntryProps> = ({
             paddingX={[3, 3, 3, 3, 0]}
             display="flex"
             flexGrow={1}
-            flexDirection={['column', 'column', 'column', 'column', 'row']}
+            flexDirection={['column', 'column', 'row', 'row', 'row']}
           >
             <Box flexGrow={1}>
               <Stack space={1}>


### PR DESCRIPTION
# Layout issues on articles

Fix minor layout on articles

## What & Why

Videos and images were not showing in less than XL screen sizes
Process entry button section was wrapping too soon

## Screenshots / Gifs

Before: 
![image](https://user-images.githubusercontent.com/70899104/94701651-69003e00-032c-11eb-8eec-7b284e31bda6.png)

After:
![image](https://user-images.githubusercontent.com/70899104/94701841-a2d14480-032c-11eb-8331-112ebe5e9d31.png)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against master before asking for a review
