### PR TITLE
Judicial-system/Added gender to step one screen

### DIFF
--- a/apps/judicial-system/web/src/routes/Prosecutor/CreateDetentionRequest/StepOne/StepOne.spec.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/CreateDetentionRequest/StepOne/StepOne.spec.tsx
@@ -11,7 +11,7 @@ import {
   mockUpdateCaseMutation,
 } from '@island.is/judicial-system-web/src/utils/mocks'
 import { MockedProvider } from '@apollo/client/testing'
-import { UpdateCase } from '@island.is/judicial-system/types'
+import { CaseGender, UpdateCase } from '@island.is/judicial-system/types'
 import formatISO from 'date-fns/formatISO'
 
 describe('/krafa with an id', () => {
@@ -22,7 +22,7 @@ describe('/krafa with an id', () => {
     render(
       <MockedProvider mocks={mockCaseQueries} addTypename={false}>
         <userContext.Provider value={mockProsecutorUserContext}>
-          <MemoryRouter initialEntries={['/krafa/test_id']}>
+          <MemoryRouter initialEntries={['/krafa/test_id_2']}>
             <Route path={`${Constants.SINGLE_REQUEST_BASE_ROUTE}/:id`}>
               <StepOne />
             </Route>
@@ -112,6 +112,15 @@ describe('/krafa without ID', () => {
     expect(court).toEqual('Héraðsdómur Reykjavíkur')
     expect(datepickers.length).toEqual(0)
     expect(
+      screen.getByRole('radio', { name: 'Karl' }) as HTMLInputElement,
+    ).not.toBeChecked()
+    expect(
+      screen.getByRole('radio', { name: 'Kona' }) as HTMLInputElement,
+    ).not.toBeChecked()
+    expect(
+      screen.getByRole('radio', { name: 'Annað' }) as HTMLInputElement,
+    ).not.toBeChecked()
+    expect(
       screen.getByRole('button', {
         name: /Halda áfram/i,
       }) as HTMLButtonElement,
@@ -154,6 +163,7 @@ describe('/krafa without ID', () => {
                     court: 'Héraðsdómur Reykjavíkur',
                     accusedName: '',
                     accusedAddress: '',
+                    accusedGender: null,
                     arrestDate: null,
                     requestedCourtDate: null,
                   },
@@ -175,6 +185,10 @@ describe('/krafa without ID', () => {
               {
                 id: 'testid',
                 accusedAddress: 'Harringvej 2',
+              } as UpdateCase,
+              {
+                id: 'testid',
+                accusedGender: CaseGender.FEMALE,
               } as UpdateCase,
               {
                 id: 'testid',
@@ -259,6 +273,8 @@ describe('/krafa without ID', () => {
     )
     userEvent.tab()
 
+    userEvent.click(screen.getByRole('radio', { name: 'Kona' }))
+
     // Select dates
     const datePickerWrappers = screen.getAllByTestId('datepicker')
 
@@ -335,6 +351,7 @@ describe('/krafa without ID', () => {
                   court: 'Héraðsdómur Reykjavíkur',
                   accusedName: 'Gervipersona',
                   accusedAddress: 'Batcave',
+                  accusedGender: CaseGender.OTHER,
                   arrestDate: null,
                   requestedCourtDate: null,
                 },
@@ -368,6 +385,8 @@ describe('/krafa without ID', () => {
     )
 
     userEvent.tab()
+
+    userEvent.click(screen.getByRole('radio', { name: 'Annað' }))
 
     await userEvent.type(
       screen.getByLabelText('Lögheimili/dvalarstaður *') as HTMLInputElement,

--- a/apps/judicial-system/web/src/routes/Prosecutor/CreateDetentionRequest/StepOne/StepOne.treat.ts
+++ b/apps/judicial-system/web/src/routes/Prosecutor/CreateDetentionRequest/StepOne/StepOne.treat.ts
@@ -1,0 +1,5 @@
+import { style } from 'treat'
+
+export const genderColumn = style({
+  flex: 1,
+})

--- a/apps/judicial-system/web/src/routes/Prosecutor/CreateDetentionRequest/StepOne/StepOne.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/CreateDetentionRequest/StepOne/StepOne.tsx
@@ -11,6 +11,8 @@ import {
   Select,
   Option,
   DatePicker,
+  GridContainer,
+  RadioButton,
 } from '@island.is/island-ui/core'
 import { validate, Validation } from '../../../../utils/validate'
 import { isNextDisabled } from '../../../../utils/stepHelper'
@@ -28,7 +30,12 @@ import {
   parseTime,
 } from '@island.is/judicial-system-web/src/utils/formatters'
 import { PageLayout } from '@island.is/judicial-system-web/src/shared-components/PageLayout/PageLayout'
-import { Case, UpdateCase, CaseState } from '@island.is/judicial-system/types'
+import {
+  Case,
+  UpdateCase,
+  CaseState,
+  CaseGender,
+} from '@island.is/judicial-system/types'
 import { gql, useMutation, useQuery } from '@apollo/client'
 import {
   CaseQuery,
@@ -39,6 +46,7 @@ import {
   ProsecutorSubsections,
   Sections,
 } from '@island.is/judicial-system-web/src/types'
+import * as styles from './StepOne.treat'
 
 export const CreateCaseMutation = gql`
   mutation CreateCaseMutation($input: CreateCaseInput!) {
@@ -197,6 +205,7 @@ export const StepOne: React.FC = () => {
             court: workingCase.court,
             accusedName: workingCase.accusedName,
             accusedAddress: workingCase.accusedAddress,
+            accusedGender: workingCase.accusedGender,
             arrestDate: workingCase.arrestDate,
             requestedCourtDate: workingCase.requestedCourtDate,
           },
@@ -274,6 +283,7 @@ export const StepOne: React.FC = () => {
         accusedNationalId: '',
         accusedName: '',
         accusedAddress: '',
+        accusedGender: null,
         court: 'Héraðsdómur Reykjavíkur',
         arrestDate: null,
         requestedCourtDate: null,
@@ -300,6 +310,7 @@ export const StepOne: React.FC = () => {
       },
       { value: workingCase?.accusedName, validations: ['empty'] },
       { value: workingCase?.accusedAddress, validations: ['empty'] },
+      { value: workingCase?.accusedGender, validations: ['empty'] },
       { value: workingCase?.arrestDate, validations: ['empty'] },
       {
         value: arrestTimeRef.current?.value,
@@ -383,7 +394,7 @@ export const StepOne: React.FC = () => {
               required
             />
           </Box>
-          <Box component="section" marginBottom={7}>
+          <Box component="section" marginBottom={3}>
             <Box marginBottom={2}>
               <Text as="h3" variant="h3">
                 Sakborningur
@@ -500,6 +511,86 @@ export const StepOne: React.FC = () => {
                 required
               />
             </Box>
+          </Box>
+          <Box component="section" marginBottom={7}>
+            <Box marginBottom={2}>
+              <Text as="h3" variant="h3">
+                Kyn{' '}
+                <Text as="span" color="red600" fontWeight="semiBold">
+                  *
+                </Text>
+              </Text>
+            </Box>
+            <GridContainer>
+              <GridRow>
+                <GridColumn className={styles.genderColumn}>
+                  <RadioButton
+                    name="accused-gender"
+                    id="genderMale"
+                    label="Karl"
+                    checked={workingCase.accusedGender === CaseGender.MALE}
+                    onChange={() => {
+                      setWorkingCase({
+                        ...workingCase,
+                        accusedGender: CaseGender.MALE,
+                      })
+
+                      if (workingCase.id) {
+                        updateCase(
+                          workingCase.id,
+                          parseString('accusedGender', CaseGender.MALE),
+                        )
+                      }
+                    }}
+                    large
+                  />
+                </GridColumn>
+                <GridColumn className={styles.genderColumn}>
+                  <RadioButton
+                    name="accused-gender"
+                    id="genderFemale"
+                    label="Kona"
+                    checked={workingCase.accusedGender === CaseGender.FEMALE}
+                    onChange={() => {
+                      setWorkingCase({
+                        ...workingCase,
+                        accusedGender: CaseGender.FEMALE,
+                      })
+
+                      if (workingCase.id) {
+                        updateCase(
+                          workingCase.id,
+                          parseString('accusedGender', CaseGender.FEMALE),
+                        )
+                      }
+                    }}
+                    large
+                  />
+                </GridColumn>
+                <GridColumn className={styles.genderColumn}>
+                  <RadioButton
+                    name="accused-gender"
+                    id="genderOther"
+                    label="Annað"
+                    checked={workingCase.accusedGender === CaseGender.OTHER}
+                    onChange={() => {
+                      setWorkingCase({
+                        ...workingCase,
+                        accusedGender: CaseGender.OTHER,
+                      })
+
+                      if (workingCase.id) {
+                        updateCase(
+                          workingCase.id,
+                          parseString('accusedGender', CaseGender.OTHER),
+                        )
+                      }
+                    }}
+                    large
+                  />
+                </GridColumn>
+              </GridRow>
+            </GridContainer>
           </Box>
           <Box component="section" marginBottom={7}>
             <Box marginBottom={2}>

--- a/apps/judicial-system/web/src/utils/mocks.ts
+++ b/apps/judicial-system/web/src/utils/mocks.ts
@@ -1,6 +1,7 @@
 import {
   CaseAppealDecision,
   CaseCustodyProvisions,
+  CaseGender,
   UpdateCase,
   User,
   UserRole,
@@ -86,6 +87,7 @@ const testCase2 = {
   accusedNationalId: 'string',
   accusedName: 'Jon Harring',
   accusedAddress: 'Harringvej 2',
+  accusedGender: CaseGender.MALE,
   court: 'string',
   arrestDate: '2020-09-16T19:51:28.224Z',
   requestedCourtDate: '2020-09-12T14:51:00.000Z',
@@ -128,6 +130,7 @@ const testCase3 = {
   accusedNationalId: '1111110000',
   accusedName: 'Jon Harring',
   accusedAddress: 'Harringvej 2',
+  accusedGender: CaseGender.MALE,
   court: 'string',
   arrestDate: '2020-09-16T19:51:28.224Z',
   requestedCourtDate: '2020-09-16T19:51:00.000Z',


### PR DESCRIPTION
# Added gender to step one screen

https://app.asana.com/0/1197628843274291/1197851580977337

## What

Added radio buttons for gender on the first screen of the prosecutor flow.

## Why

Because when we start sending notifications to prisons, they want to know the gender of people being sent to them.

## Screenshots / Gifs

![screencapture-localhost-4200-krafa-cd18458e-675e-497c-b9d1-edcb2ee4f098-2020-11-10-11_07_12](https://user-images.githubusercontent.com/3789875/98666408-e748fa80-2344-11eb-9347-102dc82f97bb.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
