### PR TITLE
Replace Typography with Text component

### DIFF
--- a/libs/application/templates/parental-leave/src/fields/Usage/index.tsx
+++ b/libs/application/templates/parental-leave/src/fields/Usage/index.tsx
@@ -3,7 +3,7 @@ import { Controller, useFormContext } from 'react-hook-form'
 
 import { FieldBaseProps } from '@island.is/application/core'
 import Slider from '../components/Slider'
-import { Box, Typography } from '@island.is/island-ui/core'
+import { Box, Text } from '@island.is/island-ui/core'
 
 import * as styles from './Usage.treat'
 import { theme } from '@island.is/island-ui/theme'
@@ -23,18 +23,16 @@ const ParentalLeaveUsage: FC<FieldBaseProps> = ({ field }) => {
           className={styles.key}
           style={{ background: theme.color.blue400 }}
         />
-        <Typography variant="p">
+        <Text>
           Sjálfstæður réttur hvors foreldris fyrir sig er 3 mánuðir (90 dagar).
-        </Typography>
+        </Text>
       </Box>
       <Box display="flex" flexDirection="row" alignItems="center">
         <Box
           className={styles.key}
           style={{ background: theme.color.mint400 }}
         />
-        <Typography variant="p">
-          Sameiginlegur réttur foreldra er 3 mánuðir (90 dagar).
-        </Typography>
+        <Text>Sameiginlegur réttur foreldra er 3 mánuðir (90 dagar).</Text>
       </Box>
       <Box marginTop={6}>
         <Controller

--- a/libs/application/templates/parental-leave/src/fields/components/Slider/index.tsx
+++ b/libs/application/templates/parental-leave/src/fields/components/Slider/index.tsx
@@ -2,7 +2,7 @@ import React, { CSSProperties, FC, useRef, useState, useEffect } from 'react'
 import useComponentSize from '@rehooks/component-size'
 
 import * as styles from './Slider.treat'
-import { Box, Typography } from '@island.is/island-ui/core'
+import { Box, Text } from '@island.is/island-ui/core'
 
 interface TooltipProps {
   style?: CSSProperties
@@ -233,18 +233,18 @@ const Slider = ({
     <Box>
       {showMinMaxLabels && (
         <Box display="flex" justifyContent="spaceBetween" width="full">
-          <Typography color="blue400" variant="eyebrow">
+          <Text color="blue400" variant="eyebrow">
             {min}
-          </Typography>
-          <Typography color="blue400" variant="eyebrow">
+          </Text>
+          <Text color="blue400" variant="eyebrow">
             {max}
-          </Typography>
+          </Text>
         </Box>
       )}
       {showLabel && (
-        <Typography variant="h4" as="p">
+        <Text variant="h4" as="p">
           {formatTooltip(currentIndex)}
-        </Typography>
+        </Text>
       )}
       <Box
         className={styles.TrackGrid}

--- a/libs/application/ui-fields/src/lib/CheckboxFormField.tsx
+++ b/libs/application/ui-fields/src/lib/CheckboxFormField.tsx
@@ -4,7 +4,7 @@ import {
   FieldBaseProps,
   getValueViaPath,
 } from '@island.is/application/core'
-import { Typography, Box } from '@island.is/island-ui/core'
+import { Text, Box } from '@island.is/island-ui/core'
 import { CheckboxController } from '@island.is/shared/form-fields'
 import { useLocale } from '@island.is/localization'
 import Description from './components/Description'
@@ -23,9 +23,7 @@ const CheckboxFormField: FC<Props> = ({
 
   return (
     <div>
-      {showFieldName && (
-        <Typography variant="p">{formatMessage(name)}</Typography>
-      )}
+      {showFieldName && <Text>{formatMessage(name)}</Text>}
 
       {description && <Description description={formatMessage(description)} />}
 

--- a/libs/application/ui-fields/src/lib/DividerFormField.tsx
+++ b/libs/application/ui-fields/src/lib/DividerFormField.tsx
@@ -1,15 +1,15 @@
 import React, { FC } from 'react'
 import { DividerField } from '@island.is/application/core'
-import { Box, Typography } from '@island.is/island-ui/core'
+import { Box, Text } from '@island.is/island-ui/core'
 
 const DividerFormField: FC<{
   field: DividerField
 }> = ({ field }) => {
   return (
     <Box marginTop={5} marginBottom={1}>
-      <Typography variant="h3" color="blue400">
+      <Text variant="h3" color="blue400">
         {field.name}
-      </Typography>
+      </Text>
     </Box>
   )
 }

--- a/libs/application/ui-fields/src/lib/FileUploadFormField/index.tsx
+++ b/libs/application/ui-fields/src/lib/FileUploadFormField/index.tsx
@@ -9,7 +9,7 @@ import {
   InputFileUpload,
   UploadFile,
   fileToObject,
-  Typography,
+  Text,
 } from '@island.is/island-ui/core'
 import { useFormContext, Controller } from 'react-hook-form'
 import { useMutation } from '@apollo/client'
@@ -226,7 +226,7 @@ const FileUploadFormField: FC<Props> = ({
 
   return (
     <Box>
-      <Typography variant="p">{formatMessage(introduction)}</Typography>
+      <Text>{formatMessage(introduction)}</Text>
       <Controller
         name={`${id}`}
         defaultValue={initialUploadFiles}

--- a/libs/application/ui-fields/src/lib/IntroductionFormField.tsx
+++ b/libs/application/ui-fields/src/lib/IntroductionFormField.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react'
 import { IntroductionField } from '@island.is/application/core'
-import { Typography } from '@island.is/island-ui/core'
+import { Text } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
 
 const IntroductionFormField: FC<{
@@ -11,10 +11,8 @@ const IntroductionFormField: FC<{
 
   return (
     <div>
-      {showFieldName && (
-        <Typography variant="h2">{formatMessage(field.name)}</Typography>
-      )}
-      <Typography variant="p">{formatMessage(field.introduction)}</Typography>
+      {showFieldName && <Text variant="h2">{formatMessage(field.name)}</Text>}
+      <Text>{formatMessage(field.introduction)}</Text>
     </div>
   )
 }

--- a/libs/application/ui-fields/src/lib/RadioFormField.tsx
+++ b/libs/application/ui-fields/src/lib/RadioFormField.tsx
@@ -5,7 +5,7 @@ import {
   RadioField,
 } from '@island.is/application/core'
 import { useLocale } from '@island.is/localization'
-import { Typography, Box } from '@island.is/island-ui/core'
+import { Text, Box } from '@island.is/island-ui/core'
 import { RadioController } from '@island.is/shared/form-fields'
 import Description from './components/Description'
 
@@ -31,9 +31,7 @@ const RadioFormField: FC<Props> = ({
 
   return (
     <div>
-      {showFieldName && (
-        <Typography variant="p">{formatMessage(name)}</Typography>
-      )}
+      {showFieldName && <Text>{formatMessage(name)}</Text>}
 
       {description && <Description description={formatMessage(description)} />}
 

--- a/libs/application/ui-fields/src/lib/ReviewFormField.tsx
+++ b/libs/application/ui-fields/src/lib/ReviewFormField.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useMemo } from 'react'
 import { ReviewField, FieldBaseProps } from '@island.is/application/core'
-import { Typography, Box } from '@island.is/island-ui/core'
+import { Text, Box } from '@island.is/island-ui/core'
 import { RadioController } from '@island.is/shared/form-fields'
 
 interface Props extends FieldBaseProps {
@@ -21,7 +21,7 @@ const ReviewFormField: FC<Props> = ({ field, error }) => {
       padding={4}
       marginTop={4}
     >
-      <Typography variant="h4">{name}</Typography>
+      <Text variant="h4">{name}</Text>
       <Box paddingTop={1}>
         <RadioController id={id} options={actionsAsOptions} error={error} />
       </Box>

--- a/libs/application/ui-fields/src/lib/components/Description.tsx
+++ b/libs/application/ui-fields/src/lib/components/Description.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react'
-import { Typography } from '@island.is/island-ui/core'
+import { Text } from '@island.is/island-ui/core'
 
 const Description: FC<{ description: string }> = ({ description }) => {
   const getMarkup = () => {
@@ -8,9 +8,9 @@ const Description: FC<{ description: string }> = ({ description }) => {
     }
   }
   return (
-    <Typography marginTop={2} marginBottom={1} variant="p">
+    <Text marginTop={2} marginBottom={1}>
       <span dangerouslySetInnerHTML={getMarkup()} />
-    </Typography>
+    </Text>
   )
 }
 

--- a/libs/application/ui-shell/src/components/FormMultiField.tsx
+++ b/libs/application/ui-shell/src/components/FormMultiField.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react'
 import FormField from './FormField'
 import { MultiFieldScreen } from '../types'
 import { Box, GridColumn, GridRow } from '@island.is/island-ui/core'
-import { FieldBaseProps, FormValue } from '@island.is/application/core'
+import { FormValue } from '@island.is/application/core'
 import ConditionHandler from './ConditionHandler'
 
 const FormMultiField: FC<{

--- a/libs/application/ui-shell/src/components/Screen.tsx
+++ b/libs/application/ui-shell/src/components/Screen.tsx
@@ -2,7 +2,6 @@ import React, { FC, useCallback } from 'react'
 import { useMutation } from '@apollo/client'
 import {
   ExternalData,
-  FieldBaseProps,
   FormItemTypes,
   FormMode,
   FormValue,
@@ -12,7 +11,7 @@ import {
   Box,
   ButtonDeprecated as Button,
   GridColumn,
-  Typography,
+  Text,
 } from '@island.is/island-ui/core'
 import {
   SUBMIT_APPLICATION,
@@ -142,7 +141,7 @@ const Screen: FC<ScreenProps> = ({
           span={['12/12', '12/12', '7/9', '7/9']}
           offset={['0', '0', '1/9']}
         >
-          <Typography variant="h2">{formatMessage(screen.name)}</Typography>
+          <Text variant="h2">{formatMessage(screen.name)}</Text>
           <Box>
             {screen.type === FormItemTypes.REPEATER ? (
               <FormRepeater

--- a/libs/application/ui-shell/src/types.ts
+++ b/libs/application/ui-shell/src/types.ts
@@ -1,6 +1,5 @@
 import {
   Field,
-  FormValue,
   MultiField,
   ExternalDataProvider,
   Repeater,


### PR DESCRIPTION
## Why

Typography component is deprecated

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
