### PR TITLE
Change default text font size from 15 to 16 in sm breakpoint

### DIFF
--- a/libs/island-ui/core/src/lib/Text/Text.treat.ts
+++ b/libs/island-ui/core/src/lib/Text/Text.treat.ts
@@ -61,7 +61,7 @@ const availableLineHeights = {
 
 const availableFontSizes = {
   xs: { xs: 12, md: 14 },
-  sm: { xs: 15, md: 18 },
+  sm: { xs: 16, md: 18 },
   md: { xs: 18, md: 20 },
   lg: { xs: 20, md: 24 },
   xl: { xs: 26, md: 34 },


### PR DESCRIPTION
## What

Increase default text size to 16 from 15.

## Why

A designer noticed it was 15 but should be 16.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
