### PR TITLE
Change filters on covid page

### DIFF
--- a/apps/web/components/Adgerdir/AdgerdirArticles/AdgerdirArticles.tsx
+++ b/apps/web/components/Adgerdir/AdgerdirArticles/AdgerdirArticles.tsx
@@ -6,6 +6,7 @@ import React, {
   useEffect,
   useRef,
 } from 'react'
+import uniq from 'lodash/uniq'
 import intersection from 'lodash/intersection'
 import {
   Box,
@@ -61,6 +62,9 @@ export const AdgerdirArticles: FC<AdgerdirArticlesProps> = ({
   const { isOpen: sleeveIsOpen, setIsOpen } = useContext(SleeveContext)
   const { makePath } = routeNames(activeLocale)
   const [filterString, setFilterString] = useState<string>('')
+  const [usableFilters, setUsableFilters] = useState<Array<AdgerdirTag['id']>>(
+    [],
+  )
   const [startingItems, setstartingItems] = useState<Array<AdgerdirPage>>(
     items.filter((x) => startingIds.includes(x.id)),
   )
@@ -76,6 +80,20 @@ export const AdgerdirArticles: FC<AdgerdirArticlesProps> = ({
   const timerRef = useRef(null)
 
   const visibleItems = startingItems.length ? startingItems : items
+
+  useEffect(() => {
+    setUsableFilters(
+      items.reduce((all, cur) => {
+        const ids = cur.tags.map((x) => x.id)
+
+        if (ids.length) {
+          return uniq(ids.concat(all))
+        }
+
+        return all
+      }, []),
+    )
+  }, [])
 
   const handleChange = (e) => {
     e.preventDefault()
@@ -100,7 +118,9 @@ export const AdgerdirArticles: FC<AdgerdirArticlesProps> = ({
     const arr = []
 
     visibleItems.forEach(({ tags }, index) => {
-      if (tags.some(({ id }) => tagIds.includes(id as string))) {
+      const ids = tags.map((x) => x.id)
+
+      if (tagIds.every((id) => ids.includes(id))) {
         arr.push(index)
       }
     })
@@ -150,9 +170,7 @@ export const AdgerdirArticles: FC<AdgerdirArticlesProps> = ({
   }, [onUpdateFilters])
 
   const filteredItems = visibleItems.filter((_, index) => {
-    const indexList = [indexesFilteredByTag, indexesFilteredByString].filter(
-      (x) => x.length > 0,
-    )
+    const indexList = [indexesFilteredByTag, indexesFilteredByString]
 
     return intersection(...indexList).includes(index)
   })
@@ -213,7 +231,10 @@ export const AdgerdirArticles: FC<AdgerdirArticlesProps> = ({
           <Stack space={2}>
             <Inline space={2} alignY="center">
               {tags
-                .filter(({ id }) => !DIVIDER_FILTERS.includes(id))
+                .filter(
+                  ({ id }) =>
+                    !DIVIDER_FILTERS.includes(id) && usableFilters.includes(id),
+                )
                 .map(({ title, id }, index) => {
                   return (
                     <Tag


### PR DESCRIPTION
- Selected filters now narrow cards down better.
- Filters that aren't used on any page are now hidden.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
