### PR TITLE
island-ui/ Allow 'title' prop on Button

### DIFF
--- a/libs/island-ui/core/src/lib/Button/Button.stories.tsx
+++ b/libs/island-ui/core/src/lib/Button/Button.stories.tsx
@@ -160,6 +160,7 @@ export const Circle = Template.bind({})
 Circle.args = {
   circle: true,
   icon: 'arrowForward',
+  title: 'Go forward',
 }
 
 export const CircleSmall = Template.bind({})
@@ -167,6 +168,7 @@ CircleSmall.args = {
   circle: true,
   icon: 'arrowForward',
   size: 'small',
+  title: 'Go forward',
 }
 
 export const CircleLarge = Template.bind({})
@@ -174,6 +176,7 @@ CircleLarge.args = {
   circle: true,
   icon: 'arrowForward',
   size: 'large',
+  title: 'Go forward',
 }
 
 export const CircleDestructive = Template.bind({})

--- a/libs/island-ui/core/src/lib/Button/Button.tsx
+++ b/libs/island-ui/core/src/lib/Button/Button.tsx
@@ -56,6 +56,7 @@ export interface ButtonProps {
   lang?: string
   loading?: boolean
   nowrap?: boolean
+  title?: string
 }
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps & ButtonTypes>(


### PR DESCRIPTION
# Allow 'title' prop on Button

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
