### PR TITLE
Skilavottord - Fix tablet view on action card

### DIFF
--- a/apps/skilavottord/web/screens/Confirm/Confirm.tsx
+++ b/apps/skilavottord/web/screens/Confirm/Confirm.tsx
@@ -22,7 +22,7 @@ import { ACCEPTED_TERMS_AND_CONDITION } from '@island.is/skilavottord-web/utils/
 const Confirm = ({ apolloState }) => {
   const { user } = useContext(UserContext)
   const [checkbox, setCheckbox] = useState(false)
-  const [isMobile, setIsMobile] = useState(false)
+  const [isTablet, setIsTablet] = useState(false)
   const { width } = useWindowSize()
 
   const {
@@ -44,9 +44,9 @@ const Confirm = ({ apolloState }) => {
 
   useEffect(() => {
     if (width < theme.breakpoints.lg) {
-      return setIsMobile(true)
+      return setIsTablet(true)
     }
-    setIsMobile(false)
+    setIsTablet(false)
   }, [width])
 
   const [setVehicle] = useMutation(CREATE_VEHICLE)
@@ -127,7 +127,7 @@ const Confirm = ({ apolloState }) => {
               display="inlineFlex"
               justifyContent="spaceBetween"
             >
-              {isMobile ? (
+              {isTablet ? (
                 <Button
                   variant="ghost"
                   onClick={onCancel}

--- a/apps/skilavottord/web/screens/Overview/components/ActionCard/ActionCard.tsx
+++ b/apps/skilavottord/web/screens/Overview/components/ActionCard/ActionCard.tsx
@@ -30,7 +30,7 @@ export const ActionCard: FC<ActionCardProps> = ({
   } = useI18n()
 
   const { width } = useWindowSize()
-  const isMobile = width < theme.breakpoints.md
+  const isTablet = width < theme.breakpoints.lg
 
   const toolTipText = (
     <>
@@ -46,9 +46,9 @@ export const ActionCard: FC<ActionCardProps> = ({
     <OutlinedBox backgroundColor="white">
       <GridContainer>
         <GridRow>
-          <GridColumn span={['10/10', '10/10', '6/10', '7/10']}>
+          <GridColumn span={['10/10', '10/10', '10/10', '7/10']}>
             <GridRow>
-              <GridColumn span={['6/10', '8/10', '8/10', '7/10']}>
+              <GridColumn span={['6/10', '7/10', '7/10', '7/10']}>
                 <Box paddingLeft={4} paddingY={4}>
                   <Stack space={1}>
                     <Text variant="h3">{permno}</Text>
@@ -56,7 +56,7 @@ export const ActionCard: FC<ActionCardProps> = ({
                   </Stack>
                 </Box>
               </GridColumn>
-              <GridColumn span={['4/10', '2/10', '2/10', '3/10']}>
+              <GridColumn span={['4/10', '3/10', '3/10', '3/10']}>
                 {hasCoOwner && (
                   <ColumnBox width="full" paddingRight={[4, 4, 4, 1]}>
                     <Text variant="h5">{t.status.coOwned}</Text>
@@ -65,7 +65,7 @@ export const ActionCard: FC<ActionCardProps> = ({
               </GridColumn>
             </GridRow>
           </GridColumn>
-          <GridColumn span={['10/10', '10/10', '4/10', '3/10']}>
+          <GridColumn span={['10/10', '10/10', '10/10', '3/10']}>
             {isRecyclable ? (
               <ColumnBox
                 background="blue100"
@@ -75,15 +75,15 @@ export const ActionCard: FC<ActionCardProps> = ({
                 paddingX={4}
                 paddingY={4}
               >
-                <Button onClick={onContinue} fluid={isMobile}>
+                <Button onClick={onContinue} fluid={isTablet}>
                   {t.actions.valid}
                 </Button>
               </ColumnBox>
             ) : (
               <ColumnBox
                 borderColor="blue200"
-                borderTopWidth={isMobile ? 'standard' : 'none'}
-                borderLeftWidth={isMobile ? 'none' : 'standard'}
+                borderTopWidth={isTablet ? 'standard' : 'none'}
+                borderLeftWidth={isTablet ? 'none' : 'standard'}
                 borderStyle="solid"
                 borderRadius="large"
                 padding={4}


### PR DESCRIPTION
# Skilavottord - Fix tablet view on action card if cars has coowner

## What

This fixes the displaying of a car being co-owned to look better in tablet view and smaller browser windows.

## Why

This fixes an issue that squeezed the text between button and car registration number

## Screenshots / Gifs

Result:
![Screenshot 2020-11-16 at 12 26 47](https://user-images.githubusercontent.com/64913954/99247263-0218e480-2807-11eb-8c78-7f729f7d3e71.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
