### PR TITLE
Covid operations in search results

### DIFF
--- a/apps/web/screens/Search/Search.tsx
+++ b/apps/web/screens/Search/Search.tsx
@@ -124,7 +124,6 @@ const Search: Screen<CategoryProps> = ({
     // create a map of sidebar type data for easier lookup later
     const typeNames = {
       webNews: n('newsTitle'),
-      webAdgerdirPage: n('adgerdirTitle'),
     }
     const typeCountResults = countResults.typesCount.reduce(
       (typeList: SidebarTagMap, { key, count: total }) => {
@@ -147,7 +146,6 @@ const Search: Screen<CategoryProps> = ({
 
   const getLabels = (item) => {
     const labels = []
-
     switch (
       item.__typename as LifeEventPage['__typename'] &
         News['__typename'] &
@@ -161,6 +159,9 @@ const Search: Screen<CategoryProps> = ({
         break
       case 'News':
         labels.push(n('newsTitle'))
+        break
+      case 'AdgerdirPage':
+        labels.push(n('adgerdirTitle'))
         break
       default:
         break
@@ -446,6 +447,7 @@ Search.getInitialProps = async ({ apolloClient, locale, query }) => {
       'webArticle' as SearchableContentTypes,
       'webLifeEventPage' as SearchableContentTypes,
       'webAboutPage' as SearchableContentTypes,
+      'webAdgerdirPage' as SearchableContentTypes,
     ]
   }
 


### PR DESCRIPTION
# \<Description\>

https://app.asana.com/0/1199123945323117/1199585689963197

## What

- Removed Covid operations from other search results box
- Made covid operations appear in search results
- Added Covid operations tag to covid operations search results

## Why

- Covid operations were to hidden in other search results, better UX

## Screenshots / Gifs

![Screenshot 2020-12-11 at 16 25 23](https://user-images.githubusercontent.com/6640435/101928892-11a10880-3bce-11eb-98f1-54321384b1c5.png)
![Screenshot 2020-12-11 at 16 25 01](https://user-images.githubusercontent.com/6640435/101928900-136acc00-3bce-11eb-87d3-f8ba5e0e4ddd.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
