### PR TITLE
Fix for hash memory problem

### DIFF
--- a/libs/api/domains/cms/src/lib/search/cmsSync.service.ts
+++ b/libs/api/domains/cms/src/lib/search/cmsSync.service.ts
@@ -85,9 +85,11 @@ export class CmsSyncService {
     return this.elasticService.index(elasticIndex, folderHashDocument)
   }
 
-  // this will generate diffrent hash for each build
+  // this will generate diffrent hash when any file has been changed in the importer app
   private async getModelsFolderHash(): Promise<string> {
-    const hashResult = await hashElement(__dirname)
+    // node_modules is quite big, it's unlikely that changes here will effect the cms importers mappings
+    const options = { folders: { exclude: ['node_modules'] } }
+    const hashResult = await hashElement(__dirname, options)
     return hashResult.hash.toString()
   }
 


### PR DESCRIPTION
# \<Description\>

https://app.asana.com/0/1183498341031105/1199101557028143

## What

Made folder hash algorithm not calculate hash for node_modules

## Why

node_modules calculating a hash for node_modlues depletes the container resources causing it to crash

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
