### PR TITLE
Prevent multiple redis connections in application system

### DIFF
--- a/apps/application-system/api/src/app/modules/application/application.module.ts
+++ b/apps/application-system/api/src/app/modules/application/application.module.ts
@@ -16,17 +16,16 @@ if (process.env.INIT_SCHEMA === 'true') {
   BullModule = NestBullModule.registerQueueAsync()
 } else {
   const bullModuleName = 'application_system_api_bull_module'
+  const redisClient = createRedisCluster({
+    name: bullModuleName,
+    ssl: environment.production,
+    nodes: environment.redis.urls,
+  })
   BullModule = NestBullModule.registerQueueAsync({
     name: 'upload',
     useFactory: () => ({
       prefix: `{${bullModuleName}}`,
-      createClient: () => {
-        return createRedisCluster({
-          name: bullModuleName,
-          ssl: environment.production,
-          nodes: environment.redis.urls,
-        })
-      },
+      createClient: () => redisClient,
     }),
   })
 }


### PR DESCRIPTION
## What

Only create a one redis connection not three as it was before.
I recently introduced this bug in #1787 

## Why

Because one is quite enough

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
