### PR TITLE
Remove sleeve from home screen and fix breadcrumb tag on news item

### DIFF
--- a/apps/web/screens/Home.tsx
+++ b/apps/web/screens/Home.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import React, { useContext } from 'react'
-import { Box, Stack, Inline, Tag, Sleeve } from '@island.is/island-ui/core'
+import { Box, Stack, Inline, Tag } from '@island.is/island-ui/core'
 import { useI18n } from '@island.is/web/i18n'
 import { Screen } from '@island.is/web/types'
 import { useNamespace } from '@island.is/web/hooks'
@@ -116,12 +116,6 @@ const Home: Screen<HomeProps> = ({
       </Stack>
     </Box>
   )
-
-  const LIFE_EVENTS_THRESHOLD = 6
-  const includeLifeEventSectionBleed =
-    lifeEvents.length <= LIFE_EVENTS_THRESHOLD
-  const showSleeve = lifeEvents.length > LIFE_EVENTS_THRESHOLD
-
   return (
     <div id="main-content">
       <Section paddingY={[0, 0, 4, 4, 6]} aria-label={t.carouselTitle}>
@@ -133,32 +127,20 @@ const Home: Screen<HomeProps> = ({
       <Section
         aria-labelledby="lifeEventsTitle"
         paddingTop={4}
-        backgroundBleed={
-          includeLifeEventSectionBleed && {
-            bleedAmount: 100,
-            mobileBleedAmount: 50,
-            bleedDirection: 'bottom',
-            fromColor: 'white',
-            toColor: 'purple100',
-            bleedInMobile: true,
-          }
-        }
+        backgroundBleed={{
+          bleedAmount: 100,
+          mobileBleedAmount: 50,
+          bleedDirection: 'bottom',
+          fromColor: 'white',
+          toColor: 'purple100',
+          bleedInMobile: true,
+        }}
       >
-        {showSleeve ? (
-          <Sleeve sleeveShadow="purple">
-            <LifeEventsCardsSection
-              title={n('lifeEventsTitle')}
-              titleId="lifeEventsTitle"
-              lifeEvents={lifeEvents}
-            />
-          </Sleeve>
-        ) : (
-          <LifeEventsCardsSection
-            title={n('lifeEventsTitle')}
-            titleId="lifeEventsTitle"
-            lifeEvents={lifeEvents}
-          />
-        )}
+        <LifeEventsCardsSection
+          title={n('lifeEventsTitle')}
+          titleId="lifeEventsTitle"
+          lifeEvents={lifeEvents}
+        />
       </Section>
       <Section
         paddingTop={[8, 8, 6]}

--- a/apps/web/screens/NewsItem.tsx
+++ b/apps/web/screens/NewsItem.tsx
@@ -75,7 +75,7 @@ const NewsItem: Screen<NewsItemProps> = ({ newsItem, namespace }) => {
         isTag: true,
         title: title,
         typename: 'newsoverview',
-        slug: [`?tag=${id}`],
+        href: id,
       }
     })
 
@@ -104,12 +104,17 @@ const NewsItem: Screen<NewsItemProps> = ({ newsItem, namespace }) => {
                           ? breadCrumbs.concat(breadCrumbTags)
                           : breadCrumbs
                       }
-                      renderLink={(link, { typename, slug }) => {
+                      renderLink={(link, { isTag, typename, slug, href }) => {
+                        const linkProps = isTag
+                          ? {
+                              href: {
+                                pathname: linkResolver('newsoverview').href,
+                                query: { tag: href },
+                              },
+                            }
+                          : linkResolver(typename as LinkType, slug)
                         return (
-                          <NextLink
-                            {...linkResolver(typename as LinkType, slug)}
-                            passHref
-                          >
+                          <NextLink {...linkProps} passHref>
                             {link}
                           </NextLink>
                         )


### PR DESCRIPTION
# Bug fixes

Remove sleeve all together from home screen
Fix tag link in newsitem breadcrumbs

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
