### PR TITLE
Fix title in mobile navigation if it has no active state

### DIFF
--- a/libs/island-ui/core/src/lib/Navigation/Navigation.tsx
+++ b/libs/island-ui/core/src/lib/Navigation/Navigation.tsx
@@ -187,7 +187,7 @@ export const Navigation: FC<NavigationProps> = ({
             onClick={() => menu.show}
           >
             <MobileButton
-              title={activeItemTitle ?? title}
+              title={activeItemTitle ? activeItemTitle : title}
               colorScheme={colorScheme}
               aria-expanded={!mobileMenuOpen}
               aria-controls={'OpenNavigationDialog'}


### PR DESCRIPTION
# Bug fix in mobile navigation

Use default title if no navigation item is selected

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
