### PR TITLE
fix: missing projectType

### DIFF
--- a/workspace.json
+++ b/workspace.json
@@ -1937,7 +1937,8 @@
       }
     },
     "island-ui-fonts": {
-      "root": "libs/island-ui/fonts"
+      "root": "libs/island-ui/fonts",
+      "projectType": "library"
     },
     "island-ui-storybook": {
       "root": "libs/island-ui/storybook",


### PR DESCRIPTION
## What

Add projectType field required to run nx commands.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
