### PR TITLE
Fix modal dialog margins

### DIFF
--- a/libs/island-ui/core/src/lib/DialogPrompt/DialogPrompt.treat.ts
+++ b/libs/island-ui/core/src/lib/DialogPrompt/DialogPrompt.treat.ts
@@ -1,7 +1,7 @@
 import { style } from 'treat'
 import { theme } from '@island.is/island-ui/theme'
 
-const spacing = theme.spacing[3]
+const spacing = theme.spacing[2]
 
 export const content = style({
   filter: `drop-shadow(0 4px 70px rgba(0, 97, 255, 0.1))`,

--- a/libs/island-ui/core/src/lib/DialogPrompt/DialogPrompt.tsx
+++ b/libs/island-ui/core/src/lib/DialogPrompt/DialogPrompt.tsx
@@ -84,9 +84,8 @@ export const DialogPrompt = ({
         return (
           <Box
             position="relative"
-            width="full"
             marginX={3}
-            paddingX={[3, 4, 4, 8]}
+            paddingX={[1, 4, 4, 8]}
             paddingY={[6, 6, 6, 12]}
             borderRadius="large"
             background="white"


### PR DESCRIPTION
# Fix mobile dialog margins

In mobile the dialog looked like it was escaping the screen to the right
(see screenshots below)

## Screenshots / Gifs
Before:
![image](https://user-images.githubusercontent.com/70899104/100259480-2891fa80-2f40-11eb-84b6-784e4664d1ca.png)

After:
![image](https://user-images.githubusercontent.com/70899104/100259403-144dfd80-2f40-11eb-94e3-b7de864d251f.png)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
