### PR TITLE
Sjukratryggingar/old pending applications

### DIFF
--- a/libs/application/templates/health-insurance/src/dataProviders/HealthInsuranceProvider.ts
+++ b/libs/application/templates/health-insurance/src/dataProviders/HealthInsuranceProvider.ts
@@ -5,8 +5,8 @@ import {
   FailedDataProviderResult,
 } from '@island.is/application/core'
 
-export class SjukratryggingarProvider extends BasicDataProvider {
-  type = 'SjukratryggingarProvider'
+export class HealthInsuranceProvider extends BasicDataProvider {
+  type = 'HealthInsuranceProvider'
 
   provide(application: Application): Promise<string> {
     const query = `query HealthInsuranceIsHealthInsured {

--- a/libs/application/templates/health-insurance/src/dataProviders/OldPendingApplications.ts
+++ b/libs/application/templates/health-insurance/src/dataProviders/OldPendingApplications.ts
@@ -1,0 +1,48 @@
+import {
+  BasicDataProvider,
+  Application,
+  SuccessfulDataProviderResult,
+  FailedDataProviderResult,
+} from '@island.is/application/core'
+
+export class OldPendingApplications extends BasicDataProvider {
+  type = 'OldPendingApplications'
+
+  provide(application: Application): Promise<string> {
+    const query = `query HealthInsuranceGetPendingApplication {
+      healthInsuranceGetPendingApplication 
+    }`
+
+    return this.useGraphqlGateway(query)
+      .then(async (res: Response) => {
+        const response = await res.json()
+        if (response.errors) {
+          return this.handleError()
+        }
+
+        return Promise.resolve(
+          response.data?.healthInsuranceGetPendingApplication,
+        )
+      })
+      .catch(() => {
+        return this.handleError()
+      })
+  }
+
+  handleError() {
+    return Promise.resolve({})
+  }
+
+  onProvideError(result: string): FailedDataProviderResult {
+    return {
+      date: new Date(),
+      reason: result,
+      status: 'failure',
+      data: result,
+    }
+  }
+
+  onProvideSuccess(result: object): SuccessfulDataProviderResult {
+    return { date: new Date(), status: 'success', data: result }
+  }
+}

--- a/libs/application/templates/health-insurance/src/dataProviders/SjukratryggingarProvider.ts
+++ b/libs/application/templates/health-insurance/src/dataProviders/SjukratryggingarProvider.ts
@@ -10,21 +10,25 @@ export class SjukratryggingarProvider extends BasicDataProvider {
 
   provide(application: Application): Promise<string> {
     const query = `query HealthInsuranceIsHealthInsured {
-      healthInsuranceIsHealthInsured(nationalId: "2811638099") 
+      healthInsuranceIsHealthInsured 
     }`
 
     return this.useGraphqlGateway(query)
       .then(async (res: Response) => {
         const response = await res.json()
         if (response.errors) {
-          return Promise.reject(response.errors)
+          return this.handleError()
         }
 
         return Promise.resolve(response.data?.healthInsuranceIsHealthInsured)
       })
-      .catch((e) => {
-        return Promise.reject(e)
+      .catch(() => {
+        return this.handleError()
       })
+  }
+
+  handleError() {
+    return Promise.resolve({})
   }
 
   onProvideError(result: string): FailedDataProviderResult {

--- a/libs/application/templates/health-insurance/src/dataProviders/index.ts
+++ b/libs/application/templates/health-insurance/src/dataProviders/index.ts
@@ -1,4 +1,5 @@
-export { SjukratryggingarProvider } from './SjukratryggingarProvider'
+export { HealthInsuranceProvider } from './HealthInsuranceProvider'
+export { OldPendingApplications } from './OldPendingApplications'
 export {
   UserProfileProvider,
   NationalRegistryProvider,

--- a/libs/application/templates/health-insurance/src/fields/ConfirmationScreen/ConfirmationScreen.tsx
+++ b/libs/application/templates/health-insurance/src/fields/ConfirmationScreen/ConfirmationScreen.tsx
@@ -34,7 +34,6 @@ const ConfirmationScreen: FC<FieldBaseProps> = ({ field, application }) => {
         </Markdown>
       </Text>
       <Box display="flex" justifyContent="center" paddingY={2} size={1}>
-        {/* TODO: When illustration is available in library, switch to that instead */}
         <ManOnBenchIllustration />
       </Box>
       <Box marginBottom={6}>

--- a/libs/application/templates/health-insurance/src/fields/ErrorModal/ErrorModal.tsx
+++ b/libs/application/templates/health-insurance/src/fields/ErrorModal/ErrorModal.tsx
@@ -53,7 +53,7 @@ const ErrorModal: FC<FieldBaseProps> = ({ application }) => {
     })?.address
     const isInsured = externalData?.sjukratryggingar?.data
 
-    if (isInsured === 'true') {
+    if (isInsured) {
       setContent({
         title: 'Already insured',
         description:

--- a/libs/application/templates/health-insurance/src/forms/HealthInsuranceForm.ts
+++ b/libs/application/templates/health-insurance/src/forms/HealthInsuranceForm.ts
@@ -43,8 +43,14 @@ export const HealthInsuranceForm: Form = buildForm({
               subTitle: '',
             }),
             buildDataProviderItem({
-              id: 'sjukratryggingar',
-              type: 'SjukratryggingarProvider',
+              id: 'healthInsurance',
+              type: 'HealthInsuranceProvider',
+              title: '',
+              subTitle: '',
+            }),
+            buildDataProviderItem({
+              id: 'oldPendingApplications',
+              type: 'OldPendingApplications',
               title: '',
               subTitle: '',
             }),

--- a/libs/application/templates/health-insurance/src/forms/messages.ts
+++ b/libs/application/templates/health-insurance/src/forms/messages.ts
@@ -181,7 +181,7 @@ export const m = defineMessages({
     description: 'Confirmation of studies must be submitted',
   },
   confirmationOfStudiesTooltip: {
-    id: 'hi.application:student.confirmationOfStudies',
+    id: 'hi.application:student.confirmationOfStudiesTooltip',
     defaultMessage:
       'You need to submit a copy of your Graduation certificate or a confirmation of completed credits for each semester.\n' +
       'Admission or enrollement letters are not sufficient.',
@@ -259,7 +259,7 @@ export const m = defineMessages({
     description: 'Former insurance entitlement',
   },
   formerInsuranceEntitlementTooltip: {
-    id: 'hi.application:formerInsurance.entitlement',
+    id: 'hi.application:formerInsurance.entitlementTooltip',
     defaultMessage:
       'Most likely yes if you are still employed/receiving unemployment benefits, pension, benefits in cash or paternity/maternity benefits from your former country of insurance.',
     description: 'Former insurance entitlement tooltip',
@@ -305,17 +305,17 @@ export const m = defineMessages({
     description: 'Confirm and submit your application',
   },
   additionalInfo: {
-    id: 'hi.application.hasAdditionalRemarks',
+    id: 'hi.application:hasAdditionalRemarks',
     defaultMessage: 'Do you have any additional information or remarks?',
     description: 'Do you have any additional information or remarks?',
   },
   additionalRemarks: {
-    id: 'hi.application.additionalRemarks',
+    id: 'hi.application:additionalRemarks',
     defaultMessage: 'Additional information or remarks',
     description: 'Remarks or additional information',
   },
   additionalRemarksPlaceholder: {
-    id: 'hi.application.additionalRemarks.placeholder',
+    id: 'hi.application:additionalRemarks.placeholder',
     defaultMessage: 'Enter your text here',
     description: 'Enter your text here',
   },
@@ -440,5 +440,16 @@ export const m = defineMessages({
     id: 'hi.application:activeApplication.buttonText',
     defaultMessage: 'See status',
     description: 'See status',
+  },
+  oldPendingApplicationDescription: {
+    id: 'hi.application:activeApplication.description',
+    defaultMessage:
+      'You have already submitted an application for health insurance. Your application number is **{applicationNumber}**. Please contact the Icelandic Health Insurance if you have any questions.',
+    description: 'Old active application description',
+  },
+  oldPendingApplicationButtonText: {
+    id: 'hi.application:activeApplication.buttonText',
+    defaultMessage: 'Contact info',
+    description: 'Contact info',
   },
 })


### PR DESCRIPTION
# Sjukratryggingar - get old pending application from 

## What

- Remove national id from query
- Added query to get old pending applications in sjukra
- Show modal if pending applications exist

## Why

Because in the transition period of using this application and the old, there might be users that have active applications with the old. We want to inform those users with this feature.

## Screenshots / Gifs
![Screenshot 2021-01-27 at 18 23 53](https://user-images.githubusercontent.com/64913954/106028903-d189dc80-60cc-11eb-9331-58f0b66bb98e.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
