### PR TITLE
fix(service-portal): nationalId should be included in ff request

### DIFF
--- a/apps/service-portal/src/hooks/useModules/useModules.ts
+++ b/apps/service-portal/src/hooks/useModules/useModules.ts
@@ -15,7 +15,7 @@ const featureFlagClient = createClient({
 })
 
 export const useModules = () => {
-  const [{ modules }, dispatch] = useStore()
+  const [{ modules, userInfo }, dispatch] = useStore()
 
   async function filterModulesBasedOnFeatureFlags() {
     const flagValues = await Promise.all(
@@ -24,6 +24,14 @@ export const useModules = () => {
         return featureFlagClient.getValue(
           `isServicePortal${capKey}ModuleEnabled`,
           false,
+          userInfo && userInfo.profile.sid
+            ? {
+                id: userInfo.profile.sid,
+                attributes: {
+                  nationalId: userInfo.profile.nationalId,
+                },
+              }
+            : undefined,
         )
       }),
     )

--- a/libs/feature-flags/README.md
+++ b/libs/feature-flags/README.md
@@ -34,7 +34,7 @@ then wrap your application using `<FeatureFlagContextProvider>`.
                 'isAwesomeFeatureEnabled',
                 false,
                 {
-                    uuid: 'sindri',
+                    id: 'sindri',
                 },
                 )
                 setShowAwesome(featureEnabled as boolean)

--- a/libs/feature-flags/src/lib/configcat.ts
+++ b/libs/feature-flags/src/lib/configcat.ts
@@ -31,7 +31,7 @@ export class Client implements FeatureFlagClient {
     return await this.configcat.getValueAsync(
       key,
       defaultValue,
-      user ? { identifier: user.uuid, custom: user.attributes } : undefined,
+      user ? { identifier: user.id, custom: user.attributes } : undefined,
     )
   }
 }

--- a/libs/feature-flags/src/lib/types.ts
+++ b/libs/feature-flags/src/lib/types.ts
@@ -1,5 +1,5 @@
 export interface User {
-  uuid: string
+  id: string
   attributes?: { [key: string]: string }
 }
 


### PR DESCRIPTION
## What

NationalId should be included in configcat request

## Why

So we will be able to use user segments for special users until we get the delegation system

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
