### PR TITLE
feat: Restrict access to the DocumentProvider module.

### DIFF
--- a/apps/service-portal/src/environments/environment.prod.ts
+++ b/apps/service-portal/src/environments/environment.prod.ts
@@ -11,5 +11,6 @@ export default {
     dsn:
       'https://3c45a55273774b91a897b85e0a1243d1@o406638.ingest.sentry.io/5501494',
   },
+  documentProviderAdmins: process.env.NX_DOCUMENT_PROVIDER_ADMINS || '',
   featureFlagSdkKey: getStaticEnv('SI_PUBLIC_CONFIGCAT_SDK_KEY'),
 }

--- a/apps/service-portal/src/environments/environment.ts
+++ b/apps/service-portal/src/environments/environment.ts
@@ -10,5 +10,6 @@ export default {
     dsn:
       'https://3c45a55273774b91a897b85e0a1243d1@o406638.ingest.sentry.io/5501494',
   },
+  documentProviderAdmins: process.env.NX_DOCUMENT_PROVIDER_ADMINS || '',
   featureFlagSdkKey: 'YcfYCOwBTUeI04mWOWpPdA/KgCHhUk0_k2BdiKMaNh3qA',
 }

--- a/apps/service-portal/src/hooks/useNavigation/useNavigation.ts
+++ b/apps/service-portal/src/hooks/useNavigation/useNavigation.ts
@@ -23,6 +23,12 @@ const filterNavigationTree = (
           route.path.includes(item.path)),
     ) !== undefined || item.systemRoute === true
 
+  // Only display the document-provider module for those who have access
+  if (item.path === '/skjalaveitur') {
+    if (!env.documentProviderAdmins?.includes(userInfo.profile.nationalId))
+      return false
+  }
+
   // Filters out any children that do not have a module route defined
   item.children = item.children?.filter((child) => {
     return filterNavigationTree(child, routes, userInfo)


### PR DESCRIPTION
# Restrict access to the DocumentProvider module.

## What

Restrict access to the DocumentProvider module.

## Why

Only staff of island.is is allowed to view this module. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
