### PR TITLE
fix: missing outputPath for Dockerfile

### DIFF
--- a/workspace.json
+++ b/workspace.json
@@ -2215,9 +2215,11 @@
         "build": {
           "builder": "@nrwl/workspace:run-commands",
           "options": {
+            "outputPath": "dist/contentful-translation-extension",
             "command": "contentful-extension-scripts build --input libs/contentful-translation-extension --output dist/contentful-translation-extension"
           }
-        }
+        },
+        "docker-static": {}
       }
     },
     "dokobit-signing": {


### PR DESCRIPTION
## What

- Allow Docker to find the required outputPath

