### PR TITLE
Showing articles that have more than one process entry in a data table

### DIFF
--- a/apps/services/search-indexer/config/kibana/dashboard-articles.json
+++ b/apps/services/search-indexer/config/kibana/dashboard-articles.json
@@ -197,6 +197,19 @@
         "panelIndex": "95ef75c0-76f7-4b4f-b9aa-265c720b70fc",
         "panelRefName": "panel_11",
         "version": "7.4.2"
+      },
+      {
+        "embeddableConfig": {},
+        "gridData": {
+          "h": 18,
+          "i": "2da624c5-eabb-446f-a886-7ff567b08071",
+          "w": 22,
+          "x": 22,
+          "y": 42
+        },
+        "panelIndex": "2da624c5-eabb-446f-a886-7ff567b08071",
+        "panelRefName": "panel_12",
+        "version": "7.4.2"
       }
     ],
     "refreshInterval": {
@@ -283,6 +296,11 @@
     {
       "id": "cf3b02f0-34b8-11eb-83e6-db8492ac723e",
       "name": "panel_11",
+      "type": "visualization"
+    },
+    {
+      "id": "1def3c10-3aed-11eb-88b7-630ea8059e64",
+      "name": "panel_12",
       "type": "visualization"
     }
   ],

--- a/apps/services/search-indexer/config/kibana/index-pattern-island.json
+++ b/apps/services/search-indexer/config/kibana/index-pattern-island.json
@@ -125,18 +125,18 @@
       {
         "aggregatable": true,
         "count": 0,
-        "esTypes": ["boolean"],
-        "name": "hasProcessEntry",
+        "esTypes": ["integer"],
+        "name": "pdfLinks",
         "readFromDocValues": true,
         "scripted": false,
         "searchable": true,
-        "type": "boolean"
+        "type": "number"
       },
       {
         "aggregatable": true,
         "count": 0,
         "esTypes": ["integer"],
-        "name": "pdfLinks",
+        "name": "processEntryCount",
         "readFromDocValues": true,
         "scripted": false,
         "searchable": true,
@@ -241,8 +241,8 @@
       {
         "aggregatable": true,
         "conflictDescriptions": {
-          "icu_collation_keyword": ["island-is-v12"],
-          "keyword": ["island-en-v12"]
+          "icu_collation_keyword": ["island-is-v13"],
+          "keyword": ["island-en-v13"]
         },
         "count": 0,
         "esTypes": ["icu_collation_keyword", "keyword"],

--- a/apps/services/search-indexer/config/kibana/visualization-articles-contain-multiple-process-entries.json
+++ b/apps/services/search-indexer/config/kibana/visualization-articles-contain-multiple-process-entries.json
@@ -1,0 +1,143 @@
+{
+  "attributes": {
+    "description": "",
+    "kibanaSavedObjectMeta": {
+      "searchSourceJSON": {
+        "filter": [],
+        "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+        "query": {
+          "language": "kuery",
+          "query": ""
+        }
+      }
+    },
+    "title": "Articles that contain multiple process entries",
+    "uiStateJSON": {
+      "vis": {
+        "params": {
+          "sort": {
+            "columnIndex": null,
+            "direction": null
+          }
+        }
+      }
+    },
+    "version": 1,
+    "visState": {
+      "aggs": [
+        {
+          "enabled": true,
+          "id": 1,
+          "params": {
+            "customLabel": "Process Entries",
+            "field": "processEntryCount"
+          },
+          "schema": "metric",
+          "type": "sum"
+        },
+        {
+          "enabled": true,
+          "id": 2,
+          "params": {
+            "filters": [
+              {
+                "input": {
+                  "language": "kuery",
+                  "query": "type : \"webArticle\" and processEntryCount >= 2"
+                },
+                "label": "Multiple process entries"
+              }
+            ]
+          },
+          "schema": "bucket",
+          "type": "filters"
+        },
+        {
+          "enabled": true,
+          "id": 3,
+          "params": {
+            "customLabel": "Title",
+            "field": "title.keyword",
+            "missingBucket": false,
+            "missingBucketLabel": "Missing",
+            "order": "desc",
+            "orderBy": 1,
+            "otherBucket": false,
+            "otherBucketLabel": "Other",
+            "size": 1000
+          },
+          "schema": "bucket",
+          "type": "terms"
+        }
+      ],
+      "params": {
+        "dimensions": {
+          "buckets": [
+            {
+              "accessor": 0,
+              "aggType": "filters",
+              "format": {},
+              "params": {}
+            },
+            {
+              "accessor": 1,
+              "aggType": "terms",
+              "format": {
+                "id": "terms",
+                "params": {
+                  "id": "string",
+                  "missingBucketLabel": "Missing",
+                  "otherBucketLabel": "Other"
+                }
+              },
+              "params": {}
+            }
+          ],
+          "metrics": [
+            {
+              "accessor": 2,
+              "aggType": "sum",
+              "format": {
+                "id": "number"
+              },
+              "params": {}
+            }
+          ]
+        },
+        "perPage": 10,
+        "percentageCol": "",
+        "showMetricsAtAllLevels": false,
+        "showPartialRows": false,
+        "showTotal": false,
+        "sort": {
+          "columnIndex": null,
+          "direction": null
+        },
+        "totalFunc": "sum"
+      },
+      "title": "Articles that contain multiple process entries",
+      "type": "table"
+    }
+  },
+  "id": "1def3c10-3aed-11eb-88b7-630ea8059e64",
+  "migrationVersion": {
+    "visualization": "7.4.2"
+  },
+  "nestedJsonPaths": [
+    "attributes.kibanaSavedObjectMeta.searchSourceJSON",
+    "attributes.uiStateJSON",
+    "attributes.visState",
+    "attributes.visState.aggs[0].id",
+    "attributes.visState.aggs[1].id",
+    "attributes.visState.aggs[2].id",
+    "attributes.visState.aggs[2].params.orderBy"
+  ],
+  "references": [
+    {
+      "id": "b83598d0-34b4-11eb-83e6-db8492ac723e",
+      "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+      "type": "index-pattern"
+    }
+  ],
+  "type": "visualization"
+}

--- a/apps/services/search-indexer/config/kibana/visualization-articles-with-process-entry.json
+++ b/apps/services/search-indexer/config/kibana/visualization-articles-with-process-entry.json
@@ -51,17 +51,20 @@
           "enabled": true,
           "id": 3,
           "params": {
-            "field": "hasProcessEntry",
-            "missingBucket": false,
-            "missingBucketLabel": "Missing",
-            "order": "desc",
-            "orderBy": 1,
-            "otherBucket": false,
-            "otherBucketLabel": "Other",
-            "size": 5
+            "customLabel": "Process Entry range",
+            "field": "processEntryCount",
+            "ranges": [
+              {
+                "from": 1
+              },
+              {
+                "from": 0,
+                "to": 1
+              }
+            ]
           },
           "schema": "group",
-          "type": "terms"
+          "type": "range"
         }
       ],
       "params": {
@@ -90,13 +93,11 @@
           "series": [
             {
               "accessor": 1,
-              "aggType": "terms",
+              "aggType": "range",
               "format": {
-                "id": "terms",
+                "id": "range",
                 "params": {
-                  "id": "boolean",
-                  "missingBucketLabel": "Missing",
-                  "otherBucketLabel": "Other"
+                  "id": "number"
                 }
               },
               "params": {}
@@ -188,7 +189,6 @@
     "attributes.visState.aggs[0].id",
     "attributes.visState.aggs[1].id",
     "attributes.visState.aggs[2].id",
-    "attributes.visState.aggs[2].params.orderBy",
     "attributes.visState.params.seriesParams[0].data.id",
     "attributes.visState.params.seriesParams[0].show"
   ],

--- a/apps/services/search-indexer/config/template-en.json
+++ b/apps/services/search-indexer/config/template-en.json
@@ -1,6 +1,6 @@
 {
   "order": 0,
-  "version": 12,
+  "version": 13,
   "index_patterns": ["island-en-v*"],
   "settings": {
     "analysis": {
@@ -62,8 +62,8 @@
       "contentWordCount": {
         "type": "integer"
       },
-      "hasProcessEntry": {
-        "type": "boolean"
+      "processEntryCount": {
+        "type": "integer"
       },
       "fillAndSignLinks": {
         "type": "integer"

--- a/apps/services/search-indexer/config/template-is.json
+++ b/apps/services/search-indexer/config/template-is.json
@@ -1,6 +1,6 @@
 {
   "order": 0,
-  "version": 12,
+  "version": 13,
   "index_patterns": ["island-is-v*"],
   "settings": {
     "analysis": {
@@ -122,8 +122,8 @@
       "contentWordCount": {
         "type": "integer"
       },
-      "hasProcessEntry": {
-        "type": "boolean"
+      "processEntryCount": {
+        "type": "integer"
       },
       "fillAndSignLinks": {
         "type": "integer"

--- a/libs/api/domains/cms/src/lib/search/importers/aboutPage.service.ts
+++ b/libs/api/domains/cms/src/lib/search/importers/aboutPage.service.ts
@@ -14,7 +14,7 @@ import {
 import {
   createTerms,
   extractStringsFromObject,
-  hasProcessEntry,
+  numberOfProcessEntries,
   numberOfLinks,
 } from './utils'
 
@@ -43,7 +43,7 @@ export class AboutPageSyncService implements CmsSyncProvider<IPage> {
             title: mapped.title,
             content,
             contentWordCount: content.split(/\s+/).length,
-            hasProcessEntry: hasProcessEntry(mapped.slices),
+            processEntryCount: numberOfProcessEntries(mapped.slices),
             ...numberOfLinks(mapped.slices),
             type: 'webAboutPage',
             termPool: createTerms([mapped.title]),

--- a/libs/api/domains/cms/src/lib/search/importers/adgerdirPage.ts
+++ b/libs/api/domains/cms/src/lib/search/importers/adgerdirPage.ts
@@ -14,7 +14,7 @@ import {
 import {
   createTerms,
   extractStringsFromObject,
-  hasProcessEntry,
+  numberOfProcessEntries,
   numberOfLinks,
 } from './utils'
 
@@ -46,7 +46,7 @@ export class AdgerdirPageSyncService
             title: mapped.title,
             content,
             contentWordCount: content.split(/\s+/).length,
-            hasProcessEntry: hasProcessEntry(mapped.content),
+            processEntryCount: numberOfProcessEntries(mapped.content),
             ...numberOfLinks(mapped.content),
             type: 'webAdgerdirPage',
             termPool: createTerms([mapped.title]),

--- a/libs/api/domains/cms/src/lib/search/importers/article.service.ts
+++ b/libs/api/domains/cms/src/lib/search/importers/article.service.ts
@@ -13,7 +13,7 @@ import {
 import {
   createTerms,
   extractStringsFromObject,
-  hasProcessEntry,
+  numberOfProcessEntries,
   numberOfLinks,
 } from './utils'
 
@@ -79,7 +79,7 @@ export class ArticleSyncService implements CmsSyncProvider<IArticle> {
             title: mapped.title,
             content,
             contentWordCount: content.split(/\s+/).length,
-            hasProcessEntry: hasProcessEntry(mapped.body),
+            processEntryCount: numberOfProcessEntries(mapped.body),
             ...numberOfLinks(mapped.body),
             type: 'webArticle',
             termPool: createTerms([

--- a/libs/api/domains/cms/src/lib/search/importers/utils.ts
+++ b/libs/api/domains/cms/src/lib/search/importers/utils.ts
@@ -93,5 +93,5 @@ export const numberOfLinks = (contentList: object[]) => {
   }
 }
 
-export const hasProcessEntry = (contentList: any[]) =>
-  getProcessEntries(contentList).length !== 0
+export const numberOfProcessEntries = (contentList: any[]) =>
+  getProcessEntries(contentList).length

--- a/libs/content-search-indexer/types/src/index.ts
+++ b/libs/content-search-indexer/types/src/index.ts
@@ -8,7 +8,7 @@ export interface MappedData {
   title: string
   content?: string
   contentWordCount?: number
-  hasProcessEntry?: boolean
+  processEntryCount?: number
   fillAndSignLinks?: number
   pdfLinks?: number
   wordLinks?: number


### PR DESCRIPTION
Datatable that shows all articles that have more than 1 process entry

![2020-12-10-154555_865x514_scrot](https://user-images.githubusercontent.com/5678012/101794545-e26f9600-3afe-11eb-8b79-f4ac084e8ad9.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
