### PR TITLE
Service Portal - Set Onboarding Language on Change

### DIFF
--- a/libs/service-portal/settings/src/components/Forms/LanguageForm.tsx
+++ b/libs/service-portal/settings/src/components/Forms/LanguageForm.tsx
@@ -16,6 +16,7 @@ interface Props {
   language: LanguageFormOption | null
   renderBackButton?: () => JSX.Element
   renderSubmitButton?: () => JSX.Element
+  onValueChange?: (data: LanguageFormData) => void
   onSubmit: (data: LanguageFormData) => void
 }
 
@@ -23,6 +24,7 @@ export const LanguageForm: FC<Props> = ({
   language,
   renderBackButton,
   renderSubmitButton,
+  onValueChange,
   onSubmit,
 }) => {
   const { handleSubmit, control, reset } = useForm()
@@ -46,7 +48,13 @@ export const LanguageForm: FC<Props> = ({
             <Select
               name={name}
               value={value}
-              onChange={onChange}
+              onChange={(value, actionMeta) => {
+                onChange(value, actionMeta)
+                if (onValueChange)
+                  onValueChange({
+                    language: value as LanguageFormOption,
+                  })
+              }}
               label={formatMessage({
                 id: 'service.portal:language',
                 defaultMessage: 'Tungumál',

--- a/libs/service-portal/settings/src/components/UserOnboardingModal/Steps/LanguageStep.tsx
+++ b/libs/service-portal/settings/src/components/UserOnboardingModal/Steps/LanguageStep.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react'
 import { Button, Text } from '@island.is/island-ui/core'
-import { useLocale } from '@island.is/localization'
+import { useLocale, useNamespaces } from '@island.is/localization'
 import {
   LanguageForm,
   LanguageFormData,
@@ -22,6 +22,10 @@ export const LanguageStep: FC<Props> = ({
   userInfo,
 }) => {
   const { formatMessage } = useLocale()
+  const { changeLanguage } = useNamespaces()
+
+  const handleValueChange = (data: LanguageFormData) =>
+    data.language?.value && changeLanguage(data.language.value)
 
   return (
     <>
@@ -42,6 +46,7 @@ export const LanguageStep: FC<Props> = ({
       </Text>
       <LanguageForm
         language={language}
+        onValueChange={handleValueChange}
         renderBackButton={() => (
           <Button variant="ghost" onClick={onClose}>
             {formatMessage({


### PR DESCRIPTION
# \<Set Onboarding Language on Change\>

## What

Switch the current language as soon as the user selects it in the onboarding modal

## Why

Improve onboarding UX

## Screenshots / Gifs

![2020-12-14 16_21_49-Window](https://user-images.githubusercontent.com/20952302/102106466-853e5200-3e28-11eb-9ad8-f665994bab69.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
