### PR TITLE
Breadcrumbs/Text next.js links (build) fix

### DIFF
--- a/libs/island-ui/core/src/lib/Text/Text.tsx
+++ b/libs/island-ui/core/src/lib/Text/Text.tsx
@@ -85,13 +85,10 @@ export const Text = ({
       {React.Children.map<React.ReactNode, React.ReactNode>(
         children,
         (child: any) => {
-          if (
-            child?.props?.href &&
-            child?.props?.as &&
-            child?.type?.name === 'Link'
-          ) {
-            // Checking to see if the child is a Link component and using "href" and "as" props,
-            // which indicates it is a next.js link since the linkRenderer breaks this functionality
+          if (child?.props?.href && child?.props?.as) {
+            // Checking to see if the child  using "href" and "as" props, which indicates it
+            // is (most likely) a next.js link since the linkRenderer breaks this functionality.
+            // TODO: Make linkRenderer handle next.js links.
             return child
           } else if (child?.props?.href && typeof linkRenderer === 'function') {
             return linkRenderer(child.props.href, child.props.children)


### PR DESCRIPTION
## What

Breadcrumbs Next.js links not working on production.

## Why

Seemed to work locally and serving production locally but not on live production web for some reason. I have a theory it is because of the `child?.type?.name === 'Link'` check. It is not really needed anyway so removing it and hoping it fixes the issue.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
