### PR TITLE
Skilavottord/fix page access

### DIFF
--- a/apps/skilavottord/web/components/FormStepper/FormStepperMobile.tsx
+++ b/apps/skilavottord/web/components/FormStepper/FormStepperMobile.tsx
@@ -1,10 +1,5 @@
 import React from 'react'
-import {
-  Box,
-  FormStepperSection,
-  IconDeprecated as Icon,
-  Text,
-} from '@island.is/island-ui/core'
+import { Box, FormStepperSection, Icon, Text } from '@island.is/island-ui/core'
 import * as styles from './FormStepperMobile.treat'
 
 interface ProcessProps {
@@ -38,9 +33,9 @@ const FormStepperMobile = ({ sections, activeSection }: ProcessProps) => (
           {isActive || isCompleted ? (
             <IconBackground>
               {isCompleted ? (
-                <Icon type="check" color="white" width="16px" />
+                <Icon icon="checkmark" color="white" />
               ) : (
-                <Text variant="h5" color="white">
+                <Text variant="h3" color="white">
                   {activeSection + 1}
                 </Text>
               )}

--- a/apps/skilavottord/web/screens/Confirm/Confirm.tsx
+++ b/apps/skilavottord/web/screens/Confirm/Confirm.tsx
@@ -15,6 +15,7 @@ import {
   CREATE_VEHICLE_OWNER,
   CREATE_VEHICLE,
 } from '@island.is/skilavottord-web/graphql/mutations'
+import { ACCEPTED_TERMS_AND_CONDITION } from '@island.is/skilavottord-web/utils/consts'
 
 const Confirm = ({ apolloState }) => {
   const { user } = useContext(UserContext)
@@ -70,6 +71,7 @@ const Confirm = ({ apolloState }) => {
         },
       }),
     )
+    localStorage.setItem(ACCEPTED_TERMS_AND_CONDITION, 'true')
     router.replace(
       `${AUTH_URL['citizen']}/login?returnUrl=${routes.recycleVehicle.baseRoute}/${id}/handover`,
     )

--- a/apps/skilavottord/web/screens/Handover/Handover.tsx
+++ b/apps/skilavottord/web/screens/Handover/Handover.tsx
@@ -21,6 +21,7 @@ import { CREATE_RECYCLING_REQUEST_CITIZEN } from '@island.is/skilavottord-web/gr
 import { VEHICLES_BY_NATIONAL_ID } from '@island.is/skilavottord-web/graphql/queries'
 import CompanyList from './components/CompanyList'
 import * as styles from './Handover.treat'
+import { ACCEPTED_TERMS_AND_CONDITION } from '@island.is/skilavottord-web/utils/consts'
 
 const Handover: FC = () => {
   const { user } = useContext(UserContext)
@@ -77,14 +78,19 @@ const Handover: FC = () => {
       switch (activeCar.status) {
         case 'inUse':
         case 'cancelled':
-          setRequestType('pendingRecycle')
-          setRecyclingRequest({
-            variables: {
-              permno: id,
-              nameOfRequestor: user?.name,
-              requestType: 'pendingRecycle',
-            },
-          })
+          if (localStorage.getItem(ACCEPTED_TERMS_AND_CONDITION)) {
+            setRequestType('pendingRecycle')
+            setRecyclingRequest({
+              variables: {
+                permno: id,
+                nameOfRequestor: user?.name,
+                requestType: 'pendingRecycle',
+              },
+            })
+            localStorage.clear()
+          } else {
+            setInvalidCar(true)
+          }
         default:
           break
       }

--- a/apps/skilavottord/web/utils/consts.ts
+++ b/apps/skilavottord/web/utils/consts.ts
@@ -1,0 +1,1 @@
+export const ACCEPTED_TERMS_AND_CONDITION = 'acceptedTermsAndConditions'


### PR DESCRIPTION
# Skilavottord - fix access to handover page

Attach a link to issue if relevant

## What

- Prevent logged in users to access the handover page by typing/pasting in the url with specific permno
- Switched deprecated icon

## Why

If a logged in user would try to access the handover page directly in browser url with one of his/her cars that valid for recycling and without passing confirmation first, it should not mark the car for recycling.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
