### PR TITLE
Remove about page jumper from navbar

### DIFF
--- a/apps/web/screens/AboutPage/AboutPage.tsx
+++ b/apps/web/screens/AboutPage/AboutPage.tsx
@@ -82,16 +82,9 @@ interface SliceItem {
 
 const sidebarContent = (
   navigation: SliceItem[],
-  currentSliceId: string,
   sliceLinks: SliceItem[],
 ): NavigationItem[] => {
   const [navigationTitle, ...navigationList] = navigation
-
-  const items: NavigationItem[] = navigationList.map(({ id, text }) => ({
-    href: `#${id}`,
-    title: text,
-    active: id === currentSliceId,
-  }))
 
   const subPages: NavigationItem[] = sliceLinks.map(({ url, text }) => ({
     href: url,
@@ -103,7 +96,6 @@ const sidebarContent = (
     href: `#${navigationTitle.id}`,
     title: navigationTitle.text,
     active: true,
-    items: items,
   }
 
   return [currentPage].concat(subPages)
@@ -203,7 +195,7 @@ const PageHeader: FC<PageHeaderProps> = ({
               }
               baseId="LeftNavigation"
               isMenuDialog={false}
-              items={sidebarContent(navigation, currentSliceId, slice.links)}
+              items={sidebarContent(navigation, slice.links)}
               title={page.title}
             />
           </Sidebar>
@@ -226,11 +218,7 @@ const PageHeader: FC<PageHeaderProps> = ({
                     baseId="MobileMenuNavigation"
                     isMenuDialog={true}
                     activeItemTitle={slice.navigationText}
-                    items={sidebarContent(
-                      navigation,
-                      currentSliceId,
-                      slice.links,
-                    )}
+                    items={sidebarContent(navigation, slice.links)}
                     title={page.title}
                   />
                 </Box>
@@ -453,7 +441,6 @@ const AboutPageScreen: Screen<AboutPageProps> = ({
               isMenuDialog={false}
               items={sidebarContent(
                 navigation as SliceItem[],
-                page.pageHeader.id,
                 page.pageHeader.links,
               )}
               title={page.title}


### PR DESCRIPTION
# Remove jumpers

## What

Remove page navigation from about page navbar

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/70899104/102482565-53f99800-405b-11eb-898d-4afc0ad90276.png)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
