### PR TITLE
Added accessToken property to User.

### DIFF
--- a/libs/auth-api-lib/src/lib/auth/current-user.decorator.ts
+++ b/libs/auth-api-lib/src/lib/auth/current-user.decorator.ts
@@ -5,6 +5,9 @@ import { User } from './user'
 export const CurrentUser = createParamDecorator(
   (data: unknown, context: ExecutionContext): User => {
     const ctx = GqlExecutionContext.create(context)
-    return ctx.getContext().req.user
+    const request = ctx.getContext().req
+    const user = request.user
+    user.accessToken = request.headers.authorization.replace('Bearer ', '')
+    return user
   },
 )

--- a/libs/auth-api-lib/src/lib/auth/jwt.strategy.ts
+++ b/libs/auth-api-lib/src/lib/auth/jwt.strategy.ts
@@ -28,6 +28,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     return {
       nationalId: payload.nationalId ?? payload.natreg,
       scope: payload.scope,
+      accessToken: '',
     }
   }
 }

--- a/libs/auth-api-lib/src/lib/auth/user.ts
+++ b/libs/auth-api-lib/src/lib/auth/user.ts
@@ -1,4 +1,5 @@
 export class User {
   nationalId: string
   scope: string[]
+  accessToken: string
 }


### PR DESCRIPTION
# Add `accessToken` property to User object

## What

Make access token available in the User object returned by the @CurrentUser decorator.

## Why

So that GraphQL resolvers can use it for authorization when they call REST APIs.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x ] Formatting passes locally with my changes
- [ x] I have rebased against main before asking for a review
