### PR TITLE
hotfix: Live data shows tha fileType can be both upper- and lowercase

### DIFF
--- a/libs/service-portal/documents/src/components/DocumentCard/DocumentCard.tsx
+++ b/libs/service-portal/documents/src/components/DocumentCard/DocumentCard.tsx
@@ -48,7 +48,7 @@ const DocumentCard: FC<Props> = ({ document }) => {
   }, [data, error])
 
   const handleOnFetch = () => {
-    if (data?.fileType === 'pdf' && data?.content) {
+    if ((data?.fileType || '').toLowerCase() === 'pdf' && data?.content) {
       downloadAsPdf(data.content, fileName)
       return
     }


### PR DESCRIPTION
# \<Hotfix documents\>

## Why

Live data shows inconsistency in casing, some documents would not be treated as pdf documents because the filetype did not match.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against master before asking for a review
