### PR TITLE
Judicial-system/Refactor util tests

### DIFF
--- a/apps/judicial-system/web/src/utils/utils.spec.tsx
+++ b/apps/judicial-system/web/src/utils/utils.spec.tsx
@@ -25,7 +25,7 @@ import {
   CaseDecision,
 } from '@island.is/judicial-system/types'
 import { validate } from './validate'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import React from 'react'
 import userEvent from '@testing-library/user-event'
 
@@ -324,7 +324,7 @@ describe('Step helper', () => {
   })
 
   describe('constructConclution', () => {
-    test('should return rejected message if the case is being rejected', () => {
+    test('should return rejected message if the case is being rejected', async () => {
       // Arrange
       const wc = {
         decision: CaseDecision.REJECTING,
@@ -334,27 +334,29 @@ describe('Step helper', () => {
       }
 
       // Act
-      const { getByText } = render(constructConclusion(wc as Case))
+      render(constructConclusion(wc as Case))
 
       // Assert
       expect(
-        getByText((_, node) => {
-          // Credit: https://www.polvara.me/posts/five-things-you-didnt-know-about-testing-library/
-          const hasText = (node: Element) =>
-            node.textContent ===
-            'Kröfu um að kærði, Mikki Refur, kt. 121212-1299, sæti gæsluvarðhaldi er hafnað.'
+        await waitFor(() =>
+          screen.getByText((_, node) => {
+            // Credit: https://www.polvara.me/posts/five-things-you-didnt-know-about-testing-library/
+            const hasText = (node: Element) =>
+              node.textContent ===
+              'Kröfu um að kærði, Mikki Refur, kt. 121212-1299, sæti gæsluvarðhaldi er hafnað.'
 
-          const nodeHasText = hasText(node)
-          const childrenDontHaveText = Array.from(node.children).every(
-            (child) => !hasText(child),
-          )
+            const nodeHasText = hasText(node)
+            const childrenDontHaveText = Array.from(node.children).every(
+              (child) => !hasText(child),
+            )
 
-          return nodeHasText && childrenDontHaveText
-        }),
+            return nodeHasText && childrenDontHaveText
+          }),
+        ),
       ).toBeTruthy()
     })
 
-    test('should return the correct string if there is no isolation and the case is not being rejected', () => {
+    test('should return the correct string if there is no isolation and the case is not being rejected', async () => {
       // Arrange
       const wc = {
         id: 'testid',
@@ -371,27 +373,29 @@ describe('Step helper', () => {
       }
 
       // Act
-      const { getByText } = render(constructConclusion(wc as Case))
+      render(constructConclusion(wc as Case))
 
       // Assert
       expect(
-        getByText((_, node) => {
-          // Credit: https://www.polvara.me/posts/five-things-you-didnt-know-about-testing-library/
-          const hasText = (node: Element) =>
-            node.textContent ===
-            'Kærði, Doe kt. 012345-6789, skal sæta gæsluvarðhaldi, þó ekki lengur en til fimmtudagsins 22. október 2020, kl. 12:31.'
+        await waitFor(() =>
+          screen.getByText((_, node) => {
+            // Credit: https://www.polvara.me/posts/five-things-you-didnt-know-about-testing-library/
+            const hasText = (node: Element) =>
+              node.textContent ===
+              'Kærði, Doe kt. 012345-6789, skal sæta gæsluvarðhaldi, þó ekki lengur en til fimmtudagsins 22. október 2020, kl. 12:31.'
 
-          const nodeHasText = hasText(node)
-          const childrenDontHaveText = Array.from(node.children).every(
-            (child) => !hasText(child),
-          )
+            const nodeHasText = hasText(node)
+            const childrenDontHaveText = Array.from(node.children).every(
+              (child) => !hasText(child),
+            )
 
-          return nodeHasText && childrenDontHaveText
-        }),
+            return nodeHasText && childrenDontHaveText
+          }),
+        ),
       ).toBeTruthy()
     })
 
-    test('should return the correct string if there is isolation and the case is not being rejected', () => {
+    test('should return the correct string if there is isolation and the case is not being rejected', async () => {
       // Arrange
       const wc = {
         decision: CaseDecision.ACCEPTING,
@@ -403,27 +407,29 @@ describe('Step helper', () => {
       }
 
       // Act
-      const { getByText } = render(constructConclusion(wc as Case))
+      render(constructConclusion(wc as Case))
 
       // Assert
       expect(
-        getByText((_, node) => {
-          // Credit: https://www.polvara.me/posts/five-things-you-didnt-know-about-testing-library/
-          const hasText = (node: Element) =>
-            node.textContent ===
-            'Kærði, Doe kt. 012345-6789, skal sæta gæsluvarðhaldi, þó ekki lengur en til fimmtudagsins 22. október 2020, kl. 12:31. Kærði skal sæta einangrun á meðan á gæsluvarðhaldinu stendur.'
+        await waitFor(() =>
+          screen.getByText((_, node) => {
+            // Credit: https://www.polvara.me/posts/five-things-you-didnt-know-about-testing-library/
+            const hasText = (node: Element) =>
+              node.textContent ===
+              'Kærði, Doe kt. 012345-6789, skal sæta gæsluvarðhaldi, þó ekki lengur en til fimmtudagsins 22. október 2020, kl. 12:31. Kærði skal sæta einangrun á meðan á gæsluvarðhaldinu stendur.'
 
-          const nodeHasText = hasText(node)
-          const childrenDontHaveText = Array.from(node.children).every(
-            (child) => !hasText(child),
-          )
+            const nodeHasText = hasText(node)
+            const childrenDontHaveText = Array.from(node.children).every(
+              (child) => !hasText(child),
+            )
 
-          return nodeHasText && childrenDontHaveText
-        }),
+            return nodeHasText && childrenDontHaveText
+          }),
+        ),
       ).toBeTruthy()
     })
 
-    test('should return the correct string if the case is accepted with travel ban', () => {
+    test('should return the correct string if the case is accepted with travel ban', async () => {
       // Arrange
       const wc = {
         decision: CaseDecision.ACCEPTING_ALTERNATIVE_TRAVEL_BAN,
@@ -434,27 +440,29 @@ describe('Step helper', () => {
       }
 
       // Act
-      const { getByText } = render(constructConclusion(wc as Case))
+      render(constructConclusion(wc as Case))
 
       // Assert
       expect(
-        getByText((_, node) => {
-          // Credit: https://www.polvara.me/posts/five-things-you-didnt-know-about-testing-library/
-          const hasText = (node: Element) =>
-            node.textContent ===
-            'Kærði, Doe kt. 012345-6789, skal sæta farbanni, þó ekki lengur en til fimmtudagsins 22. október 2020, kl. 12:31.'
+        await waitFor(() =>
+          screen.getByText((_, node) => {
+            // Credit: https://www.polvara.me/posts/five-things-you-didnt-know-about-testing-library/
+            const hasText = (node: Element) =>
+              node.textContent ===
+              'Kærði, Doe kt. 012345-6789, skal sæta farbanni, þó ekki lengur en til fimmtudagsins 22. október 2020, kl. 12:31.'
 
-          const nodeHasText = hasText(node)
-          const childrenDontHaveText = Array.from(node.children).every(
-            (child) => !hasText(child),
-          )
+            const nodeHasText = hasText(node)
+            const childrenDontHaveText = Array.from(node.children).every(
+              (child) => !hasText(child),
+            )
 
-          return nodeHasText && childrenDontHaveText
-        }),
+            return nodeHasText && childrenDontHaveText
+          }),
+        ),
       ).toBeTruthy()
     })
 
-    test('should return the correct string if the case is an extension on alternative travel ban', () => {
+    test('should return the correct string if the case is an extension on alternative travel ban', async () => {
       // Arrange
       const wc = {
         decision: CaseDecision.ACCEPTING_ALTERNATIVE_TRAVEL_BAN,
@@ -469,27 +477,29 @@ describe('Step helper', () => {
       }
 
       // Act
-      const { getByText } = render(constructConclusion(wc as Case))
+      render(constructConclusion(wc as Case))
 
       // Assert
       expect(
-        getByText((_, node) => {
-          // Credit: https://www.polvara.me/posts/five-things-you-didnt-know-about-testing-library/
-          const hasText = (node: Element) =>
-            node.textContent ===
-            'Kærði, Doe kt. 012345-6789, skal sæta áframhaldandi farbanni, þó ekki lengur en til fimmtudagsins 22. október 2020, kl. 12:31.'
+        await waitFor(() =>
+          screen.getByText((_, node) => {
+            // Credit: https://www.polvara.me/posts/five-things-you-didnt-know-about-testing-library/
+            const hasText = (node: Element) =>
+              node.textContent ===
+              'Kærði, Doe kt. 012345-6789, skal sæta áframhaldandi farbanni, þó ekki lengur en til fimmtudagsins 22. október 2020, kl. 12:31.'
 
-          const nodeHasText = hasText(node)
-          const childrenDontHaveText = Array.from(node.children).every(
-            (child) => !hasText(child),
-          )
+            const nodeHasText = hasText(node)
+            const childrenDontHaveText = Array.from(node.children).every(
+              (child) => !hasText(child),
+            )
 
-          return nodeHasText && childrenDontHaveText
-        }),
+            return nodeHasText && childrenDontHaveText
+          }),
+        ),
       ).toBeTruthy()
     })
 
-    test('should return the correct string if the case is an extension on accepted custody', () => {
+    test('should return the correct string if the case is an extension on accepted custody', async () => {
       // Arrange
       const wc = {
         decision: CaseDecision.ACCEPTING,
@@ -504,29 +514,31 @@ describe('Step helper', () => {
       }
 
       // Act
-      const { getByText } = render(constructConclusion(wc as Case))
+      render(constructConclusion(wc as Case))
 
       // Assert
       expect(
-        getByText((_, node) => {
-          // Credit: https://www.polvara.me/posts/five-things-you-didnt-know-about-testing-library/
-          const hasText = (node: Element) =>
-            node.textContent ===
-            'Kærði, Doe kt. 012345-6789, skal sæta áframhaldandi gæsluvarðhaldi, þó ekki lengur en til fimmtudagsins 22. október 2020, kl. 12:31.'
+        await waitFor(() =>
+          screen.getByText((_, node) => {
+            // Credit: https://www.polvara.me/posts/five-things-you-didnt-know-about-testing-library/
+            const hasText = (node: Element) =>
+              node.textContent ===
+              'Kærði, Doe kt. 012345-6789, skal sæta áframhaldandi gæsluvarðhaldi, þó ekki lengur en til fimmtudagsins 22. október 2020, kl. 12:31.'
 
-          const nodeHasText = hasText(node)
-          const childrenDontHaveText = Array.from(node.children).every(
-            (child) => !hasText(child),
-          )
+            const nodeHasText = hasText(node)
+            const childrenDontHaveText = Array.from(node.children).every(
+              (child) => !hasText(child),
+            )
 
-          return nodeHasText && childrenDontHaveText
-        }),
+            return nodeHasText && childrenDontHaveText
+          }),
+        ),
       ).toBeTruthy()
     })
   })
 
   describe('constructPoliceDemands', () => {
-    test('should render a message if requestedCustodyEndDate is not set', () => {
+    test('should render a message if requestedCustodyEndDate is not set', async () => {
       // Arrange
       const wc = {
         decision: CaseDecision.ACCEPTING,
@@ -542,26 +554,28 @@ describe('Step helper', () => {
       }
 
       // Act
-      const { getByText } = render(constructProsecutorDemands(wc as Case))
+      render(constructProsecutorDemands(wc as Case))
 
       // Assert
       expect(
-        getByText((_, node) => {
-          // Credit: https://www.polvara.me/posts/five-things-you-didnt-know-about-testing-library/
-          const hasText = (node: Element) =>
-            node.textContent === 'Saksóknari hefur ekki fyllt út dómkröfur.'
+        await waitFor(() =>
+          screen.getByText((_, node) => {
+            // Credit: https://www.polvara.me/posts/five-things-you-didnt-know-about-testing-library/
+            const hasText = (node: Element) =>
+              node.textContent === 'Saksóknari hefur ekki fyllt út dómkröfur.'
 
-          const nodeHasText = hasText(node)
-          const childrenDontHaveText = Array.from(node.children).every(
-            (child) => !hasText(child),
-          )
+            const nodeHasText = hasText(node)
+            const childrenDontHaveText = Array.from(node.children).every(
+              (child) => !hasText(child),
+            )
 
-          return nodeHasText && childrenDontHaveText
-        }),
+            return nodeHasText && childrenDontHaveText
+          }),
+        ),
       ).toBeTruthy()
     })
 
-    test('should render the corrent string if the case is an extension', () => {
+    test('should render the corrent string if the case is an extension', async () => {
       // Arrange
       const wc = {
         decision: CaseDecision.ACCEPTING,
@@ -582,27 +596,29 @@ describe('Step helper', () => {
       }
 
       // Act
-      const { getByText } = render(constructProsecutorDemands(wc as Case))
+      render(constructProsecutorDemands(wc as Case))
 
       // Assert
       expect(
-        getByText((_, node) => {
-          // Credit: https://www.polvara.me/posts/five-things-you-didnt-know-about-testing-library/
-          const hasText = (node: Element) =>
-            node.textContent ===
-            'Þess er krafist að Doe, kt.012345-6789, sæti áframhaldandi gæsluvarðhaldi með úrskurði Héraðsdóms Reykjavíkur, til fimmtudagsins 26. nóvember 2020, kl. 12:31.'
+        await waitFor(() =>
+          screen.getByText((_, node) => {
+            // Credit: https://www.polvara.me/posts/five-things-you-didnt-know-about-testing-library/
+            const hasText = (node: Element) =>
+              node.textContent ===
+              'Þess er krafist að Doe, kt.012345-6789, sæti áframhaldandi gæsluvarðhaldi með úrskurði Héraðsdóms Reykjavíkur, til fimmtudagsins 26. nóvember 2020, kl. 12:31.'
 
-          const nodeHasText = hasText(node)
-          const childrenDontHaveText = Array.from(node.children).every(
-            (child) => !hasText(child),
-          )
+            const nodeHasText = hasText(node)
+            const childrenDontHaveText = Array.from(node.children).every(
+              (child) => !hasText(child),
+            )
 
-          return nodeHasText && childrenDontHaveText
-        }),
+            return nodeHasText && childrenDontHaveText
+          }),
+        ),
       ).toBeTruthy()
     })
 
-    test('should render the corrent string there are other demands', () => {
+    test('should render the corrent string there are other demands', async () => {
       // Arrange
       const wc = {
         decision: CaseDecision.ACCEPTING,
@@ -620,27 +636,29 @@ describe('Step helper', () => {
       }
 
       // Act
-      const { getByText } = render(constructProsecutorDemands(wc as Case))
+      render(constructProsecutorDemands(wc as Case))
 
       // Assert
       expect(
-        getByText((_, node) => {
-          // Credit: https://www.polvara.me/posts/five-things-you-didnt-know-about-testing-library/
-          const hasText = (node: Element) =>
-            node.textContent ===
-            'Þess er krafist að Doe, kt.012345-6789, sæti gæsluvarðhaldi með úrskurði Héraðsdóms Reykjavíkur, til fimmtudagsins 26. nóvember 2020, kl. 12:31. Lorem ipsum.'
+        await waitFor(() =>
+          screen.getByText((_, node) => {
+            // Credit: https://www.polvara.me/posts/five-things-you-didnt-know-about-testing-library/
+            const hasText = (node: Element) =>
+              node.textContent ===
+              'Þess er krafist að Doe, kt.012345-6789, sæti gæsluvarðhaldi með úrskurði Héraðsdóms Reykjavíkur, til fimmtudagsins 26. nóvember 2020, kl. 12:31. Lorem ipsum.'
 
-          const nodeHasText = hasText(node)
-          const childrenDontHaveText = Array.from(node.children).every(
-            (child) => !hasText(child),
-          )
+            const nodeHasText = hasText(node)
+            const childrenDontHaveText = Array.from(node.children).every(
+              (child) => !hasText(child),
+            )
 
-          return nodeHasText && childrenDontHaveText
-        }),
+            return nodeHasText && childrenDontHaveText
+          }),
+        ),
       ).toBeTruthy()
     })
 
-    test('should not render the other demands if skipOtherDemands parameter is set to true', () => {
+    test('should not render the other demands if skipOtherDemands parameter is set to true', async () => {
       // Arrange
       const wc = {
         decision: CaseDecision.ACCEPTING,
@@ -658,23 +676,25 @@ describe('Step helper', () => {
       }
 
       // Act
-      const { getByText } = render(constructProsecutorDemands(wc as Case, true))
+      render(constructProsecutorDemands(wc as Case, true))
 
       // Assert
       expect(
-        getByText((_, node) => {
-          // Credit: https://www.polvara.me/posts/five-things-you-didnt-know-about-testing-library/
-          const hasText = (node: Element) =>
-            node.textContent ===
-            'Þess er krafist að Doe, kt.012345-6789, sæti gæsluvarðhaldi með úrskurði Héraðsdóms Reykjavíkur, til fimmtudagsins 26. nóvember 2020, kl. 12:31.'
+        await waitFor(() =>
+          screen.getByText((_, node) => {
+            // Credit: https://www.polvara.me/posts/five-things-you-didnt-know-about-testing-library/
+            const hasText = (node: Element) =>
+              node.textContent ===
+              'Þess er krafist að Doe, kt.012345-6789, sæti gæsluvarðhaldi með úrskurði Héraðsdóms Reykjavíkur, til fimmtudagsins 26. nóvember 2020, kl. 12:31.'
 
-          const nodeHasText = hasText(node)
-          const childrenDontHaveText = Array.from(node.children).every(
-            (child) => !hasText(child),
-          )
+            const nodeHasText = hasText(node)
+            const childrenDontHaveText = Array.from(node.children).every(
+              (child) => !hasText(child),
+            )
 
-          return nodeHasText && childrenDontHaveText
-        }),
+            return nodeHasText && childrenDontHaveText
+          }),
+        ),
       ).toBeTruthy()
     })
   })


### PR DESCRIPTION
# Refactor util tests 

https://app.asana.com/0/1199153462262248/1199683723918407

## What

Refactor utils test so that they use `screen.getByText` instead of `const { getByText } = ...`.

## Why

According to [this blog post](https://kentcdodds.com/blog/common-mistakes-with-react-testing-library#not-using-screen), this is best practice. I'm also hoping it fixes broken tests on another PR #2570. 

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
