### PR TITLE
Added a fonts project to workspace.json and nx.json

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -157,6 +157,7 @@ jobs:
     if: needs.prepare.outputs.LINT_CHUNKS
     env:
       AFFECTED_PROJECTS: ${{ matrix.projects }}
+      NODE_OPTION: --max-old-space-size=4096
       MAX_JOBS: 4
     strategy:
       fail-fast: false

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -157,7 +157,7 @@ jobs:
     if: needs.prepare.outputs.LINT_CHUNKS
     env:
       AFFECTED_PROJECTS: ${{ matrix.projects }}
-      NODE_OPTION: --max-old-space-size=4096
+      NODE_OPTIONS: --max-old-space-size=4096
       MAX_JOBS: 4
     strategy:
       fail-fast: false

--- a/nx.json
+++ b/nx.json
@@ -174,6 +174,9 @@
       "tags": [],
       "implicitDependencies": ["island-ui-theme"]
     },
+    "island-ui-fonts": {
+      "tags": []
+    },
     "island-ui-storybook": {
       "tags": []
     },

--- a/workspace.json
+++ b/workspace.json
@@ -1936,6 +1936,9 @@
         }
       }
     },
+    "island-ui-fonts": {
+      "root": "libs/island-ui/fonts"
+    },
     "island-ui-storybook": {
       "root": "libs/island-ui/storybook",
       "sourceRoot": "libs/island-ui/storybook/src",


### PR DESCRIPTION
## What

After #1315 was merged, running lint gave the following error 

![Screenshot 2020-10-13 at 14 02 42](https://user-images.githubusercontent.com/3789875/95871212-eaa89080-0d5c-11eb-9cc0-7021459bf98b.png)

Turns out, NX requires us to create a project for the fonts, so that's what I did.

## Why

It's a bug

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
