### PR TITLE
Remove extra padding on mobile

### DIFF
--- a/apps/web/components/CardsSlider/CardsSlider.tsx
+++ b/apps/web/components/CardsSlider/CardsSlider.tsx
@@ -43,12 +43,7 @@ export const CardsSlider: FC<CardsSliderProps> = ({ title, cards }) => {
     setCardHeight('auto')
     setStagePadding({
       paddingLeft: 0,
-      paddingRight:
-        width >= theme.breakpoints.md
-          ? 124
-          : width > theme.breakpoints.xs
-          ? 50
-          : 20,
+      paddingRight: width >= theme.breakpoints.md ? 124 : 20,
     })
   }, [ref])
 

--- a/apps/web/screens/LifeEvent/LifeEvent.tsx
+++ b/apps/web/screens/LifeEvent/LifeEvent.tsx
@@ -60,23 +60,23 @@ export const LifeEvent: Screen<LifeEventProps> = ({
         imageWidth={image.width.toString()}
         imageHeight={image.height.toString()}
       />
-      <GridRow>
-        <Box
-          marginBottom={[4, 4, 4, 8]}
-          display="inlineBlock"
-          width="full"
-          printHidden
-        >
-          <BackgroundImage
-            ratio="12:4"
-            background="transparent"
-            boxProps={{ background: 'white' }}
-            image={image}
-          />
-        </Box>
-      </GridRow>
 
       <GridContainer id="main-content">
+        <GridRow>
+          <Box
+            marginBottom={[4, 4, 4, 8]}
+            display="inlineBlock"
+            width="full"
+            printHidden
+          >
+            <BackgroundImage
+              ratio="12:4"
+              background="transparent"
+              boxProps={{ background: 'white' }}
+              image={image}
+            />
+          </Box>
+        </GridRow>
         <GridRow>
           <GridColumn span={['12/12', '12/12', '12/12', '8/12', '9/12']}>
             <GridRow>


### PR DESCRIPTION
# Remove extra padding on mobile & fix life event header image

To show more content on life event screen
To show more of the card on the screen

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/70899104/108513482-938e6b80-72ba-11eb-850e-2c87ec9ef349.png)
![image](https://user-images.githubusercontent.com/70899104/108512677-7ad18600-72b9-11eb-8a24-3a5a23ecad21.png)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
