### PR TITLE
fix: add skilavorttord-backend inside nx/workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -341,6 +341,9 @@
     "shared-types": {
       "tags": []
     },
+    "skilavottord-backend": {
+      "tags": []
+    },
     "skilavottord-consts": {
       "tags": []
     },

--- a/workspace.json
+++ b/workspace.json
@@ -4145,6 +4145,61 @@
         }
       }
     },
+    "skilavottord-backend": {
+      "root": "apps/skilavottord/backend",
+      "sourceRoot": "apps/skilavottord/backend/src",
+      "projectType": "application",
+      "prefix": "skilavottord-backend",
+      "schematics": {},
+      "architect": {
+        "build": {
+          "builder": "@nrwl/node:build",
+          "options": {
+            "outputPath": "dist/apps/skilavottord/backend",
+            "main": "apps/skilavottord/backend/src/main.ts",
+            "tsConfig": "apps/skilavottord/backend/tsconfig.app.json",
+            "assets": ["apps/skilavottord/backend/src/assets"]
+          },
+          "configurations": {
+            "production": {
+              "optimization": true,
+              "extractLicenses": true,
+              "inspect": false,
+              "fileReplacements": [
+                {
+                  "replace": "apps/skilavottord/backend/src/environments/environment.ts",
+                  "with": "apps/skilavottord/backend/src/environments/environment.prod.ts"
+                }
+              ]
+            }
+          }
+        },
+        "serve": {
+          "builder": "@nrwl/node:execute",
+          "options": {
+            "buildTarget": "skilavottord-backend:build"
+          }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "apps/skilavottord/backend/tsconfig.app.json",
+              "apps/skilavottord/backend/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**", "!apps/skilavottord/backend/**/*"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "apps/skilavottord/backend/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
     "skilavottord-consts": {
       "root": "libs/skilavottord/consts",
       "sourceRoot": "libs/skilavottord/consts/src",


### PR DESCRIPTION
## What

- skilavottord was missing from nx/workspace files and was failing when running workspace-lint command

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
