### PR TITLE
Added a default value to the DTO for SingleNews

### DIFF
--- a/libs/api/domains/cms/src/lib/dto/getSingleNews.input.ts
+++ b/libs/api/domains/cms/src/lib/dto/getSingleNews.input.ts
@@ -11,5 +11,5 @@ export class GetSingleNewsInput {
   @Field(() => String, { nullable: true })
   @IsString()
   @IsOptional()
-  lang?: ElasticsearchIndexLocale
+  lang?: ElasticsearchIndexLocale = 'is'
 }


### PR DESCRIPTION
# \<Description\>

Added a default value to the DTO for SingleNews

## What

Defend against errors

## Why

lang is an optional input in the input DTO but it is passed directly down to getElasticsearchIndex() which doesn't have precautions against that