### PR TITLE
Prettier plugin to sort nx project lists

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,6 @@
   "semi": false,
   "trailingComma": "all",
   "arrowParens": "always",
+  "plugins": ["./scripts/prettier-plugins/sort-projects"],
   "endOfLine": "lf"
 }

--- a/nx.json
+++ b/nx.json
@@ -24,136 +24,23 @@
     }
   },
   "projects": {
-    "web": {
+    "adgerdir": {
       "tags": []
     },
-    "web-e2e": {
+    "adgerdir-e2e": {
       "tags": [],
-      "implicitDependencies": ["web"]
-    },
-    "island-ui-core": {
-      "tags": [],
-      "implicitDependencies": ["island-ui-theme"]
-    },
-    "gjafakort-web": {
-      "tags": [],
-      "implicitDependencies": ["gjafakort-api"]
-    },
-    "gjafakort-web-e2e": {
-      "tags": [],
-      "implicitDependencies": ["gjafakort-web"]
-    },
-    "gjafakort-api": {
-      "tags": []
-    },
-    "gjafakort-application": {
-      "tags": []
-    },
-    "api": {
-      "tags": []
-    },
-    "api-domains-cms": {
-      "tags": []
-    },
-    "api-schema": {
-      "tags": []
-    },
-    "island-ui-storybook": {
-      "tags": []
-    },
-    "gjafakort-queue-listener": {
-      "tags": []
-    },
-    "message-queue": {
-      "tags": []
-    },
-    "logging": {
-      "tags": []
-    },
-    "cache": {
-      "tags": []
-    },
-    "reference-backend": {
-      "tags": []
-    },
-    "infra-tracing": {
-      "tags": []
-    },
-    "infra-express-server": {
-      "tags": []
-    },
-    "infra-nest-server": {
-      "tags": []
-    },
-    "api-content-search": {
-      "tags": []
-    },
-    "services-search-indexer": {
-      "tags": []
-    },
-    "api-domains-content-search": {
-      "tags": []
-    },
-    "contentful-importer": {
-      "tags": []
-    },
-    "gjafakort-types": {
-      "tags": []
-    },
-    "gjafakort-consts": {
-      "tags": []
-    },
-    "application-system-form": {
-      "tags": []
-    },
-    "application-system-form-e2e": {
-      "tags": [],
-      "implicitDependencies": ["application-system-form"]
-    },
-    "application-system-api": {
-      "tags": []
-    },
-    "island-ui-theme": {
-      "tags": []
-    },
-    "service-portal": {
-      "tags": []
-    },
-    "service-portal-e2e": {
-      "tags": [],
-      "implicitDependencies": ["service-portal"]
-    },
-    "service-portal-constants": {
-      "tags": []
-    },
-    "service-portal-core": {
-      "tags": []
-    },
-    "service-portal-applications": {
-      "tags": []
-    },
-    "service-portal-documents": {
-      "tags": []
-    },
-    "service-portal-settings": {
-      "tags": []
-    },
-    "service-portal-finance": {
-      "tags": []
-    },
-    "service-portal-family": {
-      "tags": []
-    },
-    "service-portal-health": {
-      "tags": []
-    },
-    "service-portal-education": {
-      "tags": []
-    },
-    "island-ui-contentful": {
-      "tags": []
+      "implicitDependencies": ["adgerdir"]
     },
     "air-discount-scheme-api": {
+      "tags": []
+    },
+    "air-discount-scheme-backend": {
+      "tags": []
+    },
+    "air-discount-scheme-consts": {
+      "tags": []
+    },
+    "air-discount-scheme-types": {
       "tags": []
     },
     "air-discount-scheme-web": {
@@ -163,35 +50,146 @@
       "tags": [],
       "implicitDependencies": ["air-discount-scheme-web"]
     },
-    "air-discount-scheme-backend": {
+    "api": {
       "tags": []
     },
-    "air-discount-scheme-consts": {
+    "api-content-search": {
       "tags": []
     },
     "api-domains-application": {
       "tags": []
     },
-    "adgerdir": {
+    "api-domains-cms": {
       "tags": []
     },
-    "adgerdir-e2e": {
-      "tags": [],
-      "implicitDependencies": ["adgerdir"]
+    "api-domains-content-search": {
+      "tags": []
+    },
+    "api-domains-documents": {
+      "tags": []
     },
     "api-domains-file-upload": {
       "tags": []
     },
-    "file-storage": {
+    "api-domains-translations": {
+      "tags": []
+    },
+    "api-schema": {
+      "tags": []
+    },
+    "application-core": {
+      "tags": []
+    },
+    "application-data-providers": {
       "tags": []
     },
     "application-graphql": {
       "tags": []
     },
-    "air-discount-scheme-types": {
+    "application-system-api": {
+      "tags": []
+    },
+    "application-system-form": {
+      "tags": []
+    },
+    "application-system-form-e2e": {
+      "tags": [],
+      "implicitDependencies": ["application-system-form"]
+    },
+    "application-template-loader": {
+      "tags": []
+    },
+    "application-templates-driving-lessons": {
+      "tags": []
+    },
+    "application-templates-parental-leave": {
+      "tags": []
+    },
+    "application-templates-reference-template": {
+      "tags": []
+    },
+    "application-ui-fields": {
+      "tags": []
+    },
+    "application-ui-shell": {
+      "tags": []
+    },
+    "cache": {
+      "tags": []
+    },
+    "contentful-importer": {
+      "tags": []
+    },
+    "dokobit-signing": {
+      "tags": []
+    },
+    "elastic-indexing": {
+      "tags": []
+    },
+    "email-service": {
+      "tags": []
+    },
+    "file-storage": {
+      "tags": []
+    },
+    "gjafakort-api": {
+      "tags": []
+    },
+    "gjafakort-application": {
+      "tags": []
+    },
+    "gjafakort-consts": {
+      "tags": []
+    },
+    "gjafakort-queue-listener": {
+      "tags": []
+    },
+    "gjafakort-types": {
+      "tags": []
+    },
+    "gjafakort-web": {
+      "tags": [],
+      "implicitDependencies": ["gjafakort-api"]
+    },
+    "gjafakort-web-e2e": {
+      "tags": [],
+      "implicitDependencies": ["gjafakort-web"]
+    },
+    "infra-express-server": {
+      "tags": []
+    },
+    "infra-monitoring": {
+      "tags": []
+    },
+    "infra-nest-server": {
+      "tags": []
+    },
+    "infra-tracing": {
+      "tags": []
+    },
+    "island-ui-contentful": {
+      "tags": []
+    },
+    "island-ui-core": {
+      "tags": [],
+      "implicitDependencies": ["island-ui-theme"]
+    },
+    "island-ui-storybook": {
+      "tags": []
+    },
+    "island-ui-theme": {
       "tags": []
     },
     "judicial-system-api": {
+      "tags": []
+    },
+    "judicial-system-consts": {
+      "tags": []
+    },
+    "judicial-system-formatters": {
+      "tags": []
+    },
+    "judicial-system-types": {
       "tags": []
     },
     "judicial-system-web": {
@@ -201,28 +199,68 @@
       "tags": [],
       "implicitDependencies": ["judicial-system-web"]
     },
-    "api-domains-documents": {
+    "localization": {
+      "tags": []
+    },
+    "logging": {
+      "tags": []
+    },
+    "message-queue": {
+      "tags": []
+    },
+    "nova-sms": {
+      "tags": []
+    },
+    "reference-backend": {
+      "tags": []
+    },
+    "reference-next-app": {
+      "tags": []
+    },
+    "service-portal": {
+      "tags": []
+    },
+    "service-portal-applications": {
+      "tags": []
+    },
+    "service-portal-assets": {
+      "tags": []
+    },
+    "service-portal-constants": {
+      "tags": []
+    },
+    "service-portal-core": {
+      "tags": []
+    },
+    "service-portal-documents": {
+      "tags": []
+    },
+    "service-portal-e2e": {
+      "tags": [],
+      "implicitDependencies": ["service-portal"]
+    },
+    "service-portal-education": {
+      "tags": []
+    },
+    "service-portal-family": {
+      "tags": []
+    },
+    "service-portal-finance": {
       "tags": []
     },
     "service-portal-graphql": {
       "tags": []
     },
-    "application-data-providers": {
+    "service-portal-health": {
       "tags": []
     },
-    "skilavottord-ws": {
+    "service-portal-settings": {
       "tags": []
     },
-    "api-domains-translations": {
+    "services-search-indexer": {
       "tags": []
     },
-    "localization": {
-      "tags": []
-    },
-    "infra-monitoring": {
-      "tags": []
-    },
-    "judicial-system-consts": {
+    "shared-form-fields": {
       "tags": []
     },
     "skilavottord-consts": {
@@ -231,60 +269,22 @@
     "skilavottord-types": {
       "tags": []
     },
-    "elastic-indexing": {
-      "tags": []
-    },
-    "reference-next-app": {
-      "tags": []
-    },
-    "nova-sms": {
-      "tags": []
-    },
-    "service-portal-assets": {
-      "tags": []
-    },
-    "dokobit-signing": {
-      "tags": []
-    },
-    "judicial-system-types": {
-      "tags": []
-    },
     "skilavottord-web": {
+      "tags": []
+    },
+    "skilavottord-ws": {
       "tags": []
     },
     "skilavottord/web-e2e": {
       "tags": [],
       "implicitDependencies": ["skilavottord-web"]
     },
-    "application-templates-parental-leave": {
+    "web": {
       "tags": []
     },
-    "application-templates-driving-lessons": {
-      "tags": []
-    },
-    "application-template-loader": {
-      "tags": []
-    },
-    "application-templates-reference-template": {
-      "tags": []
-    },
-    "application-core": {
-      "tags": []
-    },
-    "application-ui-shell": {
-      "tags": []
-    },
-    "application-ui-fields": {
-      "tags": []
-    },
-    "shared-form-fields": {
-      "tags": []
-    },
-    "judicial-system-formatters": {
-      "tags": []
-    },
-    "email-service": {
-      "tags": []
+    "web-e2e": {
+      "tags": [],
+      "implicitDependencies": ["web"]
     }
   },
   "affected": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "generate": "nx generate",
     "env-secrets": "./scripts/secrets.sh",
     "format": "nx format:write",
-    "format:write": "nx format:write",
     "format:check": "nx format:check",
     "update": "nx migrate latest",
     "workspace-schematic": "nx workspace-schematic",

--- a/scripts/prettier-plugins/sort-projects.js
+++ b/scripts/prettier-plugins/sort-projects.js
@@ -1,0 +1,65 @@
+const { parsers } = require('prettier/parser-babel')
+const parser = parsers['json']
+const _ = require('lodash')
+const { basename } = require('path')
+
+const sortObjectByKey = (obj) => {
+  return _(obj).toPairs().sortBy(0).fromPairs().value()
+}
+
+const editStringJSON = (text, handler) => {
+  const inJson = JSON.parse(text)
+  const outJson = handler(inJson)
+  return JSON.stringify(outJson, null, '  ')
+}
+
+const sortWorkspace = (text) => {
+  return editStringJSON(text, (json) => {
+    if (json.projects) {
+      json.projects = sortObjectByKey(json.projects)
+    }
+    return json
+  })
+}
+
+const sortNx = (text) => {
+  return editStringJSON(text, (json) => {
+    if (json.projects) {
+      json.projects = sortObjectByKey(json.projects)
+    }
+    return json
+  })
+}
+
+const sortTsConfig = (text) => {
+  return editStringJSON(text, (json) => {
+    if (json.compilerOptions && json.compilerOptions.paths) {
+      json.compilerOptions.paths = sortObjectByKey(json.compilerOptions.paths)
+    }
+    return json
+  })
+}
+
+exports.parsers = {
+  json: {
+    ...parser,
+    preprocess(text, options) {
+      if (parser.preprocess) {
+        text = parser.preprocess(text, options)
+      }
+
+      const fileName = options.filepath && basename(options.filepath)
+
+      switch (fileName) {
+        case 'workspace.json':
+          return sortWorkspace(text)
+        case 'tsconfig.base.json':
+          return sortTsConfig(text)
+        case 'nx.json':
+          return sortNx(text)
+        default:
+          return text
+      }
+    },
+  },
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -18,40 +18,103 @@
     "baseUrl": ".",
     "strict": true,
     "paths": {
-      "@island.is/island-ui/core": ["libs/island-ui/core/src/index.ts"],
-      "@island.is/web/*": ["apps/web/*"],
       "@island.is/adgerdir/*": ["apps/adgerdir/*"],
-      "@island.is/gjafakort-web/*": ["apps/gjafakort/web/*"],
-      "@island.is/judicial-system-web/*": ["apps/judicial-system/web/*"],
-      "@island.is/skilavottord-web/*": ["apps/skilavottord/web/*"],
       "@island.is/air-discount-scheme-web/*": [
         "apps/air-discount-scheme/web/*"
+      ],
+      "@island.is/air-discount-scheme/consts": [
+        "libs/air-discount-scheme/consts/src/index.ts"
+      ],
+      "@island.is/air-discount-scheme/types": [
+        "libs/air-discount-scheme/types/src/index.ts"
+      ],
+      "@island.is/api/content-search": ["libs/api/content-search/src/index.ts"],
+      "@island.is/api/domains/application": [
+        "libs/api/domains/application/src/index.ts"
+      ],
+      "@island.is/api/domains/cms": ["libs/api/domains/cms/src/index.ts"],
+      "@island.is/api/domains/content-search": [
+        "libs/api/domains/content-search/src/index.ts"
+      ],
+      "@island.is/api/domains/documents": [
+        "libs/api/domains/documents/src/index.ts"
+      ],
+      "@island.is/api/domains/file-upload": [
+        "libs/api/domains/file-upload/src/index.ts"
       ],
       "@island.is/api/domains/hello-world": [
         "libs/api/domains/hello-world/src/index.ts"
       ],
-      "@island.is/api/domains/cms": ["libs/api/domains/cms/src/index.ts"],
+      "@island.is/api/domains/translations": [
+        "libs/api/domains/translations/src/index.ts"
+      ],
       "@island.is/api/schema": ["libs/api/schema/src/index.ts"],
+      "@island.is/application/core": ["libs/application/core/src/index.ts"],
+      "@island.is/application/data-providers": [
+        "libs/application/data-providers/src/index.ts"
+      ],
+      "@island.is/application/graphql": [
+        "libs/application/graphql/src/index.ts"
+      ],
+      "@island.is/application/template-loader": [
+        "libs/application/template-loader/src/index.ts"
+      ],
+      "@island.is/application/templates/driving-lessons": [
+        "libs/application/templates/driving-lessons/src/index.ts"
+      ],
+      "@island.is/application/templates/parental-leave": [
+        "libs/application/templates/parental-leave/src/index.ts"
+      ],
+      "@island.is/application/templates/reference-template": [
+        "libs/application/templates/reference-template/src/index.ts"
+      ],
+      "@island.is/application/ui-fields": [
+        "libs/application/ui-fields/src/index.ts"
+      ],
+      "@island.is/application/ui-shell": [
+        "libs/application/ui-shell/src/index.ts"
+      ],
+      "@island.is/cache": ["libs/cache/src/index.ts"],
+      "@island.is/dokobit-signing": ["libs/dokobit-signing/src/index.ts"],
+      "@island.is/elastic-indexing": ["libs/elastic-indexing/src/index.ts"],
+      "@island.is/email-service": ["libs/email-service/src/index.ts"],
+      "@island.is/file-storage": ["libs/file-storage/src/index.ts"],
+      "@island.is/gjafakort-web/*": ["apps/gjafakort/web/*"],
       "@island.is/gjafakort/application/*": [
         "apps/gjafakort/application/src/*"
       ],
-      "@island.is/message-queue": ["libs/message-queue/src/index.ts"],
-      "@island.is/logging": ["libs/logging/src/index.ts"],
-      "@island.is/cache": ["libs/cache/src/index.ts"],
-      "@island.is/infra-tracing": ["libs/infra-tracing/src/index.ts"],
+      "@island.is/gjafakort/consts": ["libs/gjafakort/consts/src/index.ts"],
+      "@island.is/gjafakort/types": ["libs/gjafakort/types/src/index.ts"],
       "@island.is/infra-express-server": [
         "libs/infra-express-server/src/index.ts"
       ],
+      "@island.is/infra-monitoring": ["libs/infra-monitoring/src/index.ts"],
       "@island.is/infra-nest-server": ["libs/infra-nest-server/src/index.ts"],
-      "@island.is/api/domains/content-search": [
-        "libs/api/domains/content-search/src/index.ts"
+      "@island.is/infra-tracing": ["libs/infra-tracing/src/index.ts"],
+      "@island.is/island-ui/contentful": [
+        "libs/island-ui/contentful/src/index.ts"
       ],
-      "@island.is/api/content-search": ["libs/api/content-search/src/index.ts"],
-      "@island.is/gjafakort/types": ["libs/gjafakort/types/src/index.ts"],
-      "@island.is/gjafakort/consts": ["libs/gjafakort/consts/src/index.ts"],
+      "@island.is/island-ui/core": ["libs/island-ui/core/src/index.ts"],
       "@island.is/island-ui/theme": ["libs/island-ui/theme/src/index.ts"],
-      "@island.is/service-portal/modules": [
-        "libs/service-portal/modules/src/index.ts"
+      "@island.is/judicial-system-web/*": ["apps/judicial-system/web/*"],
+      "@island.is/judicial-system/consts": [
+        "libs/judicial-system/consts/src/index.ts"
+      ],
+      "@island.is/judicial-system/formatters": [
+        "libs/judicial-system/formatters/src/index.ts"
+      ],
+      "@island.is/judicial-system/types": [
+        "libs/judicial-system/types/src/index.ts"
+      ],
+      "@island.is/localization": ["libs/localization/src/index.ts"],
+      "@island.is/logging": ["libs/logging/src/index.ts"],
+      "@island.is/message-queue": ["libs/message-queue/src/index.ts"],
+      "@island.is/nova-sms": ["libs/nova-sms/src/index.ts"],
+      "@island.is/service-portal/applications": [
+        "libs/service-portal/applications/src/index.ts"
+      ],
+      "@island.is/service-portal/assets": [
+        "libs/service-portal/assets/src/index.ts"
       ],
       "@island.is/service-portal/constants": [
         "libs/service-portal/constants/src/index.ts"
@@ -59,100 +122,37 @@
       "@island.is/service-portal/core": [
         "libs/service-portal/core/src/index.ts"
       ],
-      "@island.is/service-portal/applications": [
-        "libs/service-portal/applications/src/index.ts"
-      ],
       "@island.is/service-portal/documents": [
         "libs/service-portal/documents/src/index.ts"
-      ],
-      "@island.is/service-portal/settings": [
-        "libs/service-portal/settings/src/index.ts"
-      ],
-      "@island.is/service-portal/finance": [
-        "libs/service-portal/finance/src/index.ts"
-      ],
-      "@island.is/service-portal/family": [
-        "libs/service-portal/family/src/index.ts"
-      ],
-      "@island.is/service-portal/health": [
-        "libs/service-portal/health/src/index.ts"
       ],
       "@island.is/service-portal/education": [
         "libs/service-portal/education/src/index.ts"
       ],
-      "@island.is/island-ui/contentful": [
-        "libs/island-ui/contentful/src/index.ts"
+      "@island.is/service-portal/family": [
+        "libs/service-portal/family/src/index.ts"
       ],
-      "@island.is/air-discount-scheme/consts": [
-        "libs/air-discount-scheme/consts/src/index.ts"
-      ],
-      "@island.is/api/domains/application": [
-        "libs/api/domains/application/src/index.ts"
-      ],
-      "@island.is/api/domains/file-upload": [
-        "libs/api/domains/file-upload/src/index.ts"
-      ],
-      "@island.is/file-storage": ["libs/file-storage/src/index.ts"],
-      "@island.is/application/graphql": [
-        "libs/application/graphql/src/index.ts"
-      ],
-      "@island.is/air-discount-scheme/types": [
-        "libs/air-discount-scheme/types/src/index.ts"
-      ],
-      "@island.is/api/domains/documents": [
-        "libs/api/domains/documents/src/index.ts"
+      "@island.is/service-portal/finance": [
+        "libs/service-portal/finance/src/index.ts"
       ],
       "@island.is/service-portal/graphql": [
         "libs/service-portal/graphql/src/index.ts"
       ],
-      "@island.is/api/domains/translations": [
-        "libs/api/domains/translations/src/index.ts"
+      "@island.is/service-portal/health": [
+        "libs/service-portal/health/src/index.ts"
       ],
-      "@island.is/localization": ["libs/localization/src/index.ts"],
-      "@island.is/application/data-providers": [
-        "libs/application/data-providers/src/index.ts"
+      "@island.is/service-portal/modules": [
+        "libs/service-portal/modules/src/index.ts"
       ],
-      "@island.is/infra-monitoring": ["libs/infra-monitoring/src/index.ts"],
-      "@island.is/judicial-system/consts": [
-        "libs/judicial-system/consts/src/index.ts"
+      "@island.is/service-portal/settings": [
+        "libs/service-portal/settings/src/index.ts"
       ],
+      "@island.is/shared/form-fields": ["libs/shared/form-fields/src/index.ts"],
+      "@island.is/skilavottord-web/*": ["apps/skilavottord/web/*"],
       "@island.is/skilavottord/consts": [
         "libs/skilavottord/consts/src/index.ts"
       ],
       "@island.is/skilavottord/types": ["libs/skilavottord/types/src/index.ts"],
-      "@island.is/elastic-indexing": ["libs/elastic-indexing/src/index.ts"],
-      "@island.is/nova-sms": ["libs/nova-sms/src/index.ts"],
-      "@island.is/service-portal/assets": [
-        "libs/service-portal/assets/src/index.ts"
-      ],
-      "@island.is/dokobit-signing": ["libs/dokobit-signing/src/index.ts"],
-      "@island.is/judicial-system/types": [
-        "libs/judicial-system/types/src/index.ts"
-      ],
-      "@island.is/application/templates/parental-leave": [
-        "libs/application/templates/parental-leave/src/index.ts"
-      ],
-      "@island.is/application/templates/driving-lessons": [
-        "libs/application/templates/driving-lessons/src/index.ts"
-      ],
-      "@island.is/application/template-loader": [
-        "libs/application/template-loader/src/index.ts"
-      ],
-      "@island.is/application/templates/reference-template": [
-        "libs/application/templates/reference-template/src/index.ts"
-      ],
-      "@island.is/application/core": ["libs/application/core/src/index.ts"],
-      "@island.is/application/ui-shell": [
-        "libs/application/ui-shell/src/index.ts"
-      ],
-      "@island.is/application/ui-fields": [
-        "libs/application/ui-fields/src/index.ts"
-      ],
-      "@island.is/shared/form-fields": ["libs/shared/form-fields/src/index.ts"],
-      "@island.is/judicial-system/formatters": [
-        "libs/judicial-system/formatters/src/index.ts"
-      ],
-      "@island.is/email-service": ["libs/email-service/src/index.ts"]
+      "@island.is/web/*": ["apps/web/*"]
     }
   },
   "exclude": ["node_modules", "tmp"]

--- a/workspace.json
+++ b/workspace.json
@@ -1,24 +1,24 @@
 {
   "version": 1,
   "projects": {
-    "web": {
-      "root": "apps/web",
-      "sourceRoot": "apps/web",
+    "adgerdir": {
+      "root": "apps/adgerdir",
+      "sourceRoot": "apps/adgerdir/src",
       "projectType": "application",
       "schematics": {},
       "architect": {
         "build": {
           "builder": "@nrwl/next:build",
           "options": {
-            "root": "apps/web",
-            "outputPath": "dist/apps/web"
+            "root": "apps/adgerdir",
+            "outputPath": "dist/apps/adgerdir"
           },
           "configurations": {
             "production": {
               "fileReplacements": [
                 {
-                  "replace": "apps/web/environments/environment.ts",
-                  "with": "apps/web/environments/environment.prod.ts"
+                  "replace": "apps/adgerdir/environments/environment.ts",
+                  "with": "apps/adgerdir/environments/environment.prod.ts"
                 }
               ]
             }
@@ -27,13 +27,13 @@
         "serve": {
           "builder": "@nrwl/next:server",
           "options": {
-            "buildTarget": "web:build",
+            "buildTarget": "adgerdir:build",
             "dev": true,
-            "proxyConfig": "apps/web/proxy.config.json"
+            "proxyConfig": "apps/adgerdir/proxy.config.json"
           },
           "configurations": {
             "production": {
-              "buildTarget": "web:build:production",
+              "buildTarget": "adgerdir:build:production",
               "dev": false
             }
           }
@@ -41,7 +41,7 @@
         "export": {
           "builder": "@nrwl/next:export",
           "options": {
-            "buildTarget": "web:build:production"
+            "buildTarget": "adgerdir:build:production"
           }
         },
         "lint": {
@@ -49,54 +49,49 @@
           "options": {
             "linter": "eslint",
             "tsConfig": [
-              "apps/web/tsconfig.json",
-              "apps/web/tsconfig.spec.json"
+              "apps/adgerdir/tsconfig.json",
+              "apps/adgerdir/tsconfig.spec.json"
             ],
-            "exclude": ["**/node_modules/**", "!apps/web/**/*"]
+            "exclude": ["**/node_modules/**", "!apps/adgerdir/**/*"]
           }
         },
         "test": {
           "builder": "@nrwl/jest:jest",
           "options": {
-            "jestConfig": "apps/web/jest.config.js",
+            "jestConfig": "apps/adgerdir/jest.config.js",
             "passWithNoTests": true
-          }
-        },
-        "init-schema": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "command": "yarn nx run web:codegen"
           }
         },
         "codegen": {
           "builder": "@nrwl/workspace:run-commands",
           "options": {
-            "command": "graphql-codegen --config apps/web/codegen.yml"
-          },
-          "configurations": {
-            "watch": {
-              "command": "graphql-codegen --config apps/web/codegen.yml --watch"
-            }
+            "command": "graphql-codegen --config apps/adgerdir/codegen.yml"
+          }
+        },
+        "init-schema": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "command": "yarn nx run adgerdir:codegen"
           }
         },
         "docker-next": {}
       }
     },
-    "web-e2e": {
-      "root": "apps/web-e2e",
-      "sourceRoot": "apps/web-e2e/src",
+    "adgerdir-e2e": {
+      "root": "apps/adgerdir-e2e",
+      "sourceRoot": "apps/adgerdir-e2e/src",
       "projectType": "application",
       "architect": {
         "e2e": {
           "builder": "@nrwl/cypress:cypress",
           "options": {
-            "cypressConfig": "apps/web-e2e/cypress.json",
-            "tsConfig": "apps/web-e2e/tsconfig.e2e.json",
-            "devServerTarget": "web:serve"
+            "cypressConfig": "apps/adgerdir-e2e/cypress.json",
+            "tsConfig": "apps/adgerdir-e2e/tsconfig.e2e.json",
+            "devServerTarget": "adgerdir:serve"
           },
           "configurations": {
             "production": {
-              "devServerTarget": "web:serve:production"
+              "devServerTarget": "adgerdir:serve:production"
             }
           }
         },
@@ -104,1434 +99,8 @@
           "builder": "@nrwl/linter:lint",
           "options": {
             "linter": "eslint",
-            "tsConfig": ["apps/web-e2e/tsconfig.e2e.json"],
-            "exclude": ["**/node_modules/**", "!apps/web-e2e/**/*"]
-          }
-        }
-      }
-    },
-    "island-ui-core": {
-      "root": "libs/island-ui/core",
-      "sourceRoot": "libs/island-ui/core/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/island-ui/core/tsconfig.lib.json",
-              "libs/island-ui/core/tsconfig.spec.json"
-            ],
-            "exclude": ["**/node_modules/**", "!libs/island-ui/core/**/*"]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/island-ui/core/jest.config.js",
-            "passWithNoTests": true
-          }
-        }
-      }
-    },
-    "gjafakort-web": {
-      "root": "apps/gjafakort/web",
-      "sourceRoot": "apps/gjafakort/web",
-      "projectType": "application",
-      "schematics": {},
-      "architect": {
-        "build": {
-          "builder": "@nrwl/next:build",
-          "options": {
-            "root": "apps/gjafakort/web",
-            "outputPath": "dist/apps/gjafakort/web"
-          },
-          "configurations": {
-            "production": {
-              "fileReplacements": [
-                {
-                  "replace": "apps/gjafakort/web/environments/environment.ts",
-                  "with": "apps/gjafakort/web/environments/environment.prod.ts"
-                }
-              ]
-            }
-          }
-        },
-        "translations": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "command": "quicktype is.json -o translation.d.ts --top-level Translation",
-            "cwd": "apps/gjafakort/web/i18n/locales"
-          }
-        },
-        "serve": {
-          "builder": "@nrwl/next:server",
-          "options": {
-            "buildTarget": "gjafakort-web:build",
-            "dev": true
-          },
-          "configurations": {
-            "production": {
-              "buildTarget": "gjafakort-web:build:production",
-              "dev": false
-            }
-          }
-        },
-        "export": {
-          "builder": "@nrwl/next:export",
-          "options": {
-            "buildTarget": "gjafakort-web:build:production"
-          }
-        },
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "apps/gjafakort/web/tsconfig.json",
-              "apps/gjafakort/web/tsconfig.spec.json"
-            ],
-            "exclude": ["**/node_modules/**", "!apps/gjafakort/web/**/*"]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "apps/gjafakort/web/jest.config.js",
-            "passWithNoTests": true
-          }
-        },
-        "docker-next": {}
-      }
-    },
-    "gjafakort-web-e2e": {
-      "root": "apps/gjafakort/web-e2e",
-      "sourceRoot": "apps/gjafakort/web-e2e/src",
-      "projectType": "application",
-      "architect": {
-        "e2e": {
-          "builder": "@nrwl/cypress:cypress",
-          "options": {
-            "cypressConfig": "apps/gjafakort/web-e2e/cypress.json",
-            "tsConfig": "apps/gjafakort/web-e2e/tsconfig.e2e.json",
-            "devServerTarget": "gjafakort/web:serve"
-          },
-          "configurations": {
-            "production": {
-              "devServerTarget": "gjafakort/web:serve:production"
-            }
-          }
-        },
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": ["apps/gjafakort/web-e2e/tsconfig.e2e.json"],
-            "exclude": ["**/node_modules/**", "!apps/gjafakort/web-e2e/**/*"]
-          }
-        }
-      }
-    },
-    "gjafakort-api": {
-      "root": "apps/gjafakort/api",
-      "sourceRoot": "apps/gjafakort/api/src",
-      "projectType": "application",
-      "prefix": "gjafakort-api",
-      "schematics": {},
-      "architect": {
-        "build": {
-          "builder": "@nrwl/node:build",
-          "options": {
-            "outputPath": "dist/apps/gjafakort/api",
-            "main": "apps/gjafakort/api/src/main.ts",
-            "tsConfig": "apps/gjafakort/api/tsconfig.app.json",
-            "assets": []
-          },
-          "configurations": {
-            "production": {
-              "optimization": true,
-              "extractLicenses": true,
-              "inspect": false,
-              "fileReplacements": [
-                {
-                  "replace": "apps/gjafakort/api/src/environments/environment.ts",
-                  "with": "apps/gjafakort/api/src/environments/environment.prod.ts"
-                }
-              ]
-            }
-          }
-        },
-        "serve": {
-          "builder": "@nrwl/node:execute",
-          "options": {
-            "buildTarget": "gjafakort-api:build"
-          }
-        },
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "apps/gjafakort/api/tsconfig.app.json",
-              "apps/gjafakort/api/tsconfig.spec.json"
-            ],
-            "exclude": ["**/node_modules/**", "!apps/gjafakort/api/**/*"]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "apps/gjafakort/api/jest.config.js",
-            "passWithNoTests": true
-          }
-        },
-        "codegen": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "command": "graphql-codegen --config apps/gjafakort/codegen.yml"
-          }
-        },
-        "init-schema": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "command": "yarn nx run gjafakort-api:codegen"
-          }
-        },
-        "docker-express": {}
-      }
-    },
-    "api": {
-      "root": "apps/api",
-      "sourceRoot": "apps/api/src",
-      "projectType": "application",
-      "prefix": "api",
-      "schematics": {},
-      "architect": {
-        "build": {
-          "builder": "@nrwl/node:build",
-          "options": {
-            "outputPath": "dist/apps/api",
-            "main": "apps/api/src/main.ts",
-            "tsConfig": "apps/api/tsconfig.app.json",
-            "showCircularDependencies": false
-          },
-          "configurations": {
-            "production": {
-              "optimization": true,
-              "extractLicenses": true,
-              "inspect": false
-            }
-          }
-        },
-        "serve": {
-          "builder": "@nrwl/node:execute",
-          "options": {
-            "buildTarget": "api:build"
-          }
-        },
-        "build-schema": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "command": "yarn ts-node -P apps/api/tsconfig.app.json apps/api/src/buildSchema.ts"
-          }
-        },
-        "init-schema": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "command": "yarn nx run api:codegen"
-          }
-        },
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "apps/api/tsconfig.app.json",
-              "apps/api/tsconfig.spec.json"
-            ],
-            "exclude": ["**/node_modules/**", "!apps/api/**/*"]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "apps/api/jest.config.js",
-            "passWithNoTests": true
-          }
-        },
-        "codegen": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "command": "graphql-codegen --config apps/api/codegen.yml"
-          },
-          "configurations": {
-            "watch": {
-              "command": "graphql-codegen --config apps/api/codegen.yml --watch"
-            }
-          }
-        },
-        "env-secrets": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "command": "./scripts/secrets.sh api --reset"
-          }
-        },
-        "contentful-types": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "command": "yarn ts-node -P apps/api/tsconfig.app.json ./libs/api/domains/cms/scripts/generateContentfulTypes.ts"
-          }
-        },
-        "contentType": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "command": "yarn ts-node -P apps/api/tsconfig.app.json ./libs/api/domains/cms/scripts/contentType.ts {args.id} {args.sys} {args.overwrite}"
-          }
-        },
-        "docker-express": {}
-      }
-    },
-    "api-domains-cms": {
-      "root": "libs/api/domains/cms",
-      "sourceRoot": "libs/api/domains/cms/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/api/domains/cms/tsconfig.lib.json",
-              "libs/api/domains/cms/tsconfig.spec.json"
-            ],
-            "exclude": ["**/node_modules/**", "!libs/api/domains/cms/**/*"]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/api/domains/cms/jest.config.js",
-            "passWithNoTests": true
-          }
-        }
-      }
-    },
-    "api-schema": {
-      "root": "libs/api/schema",
-      "sourceRoot": "libs/api/schema/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": ["libs/api/schema/tsconfig.lib.json"],
-            "exclude": ["**/node_modules/**", "!libs/api/schema/**/*"]
-          }
-        }
-      }
-    },
-    "island-ui-storybook": {
-      "root": "libs/island-ui/storybook",
-      "sourceRoot": "libs/island-ui/storybook/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": ["libs/island-ui/storybook/tsconfig.lib.json"],
-            "exclude": ["**/node_modules/**", "!libs/island-ui/storybook/**/*"]
-          }
-        },
-        "serve": {
-          "builder": "@nrwl/storybook:storybook",
-          "options": {
-            "uiFramework": "@storybook/react",
-            "port": 4400,
-            "config": {
-              "configFolder": "libs/island-ui/storybook/config"
-            }
-          },
-          "configurations": {
-            "ci": {
-              "quiet": true
-            }
-          }
-        },
-        "build-storybook": {
-          "builder": "@nrwl/storybook:build",
-          "options": {
-            "uiFramework": "@storybook/react",
-            "outputPath": "dist/storybook/island-ui",
-            "config": {
-              "configFolder": "libs/island-ui/storybook/config"
-            }
-          },
-          "configurations": {
-            "ci": {
-              "quiet": true
-            }
-          }
-        }
-      }
-    },
-    "gjafakort-application": {
-      "root": "apps/gjafakort/application",
-      "sourceRoot": "apps/gjafakort/application/src",
-      "projectType": "application",
-      "prefix": "gjafakort-application",
-      "schematics": {},
-      "architect": {
-        "build": {
-          "builder": "@nrwl/node:build",
-          "options": {
-            "outputPath": "dist/apps/gjafakort/application",
-            "main": "apps/gjafakort/application/src/main.ts",
-            "tsConfig": "apps/gjafakort/application/tsconfig.app.json",
-            "assets": [
-              {
-                "glob": "*sequelize*",
-                "input": "apps/gjafakort/application",
-                "output": "./"
-              },
-              {
-                "glob": "migrations/**",
-                "input": "apps/gjafakort/application",
-                "output": "./"
-              }
-            ]
-          },
-          "configurations": {
-            "production": {
-              "optimization": true,
-              "extractLicenses": true,
-              "inspect": false,
-              "fileReplacements": [
-                {
-                  "replace": "apps/gjafakort/application/src/environments/environment.ts",
-                  "with": "apps/gjafakort/application/src/environments/environment.prod.ts"
-                }
-              ]
-            }
-          }
-        },
-        "serve": {
-          "builder": "@nrwl/node:execute",
-          "options": {
-            "buildTarget": "gjafakort-application:build"
-          }
-        },
-        "migrate": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "command": "sequelize-cli db:migrate",
-            "cwd": "apps/gjafakort/application"
-          }
-        },
-        "migrate/generate": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "command": "sequelize-cli migration:generate --name $(whoami)",
-            "cwd": "apps/gjafakort/application"
-          }
-        },
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "apps/gjafakort/application/tsconfig.app.json",
-              "apps/gjafakort/application/tsconfig.spec.json"
-            ],
-            "exclude": [
-              "**/node_modules/**",
-              "!apps/gjafakort/application/**/*"
-            ]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "apps/gjafakort/application/jest.config.js",
-            "passWithNoTests": true
-          }
-        },
-        "docker-express": {}
-      }
-    },
-    "gjafakort-queue-listener": {
-      "root": "apps/gjafakort/queue-listener",
-      "sourceRoot": "apps/gjafakort/queue-listener/src",
-      "projectType": "application",
-      "prefix": "gjafakort-queue-listener",
-      "schematics": {},
-      "architect": {
-        "build": {
-          "builder": "@nrwl/node:build",
-          "options": {
-            "outputPath": "dist/apps/gjafakort/queue-listener",
-            "main": "apps/gjafakort/queue-listener/src/main.ts",
-            "tsConfig": "apps/gjafakort/queue-listener/tsconfig.app.json"
-          },
-          "configurations": {
-            "production": {
-              "optimization": true,
-              "extractLicenses": true,
-              "inspect": false,
-              "fileReplacements": [
-                {
-                  "replace": "apps/gjafakort/queue-listener/src/environments/environment.ts",
-                  "with": "apps/gjafakort/queue-listener/src/environments/environment.prod.ts"
-                }
-              ]
-            }
-          }
-        },
-        "serve": {
-          "builder": "@nrwl/node:execute",
-          "options": {
-            "buildTarget": "gjafakort-queue-listener:build"
-          }
-        },
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "apps/gjafakort/queue-listener/tsconfig.app.json",
-              "apps/gjafakort/queue-listener/tsconfig.spec.json"
-            ],
-            "exclude": [
-              "**/node_modules/**",
-              "!apps/gjafakort/queue-listener/**/*"
-            ]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "apps/gjafakort/queue-listener/jest.config.js",
-            "passWithNoTests": true
-          }
-        },
-        "docker-express": {}
-      }
-    },
-    "message-queue": {
-      "root": "libs/message-queue",
-      "sourceRoot": "libs/message-queue/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/message-queue/tsconfig.lib.json",
-              "libs/message-queue/tsconfig.spec.json"
-            ],
-            "exclude": ["**/node_modules/**", "!libs/message-queue/**/*"]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/message-queue/jest.config.js",
-            "passWithNoTests": true
-          }
-        }
-      }
-    },
-    "logging": {
-      "root": "libs/logging",
-      "sourceRoot": "libs/logging/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/logging/tsconfig.lib.json",
-              "libs/logging/tsconfig.spec.json"
-            ],
-            "exclude": ["**/node_modules/**", "!libs/logging/**/*"]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/logging/jest.config.js",
-            "passWithNoTests": true
-          }
-        }
-      }
-    },
-    "reference-backend": {
-      "root": "apps/reference-backend",
-      "sourceRoot": "apps/reference-backend/src",
-      "projectType": "application",
-      "prefix": "reference-backend",
-      "schematics": {},
-      "architect": {
-        "build": {
-          "builder": "@nrwl/node:build",
-          "options": {
-            "outputPath": "dist/apps/reference-backend",
-            "main": "apps/reference-backend/src/main.ts",
-            "tsConfig": "apps/reference-backend/tsconfig.app.json",
-            "assets": ["apps/reference-backend/src/assets"]
-          },
-          "configurations": {
-            "production": {
-              "optimization": true,
-              "extractLicenses": true,
-              "inspect": false,
-              "fileReplacements": [
-                {
-                  "replace": "apps/reference-backend/src/environments/environment.ts",
-                  "with": "apps/reference-backend/src/environments/environment.prod.ts"
-                }
-              ]
-            }
-          }
-        },
-        "serve": {
-          "builder": "@nrwl/node:execute",
-          "options": {
-            "buildTarget": "reference-backend:build"
-          }
-        },
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "apps/reference-backend/tsconfig.app.json",
-              "apps/reference-backend/tsconfig.spec.json"
-            ],
-            "exclude": ["**/node_modules/**", "!apps/reference-backend/**/*"]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "apps/reference-backend/jest.config.js",
-            "passWithNoTests": true
-          }
-        },
-        "docker-express": {},
-        "dev-services": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "command": "docker-compose -f docker-compose.base.yml -f docker-compose.dev.yml up -d",
-            "cwd": "apps/reference-backend"
-          }
-        },
-        "init-schema": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "outputPath": "apps/reference-backend/src/openapi.yaml",
-            "command": "yarn ts-node -P apps/reference-backend/tsconfig.app.json apps/reference-backend/src/buildOpenApi.ts"
-          }
-        },
-        "generate-schema": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "parallel": false,
-            "outputPath": "apps/reference-backend/src/openapi.yaml",
-            "commands": [
-              "yarn build reference-backend",
-              "node dist/apps/reference-backend/main --generate-schema apps/reference-backend/src/openapi.yaml"
-            ]
-          }
-        },
-        "migrate": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "command": "../../node_modules/.bin/sequelize-cli db:migrate",
-            "cwd": "apps/reference-backend"
-          }
-        },
-        "migrate/generate": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "command": "../../node_modules/.bin/sequelize-cli migration:generate --name $(whoami)",
-            "cwd": "apps/reference-backend"
-          }
-        }
-      }
-    },
-    "infra-tracing": {
-      "root": "libs/infra-tracing",
-      "sourceRoot": "libs/infra-tracing/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/infra-tracing/tsconfig.lib.json",
-              "libs/infra-tracing/tsconfig.spec.json"
-            ],
-            "exclude": ["**/node_modules/**", "!libs/infra-tracing/**/*"]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/infra-tracing/jest.config.js",
-            "passWithNoTests": true
-          }
-        }
-      }
-    },
-    "infra-express-server": {
-      "root": "libs/infra-express-server",
-      "sourceRoot": "libs/infra-express-server/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/infra-express-server/tsconfig.lib.json",
-              "libs/infra-express-server/tsconfig.spec.json"
-            ],
-            "exclude": ["**/node_modules/**", "!libs/infra-express-server/**/*"]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/infra-express-server/jest.config.js",
-            "passWithNoTests": true
-          }
-        }
-      }
-    },
-    "infra-nest-server": {
-      "root": "libs/infra-nest-server",
-      "sourceRoot": "libs/infra-nest-server/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/infra-nest-server/tsconfig.lib.json",
-              "libs/infra-nest-server/tsconfig.spec.json"
-            ],
-            "exclude": ["**/node_modules/**", "!libs/infra-nest-server/**/*"]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/infra-nest-server/jest.config.js",
-            "passWithNoTests": true
-          }
-        }
-      }
-    },
-    "cache": {
-      "root": "libs/cache",
-      "sourceRoot": "libs/cache/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/cache/tsconfig.lib.json",
-              "libs/cache/tsconfig.spec.json"
-            ],
-            "exclude": ["**/node_modules/**", "!libs/cache/**/*"]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/cache/jest.config.js",
-            "passWithNoTests": true
-          }
-        }
-      }
-    },
-    "api-content-search": {
-      "root": "libs/api/content-search",
-      "sourceRoot": "libs/api/content-search/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/api/content-search/tsconfig.lib.json",
-              "libs/api/content-search/tsconfig.spec.json"
-            ],
-            "exclude": ["**/node_modules/**", "!libs/api/content-search/**/*"]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/api/content-search/jest.config.js",
-            "passWithNoTests": true
-          }
-        }
-      }
-    },
-    "services-search-indexer": {
-      "root": "apps/services/search-indexer",
-      "sourceRoot": "apps/services/search-indexer/src",
-      "projectType": "application",
-      "prefix": "services-search-indexer",
-      "schematics": {},
-      "architect": {
-        "build": {
-          "builder": "@nrwl/node:build",
-          "options": {
-            "outputPath": "dist/apps/services/search-indexer",
-            "main": "apps/services/search-indexer/src/main.ts",
-            "tsConfig": "apps/services/search-indexer/tsconfig.app.json",
-            "assets": [
-              {
-                "glob": "config/**",
-                "input": "apps/services/search-indexer",
-                "output": "./"
-              }
-            ],
-            "webpackConfig": "apps/services/search-indexer/webpack.config.js"
-          },
-          "configurations": {
-            "production": {
-              "optimization": true,
-              "extractLicenses": true,
-              "inspect": false,
-              "fileReplacements": [
-                {
-                  "replace": "apps/services/search-indexer/src/environments/environment.ts",
-                  "with": "apps/services/search-indexer/src/environments/environment.prod.ts"
-                }
-              ]
-            }
-          }
-        },
-        "serve": {
-          "builder": "@nrwl/node:execute",
-          "options": {
-            "buildTarget": "services-search-indexer:build"
-          }
-        },
-        "dev-services": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "command": "docker-compose -f docker-compose.yml up -d --build",
-            "cwd": "apps/services/search-indexer/dev-services"
-          }
-        },
-        "migrate": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "command": "node migrate.js",
-            "cwd": "dist/apps/services/search-indexer"
-          }
-        },
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "apps/services/search-indexer/tsconfig.app.json",
-              "apps/services/search-indexer/tsconfig.spec.json"
-            ],
-            "exclude": [
-              "**/node_modules/**",
-              "!apps/services/search-indexer/**/*"
-            ]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "apps/services/search-indexer/jest.config.js",
-            "passWithNoTests": true
-          }
-        },
-        "docker-express": {}
-      }
-    },
-    "api-domains-content-search": {
-      "root": "libs/api/domains/content-search",
-      "sourceRoot": "libs/api/domains/content-search/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/api/domains/content-search/tsconfig.lib.json",
-              "libs/api/domains/content-search/tsconfig.spec.json"
-            ],
-            "exclude": [
-              "**/node_modules/**",
-              "!libs/api/domains/content-search/**/*"
-            ]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/api/domains/content-search/jest.config.js",
-            "passWithNoTests": true
-          }
-        }
-      }
-    },
-    "contentful-importer": {
-      "root": "libs/contentful-importer",
-      "sourceRoot": "libs/contentful-importer/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/contentful-importer/tsconfig.lib.json",
-              "libs/contentful-importer/tsconfig.spec.json"
-            ],
-            "exclude": ["**/node_modules/**", "!libs/contentful-importer/**/*"]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/contentful-importer/jest.config.js",
-            "passWithNoTests": true
-          }
-        }
-      }
-    },
-    "gjafakort-types": {
-      "root": "libs/gjafakort/types",
-      "sourceRoot": "libs/gjafakort/types/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/gjafakort/types/tsconfig.lib.json",
-              "libs/gjafakort/types/tsconfig.spec.json"
-            ],
-            "exclude": ["**/node_modules/**", "!libs/gjafakort/types/**/*"]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/gjafakort/types/jest.config.js",
-            "passWithNoTests": true
-          }
-        }
-      }
-    },
-    "gjafakort-consts": {
-      "root": "libs/gjafakort/consts",
-      "sourceRoot": "libs/gjafakort/consts/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/gjafakort/consts/tsconfig.lib.json",
-              "libs/gjafakort/consts/tsconfig.spec.json"
-            ],
-            "exclude": ["**/node_modules/**", "!libs/gjafakort/consts/**/*"]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/gjafakort/consts/jest.config.js",
-            "passWithNoTests": true
-          }
-        }
-      }
-    },
-    "island-ui-theme": {
-      "root": "libs/island-ui/theme",
-      "sourceRoot": "libs/island-ui/theme/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/island-ui/theme/tsconfig.lib.json",
-              "libs/island-ui/theme/tsconfig.spec.json"
-            ],
-            "exclude": ["**/node_modules/**", "!libs/island-ui/theme/**/*"]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/island-ui/theme/jest.config.js",
-            "passWithNoTests": true
-          }
-        }
-      }
-    },
-    "service-portal": {
-      "root": "apps/service-portal",
-      "sourceRoot": "apps/service-portal/src",
-      "projectType": "application",
-      "schematics": {},
-      "architect": {
-        "build": {
-          "builder": "@nrwl/web:build",
-          "options": {
-            "outputPath": "dist/apps/service-portal",
-            "index": "apps/service-portal/src/index.html",
-            "main": "apps/service-portal/src/Main.tsx",
-            "polyfills": "apps/service-portal/src/polyfills.ts",
-            "tsConfig": "apps/service-portal/tsconfig.app.json",
-            "assets": [
-              "apps/service-portal/src/favicon.ico",
-              "apps/service-portal/src/assets"
-            ],
-            "scripts": [],
-            "webpackConfig": "apps/service-portal/webpack.config.js"
-          },
-          "configurations": {
-            "production": {
-              "fileReplacements": [
-                {
-                  "replace": "apps/service-portal/src/environments/environment.ts",
-                  "with": "apps/service-portal/src/environments/environment.prod.ts"
-                }
-              ],
-              "optimization": true,
-              "outputHashing": "all",
-              "sourceMap": false,
-              "extractCss": true,
-              "namedChunks": false,
-              "extractLicenses": true,
-              "vendorChunk": false,
-              "budgets": [
-                {
-                  "type": "initial",
-                  "maximumWarning": "2mb",
-                  "maximumError": "5mb"
-                }
-              ]
-            }
-          }
-        },
-        "serve": {
-          "builder": "@nrwl/web:dev-server",
-          "options": {
-            "buildTarget": "service-portal:build"
-          },
-          "configurations": {
-            "production": {
-              "buildTarget": "service-portal:build:production"
-            }
-          }
-        },
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "apps/service-portal/tsconfig.app.json",
-              "apps/service-portal/tsconfig.spec.json"
-            ],
-            "exclude": ["**/node_modules/**", "!apps/service-portal/**/*"]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "apps/service-portal/jest.config.js",
-            "passWithNoTests": true
-          }
-        },
-        "extract-strings": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "parallel": false,
-            "commands": [
-              {
-                "command": "yarn ts-node libs/localization/scripts/extract apps/service-portal/src/{screens,components}/**/*.{js,ts,tsx}"
-              }
-            ]
-          }
-        },
-        "docker-static": {}
-      }
-    },
-    "service-portal-e2e": {
-      "root": "apps/service-portal-e2e",
-      "sourceRoot": "apps/service-portal-e2e/src",
-      "projectType": "application",
-      "architect": {
-        "e2e": {
-          "builder": "@nrwl/cypress:cypress",
-          "options": {
-            "cypressConfig": "apps/service-portal-e2e/cypress.json",
-            "tsConfig": "apps/service-portal-e2e/tsconfig.e2e.json",
-            "devServerTarget": "service-portal:serve"
-          },
-          "configurations": {
-            "production": {
-              "devServerTarget": "service-portal:serve:production"
-            }
-          }
-        },
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": ["apps/service-portal-e2e/tsconfig.e2e.json"],
-            "exclude": ["**/node_modules/**", "!apps/service-portal-e2e/**/*"]
-          }
-        }
-      }
-    },
-    "service-portal-constants": {
-      "root": "libs/service-portal/constants",
-      "sourceRoot": "libs/service-portal/constants/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/service-portal/constants/tsconfig.lib.json",
-              "libs/service-portal/constants/tsconfig.spec.json"
-            ],
-            "exclude": [
-              "**/node_modules/**",
-              "!libs/service-portal/constants/**/*"
-            ]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/service-portal/constants/jest.config.js",
-            "passWithNoTests": true
-          }
-        }
-      }
-    },
-    "service-portal-core": {
-      "root": "libs/service-portal/core",
-      "sourceRoot": "libs/service-portal/core/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/service-portal/core/tsconfig.lib.json",
-              "libs/service-portal/core/tsconfig.spec.json"
-            ],
-            "exclude": ["**/node_modules/**", "!libs/service-portal/core/**/*"]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/service-portal/core/jest.config.js",
-            "passWithNoTests": true
-          }
-        },
-        "extract-strings": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "parallel": false,
-            "commands": [
-              {
-                "command": "yarn ts-node libs/localization/scripts/extract libs/service-portal/core/src/{lib,components}/**/*.{js,ts,tsx}"
-              }
-            ]
-          }
-        }
-      }
-    },
-    "service-portal-applications": {
-      "root": "libs/service-portal/applications",
-      "sourceRoot": "libs/service-portal/applications/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/service-portal/applications/tsconfig.lib.json",
-              "libs/service-portal/applications/tsconfig.spec.json"
-            ],
-            "exclude": [
-              "**/node_modules/**",
-              "!libs/service-portal/applications/**/*"
-            ]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/service-portal/applications/jest.config.js",
-            "passWithNoTests": true
-          }
-        }
-      }
-    },
-    "service-portal-documents": {
-      "root": "libs/service-portal/documents",
-      "sourceRoot": "libs/service-portal/documents/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/service-portal/documents/tsconfig.lib.json",
-              "libs/service-portal/documents/tsconfig.spec.json"
-            ],
-            "exclude": [
-              "**/node_modules/**",
-              "!libs/service-portal/documents/**/*"
-            ]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/service-portal/documents/jest.config.js",
-            "passWithNoTests": true
-          }
-        }
-      }
-    },
-    "service-portal-settings": {
-      "root": "libs/service-portal/settings",
-      "sourceRoot": "libs/service-portal/settings/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/service-portal/settings/tsconfig.lib.json",
-              "libs/service-portal/settings/tsconfig.spec.json"
-            ],
-            "exclude": [
-              "**/node_modules/**",
-              "!libs/service-portal/settings/**/*"
-            ]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/service-portal/settings/jest.config.js",
-            "passWithNoTests": true
-          }
-        }
-      }
-    },
-    "service-portal-finance": {
-      "root": "libs/service-portal/finance",
-      "sourceRoot": "libs/service-portal/finance/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/service-portal/finance/tsconfig.lib.json",
-              "libs/service-portal/finance/tsconfig.spec.json"
-            ],
-            "exclude": [
-              "**/node_modules/**",
-              "!libs/service-portal/finance/**/*"
-            ]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/service-portal/finance/jest.config.js",
-            "passWithNoTests": true
-          }
-        }
-      }
-    },
-    "service-portal-family": {
-      "root": "libs/service-portal/family",
-      "sourceRoot": "libs/service-portal/family/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/service-portal/family/tsconfig.lib.json",
-              "libs/service-portal/family/tsconfig.spec.json"
-            ],
-            "exclude": [
-              "**/node_modules/**",
-              "!libs/service-portal/family/**/*"
-            ]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/service-portal/family/jest.config.js",
-            "passWithNoTests": true
-          }
-        },
-        "extract-strings": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "parallel": false,
-            "commands": [
-              {
-                "command": "yarn ts-node libs/localization/scripts/extract libs/service-portal/family/src/{screens,components}/**/*.{js,ts,tsx}"
-              }
-            ]
-          }
-        }
-      }
-    },
-    "service-portal-health": {
-      "root": "libs/service-portal/health",
-      "sourceRoot": "libs/service-portal/health/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/service-portal/health/tsconfig.lib.json",
-              "libs/service-portal/health/tsconfig.spec.json"
-            ],
-            "exclude": [
-              "**/node_modules/**",
-              "!libs/service-portal/health/**/*"
-            ]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/service-portal/health/jest.config.js",
-            "passWithNoTests": true
-          }
-        }
-      }
-    },
-    "service-portal-education": {
-      "root": "libs/service-portal/education",
-      "sourceRoot": "libs/service-portal/education/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/service-portal/education/tsconfig.lib.json",
-              "libs/service-portal/education/tsconfig.spec.json"
-            ],
-            "exclude": [
-              "**/node_modules/**",
-              "!libs/service-portal/education/**/*"
-            ]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/service-portal/education/jest.config.js",
-            "passWithNoTests": true
-          }
-        }
-      }
-    },
-    "island-ui-contentful": {
-      "root": "libs/island-ui/contentful",
-      "sourceRoot": "libs/island-ui/contentful/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/island-ui/contentful/tsconfig.lib.json",
-              "libs/island-ui/contentful/tsconfig.spec.json"
-            ],
-            "exclude": ["**/node_modules/**", "!libs/island-ui/contentful/**/*"]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/island-ui/contentful/jest.config.js",
-            "passWithNoTests": true
+            "tsConfig": ["apps/adgerdir-e2e/tsconfig.e2e.json"],
+            "exclude": ["**/node_modules/**", "!apps/adgerdir-e2e/**/*"]
           }
         }
       }
@@ -1609,110 +178,6 @@
           }
         },
         "docker-express": {}
-      }
-    },
-    "air-discount-scheme-web": {
-      "root": "apps/air-discount-scheme/web",
-      "sourceRoot": "apps/air-discount-scheme/web",
-      "projectType": "application",
-      "schematics": {},
-      "architect": {
-        "build": {
-          "builder": "@nrwl/next:build",
-          "options": {
-            "root": "apps/air-discount-scheme/web",
-            "outputPath": "dist/apps/air-discount-scheme/web"
-          },
-          "configurations": {
-            "production": {
-              "fileReplacements": [
-                {
-                  "replace": "apps/air-discount-scheme/web/environments/environment.ts",
-                  "with": "apps/air-discount-scheme/web/environments/environment.prod.ts"
-                }
-              ]
-            }
-          }
-        },
-        "serve": {
-          "builder": "@nrwl/next:server",
-          "options": {
-            "buildTarget": "air-discount-scheme-web:build",
-            "dev": true
-          },
-          "configurations": {
-            "production": {
-              "buildTarget": "air-discount-scheme-web:build:production",
-              "dev": false
-            }
-          }
-        },
-        "export": {
-          "builder": "@nrwl/next:export",
-          "options": {
-            "buildTarget": "air-discount-scheme-web:build:production"
-          }
-        },
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "apps/air-discount-scheme/web/tsconfig.json",
-              "apps/air-discount-scheme/web/tsconfig.spec.json"
-            ],
-            "exclude": [
-              "**/node_modules/**",
-              "!apps/air-discount-scheme/web/**/*"
-            ]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "apps/air-discount-scheme/web/jest.config.js",
-            "passWithNoTests": true
-          }
-        },
-        "translations": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "command": "quicktype is.json -o translation.d.ts --top-level Translation",
-            "cwd": "apps/air-discount-scheme/web/i18n/locales"
-          }
-        },
-        "docker-next": {}
-      }
-    },
-    "air-discount-scheme/web-e2e": {
-      "root": "apps/air-discount-scheme/web-e2e",
-      "sourceRoot": "apps/air-discount-scheme/web-e2e/src",
-      "projectType": "application",
-      "architect": {
-        "e2e": {
-          "builder": "@nrwl/cypress:cypress",
-          "options": {
-            "cypressConfig": "apps/air-discount-scheme/web-e2e/cypress.json",
-            "tsConfig": "apps/air-discount-scheme/web-e2e/tsconfig.e2e.json",
-            "devServerTarget": "air-discount-scheme-web:serve"
-          },
-          "configurations": {
-            "production": {
-              "devServerTarget": "air-discount-scheme-web:serve:production"
-            }
-          }
-        },
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": ["apps/air-discount-scheme/web-e2e/tsconfig.e2e.json"],
-            "exclude": [
-              "**/node_modules/**",
-              "!apps/air-discount-scheme/web-e2e/**/*"
-            ]
-          }
-        }
       }
     },
     "air-discount-scheme-backend": {
@@ -1859,6 +324,633 @@
         }
       }
     },
+    "air-discount-scheme-types": {
+      "root": "libs/air-discount-scheme/types",
+      "sourceRoot": "libs/air-discount-scheme/types/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/air-discount-scheme/types/tsconfig.lib.json",
+              "libs/air-discount-scheme/types/tsconfig.spec.json"
+            ],
+            "exclude": [
+              "**/node_modules/**",
+              "!libs/air-discount-scheme/types/**/*"
+            ]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/air-discount-scheme/types/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "air-discount-scheme-web": {
+      "root": "apps/air-discount-scheme/web",
+      "sourceRoot": "apps/air-discount-scheme/web",
+      "projectType": "application",
+      "schematics": {},
+      "architect": {
+        "build": {
+          "builder": "@nrwl/next:build",
+          "options": {
+            "root": "apps/air-discount-scheme/web",
+            "outputPath": "dist/apps/air-discount-scheme/web"
+          },
+          "configurations": {
+            "production": {
+              "fileReplacements": [
+                {
+                  "replace": "apps/air-discount-scheme/web/environments/environment.ts",
+                  "with": "apps/air-discount-scheme/web/environments/environment.prod.ts"
+                }
+              ]
+            }
+          }
+        },
+        "serve": {
+          "builder": "@nrwl/next:server",
+          "options": {
+            "buildTarget": "air-discount-scheme-web:build",
+            "dev": true
+          },
+          "configurations": {
+            "production": {
+              "buildTarget": "air-discount-scheme-web:build:production",
+              "dev": false
+            }
+          }
+        },
+        "export": {
+          "builder": "@nrwl/next:export",
+          "options": {
+            "buildTarget": "air-discount-scheme-web:build:production"
+          }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "apps/air-discount-scheme/web/tsconfig.json",
+              "apps/air-discount-scheme/web/tsconfig.spec.json"
+            ],
+            "exclude": [
+              "**/node_modules/**",
+              "!apps/air-discount-scheme/web/**/*"
+            ]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "apps/air-discount-scheme/web/jest.config.js",
+            "passWithNoTests": true
+          }
+        },
+        "translations": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "command": "quicktype is.json -o translation.d.ts --top-level Translation",
+            "cwd": "apps/air-discount-scheme/web/i18n/locales"
+          }
+        },
+        "docker-next": {}
+      }
+    },
+    "air-discount-scheme/web-e2e": {
+      "root": "apps/air-discount-scheme/web-e2e",
+      "sourceRoot": "apps/air-discount-scheme/web-e2e/src",
+      "projectType": "application",
+      "architect": {
+        "e2e": {
+          "builder": "@nrwl/cypress:cypress",
+          "options": {
+            "cypressConfig": "apps/air-discount-scheme/web-e2e/cypress.json",
+            "tsConfig": "apps/air-discount-scheme/web-e2e/tsconfig.e2e.json",
+            "devServerTarget": "air-discount-scheme-web:serve"
+          },
+          "configurations": {
+            "production": {
+              "devServerTarget": "air-discount-scheme-web:serve:production"
+            }
+          }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": ["apps/air-discount-scheme/web-e2e/tsconfig.e2e.json"],
+            "exclude": [
+              "**/node_modules/**",
+              "!apps/air-discount-scheme/web-e2e/**/*"
+            ]
+          }
+        }
+      }
+    },
+    "api": {
+      "root": "apps/api",
+      "sourceRoot": "apps/api/src",
+      "projectType": "application",
+      "prefix": "api",
+      "schematics": {},
+      "architect": {
+        "build": {
+          "builder": "@nrwl/node:build",
+          "options": {
+            "outputPath": "dist/apps/api",
+            "main": "apps/api/src/main.ts",
+            "tsConfig": "apps/api/tsconfig.app.json",
+            "showCircularDependencies": false
+          },
+          "configurations": {
+            "production": {
+              "optimization": true,
+              "extractLicenses": true,
+              "inspect": false
+            }
+          }
+        },
+        "serve": {
+          "builder": "@nrwl/node:execute",
+          "options": {
+            "buildTarget": "api:build"
+          }
+        },
+        "build-schema": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "command": "yarn ts-node -P apps/api/tsconfig.app.json apps/api/src/buildSchema.ts"
+          }
+        },
+        "init-schema": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "command": "yarn nx run api:codegen"
+          }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "apps/api/tsconfig.app.json",
+              "apps/api/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**", "!apps/api/**/*"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "apps/api/jest.config.js",
+            "passWithNoTests": true
+          }
+        },
+        "codegen": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "command": "graphql-codegen --config apps/api/codegen.yml"
+          },
+          "configurations": {
+            "watch": {
+              "command": "graphql-codegen --config apps/api/codegen.yml --watch"
+            }
+          }
+        },
+        "env-secrets": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "command": "./scripts/secrets.sh api --reset"
+          }
+        },
+        "contentful-types": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "command": "yarn ts-node -P apps/api/tsconfig.app.json ./libs/api/domains/cms/scripts/generateContentfulTypes.ts"
+          }
+        },
+        "contentType": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "command": "yarn ts-node -P apps/api/tsconfig.app.json ./libs/api/domains/cms/scripts/contentType.ts {args.id} {args.sys} {args.overwrite}"
+          }
+        },
+        "docker-express": {}
+      }
+    },
+    "api-content-search": {
+      "root": "libs/api/content-search",
+      "sourceRoot": "libs/api/content-search/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/api/content-search/tsconfig.lib.json",
+              "libs/api/content-search/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**", "!libs/api/content-search/**/*"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/api/content-search/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "api-domains-application": {
+      "root": "libs/api/domains/application",
+      "sourceRoot": "libs/api/domains/application/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/api/domains/application/tsconfig.lib.json",
+              "libs/api/domains/application/tsconfig.spec.json"
+            ],
+            "exclude": [
+              "**/node_modules/**",
+              "!libs/api/domains/application/**/*"
+            ]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/api/domains/application/jest.config.js",
+            "passWithNoTests": true
+          }
+        },
+        "codegen": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "command": "openapi-generator generate -g typescript-fetch --additional-properties=typescriptThreePlus=true -o libs/api/domains/application/gen/fetch -i apps/application-system/api/src/openapi.yaml"
+          }
+        }
+      }
+    },
+    "api-domains-cms": {
+      "root": "libs/api/domains/cms",
+      "sourceRoot": "libs/api/domains/cms/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/api/domains/cms/tsconfig.lib.json",
+              "libs/api/domains/cms/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**", "!libs/api/domains/cms/**/*"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/api/domains/cms/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "api-domains-content-search": {
+      "root": "libs/api/domains/content-search",
+      "sourceRoot": "libs/api/domains/content-search/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/api/domains/content-search/tsconfig.lib.json",
+              "libs/api/domains/content-search/tsconfig.spec.json"
+            ],
+            "exclude": [
+              "**/node_modules/**",
+              "!libs/api/domains/content-search/**/*"
+            ]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/api/domains/content-search/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "api-domains-documents": {
+      "root": "libs/api/domains/documents",
+      "sourceRoot": "libs/api/domains/documents/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "config": "libs/service-portal/graphql/.eslintrc",
+            "tsConfig": [
+              "libs/api/domains/documents/tsconfig.lib.json",
+              "libs/api/domains/documents/tsconfig.spec.json"
+            ],
+            "exclude": [
+              "**/node_modules/**",
+              "!libs/api/domains/documents/**/*"
+            ]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/api/domains/documents/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "api-domains-file-upload": {
+      "root": "libs/api/domains/file-upload",
+      "sourceRoot": "libs/api/domains/file-upload/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/api/domains/file-upload/tsconfig.lib.json",
+              "libs/api/domains/file-upload/tsconfig.spec.json"
+            ],
+            "exclude": [
+              "**/node_modules/**",
+              "!libs/api/domains/file-upload/**/*"
+            ]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/api/domains/file-upload/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "api-domains-translations": {
+      "root": "libs/api/domains/translations",
+      "sourceRoot": "libs/api/domains/translations/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/api/domains/translations/tsconfig.lib.json",
+              "libs/api/domains/translations/tsconfig.spec.json"
+            ],
+            "exclude": [
+              "**/node_modules/**",
+              "!libs/api/domains/translations/**/*"
+            ]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/api/domains/translations/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "api-schema": {
+      "root": "libs/api/schema",
+      "sourceRoot": "libs/api/schema/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": ["libs/api/schema/tsconfig.lib.json"],
+            "exclude": ["**/node_modules/**", "!libs/api/schema/**/*"]
+          }
+        }
+      }
+    },
+    "application-core": {
+      "root": "libs/application/core",
+      "sourceRoot": "libs/application/core/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/application/core/tsconfig.lib.json",
+              "libs/application/core/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**", "!libs/application/core/**/*"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/application/core/jest.config.js",
+            "passWithNoTests": true
+          }
+        },
+        "extract-strings": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "command": "yarn ts-node libs/localization/scripts/extract 'libs/application/core/src/templates/**/*.{js,ts,tsx}'"
+          }
+        }
+      }
+    },
+    "application-data-providers": {
+      "root": "libs/application/data-providers",
+      "sourceRoot": "libs/application/data-providers/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/application/data-providers/tsconfig.lib.json",
+              "libs/application/data-providers/tsconfig.spec.json"
+            ],
+            "exclude": [
+              "**/node_modules/**",
+              "!libs/application/data-providers/**/*"
+            ]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/application/data-providers/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "application-graphql": {
+      "root": "libs/application/graphql",
+      "sourceRoot": "libs/application/graphql/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/application/graphql/tsconfig.lib.json",
+              "libs/application/graphql/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**", "!libs/application/graphql/**/*"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/application/graphql/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "application-system-api": {
+      "root": "apps/application-system/api",
+      "sourceRoot": "apps/application-system/api/src",
+      "projectType": "application",
+      "prefix": "application-system-api",
+      "schematics": {},
+      "architect": {
+        "build": {
+          "builder": "@nrwl/node:build",
+          "options": {
+            "outputPath": "dist/apps/application-system/api",
+            "main": "apps/application-system/api/src/main.ts",
+            "tsConfig": "apps/application-system/api/tsconfig.app.json",
+            "assets": ["apps/application-system/api/src/assets"]
+          },
+          "configurations": {
+            "production": {
+              "optimization": true,
+              "extractLicenses": true,
+              "inspect": false,
+              "fileReplacements": [
+                {
+                  "replace": "apps/application-system/api/src/environments/environment.ts",
+                  "with": "apps/application-system/api/src/environments/environment.prod.ts"
+                }
+              ]
+            }
+          }
+        },
+        "serve": {
+          "builder": "@nrwl/node:execute",
+          "options": {
+            "buildTarget": "application-system-api:build"
+          }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "apps/application-system/api/tsconfig.app.json",
+              "apps/application-system/api/tsconfig.spec.json"
+            ],
+            "exclude": [
+              "**/node_modules/**",
+              "!apps/application-system/api/**/*"
+            ]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "apps/application-system/api/jest.config.js",
+            "passWithNoTests": true
+          }
+        },
+        "dev-services": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "command": "docker-compose -f docker-compose.base.yml -f docker-compose.dev.yml up -d",
+            "cwd": "apps/application-system/api"
+          }
+        },
+        "build-schema": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "command": "cross-env INIT_SCHEMA=true yarn ts-node -P apps/application-system/api/tsconfig.app.json apps/application-system/api/src/buildOpenApi.ts"
+          }
+        },
+        "generate-schema": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "parallel": false,
+            "outputPath": "apps/application-system/api/src/openapi.yaml",
+            "commands": [
+              "yarn build application-system-api",
+              "node dist/apps/application-system/api/main --generate-schema apps/application-system/api/src/openapi.yaml"
+            ]
+          }
+        },
+        "migrate": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "command": "../../../node_modules/.bin/sequelize-cli db:migrate",
+            "cwd": "apps/application-system/api"
+          }
+        },
+        "migrate/generate": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "command": "../../../node_modules/.bin/sequelize-cli migration:generate --name $(whoami)",
+            "cwd": "apps/application-system/api"
+          }
+        }
+      }
+    },
     "application-system-form": {
       "root": "apps/application-system/form",
       "sourceRoot": "apps/application-system/form/src",
@@ -1977,105 +1069,9 @@
         }
       }
     },
-    "application-system-api": {
-      "root": "apps/application-system/api",
-      "sourceRoot": "apps/application-system/api/src",
-      "projectType": "application",
-      "prefix": "application-system-api",
-      "schematics": {},
-      "architect": {
-        "build": {
-          "builder": "@nrwl/node:build",
-          "options": {
-            "outputPath": "dist/apps/application-system/api",
-            "main": "apps/application-system/api/src/main.ts",
-            "tsConfig": "apps/application-system/api/tsconfig.app.json",
-            "assets": ["apps/application-system/api/src/assets"]
-          },
-          "configurations": {
-            "production": {
-              "optimization": true,
-              "extractLicenses": true,
-              "inspect": false,
-              "fileReplacements": [
-                {
-                  "replace": "apps/application-system/api/src/environments/environment.ts",
-                  "with": "apps/application-system/api/src/environments/environment.prod.ts"
-                }
-              ]
-            }
-          }
-        },
-        "serve": {
-          "builder": "@nrwl/node:execute",
-          "options": {
-            "buildTarget": "application-system-api:build"
-          }
-        },
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "apps/application-system/api/tsconfig.app.json",
-              "apps/application-system/api/tsconfig.spec.json"
-            ],
-            "exclude": [
-              "**/node_modules/**",
-              "!apps/application-system/api/**/*"
-            ]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "apps/application-system/api/jest.config.js",
-            "passWithNoTests": true
-          }
-        },
-        "dev-services": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "command": "docker-compose -f docker-compose.base.yml -f docker-compose.dev.yml up -d",
-            "cwd": "apps/application-system/api"
-          }
-        },
-        "build-schema": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "command": "cross-env INIT_SCHEMA=true yarn ts-node -P apps/application-system/api/tsconfig.app.json apps/application-system/api/src/buildOpenApi.ts"
-          }
-        },
-        "generate-schema": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "parallel": false,
-            "outputPath": "apps/application-system/api/src/openapi.yaml",
-            "commands": [
-              "yarn build application-system-api",
-              "node dist/apps/application-system/api/main --generate-schema apps/application-system/api/src/openapi.yaml"
-            ]
-          }
-        },
-        "migrate": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "command": "../../../node_modules/.bin/sequelize-cli db:migrate",
-            "cwd": "apps/application-system/api"
-          }
-        },
-        "migrate/generate": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "command": "../../../node_modules/.bin/sequelize-cli migration:generate --name $(whoami)",
-            "cwd": "apps/application-system/api"
-          }
-        }
-      }
-    },
-    "api-domains-application": {
-      "root": "libs/api/domains/application",
-      "sourceRoot": "libs/api/domains/application/src",
+    "application-template-loader": {
+      "root": "libs/application/template-loader",
+      "sourceRoot": "libs/application/template-loader/src",
       "projectType": "library",
       "schematics": {},
       "architect": {
@@ -2084,137 +1080,27 @@
           "options": {
             "linter": "eslint",
             "tsConfig": [
-              "libs/api/domains/application/tsconfig.lib.json",
-              "libs/api/domains/application/tsconfig.spec.json"
+              "libs/application/template-loader/tsconfig.lib.json",
+              "libs/application/template-loader/tsconfig.spec.json"
             ],
             "exclude": [
               "**/node_modules/**",
-              "!libs/api/domains/application/**/*"
+              "!libs/application/template-loader/**"
             ]
           }
         },
         "test": {
           "builder": "@nrwl/jest:jest",
           "options": {
-            "jestConfig": "libs/api/domains/application/jest.config.js",
+            "jestConfig": "libs/application/template-loader/jest.config.js",
             "passWithNoTests": true
-          }
-        },
-        "codegen": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "command": "openapi-generator generate -g typescript-fetch --additional-properties=typescriptThreePlus=true -o libs/api/domains/application/gen/fetch -i apps/application-system/api/src/openapi.yaml"
           }
         }
       }
     },
-    "adgerdir": {
-      "root": "apps/adgerdir",
-      "sourceRoot": "apps/adgerdir/src",
-      "projectType": "application",
-      "schematics": {},
-      "architect": {
-        "build": {
-          "builder": "@nrwl/next:build",
-          "options": {
-            "root": "apps/adgerdir",
-            "outputPath": "dist/apps/adgerdir"
-          },
-          "configurations": {
-            "production": {
-              "fileReplacements": [
-                {
-                  "replace": "apps/adgerdir/environments/environment.ts",
-                  "with": "apps/adgerdir/environments/environment.prod.ts"
-                }
-              ]
-            }
-          }
-        },
-        "serve": {
-          "builder": "@nrwl/next:server",
-          "options": {
-            "buildTarget": "adgerdir:build",
-            "dev": true,
-            "proxyConfig": "apps/adgerdir/proxy.config.json"
-          },
-          "configurations": {
-            "production": {
-              "buildTarget": "adgerdir:build:production",
-              "dev": false
-            }
-          }
-        },
-        "export": {
-          "builder": "@nrwl/next:export",
-          "options": {
-            "buildTarget": "adgerdir:build:production"
-          }
-        },
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "apps/adgerdir/tsconfig.json",
-              "apps/adgerdir/tsconfig.spec.json"
-            ],
-            "exclude": ["**/node_modules/**", "!apps/adgerdir/**/*"]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "apps/adgerdir/jest.config.js",
-            "passWithNoTests": true
-          }
-        },
-        "codegen": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "command": "graphql-codegen --config apps/adgerdir/codegen.yml"
-          }
-        },
-        "init-schema": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "command": "yarn nx run adgerdir:codegen"
-          }
-        },
-        "docker-next": {}
-      }
-    },
-    "adgerdir-e2e": {
-      "root": "apps/adgerdir-e2e",
-      "sourceRoot": "apps/adgerdir-e2e/src",
-      "projectType": "application",
-      "architect": {
-        "e2e": {
-          "builder": "@nrwl/cypress:cypress",
-          "options": {
-            "cypressConfig": "apps/adgerdir-e2e/cypress.json",
-            "tsConfig": "apps/adgerdir-e2e/tsconfig.e2e.json",
-            "devServerTarget": "adgerdir:serve"
-          },
-          "configurations": {
-            "production": {
-              "devServerTarget": "adgerdir:serve:production"
-            }
-          }
-        },
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": ["apps/adgerdir-e2e/tsconfig.e2e.json"],
-            "exclude": ["**/node_modules/**", "!apps/adgerdir-e2e/**/*"]
-          }
-        }
-      }
-    },
-    "api-domains-file-upload": {
-      "root": "libs/api/domains/file-upload",
-      "sourceRoot": "libs/api/domains/file-upload/src",
+    "application-templates-driving-lessons": {
+      "root": "libs/application/templates/driving-lessons",
+      "sourceRoot": "libs/application/templates/driving-lessons/src",
       "projectType": "library",
       "schematics": {},
       "architect": {
@@ -2223,27 +1109,33 @@
           "options": {
             "linter": "eslint",
             "tsConfig": [
-              "libs/api/domains/file-upload/tsconfig.lib.json",
-              "libs/api/domains/file-upload/tsconfig.spec.json"
+              "libs/application/templates/driving-lessons/tsconfig.lib.json",
+              "libs/application/templates/driving-lessons/tsconfig.spec.json"
             ],
             "exclude": [
               "**/node_modules/**",
-              "!libs/api/domains/file-upload/**/*"
+              "!libs/application/templates/driving-lessons/**"
             ]
           }
         },
         "test": {
           "builder": "@nrwl/jest:jest",
           "options": {
-            "jestConfig": "libs/api/domains/file-upload/jest.config.js",
+            "jestConfig": "libs/application/templates/driving-lessons/jest.config.js",
             "passWithNoTests": true
+          }
+        },
+        "extract-strings": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "command": "yarn ts-node libs/localization/scripts/extract 'libs/application/templates/driving-lessons/src/**/*.{js,ts,tsx}'"
           }
         }
       }
     },
-    "air-discount-scheme-types": {
-      "root": "libs/air-discount-scheme/types",
-      "sourceRoot": "libs/air-discount-scheme/types/src",
+    "application-templates-parental-leave": {
+      "root": "libs/application/templates/parental-leave",
+      "sourceRoot": "libs/application/templates/parental-leave/src",
       "projectType": "library",
       "schematics": {},
       "architect": {
@@ -2252,19 +1144,251 @@
           "options": {
             "linter": "eslint",
             "tsConfig": [
-              "libs/air-discount-scheme/types/tsconfig.lib.json",
-              "libs/air-discount-scheme/types/tsconfig.spec.json"
+              "libs/application/templates/parental-leave/tsconfig.lib.json",
+              "libs/application/templates/parental-leave/tsconfig.spec.json"
             ],
             "exclude": [
               "**/node_modules/**",
-              "!libs/air-discount-scheme/types/**/*"
+              "!libs/application/templates/parental-leave/**"
             ]
           }
         },
         "test": {
           "builder": "@nrwl/jest:jest",
           "options": {
-            "jestConfig": "libs/air-discount-scheme/types/jest.config.js",
+            "jestConfig": "libs/application/templates/parental-leave/jest.config.js",
+            "passWithNoTests": true
+          }
+        },
+        "extract-strings": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "command": "yarn ts-node libs/localization/scripts/extract 'libs/application/templates/parental-leave/src/**/*.{js,ts,tsx}'"
+          }
+        }
+      }
+    },
+    "application-templates-reference-template": {
+      "root": "libs/application/templates/reference-template",
+      "sourceRoot": "libs/application/templates/reference-template/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/application/templates/reference-template/tsconfig.lib.json",
+              "libs/application/templates/reference-template/tsconfig.spec.json"
+            ],
+            "exclude": [
+              "**/node_modules/**",
+              "!libs/application/templates/reference-template/**"
+            ]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/application/templates/reference-template/jest.config.js",
+            "passWithNoTests": true
+          }
+        },
+        "extract-strings": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "command": "yarn ts-node libs/localization/scripts/extract 'libs/application/templates/reference-template/src/**/*.{js,ts,tsx}'"
+          }
+        }
+      }
+    },
+    "application-ui-fields": {
+      "root": "libs/application/ui-fields",
+      "sourceRoot": "libs/application/ui-fields/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/application/ui-fields/tsconfig.lib.json",
+              "libs/application/ui-fields/tsconfig.spec.json"
+            ],
+            "exclude": [
+              "**/node_modules/**",
+              "!libs/application/ui-fields/**/*"
+            ]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/application/ui-fields/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "application-ui-shell": {
+      "root": "libs/application/ui-shell",
+      "sourceRoot": "libs/application/ui-shell/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/application/ui-shell/tsconfig.lib.json",
+              "libs/application/ui-shell/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**", "!libs/application/ui-shell/**/*"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/application/ui-shell/jest.config.js",
+            "passWithNoTests": true
+          }
+        },
+        "extract-strings": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "command": "yarn ts-node libs/localization/scripts/extract 'libs/application/ui-shell/src/{lib,components}/**/*.{js,ts,tsx}'"
+          }
+        }
+      }
+    },
+    "cache": {
+      "root": "libs/cache",
+      "sourceRoot": "libs/cache/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/cache/tsconfig.lib.json",
+              "libs/cache/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**", "!libs/cache/**/*"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/cache/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "contentful-importer": {
+      "root": "libs/contentful-importer",
+      "sourceRoot": "libs/contentful-importer/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/contentful-importer/tsconfig.lib.json",
+              "libs/contentful-importer/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**", "!libs/contentful-importer/**/*"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/contentful-importer/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "dokobit-signing": {
+      "root": "libs/dokobit-signing",
+      "sourceRoot": "libs/dokobit-signing/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/dokobit-signing/tsconfig.lib.json",
+              "libs/dokobit-signing/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**", "!libs/dokobit-signing/**/*"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/dokobit-signing/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "elastic-indexing": {
+      "root": "libs/elastic-indexing",
+      "sourceRoot": "libs/elastic-indexing/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/elastic-indexing/tsconfig.lib.json",
+              "libs/elastic-indexing/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**", "!libs/elastic-indexing/**/*"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/elastic-indexing/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "email-service": {
+      "root": "libs/email-service",
+      "sourceRoot": "libs/email-service/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/email-service/tsconfig.lib.json",
+              "libs/email-service/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**", "!libs/email-service/**/*"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/email-service/jest.config.js",
             "passWithNoTests": true
           }
         }
@@ -2296,9 +1420,161 @@
         }
       }
     },
-    "application-graphql": {
-      "root": "libs/application/graphql",
-      "sourceRoot": "libs/application/graphql/src",
+    "gjafakort-api": {
+      "root": "apps/gjafakort/api",
+      "sourceRoot": "apps/gjafakort/api/src",
+      "projectType": "application",
+      "prefix": "gjafakort-api",
+      "schematics": {},
+      "architect": {
+        "build": {
+          "builder": "@nrwl/node:build",
+          "options": {
+            "outputPath": "dist/apps/gjafakort/api",
+            "main": "apps/gjafakort/api/src/main.ts",
+            "tsConfig": "apps/gjafakort/api/tsconfig.app.json",
+            "assets": []
+          },
+          "configurations": {
+            "production": {
+              "optimization": true,
+              "extractLicenses": true,
+              "inspect": false,
+              "fileReplacements": [
+                {
+                  "replace": "apps/gjafakort/api/src/environments/environment.ts",
+                  "with": "apps/gjafakort/api/src/environments/environment.prod.ts"
+                }
+              ]
+            }
+          }
+        },
+        "serve": {
+          "builder": "@nrwl/node:execute",
+          "options": {
+            "buildTarget": "gjafakort-api:build"
+          }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "apps/gjafakort/api/tsconfig.app.json",
+              "apps/gjafakort/api/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**", "!apps/gjafakort/api/**/*"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "apps/gjafakort/api/jest.config.js",
+            "passWithNoTests": true
+          }
+        },
+        "codegen": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "command": "graphql-codegen --config apps/gjafakort/codegen.yml"
+          }
+        },
+        "init-schema": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "command": "yarn nx run gjafakort-api:codegen"
+          }
+        },
+        "docker-express": {}
+      }
+    },
+    "gjafakort-application": {
+      "root": "apps/gjafakort/application",
+      "sourceRoot": "apps/gjafakort/application/src",
+      "projectType": "application",
+      "prefix": "gjafakort-application",
+      "schematics": {},
+      "architect": {
+        "build": {
+          "builder": "@nrwl/node:build",
+          "options": {
+            "outputPath": "dist/apps/gjafakort/application",
+            "main": "apps/gjafakort/application/src/main.ts",
+            "tsConfig": "apps/gjafakort/application/tsconfig.app.json",
+            "assets": [
+              {
+                "glob": "*sequelize*",
+                "input": "apps/gjafakort/application",
+                "output": "./"
+              },
+              {
+                "glob": "migrations/**",
+                "input": "apps/gjafakort/application",
+                "output": "./"
+              }
+            ]
+          },
+          "configurations": {
+            "production": {
+              "optimization": true,
+              "extractLicenses": true,
+              "inspect": false,
+              "fileReplacements": [
+                {
+                  "replace": "apps/gjafakort/application/src/environments/environment.ts",
+                  "with": "apps/gjafakort/application/src/environments/environment.prod.ts"
+                }
+              ]
+            }
+          }
+        },
+        "serve": {
+          "builder": "@nrwl/node:execute",
+          "options": {
+            "buildTarget": "gjafakort-application:build"
+          }
+        },
+        "migrate": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "command": "sequelize-cli db:migrate",
+            "cwd": "apps/gjafakort/application"
+          }
+        },
+        "migrate/generate": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "command": "sequelize-cli migration:generate --name $(whoami)",
+            "cwd": "apps/gjafakort/application"
+          }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "apps/gjafakort/application/tsconfig.app.json",
+              "apps/gjafakort/application/tsconfig.spec.json"
+            ],
+            "exclude": [
+              "**/node_modules/**",
+              "!apps/gjafakort/application/**/*"
+            ]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "apps/gjafakort/application/jest.config.js",
+            "passWithNoTests": true
+          }
+        },
+        "docker-express": {}
+      }
+    },
+    "gjafakort-consts": {
+      "root": "libs/gjafakort/consts",
+      "sourceRoot": "libs/gjafakort/consts/src",
       "projectType": "library",
       "schematics": {},
       "architect": {
@@ -2307,16 +1583,426 @@
           "options": {
             "linter": "eslint",
             "tsConfig": [
-              "libs/application/graphql/tsconfig.lib.json",
-              "libs/application/graphql/tsconfig.spec.json"
+              "libs/gjafakort/consts/tsconfig.lib.json",
+              "libs/gjafakort/consts/tsconfig.spec.json"
             ],
-            "exclude": ["**/node_modules/**", "!libs/application/graphql/**/*"]
+            "exclude": ["**/node_modules/**", "!libs/gjafakort/consts/**/*"]
           }
         },
         "test": {
           "builder": "@nrwl/jest:jest",
           "options": {
-            "jestConfig": "libs/application/graphql/jest.config.js",
+            "jestConfig": "libs/gjafakort/consts/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "gjafakort-queue-listener": {
+      "root": "apps/gjafakort/queue-listener",
+      "sourceRoot": "apps/gjafakort/queue-listener/src",
+      "projectType": "application",
+      "prefix": "gjafakort-queue-listener",
+      "schematics": {},
+      "architect": {
+        "build": {
+          "builder": "@nrwl/node:build",
+          "options": {
+            "outputPath": "dist/apps/gjafakort/queue-listener",
+            "main": "apps/gjafakort/queue-listener/src/main.ts",
+            "tsConfig": "apps/gjafakort/queue-listener/tsconfig.app.json"
+          },
+          "configurations": {
+            "production": {
+              "optimization": true,
+              "extractLicenses": true,
+              "inspect": false,
+              "fileReplacements": [
+                {
+                  "replace": "apps/gjafakort/queue-listener/src/environments/environment.ts",
+                  "with": "apps/gjafakort/queue-listener/src/environments/environment.prod.ts"
+                }
+              ]
+            }
+          }
+        },
+        "serve": {
+          "builder": "@nrwl/node:execute",
+          "options": {
+            "buildTarget": "gjafakort-queue-listener:build"
+          }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "apps/gjafakort/queue-listener/tsconfig.app.json",
+              "apps/gjafakort/queue-listener/tsconfig.spec.json"
+            ],
+            "exclude": [
+              "**/node_modules/**",
+              "!apps/gjafakort/queue-listener/**/*"
+            ]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "apps/gjafakort/queue-listener/jest.config.js",
+            "passWithNoTests": true
+          }
+        },
+        "docker-express": {}
+      }
+    },
+    "gjafakort-types": {
+      "root": "libs/gjafakort/types",
+      "sourceRoot": "libs/gjafakort/types/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/gjafakort/types/tsconfig.lib.json",
+              "libs/gjafakort/types/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**", "!libs/gjafakort/types/**/*"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/gjafakort/types/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "gjafakort-web": {
+      "root": "apps/gjafakort/web",
+      "sourceRoot": "apps/gjafakort/web",
+      "projectType": "application",
+      "schematics": {},
+      "architect": {
+        "build": {
+          "builder": "@nrwl/next:build",
+          "options": {
+            "root": "apps/gjafakort/web",
+            "outputPath": "dist/apps/gjafakort/web"
+          },
+          "configurations": {
+            "production": {
+              "fileReplacements": [
+                {
+                  "replace": "apps/gjafakort/web/environments/environment.ts",
+                  "with": "apps/gjafakort/web/environments/environment.prod.ts"
+                }
+              ]
+            }
+          }
+        },
+        "translations": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "command": "quicktype is.json -o translation.d.ts --top-level Translation",
+            "cwd": "apps/gjafakort/web/i18n/locales"
+          }
+        },
+        "serve": {
+          "builder": "@nrwl/next:server",
+          "options": {
+            "buildTarget": "gjafakort-web:build",
+            "dev": true
+          },
+          "configurations": {
+            "production": {
+              "buildTarget": "gjafakort-web:build:production",
+              "dev": false
+            }
+          }
+        },
+        "export": {
+          "builder": "@nrwl/next:export",
+          "options": {
+            "buildTarget": "gjafakort-web:build:production"
+          }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "apps/gjafakort/web/tsconfig.json",
+              "apps/gjafakort/web/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**", "!apps/gjafakort/web/**/*"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "apps/gjafakort/web/jest.config.js",
+            "passWithNoTests": true
+          }
+        },
+        "docker-next": {}
+      }
+    },
+    "gjafakort-web-e2e": {
+      "root": "apps/gjafakort/web-e2e",
+      "sourceRoot": "apps/gjafakort/web-e2e/src",
+      "projectType": "application",
+      "architect": {
+        "e2e": {
+          "builder": "@nrwl/cypress:cypress",
+          "options": {
+            "cypressConfig": "apps/gjafakort/web-e2e/cypress.json",
+            "tsConfig": "apps/gjafakort/web-e2e/tsconfig.e2e.json",
+            "devServerTarget": "gjafakort/web:serve"
+          },
+          "configurations": {
+            "production": {
+              "devServerTarget": "gjafakort/web:serve:production"
+            }
+          }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": ["apps/gjafakort/web-e2e/tsconfig.e2e.json"],
+            "exclude": ["**/node_modules/**", "!apps/gjafakort/web-e2e/**/*"]
+          }
+        }
+      }
+    },
+    "infra-express-server": {
+      "root": "libs/infra-express-server",
+      "sourceRoot": "libs/infra-express-server/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/infra-express-server/tsconfig.lib.json",
+              "libs/infra-express-server/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**", "!libs/infra-express-server/**/*"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/infra-express-server/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "infra-monitoring": {
+      "root": "libs/infra-monitoring",
+      "sourceRoot": "libs/infra-monitoring/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/infra-monitoring/tsconfig.lib.json",
+              "libs/infra-monitoring/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**", "!libs/infra-monitoring/**/*"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/infra-monitoring/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "infra-nest-server": {
+      "root": "libs/infra-nest-server",
+      "sourceRoot": "libs/infra-nest-server/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/infra-nest-server/tsconfig.lib.json",
+              "libs/infra-nest-server/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**", "!libs/infra-nest-server/**/*"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/infra-nest-server/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "infra-tracing": {
+      "root": "libs/infra-tracing",
+      "sourceRoot": "libs/infra-tracing/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/infra-tracing/tsconfig.lib.json",
+              "libs/infra-tracing/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**", "!libs/infra-tracing/**/*"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/infra-tracing/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "island-ui-contentful": {
+      "root": "libs/island-ui/contentful",
+      "sourceRoot": "libs/island-ui/contentful/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/island-ui/contentful/tsconfig.lib.json",
+              "libs/island-ui/contentful/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**", "!libs/island-ui/contentful/**/*"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/island-ui/contentful/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "island-ui-core": {
+      "root": "libs/island-ui/core",
+      "sourceRoot": "libs/island-ui/core/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/island-ui/core/tsconfig.lib.json",
+              "libs/island-ui/core/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**", "!libs/island-ui/core/**/*"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/island-ui/core/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "island-ui-storybook": {
+      "root": "libs/island-ui/storybook",
+      "sourceRoot": "libs/island-ui/storybook/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": ["libs/island-ui/storybook/tsconfig.lib.json"],
+            "exclude": ["**/node_modules/**", "!libs/island-ui/storybook/**/*"]
+          }
+        },
+        "serve": {
+          "builder": "@nrwl/storybook:storybook",
+          "options": {
+            "uiFramework": "@storybook/react",
+            "port": 4400,
+            "config": {
+              "configFolder": "libs/island-ui/storybook/config"
+            }
+          },
+          "configurations": {
+            "ci": {
+              "quiet": true
+            }
+          }
+        },
+        "build-storybook": {
+          "builder": "@nrwl/storybook:build",
+          "options": {
+            "uiFramework": "@storybook/react",
+            "outputPath": "dist/storybook/island-ui",
+            "config": {
+              "configFolder": "libs/island-ui/storybook/config"
+            }
+          },
+          "configurations": {
+            "ci": {
+              "quiet": true
+            }
+          }
+        }
+      }
+    },
+    "island-ui-theme": {
+      "root": "libs/island-ui/theme",
+      "sourceRoot": "libs/island-ui/theme/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/island-ui/theme/tsconfig.lib.json",
+              "libs/island-ui/theme/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**", "!libs/island-ui/theme/**/*"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/island-ui/theme/jest.config.js",
             "passWithNoTests": true
           }
         }
@@ -2450,6 +2136,93 @@
         "docker-express": {}
       }
     },
+    "judicial-system-consts": {
+      "root": "libs/judicial-system/consts",
+      "sourceRoot": "libs/judicial-system/consts/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/judicial-system/consts/tsconfig.lib.json",
+              "libs/judicial-system/consts/tsconfig.spec.json"
+            ],
+            "exclude": [
+              "**/node_modules/**",
+              "!libs/judicial-system/consts/**/*"
+            ]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/judicial-system/consts/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "judicial-system-formatters": {
+      "root": "libs/judicial-system/formatters",
+      "sourceRoot": "libs/judicial-system/formatters/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/judicial-system/formatters/tsconfig.lib.json",
+              "libs/judicial-system/formatters/tsconfig.spec.json"
+            ],
+            "exclude": [
+              "**/node_modules/**",
+              "!libs/judicial-system/formatters/**/*"
+            ]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/judicial-system/formatters/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "judicial-system-types": {
+      "root": "libs/judicial-system/types",
+      "sourceRoot": "libs/judicial-system/types/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/judicial-system/types/tsconfig.lib.json",
+              "libs/judicial-system/types/tsconfig.spec.json"
+            ],
+            "exclude": [
+              "**/node_modules/**",
+              "!libs/judicial-system/types/**/*"
+            ]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/judicial-system/types/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
     "judicial-system-web": {
       "root": "apps/judicial-system/web",
       "sourceRoot": "apps/judicial-system/web/src",
@@ -2561,185 +2334,6 @@
         }
       }
     },
-    "service-portal-graphql": {
-      "root": "libs/service-portal/graphql",
-      "sourceRoot": "libs/service-portal/graphql/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/service-portal/graphql/tsconfig.lib.json",
-              "libs/service-portal/graphql/tsconfig.spec.json"
-            ],
-            "exclude": [
-              "**/node_modules/**",
-              "!libs/service-portal/graphql/**/*"
-            ]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/service-portal/graphql/jest.config.js",
-            "passWithNoTests": true
-          }
-        }
-      }
-    },
-    "api-domains-documents": {
-      "root": "libs/api/domains/documents",
-      "sourceRoot": "libs/api/domains/documents/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "config": "libs/service-portal/graphql/.eslintrc",
-            "tsConfig": [
-              "libs/api/domains/documents/tsconfig.lib.json",
-              "libs/api/domains/documents/tsconfig.spec.json"
-            ],
-            "exclude": [
-              "**/node_modules/**",
-              "!libs/api/domains/documents/**/*"
-            ]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/api/domains/documents/jest.config.js",
-            "passWithNoTests": true
-          }
-        }
-      }
-    },
-    "application-data-providers": {
-      "root": "libs/application/data-providers",
-      "sourceRoot": "libs/application/data-providers/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/application/data-providers/tsconfig.lib.json",
-              "libs/application/data-providers/tsconfig.spec.json"
-            ],
-            "exclude": [
-              "**/node_modules/**",
-              "!libs/application/data-providers/**/*"
-            ]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/application/data-providers/jest.config.js",
-            "passWithNoTests": true
-          }
-        }
-      }
-    },
-    "skilavottord-ws": {
-      "root": "apps/skilavottord/ws",
-      "sourceRoot": "apps/skilavottord/ws/src",
-      "projectType": "application",
-      "prefix": "skilavottord-ws",
-      "schematics": {},
-      "architect": {
-        "build": {
-          "builder": "@nrwl/node:build",
-          "options": {
-            "outputPath": "dist/apps/skilavottord/ws",
-            "main": "apps/skilavottord/ws/src/main.ts",
-            "tsConfig": "apps/skilavottord/ws/tsconfig.app.json",
-            "assets": ["apps/skilavottord/ws/src/assets"]
-          },
-          "configurations": {
-            "production": {
-              "optimization": true,
-              "extractLicenses": true,
-              "inspect": false,
-              "fileReplacements": [
-                {
-                  "replace": "apps/skilavottord/ws/src/environments/environment.ts",
-                  "with": "apps/skilavottord/ws/src/environments/environment.prod.ts"
-                }
-              ]
-            }
-          }
-        },
-        "serve": {
-          "builder": "@nrwl/node:execute",
-          "options": {
-            "buildTarget": "skilavottord-ws:build"
-          }
-        },
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "apps/skilavottord/ws/tsconfig.app.json",
-              "apps/skilavottord/ws/tsconfig.spec.json"
-            ],
-            "exclude": ["**/node_modules/**", "!apps/skilavottord/ws/**/*"]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "apps/skilavottord/ws/jest.config.js",
-            "passWithNoTests": true
-          }
-        },
-        "init-schema": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "command": "yarn ts-node -P apps/skilavottord/ws/tsconfig.app.json apps/skilavottord/ws/src/buildSchema.ts"
-          }
-        },
-        "docker-express": {}
-      }
-    },
-    "api-domains-translations": {
-      "root": "libs/api/domains/translations",
-      "sourceRoot": "libs/api/domains/translations/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/api/domains/translations/tsconfig.lib.json",
-              "libs/api/domains/translations/tsconfig.spec.json"
-            ],
-            "exclude": [
-              "**/node_modules/**",
-              "!libs/api/domains/translations/**/*"
-            ]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/api/domains/translations/jest.config.js",
-            "passWithNoTests": true
-          }
-        }
-      }
-    },
     "localization": {
       "root": "libs/localization",
       "sourceRoot": "libs/localization/src",
@@ -2766,9 +2360,9 @@
         }
       }
     },
-    "infra-monitoring": {
-      "root": "libs/infra-monitoring",
-      "sourceRoot": "libs/infra-monitoring/src",
+    "logging": {
+      "root": "libs/logging",
+      "sourceRoot": "libs/logging/src",
       "projectType": "library",
       "schematics": {},
       "architect": {
@@ -2777,24 +2371,24 @@
           "options": {
             "linter": "eslint",
             "tsConfig": [
-              "libs/infra-monitoring/tsconfig.lib.json",
-              "libs/infra-monitoring/tsconfig.spec.json"
+              "libs/logging/tsconfig.lib.json",
+              "libs/logging/tsconfig.spec.json"
             ],
-            "exclude": ["**/node_modules/**", "!libs/infra-monitoring/**/*"]
+            "exclude": ["**/node_modules/**", "!libs/logging/**/*"]
           }
         },
         "test": {
           "builder": "@nrwl/jest:jest",
           "options": {
-            "jestConfig": "libs/infra-monitoring/jest.config.js",
+            "jestConfig": "libs/logging/jest.config.js",
             "passWithNoTests": true
           }
         }
       }
     },
-    "judicial-system-consts": {
-      "root": "libs/judicial-system/consts",
-      "sourceRoot": "libs/judicial-system/consts/src",
+    "message-queue": {
+      "root": "libs/message-queue",
+      "sourceRoot": "libs/message-queue/src",
       "projectType": "library",
       "schematics": {},
       "architect": {
@@ -2803,46 +2397,138 @@
           "options": {
             "linter": "eslint",
             "tsConfig": [
-              "libs/judicial-system/consts/tsconfig.lib.json",
-              "libs/judicial-system/consts/tsconfig.spec.json"
+              "libs/message-queue/tsconfig.lib.json",
+              "libs/message-queue/tsconfig.spec.json"
             ],
-            "exclude": [
-              "**/node_modules/**",
-              "!libs/judicial-system/consts/**/*"
+            "exclude": ["**/node_modules/**", "!libs/message-queue/**/*"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/message-queue/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "nova-sms": {
+      "root": "libs/nova-sms",
+      "sourceRoot": "libs/nova-sms/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/nova-sms/tsconfig.lib.json",
+              "libs/nova-sms/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**", "!libs/nova-sms/**/*"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/nova-sms/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "reference-backend": {
+      "root": "apps/reference-backend",
+      "sourceRoot": "apps/reference-backend/src",
+      "projectType": "application",
+      "prefix": "reference-backend",
+      "schematics": {},
+      "architect": {
+        "build": {
+          "builder": "@nrwl/node:build",
+          "options": {
+            "outputPath": "dist/apps/reference-backend",
+            "main": "apps/reference-backend/src/main.ts",
+            "tsConfig": "apps/reference-backend/tsconfig.app.json",
+            "assets": ["apps/reference-backend/src/assets"]
+          },
+          "configurations": {
+            "production": {
+              "optimization": true,
+              "extractLicenses": true,
+              "inspect": false,
+              "fileReplacements": [
+                {
+                  "replace": "apps/reference-backend/src/environments/environment.ts",
+                  "with": "apps/reference-backend/src/environments/environment.prod.ts"
+                }
+              ]
+            }
+          }
+        },
+        "serve": {
+          "builder": "@nrwl/node:execute",
+          "options": {
+            "buildTarget": "reference-backend:build"
+          }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "apps/reference-backend/tsconfig.app.json",
+              "apps/reference-backend/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**", "!apps/reference-backend/**/*"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "apps/reference-backend/jest.config.js",
+            "passWithNoTests": true
+          }
+        },
+        "docker-express": {},
+        "dev-services": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "command": "docker-compose -f docker-compose.base.yml -f docker-compose.dev.yml up -d",
+            "cwd": "apps/reference-backend"
+          }
+        },
+        "init-schema": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "outputPath": "apps/reference-backend/src/openapi.yaml",
+            "command": "yarn ts-node -P apps/reference-backend/tsconfig.app.json apps/reference-backend/src/buildOpenApi.ts"
+          }
+        },
+        "generate-schema": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "parallel": false,
+            "outputPath": "apps/reference-backend/src/openapi.yaml",
+            "commands": [
+              "yarn build reference-backend",
+              "node dist/apps/reference-backend/main --generate-schema apps/reference-backend/src/openapi.yaml"
             ]
           }
         },
-        "test": {
-          "builder": "@nrwl/jest:jest",
+        "migrate": {
+          "builder": "@nrwl/workspace:run-commands",
           "options": {
-            "jestConfig": "libs/judicial-system/consts/jest.config.js",
-            "passWithNoTests": true
-          }
-        }
-      }
-    },
-    "elastic-indexing": {
-      "root": "libs/elastic-indexing",
-      "sourceRoot": "libs/elastic-indexing/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/elastic-indexing/tsconfig.lib.json",
-              "libs/elastic-indexing/tsconfig.spec.json"
-            ],
-            "exclude": ["**/node_modules/**", "!libs/elastic-indexing/**/*"]
+            "command": "../../node_modules/.bin/sequelize-cli db:migrate",
+            "cwd": "apps/reference-backend"
           }
         },
-        "test": {
-          "builder": "@nrwl/jest:jest",
+        "migrate/generate": {
+          "builder": "@nrwl/workspace:run-commands",
           "options": {
-            "jestConfig": "libs/elastic-indexing/jest.config.js",
-            "passWithNoTests": true
+            "command": "../../node_modules/.bin/sequelize-cli migration:generate --name $(whoami)",
+            "cwd": "apps/reference-backend"
           }
         }
       }
@@ -2915,9 +2601,98 @@
         }
       }
     },
-    "nova-sms": {
-      "root": "libs/nova-sms",
-      "sourceRoot": "libs/nova-sms/src",
+    "service-portal": {
+      "root": "apps/service-portal",
+      "sourceRoot": "apps/service-portal/src",
+      "projectType": "application",
+      "schematics": {},
+      "architect": {
+        "build": {
+          "builder": "@nrwl/web:build",
+          "options": {
+            "outputPath": "dist/apps/service-portal",
+            "index": "apps/service-portal/src/index.html",
+            "main": "apps/service-portal/src/Main.tsx",
+            "polyfills": "apps/service-portal/src/polyfills.ts",
+            "tsConfig": "apps/service-portal/tsconfig.app.json",
+            "assets": [
+              "apps/service-portal/src/favicon.ico",
+              "apps/service-portal/src/assets"
+            ],
+            "scripts": [],
+            "webpackConfig": "apps/service-portal/webpack.config.js"
+          },
+          "configurations": {
+            "production": {
+              "fileReplacements": [
+                {
+                  "replace": "apps/service-portal/src/environments/environment.ts",
+                  "with": "apps/service-portal/src/environments/environment.prod.ts"
+                }
+              ],
+              "optimization": true,
+              "outputHashing": "all",
+              "sourceMap": false,
+              "extractCss": true,
+              "namedChunks": false,
+              "extractLicenses": true,
+              "vendorChunk": false,
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "2mb",
+                  "maximumError": "5mb"
+                }
+              ]
+            }
+          }
+        },
+        "serve": {
+          "builder": "@nrwl/web:dev-server",
+          "options": {
+            "buildTarget": "service-portal:build"
+          },
+          "configurations": {
+            "production": {
+              "buildTarget": "service-portal:build:production"
+            }
+          }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "apps/service-portal/tsconfig.app.json",
+              "apps/service-portal/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**", "!apps/service-portal/**/*"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "apps/service-portal/jest.config.js",
+            "passWithNoTests": true
+          }
+        },
+        "extract-strings": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "parallel": false,
+            "commands": [
+              {
+                "command": "yarn ts-node libs/localization/scripts/extract apps/service-portal/src/{screens,components}/**/*.{js,ts,tsx}"
+              }
+            ]
+          }
+        },
+        "docker-static": {}
+      }
+    },
+    "service-portal-applications": {
+      "root": "libs/service-portal/applications",
+      "sourceRoot": "libs/service-portal/applications/src",
       "projectType": "library",
       "schematics": {},
       "architect": {
@@ -2926,16 +2701,19 @@
           "options": {
             "linter": "eslint",
             "tsConfig": [
-              "libs/nova-sms/tsconfig.lib.json",
-              "libs/nova-sms/tsconfig.spec.json"
+              "libs/service-portal/applications/tsconfig.lib.json",
+              "libs/service-portal/applications/tsconfig.spec.json"
             ],
-            "exclude": ["**/node_modules/**", "!libs/nova-sms/**/*"]
+            "exclude": [
+              "**/node_modules/**",
+              "!libs/service-portal/applications/**/*"
+            ]
           }
         },
         "test": {
           "builder": "@nrwl/jest:jest",
           "options": {
-            "jestConfig": "libs/nova-sms/jest.config.js",
+            "jestConfig": "libs/service-portal/applications/jest.config.js",
             "passWithNoTests": true
           }
         }
@@ -2981,9 +2759,9 @@
         }
       }
     },
-    "dokobit-signing": {
-      "root": "libs/dokobit-signing",
-      "sourceRoot": "libs/dokobit-signing/src",
+    "service-portal-constants": {
+      "root": "libs/service-portal/constants",
+      "sourceRoot": "libs/service-portal/constants/src",
       "projectType": "library",
       "schematics": {},
       "architect": {
@@ -2992,45 +2770,404 @@
           "options": {
             "linter": "eslint",
             "tsConfig": [
-              "libs/dokobit-signing/tsconfig.lib.json",
-              "libs/dokobit-signing/tsconfig.spec.json"
-            ],
-            "exclude": ["**/node_modules/**", "!libs/dokobit-signing/**/*"]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/dokobit-signing/jest.config.js",
-            "passWithNoTests": true
-          }
-        }
-      }
-    },
-    "judicial-system-types": {
-      "root": "libs/judicial-system/types",
-      "sourceRoot": "libs/judicial-system/types/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/judicial-system/types/tsconfig.lib.json",
-              "libs/judicial-system/types/tsconfig.spec.json"
+              "libs/service-portal/constants/tsconfig.lib.json",
+              "libs/service-portal/constants/tsconfig.spec.json"
             ],
             "exclude": [
               "**/node_modules/**",
-              "!libs/judicial-system/types/**/*"
+              "!libs/service-portal/constants/**/*"
             ]
           }
         },
         "test": {
           "builder": "@nrwl/jest:jest",
           "options": {
-            "jestConfig": "libs/judicial-system/types/jest.config.js",
+            "jestConfig": "libs/service-portal/constants/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "service-portal-core": {
+      "root": "libs/service-portal/core",
+      "sourceRoot": "libs/service-portal/core/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/service-portal/core/tsconfig.lib.json",
+              "libs/service-portal/core/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**", "!libs/service-portal/core/**/*"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/service-portal/core/jest.config.js",
+            "passWithNoTests": true
+          }
+        },
+        "extract-strings": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "parallel": false,
+            "commands": [
+              {
+                "command": "yarn ts-node libs/localization/scripts/extract libs/service-portal/core/src/{lib,components}/**/*.{js,ts,tsx}"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "service-portal-documents": {
+      "root": "libs/service-portal/documents",
+      "sourceRoot": "libs/service-portal/documents/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/service-portal/documents/tsconfig.lib.json",
+              "libs/service-portal/documents/tsconfig.spec.json"
+            ],
+            "exclude": [
+              "**/node_modules/**",
+              "!libs/service-portal/documents/**/*"
+            ]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/service-portal/documents/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "service-portal-e2e": {
+      "root": "apps/service-portal-e2e",
+      "sourceRoot": "apps/service-portal-e2e/src",
+      "projectType": "application",
+      "architect": {
+        "e2e": {
+          "builder": "@nrwl/cypress:cypress",
+          "options": {
+            "cypressConfig": "apps/service-portal-e2e/cypress.json",
+            "tsConfig": "apps/service-portal-e2e/tsconfig.e2e.json",
+            "devServerTarget": "service-portal:serve"
+          },
+          "configurations": {
+            "production": {
+              "devServerTarget": "service-portal:serve:production"
+            }
+          }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": ["apps/service-portal-e2e/tsconfig.e2e.json"],
+            "exclude": ["**/node_modules/**", "!apps/service-portal-e2e/**/*"]
+          }
+        }
+      }
+    },
+    "service-portal-education": {
+      "root": "libs/service-portal/education",
+      "sourceRoot": "libs/service-portal/education/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/service-portal/education/tsconfig.lib.json",
+              "libs/service-portal/education/tsconfig.spec.json"
+            ],
+            "exclude": [
+              "**/node_modules/**",
+              "!libs/service-portal/education/**/*"
+            ]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/service-portal/education/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "service-portal-family": {
+      "root": "libs/service-portal/family",
+      "sourceRoot": "libs/service-portal/family/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/service-portal/family/tsconfig.lib.json",
+              "libs/service-portal/family/tsconfig.spec.json"
+            ],
+            "exclude": [
+              "**/node_modules/**",
+              "!libs/service-portal/family/**/*"
+            ]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/service-portal/family/jest.config.js",
+            "passWithNoTests": true
+          }
+        },
+        "extract-strings": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "parallel": false,
+            "commands": [
+              {
+                "command": "yarn ts-node libs/localization/scripts/extract libs/service-portal/family/src/{screens,components}/**/*.{js,ts,tsx}"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "service-portal-finance": {
+      "root": "libs/service-portal/finance",
+      "sourceRoot": "libs/service-portal/finance/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/service-portal/finance/tsconfig.lib.json",
+              "libs/service-portal/finance/tsconfig.spec.json"
+            ],
+            "exclude": [
+              "**/node_modules/**",
+              "!libs/service-portal/finance/**/*"
+            ]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/service-portal/finance/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "service-portal-graphql": {
+      "root": "libs/service-portal/graphql",
+      "sourceRoot": "libs/service-portal/graphql/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/service-portal/graphql/tsconfig.lib.json",
+              "libs/service-portal/graphql/tsconfig.spec.json"
+            ],
+            "exclude": [
+              "**/node_modules/**",
+              "!libs/service-portal/graphql/**/*"
+            ]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/service-portal/graphql/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "service-portal-health": {
+      "root": "libs/service-portal/health",
+      "sourceRoot": "libs/service-portal/health/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/service-portal/health/tsconfig.lib.json",
+              "libs/service-portal/health/tsconfig.spec.json"
+            ],
+            "exclude": [
+              "**/node_modules/**",
+              "!libs/service-portal/health/**/*"
+            ]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/service-portal/health/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "service-portal-settings": {
+      "root": "libs/service-portal/settings",
+      "sourceRoot": "libs/service-portal/settings/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/service-portal/settings/tsconfig.lib.json",
+              "libs/service-portal/settings/tsconfig.spec.json"
+            ],
+            "exclude": [
+              "**/node_modules/**",
+              "!libs/service-portal/settings/**/*"
+            ]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/service-portal/settings/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "services-search-indexer": {
+      "root": "apps/services/search-indexer",
+      "sourceRoot": "apps/services/search-indexer/src",
+      "projectType": "application",
+      "prefix": "services-search-indexer",
+      "schematics": {},
+      "architect": {
+        "build": {
+          "builder": "@nrwl/node:build",
+          "options": {
+            "outputPath": "dist/apps/services/search-indexer",
+            "main": "apps/services/search-indexer/src/main.ts",
+            "tsConfig": "apps/services/search-indexer/tsconfig.app.json",
+            "assets": [
+              {
+                "glob": "config/**",
+                "input": "apps/services/search-indexer",
+                "output": "./"
+              }
+            ],
+            "webpackConfig": "apps/services/search-indexer/webpack.config.js"
+          },
+          "configurations": {
+            "production": {
+              "optimization": true,
+              "extractLicenses": true,
+              "inspect": false,
+              "fileReplacements": [
+                {
+                  "replace": "apps/services/search-indexer/src/environments/environment.ts",
+                  "with": "apps/services/search-indexer/src/environments/environment.prod.ts"
+                }
+              ]
+            }
+          }
+        },
+        "serve": {
+          "builder": "@nrwl/node:execute",
+          "options": {
+            "buildTarget": "services-search-indexer:build"
+          }
+        },
+        "dev-services": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "command": "docker-compose -f docker-compose.yml up -d --build",
+            "cwd": "apps/services/search-indexer/dev-services"
+          }
+        },
+        "migrate": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "command": "node migrate.js",
+            "cwd": "dist/apps/services/search-indexer"
+          }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "apps/services/search-indexer/tsconfig.app.json",
+              "apps/services/search-indexer/tsconfig.spec.json"
+            ],
+            "exclude": [
+              "**/node_modules/**",
+              "!apps/services/search-indexer/**/*"
+            ]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "apps/services/search-indexer/jest.config.js",
+            "passWithNoTests": true
+          }
+        },
+        "docker-express": {}
+      }
+    },
+    "shared-form-fields": {
+      "root": "libs/shared/form-fields",
+      "sourceRoot": "libs/shared/form-fields/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/shared/form-fields/tsconfig.lib.json",
+              "libs/shared/form-fields/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**", "!libs/shared/form-fields/**/*"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/shared/form-fields/jest.config.js",
             "passWithNoTests": true
           }
         }
@@ -3152,6 +3289,68 @@
         "docker-next": {}
       }
     },
+    "skilavottord-ws": {
+      "root": "apps/skilavottord/ws",
+      "sourceRoot": "apps/skilavottord/ws/src",
+      "projectType": "application",
+      "prefix": "skilavottord-ws",
+      "schematics": {},
+      "architect": {
+        "build": {
+          "builder": "@nrwl/node:build",
+          "options": {
+            "outputPath": "dist/apps/skilavottord/ws",
+            "main": "apps/skilavottord/ws/src/main.ts",
+            "tsConfig": "apps/skilavottord/ws/tsconfig.app.json",
+            "assets": ["apps/skilavottord/ws/src/assets"]
+          },
+          "configurations": {
+            "production": {
+              "optimization": true,
+              "extractLicenses": true,
+              "inspect": false,
+              "fileReplacements": [
+                {
+                  "replace": "apps/skilavottord/ws/src/environments/environment.ts",
+                  "with": "apps/skilavottord/ws/src/environments/environment.prod.ts"
+                }
+              ]
+            }
+          }
+        },
+        "serve": {
+          "builder": "@nrwl/node:execute",
+          "options": {
+            "buildTarget": "skilavottord-ws:build"
+          }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "apps/skilavottord/ws/tsconfig.app.json",
+              "apps/skilavottord/ws/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**", "!apps/skilavottord/ws/**/*"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "apps/skilavottord/ws/jest.config.js",
+            "passWithNoTests": true
+          }
+        },
+        "init-schema": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "command": "yarn ts-node -P apps/skilavottord/ws/tsconfig.app.json apps/skilavottord/ws/src/buildSchema.ts"
+          }
+        },
+        "docker-express": {}
+      }
+    },
     "skilavottord/web-e2e": {
       "root": "apps/skilavottord/web-e2e",
       "sourceRoot": "apps/skilavottord/web-e2e/src",
@@ -3180,310 +3379,111 @@
         }
       }
     },
-    "application-templates-parental-leave": {
-      "root": "libs/application/templates/parental-leave",
-      "sourceRoot": "libs/application/templates/parental-leave/src",
-      "projectType": "library",
+    "web": {
+      "root": "apps/web",
+      "sourceRoot": "apps/web",
+      "projectType": "application",
       "schematics": {},
       "architect": {
+        "build": {
+          "builder": "@nrwl/next:build",
+          "options": {
+            "root": "apps/web",
+            "outputPath": "dist/apps/web"
+          },
+          "configurations": {
+            "production": {
+              "fileReplacements": [
+                {
+                  "replace": "apps/web/environments/environment.ts",
+                  "with": "apps/web/environments/environment.prod.ts"
+                }
+              ]
+            }
+          }
+        },
+        "serve": {
+          "builder": "@nrwl/next:server",
+          "options": {
+            "buildTarget": "web:build",
+            "dev": true,
+            "proxyConfig": "apps/web/proxy.config.json"
+          },
+          "configurations": {
+            "production": {
+              "buildTarget": "web:build:production",
+              "dev": false
+            }
+          }
+        },
+        "export": {
+          "builder": "@nrwl/next:export",
+          "options": {
+            "buildTarget": "web:build:production"
+          }
+        },
         "lint": {
           "builder": "@nrwl/linter:lint",
           "options": {
             "linter": "eslint",
             "tsConfig": [
-              "libs/application/templates/parental-leave/tsconfig.lib.json",
-              "libs/application/templates/parental-leave/tsconfig.spec.json"
+              "apps/web/tsconfig.json",
+              "apps/web/tsconfig.spec.json"
             ],
-            "exclude": [
-              "**/node_modules/**",
-              "!libs/application/templates/parental-leave/**"
-            ]
+            "exclude": ["**/node_modules/**", "!apps/web/**/*"]
           }
         },
         "test": {
           "builder": "@nrwl/jest:jest",
           "options": {
-            "jestConfig": "libs/application/templates/parental-leave/jest.config.js",
+            "jestConfig": "apps/web/jest.config.js",
             "passWithNoTests": true
           }
         },
-        "extract-strings": {
+        "init-schema": {
           "builder": "@nrwl/workspace:run-commands",
           "options": {
-            "command": "yarn ts-node libs/localization/scripts/extract 'libs/application/templates/parental-leave/src/**/*.{js,ts,tsx}'"
-          }
-        }
-      }
-    },
-    "application-templates-driving-lessons": {
-      "root": "libs/application/templates/driving-lessons",
-      "sourceRoot": "libs/application/templates/driving-lessons/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/application/templates/driving-lessons/tsconfig.lib.json",
-              "libs/application/templates/driving-lessons/tsconfig.spec.json"
-            ],
-            "exclude": [
-              "**/node_modules/**",
-              "!libs/application/templates/driving-lessons/**"
-            ]
+            "command": "yarn nx run web:codegen"
           }
         },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/application/templates/driving-lessons/jest.config.js",
-            "passWithNoTests": true
-          }
-        },
-        "extract-strings": {
+        "codegen": {
           "builder": "@nrwl/workspace:run-commands",
           "options": {
-            "command": "yarn ts-node libs/localization/scripts/extract 'libs/application/templates/driving-lessons/src/**/*.{js,ts,tsx}'"
+            "command": "graphql-codegen --config apps/web/codegen.yml"
+          },
+          "configurations": {
+            "watch": {
+              "command": "graphql-codegen --config apps/web/codegen.yml --watch"
+            }
           }
-        }
+        },
+        "docker-next": {}
       }
     },
-    "application-template-loader": {
-      "root": "libs/application/template-loader",
-      "sourceRoot": "libs/application/template-loader/src",
-      "projectType": "library",
-      "schematics": {},
+    "web-e2e": {
+      "root": "apps/web-e2e",
+      "sourceRoot": "apps/web-e2e/src",
+      "projectType": "application",
       "architect": {
+        "e2e": {
+          "builder": "@nrwl/cypress:cypress",
+          "options": {
+            "cypressConfig": "apps/web-e2e/cypress.json",
+            "tsConfig": "apps/web-e2e/tsconfig.e2e.json",
+            "devServerTarget": "web:serve"
+          },
+          "configurations": {
+            "production": {
+              "devServerTarget": "web:serve:production"
+            }
+          }
+        },
         "lint": {
           "builder": "@nrwl/linter:lint",
           "options": {
             "linter": "eslint",
-            "tsConfig": [
-              "libs/application/template-loader/tsconfig.lib.json",
-              "libs/application/template-loader/tsconfig.spec.json"
-            ],
-            "exclude": [
-              "**/node_modules/**",
-              "!libs/application/template-loader/**"
-            ]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/application/template-loader/jest.config.js",
-            "passWithNoTests": true
-          }
-        }
-      }
-    },
-    "application-templates-reference-template": {
-      "root": "libs/application/templates/reference-template",
-      "sourceRoot": "libs/application/templates/reference-template/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/application/templates/reference-template/tsconfig.lib.json",
-              "libs/application/templates/reference-template/tsconfig.spec.json"
-            ],
-            "exclude": [
-              "**/node_modules/**",
-              "!libs/application/templates/reference-template/**"
-            ]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/application/templates/reference-template/jest.config.js",
-            "passWithNoTests": true
-          }
-        },
-        "extract-strings": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "command": "yarn ts-node libs/localization/scripts/extract 'libs/application/templates/reference-template/src/**/*.{js,ts,tsx}'"
-          }
-        }
-      }
-    },
-    "application-core": {
-      "root": "libs/application/core",
-      "sourceRoot": "libs/application/core/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/application/core/tsconfig.lib.json",
-              "libs/application/core/tsconfig.spec.json"
-            ],
-            "exclude": ["**/node_modules/**", "!libs/application/core/**/*"]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/application/core/jest.config.js",
-            "passWithNoTests": true
-          }
-        },
-        "extract-strings": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "command": "yarn ts-node libs/localization/scripts/extract 'libs/application/core/src/templates/**/*.{js,ts,tsx}'"
-          }
-        }
-      }
-    },
-    "application-ui-shell": {
-      "root": "libs/application/ui-shell",
-      "sourceRoot": "libs/application/ui-shell/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/application/ui-shell/tsconfig.lib.json",
-              "libs/application/ui-shell/tsconfig.spec.json"
-            ],
-            "exclude": ["**/node_modules/**", "!libs/application/ui-shell/**/*"]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/application/ui-shell/jest.config.js",
-            "passWithNoTests": true
-          }
-        },
-        "extract-strings": {
-          "builder": "@nrwl/workspace:run-commands",
-          "options": {
-            "command": "yarn ts-node libs/localization/scripts/extract 'libs/application/ui-shell/src/{lib,components}/**/*.{js,ts,tsx}'"
-          }
-        }
-      }
-    },
-    "application-ui-fields": {
-      "root": "libs/application/ui-fields",
-      "sourceRoot": "libs/application/ui-fields/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/application/ui-fields/tsconfig.lib.json",
-              "libs/application/ui-fields/tsconfig.spec.json"
-            ],
-            "exclude": [
-              "**/node_modules/**",
-              "!libs/application/ui-fields/**/*"
-            ]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/application/ui-fields/jest.config.js",
-            "passWithNoTests": true
-          }
-        }
-      }
-    },
-    "shared-form-fields": {
-      "root": "libs/shared/form-fields",
-      "sourceRoot": "libs/shared/form-fields/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/shared/form-fields/tsconfig.lib.json",
-              "libs/shared/form-fields/tsconfig.spec.json"
-            ],
-            "exclude": ["**/node_modules/**", "!libs/shared/form-fields/**/*"]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/shared/form-fields/jest.config.js",
-            "passWithNoTests": true
-          }
-        }
-      }
-    },
-    "judicial-system-formatters": {
-      "root": "libs/judicial-system/formatters",
-      "sourceRoot": "libs/judicial-system/formatters/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/judicial-system/formatters/tsconfig.lib.json",
-              "libs/judicial-system/formatters/tsconfig.spec.json"
-            ],
-            "exclude": [
-              "**/node_modules/**",
-              "!libs/judicial-system/formatters/**/*"
-            ]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/judicial-system/formatters/jest.config.js",
-            "passWithNoTests": true
-          }
-        }
-      }
-    },
-    "email-service": {
-      "root": "libs/email-service",
-      "sourceRoot": "libs/email-service/src",
-      "projectType": "library",
-      "schematics": {},
-      "architect": {
-        "lint": {
-          "builder": "@nrwl/linter:lint",
-          "options": {
-            "linter": "eslint",
-            "tsConfig": [
-              "libs/email-service/tsconfig.lib.json",
-              "libs/email-service/tsconfig.spec.json"
-            ],
-            "exclude": ["**/node_modules/**", "!libs/email-service/**/*"]
-          }
-        },
-        "test": {
-          "builder": "@nrwl/jest:jest",
-          "options": {
-            "jestConfig": "libs/email-service/jest.config.js",
-            "passWithNoTests": true
+            "tsConfig": ["apps/web-e2e/tsconfig.e2e.json"],
+            "exclude": ["**/node_modules/**", "!apps/web-e2e/**/*"]
           }
         }
       }


### PR DESCRIPTION
## What

Make sure nx project lists are always sorted (in workspace.json, nx.json and tsconfig.base.json).

This is implemented as a prettier plugin, so it is applied every time we run `yarn format`. `yarn generate` also runs prettier on all added/updated files. "Just Works ™️ "

## Why

To reduce the chance of conflicts when teams are generating nx apps and libs.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
