### PR TITLE
Enabling truncate flag on CategoryCard use in ServiceList

### DIFF
--- a/apps/web/components/ServiceList/ServiceList.tsx
+++ b/apps/web/components/ServiceList/ServiceList.tsx
@@ -78,6 +78,7 @@ export const ServiceList: React.FC<ServiceListProps> = ({
                 heading={item.name}
                 text={item.owner}
                 tags={CategoriesToTags(item)}
+                truncateHeading={true}
               />
             </GridColumn>
           )


### PR DESCRIPTION
# Enabling truncate flag on CategoryCard 

## What

Enabling truncate flag on CategoryCard used in the ServiceList.

## Why

For some screen widths the service title can be come to long for the card so we need to truncate it.

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/54210288/103548470-c234bc00-4e9d-11eb-9776-9713168ad85a.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
