### PR TITLE
feature(judicial-system): Removes case type and accused info from defender email

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/formatters.spec.ts
+++ b/apps/judicial-system/backend/src/app/formatters/formatters.spec.ts
@@ -822,9 +822,6 @@ describe('formatPrisonCourtDateEmailNotification', () => {
 describe('formatDefenderCourtDateEmailNotification', () => {
   test('should format defender court date notification', () => {
     // Arrange
-    const type = CaseType.CUSTODY
-    const accusedNationalId = '1212129999'
-    const accusedName = 'Robbi Ræningi'
     const court = 'Héraðsdómur Norðurlands'
     const courtCaseNumber = 'R-77/2021'
     const courtDate = new Date('2020-12-19T10:19')
@@ -832,9 +829,6 @@ describe('formatDefenderCourtDateEmailNotification', () => {
 
     // Act
     const res = formatDefenderCourtDateEmailNotification(
-      type,
-      accusedNationalId,
-      accusedName,
       court,
       courtCaseNumber,
       courtDate,
@@ -843,15 +837,12 @@ describe('formatDefenderCourtDateEmailNotification', () => {
 
     // Assert
     expect(res).toBe(
-      'Héraðsdómur Norðurlands hefur staðfest fyrirtökutíma fyrir gæsluvarðhaldskröfu (sjá viðhengi).<br /><br />Fyrirtaka mun fara fram laugardaginn, 19. desember 2020, kl. 10:19.<br /><br />Málsnúmer: R-77/2021.<br /><br />Dómsalur: 101.<br /><br />Sakborningur: Robbi Ræningi, kt. 121212-9999.<br /><br />Dómstóllinn hefur skráð þig sem verjanda sakbornings.',
+      'Héraðsdómur Norðurlands hefur boðað þig í fyrirtöku sem verjanda sakbornings.<br /><br />Fyrirtaka mun fara fram laugardaginn, 19. desember 2020, kl. 10:19.<br /><br />Málsnúmer: R-77/2021.<br /><br />Dómsalur: 101.',
     )
   })
 
   test('should format defender court date notification for travel ban', () => {
     // Arrange
-    const type = CaseType.TRAVEL_BAN
-    const accusedNationalId = '1212129999'
-    const accusedName = 'Robbi Ræningi'
     const court = 'Héraðsdómur Norðurlands'
     const courtCaseNumber = 'R-77/2021'
     const courtDate = new Date('2020-12-19T10:19')
@@ -859,9 +850,6 @@ describe('formatDefenderCourtDateEmailNotification', () => {
 
     // Act
     const res = formatDefenderCourtDateEmailNotification(
-      type,
-      accusedNationalId,
-      accusedName,
       court,
       courtCaseNumber,
       courtDate,
@@ -870,7 +858,7 @@ describe('formatDefenderCourtDateEmailNotification', () => {
 
     // Assert
     expect(res).toBe(
-      'Héraðsdómur Norðurlands hefur staðfest fyrirtökutíma fyrir farbannskröfu (sjá viðhengi).<br /><br />Fyrirtaka mun fara fram laugardaginn, 19. desember 2020, kl. 10:19.<br /><br />Málsnúmer: R-77/2021.<br /><br />Dómsalur: 101.<br /><br />Sakborningur: Robbi Ræningi, kt. 121212-9999.<br /><br />Dómstóllinn hefur skráð þig sem verjanda sakbornings.',
+      'Héraðsdómur Norðurlands hefur boðað þig í fyrirtöku sem verjanda sakbornings.<br /><br />Fyrirtaka mun fara fram laugardaginn, 19. desember 2020, kl. 10:19.<br /><br />Málsnúmer: R-77/2021.<br /><br />Dómsalur: 101.',
     )
   })
 })

--- a/apps/judicial-system/backend/src/app/formatters/formatters.ts
+++ b/apps/judicial-system/backend/src/app/formatters/formatters.ts
@@ -235,17 +235,12 @@ export function formatPrisonCourtDateEmailNotification(
 }
 
 export function formatDefenderCourtDateEmailNotification(
-  type: CaseType,
-  accusedNationalId: string,
-  accusedName: string,
   court: string,
   courtCaseNumber: string,
   courtDate: Date,
   courtRoom: string,
 ): string {
-  return `${court} hefur staðfest fyrirtökutíma fyrir ${
-    type === CaseType.CUSTODY ? 'gæsluvarðhaldskröfu' : 'farbannskröfu'
-  } (sjá viðhengi).<br /><br />Fyrirtaka mun fara fram ${formatDate(
+  return `${court} hefur boðað þig í fyrirtöku sem verjanda sakbornings.<br /><br />Fyrirtaka mun fara fram ${formatDate(
     courtDate,
     'PPPPp',
   )
@@ -253,9 +248,7 @@ export function formatDefenderCourtDateEmailNotification(
     ?.replace(
       ' kl.',
       ', kl.',
-    )}.<br /><br />Málsnúmer: ${courtCaseNumber}.<br /><br />Dómsalur: ${courtRoom}.<br /><br />Sakborningur: ${accusedName}, kt. ${formatNationalId(
-    accusedNationalId,
-  )}.<br /><br />Dómstóllinn hefur skráð þig sem verjanda sakbornings.`
+    )}.<br /><br />Málsnúmer: ${courtCaseNumber}.<br /><br />Dómsalur: ${courtRoom}.`
 }
 
 export function formatCourtDateNotificationCondition(

--- a/apps/judicial-system/backend/src/app/modules/notification/notification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/notification.service.ts
@@ -313,9 +313,6 @@ export class NotificationService {
 
     const subject = `Fyrirtaka í máli ${existingCase.courtCaseNumber}`
     const html = formatDefenderCourtDateEmailNotification(
-      existingCase.type,
-      existingCase.accusedNationalId,
-      existingCase.accusedName,
       existingCase.court,
       existingCase.courtCaseNumber,
       existingCase.courtDate,


### PR DESCRIPTION
# Removes case type and accused info from defender email

https://app.asana.com/0/1199153462262248/1199133898379444

## What

☝️ 

## Why

Sometimes, the removed info is too sensitive when the email is sent.

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/795382/110465241-15a8cd80-80cc-11eb-8ba5-68b09052e51e.png)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
