### PR TITLE
Set NODE_ENV when building production builds

### DIFF
--- a/libs/shared/babel/README.md
+++ b/libs/shared/babel/README.md
@@ -8,6 +8,20 @@ Shared babel presets.
 
 Configures babel-plugin-transform-imports to use deep imports instead of importing stuff from index files.
 
+## Deep Imports
+
+Let's say we have a web-app which code-splits per page (like NextJS), and PageA uses a SectionA component and PageB uses a SectionB component, which are defined in our UI library. This creates the following chunks:
+
+[![](https://mermaid.ink/img/eyJjb2RlIjoiZ3JhcGggVEJcbnN1YmdyYXBoIGNodW5rIGFcblBhZ2VBXG5lbmRcbnN1YmdyYXBoIGNodW5rIGJcblBhZ2VCXG5lbmRcblBhZ2VBIC0tPiBVSVxuUGFnZUIgLS0-IFVJXG5zdWJncmFwaCBjaHVuayBzaGFyZWRcblVJW2lzbGFuZC11aS9pbmRleC50c11cblVJIC0tPiBTZWN0aW9uQVxuVUkgLS0-IFNlY3Rpb25CXG5lbmRcbiIsIm1lcm1haWQiOnsidGhlbWUiOiJkZWZhdWx0In0sInVwZGF0ZUVkaXRvciI6ZmFsc2V9)](https://mermaid-js.github.io/mermaid-live-editor/#/edit/eyJjb2RlIjoiZ3JhcGggVEJcbnN1YmdyYXBoIGNodW5rIGFcblBhZ2VBXG5lbmRcbnN1YmdyYXBoIGNodW5rIGJcblBhZ2VCXG5lbmRcblBhZ2VBIC0tPiBVSVxuUGFnZUIgLS0-IFVJXG5zdWJncmFwaCBjaHVuayBzaGFyZWRcblVJW2lzbGFuZC11aS9pbmRleC50c11cblVJIC0tPiBTZWN0aW9uQVxuVUkgLS0-IFNlY3Rpb25CXG5lbmRcbiIsIm1lcm1haWQiOnsidGhlbWUiOiJkZWZhdWx0In0sInVwZGF0ZUVkaXRvciI6ZmFsc2V9)
+
+Note that PageA gets code that is only used on PageB and vice-versa, because they are imported from the index.ts file. Tree shaking only applies to code that is not used by the whole app (unfortunately).
+
+For DX, and isolation, it's ideal to import everything from index.ts. However, for optimal code splitting, it's ideal to import stuff from where it is actually defined, with these chunks:
+
+[![](https://mermaid.ink/img/eyJjb2RlIjoiZ3JhcGggVEJcbnN1YmdyYXBoIGNodW5rIGFcblBhZ2VBXG5QYWdlQSAtLT4gU2VjdGlvbkFcbmVuZFxuc3ViZ3JhcGggY2h1bmsgYlxuUGFnZUJcblBhZ2VCIC0tPiBTZWN0aW9uQlxuZW5kXG4iLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9LCJ1cGRhdGVFZGl0b3IiOmZhbHNlfQ)](https://mermaid-js.github.io/mermaid-live-editor/#/edit/eyJjb2RlIjoiZ3JhcGggVEJcbnN1YmdyYXBoIGNodW5rIGFcblBhZ2VBXG5QYWdlQSAtLT4gU2VjdGlvbkFcbmVuZFxuc3ViZ3JhcGggY2h1bmsgYlxuUGFnZUJcblBhZ2VCIC0tPiBTZWN0aW9uQlxuZW5kXG4iLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9LCJ1cGRhdGVFZGl0b3IiOmZhbHNlfQ)
+
+So we configure babel-plugin-transform-imports to change import statements and use `exportFinder` to recursively find the actual module that defines each export.
+
 ## Running unit tests
 
 Run `ng test cache` to execute the unit tests via [Jest](https://jestjs.io).

--- a/scripts/ci/Dockerfile
+++ b/scripts/ci/Dockerfile
@@ -19,6 +19,7 @@ ADD . .
 FROM src as builder
 ARG APP
 ENV APP=${APP}
+ENV NODE_ENV=production
 
 RUN yarn run build ${APP} --prod
 


### PR DESCRIPTION
## What

Make sure production builds use production babel configuration.

Also, add more documentation about deep imports.

## Why

To pick up our production optimizations in `libs/shared/babel/web`, which configures `babel-plugin-transform-imports` with `exportFinder`.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
