### PR TITLE
Adgerdir add button to bottom of article

### DIFF
--- a/apps/web/screens/Adgerdir/Article.tsx
+++ b/apps/web/screens/Adgerdir/Article.tsx
@@ -72,11 +72,11 @@ const AdgerdirArticle: Screen<AdgerdirArticleProps> = ({
           {article.linkButtonText ?? n('seeMoreDetails')}
         </Button>
       </Link>
-    ) : (
+    ) : article.linkButtonText && article.linkButtonText.trim().length > 0 ? (
       <Button iconType="outline" icon="open" disabled fluid>
         {article.linkButtonText ?? n('seeMoreDetails')}
       </Button>
-    )
+    ) : null
 
   return (
     <>
@@ -141,7 +141,10 @@ const AdgerdirArticle: Screen<AdgerdirArticleProps> = ({
               locale={activeLocale}
             />
             <GridRow>
-              <GridColumn span={['12/12', '6/12', '6/12', '5/12', '4/12']}>
+              <GridColumn
+                paddingTop={4}
+                span={['12/12', '6/12', '6/12', '5/12', '4/12']}
+              >
                 {renderButton}
               </GridColumn>
             </GridRow>

--- a/apps/web/screens/Adgerdir/Article.tsx
+++ b/apps/web/screens/Adgerdir/Article.tsx
@@ -65,6 +65,19 @@ const AdgerdirArticle: Screen<AdgerdirArticleProps> = ({
 
   const description = article.longDescription || article.description
 
+  const renderButton =
+    article.link && article.link.trim().length > 0 ? (
+      <Link href={article.link}>
+        <Button iconType="outline" icon="open" fluid>
+          {article.linkButtonText ?? n('seeMoreDetails')}
+        </Button>
+      </Link>
+    ) : (
+      <Button iconType="outline" icon="open" disabled fluid>
+        {article.linkButtonText ?? n('seeMoreDetails')}
+      </Button>
+    )
+
   return (
     <>
       <HeadWithSocialSharing
@@ -75,17 +88,7 @@ const AdgerdirArticle: Screen<AdgerdirArticleProps> = ({
         sidebar={
           <Box marginBottom={10}>
             <Stack space={3}>
-              {article.link && article.link.trim().length > 0 ? (
-                <Link href={article.link}>
-                  <Button iconType="outline" icon="open" fluid>
-                    {article.linkButtonText ?? n('seeMoreDetails')}
-                  </Button>
-                </Link>
-              ) : (
-                <Button iconType="outline" icon="open" disabled fluid>
-                  {article.linkButtonText ?? n('seeMoreDetails')}
-                </Button>
-              )}
+              {renderButton}
               <Stack space={1}>
                 <Text variant="tag" color="red600">
                   {n('malefni', 'Málefni')}:
@@ -137,6 +140,11 @@ const AdgerdirArticle: Screen<AdgerdirArticleProps> = ({
               config={{ defaultPadding: [2, 2, 4], skipGrid: true }}
               locale={activeLocale}
             />
+            <GridRow>
+              <GridColumn span={['12/12', '6/12', '6/12', '5/12', '4/12']}>
+                {renderButton}
+              </GridColumn>
+            </GridRow>
           </GridColumn>
         </GridRow>
       </ArticleLayout>


### PR DESCRIPTION
# \<Description\>

Add button to the bottom of adgerdir article page
Fix bug with button that has no buttontext

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/70899104/98971639-57a07900-2509-11eb-9720-564083eb18a6.png)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against master before asking for a review
