### PR TITLE
Judicial System: Uses hostname in audit trail stream name

### DIFF
--- a/apps/judicial-system/api/src/environments/environment.prod.ts
+++ b/apps/judicial-system/api/src/environments/environment.prod.ts
@@ -9,7 +9,7 @@ export default {
   auditTrail: {
     useGenericLogger: process.env.AUDIT_TRAIL_USE_GENERIC_LOGGER,
     groupName: process.env.AUDIT_TRAIL_GROUP_NAME,
-    streamName: `${process.env.AUDIT_TRAIL_GROUP_NAME}-${process.env.POD_NAME}`,
+    streamName: `${process.env.AUDIT_TRAIL_GROUP_NAME}-${process.env.HOSTNAME}`,
     region: process.env.AUDIT_TRAIL_REGION,
   },
   backendUrl: process.env.BACKEND_URL,


### PR DESCRIPTION
# Use HOSTNAME in Audit Trail Stream Name

## What

HOSTNAMEs are unique and ideal for distinguishing between pods.

## Why

We need to use separate streams for pods to avoid conflicts.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
