### PR TITLE
Fix global styles in island-ui

### DIFF
--- a/libs/island-ui/core/package.json
+++ b/libs/island-ui/core/package.json
@@ -1,4 +1,6 @@
 {
   "name": "@island.is/island-ui-core",
-  "sideEffects": false
+  "sideEffects": [
+    "src/index.ts"
+  ]
 }


### PR DESCRIPTION
## What

Fix global styles in legacy projects by marking island-ui/core/src/index.ts as having sideEffects (global styles).

## Why

This is a regression from the performance work in #2530. New projects should start using `shared/babel/web` and explicitly import and run `globalStyles()`.
