### PR TITLE
Adding labelColor to control the color for the AccordionItem

### DIFF
--- a/libs/island-ui/core/src/lib/Accordion/Accordion.stories.mdx
+++ b/libs/island-ui/core/src/lib/Accordion/Accordion.stories.mdx
@@ -130,6 +130,50 @@ control the size.
   </Story>
 </Canvas>
 
+### With colored label
+
+We can use `labelColor` to change the color on the label for the `AccordionItem`
+
+<Canvas>
+  <Story name="Colored label">
+    <Accordion singleExpand>
+      <AccordionItem
+        id="id_1"
+        label="Hvenær þarf að skila umsókn?"
+        labelColor="blue400"
+      >
+        <Text>
+          Hægt er að senda umsóknir og önnur gögn með pósti, tölvupósti eða
+          faxi. Læknisvottorð verða að berast með pósti þar sem við þurfum
+          frumritið.
+        </Text>
+      </AccordionItem>
+      <AccordionItem
+        id="id_2"
+        label="Er hægt að leggja inn greiðslur á bankareikning maka?"
+        labelColor="blue400"
+      >
+        <Text>
+          Hægt er að senda umsóknir og önnur gögn með pósti, tölvupósti eða
+          faxi. Læknisvottorð verða að berast með pósti þar sem við þurfum
+          frumritið.
+        </Text>
+      </AccordionItem>
+      <AccordionItem
+        id="id_3"
+        label="Hvernig kem ég umsókninni til ykkar?"
+        labelColor="blue400"
+      >
+        <Text>
+          Hægt er að senda umsóknir og önnur gögn með pósti, tölvupósti eða
+          faxi. Læknisvottorð verða að berast með pósti þar sem við þurfum
+          frumritið.
+        </Text>
+      </AccordionItem>
+    </Accordion>
+  </Story>
+</Canvas>
+
 ### With single card
 
 We use the standalone `<AccordionCard />` component

--- a/libs/island-ui/core/src/lib/Accordion/AccordionItem/AccordionItem.tsx
+++ b/libs/island-ui/core/src/lib/Accordion/AccordionItem/AccordionItem.tsx
@@ -21,6 +21,7 @@ import { Text } from '../../Text/Text'
 import { TextVariants } from '../../Text/Text.treat'
 import { AccordionContext } from '../../Accordion/Accordion'
 import * as styles from './AccordionItem.treat'
+import { Colors } from 'libs/island-ui/theme/src'
 
 type IconVariantTypes = 'default' | 'small' | 'sidebar'
 
@@ -31,6 +32,7 @@ export type AccordionItemBaseProps = {
   label: string
   labelVariant?: TextVariants
   labelUse?: AccordionItemLabelTags
+  labelColor: Colors
   iconVariant?: IconVariantTypes
   visibleContent?: ReactNode
   children: ReactNode
@@ -55,6 +57,7 @@ export const AccordionItem = forwardRef<HTMLButtonElement, AccordionItemProps>(
       label,
       labelVariant = 'h4',
       labelUse = 'h3',
+      labelColor = 'currentColor',
       iconVariant = 'default',
       visibleContent,
       expanded: expandedProp,
@@ -152,7 +155,7 @@ export const AccordionItem = forwardRef<HTMLButtonElement, AccordionItemProps>(
                   display="flex"
                   alignItems="center"
                 >
-                  <Text variant={labelVariant} as={labelUse}>
+                  <Text variant={labelVariant} as={labelUse} color={labelColor}>
                     {label}
                   </Text>
                 </Box>

--- a/libs/island-ui/core/src/lib/Accordion/AccordionItem/AccordionItem.tsx
+++ b/libs/island-ui/core/src/lib/Accordion/AccordionItem/AccordionItem.tsx
@@ -21,7 +21,7 @@ import { Text } from '../../Text/Text'
 import { TextVariants } from '../../Text/Text.treat'
 import { AccordionContext } from '../../Accordion/Accordion'
 import * as styles from './AccordionItem.treat'
-import { Colors } from 'libs/island-ui/theme/src'
+import { Colors } from '@island.is/island-ui/theme'
 
 type IconVariantTypes = 'default' | 'small' | 'sidebar'
 

--- a/libs/island-ui/core/src/lib/Accordion/AccordionItem/AccordionItem.tsx
+++ b/libs/island-ui/core/src/lib/Accordion/AccordionItem/AccordionItem.tsx
@@ -32,7 +32,7 @@ export type AccordionItemBaseProps = {
   label: string
   labelVariant?: TextVariants
   labelUse?: AccordionItemLabelTags
-  labelColor: Colors
+  labelColor?: Colors
   iconVariant?: IconVariantTypes
   visibleContent?: ReactNode
   children: ReactNode


### PR DESCRIPTION
# Adding `labelColor` prop on `AccordionItem`

## What

Adding `labelColor` prop so the color of the label on `AccordionItem` can be controlled.

## Why

The `Filter` component is using this to change the color of the label to blue when there is 
a selected value for a specific group.

## Screenshots / Gifs


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
