### PR TITLE
Dont use generated files when building for dummy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,12 +213,14 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-yarn
 
       - name: Cache for generated files
+        if: ${{ matrix.projects != 'dummy' }}
         uses: actions/cache@v2
         with:
           path: generated_files.tar.gz
           key: ${{ runner.os }}-${{ hashFiles('libs/api/domains/cms/src/lib/generated/contentfulTypes.d.ts', 'apps/**/codegen.yml', 'apps/**/modules/**.ts?', 'libs/**/modules/**.ts?', 'apps/**/models/**.ts?', 'libs/**/models/**.ts?', 'apps/**/dto/**.ts?', 'libs/**/dto/**.ts?', 'apps/**/enums/**.ts?', 'libs/**/enums/**.ts?', 'apps/**/queries/**.ts?', 'libs/**/queries/**.ts?', 'apps/**/*.resolver.ts', 'libs/**/*.resolver.ts', 'apps/**/*.service.ts', 'libs/**/*.service.ts', 'apps/air-discount-scheme/web/screens/**/*.tsx', 'apps/air-discount-scheme/web/i18n/withLocale.tsx', 'apps/air-discount-scheme/web/components/AppLayout/AppLayout.tsx', 'apps/air-discount-scheme/web/components/Header/Header.tsx', 'apps/gjafakort/api/src/**/typeDefs.ts') }}-generated-files
 
       - name: Untar generated files
+        if: ${{ matrix.projects != 'dummy' }}
         run: tar zxvf generated_files.tar.gz
 
       - name: Set up Docker Buildx
@@ -275,12 +277,14 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-yarn
 
       - name: Cache for generated files
+        if: ${{ matrix.projects != 'dummy' }}
         uses: actions/cache@v2
         with:
           path: generated_files.tar.gz
           key: ${{ runner.os }}-${{ hashFiles('libs/api/domains/cms/src/lib/generated/contentfulTypes.d.ts', 'apps/**/codegen.yml', 'apps/**/modules/**.ts?', 'libs/**/modules/**.ts?', 'apps/**/models/**.ts?', 'libs/**/models/**.ts?', 'apps/**/dto/**.ts?', 'libs/**/dto/**.ts?', 'apps/**/enums/**.ts?', 'libs/**/enums/**.ts?', 'apps/**/queries/**.ts?', 'libs/**/queries/**.ts?', 'apps/**/*.resolver.ts', 'libs/**/*.resolver.ts', 'apps/**/*.service.ts', 'libs/**/*.service.ts', 'apps/air-discount-scheme/web/screens/**/*.tsx', 'apps/air-discount-scheme/web/i18n/withLocale.tsx', 'apps/air-discount-scheme/web/components/AppLayout/AppLayout.tsx', 'apps/air-discount-scheme/web/components/Header/Header.tsx', 'apps/gjafakort/api/src/**/typeDefs.ts') }}-generated-files
 
       - name: Untar generated files
+        if: ${{ matrix.projects != 'dummy' }}
         run: tar zxvf generated_files.tar.gz
 
       - name: Linting
@@ -304,12 +308,14 @@ jobs:
         if: ${{ matrix.projects != 'dummy' }}
 
       - name: Cache for generated files
+        if: ${{ matrix.projects != 'dummy' }}
         uses: actions/cache@v2
         with:
           path: generated_files.tar.gz
           key: ${{ runner.os }}-${{ hashFiles('libs/api/domains/cms/src/lib/generated/contentfulTypes.d.ts', 'apps/**/codegen.yml', 'apps/**/modules/**.ts?', 'libs/**/modules/**.ts?', 'apps/**/models/**.ts?', 'libs/**/models/**.ts?', 'apps/**/dto/**.ts?', 'libs/**/dto/**.ts?', 'apps/**/enums/**.ts?', 'libs/**/enums/**.ts?', 'apps/**/queries/**.ts?', 'libs/**/queries/**.ts?', 'apps/**/*.resolver.ts', 'libs/**/*.resolver.ts', 'apps/**/*.service.ts', 'libs/**/*.service.ts', 'apps/air-discount-scheme/web/screens/**/*.tsx', 'apps/air-discount-scheme/web/i18n/withLocale.tsx', 'apps/air-discount-scheme/web/components/AppLayout/AppLayout.tsx', 'apps/air-discount-scheme/web/components/Header/Header.tsx', 'apps/gjafakort/api/src/**/typeDefs.ts') }}-generated-files
 
       - name: Untar generated files
+        if: ${{ matrix.projects != 'dummy' }}
         run: tar zxvf generated_files.tar.gz
 
       - name: Cache for dependencies Docker layer
@@ -362,12 +368,14 @@ jobs:
         if: ${{ matrix.projects != 'dummy' }}
 
       - name: Cache for generated files
+        if: ${{ matrix.projects != 'dummy' }}
         uses: actions/cache@v2
         with:
           path: generated_files.tar.gz
           key: ${{ runner.os }}-${{ hashFiles('libs/api/domains/cms/src/lib/generated/contentfulTypes.d.ts', 'apps/**/codegen.yml', 'apps/**/modules/**.ts?', 'libs/**/modules/**.ts?', 'apps/**/models/**.ts?', 'libs/**/models/**.ts?', 'apps/**/dto/**.ts?', 'libs/**/dto/**.ts?', 'apps/**/enums/**.ts?', 'libs/**/enums/**.ts?', 'apps/**/queries/**.ts?', 'libs/**/queries/**.ts?', 'apps/**/*.resolver.ts', 'libs/**/*.resolver.ts', 'apps/**/*.service.ts', 'libs/**/*.service.ts', 'apps/air-discount-scheme/web/screens/**/*.tsx', 'apps/air-discount-scheme/web/i18n/withLocale.tsx', 'apps/air-discount-scheme/web/components/AppLayout/AppLayout.tsx', 'apps/air-discount-scheme/web/components/Header/Header.tsx', 'apps/gjafakort/api/src/**/typeDefs.ts') }}-generated-files
 
       - name: Untar generated files
+        if: ${{ matrix.projects != 'dummy' }}
         run: tar zxvf generated_files.tar.gz
 
       - name: Cache for dependencies Docker layer
@@ -420,12 +428,14 @@ jobs:
         if: ${{ matrix.projects != 'dummy' }}
 
       - name: Cache for generated files
+        if: ${{ matrix.projects != 'dummy' }}
         uses: actions/cache@v2
         with:
           path: generated_files.tar.gz
           key: ${{ runner.os }}-${{ hashFiles('libs/api/domains/cms/src/lib/generated/contentfulTypes.d.ts', 'apps/**/codegen.yml', 'apps/**/modules/**.ts?', 'libs/**/modules/**.ts?', 'apps/**/models/**.ts?', 'libs/**/models/**.ts?', 'apps/**/dto/**.ts?', 'libs/**/dto/**.ts?', 'apps/**/enums/**.ts?', 'libs/**/enums/**.ts?', 'apps/**/queries/**.ts?', 'libs/**/queries/**.ts?', 'apps/**/*.resolver.ts', 'libs/**/*.resolver.ts', 'apps/**/*.service.ts', 'libs/**/*.service.ts', 'apps/air-discount-scheme/web/screens/**/*.tsx', 'apps/air-discount-scheme/web/i18n/withLocale.tsx', 'apps/air-discount-scheme/web/components/AppLayout/AppLayout.tsx', 'apps/air-discount-scheme/web/components/Header/Header.tsx', 'apps/gjafakort/api/src/**/typeDefs.ts') }}-generated-files
 
       - name: Untar generated files
+        if: ${{ matrix.projects != 'dummy' }}
         run: tar zxvf generated_files.tar.gz
 
       - name: Cache for dependencies Docker layer


### PR DESCRIPTION
## What

Builds failing on master for docker-static(dummy) with the error: `Cache not found for input keys: Linux--generated-files`

## Why

So master can be green again :)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against master before asking for a review
