### PR TITLE
Service version options in front of redoc

### DIFF
--- a/apps/web/components/OpenApiView/OpenApiView.treat.ts
+++ b/apps/web/components/OpenApiView/OpenApiView.treat.ts
@@ -1,5 +1,5 @@
 import { style } from 'treat'
 
-export const wrapper = style({
+export const bringFront = style({
   zIndex: 2,
 })

--- a/apps/web/components/OpenApiView/OpenApiView.treat.ts
+++ b/apps/web/components/OpenApiView/OpenApiView.treat.ts
@@ -1,0 +1,5 @@
+import { style } from 'treat'
+
+export const wrapper = style({
+  zIndex: 2,
+})

--- a/apps/web/components/OpenApiView/OpenApiView.tsx
+++ b/apps/web/components/OpenApiView/OpenApiView.tsx
@@ -20,7 +20,6 @@ import { GET_OPEN_API_QUERY } from '@island.is/web/screens/queries'
 import YamlParser from 'js-yaml'
 import { OpenApiDocumentation } from '..'
 import * as styles from './OpenApiView.treat'
-import cn from 'classnames'
 
 export interface OpenApiViewProps {
   service: ApiService
@@ -136,7 +135,7 @@ export const OpenApiView = ({ service, strings }: OpenApiViewProps) => {
           span={['8/8', '4/8', '4/8', '2/8']}
           paddingTop="containerGutter"
           paddingBottom="containerGutter"
-          className={cn(styles.wrapper)}
+          className={styles.wrapper}
         >
           <Select
             label="Version"

--- a/apps/web/components/OpenApiView/OpenApiView.tsx
+++ b/apps/web/components/OpenApiView/OpenApiView.tsx
@@ -19,6 +19,8 @@ import { OpenApi } from '@island.is/api-catalogue/types'
 import { GET_OPEN_API_QUERY } from '@island.is/web/screens/queries'
 import YamlParser from 'js-yaml'
 import { OpenApiDocumentation } from '..'
+import * as styles from './OpenApiView.treat'
+import cn from 'classnames'
 
 export interface OpenApiViewProps {
   service: ApiService
@@ -134,6 +136,7 @@ export const OpenApiView = ({ service, strings }: OpenApiViewProps) => {
           span={['8/8', '4/8', '4/8', '2/8']}
           paddingTop="containerGutter"
           paddingBottom="containerGutter"
+          className={cn(styles.wrapper)}
         >
           <Select
             label="Version"

--- a/apps/web/components/OpenApiView/OpenApiView.tsx
+++ b/apps/web/components/OpenApiView/OpenApiView.tsx
@@ -135,7 +135,7 @@ export const OpenApiView = ({ service, strings }: OpenApiViewProps) => {
           span={['8/8', '4/8', '4/8', '2/8']}
           paddingTop="containerGutter"
           paddingBottom="containerGutter"
-          className={styles.wrapper}
+          className={styles.bringFront}
         >
           <Select
             label="Version"


### PR DESCRIPTION
# Select Option focus with redoc

Links to a service with two versions
dev: https://beta.dev01.devland.is/throun/vefthjonustur/vorulisti/SVMtREVWX0NPTV8xMDAwMl9Pcmlnby1Qcm90ZWN0ZWRfcGV0c3RvcmU
local: http://localhost:4200/throun/vefthjonustur/vorulisti/SVMtREVWX0NPTV8xMDAwMl9Pcmlnby1Qcm90ZWN0ZWRfcGV0c3RvcmU

## What

When there are two or more versions of a service, lower select options are un-clickable (fall behind the redoc element).  So we will need to set the z-index to 2  on the column containing the select component because one of the redoc items is set to z-index: 1

## Why

Because redoc is an external javascript module

## Screenshots / Gifs
The problem being fixed:
![selectOptionBehind](https://user-images.githubusercontent.com/545586/103556103-2c9f2980-4ea9-11eb-90bd-157f5dd6b519.gif)


## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
