### PR TITLE
InfoMessage margin top fix, removing nationality field from review page

### DIFF
--- a/libs/application/templates/health-insurance/src/fields/ChildrenInfoMessage/ChildrenInfoMessage.treat.ts
+++ b/libs/application/templates/health-insurance/src/fields/ChildrenInfoMessage/ChildrenInfoMessage.treat.ts
@@ -1,5 +1,5 @@
 import { style } from 'treat'
 
 export const marginFix = style({
-  marginTop: '-24px',
+  marginTop: '-8px',
 })

--- a/libs/application/templates/health-insurance/src/fields/Review/ContactInfo.tsx
+++ b/libs/application/templates/health-insurance/src/fields/Review/ContactInfo.tsx
@@ -99,16 +99,6 @@ const ContactInfo: FC<ReviewFieldProps> = ({ application, isEditable }) => {
                   defaultValue={data?.city}
                 />
               </GridColumn>
-              <GridColumn span={['12/12', '6/12']}>
-                <Input
-                  id={'applicant.nationality'}
-                  name={'applicant.nationality'}
-                  label={formatText(m.nationality, application, formatMessage)}
-                  ref={register}
-                  disabled
-                  defaultValue={data?.nationality}
-                />
-              </GridColumn>
             </GridRow>
           </Stack>
           <FieldDescription

--- a/libs/application/templates/health-insurance/src/fields/Review/StatusAndChildren.tsx
+++ b/libs/application/templates/health-insurance/src/fields/Review/StatusAndChildren.tsx
@@ -127,35 +127,45 @@ const StatusAndChildren: FC<ReviewFieldProps> = ({
             </Stack>
           </Box>
         )}
-        <Stack space={2}>
-          <FieldDescription
-            description={formatText(
-              m.childrenDescription,
-              application,
-              formatMessage,
-            )}
-          />
-          <RadioController
-            id={'children'}
-            name={'children'}
-            disabled={!isEditable}
-            defaultValue={
-              getValueViaPath(application.answers, 'children') as string[]
-            }
-            onSelect={(value) => setChildren(value as string)}
-            largeButtons={true}
-            split={'1/2'}
-            options={[
-              {
-                label: formatText(m.noOptionLabel, application, formatMessage),
-                value: NO,
-              },
-              {
-                label: formatText(m.yesOptionLabel, application, formatMessage),
-                value: YES,
-              },
-            ]}
-          />
+        <Stack space={1}>
+          <Stack space={2}>
+            <FieldDescription
+              description={formatText(
+                m.childrenDescription,
+                application,
+                formatMessage,
+              )}
+            />
+            <RadioController
+              id={'children'}
+              name={'children'}
+              disabled={!isEditable}
+              defaultValue={
+                getValueViaPath(application.answers, 'children') as string[]
+              }
+              onSelect={(value) => setChildren(value as string)}
+              largeButtons={true}
+              split={'1/2'}
+              options={[
+                {
+                  label: formatText(
+                    m.noOptionLabel,
+                    application,
+                    formatMessage,
+                  ),
+                  value: NO,
+                },
+                {
+                  label: formatText(
+                    m.yesOptionLabel,
+                    application,
+                    formatMessage,
+                  ),
+                  value: YES,
+                },
+              ]}
+            />
+          </Stack>
           {children === YES && (
             <Box marginBottom={[2, 2, 4]}>
               <ChildrenInfoMessage application={application} field={field} />


### PR DESCRIPTION
# InfoMessage margin top fix, removing nationality field from review page

## What

- Changing the margin top of the ChildrenInfoMessage component to look like design
- Removing the nationality field from the review page

## Screenshots / Gifs

![Screenshot 2021-02-09 at 16 52 52](https://user-images.githubusercontent.com/70507494/107389698-4ca0b900-6af7-11eb-9a26-955d99dd0fae.png)
![Screenshot 2021-02-09 at 16 43 23](https://user-images.githubusercontent.com/70507494/107389554-2aa73680-6af7-11eb-8044-5a15b4d979df.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
