### PR TITLE
Fix e2e false success

### DIFF
--- a/scripts/e2e-ci.js
+++ b/scripts/e2e-ci.js
@@ -73,7 +73,7 @@ const CMD = {
   ],
   TEST: `yarn nx run ${argv.name}:e2e:production --headless --production${
       argv.ci ? 
-        ` --record --group=${argv.name}` :
+        ` --record --group=${argv.name} --ci-build-id=saevar-manual-004` :
         ''
     }${
       argv['skip-cache'] ?
@@ -131,9 +131,13 @@ const main = async () => {
     const testResult = await pexec(CMD.TEST)
     console.log(testResult.stdout)
     console.log(testResult.stderr)
-    console.log(`Test process exited with status ${testResult.status}`)
-    if (testResult.status) {
-      exitCode = testResult.status
+
+    // Tests can fail without the command exiting with code 1
+    // So to be sure that all tests where successful we check
+    // for the string 'All specs passed!'
+    if (!testResult.stdout.includes('All specs passed!')) {
+      console.log('Tests have failed. See output above for further details.')
+      exitCode = 1
     }
   } catch (err) {
     exitCode = 1

--- a/scripts/e2e-ci.js
+++ b/scripts/e2e-ci.js
@@ -73,7 +73,7 @@ const CMD = {
   ],
   TEST: `yarn nx run ${argv.name}:e2e:production --headless --production${
       argv.ci ? 
-        ` --record --group=${argv.name} --ci-build-id=saevar-manual-004` :
+        ` --record --group=${argv.name}` :
         ''
     }${
       argv['skip-cache'] ?

--- a/scripts/e2e-ci.js
+++ b/scripts/e2e-ci.js
@@ -130,6 +130,11 @@ const main = async () => {
   try {
     const testResult = await pexec(CMD.TEST)
     console.log(testResult.stdout)
+    console.log(testResult.stderr)
+    console.log(`Test process exited with status ${testResult.status}`)
+    if (testResult.status) {
+      exitCode = testResult.status
+    }
   } catch (err) {
     exitCode = 1
     console.log(err.stdout)


### PR DESCRIPTION
# Fix e2e false success

## What

In CI pipeline e2e step succeeds even test specs fails.

## Why

To stop build wrongly passing on e2e failure.

## Screenshots / Gifs

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
