### PR TITLE
Sjukratryggingar/Enable click outside modal for testing

### DIFF
--- a/libs/application/templates/health-insurance/src/fields/ErrorModal/ErrorModal.tsx
+++ b/libs/application/templates/health-insurance/src/fields/ErrorModal/ErrorModal.tsx
@@ -26,14 +26,13 @@ const ErrorModal: FC<FieldBaseProps> = ({ application }) => {
   const { formatMessage, lang } = useLocale()
   const history = useHistory()
   const content = useModalContent(externalData)
-  const canClose = process.env.NODE_ENV !== 'development' ? false : true
 
   return (
     <ModalBase
       baseId="healthInsuranceErrorModal"
       initialVisibility={true}
       className={`${styles.dialog} ${styles.background} ${styles.center}`}
-      hideOnClickOutside={canClose}
+      // hideOnClickOutside={false}
     >
       {({ closeModal }: { closeModal: () => void }) => (
         <Box


### PR DESCRIPTION
# Sjukratryggingar/Enable click outside modal for testing

## What

During testing we need to be able to close the modal and continue as we dont have a user that does not show the modal.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
