### PR TITLE
Skilavottord/Handle error on cancel recycling

### DIFF
--- a/apps/skilavottord/web/components/Modal/Modal.tsx
+++ b/apps/skilavottord/web/components/Modal/Modal.tsx
@@ -23,7 +23,7 @@ export interface ModalProps {
   continueButtonText: string
   cancelButtonText: string
   loading?: boolean
-  error?: ApolloError
+  error?: ApolloError | string
   errorText?: Errors
 }
 

--- a/apps/skilavottord/web/screens/Handover/Handover.tsx
+++ b/apps/skilavottord/web/screens/Handover/Handover.tsx
@@ -88,12 +88,6 @@ const Handover: FC = () => {
   ] = useMutation<RecyclingRequestMutation>(
     skilavottordRecyclingRequestMutation,
     {
-      onCompleted() {
-        if (requestType === 'cancelled') {
-          setModal(false)
-          routeHome()
-        }
-      },
       onError() {
         return mutationError
       },
@@ -158,6 +152,14 @@ const Handover: FC = () => {
         nameOfRequestor: user?.name,
         requestType: 'cancelled',
       },
+    }).then(({ data }) => {
+      // setRecyclingRequest is completed with no mutationErrors
+      // errors are returned in mutationResponse.message,
+      // we must therefore double check for errors in this way before closing modal and routing home
+      if (!data?.createSkilavottordRecyclingRequest?.message) {
+        setModal(false)
+        routeHome()
+      }
     })
   }
 
@@ -166,10 +168,10 @@ const Handover: FC = () => {
   }
 
   if (
-    (requestType !== 'cancelled' && (mutationError || mutationLoading)) ||
+    (requestType !== 'cancelled' &&
+      (mutationError || mutationLoading || mutationResponse?.message)) ||
     error ||
     isInvalidCar ||
-    mutationResponse?.message ||
     (loading && !data)
   ) {
     return (
@@ -261,7 +263,7 @@ const Handover: FC = () => {
         continueButtonText={t.cancelModal.buttons.continue}
         cancelButtonText={t.cancelModal.buttons.cancel}
         loading={mutationLoading}
-        error={mutationError}
+        error={mutationResponse?.message || mutationError}
         errorText={t.cancelModal.error}
       />
     </ProcessPageLayout>


### PR DESCRIPTION
# Skilavottord - handle error on cancel recycling

## What

Catch error if something goes wrong when user requests to cancel to recycle car.

## Why

Because errors on requesting cancellation is returned as if the mutation request passes, this fix will be able to catch if any error occurs and display it to the user.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
