### PR TITLE
Fix builds after attempted PUBLISH removal

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -351,6 +351,7 @@ jobs:
       GIT_BRANCH: ${{ needs.prepare.outputs.GIT_BRANCH}}
       DOCKER_TAG: ${{ needs.prepare.outputs.DOCKER_TAG}}
       MAX_JOBS: 4
+      PUBLISH: true
     strategy:
       fail-fast: false
       matrix:
@@ -363,7 +364,7 @@ jobs:
         id: gather
         run: |
           AFFECTED_PROJECTS=$(echo '${{ needs.prepare.outputs.BUILD_MAP }}' | jq -r '.["docker-${{ matrix.docker-type }}"]')
-          if [[ "$AFFECTED_PROJECTS" == "" ]]; then
+          if [[ "$AFFECTED_PROJECTS" == "null" ]]; then
             # Early exit
             exit 1
           fi


### PR DESCRIPTION
We still need the PUBLISH flag low in the stack... We should try to limit the usage of random environment variables in scripts.