### PR TITLE
island-ui/ Responsify Column component 

### DIFF
--- a/libs/island-ui/core/src/lib/Column/Column.stories.mdx
+++ b/libs/island-ui/core/src/lib/Column/Column.stories.mdx
@@ -19,7 +19,7 @@ export const DemoBox = ({ background, minHeight = 'auto', children }) => (
 
 <br />
 
-### Width
+### Default
 
 Dy default they size fluidly
 
@@ -45,12 +45,40 @@ Dy default they size fluidly
   </Story>
 </Canvas>
 
+### Content
+
+Size by content
+
+<Canvas>
+  <Story name="Content">
+    <Columns>
+      <Column width="content">
+        <DemoBox background="blue100">
+          <Text>
+            My width is controlled by my content. Lorem ipsum dolor sit amet!
+          </Text>
+        </DemoBox>
+      </Column>
+      <Column>
+        <DemoBox background="blue200">
+          <Text>I'm fluid</Text>
+        </DemoBox>
+      </Column>
+      <Column background="blue300">
+        <DemoBox background="blue300">
+          <Text>I'm fluid</Text>
+        </DemoBox>
+      </Column>
+    </Columns>
+  </Story>
+</Canvas>
+
 ### Set width
 
 See _width_ props for available widths
 
 <Canvas>
-  <Story name="Responsive width">
+  <Story name="Width">
     <Columns>
       <Column width="3/12">
         <DemoBox background="blue100">
@@ -65,6 +93,32 @@ See _width_ props for available widths
       <Column width="3/12">
         <DemoBox background="blue300">
           <Text>Span 3/12</Text>
+        </DemoBox>
+      </Column>
+    </Columns>
+  </Story>
+</Canvas>
+
+### Responsive width
+
+See _width_ props for available widths
+
+<Canvas>
+  <Story name="Responsive width">
+    <Columns>
+      <Column width={['1/3', '2/5', '3/12', 'content']}>
+        <DemoBox background="blue100">
+          <Text>['1/3', '2/5', '3/12', 'content']</Text>
+        </DemoBox>
+      </Column>
+      <Column width={['1/3', '1/5', '3/12', 'content']}>
+        <DemoBox background="blue200">
+          <Text>['1/3', '1/5', '3/12', 'content']</Text>
+        </DemoBox>
+      </Column>
+      <Column width={['1/3', '2/5', '3/12', 'content']}>
+        <DemoBox background="blue300">
+          <Text>['1/3', '2/5', '3/12', 'content']</Text>
         </DemoBox>
       </Column>
     </Columns>

--- a/libs/island-ui/core/src/lib/Column/Column.treat.ts
+++ b/libs/island-ui/core/src/lib/Column/Column.treat.ts
@@ -1,4 +1,8 @@
 import { style, styleMap } from 'treat'
+import mapValues from 'lodash/mapValues'
+import { themeUtils, Theme } from '@island.is/island-ui/theme'
+
+type Breakpoint = keyof Theme['breakpoints']
 
 export const column = style({})
 
@@ -10,29 +14,58 @@ export const columnContent = style({
   },
 })
 
-const getSizeStyle = (scale: number) => ({
-  flex: `0 0 ${scale * 100}%`,
-})
+const availableWidths = [
+  '11/12',
+  '10/12',
+  '9/12',
+  '8/12',
+  '7/12',
+  '6/12',
+  '5/12',
+  '4/12',
+  '3/12',
+  '2/12',
+  '1/12',
+  '4/5',
+  '3/5',
+  '2/5',
+  '1/5',
+  '3/4',
+  '1/4',
+  '2/3',
+  '1/3',
+  '1/2',
+  'content',
+] as const
 
-export const width = styleMap({
-  '1/2': getSizeStyle(1 / 2),
-  '1/3': getSizeStyle(1 / 3),
-  '2/3': getSizeStyle(2 / 3),
-  '1/4': getSizeStyle(1 / 4),
-  '3/4': getSizeStyle(3 / 4),
-  '1/5': getSizeStyle(1 / 5),
-  '2/5': getSizeStyle(2 / 5),
-  '3/5': getSizeStyle(3 / 5),
-  '4/5': getSizeStyle(4 / 5),
-  '1/12': getSizeStyle(1 / 12),
-  '2/12': getSizeStyle(2 / 12),
-  '3/12': getSizeStyle(3 / 12),
-  '4/12': getSizeStyle(4 / 12),
-  '5/12': getSizeStyle(5 / 12),
-  '6/12': getSizeStyle(6 / 12),
-  '7/12': getSizeStyle(7 / 12),
-  '8/12': getSizeStyle(8 / 12),
-  '9/12': getSizeStyle(9 / 12),
-  '10/12': getSizeStyle(10 / 12),
-  '11/12': getSizeStyle(11 / 12),
-})
+export type AvailableWidths = typeof availableWidths[number]
+
+const widths = availableWidths.reduce((acc, column) => {
+  if (column === 'content') {
+    acc[column] = 'content'
+    return acc
+  }
+  const range = column.split('/')
+
+  acc[column] = parseInt(range[0]) / parseInt(range[1])
+  return acc
+}, {})
+
+const makeWidth = (breakpoint: Breakpoint) =>
+  styleMap(
+    mapValues(widths, (width) =>
+      themeUtils.responsiveStyle({
+        [breakpoint]:
+          width === 'content'
+            ? { flex: 'initial', flexShrink: 0, width: 'auto' }
+            : { flex: `0 0 ${width * 100}%`, width: '100%' },
+      }),
+    ),
+    `columnWidth_${breakpoint}`,
+  ) as any
+
+export const widthXs = makeWidth('xs')
+export const widthSm = makeWidth('sm')
+export const widthMd = makeWidth('md')
+export const widthLg = makeWidth('lg')
+export const widthXl = makeWidth('xl')

--- a/libs/island-ui/core/src/lib/Column/Column.tsx
+++ b/libs/island-ui/core/src/lib/Column/Column.tsx
@@ -1,12 +1,16 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import React, { ReactNode, useContext } from 'react'
+import cn from 'classnames'
+import {
+  resolveResponsiveProp,
+  ResponsiveProp,
+} from '../../utils/responsiveProp'
 import { Box } from '../Box/Box'
 import { ColumnsContext } from '../Columns/Columns'
 import * as styles from './Column.treat'
 
 export interface ColumnProps {
   children: ReactNode
-  width?: keyof typeof styles.width | 'content'
+  width?: ResponsiveProp<styles.AvailableWidths>
 }
 
 /** Standard columns */
@@ -23,16 +27,24 @@ export const Column = ({ children, width }: ColumnProps) => {
     xlSpace,
     collapsibleAlignmentChildProps,
   } = useContext(ColumnsContext)
+  const isFluid = width === undefined
 
   return (
     <Box
       minWidth={0}
-      width={width !== 'content' ? 'full' : undefined}
-      flexShrink={width === 'content' ? 0 : undefined}
-      className={[
+      width={isFluid ? 'full' : undefined}
+      className={cn(
         styles.column,
-        width !== 'content' ? styles.width[width!] : null,
-      ]}
+        !isFluid &&
+          resolveResponsiveProp(
+            width,
+            styles.widthXs,
+            styles.widthSm,
+            styles.widthMd,
+            styles.widthLg,
+            styles.widthXl,
+          ),
+      )}
     >
       <Box
         paddingLeft={[


### PR DESCRIPTION
# Responsify Column component by making it handle array of widths

## Why

To be able to set widths like `['1/3', '1/5', '3/12', 'content']`, see https://github.com/island-is/island.is/pull/1405#discussion_r509122773

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
