### PR TITLE
Fix generate schemas

### DIFF
--- a/scripts/ci/get-files-touched-by.sh
+++ b/scripts/ci/get-files-touched-by.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." >/dev/null 2>&1 && pwd )"
+DIR="$(git rev-parse --show-toplevel)"
 marker=$(mktemp)
 touch $marker -r ${BASH_SOURCE[0]}
 


### PR DESCRIPTION
## What

Fix generate schemas. Change how we detect the root folder.

## Why

It stopped working when we moved the script that detects changed files down one level.
