### PR TITLE
Sjukratryggingar/fix country code usage

### DIFF
--- a/libs/application/templates/health-insurance/src/fields/CitizenshipField/CitizenshipField.tsx
+++ b/libs/application/templates/health-insurance/src/fields/CitizenshipField/CitizenshipField.tsx
@@ -22,9 +22,9 @@ const CountrySelectField: FC<FieldBaseProps> = ({ field, application }) => {
       .then((res) => res.json())
       .then((data: CountryDataResult) => {
         if (!data.status) {
-          const { name, regionalBlocs } = data
+          const { regionalBlocs } = data
           const regions = regionalBlocs.map((blocs) => blocs.acronym)
-          setCountryData(JSON.stringify({ name, countryCode, regions }))
+          setCountryData(JSON.stringify({ ...citizenship, regions }))
         }
       })
   }


### PR DESCRIPTION
# Sjukratryggingar/fix country code usage

## What

If we get data, we shouldnt transofrm it, just add the regions that we get form country api

## Why

So that we dont modify any data and be consistent with the keys in the saved object

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
