### PR TITLE
Remove deprecated Icon component

### DIFF
--- a/apps/judicial-system/web/src/shared-components/Modal/Modal.tsx
+++ b/apps/judicial-system/web/src/shared-components/Modal/Modal.tsx
@@ -1,7 +1,7 @@
 import {
   Box,
   ButtonDeprecated as Button,
-  IconDeprecated as Icon,
+  Icon,
   Typography,
 } from '@island.is/island-ui/core'
 import React from 'react'
@@ -34,7 +34,7 @@ const Modal: React.FC<ModalProps> = ({
         {handleClose && (
           <Box position="absolute" top={0} right={0}>
             <button className={styles.closeButton} onClick={handleClose}>
-              <Icon type="close" />
+              <Icon icon="close" type="outline" color="blue400" />
             </button>
           </Box>
         )}


### PR DESCRIPTION
# Remove deprecated Icon component

## What

Remove deprecated Icon component

## Why

Icon has been deprecated

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
