### PR TITLE
Search indexer fixed warning error

### DIFF
--- a/libs/api/domains/cms/src/lib/search/cmsSync.service.ts
+++ b/libs/api/domains/cms/src/lib/search/cmsSync.service.ts
@@ -57,7 +57,7 @@ export class CmsSyncService {
       .then((document) => document.body._source.title)
       .catch((error) => {
         // we expect this to throw when this does not exist, this might happen if we reindex a fresh elasticsearch index
-        logger.warning('Failed to get last folder hash', {
+        logger.warn('Failed to get last folder hash', {
           error: error.message,
         })
         return ''

--- a/libs/api/domains/cms/src/lib/search/contentful.service.ts
+++ b/libs/api/domains/cms/src/lib/search/contentful.service.ts
@@ -99,7 +99,7 @@ export class ContentfulService {
       .then((document) => document.body._source.title)
       .catch((error) => {
         // we expect this to throw when this does not exist, this might happen if we reindex a fresh elasticsearch index
-        logger.warning('Failed to get next sync token', {
+        logger.warn('Failed to get next sync token', {
           error: error.message,
         })
         return ''


### PR DESCRIPTION
# \<Description\>

## What

Changed warning to warn

## Why

warning is not a valid function on logger to log warnings

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
