### PR TITLE
Judicial-system/Detention request table scales a little better now

### DIFF
--- a/apps/judicial-system/web/src/routes/DetentionRequests/DetentionRequests.spec.tsx
+++ b/apps/judicial-system/web/src/routes/DetentionRequests/DetentionRequests.spec.tsx
@@ -174,9 +174,9 @@ describe('Detention requests route', () => {
       </userContext.Provider>,
     )
 
-    await waitFor(() => queryByText('1. nóv. 2020 kl. 12:31'))
+    await waitFor(() => queryByText('1. nóv. 2020'))
 
-    expect(queryByText('1. nóv. 2020 kl. 12:31')).toBeTruthy()
+    expect(queryByText('1. nóv. 2020')).toBeTruthy()
 
     fetchMock.restore()
   })

--- a/apps/judicial-system/web/src/routes/DetentionRequests/DetentionRequests.tsx
+++ b/apps/judicial-system/web/src/routes/DetentionRequests/DetentionRequests.tsx
@@ -23,7 +23,8 @@ import { UserRole } from '../../utils/authenticate'
 import * as Constants from '../../utils/constants'
 import { Link } from 'react-router-dom'
 import { userContext } from '@island.is/judicial-system-web/src/utils/userContext'
-import { formatDate, TIME_FORMAT } from '@island.is/judicial-system/formatters'
+import { formatDate } from '@island.is/judicial-system/formatters'
+import { insertAt } from '../../utils/formatters'
 
 export const DetentionRequests: React.FC = () => {
   const [cases, setCases] = useState<DetentionRequest[]>(null)
@@ -109,7 +110,7 @@ export const DetentionRequests: React.FC = () => {
               <th>Kennitala</th>
               <th>Krafa stofnuð</th>
               <th>Staða</th>
-              <th>Gæsluvarðhaldstími</th>
+              <th>Gæsluvarðhald til</th>
               <th></th>
             </tr>
           </thead>
@@ -122,7 +123,10 @@ export const DetentionRequests: React.FC = () => {
               >
                 <td>{c.policeCaseNumber || '-'}</td>
                 <td>{c.accusedName || '-'}</td>
-                <td>{c.accusedNationalId || '-'}</td>
+                <td>
+                  {insertAt(c.accusedNationalId.replace('-', ''), '-', 6) ||
+                    '-'}
+                </td>
                 <td>
                   {format(parseISO(c.created), 'PP', { locale: localeIS })}
                 </td>
@@ -133,10 +137,7 @@ export const DetentionRequests: React.FC = () => {
                 </td>
                 <td>
                   {c.state === CaseState.ACCEPTED
-                    ? `${formatDate(c.custodyEndDate, 'PP')} kl. ${formatDate(
-                        c.custodyEndDate,
-                        TIME_FORMAT,
-                      )}`
+                    ? formatDate(c.custodyEndDate, 'PP')
                     : null}
                 </td>
                 <td>
@@ -148,7 +149,10 @@ export const DetentionRequests: React.FC = () => {
                             ? `${Constants.JUDGE_SINGLE_REQUEST_BASE_ROUTE}/${c.id}`
                             : `${Constants.SINGLE_REQUEST_BASE_ROUTE}/${c.id}`
                         }
-                        style={{ textDecoration: 'none' }}
+                        style={{
+                          textDecoration: 'none',
+                          whiteSpace: 'nowrap',
+                        }}
                       >
                         <Button icon="arrowRight" variant="text">
                           Opna kröfu

--- a/apps/judicial-system/web/src/utils/formatters.ts
+++ b/apps/judicial-system/web/src/utils/formatters.ts
@@ -65,3 +65,7 @@ export const parseTime = (date: string, time: string) => {
     return date.indexOf('T') > -1 ? date.substring(0, date.indexOf('T')) : date
   }
 }
+
+// Credit: https://stackoverflow.com/a/53060314
+export const insertAt = (str: string, sub: string, pos: number) =>
+  `${str.slice(0, pos)}${sub}${str.slice(pos)}`

--- a/apps/judicial-system/web/src/utils/utils.spec.ts
+++ b/apps/judicial-system/web/src/utils/utils.spec.ts
@@ -1,4 +1,5 @@
 import {
+  insertAt,
   parseArray,
   parseString,
   parseTime,
@@ -101,6 +102,20 @@ ipsum`
       // Assert
       expect(d).toEqual('2020-10-24')
       expect(dd).toEqual('2020-10-24')
+    })
+  })
+
+  describe('insertAt()', () => {
+    test('should insert a string at a certain position into another string', () => {
+      // Arrange
+      const str = 'Lorem ipsum dolum kara'
+      const insertion = ' lara'
+
+      // Act
+      const result = insertAt(str, insertion, 5)
+
+      // Assert
+      expect(result).toEqual('Lorem lara ipsum dolum kara')
     })
   })
 })


### PR DESCRIPTION
# Minor tweeks to detention request table

https://app.asana.com/0/322488613152836/1189677453581096

## What

- Remove time from Gæsluvarðhald til section of detention request table
- Rename the table head column from "Gæsluvarðhaldstími" to "Gæsluvarðhald til"
- Prevent "Opna kröfu" button from wrapping
- Make sure all national ids have a hyphen.

## Why

The table does now scale well, even on large screens.

## Screenshots / Gifs

### How it looks on a 12inch screen (Smallest mac is 13inch).

![Screenshot 2020-10-30 at 15 34 21](https://user-images.githubusercontent.com/3789875/97724942-7ba19a80-1ac5-11eb-97b0-44cdaa8d4003.png)



## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
