### PR TITLE
Give docker build more time

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -161,7 +161,7 @@ jobs:
     needs:
       - prepare
     runs-on: ubuntu-20.04
-    timeout-minutes: 25
+    timeout-minutes: 35
     env:
       AFFECTED_ALL: ${{ secrets.AFFECTED_ALL }}
       GIT_BRANCH: ${{ needs.prepare.outputs.GIT_BRANCH}}


### PR DESCRIPTION
This was expected since we are now building all apps of the same type at the same time. With 20 min start time parallelism doesn't work that well for less than 10 builds. I say we increase the docker build timeout for now. And then look into faster build times now that test and lint times are down. 