### PR TITLE
Changed aws check

### DIFF
--- a/libs/content-search-toolkit/src/services/elastic.service.ts
+++ b/libs/content-search-toolkit/src/services/elastic.service.ts
@@ -301,7 +301,7 @@ export class ElasticService {
   }
 
   async createEsClient(): Promise<Client> {
-    const hasAWS = 'S3_BUCKET' in process.env
+    const hasAWS = 'AWS_WEB_IDENTITY_TOKEN_FILE' in process.env
 
     logger.info('Create AWS ES Client', {
       esConfig: elastic,

--- a/libs/content-search-toolkit/src/services/elastic.service.ts
+++ b/libs/content-search-toolkit/src/services/elastic.service.ts
@@ -301,9 +301,7 @@ export class ElasticService {
   }
 
   async createEsClient(): Promise<Client> {
-    const hasAWS =
-      'AWS_WEB_IDENTITY_TOKEN_FILE' in process.env &&
-      'AWS_SECRET_ACCESS_KEY' in process.env
+    const hasAWS = 'S3_BUCKET' in process.env
 
     logger.info('Create AWS ES Client', {
       esConfig: elastic,


### PR DESCRIPTION
# \<Description\>

https://app.asana.com/0/1199123945323117/1199597433453861
Checking for `AWS_SECRET_ACCESS_KEY` causes issues when going from `ES proxy` to `ES locally`.
Just checking for `AWS_WEB_IDENTITY_TOKEN_FILE ` should suffice 

## What

- Changed AWS check so it does not conflict with proxy

## Why

- Previous check fails in our environments

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
