### PR TITLE
Judicial-system/Accused plea announcement should not be bold in court record accordion item

### DIFF
--- a/apps/judicial-system/web/src/shared-components/CourtRecordAccordionItem/CourtRecordAccordionItem.tsx
+++ b/apps/judicial-system/web/src/shared-components/CourtRecordAccordionItem/CourtRecordAccordionItem.tsx
@@ -86,14 +86,13 @@ const CourtRecordAccordionItem: React.FC<Props> = ({ workingCase }: Props) => {
         breakSpaces
       >
         <Text>
-          <Text as="span" fontWeight="semiBold">
-            {workingCase.accusedPleaDecision === AccusedPleaDecision.REJECT
+          {`${
+            workingCase.accusedPleaDecision === AccusedPleaDecision.REJECT
               ? `Kærði hafnar kröfunni. `
               : workingCase.accusedPleaDecision === AccusedPleaDecision.ACCEPT
               ? `Kærði samþykkir kröfuna. `
-              : ''}
-          </Text>
-          {workingCase.accusedPleaAnnouncement}
+              : ''
+          }${workingCase.accusedPleaAnnouncement}`}
         </Text>
       </AccordionListItem>
       <AccordionListItem title="Málflutningur" breakSpaces>


### PR DESCRIPTION
# Accused plea announcement should not be bold in court record accordion item

https://app.asana.com/0/322488613152836/1199925504424433

## What

Accused plea announcement should not be bold in court record accordion item

## Why

Better UI

## Screenshots / Gifs

![Screen Shot 2021-02-11 at 13 32 04](https://user-images.githubusercontent.com/3789875/107643031-8a275280-6c6d-11eb-81fb-fa74692b042c.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
