### PR TITLE
island-ui/Tooltip style changes

### DIFF
--- a/apps/skilavottord/web/screens/Overview/components/ActionCard/ActionCard.tsx
+++ b/apps/skilavottord/web/screens/Overview/components/ActionCard/ActionCard.tsx
@@ -83,7 +83,7 @@ export const ActionCard: FC<ActionCardProps> = ({
               >
                 <Inline space={'smallGutter'}>
                   <Typography variant="pSmall">{t.actions.invalid}</Typography>
-                  <Tooltip text={t.tooltip} colored />
+                  <Tooltip text={t.tooltip} />
                 </Inline>
               </ColumnBox>
             )}

--- a/libs/island-ui/core/src/lib/Tooltip/Tooltip.stories.mdx
+++ b/libs/island-ui/core/src/lib/Tooltip/Tooltip.stories.mdx
@@ -24,13 +24,7 @@ export const tooltipText =
     <Box padding="gutter">
       <Text variant="p" as="span">
         Here is some text that has a tooltip with the default icon at the end of
-        it.{' '}
-        <Tooltip
-          colored={false}
-          placement="right"
-          as="button"
-          text={tooltipText}
-        />
+        it. <Tooltip placement="right" as="button" text={tooltipText} />
       </Text>
     </Box>
   </Story>
@@ -43,7 +37,7 @@ export const tooltipText =
     <Box padding="gutter">
       <Text variant="p" as="span">
         Here is some text that has a tooltip wrapped around{' '}
-        <Tooltip colored={false} placement="top" as="span" text={tooltipText}>
+        <Tooltip placement="top" as="span" text={tooltipText}>
           <span>this text</span>
         </Tooltip>
         .
@@ -54,7 +48,7 @@ export const tooltipText =
         <Text variant="p" as="span">
           Here is some text.
         </Text>
-        <Tooltip colored={false} placement="bottom" text={tooltipText} />
+        <Tooltip placement="bottom" text={tooltipText} />
       </Inline>
     </Box>
   </Story>

--- a/libs/island-ui/core/src/lib/Tooltip/Tooltip.treat.ts
+++ b/libs/island-ui/core/src/lib/Tooltip/Tooltip.treat.ts
@@ -1,11 +1,11 @@
-import { style } from 'treat'
+import { globalStyle, style } from 'treat'
 import { theme } from '@island.is/island-ui/theme'
 
 export const tooltip = style({
   display: 'inline-block',
-  backgroundColor: theme.color.white,
-  borderRadius: '10px',
-  padding: '16px',
+  backgroundColor: theme.color.blue100,
+  borderRadius: theme.border.radius.large,
+  padding: theme.spacing[2],
   maxWidth: '240px',
   border: `1px solid ${theme.color.blue200}`,
   transition: theme.transitions.fast,
@@ -13,9 +13,9 @@ export const tooltip = style({
   transformOrigin: 'top center',
   transform: 'translate3d(0, -10px, 0)',
   fontWeight: theme.typography.light,
-  fontSize: '14px',
-  fontFamily: theme.typography.fontFamily,
+  fontSize: '15px',
   lineHeight: '20px',
+  fontFamily: theme.typography.fontFamily,
   color: theme.color.dark400,
   selectors: {
     '[data-enter] &': {
@@ -25,11 +25,16 @@ export const tooltip = style({
   },
 })
 
-export const colored = style({
-  backgroundColor: theme.color.blue100,
-})
-
 export const icon = style({
   display: 'inline-block',
   lineHeight: 1,
+})
+
+export const iconPath = style({
+  fill: theme.color.dark200,
+  transition: 'fill .125s ease',
+})
+
+globalStyle(`${icon}:hover path`, {
+  fill: theme.color.blue400,
 })

--- a/libs/island-ui/core/src/lib/Tooltip/Tooltip.tsx
+++ b/libs/island-ui/core/src/lib/Tooltip/Tooltip.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactElement, ReactType } from 'react'
+import React, { ElementType, FC, ReactElement } from 'react'
 import cn from 'classnames'
 import {
   Tooltip as ReakitTooltip,
@@ -10,11 +10,7 @@ import * as styles from './Tooltip.treat'
 
 type Placement = 'top' | 'right' | 'bottom' | 'left'
 
-interface InfoIconProps {
-  color?: string
-}
-
-const InfoIcon: FC<InfoIconProps> = ({ color = '#0061FF' }) => {
+const InfoIcon: FC = () => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -23,7 +19,7 @@ const InfoIcon: FC<InfoIconProps> = ({ color = '#0061FF' }) => {
       viewBox={`0 0 20 20`}
     >
       <path
-        fill={color}
+        className={styles.iconPath}
         d="M10 0C4.48 0 0 4.48 0 10s4.48 10 10 10 10-4.48 10-10S15.52 0 10 0zm0 15c-.55 0-1-.45-1-1v-4c0-.55.45-1 1-1s1 .45 1 1v4c0 .55-.45 1-1 1zm1-8H9V5h2v2z"
       ></path>
     </svg>
@@ -32,15 +28,9 @@ const InfoIcon: FC<InfoIconProps> = ({ color = '#0061FF' }) => {
 
 interface ArrowIconProps {
   placement: string
-  color?: string
-  colored?: boolean
 }
 
-const ArrowIcon: FC<ArrowIconProps> = ({
-  placement,
-  color = '#CCDFFF',
-  colored,
-}) => {
+const ArrowIcon: FC<ArrowIconProps> = ({ placement }) => {
   let deg = 0
 
   if (placement.startsWith('left')) {
@@ -62,12 +52,9 @@ const ArrowIcon: FC<ArrowIconProps> = ({
       viewBox="0 0 16 16"
       style={{ transform }}
     >
+      <path fill="#F2F7FF" d="M7 12l6.928-12H.072L7 12z"></path>
       <path
-        fill={colored ? '#F2F7FF' : '#FFFFFF'}
-        d="M7 12l6.928-12H.072L7 12z"
-      ></path>
-      <path
-        fill={color}
+        fill="#CCDFFF"
         fillRule="evenodd"
         d="M6.998 12L.07 0h13.856L6.998 12zm0-2L1.22 0h11.56L6.998 10z"
         clipRule="evenodd"
@@ -78,16 +65,14 @@ const ArrowIcon: FC<ArrowIconProps> = ({
 
 interface TooltipProps {
   placement?: Placement
-  colored?: boolean
   text: string
   iconSize?: number
   children?: ReactElement
-  as?: ReactType
+  as?: ElementType
 }
 
 export const Tooltip: FC<TooltipProps> = ({
   placement,
-  colored = false,
   text,
   iconSize = 14,
   children,
@@ -118,9 +103,9 @@ export const Tooltip: FC<TooltipProps> = ({
         </TooltipReference>
       )}
       <ReakitTooltip {...tooltip}>
-        <div className={cn(styles.tooltip, { [styles.colored]: colored })}>
+        <div className={styles.tooltip}>
           <TooltipArrow {...tooltip}>
-            <ArrowIcon colored={colored} placement={tooltip.placement} />
+            <ArrowIcon placement={tooltip.placement} />
           </TooltipArrow>
           {text}
         </div>

--- a/libs/shared/form-fields/src/lib/CheckboxController/CheckboxController.tsx
+++ b/libs/shared/form-fields/src/lib/CheckboxController/CheckboxController.tsx
@@ -71,11 +71,7 @@ export const CheckboxController: FC<CheckboxControllerProps> = ({
                 />
                 {option.tooltip && (
                   <Box marginLeft={1}>
-                    <Tooltip
-                      colored={true}
-                      placement="top"
-                      text={option.tooltip}
-                    />
+                    <Tooltip placement="top" text={option.tooltip} />
                   </Box>
                 )}
               </Box>

--- a/libs/shared/form-fields/src/lib/RadioController/RadioController.tsx
+++ b/libs/shared/form-fields/src/lib/RadioController/RadioController.tsx
@@ -37,25 +37,31 @@ export const RadioController: FC<Props> = ({
         return (
           <Stack space={2}>
             {options.map((option, index) => (
-              <RadioButton
-                large={largeButtons || emphasize}
-                filled={emphasize}
-                tooltip={option.tooltip}
-                key={`${id}-${index}`}
-                onChange={({ target }) => {
-                  clearErrors(id)
-                  onChange(target.value)
-                  setValue(id, target.value)
-                }}
-                checked={option.value === value}
-                id={`${id}-${index}`}
-                name={`${id}`}
-                label={option.label}
-                value={option.value}
-                disabled={disabled}
-                errorMessage={index === options.length - 1 ? error : undefined}
-                hasError={error !== undefined}
-              />
+              <Box display="flex" alignItems="center" key={option.value}>
+                <RadioButton
+                  key={`${id}-${index}`}
+                  onChange={({ target }) => {
+                    clearErrors(id)
+                    onChange(target.value)
+                    setValue(id, target.value)
+                  }}
+                  checked={option.value === value}
+                  id={`${id}-${index}`}
+                  name={`${id}`}
+                  label={option.label}
+                  value={option.value}
+                  disabled={disabled}
+                  errorMessage={
+                    index === options.length - 1 ? error : undefined
+                  }
+                  hasError={error !== undefined}
+                />
+                {option.tooltip && (
+                  <Box marginLeft={1}>
+                    <Tooltip placement="top" text={option.tooltip} />
+                  </Box>
+                )}
+              </Box>
             ))}
           </Stack>
         )


### PR DESCRIPTION
# Change styles of the Tooltip component

## What

Changed the background colour of the tooltip popover from white to blue100. Also changed the default colour of the icon to dark200 and to blue400 on hover and a few other minor style changes.

## Why

According to the design, the tooltip icon should be grey by default, and blue on hover. The tooltip popover should always have a light blue background.

## Screenshots / Gifs

![chrome-capture (2)](https://user-images.githubusercontent.com/3789875/95472684-db979c00-0972-11eb-9041-b68239a070c7.gif)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
