### PR TITLE
island-ui / Footer top links hyphen

### DIFF
--- a/libs/island-ui/core/src/lib/Footer/Footer.tsx
+++ b/libs/island-ui/core/src/lib/Footer/Footer.tsx
@@ -17,6 +17,7 @@ import { Link } from '../Link/Link'
 
 import * as styles from './Footer.treat'
 import { Button } from '../Button/Button'
+import Hyphen from '../Hyphen/Hyphen'
 
 export interface FooterLinkProps {
   title: string
@@ -81,7 +82,7 @@ export const Footer = ({
                       color={'blue600'}
                     >
                       <Link href={href} color="blue600" underline="normal">
-                        {title}
+                        <Hyphen>{title}</Hyphen>
                       </Link>
                     </Text>
                   )


### PR DESCRIPTION
# Footer top links hyphen

## What

Add hyphen to footer top links

## Why

Some links have a long name that breaks the layout

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
