### PR TITLE
Fix: Refactor absolute imports to be relative inside island-ui/core

### DIFF
--- a/libs/island-ui/core/.eslintrc
+++ b/libs/island-ui/core/.eslintrc
@@ -1,5 +1,15 @@
 {
   "extends": ["../../../.eslintrc.react.json"],
-  "rules": {},
+  "rules": {
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [{
+          "name": "@island.is/island-ui/core",
+          "message": "Cannot self reference library. Please us a relative import within @island.is/island-ui/core"
+        }]
+      }
+    ]
+  },
   "ignorePatterns": ["!**/*"]
 }

--- a/libs/island-ui/core/src/lib/Checkbox/Checkbox.tsx
+++ b/libs/island-ui/core/src/lib/Checkbox/Checkbox.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import cn from 'classnames'
-import { Text } from '@island.is/island-ui/core'
-
+import { Text } from '../Text/Text'
 import { Icon } from '../Icon/Icon'
 import { Tooltip } from '../Tooltip/Tooltip'
 import * as styles from './Checkbox.treat'

--- a/libs/island-ui/core/src/lib/RadioButton/RadioButton.tsx
+++ b/libs/island-ui/core/src/lib/RadioButton/RadioButton.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import cn from 'classnames'
-import { Text } from '@island.is/island-ui/core'
-
+import { Text } from '../Text/Text'
 import { Tooltip } from '../Tooltip/Tooltip'
 import * as styles from './RadioButton.treat'
 


### PR DESCRIPTION
## What

- Fix absolute imports within `island-ui/core` to be relative
- Force this convention by adding an eslint rule

## Why

Absolute imports are breaking CI in other PRs

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
