### PR TITLE
feat(web): Add type for components to signal they accept `NoChildren`

### DIFF
--- a/apps/web/components/Image/Image.tsx
+++ b/apps/web/components/Image/Image.tsx
@@ -3,6 +3,7 @@ import cn from 'classnames'
 import { Image as ApiImage } from '@island.is/web/graphql/schema'
 
 import * as styles from './Image.treat'
+import { NoChildren } from '../../types'
 
 export type CustomImage = {
   type: 'custom'
@@ -49,7 +50,7 @@ const useImageLoader = (url: string): boolean => {
   return loaded
 }
 
-export const Image: FC<AnyImageType> = (image) => {
+export const Image: FC<AnyImageType & NoChildren> = (image) => {
   const { src, thumbnail, alt, originalWidth, originalHeight } = normalizeImage(
     image,
   )

--- a/apps/web/components/SubpageDetailsContent/SubpageDetailsContent.tsx
+++ b/apps/web/components/SubpageDetailsContent/SubpageDetailsContent.tsx
@@ -1,5 +1,6 @@
 import React, { FC, ReactNode } from 'react'
 import { Box, GridContainer, ResponsiveSpace } from '@island.is/island-ui/core'
+import { NoChildren } from '@island.is/web/types'
 
 interface SubpageDetailsProps {
   header: ReactNode
@@ -7,7 +8,7 @@ interface SubpageDetailsProps {
   paddingBottom?: ResponsiveSpace
 }
 
-export const SubpageDetailsContent: FC<SubpageDetailsProps> = ({
+export const SubpageDetailsContent: FC<SubpageDetailsProps & NoChildren> = ({
   header,
   content,
   paddingBottom,

--- a/apps/web/components/SubpageMainContent/SubpageMainContent.tsx
+++ b/apps/web/components/SubpageMainContent/SubpageMainContent.tsx
@@ -5,13 +5,17 @@ import {
   GridRow,
   GridColumn,
 } from '@island.is/island-ui/core'
+import { NoChildren } from '@island.is/web/types'
 
 interface SubpageMainProps {
   main: ReactNode
   image?: ReactNode
 }
 
-export const SubpageMainContent: FC<SubpageMainProps> = ({ main, image }) => {
+export const SubpageMainContent: FC<SubpageMainProps & NoChildren> = ({
+  main,
+  image,
+}) => {
   return (
     <GridContainer>
       <GridRow>

--- a/apps/web/screens/Layouts/Layouts.tsx
+++ b/apps/web/screens/Layouts/Layouts.tsx
@@ -1,5 +1,6 @@
 import React, { FC, ReactNode } from 'react'
 import { Box, GridContainer, ResponsiveSpace } from '@island.is/island-ui/core'
+import { NoChildren } from '@island.is/web/types'
 
 interface SubpageProps {
   main: ReactNode
@@ -8,7 +9,7 @@ interface SubpageProps {
   mainPaddingBottom?: ResponsiveSpace
 }
 
-export const SubpageLayout: FC<SubpageProps> = ({
+export const SubpageLayout: FC<SubpageProps & NoChildren> = ({
   main,
   details,
   paddingTop,

--- a/apps/web/types.tsx
+++ b/apps/web/types.tsx
@@ -13,3 +13,6 @@ export type Screen<Props = {}> = NextComponentType<
   Props,
   Props
 >
+
+/** Type for React Components to signal they don't receive children  */
+export type NoChildren = { children?: undefined }


### PR DESCRIPTION
## What

This introduces an optional prop type to add to components (and a couple of examples of it being used) to signal that they don't accept `children`.

## Why

This way we leverage TypeScript to help developers avoid simple JSX/React mistakes while using our components.

It's nice to get a TS warning when you pass children to a component that has no intention of using/displaying them.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
