### PR TITLE
Add optional chaining to possibly null field

### DIFF
--- a/libs/application/templates/driving-license/src/forms/application.tsx
+++ b/libs/application/templates/driving-license/src/forms/application.tsx
@@ -224,7 +224,7 @@ export const application: Form = buildForm({
               width: 'half',
               value: ({ externalData: { nationalRegistry } }) =>
                 (nationalRegistry.data as NationalRegistryUser).address
-                  .streetAddress,
+                  ?.streetAddress,
             }),
             buildKeyValueField({
               label: 'Kennitala',
@@ -237,7 +237,7 @@ export const application: Form = buildForm({
               width: 'half',
               value: ({ externalData: { nationalRegistry } }) =>
                 (nationalRegistry.data as NationalRegistryUser).address
-                  .postalCode,
+                  ?.postalCode,
             }),
             buildKeyValueField({
               label: 'Netfang',
@@ -249,7 +249,7 @@ export const application: Form = buildForm({
               label: 'Staður',
               width: 'half',
               value: ({ externalData: { nationalRegistry } }) =>
-                (nationalRegistry.data as NationalRegistryUser).address.city,
+                (nationalRegistry.data as NationalRegistryUser).address?.city,
             }),
             buildDividerField({}),
             buildKeyValueField({


### PR DESCRIPTION
# Added optional chaining to address field as it can be null

## What

After changing the national registry api to accept null on address fields it will break if we don't have optional chaining

## Screenshots / Gifs

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
