### PR TITLE
Service portal: Prevent emails from landing in the promotions tab

### DIFF
--- a/apps/services/user-profile/src/app/user-profile/verification.service.ts
+++ b/apps/services/user-profile/src/app/user-profile/verification.service.ts
@@ -53,7 +53,7 @@ export class VerificationService {
     private readonly smsService: SmsService,
     @Inject(EmailService)
     private readonly emailService: EmailService,
-  ) {}
+  ) { }
 
   async createEmailVerification(
     nationalId: string,
@@ -163,6 +163,7 @@ export class VerificationService {
   }
 
   async sendConfirmationEmail(verification: EmailVerification) {
+    //rerun build
     const resetLink = `${environment.email.servicePortalBaseUrl}/stillingar/stadfesta-netfang/${verification.hash}`
     try {
       await this.emailService.sendEmail({

--- a/apps/services/user-profile/src/app/user-profile/verification.service.ts
+++ b/apps/services/user-profile/src/app/user-profile/verification.service.ts
@@ -177,7 +177,7 @@ export class VerificationService {
           },
         ],
         subject: `Staðfesting netfangs á Ísland.is`,
-        html: `Þú hefur skráð ${verification.email} á Mínum síðum á Ísland.is. Vinsamlegast staðfestu skráninguna með því að smella á hlekkinn hér fyrir neðan:
+        html: `Þú hefur skráð netfangið þitt á Mínum síðum á Ísland.is. Vinsamlegast staðfestu skráninguna með því að smella á hlekkinn hér fyrir neðan:
         <br><br><a href="${resetLink}" target="_blank">${resetLink}</a><br>
         <br>Ef hlekkurinn er ekki lengur í gildi biðjum við þig að endurtaka skráninguna á Ísland.is.
         <br><br>Ef þú kannast ekki við að hafa sett inn þetta netfang, vinsamlegast hunsaðu þennan póst.`,

--- a/apps/services/user-profile/src/app/user-profile/verification.service.ts
+++ b/apps/services/user-profile/src/app/user-profile/verification.service.ts
@@ -53,7 +53,7 @@ export class VerificationService {
     private readonly smsService: SmsService,
     @Inject(EmailService)
     private readonly emailService: EmailService,
-  ) { }
+  ) {}
 
   async createEmailVerification(
     nationalId: string,
@@ -163,7 +163,6 @@ export class VerificationService {
   }
 
   async sendConfirmationEmail(verification: EmailVerification) {
-    //rerun build
     const resetLink = `${environment.email.servicePortalBaseUrl}/stillingar/stadfesta-netfang/${verification.hash}`
     try {
       await this.emailService.sendEmail({


### PR DESCRIPTION
# \<Description\>

Reset emails were ending up in the promotions tab in Gmail.  By removing the email from the body it delivers in the main gmail tab

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
