### PR TITLE
Correctly reference x road client id

### DIFF
--- a/libs/api/domains/directorate-of-labour/src/lib/directorate-of-labour.module.ts
+++ b/libs/api/domains/directorate-of-labour/src/lib/directorate-of-labour.module.ts
@@ -10,7 +10,7 @@ const XROAD_BASE_PATH_WITH_ENV = process.env.XROAD_BASE_PATH_WITH_ENV ?? ''
 const XROAD_VMST_MEMBER_CODE = process.env.XROAD_VMST_MEMBER_CODE ?? ''
 const XROAD_VMST_API_PATH = process.env.XROAD_VMST_API_PATH ?? ''
 const VMST_API_KEY = process.env.VMST_API_KEY ?? ''
-const XROAD_VMST_CLIENT_ID = process.env.XROAD_VMST_CLIENT_ID ?? ''
+const XROAD_CLIENT_ID = process.env.XROAD_CLIENT_ID ?? ''
 
 const XROAD_VMST_MEMBER_CLASS = XRoadMemberClass.GovernmentInstitution
 
@@ -32,7 +32,7 @@ export class DirectorateOfLabourModule {
             XROAD_VMST_MEMBER_CODE,
             XROAD_VMST_API_PATH,
           ),
-          xRoadClient: XROAD_VMST_CLIENT_ID,
+          xRoadClient: XROAD_CLIENT_ID,
           apiKey: VMST_API_KEY,
         }),
       ],

--- a/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/parental-leave.module.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/parental-leave.module.ts
@@ -8,7 +8,7 @@ import { ParentalLeaveService } from './parental-leave.service'
 
 const XROAD_VMST_MEMBER_CODE = process.env.XROAD_VMST_MEMBER_CODE ?? ''
 const XROAD_VMST_API_PATH = process.env.XROAD_VMST_API_PATH ?? ''
-const XROAD_VMST_CLIENT_ID = process.env.XROAD_VMST_CLIENT_ID ?? ''
+const XROAD_CLIENT_ID = process.env.XROAD_CLIENT_ID ?? ''
 const VMST_API_KEY = process.env.VMST_API_KEY ?? ''
 
 export class ParentalLeaveModule {
@@ -23,7 +23,7 @@ export class ParentalLeaveModule {
             XROAD_VMST_MEMBER_CODE,
             XROAD_VMST_API_PATH,
           ),
-          xRoadClient: XROAD_VMST_CLIENT_ID,
+          xRoadClient: XROAD_CLIENT_ID,
           apiKey: VMST_API_KEY,
         }),
         SharedTemplateAPIModule.register(config),

--- a/libs/vmst-client/src/lib/vmst-client.module.ts
+++ b/libs/vmst-client/src/lib/vmst-client.module.ts
@@ -1,8 +1,5 @@
 import { DynamicModule } from '@nestjs/common'
 import fetch from 'isomorphic-fetch'
-
-import { logger } from '@island.is/logging'
-
 import {
   Configuration,
   ParentalLeaveApi,
@@ -17,52 +14,6 @@ export interface VMSTClientModuleConfig {
   xRoadClient: string
 }
 
-const stringify = (json: unknown) => {
-  try {
-    return JSON.stringify(json, null, '  ')
-  } catch {
-    return json
-  }
-}
-
-const wrappedFetchForLogging = (
-  input: RequestInfo,
-  init?: RequestInit,
-): Promise<Response> => {
-  logger.info('VMST Client request')
-  logger.info(stringify(input))
-  if (init) {
-    logger.info(
-      stringify({
-        ...init,
-        headers: {
-          ...(init['headers'] || {}),
-          'api-key': 'hidden',
-        },
-      }),
-    )
-  }
-  return new Promise((resolve, reject) => {
-    fetch(input, init)
-      .then((response) => {
-        logger.info('VMST Client response')
-        logger.info(
-          stringify({
-            status: response.status,
-            statusText: response.statusText,
-            ok: response.ok,
-          }),
-        )
-        resolve(response)
-      })
-      .catch((error) => {
-        logger.info('VMST Client error')
-        logger.info(stringify(error))
-        reject(error)
-      })
-  })
-}
-
 export class VMSTClientModule {
   static register(config: VMSTClientModuleConfig): DynamicModule {
     const headers = {
@@ -71,7 +22,7 @@ export class VMSTClientModule {
     }
 
     const providerConfiguration = new Configuration({
-      fetchApi: wrappedFetchForLogging,
+      fetchApi: fetch,
       basePath: config.xRoadPath,
       headers,
     })


### PR DESCRIPTION
# \<Description\>

XROAD_CLIENT_ID can now be used by everyone making requests on behalf of digital iceland so no need to have it namespaced to VMST

## Why

So VMST client requests work since they are now missing the client id header

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
