### PR TITLE
fix(reference-backend): Swagger plugin webpack fix

### DIFF
--- a/apps/reference-backend/sequelize.config.d.ts
+++ b/apps/reference-backend/sequelize.config.d.ts
@@ -1,0 +1,17 @@
+import { Dialect } from 'sequelize/types'
+
+interface SequelizeConfig {
+  username: string
+  password: string
+  database: string
+  host: string
+  dialect: Dialect
+}
+
+declare namespace SequelizeConfig {
+  const production: SequelizeConfig
+  const test: SequelizeConfig
+  const development: SequelizeConfig
+}
+
+export = SequelizeConfig

--- a/apps/reference-backend/src/app/modules/resource/dto/resource.dto.ts
+++ b/apps/reference-backend/src/app/modules/resource/dto/resource.dto.ts
@@ -1,9 +1,7 @@
 import { IsString, Length } from 'class-validator'
-import { ApiProperty } from '@nestjs/swagger'
 
 export class ResourceDto {
   @IsString()
   @Length(10)
-  @ApiProperty()
-  readonly nationalId: string
+  readonly nationalId!: string
 }

--- a/apps/reference-backend/src/app/modules/resource/resource.controller.ts
+++ b/apps/reference-backend/src/app/modules/resource/resource.controller.ts
@@ -9,7 +9,7 @@ import {
 import { Resource } from './resource.model'
 import { ResourceService } from './resource.service'
 import { ResourceDto } from './dto/resource.dto'
-import { ApiCreatedResponse, ApiOkResponse, ApiTags } from '@nestjs/swagger'
+import { ApiTags } from '@nestjs/swagger'
 
 @ApiTags('resource')
 @Controller('resource')
@@ -17,13 +17,11 @@ export class ResourceController {
   constructor(private readonly resourceService: ResourceService) {}
 
   @Post()
-  @ApiCreatedResponse({ type: Resource })
   async create(@Body() resource: ResourceDto): Promise<Resource> {
     return await this.resourceService.create(resource)
   }
 
   @Get(':nationalId')
-  @ApiOkResponse({ type: Resource })
   async findOne(@Param('nationalId') nationalId: string): Promise<Resource> {
     const resource = await this.resourceService.findByNationalId(nationalId)
 

--- a/apps/reference-backend/src/app/modules/resource/resource.model.ts
+++ b/apps/reference-backend/src/app/modules/resource/resource.model.ts
@@ -6,7 +6,6 @@ import {
   Table,
   UpdatedAt,
 } from 'sequelize-typescript'
-import { ApiProperty } from '@nestjs/swagger'
 
 @Table({
   tableName: 'resource',
@@ -23,22 +22,18 @@ export class Resource extends Model<Resource> {
     allowNull: false,
     defaultValue: DataType.UUIDV4,
   })
-  @ApiProperty()
-  id: string
+  id!: string
 
   @Column({
     type: DataType.STRING,
     allowNull: false,
     unique: true,
   })
-  @ApiProperty()
-  nationalId: string
+  nationalId!: string
 
   @CreatedAt
-  @ApiProperty()
-  readonly created: Date
+  readonly created!: Date
 
   @UpdatedAt
-  @ApiProperty()
-  readonly modified: Date
+  readonly modified!: Date
 }

--- a/apps/reference-backend/src/app/modules/resource/resource.service.ts
+++ b/apps/reference-backend/src/app/modules/resource/resource.service.ts
@@ -20,7 +20,7 @@ export class ResourceService {
     private logger: Logger,
   ) {}
 
-  async findByNationalId(nationalId: string): Promise<Resource> {
+  async findByNationalId(nationalId: string): Promise<Resource | null> {
     this.logger.debug(`Finding resource for nationalId - "${nationalId}"`)
     return this.resourceModel.findOne({
       where: { nationalId },

--- a/apps/reference-backend/tsconfig.json
+++ b/apps/reference-backend/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "allowJs": true,
-    "types": ["node", "jest"],
-    "strict": false
+    "types": ["node", "jest"]
   },
   "include": [],
   "files": [],

--- a/apps/reference-backend/webpack.config.js
+++ b/apps/reference-backend/webpack.config.js
@@ -1,0 +1,37 @@
+// Found in issue https://github.com/nrwl/nx/issues/2147
+const webpack = require('webpack')
+
+const swaggerPluginOptions = {
+  dtoFileNameSuffix: ['.dto.ts', '.model.ts'],
+  classValidatorShim: true,
+  introspectComments: true,
+}
+
+module.exports = (config) => {
+  const tsLoader = config.module.rules.find((rule) =>
+    rule.loader.includes('ts-loader'),
+  )
+
+  if (tsLoader) {
+    tsLoader.options.transpileOnly = false // required because if true, plugin can't work properly
+    tsLoader.options.getCustomTransformers = (program) => {
+      return {
+        before: [
+          require('@nestjs/swagger/plugin').before(
+            swaggerPluginOptions,
+            program,
+          ),
+        ],
+      }
+    }
+  }
+
+  config.plugins = [
+    ...(config.plugins || []),
+    new webpack.ProvidePlugin({
+      openapi: '@nestjs/swagger',
+    }),
+  ]
+
+  return config
+}

--- a/workspace.json
+++ b/workspace.json
@@ -4249,7 +4249,8 @@
             "main": "apps/reference-backend/src/main.ts",
             "tsConfig": "apps/reference-backend/tsconfig.app.json",
             "assets": ["apps/reference-backend/src/assets"],
-            "maxWorkers": 2
+            "maxWorkers": 2,
+            "webpackConfig": "apps/endorsement-system/webpack.config.js"
           },
           "configurations": {
             "production": {

--- a/workspace.json
+++ b/workspace.json
@@ -4250,7 +4250,7 @@
             "tsConfig": "apps/reference-backend/tsconfig.app.json",
             "assets": ["apps/reference-backend/src/assets"],
             "maxWorkers": 2,
-            "webpackConfig": "apps/endorsement-system/webpack.config.js"
+            "webpackConfig": "apps/reference-backend/webpack.config.js"
           },
           "configurations": {
             "production": {


### PR DESCRIPTION
# \<Description\>

Swagger plugin seems to not be working as intended.

## What

- Added fix for Swagger plugin
- Removed decorators handled by default in Swagger plugin
- Made TS strict

## Why

- TS strict seems like the agreed default

## Screenshots / Gifs

![Screenshot 2021-04-08 at 08 46 39](https://user-images.githubusercontent.com/6640435/113997053-4f91fe80-9847-11eb-8f89-1a59be3ee3b8.png)
![Screenshot 2021-04-08 at 08 46 23](https://user-images.githubusercontent.com/6640435/113997059-515bc200-9847-11eb-8648-69470efe96cb.png)
![Screenshot 2021-04-08 at 08 46 31](https://user-images.githubusercontent.com/6640435/113997064-515bc200-9847-11eb-9ae5-7a7cf80e0b64.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
