### PR TITLE
fix(judicial-system): Null guard accusedPleaAnnounement in PDF

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/pdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/pdf.ts
@@ -348,7 +348,7 @@ export async function generateRulingPdf(existingCase: Case): Promise<string> {
           : existingCase.accusedPleaDecision === AccusedPleaDecision.REJECT
           ? `Kærði hafnar kröfunni. `
           : ''
-      } ${existingCase.accusedPleaAnnouncement}`,
+      }${existingCase.accusedPleaAnnouncement || ''}`,
       {
         lineGap: 6,
         paragraphGap: 0,


### PR DESCRIPTION
# Null guard accusedPleaAnnounement in PDF

https://app.asana.com/0/1199153462262248/1199999639914930

## What

If accousedPleaAnnouncement was left empty,  the PDF would display null instead of an empty string

## Why

It's a bug.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
