### PR TITLE
chore(core): configure kodiak to always use PR title

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -1,3 +1,6 @@
 # .kodiak.toml
 # Minimal config. version is the only required field.
 version = 1
+
+# Always use the pull request title, which has been validated using conventional commit.
+merge.message.title = "pull_request_title"


### PR DESCRIPTION
## What

See title

## Why

To get consistent git history. The default configuration is "github_default", which sometimes uses PR title and sometimes the commit title, depending on how many commits there are. Instead we always want the conventional commit validated PR title.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new warnings
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~Formatting passes locally with my changes~~
- [ ] ~~I have rebased against main before asking for a review~~
