### PR TITLE
fix(crc): Refactor types in signature modal

### DIFF
--- a/libs/application/templates/children-residence-change/src/fields/Overview/SignatureModal/ModalConditionalContent.tsx
+++ b/libs/application/templates/children-residence-change/src/fields/Overview/SignatureModal/ModalConditionalContent.tsx
@@ -1,30 +1,33 @@
 import React from 'react'
-import { FileSignatureStatus } from '../fileSignatureReducer'
+import { FileSignatureStatus, ReducerState } from '../fileSignatureReducer'
 import ErrorMessage from './ErrorMessage'
 import ControlCode from './ControlCode'
 import Skeleton from './SkeletonLoader'
 
 interface SignatureModalProps {
-  signatureStatus: FileSignatureStatus
+  fileSignatureState: ReducerState
   onClose: () => void
   controlCode: string
-  errorCode?: number
 }
 
 const ModalConditionalContent = ({
+  fileSignatureState,
   controlCode,
-  signatureStatus,
   onClose,
-  errorCode,
 }: SignatureModalProps) => {
-  switch (signatureStatus) {
+  switch (fileSignatureState.status) {
     case FileSignatureStatus.REQUEST:
       return <Skeleton />
     case FileSignatureStatus.UPLOAD:
       return <ControlCode controlCode={controlCode} />
     case FileSignatureStatus.REQUEST_ERROR:
     case FileSignatureStatus.UPLOAD_ERROR:
-      return <ErrorMessage errorCode={errorCode ?? 500} onClose={onClose} />
+      return (
+        <ErrorMessage
+          errorCode={fileSignatureState.errorCode}
+          onClose={onClose}
+        />
+      )
     default:
       return null
   }

--- a/libs/application/templates/children-residence-change/src/fields/Overview/SignatureModal/index.tsx
+++ b/libs/application/templates/children-residence-change/src/fields/Overview/SignatureModal/index.tsx
@@ -2,36 +2,32 @@ import React from 'react'
 import { useIntl } from 'react-intl'
 import { Box, Text, ModalBase } from '@island.is/island-ui/core'
 import { signatureModal } from '../../../lib/messages'
-import { FileSignatureStatus } from '../fileSignatureReducer'
+import { FileSignatureStatus, ReducerState } from '../fileSignatureReducer'
 import ModalConditionalContent from './ModalConditionalContent'
 import * as style from './Modal.treat'
 
 interface SignatureModalProps {
-  signatureStatus: FileSignatureStatus
+  fileSignatureState: ReducerState
   onClose: () => void
-  modalOpen: boolean
   controlCode: string
-  errorCode?: number
 }
 
 const SignatureModal = ({
+  fileSignatureState,
   controlCode,
-  signatureStatus,
-  modalOpen,
   onClose,
-  errorCode,
 }: SignatureModalProps) => {
   const { formatMessage } = useIntl()
   const hasError = [
     FileSignatureStatus.REQUEST_ERROR,
     FileSignatureStatus.UPLOAD_ERROR,
-  ].includes(signatureStatus)
+  ].includes(fileSignatureState.status)
   return (
     <ModalBase
       baseId="signatureDialog"
       className={style.modal}
       modalLabel={formatMessage(signatureModal.general.title)}
-      isVisible={modalOpen}
+      isVisible={fileSignatureState.modalOpen}
       onVisibilityChange={(visibility: boolean) => {
         if (!visibility) {
           onClose()
@@ -54,10 +50,9 @@ const SignatureModal = ({
           {formatMessage(signatureModal.general.title)}
         </Text>
         <ModalConditionalContent
+          fileSignatureState={fileSignatureState}
           onClose={onClose}
           controlCode={controlCode}
-          signatureStatus={signatureStatus}
-          errorCode={errorCode}
         />
       </Box>
     </ModalBase>

--- a/libs/application/templates/children-residence-change/src/fields/Overview/index.tsx
+++ b/libs/application/templates/children-residence-change/src/fields/Overview/index.tsx
@@ -112,7 +112,7 @@ const Overview = ({
           dispatchFileSignature({
             type: FileSignatureActionTypes.ERROR,
             status: FileSignatureStatus.REQUEST_ERROR,
-            error: error.graphQLErrors[0].extensions?.code,
+            error: error.graphQLErrors[0].extensions?.code ?? 500,
           })
           throw new Error(`Request signature error ${JSON.stringify(error)}`)
         })
@@ -134,7 +134,7 @@ const Overview = ({
             dispatchFileSignature({
               type: FileSignatureActionTypes.ERROR,
               status: FileSignatureStatus.UPLOAD_ERROR,
-              error: error.graphQLErrors[0].extensions?.code,
+              error: error.graphQLErrors[0].extensions?.code ?? 500,
             })
             throw new Error(`Upload signed pdf error ${JSON.stringify(error)}`)
           })
@@ -162,14 +162,7 @@ const Overview = ({
             type: FileSignatureActionTypes.RESET,
           })
         }
-        modalOpen={fileSignatureState.modalOpen}
-        signatureStatus={fileSignatureState.status}
-        errorCode={
-          fileSignatureState.status === FileSignatureStatus.UPLOAD_ERROR ||
-          fileSignatureState.status === FileSignatureStatus.REQUEST_ERROR
-            ? fileSignatureState.errorCode
-            : undefined
-        }
+        fileSignatureState={fileSignatureState}
       />
       <AlertMessage
         type="info"


### PR DESCRIPTION
Changes type we send to signature modal to skip null checking all over the place.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
