### PR TITLE
Judicial-system/Save case fix

### DIFF
--- a/apps/judicial-system/web/src/routes/Prosecutor/CreateDetentionRequest/StepOne/StepOne.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/CreateDetentionRequest/StepOne/StepOne.tsx
@@ -117,6 +117,10 @@ export const StepOne: React.FC = () => {
         policeCaseNumber: policeCaseNumberRef.current.value,
         accusedNationalId: accusedNationalIdRef.current.value.replace('-', ''),
         court: workingCase.court,
+        accusedName: workingCase.accusedName,
+        accusedAddress: workingCase.accusedAddress,
+        arrestDate: workingCase.arrestDate,
+        requestedCourtDate: workingCase.requestedCourtDate,
       })
 
       window.localStorage.setItem(

--- a/apps/judicial-system/web/src/types.ts
+++ b/apps/judicial-system/web/src/types.ts
@@ -91,6 +91,10 @@ export interface CreateCaseRequest {
   policeCaseNumber: string
   accusedNationalId: string
   court: string
+  accusedName?: string
+  accusedAddress?: string
+  arrestDate?: string
+  requestedCourtDate?: string
 }
 
 export interface User {


### PR DESCRIPTION
# Save case with all fields on the first screen for prosecutors.

https://app.asana.com/0/1197628843274291/1197773320394651

## What

See ☝️

## Why

If the name of the accused is entered first, then police case number and national id, the name would not be saved with the case.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
