### PR TITLE
Update providers to include the org name from xroad

### DIFF
--- a/libs/api-catalogue/services/src/lib/provider.service.spec.ts
+++ b/libs/api-catalogue/services/src/lib/provider.service.spec.ts
@@ -127,6 +127,7 @@ describe('ProviderService', () => {
       expect(providers).toEqual([
         {
           type: 'private',
+          name: 'VMST',
           xroadInfo: {
             instance: 'IS-DEV',
             memberClass: 'GOV',
@@ -144,6 +145,7 @@ describe('ProviderService', () => {
       expect(providers).toEqual([
         {
           type: 'protected',
+          name: 'VMST',
           xroadInfo: {
             instance: 'IS-DEV',
             memberClass: 'GOV',
@@ -153,6 +155,7 @@ describe('ProviderService', () => {
         },
         {
           type: 'protected',
+          name: 'SKRA',
           xroadInfo: {
             instance: 'IS-DEV',
             memberClass: 'GOV',
@@ -170,6 +173,7 @@ describe('ProviderService', () => {
       expect(providers).toEqual([
         {
           type: 'public',
+          name: 'VMST',
           xroadInfo: {
             instance: 'IS-DEV',
             memberClass: 'GOV',
@@ -179,6 +183,7 @@ describe('ProviderService', () => {
         },
         {
           type: 'public',
+          name: 'SKRA',
           xroadInfo: {
             instance: 'IS-DEV',
             memberClass: 'GOV',

--- a/libs/api-catalogue/services/src/lib/provider.service.ts
+++ b/libs/api-catalogue/services/src/lib/provider.service.ts
@@ -46,7 +46,7 @@ export class ProviderService {
           (item: XroadIdentifier): Provider => {
             return {
               type: providerType,
-              name: item.name ?? '',
+              name: item.name ?? item.id?.subsystemCode!,
               xroadInfo: {
                 instance: item.id?.xroadInstance ?? '',
                 memberClass: item.id?.memberClass ?? '',

--- a/libs/api-catalogue/services/src/lib/provider.service.ts
+++ b/libs/api-catalogue/services/src/lib/provider.service.ts
@@ -46,6 +46,7 @@ export class ProviderService {
           (item: XroadIdentifier): Provider => {
             return {
               type: providerType,
+              name: item.name ?? '',
               xroadInfo: {
                 instance: item.id?.xroadInstance ?? '',
                 memberClass: item.id?.memberClass ?? '',

--- a/libs/api-catalogue/services/src/lib/provider.service.ts
+++ b/libs/api-catalogue/services/src/lib/provider.service.ts
@@ -46,7 +46,7 @@ export class ProviderService {
           (item: XroadIdentifier): Provider => {
             return {
               type: providerType,
-              name: item.name ?? item.id?.subsystemCode!,
+              name: item.name ?? item.id!.subsystemCode!,
               xroadInfo: {
                 instance: item.id?.xroadInstance ?? '',
                 memberClass: item.id?.memberClass ?? '',

--- a/libs/api-catalogue/services/src/lib/restmetadata.service.ts
+++ b/libs/api-catalogue/services/src/lib/restmetadata.service.ts
@@ -61,8 +61,9 @@ export class RestMetadataService {
           // The list is sorted for the latest service version to be the last element
           // so name, owner and description will be from the latest version.
           service.name = spec.info.title
-          service.owner =
-            spec.info.contact?.name || provider.xroadInfo.subsystemCode // ToDo: Maybe update to use provider.memberCode to look up the name
+          service.owner = provider.name
+            ? provider.name
+            : provider.xroadInfo.subsystemCode
           service.description = spec.info.description ?? ''
           service.data = union(service.data, spec.info['x-category'])
           service.pricing = union(service.pricing, spec.info['x-pricing'])

--- a/libs/api-catalogue/services/src/lib/restmetadata.service.ts
+++ b/libs/api-catalogue/services/src/lib/restmetadata.service.ts
@@ -62,8 +62,6 @@ export class RestMetadataService {
           // so name, owner and description will be from the latest version.
           service.name = spec.info.title
           service.owner = provider.name
-            ? provider.name
-            : provider.xroadInfo.subsystemCode
           service.description = spec.info.description ?? ''
           service.data = union(service.data, spec.info['x-category'])
           service.pricing = union(service.pricing, spec.info['x-pricing'])

--- a/libs/api-catalogue/types/src/lib/provider.model.ts
+++ b/libs/api-catalogue/types/src/lib/provider.model.ts
@@ -3,6 +3,7 @@ import { XroadIdentifier } from './xroadIdentifier.model'
 
 export interface Provider {
   type: ProviderType
+  name: string
   xroadInfo: XroadIdentifier
 }
 


### PR DESCRIPTION
## What

Updating the service registration to use the org name available from x-road

## Why

So that the org name is tied to x-road and prevent users from setting multiple org names by accident

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
