### PR TITLE
Adding Navigation to ApiCatalogue

### DIFF
--- a/apps/web/screens/ApiCatalogue/ApiCatalogue.tsx
+++ b/apps/web/screens/ApiCatalogue/ApiCatalogue.tsx
@@ -3,6 +3,8 @@ import { Screen } from '@island.is/web/types'
 import { withMainLayout } from '@island.is/web/layouts/main'
 import { SubpageLayout } from '@island.is/web/screens/Layouts/Layouts'
 import SidebarLayout from '@island.is/web/screens/Layouts/SidebarLayout'
+import { default as NextLink } from 'next/link'
+
 import {
   Text,
   Stack,
@@ -17,6 +19,7 @@ import {
   FilterMultiChoice,
   Navigation,
 } from '@island.is/island-ui/core'
+
 import {
   ServiceList,
   SubpageDetailsContent,
@@ -257,19 +260,21 @@ const ApiCatalogue: Screen<ApiCatalogueProps> = ({
                 <Box display={['inline', 'inline', 'none']}>
                   {/* Show when a device */}
                   <Box paddingBottom="gutter">
-                    <Link href={nn('linkServices')}>
-                      <Button
-                        colorScheme="default"
-                        iconType="filled"
-                        preTextIcon="arrowBack"
-                        preTextIconType="filled"
-                        size="small"
-                        type="button"
-                        variant="text"
-                      >
-                        {nn('linkServicesText')}
-                      </Button>
-                    </Link>
+                    <NextLink passHref href={nn('linkServices')}>
+                      <a href={nn('linkServices')}>
+                        <Button
+                          colorScheme="default"
+                          iconType="filled"
+                          preTextIcon="arrowBack"
+                          preTextIconType="filled"
+                          size="small"
+                          type="button"
+                          variant="text"
+                        >
+                          {nn('linkServicesText')}
+                        </Button>
+                      </a>
+                    </NextLink>
                   </Box>
                   <Box marginBottom="gutter">
                     <Navigation

--- a/apps/web/screens/ApiCatalogue/ApiCatalogue.tsx
+++ b/apps/web/screens/ApiCatalogue/ApiCatalogue.tsx
@@ -15,6 +15,7 @@ import {
   Filter,
   FilterInput,
   FilterMultiChoice,
+  Navigation,
 } from '@island.is/island-ui/core'
 import {
   ServiceList,
@@ -62,12 +63,14 @@ interface ApiCatalogueProps {
   subpageHeader: GetSubpageHeaderQuery['getSubpageHeader']
   staticContent: GetNamespaceQuery['getNamespace']
   filterContent: GetNamespaceQuery['getNamespace']
+  navigationLinks: GetNamespaceQuery['getNamespace']
 }
 
 const ApiCatalogue: Screen<ApiCatalogueProps> = ({
   subpageHeader,
   staticContent,
   filterContent,
+  navigationLinks,
 }) => {
   /* DISABLE FROM WEB WHILE WIP */
   const { disableApiCatalog: disablePage } = publicRuntimeConfig
@@ -79,6 +82,7 @@ const ApiCatalogue: Screen<ApiCatalogueProps> = ({
   const { activeLocale } = useI18n()
   const sn = useNamespace(staticContent)
   const fn = useNamespace(filterContent)
+  const nn = useNamespace(navigationLinks)
 
   const onLoadMore = () => {
     if (data?.getApiCatalogue.pageInfo?.nextCursor === null) {
@@ -200,19 +204,96 @@ const ApiCatalogue: Screen<ApiCatalogueProps> = ({
     },
   ]
 
+  const navigationItems = [
+    {
+      active: true,
+      href: nn('linkServices'),
+      title: nn('linkServicesText'),
+      items: [
+        {
+          active: true,
+          title: nn('linkServiceListText'),
+        },
+        {
+          href: nn('linkDesignGuide'),
+          title: nn('linkDesignGuideText'),
+        },
+      ],
+    },
+    {
+      href: nn('linkIslandUI'),
+      title: nn('linkIslandUIText'),
+    },
+    {
+      href: nn('linkDesignSystem'),
+      title: nn('linkDesignSystemText'),
+    },
+    {
+      href: nn('linkContentPolicy'),
+      title: nn('linkContentPolicyText'),
+    },
+  ]
+
   return (
     <SubpageLayout
       main={
-        <SidebarLayout sidebarContent={<>Navigation goes here</>}>
+        <SidebarLayout
+          sidebarContent={
+            <Navigation
+              baseId="service-list-navigation"
+              colorScheme="blue"
+              items={navigationItems}
+              title={nn('linkThrounText')}
+              titleLink={{
+                active: true,
+                href: nn('linkThroun'),
+              }}
+            />
+          }
+        >
           <SubpageMainContent
             main={
               <Box>
-                <Box marginBottom={2}>
+                <Box display={['inline', 'inline', 'none']}>
+                  {/* Show when a device */}
+                  <Box paddingBottom="gutter">
+                    <Link href={nn('linkServices')}>
+                      <Button
+                        colorScheme="default"
+                        iconType="filled"
+                        preTextIcon="arrowBack"
+                        preTextIconType="filled"
+                        size="small"
+                        type="button"
+                        variant="text"
+                      >
+                        {nn('linkServicesText')}
+                      </Button>
+                    </Link>
+                  </Box>
+                  <Box marginBottom="gutter">
+                    <Navigation
+                      baseId="service-list-navigation"
+                      colorScheme="blue"
+                      isMenuDialog
+                      items={navigationItems}
+                      title={nn('linkThrounText')}
+                      titleLink={{
+                        active: true,
+                        href: nn('linkThroun'),
+                      }}
+                    />
+                  </Box>
+                </Box>
+                <Box marginBottom={2} display={['none', 'none', 'inline']}>
+                  {/* Show when NOT a device */}
                   <Breadcrumbs>
-                    <Link href="/">Ísland.is</Link>
-                    <a href="/throun">Þróun</a>
-                    <a href="/throun/vefthjonustur">Vefþjónustur</a>
-                    <span>{subpageHeader.title}</span>
+                    <Link href={nn('linkIslandIs')}>
+                      {nn('linkIslandIsText')}
+                    </Link>
+                    <a href={nn('linkThroun')}>{nn('linkThrounText')}</a>
+                    <a href={nn('linkServices')}>{nn('linkServicesText')}</a>
+                    <span>{nn('linkServiceListText')}</span>
                   </Breadcrumbs>
                 </Box>
                 <Stack space={1}>
@@ -348,6 +429,7 @@ ApiCatalogue.getInitialProps = async ({ apolloClient, locale, query }) => {
     },
     staticContent,
     filterContent,
+    navigationLinks,
   ] = await Promise.all([
     apolloClient.query<GetSubpageHeaderQuery, QueryGetSubpageHeaderArgs>({
       query: GET_SUBPAGE_HEADER_QUERY,
@@ -380,12 +462,24 @@ ApiCatalogue.getInitialProps = async ({ apolloClient, locale, query }) => {
         },
       })
       .then((res) => JSON.parse(res.data.getNamespace.fields)),
+    apolloClient
+      .query<GetNamespaceQuery, QueryGetNamespaceArgs>({
+        query: GET_NAMESPACE_QUERY,
+        variables: {
+          input: {
+            namespace: 'ApiCatalogueLinks',
+            lang: locale,
+          },
+        },
+      })
+      .then((res) => JSON.parse(res.data.getNamespace.fields)),
   ])
 
   return {
     subpageHeader,
     staticContent,
     filterContent,
+    navigationLinks,
   }
 }
 

--- a/apps/web/screens/ServiceDetails/ServiceDetails.tsx
+++ b/apps/web/screens/ServiceDetails/ServiceDetails.tsx
@@ -19,7 +19,14 @@ import {
 } from '../../components'
 import { SubpageLayout } from '../Layouts/Layouts'
 import SidebarLayout from '../Layouts/SidebarLayout'
-import { Box, Breadcrumbs, Button, Link, Text } from '@island.is/island-ui/core'
+import {
+  Box,
+  Breadcrumbs,
+  Button,
+  Link,
+  Navigation,
+  Text,
+} from '@island.is/island-ui/core'
 import { useNamespace } from '../../hooks'
 import { useScript } from '../../hooks/useScript'
 
@@ -47,22 +54,69 @@ const ServiceDetails: Screen<ServiceDetailsProps> = ({
   const n = useNamespace(strings)
   const nfc = useNamespace(filterContent)
   const { disableApiCatalog: disablePage } = publicRuntimeConfig
-  const serviceListLink = '/throun/vefthjonustur/vorulisti'
 
   if (disablePage === 'true') {
     throw new CustomNextError(404, 'Not found')
   }
 
+  const navigationItems = [
+    {
+      active: true,
+      href: n('linkServices'),
+      title: n('linkServicesText'),
+      items: [
+        {
+          href: n('linkServiceList'),
+          title: n('linkServiceListText'),
+        },
+        {
+          href: n('linkDesignGuide'),
+          title: n('linkDesignGuideText'),
+        },
+        {
+          active: true,
+          title: n('linkDetailsLastText'),
+        },
+      ],
+    },
+    {
+      href: n('linkIslandUI'),
+      title: n('linkIslandUIText'),
+    },
+    {
+      href: n('linkDesignSystem'),
+      title: n('linkDesignSystemText'),
+    },
+    {
+      href: n('linkContentPolicy'),
+      title: n('linkContentPolicyText'),
+    },
+  ]
+
   return (
     <SubpageLayout
       main={
-        <SidebarLayout sidebarContent={<></>}>
+        <SidebarLayout
+          sidebarContent={
+            <Navigation
+              baseId="service-details-navigation"
+              colorScheme="blue"
+              items={navigationItems}
+              title={n('linkThrounText')}
+              titleLink={{
+                active: true,
+                href: n('linkThroun'),
+              }}
+            />
+          }
+        >
           <SubpageMainContent
             main={
               <Box>
-                <Box marginBottom={2}>
-                  <Box display={['inline', 'none']}>
-                    <Link href={serviceListLink}>
+                <Box display={['inline', 'inline', 'none']}>
+                  {/* Show only on a device */}
+                  <Box paddingBottom="gutter">
+                    <Link href={n('linkServiceList')}>
                       <Button
                         colorScheme="default"
                         iconType="filled"
@@ -72,18 +126,36 @@ const ServiceDetails: Screen<ServiceDetailsProps> = ({
                         type="button"
                         variant="text"
                       >
-                        {n('linkTextVefthjonustur')}
+                        {n('linkServiceListText')}
                       </Button>
                     </Link>
                   </Box>
-                  <Box display={['none', 'inline']}>
-                    <Breadcrumbs>
-                      <Link href="/">Ísland.is</Link>
-                      <a href="/throun">{n('linkTextThroun')}</a>
-                      <a href={serviceListLink}>{n('linkTextVefthjonustur')}</a>
-                      <span>{n('linkTextLast')}</span>
-                    </Breadcrumbs>
+                  <Box marginBottom="gutter">
+                    <Navigation
+                      baseId="service-details-navigation"
+                      colorScheme="blue"
+                      isMenuDialog
+                      items={navigationItems}
+                      title={n('linkThrounText')}
+                      titleLink={{
+                        active: true,
+                        href: n('linkThroun'),
+                      }}
+                    />
                   </Box>
+                </Box>
+                <Box marginBottom={2} display={['none', 'none', 'inline']}>
+                  {/* Show when NOT a device */}
+                  <Breadcrumbs>
+                    <Link href={n('linkIslandIs')}>
+                      {n('linkIslandIsText')}
+                    </Link>
+                    <a href={n('linkThroun')}>{n('linkThrounText')}</a>
+                    <a href={n('linkServiceList')}>
+                      {n('linkServiceListText')}
+                    </a>
+                    <span>{n('linkDetailsLastText')}</span>
+                  </Breadcrumbs>
                 </Box>
                 {!service ? (
                   <Box>
@@ -117,7 +189,7 @@ ServiceDetails.getInitialProps = async ({ apolloClient, locale, query }) => {
   const serviceId = String(query.slug)
 
   const [
-    serviceDetails,
+    linkStrings,
     filterContent,
     openApiContent,
     { data },
@@ -127,7 +199,7 @@ ServiceDetails.getInitialProps = async ({ apolloClient, locale, query }) => {
         query: GET_NAMESPACE_QUERY,
         variables: {
           input: {
-            namespace: 'ServiceDetails',
+            namespace: 'ApiCatalogueLinks',
             lang: locale,
           },
         },
@@ -167,7 +239,7 @@ ServiceDetails.getInitialProps = async ({ apolloClient, locale, query }) => {
 
   return {
     serviceId: serviceId,
-    strings: serviceDetails,
+    strings: linkStrings,
     filterContent: filterContent,
     openApiContent: openApiContent,
     service: data?.getApiServiceById,

--- a/apps/web/screens/ServiceDetails/ServiceDetails.tsx
+++ b/apps/web/screens/ServiceDetails/ServiceDetails.tsx
@@ -115,7 +115,7 @@ const ServiceDetails: Screen<ServiceDetailsProps> = ({
             main={
               <Box>
                 <Box display={['inline', 'inline', 'none']}>
-                  {/* Show when a device */}
+                  {/* Show when a device  */}
                   <Box paddingBottom="gutter">
                     <NextLink passHref href={n('linkServiceList')}>
                       <a href={n('linkServiceList')}>

--- a/apps/web/screens/ServiceDetails/ServiceDetails.tsx
+++ b/apps/web/screens/ServiceDetails/ServiceDetails.tsx
@@ -114,7 +114,7 @@ const ServiceDetails: Screen<ServiceDetailsProps> = ({
             main={
               <Box>
                 <Box display={['inline', 'inline', 'none']}>
-                  {/* Show only on a device */}
+                  {/* Show when a device */}
                   <Box paddingBottom="gutter">
                     <Link href={n('linkServiceList')}>
                       <Button

--- a/apps/web/screens/ServiceDetails/ServiceDetails.tsx
+++ b/apps/web/screens/ServiceDetails/ServiceDetails.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Screen } from '@island.is/web/types'
 import { withMainLayout } from '@island.is/web/layouts/main'
 import getConfig from 'next/config'
+import { default as NextLink } from 'next/link'
 import { CustomNextError } from '@island.is/web/units/errors'
 
 import {
@@ -116,19 +117,21 @@ const ServiceDetails: Screen<ServiceDetailsProps> = ({
                 <Box display={['inline', 'inline', 'none']}>
                   {/* Show when a device */}
                   <Box paddingBottom="gutter">
-                    <Link href={n('linkServiceList')}>
-                      <Button
-                        colorScheme="default"
-                        iconType="filled"
-                        preTextIcon="arrowBack"
-                        preTextIconType="filled"
-                        size="small"
-                        type="button"
-                        variant="text"
-                      >
-                        {n('linkServiceListText')}
-                      </Button>
-                    </Link>
+                    <NextLink passHref href={n('linkServiceList')}>
+                      <a href={n('linkServiceList')}>
+                        <Button
+                          colorScheme="default"
+                          iconType="filled"
+                          preTextIcon="arrowBack"
+                          preTextIconType="filled"
+                          size="small"
+                          type="button"
+                          variant="text"
+                        >
+                          {n('linkServiceListText')}
+                        </Button>
+                      </a>
+                    </NextLink>
                   </Box>
                   <Box marginBottom="gutter">
                     <Navigation

--- a/apps/web/screens/ServiceDetails/ServiceDetails.tsx
+++ b/apps/web/screens/ServiceDetails/ServiceDetails.tsx
@@ -115,7 +115,7 @@ const ServiceDetails: Screen<ServiceDetailsProps> = ({
             main={
               <Box>
                 <Box display={['inline', 'inline', 'none']}>
-                  {/* Show when a device  */}
+                  {/* Show when a device */}
                   <Box paddingBottom="gutter">
                     <NextLink passHref href={n('linkServiceList')}>
                       <a href={n('linkServiceList')}>


### PR DESCRIPTION
# Adding navigation Api Catalogue
Adding the Navigation component to two pages in the Api Catalogue 

Design Desktop:
 - *Service list* : https://www.figma.com/file/IQ006wy2vR1jIWJ6Uqwis5/Viskuausan?node-id=570%3A1713
 - *Service details* : https://www.figma.com/file/IQ006wy2vR1jIWJ6Uqwis5/Viskuausan?node-id=361%3A1
Design Mobile:
 - *Service list* : https://www.figma.com/file/IQ006wy2vR1jIWJ6Uqwis5/Viskuausan?node-id=364%3A36
 - *Service details* : https://www.figma.com/file/IQ006wy2vR1jIWJ6Uqwis5/Viskuausan?node-id=500%3A1692

## What

Adding navigation to the upper left corner on the two pages (screens) ApiCatalogue and ServiceDetails

## Why

For easy navigation for user

## Screenshots / Gifs
### Service list
**Desktop**
![image](https://user-images.githubusercontent.com/545586/102910202-14271c00-4472-11eb-9416-92f579d1c198.png)
**Mobile**
![image](https://user-images.githubusercontent.com/545586/102910425-72ec9580-4472-11eb-8ab4-c6cc5fe36d75.png)

### Service Details
**Desktop**
![image](https://user-images.githubusercontent.com/545586/102910560-ad563280-4472-11eb-8330-b6d379b16032.png)

**Mobile**
![image](https://user-images.githubusercontent.com/545586/102910621-c3fc8980-4472-11eb-87d8-3cc66e5683a0.png)


## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
