### PR TITLE
fix(web): Add language string and skip untranslated life event cards

### DIFF
--- a/apps/web/components/LifeEventsCardsSection/LifeEventsCardsSection.tsx
+++ b/apps/web/components/LifeEventsCardsSection/LifeEventsCardsSection.tsx
@@ -27,19 +27,21 @@ export const LifeEventsCardsSection: React.FC<LifeEventsSectionProps> = ({
     <GridContainer>
       <CardsSlider
         title={title}
-        cards={lifeEvents.map((lifeEvent) => {
-          return {
-            title: lifeEvent.title,
-            description: lifeEvent.intro,
-            link: linkResolver('lifeeventpage', [lifeEvent.slug]),
-            image: lifeEvent.thumbnail
-              ? {
-                  title: lifeEvent.thumbnail.title,
-                  url: lifeEvent.thumbnail.url,
-                }
-              : { title: lifeEvent.image.title, url: lifeEvent.image.url },
-          }
-        })}
+        cards={lifeEvents
+          .filter((x) => x.slug && x.title)
+          .map((lifeEvent) => {
+            return {
+              title: lifeEvent.title,
+              description: lifeEvent.intro,
+              link: linkResolver('lifeeventpage', [lifeEvent.slug]),
+              image: lifeEvent.thumbnail
+                ? {
+                    title: lifeEvent.thumbnail.title,
+                    url: lifeEvent.thumbnail.url,
+                  }
+                : { title: lifeEvent.image.title, url: lifeEvent.image.url },
+            }
+          })}
       />
       <Box display={'flex'} justifyContent="flexEnd" marginTop={[3, 3, 4]}>
         <Link {...linkResolver('lifeevents')} skipTab>

--- a/apps/web/components/SearchInput/SearchInput.tsx
+++ b/apps/web/components/SearchInput/SearchInput.tsx
@@ -210,6 +210,7 @@ interface SearchInputProps {
   id?: string
   onRouting?: () => void
   skipContext?: boolean
+  quickContentLabel?: string
 }
 
 export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
@@ -227,6 +228,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
       id = 'downshift',
       onRouting,
       skipContext,
+      quickContentLabel,
     },
     ref,
   ) => {
@@ -325,6 +327,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
             >
               {isOpen && !isEmpty(search) && (
                 <Results
+                  quickContentLabel={quickContentLabel}
                   search={search}
                   highlightedIndex={highlightedIndex}
                   getItemProps={getItemProps}
@@ -351,7 +354,15 @@ const Results: FC<{
   getItemProps: any
   autosuggest: boolean
   onRouting?: () => void
-}> = ({ search, highlightedIndex, getItemProps, autosuggest, onRouting }) => {
+  quickContentLabel?: string
+}> = ({
+  search,
+  highlightedIndex,
+  getItemProps,
+  autosuggest,
+  onRouting,
+  quickContentLabel = 'Beint að efninu',
+}) => {
   const { linkResolver } = useLinkResolver()
 
   if (!search.term) {
@@ -411,7 +422,7 @@ const Results: FC<{
           <div className={styles.menuRow}>
             <Stack space={2}>
               <Text variant="eyebrow" color="purple400">
-                Beint að efninu
+                {quickContentLabel}
               </Text>
               {(search.results.items as Article[] &
                 LifeEventPage[] &

--- a/apps/web/screens/Home.tsx
+++ b/apps/web/screens/Home.tsx
@@ -69,6 +69,7 @@ const Home: Screen<HomeProps> = ({ categories, news, page }) => {
             size="medium"
             colored={false}
             activeLocale={activeLocale}
+            quickContentLabel={n('quickContentLabel', 'Beint að efninu')}
             placeholder={n('heroSearchPlaceholder')}
           />
         </Box>

--- a/apps/web/screens/Search/Search.tsx
+++ b/apps/web/screens/Search/Search.tsx
@@ -338,6 +338,7 @@ const Search: Screen<CategoryProps> = ({
             id="search_input_search_page"
             ref={searchRef}
             size="large"
+            quickContentLabel={n('quickContentLabel', 'Beint að efninu')}
             activeLocale={activeLocale}
             initialInputValue={q}
           />


### PR DESCRIPTION
- Life event cards on front page slider are shown even if there is no content. Only showing if it has title and slug for link.
- Added language string that was missing in search results dropdown.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
