### PR TITLE
Sjukratryggingar/Handle fetch failures

### DIFF
--- a/libs/application/templates/health-insurance/src/dataProviders/ApplicationsProvider.ts
+++ b/libs/application/templates/health-insurance/src/dataProviders/ApplicationsProvider.ts
@@ -34,7 +34,7 @@ export class ApplicationsProvider extends BasicDataProvider {
 
   handleError(error: any) {
     console.log('Provider error - Applications', error)
-    return Promise.resolve(error)
+    return Promise.resolve({})
   }
 
   onProvideError(result: string): FailedDataProviderResult {

--- a/libs/application/templates/health-insurance/src/dataProviders/HealthInsuranceProvider.ts
+++ b/libs/application/templates/health-insurance/src/dataProviders/HealthInsuranceProvider.ts
@@ -29,7 +29,7 @@ export class HealthInsuranceProvider extends BasicDataProvider {
 
   handleError(error: any) {
     console.log('Provider error - HealthInsurance:', error)
-    return Promise.resolve(error)
+    return Promise.resolve({})
   }
 
   onProvideError(result: string): FailedDataProviderResult {

--- a/libs/application/templates/health-insurance/src/dataProviders/PendingApplications.ts
+++ b/libs/application/templates/health-insurance/src/dataProviders/PendingApplications.ts
@@ -31,7 +31,7 @@ export class PendingApplications extends BasicDataProvider {
 
   handleError(error: any) {
     console.log('Provider error - PendingApplications:', error)
-    return Promise.resolve(error)
+    return Promise.resolve({})
   }
 
   onProvideError(result: string): FailedDataProviderResult {

--- a/libs/application/templates/health-insurance/src/lib/answerValidators.ts
+++ b/libs/application/templates/health-insurance/src/lib/answerValidators.ts
@@ -71,7 +71,7 @@ export const answerValidators: Record<string, AnswerValidator> = {
       return buildError('You must select one of the above', field)
     }
 
-    // Check that country is a string and not empty
+    // Check that country is not empty
     if (!formerInsurance.country) {
       const field = `${FORMER_INSURANCE}.country`
       const buildError = buildValidationError(field)
@@ -94,7 +94,7 @@ export const answerValidators: Record<string, AnswerValidator> = {
     if (
       !requireWaitingPeriod(formerInsurance.country, applicant?.citizenship)
     ) {
-      // Check that national ID is string and not empty
+      // Check that national ID is not empty
       if (!formerInsurance.personalId) {
         const field = `${FORMER_INSURANCE}.personalId`
         const buildError = buildValidationError(field)
@@ -112,7 +112,7 @@ export const answerValidators: Record<string, AnswerValidator> = {
         const buildError = buildValidationError(field)
         return buildError('You must select one of the above', field)
       }
-      // Check that entitelmentReason is a string and not empty (field is conditionally renderd if entitlement === YES)
+      // Check that entitelmentReason is not empty if field is rendered (rendered if entitlement === YES)
       if (
         formerInsurance.entitlement === YES &&
         !formerInsurance.entitlementReason


### PR DESCRIPTION
# Sjukratryggingar/Handle fetch failures

## What

Resolved providers with empty objects if fail.

## Why

If we can not determine if user
- has an active draft
- is already insured
- has pending application
(because of failed providers) this will let the user continue to create and submit a new application anyway.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
