### PR TITLE
Remove api-catalogue from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -76,7 +76,6 @@
 /scripts/postinstall.js                                   @island-is/devops @jeremybarbet
 /scripts/schemas.js                                       @island-is/devops @jeremybarbet
 
-/apps/api-catalogue/                                      @island-is/advania
 /libs/api/domains/api-catalogue/                          @island-is/advania
 /libs/api/domains/document-provider/                      @island-is/advania
 /libs/api-catalogue/                                      @island-is/advania
@@ -92,4 +91,3 @@
 /apps/auth-admin-web-e2e/                                 @island-is/fuglar
 /libs/auth-api-lib/                                       @island-is/fuglar
 /libs/auth-nest-tools/                                    @island-is/fuglar
-


### PR DESCRIPTION
## What

API catalogue was removed in #2498 but not from [codeowners](https://github.com/island-is/island.is/blob/main/.github/CODEOWNERS#L79).

## Why

This breaks all PRs since linting of codeowners complains about it not existing in the project anymore.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

![image](https://user-images.githubusercontent.com/6312838/105854678-18010d80-5fdf-11eb-9770-9f9d3e704e5c.png)

![image](https://user-images.githubusercontent.com/6312838/105854693-1b949480-5fdf-11eb-9a04-5e8a35edc287.png)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
