### PR TITLE
Use global namespace in frontpage tabs

### DIFF
--- a/apps/web/components/FrontpageTabs/FrontpageTabs.tsx
+++ b/apps/web/components/FrontpageTabs/FrontpageTabs.tsx
@@ -6,6 +6,7 @@ import React, {
   useState,
   useCallback,
   useEffect,
+  useContext,
 } from 'react'
 import Link from 'next/link'
 import cn from 'classnames'
@@ -27,6 +28,8 @@ import { useI18n } from '../../i18n'
 import { theme } from '@island.is/island-ui/theme'
 import Illustration from './illustrations/Illustration'
 import * as styles from './FrontpageTabs.treat'
+import { GlobalContext } from '@island.is/web/context'
+import { useNamespace } from '@island.is/web/hooks'
 
 type TabsProps = {
   subtitle?: string
@@ -63,6 +66,9 @@ export const FrontpageTabs: FC<FrontpageTabsProps> = ({
   tabs,
   searchContent,
 }) => {
+  const { globalNamespace } = useContext(GlobalContext)
+  const gn = useNamespace(globalNamespace)
+
   const contentRef = useRef(null)
   const [minHeight, setMinHeight] = useState<number>(0)
   const itemRefs = useRef<Array<HTMLElement | null>>([])
@@ -250,7 +256,7 @@ export const FrontpageTabs: FC<FrontpageTabsProps> = ({
                                 icon="arrowForward"
                                 aria-labelledby={tabTitleId}
                               >
-                                Sjá nánar
+                                {gn('seeMore')}
                               </Button>
                             </Link>
                           </span>


### PR DESCRIPTION
# Hardcoded string

Remove hardcoded string and use translated stiring insteda

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
