### PR TITLE
Fix articles are not being mapped

### DIFF
--- a/libs/api/domains/cms/src/lib/search/importers/article.service.ts
+++ b/libs/api/domains/cms/src/lib/search/importers/article.service.ts
@@ -34,12 +34,13 @@ export class ArticleSyncService {
               ) as IArticle[])
             : []
 
+          mapped = mapArticle(entry)
+
           // we consider article that dont have a title to be empty
           if (!mapped.title) {
             throw new Error('Trying to import empty article entry')
           }
 
-          mapped = mapArticle(entry)
           const type = 'webArticle'
           return {
             _id: mapped.id,


### PR DESCRIPTION
Quick fix for a minor bug: Articles are not being mapped before checking for title.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
