### PR TITLE
fix(license): presign using a promise

### DIFF
--- a/libs/api/domains/education/src/lib/s3.service.ts
+++ b/libs/api/domains/education/src/lib/s3.service.ts
@@ -54,7 +54,7 @@ export class S3Service {
     return promise
       .then((result) => {
         const fiveSeconds = 5
-        return this.s3.getSignedUrl('getObject', {
+        return this.s3.getSignedUrlPromise('getObject', {
           Bucket: s3Location.bucket,
           Key: result.Key,
           Expires: fiveSeconds,


### PR DESCRIPTION
# Presign using a promise

## What

Presign using a promise

## Why

> GetPresignedUrl: You must ensure that you have static or previously resolved credentials if you call this method synchronously (with no callback), otherwise it may not properly sign the request. If you cannot guarantee this (you are using an asynchronous credential provider, i.e., EC2 IAM roles), you should always call this method with an asynchronous callback.

So using a promise instead.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
