### PR TITLE
Added menu as nested for grouped menu

### DIFF
--- a/libs/api/domains/cms/src/lib/environments/environment.ts
+++ b/libs/api/domains/cms/src/lib/environments/environment.ts
@@ -30,6 +30,7 @@ export default {
     'articleCategory',
     'menuLink',
     'menuLinkWithChildren',
+    'menu',
   ],
   contentful: {
     space: process.env.CONTENTFUL_SPACE || '8k0h54kbe6bj',


### PR DESCRIPTION
# \<Description\>

Grouped menu is not correctly updated when a nested menu updates

## What

- Added menu as a nested content type

## Why

- This will trigger an update on grouped menu on menu updates

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
