### PR TITLE
Setup a test environment that ignores various guards on controllers

### DIFF
--- a/apps/services/auth-api/test/setup.ts
+++ b/apps/services/auth-api/test/setup.ts
@@ -1,4 +1,4 @@
-import { testServer, TestServerOptions } from '@island.is/infra-nest-server'
+import { testServerActivateAuthGuards, TestServerOptions } from '@island.is/infra-nest-server'
 import { INestApplication } from '@nestjs/common'
 import { Sequelize } from 'sequelize-typescript'
 import { AppModule } from '../src/app/app.module'
@@ -29,7 +29,7 @@ export const truncate = () => {
 }
 
 export const setup = async (options?: Partial<TestServerOptions>) => {
-  app = await testServer({
+  app = await testServerActivateAuthGuards({
     appModule: AppModule,
     ...options,
   })

--- a/libs/infra-nest-server/src/lib/testServer.ts
+++ b/libs/infra-nest-server/src/lib/testServer.ts
@@ -2,6 +2,7 @@ import { Type, ValidationPipe } from '@nestjs/common'
 import { InfraModule } from './infra/infra.module'
 import { Test } from '@nestjs/testing'
 import { TestingModuleBuilder } from '@nestjs/testing/testing-module.builder'
+import { ScopesGuard, IdsAuthGuard } from '@island.is/auth-api-lib'
 
 export type TestServerOptions = {
   /**
@@ -26,6 +27,25 @@ export const testServer = async (options: TestServerOptions) => {
 
   const moduleRef = await builder.compile()
   const app = moduleRef.createNestApplication()
+  app.useGlobalPipes(
+    new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true }),
+  )
+
+  return app.init()
+}
+
+// Sets up a test environment that ignores various Guards on controllers
+export const testServerActivateAuthGuards = async (options: TestServerOptions) => {
+  const moduleFixture = await Test.createTestingModule({
+    imports: [InfraModule.forRoot(options.appModule)],
+  })
+    .overrideGuard(IdsAuthGuard)
+    .useValue({ canActivate: () => true })
+    .overrideGuard(ScopesGuard)
+    .useValue({ canActivate: () => true })
+    .compile()
+
+  const app = moduleFixture.createNestApplication()
   app.useGlobalPipes(
     new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true }),
   )


### PR DESCRIPTION
# \<Description\>

Attach a link to issue if relevant

## What

Programmer can choose between two test environments, one that ignores guards and one that doesn´t

## Why

So that we can run tests on services-auth-api once we put Guards back on controllers in services-auth-api

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
