### PR TITLE
island-ui / Rename button imports

### DIFF
--- a/apps/adgerdir/components/Articles/Articles.tsx
+++ b/apps/adgerdir/components/Articles/Articles.tsx
@@ -5,7 +5,7 @@ import cn from 'classnames'
 import {
   Box,
   Tiles,
-  Button,
+  ButtonDeprecated as Button,
   Stack,
   Typography,
   Tag,

--- a/apps/adgerdir/components/BulletList/BulletList.tsx
+++ b/apps/adgerdir/components/BulletList/BulletList.tsx
@@ -2,7 +2,13 @@ import React, { FC, useState, ReactNode } from 'react'
 import cn from 'classnames'
 import AnimateHeight from 'react-animate-height'
 import IconBullet from '../IconBullet/IconBullet'
-import { Stack, Box, Typography, Button, Icon } from '@island.is/island-ui/core'
+import {
+  Stack,
+  Box,
+  Typography,
+  ButtonDeprecated as Button,
+  Icon,
+} from '@island.is/island-ui/core'
 import * as styles from './BulletList.treat'
 
 type IconBullet = {

--- a/apps/adgerdir/components/FeaturedNews/FeaturedNews.tsx
+++ b/apps/adgerdir/components/FeaturedNews/FeaturedNews.tsx
@@ -7,7 +7,7 @@ import {
   GridRow,
   GridColumn,
   Stack,
-  Button,
+  ButtonDeprecated as Button,
 } from '@island.is/island-ui/core'
 import { AdgerdirNews } from '@island.is/api/schema'
 import { Heading, BackgroundImage } from '@island.is/adgerdir/components'

--- a/apps/adgerdir/components/Header/Header.tsx
+++ b/apps/adgerdir/components/Header/Header.tsx
@@ -6,7 +6,7 @@ import {
   Columns,
   Column,
   Box,
-  Button,
+  ButtonDeprecated as Button,
   Hidden,
   ResponsiveSpace,
   GridContainer,

--- a/apps/adgerdir/components/Hyperlink/Hyperlink.tsx
+++ b/apps/adgerdir/components/Hyperlink/Hyperlink.tsx
@@ -5,7 +5,7 @@ import {
   Icon,
   Typography,
   TypographyProps,
-  Button,
+  ButtonDeprecated as Button,
 } from '@island.is/island-ui/core'
 import useRouteNames, { pathTypes } from '../../i18n/useRouteNames'
 import { Locale } from '@island.is/adgerdir/i18n/I18n'

--- a/apps/adgerdir/screens/Article.tsx
+++ b/apps/adgerdir/screens/Article.tsx
@@ -9,7 +9,7 @@ import {
   Typography,
   Stack,
   Breadcrumbs,
-  Button,
+  ButtonDeprecated as Button,
   Inline,
   Tag,
 } from '@island.is/island-ui/core'

--- a/apps/adgerdir/screens/NewsArticle.tsx
+++ b/apps/adgerdir/screens/NewsArticle.tsx
@@ -11,7 +11,7 @@ import {
   Typography,
   Stack,
   Breadcrumbs,
-  Button,
+  ButtonDeprecated as Button,
 } from '@island.is/island-ui/core'
 import {
   Query,

--- a/apps/adgerdir/screens/NewsList.tsx
+++ b/apps/adgerdir/screens/NewsList.tsx
@@ -25,7 +25,7 @@ import {
   GridContainer,
   GridRow,
   GridColumn,
-  Button,
+  ButtonDeprecated as Button,
 } from '@island.is/island-ui/core'
 import { GET_NEWS_LIST_QUERY } from './queries'
 import { NewsListLayout } from './Layouts/Layouts'

--- a/apps/air-discount-scheme/web/components/Content/Content.tsx
+++ b/apps/air-discount-scheme/web/components/Content/Content.tsx
@@ -6,7 +6,7 @@ import {
   Stack,
   Accordion,
   AccordionItem,
-  Button,
+  ButtonDeprecated as Button,
   Divider,
 } from '@island.is/island-ui/core'
 import { documentToReactComponents } from '@contentful/rich-text-react-renderer'

--- a/apps/air-discount-scheme/web/screens/Admin/Admin.tsx
+++ b/apps/air-discount-scheme/web/screens/Admin/Admin.tsx
@@ -15,7 +15,7 @@ import {
   GridColumn,
   GridContainer,
   SkeletonLoader,
-  Button,
+  ButtonDeprecated as Button,
 } from '@island.is/island-ui/core'
 import { Filters, Panel, Summary, Modal } from './components'
 import { FilterInput } from './consts'

--- a/apps/air-discount-scheme/web/screens/Admin/components/Filters/Filters.tsx
+++ b/apps/air-discount-scheme/web/screens/Admin/components/Filters/Filters.tsx
@@ -8,7 +8,7 @@ import {
   Typography,
   Divider,
   DatePicker,
-  Button,
+  ButtonDeprecated as Button,
   Input,
   Select,
 } from '@island.is/island-ui/core'

--- a/apps/air-discount-scheme/web/screens/Admin/components/Modal/Modal.tsx
+++ b/apps/air-discount-scheme/web/screens/Admin/components/Modal/Modal.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react'
 import HtmlParser from 'react-html-parser'
 
 import {
-  Button,
+  ButtonDeprecated as Button,
   Box,
   Typography,
   Stack,

--- a/apps/air-discount-scheme/web/screens/ErrorPage/ErrorPage.tsx
+++ b/apps/air-discount-scheme/web/screens/ErrorPage/ErrorPage.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/router'
 
 import {
   Box,
-  Button,
+  ButtonDeprecated as Button,
   ContentBlock,
   Typography,
 } from '@island.is/island-ui/core'

--- a/apps/air-discount-scheme/web/screens/NotFound/NotFound.tsx
+++ b/apps/air-discount-scheme/web/screens/NotFound/NotFound.tsx
@@ -3,7 +3,7 @@ import Router from 'next/router'
 
 import {
   Box,
-  Button,
+  ButtonDeprecated as Button,
   Icon,
   Typography,
   GridContainer,

--- a/apps/air-discount-scheme/web/screens/Subsidy/components/NoBenefits/NoBenefits.tsx
+++ b/apps/air-discount-scheme/web/screens/Subsidy/components/NoBenefits/NoBenefits.tsx
@@ -1,5 +1,11 @@
 import React from 'react'
-import { Box, Typography, Button, Stack, Icon } from '@island.is/island-ui/core'
+import {
+  Box,
+  Typography,
+  ButtonDeprecated as Button,
+  Stack,
+  Icon,
+} from '@island.is/island-ui/core'
 import { Link } from '@island.is/air-discount-scheme-web/components'
 
 interface PropTypes {

--- a/apps/air-discount-scheme/web/screens/Subsidy/components/UserCredit/UserCredit.tsx
+++ b/apps/air-discount-scheme/web/screens/Subsidy/components/UserCredit/UserCredit.tsx
@@ -3,7 +3,11 @@ import React, { useContext } from 'react'
 import { UserContext } from '@island.is/air-discount-scheme-web/context'
 import { copyToClipboard } from '@island.is/air-discount-scheme-web/utils'
 import { Discount } from '@island.is/air-discount-scheme-web/graphql/schema'
-import { Box, Typography, Button } from '@island.is/island-ui/core'
+import {
+  Box,
+  Typography,
+  ButtonDeprecated as Button,
+} from '@island.is/island-ui/core'
 import { Colors } from '@island.is/island-ui/theme'
 
 type StatusOptions = {

--- a/apps/gjafakort/web/screens/Admin/Admin.tsx
+++ b/apps/gjafakort/web/screens/Admin/Admin.tsx
@@ -9,7 +9,7 @@ import {
   Column,
   Icon,
   Box,
-  Button,
+  ButtonDeprecated as Button,
   Typography,
 } from '@island.is/island-ui/core'
 

--- a/apps/gjafakort/web/screens/Admin/Application/Application.tsx
+++ b/apps/gjafakort/web/screens/Admin/Application/Application.tsx
@@ -4,7 +4,12 @@ import { useRouter } from 'next/router'
 import { useQuery } from 'react-apollo'
 import gql from 'graphql-tag'
 
-import { Icon, Box, Button, Typography } from '@island.is/island-ui/core'
+import {
+  Icon,
+  Box,
+  ButtonDeprecated as Button,
+  Typography,
+} from '@island.is/island-ui/core'
 
 import { ContentLoader, Layout } from '@island.is/gjafakort-web/components'
 import { NotFound } from '@island.is/gjafakort-web/screens'

--- a/apps/gjafakort/web/screens/Admin/Application/components/FormInfo/FormInfo.tsx
+++ b/apps/gjafakort/web/screens/Admin/Application/components/FormInfo/FormInfo.tsx
@@ -15,7 +15,7 @@ import {
   Bullet,
   Stack,
   Box,
-  Button,
+  ButtonDeprecated as Button,
   Typography,
 } from '@island.is/island-ui/core'
 

--- a/apps/gjafakort/web/screens/Admin/Summary/Summary.tsx
+++ b/apps/gjafakort/web/screens/Admin/Summary/Summary.tsx
@@ -10,7 +10,7 @@ import {
   ContentBlock,
   Typography,
   Icon,
-  Button,
+  ButtonDeprecated as Button,
   Select,
   Column,
   Columns,

--- a/apps/gjafakort/web/screens/Admin/components/ReviewStatus/ReviewStatus.tsx
+++ b/apps/gjafakort/web/screens/Admin/components/ReviewStatus/ReviewStatus.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import Link from 'next/link'
 
-import { Icon, Box, Button, Typography } from '@island.is/island-ui/core'
+import {
+  Icon,
+  Box,
+  ButtonDeprecated as Button,
+  Typography,
+} from '@island.is/island-ui/core'
 
 import { KeyValue } from '../../../../components'
 

--- a/apps/gjafakort/web/screens/Companies/Application/Company/components/Congratulations/Congratulations.tsx
+++ b/apps/gjafakort/web/screens/Companies/Application/Company/components/Congratulations/Congratulations.tsx
@@ -1,6 +1,12 @@
 import React from 'react'
 
-import { Box, Typography, Stack, Button, Icon } from '@island.is/island-ui/core'
+import {
+  Box,
+  Typography,
+  Stack,
+  ButtonDeprecated as Button,
+  Icon,
+} from '@island.is/island-ui/core'
 
 import packageSvg from '@island.is/gjafakort-web/assets/ferdagjof-pakki.svg'
 import Layout from '@island.is/gjafakort-web/components/Layout/Layout'

--- a/apps/gjafakort/web/screens/Companies/Application/Company/components/NotQualified/NotQualified.tsx
+++ b/apps/gjafakort/web/screens/Companies/Application/Company/components/NotQualified/NotQualified.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 
 import {
   Box,
-  Button,
+  ButtonDeprecated as Button,
   Typography,
   BulletList,
   Bullet,

--- a/apps/gjafakort/web/screens/Companies/Application/Company/components/Signup/Signup.tsx
+++ b/apps/gjafakort/web/screens/Companies/Application/Company/components/Signup/Signup.tsx
@@ -12,7 +12,7 @@ import {
   Box,
   Tiles,
   Stack,
-  Button,
+  ButtonDeprecated as Button,
   Typography,
   FieldSelect,
   FieldPolarQuestion,

--- a/apps/gjafakort/web/screens/Companies/Application/components/NoConnection/NoConnection.tsx
+++ b/apps/gjafakort/web/screens/Companies/Application/components/NoConnection/NoConnection.tsx
@@ -1,7 +1,11 @@
 import React from 'react'
 import Link from 'next/link'
 
-import { Box, Button, Typography } from '@island.is/island-ui/core'
+import {
+  Box,
+  ButtonDeprecated as Button,
+  Typography,
+} from '@island.is/island-ui/core'
 
 import { useI18n } from '@island.is/gjafakort-web/i18n'
 

--- a/apps/gjafakort/web/screens/Companies/Application/components/SelectionForm/SelectionForm.tsx
+++ b/apps/gjafakort/web/screens/Companies/Application/components/SelectionForm/SelectionForm.tsx
@@ -6,7 +6,7 @@ import {
   Box,
   Column,
   Columns,
-  Button,
+  ButtonDeprecated as Button,
   Typography,
   Option,
 } from '@island.is/island-ui/core'

--- a/apps/gjafakort/web/screens/Companies/components/CompanyCTA/CompanyCTA.tsx
+++ b/apps/gjafakort/web/screens/Companies/components/CompanyCTA/CompanyCTA.tsx
@@ -1,7 +1,11 @@
 import React, { useContext } from 'react'
 import Link from 'next/link'
 
-import { Box, Typography, Button } from '@island.is/island-ui/core'
+import {
+  Box,
+  Typography,
+  ButtonDeprecated as Button,
+} from '@island.is/island-ui/core'
 
 import { useI18n } from '@island.is/gjafakort-web/i18n'
 import { UserContext } from '@island.is/gjafakort-web/context'

--- a/apps/gjafakort/web/screens/ErrorPage/ErrorPage.tsx
+++ b/apps/gjafakort/web/screens/ErrorPage/ErrorPage.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/router'
 
 import {
   Box,
-  Button,
+  ButtonDeprecated as Button,
   ContentBlock,
   Typography,
 } from '@island.is/island-ui/core'

--- a/apps/gjafakort/web/screens/Home/Home.tsx
+++ b/apps/gjafakort/web/screens/Home/Home.tsx
@@ -9,7 +9,7 @@ import {
   Stack,
   Typography,
   Breadcrumbs,
-  Button,
+  ButtonDeprecated as Button,
 } from '@island.is/island-ui/core'
 
 import { useI18n } from '../../i18n'

--- a/apps/gjafakort/web/screens/Home/components/GiftCTA/GiftCTA.tsx
+++ b/apps/gjafakort/web/screens/Home/components/GiftCTA/GiftCTA.tsx
@@ -1,7 +1,11 @@
 import React, { useContext } from 'react'
 import Link from 'next/link'
 
-import { Box, Typography, Button } from '@island.is/island-ui/core'
+import {
+  Box,
+  Typography,
+  ButtonDeprecated as Button,
+} from '@island.is/island-ui/core'
 
 import packageSvg from '@island.is/gjafakort-web/assets/ferdagjof-pakki.svg'
 import { UserContext } from '@island.is/gjafakort-web/context'

--- a/apps/gjafakort/web/screens/NotFound/NotFound.tsx
+++ b/apps/gjafakort/web/screens/NotFound/NotFound.tsx
@@ -3,7 +3,7 @@ import Router from 'next/router'
 
 import {
   Box,
-  Button,
+  ButtonDeprecated as Button,
   ContentBlock,
   Columns,
   Column,

--- a/apps/gjafakort/web/screens/PrivacyPolicy/PrivacyPolicy.tsx
+++ b/apps/gjafakort/web/screens/PrivacyPolicy/PrivacyPolicy.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import HtmlParser from 'react-html-parser'
 
-import { Stack, Typography, Box, Button } from '@island.is/island-ui/core'
+import {
+  Stack,
+  Typography,
+  Box,
+  ButtonDeprecated as Button,
+} from '@island.is/island-ui/core'
 import { useI18n } from '@island.is/gjafakort-web/i18n'
 import { Layout, AppsSidebar } from '@island.is/gjafakort-web/components'
 import Link from 'next/link'

--- a/apps/gjafakort/web/screens/User/User.tsx
+++ b/apps/gjafakort/web/screens/User/User.tsx
@@ -4,7 +4,12 @@ import { useLazyQuery, useMutation } from 'react-apollo'
 import gql from 'graphql-tag'
 import get from 'lodash/get'
 
-import { Box, Stack, Typography, Button } from '@island.is/island-ui/core'
+import {
+  Box,
+  Stack,
+  Typography,
+  ButtonDeprecated as Button,
+} from '@island.is/island-ui/core'
 import { CONFIRM_CODE_ERROR } from '@island.is/gjafakort/consts'
 
 import { UserContext } from '@island.is/gjafakort-web/context'

--- a/apps/gjafakort/web/screens/User/components/Barcode/Barcode.tsx
+++ b/apps/gjafakort/web/screens/User/components/Barcode/Barcode.tsx
@@ -10,7 +10,7 @@ import {
   Box,
   Stack,
   Typography,
-  Button,
+  ButtonDeprecated as Button,
   Icon,
   Columns,
   Column,

--- a/apps/gjafakort/web/screens/User/components/ConfirmCodeForm/ConfirmCodeForm.tsx
+++ b/apps/gjafakort/web/screens/User/components/ConfirmCodeForm/ConfirmCodeForm.tsx
@@ -6,7 +6,7 @@ import {
   FieldNumberInput,
   Box,
   Stack,
-  Button,
+  ButtonDeprecated as Button,
   Typography,
 } from '@island.is/island-ui/core'
 

--- a/apps/gjafakort/web/screens/User/components/MobileForm/MobileForm.tsx
+++ b/apps/gjafakort/web/screens/User/components/MobileForm/MobileForm.tsx
@@ -13,7 +13,7 @@ import {
   FieldNumberInput,
   Box,
   Stack,
-  Button,
+  ButtonDeprecated as Button,
   Typography,
 } from '@island.is/island-ui/core'
 

--- a/apps/judicial-system/web/src/routes/DetentionRequests/DetentionRequests.tsx
+++ b/apps/judicial-system/web/src/routes/DetentionRequests/DetentionRequests.tsx
@@ -9,7 +9,7 @@ import {
 } from '@island.is/judicial-system-web/src/shared-components/Logos'
 import {
   AlertMessage,
-  Button,
+  ButtonDeprecated as Button,
   Typography,
   Tag,
   TagVariant,

--- a/apps/judicial-system/web/src/routes/Login/Login.tsx
+++ b/apps/judicial-system/web/src/routes/Login/Login.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react'
 
 import {
   Typography,
-  Button,
+  ButtonDeprecated as Button,
   Box,
   AlertMessage,
 } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/shared-components/FormFooter/FormFooter.tsx
+++ b/apps/judicial-system/web/src/shared-components/FormFooter/FormFooter.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Box, Button } from '@island.is/island-ui/core'
+import { Box, ButtonDeprecated as Button } from '@island.is/island-ui/core'
 import { useHistory } from 'react-router-dom'
 
 import * as styles from './FormFooter.treat'

--- a/apps/judicial-system/web/src/shared-components/Header/Header.tsx
+++ b/apps/judicial-system/web/src/shared-components/Header/Header.tsx
@@ -1,5 +1,10 @@
 import React, { useContext } from 'react'
-import { Logo, Typography, Box, Button } from '@island.is/island-ui/core'
+import {
+  Logo,
+  Typography,
+  Box,
+  ButtonDeprecated as Button,
+} from '@island.is/island-ui/core'
 import { Link } from 'react-router-dom'
 
 import { userContext } from '../../utils/userContext'

--- a/apps/judicial-system/web/src/shared-components/Modal/Modal.tsx
+++ b/apps/judicial-system/web/src/shared-components/Modal/Modal.tsx
@@ -1,4 +1,9 @@
-import { Box, Button, Icon, Typography } from '@island.is/island-ui/core'
+import {
+  Box,
+  ButtonDeprecated as Button,
+  Icon,
+  Typography,
+} from '@island.is/island-ui/core'
 import React from 'react'
 import ReactDOM from 'react-dom'
 

--- a/apps/service-portal/src/components/Header/Header.tsx
+++ b/apps/service-portal/src/components/Header/Header.tsx
@@ -5,7 +5,7 @@ import {
   Hidden,
   ResponsiveSpace,
   ContentBlock,
-  Button,
+  ButtonDeprecated as Button,
   Inline,
 } from '@island.is/island-ui/core'
 import * as styles from './Header.treat'

--- a/apps/service-portal/src/components/Notifications/NotificationMenu/NotificationCard/NotificationCard.tsx
+++ b/apps/service-portal/src/components/Notifications/NotificationMenu/NotificationCard/NotificationCard.tsx
@@ -1,6 +1,12 @@
 import React, { FC } from 'react'
 import { NotificationCard as Card } from '../mockNotifications'
-import { Box, Typography, Icon, Stack, Button } from '@island.is/island-ui/core'
+import {
+  Box,
+  Typography,
+  Icon,
+  Stack,
+  ButtonDeprecated as Button,
+} from '@island.is/island-ui/core'
 import { Link } from 'react-router-dom'
 import * as styles from './Notificationcard.treat'
 import cn from 'classnames'

--- a/apps/service-portal/src/components/Notifications/NotificationMenu/NotificationMenu.tsx
+++ b/apps/service-portal/src/components/Notifications/NotificationMenu/NotificationMenu.tsx
@@ -1,7 +1,12 @@
 import React, { FC } from 'react'
 import * as styles from './NotificationMenu.treat'
 import cn from 'classnames'
-import { Box, Typography, Stack, Button } from '@island.is/island-ui/core'
+import {
+  Box,
+  Typography,
+  Stack,
+  ButtonDeprecated as Button,
+} from '@island.is/island-ui/core'
 import { notifications } from './mockNotifications'
 import NotificationCard from './NotificationCard/NotificationCard'
 import { MenuState } from '../../../store/actions'

--- a/apps/service-portal/src/components/Notifications/NotificationMenuTrigger/NotificationMenuTrigger.tsx
+++ b/apps/service-portal/src/components/Notifications/NotificationMenuTrigger/NotificationMenuTrigger.tsx
@@ -1,6 +1,10 @@
 import React, { FC, useRef } from 'react'
 import * as styles from './NotificationMenuTrigger.treat'
-import { Button, Box, Icon } from '@island.is/island-ui/core'
+import {
+  ButtonDeprecated as Button,
+  Box,
+  Icon,
+} from '@island.is/island-ui/core'
 import { useStore } from '../../../store/stateProvider'
 import { ActionType, MenuState } from '../../../store/actions'
 import NotificationMenu from '../NotificationMenu/NotificationMenu'

--- a/apps/service-portal/src/components/UserMenu/UserMenu.tsx
+++ b/apps/service-portal/src/components/UserMenu/UserMenu.tsx
@@ -2,7 +2,7 @@ import React, { FC, useState, useRef } from 'react'
 import { useStore } from '../../store/stateProvider'
 import {
   Box,
-  Button,
+  ButtonDeprecated as Button,
   Hidden,
   Icon,
   Stack,

--- a/apps/skilavottord/web/components/Button/Button.tsx
+++ b/apps/skilavottord/web/components/Button/Button.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { ButtonDeprecated as Button as IslandUIButton } from '@island.is/island-ui/core'
+import { ButtonDeprecated as IslandUIButton } from '@island.is/island-ui/core'
 import { theme } from '@island.is/island-ui/theme'
 import { useWindowSize } from 'react-use'
 

--- a/apps/skilavottord/web/components/Button/Button.tsx
+++ b/apps/skilavottord/web/components/Button/Button.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Button as IslandUIButton } from '@island.is/island-ui/core'
+import { ButtonDeprecated as Button as IslandUIButton } from '@island.is/island-ui/core'
 import { theme } from '@island.is/island-ui/theme'
 import { useWindowSize } from 'react-use'
 

--- a/apps/skilavottord/web/components/LanguageToggler/LanguageToggler.tsx
+++ b/apps/skilavottord/web/components/LanguageToggler/LanguageToggler.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react'
 import Link from 'next/link'
-import { Button, Hidden } from '@island.is/island-ui/core'
+import { ButtonDeprecated as Button, Hidden } from '@island.is/island-ui/core'
 import { useI18n } from '@island.is/skilavottord-web/i18n'
 
 export const LanguageToggler: FC<{

--- a/apps/skilavottord/web/components/Modal/Modal.tsx
+++ b/apps/skilavottord/web/components/Modal/Modal.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useEffect } from 'react'
 import {
-  Button,
+  ButtonDeprecated as Button,
   Box,
   Typography,
   Stack,

--- a/apps/skilavottord/web/screens/Confirm/Confirm.tsx
+++ b/apps/skilavottord/web/screens/Confirm/Confirm.tsx
@@ -3,7 +3,7 @@ import {
   Box,
   Stack,
   Typography,
-  Button,
+  ButtonDeprecated as Button,
   Checkbox,
   Inline,
   Link,

--- a/apps/skilavottord/web/screens/Handover/Handover.tsx
+++ b/apps/skilavottord/web/screens/Handover/Handover.tsx
@@ -1,5 +1,10 @@
 import React, { useState, useEffect } from 'react'
-import { Box, Stack, Typography, Button } from '@island.is/island-ui/core'
+import {
+  Box,
+  Stack,
+  Typography,
+  ButtonDeprecated as Button,
+} from '@island.is/island-ui/core'
 import { ProcessPageLayout } from '@island.is/skilavottord-web/components/Layouts'
 import CompanyList from './components/CompanyList'
 import { useRouter } from 'next/router'

--- a/apps/skilavottord/web/screens/Home/Home.tsx
+++ b/apps/skilavottord/web/screens/Home/Home.tsx
@@ -5,7 +5,7 @@ import {
   Typography,
   Box,
   Stack,
-  Button,
+  ButtonDeprecated as Button,
   BulletList,
   Bullet,
   ArrowLink,

--- a/apps/skilavottord/web/screens/Overview/components/Error/Error.tsx
+++ b/apps/skilavottord/web/screens/Overview/components/Error/Error.tsx
@@ -1,4 +1,9 @@
-import { Box, Button, Stack, Typography } from '@island.is/island-ui/core'
+import {
+  Box,
+  ButtonDeprecated as Button,
+  Stack,
+  Typography,
+} from '@island.is/island-ui/core'
 import { InlineError } from '@island.is/skilavottord-web/components'
 import { useI18n } from '@island.is/skilavottord-web/i18n'
 import { useRouter } from 'next/router'

--- a/apps/skilavottord/web/screens/Overview/components/ProgressCard/ProgressCard.tsx
+++ b/apps/skilavottord/web/screens/Overview/components/ProgressCard/ProgressCard.tsx
@@ -4,7 +4,7 @@ import {
   Stack,
   Typography,
   Tag,
-  Button,
+  ButtonDeprecated as Button,
   GridContainer,
   GridRow,
   GridColumn,

--- a/apps/web/components/BulletList/BulletList.tsx
+++ b/apps/web/components/BulletList/BulletList.tsx
@@ -2,7 +2,13 @@ import React, { FC, useState, ReactNode } from 'react'
 import cn from 'classnames'
 import AnimateHeight from 'react-animate-height'
 import IconBullet from '../IconBullet/IconBullet'
-import { Stack, Box, Text, Icon, Button } from '@island.is/island-ui/core'
+import {
+  Stack,
+  Box,
+  Text,
+  Icon,
+  ButtonDeprecated as Button,
+} from '@island.is/island-ui/core'
 import * as styles from './BulletList.treat'
 
 type IconBullet = {

--- a/apps/web/components/Content/Content.tsx
+++ b/apps/web/components/Content/Content.tsx
@@ -6,7 +6,7 @@ import {
   Stack,
   Accordion,
   AccordionItem,
-  Button,
+  ButtonDeprecated as Button,
   Link,
   Divider,
 } from '@island.is/island-ui/core'

--- a/apps/web/components/EmailSignup/EmailSignup.tsx
+++ b/apps/web/components/EmailSignup/EmailSignup.tsx
@@ -5,7 +5,7 @@ import {
   Text,
   Stack,
   Input,
-  Button,
+  ButtonDeprecated as Button,
 } from '@island.is/island-ui/core'
 
 export interface EmailSignupProps {

--- a/apps/web/components/FilteredCards/FilteredCards.tsx
+++ b/apps/web/components/FilteredCards/FilteredCards.tsx
@@ -5,7 +5,7 @@ import cn from 'classnames'
 import {
   Box,
   Tiles,
-  Button,
+  ButtonDeprecated as Button,
   Stack,
   Text,
   Tag,

--- a/apps/web/components/FixedNav/FixedNav.tsx
+++ b/apps/web/components/FixedNav/FixedNav.tsx
@@ -5,7 +5,7 @@ import {
   ContentBlock,
   Box,
   Icon,
-  Button,
+  ButtonDeprecated as Button,
   FocusableBox,
 } from '@island.is/island-ui/core'
 import SearchInput from '../SearchInput/SearchInput'

--- a/apps/web/components/FrontpageTabs/FrontpageTabs.tsx
+++ b/apps/web/components/FrontpageTabs/FrontpageTabs.tsx
@@ -15,7 +15,7 @@ import {
   Text,
   Stack,
   Box,
-  Button,
+  ButtonDeprecated as Button,
   GridContainer,
   GridRow,
   GridColumn,

--- a/apps/web/components/Header/Header.tsx
+++ b/apps/web/components/Header/Header.tsx
@@ -5,7 +5,7 @@ import {
   Columns,
   Column,
   Box,
-  Button,
+  ButtonDeprecated as Button,
   Hidden,
   ResponsiveSpace,
   GridContainer,

--- a/apps/web/components/LanguageToggler/LanguageToggler.tsx
+++ b/apps/web/components/LanguageToggler/LanguageToggler.tsx
@@ -2,7 +2,11 @@ import React, { FC, useContext } from 'react'
 import { useRouter } from 'next/router'
 import { findKey } from 'lodash'
 import { useApolloClient } from 'react-apollo'
-import { Button, Hidden, Text } from '@island.is/island-ui/core'
+import {
+  ButtonDeprecated as Button,
+  Hidden,
+  Text,
+} from '@island.is/island-ui/core'
 import { useI18n } from '@island.is/web/i18n'
 import routeNames, { PathTypes, routes } from '@island.is/web/i18n/routeNames'
 import { GET_CONTENT_SLUG } from '@island.is/web/screens/queries/Article'

--- a/apps/web/components/LinkCardList/LinkCardList.tsx
+++ b/apps/web/components/LinkCardList/LinkCardList.tsx
@@ -1,7 +1,12 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import React, { FC } from 'react'
 import Link from 'next/link'
-import { Button, Text, Box, Tiles } from '@island.is/island-ui/core'
+import {
+  ButtonDeprecated as Button,
+  Text,
+  Box,
+  Tiles,
+} from '@island.is/island-ui/core'
 
 export interface LinkCardProps {
   title: string

--- a/apps/web/components/Modal/Modal.tsx
+++ b/apps/web/components/Modal/Modal.tsx
@@ -10,7 +10,7 @@ import React, {
   useState,
 } from 'react'
 import {
-  Button,
+  ButtonDeprecated as Button,
   Box,
   Stack,
   Text,

--- a/apps/web/components/SideMenu/SideMenu.tsx
+++ b/apps/web/components/SideMenu/SideMenu.tsx
@@ -14,7 +14,7 @@ import {
   Text,
   Icon,
   Hidden,
-  Button,
+  ButtonDeprecated as Button,
   GridContainer,
   GridRow,
   GridColumn,

--- a/apps/web/components/StoryList/StoryList.tsx
+++ b/apps/web/components/StoryList/StoryList.tsx
@@ -1,5 +1,9 @@
 import React, { FC } from 'react'
-import { Button, Text, Stack } from '@island.is/island-ui/core'
+import {
+  ButtonDeprecated as Button,
+  Text,
+  Stack,
+} from '@island.is/island-ui/core'
 import IconBullet from '../IconBullet/IconBullet'
 import { ContentLink } from '@island.is/web/components'
 

--- a/apps/web/components/Timeline/Timeline.tsx
+++ b/apps/web/components/Timeline/Timeline.tsx
@@ -17,7 +17,7 @@ import ReactDOM from 'react-dom'
 import {
   Box,
   Icon,
-  Button,
+  ButtonDeprecated as Button,
   Stack,
   Tag,
   Text,

--- a/apps/web/screens/Article.tsx
+++ b/apps/web/screens/Article.tsx
@@ -23,7 +23,7 @@ import {
   Divider,
   Link,
   Icon,
-  Button,
+  ButtonDeprecated as Button,
 } from '@island.is/island-ui/core'
 import {
   DrawerMenu,

--- a/apps/web/screens/LandingPage/LandingPage.tsx
+++ b/apps/web/screens/LandingPage/LandingPage.tsx
@@ -8,7 +8,7 @@ import Head from 'next/head'
 import { useI18n } from '@island.is/web/i18n'
 import {
   Stack,
-  Button,
+  ButtonDeprecated as Button,
   Text,
   Box,
   Breadcrumbs,

--- a/libs/application/templates/reference-template/src/fields/CustomRepeater.tsx
+++ b/libs/application/templates/reference-template/src/fields/CustomRepeater.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react'
 import { RepeaterProps } from '@island.is/application/core'
-import { Button, Text } from '@island.is/island-ui/core'
+import { ButtonDeprecated as Button, Text } from '@island.is/island-ui/core'
 
 const CustomRepeater: FC<RepeaterProps> = ({ expandRepeater }) => {
   return (

--- a/libs/application/templates/reference-template/src/fields/ExampleCountryField.tsx
+++ b/libs/application/templates/reference-template/src/fields/ExampleCountryField.tsx
@@ -5,7 +5,7 @@ import {
   AsyncSearch,
   AsyncSearchOption,
   Box,
-  Button,
+  ButtonDeprecated as Button,
   Input,
   Typography,
 } from '@island.is/island-ui/core'

--- a/libs/application/ui-shell/src/components/Screen.tsx
+++ b/libs/application/ui-shell/src/components/Screen.tsx
@@ -8,7 +8,12 @@ import {
   FormValue,
   Schema,
 } from '@island.is/application/core'
-import { Box, Button, GridColumn, Typography } from '@island.is/island-ui/core'
+import {
+  Box,
+  ButtonDeprecated as Button,
+  GridColumn,
+  Typography,
+} from '@island.is/island-ui/core'
 import {
   SUBMIT_APPLICATION,
   UPDATE_APPLICATION,

--- a/libs/island-ui/contentful/src/lib/ContactUs/ContactUs.tsx
+++ b/libs/island-ui/contentful/src/lib/ContactUs/ContactUs.tsx
@@ -7,7 +7,7 @@ import {
   GridRow,
   GridColumn,
   Box,
-  Button,
+  ButtonDeprecated as Button,
 } from '@island.is/island-ui/core'
 
 export interface ContactUsFormState {

--- a/libs/island-ui/contentful/src/lib/Content/Content.tsx
+++ b/libs/island-ui/contentful/src/lib/Content/Content.tsx
@@ -5,7 +5,7 @@ import {
   Typography,
   BulletList,
   Bullet,
-  Button,
+  ButtonDeprecated as Button,
   Box,
   Accordion,
   AccordionItem,

--- a/libs/island-ui/contentful/src/lib/ProcessEntry/ProcessEntry.tsx
+++ b/libs/island-ui/contentful/src/lib/ProcessEntry/ProcessEntry.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react'
 import {
   Typography,
-  Button,
+  ButtonDeprecated as Button,
   Box,
   GridRow,
   GridColumn,

--- a/libs/island-ui/core/src/index.ts
+++ b/libs/island-ui/core/src/index.ts
@@ -1,7 +1,7 @@
 // Components
 export * from './lib/Pagination/Pagination'
 export * from './lib/AsyncSearch/AsyncSearch'
-export * from './lib/Button/Button'
+export { Button as ButtonDeprecated } from './lib/Button/Button'
 export * from './lib/Logo/Logo'
 export * from './lib/Typography/Typography'
 export * from './lib/Text/Text'

--- a/libs/island-ui/core/src/index.ts
+++ b/libs/island-ui/core/src/index.ts
@@ -2,6 +2,7 @@
 export * from './lib/Pagination/Pagination'
 export * from './lib/AsyncSearch/AsyncSearch'
 export { Button as ButtonDeprecated } from './lib/Button/Button'
+export * from './lib/ButtonRC/Button'
 export * from './lib/Logo/Logo'
 export * from './lib/Typography/Typography'
 export * from './lib/Text/Text'

--- a/libs/island-ui/core/src/lib/Button/Button.tsx
+++ b/libs/island-ui/core/src/lib/Button/Button.tsx
@@ -7,6 +7,7 @@ import { IconTypes, Icon as IconComponent } from '../Icon/Icon'
 import { ColorSchemeContext } from '../context'
 
 import * as styles from './Button.treat'
+import useDeprecatedComponent from '../private/useDeprecatedComponent'
 
 export type ButtonSize = 'small' | 'medium' | 'large'
 export type ButtonVariant = 'normal' | 'ghost' | 'redGhost' | 'text' | 'menu'
@@ -70,9 +71,10 @@ export const Button = forwardRef<
     },
     ref,
   ) => {
-    if (process.env.NODE_ENV === 'development') {
-      console.warn('ButtonDeprecated has been deprecated in favor of Button.')
-    }
+    useDeprecatedComponent(
+      'Button',
+      'ButtonDeprecated has been deprecated in favor of Button.',
+    )
     const { colorScheme } = useContext(ColorSchemeContext)
 
     const className = cn(

--- a/libs/island-ui/core/src/lib/Button/Button.tsx
+++ b/libs/island-ui/core/src/lib/Button/Button.tsx
@@ -1,3 +1,4 @@
+/** @deprecated ButtonDeprecated has been deprecated in favor of Button */
 import React, { forwardRef, ReactNode, FC, useContext } from 'react'
 import cn from 'classnames'
 import { Box } from '../Box'
@@ -69,6 +70,9 @@ export const Button = forwardRef<
     },
     ref,
   ) => {
+    if (process.env.NODE_ENV === 'development') {
+      console.warn('ButtonDeprecated has been deprecated in favor of Button.')
+    }
     const { colorScheme } = useContext(ColorSchemeContext)
 
     const className = cn(

--- a/libs/island-ui/core/src/lib/ButtonRC/Button.tsx
+++ b/libs/island-ui/core/src/lib/ButtonRC/Button.tsx
@@ -81,7 +81,7 @@ type ButtonIconProps = {
 
 const ButtonIcon = ({ icon }: ButtonIconProps) => (
   <Icon
-    type={icon}
+    type={icon!}
     width="none"
     height="none"
     color="currentColor"

--- a/libs/island-ui/core/src/lib/private/useDeprecatedComponent.ts
+++ b/libs/island-ui/core/src/lib/private/useDeprecatedComponent.ts
@@ -8,6 +8,6 @@ const useDeprecatedComponent = (
     if (process.env.NODE_ENV === 'development') {
       console.warn(customMsg)
     }
-  }, [componentName])
+  }, [customMsg])
 
 export default useDeprecatedComponent

--- a/libs/island-ui/core/src/lib/private/useDeprecatedComponent.ts
+++ b/libs/island-ui/core/src/lib/private/useDeprecatedComponent.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 
 const useDeprecatedComponent = (
   componentName: string,
-  customMsg: string = `${componentName} is deprecated`,
+  customMsg = `${componentName} is deprecated`,
 ) =>
   useEffect(() => {
     if (process.env.NODE_ENV === 'development') {

--- a/libs/island-ui/core/src/lib/private/useDeprecatedComponent.ts
+++ b/libs/island-ui/core/src/lib/private/useDeprecatedComponent.ts
@@ -1,9 +1,12 @@
 import { useEffect } from 'react'
 
-const useDeprecatedComponent = (componentName: string) =>
+const useDeprecatedComponent = (
+  componentName: string,
+  customMsg: string = `${componentName} is deprecated`,
+) =>
   useEffect(() => {
     if (process.env.NODE_ENV === 'development') {
-      console.warn(`${componentName} is deprecated`)
+      console.warn(customMsg)
     }
   }, [componentName])
 

--- a/libs/service-portal/applications/src/components/ApplicationCard/ApplicationCard.tsx
+++ b/libs/service-portal/applications/src/components/ApplicationCard/ApplicationCard.tsx
@@ -6,7 +6,7 @@ import {
   Icon,
   Typography,
   Tag,
-  Button,
+  ButtonDeprecated as Button,
   Columns,
   Column,
 } from '@island.is/island-ui/core'

--- a/libs/service-portal/core/src/components/ActionSidebar/ActionSidebar.tsx
+++ b/libs/service-portal/core/src/components/ActionSidebar/ActionSidebar.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState, useEffect } from 'react'
 import cn from 'classnames'
 import * as styles from './ActionSidebar.treat'
-import { Box, Button } from '@island.is/island-ui/core'
+import { Box, ButtonDeprecated as Button } from '@island.is/island-ui/core'
 
 interface Props {
   isActive: boolean

--- a/libs/service-portal/documents/src/screens/Overview/Overview.tsx
+++ b/libs/service-portal/documents/src/screens/Overview/Overview.tsx
@@ -5,7 +5,7 @@ import {
   Stack,
   Columns,
   Column,
-  Button,
+  ButtonDeprecated as Button,
   Select,
   Input,
   Pagination,

--- a/libs/service-portal/documents/src/widgets/documentList.tsx
+++ b/libs/service-portal/documents/src/widgets/documentList.tsx
@@ -1,5 +1,10 @@
 import React from 'react'
-import { Typography, Box, Stack, Button } from '@island.is/island-ui/core'
+import {
+  Typography,
+  Box,
+  Stack,
+  ButtonDeprecated as Button,
+} from '@island.is/island-ui/core'
 import { useListDocuments } from '@island.is/service-portal/graphql'
 import {
   ServicePortalModuleComponent,

--- a/libs/service-portal/family/src/components/UserInfoLine/UserInfoLine.tsx
+++ b/libs/service-portal/family/src/components/UserInfoLine/UserInfoLine.tsx
@@ -4,7 +4,7 @@ import {
   Columns,
   Column,
   Typography,
-  Button,
+  ButtonDeprecated as Button,
 } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
 import { MessageDescriptor } from 'react-intl'

--- a/libs/service-portal/family/src/components/forms/ExternalFormDirect/ExternalFormDirect.tsx
+++ b/libs/service-portal/family/src/components/forms/ExternalFormDirect/ExternalFormDirect.tsx
@@ -1,5 +1,11 @@
 import React, { FC } from 'react'
-import { Box, Tag, Stack, Typography, Button } from '@island.is/island-ui/core'
+import {
+  Box,
+  Tag,
+  Stack,
+  Typography,
+  ButtonDeprecated as Button,
+} from '@island.is/island-ui/core'
 
 interface Props {
   label: string

--- a/libs/service-portal/family/src/screens/UserInfo/UserInfo.tsx
+++ b/libs/service-portal/family/src/screens/UserInfo/UserInfo.tsx
@@ -3,7 +3,7 @@ import {
   Typography,
   Box,
   Stack,
-  Button,
+  ButtonDeprecated as Button,
   Icon,
   Hidden,
 } from '@island.is/island-ui/core'


### PR DESCRIPTION
# Deprecating old button component

## What

We want to rename the old Button to ButtonDeprecated and add deprecated warnings to it and export new button as Button from island-ui

## Why

Old button was drifting apart from the updated UI Library and was getting harder to maintain, the new Button RC will replace it.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
