### PR TITLE
island-ui / datepicker remove default padding from ios

### DIFF
--- a/libs/island-ui/core/src/lib/DatePicker/DatePicker.treat.ts
+++ b/libs/island-ui/core/src/lib/DatePicker/DatePicker.treat.ts
@@ -104,7 +104,8 @@ export const headerSelect = style({
   appearance: 'none',
   fontSize: 18,
   fontWeight: 600,
-  background: theme.color.transparent,
+  backgroundColor: theme.color.transparent,
+  padding: 0,
   ...themeUtils.responsiveStyle({
     md: {
       fontSize: 20,


### PR DESCRIPTION
# Remove default padding

ios adds padding to select which causes the text to overflow

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
