### PR TITLE
Add outputPath to next build targets

### DIFF
--- a/handbook/technical-overview/devops/next-server.md
+++ b/handbook/technical-overview/devops/next-server.md
@@ -33,6 +33,7 @@ bootstrap({
 "build": {
   "builder": "@nrwl/workspace:run-commands",
   "options": {
+    "outputPath": "dist/apps/{{pathToAppDir}}",
     "commands": [
       "yarn nx run {{projectName}}:build-next:production",
       "yarn nx run {{projectName}}:build-server:production"

--- a/workspace.json
+++ b/workspace.json
@@ -246,6 +246,7 @@
         "build": {
           "builder": "@nrwl/workspace:run-commands",
           "options": {
+            "outputPath": "dist/apps/air-discount-scheme/web",
             "commands": [
               "yarn nx run air-discount-scheme-web:build-next:production",
               "yarn nx run air-discount-scheme-web:build-server:production"
@@ -1849,6 +1850,7 @@
         "build": {
           "builder": "@nrwl/workspace:run-commands",
           "options": {
+            "outputPath": "dist/apps/auth-admin-web",
             "commands": [
               "yarn nx run auth-admin-web:build-next:production",
               "yarn nx run auth-admin-web:build-server:production"
@@ -2594,6 +2596,7 @@
         "build": {
           "builder": "@nrwl/workspace:run-commands",
           "options": {
+            "outputPath": "dist/apps/gjafakort/web",
             "commands": [
               "yarn nx run gjafakort-web:build-next:production",
               "yarn nx run gjafakort-web:build-server:production"
@@ -3681,6 +3684,7 @@
         "build": {
           "builder": "@nrwl/workspace:run-commands",
           "options": {
+            "outputPath": "dist/apps/reference-next-app",
             "commands": [
               "yarn nx run reference-next-app:build-next:production",
               "yarn nx run reference-next-app:build-server:production"
@@ -5077,6 +5081,7 @@
         "build": {
           "builder": "@nrwl/workspace:run-commands",
           "options": {
+            "outputPath": "dist/apps/skilavottord/web",
             "commands": [
               "yarn nx run skilavottord-web:build-next:production",
               "yarn nx run skilavottord-web:build-server:production"
@@ -5351,6 +5356,7 @@
         "build": {
           "builder": "@nrwl/workspace:run-commands",
           "options": {
+            "outputPath": "dist/apps/web",
             "commands": [
               "yarn nx run web:build-next:production",
               "yarn nx run web:build-server:production"


### PR DESCRIPTION
## What

Configure outputPath on next build targets.

## Why

To fix the CI build, which depends on this property being around.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
