### PR TITLE
Locking environment checkbox

### DIFF
--- a/apps/web/components/ServiceInformation/ServiceInformation.tsx
+++ b/apps/web/components/ServiceInformation/ServiceInformation.tsx
@@ -136,6 +136,7 @@ export const ServiceInformation: FC<ServiceInformationProps> = ({
             defaultValue={selectedEnviromentOption}
             options={enviromentOptions}
             onChange={onSelectEnviroment}
+            disabled
           />
         </GridColumn>
         <GridColumn span={['6/12', '6/12', '6/12', '6/12', '3/12']}>


### PR DESCRIPTION
# Locking the environment



## What
Disabling the environment select box.


## Why

There is always one environment here for now, so we want it un-selectable, until there will be more environments to choose from.

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/545586/109943796-78195c80-7ccd-11eb-935e-b3da25fce1ca.png)

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
