### PR TITLE
Island-ui / Add inline to button

### DIFF
--- a/libs/island-ui/core/src/lib/Button/Button.treat.ts
+++ b/libs/island-ui/core/src/lib/Button/Button.treat.ts
@@ -5,7 +5,6 @@ import { theme, themeUtils } from '@island.is/island-ui/theme'
 export const isEmpty = style({})
 
 const buttonBase = {
-  display: 'flex',
   alignItems: 'center',
   fontWeight: theme.typography.semiBold,
   borderRadius: 8,
@@ -416,7 +415,6 @@ export const colors = {
 }
 
 export const circle = style({
-  display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
   borderRadius: '50%',

--- a/libs/island-ui/core/src/lib/Button/Button.tsx
+++ b/libs/island-ui/core/src/lib/Button/Button.tsx
@@ -57,6 +57,7 @@ export interface ButtonProps {
   loading?: boolean
   nowrap?: boolean
   title?: string
+  inline?: boolean
 }
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps & ButtonTypes>(
@@ -76,6 +77,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps & ButtonTypes>(
       disabled,
       loading,
       nowrap,
+      inline,
       ...buttonProps
     },
     ref,
@@ -108,6 +110,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps & ButtonTypes>(
             [styles.loading]: loading,
           },
         )}
+        display={variant === 'text' ? 'inline' : inline ? 'inlineFlex' : 'flex'}
         disabled={disabled || loading}
         {...buttonProps}
       >


### PR DESCRIPTION
# Add inline to button

## What

It might make more sense to make all buttons inline-flex. But since we don't want to make a global change that might have some unseen consequences and buttons are working in general we will add the option for inline buttons

## Why

Inline buttons will listen to text style properties like `align-text`, in some cases that will make them easier handle and it will be closer to the default button display `inline-block` property

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
