### PR TITLE
Fix: Make address update date nullable

### DIFF
--- a/libs/api/domains/national-registry/src/lib/graphql/models/address.model.ts
+++ b/libs/api/domains/national-registry/src/lib/graphql/models/address.model.ts
@@ -5,8 +5,8 @@ export class Address {
   @Field(() => ID)
   code!: string
 
-  @Field(() => String)
-  lastUpdated!: string
+  @Field(() => String, { nullable: true })
+  lastUpdated?: string
 
   @Field(() => String, { nullable: true })
   streetAddress?: string


### PR DESCRIPTION
# National registry fix nullalbe address date

## What

Make last update date nullable.

## Why

Data from national registry api returns null even if users have correctly registered addresses. It is possibly that the data in the dev env is not complete. But this fix will prevent queries to fail.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
