### PR TITLE
Sjukratryggingar/changing active modal adding draft modal

### DIFF
--- a/libs/application/templates/health-insurance/src/dataProviders/APIDataTypes.ts
+++ b/libs/application/templates/health-insurance/src/dataProviders/APIDataTypes.ts
@@ -1,4 +1,5 @@
 export interface Applications {
   id: string
   state: string
+  created: string
 }

--- a/libs/application/templates/health-insurance/src/dataProviders/ApplicationsProvider.ts
+++ b/libs/application/templates/health-insurance/src/dataProviders/ApplicationsProvider.ts
@@ -14,6 +14,7 @@ export class ApplicationsProvider extends BasicDataProvider {
       getApplicationsByApplicant(typeId: ${ApplicationTypes.HEALTH_INSURANCE}) {
         id
         state
+        created
       }
     }`
 

--- a/libs/application/templates/health-insurance/src/forms/messages.ts
+++ b/libs/application/templates/health-insurance/src/forms/messages.ts
@@ -437,22 +437,27 @@ export const m = defineMessages({
     defaultMessage: 'Leiðbeiningar',
     description: 'How to register',
   },
+  activeDraftApplicationTitle: {
+    id: 'hi.application:activeDraftApplication.title',
+    defaultMessage: 'Open your previous draft',
+    description: 'Open your previous draft',
+  },
+  activeDraftApplicationDescription: {
+    id: 'hi.application:activeDraftApplication.description',
+    defaultMessage:
+      'You have already started to fill out an application. Please open your previous draft to continue.',
+    description:
+      'You have already started to fill out an application. Please open your previous draft to continue.',
+  },
+  activeDraftApplicationButtonText: {
+    id: 'hi.application:activeDraftApplication.buttonText',
+    defaultMessage: 'Open draft',
+    description: 'Open draft',
+  },
   activeApplicationTitle: {
     id: 'hi.application:activeApplication.title',
     defaultMessage: 'Virk umsókn',
     description: 'Active application',
-  },
-  activeApplicationDescription: {
-    id: 'hi.application:activeApplication.description',
-    defaultMessage:
-      'Þú hefur nú þegar sótt um sjúkratryggingu. Við umsókn voru sendar upplýsingar á netfang sem gefið var upp. Þú getur alltaf séð stöðu umsóknar á Mínum síðum',
-    description:
-      'You have already submitted an application for health insurance. We will notify you on the e-mail address you provided in the application when the status changes. You can always see your application status in My Pages.',
-  },
-  activeApplicationButtonText: {
-    id: 'hi.application:activeApplication.buttonText',
-    defaultMessage: 'Sjá stöðu',
-    description: 'See status',
   },
   oldPendingApplicationDescription: {
     id: 'hi.application:oldPendingApplication.description',

--- a/libs/application/templates/health-insurance/src/forms/messages.ts
+++ b/libs/application/templates/health-insurance/src/forms/messages.ts
@@ -446,27 +446,26 @@ export const m = defineMessages({
     id: 'hi.application:activeDraftApplication.description',
     defaultMessage:
       'You have already started to fill out an application. Please open your previous draft to continue.',
-    description:
-      'You have already started to fill out an application. Please open your previous draft to continue.',
+    description: 'Information for those that alreade have a started draft',
   },
   activeDraftApplicationButtonText: {
     id: 'hi.application:activeDraftApplication.buttonText',
     defaultMessage: 'Open draft',
     description: 'Open draft',
   },
-  activeApplicationTitle: {
+  pendingApplicationTitle: {
     id: 'hi.application:activeApplication.title',
     defaultMessage: 'Virk umsókn',
     description: 'Active application',
   },
-  oldPendingApplicationDescription: {
+  pendingApplicationDescription: {
     id: 'hi.application:oldPendingApplication.description',
     defaultMessage:
       'Þú hefur nú þegar sótt um sjúkratryggingu. Númer umsókninnar er **{applicationNumber}**. Vinsamlegast hafið samband við Sjúkratryggingar Íslands ef spurningar vakna.',
     description:
       'You have already submitted an application for health insurance. Your application number is **{applicationNumber}**. Please contact the Icelandic Health Insurance if you have any questions.',
   },
-  oldPendingApplicationButtonText: {
+  pendingApplicationButtonText: {
     id: 'hi.application:oldPendingApplication.buttonText',
     defaultMessage: 'Hafa samband',
     description: 'Contact info',

--- a/libs/application/templates/health-insurance/src/healthInsuranceUtils.ts
+++ b/libs/application/templates/health-insurance/src/healthInsuranceUtils.ts
@@ -13,8 +13,7 @@ export const hasActiveDraftApplication = (externalData: ExternalData) => {
   if (response && response?.status === 'success') {
     const applications = response.data as Applications[]
     const pendingApplications = applications?.filter(
-      (application) =>
-        application.state === 'draft' 
+      (application) => application.state === 'draft',
     )
     return pendingApplications?.length > 1
   }
@@ -40,9 +39,9 @@ export const hasIcelandicAddress = (externalData: ExternalData) => {
 export const shouldShowModal = (externalData: ExternalData) => {
   return (
     hasHealthInsurance(externalData) ||
-    hasActiveDraftApplication(externalData) ||
     hasOldPendingApplications(externalData) ||
-    hasIcelandicAddress(externalData)
+    hasIcelandicAddress(externalData) ||
+    hasActiveDraftApplication(externalData)
   )
 }
 

--- a/libs/application/templates/health-insurance/src/healthInsuranceUtils.ts
+++ b/libs/application/templates/health-insurance/src/healthInsuranceUtils.ts
@@ -8,15 +8,13 @@ export const hasHealthInsurance = (externalData: ExternalData) => {
   return isInsured === true
 }
 
-export const hasActiveApplication = (externalData: ExternalData) => {
+export const hasActiveDraftApplication = (externalData: ExternalData) => {
   const response = externalData?.applications
   if (response && response?.status === 'success') {
     const applications = response.data as Applications[]
     const pendingApplications = applications?.filter(
       (application) =>
-        application.state === 'draft' ||
-        application.state === 'inReview' ||
-        application.state === 'missingInfo',
+        application.state === 'draft' 
     )
     return pendingApplications?.length > 1
   }
@@ -42,7 +40,7 @@ export const hasIcelandicAddress = (externalData: ExternalData) => {
 export const shouldShowModal = (externalData: ExternalData) => {
   return (
     hasHealthInsurance(externalData) ||
-    hasActiveApplication(externalData) ||
+    hasActiveDraftApplication(externalData) ||
     hasOldPendingApplications(externalData) ||
     hasIcelandicAddress(externalData)
   )

--- a/libs/application/templates/health-insurance/src/healthInsuranceUtils.ts
+++ b/libs/application/templates/health-insurance/src/healthInsuranceUtils.ts
@@ -21,10 +21,10 @@ export const hasActiveDraftApplication = (externalData: ExternalData) => {
   return false
 }
 
-export const hasOldPendingApplications = (externalData: ExternalData) => {
-  const oldPendingApplications = externalData?.oldPendingApplications
+export const pendingApplications = (externalData: ExternalData) => {
+  const pendingApplications = externalData?.oldPendingApplications
     ?.data as string[]
-  return oldPendingApplications?.length > 0
+  return pendingApplications?.length > 0
 }
 
 export const hasIcelandicAddress = (externalData: ExternalData) => {
@@ -39,7 +39,7 @@ export const hasIcelandicAddress = (externalData: ExternalData) => {
 export const shouldShowModal = (externalData: ExternalData) => {
   return (
     hasHealthInsurance(externalData) ||
-    hasOldPendingApplications(externalData) ||
+    pendingApplications(externalData) ||
     hasIcelandicAddress(externalData) ||
     hasActiveDraftApplication(externalData)
   )

--- a/libs/application/templates/health-insurance/src/hooks/useModalContent.ts
+++ b/libs/application/templates/health-insurance/src/hooks/useModalContent.ts
@@ -4,7 +4,7 @@ import { ApplicationTypes, ExternalData } from '@island.is/application/core'
 import {
   hasHealthInsurance,
   hasActiveDraftApplication,
-  hasOldPendingApplications,
+  pendingApplications,
   hasIcelandicAddress,
 } from '../healthInsuranceUtils'
 import { ContentType } from '../types'
@@ -28,16 +28,16 @@ export const useModalContent = (externalData: ExternalData) => {
       buttonAction: () =>
         history.push(`../umsoknir/${ApplicationTypes.HEALTH_INSURANCE}`),
     },
-    activeApplication: {
+    activeDraftApplication: {
       title: m.activeDraftApplicationTitle,
       description: m.activeDraftApplicationDescription,
       buttonText: m.activeDraftApplicationButtonText,
       buttonAction: () =>
-        history.push(`../umsokn/${firstCreatedApplicationId}`), //TODO, redirect to the active draft
+        history.push(`../umsokn/${firstCreatedApplicationId}`),
     },
-    oldPendingApplications: {
-      title: m.activeApplicationTitle,
-      buttonText: m.oldPendingApplicationButtonText,
+    pendingApplication: {
+      title: m.pendingApplicationTitle,
+      buttonText: m.pendingApplicationButtonText,
       buttonAction: () =>
         (window.location.href = `https://www.sjukra.is/um-okkur/thjonustuleidir/`),
     },
@@ -60,20 +60,20 @@ export const useModalContent = (externalData: ExternalData) => {
   useEffect(() => {
     if (hasHealthInsurance(externalData)) {
       setContent(contentList.hasHealthInsurance)
-    } else if (hasOldPendingApplications(externalData)) {
+    } else if (pendingApplications(externalData)) {
       const oldPendingApplications = externalData?.oldPendingApplications
         ?.data as string[]
       setContent({
-        ...contentList.oldPendingApplications,
+        ...contentList.pendingApplication,
         description: () => ({
-          ...m.oldPendingApplicationDescription,
+          ...m.pendingApplicationDescription,
           values: { applicationNumber: oldPendingApplications[0] },
         }),
       })
     } else if (hasIcelandicAddress(externalData)) {
       setContent(contentList.registerAddress)
     } else if (hasActiveDraftApplication(externalData)) {
-      setContent(contentList.activeApplication)
+      setContent(contentList.activeDraftApplication)
     }
   }, [externalData])
 

--- a/libs/application/templates/health-insurance/src/hooks/useModalContent.ts
+++ b/libs/application/templates/health-insurance/src/hooks/useModalContent.ts
@@ -3,16 +3,20 @@ import { useHistory } from 'react-router-dom'
 import { ApplicationTypes, ExternalData } from '@island.is/application/core'
 import {
   hasHealthInsurance,
-  hasActiveApplication,
+  hasActiveDraftApplication,
   hasOldPendingApplications,
   hasIcelandicAddress,
 } from '../healthInsuranceUtils'
 import { ContentType } from '../types'
 import { m } from '../forms/messages'
+import { Applications } from '../dataProviders/APIDataTypes'
 
 export const useModalContent = (externalData: ExternalData) => {
   const [content, setContent] = useState<ContentType>()
   const history = useHistory()
+  const applications = externalData?.applications.data as Applications[]
+  const sortedApplications = applications.sort((a,b) => new Date(a.created) > new Date(b.created) ? 1 : -1)
+  const firstCreatedApplicationId = sortedApplications[0].id
 
   const contentList = {
     hasHealthInsurance: {
@@ -23,11 +27,11 @@ export const useModalContent = (externalData: ExternalData) => {
         history.push(`../umsoknir/${ApplicationTypes.HEALTH_INSURANCE}`),
     },
     activeApplication: {
-      title: m.activeApplicationTitle,
-      description: m.activeApplicationDescription,
-      buttonText: m.activeApplicationButtonText,
+      title: m.activeDraftApplicationTitle,
+      description: m.activeDraftApplicationDescription,
+      buttonText: m.activeDraftApplicationButtonText,
       buttonAction: () =>
-        history.push(`../umsoknir/${ApplicationTypes.HEALTH_INSURANCE}`), //TODO, add when we have link to mypages
+        history.push(`../umsokn/${firstCreatedApplicationId}`), //TODO, redirect to the active draft
     },
     oldPendingApplications: {
       title: m.activeApplicationTitle,
@@ -54,7 +58,7 @@ export const useModalContent = (externalData: ExternalData) => {
   useEffect(() => {
     if (hasHealthInsurance(externalData)) {
       setContent(contentList.hasHealthInsurance)
-    } else if (hasActiveApplication(externalData)) {
+    } else if (hasActiveDraftApplication(externalData)) {
       setContent(contentList.activeApplication)
     } else if (hasOldPendingApplications(externalData)) {
       const oldPendingApplications = externalData?.oldPendingApplications

--- a/libs/application/templates/health-insurance/src/hooks/useModalContent.ts
+++ b/libs/application/templates/health-insurance/src/hooks/useModalContent.ts
@@ -15,7 +15,9 @@ export const useModalContent = (externalData: ExternalData) => {
   const [content, setContent] = useState<ContentType>()
   const history = useHistory()
   const applications = externalData?.applications.data as Applications[]
-  const sortedApplications = applications.sort((a,b) => new Date(a.created) > new Date(b.created) ? 1 : -1)
+  const sortedApplications = applications.sort((a, b) =>
+    new Date(a.created) > new Date(b.created) ? 1 : -1,
+  )
   const firstCreatedApplicationId = sortedApplications[0].id
 
   const contentList = {
@@ -58,8 +60,6 @@ export const useModalContent = (externalData: ExternalData) => {
   useEffect(() => {
     if (hasHealthInsurance(externalData)) {
       setContent(contentList.hasHealthInsurance)
-    } else if (hasActiveDraftApplication(externalData)) {
-      setContent(contentList.activeApplication)
     } else if (hasOldPendingApplications(externalData)) {
       const oldPendingApplications = externalData?.oldPendingApplications
         ?.data as string[]
@@ -72,6 +72,8 @@ export const useModalContent = (externalData: ExternalData) => {
       })
     } else if (hasIcelandicAddress(externalData)) {
       setContent(contentList.registerAddress)
+    } else if (hasActiveDraftApplication(externalData)) {
+      setContent(contentList.activeApplication)
     }
   }, [externalData])
 


### PR DESCRIPTION
# Refactoring modals

## What

- Changing the active application modal to only be handled if the application is at Sjukra
- Adding a new modal for handling a application in draft state
- New modal routes to the already existing draft (the draft that was created first)

## Screenshots / Gifs

![Screenshot 2021-02-10 at 17 25 45](https://user-images.githubusercontent.com/70507494/107539219-087bea00-6bc5-11eb-91d9-ac54d62dab6a.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
