### PR TITLE
Skilavottord / Fix error handling in deregister vehicle

### DIFF
--- a/apps/skilavottord/web/screens/DeregisterVehicle/Confirm/Confirm.tsx
+++ b/apps/skilavottord/web/screens/DeregisterVehicle/Confirm/Confirm.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext } from 'react'
+import React, { FC, useContext, useEffect } from 'react'
 import { useMutation, useQuery } from '@apollo/client'
 import { useRouter } from 'next/router'
 import {
@@ -45,15 +45,20 @@ const Confirm: FC = () => {
 
   const [
     setRecyclingRequest,
-    { error: mutationError, loading: mutationLoading },
+    { data: mutationData, error: mutationError, loading: mutationLoading },
   ] = useMutation(CREATE_RECYCLING_REQUEST_COMPANY, {
-    onCompleted() {
-      router.replace(routes.baseRoute).then(() => toast.success(t.success))
-    },
     onError() {
       return mutationError
     },
   })
+
+  const mutationResponse = mutationData?.createSkilavottordRecyclingRequest
+
+  useEffect(() => {
+    if (mutationResponse?.status) {
+      router.replace(routes.baseRoute).then(() => toast.success(t.success))
+    }
+  }, [mutationResponse])
 
   const partnerId = user?.partnerId
 
@@ -77,7 +82,7 @@ const Confirm: FC = () => {
     return <NotFound />
   }
 
-  if (mutationError || mutationLoading) {
+  if (mutationError || mutationLoading || mutationResponse?.message) {
     return (
       <ProcessPageLayout sectionType={'company'} activeSection={1}>
         {mutationLoading ? (


### PR DESCRIPTION
# Skilavottord -  Fix error handling in deregister vehicle after endpoint was changed

## What

- Because the error from backend is returned differently, this fix will catch the error accordingly

## Why

- With this fix the app will be able to catch the error, otherwise it will pass as successful in the UI

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
