### PR TITLE
Use the dynamic sticky for left sidebar

### DIFF
--- a/apps/web/components/Sticky/Sticky.tsx
+++ b/apps/web/components/Sticky/Sticky.tsx
@@ -16,12 +16,12 @@ export const Sticky: FC<Props> = ({
   const [usesSticky, setUsesSticky] = useState<boolean>(constantSticky)
 
   const onResize = useCallback(() => {
-    if (
-      ref?.current &&
-      !constantSticky &&
-      ref.current.offsetHeight < window.innerHeight - STICKY_NAV_HEIGHT
-    ) {
-      setUsesSticky(true)
+    if (ref?.current && !constantSticky) {
+      setUsesSticky(
+        Boolean(
+          ref.current.offsetHeight < window.innerHeight - STICKY_NAV_HEIGHT,
+        ),
+      )
     }
   }, [ref])
 

--- a/apps/web/screens/Article.tsx
+++ b/apps/web/screens/Article.tsx
@@ -24,6 +24,7 @@ import {
 import {
   HeadWithSocialSharing,
   InstitutionPanel,
+  Sticky,
 } from '@island.is/web/components'
 import { withMainLayout } from '@island.is/web/layouts/main'
 import { GET_ARTICLE_QUERY, GET_NAMESPACE_QUERY } from './queries'
@@ -320,8 +321,15 @@ const ArticleScreen: Screen<ArticleProps> = ({ article, namespace }) => {
         imageHeight={article.featuredImage?.height.toString()}
       />
       <SidebarLayout
+        isSticky={false}
         sidebarContent={
-          <ArticleSidebar article={article} n={n} activeSlug={query.subSlug} />
+          <Sticky>
+            <ArticleSidebar
+              article={article}
+              n={n}
+              activeSlug={query.subSlug}
+            />
+          </Sticky>
         }
       >
         <Box

--- a/apps/web/screens/Category/Category.tsx
+++ b/apps/web/screens/Category/Category.tsx
@@ -13,7 +13,7 @@ import {
   FocusableBox,
   Navigation,
 } from '@island.is/island-ui/core'
-import { Card } from '@island.is/web/components'
+import { Card, Sticky } from '@island.is/web/components'
 import { useI18n } from '@island.is/web/i18n'
 import { withMainLayout } from '@island.is/web/layouts/main'
 import { Screen } from '@island.is/web/types'
@@ -250,24 +250,26 @@ const Category: Screen<CategoryProps> = ({
         <title>{category.title} | Ísland.is</title>
       </Head>
       <SidebarLayout
-        isSticky
+        isSticky={false}
         sidebarContent={
-          <Navigation
-            baseId="desktopNav"
-            colorScheme="purple"
-            items={sidebarCategoryLinks}
-            title={n('sidebarHeader')}
-            renderLink={(link, { typename, slug }) => {
-              return (
-                <NextLink
-                  {...linkResolver(typename as LinkType, slug)}
-                  passHref
-                >
-                  {link}
-                </NextLink>
-              )
-            }}
-          />
+          <Sticky>
+            <Navigation
+              baseId="desktopNav"
+              colorScheme="purple"
+              items={sidebarCategoryLinks}
+              title={n('sidebarHeader')}
+              renderLink={(link, { typename, slug }) => {
+                return (
+                  <NextLink
+                    {...linkResolver(typename as LinkType, slug)}
+                    passHref
+                  >
+                    {link}
+                  </NextLink>
+                )
+              }}
+            />
+          </Sticky>
         }
       >
         <Box paddingBottom={[2, 2, 4]}>


### PR DESCRIPTION
# Description

Reusing the Sticky component for article and category sidebars. Also fixed where it did not update correctly on resize.

## What

Detects if the screen is not tall enough for the whole sidebar to be visible and if so it will remove position = sticky.

## Why

On smaller screens (or lower resolutions) the bottom half of the sidebar (if it was a tall one) was not visible until you scrolled all the way down.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
