### PR TITLE
Judicial-system/Sort arrow tweeks

### DIFF
--- a/apps/judicial-system/web/src/routes/Shared/DetentionRequests/DetentionRequests.treat.ts
+++ b/apps/judicial-system/web/src/routes/Shared/DetentionRequests/DetentionRequests.treat.ts
@@ -53,6 +53,8 @@ export const deleteButtonContainer = style({
 })
 
 export const thButton = style({
+  outline: 'none',
+
   ':active': {
     color: theme.color.dark400,
   },
@@ -137,18 +139,24 @@ export const deleteButtonText = style({
 })
 
 export const sortIcon = style({
-  opacity: 0,
-  transition: 'opacity .5s ease-in-out, transform .5s ease-in-out .2s',
+  opacity: 0.4,
+  transition: 'opacity .2s ease-in-out',
+
+  selectors: {
+    [`${thButton}:hover &`]: {
+      opacity: 1,
+    },
+  },
 })
 
 export const sortCreatedAsc = style({
   opacity: 1,
-  transform: 'rotate(0deg)',
+  transform: 'rotate(180deg)',
 })
 
 export const sortCreatedDes = style({
   opacity: 1,
-  transform: 'rotate(180deg)',
+  transform: 'rotate(0deg)',
 })
 
 export const sortAccusedNameAsc = style({

--- a/apps/judicial-system/web/src/routes/Shared/DetentionRequests/DetentionRequests.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/DetentionRequests/DetentionRequests.tsx
@@ -286,9 +286,9 @@ export const DetentionRequests: React.FC = () => {
                       Krafa stofnuð
                       <Box
                         className={cn(styles.sortIcon, {
-                          [styles.sortAccusedNameAsc]:
+                          [styles.sortCreatedAsc]:
                             getClassNamesFor('created') === 'ascending',
-                          [styles.sortAccusedNameDes]:
+                          [styles.sortCreatedDes]:
                             getClassNamesFor('created') === 'descending',
                         })}
                         marginLeft={1}
@@ -296,7 +296,7 @@ export const DetentionRequests: React.FC = () => {
                         display="flex"
                         alignItems="center"
                       >
-                        <Icon icon="caretDown" size="small" />
+                        <Icon icon="caretUp" size="small" />
                       </Box>
                     </Box>
                   </Text>

--- a/libs/island-ui/core/src/lib/IconRC/iconMap.ts
+++ b/libs/island-ui/core/src/lib/IconRC/iconMap.ts
@@ -11,6 +11,7 @@ export type Icon =
   | 'call'
   | 'car'
   | 'caretDown'
+  | 'caretUp'
   | 'cellular'
   | 'chatbubble'
   | 'checkmark'
@@ -61,6 +62,7 @@ export default {
     call: 'Call',
     car: 'Car',
     caretDown: 'CaretDown',
+    caretUp: 'CaretUp',
     cellular: 'Cellular',
     chatbubble: 'Chatbubble',
     checkmark: 'Checkmark',
@@ -110,6 +112,7 @@ export default {
     call: 'CallOutline',
     car: 'CarOutline',
     caretDown: 'CaretDownOutline',
+    caretUp: 'CaretUpOutline',
     cellular: 'CellularOutline',
     chatbubble: 'ChatbubbleOutline',
     checkmark: 'Checkmark',

--- a/libs/island-ui/core/src/lib/IconRC/icons/CaretUp.tsx
+++ b/libs/island-ui/core/src/lib/IconRC/icons/CaretUp.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react'
+import { SvgProps as SVGRProps } from '../Icon'
+
+const CaretUp = ({
+  title,
+  titleId,
+  ...props
+}: React.SVGProps<SVGSVGElement> & SVGRProps) => {
+  return (
+    <svg
+      className="caret_up_svg__ionicon"
+      viewBox="0 0 512 512"
+      aria-labelledby={titleId}
+      {...props}
+    >
+      <title>Caret Up</title>
+      <path d="M414 321.94L274.22 158.82a24 24 0 00-36.44 0L98 321.94c-13.34 15.57-2.28 39.62 18.22 39.62h279.6c20.5 0 31.56-24.05 18.18-39.62z" />
+    </svg>
+  )
+}
+
+export default CaretUp

--- a/libs/island-ui/core/src/lib/IconRC/icons/CaretUpOutline.tsx
+++ b/libs/island-ui/core/src/lib/IconRC/icons/CaretUpOutline.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react'
+import { SvgProps as SVGRProps } from '../Icon'
+
+const CaretUpOutline = ({
+  title,
+  titleId,
+  ...props
+}: React.SVGProps<SVGSVGElement> & SVGRProps) => {
+  return (
+    <svg
+      className="caret_up-outline_svg__ionicon"
+      viewBox="0 0 512 512"
+      aria-labelledby={titleId}
+      {...props}
+    >
+      <title>Caret Up</title>
+      <path d="M414 321.94L274.22 158.82a24 24 0 00-36.44 0L98 321.94c-13.34 15.57-2.28 39.62 18.22 39.62h279.6c20.5 0 31.56-24.05 18.18-39.62z" />
+    </svg>
+  )
+}
+
+export default CaretUpOutline


### PR DESCRIPTION
# Sort arrow style update

https://app.asana.com/0/1199153462262248/1199597549258731

## What

It's unclear that users can sort the detention request table because the sort arrows are currently not visible by default. In this PR, we make the arrows visible by default, although slightly transparent to indicate that the table can be sorted.

## Why

UX

## Screenshots / Gifs

https://user-images.githubusercontent.com/3789875/103631284-b0edbd00-4f3a-11eb-833f-40049adeaf89.mov

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
