### PR TITLE
Don't use background bleed styles if bleed amount is not specified

### DIFF
--- a/apps/web/components/Section/Section.tsx
+++ b/apps/web/components/Section/Section.tsx
@@ -45,7 +45,7 @@ export const Section: React.FC<SectionProps> = ({
 
   const generateBackgroundBleed = () => {
     //Background bleed is not available on mobile.
-    if (!backgroundBleed || isMobile) {
+    if (!backgroundBleed.bleedAmount || isMobile) {
       return null
     }
 


### PR DESCRIPTION
## What/why

Don't use background bleed styles if bleed amount is not specified. Styles were being used and had 'undefinedpx' as values. 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
