### PR TITLE
Island-ui: Rose variant for outlined tag

### DIFF
--- a/libs/island-ui/core/src/lib/Tag/Tag.stories.tsx
+++ b/libs/island-ui/core/src/lib/Tag/Tag.stories.tsx
@@ -60,6 +60,9 @@ export const outlined = () => (
         <Tag variant="white" outlined>
           Færnimat
         </Tag>
+        <Tag variant="rose" outlined>
+          Færnimat
+        </Tag>
         <Tag variant="darkerMint" outlined attention>
           Mikilvægt
         </Tag>

--- a/libs/island-ui/core/src/lib/Tag/Tag.treat.ts
+++ b/libs/island-ui/core/src/lib/Tag/Tag.treat.ts
@@ -113,6 +113,10 @@ export const outlined = style({
       borderColor: theme.color.mint200,
       color: theme.color.mint600,
     },
+    [`&${variants.rose}`]: {
+      borderColor: theme.color.roseTinted200,
+      color: theme.color.roseTinted400,
+    },
     [`&${variants.blueberry}`]: {
       borderColor: theme.color.blueberry200,
       color: theme.color.blueberry400,


### PR DESCRIPTION
# Rose variant for outlined tag

## What

Added a rose variant to the outlined tag.

## Why

In Skilavottord project, the design is to use a rose colored tag so I hope it's ok to add this variant to the lib as well.

## Screenshots / Gifs

![Screenshot 2020-11-27 at 11 03 00](https://user-images.githubusercontent.com/64913954/100436835-3199dd80-30a0-11eb-8ca0-bb1119fc1a52.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
