### PR TITLE
moving OpenApi links to OpenApiView

### DIFF
--- a/apps/web/components/OpenApiDocumentation/OpenApiDocumentation.tsx
+++ b/apps/web/components/OpenApiDocumentation/OpenApiDocumentation.tsx
@@ -1,12 +1,6 @@
 import React, { FC, useEffect } from 'react'
 import { OpenApi } from '@island.is/api-catalogue/types'
-import {
-  ArrowLink,
-  Box,
-  GridColumn,
-  GridRow,
-  Text,
-} from '@island.is/island-ui/core'
+import { Box } from '@island.is/island-ui/core'
 
 ///////////////////////////////////////////////////////////////////////////////
 //
@@ -21,11 +15,6 @@ import {
 
 export interface OpenApiDocumentationProps {
   spec: OpenApi
-  linkTitle?: string
-  documentationLinkText?: string
-  responsiblePartyLinkText?: string
-  bugReportLinkText?: string
-  featureRequestLinkText?: string
 }
 
 interface Window {
@@ -36,34 +25,7 @@ declare const window: Window
 
 export const OpenApiDocumentation: FC<OpenApiDocumentationProps> = ({
   spec,
-  linkTitle = 'Additional links',
-  documentationLinkText = 'Documentation',
-  responsiblePartyLinkText = 'Responsible party',
-  bugReportLinkText = 'Report a bug',
-  featureRequestLinkText = 'Make a feature request',
 }: OpenApiDocumentationProps) => {
-  const GetDefaultLinkText = (key: string) => {
-    let text: string
-    switch (key) {
-      case 'documentation':
-        text = documentationLinkText
-        break
-      case 'responsibleParty':
-        text = responsiblePartyLinkText
-        break
-      case 'bugReport':
-        text = bugReportLinkText
-        break
-      case 'featureRequest':
-        text = featureRequestLinkText
-        break
-      default:
-        text = key
-    }
-
-    return text
-  }
-
   useEffect(() => {
     window.Redoc.init(
       spec,
@@ -76,24 +38,8 @@ export const OpenApiDocumentation: FC<OpenApiDocumentationProps> = ({
   }, [spec])
 
   return (
-    <Box width="full">
-      {spec !== undefined && spec !== null && 'x-links' in spec.info && (
-        <Box width="full">
-          <Text variant="h4" as="h4">
-            {linkTitle}
-          </Text>
-          <GridRow align="spaceBetween">
-            {Object.keys(spec?.info['x-links']).map((key) => (
-              <GridColumn key={key}>
-                <ArrowLink href={spec.info['x-links'][key]}>
-                  {GetDefaultLinkText(key)}
-                </ArrowLink>
-              </GridColumn>
-            ))}
-          </GridRow>
-        </Box>
-      )}
-      <Box id="redoc-container" paddingTop="containerGutter" />
+    <Box width="full" paddingTop="containerGutter">
+      <Box id="redoc-container" background="white" />
     </Box>
   )
 }

--- a/apps/web/components/OpenApiView/OpenApiView.treat.ts
+++ b/apps/web/components/OpenApiView/OpenApiView.treat.ts
@@ -1,5 +1,13 @@
 import { style } from 'treat'
+import { themeUtils } from '@island.is/island-ui/theme'
 
-export const bringFront = style({
+export const selectDesktop = style({
   zIndex: 2,
+
+  ...themeUtils.responsiveStyle({
+    xs: { width: '100%' },
+    md: { width: 144 },
+    lg: { width: 220 },
+    xl: { width: 316 },
+  }),
 })

--- a/apps/web/components/OpenApiView/OpenApiView.tsx
+++ b/apps/web/components/OpenApiView/OpenApiView.tsx
@@ -300,7 +300,7 @@ export const OpenApiView = ({ service, strings }: OpenApiViewProps) => {
           />
         </Box>
       )}
-
+      {/* Showing Api documentation with redoc */}
       <Box width="full">
         {!loading &&
           !error &&

--- a/apps/web/components/OpenApiView/OpenApiView.tsx
+++ b/apps/web/components/OpenApiView/OpenApiView.tsx
@@ -1,13 +1,14 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useQuery } from '@apollo/client'
 import {
   AlertBanner,
   Box,
   Text,
-  GridColumn,
-  GridRow,
   LoadingIcon,
   Select,
+  Stack,
+  Link,
+  Button,
 } from '@island.is/island-ui/core'
 import {
   ApiService,
@@ -15,7 +16,7 @@ import {
   GetNamespaceQuery,
 } from '@island.is/web/graphql/schema'
 import { useNamespace } from '@island.is/web/hooks'
-import { OpenApi } from '@island.is/api-catalogue/types'
+import { OpenApi, LinksObject } from '@island.is/api-catalogue/types'
 import { GET_OPEN_API_QUERY } from '@island.is/web/screens/queries'
 import YamlParser from 'js-yaml'
 import { OpenApiDocumentation } from '..'
@@ -81,78 +82,215 @@ export const OpenApiView = ({ service, strings }: OpenApiViewProps) => {
     if (!option.value) return
 
     setSelectedOption(option)
-    setOpenApi(selectOptionValueToGetOpenApiInput(option))
+    setOpenApiInput(selectOptionValueToGetOpenApiInput(option))
   }
 
-  const [openApi, setOpenApi] = useState<GetOpenApiInput>(
+  const [documentation, setDocumentation] = useState<OpenApi>(null)
+  const [openApiInput, setOpenApiInput] = useState<GetOpenApiInput>(
     selectOptionValueToGetOpenApiInput(selectedOption),
   )
   const { data, loading, error } = useQuery(GET_OPEN_API_QUERY, {
     variables: {
-      input: openApi,
+      input: openApiInput,
     },
   })
 
-  const ShowOpenApiDocumentation = (theSpec: any) => {
-    const converted = YamlParser.safeLoad(theSpec)
-    if (typeof converted === 'undefined') {
-      return (
-        <Box paddingY={2}>
-          <AlertBanner
-            title={n('queryErrorTitle')}
-            description={n('queryErrorText')}
-            variant="error"
-          />
+  useEffect(() => {
+    const onCompleted = (data) => {
+      const converted = YamlParser.safeLoad(data.getOpenApi.spec)
+
+      setDocumentation(converted as OpenApi)
+    }
+    if (onCompleted) {
+      if (onCompleted && !loading && !error) {
+        onCompleted(data)
+      } else {
+        setDocumentation(null)
+      }
+    }
+  }, [loading, data, error])
+
+  const showTextLinks = (links: LinksObject) => {
+    return (
+      (links.documentation || links.responsibleParty) && (
+        <Box
+          display="flex"
+          marginRight={[0, 0, 0, 0, 2]}
+          justifyContent={[
+            'spaceBetween',
+            'spaceBetween',
+            'flexStart',
+            'flexEnd',
+          ]}
+          marginTop={['gutter', 'gutter', 'none']}
+          marginBottom={['gutter', 'gutter', 'none']}
+        >
+          {links.documentation && (
+            <Box
+              display="flex"
+              marginRight={[0, 0, 1, 1, 2]}
+              alignItems="center"
+            >
+              <Link href={links.documentation}>
+                <Button
+                  fluid
+                  iconType="outline"
+                  icon="open"
+                  colorScheme="light"
+                  size="small"
+                  variant="text"
+                >
+                  {n('linkDocumentation')}
+                </Button>
+              </Link>
+            </Box>
+          )}
+          {links.responsibleParty && (
+            <Box
+              display="flex"
+              marginRight={[0, 0, 1, 1, 2]}
+              alignItems="center"
+            >
+              <Link href={links.responsibleParty}>
+                <Button
+                  fluid
+                  iconType="outline"
+                  icon="open"
+                  colorScheme="light"
+                  size="small"
+                  variant="text"
+                >
+                  {n('linkResponsible')}
+                </Button>
+              </Link>
+            </Box>
+          )}
         </Box>
       )
-    }
+    )
+  }
 
+  const showButtonLinks = (links: LinksObject) => {
     return (
-      <OpenApiDocumentation
-        spec={converted as OpenApi}
-        linkTitle={n('linkTitle')}
-        documentationLinkText={n('linkDocumentation')}
-        responsiblePartyLinkText={n('linkResponsible')}
-        bugReportLinkText={n('linkBugReport')}
-        featureRequestLinkText={n('linkFeatureRequest')}
-      />
+      (links.bugReport || links.featureRequest) && (
+        <Box
+          display="flex"
+          marginRight={[0, 0, 0, 0, 2]}
+          alignItems="center"
+          justifyContent={[
+            'spaceBetween',
+            'spaceBetween',
+            'flexStart',
+            'flexEnd',
+          ]}
+          marginBottom={['gutter', 'gutter', 'none']}
+        >
+          {links.bugReport && (
+            <Box display="flex" marginRight={[0, 0, 1, 1, 2]}>
+              <Link href={links.bugReport}>
+                <Button
+                  colorScheme="light"
+                  iconType="filled"
+                  size="small"
+                  type="button"
+                  variant="utility"
+                  fluid
+                >
+                  {n('linkBugReport')}
+                </Button>
+              </Link>
+            </Box>
+          )}
+          {links.featureRequest && (
+            <Box display="flex" marginRight={[0, 0, 1, 1, 2]}>
+              <Link href={links.featureRequest}>
+                <Button
+                  colorScheme="light"
+                  iconType="filled"
+                  size="small"
+                  type="button"
+                  variant="utility"
+                >
+                  {n('linkFeatureRequest')}
+                </Button>
+              </Link>
+            </Box>
+          )}
+        </Box>
+      )
     )
   }
 
   return (
     <Box>
-      <GridRow align="spaceBetween">
-        <GridColumn
-          span={['8/8', '4/8', '4/8', '2/8']}
-          paddingTop="containerGutter"
-          paddingBottom="containerGutter"
-        >
-          <Text color="blue600" variant="h4" as="h4">
+      {/* First Line */}
+      <Box
+        display="flex"
+        flexDirection={['column', 'column', 'column', 'row', 'row']}
+        justifyContent={[
+          'flexStart',
+          'flexStart',
+          'spaceBetween',
+          'spaceBetween',
+        ]}
+      >
+        <Box display="flex" alignItems="center">
+          <Text color="blue600" variant="h4" as="h4" truncate>
             {n('title')}
           </Text>
-        </GridColumn>
-        <GridColumn
-          span={['8/8', '4/8', '4/8', '2/8']}
-          paddingTop="containerGutter"
-          paddingBottom="containerGutter"
-          className={styles.bringFront}
-        >
-          <Select
-            label="Version"
-            name="version"
-            disabled={options.length < 2}
-            isSearchable={false}
-            defaultValue={selectedOption}
-            options={options}
-            onChange={onSelectChange}
-          />
-        </GridColumn>
-      </GridRow>
-      {loading && (
-        <Box textAlign="center">
-          <LoadingIcon animate color="blue400" size={64} />
         </Box>
-      )}
+        {/* Links and Select box */}
+        <Box
+          display="flex"
+          flexDirection={['column', 'column', 'row', 'row']}
+          justifyContent={[
+            'flexStart',
+            'spaceBetween',
+            'spaceBetween',
+            'flexEnd',
+          ]}
+        >
+          {/* Links */}
+          {documentation && documentation?.info['x-links'] && (
+            <Box
+              display="flex"
+              flexDirection={['column', 'column', 'row']}
+              justifyContent={[
+                'flexStart',
+                'flexStart',
+                'flexStart',
+                'flexStart',
+                'flexEnd',
+              ]}
+            >
+              {showTextLinks(documentation.info['x-links'])}
+              {showButtonLinks(documentation.info['x-links'])}
+            </Box>
+          )}
+          <Box className={styles.selectDesktop}>
+            <Select
+              size="sm"
+              label="Version"
+              name="version"
+              disabled={options.length < 2}
+              isSearchable={false}
+              defaultValue={selectedOption}
+              options={options}
+              onChange={onSelectChange}
+            />
+          </Box>
+        </Box>
+      </Box>
+      <Box>
+        {loading && (
+          <Stack space={3} align="center">
+            <LoadingIcon animate size={40} color="blue400" />
+            <Text variant="h4" color="blue600">
+              {n('gettingDocumentation')}
+            </Text>
+          </Stack>
+        )}
+      </Box>
       {error && (
         <Box paddingY={2}>
           <AlertBanner
@@ -163,11 +301,22 @@ export const OpenApiView = ({ service, strings }: OpenApiViewProps) => {
         </Box>
       )}
 
-      {!loading && !error && (
-        <Box width="full">
-          {ShowOpenApiDocumentation(data?.getOpenApi.spec)}
-        </Box>
-      )}
+      <Box width="full">
+        {!loading &&
+          !error &&
+          (documentation ? (
+            <OpenApiDocumentation spec={documentation} />
+          ) : (
+            // documentation missing
+            <Box paddingY={2}>
+              <AlertBanner
+                title={n('queryErrorTitle')}
+                description={n('queryErrorText')}
+                variant="error"
+              />
+            </Box>
+          ))}
+      </Box>
     </Box>
   )
 }

--- a/apps/web/components/OpenApiView/OpenApiView.tsx
+++ b/apps/web/components/OpenApiView/OpenApiView.tsx
@@ -223,7 +223,7 @@ export const OpenApiView = ({ service, strings }: OpenApiViewProps) => {
 
   return (
     <Box>
-      {/* First Line */}
+      {/* Top Line */}
       <Box
         display="flex"
         flexDirection={['column', 'column', 'column', 'row', 'row']}

--- a/apps/web/components/ServiceInformation/ServiceInformation.tsx
+++ b/apps/web/components/ServiceInformation/ServiceInformation.tsx
@@ -26,7 +26,7 @@ export const ServiceInformation = ({
   const n = useNamespace(strings)
 
   return (
-    <Box>
+    <Box paddingTop="gutter">
       <Inline space={1}>
         <Text variant="h1" as="h1">
           {service.name}

--- a/apps/web/screens/ServiceDetails/ServiceDetails.tsx
+++ b/apps/web/screens/ServiceDetails/ServiceDetails.tsx
@@ -24,7 +24,6 @@ import {
   Box,
   Breadcrumbs,
   Button,
-  Link,
   Navigation,
   Text,
 } from '@island.is/island-ui/core'

--- a/apps/web/screens/ServiceDetails/ServiceDetails.tsx
+++ b/apps/web/screens/ServiceDetails/ServiceDetails.tsx
@@ -67,7 +67,7 @@ const ServiceDetails: Screen<ServiceDetailsProps> = ({
       items: [
         {
           active: true,
-          title: service.name,
+          title: service?.name,
         },
       ],
     },


### PR DESCRIPTION
# Moving service links to header

Needed to move fetching of links from component OpenApiDocumentation to OpenApiView

## What

Displaying links in the header

## Why

Change of design.
see: https://www.figma.com/file/IQ006wy2vR1jIWJ6Uqwis5/Viskuausan

## Screenshots / Gifs

![linksPullrequest](https://user-images.githubusercontent.com/545586/104046355-dcd99e80-51d7-11eb-8bda-7a3605b9c29d.gif)


## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review

## To view changes

No current service in X-Road has these links yet, but if you want to view them you can hardcode them by change the **useEffect** hook like so
```
useEffect(() => {
const onCompleted = (data) => {
  //const converted = YamlParser.safeLoad(data.getOpenApi.spec)
  let converted = YamlParser.safeLoad(data.getOpenApi.spec) as any
  converted.info['x-links'] = {
	documentation:
	  'https://github.com/guttih/voffcon/blob/master/README.md',
	responsibleParty: 'https://guttih.com/contact',
	bugReport:
	  'https://github.com/guttih/voffcon/issues/new?assignees=&labels=&template=bug_report.md&title=',
	featureRequest:
	  'https://github.com/guttih/voffcon/issues/new?assignees=&labels=&template=feature_request.md&title=',
  }
  setDocumentation(converted as OpenApi)
}
if (onCompleted) {
  if (onCompleted && !loading && !error) {
	onCompleted(data)
  } else {
	setDocumentation(null)
  }
}
}, [loading, data, error])
```
