### PR TITLE
Checkbox on missing information page

### DIFF
--- a/libs/application/templates/health-insurance/src/forms/MissingInfoForm.ts
+++ b/libs/application/templates/health-insurance/src/forms/MissingInfoForm.ts
@@ -60,7 +60,7 @@ export const MissingInfoForm: Form = buildForm({
               component: 'Review',
             }),
             buildCustomField({
-              id: 'confirmCorrectInfo',
+              id: 'confirmMissingInfo',
               title: '',
               component: 'ConfirmCheckbox',
             }),

--- a/libs/application/templates/health-insurance/src/lib/HealthInsuranceTemplate.ts
+++ b/libs/application/templates/health-insurance/src/lib/HealthInsuranceTemplate.ts
@@ -40,6 +40,7 @@ const HealthInsuranceSchema = z.object({
     remarks: z.string(),
   }),
   confirmCorrectInfo: z.boolean().refine((v) => v),
+  confirmMissingInfo: z.boolean().refine((y) => y),
   agentComments: z.array(z.string().nonempty()),
   formerInsurance: z.object({
     country: z.string().nonempty(),


### PR DESCRIPTION
# Checkbox on Missing information

## What

- Changed so that the checkbox is not filled upon arrival at missing information page

## Screenshots / Gifs

![Screenshot 2021-01-12 at 17 22 37](https://user-images.githubusercontent.com/70507494/104342150-d0688500-54fa-11eb-9884-02c4b84a7ffc.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
