### PR TITLE
Judicial-system: Added a heading for the 'comments to judge section'

### DIFF
--- a/apps/judicial-system/web/src/routes/Judge/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Judge/Overview/Overview.tsx
@@ -313,6 +313,14 @@ export const JudgeOverview: React.FC = () => {
                     </Box>
                   )}
                 </AccordionItem>
+                <AccordionItem
+                  id="id_5"
+                  label="Skilaboð til dómara"
+                  startExpanded
+                  labelVariant="h3"
+                >
+                  <Text>{workingCase?.comments}</Text>
+                </AccordionItem>
               </Accordion>
             </Box>
             <FormFooter

--- a/apps/judicial-system/web/src/routes/Prosecutor/CreateDetentionRequest/StepTwo/StepTwo.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/CreateDetentionRequest/StepTwo/StepTwo.tsx
@@ -10,6 +10,7 @@ import {
   DatePicker,
   Input,
   Checkbox,
+  Tooltip,
 } from '@island.is/island-ui/core'
 import { Case } from '@island.is/judicial-system-web/src/types'
 import {
@@ -655,23 +656,35 @@ export const StepTwo: React.FC = () => {
                     }}
                   />
                 </Box>
-                <Box marginBottom={3}>
-                  <Input
-                    textarea
-                    rows={2}
-                    name="comments"
-                    label="Athugasemdir til dómara"
-                    placeholder="Skrifa hér..."
-                    defaultValue={workingCase?.comments}
-                    onBlur={(evt) => {
-                      autoSave(
-                        workingCase,
-                        'comments',
-                        evt.target.value,
-                        setWorkingCase,
-                      )
-                    }}
-                  />
+                <Box component="section" marginBottom={7}>
+                  <Box marginBottom={2}>
+                    <Text as="h3" variant="h3">
+                      Skilaboð til dómara{' '}
+                      <Tooltip
+                        placement="right"
+                        as="span"
+                        text="Hér er hægt að skrá athugasemdir eða skilaboð til dómara sem verður ekki vistað sem hluti af kröfunni. Til dæmis aðrar upplýsingar en koma fram í kröfunni og/eða upplýsingar ástand sakbornings"
+                      />
+                    </Text>
+                  </Box>
+                  <Box marginBottom={3}>
+                    <Input
+                      textarea
+                      rows={2}
+                      name="comments"
+                      label="Athugasemdir til dómara"
+                      placeholder="Skrifa hér..."
+                      defaultValue={workingCase?.comments}
+                      onBlur={(evt) => {
+                        autoSave(
+                          workingCase,
+                          'comments',
+                          evt.target.value,
+                          setWorkingCase,
+                        )
+                      }}
+                    />
+                  </Box>
                 </Box>
               </Box>
               <FormFooter

--- a/apps/judicial-system/web/src/routes/Prosecutor/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Overview/Overview.tsx
@@ -267,6 +267,13 @@ export const Overview: React.FC = () => {
                       </Box>
                     )}
                   </AccordionItem>
+                  <AccordionItem
+                    id="id_5"
+                    label="Skilaboð til dómara"
+                    labelVariant="h3"
+                  >
+                    <Text>{workingCase?.comments}</Text>
+                  </AccordionItem>
                 </Accordion>
               </Box>
               <Box marginBottom={15}>

--- a/libs/island-ui/core/src/lib/Tooltip/Tooltip.treat.ts
+++ b/libs/island-ui/core/src/lib/Tooltip/Tooltip.treat.ts
@@ -28,6 +28,14 @@ export const tooltip = style({
 export const icon = style({
   display: 'inline-block',
   lineHeight: 1,
+  position: 'relative',
+})
+
+export const iconSVG = style({
+  width: '100%',
+  position: 'absolute',
+  top: 0,
+  left: 0,
 })
 
 export const iconPath = style({

--- a/libs/island-ui/core/src/lib/Tooltip/Tooltip.tsx
+++ b/libs/island-ui/core/src/lib/Tooltip/Tooltip.tsx
@@ -15,7 +15,7 @@ const InfoIcon: FC = () => {
     <svg
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
-      style={{ width: '100%' }}
+      className={styles.iconSVG}
       viewBox={`0 0 20 20`}
     >
       <path


### PR DESCRIPTION
# Added a heading for the 'comments to judge section' and a minor fix to the tooltip.

## What

This PR addresses two issues, one in the judicial-system project and the other in island-ui. These issues are 

- The comments to judge section needs to be separated from the request for detention.
- The tooltip becomes misplaced with a bigger font-size.

 Regarding the tooltip:

When using the Text component with a variant that has a bigger font-size than the default, say h3 f.x., the tooltip is misplaced. The examples below have a font-size of 30px.

**Before**
![Screenshot 2020-10-15 at 08 30 25](https://user-images.githubusercontent.com/3789875/96097656-bea62000-0ec0-11eb-9d7b-aac4de55cd26.png)

**After**
![Screenshot 2020-10-15 at 08 33 14](https://user-images.githubusercontent.com/3789875/96097948-18a6e580-0ec1-11eb-847f-17cf38a5d4e7.png)


## Why

Improvements.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
