### PR TITLE
Island-ui-core is now typescript strict.

### DIFF
--- a/libs/island-ui/core/src/lib/Button/Button.treat.ts
+++ b/libs/island-ui/core/src/lib/Button/Button.treat.ts
@@ -502,13 +502,13 @@ export const loadingDot = style({
   borderRadius: '50%',
   background: 'currentcolor',
   selectors: {
-    ['&:not(:last-child)']: {
+    '&:not(:last-child)': {
       marginRight: 10,
     },
-    ['&:nth-child(2)']: {
+    '&:nth-child(2)': {
       animationDelay: '0.4s',
     },
-    ['&:nth-child(3)']: {
+    '&:nth-child(3)': {
       animationDelay: '0.8s',
     },
     [`${loadingCircle} &:nth-child(2), ${loadingCircle} &:nth-child(3)`]: {

--- a/libs/island-ui/core/src/lib/DatePicker/DatePicker.tsx
+++ b/libs/island-ui/core/src/lib/DatePicker/DatePicker.tsx
@@ -204,7 +204,7 @@ const CustomHeader = ({
     if (locale.localize) {
       return locale.localize.month(i)
     }
-    return
+    return undefined
   })
   return (
     <div className={styles.customHeaderContainer}>

--- a/libs/island-ui/core/src/lib/Grid/GridRow/GridRow.treat.ts
+++ b/libs/island-ui/core/src/lib/Grid/GridRow/GridRow.treat.ts
@@ -1,4 +1,4 @@
-import { style, styleMap } from 'treat'
+import { style } from 'treat'
 import { theme } from '@island.is/island-ui/theme'
 
 export const gridRow = style({

--- a/libs/island-ui/core/src/lib/Header/Header.treat.ts
+++ b/libs/island-ui/core/src/lib/Header/Header.treat.ts
@@ -1,5 +1,4 @@
 import { style } from 'treat'
-import { theme } from '@island.is/island-ui/theme'
 import { responsiveStyleMap } from '../../utils/responsiveStyleMap'
 
 export const container = responsiveStyleMap({

--- a/libs/island-ui/core/src/lib/InputFileUpload/InputFileUpload.tsx
+++ b/libs/island-ui/core/src/lib/InputFileUpload/InputFileUpload.tsx
@@ -130,7 +130,7 @@ export interface InputFileUploadProps {
   multiple?: boolean
   fileList: UploadFile[]
   maxSize?: number
-  onRemove: (file: any) => void
+  onRemove: (file: UploadFile) => void
   onChange?: (files: File[]) => void
   errorMessage?: string
 }

--- a/libs/island-ui/core/src/lib/NewsletterSignup/NewsletterSignup.tsx
+++ b/libs/island-ui/core/src/lib/NewsletterSignup/NewsletterSignup.tsx
@@ -19,8 +19,10 @@ interface Props {
   variant?: ColorVariant
   state?: State
   errorMessage?: string
-  onChange: (event: React.ChangeEvent<any>) => void
-  onSubmit: (event: React.FormEvent<any>) => void
+  onChange: (
+    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => void
+  onSubmit: (event: React.FormEvent<unknown>) => void
   value: string
 }
 

--- a/libs/island-ui/core/src/lib/ProfileCard/ProfileCard.treat.ts
+++ b/libs/island-ui/core/src/lib/ProfileCard/ProfileCard.treat.ts
@@ -1,5 +1,4 @@
 import { style } from 'treat'
-import { theme } from '@island.is/island-ui/theme'
 
 export const image = style({
   paddingTop: '69.18238994%',

--- a/libs/island-ui/core/src/lib/Select/Select.tsx
+++ b/libs/island-ui/core/src/lib/Select/Select.tsx
@@ -18,7 +18,6 @@ import cn from 'classnames'
 import * as styles from './Select.treat'
 import { Icon } from '../IconRC/Icon'
 import { InputBackgroundColor } from '../Input/Input'
-import { Box } from '../Box/Box'
 
 export type Option = {
   label: string

--- a/libs/island-ui/core/src/lib/Swiper/Swiper.treat.ts
+++ b/libs/island-ui/core/src/lib/Swiper/Swiper.treat.ts
@@ -35,7 +35,7 @@ export const slide = style({
   marginBottom: theme.spacing[2],
   selectors: {
     // First and last slides fake the horizontal grid margin
-    ['&:last-child::after']: {
+    '&:last-child::after': {
       content: "''",
       display: 'block',
       flex: 'none',

--- a/libs/island-ui/core/src/lib/Toast/Toast.treat.ts
+++ b/libs/island-ui/core/src/lib/Toast/Toast.treat.ts
@@ -1,4 +1,4 @@
-import { style, styleMap, globalStyle } from 'treat'
+import { style, globalStyle } from 'treat'
 import { theme } from '@island.is/island-ui/theme'
 
 export const root = style({

--- a/libs/island-ui/core/tsconfig.json
+++ b/libs/island-ui/core/tsconfig.json
@@ -5,8 +5,7 @@
     "allowJs": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "types": ["node", "jest"],
-    "strict": false
+    "types": ["node", "jest"]
   },
   "files": [],
   "include": [],

--- a/libs/island-ui/core/tsconfig.lib.json
+++ b/libs/island-ui/core/tsconfig.lib.json
@@ -8,6 +8,8 @@
     "**/*.spec.ts",
     "**/*.spec.tsx",
     "**/*.stories.ts",
+    "**/*.stories.tsx",
+    "**/*.stories.mdx",
     "**/*.stories.js"
   ],
   "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"],


### PR DESCRIPTION
# \<Description\>

Remove "strict": false from tsconfig in island-ui core. Fix some of the warnings, still multiple left that can be fixed later.
## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
