### PR TITLE
Adding support for release-train builds (and hotfixes)

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,6 +1,10 @@
 name: Monorepo pipeline - push
 
 on:
+  create:
+    branches:
+      - 'release/**'
+      - 'hotfix/**'
   push:
     branches:
       - 'master'


### PR DESCRIPTION
## What

Create builds for release trains

## Why

We need them right away before pushing to them
