### PR TITLE
Resolve node-forge to 0.10.0 due to security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -287,6 +287,7 @@
   "resolutions": {
     "webpack": "4.44.1",
     "serialize-javascript": "4.0.0",
-    "http-proxy": "1.18.1"
+    "http-proxy": "1.18.1",
+    "node-forge": "0.10.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16411,10 +16411,10 @@ node-fetch@^1.0.1, node-fetch@^1.7.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-forge@0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.9.0.tgz#d624050edbb44874adca12bb9a52ec63cb782579"
-  integrity sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==
+node-forge@0.10.0, node-forge@0.9.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
+  integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
 
 node-gyp-build@^3.8.0:
   version "3.9.0"


### PR DESCRIPTION
# Resolve node-forge to 0.10.0

## What

The version of node-forge we were using was breaking our build due to a security vuln. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
