### PR TITLE
Fixed get param causing error

### DIFF
--- a/apps/web/screens/AboutSubPage/AboutSubPage.tsx
+++ b/apps/web/screens/AboutSubPage/AboutSubPage.tsx
@@ -132,7 +132,8 @@ AboutSubPage.getInitialProps = async ({ apolloClient, locale, asPath }) => {
         query: GET_ABOUT_SUB_PAGE_QUERY,
         variables: {
           input: {
-            url: asPath,
+            // TODO: Revisit when updating language switch
+            url: asPath.split('?')[0], // split is so path ignores get query param
             lang: locale,
           },
         },


### PR DESCRIPTION
# \<Description\>

https://app.asana.com/0/1199123945323117/1199587953442157

## What

- Remove everything after the symbol "?" in as path

## Why

- Get query params are causing errors when getting page content

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
