### PR TITLE
feature(health-insurance): Disabled hide on click outside for error modal

### DIFF
--- a/libs/application/templates/health-insurance/src/fields/ErrorModal/ErrorModal.tsx
+++ b/libs/application/templates/health-insurance/src/fields/ErrorModal/ErrorModal.tsx
@@ -36,7 +36,7 @@ const ErrorModal: FC<FieldBaseProps> = ({ application }) => {
       initialVisibility={true}
       className={`${styles.dialog} ${styles.background} ${styles.center}`}
       modalLabel="Error prompt"
-      // hideOnClickOutside={false}
+      hideOnClickOutside={false}
     >
       {({ closeModal }: { closeModal: () => void }) => (
         <Box


### PR DESCRIPTION
# Disabled hide on click outside for error modal

## What

Disabled hide on click outside for error modal

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
