### PR TITLE
feat(data-protection-complaint): Add custom field repeater and start commission screen

### DIFF
--- a/libs/application/templates/data-protection-complaint/src/fields/CommissionFieldRepeater/CommissionFieldRepeater.treat.ts
+++ b/libs/application/templates/data-protection-complaint/src/fields/CommissionFieldRepeater/CommissionFieldRepeater.treat.ts
@@ -1,0 +1,7 @@
+import { theme } from 'libs/island-ui/theme/src'
+import { style } from 'treat'
+
+export const removeFieldButton = style({
+  top: 3,
+  left: -theme.spacing['5'],
+})

--- a/libs/application/templates/data-protection-complaint/src/fields/CommissionFieldRepeater/CommissionFieldRepeater.tsx
+++ b/libs/application/templates/data-protection-complaint/src/fields/CommissionFieldRepeater/CommissionFieldRepeater.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FC, useEffect } from 'react'
 import { useLocale } from '@island.is/localization'
 import { FieldBaseProps, formatText } from '@island.is/application/core'
 import { InputController } from '@island.is/shared/form-fields'
@@ -26,6 +26,11 @@ export const CommissionFieldRepeater: FC<FieldBaseProps> = ({
   const { id, title } = field
   const { formatMessage } = useLocale()
   const { fields, append, remove } = useFieldArray<PersonField>({ name: id })
+
+  useEffect(() => {
+    // The repeater should include one line by default
+    if (fields.length === 0) handleAddPerson()
+  }, [fields])
 
   const handleAddPerson = () =>
     append({

--- a/libs/application/templates/data-protection-complaint/src/fields/CommissionFieldRepeater/CommissionFieldRepeater.tsx
+++ b/libs/application/templates/data-protection-complaint/src/fields/CommissionFieldRepeater/CommissionFieldRepeater.tsx
@@ -1,0 +1,114 @@
+import React, { FC } from 'react'
+import { useLocale } from '@island.is/localization'
+import { FieldBaseProps, formatText } from '@island.is/application/core'
+import { InputController } from '@island.is/shared/form-fields'
+import {
+  Box,
+  Text,
+  GridColumn,
+  GridRow,
+  Button,
+} from '@island.is/island-ui/core'
+import { useFieldArray } from 'react-hook-form'
+import * as styles from './CommissionFieldRepeater.treat'
+import { info } from '../../lib/messages'
+
+type PersonField = {
+  name: string
+  nationalId: string
+}
+
+export const CommissionFieldRepeater: FC<FieldBaseProps> = ({
+  application,
+  errors,
+  field,
+}) => {
+  const { id, title } = field
+  const { formatMessage } = useLocale()
+  const { fields, append, remove } = useFieldArray<PersonField>({ name: id })
+
+  const handleAddPerson = () =>
+    append({
+      name: '',
+      nationalId: '',
+    })
+  const handleRemovePerson = (index: number) => remove(index)
+
+  return (
+    <Box marginTop={5}>
+      {fields.map((field, index) => {
+        return (
+          <Box position="relative" key={field.id} marginTop={3}>
+            {index > 0 && (
+              <Box position="absolute" className={styles.removeFieldButton}>
+                <Button
+                  variant="ghost"
+                  size="small"
+                  circle
+                  icon="remove"
+                  onClick={handleRemovePerson.bind(null, index)}
+                />
+              </Box>
+            )}
+            <Text variant="h4" marginBottom={3}>
+              {formatText(title, application, formatMessage)}{' '}
+              {index > 0 ? index + 1 : ''}
+            </Text>
+            <GridRow>
+              <GridColumn span={['1/1', '1/2']}>
+                <InputController
+                  id={`${id}[${index}].name`}
+                  name={`${id}[${index}].name`}
+                  label={formatText(
+                    info.labels.name,
+                    application,
+                    formatMessage,
+                  )}
+                  error={errors && (errors[`${id}[${index}].name`] as string)}
+                  backgroundColor="blue"
+                />
+              </GridColumn>
+              <GridColumn span={['1/1', '1/2']}>
+                <InputController
+                  id={`${id}[${index}].nationalId`}
+                  name={`${id}[${index}].nationalId`}
+                  label={formatText(
+                    info.labels.nationalId,
+                    application,
+                    formatMessage,
+                  )}
+                  error={
+                    errors && (errors[`${id}[${index}].nationalId`] as string)
+                  }
+                  backgroundColor="blue"
+                />
+              </GridColumn>
+            </GridRow>
+          </Box>
+        )
+      })}
+      <Box marginTop={3}>
+        <Text marginBottom={3}>
+          {formatText(
+            info.labels.commissionsAddMoreDescription,
+            application,
+            formatMessage,
+          )}
+        </Text>
+        <Button
+          variant="ghost"
+          icon="add"
+          iconType="outline"
+          onClick={handleAddPerson}
+          size="small"
+        >
+          {formatText(
+            info.labels.commissionsAddMoreButtonLabel,
+            application,
+            formatMessage,
+          )}
+        </Button>
+      </Box>
+    </Box>
+  )
+}

--- a/libs/application/templates/data-protection-complaint/src/fields/CommissionFieldRepeater/index.ts
+++ b/libs/application/templates/data-protection-complaint/src/fields/CommissionFieldRepeater/index.ts
@@ -1,2 +1,1 @@
-export { FieldAlertMessage } from './FieldAlertMessage'
 export { CommissionFieldRepeater } from './CommissionFieldRepeater'

--- a/libs/application/templates/data-protection-complaint/src/forms/ComplaintForm.ts
+++ b/libs/application/templates/data-protection-complaint/src/forms/ComplaintForm.ts
@@ -352,6 +352,7 @@ export const ComplaintForm: Form = buildForm({
                   id: 'commissions.persons',
                   title: info.labels.commissionsPerson,
                   component: 'CommissionFieldRepeater',
+                  defaultValue: [{ name: '', nationalId: '' }],
                 }),
               ],
             }),

--- a/libs/application/templates/data-protection-complaint/src/forms/ComplaintForm.ts
+++ b/libs/application/templates/data-protection-complaint/src/forms/ComplaintForm.ts
@@ -10,17 +10,25 @@ import {
   buildCustomField,
   FormValue,
   buildSubSection,
+  buildFileUploadField,
 } from '@island.is/application/core'
-import { YES } from '../shared'
-import { section, delimitation, errorCards, info } from '../lib/messages'
+import { FILE_SIZE_LIMIT, YES } from '../shared'
+import {
+  section,
+  delimitation,
+  errorCards,
+  info,
+  application,
+  sharedFields,
+} from '../lib/messages'
 import { OnBehalf } from '../lib/dataSchema'
 
-const yesOption = { value: 'yes', label: 'Já' }
-const noOption = { value: 'no', label: 'Nei' }
+const yesOption = { value: 'yes', label: sharedFields.yes }
+const noOption = { value: 'no', label: sharedFields.no }
 
 export const ComplaintForm: Form = buildForm({
   id: 'DataProtectionComplaintForm',
-  title: 'Atvinnuleysisbætur',
+  title: application.name,
   mode: FormModes.APPLYING,
   children: [
     buildSection({
@@ -43,14 +51,22 @@ export const ComplaintForm: Form = buildForm({
                   largeButtons: true,
                   width: 'half',
                 }),
-                buildCustomField({
-                  component: 'FieldAlertMessage',
-                  id: 'inCourtProceedingsAlert',
-                  title: errorCards.inCourtProceedingsTitle,
-                  description: errorCards.inCourtProceedingsDescription,
-                  condition: (formValue) =>
-                    formValue.inCourtProceedings === YES,
-                }),
+                buildCustomField(
+                  {
+                    component: 'FieldAlertMessage',
+                    id: 'inCourtProceedingsAlert',
+                    title: errorCards.inCourtProceedingsTitle,
+                    description: errorCards.inCourtProceedingsDescription,
+                    // TODO: The application system is not passing props down to custom components
+                    // Use defaultValue as a workaround until that gets fixed
+                    defaultValue: 'https://example.com/',
+                    condition: (formValue) =>
+                      formValue.inCourtProceedings === YES,
+                  },
+                  {
+                    url: 'https://example.com/',
+                  },
+                ),
               ],
             }),
           ],
@@ -187,7 +203,7 @@ export const ComplaintForm: Form = buildForm({
           id: 'applicant',
           title: section.applicant.defaultMessage,
           condition: (formValue) => {
-            const onBehalf = (formValue.info as FormValue).onBehalf
+            const onBehalf = (formValue.info as FormValue)?.onBehalf
             return (
               onBehalf === OnBehalf.MYSELF ||
               onBehalf === OnBehalf.MYSELF_AND_OR_OTHERS
@@ -310,19 +326,32 @@ export const ComplaintForm: Form = buildForm({
           id: 'commissions',
           title: section.commissions.defaultMessage,
           condition: (formValue) => {
-            const onBehalf = (formValue.info as FormValue).onBehalf
+            const onBehalf = (formValue.info as FormValue)?.onBehalf
             return onBehalf === OnBehalf.MYSELF_AND_OR_OTHERS
           },
           children: [
             buildMultiField({
-              title: 'Umboð',
-              description: 'Lýsing',
+              id: 'comissionsSection',
+              title: info.general.commissionsPageTitle,
+              // TODO: We probably need a custom component for the description
+              // so we can include the document link
+              description: info.general.commissionsPageDescription,
               children: [
-                buildTextField({
-                  id: 'commissions.name',
-                  title: info.labels.name,
-                  backgroundColor: 'blue',
-                  width: 'half',
+                buildFileUploadField({
+                  id: 'commissions.documents',
+                  title: '',
+                  introduction: '',
+                  maxSize: FILE_SIZE_LIMIT,
+                  uploadHeader: info.labels.commissionsDocumentsHeader,
+                  uploadDescription:
+                    info.labels.commissionsDocumentsDescription,
+                  uploadButtonLabel:
+                    info.labels.commissionsDocumentsButtonLabel,
+                }),
+                buildCustomField({
+                  id: 'commissions.persons',
+                  title: info.labels.commissionsPerson,
+                  component: 'CommissionFieldRepeater',
                 }),
               ],
             }),

--- a/libs/application/templates/data-protection-complaint/src/lib/dataSchema.ts
+++ b/libs/application/templates/data-protection-complaint/src/lib/dataSchema.ts
@@ -10,6 +10,12 @@ export enum OnBehalf {
   ORGANIZATION_OR_INSTITUTION = 'organizationOrInsititution',
 }
 
+const FileSchema = z.object({
+  name: z.string(),
+  key: z.string(),
+  url: z.string(),
+})
+
 export const DataProtectionComplaintSchema = z.object({
   inCourtProceedings: z.enum([YES, NO]).refine((p) => p === NO, {
     message: error.inCourtProceedings.defaultMessage,
@@ -58,5 +64,18 @@ export const DataProtectionComplaintSchema = z.object({
     city: z.string().nonempty(),
     email: z.string().email().optional(),
     phoneNumber: z.string().optional(),
+  }),
+  commissions: z.object({
+    documents: z.array(FileSchema),
+    persons: z
+      .array(
+        z.object({
+          name: z.string().nonempty(),
+          nationalId: z
+            .string()
+            .refine((x) => (x ? kennitala.isPerson(x) : false)),
+        }),
+      )
+      .nonempty(),
   }),
 })

--- a/libs/application/templates/data-protection-complaint/src/lib/messages/application.ts
+++ b/libs/application/templates/data-protection-complaint/src/lib/messages/application.ts
@@ -53,7 +53,7 @@ export const section = defineMessages({
   },
   organizationOrInstitution: {
     id: 'dpac.application:section.organizationOrInstitution',
-    defaultMessage: 'Upplýsingar um félagasamtök / stofnun',
+    defaultMessage: 'Félagasamtök / stofnun',
     description: 'Details about the organizationOrInstitution',
   },
   commissions: {
@@ -75,5 +75,23 @@ export const section = defineMessages({
     id: 'dpac.application:section.received',
     defaultMessage: 'Staðfesting',
     description: 'Application Received',
+  },
+})
+
+export const sharedFields = defineMessages({
+  moreInfoButtonLabel: {
+    id: 'dpac.application:sharedFields.moreInfoButtonLabel',
+    defaultMessage: 'Nánari upplýsingar hér',
+    description: 'More Info Button Label',
+  },
+  yes: {
+    id: 'dpac.application:sharedFields.yes',
+    defaultMessage: 'Já',
+    description: 'Used to give an affirmative response',
+  },
+  no: {
+    id: 'dpac.application:sharedFields.no',
+    defaultMessage: 'Nei',
+    description: 'Used to give a negative response',
   },
 })

--- a/libs/application/templates/data-protection-complaint/src/lib/messages/delimitation.ts
+++ b/libs/application/templates/data-protection-complaint/src/lib/messages/delimitation.ts
@@ -1,6 +1,5 @@
 import { defineMessages } from 'react-intl'
 
-// Confirmation
 export const delimitation = {
   general: defineMessages({
     pageTitle: {

--- a/libs/application/templates/data-protection-complaint/src/lib/messages/info.ts
+++ b/libs/application/templates/data-protection-complaint/src/lib/messages/info.ts
@@ -1,6 +1,5 @@
 import { defineMessages } from 'react-intl'
 
-// Confirmation
 export const info = {
   general: defineMessages({
     pageTitle: {
@@ -33,6 +32,17 @@ export const info = {
         'dpac.application:section.info.organizationOrInstitutionPageDescription',
       defaultMessage: 'Vinsamlegast fylltu út uppýsingar',
       description: 'Organization or Institution page description',
+    },
+    commissionsPageTitle: {
+      id: 'dpac.application:section.info.commissionsPageTitle',
+      defaultMessage: 'Umboð og upplýsingar fyrir annan en sjálfan þig',
+      description: 'Commissions page title',
+    },
+    commissionsPageDescription: {
+      id: 'dpac.application:section.info.commissionsPageDescriptions',
+      defaultMessage: `Til þess að senda inn kvörtun fyrir annan en þig sjálfan þarft þú skila inn umboðskjali. Þegar þú hefur fyllt út umboðsskjalið þá þarftu að hlaða því upp hér.
+      Þú getur sótt umboðsskjal hér til útfyllingar.`,
+      description: 'Commissions page description',
     },
   }),
   labels: defineMessages({
@@ -95,6 +105,36 @@ export const info = {
       id: 'dpac.application:section.info.organizationOrInstitutionName',
       defaultMessage: 'Nafn félagssamtaka',
       description: 'Organization or institution name',
+    },
+    commissionsDocumentsHeader: {
+      id: 'dpac.application:section.info.commissionsDocumentsHeader',
+      defaultMessage: 'Dragðu skjöl hingað til að hlaða upp',
+      description: 'Header of the commissions file upload field',
+    },
+    commissionsDocumentsDescription: {
+      id: 'dpac.application:section.info.commissionsDocumentsDescription',
+      defaultMessage: 'Tekið er við skjölum með endingu: .pdf, .docx, .rtf',
+      description: 'Description of the commissions file upload field',
+    },
+    commissionsDocumentsButtonLabel: {
+      id: 'dpac.application:section.info.commissionsDocumentsButtonLabel',
+      defaultMessage: 'Velja skjöl til að hlaða upp',
+      description: 'Label of the commissions file upload field button',
+    },
+    commissionsPerson: {
+      id: 'dpac.application:section.info.commissionsPerson',
+      defaultMessage: 'Upplýsingar um umbjóðanda',
+      description: 'Commission person repeater field',
+    },
+    commissionsAddMoreDescription: {
+      id: 'dpac.application:section.info.commissionsAddMoreDescription',
+      defaultMessage: 'Eru fleiri umbjóðendur að baki kvörtunar?',
+      description: 'Commission Add More Description',
+    },
+    commissionsAddMoreButtonLabel: {
+      id: 'dpac.application:section.info.commissionsAddMoreButtonLabel',
+      defaultMessage: 'Bæta við aðila',
+      description: 'Commissions add more button label',
     },
   }),
 }

--- a/libs/application/templates/data-protection-complaint/src/shared/constants.ts
+++ b/libs/application/templates/data-protection-complaint/src/shared/constants.ts
@@ -4,3 +4,5 @@ export const NO = 'no'
 export enum API_MODULE {
   sendApplication = 'sendApplication',
 }
+
+export const FILE_SIZE_LIMIT = 10000000


### PR DESCRIPTION
# \<Custom Field Repeater, Commission screen\>

## What

Add Custom FieldRepeater to form
Start work on commission screen

## Why

Design calls for repeatable fields that require a custom component

## Screenshots / Gifs

![2021-03-09 13_44_36-Window](https://user-images.githubusercontent.com/20952302/110479730-a1772580-80dd-11eb-9fac-c9e084b83ab8.png)
![2021-03-09 13_43_49-Window](https://user-images.githubusercontent.com/20952302/110479741-a340e900-80dd-11eb-89d6-070abedcca07.png)
![2021-03-09 13_44_10-Window](https://user-images.githubusercontent.com/20952302/110479746-a4721600-80dd-11eb-86c4-fe01312e7015.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
