### PR TITLE
Standardized the parameter format in the contentful service

### DIFF
--- a/libs/api/domains/cms/src/lib/cms.contentful.service.ts
+++ b/libs/api/domains/cms/src/lib/cms.contentful.service.ts
@@ -86,11 +86,13 @@ export class CmsContentfulService {
   constructor(private contentfulRepository: ContentfulRepository) {}
 
   async getAdgerdirFrontpage(lang = 'is-IS'): Promise<AdgerdirFrontpage> {
+    const params = {
+      ['content_type']: 'vidspyrna-frontpage',
+      include: 10,
+    }
+
     const result = await this.contentfulRepository
-      .getLocalizedEntries<types.IVidspyrnaFrontpageFields>(lang, {
-        ['content_type']: 'vidspyrna-frontpage',
-        include: 10,
-      })
+      .getLocalizedEntries<types.IVidspyrnaFrontpageFields>(lang, params)
       .catch(errorHandler('getVidspyrnaFrontpage'))
 
     return result.items.map(mapAdgerdirFrontpage)[0] ?? null
@@ -177,62 +179,72 @@ export class CmsContentfulService {
   }
 
   async getAdgerdirPage(slug: string, lang: string): Promise<AdgerdirPage> {
+    const params = {
+      ['content_type']: 'vidspyrnaPage',
+      include: 10,
+      'fields.slug': slug,
+    }
+
     const result = await this.contentfulRepository
-      .getLocalizedEntries<types.IVidspyrnaPageFields>(lang, {
-        ['content_type']: 'vidspyrnaPage',
-        include: 10,
-        'fields.slug': slug,
-      })
+      .getLocalizedEntries<types.IVidspyrnaPageFields>(lang, params)
       .catch(errorHandler('getAdgerdirPage'))
 
     return result.items.map(mapAdgerdirPage)[0] ?? null
   }
 
   async getOrganization(slug: string, lang: string): Promise<Organization> {
+    const params = {
+      ['content_type']: 'organization',
+      include: 10,
+      'fields.slug': slug,
+    }
+
     const result = await this.contentfulRepository
-      .getLocalizedEntries<types.IOrganizationFields>(lang, {
-        ['content_type']: 'organization',
-        include: 10,
-        'fields.slug': slug,
-      })
+      .getLocalizedEntries<types.IOrganizationFields>(lang, params)
       .catch(errorHandler('getOrganization'))
 
     return result.items.map(mapOrganization)[0] ?? null
   }
 
   async getArticle(slug: string, lang: string): Promise<Article | null> {
+    const params = {
+      ['content_type']: 'article',
+      'fields.slug': slug,
+      select: ArticleFields,
+      include: 10,
+    }
+
     const result = await this.contentfulRepository
-      .getLocalizedEntries<types.IArticleFields>(lang, {
-        ['content_type']: 'article',
-        'fields.slug': slug,
-        select: ArticleFields,
-        include: 10,
-      })
+      .getLocalizedEntries<types.IArticleFields>(lang, params)
       .catch(errorHandler('getArticle'))
 
     return result.items.map(mapArticle)[0] ?? null
   }
 
   async getRelatedArticles(slug: string, lang: string): Promise<Article[]> {
+    const params = {
+      ['content_type']: 'article',
+      'fields.slug': slug,
+      select: 'fields.relatedArticles',
+      include: 1,
+    }
+
     const articleResult = await this.contentfulRepository
-      .getLocalizedEntries<types.IArticleFields>(lang, {
-        ['content_type']: 'article',
-        'fields.slug': slug,
-        select: 'fields.relatedArticles',
-        include: 1,
-      })
+      .getLocalizedEntries<types.IArticleFields>(lang, params)
       .catch(errorHandler('getRelatedArticles'))
 
     const articles = articleResult.items[0]?.fields?.relatedArticles ?? []
     if (articles.length === 0) return []
 
+    const relatedResultParams = {
+      ['content_type']: 'article',
+      'sys.id[in]': articles.map((a) => a.sys.id).join(','),
+      select: ArticleFields,
+      include: 10,
+    }
+
     const relatedResult = await this.contentfulRepository
-      .getLocalizedEntries<types.IArticleFields>(lang, {
-        ['content_type']: 'article',
-        'sys.id[in]': articles.map((a) => a.sys.id).join(','),
-        select: ArticleFields,
-        include: 10,
-      })
+      .getLocalizedEntries<types.IArticleFields>(lang, relatedResultParams)
       .catch(errorHandler('getRelatedArticles'))
 
     const sortedIds = articles.map((a) => a.sys.id)
@@ -241,24 +253,28 @@ export class CmsContentfulService {
   }
 
   async getNews(lang: string, slug: string): Promise<News | null> {
+    const params = {
+      ['content_type']: 'news',
+      include: 10,
+      'fields.slug': slug,
+    }
+
     const result = await this.contentfulRepository
-      .getLocalizedEntries<types.INewsFields>(lang, {
-        ['content_type']: 'news',
-        include: 10,
-        'fields.slug': slug,
-      })
+      .getLocalizedEntries<types.INewsFields>(lang, params)
       .catch(errorHandler('getNews'))
 
     return result.items.map(mapNews)[0] ?? null
   }
 
   async getAboutPage({ lang }: GetAboutPageInput): Promise<AboutPage | null> {
+    const params = {
+      ['content_type']: 'page',
+      include: 10,
+      order: '-sys.createdAt',
+    }
+
     const result = await this.contentfulRepository
-      .getLocalizedEntries<types.IPageFields>(lang, {
-        ['content_type']: 'page',
-        include: 10,
-        order: '-sys.createdAt',
-      })
+      .getLocalizedEntries<types.IPageFields>(lang, params)
       .catch(errorHandler('getAboutPage'))
 
     return result.items.map(mapAboutPage)[0] ?? null
@@ -271,12 +287,14 @@ export class CmsContentfulService {
     lang: string
     url: string
   }): Promise<AboutSubPage | null> {
+    const params = {
+      ['content_type']: 'aboutSubPage',
+      include: 10,
+      'fields.url': url,
+    }
+
     const result = await this.contentfulRepository
-      .getLocalizedEntries<types.IAboutSubPageFields>(lang, {
-        ['content_type']: 'aboutSubPage',
-        include: 10,
-        'fields.url': url,
-      })
+      .getLocalizedEntries<types.IAboutSubPageFields>(lang, params)
       .catch(errorHandler('getAboutSubPage'))
 
     return result.items.map(mapAboutSubPage)[0] ?? null
@@ -286,11 +304,13 @@ export class CmsContentfulService {
     id,
     lang,
   }: GetContentSlugInput): Promise<ContentSlug | null> {
+    const params = {
+      'sys.id': id,
+      include: 10,
+    }
+
     const result = await this.contentfulRepository
-      .getLocalizedEntries<types.IArticleFields>(lang, {
-        'sys.id': id,
-        include: 10,
-      })
+      .getLocalizedEntries<types.IArticleFields>(lang, params)
       .catch(errorHandler('getContentSlug'))
 
     return result.items.map(mapContentSlug)[0] ?? null
@@ -300,12 +320,14 @@ export class CmsContentfulService {
     lang,
     slug,
   }: GetGenericPageInput): Promise<GenericPage> {
+    const params = {
+      ['content_type']: 'genericPage',
+      'fields.slug': slug,
+      include: 10,
+    }
+
     const result = await this.contentfulRepository
-      .getLocalizedEntries<types.IGenericPageFields>(lang, {
-        ['content_type']: 'genericPage',
-        'fields.slug': slug,
-        include: 10,
-      })
+      .getLocalizedEntries<types.IGenericPageFields>(lang, params)
       .catch(errorHandler('getGenericPage'))
 
     return result.items.map(mapGenericPage)[0] ?? null
@@ -315,12 +337,14 @@ export class CmsContentfulService {
     lang,
     pageIdentifier,
   }: GetGenericOverviewPageInput): Promise<GenericOverviewPage> {
+    const params = {
+      ['content_type']: 'genericOverviewPage',
+      'fields.pageIdentifier': pageIdentifier,
+      include: 10,
+    }
+
     const result = await this.contentfulRepository
-      .getLocalizedEntries<types.IGenericOverviewPageFields>(lang, {
-        ['content_type']: 'genericOverviewPage',
-        'fields.pageIdentifier': pageIdentifier,
-        include: 10,
-      })
+      .getLocalizedEntries<types.IGenericOverviewPageFields>(lang, params)
       .catch(errorHandler('getGenericOverviewPage'))
 
     return result.items.map(mapGenericOverviewPage)[0] ?? null
@@ -330,22 +354,26 @@ export class CmsContentfulService {
     namespace: string,
     lang: string,
   ): Promise<Namespace | null> {
+    const params = {
+      ['content_type']: 'uiConfiguration',
+      'fields.namespace': namespace,
+    }
+
     const result = await this.contentfulRepository
-      .getLocalizedEntries<types.IUiConfigurationFields>(lang, {
-        ['content_type']: 'uiConfiguration',
-        'fields.namespace': namespace,
-      })
+      .getLocalizedEntries<types.IUiConfigurationFields>(lang, params)
       .catch(errorHandler('getNamespace'))
 
     return result.items.map(mapNamespace)[0] ?? null
   }
 
   async getMenu(name: string, lang: string): Promise<Menu | null> {
+    const params = {
+      ['content_type']: 'menu',
+      'fields.title': name,
+    }
+
     const result = await this.contentfulRepository
-      .getLocalizedEntries<types.IMenuFields>(lang, {
-        ['content_type']: 'menu',
-        'fields.title': name,
-      })
+      .getLocalizedEntries<types.IMenuFields>(lang, params)
       .catch(errorHandler('getMenu'))
 
     return result.items.map(mapMenu)[0] ?? null
@@ -355,22 +383,26 @@ export class CmsContentfulService {
     slug: string,
     lang: string,
   ): Promise<LifeEventPage | null> {
+    const params = {
+      ['content_type']: 'lifeEventPage',
+      'fields.slug': slug,
+    }
+
     const result = await this.contentfulRepository
-      .getLocalizedEntries<types.ILifeEventPageFields>(lang, {
-        ['content_type']: 'lifeEventPage',
-        'fields.slug': slug,
-      })
+      .getLocalizedEntries<types.ILifeEventPageFields>(lang, params)
       .catch(errorHandler('getLifeEventPage'))
 
     return result.items.map(mapLifeEventPage)[0] ?? null
   }
 
   async getLifeEvents(lang: string): Promise<LifeEventPage[]> {
+    const params = {
+      ['content_type']: 'lifeEventPage',
+      order: 'sys.createdAt',
+    }
+
     const result = await this.contentfulRepository
-      .getLocalizedEntries<types.ILifeEventPageFields>(lang, {
-        ['content_type']: 'lifeEventPage',
-        order: 'sys.createdAt',
-      })
+      .getLocalizedEntries<types.ILifeEventPageFields>(lang, params)
       .catch(errorHandler('getLifeEvents'))
 
     return result.items.map(mapLifeEventPage)
@@ -380,23 +412,27 @@ export class CmsContentfulService {
     lang,
     id,
   }: GetAlertBannerInput): Promise<AlertBanner | null> {
+    const params = {
+      ['content_type']: 'alertBanner',
+      'sys.id': id,
+    }
+
     const result = await this.contentfulRepository
-      .getLocalizedEntries<types.IAlertBannerFields>(lang, {
-        ['content_type']: 'alertBanner',
-        'sys.id': id,
-      })
+      .getLocalizedEntries<types.IAlertBannerFields>(lang, params)
       .catch(errorHandler('getAlertBanner'))
 
     return result.items.map(mapAlertBanner)[0] ?? null
   }
 
   async getUrl(slug: string, lang: string): Promise<Url | null> {
+    const params = {
+      ['content_type']: 'url',
+      'fields.urlsList[all]': slug,
+      include: 1,
+    }
+
     const result = await this.contentfulRepository
-      .getLocalizedEntries<types.IUrlFields>(lang, {
-        ['content_type']: 'url',
-        'fields.urlsList[all]': slug,
-        include: 1,
-      })
+      .getLocalizedEntries<types.IUrlFields>(lang, params)
       .catch(errorHandler('getUrl'))
     return result.items.map(mapUrl)[0] ?? null
   }
@@ -405,36 +441,42 @@ export class CmsContentfulService {
     lang: string,
     slug: string,
   ): Promise<LifeEventPage[]> {
+    const params = {
+      ['content_type']: 'lifeEventPage',
+      'fields.category.sys.contentType.sys.id': 'articleCategory',
+      'fields.category.fields.slug': slug,
+    }
+
     const result = await this.contentfulRepository
-      .getLocalizedEntries<types.ILifeEventPageFields>(lang, {
-        ['content_type']: 'lifeEventPage',
-        'fields.category.sys.contentType.sys.id': 'articleCategory',
-        'fields.category.fields.slug': slug,
-      })
+      .getLocalizedEntries<types.ILifeEventPageFields>(lang, params)
       .catch(errorHandler('getLifeEventsInCategory'))
 
     return result.items.map(mapLifeEventPage)
   }
 
   async getHomepage({ lang }: { lang: string }): Promise<Homepage> {
+    const params = {
+      ['content_type']: 'homepage',
+      include: 10,
+      order: '-sys.createdAt',
+    }
+
     const result = await this.contentfulRepository
-      .getLocalizedEntries<types.IHomepageFields>(lang, {
-        ['content_type']: 'homepage',
-        include: 10,
-        order: '-sys.createdAt',
-      })
+      .getLocalizedEntries<types.IHomepageFields>(lang, params)
       .catch(errorHandler('getHomepage'))
 
     return result.items.map(mapHomepage)[0]
   }
 
   async getTellUsAStory({ lang }: { lang: string }): Promise<TellUsAStory> {
+    const params = {
+      ['content_type']: 'tellUsAStory',
+      include: 10,
+      order: '-sys.createdAt',
+    }
+
     const result = await this.contentfulRepository
-      .getLocalizedEntries<types.ITellUsAStoryFields>(lang, {
-        ['content_type']: 'tellUsAStory',
-        include: 10,
-        order: '-sys.createdAt',
-      })
+      .getLocalizedEntries<types.ITellUsAStoryFields>(lang, params)
       .catch(errorHandler('getTellUsAStory'))
 
     return result.items.map(mapTellUsAStory)[0]
@@ -444,11 +486,13 @@ export class CmsContentfulService {
     lang,
     id,
   }: GetSubpageHeaderInput): Promise<SubpageHeader> {
+    const params = {
+      ['content_type']: 'subpageHeader',
+      'fields.subpageId': id,
+    }
+
     const result = await this.contentfulRepository
-      .getLocalizedEntries<types.ISubpageHeaderFields>(lang, {
-        ['content_type']: 'subpageHeader',
-        'fields.subpageId': id,
-      })
+      .getLocalizedEntries<types.ISubpageHeaderFields>(lang, params)
       .catch(errorHandler('getSubpageHeader'))
 
     return result.items.map(mapSubpageHeader)[0]


### PR DESCRIPTION
# \<Description\>

Some of the functions in the contentful service declared a parameter object whereas other did not.

## What

I standardized the contentful service to parameter object declaration instead of constructing it in the function call itself

## Why

consistency
