### PR TITLE
fix: update immer for security report

### DIFF
--- a/package.json
+++ b/package.json
@@ -356,11 +356,12 @@
   },
   "resolutions": {
     "@testing-library/dom": "7.29.1",
-    "webpack": "4.44.1",
-    "serialize-javascript": "4.0.0",
+    "axios": "0.21.1",
+    "immer": "8.0.1",
     "node-forge": "0.10.0",
     "object-path": "0.11.5",
-    "xml-crypto": "2.0.0",
-    "axios": "0.21.1"
+    "serialize-javascript": "4.0.0",
+    "webpack": "4.44.1",
+    "xml-crypto": "2.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15246,15 +15246,10 @@ immediate@~3.0.5:
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
   integrity sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
 
-immer@1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-1.10.0.tgz#bad67605ba9c810275d91e1c2a47d4582e98286d"
-  integrity sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg==
-
-immer@^5.0.0:
-  version "5.3.6"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-5.3.6.tgz#51eab8cbbeb13075fe2244250f221598818cac04"
-  integrity sha512-pqWQ6ozVfNOUDjrLfm4Pt7q4Q12cGw2HUZgry4Q5+Myxu9nmHRkWBpI0J4+MK0AxbdFtdMTwEGVl7Vd+vEiK+A==
+immer@1.10.0, immer@8.0.1, immer@^5.0.0:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656"
+  integrity sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
 
 immutable@~3.7.6:
   version "3.7.6"


### PR DESCRIPTION
## What

- `yarn run security-audit` repors high vulnerabilities regarding immer.
- We have warnings for two packages, storybook and slate/* both have open issues https://github.com/storybookjs/storybook/issues/13961 and https://github.com/ianstormtaylor/slate/pull/4050, it should be a matter of time a patch version is published, using resolutions shouldn't impact the usage of these two packages