### PR TITLE
Website/ Frontpage illustration tweaks

### DIFF
--- a/apps/web/components/FrontpageTabs/FrontpageTabs.tsx
+++ b/apps/web/components/FrontpageTabs/FrontpageTabs.tsx
@@ -79,7 +79,6 @@ export const FrontpageTabs: FC<FrontpageTabsProps> = ({
 
   const { activeLocale, t } = useI18n()
   const { makePath } = routeNames(activeLocale as Locale)
-  const { width } = useWindowSize()
 
   const nextSlide = useCallback(() => {
     tab.next()
@@ -122,6 +121,8 @@ export const FrontpageTabs: FC<FrontpageTabsProps> = ({
       return { href: null, as: null }
     }
   }
+
+  const { width } = useWindowSize()
 
   const onResize = useCallback(() => {
     setMinHeight(0)
@@ -206,7 +207,7 @@ export const FrontpageTabs: FC<FrontpageTabsProps> = ({
                     })}
                   >
                     <Box
-                      paddingY={3}
+                      marginY={3}
                       ref={(el) => (itemRefs.current[index] = el)}
                       style={{ minHeight: `${minHeight}px` }}
                     >
@@ -321,8 +322,8 @@ export const FrontpageTabs: FC<FrontpageTabsProps> = ({
           <Box
             display="flex"
             flexDirection="column"
-            justifyContent="center"
             height="full"
+            justifyContent="center"
           >
             <Illustration illustrationIndex={selectedIndex} />
           </Box>

--- a/apps/web/components/FrontpageTabs/FrontpageTabs.tsx
+++ b/apps/web/components/FrontpageTabs/FrontpageTabs.tsx
@@ -164,7 +164,7 @@ export const FrontpageTabs: FC<FrontpageTabsProps> = ({
       <GridRow className={styles.tabPanelRow}>
         <GridColumn hiddenBelow="lg" span="1/12" />
         <GridColumn
-          span={['12/12', '12/12', '12/12', '6/12']}
+          span={['12/12', '12/12', '7/12', '6/12']}
           position="static"
         >
           <Box ref={contentRef}>
@@ -318,7 +318,7 @@ export const FrontpageTabs: FC<FrontpageTabsProps> = ({
             {searchContent}
           </Box>
         </GridColumn>
-        <GridColumn hiddenBelow="lg" span={['0', '0', '0', '4/12']}>
+        <GridColumn hiddenBelow="md" span={['0', '0', '5/12', '4/12']}>
           <Box
             display="flex"
             flexDirection="column"

--- a/apps/web/components/FrontpageTabs/FrontpageTabs.tsx
+++ b/apps/web/components/FrontpageTabs/FrontpageTabs.tsx
@@ -79,6 +79,7 @@ export const FrontpageTabs: FC<FrontpageTabsProps> = ({
 
   const { activeLocale, t } = useI18n()
   const { makePath } = routeNames(activeLocale as Locale)
+  const { width } = useWindowSize()
 
   const nextSlide = useCallback(() => {
     tab.next()
@@ -122,8 +123,6 @@ export const FrontpageTabs: FC<FrontpageTabsProps> = ({
     }
   }
 
-  const { width } = useWindowSize()
-
   const onResize = useCallback(() => {
     setMinHeight(0)
     let height = 0
@@ -163,10 +162,7 @@ export const FrontpageTabs: FC<FrontpageTabsProps> = ({
     <GridContainer>
       <GridRow className={styles.tabPanelRow}>
         <GridColumn hiddenBelow="lg" span="1/12" />
-        <GridColumn
-          span={['12/12', '12/12', '7/12', '6/12']}
-          position="static"
-        >
+        <GridColumn span={['12/12', '12/12', '7/12', '6/12']} position="static">
           <Box ref={contentRef}>
             <TabList
               {...tab}

--- a/apps/web/components/FrontpageTabs/illustrations/Illustration.tsx
+++ b/apps/web/components/FrontpageTabs/illustrations/Illustration.tsx
@@ -25,6 +25,8 @@ const Illustration: React.FC<IllustrationProps> = ({
   }
 
   const SelectedIllustration = illustrations[illustrationIndex]
+  const NextIllustration =
+    illustrations[(illustrationIndex + 1) % illustrations.length]
 
   if (!SelectedIllustration) {
     return null
@@ -413,6 +415,9 @@ const Illustration: React.FC<IllustrationProps> = ({
         <circle cx="383.5" cy="530.243" r="2"></circle>
       </g>
       <SelectedIllustration />
+      <g style={{ display: 'none' }}>
+        <NextIllustration />
+      </g>
     </svg>
   )
 }


### PR DESCRIPTION
# Frontpage illustration tweaks

## What
- Change slide content's spacing from padding to margin since it was causing the wrong height to be reported.
- Preload one extra illustration to remove flicker.
- Display the illustrations on `md` breakpoint as well.

## Why

-

## Screenshots / Gifs

-

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
