### PR TITLE
Fix spacing in article rich text

### DIFF
--- a/apps/web/screens/Article.tsx
+++ b/apps/web/screens/Article.tsx
@@ -484,7 +484,10 @@ const ArticleScreen: Screen<ArticleProps> = ({ article, namespace }) => {
           </GridColumn>
         </GridRow>
         <Box paddingTop={subArticle ? 2 : 4}>
-          <RichText body={(subArticle ?? article).body} />
+          <RichText
+            body={(subArticle ?? article).body}
+            config={{ defaultPadding: 4 }}
+          />
         </Box>
       </ArticleLayout>
     </>


### PR DESCRIPTION
## Screenshots / Gifs

Before:
![image](https://user-images.githubusercontent.com/70899104/95343424-0a950b80-08a8-11eb-89f2-ab7daeb99b82.png)

After:
![image](https://user-images.githubusercontent.com/70899104/95343454-141e7380-08a8-11eb-934f-8f8f82612b39.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
