### PR TITLE
fix (Health insurance): Already insured modal link, translation on status and children review

### DIFF
--- a/libs/application/templates/health-insurance/src/fields/Review/StatusAndChildren.tsx
+++ b/libs/application/templates/health-insurance/src/fields/Review/StatusAndChildren.tsx
@@ -47,7 +47,7 @@ const StatusAndChildren: FC<ReviewFieldProps> = ({
             }
             options={[
               {
-                label: m.statusEmployed.defaultMessage,
+                label: formatText(m.statusEmployed, application, formatMessage),
                 value: StatusTypes.EMPLOYED,
                 tooltip: formatText(
                   m.statusEmployedInformation,
@@ -56,7 +56,7 @@ const StatusAndChildren: FC<ReviewFieldProps> = ({
                 ),
               },
               {
-                label: m.statusStudent.defaultMessage,
+                label: formatText(m.statusStudent, application, formatMessage),
                 value: StatusTypes.STUDENT,
                 tooltip: formatText(
                   m.statusStudentInformation,
@@ -78,7 +78,7 @@ const StatusAndChildren: FC<ReviewFieldProps> = ({
                 ),
               },
               {
-                label: m.statusOther.defaultMessage,
+                label: formatText(m.statusOther, application, formatMessage),
                 value: StatusTypes.OTHER,
                 tooltip: formatText(
                   m.statusOtherInformation,

--- a/libs/application/templates/health-insurance/src/forms/messages.ts
+++ b/libs/application/templates/health-insurance/src/forms/messages.ts
@@ -504,7 +504,7 @@ export const m = defineMessages({
     defaultMessage:
       'Þú ert nú þegar með virka sjúkratryggingu hjá Sjúkratryggingum Íslands og þarft því ekki að sækja um.\n Nánari upplýsingar er að finna á heimasíðu Sjúkratrygginga Íslands.',
     description:
-      'You are already covered by the Icelandic Health Insurance. You do not need to apply. You can read more about your health insurance at sjukra.is/english',
+      'You are already covered by the Icelandic Health Insurance. You do not need to apply. You can read more about your health insurance at **[sjukra.is/english](https://www.sjukra.is/english)**',
   },
   alreadyInsuredButtonText: {
     id: 'hi.application:alreadyInsured.buttonText',


### PR DESCRIPTION
# Already insured modal link fix, translation on status and children review

## What

Fixed markdown on link in already insured modal
Translation fix on status and children review 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
