### PR TITLE
Removing version select options fix

### DIFF
--- a/apps/web/components/OpenApiDocumentation/OpenApiDocumentation.tsx
+++ b/apps/web/components/OpenApiDocumentation/OpenApiDocumentation.tsx
@@ -72,17 +72,6 @@ export const OpenApiDocumentation: FC<OpenApiDocumentationProps> = ({
         showExtensions: true,
       },
       document.getElementById('redoc-container'),
-      () => {
-        setTimeout(() => {
-          //Put select options in front of the redoc div.
-          const element: HTMLElement = document.querySelector(
-            '#redoc-container div.aczea.api-content',
-          )
-          if (element) {
-            element.style.zIndex = '0'
-          }
-        }, 200)
-      },
     )
   }, [spec])
 


### PR DESCRIPTION
# Removing select option fix
The fix did not work after merge, so removing it again

## What

The redoc reqest sample window (gray one to the right) dissapears, so removing the fix

## Why

I was trying to fix that the select options are not clickable when versions are more than one
You can see the problem in this pull-reqest: https://github.com/island-is/island.is/pull/2393


## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
