### PR TITLE
fix/subpage-img-size

### DIFF
--- a/apps/web/components/SubpageMainContent/SubpageMainContent.tsx
+++ b/apps/web/components/SubpageMainContent/SubpageMainContent.tsx
@@ -15,11 +15,13 @@ export const SubpageMainContent: FC<SubpageMainProps> = ({ main, image }) => {
   return (
     <GridContainer>
       <GridRow>
-        <GridColumn span={image ? ['12/12', '12/12', '9/12'] : '12/12'}>
+        <GridColumn
+          span={image ? ['12/12', '12/12', '12/12', '8/12'] : '12/12'}
+        >
           {main}
         </GridColumn>
         {image && (
-          <GridColumn span="3/12" hiddenBelow="md">
+          <GridColumn span="4/12" hiddenBelow="lg">
             {image}
           </GridColumn>
         )}


### PR DESCRIPTION
# Change subpage image size

## What

We need the image to be a bit bigger on the subpages.

## Why

The figma design specifies that the image needs to be bigger.

## Screenshots / Gifs

Before:

![image](https://user-images.githubusercontent.com/23635966/104437242-71505200-5586-11eb-974b-02a978687b72.png)


After:

![image](https://user-images.githubusercontent.com/23635966/104437145-5978ce00-5586-11eb-9d32-7dd72eeca0fc.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
