### PR TITLE
island-ui / Paragraph spacings

### DIFF
--- a/libs/island-ui/theme/src/lib/theme.ts
+++ b/libs/island-ui/theme/src/lib/theme.ts
@@ -35,6 +35,11 @@ export const spacing = {
   gutter: UNIT * 2,
   containerGutter: UNIT * 6,
   auto: 'auto',
+  p1: 8,
+  p2: 12,
+  p3: 14,
+  p4: 16,
+  p5: 18,
 }
 
 export const theme = {


### PR DESCRIPTION
# Add paragraph spacings to theme

## What

Add paragraph spacings to theme, as defined in figma

## Why

Figma has defined paragraph spacings for breaks in text that are not defined in our spacing scheme

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
