### PR TITLE
Judicial-system/Format nationalID and remove gender from info card

### DIFF
--- a/apps/judicial-system/web/src/routes/Prosecutor/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Overview/Overview.tsx
@@ -205,7 +205,6 @@ export const Overview: React.FC = () => {
                 },
               ]}
               accusedName={workingCase.accusedName}
-              accusedGender={workingCase.accusedGender}
               accusedNationalId={workingCase.accusedNationalId}
               accusedAddress={workingCase.accusedAddress}
             />

--- a/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/SignedVerdictOverview.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/SignedVerdictOverview.tsx
@@ -255,7 +255,6 @@ export const SignedVerdictOverview: React.FC = () => {
                 { title: 'Dómari', value: workingCase.judge?.name },
               ]}
               accusedName={workingCase.accusedName}
-              accusedGender={workingCase.accusedGender}
               accusedNationalId={workingCase.accusedNationalId}
               accusedAddress={workingCase.accusedAddress}
             />

--- a/apps/judicial-system/web/src/shared-components/InfoCard/InfoCard.tsx
+++ b/apps/judicial-system/web/src/shared-components/InfoCard/InfoCard.tsx
@@ -1,13 +1,11 @@
 import { Box, Text } from '@island.is/island-ui/core'
-import { CaseGender } from '@island.is/judicial-system/types'
+import { formatNationalId } from '@island.is/judicial-system/formatters'
 import React, { PropsWithChildren } from 'react'
-import { getShortGender } from '../../utils/stepHelper'
 import * as styles from './InfoCard.treat'
 
 interface Props {
   data: Array<{ title: string; value?: string }>
   accusedName?: string
-  accusedGender?: CaseGender
   accusedNationalId?: string
   accusedAddress?: string
 }
@@ -18,9 +16,9 @@ const InfoCard: React.FC<Props> = (props: PropsWithChildren<Props>) => {
       <Text variant="h4">Sakborningur</Text>
       <Box className={styles.infoCardTitleContainer}>
         <Text fontWeight="semiBold">
-          {`${props.accusedName} `}
-          <Text as="span">{`(${getShortGender(props.accusedGender)}), `}</Text>
-          {`${props.accusedNationalId}, `}
+          {`${props.accusedName}, kt. ${formatNationalId(
+            props.accusedNationalId || '',
+          )}, `}
           <Text as="span">{props.accusedAddress}</Text>
         </Text>
       </Box>


### PR DESCRIPTION
# Format nationalID and remove gender from info card

https://app.asana.com/0/1199153462262248/1199716090325397

## What

Name and national id are now both bold and national id has a hyphen and "kt." preceding it. Removed gender.

## Why

Better readability.

## Screenshots / Gifs

![screencapture-localhost-4200-stadfest-krafa-f5e0e733-bec3-44dd-b114-8e9378717fe7-2021-01-20-13_55_34](https://user-images.githubusercontent.com/3789875/105184641-7c2b5980-5b27-11eb-9829-3d0266f9201f.png)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
