### PR TITLE
Allow contentful documents as messages and display with <Richtext> co…

### DIFF
--- a/apps/application-system/form/src/routes/Application.tsx
+++ b/apps/application-system/form/src/routes/Application.tsx
@@ -7,7 +7,12 @@ import useAuth from '../hooks/useAuth'
 export const Application = () => {
   const { id } = useParams()
   const { userInfo } = useAuth()
-  useNamespaces(['dl.application', 'pl.application', 'application.system'])
+  useNamespaces([
+    'dl.application',
+    'pl.application',
+    'application.system',
+    'example.application',
+  ])
 
   const nationalRegistryId = userInfo?.profile?.natreg
 

--- a/apps/application-system/form/tsconfig.json
+++ b/apps/application-system/form/tsconfig.json
@@ -5,7 +5,8 @@
     "allowJs": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "types": ["node", "jest"]
+    "types": ["node", "jest"],
+    "strict": false
   },
   "files": [],
   "include": [],

--- a/apps/application-system/form/webpack.config.js
+++ b/apps/application-system/form/webpack.config.js
@@ -5,6 +5,11 @@ const nrwlConfig = require('@nrwl/react/plugins/webpack.js')
 
 module.exports = (config) => {
   nrwlConfig(config) // first call it so that it @nrwl/react plugin adds its configs,
+  config.stats.chunks = false
+  config.stats.modules = false
+  config.devServer.stats.chunks = false
+  config.devServer.stats.modules = false
+  config.devServer.noInfo = true
   return {
     ...config,
     plugins: [...config.plugins, new TreatPlugin()],

--- a/libs/api/domains/translations/src/lib/translations.service.ts
+++ b/libs/api/domains/translations/src/lib/translations.service.ts
@@ -15,6 +15,12 @@ const errorHandler = (name: string) => {
   }
 }
 
+const stringify = (x: string | object) => {
+  if (typeof x === 'string') return x
+
+  return JSON.stringify(x)
+}
+
 @Injectable()
 export class TranslationsService {
   constructor(private contentfulRepository: ContentfulRepository) {}
@@ -33,7 +39,7 @@ export class TranslationsService {
 
     const withFallbacks = result?.items?.map(({ fields }) =>
       mergeWith({}, fields.fallback, fields.strings, (o, s) =>
-        isEmpty(s) ? o : s,
+        isEmpty(s) ? stringify(o) : stringify(s),
       ),
     )
 

--- a/libs/application/core/src/lib/formUtils.ts
+++ b/libs/application/core/src/lib/formUtils.ts
@@ -177,6 +177,7 @@ export function mergeAnswers(
     arrayMerge: overwriteMerge,
   })
 }
+
 type MessageFormatter = (descriptor: StaticText, values?: any) => string
 
 export function formatText(
@@ -185,7 +186,13 @@ export function formatText(
   formatMessage: MessageFormatter,
 ): string {
   if (typeof text === 'function') {
-    return formatMessage(text(application))
+    const message = text(application)
+
+    if (typeof message === 'string') return formatMessage(message)
+
+    const { values = {}, ...descriptor } = message
+
+    return formatMessage(descriptor, values)
   }
   return formatMessage(text)
 }

--- a/libs/application/core/src/types/Form.ts
+++ b/libs/application/core/src/types/Form.ts
@@ -6,7 +6,7 @@ import { DataProviderTypes } from './DataProvider'
 import { MessageDescriptor } from 'react-intl'
 import { Application } from './Application'
 
-export type StaticText = MessageDescriptor | string
+export type StaticText = (MessageDescriptor & { values?: object }) | string
 
 export type FormText = StaticText | ((application: Application) => StaticText)
 

--- a/libs/application/templates/reference-template/src/forms/ExampleForm.ts
+++ b/libs/application/templates/reference-template/src/forms/ExampleForm.ts
@@ -31,10 +31,12 @@ export const ExampleForm: Form = buildForm({
         buildIntroductionField({
           id: 'field',
           name: m.introField,
-          introduction: (application) =>
+          introduction: (application) => ({
+            ...m.introIntroduction,
             // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
             // @ts-ignore
-            `Halló ${application.answers.person?.name}`,
+            values: { name: application.answers.person?.name },
+          }),
         }),
         buildMultiField({
           id: 'about',
@@ -125,8 +127,7 @@ export const ExampleForm: Form = buildForm({
         buildIntroductionField({
           id: 'overview',
           name: 'Takk fyrir að sækja um',
-          introduction:
-            'Með því að smella á "Senda" hér að neðan, þá sendist umsóknin inn til úrvinnslu. Við látum þig vita þegar hún er samþykkt eða henni er hafnað.',
+          introduction: m.overviewIntroduction,
         }),
         buildIntroductionField({
           id: 'final',

--- a/libs/application/templates/reference-template/src/forms/messages.ts
+++ b/libs/application/templates/reference-template/src/forms/messages.ts
@@ -1,4 +1,5 @@
 import { defineMessages } from 'react-intl'
+import { EMPTY_DOCUMENT } from '@contentful/rich-text-types'
 
 export const m = defineMessages({
   introSection: {
@@ -13,7 +14,7 @@ export const m = defineMessages({
   },
   introIntroduction: {
     id: 'example.application:intro.introduction',
-    defaultMessage: 'Þessi umsókn snýr að atvinnuleysisbótum',
+    defaultMessage: 'Halló {name}',
     description: 'Some description',
   },
   about: {
@@ -89,6 +90,10 @@ export const m = defineMessages({
   governmentOptionLabel: {
     id: 'example.application:government.option.label',
     defaultMessage: 'The government',
+    description: 'Some description',
+  },
+  overviewIntroduction: {
+    id: 'example.application:overview.introduction',
     description: 'Some description',
   },
 })

--- a/libs/application/ui-fields/src/lib/IntroductionFormField.tsx
+++ b/libs/application/ui-fields/src/lib/IntroductionFormField.tsx
@@ -6,6 +6,7 @@ import {
 } from '@island.is/application/core'
 import { Text } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
+import { RichText } from '@island.is/island-ui/contentful'
 
 const IntroductionFormField: FC<{
   application: Application
@@ -21,7 +22,9 @@ const IntroductionFormField: FC<{
           {formatText(field.name, application, formatMessage)}
         </Text>
       )}
-      <Text>{formatText(field.introduction, application, formatMessage)}</Text>
+      <RichText
+        document={formatText(field.introduction, application, formatMessage)}
+      />
     </div>
   )
 }

--- a/libs/application/ui-fields/tsconfig.json
+++ b/libs/application/ui-fields/tsconfig.json
@@ -4,7 +4,8 @@
     "jsx": "react",
     "allowJs": true,
     "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "strict": false
   },
   "files": [],
   "include": [],

--- a/libs/application/ui-fields/tsconfig.json
+++ b/libs/application/ui-fields/tsconfig.json
@@ -4,8 +4,7 @@
     "jsx": "react",
     "allowJs": true,
     "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "strict": false
+    "allowSyntheticDefaultImports": true
   },
   "files": [],
   "include": [],

--- a/libs/localization/scripts/formatter.js
+++ b/libs/localization/scripts/formatter.js
@@ -14,6 +14,7 @@ exports.format = function (msgs) {
         ...arr[namespace],
         [id]: {
           ...msg,
+          isRichText: !msg.defaultMessage,
         },
       },
     }


### PR DESCRIPTION
…mponent

TODO find a better way to mark richtext messages in defineMessage, atm it will asume it is richtext if defaultMessage is left out.

# \<Description\>

Attach a link to issue if relevant

## What

Localized richtext from contentful using translations lib

## Why

We want some messages to be richtext

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
