### PR TITLE
Service Portal Documents Fuse Type Fix

### DIFF
--- a/apps/service-portal/src/components/UserMenu/UserMenu.tsx
+++ b/apps/service-portal/src/components/UserMenu/UserMenu.tsx
@@ -94,8 +94,8 @@ const UserMenu: FC<{}> = () => {
                   </NavItem>
                 </Stack>
               </Box>
-              <Box marginTop={3}>
-                <Button onClick={handleLogoutClick}>
+              <Box marginTop={6}>
+                <Button onClick={handleLogoutClick} fluid>
                   {formatMessage({
                     id: 'global:logout',
                     defaultMessage: 'Útskráning',

--- a/libs/service-portal/applications/src/index.ts
+++ b/libs/service-portal/applications/src/index.ts
@@ -12,13 +12,7 @@ const rootName = defineMessage({
 
 export const applicationsModule: ServicePortalModule = {
   name: rootName,
-  widgets: () => [
-    {
-      name: rootName,
-      render: () => lazy(() => import('./widgets/applicationList')),
-      weight: 0,
-    },
-  ],
+  widgets: () => [],
   routes: () => {
     const applicationRoutes = [
       {

--- a/libs/service-portal/documents/src/screens/Overview/Overview.tsx
+++ b/libs/service-portal/documents/src/screens/Overview/Overview.tsx
@@ -24,7 +24,6 @@ import { Document } from '@island.is/api/schema'
 import DocumentCard from '../../components/DocumentCard/DocumentCard'
 import { ValueType } from 'react-select'
 import { useLocale, useNamespaces } from '@island.is/localization'
-import Fuse from 'fuse.js'
 import { isAfter, subYears, startOfTomorrow, isWithinInterval } from 'date-fns'
 import { isEqual } from 'lodash'
 
@@ -33,10 +32,10 @@ const pageSize = 6
 const defaultStartDate = subYears(new Date(), 20)
 const defaultEndDate = startOfTomorrow()
 
-type FuseItem = {
-  item: Document
-  refIndex: number
-}
+// type FuseItem = {
+//   item: Document
+//   refIndex: number
+// }
 
 const defaultFilterValues = {
   dateFrom: defaultStartDate,
@@ -75,13 +74,18 @@ const getFilteredDocuments = (
     )
   }
 
+  // if (searchQuery) {
+  //   const fuse = new Fuse(filteredDocuments, defaultSearchOptions)
+  //   return fuse.search(searchQuery).map((elem) => {
+  //     // const fuseItem = (elem as unknown) as FuseItem
+  //     // return fuseItem.item
+  //     return elem.item
+  //   })
+  // }
   if (searchQuery) {
-    const fuse = new Fuse(filteredDocuments, defaultSearchOptions)
-    return fuse.search(searchQuery).map((elem) => {
-      // const fuseItem = (elem as unknown) as FuseItem
-      // return fuseItem.item
-      return elem.item
-    })
+    return filteredDocuments.filter((x) =>
+      x.subject.toLowerCase().includes(searchQuery.toLowerCase()),
+    )
   }
 
   return filteredDocuments

--- a/libs/service-portal/documents/src/screens/Overview/Overview.tsx
+++ b/libs/service-portal/documents/src/screens/Overview/Overview.tsx
@@ -33,6 +33,11 @@ const pageSize = 6
 const defaultStartDate = subYears(new Date(), 20)
 const defaultEndDate = startOfTomorrow()
 
+type FuseItem = {
+  item: Document
+  refIndex: number
+}
+
 const defaultFilterValues = {
   dateFrom: defaultStartDate,
   dateTo: defaultEndDate,
@@ -70,11 +75,14 @@ const getFilteredDocuments = (
     )
   }
 
-  // TODO: Fix type errors
-  // if (searchQuery) {
-  //   const fuse = new Fuse(filteredDocuments, defaultSearchOptions)
-  //   return fuse.search(searchQuery).map((elem) => elem)
-  // }
+  if (searchQuery) {
+    const fuse = new Fuse(filteredDocuments, defaultSearchOptions)
+    return fuse.search(searchQuery).map((elem) => {
+      // const fuseItem = (elem as unknown) as FuseItem
+      // return fuseItem.item
+      return elem.item
+    })
+  }
 
   return filteredDocuments
 }

--- a/libs/service-portal/documents/src/widgets/documentList.tsx
+++ b/libs/service-portal/documents/src/widgets/documentList.tsx
@@ -1,10 +1,5 @@
 import React from 'react'
-import {
-  Typography,
-  Box,
-  Stack,
-  ButtonDeprecated as Button,
-} from '@island.is/island-ui/core'
+import { Typography, Box, Stack, Button } from '@island.is/island-ui/core'
 import { useListDocuments } from '@island.is/service-portal/graphql'
 import {
   ServicePortalModuleComponent,
@@ -52,9 +47,9 @@ export const DocumentList: ServicePortalModuleComponent = ({ userInfo }) => {
           <DocumentCard key={document.id} document={document} />
         ))}
       </Stack>
-      <Box display="flex" justifyContent="flexEnd" marginTop={3}>
+      <Box display="flex" justifyContent="flexEnd" marginTop={[4, 8]}>
         <Link to={ServicePortalPath.RafraenSkjolRoot}>
-          <Button variant="text" icon="arrowRight">
+          <Button variant="primary">
             {formatMessage({
               id: 'sp.documents:goto-documents',
               defaultMessage: 'Fara í rafræn skjöl',


### PR DESCRIPTION
# \<Service Portal Documents Fuse Type Fix\>

## What

Effort to fix type errors in Fuse.js for service portal documents
Remove Fuse as a dependancy from documents for now

## Why

Version mismatch has been causing builds to break on type errors randomly

@storybook/ui@6.0.26 depends on fuse.js "^3.6.1"
The currently installed version of fuse is locked as "fuse.js": "6.4.2"
Building the project on other branches has been causing a type error in documents Overview.tsx where fuse.search is interpreted as returning Document[] instead of FuseResult<Document[]>

**This needs to be addressed later**

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against master before asking for a review
