### PR TITLE
Update to default import for AwsConnector

### DIFF
--- a/libs/api-catalogue/elastic/src/lib/elastic.service.ts
+++ b/libs/api-catalogue/elastic/src/lib/elastic.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common'
 import { Client, ApiResponse } from '@elastic/elasticsearch'
 import * as AWS from 'aws-sdk'
-import * as AwsConnector from 'aws-elasticsearch-connector'
+import AwsConnector from 'aws-elasticsearch-connector'
 import { environment } from '../environments/environments'
 import { Service } from '@island.is/api-catalogue/types'
 import { SearchResponse } from '@island.is/shared/types'

--- a/libs/content-search-toolkit/src/services/elastic.service.ts
+++ b/libs/content-search-toolkit/src/services/elastic.service.ts
@@ -1,7 +1,7 @@
 import { Client } from '@elastic/elasticsearch'
 import merge from 'lodash/merge'
 import * as AWS from 'aws-sdk'
-import * as AwsConnector from 'aws-elasticsearch-connector'
+import AwsConnector from 'aws-elasticsearch-connector'
 import { Injectable } from '@nestjs/common'
 import { logger } from '@island.is/logging'
 import { autocompleteTermQuery } from '../queries/autocomplete'


### PR DESCRIPTION
# Update to default import for AwsConnector

https://islandis.slack.com/archives/C019VN1KG04/p1611822247029600

## What

`codegen` for `api` sometimes fail with the error: `AwsConnector is not a function`

## Why

`import * as AwsConnector from 'aws-elasticsearch-connector'` expects the AwsConnector to be an object.
As the `aws-elasticsearch-connector' is only exporting a function we should use the default import
`import AwsConnector from 'aws-elasticsearch-connector'`

## Screenshots / Gifs

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
