### PR TITLE
Confirmation of Residency page

### DIFF
--- a/libs/application/templates/health-insurance/src/forms/HealthInsuranceForm.ts
+++ b/libs/application/templates/health-insurance/src/forms/HealthInsuranceForm.ts
@@ -15,6 +15,7 @@ import {
   FormModes,
   Comparators,
   Application,
+  FormValue,
 } from '@island.is/application/core'
 import { m } from './messages'
 import { YES, NO } from '../constants'
@@ -35,7 +36,12 @@ export const HealthInsuranceForm: Form = buildForm({
           title: m.externalDataTitle,
           id: 'approveExternalData',
           dataProviders: [
-            // TODO: Add UserProfilProvider for email and phone data
+            buildDataProviderItem({
+              id: 'userProfile',
+              type: 'UserProfileProvider',
+              title: '',
+              subTitle: '',
+            }),
             buildDataProviderItem({
               id: 'nationalRegistry',
               type: 'NationalRegistry',
@@ -55,6 +61,28 @@ export const HealthInsuranceForm: Form = buildForm({
               subTitle: m.internalRevenueSubTitle,
             }),
           ],
+        }),
+        buildMultiField({
+          id: 'confirmationOfResidency',
+          title: m.confirmationOfResidencyTitle,
+          description: m.confirmationOfResidencyDescription,
+          children: [
+            buildDividerField({
+              title: ' ',
+              color: 'transparent',
+            }),
+            buildFileUploadField({
+              id: 'confirmationOfResidencyDocument',
+              title: '',
+              introduction: m.confirmationOfResidencyFileUpload,
+              uploadHeader: m.fileUploadHeader.defaultMessage,
+              uploadDescription: m.fileUploadDescription.defaultMessage,
+            }),
+          ],
+          condition: (formValue: FormValue, externalData) => {
+            // TODO: when it is possible in NationalRegistry api, check if country is Greenland or Faroe Islands
+            return true
+          },
         }),
         buildMultiField({
           id: 'contactInfoSection',

--- a/libs/application/templates/health-insurance/src/forms/messages.ts
+++ b/libs/application/templates/health-insurance/src/forms/messages.ts
@@ -49,6 +49,23 @@ export const m = defineMessages({
       'Handles the collection of taxes and duties as well as oversees the legitimacy of tax returns. The Directorate of Internal Revenue also plays a multifaceted customs role at the border and provides society with protection against illegal import and export of goods.',
     description: 'About Directorate of Internal Revenue data retrieval',
   },
+  confirmationOfResidencyTitle: {
+    id: 'hi.application:confirmationOfResidency.title',
+    defaultMessage: 'Confirmation of residency',
+    description: 'Confirmation of residency',
+  },
+  confirmationOfResidencyDescription: {
+    id: 'hi.application:confirmationOfResidency.description',
+    defaultMessage:
+      'According to Registers Iceland’s data it seems like you are moving to Iceland from Greenland or the Faroe Islands. To apply for the national health insurance, you need to provide a confirmation of residency from Greenland or the Faroe Islands.',
+    description:
+      'Instructions for when moving from Greenland or the Faroe Isalnds',
+  },
+  confirmationOfResidencyFileUpload: {
+    id: 'hi.application:confirmationOfResidency.fileUpload',
+    defaultMessage: 'Please add your confirmation of residency',
+    description: 'Please add your confirmation of residency',
+  },
   contactInfoTitle: {
     id: 'hi.application:contactInfo.title',
     defaultMessage: 'Confirm your contact information',
@@ -206,7 +223,7 @@ export const m = defineMessages({
   fileUploadDescription: {
     id: 'hi.application:fileUpload.description',
     defaultMessage: 'Accepted documents: .pdf, .docx, .rtf',
-    description: 'Accepted docuemnt types',
+    description: 'Accepted document types',
   },
   fileUploadButton: {
     id: 'hi.application:fileUpload.button',

--- a/libs/application/templates/health-insurance/src/lib/HealthInsuranceTemplate.ts
+++ b/libs/application/templates/health-insurance/src/lib/HealthInsuranceTemplate.ts
@@ -20,6 +20,7 @@ type Events =
 
 const HealthInsuranceSchema = z.object({
   approveExternalData: z.boolean().refine((v) => v),
+  confirmationOfResidencyDocument: z.array(z.string()).optional(),
   applicant: z.object({
     name: z.string().nonempty(),
     nationalId: z.string().refine((x) => (x ? nationalIdRegex.test(x) : false)),


### PR DESCRIPTION
# Sjukratryggingar - confirmation of residency page

## What

- Confirmation of residency page for applicants moving from Greenland or Faroe Islands. 
- Also added UserProfile provider for prefilled form fields under Contact information section

## Why

If users move from Greenland or Faroe Islands the user needs to upload additional documents. This page allows the user to provide the details.

## Screenshots / Gifs

![Screenshot 2021-01-11 at 15 37 43](https://user-images.githubusercontent.com/64913954/104195468-f6225b00-5422-11eb-802a-0e9dfc5bfddc.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
