### PR TITLE
Skip empty types on import

### DIFF
--- a/libs/api/domains/cms/src/lib/models/slice.model.ts
+++ b/libs/api/domains/cms/src/lib/models/slice.model.ts
@@ -151,7 +151,7 @@ export const safelyMapSlices = (data) => {
   try {
     return mapSlice(data)
   } catch (error) {
-    logger.error('Failed to map slice', error)
+    logger.warn('Failed to map slice', { error: error.message })
     return null
   }
 }

--- a/libs/api/domains/cms/src/lib/search/importers/aboutPage.service.ts
+++ b/libs/api/domains/cms/src/lib/search/importers/aboutPage.service.ts
@@ -19,6 +19,12 @@ export class AboutPageSyncService {
       .map<MappedData | boolean>((entry) => {
         try {
           const mapped = mapAboutPage(entry)
+
+          // we consider about page that dont have a title to be empty
+          if (!mapped.title) {
+            throw new Error('Trying to import empty about page entry')
+          }
+
           const type = 'webAboutPage'
           return {
             _id: mapped.id,
@@ -37,7 +43,7 @@ export class AboutPageSyncService {
             dateUpdated: new Date().getTime().toString(),
           }
         } catch (error) {
-          logger.error('Failed to import about page', error)
+          logger.warn('Failed to import about page', error)
           return false
         }
       })

--- a/libs/api/domains/cms/src/lib/search/importers/aboutPage.service.ts
+++ b/libs/api/domains/cms/src/lib/search/importers/aboutPage.service.ts
@@ -43,7 +43,7 @@ export class AboutPageSyncService {
             dateUpdated: new Date().getTime().toString(),
           }
         } catch (error) {
-          logger.warn('Failed to import about page', error)
+          logger.warn('Failed to import about page', { error: error.message })
           return false
         }
       })

--- a/libs/api/domains/cms/src/lib/search/importers/article.service.ts
+++ b/libs/api/domains/cms/src/lib/search/importers/article.service.ts
@@ -77,7 +77,7 @@ export class ArticleSyncService {
             dateUpdated: new Date().getTime().toString(),
           }
         } catch (error) {
-          logger.warn('Failed to import article', error)
+          logger.warn('Failed to import article', { error: error.message })
           return false
         }
       })

--- a/libs/api/domains/cms/src/lib/search/importers/article.service.ts
+++ b/libs/api/domains/cms/src/lib/search/importers/article.service.ts
@@ -34,6 +34,11 @@ export class ArticleSyncService {
               ) as IArticle[])
             : []
 
+          // we consider article that dont have a title to be empty
+          if (!mapped.title) {
+            throw new Error('Trying to import empty article entry')
+          }
+
           mapped = mapArticle(entry)
           const type = 'webArticle'
           return {
@@ -72,7 +77,7 @@ export class ArticleSyncService {
             dateUpdated: new Date().getTime().toString(),
           }
         } catch (error) {
-          logger.error('Failed to import article', error)
+          logger.warn('Failed to import article', error)
           return false
         }
       })

--- a/libs/api/domains/cms/src/lib/search/importers/articleCategory.service.ts
+++ b/libs/api/domains/cms/src/lib/search/importers/articleCategory.service.ts
@@ -40,7 +40,9 @@ export class ArticleCategorySyncService {
             dateUpdated: new Date().getTime().toString(),
           }
         } catch (error) {
-          logger.warn('Failed to import article category', error)
+          logger.warn('Failed to import article category', {
+            error: error.message,
+          })
           return false
         }
       })

--- a/libs/api/domains/cms/src/lib/search/importers/articleCategory.service.ts
+++ b/libs/api/domains/cms/src/lib/search/importers/articleCategory.service.ts
@@ -22,6 +22,12 @@ export class ArticleCategorySyncService {
       .map<MappedData | boolean>((entry) => {
         try {
           const mapped = mapArticleCategory(entry)
+
+          // we consider article categories that dont have a title to be empty
+          if (!mapped.title) {
+            throw new Error('Trying to import empty article category entry')
+          }
+
           const type = 'webArticleCategory'
           return {
             _id: mapped.slug,
@@ -34,7 +40,7 @@ export class ArticleCategorySyncService {
             dateUpdated: new Date().getTime().toString(),
           }
         } catch (error) {
-          logger.error('Failed to import article category', error)
+          logger.warn('Failed to import article category', error)
           return false
         }
       })

--- a/libs/api/domains/cms/src/lib/search/importers/lifeEventsPage.service.ts
+++ b/libs/api/domains/cms/src/lib/search/importers/lifeEventsPage.service.ts
@@ -40,7 +40,9 @@ export class LifeEventsPageSyncService {
             dateUpdated: new Date().getTime().toString(),
           }
         } catch (error) {
-          logger.warn('Failed to import life event page', error)
+          logger.warn('Failed to import life event page', {
+            error: error.message,
+          })
           return false
         }
       })

--- a/libs/api/domains/cms/src/lib/search/importers/lifeEventsPage.service.ts
+++ b/libs/api/domains/cms/src/lib/search/importers/lifeEventsPage.service.ts
@@ -21,6 +21,12 @@ export class LifeEventsPageSyncService {
       .map<MappedData | boolean>((entry) => {
         try {
           const mapped = mapLifeEventPage(entry)
+
+          // we consider life events that dont have a title to be empty
+          if (!mapped.title) {
+            throw new Error('Trying to import empty life event entry')
+          }
+
           const type = 'webLifeEventPage'
           return {
             _id: mapped.id,
@@ -34,7 +40,7 @@ export class LifeEventsPageSyncService {
             dateUpdated: new Date().getTime().toString(),
           }
         } catch (error) {
-          logger.error('Failed to import life event page', error)
+          logger.warn('Failed to import life event page', error)
           return false
         }
       })

--- a/libs/api/domains/cms/src/lib/search/importers/news.service.ts
+++ b/libs/api/domains/cms/src/lib/search/importers/news.service.ts
@@ -43,7 +43,7 @@ export class NewsSyncService {
             dateUpdated: new Date().getTime().toString(),
           }
         } catch (error) {
-          logger.warn('Failed to import news', error)
+          logger.warn('Failed to import news', { error: error.message })
           return false
         }
       })

--- a/libs/api/domains/cms/src/lib/search/importers/news.service.ts
+++ b/libs/api/domains/cms/src/lib/search/importers/news.service.ts
@@ -19,6 +19,12 @@ export class NewsSyncService {
       .map<MappedData | boolean>((entry) => {
         try {
           const mapped = mapNews(entry)
+
+          // we consider news that dont have a title to be empty
+          if (!mapped.title) {
+            throw new Error('Trying to import empty news entry')
+          }
+
           const type = 'webNews'
           return {
             _id: mapped.id,
@@ -37,7 +43,7 @@ export class NewsSyncService {
             dateUpdated: new Date().getTime().toString(),
           }
         } catch (error) {
-          logger.error('Failed to import news', error)
+          logger.warn('Failed to import news', error)
           return false
         }
       })


### PR DESCRIPTION
# \<Description\>

This will patch empty imports, this patch will probably be reworked when we iterate migration
https://app.asana.com/0/1183498341031105/1198954651970197

## What

- Make importer not import entries we consider empty
- Change log level from error to warn
- Changed error logging messages

## Why

- Importer is importing empty entries due to them being published in another language
- Error level in logs is considered critical failure and sets of alarms
- Logging the whole error object is causing noise in logs

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
