### PR TITLE
Generate all schemas

### DIFF
--- a/scripts/generate-schemas.js
+++ b/scripts/generate-schemas.js
@@ -2,15 +2,12 @@ const fs = require('fs')
 const { exec } = require('child_process')
 const { promisify } = require('util')
 
-const HEAD = process.env.HEAD
-const BASE = process.env.BASE
-
 const SCHEMA_PATH = 'libs/api/schema/src/lib/schema.d.ts'
 const YARN_COMMANDS = [
   'yarn nx run application-system-api:build-schema',
   'yarn nx run api-domains-application:codegen',
   'yarn nx run api:build-schema',
-  `yarn affected:schemas --head=${HEAD} --base=${BASE}`,
+  `yarn affected:schemas --all`,
 ]
 
 const main = async () => {


### PR DESCRIPTION
## What

Make sure we always have all of the schemas. 

## Why

"Affected" logic does not make sense for code generation unless we have all of the schemas in the beginning and always run `generate` with the correct HEAD/BASE as we pull more code. This is tricky for CI. Even more so for developers.

For new developers, the `schemas` command is failing, since there is no HEAD/BASE variables, and there's no affected projects, so it doesn't generate any schemas.

This is a quick fix until most of this logic is replaced in #1225.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
