### PR TITLE
onLoad setting redoc div z-index to 0

### DIFF
--- a/apps/web/components/OpenApiDocumentation/OpenApiDocumentation.tsx
+++ b/apps/web/components/OpenApiDocumentation/OpenApiDocumentation.tsx
@@ -72,6 +72,17 @@ export const OpenApiDocumentation: FC<OpenApiDocumentationProps> = ({
         showExtensions: true,
       },
       document.getElementById('redoc-container'),
+      () => {
+        setTimeout(() => {
+          //Put select options in front of the redoc div.
+          const element: HTMLElement = document.querySelector(
+            '#redoc-container div.aczea.api-content',
+          )
+          if (element) {
+            element.style.zIndex = '0'
+          }
+        }, 200)
+      },
     )
   }, [spec])
 


### PR DESCRIPTION
# Fix Select Option focus with redoc

Links to a service with two versions
dev: https://beta.dev01.devland.is/throun/vefthjonustur/vorulisti/SVMtREVWX0NPTV8xMDAwMl9Pcmlnby1Qcm90ZWN0ZWRfcGV0c3RvcmU
local: http://localhost:4200/throun/vefthjonustur/vorulisti/SVMtREVWX0NPTV8xMDAwMl9Pcmlnby1Qcm90ZWN0ZWRfcGV0c3RvcmU

## What

When there are two or more versions of a service, lower select options are un-clickable (fall behind the redoc element).  So we will need to set it's z-index to 0 after it has been created.

## Why

Because redoc is an external javascript module

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request
![selectOptionBehind](https://user-images.githubusercontent.com/545586/103556103-2c9f2980-4ea9-11eb-90bd-157f5dd6b519.gif)


## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
