### PR TITLE
Rethrow original exception in handleError

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -334,6 +334,7 @@ jobs:
               GIT_BRANCH=feature/$GIT_BRANCH
             fi
           fi
+          echo "Sending webhook with branch: '$GIT_BRANCH'"
           curl -v $SPINNAKER_URL/webhooks/webhook/${{matrix.service}} -H "content-type: application/json" --data-binary @- <<BODY
           {
             "token": "$SPINNAKER_WEBHOOK_TOKEN",

--- a/libs/content-search-toolkit/src/services/elastic.service.ts
+++ b/libs/content-search-toolkit/src/services/elastic.service.ts
@@ -321,9 +321,9 @@ export class ElasticService {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  static handleError(message: string, context: any, error: any): never {
+  static handleError(message: string, context: any, error: Error): never {
     ElasticService.logError(message, context, error)
-    throw new Error(message)
+    throw error
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## What

Throw exception that caused the error

## Why

Don't mask the original exception that caused the error, leading to harder-to-debug errors. We want to be able to see the code-path that led to the exception.