### PR TITLE
Website/aria labels

### DIFF
--- a/apps/web/components/FixedNav/FixedNav.tsx
+++ b/apps/web/components/FixedNav/FixedNav.tsx
@@ -80,6 +80,7 @@ export const FixedNav: FC = () => {
                 onClick={() => {
                   window.scrollTo(0, 0)
                 }}
+                aria-label={t.gotoTop}
               />
             </Box>
           </Box>

--- a/apps/web/components/FrontpageTabs/FrontpageTabs.tsx
+++ b/apps/web/components/FrontpageTabs/FrontpageTabs.tsx
@@ -82,7 +82,7 @@ export const FrontpageTabs: FC<FrontpageTabsProps> = ({
   const tab = useTabState({
     baseId: 'frontpage-tab',
   })
-  const { activeLocale } = useI18n()
+  const { activeLocale, t } = useI18n()
   const { makePath } = routeNames(activeLocale as Locale)
   const { width } = useWindowSize()
 
@@ -311,6 +311,7 @@ export const FrontpageTabs: FC<FrontpageTabsProps> = ({
                 <button
                   onClick={() => goTo('prev')}
                   type="button"
+                  aria-label={t.frontpageTabsPrevious}
                   className={cn(styles.arrowButton, {
                     [styles.arrowButtonDisabled]: false,
                   })}
@@ -333,6 +334,7 @@ export const FrontpageTabs: FC<FrontpageTabsProps> = ({
                 <button
                   onClick={() => goTo('next')}
                   type="button"
+                  aria-label={t.frontpageTabsNext}
                   className={cn(styles.arrowButton, {
                     [styles.arrowButtonDisabled]: false,
                   })}

--- a/apps/web/components/SearchInput/SearchInput.tsx
+++ b/apps/web/components/SearchInput/SearchInput.tsx
@@ -286,6 +286,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
                 },
                 onFocus,
                 onBlur,
+                "aria-label" : locale === 'is' ? 'Leita' : 'Search',
               }}
               inputProps={getInputProps({
                 inputSize: size,

--- a/apps/web/components/SearchInput/SearchInput.tsx
+++ b/apps/web/components/SearchInput/SearchInput.tsx
@@ -286,7 +286,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
                 },
                 onFocus,
                 onBlur,
-                "aria-label" : locale === 'is' ? 'Leita' : 'Search',
+                'aria-label': locale === 'is' ? 'Leita' : 'Search',
               }}
               inputProps={getInputProps({
                 inputSize: size,

--- a/apps/web/components/SideMenu/SideMenu.tsx
+++ b/apps/web/components/SideMenu/SideMenu.tsx
@@ -230,7 +230,7 @@ export const SideMenu: FC<Props> = ({
               <div
                 id={`tab-content-${index}`}
                 key={index}
-                aria-labelledby={`tab${index}`}
+                aria-labelledby={`tab-${index}`}
                 role="tabpanel"
                 className={styles.content}
                 aria-hidden={activeTab !== index}

--- a/libs/island-ui/core/src/lib/AsyncSearch/AsyncSearch.treat.ts
+++ b/libs/island-ui/core/src/lib/AsyncSearch/AsyncSearch.treat.ts
@@ -144,3 +144,14 @@ export const white = style({
     },
   },
 })
+
+export const srOnly = style({
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  padding: '0',
+  margin: '-1px',
+  overflow: 'hidden',
+  clip: 'rect(0,0,0,0)',
+  border: '0',
+})

--- a/libs/island-ui/core/src/lib/AsyncSearch/AsyncSearch.tsx
+++ b/libs/island-ui/core/src/lib/AsyncSearch/AsyncSearch.tsx
@@ -315,6 +315,11 @@ export const AsyncSearchInput = forwardRef<
           </span>
         )}
         {showLabel && <Label {...labelProps}>{label}</Label>}
+        {!showLabel && (
+          <label className={styles.srOnly} id={inputProps['aria-labelledby']}>
+            {inputProps.placeholder}
+          </label>
+        )}
         <Menu {...{ isOpen, shouldShowItems: isOpen, ...menuProps }}>
           {children}
         </Menu>


### PR DESCRIPTION
# \<Description\>

## What

Add missing aria labels to buttons, fix aria-labelledby references
If search form has no label, only placeholder attribute on the search input, we need to add label element that has "srOnly" styles, 
otherwise we get errors because input element and parent div are referring to label through aria-labelledby attribute. 
This way, screen readers will be able to read the label, even though it is not visible on screens.

## Why
We want the site to be accessible in screen readers.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
