### PR TITLE
test(health-insurance): add test to check draft util

### DIFF
--- a/libs/application/templates/health-insurance/jest.config.js
+++ b/libs/application/templates/health-insurance/jest.config.js
@@ -1,5 +1,10 @@
 module.exports = {
   preset: '../../../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      babelConfig: true,
+    },
+  },
   transform: {
     '^.+\\.[tj]sx?$': [
       'babel-jest',

--- a/libs/application/templates/health-insurance/src/healthInsuranceUtils.spec.ts
+++ b/libs/application/templates/health-insurance/src/healthInsuranceUtils.spec.ts
@@ -171,13 +171,13 @@ describe('Health insurance utils', () => {
       // assert
       const currentApplicationId = faker.random.uuid()
 
-      window = Object.create(window)
-      Object.defineProperty(window, 'location', {
-        value: {
+      const windowSpy = jest.spyOn(window, "window", "get");
+
+      windowSpy.mockImplementation(() => (({
+        location: {
           pathname: `/umsoknir/sjukratryggingar/${currentApplicationId}`,
-        },
-        writable: true,
-      })
+        }
+      }) as any))
 
       const yesterday = new Date()
       yesterday.setDate(yesterday.getDate() - 1)
@@ -218,6 +218,8 @@ describe('Health insurance utils', () => {
       // arrange
       expect(hasActiveDraft).toEqual(false)
       expect(currentApplicationId).toBe(oldestDraftId)
+
+      windowSpy.mockRestore();
     })
   })
   describe('Getting oldest draft application id', () => {

--- a/libs/application/templates/health-insurance/src/healthInsuranceUtils.spec.ts
+++ b/libs/application/templates/health-insurance/src/healthInsuranceUtils.spec.ts
@@ -23,22 +23,20 @@ describe('health insurance utils', () => {
   }
 
   const createApplication = (
-    answers?: object,
-    typeId?: string,
-    externalData?: any,
-    applicationState = 'draft',
     id = faker.random.uuid(),
+    applicationState = 'draft',
+    externalData?: any,
   ) =>
     (({
       id: id,
       state: applicationState,
       applicant: applicant.nationalId,
       assignees: [],
-      typeId: typeId ?? ApplicationTypes.HEALTH_INSURANCE,
+      typeId: ApplicationTypes.HEALTH_INSURANCE,
       modified: new Date(),
       created: new Date(),
       attachments: {},
-      answers: answers ?? {},
+      answers: {},
       externalData: {
         nationalRegistry:
           externalData?.nationalRegistry ?? undefinedExternalData,
@@ -81,22 +79,16 @@ describe('health insurance utils', () => {
       expect(hasActiveDraftApplication(application.externalData)).toEqual(false)
     })
 
-    it('should return false if there is only one (current) draft in application list', () => {
+    it('should return false if there is only one draft in application list', () => {
       // assert
       const currentApplicationId = faker.random.uuid()
 
       const otherApplications = {
         data: [
-          createApplication(
-            undefined,
-            undefined,
-            undefined,
-            'draft',
-            currentApplicationId,
-          ),
-          createApplication(undefined, undefined, undefined, 'inReview'),
-          createApplication(undefined, undefined, undefined, 'inReview'),
-          createApplication(undefined, undefined, undefined, 'inReview'),
+          createApplication(currentApplicationId, 'draft'),
+          createApplication(undefined, 'inReview'),
+          createApplication(undefined, 'inReview'),
+          createApplication(undefined, 'inReview'),
         ],
         status: 'success',
         date: new Date(),
@@ -107,32 +99,25 @@ describe('health insurance utils', () => {
       }
 
       const application = createApplication(
-        undefined,
+        currentApplicationId,
         undefined,
         externalData,
-        currentApplicationId,
       )
 
       // act and arrange
       expect(hasActiveDraftApplication(application.externalData)).toEqual(false)
     })
 
-    it('should return true if there is more than one drafts in application list and is not active application', () => {
+    it('should return true if there is more than one drafts in application list', () => {
       // assert
       const currentApplicationId = faker.random.uuid()
 
       const otherApplications = {
         data: [
-          createApplication(
-            undefined,
-            undefined,
-            undefined,
-            'draft',
-            currentApplicationId,
-          ),
-          createApplication(undefined, undefined, undefined),
-          createApplication(undefined, undefined, undefined, 'inReview'),
-          createApplication(undefined, undefined, undefined, 'inReview'),
+          createApplication(currentApplicationId, 'draft'),
+          createApplication(),
+          createApplication(undefined, 'inReview'),
+          createApplication(undefined, 'inReview'),
         ],
         status: 'success',
         date: new Date(),
@@ -144,10 +129,9 @@ describe('health insurance utils', () => {
 
       // act
       const application = createApplication(
-        undefined,
+        currentApplicationId,
         undefined,
         externalData,
-        currentApplicationId,
       )
 
       const hasActiveDraft = hasActiveDraftApplication(application.externalData)
@@ -162,7 +146,7 @@ describe('health insurance utils', () => {
       // Check so that we get true
       expect(hasActiveDraft).toEqual(true)
 
-      // check so that the oldest is not the current active.
+      // Check so that the oldest is not the current active.
       expect(currentApplicationId).not.toBe(oldestDraftId)
 
       // Check that we dont use any applications that are not drafts.
@@ -171,10 +155,6 @@ describe('health insurance utils', () => {
           expect.not.objectContaining({
             state: 'inReview',
           }),
-        ]),
-      )
-      expect(drafts).toEqual(
-        expect.arrayContaining([
           expect.objectContaining({
             state: 'draft',
           }),
@@ -182,9 +162,54 @@ describe('health insurance utils', () => {
       )
     })
 
-    // it('should return false if oldest draft is current application', () => {
-    // })
+    it('should return false if oldest draft is current application', () => {
+      // assert
+      const currentApplicationId = faker.random.uuid()
+
+      window = Object.create(window)
+      Object.defineProperty(window, 'location', {
+        value: {
+          pathname: `/umsoknir/sjukratryggingar/${currentApplicationId}`,
+        },
+        writable: true,
+      })
+
+      const otherApplications = {
+        data: [
+          createApplication(),
+          createApplication(undefined, 'inReview'),
+          createApplication(undefined, 'inReview'),
+          createApplication(currentApplicationId, 'draft'),
+        ],
+        status: 'success',
+        date: new Date(),
+      }
+
+      const externalData = {
+        applications: otherApplications,
+      }
+
+      // act
+      const application = createApplication(
+        currentApplicationId,
+        undefined,
+        externalData,
+      )
+
+      const hasActiveDraft = hasActiveDraftApplication(application.externalData)
+
+      const oldestDraftId = getOldestDraftApplicationId(
+        application.externalData?.applications?.data as Applications[],
+      )
+
+      // arrange
+      expect(hasActiveDraft).toEqual(false)
+      expect(currentApplicationId).toBe(oldestDraftId)
+    })
 
     // TODO add test to check that dates are sorted by ascending
+    // it('should return application that was created first', () => {
+
+    // })
   })
 })

--- a/libs/application/templates/health-insurance/src/healthInsuranceUtils.spec.ts
+++ b/libs/application/templates/health-insurance/src/healthInsuranceUtils.spec.ts
@@ -7,7 +7,7 @@ import {
   getDraftApplications,
 } from './healthInsuranceUtils'
 
-describe('health insurance utils', () => {
+describe('Health insurance utils', () => {
   const applicant = {
     nationalId: '1234567890',
     fullName: 'Test name',
@@ -51,7 +51,7 @@ describe('health insurance utils', () => {
       },
     } as unknown) as Application)
 
-  describe('Filter draft applications', () => {
+  describe('Check draft applications', () => {
     it('should return false if draft application list is undefined', () => {
       // assert
       const application = createApplication()
@@ -220,7 +220,7 @@ describe('health insurance utils', () => {
       expect(currentApplicationId).toBe(oldestDraftId)
     })
   })
-  describe('oldest draft application id', () => {
+  describe('Getting oldest draft application id', () => {
     it('should return application that was created first', () => {
       // assert
       const expectedApplicationId = faker.random.uuid()

--- a/libs/application/templates/health-insurance/src/healthInsuranceUtils.spec.ts
+++ b/libs/application/templates/health-insurance/src/healthInsuranceUtils.spec.ts
@@ -171,13 +171,16 @@ describe('Health insurance utils', () => {
       // assert
       const currentApplicationId = faker.random.uuid()
 
-      const windowSpy = jest.spyOn(window, "window", "get");
+      const windowSpy = jest.spyOn(window, 'window', 'get')
 
-      windowSpy.mockImplementation(() => (({
-        location: {
-          pathname: `/umsoknir/sjukratryggingar/${currentApplicationId}`,
-        }
-      }) as any))
+      windowSpy.mockImplementation(
+        () =>
+          ({
+            location: {
+              pathname: `/umsoknir/sjukratryggingar/${currentApplicationId}`,
+            },
+          } as any),
+      )
 
       const yesterday = new Date()
       yesterday.setDate(yesterday.getDate() - 1)
@@ -219,7 +222,7 @@ describe('Health insurance utils', () => {
       expect(hasActiveDraft).toEqual(false)
       expect(currentApplicationId).toBe(oldestDraftId)
 
-      windowSpy.mockRestore();
+      windowSpy.mockRestore()
     })
   })
   describe('Getting oldest draft application id', () => {


### PR DESCRIPTION
# test(health-insurance): add test to check draft util

## What

Added additional test for the draft util to check that:
- error modal about active draft doesn't show if the user already is on the oldest draft
- function is returning the oldest draft id

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
