### PR TITLE
Make rich text render newlines within paragraphs

### DIFF
--- a/libs/island-ui/contentful/src/lib/RichTextRC/RichText.tsx
+++ b/libs/island-ui/contentful/src/lib/RichTextRC/RichText.tsx
@@ -113,6 +113,11 @@ export const richText: RichText = (
   locale = 'is',
 ) => {
   const options = {
+    renderText: (text) => {
+      return text.split('\n').reduce((children, textSegment, index) => {
+        return [...children, index > 0 && <br key={index} />, textSegment]
+      }, [])
+    },
     renderNode: { ...defaultRenderNode, ...opt.renderNode },
     renderMark: { ...defaultRenderMark, ...opt.renderMark },
   }


### PR DESCRIPTION
# Make rich text render newlines within paragraphs

## What

Rich text currently does not render newlines within paragraphs. This PR makes the renderer replace `\n` with `<br>`.

## Why

## Screenshots / Gifs

This hello world text block would previously have rendered in a single line.
![image](https://user-images.githubusercontent.com/3607456/107770178-f0c17480-6d30-11eb-945d-b87cc61dab96.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [   I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
