### PR TITLE
Sjukratryggingar/Fix spacing between buttons for safari

### DIFF
--- a/libs/application/templates/health-insurance/src/fields/ErrorModal/ErrorModal.treat.ts
+++ b/libs/application/templates/health-insurance/src/fields/ErrorModal/ErrorModal.treat.ts
@@ -40,8 +40,6 @@ export const center = style({
 })
 
 export const gridFix = style({
-  gridGap: '16px',
-
   '@media': {
     [`screen and (max-width: ${theme.breakpoints.sm}px)`]: {
       flexDirection: 'column-reverse',

--- a/libs/application/templates/health-insurance/src/fields/ErrorModal/ErrorModal.tsx
+++ b/libs/application/templates/health-insurance/src/fields/ErrorModal/ErrorModal.tsx
@@ -62,7 +62,7 @@ const ErrorModal: FC<FieldBaseProps> = ({ application }) => {
               </Text>
             </Stack>
             <GridRow align="spaceBetween" className={styles.gridFix}>
-              <GridColumn span={['12/12', '12/12', '1/3']}>
+              <GridColumn span={['12/12', '12/12', '1/3']} paddingTop={[2, 0]}>
                 <Button
                   size="default"
                   variant="ghost"


### PR DESCRIPTION
# Sjukratryggingar / Fix button spacing on safari 

## What

Changed css gridGap to padding instead because of lack of support on Safari.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
