### PR TITLE
Add articleSubgroup to nested content types

### DIFF
--- a/libs/api/domains/cms/src/lib/environments/environment.ts
+++ b/libs/api/domains/cms/src/lib/environments/environment.ts
@@ -27,6 +27,7 @@ export default {
     'subArticle',
     'url',
     'articleGroup',
+    'articleSubgroup',
     'articleCategory',
     'menuLink',
     'menuLinkWithChildren',


### PR DESCRIPTION
# Add articleSubgroup to nested content types

## What

This makes articles in ES update when a subgroup that is referenced in them changes. 

## Why

When a subgroup is renamed the change should appear on the website without requiring a full resync.

## Screenshots / Gifs

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
