### PR TITLE
Using redis cluster instead of redis instance in applicaiton system api

### DIFF
--- a/SCHEMAS.md
+++ b/SCHEMAS.md
@@ -75,7 +75,7 @@ if (process.env.INIT_SCHEMA === 'true') {
 } else {
   CacheModule = NestCacheModule.register({
     store: redisStore,
-    redisInstance: createNestJSCache({...}),
+    redisInstance: createRedisCluster({...}),
   })
 }
 ```

--- a/apps/air-discount-scheme/backend/src/app/modules/cache/cache.module.ts
+++ b/apps/air-discount-scheme/backend/src/app/modules/cache/cache.module.ts
@@ -1,6 +1,6 @@
 import { CacheModule as NestCacheModule, DynamicModule } from '@nestjs/common'
 import * as redisStore from 'cache-manager-ioredis'
-import { createNestJSCache } from '@island.is/cache'
+import { createRedisCluster } from '@island.is/cache'
 import { environment } from '../../../environments'
 
 const { redis, production } = environment
@@ -11,7 +11,7 @@ if (process.env.NODE_ENV === 'test' || process.env.INIT_SCHEMA === 'true') {
 } else {
   CacheModule = NestCacheModule.register({
     store: redisStore,
-    redisInstance: createNestJSCache({
+    redisInstance: createRedisCluster({
       name: 'air_discount_scheme_backend_service_cache',
       ssl: production,
       nodes: redis.urls,

--- a/apps/application-system/api/docker-compose.base.yml
+++ b/apps/application-system/api/docker-compose.base.yml
@@ -1,11 +1,6 @@
 version: '3.3'
 
 services:
-  redis:
-    image: redis
-    ports:
-      - "127.0.0.1:6379:6379"
-
   db_application_system:
     image: postgres:11.6
     container_name: db_application_system

--- a/apps/application-system/api/docker-compose.dev.yml
+++ b/apps/application-system/api/docker-compose.dev.yml
@@ -4,3 +4,14 @@ services:
   db_application_system:
     ports:
       - 5432:5432
+
+  redis-cluster:
+    container_name: redis_cluster
+    image: grokzen/redis-cluster:5.0.6
+    privileged: true
+    sysctls:
+      net.core.somaxconn: '511'
+    environment:
+      - IP=0.0.0.0
+    ports:
+      - '7000-7005:7000-7005'

--- a/apps/application-system/api/src/app/modules/application/application.module.ts
+++ b/apps/application-system/api/src/app/modules/application/application.module.ts
@@ -2,23 +2,30 @@ import { DynamicModule, Module } from '@nestjs/common'
 import { BullModule as NestBullModule } from '@nestjs/bull'
 import { SequelizeModule } from '@nestjs/sequelize'
 import { FileStorageModule } from '@island.is/file-storage'
+import { createRedisCluster } from '@island.is/cache'
 
 import { Application } from './application.model'
 import { ApplicationController } from './application.controller'
 import { ApplicationService } from './application.service'
 import { UploadProcessor } from './upload.processor'
+import { environment } from '../../../environments'
 
 let BullModule: DynamicModule
 
 if (process.env.INIT_SCHEMA === 'true') {
   BullModule = NestBullModule.registerQueueAsync()
 } else {
+  const bullModuleName = 'application_system_api_bull_module'
   BullModule = NestBullModule.registerQueueAsync({
     name: 'upload',
     useFactory: () => ({
-      redis: {
-        host: 'localhost',
-        port: 6379,
+      prefix: `{${bullModuleName}}`,
+      createClient: () => {
+        return createRedisCluster({
+          name: bullModuleName,
+          ssl: environment.production,
+          nodes: environment.redis.urls,
+        })
       },
     }),
   })

--- a/apps/application-system/api/src/environments/environment.prod.ts
+++ b/apps/application-system/api/src/environments/environment.prod.ts
@@ -1,3 +1,6 @@
-export const environment = {
+export default {
   production: true,
+  redis: {
+    urls: [process.env.REDIS_URL_NODE_01],
+  },
 }

--- a/apps/application-system/api/src/environments/environment.ts
+++ b/apps/application-system/api/src/environments/environment.ts
@@ -1,3 +1,13 @@
-export const environment = {
+export default {
   production: false,
+  redis: {
+    urls: [
+      'localhost:7000',
+      'localhost:7001',
+      'localhost:7002',
+      'localhost:7003',
+      'localhost:7004',
+      'localhost:7005',
+    ],
+  },
 }

--- a/apps/application-system/api/src/environments/index.ts
+++ b/apps/application-system/api/src/environments/index.ts
@@ -1,0 +1,1 @@
+export { default as environment } from './environment'

--- a/libs/cache/src/lib/cache.ts
+++ b/libs/cache/src/lib/cache.ts
@@ -89,7 +89,7 @@ export const createApolloCache = (options: Options) => {
   return new RedisClusterCache(nodes, getRedisClusterOptions(options))
 }
 
-export const createNestJSCache = (options: Options) => {
+export const createRedisCluster = (options: Options) => {
   const nodes = parseNodes(options.nodes)
   logger.info(`Making caching connection with nodes: `, nodes)
   return new Redis.Cluster(nodes, getRedisClusterOptions(options))


### PR DESCRIPTION
## What

Use a redis cluster in the application system api project.

## Why

Because our AWS environment uses a redis cluster but not a redis instance.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
