### PR TITLE
Update codeowners to reflect team name change

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,11 +37,11 @@
 /libs/application/templates/parental-leave/               @island-is/aranja
 /libs/application/templates/reference-template/           @island-is/aranja
 
-/apps/judicial-system/                                    @island-is/kolibri
-/libs/judicial-system/                                    @island-is/kolibri
-/libs/nova-sms/                                           @island-is/kolibri
-/libs/dokobit-signing/                                    @island-is/kolibri
-/libs/email-service/                                      @island-is/kolibri
+/apps/judicial-system/                                    @island-is/kolibri-justice-league
+/libs/judicial-system/                                    @island-is/kolibri-justice-league
+/libs/nova-sms/                                           @island-is/kolibri-justice-league
+/libs/dokobit-signing/                                    @island-is/kolibri-justice-league
+/libs/email-service/                                      @island-is/kolibri-justice-league
 
 /*/service-portal*/                                       @island-is/sendiradid
 /libs/api/domains/documents/                              @island-is/sendiradid

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -32,7 +32,7 @@ jobs:
             cat .github/CODEOWNERS | grep -v '^#' | awk NF
             exit 1
           fi
-      - uses: mszostok/codeowners-validator@v0.4.0
+      - uses: mszostok/codeowners-validator@v0.5.1
         if: env.CHECK
         with:
           checks: 'files,owners,duppatterns'


### PR DESCRIPTION
Kolibri now has two teams. These are the OGs.