### PR TITLE
fix: date-fns tree-shaked imports

### DIFF
--- a/apps/air-discount-scheme/backend/src/app/modules/discount/test/e2e/discount.spec.ts
+++ b/apps/air-discount-scheme/backend/src/app/modules/discount/test/e2e/discount.spec.ts
@@ -1,5 +1,5 @@
+const request = require('supertest')
 import { setup } from '../../../../../../test/setup'
-import * as request from 'supertest'
 import { INestApplication, CACHE_MANAGER } from '@nestjs/common'
 import {
   NationalRegistryService,

--- a/apps/air-discount-scheme/backend/src/app/modules/flight/test/e2e/flight.spec.ts
+++ b/apps/air-discount-scheme/backend/src/app/modules/flight/test/e2e/flight.spec.ts
@@ -1,5 +1,5 @@
+const request = require('supertest')
 import { setup } from '../../../../../../test/setup'
-import * as request from 'supertest'
 import { INestApplication, CACHE_MANAGER } from '@nestjs/common'
 import {
   NationalRegistryService,

--- a/apps/air-discount-scheme/backend/src/app/modules/user/test/e2e/user.spec.ts
+++ b/apps/air-discount-scheme/backend/src/app/modules/user/test/e2e/user.spec.ts
@@ -1,5 +1,5 @@
+const request = require('supertest')
 import { setup } from '../../../../../../test/setup'
-import * as request from 'supertest'
 import { INestApplication, CACHE_MANAGER } from '@nestjs/common'
 import { NationalRegistryService } from '../../../nationalRegistry'
 

--- a/apps/application-system/api/src/app/modules/application/e2e/application.spec.ts
+++ b/apps/application-system/api/src/app/modules/application/e2e/application.spec.ts
@@ -1,5 +1,5 @@
+const request = require('supertest')
 import { setup } from '../../../../../test/setup'
-import request from 'supertest'
 import { INestApplication } from '@nestjs/common'
 import * as tokenUtils from '../utils/tokenUtils'
 import { environment } from '../../../../environments'

--- a/apps/judicial-system/backend/src/app/formatters/pdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/pdf.ts
@@ -590,6 +590,5 @@ export async function generateRulingPdf(
   if (!environment.production) {
     writeFile(`${existingCase.id}-ruling.pdf`, pdf as string)
   }
-
   return pdf
 }

--- a/apps/judicial-system/backend/test/e2e.spec.ts
+++ b/apps/judicial-system/backend/test/e2e.spec.ts
@@ -1,4 +1,4 @@
-import * as request from 'supertest'
+const request = require('supertest')
 
 import { INestApplication } from '@nestjs/common'
 

--- a/apps/judicial-system/backend/test/setup.ts
+++ b/apps/judicial-system/backend/test/setup.ts
@@ -8,6 +8,7 @@ import { testServer, TestServerOptions } from '@island.is/infra-nest-server'
 
 import { AppModule } from '../src/app'
 
+/*
 jest.mock('pdfkit', function () {
   class MockPDFDocument {
     pipe(stream) {
@@ -34,7 +35,9 @@ jest.mock('pdfkit', function () {
     default: MockPDFDocument,
   }
 })
+*/
 
+/*
 jest.mock('stream-buffers', function () {
   class MockWritableStreamBuffer {
     on(_, fn) {
@@ -51,6 +54,7 @@ jest.mock('stream-buffers', function () {
     },
   }
 })
+*/
 
 let app: INestApplication
 let sequelize: Sequelize

--- a/apps/judicial-system/backend/tsconfig.json
+++ b/apps/judicial-system/backend/tsconfig.json
@@ -3,8 +3,9 @@
   "compilerOptions": {
     "types": ["node", "jest"],
     "emitDecoratorMetadata": true,
-    "target": "es2015",
-    "strict": false
+    "allowJs": true,
+    "strict": false,
+    "esModuleInterop": true
   },
   "include": [],
   "allowJs": true,

--- a/apps/reference-backend/src/app/modules/resource/e2e/resource.spec.ts
+++ b/apps/reference-backend/src/app/modules/resource/e2e/resource.spec.ts
@@ -1,5 +1,5 @@
+const request = require('supertest')
 import { setup } from '../../../../../test/setup'
-import * as request from 'supertest'
 import { INestApplication } from '@nestjs/common'
 
 let app: INestApplication

--- a/apps/services/auth-api/src/app/modules/case/e2e/auth-api.spec.ts
+++ b/apps/services/auth-api/src/app/modules/case/e2e/auth-api.spec.ts
@@ -1,7 +1,7 @@
+const request = require('supertest')
 import { GrantDto, UserIdentityDto } from '@island.is/auth-api-lib'
 import { INestApplication } from '@nestjs/common'
 import { setup } from '../../../../../test/setup'
-import * as request from 'supertest'
 
 let app: INestApplication
 

--- a/apps/services/user-profile/src/app/user-profile/e2e/userProfile.spec.ts
+++ b/apps/services/user-profile/src/app/user-profile/e2e/userProfile.spec.ts
@@ -1,5 +1,5 @@
+const request = require('supertest')
 import { setup } from '../../../../test/setup'
-import * as request from 'supertest'
 import { INestApplication } from '@nestjs/common'
 import { EmailService } from '@island.is/email-service'
 import { EmailVerification } from '../emailVerification.model'

--- a/libs/judicial-system/formatters/src/lib/formatters.ts
+++ b/libs/judicial-system/formatters/src/lib/formatters.ts
@@ -1,6 +1,7 @@
-import { format, parseISO, isValid } from 'date-fns' // eslint-disable-line no-restricted-imports
-// Importing 'is' directly from date-fns/locale/is has caused unexpected problems
-import { is } from 'date-fns/locale' // eslint-disable-line no-restricted-imports
+import format from 'date-fns/format'
+import parseISO from 'date-fns/parseISO'
+import isValid from 'date-fns/isValid'
+import is from 'date-fns/locale/is'
 
 import {
   CaseCustodyRestrictions,

--- a/libs/judicial-system/formatters/tsconfig.json
+++ b/libs/judicial-system/formatters/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "types": ["node", "jest"],
-    "strict": true
+    "strict": true,
+    "esModuleInterop": true
   },
   "files": [],
   "include": [],


### PR DESCRIPTION
## What

- Last bit of code in the repository not using three shaked date-fns imports. Been trying locally judicial-system tests and it was passing. Opening PR to see if everything is fine with theses changes