### PR TITLE
Judicial System: Improves typescript declaration for entropy class

### DIFF
--- a/apps/judicial-system/api/src/types/entropy-string.d.ts
+++ b/apps/judicial-system/api/src/types/entropy-string.d.ts
@@ -1,3 +1,6 @@
 declare module 'entropy-string' {
-  export const Entropy
+  export class Entropy {
+    constructor({ bits: number })
+    string: () => string
+  }
 }

--- a/apps/judicial-system/api/tsconfig.json
+++ b/apps/judicial-system/api/tsconfig.json
@@ -4,7 +4,7 @@
     "types": ["node", "jest"],
     "emitDecoratorMetadata": true,
     "target": "es2015",
-    "strict": false
+    "strict": true
   },
   "allowJs": true,
   "files": [],


### PR DESCRIPTION
# Improved Typescript Declaration File for Entropy Class

## What

Extends the typescript declaration for Entropy Class to get rid of "any" inference.

## Why

Without this, building GraphQL schemas for the judicial system api fails.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
