### PR TITLE
fix(web): AlertBanner link not required and uses LinkResolver

### DIFF
--- a/apps/web/layouts/main.tsx
+++ b/apps/web/layouts/main.tsx
@@ -260,8 +260,13 @@ const Layout: NextComponentType<
             title={alertBannerContent.title}
             description={alertBannerContent.description}
             link={{
-              href: alertBannerContent.link.url,
-              title: alertBannerContent.link.text,
+              ...(!!alertBannerContent.link &&
+                !!alertBannerContent.linkTitle && {
+                  href: linkResolver(alertBannerContent.link.type as LinkType, [
+                    alertBannerContent.link.slug,
+                  ]).href,
+                  title: alertBannerContent.linkTitle,
+                }),
             }}
             variant={alertBannerContent.bannerVariant as AlertBannerVariants}
             dismissable={alertBannerContent.isDismissable}

--- a/apps/web/screens/queries/AlertBanner.tsx
+++ b/apps/web/screens/queries/AlertBanner.tsx
@@ -7,9 +7,10 @@ export const GET_ALERT_BANNER_QUERY = gql`
       bannerVariant
       title
       description
+      linkTitle
       link {
-        text
-        url
+        slug
+        type
       }
       isDismissable
       dismissedForDays

--- a/libs/api/domains/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/api/domains/cms/src/lib/generated/contentfulTypes.d.ts
@@ -698,6 +698,9 @@ export interface IFeaturedArticlesFields {
 
   /** Link */
   link?: ILink | undefined
+
+  /** Application Label */
+  applicationLabel: string
 }
 
 export interface IFeaturedArticles extends Entry<IFeaturedArticlesFields> {
@@ -1863,8 +1866,23 @@ export interface IOrganizationPageFields {
   /** Description */
   description?: string | undefined
 
+  /** Theme */
+  theme: 'default' | 'syslumenn' | 'digital_iceland'
+
   /** Slices */
-  slices?: (IDistricts | IFeaturedArticles)[] | undefined
+  slices?:
+    | (
+        | IBigBulletList
+        | IDistricts
+        | IMailingListSignup
+        | IFeaturedArticles
+        | ISectionHeading
+        | ILogoListSlice
+        | IStorySection
+        | ITabSection
+        | ITimeline
+      )[]
+    | undefined
 
   /** Menu Links */
   menuLinks?: ILinkGroup[] | undefined
@@ -1875,8 +1893,14 @@ export interface IOrganizationPageFields {
   /** Featured Image */
   featuredImage?: Asset | undefined
 
+  /** Sidebar Cards */
+  sidebarCards?: ISidebarCard[] | undefined
+
   /** Footer Items */
   footerItems?: IFooterItem[] | undefined
+
+  /** Theme Properties */
+  themeProperties?: Record<string, any> | undefined
 }
 
 export interface IOrganizationPage extends Entry<IOrganizationPageFields> {
@@ -1913,9 +1937,12 @@ export interface IOrganizationSubpageFields {
   slices?:
     | (
         | IAccordionSlice
+        | IContactUs
         | IDistricts
         | IOffices
         | IOneColumnText
+        | ITeamList
+        | ITellUsAStory
         | ITwoColumnText
       )[]
     | undefined
@@ -2322,6 +2349,37 @@ export interface ISectionWithImage extends Entry<ISectionWithImageFields> {
     contentType: {
       sys: {
         id: 'sectionWithImage'
+        linkType: 'ContentType'
+        type: 'Link'
+      }
+    }
+  }
+}
+
+export interface ISidebarCardFields {
+  /** Type */
+  type?: 'info' | 'warning' | undefined
+
+  /** Title */
+  title?: string | undefined
+
+  /** Content */
+  content?: string | undefined
+
+  /** Link */
+  link?: ILink | undefined
+}
+
+export interface ISidebarCard extends Entry<ISidebarCardFields> {
+  sys: {
+    id: string
+    type: string
+    createdAt: string
+    updatedAt: string
+    locale: string
+    contentType: {
+      sys: {
+        id: 'sidebarCard'
         linkType: 'ContentType'
         type: 'Link'
       }
@@ -3342,6 +3400,7 @@ export type CONTENT_TYPE =
   | 'questionAndAnswer'
   | 'sectionHeading'
   | 'sectionWithImage'
+  | 'sidebarCard'
   | 'sideMenu'
   | 'sliceConnectedComponent'
   | 'statistic'

--- a/libs/api/domains/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/api/domains/cms/src/lib/generated/contentfulTypes.d.ts
@@ -91,8 +91,22 @@ export interface IAlertBannerFields {
   /** description */
   description?: string | undefined
 
-  /** link */
-  link?: ILink | undefined
+  /** Link title */
+  linkTitle?: string | undefined
+
+  /** Link */
+  link?:
+    | IAboutSubPage
+    | IArticle
+    | IArticleCategory
+    | ISubArticle
+    | ILifeEventPage
+    | ILinkUrl
+    | INews
+    | IPage
+    | IVidspyrnaFrontpage
+    | IVidspyrnaPage
+    | undefined
 
   /** Is dismissable */
   isDismissable: boolean
@@ -343,9 +357,6 @@ export interface IAuctionFields {
 
   /** Content */
   content?: Document | undefined
-
-  /** Content Old */
-  contentOld?: string | undefined
 
   /** Organization */
   organization: IOrganization
@@ -715,9 +726,6 @@ export interface IFooterItemFields {
 
   /** Content */
   content?: Document | undefined
-
-  /** Content Old */
-  contentOld?: string | undefined
 }
 
 export interface IFooterItem extends Entry<IFooterItemFields> {
@@ -739,16 +747,13 @@ export interface IFooterItem extends Entry<IFooterItemFields> {
 
 export interface IFrontpageFields {
   /** Title */
-  title?: string | undefined
+  title: string
 
   /** Featured */
   featured?: IFeatured[] | undefined
 
   /** Slides */
   slides?: IFrontpageSlider[] | undefined
-
-  /** Namespace */
-  namespace?: IUiConfiguration | undefined
 
   /** Life Events */
   lifeEvents?: ILifeEventPage[] | undefined
@@ -1744,9 +1749,6 @@ export interface IOneColumnTextFields {
   /** Title */
   title: string
 
-  /** Content Old */
-  contentOld?: string | undefined
-
   /** Content */
   content?: Document | undefined
 
@@ -1901,9 +1903,6 @@ export interface IOrganizationSubpageFields {
   /** Slug */
   slug: string
 
-  /** Description Old */
-  descriptionOld?: string | undefined
-
   /** Description */
   description?: Document | undefined
 
@@ -1912,7 +1911,13 @@ export interface IOrganizationSubpageFields {
 
   /** Slices */
   slices?:
-    | (IDistricts | IOffices | IOneColumnText | ITwoColumnText)[]
+    | (
+        | IAccordionSlice
+        | IDistricts
+        | IOffices
+        | IOneColumnText
+        | ITwoColumnText
+      )[]
     | undefined
 
   /** Slice Custom Renderer */
@@ -2383,40 +2388,6 @@ export interface ISliceConnectedComponent
     contentType: {
       sys: {
         id: 'sliceConnectedComponent'
-        linkType: 'ContentType'
-        type: 'Link'
-      }
-    }
-  }
-}
-
-export interface IStaffCardFields {
-  /** Name */
-  name: string
-
-  /** Intro */
-  intro?: string | undefined
-
-  /** Email */
-  email?: string | undefined
-
-  /** Phone */
-  phone?: string | undefined
-
-  /** Logo */
-  logo?: Asset | undefined
-}
-
-export interface IStaffCard extends Entry<IStaffCardFields> {
-  sys: {
-    id: string
-    type: string
-    createdAt: string
-    updatedAt: string
-    locale: string
-    contentType: {
-      sys: {
-        id: 'staffCard'
         linkType: 'ContentType'
         type: 'Link'
       }
@@ -2958,9 +2929,6 @@ export interface ITwoColumnTextFields {
   /** Left Title */
   leftTitle?: string | undefined
 
-  /** Left Content Old */
-  leftContentOld?: string | undefined
-
   /** Left Content */
   leftContent?: Document | undefined
 
@@ -2969,9 +2937,6 @@ export interface ITwoColumnTextFields {
 
   /** Right Title */
   rightTitle?: string | undefined
-
-  /** Right Content Old */
-  rightContentOld?: string | undefined
 
   /** Right Content */
   rightContent?: Document | undefined
@@ -3379,7 +3344,6 @@ export type CONTENT_TYPE =
   | 'sectionWithImage'
   | 'sideMenu'
   | 'sliceConnectedComponent'
-  | 'staffCard'
   | 'statistic'
   | 'statistics'
   | 'story'

--- a/libs/api/domains/cms/src/lib/models/alertBanner.model.ts
+++ b/libs/api/domains/cms/src/lib/models/alertBanner.model.ts
@@ -23,7 +23,7 @@ export class AlertBanner {
   linkTitle?: string
 
   @Field(() => ReferenceLink, { nullable: true })
-  link: ReferenceLink
+  link?: ReferenceLink | null
 
   @Field()
   isDismissable!: boolean

--- a/libs/api/domains/cms/src/lib/models/alertBanner.model.ts
+++ b/libs/api/domains/cms/src/lib/models/alertBanner.model.ts
@@ -1,6 +1,6 @@
 import { Field, ObjectType, ID, Int } from '@nestjs/graphql'
 import { IAlertBanner } from '../generated/contentfulTypes'
-import { Link, mapLink } from './link.model'
+import { mapReferenceLink, ReferenceLink } from './referenceLink.model'
 
 @ObjectType()
 export class AlertBanner {
@@ -19,8 +19,11 @@ export class AlertBanner {
   @Field({ nullable: true })
   description?: string
 
-  @Field(() => Link, { nullable: true })
-  link?: Link | null
+  @Field({ nullable: true })
+  linkTitle?: string
+
+  @Field(() => ReferenceLink, { nullable: true })
+  link: ReferenceLink
 
   @Field()
   isDismissable!: boolean
@@ -35,7 +38,8 @@ export const mapAlertBanner = ({ fields, sys }: IAlertBanner): AlertBanner => ({
   bannerVariant: fields.bannerVariant ?? 'default',
   title: fields.title ?? '',
   description: fields.description ?? '',
-  link: fields.link ? mapLink(fields.link) : null,
+  linkTitle: fields.linkTitle ?? '',
+  link: fields.link ? mapReferenceLink(fields.link) : null,
   isDismissable: fields.isDismissable ?? true,
   dismissedForDays: fields.dismissedForDays ?? 7,
 })

--- a/libs/api/mocks/src/domains/cms/factories.ts
+++ b/libs/api/mocks/src/domains/cms/factories.ts
@@ -143,7 +143,7 @@ export const alertBanner = factory<AlertBanner>({
   description: () => faker.lorem.sentence(),
   isDismissable: () => faker.random.boolean(),
   dismissedForDays: 7,
-  link: () => link(),
+  link: () => referenceLink(),
   bannerVariant: () => alertBannerVariant(),
   showAlertBanner: () => faker.random.boolean(),
 })


### PR DESCRIPTION
## What

- If there is no link (and link title) provided it will simply not appear in the AlertBanner.
- Made the link use the LinkResolver

## Why

AlertBanner was broken when there was no link (or there was a link but the reference to it was removed). 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
