### PR TITLE
fix(crc): Locale in datepicker

### DIFF
--- a/libs/application/templates/children-residence-change/src/fields/Duration/index.tsx
+++ b/libs/application/templates/children-residence-change/src/fields/Duration/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { useIntl } from 'react-intl'
+import { useLocale } from '@island.is/localization'
 import { duration } from '../../lib/messages'
 import { CRCFieldBaseProps } from '../../types'
 import { DescriptionText } from '../components'
@@ -16,6 +17,7 @@ const Duration = ({ field, application, error }: CRCFieldBaseProps) => {
     ? (application.answers.selectDuration[0] as ValidAnswers)
     : undefined
   const { formatMessage } = useIntl()
+  const { lang } = useLocale()
 
   const [statefulAnswer, setStatefulAnswer] = useState<ValidAnswers>(
     currentAnswer,
@@ -54,6 +56,7 @@ const Duration = ({ field, application, error }: CRCFieldBaseProps) => {
             <DatePickerController
               id={`${field.id}[1]`}
               backgroundColor="blue"
+              locale={lang}
               label={formatMessage(duration.dateInput.label)}
               placeholder={formatMessage(duration.dateInput.placeholder)}
               error={error}


### PR DESCRIPTION
# \<Description\>
Adds locale to datepicker

## Why

So it is in correct format

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
