### PR TITLE
use mock data

### DIFF
--- a/libs/api/domains/document-provider/src/lib/document-provider.service.ts
+++ b/libs/api/domains/document-provider/src/lib/document-provider.service.ts
@@ -23,46 +23,60 @@ export class DocumentProviderService {
     nationalId: string,
     clientName: string,
   ): Promise<ClientCredentials> {
-    const currentProvider = await this.documentProviderRepository.getProvider(
-      nationalId,
+    logger.info(`Create client: ${nationalId} - ${clientName}`)
+
+    return new ClientCredentials(
+      '5016d8d5cb6ce0758107b9969ea3c301',
+      '7a557951364a960a608735371db61ed8ed320d6bfc59f52fe37fc08e23dbd8d1',
     )
 
-    if (currentProvider !== null) {
-      throw new ApolloError('Provider already exists for this organisation.')
-    }
+    // const currentProvider = await this.documentProviderRepository.getProvider(
+    //   nationalId,
+    // )
 
-    const result = await this.documentProviderClient
-      .createClient(nationalId, clientName)
-      .catch(handleError)
+    // if (currentProvider !== null) {
+    //   throw new ApolloError('Provider already exists for this organisation.')
+    // }
 
-    const { providerId } = result
-    await this.documentProviderRepository.saveProvider(nationalId, providerId)
+    // const result = await this.documentProviderClient
+    //   .createClient(nationalId, clientName)
+    //   .catch(handleError)
 
-    const credentials = new ClientCredentials(
-      result.clientId,
-      result.clientSecret,
-    )
-    return credentials
+    // const { providerId } = result
+    // await this.documentProviderRepository.saveProvider(nationalId, providerId)
+
+    // const credentials = new ClientCredentials(
+    //   result.clientId,
+    //   result.clientSecret,
+    // )
+    // return credentials
   }
 
   async registerEndpoint(
     nationalId: string,
     endpoint: string,
   ): Promise<AudienceAndScope> {
-    const providerId = await this.documentProviderRepository.getProvider(
-      nationalId,
+    logger.info(`Register endpoint: ${nationalId} - ${endpoint}`)
+
+    return new AudienceAndScope(
+      'https://test-skjalaveita-island-is.azurewebsites.net',
+      'https://test-skjalaveita-island-is.azurewebsites.net/api/v1/customer/.default',
     )
 
-    if (providerId === null) {
-      throw new ApolloError('No provider exists for this organisation.')
-    }
+    // const providerId = await this.documentProviderRepository.getProvider(
+    //   nationalId,
+    // )
 
-    const result = await this.documentProviderClient
-      .updateEndpoint(providerId, endpoint)
-      .catch(handleError)
+    // if (providerId === null) {
+    //   throw new ApolloError('No provider exists for this organisation.')
+    // }
 
-    const audienceAndScope = new AudienceAndScope(result.audience, result.scope)
-    return audienceAndScope
+    // const result = await this.documentProviderClient
+    //   .updateEndpoint(providerId, endpoint)
+    //   .catch(handleError)
+
+    // const audienceAndScope = new AudienceAndScope(result.audience, result.scope)
+    // return audienceAndScope
   }
 
   async runEndpointTests(


### PR DESCRIPTION
# Use mockdata for document provider api


## What

Use mock data for document-provider api

## Why

So frontend developers can test the application without create provider on test environment on the old mailbox

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
