### PR TITLE
Judicial-system/Extension indicator

### DIFF
--- a/apps/judicial-system/web/src/routes/Shared/DetentionRequests/DetentionRequests.spec.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/DetentionRequests/DetentionRequests.spec.tsx
@@ -31,6 +31,9 @@ const mockCasesQuery = [
             accusedNationalId: 'string',
             accusedName: 'Jon Harring Sr.',
             custodyEndDate: null,
+            parentCase: {
+              id: '1337',
+            },
           },
           {
             id: 'test_id_2',
@@ -444,5 +447,28 @@ describe('Detention requests route', () => {
         'Ekki tókst að ná sambandi við gagnagrunn. Málið hefur verið skráð og viðeigandi aðilar látnir vita. Vinsamlega reynið aftur síðar.',
       ),
     ).toBeInTheDocument()
+  })
+
+  test('should display a reload icon next to the case type in extended cases', async () => {
+    /**
+     * This test could be better since it doesn't actually check if the icon is
+     * displayed next to the case type, but I figure this is good enough.
+     */
+    render(
+      <MockedProvider
+        mocks={[...mockCasesQuery, ...mockProsecutorQuery]}
+        addTypename={false}
+      >
+        <MemoryRouter initialEntries={[`${Constants.REQUEST_LIST_ROUTE}`]}>
+          <UserProvider>
+            <Route path={`${Constants.REQUEST_LIST_ROUTE}`}>
+              <DetentionRequests />
+            </Route>
+          </UserProvider>
+        </MemoryRouter>
+      </MockedProvider>,
+    )
+
+    expect(await screen.findByTitle('A reload icon')).toBeInTheDocument()
   })
 })

--- a/apps/judicial-system/web/src/routes/Shared/DetentionRequests/DetentionRequests.spec.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/DetentionRequests/DetentionRequests.spec.tsx
@@ -448,27 +448,4 @@ describe('Detention requests route', () => {
       ),
     ).toBeInTheDocument()
   })
-
-  test('should display a reload icon next to the case type in extended cases', async () => {
-    /**
-     * This test could be better since it doesn't actually check if the icon is
-     * displayed next to the case type, but I figure this is good enough.
-     */
-    render(
-      <MockedProvider
-        mocks={[...mockCasesQuery, ...mockProsecutorQuery]}
-        addTypename={false}
-      >
-        <MemoryRouter initialEntries={[`${Constants.REQUEST_LIST_ROUTE}`]}>
-          <UserProvider>
-            <Route path={`${Constants.REQUEST_LIST_ROUTE}`}>
-              <DetentionRequests />
-            </Route>
-          </UserProvider>
-        </MemoryRouter>
-      </MockedProvider>,
-    )
-
-    expect(await screen.findByTitle('A reload icon')).toBeInTheDocument()
-  })
 })

--- a/apps/judicial-system/web/src/routes/Shared/DetentionRequests/DetentionRequests.treat.ts
+++ b/apps/judicial-system/web/src/routes/Shared/DetentionRequests/DetentionRequests.treat.ts
@@ -99,9 +99,6 @@ export const td = style({
       height: '100%',
       padding: 0,
     },
-    '&.noWrap': {
-      whiteSpace: 'nowrap',
-    },
   },
 })
 

--- a/apps/judicial-system/web/src/routes/Shared/DetentionRequests/DetentionRequests.treat.ts
+++ b/apps/judicial-system/web/src/routes/Shared/DetentionRequests/DetentionRequests.treat.ts
@@ -99,6 +99,9 @@ export const td = style({
       height: '100%',
       padding: 0,
     },
+    '&.noWrap': {
+      whiteSpace: 'nowrap',
+    },
   },
 })
 

--- a/apps/judicial-system/web/src/routes/Shared/DetentionRequests/DetentionRequests.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/DetentionRequests/DetentionRequests.tsx
@@ -376,13 +376,13 @@ export const DetentionRequests: React.FC = () => {
                     <Text>
                       {c.accusedNationalId && (
                         <Text as="span" variant="small" color="dark400">
-                          {`(${
+                          {`kt: ${
                             insertAt(
                               c.accusedNationalId.replace('-', ''),
                               '-',
                               6,
                             ) || '-'
-                          })`}
+                          }`}
                         </Text>
                       )}
                     </Text>
@@ -394,22 +394,17 @@ export const DetentionRequests: React.FC = () => {
                       })}
                     </Text>
                   </td>
-                  <td className={cn(styles.td, 'noWrap')}>
-                    <Box component="span" display="flex" alignItems="flexEnd">
+                  <td className={styles.td}>
+                    <Box component="span" display="flex" flexDirection="column">
                       <Text as="span">
                         {c.type === CaseType.CUSTODY
                           ? 'Gæsluvarðhald'
                           : 'Farbann'}
                       </Text>
                       {c.parentCase && (
-                        <Box component="span" marginLeft={1}>
-                          <Icon
-                            icon="reload"
-                            size="small"
-                            color="blue400"
-                            title="A reload icon"
-                          />
-                        </Box>
+                        <Text as="span" variant="small" color="dark400">
+                          Framlenging
+                        </Text>
                       )}
                     </Box>
                   </td>

--- a/apps/judicial-system/web/src/routes/Shared/DetentionRequests/DetentionRequests.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/DetentionRequests/DetentionRequests.tsx
@@ -394,12 +394,24 @@ export const DetentionRequests: React.FC = () => {
                       })}
                     </Text>
                   </td>
-                  <td className={styles.td}>
-                    <Text as="span">
-                      {c.type === CaseType.CUSTODY
-                        ? 'Gæsluvarðhald'
-                        : 'Farbann'}
-                    </Text>
+                  <td className={cn(styles.td, 'noWrap')}>
+                    <Box component="span" display="flex" alignItems="flexEnd">
+                      <Text as="span">
+                        {c.type === CaseType.CUSTODY
+                          ? 'Gæsluvarðhald'
+                          : 'Farbann'}
+                      </Text>
+                      {c.parentCase && (
+                        <Box component="span" marginLeft={1}>
+                          <Icon
+                            icon="reload"
+                            size="small"
+                            color="blue400"
+                            title="A reload icon"
+                          />
+                        </Box>
+                      )}
+                    </Box>
                   </td>
                   <td className={styles.td}>
                     <Tag

--- a/apps/judicial-system/web/src/utils/mutations.ts
+++ b/apps/judicial-system/web/src/utils/mutations.ts
@@ -98,6 +98,9 @@ export const CasesQuery = gql`
       custodyEndDate
       decision
       isCustodyEndDateInThePast
+      parentCase {
+        id
+      }
     }
   }
 `


### PR DESCRIPTION
# Add an indicator that indicates if a case is an extension in the list of cases.

https://app.asana.com/0/1199153462262248/1199612302735343

## What

Add text that indicates whether or not a case is an extension in the list of cases.

## Why

Otherwise, two rows look exactly alike in the table of requests when one is the original request and the other is an extension.

## Screenshots / Gifs

![Screen Shot 2021-02-09 at 12 34 28](https://user-images.githubusercontent.com/3789875/107364803-d3439f00-6ad3-11eb-952f-d85cc1e2e554.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
