### PR TITLE
updating the method used to create ids for services

### DIFF
--- a/libs/api-catalogue/services/src/lib/restmetadata.service.ts
+++ b/libs/api-catalogue/services/src/lib/restmetadata.service.ts
@@ -219,6 +219,6 @@ export class RestMetadataService {
       .toString('base64')
       .replace(/\+/g, '-')
       .replace(/\//g, '_')
-      .replace(/\=+$/, '')
+      .replace(/=+$/, '')
   }
 }

--- a/libs/api-catalogue/services/src/lib/restmetadata.service.ts
+++ b/libs/api-catalogue/services/src/lib/restmetadata.service.ts
@@ -18,7 +18,6 @@ import {
   TypeCategory,
 } from '@island.is/api-catalogue/consts'
 import { serviceIdSort, exceptionHandler } from './utils'
-import { uuid } from 'uuidv4'
 
 @Injectable()
 export class RestMetadataService {
@@ -36,9 +35,10 @@ export class RestMetadataService {
 
     for (const [_, value] of serviceMap) {
       const sorted = value.sort(serviceIdSort)
+      const serviceId = this.createServiceId(sorted[0])
 
       const service: Service = {
-        id: uuid().split('-').join(''),
+        id: serviceId,
         name: '',
         owner: '',
         description: '',
@@ -204,5 +204,18 @@ export class RestMetadataService {
     }
 
     return true
+  }
+
+
+   /**
+   * Creates a single service id for the service based on the service code and X-Road info.
+   * @param xroadIdentifier
+   */
+  private createServiceId(xroadIdentifier: XroadIdentifier): string {
+      const serviceCode = xroadIdentifier.serviceCode?.split('-')[0]
+      const serviceId = `${xroadIdentifier.instance}_${xroadIdentifier.memberClass}_${xroadIdentifier.memberCode}_${xroadIdentifier.subsystemCode}_${serviceCode}`
+      
+      //Remove tokens that interrupt URLs
+      return Buffer.from(serviceId).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/\=+$/, '')
   }
 }

--- a/libs/api-catalogue/services/src/lib/restmetadata.service.ts
+++ b/libs/api-catalogue/services/src/lib/restmetadata.service.ts
@@ -206,16 +206,19 @@ export class RestMetadataService {
     return true
   }
 
-
-   /**
+  /**
    * Creates a single service id for the service based on the service code and X-Road info.
    * @param xroadIdentifier
    */
   private createServiceId(xroadIdentifier: XroadIdentifier): string {
-      const serviceCode = xroadIdentifier.serviceCode?.split('-')[0]
-      const serviceId = `${xroadIdentifier.instance}_${xroadIdentifier.memberClass}_${xroadIdentifier.memberCode}_${xroadIdentifier.subsystemCode}_${serviceCode}`
-      
-      //Remove tokens that interrupt URLs
-      return Buffer.from(serviceId).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/\=+$/, '')
+    const serviceCode = xroadIdentifier.serviceCode?.split('-')[0]
+    const serviceId = `${xroadIdentifier.instance}_${xroadIdentifier.memberClass}_${xroadIdentifier.memberCode}_${xroadIdentifier.subsystemCode}_${serviceCode}`
+
+    //Remove tokens that interrupt URLs
+    return Buffer.from(serviceId)
+      .toString('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/\=+$/, '')
   }
 }


### PR DESCRIPTION
Updating the way we create IDs for services from xroad, so the URLs stay the same after night schedule run

## What

Create a single reusable id for each service

## Why

So that URLs can be reused

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
