### PR TITLE
Made frontpage slider resolve covid page url correctly

### DIFF
--- a/apps/web/components/FrontpageTabs/FrontpageTabs.tsx
+++ b/apps/web/components/FrontpageTabs/FrontpageTabs.tsx
@@ -105,10 +105,18 @@ export const FrontpageTabs: FC<FrontpageTabsProps> = ({
     if (link) {
       const linkData = JSON.parse(link)
       const contentId = linkData.sys?.contentType?.sys?.id
-
       const slug = String(linkData.fields?.slug)
+
       if (slug) {
-        return pathNames(activeLocale as Locale, contentId, [slug])
+        // the need for this check is caused by miss match in cache typename and cms typename
+        // TODO: Make CMS get this content from cache to standardize type
+        let type
+        if (contentId === 'vidspyrna-frontpage') {
+          type = 'adgerdirfrontpage'
+        } else {
+          type = contentId
+        }
+        return pathNames(activeLocale as Locale, type, [slug])
       }
       return { href: null, as: null }
     }


### PR DESCRIPTION
# \<Description\>

https://app.asana.com/0/1199123945323117/1199600556560461

## What

- Made frontpage slider correctly resolve covid frontpage url

## Why

- Currently url is resolved to frontpage

## Screenshots / Gifs

![Screenshot 2020-12-14 at 15 16 56](https://user-images.githubusercontent.com/6640435/102098775-7f903e80-3e1f-11eb-9930-c7aea99602e5.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
