### PR TITLE
fix: yarn schemas shouldn't run contentful-types command

### DIFF
--- a/workspace.json
+++ b/workspace.json
@@ -511,10 +511,7 @@
           "builder": "@nrwl/workspace:run-commands",
           "options": {
             "parallel": false,
-            "commands": [
-              "yarn nx run api:contentful-types",
-              "graphql-codegen --config apps/api/codegen.yml"
-            ]
+            "command": "graphql-codegen --config apps/api/codegen.yml"
           }
         },
         "contentful-types": {


### PR DESCRIPTION
## What

- Since the file is committed to the repo it shouldn't be re-generate each time we run yarn schemas. This file should be updated manually by developers when they are changing the contentful models. It's a leftover I forgot when cleaning the commands last time.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against master before asking for a review
