### PR TITLE
Breadcrumbs text nextjs link fix2

### DIFF
--- a/apps/web/screens/AboutPage/RenderForm.tsx
+++ b/apps/web/screens/AboutPage/RenderForm.tsx
@@ -147,6 +147,7 @@ export const RenderForm: React.FC<{
         variant="blue"
         buttonText={submitButtonText}
         onChange={formik.handleChange}
+        onSubmit={formik.handleSubmit}
         value={formik.values.email}
         errorMessage={formatMessage(status.message)}
         state={status.type || 'default'}

--- a/libs/island-ui/core/src/lib/NewsletterSignup/NewsletterSignup.tsx
+++ b/libs/island-ui/core/src/lib/NewsletterSignup/NewsletterSignup.tsx
@@ -20,6 +20,7 @@ interface Props {
   state?: State
   errorMessage?: string
   onChange: (event: React.ChangeEvent<any>) => void
+  onSubmit: (event: React.FormEvent<any>) => void
   value: string
 }
 
@@ -33,6 +34,7 @@ export const NewsletterSignup: React.FC<Props> = ({
   variant = 'white',
   state = 'default',
   onChange,
+  onSubmit,
   value,
   errorMessage,
 }) => {
@@ -63,7 +65,7 @@ export const NewsletterSignup: React.FC<Props> = ({
           paddingTop={[3, 2, 1]}
           marginLeft={[0, 0, 8]}
         >
-          <Button variant="text" icon="arrowForward">
+          <Button onClick={onSubmit} variant="text" icon="arrowForward">
             {buttonText}
           </Button>
         </Box>

--- a/libs/island-ui/core/src/lib/Text/Text.tsx
+++ b/libs/island-ui/core/src/lib/Text/Text.tsx
@@ -85,13 +85,10 @@ export const Text = ({
       {React.Children.map<React.ReactNode, React.ReactNode>(
         children,
         (child: any) => {
-          if (
-            child?.props?.href &&
-            child?.props?.as &&
-            child?.type?.name === 'Link'
-          ) {
-            // Checking to see if the child is a Link component and using "href" and "as" props,
-            // which indicates it is a next.js link since the linkRenderer breaks this functionality
+          if (child?.props?.href && child?.props?.as) {
+            // Checking to see if the child  using "href" and "as" props, which indicates it
+            // is (most likely) a next.js link since the linkRenderer breaks this functionality.
+            // TODO: Make linkRenderer handle next.js links.
             return child
           } else if (child?.props?.href && typeof linkRenderer === 'function') {
             return linkRenderer(child.props.href, child.props.children)


### PR DESCRIPTION
## What

Breadcrumbs Next.js links not working on production.

## Why

Seemed to work locally and serving production locally but not on live production web for some reason. I have a theory it is because of the `child?.type?.name === 'Link'` check. It is not really needed anyway so removing it and hoping it fixes the issue.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
