### PR TITLE
Fix build issue in build-graphql-schema

### DIFF
--- a/scripts/build-graphql-schema.ts
+++ b/scripts/build-graphql-schema.ts
@@ -4,7 +4,7 @@ import { GraphQLDefinitionsFactory } from '@nestjs/graphql'
 import { createApp } from '@island.is/infra-nest-server'
 
 const argv = yargs(process.argv.slice(2))
-const args = argv.string('rootModule').string('_').help().argv
+const args = argv.string('_').help().argv
 
 const main = () => {
   const { AppModule } = require(args._[0])

--- a/scripts/build-graphql-schema.ts
+++ b/scripts/build-graphql-schema.ts
@@ -4,7 +4,7 @@ import { GraphQLDefinitionsFactory } from '@nestjs/graphql'
 import { createApp } from '@island.is/infra-nest-server'
 
 const argv = yargs(process.argv.slice(2))
-const args = argv.string('rootModule').help().argv
+const args = argv.string('rootModule').string('_').help().argv
 
 const main = () => {
   const { AppModule } = require(args._[0])


### PR DESCRIPTION
# Fix build-graphql-schema

In `build-graphql-schema` the [yargs.argv._](https://github.com/yargs/yargs/blob/169b815df7ae190965f04030f28adc3ab92bb4b5/docs/api.md/#argv) 
parameters can be both string and numbers.
But `require( )` only accepts strings, so using `yargs.string(key)` to make them only strings.

## What

Fix build error in `build-graphql-schema`

## Why

To enable generation of graphql schemas.

Script failing for the command:  `yarn nx run judicial-system-api:schemas/build-graphql-schema --skip-nx-cache
`
 with the following stack trace:
```
> nx run judicial-system-api:schemas/build-graphql-schema
$ cross-env ts-node -r tsconfig-paths/register -O '{\"module\":\"commonjs\",\"esModuleInterop\":true}' -P apps/judicial-system/api/tsconfig.json scripts/build-graphql-schema.ts apps/judicial-system/api/src/app/app.module

/home/saevarma/git/island-is/island.is/node_modules/ts-node/src/index.ts:500
    return new TSError(diagnosticText, diagnosticCodes)
           ^
TSError: ⨯ Unable to compile TypeScript:
scripts/build-graphql-schema.ts(10,33): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'string'.
  Type 'number' is not assignable to type 'string'.

    at createTSError (/home/saevarma/git/island-is/island.is/node_modules/ts-node/src/index.ts:500:12)
    at reportTSError (/home/saevarma/git/island-is/island.is/node_modules/ts-node/src/index.ts:504:19)
    at getOutput (/home/saevarma/git/island-is/island.is/node_modules/ts-node/src/index.ts:739:36)
    at Object.compile (/home/saevarma/git/island-is/island.is/node_modules/ts-node/src/index.ts:955:32)
    at Module.m._compile (/home/saevarma/git/island-is/island.is/node_modules/ts-node/src/index.ts:1043:43)
    at Module._extensions..js (internal/modules/cjs/loader.js:1035:10)
    at Object.require.extensions.<computed> [as .ts] (/home/saevarma/git/island-is/island.is/node_modules/ts-node/src/index.ts:1046:12)
    at Module.load (internal/modules/cjs/loader.js:879:32)
    at Function.Module._load (internal/modules/cjs/loader.js:724:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:60:12)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

## Screenshots / Gifs

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
