### PR TITLE
Judicial-system/Choose 15th instead of tomorrow in stepone test

### DIFF
--- a/apps/judicial-system/web/src/routes/Prosecutor/CreateDetentionRequest/StepOne/StepOne.spec.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/CreateDetentionRequest/StepOne/StepOne.spec.tsx
@@ -238,11 +238,7 @@ describe('/krafa without ID', () => {
   test('should not allow users to continue unless every required field has been filled out', async () => {
     // Arrange
     const now = new Date()
-    const arrestDate = new Date(
-      now.getFullYear(),
-      now.getMonth(),
-      now.getDate() + 1,
-    )
+    const arrestDate = new Date(now.getFullYear(), now.getMonth(), 15)
     arrestDate.setHours(17, 0, 0)
     const lastDateOfTheMonth = new Date(
       now.getFullYear(),
@@ -394,9 +390,7 @@ describe('/krafa without ID', () => {
 
     userEvent.click(arrestedDatePicker[0])
 
-    userEvent.click(
-      arrestedWrapper.getAllByText((now.getDate() + 1).toString())[0],
-    )
+    userEvent.click(arrestedWrapper.getAllByText('15')[0])
 
     const hearingWrapper = within(datePickerWrappers[1])
 


### PR DESCRIPTION
# Choose 15th instead of tomorrow in step one of prosecutor flow test 

https://islandis.slack.com/archives/C01BQD2F1AP/p1606299160058700

## What

See ☝️

## Why

Tomorrow is November 26th. Since the datepicker shows the trail of last month the number 26 appears twice in the date picker. We were choosing tomorrow in this test and it chose the "wrong" 26, i.e. October 26th instead of November 26th 🙈 The 15th will never appear twice in the date picker.

## Screenshots / Gifs

![Screen Shot 2020-11-25 at 11 04 35](https://user-images.githubusercontent.com/3789875/100219735-4181b800-2f0e-11eb-8ad1-344f04d663bf.png)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
