### PR TITLE
Island.is / rich text list spacing

### DIFF
--- a/libs/island-ui/contentful/src/lib/RichTextRC/RichText.treat.ts
+++ b/libs/island-ui/contentful/src/lib/RichTextRC/RichText.treat.ts
@@ -3,14 +3,8 @@ import { theme, themeUtils } from '@island.is/island-ui/theme'
 
 export const orderedList = style({
   counterReset: 'section',
-  marginTop: 12,
-  marginBottom: 12,
-  ...themeUtils.responsiveStyle({
-    md: {
-      marginTop: 14,
-      marginBottom: 14,
-    },
-  }),
+  marginTop: 16,
+  marginBottom: 16,
   selectors: {
     'ol &': {
       marginTop: 0,
@@ -21,14 +15,8 @@ export const orderedList = style({
 
 export const unorderedList = style({
   listStyle: 'none',
-  marginTop: 12,
-  marginBottom: 12,
-  ...themeUtils.responsiveStyle({
-    md: {
-      marginTop: 14,
-      marginBottom: 14,
-    },
-  }),
+  marginTop: 16,
+  marginBottom: 16,
   selectors: {
     'ul &': {
       marginTop: 0,
@@ -101,6 +89,7 @@ export const paragraph = style({
   selectors: {
     [`${listItem} &`]: {
       marginBottom: 0,
+      marginTop: 0,
     },
   },
 })

--- a/libs/island-ui/contentful/src/lib/RichTextRC/defaultRenderNode.tsx
+++ b/libs/island-ui/contentful/src/lib/RichTextRC/defaultRenderNode.tsx
@@ -72,6 +72,16 @@ export const defaultRenderNode: RenderNode = {
       {children}
     </Box>
   ),
+  [BLOCKS.HEADING_6]: (_node, children) => (
+    <Box
+      component="p"
+      className={getTextStyles({ variant: 'intro' }) + ' ' + styles.heading}
+      marginTop={4}
+      marginBottom={2}
+    >
+      {children}
+    </Box>
+  ),
   [BLOCKS.PARAGRAPH]: (_node, children) => (
     <Box component="p" className={getTextStyles({}) + ' ' + styles.paragraph}>
       {children}


### PR DESCRIPTION
# Rich text list spacing

## What

Consistent spacing around lists inside rich text, moving form mobile paragraph style to fixed 16px

## Why

Based on design

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
