### PR TITLE
island-ui / Button loading, and icon improvements

### DIFF
--- a/libs/island-ui/core/src/lib/Button/Button.treat.ts
+++ b/libs/island-ui/core/src/lib/Button/Button.treat.ts
@@ -62,8 +62,10 @@ export const size = styleMap({
   default: {
     fontSize: 16,
     lineHeight: 1.25,
+    minHeight: 48,
     ...themeUtils.responsiveStyle({
       md: {
+        minHeight: 64,
         fontSize: 18,
         lineHeight: 1.6,
       },
@@ -72,10 +74,12 @@ export const size = styleMap({
   small: {
     fontSize: 16,
     lineHeight: 1.25,
+    minHeight: 40,
     ...themeUtils.responsiveStyle({
       md: {
         fontSize: 18,
         lineHeight: 1.6,
+        minHeight: 48,
       },
     }),
   },
@@ -96,6 +100,7 @@ export const size = styleMap({
       md: {
         fontSize: 14,
         lineHeight: 1.142857,
+        minHeight: 48,
       },
     }),
   },
@@ -438,27 +443,24 @@ export const icon = style({
     },
   }),
   selectors: {
-    [`${isEmpty} &`]: {
+    [`${isEmpty} &, ${circle} &`]: {
       marginLeft: 0,
     },
-    [`${circle} &`]: {
-      marginLeft: 0,
-      width: '50%',
-      height: '50%',
-    },
-    [`${size.small} &`]: {
-      width: 15,
-      height: 15,
-    },
-    [`${variants.text}:not(${isEmpty}) &`]: {
-      width: 15,
-      height: 15,
-      marginLeft: 8,
-    },
-    [`${variants.utility}:not(${isEmpty}) &`]: {
+    [`${size.small} &, ${variants.utility} &, ${size.textSmall} &, ${circleSizes.small} &`]: {
       width: 16,
       height: 16,
+    },
+    [`${variants.utility}:not(${isEmpty}) &, ${variants.text}:not(${isEmpty}) &`]: {
       marginLeft: 8,
+    },
+    [`${variants.text}${size.textSmall}:not(${isEmpty}) &`]: {
+      marginLeft: 4,
+    },
+    [`${variants.text}:not(${size.textSmall}) &`]: {
+      marginBottom: -5,
+    },
+    [`${size.textSmall} &`]: {
+      marginBottom: -3,
     },
     ...utilityIconColor(
       'default',
@@ -470,5 +472,68 @@ export const icon = style({
       theme.color.red600,
       theme.color.roseTinted400,
     ),
+  },
+})
+
+export const loadingCircle = style({})
+
+export const hideContent = style({
+  color: 'transparent',
+})
+
+export const loading = style({
+  position: 'relative',
+})
+
+export const loader = style({
+  position: 'absolute',
+  top: 0,
+  right: 0,
+  bottom: 0,
+  left: 0,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+})
+
+export const loadingDot = style({
+  width: 8,
+  height: 8,
+  borderRadius: '50%',
+  background: 'currentcolor',
+  selectors: {
+    ['&:not(:last-child)']: {
+      marginRight: 10,
+    },
+    ['&:nth-child(2)']: {
+      animationDelay: '0.4s',
+    },
+    ['&:nth-child(3)']: {
+      animationDelay: '0.8s',
+    },
+    [`${loadingCircle} &:nth-child(2), ${loadingCircle} &:nth-child(3)`]: {
+      display: 'none',
+    },
+    [`${loadingCircle} &`]: {
+      width: 16,
+      height: 16,
+      marginRight: 0,
+    },
+  },
+  animation:
+    '@keyframes 1.4s forwards cubic-bezier(0.59, 0.01, 0.39, 1) infinite',
+  '@keyframes': {
+    '0%': {
+      transform: 'scale(1)',
+      opacity: 1,
+    },
+    '50%': {
+      transform: 'scale(0.8)',
+      opacity: 0.4,
+    },
+    '100%': {
+      transform: 'scale(1)',
+      opacity: 1,
+    },
   },
 })

--- a/libs/island-ui/core/src/lib/Button/Button.tsx
+++ b/libs/island-ui/core/src/lib/Button/Button.tsx
@@ -1,4 +1,5 @@
-import React, { AllHTMLAttributes, forwardRef, ReactNode } from 'react'
+import * as React from 'react'
+import { AllHTMLAttributes, forwardRef, ReactNode } from 'react'
 import { Button as ReaButton } from 'reakit/Button'
 import cn from 'classnames'
 
@@ -51,6 +52,7 @@ export interface ButtonProps {
   iconType?: Type
   type?: NativeButtonProps['type']
   lang?: string
+  loading?: boolean
 }
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps & ButtonTypes>(
@@ -65,40 +67,62 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps & ButtonTypes>(
       circle,
       type = 'button',
       fluid,
+      disabled,
+      loading,
       ...buttonProps
     },
     ref,
   ) => {
+    const getKeyValue = <T extends object, U extends keyof T>(obj: T) => (
+      key: U,
+    ) => obj[key]
+    let color = getKeyValue(styles.colors[variant])(
+      colorScheme as ButtonTypes['colorScheme'] | any,
+    )
     return (
       <Box
         component={ReaButton}
         as={variant === 'text' ? 'span' : 'button'}
         ref={ref}
         type={type}
-        className={cn(
-          styles.variants[variant],
-          styles.colors[variant][colorScheme],
-          {
-            [styles.size[size]]:
-              variant !== 'utility' &&
-              !circle &&
-              !(variant === 'text' && size === 'small'),
-            [styles.fluid]: fluid,
-            [styles.size.utility]: variant === 'utility',
-            [styles.size.textSmall]: variant === 'text' && size === 'small',
-            [styles.circleSizes[size]]: circle,
-            [styles.circle]: circle,
-            [styles.padding[size]]:
-              variant !== 'utility' && variant !== 'text' && !circle,
-            [styles.padding.text]: variant === 'text',
-            [styles.padding.utility]: variant === 'utility',
-            [styles.isEmpty]: !children,
-          },
-        )}
+        className={cn(styles.variants[variant], color, {
+          [styles.size[size]]:
+            variant !== 'utility' &&
+            !circle &&
+            !(variant === 'text' && size === 'small'),
+          [styles.fluid]: fluid,
+          [styles.size.utility]: variant === 'utility',
+          [styles.size.textSmall]: variant === 'text' && size === 'small',
+          [styles.circleSizes[size]]: circle,
+          [styles.circle]: circle,
+          [styles.padding[size]]:
+            variant !== 'utility' && variant !== 'text' && !circle,
+          [styles.padding.text]: variant === 'text',
+          [styles.padding.utility]: variant === 'utility',
+          [styles.isEmpty]: !children,
+          [styles.loading]: loading,
+        })}
+        disabled={disabled || loading}
         {...buttonProps}
       >
-        {children}
-        {icon && <ButtonIcon icon={icon} type={iconType} />}
+        {loading && variant !== 'text' ? (
+          <>
+            <span className={styles.hideContent}>{children}</span>
+            {icon && <ButtonIcon icon={icon} type={iconType} transparent />}
+            <div
+              className={cn(styles.loader, { [styles.loadingCircle]: circle })}
+            >
+              <div className={styles.loadingDot} />
+              <div className={styles.loadingDot} />
+              <div className={styles.loadingDot} />
+            </div>
+          </>
+        ) : (
+          <>
+            {children}
+            {icon && <ButtonIcon icon={icon} type={iconType} />}
+          </>
+        )}
       </Box>
     )
   },
@@ -107,13 +131,14 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps & ButtonTypes>(
 type ButtonIconProps = {
   icon: ButtonProps['icon']
   type: ButtonProps['iconType']
+  transparent?: boolean
 }
 
-const ButtonIcon = ({ icon, type }: ButtonIconProps) => (
+const ButtonIcon = ({ icon, type, transparent }: ButtonIconProps) => (
   <Icon
     icon={icon!}
     type={type!}
-    color="currentColor"
+    color={transparent ? 'transparent' : 'currentColor'}
     className={styles.icon}
     skipPlaceholderSize
   />

--- a/libs/island-ui/core/src/lib/Button/Button.tsx
+++ b/libs/island-ui/core/src/lib/Button/Button.tsx
@@ -73,19 +73,13 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps & ButtonTypes>(
     },
     ref,
   ) => {
-    const getKeyValue = <T extends object, U extends keyof T>(obj: T) => (
-      key: U,
-    ) => obj[key]
-    let color = getKeyValue(styles.colors[variant])(
-      colorScheme as ButtonTypes['colorScheme'] | any,
-    )
     return (
       <Box
         component={ReaButton}
         as={variant === 'text' ? 'span' : 'button'}
         ref={ref}
         type={type}
-        className={cn(styles.variants[variant], color, {
+        className={cn(styles.variants[variant], styles.colors[variant], {
           [styles.size[size]]:
             variant !== 'utility' &&
             !circle &&


### PR DESCRIPTION
# Button loading and improvements 

## What

Add loading state to button

improve icon sizes and alignments

use min height for some cases to ensure consistent button heights

## Screenshots / Gifs

some ex.
![button-loading](https://user-images.githubusercontent.com/5655741/98962247-5e75be80-24fe-11eb-80d4-aa7d2615c5f2.gif)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against master before asking for a review
