### PR TITLE
Hotfix/search indexer empty reference fix

### DIFF
--- a/libs/api/domains/cms/src/lib/search/importers/article.service.ts
+++ b/libs/api/domains/cms/src/lib/search/importers/article.service.ts
@@ -23,19 +23,23 @@ export class ArticleSyncService implements CmsSyncProvider<IArticle> {
   }
 
   processSyncData(entries: processSyncDataInput<IArticle>) {
-    // only process articles that we consider not to be empty and dont have circular structures
+    // only process articles that we consider not to be empty and don't have circular structures
     return entries.reduce((processedEntries: IArticle[], entry: Entry<any>) => {
       if (this.validateArticle(entry)) {
-        // remove nested related articles from releated articles
-        const relatedArticles = (entry.fields.relatedArticles ?? []).map(
-          ({
-            sys,
-            fields: { relatedArticles, ...prunedRelatedArticlesFields },
-          }) => ({
-            sys,
-            fields: prunedRelatedArticlesFields,
-          }),
-        )
+        // remove nested related articles from related articles
+        const relatedArticles = (entry.fields.relatedArticles || [])
+          .map(({ sys, fields }) => {
+            // handle if someone deletes an article without removing reference case, this will be fixed more permanently at a later time with nested resolvers
+            if (!fields?.relatedArticles) {
+              return undefined
+            }
+            const { relatedArticles, ...prunedRelatedArticlesFields } = fields
+            return {
+              sys,
+              fields: prunedRelatedArticlesFields,
+            }
+          })
+          .filter((relatedArticle) => Boolean(relatedArticle))
 
         // relatedArticles can include nested articles that point back to this entry
         const processedEntry = {


### PR DESCRIPTION
# \<Description\>

https://app.asana.com/0/1199123945323117/1199540938715909
Adds importer fix from #2126 

## What

- Made importer ignore empty featured articles

## Why

- empty featured article cause importer to crash

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
