### PR TITLE
nr/speed up resolvers by fetching on demand

### DIFF
--- a/apps/api/src/buildSchema.ts
+++ b/apps/api/src/buildSchema.ts
@@ -10,7 +10,10 @@ import { DocumentResolver } from '@island.is/api/domains/documents'
 import { FileUploadResolver } from '@island.is/api/domains/file-upload'
 import { TranslationsResolver } from '@island.is/api/domains/translations'
 import { UserProfileResolver } from '@island.is/api/domains/user-profile'
-import { NationalRegistryResolver } from '@island.is/api/domains/national-registry'
+import {
+  NationalRegistryUserResolver,
+  NationalRegistryFamilyMemberResolver,
+} from '@island.is/api/domains/national-registry'
 import { CommunicationsResolver } from '@island.is/api/domains/communications'
 import { ApiCatalogueResolver } from '@island.is/api/domains/api-catalogue'
 import { DocumentProviderResolver } from '@island.is/api/domains/document-provider'
@@ -26,7 +29,8 @@ buildSchema({
     FileUploadResolver,
     DocumentResolver,
     TranslationsResolver,
-    NationalRegistryResolver,
+    NationalRegistryFamilyMemberResolver,
+    NationalRegistryUserResolver,
     UserProfileResolver,
     CommunicationsResolver,
     ApiCatalogueResolver,

--- a/libs/api/domains/national-registry/src/index.ts
+++ b/libs/api/domains/national-registry/src/index.ts
@@ -1,2 +1,3 @@
-export * from './lib/nationalRegistry.module'
-export * from './lib/nationalRegistry.resolver'
+export { FamilyMemberResolver as NationalRegistryFamilyMemberResolver } from './lib/familyMember.resolver'
+export { NationalRegistryModule } from './lib/nationalRegistry.module'
+export { UserResolver as NationalRegistryUserResolver } from './lib/user.resolver'

--- a/libs/api/domains/national-registry/src/lib/familyMember.resolver.ts
+++ b/libs/api/domains/national-registry/src/lib/familyMember.resolver.ts
@@ -12,23 +12,17 @@ import {
 } from '@island.is/auth-nest-tools'
 
 @UseGuards(IdsAuthGuard, ScopesGuard)
-@Resolver()
-export class NationalRegistryResolver {
-  constructor(private nationalRegistryService: NationalRegistryService) {}
-  //Touching this
-  @Query(() => NationalRegistryUser, {
-    name: 'nationalRegistryUser',
-    nullable: true,
-  })
-  getMyInfo(@CurrentUser() user: AuthUser): Promise<User> {
-    return this.nationalRegistryService.GetMyinfo(user.nationalId)
-  }
+@Resolver(() => NationalRegistryFamilyMember)
+export class FamilyMemberResolver {
+  constructor(
+    private readonly nationalRegistryService: NationalRegistryService,
+  ) {}
 
   @Query(() => [NationalRegistryFamilyMember], {
     name: 'nationalRegistryFamily',
     nullable: true,
   })
   getMyFamily(@CurrentUser() user: AuthUser): Promise<FamilyMember[]> {
-    return this.nationalRegistryService.GetMyFamily(user.nationalId)
+    return this.nationalRegistryService.getFamily(user.nationalId)
   }
 }

--- a/libs/api/domains/national-registry/src/lib/nationalRegistry.module.ts
+++ b/libs/api/domains/national-registry/src/lib/nationalRegistry.module.ts
@@ -1,6 +1,7 @@
 import { DynamicModule } from '@nestjs/common'
 
-import { NationalRegistryResolver } from './nationalRegistry.resolver'
+import { UserResolver } from './user.resolver'
+import { FamilyMemberResolver } from './familyMember.resolver'
 import { NationalRegistryService } from './nationalRegistry.service'
 import { NationalRegistryApi } from './soap/nationalRegistryApi'
 import { SoapClient } from './soap/soapClient'
@@ -18,7 +19,8 @@ export class NationalRegistryModule {
       module: NationalRegistryModule,
       providers: [
         NationalRegistryService,
-        NationalRegistryResolver,
+        UserResolver,
+        FamilyMemberResolver,
         {
           provide: NationalRegistryApi,
           useFactory: async () =>

--- a/libs/api/domains/national-registry/src/lib/nationalRegistry.service.ts
+++ b/libs/api/domains/national-registry/src/lib/nationalRegistry.service.ts
@@ -5,25 +5,31 @@ import { logger } from '@island.is/logging'
 import { FamilyMember, User } from './types'
 import { NationalRegistryApi } from './soap/nationalRegistryApi'
 
-// eslint-disable-next-line
-const handleError = (error: any) => {
-  logger.error(error)
-  throw new ApolloError('Failed to resolve request', error)
-}
-
 @Injectable()
 export class NationalRegistryService {
   constructor(private nationalRegistryApi: NationalRegistryApi) {}
 
-  async GetMyinfo(nationalId: string): Promise<User> {
-    return await this.nationalRegistryApi
-      .getMyInfo(nationalId)
-      .catch(handleError)
+  getUserInfo(nationalId: User['nationalId']): Promise<User> {
+    return this.nationalRegistryApi.getMyInfo(nationalId)
   }
 
-  async GetMyFamily(nationalId: string): Promise<FamilyMember[]> {
-    return await this.nationalRegistryApi
-      .getMyFamily(nationalId)
-      .catch(handleError)
+  getFamily(nationalId: User['nationalId']): Promise<FamilyMember[]> {
+    return this.nationalRegistryApi.getMyFamily(nationalId)
+  }
+
+  getReligion(nationalId: User['nationalId']): Promise<string> {
+    return this.nationalRegistryApi.getReligion(nationalId)
+  }
+
+  getBirthPlace(municipalCode: User['municipalCode']): Promise<string> {
+    return this.nationalRegistryApi.getBirthPlace(municipalCode)
+  }
+
+  getBanMarking(nationalId: User['nationalId']): Promise<string> {
+    return this.nationalRegistryApi.getBanMarking(nationalId)
+  }
+
+  getLegalResidence(houseCode: User['houseCode']): Promise<string> {
+    return this.nationalRegistryApi.getLegalResidence(houseCode)
   }
 }

--- a/libs/api/domains/national-registry/src/lib/soap/nationalRegistryApi.ts
+++ b/libs/api/domains/national-registry/src/lib/soap/nationalRegistryApi.ts
@@ -39,7 +39,51 @@ export class NationalRegistryApi {
     this.clientPassword = clientPassword
   }
 
-  public async getMyInfo(nationalId: string): Promise<User> {
+  public async getReligion(nationalId: User['nationalId']): Promise<string> {
+    const response = await this.getViewKennitalaOgTrufelag(nationalId)
+    if (!response) {
+      return ''
+    }
+
+    return response.table.diffgram.DocumentElement.KennitalaOgTrufelag.Trufelag
+  }
+
+  public async getBirthPlace(
+    municipalCode: User['municipalCode'],
+  ): Promise<string> {
+    const response = await this.getViewSveitarfelag(municipalCode)
+
+    if (!response) {
+      return ''
+    }
+    return response.table.diffgram.DocumentElement.Sveitarfelag.Sokn
+  }
+
+  public async getBanMarking(nationalId: User['nationalId']): Promise<string> {
+    const response = await this.getViewKennitalaOgBannmerking(nationalId)
+
+    if (!response) {
+      return ''
+    }
+
+    const banMarking =
+      response.table.diffgram.DocumentElement.KennitalaOgBannmerking
+    const isBanmarked = banMarking.Bannmerking === '1'
+    return isBanmarked ? `Já ${banMarking.Brdagur}` : 'Nei'
+  }
+
+  public async getLegalResidence(
+    houseCode: User['houseCode'],
+  ): Promise<string> {
+    const response = await this.getViewHusaskra(houseCode)
+    if (!response) {
+      return ''
+    }
+    const houseInfo = response.table.diffgram.DocumentElement.Husaskra
+    return `${houseInfo.HusHeiti}, ${houseInfo.PostNr} ${houseInfo.Nafn}`
+  }
+
+  public async getMyInfo(nationalId: User['nationalId']): Promise<User> {
     const response = await this.getViewThjodskra(nationalId)
 
     if (!response)
@@ -48,25 +92,14 @@ export class NationalRegistryApi {
       )
 
     const userInfo = response.table.diffgram.DocumentElement.Thjodskra
-    const houseResponse = await this.getViewHusaskra(userInfo.LoghHusk)
-    const religionResponse = await this.getViewKennitalaOgTrufelag(nationalId)
-    const birthPlaceResponse = await this.getViewSveitarfelag(
-      userInfo.Faedsvfnr,
-    )
-    const banMarkingResponse = await this.getViewKennitalaOgBannmerking(
-      nationalId,
-    )
-
     return {
       nationalId,
       fullName: userInfo.Nafn,
       citizenship: userInfo.Rikisfang === 'IS' ? 'Ísland' : userInfo.Rikisfang,
       gender: this.formatGender(userInfo.Kyn),
-      birthPlace: this.formatBirthPlaceString(birthPlaceResponse),
-      religion: this.formatReligionString(religionResponse),
-      legalResidence: this.formatResidenceAddressString(houseResponse),
       maritalStatus: this.formatMartialStatus(userInfo.Hju, userInfo.Kyn),
-      banMarking: this.formatBanMarking(banMarkingResponse),
+      houseCode: userInfo.LoghHusk,
+      municipalCode: userInfo.Faedsvfnr,
     }
   }
 
@@ -129,34 +162,7 @@ export class NationalRegistryApi {
     )
   }
 
-  private formatResidenceAddressString(
-    houseDto: GetViewHomeDto | null,
-  ): string | null {
-    if (!houseDto) return null
-    const houseInfo = houseDto.table.diffgram.DocumentElement.Husaskra
-    return `${houseInfo.HusHeiti}, ${houseInfo.PostNr} ${houseInfo.Nafn}`
-  }
-
-  private formatReligionString(
-    religtionDto: GetViewReligionDto | null,
-  ): string | null {
-    if (!religtionDto) return null
-
-    return religtionDto.table.diffgram.DocumentElement.KennitalaOgTrufelag
-      .Trufelag
-  }
-
-  private formatBirthPlaceString(
-    birthPlaceDto: GetViewMunicipalityDto | null,
-  ): string | null {
-    if (!birthPlaceDto) return null
-    return birthPlaceDto.table.diffgram.DocumentElement.Sveitarfelag.Sokn
-  }
-
-  private formatMartialStatus(
-    maritalCode: string,
-    genderCode: string,
-  ): string | null {
+  private formatMartialStatus(maritalCode: string, genderCode: string): string {
     const isMale = genderCode === '1'
     switch (maritalCode) {
       case '1':
@@ -182,11 +188,11 @@ export class NationalRegistryApi {
       case 'L':
         return 'Íslendingur með lögheimili á Íslandi (t.d. námsmaður eða sendiráðsmaður); í hjúskap með útlendingi sem ekki er á skrá'
       default:
-        return null
+        return ''
     }
   }
 
-  private formatGender(genderIndex: string): string | null {
+  private formatGender(genderIndex: string): string {
     switch (genderIndex) {
       case '1':
         return 'Karl'
@@ -201,18 +207,8 @@ export class NationalRegistryApi {
       case '8':
         return 'Kynsegin'
       default:
-        return null
+        return ''
     }
-  }
-
-  private formatBanMarking(
-    banMarkingDto: GetViewBanmarkingDto | null,
-  ): string | null {
-    if (!banMarkingDto) return null
-    const banMarking =
-      banMarkingDto.table.diffgram.DocumentElement.KennitalaOgBannmerking
-    const isBanmarked = banMarking.Bannmerking === '1'
-    return isBanmarked ? `Já ${banMarking.Brdagur}` : 'Nei'
   }
 
   public async getViewThjodskra(

--- a/libs/api/domains/national-registry/src/lib/types/user.type.ts
+++ b/libs/api/domains/national-registry/src/lib/types/user.type.ts
@@ -1,11 +1,9 @@
 export interface User {
   nationalId: string
   fullName: string
-  gender: string | null
-  legalResidence: string | null
-  birthPlace: string | null
   citizenship: string
-  religion: string | null
-  maritalStatus: string | null
-  banMarking: string | null
+  gender: string
+  maritalStatus: string
+  houseCode: string
+  municipalCode: string
 }

--- a/libs/api/domains/national-registry/src/lib/user.resolver.ts
+++ b/libs/api/domains/national-registry/src/lib/user.resolver.ts
@@ -1,0 +1,28 @@
+import { UseGuards } from '@nestjs/common'
+import { Resolver, Query, ResolveField, Parent } from '@nestjs/graphql'
+
+import {
+  IdsAuthGuard,
+  ScopesGuard,
+  CurrentUser,
+  User as AuthUser,
+} from '@island.is/auth-nest-tools'
+import { NationalRegistryUser } from './models'
+import { NationalRegistryService } from './nationalRegistry.service'
+import { User } from './types'
+
+@UseGuards(IdsAuthGuard, ScopesGuard)
+@Resolver(() => NationalRegistryUser)
+export class UserResolver {
+  constructor(
+    private readonly nationalRegistryService: NationalRegistryService,
+  ) {}
+
+  @Query(() => NationalRegistryUser, {
+    name: 'nationalRegistryUser',
+    nullable: true,
+  })
+  user(@CurrentUser() user: AuthUser): Promise<User> {
+    return this.nationalRegistryService.getUserInfo(user.nationalId)
+  }
+}

--- a/libs/api/domains/national-registry/src/lib/user.resolver.ts
+++ b/libs/api/domains/national-registry/src/lib/user.resolver.ts
@@ -25,4 +25,24 @@ export class UserResolver {
   user(@CurrentUser() user: AuthUser): Promise<User> {
     return this.nationalRegistryService.getUserInfo(user.nationalId)
   }
+
+  @ResolveField('religion', () => String)
+  resolveReligion(@Parent() user: User): Promise<string> {
+    return this.nationalRegistryService.getReligion(user.nationalId)
+  }
+
+  @ResolveField('birthPlace', () => String)
+  resolveBirthPlace(@Parent() user: User): Promise<string> {
+    return this.nationalRegistryService.getBirthPlace(user.municipalCode)
+  }
+
+  @ResolveField('banMarking', () => String)
+  resolveBanMarking(@Parent() user: User): Promise<string> {
+    return this.nationalRegistryService.getBanMarking(user.nationalId)
+  }
+
+  @ResolveField('legalResidence', () => String)
+  resolveLegalResidence(@Parent() user: User): Promise<string> {
+    return this.nationalRegistryService.getLegalResidence(user.houseCode)
+  }
 }


### PR DESCRIPTION
# Speed up GraphQL querying for national registry

## What

Resolve individual fields on demand

## Why

Using a single resolver that makes 5 api requests synchronously is super slow.
Rather, use the power of GraphQL to make the requests on demand, i.e.
when and if the user requests it.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
