### PR TITLE
fix(island-ui): Reset grid offset

### DIFF
--- a/libs/island-ui/core/src/lib/Grid/Grid.stories.tsx
+++ b/libs/island-ui/core/src/lib/Grid/Grid.stories.tsx
@@ -143,45 +143,55 @@ export const Order = () => (
 )
 
 export const Offsets = () => (
-  <>
-    <Box paddingY={1}>
-      <GridContainer>
-        <GridRow>
-          <GridColumn span="1/12" offset="11/12">
-            <DemoBox text="offset 11" />
-          </GridColumn>
-          <GridColumn span="2/12" offset="10/12">
-            <DemoBox text="offset 10" />
-          </GridColumn>
-          <GridColumn span="3/12" offset="9/12">
-            <DemoBox text="offset 9" />
-          </GridColumn>
-          <GridColumn span="4/12" offset="8/12">
-            <DemoBox text="offset 8" />
-          </GridColumn>
-          <GridColumn span="5/12" offset="7/12">
-            <DemoBox text="offset 7" />
-          </GridColumn>
-          <GridColumn span="6/12" offset="6/12">
-            <DemoBox text="offset 6" />
-          </GridColumn>
-          <GridColumn span="7/12" offset="5/12">
-            <DemoBox text="offset 5" />
-          </GridColumn>
-          <GridColumn span="8/12" offset="4/12">
-            <DemoBox text="offset 4" />
-          </GridColumn>
-          <GridColumn span="9/12" offset="3/12">
-            <DemoBox text="offset 3" />
-          </GridColumn>
-          <GridColumn span="10/12" offset="2/12">
-            <DemoBox text="offset 2" />
-          </GridColumn>
-          <GridColumn span="11/12" offset="1/12">
-            <DemoBox text="offset 1" />
-          </GridColumn>
-        </GridRow>
-      </GridContainer>
-    </Box>
-  </>
+  <Box paddingY={1}>
+    <GridContainer>
+      <GridRow>
+        <GridColumn span="1/12" offset="11/12">
+          <DemoBox text="offset 11" />
+        </GridColumn>
+        <GridColumn span="2/12" offset="10/12">
+          <DemoBox text="offset 10" />
+        </GridColumn>
+        <GridColumn span="3/12" offset="9/12">
+          <DemoBox text="offset 9" />
+        </GridColumn>
+        <GridColumn span="4/12" offset="8/12">
+          <DemoBox text="offset 8" />
+        </GridColumn>
+        <GridColumn span="5/12" offset="7/12">
+          <DemoBox text="offset 7" />
+        </GridColumn>
+        <GridColumn span="6/12" offset="6/12">
+          <DemoBox text="offset 6" />
+        </GridColumn>
+        <GridColumn span="7/12" offset="5/12">
+          <DemoBox text="offset 5" />
+        </GridColumn>
+        <GridColumn span="8/12" offset="4/12">
+          <DemoBox text="offset 4" />
+        </GridColumn>
+        <GridColumn span="9/12" offset="3/12">
+          <DemoBox text="offset 3" />
+        </GridColumn>
+        <GridColumn span="10/12" offset="2/12">
+          <DemoBox text="offset 2" />
+        </GridColumn>
+        <GridColumn span="11/12" offset="1/12">
+          <DemoBox text="offset 1" />
+        </GridColumn>
+      </GridRow>
+    </GridContainer>
+  </Box>
+)
+
+export const ResponsiveOffset = () => (
+  <Box paddingY={1}>
+    <GridContainer>
+      <GridRow>
+        <GridColumn span="5/12" offset={['7/12', '4/12', '0']}>
+          <DemoBox text="['7/12', '4/12', '0']" />
+        </GridColumn>
+      </GridRow>
+    </GridContainer>
+  </Box>
 )

--- a/libs/island-ui/core/src/lib/Grid/GridColumn/GridColumn.treat.ts
+++ b/libs/island-ui/core/src/lib/Grid/GridColumn/GridColumn.treat.ts
@@ -81,6 +81,7 @@ const ColumnRange = [
   '2/2',
   '1/2',
   '1/1',
+  '0',
 ] as const
 const orderRange = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const
 export type Order = typeof orderRange[number]
@@ -94,6 +95,9 @@ const order = orderRange.reduce((acc: Record<string, number>, o) => {
 }, {})
 const columns = ColumnRange.reduce((acc, column) => {
   const range = column.split('/')
+  if (column === '0') {
+    acc[column] = '0'
+  }
   if (range.length !== 2 || isNaN(parseInt(range[0]) / parseInt(range[1]))) {
     return acc
   }


### PR DESCRIPTION
# Reset grid offset

## What

Adding '0' to columns to fix offset reset for breakpoints

## Why

When offset was set to '0' in breakpoints above mobile it was not reset

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
