### PR TITLE
fix(service-portal): nationalId should be included in ff request

### DIFF
--- a/apps/service-portal/src/hooks/useModules/useModules.ts
+++ b/apps/service-portal/src/hooks/useModules/useModules.ts
@@ -15,7 +15,7 @@ const featureFlagClient = createClient({
 })
 
 export const useModules = () => {
-  const [{ modules }, dispatch] = useStore()
+  const [{ modules, userInfo }, dispatch] = useStore()
 
   async function filterModulesBasedOnFeatureFlags() {
     const flagValues = await Promise.all(
@@ -24,6 +24,11 @@ export const useModules = () => {
         return featureFlagClient.getValue(
           `isServicePortal${capKey}ModuleEnabled`,
           false,
+          {
+            attributes: {
+              nationalId: userInfo.profile.nationalId,
+            },
+          },
         )
       }),
     )


### PR DESCRIPTION
## What

NationalId should be included in configcat request

## Why

So we will be able to use user segments for special users until we get the delegation system

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
