### PR TITLE
Sjukratryggingar/Added additional information and remarks to missing info form

### DIFF
--- a/libs/application/templates/health-insurance/src/fields/Review/ReviewAdditionalInfo.tsx
+++ b/libs/application/templates/health-insurance/src/fields/Review/ReviewAdditionalInfo.tsx
@@ -1,0 +1,90 @@
+import React, { FC } from 'react'
+import { formatText } from '@island.is/application/core'
+import {
+  Box,
+  Bullet,
+  BulletList,
+  Stack,
+  Text,
+  Input,
+} from '@island.is/island-ui/core'
+import { useLocale } from '@island.is/localization'
+import { AdditionalInfoType, ReviewFieldProps } from '../../types'
+import { m } from '../../forms/messages'
+import {
+  FieldDescription,
+  RadioController,
+} from '@island.is/shared/form-fields'
+import { NO, YES } from '../../constants'
+
+interface Props extends ReviewFieldProps {
+  additionalInfo: AdditionalInfoType
+}
+
+const ReviewMissingInfo: FC<Props> = ({
+  application,
+  isEditable,
+  additionalInfo = {},
+}) => {
+  const { formatMessage } = useLocale()
+
+  return (
+    <Box paddingBottom={2}>
+      <Stack space={3}>
+        <Box>
+          <FieldDescription
+            description={formatText(
+              m.additionalInfo,
+              application,
+              formatMessage,
+            )}
+          />
+          <RadioController
+            id={'additionalInfo.hasAdditionalInfo'}
+            name={'additionalInfo.hasAdditionalInfo'}
+            disabled={!isEditable}
+            largeButtons={true}
+            split={'1/2'}
+            options={[
+              {
+                label: formatText(m.noOptionLabel, application, formatMessage),
+                value: NO,
+              },
+              {
+                label: formatText(m.yesOptionLabel, application, formatMessage),
+                value: YES,
+              },
+            ]}
+          />
+          <Input
+            id={'additionalInfo.remarks'}
+            name={'additionalInfo.remarks'}
+            label={formatText(m.additionalRemarks, application, formatMessage)}
+            defaultValue={additionalInfo.remarks}
+            placeholder={formatText(
+              m.additionalRemarksPlaceholder,
+              application,
+              formatMessage,
+            )}
+            disabled={!isEditable}
+            textarea
+          />
+        </Box>
+        {additionalInfo.files && additionalInfo.files?.length > 0 && (
+          <Stack space={1}>
+            <Text variant="h5">
+              {formatText(m.attachedFilesTitle, application, formatMessage)}
+            </Text>
+            <BulletList type={'ul'}>
+              {additionalInfo.files.map((file: string, fileIndex: number) => (
+                <Bullet key={`additionalInfo_file${fileIndex}`}>{file}</Bullet>
+              ))}
+            </BulletList>
+          </Stack>
+        )}
+      </Stack>
+    </Box>
+  )
+}
+
+export default ReviewMissingInfo

--- a/libs/application/templates/health-insurance/src/fields/Review/ReviewMissingInfo.tsx
+++ b/libs/application/templates/health-insurance/src/fields/Review/ReviewMissingInfo.tsx
@@ -2,12 +2,16 @@ import React, { FC } from 'react'
 import { formatText } from '@island.is/application/core'
 import { Box, Bullet, BulletList, Stack, Text } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
-import { ReviewFieldProps } from '../../types'
+import { MissingInfoType, ReviewFieldProps } from '../../types'
 import AgentComment from '../AgentComment/AgentComment'
 import MissingInfoRemarks from '../MissingInfoRemarks/MissingInfoRemarks'
 import { m } from '../../forms/messages'
 
-const ReviewMissingInfo: FC<ReviewFieldProps> = ({
+interface Props extends ReviewFieldProps {
+  missingInfo: MissingInfoType
+}
+
+const ReviewMissingInfo: FC<Props> = ({
   application,
   field,
   isEditable,
@@ -21,7 +25,7 @@ const ReviewMissingInfo: FC<ReviewFieldProps> = ({
       <Stack space={4}>
         <AgentComment application={application} field={field} />
         <Stack space={1}>
-          <Text variant="h4">
+          <Text variant="h5">
             {formatText(m.missingInfoAnswersTitle, application, formatMessage)}
           </Text>
           <MissingInfoRemarks
@@ -33,7 +37,7 @@ const ReviewMissingInfo: FC<ReviewFieldProps> = ({
         </Stack>
         {missingInfo.files && missingInfo.files?.length > 0 && (
           <Stack space={1}>
-            <Text variant="h4">
+            <Text variant="h5">
               {formatText(m.attachedFilesTitle, application, formatMessage)}
             </Text>
             <BulletList type={'ul'}>

--- a/libs/application/templates/health-insurance/src/fields/Review/index.tsx
+++ b/libs/application/templates/health-insurance/src/fields/Review/index.tsx
@@ -10,8 +10,10 @@ import { m } from '../../forms/messages'
 import FormerInsurance from './FormerInsurance'
 import StatusAndChildren from './StatusAndChildren'
 import ContactInfo from './ContactInfo'
+import ReviewAdditionalInfo from './ReviewAdditionalInfo'
 import ReviewMissingInfo from './ReviewMissingInfo'
-import { MissingInfoType } from '../../types'
+import { AdditionalInfoType, MissingInfoType } from '../../types'
+import { YES } from '../../constants'
 
 const Review: FC<FieldBaseProps> = ({ field, application }) => {
   const { formatMessage } = useLocale()
@@ -22,6 +24,11 @@ const Review: FC<FieldBaseProps> = ({ field, application }) => {
       application.answers,
       'missingInfo',
     ) as MissingInfoType[]) || []
+
+  const additionalInfo = getValueViaPath(
+    application.answers,
+    'additionalInfo',
+  ) as AdditionalInfoType
 
   return (
     <Box marginBottom={[1, 1, 3]}>
@@ -57,11 +64,28 @@ const Review: FC<FieldBaseProps> = ({ field, application }) => {
           />
         </AccordionItem>
         {field.id === 'submittedData' &&
-          previousMissingInfo.length > 0 &&
+          additionalInfo.hasAdditionalInfo === YES && (
+            <AccordionItem
+              id="id_4"
+              label={formatText(
+                m.additionalRemarks,
+                application,
+                formatMessage,
+              )}
+            >
+              <ReviewAdditionalInfo
+                application={application}
+                field={field}
+                isEditable={isEditable}
+                additionalInfo={additionalInfo}
+              />
+            </AccordionItem>
+          )}
+        {previousMissingInfo.length > 0 &&
           previousMissingInfo.map((missingInfo, index) => (
             <AccordionItem
-              id={`id_${4 + index}`}
-              key={`id_${4 + index}`}
+              id={`id_${5 + index}`}
+              key={`id_${5 + index}`}
               label={`${formatText(
                 m.missingInfoSection,
                 application,

--- a/libs/application/templates/health-insurance/src/forms/MissingInfoForm.ts
+++ b/libs/application/templates/health-insurance/src/forms/MissingInfoForm.ts
@@ -3,7 +3,6 @@ import {
   buildDividerField,
   buildFileUploadField,
   buildForm,
-  buildDescriptionField,
   buildMultiField,
   buildSection,
   buildSubmitField,

--- a/libs/application/templates/health-insurance/src/forms/messages.ts
+++ b/libs/application/templates/health-insurance/src/forms/messages.ts
@@ -272,7 +272,7 @@ export const m = defineMessages({
   formerInsuranceAdditionalInformationPlaceholder: {
     id: 'hi.application:formerInsurance.additionalInformationPlaceholder',
     defaultMessage: 'I´m still entitled to health insurance because...',
-    description: 'additional infromation placeholder',
+    description: 'Additional information placeholder',
   },
   formerInsuranceNoOption: {
     id: 'hi.application:formerInsurance.noOption',

--- a/libs/application/templates/health-insurance/src/types.ts
+++ b/libs/application/templates/health-insurance/src/types.ts
@@ -7,6 +7,12 @@ export enum StatusTypes {
   EMPLOYED = 'employed',
 }
 
+export interface AdditionalInfoType {
+  remarks: string
+  files?: string[]
+  hasAdditionalInfo?: string
+}
+
 export interface MissingInfoType {
   date: string
   remarks: string
@@ -16,5 +22,4 @@ export interface MissingInfoType {
 export interface ReviewFieldProps extends FieldBaseProps {
   isEditable: boolean
   index?: number
-  missingInfo?: MissingInfoType
 }


### PR DESCRIPTION
# Sjukratryggingar - Added missing field in missing info form to display "additional information and remarks"

## What

Added an accordion to display previous answer "additional information and remarks" in missing information form

## Why

If the user has left any comments it should be shown

## Screenshots / Gifs
![Screenshot 2021-01-13 at 09 43 29](https://user-images.githubusercontent.com/64913954/104427657-cdfe3d80-5583-11eb-90ee-1aeb8f7ccef5.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
