### PR TITLE
Versions should be sorted in descending order and newest should be se…

### DIFF
--- a/apps/web/components/OpenApiView/OpenApiView.tsx
+++ b/apps/web/components/OpenApiView/OpenApiView.tsx
@@ -57,6 +57,9 @@ export const OpenApiView = ({ service, strings }: OpenApiViewProps) => {
         },
       ]
 
+  //sort in descending order, highest version first
+  options.sort((a, b) => (a.value.serviceCode < b.value.serviceCode ? 1 : -1))
+
   const selectOptionValueToGetOpenApiInput = (
     option: SelectOption,
   ): GetOpenApiInput => {


### PR DESCRIPTION

# Service details Version order
How service versions are ordered in the select component on the details page in the api catalogue

## What

Versions should be sorted in descending order and the newest version should be selected

## Why

Specify why you need to achieve this

## Screenshots / Gifs

this is a link to the only service with two versions
http://localhost:4200/throun/vefthjonustur/vorulisti/SVMtREVWX0NPTV8xMDAwMl9Pcmlnby1Qcm90ZWN0ZWRfcGV0c3RvcmU

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
