### PR TITLE
Judicial-system/Fix lint warning

### DIFF
--- a/apps/judicial-system/web/src/utils/utils.spec.ts
+++ b/apps/judicial-system/web/src/utils/utils.spec.ts
@@ -221,6 +221,17 @@ describe('Validation', () => {
       expect(validation.isValid).toEqual(true)
     })
 
+    test('should be valid if email contains - and . characters', () => {
+      // Arrange
+      const validEmail = 'garfield.lasagne-lover@garfield.io'
+
+      // Act
+      const validation = validate('', 'email-format')
+
+      // Assert
+      expect(validation.isValid).toEqual(true)
+    })
+
     test('should be valid if email is valid', () => {
       // Arrange
       const validEmail = 'garfield@garfield.io'

--- a/apps/judicial-system/web/src/utils/validate.ts
+++ b/apps/judicial-system/web/src/utils/validate.ts
@@ -46,7 +46,7 @@ export const getRegexByValidation = (validation: Validation) => {
       }
     case 'email-format':
       return {
-        regex: new RegExp(/^$|^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/g),
+        regex: new RegExp(/^$|^[\w-.]+@([\w-]+\.)+[\w-]{2,4}$/g),
         errorMessage: 'Netfang ekki á réttu formi',
       }
   }


### PR DESCRIPTION
# Remove unneccesary escape character

## What

The email-format regex had a unnecessary escape character that caused a lint warning. I'm removing it.

## Why

Dev experience

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
