### PR TITLE
Feature/content search indexer migration error fix

### DIFF
--- a/apps/services/search-indexer/src/migrate/elastic.ts
+++ b/apps/services/search-indexer/src/migrate/elastic.ts
@@ -143,3 +143,17 @@ export const rankSearchQueries = async (index: string) => {
   })
   logger.info('Content search query quality metrics', metrics)
 }
+
+export const removeIndexIfExists = async (indexName: string) => {
+  const indexExists = await checkIfIndexExists(indexName)
+
+  if (indexExists) {
+    const client = await esService.getClient()
+    await client.indices.delete({
+      index: indexName,
+    })
+    return indexName
+  }
+
+  return false
+}

--- a/apps/services/search-indexer/src/migrate/index.ts
+++ b/apps/services/search-indexer/src/migrate/index.ts
@@ -101,9 +101,9 @@ class App {
                 newIndexName,
                 error: error.message,
               })
-              // remove the index so we try and migrate this index again on next migration
+              // remove the index to make migration run again for this index
               await elastic.removeIndexIfExists(newIndexName)
-              // resolve the promise to let migrations for other indices finish
+              // resolve the promise instead of throw to let migrations for other indices finish
               return error
             }
           } else {

--- a/libs/content-search-indexer/src/lib/indexing.service.ts
+++ b/libs/content-search-indexer/src/lib/indexing.service.ts
@@ -72,8 +72,8 @@ export class IndexingService {
     })
 
     /*
-    the sync method should manage all housekeeping tasks such as removing outdated documents
-    this is here to ensure old data is cleared from the index incase sync fails to remove documents
+    calling the sync endpoint should manage all housekeeping tasks such as removing outdated documents
+    we need this check to ensure old data is cleared from the index incase sync fails to remove documents
     currently this happens in cms sync in the development environment due to limitations in the Contentful sync API
     */
     if (syncType === 'full' && didImportAll) {
@@ -81,7 +81,7 @@ export class IndexingService {
       const response = await this.elasticService.deleteAllDocumentsNotVeryRecentlyUpdated(
         elasticIndex,
       )
-      logger.info('Removed stale documents', { count: response.body.deleted })
+      logger.info('Removed stale documents', { count: response.body.deleted, index: elasticIndex })
     }
 
     logger.info('Indexing service finished sync', { index: elasticIndex })

--- a/libs/content-search-indexer/src/lib/indexing.service.ts
+++ b/libs/content-search-indexer/src/lib/indexing.service.ts
@@ -89,5 +89,3 @@ export class IndexingService {
     return didImportAll
   }
 }
-
-// TODO: Add a check in migrate that deletes all new indexes on failure to prevent index exist and wont migrate issue

--- a/libs/content-search-indexer/src/lib/indexing.service.ts
+++ b/libs/content-search-indexer/src/lib/indexing.service.ts
@@ -29,7 +29,6 @@ export class IndexingService {
       elasticIndex = getElasticsearchIndex(options.locale),
     } = options
 
-    let allImportedIds = [] // se we can delete orphans after full sync
     let didImportAll = true
     const importPromises = this.importers.map(async (importer) => {
       logger.info('Starting importer', {
@@ -81,7 +80,10 @@ export class IndexingService {
       const response = await this.elasticService.deleteAllDocumentsNotVeryRecentlyUpdated(
         elasticIndex,
       )
-      logger.info('Removed stale documents', { count: response.body.deleted, index: elasticIndex })
+      logger.info('Removed stale documents', {
+        count: response.body.deleted,
+        index: elasticIndex,
+      })
     }
 
     logger.info('Indexing service finished sync', { index: elasticIndex })

--- a/libs/shared/types/src/lib/elastic.d.ts
+++ b/libs/shared/types/src/lib/elastic.d.ts
@@ -92,3 +92,21 @@ export interface RankEvaluationResponse<searchTermsUnion = string> {
   }
   failures: {}
 }
+
+export interface DeleteByQueryResponse {
+  took: number
+  timed_out: boolean
+  total: number
+  deleted: number
+  batches: number
+  version_conflicts: number
+  noops: number
+  retries: {
+    bulk: number
+    search: number
+  }
+  throttled_millis: number
+  requests_per_second: number
+  throttled_until_millis: number
+  failures: any[]
+}


### PR DESCRIPTION
# \<Description\>

https://app.asana.com/0/1199123945323117/1199590541713548

## What

- Migration now deletes created index on failure
- Indexer now uses `dateUpdated` to find stale data

## Why

- Migration created an index then failed causing the migration not to run again for the failed index
- Indexer was using a query that included all ids imported to remove stale data, this caused an error due to query size limitations 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
