### PR TITLE
docs: Mention need for `export ` prefix for variables in `.env.secret`

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,9 @@ yarn nx dep-graph
 
 ### Making dev secrets available locally
 
-Environment variables that should not be tracked but needed locally should be added to the `.env.secret` file.
+Environment variables that should not be tracked but needed locally should be added to the `.env.secret` file.  
+_(**NOTE:** Each variable must be prefixed with `export ` for direnv to pick them up.)_
+
 Additionally, if that same variable is also stored in AWS Parameter Store, the secret can be labeled with the `dev` label from `History` -> `Attach labels`.
 
 All secrets labeled with the `dev` label can be fetched using `yarn get-secrets`.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -16,7 +16,7 @@ First off: Configure which API to fetch data from.
 
 ### Mock API (no server)
 
-Add `API_MOCKS=true` to your .env or .env.secret file.
+Add `API_MOCKS=true` to your `.env`, or `export API_MOCKS=true` to your `.env.secret` file.
 
 You can tweak the mock data in `libs/api/mocks`.
 

--- a/handbook/technical-overview/feature-flags.md
+++ b/handbook/technical-overview/feature-flags.md
@@ -6,7 +6,7 @@ If you want to introduce something behind a feature flag you can follow these st
 
 1. Ask someone from DevOps for invite to ConfigCat.
 2. Once you're in (https://app.configcat.com/) you can add your feature flag. The initial values should always be "On" in Dev and (probably always to start with) "Off" in Production and Staging.
-3. Make sure that the CONFIGCAT_SDK_KEY environment variable is in `.env.secret` in the root of the repository. You can fetch it by calling `./scripts/secrets.sh configcat`.
+3. Make sure that the CONFIGCAT_SDK_KEY environment variable is `export`ed in `.env.secret` in the root of the repository. You can fetch it by calling `./scripts/secrets.sh configcat`.
 4. Start using your flag by using the package `@island.is/feature-flags`.
 
 ## Naming convention


### PR DESCRIPTION
## Checklist:

- [ ] ~~I have performed a self-review of my own code~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [ ] ~~My changes generate no new warnings~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~Formatting passes locally with my changes~~
- [ ] ~~I have rebased against main before asking for a review~~
