### PR TITLE
Add props to FileUploadFormField

### DIFF
--- a/libs/application/core/src/lib/fieldBuilders.ts
+++ b/libs/application/core/src/lib/fieldBuilders.ts
@@ -337,6 +337,7 @@ export function buildFileUploadField(data: {
   uploadButtonLabel?: string
   uploadMultiple?: boolean
   uploadAccept?: string
+  maxSize?: number
 }): FileUploadField {
   const {
     condition,
@@ -348,6 +349,7 @@ export function buildFileUploadField(data: {
     uploadButtonLabel,
     uploadMultiple,
     uploadAccept,
+    maxSize,
   } = data
   return {
     children: undefined,
@@ -360,6 +362,7 @@ export function buildFileUploadField(data: {
     uploadButtonLabel,
     uploadMultiple,
     uploadAccept,
+    maxSize,
     type: FieldTypes.FILEUPLOAD,
     component: FieldComponents.FILEUPLOAD,
   }

--- a/libs/application/core/src/types/Fields.ts
+++ b/libs/application/core/src/types/Fields.ts
@@ -148,6 +148,7 @@ export interface FileUploadField extends BaseField {
   readonly uploadButtonLabel?: string
   readonly uploadMultiple?: boolean
   readonly uploadAccept?: string
+  readonly maxSize?: number
 }
 
 export interface SubmitField extends BaseField {

--- a/libs/application/ui-fields/src/lib/FileUploadFormField/index.tsx
+++ b/libs/application/ui-fields/src/lib/FileUploadFormField/index.tsx
@@ -77,6 +77,9 @@ const FileUploadFormField: FC<Props> = ({ application, error, field }) => {
     uploadDescription = 'Documents accepted with extension: .pdf, .docx, .rtf',
     uploadHeader = 'Drag documents here to upload',
     uploadButtonLabel = 'Select documents to upload',
+    uploadMultiple,
+    uploadAccept,
+    maxSize,
   } = field
   const { clearErrors, setValue } = useFormContext()
   const { formatMessage } = useLocale()
@@ -237,6 +240,9 @@ const FileUploadFormField: FC<Props> = ({ application, error, field }) => {
                 onChange={onFileChange}
                 onRemove={onRemoveFile}
                 errorMessage={error || uploadError}
+                multiple={uploadMultiple}
+                accept={uploadAccept}
+                maxSize={maxSize}
               />
             </Box>
           )


### PR DESCRIPTION
Add missing props to FileUploadFormField:
1. `maxSize`
2. Forward `uploadMultiple` and `uploadAccept` to the core component in the field.

Ex: 
```
  buildFileUploadField({
    id: 'uploadFiles',
    title: 'Upload files',
    introduction: 'Please upload your important files (PDF, Text)',
    uploadDescription: 'Documents accepted with extension: .pdf, .docx. With a maximum size of 1kb.',
    maxSize: 1000,
  }),
```

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
