### PR TITLE
Judicial-system/Handle undefined values in police demands

### DIFF
--- a/apps/judicial-system/web/src/routes/Judge/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Judge/Overview/Overview.tsx
@@ -14,7 +14,10 @@ import {
   formatNationalId,
   formatGender,
 } from '@island.is/judicial-system/formatters'
-import { isNextDisabled } from '../../../utils/stepHelper'
+import {
+  constructProsecutorDemands,
+  isNextDisabled,
+} from '../../../utils/stepHelper'
 import { FormFooter } from '../../../shared-components/FormFooter'
 import { useParams } from 'react-router-dom'
 import { validate } from '../../../utils/validate'
@@ -24,7 +27,6 @@ import {
   Case,
   CaseCustodyProvisions,
   UpdateCase,
-  CaseCustodyRestrictions,
 } from '@island.is/judicial-system/types'
 import {
   parseString,
@@ -257,41 +259,7 @@ export const JudgeOverview: React.FC = () => {
                 startExpanded
                 labelVariant="h3"
               >
-                <Text>
-                  Þess er krafist að
-                  <Text as="span" fontWeight="semiBold">
-                    {` ${workingCase.accusedName}
-                    ${formatNationalId(workingCase.accusedNationalId)}`}
-                  </Text>
-                  , verði með úrskurði Héraðsdóms Reykjavíkur gert að sæta
-                  gæsluvarðhaldi til
-                  <Text as="span" fontWeight="semiBold">
-                    {` ${formatDate(
-                      workingCase.requestedCustodyEndDate,
-                      'EEEE',
-                    )?.replace('dagur', 'dagsins')}
-                    ${formatDate(
-                      workingCase.requestedCustodyEndDate,
-                      'PPP',
-                    )},  kl. ${formatDate(
-                      workingCase.requestedCustodyEndDate,
-                      TIME_FORMAT,
-                    )}`}
-                  </Text>
-                  {workingCase.requestedCustodyRestrictions?.includes(
-                    CaseCustodyRestrictions.ISOLATION,
-                  ) ? (
-                    <>
-                      , og verði gert að{' '}
-                      <Text as="span" fontWeight="semiBold">
-                        sæta einangrun
-                      </Text>{' '}
-                      meðan á gæsluvarðhaldinu stendur.
-                    </>
-                  ) : (
-                    '.'
-                  )}
-                </Text>
+                {constructProsecutorDemands(workingCase)}
               </AccordionItem>
               <AccordionItem
                 id="id_2"

--- a/apps/judicial-system/web/src/routes/Prosecutor/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Overview/Overview.tsx
@@ -8,7 +8,6 @@ import {
   CaseTransition,
   NotificationType,
   TransitionCase,
-  CaseCustodyRestrictions,
   CaseState,
 } from '@island.is/judicial-system/types'
 
@@ -40,6 +39,7 @@ import {
   Sections,
 } from '@island.is/judicial-system-web/src/types'
 import { UserContext } from '@island.is/judicial-system-web/src/shared-components/UserProvider/UserProvider'
+import { constructProsecutorDemands } from '@island.is/judicial-system-web/src/utils/stepHelper'
 
 interface CaseData {
   case?: Case
@@ -261,41 +261,7 @@ export const Overview: React.FC = () => {
           <Box component="section" marginBottom={10}>
             <Accordion>
               <AccordionItem labelVariant="h3" id="id_1" label="Dómkröfur">
-                <Text>
-                  Þess er krafist að
-                  <Text as="span" fontWeight="semiBold">
-                    {` ${workingCase.accusedName}
-                    ${formatNationalId(workingCase.accusedNationalId)}`}
-                  </Text>
-                  , verði með úrskurði Héraðsdóms Reykjavíkur gert að sæta
-                  gæsluvarðhaldi til
-                  <Text as="span" fontWeight="semiBold">
-                    {` ${formatDate(
-                      workingCase.requestedCourtDate,
-                      'EEEE',
-                    )?.replace('dagur', 'dagsins')}
-                    ${formatDate(
-                      workingCase.requestedCustodyEndDate,
-                      'PPP',
-                    )},  kl. ${formatDate(
-                      workingCase.requestedCustodyEndDate,
-                      TIME_FORMAT,
-                    )}`}
-                  </Text>
-                  {workingCase.requestedCustodyRestrictions?.includes(
-                    CaseCustodyRestrictions.ISOLATION,
-                  ) ? (
-                    <>
-                      , og verði gert að{' '}
-                      <Text as="span" fontWeight="semiBold">
-                        sæta einangrun
-                      </Text>{' '}
-                      meðan á gæsluvarðhaldinu stendur.
-                    </>
-                  ) : (
-                    '.'
-                  )}
-                </Text>
+                {constructProsecutorDemands(workingCase)}
               </AccordionItem>
               <AccordionItem labelVariant="h3" id="id_2" label="Lagaákvæði">
                 <Box marginBottom={2}>

--- a/apps/judicial-system/web/src/shared-components/PoliceRequestAccordionItem/PoliceRequestAccordionItem.tsx
+++ b/apps/judicial-system/web/src/shared-components/PoliceRequestAccordionItem/PoliceRequestAccordionItem.tsx
@@ -6,10 +6,10 @@ import {
   capitalize,
   formatCustodyRestrictions,
   formatDate,
-  formatNationalId,
   TIME_FORMAT,
 } from '@island.is/judicial-system/formatters'
-import { Case, CaseCustodyRestrictions } from '@island.is/judicial-system/types'
+import { Case } from '@island.is/judicial-system/types'
+import { constructProsecutorDemands } from '../../utils/stepHelper'
 
 interface Props {
   workingCase: Case
@@ -52,41 +52,7 @@ const PoliceRequestAccordionItem: React.FC<Props> = ({
         )}`}
       </AccordionListItem>
       <AccordionListItem title="Dómkröfur">
-        <Text>
-          Þess er krafist að
-          <Text as="span" fontWeight="semiBold">
-            {` ${workingCase.accusedName}
-                    ${formatNationalId(workingCase.accusedNationalId)}`}
-          </Text>
-          , verði með úrskurði Héraðsdóms Reykjavíkur gert að sæta
-          gæsluvarðhaldi til
-          <Text as="span" fontWeight="semiBold">
-            {` ${formatDate(
-              workingCase.requestedCustodyEndDate,
-              'EEEE',
-            )?.replace('dagur', 'dagsins')}
-            ${formatDate(
-              workingCase.requestedCustodyEndDate,
-              'PPP',
-            )},  kl. ${formatDate(
-              workingCase.requestedCustodyEndDate,
-              TIME_FORMAT,
-            )}`}
-          </Text>
-          {workingCase.requestedCustodyRestrictions?.includes(
-            CaseCustodyRestrictions.ISOLATION,
-          ) ? (
-            <>
-              , og verði gert að{' '}
-              <Text as="span" fontWeight="semiBold">
-                sæta einangrun
-              </Text>{' '}
-              meðan á gæsluvarðhaldinu stendur.
-            </>
-          ) : (
-            '.'
-          )}
-        </Text>
+        {constructProsecutorDemands(workingCase)}
       </AccordionListItem>
       <AccordionListItem title="Lagaákvæði" breakSpaces>
         {workingCase.lawsBroken}

--- a/apps/judicial-system/web/src/utils/stepHelper.tsx
+++ b/apps/judicial-system/web/src/utils/stepHelper.tsx
@@ -1,7 +1,11 @@
 import React from 'react'
 import { AppealDecisionRole, RequiredField } from '../types'
 import { Text } from '@island.is/island-ui/core'
-import { formatDate } from '@island.is/judicial-system/formatters'
+import {
+  formatDate,
+  formatNationalId,
+  TIME_FORMAT,
+} from '@island.is/judicial-system/formatters'
 import {
   Case,
   CaseAppealDecision,
@@ -134,6 +138,45 @@ export const constructConclusion = (workingCase: Case) => {
       </>
     )
   }
+}
+
+export const constructProsecutorDemands = (workingCase: Case) => {
+  return workingCase.requestedCustodyEndDate ? (
+    <Text>
+      Þess er krafist að
+      <Text as="span" fontWeight="semiBold">
+        {` ${workingCase.accusedName}
+    ${formatNationalId(workingCase.accusedNationalId)}`}
+      </Text>
+      , verði með úrskurði Héraðsdóms Reykjavíkur gert að sæta gæsluvarðhaldi
+      til
+      <Text as="span" fontWeight="semiBold">
+        {` ${formatDate(workingCase.requestedCustodyEndDate, 'EEEE')?.replace(
+          'dagur',
+          'dagsins',
+        )}
+    ${formatDate(workingCase.requestedCustodyEndDate, 'PPP')}, kl. ${formatDate(
+          workingCase.requestedCustodyEndDate,
+          TIME_FORMAT,
+        )}`}
+      </Text>
+      {workingCase.requestedCustodyRestrictions?.includes(
+        CaseCustodyRestrictions.ISOLATION,
+      ) ? (
+        <>
+          , og verði gert að{' '}
+          <Text as="span" fontWeight="semiBold">
+            sæta einangrun
+          </Text>{' '}
+          meðan á gæsluvarðhaldinu stendur.
+        </>
+      ) : (
+        '.'
+      )}
+    </Text>
+  ) : (
+    <Text>Saksóknari hefur ekki fyllt út dómkröfur.</Text>
+  )
 }
 
 export const isNextDisabled = (requiredFields: RequiredField[]) => {

--- a/apps/judicial-system/web/src/utils/utils.spec.tsx
+++ b/apps/judicial-system/web/src/utils/utils.spec.tsx
@@ -9,7 +9,12 @@ import {
   replaceTabsOnChange,
 } from './formatters'
 import * as formatters from './formatters'
-import { constructConclusion, isDirty, isNextDisabled } from './stepHelper'
+import {
+  constructConclusion,
+  constructProsecutorDemands,
+  isDirty,
+  isNextDisabled,
+} from './stepHelper'
 import { RequiredField } from '../types'
 import {
   CaseTransition,
@@ -452,6 +457,43 @@ describe('Step helper', () => {
           const hasText = (node: Element) =>
             node.textContent ===
             'Kærði, Doe kt.0123456789 skal sæta gæsluvarðhaldi, þó ekki lengur en til 22. október 2020 kl. 12:31. Kærði skal sæta fjölmiðlabanni, heimsóknarbanni og einangrun á meðan á gæsluvarðhaldinu stendur.'
+
+          const nodeHasText = hasText(node)
+          const childrenDontHaveText = Array.from(node.children).every(
+            (child) => !hasText(child),
+          )
+
+          return nodeHasText && childrenDontHaveText
+        }),
+      ).toBeTruthy()
+    })
+  })
+
+  describe('constructPoliceDemands', () => {
+    test('should render a message if requestedCustodyEndDate is not set', () => {
+      // Arrange
+      const wc = {
+        rejecting: false,
+        custodyRestrictions: [
+          CaseCustodyRestrictions.MEDIA,
+          CaseCustodyRestrictions.VISITAION,
+          CaseCustodyRestrictions.ISOLATION,
+        ],
+        accusedName: 'Doe',
+        accusedNationalId: '0123456789',
+        custodyEndDate: '2020-11-26T12:31:00.000Z',
+        requestedCustodyEndDate: undefined,
+      }
+
+      // Act
+      const { getByText } = render(constructProsecutorDemands(wc as Case))
+
+      // Assert
+      expect(
+        getByText((_, node) => {
+          // Credit: https://www.polvara.me/posts/five-things-you-didnt-know-about-testing-library/
+          const hasText = (node: Element) =>
+            node.textContent === 'Saksóknari hefur ekki fyllt út dómkröfur.'
 
           const nodeHasText = hasText(node)
           const childrenDontHaveText = Array.from(node.children).every(


### PR DESCRIPTION
# Handle undefined values in police demands

https://app.asana.com/0/inbox/322488613152834/1199370521770163/1199370521770162

## What

A judge can see drafts now when the first notification has been sent. This means that a judge can see a case where the requestedCustodyEnd date has not been set and would see a lot of undefined values 👇

![Screen Shot 2020-11-26 at 15 17 46](https://user-images.githubusercontent.com/3789875/100367720-8e42bd00-2ffa-11eb-9827-fa99e71f24f3.png)

If this ever happens, we now display a custom message instead of undefined values

## Why

It's a bug

## Screenshots / Gifs

![Screen Shot 2020-11-26 at 15 19 24](https://user-images.githubusercontent.com/3789875/100367885-c8ac5a00-2ffa-11eb-8542-f8b5e83be4ff.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
