### PR TITLE
fix: throw error when script fails

### DIFF
--- a/scripts/schemas.js
+++ b/scripts/schemas.js
@@ -49,8 +49,7 @@ const main = async () => {
           throw new Error(err.stdout)
         })
     } catch (err) {
-      console.error(`Error while running generate-schemas: ${err}`)
-      process.exit(err.code)
+      throw new Error(`Error while running generate-schemas: ${err}`)
     }
   }
 }


### PR DESCRIPTION
## What

- Should break the CI when failing during NX schemas generations
- `process.exit(err.code)` err.code was undefined, I believe that's why it wasn't failing