### PR TITLE
Judicial-system/Make name column in detention requests table bigger

### DIFF
--- a/apps/judicial-system/web/src/routes/Shared/DetentionRequests/DetentionRequests.treat.ts
+++ b/apps/judicial-system/web/src/routes/Shared/DetentionRequests/DetentionRequests.treat.ts
@@ -77,6 +77,17 @@ export const tableRowContainer = style({
   },
 })
 
+export const largeColumn = style({
+  // The width needed to make sure a 33 character name doesn't wrap
+  minWidth: 334,
+  whiteSpace: 'nowrap',
+})
+
+export const accusedName = style({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+})
+
 export const tr = style({
   display: 'flex',
   flex: 1,

--- a/apps/judicial-system/web/src/routes/Shared/DetentionRequests/DetentionRequests.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/DetentionRequests/DetentionRequests.tsx
@@ -249,7 +249,7 @@ export const DetentionRequests: React.FC = () => {
                     LÖKE málsnr.
                   </Text>
                 </th>
-                <th className={styles.th}>
+                <th className={cn(styles.th, styles.largeColumn)}>
                   <Text as="span" fontWeight="regular">
                     <Box
                       component="button"
@@ -335,8 +335,18 @@ export const DetentionRequests: React.FC = () => {
                   <td className={styles.td}>
                     <Text as="span">{c.policeCaseNumber || '-'}</Text>
                   </td>
-                  <td className={cn(styles.td, 'flexDirectionCol')}>
-                    <Text>{c.accusedName || '-'}</Text>
+                  <td
+                    className={cn(
+                      styles.td,
+                      styles.largeColumn,
+                      'flexDirectionCol',
+                    )}
+                  >
+                    <Text>
+                      <Box as="span" className={styles.accusedName}>
+                        {c.accusedName || '-'}
+                      </Box>
+                    </Text>
                     <Text>
                       {c.accusedNationalId && (
                         <Text as="span" variant="small" color="dark400">


### PR DESCRIPTION
# Make name column in detention requests table bigger

https://app.asana.com/0/1199153462262248/1199716090325395

## What

Make name column in detention requests table bigger so that longer names don't wrap. Really long names get cut off with an "..." at the end.

## Why

Better UI

## Screenshots / Gifs

![Screen Shot 2021-01-15 at 13 30 40](https://user-images.githubusercontent.com/3789875/104733554-c7fc8e00-5736-11eb-93f4-df51031087fe.png)

![screencapture-localhost-4200-gaesluvardhaldskrofur-2021-01-15-13_33_58](https://user-images.githubusercontent.com/3789875/104733581-cfbc3280-5736-11eb-9d95-1b38a3fc3901.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
