### PR TITLE
Zendesk instead of email for contact form

### DIFF
--- a/apps/web/components/ContactUs/ContactUs.tsx
+++ b/apps/web/components/ContactUs/ContactUs.tsx
@@ -3,20 +3,20 @@ import {
   ContactUs as ContactUsForm,
   ContactUsProps as ContactUsFormProps,
 } from '@island.is/island-ui/contentful'
-import { CONTACT_US_MUTATION } from '@island.is/web/screens/queries'
+import { CONTACT_US_ZENDESK_TICKET_MUTATION } from '@island.is/web/screens/queries'
 import { MutationResult, useMutation } from '@apollo/client/react'
 import {
-  ContactUsMutation,
-  ContactUsMutationVariables,
+  ContactUsZendeskTicketMutation,
+  ContactUsZendeskTicketMutationVariables,
 } from '@island.is/web/graphql/schema'
 
 const getState = (
-  data: MutationResult<ContactUsMutation>['data'],
+  data: MutationResult<ContactUsZendeskTicketMutation>['data'],
   loading: MutationResult['loading'],
   error: MutationResult['error'],
 ) => {
-  if (data?.contactUs?.sent === true) return 'success'
-  if (data?.contactUs?.sent === false) return 'error'
+  if (data?.contactUsZendeskTicket?.sent === true) return 'success'
+  if (data?.contactUsZendeskTicket?.sent === false) return 'error'
   if (loading) return 'submitting'
   if (error) return 'error'
   return 'edit'
@@ -28,9 +28,9 @@ interface ContactUsProps
 
 export const ContactUs: FC<ContactUsProps> = (props) => {
   const [submit, { data, loading, error }] = useMutation<
-    ContactUsMutation,
-    ContactUsMutationVariables
-  >(CONTACT_US_MUTATION)
+    ContactUsZendeskTicketMutation,
+    ContactUsZendeskTicketMutationVariables
+  >(CONTACT_US_ZENDESK_TICKET_MUTATION)
   return (
     <ContactUsForm
       {...props}

--- a/apps/web/screens/queries/ContactUs.ts
+++ b/apps/web/screens/queries/ContactUs.ts
@@ -7,3 +7,11 @@ export const CONTACT_US_MUTATION = gql`
     }
   }
 `
+
+export const CONTACT_US_ZENDESK_TICKET_MUTATION = gql`
+  mutation ContactUsZendeskTicket($input: ContactUsInput!) {
+    contactUsZendeskTicket(input: $input) {
+      sent
+    }
+  }
+`

--- a/libs/api/domains/communications/src/lib/communications.resolver.ts
+++ b/libs/api/domains/communications/src/lib/communications.resolver.ts
@@ -27,4 +27,14 @@ export class CommunicationsResolver {
       sent: true,
     }
   }
+
+  @Mutation(() => CommunicationResponse)
+  async contactUsZendeskTicket(
+    @Args('input') input: ContactUsInput,
+  ): Promise<CommunicationResponse> {
+    await this.communicationsService.sendZendeskTicket(input)
+    return {
+      sent: true,
+    }
+  }
 }

--- a/libs/api/domains/communications/src/lib/communications.service.ts
+++ b/libs/api/domains/communications/src/lib/communications.service.ts
@@ -90,7 +90,7 @@ export class CommunicationsService {
 
     // If we did not find an existing user we will create a new one
     if (!user) {
-      let identities = []
+      const identities = []
 
       if (input.phone) {
         identities.push({
@@ -131,7 +131,7 @@ export class CommunicationsService {
     const newTicket = JSON.stringify({
       ticket: {
         requester_id: user.id,
-        subject: input.subject ?? '',
+        subject: input.subject?.trim() ?? '',
         comment: { body: input.message ?? '' },
         tags: ['web'],
       },

--- a/libs/api/domains/communications/src/lib/communications.service.ts
+++ b/libs/api/domains/communications/src/lib/communications.service.ts
@@ -1,4 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common'
+import axios from 'axios'
+import toQueryString from 'to-querystring'
 import { EmailService } from '@island.is/email-service'
 import { Logger, LOGGER_PROVIDER } from '@island.is/logging'
 import { SendMailOptions } from 'nodemailer'
@@ -6,6 +8,9 @@ import { ContactUsInput } from './dto/contactUs.input'
 import { TellUsAStoryInput } from './dto/tellUsAStory.input'
 import { getTemplate as getContactUsTemplate } from './emailTemplates/contactUs'
 import { getTemplate as getTellUsAStoryTemplate } from './emailTemplates/tellUsAStory'
+
+import { environment } from './environments/environment'
+const { zendeskOptions } = environment
 
 type SendEmailInput = ContactUsInput | TellUsAStoryInput
 interface EmailTypeTemplateMap {
@@ -43,5 +48,113 @@ export class CommunicationsService {
       // we dont want the client to see these errors since they might contain sensitive data
       throw new Error('Failed to send message')
     }
+  }
+
+  async sendZendeskTicket(input: ContactUsInput): Promise<boolean> {
+    const api = `https://${zendeskOptions.subdomain}.zendesk.com/api/v2`
+
+    const token = Buffer.from(
+      `${zendeskOptions.email}/token:${zendeskOptions.token}`,
+    ).toString('base64')
+
+    const params = {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Basic ${token}`,
+      },
+    }
+
+    let searchUserResponse
+
+    // First check if a user is found with this email
+    try {
+      searchUserResponse = await axios.get(
+        `${api}/search.json?query=${encodeURIComponent(
+          `type:user "${input.email}"`,
+        )}`,
+        params,
+      )
+    } catch (error) {
+      this.logger.error('Failed to search for user', {
+        message: error.response.data.description,
+      })
+
+      throw new Error(
+        `Failed to search for user: ${error.response.data.description}`,
+      )
+    }
+
+    let user =
+      searchUserResponse.data.results.length > 0 &&
+      searchUserResponse.data.results[0]
+
+    // If we did not find an existing user we will create a new one
+    if (!user) {
+      let identities = []
+
+      if (input.phone) {
+        identities.push({
+          type: 'phone_number',
+          value: input.phone,
+        })
+      }
+
+      const newUser = JSON.stringify({
+        user: {
+          name: input.name,
+          email: input.email,
+          identities,
+        },
+      })
+
+      let createUserResponse
+
+      try {
+        createUserResponse = await axios.post(
+          `${api}/users.json`,
+          newUser,
+          params,
+        )
+      } catch (error) {
+        this.logger.error('Failed to create Zendesk user', {
+          message: error.response.data.description,
+        })
+
+        throw new Error(
+          `Failed to create Zendesk user: ${error.response.data.description}`,
+        )
+      }
+
+      user = createUserResponse.data.user
+    }
+
+    const newTicket = JSON.stringify({
+      ticket: {
+        requester_id: user.id,
+        subject: input.subject ?? '',
+        comment: { body: input.message ?? '' },
+        tags: ['web'],
+      },
+    })
+
+    let createTicketResponse
+
+    try {
+      createTicketResponse = await axios.post(
+        `${api}/tickets.json`,
+        newTicket,
+        params,
+      )
+    } catch (error) {
+      this.logger.error('Failed to submit Zendesk ticket', {
+        message: error.response.data.description,
+      })
+
+      throw new Error(
+        `Failed to submit Zendesk ticket: ${error.response.data.description}`,
+      )
+    }
+
+    return true
   }
 }

--- a/libs/api/domains/communications/src/lib/communications.service.ts
+++ b/libs/api/domains/communications/src/lib/communications.service.ts
@@ -1,6 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common'
 import axios from 'axios'
-import toQueryString from 'to-querystring'
 import { EmailService } from '@island.is/email-service'
 import { Logger, LOGGER_PROVIDER } from '@island.is/logging'
 import { SendMailOptions } from 'nodemailer'
@@ -64,14 +63,14 @@ export class CommunicationsService {
       },
     }
 
+    const email = input.email.trim().toLowerCase()
+
     let searchUserResponse
 
     // First check if a user is found with this email
     try {
       searchUserResponse = await axios.get(
-        `${api}/search.json?query=${encodeURIComponent(
-          `type:user "${input.email}"`,
-        )}`,
+        `${api}/search.json?query=${encodeURIComponent(`email:"${email}"`)}`,
         params,
       )
     } catch (error) {
@@ -102,7 +101,7 @@ export class CommunicationsService {
       const newUser = JSON.stringify({
         user: {
           name: input.name,
-          email: input.email,
+          email,
           identities,
         },
       })

--- a/libs/api/domains/communications/src/lib/environments/environment.ts
+++ b/libs/api/domains/communications/src/lib/environments/environment.ts
@@ -8,4 +8,9 @@ export const environment = {
     contactUsDestination: process.env.CONTACT_US_EMAIL,
     tellUsAStoryDestination: process.env.TELL_US_A_STORY_EMAIL,
   },
+  zendeskOptions: {
+    email: process.env.ZENDESK_CONTACT_FORM_EMAIL,
+    token: process.env.ZENDESK_CONTACT_FORM_TOKEN,
+    subdomain: process.env.ZENDESK_CONTACT_FORM_SUBDOMAIN,
+  },
 }

--- a/libs/island-ui/contentful/src/lib/ContactUs/ContactUs.tsx
+++ b/libs/island-ui/contentful/src/lib/ContactUs/ContactUs.tsx
@@ -145,6 +145,7 @@ export const ContactUs: FC<ContactUsProps> = ({
                       <Button
                         htmlType="submit"
                         loading={state === 'submitting'}
+                        disabled={state === 'submitting'}
                       >
                         {submitButtonText}
                       </Button>


### PR DESCRIPTION
Today the contact form sends a regular email to the island.is support email address. This instead creates a Zendesk ticket and submits it.

First checks if the user with the email exists. If the user does not exist it creates it. Then it submits a ticket with that user as the requester.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
