### PR TITLE
Replace Icon with IconRC

### DIFF
--- a/libs/island-ui/core/src/lib/FormStepper/SectionNumber/SectionNumber.treat.ts
+++ b/libs/island-ui/core/src/lib/FormStepper/SectionNumber/SectionNumber.treat.ts
@@ -9,7 +9,7 @@ export const number = style({
   fontSize: 18,
   lineHeight: 0,
   borderRadius: '50%',
-  top: -1,
+  top: 0,
   left: 0,
 })
 

--- a/libs/island-ui/core/src/lib/FormStepper/SectionNumber/SectionNumber.tsx
+++ b/libs/island-ui/core/src/lib/FormStepper/SectionNumber/SectionNumber.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react'
 import { Colors } from '@island.is/island-ui/theme'
 
 import { Box } from '../../Box/Box'
-import { Icon } from '../../Icon/Icon'
+import { Icon } from '../../IconRC/Icon'
 import { SectionNumberColumn } from '../SectionNumberColumn/SectionNumberColumn'
 import * as types from '../types'
 import * as styles from './SectionNumber.treat'
@@ -57,7 +57,7 @@ export const SectionNumber: FC<SectionNumberProps> = ({
         style={{ height: `${lineHeight}px` }}
       />
       {(currentState === 'next' && (
-        <Icon type="bullet" color={currentBulletColor} width="16" height="16" />
+        <Icon color={currentBulletColor} size="small" icon="ellipse" />
       )) || (
         <Box
           position="absolute"
@@ -70,7 +70,7 @@ export const SectionNumber: FC<SectionNumberProps> = ({
           className={styles.number}
         >
           {(currentState === 'previous' && (
-            <Icon type="check" color="white" width="16" height="16" />
+            <Icon color="white" size="small" icon="checkmark" />
           )) ||
             number}
         </Box>

--- a/libs/island-ui/core/src/lib/IconRC/iconMap.ts
+++ b/libs/island-ui/core/src/lib/IconRC/iconMap.ts
@@ -10,6 +10,7 @@ export type Icon =
   | 'calendar'
   | 'car'
   | 'cellular'
+  | 'checkmark'
   | 'checkmarkCircle'
   | 'chevronBack'
   | 'chevronDown'
@@ -18,6 +19,7 @@ export type Icon =
   | 'close'
   | 'documents'
   | 'download'
+  | 'ellipse'
   | 'fileTrayFull'
   | 'heart'
   | 'home'
@@ -50,6 +52,7 @@ export default {
     calendar: 'Calendar',
     car: 'Car',
     cellular: 'Cellular',
+    checkmark: 'Checkmark',
     checkmarkCircle: 'CheckmarkCircle',
     chevronBack: 'ChevronBack',
     chevronDown: 'ChevronDown',
@@ -58,6 +61,7 @@ export default {
     close: 'Close',
     documents: 'Documents',
     download: 'Download',
+    ellipse: 'Ellipse',
     fileTrayFull: 'FileTrayFull',
     heart: 'Heart',
     home: 'Home',
@@ -89,6 +93,7 @@ export default {
     calendar: 'CalendarOutline',
     car: 'CarOutline',
     cellular: 'CellularOutline',
+    checkmark: 'Checkmark',
     checkmarkCircle: 'CheckmarkCircleOutline',
     chevronBack: 'ChevronBackOutline',
     chevronDown: 'ChevronDownOutline',
@@ -97,6 +102,7 @@ export default {
     close: 'CloseOutline',
     documents: 'DocumentsOutline',
     download: 'DownloadOutline',
+    ellipse: 'EllipseOutline',
     fileTrayFull: 'FileTrayFullOutline',
     heart: 'HeartOutline',
     home: 'HomeOutline',

--- a/libs/island-ui/core/src/lib/IconRC/icons/Checkmark.tsx
+++ b/libs/island-ui/core/src/lib/IconRC/icons/Checkmark.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react'
+import { SvgProps as SVGRProps } from '../Icon'
+
+const SvgCheckmark = ({
+  title,
+  titleId,
+  ...props
+}: React.SVGProps<SVGSVGElement> & SVGRProps) => {
+  return (
+    <svg
+      className="Checkmark_svg__ionicon"
+      viewBox="0 0 512 512"
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="square"
+        strokeMiterlimit={10}
+        strokeWidth={44}
+        d="M416 128L192 384l-96-96"
+      />
+    </svg>
+  )
+}
+
+export default SvgCheckmark

--- a/libs/island-ui/core/src/lib/IconRC/icons/Ellipse.tsx
+++ b/libs/island-ui/core/src/lib/IconRC/icons/Ellipse.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react'
+import { SvgProps as SVGRProps } from '../Icon'
+
+const SvgEllipse = ({
+  title,
+  titleId,
+  ...props
+}: React.SVGProps<SVGSVGElement> & SVGRProps) => {
+  return (
+    <svg
+      className="Ellipse_svg__ionicon"
+      viewBox="0 0 512 512"
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path d="M256 464c-114.69 0-208-93.31-208-208S141.31 48 256 48s208 93.31 208 208-93.31 208-208 208z" />
+    </svg>
+  )
+}
+
+export default SvgEllipse

--- a/libs/island-ui/core/src/lib/IconRC/icons/EllipseOutline.tsx
+++ b/libs/island-ui/core/src/lib/IconRC/icons/EllipseOutline.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react'
+import { SvgProps as SVGRProps } from '../Icon'
+
+const SvgEllipseOutline = ({
+  title,
+  titleId,
+  ...props
+}: React.SVGProps<SVGSVGElement> & SVGRProps) => {
+  return (
+    <svg
+      className="EllipseOutline_svg__ionicon"
+      viewBox="0 0 512 512"
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <circle
+        cx={256}
+        cy={256}
+        r={192}
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={32}
+      />
+    </svg>
+  )
+}
+
+export default SvgEllipseOutline


### PR DESCRIPTION
Update the FormStepper to use the newer Icon component.

## Why

The old Icon component is deprecated.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
