### PR TITLE
island-ui/Textarea font weight set to light

### DIFF
--- a/libs/island-ui/core/src/lib/Input/Input.mixins.ts
+++ b/libs/island-ui/core/src/lib/Input/Input.mixins.ts
@@ -172,6 +172,7 @@ export const inputDisabled = {
 
 export const textarea = {
   fontSize: 16,
+  fontWeight: theme.typography.light,
   ...themeUtils.responsiveStyle({
     md: {
       fontSize: 18,


### PR DESCRIPTION
# Textarea font weight set to light

## What

Textarea font weight set to light.

## Why

It's according to design

## Screenshots / Gifs

### Design
![Screenshot 2020-11-02 at 12 44 21](https://user-images.githubusercontent.com/3789875/97869290-2229ad80-1d09-11eb-9efd-533f4be4f66c.png)

### Implementation
![Screenshot 2020-11-02 at 12 45 02](https://user-images.githubusercontent.com/3789875/97869356-408fa900-1d09-11eb-957d-e19968ac42ed.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
