### PR TITLE
island-ui / Update Figma links to point to our community space.

### DIFF
--- a/libs/island-ui/core/src/lib/Accordion/Accordion.stories.mdx
+++ b/libs/island-ui/core/src/lib/Accordion/Accordion.stories.mdx
@@ -19,23 +19,16 @@ import { Box } from '../Box/Box'
 import { Text } from '../Text/Text'
 import { Stack } from '../Stack/Stack'
 
-export const links = {
-  desktop:
-    'https://www.figma.com/file/pDczqgdlWxgn3YugWZfe1v/UI-Library-%E2%80%93-%F0%9F%96%A5%EF%B8%8F-Desktop?node-id=208%3A446',
-  mobile:
-    'https://www.figma.com/file/rU3mPM1cLfHa3u7TWuutPQ/UI-Library-%E2%80%93-%F0%9F%93%B1Mobile?node-id=30%3A5',
-}
-
 <Meta
   title="Components/Accordion"
   component={Accordion}
   decorators={[withDesign]}
-  parameters={withFigma(links)}
+  parameters={withFigma('Accordion')}
 />
 
 # Accordion
 
-<DescriptionFigma links={links} />
+<DescriptionFigma name="Accordion" />
 
 The **Accordion** component has three different type of items that can be rendered.
 

--- a/libs/island-ui/core/src/lib/ActionCard/ActionCard.stories.tsx
+++ b/libs/island-ui/core/src/lib/ActionCard/ActionCard.stories.tsx
@@ -7,10 +7,7 @@ export default {
   title: 'Cards/ActionCard',
   component: ActionCard,
   decorators: [withDesign],
-  parameters: withFigma({
-    desktop:
-      'https://www.figma.com/file/pDczqgdlWxgn3YugWZfe1v/UI-Library-%E2%80%93-%F0%9F%96%A5%EF%B8%8F-Desktop?node-id=502%3A0',
-  }),
+  parameters: withFigma('ActionCard'),
 }
 
 export const Default = () => (

--- a/libs/island-ui/core/src/lib/AlertBanner/AlertBanner.stories.tsx
+++ b/libs/island-ui/core/src/lib/AlertBanner/AlertBanner.stories.tsx
@@ -9,12 +9,7 @@ export default {
   title: 'Alerts/AlertBanner',
   component: AlertBanner,
   decorators: [withDesign],
-  parameters: withFigma({
-    desktop:
-      'https://www.figma.com/file/pDczqgdlWxgn3YugWZfe1v/UI-Library-%E2%80%93-%F0%9F%96%A5%EF%B8%8F-Desktop?node-id=203%3A734',
-    mobile:
-      'https://www.figma.com/file/rU3mPM1cLfHa3u7TWuutPQ/UI-Library-%E2%80%93-%F0%9F%93%B1Mobile?node-id=1%3A12',
-  }),
+  parameters: withFigma('AlertBanner'),
 }
 
 export const Default = () => {

--- a/libs/island-ui/core/src/lib/AlertMessage/AlertMessage.stories.tsx
+++ b/libs/island-ui/core/src/lib/AlertMessage/AlertMessage.stories.tsx
@@ -12,12 +12,7 @@ export default {
   title: 'Alerts/AlertMessage',
   component: AlertMessage,
   decorators: [withDesign],
-  parameters: withFigma({
-    desktop:
-      'https://www.figma.com/file/pDczqgdlWxgn3YugWZfe1v/UI-Library-%E2%80%93-%F0%9F%96%A5%EF%B8%8F-Desktop?node-id=203%3A299',
-    mobile:
-      'https://www.figma.com/file/rU3mPM1cLfHa3u7TWuutPQ/UI-Library-%E2%80%93-%F0%9F%93%B1Mobile?node-id=1%3A12',
-  }),
+  parameters: withFigma('AlertMessage'),
 }
 
 export const Info = () => (

--- a/libs/island-ui/core/src/lib/AsyncSearch/AsyncSearch.stories.tsx
+++ b/libs/island-ui/core/src/lib/AsyncSearch/AsyncSearch.stories.tsx
@@ -12,12 +12,7 @@ export default {
   title: 'Components/AsyncSearch',
   component: AsyncSearch,
   decorators: [withDesign],
-  parameters: withFigma({
-    desktop:
-      'https://www.figma.com/file/pDczqgdlWxgn3YugWZfe1v/UI-Library-%E2%80%93-%F0%9F%96%A5%EF%B8%8F-Desktop?node-id=51%3A153',
-    mobile:
-      'https://www.figma.com/file/rU3mPM1cLfHa3u7TWuutPQ/UI-Library-%E2%80%93-%F0%9F%93%B1Mobile?node-id=1%3A10',
-  }),
+  parameters: withFigma('AsyncSearch'),
 }
 
 const items = [

--- a/libs/island-ui/core/src/lib/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/libs/island-ui/core/src/lib/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -8,12 +8,7 @@ export default {
   title: 'Navigation/Breadcrumbs',
   component: Breadcrumbs,
   decorators: [withDesign],
-  parameters: withFigma({
-    desktop:
-      'https://www.figma.com/file/pDczqgdlWxgn3YugWZfe1v/UI-Library-%E2%80%93-%F0%9F%96%A5%EF%B8%8F-Desktop?node-id=93%3A685',
-    mobile:
-      'https://www.figma.com/file/rU3mPM1cLfHa3u7TWuutPQ/UI-Library-%E2%80%93-%F0%9F%93%B1Mobile?node-id=30%3A7',
-  }),
+  parameters: withFigma('Breadcrumbs'),
 }
 
 export const Default = () => (

--- a/libs/island-ui/core/src/lib/Button/Button.stories.tsx
+++ b/libs/island-ui/core/src/lib/Button/Button.stories.tsx
@@ -14,12 +14,7 @@ export default {
     onBlur: { action: 'onBlur' },
     onFocus: { action: 'onFocus' },
   },
-  parameters: withFigma({
-    desktop:
-      'https://www.figma.com/file/pDczqgdlWxgn3YugWZfe1v/UI-Library-%E2%80%93-%F0%9F%96%A5%EF%B8%8F-Desktop?node-id=2%3A170',
-    mobile:
-      'https://www.figma.com/file/rU3mPM1cLfHa3u7TWuutPQ/UI-Library-%E2%80%93-%F0%9F%93%B1Mobile?node-id=1%3A7',
-  }),
+  parameters: withFigma('Button'),
 }
 
 const Template = (args) => <Button {...args} />

--- a/libs/island-ui/core/src/lib/CategoryCard/CategoryCard.stories.tsx
+++ b/libs/island-ui/core/src/lib/CategoryCard/CategoryCard.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { withDesign } from 'storybook-addon-designs'
+
 import { withFigma } from '../../utils/withFigma'
 import { GridColumn } from '../Grid/GridColumn/GridColumn'
 import { GridContainer } from '../Grid/GridContainer/GridContainer'
@@ -10,10 +11,7 @@ export default {
   title: 'Cards/CategoryCard',
   component: CategoryCard,
   decorators: [withDesign],
-  parameters: withFigma({
-    desktop:
-      'https://www.figma.com/file/pDczqgdlWxgn3YugWZfe1v/UI-Library-%E2%80%93-%F0%9F%96%A5%EF%B8%8F-Desktop?node-id=96%3A581',
-  }),
+  parameters: withFigma('CategoryCard'),
 }
 
 const getDemoTags = (amount: number) => {

--- a/libs/island-ui/core/src/lib/Checkbox/Checkbox.stories.tsx
+++ b/libs/island-ui/core/src/lib/Checkbox/Checkbox.stories.tsx
@@ -8,12 +8,7 @@ export default {
   title: 'Form/Checkbox',
   component: Checkbox,
   decorators: [withDesign],
-  parameters: withFigma({
-    desktop:
-      'https://www.figma.com/file/pDczqgdlWxgn3YugWZfe1v/UI-Library-%E2%80%93-%F0%9F%96%A5%EF%B8%8F-Desktop?node-id=49%3A186',
-    mobile:
-      'https://www.figma.com/file/rU3mPM1cLfHa3u7TWuutPQ/UI-Library-%E2%80%93-%F0%9F%93%B1Mobile?node-id=30%3A2',
-  }),
+  parameters: withFigma('Checkbox'),
 }
 
 const Template = (args) => <Checkbox {...args} />

--- a/libs/island-ui/core/src/lib/DatePicker/DatePicker.stories.tsx
+++ b/libs/island-ui/core/src/lib/DatePicker/DatePicker.stories.tsx
@@ -8,12 +8,7 @@ export default {
   title: 'Form/DatePicker',
   component: DatePicker,
   decorators: [withDesign],
-  parameters: withFigma({
-    desktop:
-      'https://www.figma.com/file/pDczqgdlWxgn3YugWZfe1v/UI-Library-%E2%80%93-%F0%9F%96%A5%EF%B8%8F-Desktop?node-id=50%3A155',
-    mobile:
-      'https://www.figma.com/file/rU3mPM1cLfHa3u7TWuutPQ/UI-Library-%E2%80%93-%F0%9F%93%B1Mobile?node-id=53%3A1536',
-  }),
+  parameters: withFigma('DatePicker'),
 }
 const Template = (args) => <DatePicker {...args} />
 

--- a/libs/island-ui/core/src/lib/DialogPrompt/DialogPrompt.stories.tsx
+++ b/libs/island-ui/core/src/lib/DialogPrompt/DialogPrompt.stories.tsx
@@ -8,10 +8,7 @@ export default {
   title: 'Components/DialogPrompt',
   component: DialogPrompt,
   decorators: [withDesign],
-  parameters: withFigma({
-    desktop:
-      'https://www.figma.com/file/pDczqgdlWxgn3YugWZfe1v/UI-Library-%E2%80%93-%F0%9F%96%A5%EF%B8%8F-Desktop?node-id=840%3A13',
-  }),
+  parameters: withFigma('DialogPrompt'),
 }
 
 export const Default = () => {

--- a/libs/island-ui/core/src/lib/Footer/Footer.stories.tsx
+++ b/libs/island-ui/core/src/lib/Footer/Footer.stories.tsx
@@ -8,12 +8,7 @@ export default {
   title: 'Navigation/Footer',
   component: Footer,
   decorators: [withDesign],
-  parameters: withFigma({
-    desktop:
-      'https://www.figma.com/file/pDczqgdlWxgn3YugWZfe1v/UI-Library-%E2%80%93-%F0%9F%96%A5%EF%B8%8F-Desktop?node-id=345%3A0',
-    mobile:
-      'https://www.figma.com/file/rU3mPM1cLfHa3u7TWuutPQ/UI-Library-%E2%80%93-%F0%9F%93%B1Mobile?node-id=30%3A9',
-  }),
+  parameters: withFigma('Footer'),
 }
 
 export const Default = () => <Footer showMiddleLinks showTagLinks />

--- a/libs/island-ui/core/src/lib/FormStepper/FormStepper.stories.mdx
+++ b/libs/island-ui/core/src/lib/FormStepper/FormStepper.stories.mdx
@@ -11,23 +11,16 @@ import { withFigma, DescriptionFigma } from '../../utils/withFigma'
 import { FormStepper } from './FormStepper'
 import { FormStepperThemes } from './types'
 
-export const links = {
-  desktop:
-    'https://www.figma.com/file/pDczqgdlWxgn3YugWZfe1v/UI-Library-%E2%80%93-%F0%9F%96%A5%EF%B8%8F-Desktop?node-id=324%3A211',
-  mobile:
-    'https://www.figma.com/file/rU3mPM1cLfHa3u7TWuutPQ/UI-Library-%E2%80%93-%F0%9F%93%B1Mobile?node-id=119%3A1',
-}
-
 <Meta
   title="Navigation/FormStepper"
   component={FormStepper}
   decorators={[withDesign]}
-  parameters={withFigma(links)}
+  parameters={withFigma('FormStepper')}
 />
 
 # FormStepper
 
-<DescriptionFigma links={links} />
+<DescriptionFigma name="FormStepper" />
 
 <br />
 

--- a/libs/island-ui/core/src/lib/Input/Input.stories.tsx
+++ b/libs/island-ui/core/src/lib/Input/Input.stories.tsx
@@ -7,12 +7,7 @@ export default {
   title: 'Form/Input',
   component: Input,
   decorators: [withDesign],
-  parameters: withFigma({
-    desktop:
-      'https://www.figma.com/file/pDczqgdlWxgn3YugWZfe1v/UI-Library-%E2%80%93-%F0%9F%96%A5%EF%B8%8F-Desktop?node-id=42%3A1688',
-    mobile:
-      'https://www.figma.com/file/rU3mPM1cLfHa3u7TWuutPQ/UI-Library-%E2%80%93-%F0%9F%93%B1Mobile?node-id=1%3A8',
-  }),
+  parameters: withFigma('Input'),
 }
 
 const Template = (args) => <Input {...args} />

--- a/libs/island-ui/core/src/lib/InputFileUpload/InputFileUpload.stories.tsx
+++ b/libs/island-ui/core/src/lib/InputFileUpload/InputFileUpload.stories.tsx
@@ -10,12 +10,7 @@ export default {
   title: 'Form/InputFileUpload',
   component: InputFileUpload,
   decorators: [withDesign],
-  parameters: withFigma({
-    desktop:
-      'https://www.figma.com/file/pDczqgdlWxgn3YugWZfe1v/UI-Library-%E2%80%93-%F0%9F%96%A5%EF%B8%8F-Desktop?node-id=341%3A253',
-    mobile:
-      'https://www.figma.com/file/rU3mPM1cLfHa3u7TWuutPQ/UI-Library-%E2%80%93-%F0%9F%93%B1Mobile?node-id=62%3A11',
-  }),
+  parameters: withFigma('InputFileUpload'),
 }
 
 enum ActionTypes {

--- a/libs/island-ui/core/src/lib/Link/Link.stories.mdx
+++ b/libs/island-ui/core/src/lib/Link/Link.stories.mdx
@@ -6,23 +6,16 @@ import { Box } from '../Box/Box'
 import { Link } from './Link'
 import { ArrowLink } from './ArrowLink/ArrowLink'
 
-export const links = {
-  desktop:
-    'https://www.figma.com/file/pDczqgdlWxgn3YugWZfe1v/UI-Library-%E2%80%93-%F0%9F%96%A5%EF%B8%8F-Desktop?node-id=140%3A709',
-  mobile:
-    'https://www.figma.com/file/rU3mPM1cLfHa3u7TWuutPQ/UI-Library-%E2%80%93-%F0%9F%93%B1Mobile?node-id=30%3A0',
-}
-
 <Meta
   title="Core/Link"
   component={Link}
   decorators={[withDesign]}
-  parameters={withFigma(links)}
+  parameters={withFigma('Link')}
 />
 
 # Link
 
-<DescriptionFigma links={links} />
+<DescriptionFigma name="Link" />
 
 <br />
 

--- a/libs/island-ui/core/src/lib/Menu/Menu.stories.tsx
+++ b/libs/island-ui/core/src/lib/Menu/Menu.stories.tsx
@@ -64,12 +64,7 @@ export default {
   title: 'Navigation/Menu',
   component: Menu,
   decorators: [withDesign],
-  parameters: withFigma({
-    desktop:
-      'https://www.figma.com/file/cl7qnkUWOFwgMQKt2FsiZn/H%C3%B6nnun?node-id=6170%3A685',
-    mobile:
-      'https://www.figma.com/file/cl7qnkUWOFwgMQKt2FsiZn/H%C3%B6nnun?node-id=6271%3A1298',
-  }),
+  parameters: withFigma('Menu'),
 }
 
 const Template = (args) => <Menu {...args} />

--- a/libs/island-ui/core/src/lib/Navigation/Navigation.stories.tsx
+++ b/libs/island-ui/core/src/lib/Navigation/Navigation.stories.tsx
@@ -9,10 +9,7 @@ export default {
   title: 'Navigation/Navigation',
   component: Navigation,
   decorators: [withDesign],
-  parameters: withFigma({
-    desktop:
-      'https://www.figma.com/file/cl7qnkUWOFwgMQKt2FsiZn/H%C3%B6nnun?node-id=3494%3A1&viewport=-1795%2C983%2C0.47280967235565186',
-  }),
+  parameters: withFigma('Navigation'),
 }
 
 const Template = (args) => (

--- a/libs/island-ui/core/src/lib/Pagination/Pagination.stories.tsx
+++ b/libs/island-ui/core/src/lib/Pagination/Pagination.stories.tsx
@@ -10,12 +10,7 @@ export default {
   title: 'Navigation/Pagination',
   component: Pagination,
   decorators: [withDesign],
-  parameters: withFigma({
-    desktop:
-      'https://www.figma.com/file/pDczqgdlWxgn3YugWZfe1v/UI-Library-%E2%80%93-%F0%9F%96%A5%EF%B8%8F-Desktop?node-id=342%3A143',
-    mobile:
-      'https://www.figma.com/file/rU3mPM1cLfHa3u7TWuutPQ/UI-Library-%E2%80%93-%F0%9F%93%B1Mobile?node-id=119%3A2',
-  }),
+  parameters: withFigma('Pagination'),
 }
 
 export const Default = () => {

--- a/libs/island-ui/core/src/lib/RadioButton/RadioButton.stories.tsx
+++ b/libs/island-ui/core/src/lib/RadioButton/RadioButton.stories.tsx
@@ -9,12 +9,7 @@ export default {
   title: 'Form/RadioButton',
   component: RadioButton,
   decorators: [withDesign],
-  parameters: withFigma({
-    desktop:
-      'https://www.figma.com/file/pDczqgdlWxgn3YugWZfe1v/UI-Library-%E2%80%93-%F0%9F%96%A5%EF%B8%8F-Desktop?node-id=49%3A135',
-    mobile:
-      'https://www.figma.com/file/rU3mPM1cLfHa3u7TWuutPQ/UI-Library-%E2%80%93-%F0%9F%93%B1Mobile?node-id=30%3A2',
-  }),
+  parameters: withFigma('RadioButton'),
 }
 
 const Template = (args) => <RadioButton {...args} />

--- a/libs/island-ui/core/src/lib/Select/Select.stories.tsx
+++ b/libs/island-ui/core/src/lib/Select/Select.stories.tsx
@@ -1,18 +1,13 @@
 import React from 'react'
 import { withDesign } from 'storybook-addon-designs'
-
 import { withFigma } from '../../utils/withFigma'
-import { Input } from '../Input/Input'
 import { Select } from './Select'
 
 export default {
   title: 'Form/Select',
   component: Select,
   decorators: [withDesign],
-  parameters: withFigma({
-    desktop:
-      'https://www.figma.com/file/pDczqgdlWxgn3YugWZfe1v/UI-Library-%E2%80%93-%F0%9F%96%A5%EF%B8%8F-Desktop?node-id=50%3A101',
-  }),
+  parameters: withFigma('Select'),
 }
 
 const Template = (args) => <Select {...args} />

--- a/libs/island-ui/core/src/lib/Tabs/Tabs.stories.tsx
+++ b/libs/island-ui/core/src/lib/Tabs/Tabs.stories.tsx
@@ -11,12 +11,7 @@ export default {
   title: 'Navigation/Tabs',
   component: Tabs,
   decorators: [withDesign],
-  parameters: withFigma({
-    desktop:
-      'https://www.figma.com/file/pDczqgdlWxgn3YugWZfe1v/UI-Library-%E2%80%93-%F0%9F%96%A5%EF%B8%8F-Desktop?node-id=208%3A697',
-    mobile:
-      'https://www.figma.com/file/rU3mPM1cLfHa3u7TWuutPQ/UI-Library-%E2%80%93-%F0%9F%93%B1Mobile?node-id=30%3A4',
-  }),
+  parameters: withFigma('Tabs'),
 }
 
 const content1 = (

--- a/libs/island-ui/core/src/lib/Tag/Tag.stories.tsx
+++ b/libs/island-ui/core/src/lib/Tag/Tag.stories.tsx
@@ -9,12 +9,7 @@ import { Tag } from './Tag'
 export default {
   title: 'Components/Tag',
   component: Tag,
-  parameters: withFigma({
-    desktop:
-      'https://www.figma.com/file/pDczqgdlWxgn3YugWZfe1v/UI-Library-%E2%80%93-%F0%9F%96%A5%EF%B8%8F-Desktop?node-id=49%3A285',
-    mobile:
-      'https://www.figma.com/file/rU3mPM1cLfHa3u7TWuutPQ/UI-Library-%E2%80%93-%F0%9F%93%B1Mobile?node-id=30%3A1',
-  }),
+  parameters: withFigma('Tag'),
 }
 
 export const Basic = () => (

--- a/libs/island-ui/core/src/lib/Toast/Toast.stories.tsx
+++ b/libs/island-ui/core/src/lib/Toast/Toast.stories.tsx
@@ -10,12 +10,7 @@ export default {
   title: 'Alerts/Toast',
   component: ToastContainer,
   decorators: [withDesign],
-  parameters: withFigma({
-    desktop:
-      'https://www.figma.com/file/pDczqgdlWxgn3YugWZfe1v/UI-Library-%E2%80%93-%F0%9F%96%A5%EF%B8%8F-Desktop?node-id=205%3A62',
-    mobile:
-      'https://www.figma.com/file/rU3mPM1cLfHa3u7TWuutPQ/UI-Library-%E2%80%93-%F0%9F%93%B1Mobile?node-id=1%3A12',
-  }),
+  parameters: withFigma('Toast'),
 }
 
 const Template = (args) => (

--- a/libs/island-ui/core/src/lib/Tooltip/Tooltip.stories.mdx
+++ b/libs/island-ui/core/src/lib/Tooltip/Tooltip.stories.mdx
@@ -7,23 +7,16 @@ import { Box } from '../Box/Box'
 import { Text } from '../Text/Text'
 import { Tooltip } from './Tooltip'
 
-export const links = {
-  desktop:
-    'https://www.figma.com/file/pDczqgdlWxgn3YugWZfe1v/UI-Library-%E2%80%93-%F0%9F%96%A5%EF%B8%8F-Desktop?node-id=208%3A178',
-  mobile:
-    'https://www.figma.com/file/rU3mPM1cLfHa3u7TWuutPQ/UI-Library-%E2%80%93-%F0%9F%93%B1Mobile?node-id=119%3A0',
-}
-
 <Meta
   title="Components/Tooltip"
   component={Tooltip}
   decorators={[withDesign]}
-  parameters={withFigma(links)}
+  parameters={withFigma('Tooltip')}
 />
 
 # Tooltip
 
-<DescriptionFigma links={links} />
+<DescriptionFigma name="Tooltip" />
 
 <br />
 

--- a/libs/island-ui/core/src/utils/withFigma.tsx
+++ b/libs/island-ui/core/src/utils/withFigma.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react'
 import Markdown from 'markdown-to-jsx'
 import { styled } from '@storybook/theming'
 
-const markdown = (name: string = 'this component') => {
+const markdown = (name = 'this component') => {
   return `See *${name}* in the [@islandis](https://www.figma.com/@islandis) community Figma. [Desktop](https://www.figma.com/community/file/901454156629060149) — [Mobile](https://www.figma.com/community/file/901454279005592118)`
 }
 

--- a/libs/island-ui/core/src/utils/withFigma.tsx
+++ b/libs/island-ui/core/src/utils/withFigma.tsx
@@ -2,48 +2,13 @@ import React, { FC } from 'react'
 import Markdown from 'markdown-to-jsx'
 import { styled } from '@storybook/theming'
 
-interface Links {
-  desktop?: string
-  mobile?: string
+const markdown = (name: string = 'this component') => {
+  return `See *${name}* in the [@islandis](https://www.figma.com/@islandis) community Figma. [Desktop](https://www.figma.com/community/file/901454156629060149) — [Mobile](https://www.figma.com/community/file/901454279005592118)`
 }
 
-const markdown = (links: Links) => {
-  const desktop = links.desktop
-    ? `[Desktop design in Figma](${links.desktop})`
-    : ''
-  const mobile = links.mobile ? `[Mobile design in Figma](${links.mobile})` : ''
-  const dash = links.desktop && links.mobile ? ' — ' : ''
-
-  if (!links.desktop && !links.mobile) {
-    return ``
-  }
-
-  return `${desktop}${dash}${mobile}`
-}
-
-export const withFigma = (links: Links) => {
-  const design = []
-  const component = markdown(links)
-
-  if (links.desktop) {
-    design.push({
-      name: 'Desktop',
-      type: 'figma',
-      url: links.desktop,
-    })
-  }
-
-  if (links.mobile) {
-    design.push({
-      name: 'Mobile',
-      type: 'figma',
-      url: links.mobile,
-    })
-  }
-
+export const withFigma = (name: string) => {
   return {
-    docs: { description: { component } },
-    design,
+    docs: { description: { component: markdown(name) } },
   }
 }
 
@@ -72,7 +37,7 @@ const A = styled.a(() => ({
   textDecoration: 'none',
 }))
 
-export const DescriptionFigma: FC<{ links: Links }> = ({ links }) => (
+export const DescriptionFigma: FC<{ name: string }> = ({ name }) => (
   <P>
     <Markdown
       options={{
@@ -85,7 +50,7 @@ export const DescriptionFigma: FC<{ links: Links }> = ({ links }) => (
         },
       }}
     >
-      {markdown(links)}
+      {markdown(name)}
     </Markdown>
   </P>
 )


### PR DESCRIPTION
# Update Figma links to point to our community space

Current Figma links are private. There's no way to directly link to pages using Figma communities. This PR updates the stories to point to our community space.

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/8494120/106590559-21d9c200-6545-11eb-9009-3aaadb42540d.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
