### PR TITLE
Parental Leave - Share info with other parent as conditional

### DIFF
--- a/libs/application/templates/parental-leave/src/forms/ParentalLeaveForm.ts
+++ b/libs/application/templates/parental-leave/src/forms/ParentalLeaveForm.ts
@@ -679,6 +679,7 @@ export const ParentalLeaveForm: Form = buildForm({
         buildSubSection({
           id: 'shareInformation',
           title: mm.shareInformation.subSection,
+          condition: (answers) => answers.otherParent !== NO,
           children: [
             buildRadioField({
               id: 'shareInformationWithOtherParent',


### PR DESCRIPTION
Show the "Share info with other parent" section only if they chose confirm the other parent.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
