### PR TITLE
Temporarily log all network activity in the VMST client

### DIFF
--- a/libs/vmst-client/src/lib/vmst-client.module.ts
+++ b/libs/vmst-client/src/lib/vmst-client.module.ts
@@ -1,5 +1,8 @@
 import { DynamicModule } from '@nestjs/common'
 import fetch from 'isomorphic-fetch'
+
+import { logger } from '@island.is/logging'
+
 import {
   Configuration,
   ParentalLeaveApi,
@@ -14,6 +17,52 @@ export interface VMSTClientModuleConfig {
   xRoadClient: string
 }
 
+const stringify = (json: unknown) => {
+  try {
+    return JSON.stringify(json, null, '  ')
+  } catch {
+    return json
+  }
+}
+
+const wrappedFetchForLogging = (
+  input: RequestInfo,
+  init?: RequestInit,
+): Promise<Response> => {
+  logger.info('VMST Client request')
+  logger.info(stringify(input))
+  if (init) {
+    logger.info(
+      stringify({
+        ...init,
+        headers: {
+          ...(init['headers'] || {}),
+          'api-key': 'hidden',
+        },
+      }),
+    )
+  }
+  return new Promise((resolve, reject) => {
+    fetch(input, init)
+      .then((response) => {
+        logger.info('VMST Client response')
+        logger.info(
+          stringify({
+            status: response.status,
+            statusText: response.statusText,
+            ok: response.ok,
+          }),
+        )
+        resolve(response)
+      })
+      .catch((error) => {
+        logger.info('VMST Client error')
+        logger.info(stringify(error))
+        reject(error)
+      })
+  })
+}
+
 export class VMSTClientModule {
   static register(config: VMSTClientModuleConfig): DynamicModule {
     const headers = {
@@ -22,7 +71,7 @@ export class VMSTClientModule {
     }
 
     const providerConfiguration = new Configuration({
-      fetchApi: fetch,
+      fetchApi: wrappedFetchForLogging,
       basePath: config.xRoadPath,
       headers,
     })


### PR DESCRIPTION
# \<Description\>

Temporarily logging all network activity that goes through the VMST client to find the cause of X-Road requests not getting through.

## Why

To be able to make X-Road requests to VMST

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
