### PR TITLE
fix(ui-island): datepicker storybook

### DIFF
--- a/libs/island-ui/core/src/lib/DatePicker/DatePicker.stories.tsx
+++ b/libs/island-ui/core/src/lib/DatePicker/DatePicker.stories.tsx
@@ -65,18 +65,6 @@ export const LocaleIS = () => {
     </>
   )
 }
-export const LocalePL = () => {
-  return (
-    <Wrap>
-      <DatePicker
-        label="Data"
-        placeholderText="Wybierz datę"
-        locale="pl"
-        handleChange={(date: Date) => console.log(date)}
-      />
-    </Wrap>
-  )
-}
 
 export const SelectYear = () => {
   const toDay = new Date()


### PR DESCRIPTION
The `DatePicker` storybook is crashing becuse of an error:
```
TypeError: Cannot read property 'locale' of undefined
```

- Removed the `pl` example