### PR TITLE
Adding refresh-slots-timeout to redis config

### DIFF
--- a/libs/cache/src/lib/cache.ts
+++ b/libs/cache/src/lib/cache.ts
@@ -52,6 +52,7 @@ const getRedisClusterOptions = (
   return {
     ...options,
     keyPrefix: `${options.name}:`,
+    slotsRefreshTimeout: 2000,
     connectTimeout: 5000,
     // https://www.npmjs.com/package/ioredis#special-note-aws-elasticache-clusters-with-tls
     dnsLookup: (address, callback) => callback(null, address, 0),


### PR DESCRIPTION
## What

Increasing the refresh slots timeout value

## Why

Because refresh slots in application-system have been timing out
