### PR TITLE
Island-ui / Base modal visibility

### DIFF
--- a/libs/island-ui/core/src/lib/ModalBase/ModalBase.stories.tsx
+++ b/libs/island-ui/core/src/lib/ModalBase/ModalBase.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Box } from '../Box/Box'
 import { Button } from '../Button/Button'
 import { Text } from '../Text/Text'
@@ -25,5 +25,39 @@ export const CustomModalExample = () => {
         </Box>
       )}
     </ModalBase>
+  )
+}
+export const CustomModalUsingState = () => {
+  const [isVisible, setIsVisible] = useState(false)
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        onClick={() => {
+          setIsVisible(true)
+        }}
+      >
+        Open modal using state
+      </Button>
+      <ModalBase
+        baseId="myDialog"
+        isVisible={isVisible}
+        onVisibilityChange={(visibility) => {
+          if (visibility !== isVisible) {
+            setIsVisible(visibility)
+          }
+        }}
+      >
+        {({ closeModal }) => (
+          <Box padding={4}>
+            <Text>We use onVisibilityChange to keep isVisible in sync</Text>
+            <Button onClick={closeModal} variant="text">
+              Close modal
+            </Button>
+          </Box>
+        )}
+      </ModalBase>
+    </>
   )
 }

--- a/libs/island-ui/core/src/lib/ModalBase/ModalBase.tsx
+++ b/libs/island-ui/core/src/lib/ModalBase/ModalBase.tsx
@@ -77,6 +77,14 @@ export type ModalBaseProps = {
    * Aria label for the modal
    */
   modalLabel?: string
+  /**
+   * Remove the modal from dom when closed
+   */
+  removeOnClose?: boolean
+  /**
+   * toggle visibility, useful for controlling visibility from useState. Should be used with onVisibilityChange
+   */
+  isVisible?: boolean
 }
 
 export const ModalBase: FC<ModalBaseProps> = ({
@@ -90,6 +98,8 @@ export const ModalBase: FC<ModalBaseProps> = ({
   renderDisclosure = (disclosure) => disclosure,
   backdropWhite,
   modalLabel,
+  removeOnClose,
+  isVisible,
 }) => {
   const modal = useDialogState({
     animated: true,
@@ -104,9 +114,17 @@ export const ModalBase: FC<ModalBaseProps> = ({
   }, [toggleClose])
 
   useEffect(() => {
+    if (isVisible) {
+      modal.show()
+    } else if (isVisible === false) {
+      modal.hide()
+    }
+  }, [isVisible])
+
+  useEffect(() => {
     onVisibilityChange && onVisibilityChange(modal.visible)
   }, [modal.visible])
-
+  const renderModal = !removeOnClose || (removeOnClose && modal.visible)
   return (
     <>
       {disclosure ? (
@@ -119,15 +137,23 @@ export const ModalBase: FC<ModalBaseProps> = ({
           }
         </DialogDisclosure>
       ) : null}
-      <DialogBackdrop {...modal} as={BackdropDiv} backdropWhite={backdropWhite}>
-        <BaseDialog
+      {renderModal && (
+        <DialogBackdrop
           {...modal}
-          className={cn(styles.modal, className)}
-          aria-label={modalLabel}
+          as={BackdropDiv}
+          backdropWhite={backdropWhite}
         >
-          {typeof children === 'function' ? children({ closeModal }) : children}
-        </BaseDialog>
-      </DialogBackdrop>
+          <BaseDialog
+            {...modal}
+            className={cn(styles.modal, className)}
+            aria-label={modalLabel}
+          >
+            {typeof children === 'function'
+              ? children({ closeModal })
+              : children}
+          </BaseDialog>
+        </DialogBackdrop>
+      )}
     </>
   )
 }


### PR DESCRIPTION
# Base modal visibility

## What

Make it possible to toggle visibility with state,
Make it optional to remove modal after it's closed

## Why
>Make it possible to toggle visibility with state

It's not always possible to wrap the modal using disclosure, e.g. when modal is triggered as a response of some event

>Make it optional to remove modal after it's closed

Less clutter in the DOM when rendering list of items that can trigger modals, if modals are the same it will remove problems like duplicate id's

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
