### PR TITLE
fix(judicial-system): Set custody end date's min date to today

### DIFF
--- a/apps/judicial-system/web/src/routes/Judge/Ruling/StepOne/RulingStepOne.tsx
+++ b/apps/judicial-system/web/src/routes/Judge/Ruling/StepOne/RulingStepOne.tsx
@@ -333,11 +333,7 @@ export const RulingStepOne: React.FC = () => {
                       ? new Date(workingCase.custodyEndDate)
                       : undefined
                   }
-                  minDate={
-                    workingCase.isolationTo
-                      ? new Date(workingCase.isolationTo)
-                      : undefined
-                  }
+                  minDate={new Date()}
                   onChange={(date: Date | undefined, valid: boolean) => {
                     newSetAndSendDateToServer(
                       'custodyEndDate',


### PR DESCRIPTION
# Set custody end date's min date to today

## What

Set custody end date's min date to today

## Why

The only restriction on custody end date should be that it's not in the past

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
