### PR TITLE
Island.is / Organization mobile tag

### DIFF
--- a/apps/web/screens/Article.tsx
+++ b/apps/web/screens/Article.tsx
@@ -19,6 +19,7 @@ import {
   TableOfContents,
   Button,
   Hyphen,
+  Tag,
 } from '@island.is/island-ui/core'
 import {
   RichText,
@@ -366,21 +367,34 @@ const ArticleScreen: Screen<ArticleProps> = ({ article, namespace }) => {
         </Box>
         <Box
           paddingBottom={[2, 2, 4]}
-          display={['block', 'block', 'none']}
+          display={['flex', 'flex', 'none']}
+          justifyContent="spaceBetween"
+          alignItems="center"
           printHidden
         >
           {!!article.category && (
-            <Link {...linkResolver('articlecategory', [article.category.slug])}>
-              <Button
-                preTextIcon="arrowBack"
-                preTextIconType="filled"
-                size="small"
-                type="button"
-                variant="text"
+            <Box flexGrow={1} flexShrink={0} marginRight={2}>
+              <Link
+                {...linkResolver('articlecategory', [article.category.slug])}
               >
-                {article.category.title}
-              </Button>
-            </Link>
+                <Button
+                  preTextIcon="arrowBack"
+                  preTextIconType="filled"
+                  size="small"
+                  type="button"
+                  variant="text"
+                >
+                  {article.category.title}
+                </Button>
+              </Link>
+            </Box>
+          )}
+          {article.organization.length > 0 && (
+            <Box minWidth={0}>
+              <Tag variant="purple" truncate>
+                {article.organization[0].title}
+              </Tag>
+            </Box>
           )}
         </Box>
         <Box>

--- a/apps/web/screens/Article.tsx
+++ b/apps/web/screens/Article.tsx
@@ -391,7 +391,11 @@ const ArticleScreen: Screen<ArticleProps> = ({ article, namespace }) => {
           )}
           {article.organization.length > 0 && (
             <Box minWidth={0}>
-              <Tag variant="purple" truncate>
+              <Tag
+                variant="purple"
+                truncate
+                href={article.organization[0].link}
+              >
                 {article.organization[0].title}
               </Tag>
             </Box>

--- a/libs/island-ui/core/src/lib/Tag/Tag.tsx
+++ b/libs/island-ui/core/src/lib/Tag/Tag.tsx
@@ -25,6 +25,7 @@ export interface TagProps {
   outlined?: boolean
   attention?: boolean // Renders a red dot driving attention to the tag.
   children: string | ReactNode
+  truncate?: boolean
 }
 
 const isLinkExternal = (href: string): boolean => href.indexOf('://') > 0
@@ -40,6 +41,7 @@ export const Tag = forwardRef<HTMLButtonElement & HTMLAnchorElement, TagProps>(
       disabled,
       outlined,
       attention,
+      truncate,
       ...props
     }: TagProps,
     ref,
@@ -63,7 +65,7 @@ export const Tag = forwardRef<HTMLButtonElement & HTMLAnchorElement, TagProps>(
     }
 
     const content = (
-      <Text variant="eyebrow" as="span">
+      <Text variant="eyebrow" as="span" truncate={truncate}>
         {children}
       </Text>
     )


### PR DESCRIPTION
# Organization mobile tag

## What

If article is connected to a organization we display tag in mobile

## Why

Based on design

## Screenshots / Gifs

![mobile tag](https://user-images.githubusercontent.com/5655741/104478404-294b2280-55ba-11eb-929a-b0d25e207c94.gif)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
