### PR TITLE
Refactor FormStepper Typography to Text

### DIFF
--- a/libs/island-ui/core/src/lib/FormStepper/FormStepper.tsx
+++ b/libs/island-ui/core/src/lib/FormStepper/FormStepper.tsx
@@ -1,7 +1,7 @@
 import React, { FC, ReactNode } from 'react'
 
 import { Box } from '../Box'
-import { Typography } from '../Typography/Typography'
+import { Text } from '../Text/Text'
 import { FormStepperSection } from './FormStepperSection'
 import * as types from './types'
 import * as styles from './FormStepper.treat'
@@ -48,7 +48,7 @@ export const FormStepper: FC<{
 
           {formName && (
             <Box marginLeft={formIcon ? 1 : 0}>
-              <Typography variant="h4">{formName}</Typography>
+              <Text variant="h4">{formName}</Text>
             </Box>
           )}
         </Box>

--- a/libs/island-ui/core/src/lib/FormStepper/FormStepperSection.tsx
+++ b/libs/island-ui/core/src/lib/FormStepper/FormStepperSection.tsx
@@ -2,7 +2,7 @@ import React, { FC, useRef, useState, useEffect } from 'react'
 import useComponentSize from '@rehooks/component-size'
 
 import { Box } from '../Box'
-import { Typography } from '../Typography/Typography'
+import { Text } from '../Text/Text'
 import { SectionNumber, SubSections } from './shared'
 import * as types from './types'
 
@@ -67,13 +67,9 @@ export const FormStepperSection: FC<{
           </Box>
 
           <Box paddingTop={2} width="full">
-            <Typography
-              variant={
-                isActive ? 'formStepperSectionActive' : 'formStepperSection'
-              }
-            >
+            <Text lineHeight="lg" fontWeight={isActive ? 'semiBold' : 'light'}>
               {section.name}
-            </Typography>
+            </Text>
           </Box>
         </Box>
 

--- a/libs/island-ui/core/src/lib/FormStepper/shared/SubSectionItem/SubSectionItem.tsx
+++ b/libs/island-ui/core/src/lib/FormStepper/shared/SubSectionItem/SubSectionItem.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react'
 
 import { Icon } from '../../../Icon/Icon'
-import { Typography } from '../../../Typography/Typography'
+import { Text } from '../../../Text/Text'
 import { Box } from '../../../Box'
 import { SectionNumberColumn } from '../SectionNumberColumn/SectionNumberColumn'
 import * as styles from './SubSectionItem.treat'
@@ -27,16 +27,12 @@ export const SubSectionItem: FC<SubSectionItemProps> = ({
         </span>
       )}
     </SectionNumberColumn>
-
-    <Typography
-      variant={
-        currentState === 'active'
-          ? 'formStepperSectionActive'
-          : 'formStepperSection'
-      }
+    <Text
       as="span"
+      lineHeight="lg"
+      fontWeight={currentState === 'active' ? 'semiBold' : 'light'}
     >
       {children}
-    </Typography>
+    </Text>
   </Box>
 )

--- a/libs/island-ui/core/src/lib/Typography/Typography.treat.ts
+++ b/libs/island-ui/core/src/lib/Typography/Typography.treat.ts
@@ -20,8 +20,6 @@ export type VariantTypes =
   | 'sideMenu'
   | 'placeholderText'
   | 'datepickerHeaderText'
-  | 'formStepperSection'
-  | 'formStepperSectionActive'
 
 type ResponsiveProps<T> = {
   xs?: T
@@ -74,8 +72,6 @@ const defaultFontWeightsMap: defaultFontWeights = {
   sideMenu: theme.typography.medium,
   placeholderText: theme.typography.light,
   datepickerHeaderText: theme.typography.semiBold,
-  formStepperSection: theme.typography.light,
-  formStepperSectionActive: theme.typography.semiBold,
 }
 
 export const fontWeight = styleMap(
@@ -190,20 +186,6 @@ export const variants: Variants = {
       md: 20,
     },
     lineHeight: 1.666,
-  },
-  formStepperSection: {
-    fontSize: {
-      xs: 16,
-      md: 18,
-    },
-    lineHeight: 1.75,
-  },
-  formStepperSectionActive: {
-    fontSize: {
-      xs: 16,
-      md: 18,
-    },
-    lineHeight: 1.75,
   },
 }
 


### PR DESCRIPTION
## What

Refactor FormStepper to use new Text component.

## Why

Typography is now deprecated.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
