### PR TITLE
feat(web): Add organization secondary menu

### DIFF
--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -76,6 +76,14 @@ export const OrganizationWrapper: React.FC<WrapperProps> = ({
   children,
   minimal = false,
 }) => {
+  const secondaryNavList: NavigationItem[] = organizationPage.secondaryMenu?.childrenLinks.map(
+    ({ text, url }) => ({
+      title: text,
+      href: url,
+      active: text === pageTitle,
+    }),
+  )
+
   return (
     <>
       <HeadWithSocialSharing
@@ -108,6 +116,24 @@ export const OrganizationWrapper: React.FC<WrapperProps> = ({
                     )
                   }}
                 />
+                {organizationPage.secondaryMenu && (
+                  <Box marginTop={3}>
+                    <Navigation
+                      colorScheme="purple"
+                      baseId="secondarynav"
+                      activeItemTitle={pageTitle}
+                      title={organizationPage.secondaryMenu.name}
+                      items={secondaryNavList}
+                      renderLink={(link, item) => {
+                        return item?.href ? (
+                          <NextLink href={item?.href}>{link}</NextLink>
+                        ) : (
+                          link
+                        )
+                      }}
+                    />
+                  </Box>
+                )}
                 {sidebarContent}
               </Sticky>
             }
@@ -129,6 +155,24 @@ export const OrganizationWrapper: React.FC<WrapperProps> = ({
                   }}
                 />
               </Box>
+              {organizationPage.secondaryMenu && (
+                <Box marginY={2}>
+                  <Navigation
+                    colorScheme="purple"
+                    baseId="secondarynav"
+                    isMenuDialog={true}
+                    title={organizationPage.secondaryMenu.name}
+                    items={secondaryNavList}
+                    renderLink={(link, item) => {
+                      return item?.href ? (
+                        <NextLink href={item?.href}>{link}</NextLink>
+                      ) : (
+                        link
+                      )
+                    }}
+                  />
+                </Box>
+              )}
             </Hidden>
             <Breadcrumbs
               items={breadcrumbItems ?? []}

--- a/apps/web/screens/Organization/NewsItem.tsx
+++ b/apps/web/screens/Organization/NewsItem.tsx
@@ -19,6 +19,7 @@ import {
 } from '@island.is/web/graphql/schema'
 import {
   HeadWithSocialSharing,
+  lightThemes,
   NewsArticle,
   OrganizationWrapper,
 } from '@island.is/web/components'
@@ -151,14 +152,14 @@ NewsItem.getInitialProps = async ({ apolloClient, locale, query }) => {
     throw new CustomNextError(404, 'News not found')
   }
 
+  const lightTheme = lightThemes.includes(getOrganizationPage.theme)
+
   return {
     organizationPage: getOrganizationPage,
     newsItem,
     namespace,
+    ...(lightTheme ? {} : { darkTheme: true }),
   }
 }
 
-export default withMainLayout(NewsItem, {
-  headerButtonColorScheme: 'negative',
-  headerColorScheme: 'white',
-})
+export default withMainLayout(NewsItem)

--- a/apps/web/screens/Organization/NewsList.tsx
+++ b/apps/web/screens/Organization/NewsList.tsx
@@ -7,6 +7,7 @@ import { Screen } from '../../types'
 import {
   Select as NativeSelect,
   OrganizationWrapper,
+  lightThemes,
 } from '@island.is/web/components'
 import { useDateUtils } from '@island.is/web/i18n/useDateUtils'
 import {
@@ -400,6 +401,8 @@ NewsList.getInitialProps = async ({ apolloClient, locale, query }) => {
       }),
   ])
 
+  const lightTheme = lightThemes.includes(getOrganizationPage.theme)
+
   return {
     organizationPage: getOrganizationPage,
     newsList,
@@ -410,10 +413,8 @@ NewsList.getInitialProps = async ({ apolloClient, locale, query }) => {
     datesMap: createDatesMap(newsDatesList),
     selectedPage,
     namespace,
+    ...(lightTheme ? {} : { darkTheme: true }),
   }
 }
 
-export default withMainLayout(NewsList, {
-  headerButtonColorScheme: 'negative',
-  headerColorScheme: 'white',
-})
+export default withMainLayout(NewsList)

--- a/apps/web/screens/Organization/Services.tsx
+++ b/apps/web/screens/Organization/Services.tsx
@@ -33,7 +33,7 @@ import {
 import { Screen } from '../../types'
 import { useNamespace } from '@island.is/web/hooks'
 import { LinkType, useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
-import { OrganizationWrapper } from '@island.is/web/components'
+import { lightThemes, OrganizationWrapper } from '@island.is/web/components'
 import { CustomNextError } from '@island.is/web/units/errors'
 import { useWindowSize } from 'react-use'
 import { theme } from '@island.is/island-ui/theme'
@@ -333,6 +333,8 @@ ServicesPage.getInitialProps = async ({ apolloClient, locale, query }) => {
     }
   }
 
+  const lightTheme = lightThemes.includes(getOrganizationPage.theme)
+
   return {
     organizationPage: getOrganizationPage,
     services: getArticles,
@@ -341,10 +343,8 @@ ServicesPage.getInitialProps = async ({ apolloClient, locale, query }) => {
     groups,
     sort: (query.sort as string) ?? 'popular',
     showSearchInHeader: false,
+    ...(lightTheme ? {} : { darkTheme: true }),
   }
 }
 
-export default withMainLayout(ServicesPage, {
-  headerButtonColorScheme: 'negative',
-  headerColorScheme: 'white',
-})
+export default withMainLayout(ServicesPage)

--- a/apps/web/screens/Organization/SubPage.tsx
+++ b/apps/web/screens/Organization/SubPage.tsx
@@ -27,7 +27,7 @@ import {
 import { Screen } from '../../types'
 import { useNamespace } from '@island.is/web/hooks'
 import { useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
-import { OrganizationWrapper } from '@island.is/web/components'
+import { lightThemes, OrganizationWrapper } from '@island.is/web/components'
 import { CustomNextError } from '@island.is/web/units/errors'
 import getConfig from 'next/config'
 import { Namespace } from '@island.is/api/schema'
@@ -224,15 +224,15 @@ SubPage.getInitialProps = async ({ apolloClient, locale, query }) => {
     throw new CustomNextError(404, 'Organization subpage not found')
   }
 
+  const lightTheme = lightThemes.includes(getOrganizationPage.theme)
+
   return {
     organizationPage: getOrganizationPage,
     subpage: getOrganizationSubpage,
     namespace,
     showSearchInHeader: false,
+    ...(lightTheme ? {} : { darkTheme: true }),
   }
 }
 
-export default withMainLayout(SubPage, {
-  headerButtonColorScheme: 'negative',
-  headerColorScheme: 'white',
-})
+export default withMainLayout(SubPage)

--- a/apps/web/screens/queries/Organization.tsx
+++ b/apps/web/screens/queries/Organization.tsx
@@ -56,6 +56,13 @@ export const GET_ORGANIZATION_PAGE_QUERY = gql`
           url
         }
       }
+      secondaryMenu {
+        name
+        childrenLinks {
+          text
+          url
+        }
+      }
       organization {
         logo {
           url

--- a/libs/api/domains/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/api/domains/cms/src/lib/generated/contentfulTypes.d.ts
@@ -1887,6 +1887,9 @@ export interface IOrganizationPageFields {
   /** Menu Links */
   menuLinks?: ILinkGroup[] | undefined
 
+  /** Secondary Menu */
+  secondaryMenu?: ILinkGroup | undefined
+
   /** Organization */
   organization: IOrganization
 

--- a/libs/api/domains/cms/src/lib/models/organizationPage.model.ts
+++ b/libs/api/domains/cms/src/lib/models/organizationPage.model.ts
@@ -38,6 +38,9 @@ export class OrganizationPage {
   @Field(() => [LinkGroup])
   menuLinks!: Array<LinkGroup>
 
+  @Field(() => LinkGroup, { nullable: true })
+  secondaryMenu!: LinkGroup | null
+
   @Field(() => Organization)
   organization!: Organization | null
 
@@ -63,6 +66,9 @@ export const mapOrganizationPage = ({
   themeProperties: mapOrganizationTheme(fields.themeProperties ?? {}),
   slices: (fields.slices ?? []).map(safelyMapSliceUnion),
   menuLinks: (fields.menuLinks ?? []).map(mapLinkGroup),
+  secondaryMenu: fields.secondaryMenu
+    ? mapLinkGroup(fields.secondaryMenu)
+    : null,
   organization: fields.organization
     ? mapOrganization(fields.organization)
     : null,


### PR DESCRIPTION
# Add organization secondary menu

## What

Adds option for secondary purple menu on organization pages. Also fixes header color scheme for subpages.

## Why

This is according to design.

## Screenshots / Gifs

![Screenshot from 2021-04-06 14-33-22](https://user-images.githubusercontent.com/3607456/113728290-7d5f3200-96e5-11eb-9acb-eecdf41e4277.png)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
