### PR TITLE
Judicial-system: Fixes formatting of values

### DIFF
--- a/apps/judicial-system/web/src/utils/formatters.ts
+++ b/apps/judicial-system/web/src/utils/formatters.ts
@@ -16,7 +16,7 @@ export const parseString = (
   value: string | Date | boolean,
 ) => {
   try {
-    const json = JSON.parse(`{"${property}": "${value}"}`)
+    const json = JSON.parse(`{"${property}": ${JSON.stringify(value)}}`)
     return json
   } catch (e) {
     console.log(e)

--- a/apps/judicial-system/web/src/utils/utils.spec.ts
+++ b/apps/judicial-system/web/src/utils/utils.spec.ts
@@ -38,6 +38,21 @@ describe('Formatters utils', () => {
       // Assert
       expect(parsedString).toEqual({ test: 'lorem' })
     })
+
+    test('given a value with special characters should parse correctly into JSON', () => {
+      //Arrange
+      const property = 'test'
+      const value = `lorem
+ipsum`
+
+      // Act
+      const parsedString = parseString(property, value)
+
+      // Assert
+      expect(parsedString).toEqual({
+        test: 'lorem\nipsum',
+      })
+    })
   })
 
   describe('Parse transition', () => {


### PR DESCRIPTION
# Fixes value formatting

## What

User JSON.stringify to format values

## Why

Otherwise, strings cannot include special characters in api calls

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
