### PR TITLE
island.is / Navigation title

### DIFF
--- a/apps/web/screens/Article.tsx
+++ b/apps/web/screens/Article.tsx
@@ -175,7 +175,7 @@ const ArticleNavigation: FC<
         title={n('sidebarHeader')}
         activeItemTitle={
           !activeSlug
-            ? article.shortTitle ?? article.title
+            ? article.shortTitle || article.title
             : article.subArticles.find((sub) => activeSlug === sub.slug).title
         }
         isMenuDialog={isMenuDialog}
@@ -188,7 +188,7 @@ const ArticleNavigation: FC<
         }}
         items={[
           {
-            title: article.shortTitle ?? article.title,
+            title: article.shortTitle || article.title,
             typename: article.__typename,
             slug: [article.slug],
             active: !activeSlug,


### PR DESCRIPTION
# Navigation title

## What / Why

Optional title will always have empty string as default value so we use logical OR instead of nullish coalescing operator so empty strings will return false

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
