### PR TITLE
Content search migration dictionary to index version

### DIFF
--- a/apps/services/search-indexer/src/environments/environment.ts
+++ b/apps/services/search-indexer/src/environments/environment.ts
@@ -18,7 +18,7 @@ export const environment: Environment = {
   awsRegion: process.env.AWS_REGION,
   esDomain: 'search',
   s3Folder: '',
-  dictRepo: 'https://api.github.com/repos/island-is/elasticsearch-dictionaries',
+  dictRepo: 'island-is/elasticsearch-dictionaries',
   locales: ['is', 'en'],
   configPath: path.resolve(__dirname, '../../config'),
 }

--- a/apps/services/search-indexer/src/migrate/aws.ts
+++ b/apps/services/search-indexer/src/migrate/aws.ts
@@ -4,6 +4,7 @@ import { PutObjectRequest } from 'aws-sdk/clients/s3'
 import { environment } from '../environments/environment'
 import { Dictionary } from './dictionary'
 import { PackageStatus, DomainPackageStatus } from 'aws-sdk/clients/es'
+import { ElasticsearchIndexLocale } from '@island.is/content-search-index-manager'
 
 AWS.config.update({ region: environment.awsRegion })
 const awsEs = new AWS.ES()
@@ -68,21 +69,28 @@ const getPackageStatuses = async (
   }
 }
 
-export const getAllDomainEsPackages = async (): Promise<AwsEsPackage[]> => {
+export const getAssociatedEsPackages = async (requestedVersion: string): Promise<AwsEsPackage[]> => {
   const domainPackageList = await awsEs
     .listPackagesForDomain({
       DomainName: environment.esDomain,
     })
     .promise()
-  return domainPackageList.DomainPackageDetailsList.map((esPackage) => {
-    const { locale, analyzerType } = parsePackageName(esPackage.PackageName)
-    return {
-      packageName: esPackage.PackageName,
-      packageId: esPackage.PackageID,
-      locale,
-      analyzerType,
-    }
-  })
+
+  return domainPackageList.DomainPackageDetailsList
+    // we only want to return packages for current version
+    .filter((esPackage) => {
+      const { version } = parsePackageName(esPackage.PackageName)
+      return requestedVersion === version
+    })
+    .map((esPackage) => {
+      const { locale, analyzerType } = parsePackageName(esPackage.PackageName)
+      return {
+        packageName: esPackage.PackageName,
+        packageId: esPackage.PackageID,
+        locale: locale as ElasticsearchIndexLocale,
+        analyzerType,
+      }
+    })
 }
 
 // AWS ES wont let us make multiple requests at once so we wait
@@ -144,27 +152,14 @@ export const checkAWSAccess = async (): Promise<boolean> => {
   return !!domains.find((domain) => domain.DomainName === environment.esDomain)
 }
 
-const createS3Key = (type: string, prefix = ''): string => {
-  const prefixString = prefix ? `${prefix}/` : ''
-  return `${environment.s3Folder}${prefixString}${type}.txt`
+interface CreateS3KeyInput {
+  filename: string
+  locale?: ElasticsearchIndexLocale
+  version?: string
 }
-
-export const getDictionaryVersion = (): Promise<string> => {
-  const params = {
-    Bucket: environment.s3Bucket,
-    Key: createS3Key('dictionaryVersion'),
-  }
-
-  // we don't want to stop here even if file is not found
-  return s3
-    .getObject(params)
-    .promise()
-    .then((data) => data.Body.toString())
-    .catch((error) => {
-      logger.error('Version file not found', { error })
-      // return empty string to indicate no version set
-      return ''
-    })
+const createS3Key = ({ filename, locale, version }: CreateS3KeyInput): string => {
+  const prefix = [locale, version, ''].filter((parameter) => parameter !== undefined).join('/') // creates folder prefix e.g. is/4cc9840/
+  return `${environment.s3Folder}${prefix}${filename}.txt`
 }
 
 const uploadFileToS3 = (options: Omit<PutObjectRequest, 'Bucket'>) => {
@@ -186,23 +181,29 @@ const uploadFileToS3 = (options: Omit<PutObjectRequest, 'Bucket'>) => {
 }
 
 interface S3DictionaryFile {
-  locale: string
+  locale: ElasticsearchIndexLocale
   analyzerType: string
+  version: string
 }
-export const updateS3DictionaryFiles = async (
+export const uploadS3DictionaryFiles = async (
   dictionaries: Dictionary[],
 ): Promise<S3DictionaryFile[]> => {
   const uploads = dictionaries.map(async (dictionary) => {
-    const { analyzerType, locale, file } = dictionary
-    const s3Key = createS3Key(analyzerType, locale)
+    const { analyzerType, locale, file, version } = dictionary
+
+    // we will upload the files into subfolders by locale
+    const s3Key = createS3Key({ filename: analyzerType, locale, version })
     await uploadFileToS3({ Key: s3Key, Body: file })
+
+    // the following processes just need a way to point correctly to the files
     return {
       locale,
       analyzerType,
+      version
     }
   })
 
-  return Promise.all(uploads)
+  return await Promise.all(uploads)
 }
 
 const getAwsEsPackagesDetails = async () => {
@@ -213,30 +214,26 @@ const getAwsEsPackagesDetails = async () => {
 }
 
 const removePackagesIfExist = async (
-  uploadedDictionaryFiles: S3DictionaryFile[],
-  version: string,
+  uploadedDictionaryFiles: S3DictionaryFile[]
 ) => {
   const esPackages = await getAwsEsPackagesDetails()
 
   logger.info('Checking if we have conflicting packages')
   // search esPackages to check of any package exist
-  const responses = uploadedDictionaryFiles.map(async (uploadedFile) => {
-    const { analyzerType, locale } = uploadedFile
+  const responses = uploadedDictionaryFiles.map(async (s3File) => {
+    const { analyzerType, locale, version } = s3File
     const packageName = createPackageName(locale, analyzerType, version)
     const existingPackage = esPackages.find(
       (esPackage) => esPackage.PackageName === packageName,
     )
 
     if (existingPackage) {
-      logger.info(
-        'Found conflicting AWS ES package, removing existing package to prevent conflict',
-        { existingPackage, packageName },
-      )
+      logger.info('Removing existing AWS ES package', { existingPackage })
       const params = {
         PackageID: existingPackage.PackageID,
       }
 
-      // this package should never be in use so we can delete it
+      // this package should never associated so we can naively delete it
       return awsEs
         .deletePackage(params)
         .promise()
@@ -248,7 +245,7 @@ const removePackagesIfExist = async (
           return false
         })
     } else {
-      // no file found, return promise
+      // no file found
       return false
     }
   })
@@ -260,31 +257,30 @@ const removePackagesIfExist = async (
 
 /*
 createAwsEsPackages should only run when we are updating, we can therefore assume no assigned packages exist in AWS ES for this version
-We run a remove packages for this version function to handle failed partial updates
+We run a remove packages for this version function to handle failed partial updates that might not have associated the package to the domain 
 */
 export interface AwsEsPackage {
   packageName?: string
   packageId: string
-  locale: string
+  locale: ElasticsearchIndexLocale
   analyzerType: string
 }
 export const createAwsEsPackages = async (
-  uploadedDictionaryFiles: S3DictionaryFile[],
-  version: string,
+  uploadedDictionaryFiles: S3DictionaryFile[]
 ): Promise<AwsEsPackage[]> => {
   // this handles failed updates, if everything works this should never remove packages
-  await removePackagesIfExist(uploadedDictionaryFiles, version)
+  await removePackagesIfExist(uploadedDictionaryFiles)
 
   // create a new package for each uploaded s3 file
   const createdPackages = uploadedDictionaryFiles.map(async (uploadedFile) => {
-    const { analyzerType, locale } = uploadedFile
+    const { analyzerType, locale, version } = uploadedFile
 
     const params = {
       PackageName: createPackageName(locale, analyzerType, version), // version is here so we dont conflict with older packages
       PackageType: 'TXT-DICTIONARY',
       PackageSource: {
         S3BucketName: environment.s3Bucket,
-        S3Key: createS3Key(analyzerType, locale),
+        S3Key: createS3Key({ filename: analyzerType, locale }),
       },
     }
 
@@ -307,8 +303,8 @@ export const createAwsEsPackages = async (
   return Promise.all(createdPackages)
 }
 
-export const associatePackagesWithAwsEs = async (packages: AwsEsPackage[]) => {
-  // do one at a time
+export const associatePackagesWithAwsEsSearchDomain = async (packages: AwsEsPackage[]) => {
+  // we have to do one at a time due to limitations in AWS API
   for (const awsEsPackage of packages) {
     const params = {
       DomainName: environment.esDomain,
@@ -329,13 +325,25 @@ export const associatePackagesWithAwsEs = async (packages: AwsEsPackage[]) => {
   return true
 }
 
-export const updateDictionaryVersion = async (newDictionaryVersion: string) => {
-  const params = {
-    Key: createS3Key('dictionaryVersion'),
-    Body: newDictionaryVersion,
-  }
-  await uploadFileToS3(params)
-  logger.info('Updated dictionary version to', {
-    version: newDictionaryVersion,
+export const getFirstFoundAwsEsPackageVersion = async (dictionaryVersions: string[]) => {
+  const domainPackageList = await awsEs
+    .listPackagesForDomain({
+      DomainName: environment.esDomain,
+    })
+    .promise()
+
+  // create an array containing all found es package versions
+  const domainPackageVersions = domainPackageList.DomainPackageDetailsList.map((esPackage) => {
+    const { version } = parsePackageName(esPackage.PackageName)
+    return version
   })
+
+  // find the highest version in AWS ES search domain if any exists
+  for (const dictionaryVersion of dictionaryVersions) {
+    if (domainPackageVersions.includes(dictionaryVersion)) {
+      return dictionaryVersion
+    }
+  }
+
+  return '' // we found no version
 }

--- a/apps/services/search-indexer/src/migrate/dictionary.ts
+++ b/apps/services/search-indexer/src/migrate/dictionary.ts
@@ -26,8 +26,14 @@ interface Commit {
   sha: string
 }
 
-const getDictionaryFile = (sha: string, locale: ElasticsearchIndexLocale, analyzer: string) => {
-  return fetch(`https://github.com/${environment.dictRepo}/blob/${sha}/${locale}/${analyzer}.txt?raw=true`).then((response) => {
+const getDictionaryFile = (
+  sha: string,
+  locale: ElasticsearchIndexLocale,
+  analyzer: string,
+) => {
+  return fetch(
+    `https://github.com/${environment.dictRepo}/blob/${sha}/${locale}/${analyzer}.txt?raw=true`,
+  ).then((response) => {
     if (response.ok) {
       return response.body
     } else {
@@ -41,7 +47,7 @@ const mockCommits: Commit[] = [
   { sha: '9d3a04eee314d4940a23fe46092c0365d2493ff8' },
   { sha: 'd4171f9c87909d269f6149c9fead5e51937b0709' },
   { sha: '5d2c6703ea8de3115b39cd314c34f20c4f46e65d' },
-  { sha: '4cc984082460b81263b09124598f504d6e3f5db3' }
+  { sha: '4cc984082460b81263b09124598f504d6e3f5db3' },
 ]
 
 // get a list of all latest commits for this repo
@@ -55,13 +61,18 @@ export const getDictionaryVersions = () => {
   return getCommits().map((commit) => commit.substring(0, 7))
 }
 
-export const getDictionaryFilesAfterVersion = async (currentVersion: string): Promise<Dictionary[]> => {
+export const getDictionaryFilesAfterVersion = async (
+  currentVersion: string,
+): Promise<Dictionary[]> => {
   const commits = getCommits()
 
   // find what versions are missing given the current found version
-  const currentVersionIndex = commits.findIndex((commit) => commit.startsWith(currentVersion))
+  const currentVersionIndex = commits.findIndex((commit) =>
+    commit.startsWith(currentVersion),
+  )
   // if we don't find the index location we assume we should import all found versions
-  const newCommits = currentVersionIndex === -1 ? commits : commits.slice(0, currentVersionIndex)
+  const newCommits =
+    currentVersionIndex === -1 ? commits : commits.slice(0, currentVersionIndex)
 
   logger.info('Trying to get dictionary packages', { commits: newCommits })
 
@@ -70,7 +81,6 @@ export const getDictionaryFilesAfterVersion = async (currentVersion: string): Pr
   for (const commit of newCommits) {
     for (const locale of environment.locales) {
       for (const analyzer of analyzers) {
-
         const version = commit.substring(0, 7)
         const file = await getDictionaryFile(commit, locale, analyzer)
         // all versions don't have all files
@@ -79,10 +89,9 @@ export const getDictionaryFilesAfterVersion = async (currentVersion: string): Pr
             analyzerType: analyzer,
             version,
             file,
-            locale
+            locale,
           })
         }
-
       }
     }
   }

--- a/apps/services/search-indexer/src/migrate/dictionary.ts
+++ b/apps/services/search-indexer/src/migrate/dictionary.ts
@@ -15,57 +15,81 @@ const analyzers = [
   'hyphenwhitelist',
 ]
 
-const getDictUrl = (type: string, lang: string): string => {
-  const url = environment.dictRepo
-    .replace('api.github', 'github')
-    .replace('/repos/', '/')
-  return `${url}/blob/master/${lang}/${type}.txt?raw=true`
-}
-
-const getFile = (url: string) => {
-  logger.info('Getting file from', { url })
-  return fetch(url)
-}
-
-type dictionaryVersion = { tag_name: string }
-export const getDictionaryVersion = async (): Promise<string> => {
-  const url = environment.dictRepo + '/releases/latest'
-  const data: dictionaryVersion = await getFile(url).then((raw) => {
-    return raw.json()
-  })
-  return data.tag_name
-}
-
 export interface Dictionary {
+  version: string
   analyzerType: string
   locale: ElasticsearchIndexLocale
   file: NodeJS.ReadableStream
 }
-export const getDictionaryFiles = async (): Promise<Dictionary[]> => {
-  const locales = environment.locales
 
-  const dictionaries = locales.map((locale) => {
-    return analyzers.map(async (analyzerType) => {
-      const fileUrl = getDictUrl(analyzerType, locale)
-      const response = await getFile(fileUrl)
-      // only add found dictionaries to list, this tackles no dictionary provided for lang problem
-      if (response.status === 200) {
-        return {
-          analyzerType,
-          locale,
-          file: response.body,
-        }
-      } else {
-        // we will filter this from the dictionaries later
-        return false
-      }
-    })
+interface Commit {
+  sha: string
+}
+
+const getDictionaryFile = (sha: string, locale: ElasticsearchIndexLocale, analyzer: string) => {
+  return fetch(`https://github.com/${environment.dictRepo}/blob/${sha}/${locale}/${analyzer}.txt?raw=true`).then((response) => {
+    if (response.ok) {
+      return response.body
+    } else {
+      return null
+    }
   })
+}
 
-  const allDictionaryResponses = await Promise.all(flatten(dictionaries))
-  return allDictionaryResponses.filter(
-    (response): response is Dictionary => response !== false,
-  )
+const mockCommits: Commit[] = [
+  { sha: '7139c83db5e95e9f245ebd1265f0ddd8b4e25fcc' },
+  { sha: '9d3a04eee314d4940a23fe46092c0365d2493ff8' },
+  { sha: 'd4171f9c87909d269f6149c9fead5e51937b0709' },
+  { sha: '5d2c6703ea8de3115b39cd314c34f20c4f46e65d' },
+  { sha: '4cc984082460b81263b09124598f504d6e3f5db3' }
+]
+
+// get a list of all latest commits for this repo
+const getCommits = (): string[] => {
+  const commitsEndpoint = `https://api.github.com/repos/${environment.dictRepo}/commits`
+  const commits: Commit[] = mockCommits // await fetch(commitsEndpoint).then(response => response.json()) // this is rate limited to 60 requests an hour // TODO: Fix this b4 release
+  return commits.map((commit) => commit.sha)
+}
+
+export const getDictionaryVersions = () => {
+  return getCommits().map((commit) => commit.substring(0, 7))
+}
+
+export const getDictionaryFilesAfterVersion = async (currentVersion: string): Promise<Dictionary[]> => {
+  const commits = getCommits()
+
+  // find what versions are missing given the current found version
+  const currentVersionIndex = commits.findIndex((commit) => commit.startsWith(currentVersion))
+  // if we don't find the index location we assume we should import all found versions
+  const newCommits = currentVersionIndex === -1 ? commits : commits.slice(0, currentVersionIndex)
+
+  logger.info('Trying to get dictionary packages', { commits: newCommits })
+
+  // fetch all missing dictionary files for each version
+  const dictionaryFiles: Dictionary[] = []
+  for (const commit of newCommits) {
+    for (const locale of environment.locales) {
+      for (const analyzer of analyzers) {
+
+        const version = commit.substring(0, 7)
+        const file = await getDictionaryFile(commit, locale, analyzer)
+        // all versions don't have all files
+        if (file) {
+          dictionaryFiles.push({
+            analyzerType: analyzer,
+            version,
+            file,
+            locale
+          })
+        }
+
+      }
+    }
+  }
+
+  logger.info('Done getting packages', { fileCount: dictionaryFiles.length })
+
+  return dictionaryFiles
 }
 
 export const getFakeEsPackages = (): AwsEsPackage[] => {

--- a/apps/services/search-indexer/src/migrate/index.ts
+++ b/apps/services/search-indexer/src/migrate/index.ts
@@ -38,13 +38,17 @@ class App {
     this allows us to upload all versions since last sync
     */
     const dictionaryVersions = dictionary.getDictionaryVersions() // returns versions of the dictionary in order with the newest version first
-    const latestAwsDictionaryVersion = await aws.getFirstFoundAwsEsPackageVersion(dictionaryVersions)
-    const newDictionaryFiles = await dictionary.getDictionaryFilesAfterVersion(latestAwsDictionaryVersion)
+    const latestAwsDictionaryVersion = await aws.getFirstFoundAwsEsPackageVersion(
+      dictionaryVersions,
+    )
+    const newDictionaryFiles = await dictionary.getDictionaryFilesAfterVersion(
+      latestAwsDictionaryVersion,
+    )
 
     // if we have packages we should add them (s3 -> AWS ES -> AWS ES search domain)
     if (newDictionaryFiles.length) {
       logger.info('Found new dictionary packages, uploading to AWS', {
-        packages: newDictionaryFiles
+        packages: newDictionaryFiles,
       })
       const s3Files = await aws.uploadS3DictionaryFiles(newDictionaryFiles) // upload repo files to s3
       const newEsPackages = await aws.createAwsEsPackages(s3Files) // create the dictionary packages files in AWS ES
@@ -67,7 +71,9 @@ class App {
 
       // we should always have some packages here
       if (!esPackages.length) {
-        new Error(`Failed to get dictionary packages from AWS ES search domain for the given version: ${dictionaryVersion}`)
+        new Error(
+          `Failed to get dictionary packages from AWS ES search domain for the given version: ${dictionaryVersion}`,
+        )
       }
     } else {
       logger.info('No aws access found running in local development mode')

--- a/libs/content-search-index-manager/src/lib/config.ts
+++ b/libs/content-search-index-manager/src/lib/config.ts
@@ -1,3 +1,3 @@
 export const config = {
-  dictionaryVersion: 'd4171f9' // TODO: Make this be current version
+  dictionaryVersion: 'd4171f9', // TODO: Make this be current version
 }

--- a/libs/content-search-index-manager/src/lib/config.ts
+++ b/libs/content-search-index-manager/src/lib/config.ts
@@ -1,0 +1,3 @@
+export const config = {
+  dictionaryVersion: 'd4171f9' // TODO: Make this be current version
+}

--- a/libs/content-search-index-manager/src/lib/content-search-index-manager.ts
+++ b/libs/content-search-index-manager/src/lib/content-search-index-manager.ts
@@ -1,6 +1,7 @@
 import { unique } from 'shorthash'
 import { template as isIndexTemplate } from './index-templates/template-is'
 import { template as enIndexTemplate } from './index-templates/template-en'
+import { config } from './config'
 
 export type ElasticsearchIndexLocale = 'is' | 'en'
 
@@ -12,7 +13,9 @@ const indexTemplateMap = {
 export const getIndexTemplate = (locale: ElasticsearchIndexLocale) =>
   indexTemplateMap[locale]
 
-const configAsString = indexTemplateMap['is'] + indexTemplateMap['en']
+export const getDictionaryVersion = () => config.dictionaryVersion
+
+const configAsString = getIndexTemplate('is') + getIndexTemplate('en') + getDictionaryVersion()
 const indexTemplateHash = unique(configAsString).toLowerCase()
 
 export const getElasticVersion = (): string => {

--- a/libs/content-search-index-manager/src/lib/content-search-index-manager.ts
+++ b/libs/content-search-index-manager/src/lib/content-search-index-manager.ts
@@ -15,7 +15,8 @@ export const getIndexTemplate = (locale: ElasticsearchIndexLocale) =>
 
 export const getDictionaryVersion = () => config.dictionaryVersion
 
-const configAsString = getIndexTemplate('is') + getIndexTemplate('en') + getDictionaryVersion()
+const configAsString =
+  getIndexTemplate('is') + getIndexTemplate('en') + getDictionaryVersion()
 const indexTemplateHash = unique(configAsString).toLowerCase()
 
 export const getElasticVersion = (): string => {


### PR DESCRIPTION
# \<Description\>

https://app.asana.com/0/1199123945323117/1199701993113454
Dictionaries can currently be upgraded in every environment by pushing a new release to the [dictionary repository](https://github.com/island-is/elasticsearch-dictionaries).
This impedes development and might cause problems to production environments in a non obvious way.

## What

- Made migration deploy all commits to dictionary repo as separate versions identified by git commit sha
- Baked dictionary version into index version

## Why

- Binding dictionary version to index version allows us to rollback more easily
- Deploying all commits as versions allows us to pinpoint exact versions of dictionaries to deploy
- Having dictionary version in index version ensures index updates when dictionary version is updated

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
