### PR TITLE
fix(api-domains-cms): Enabled strict and fixed a remaining typescript error

### DIFF
--- a/libs/api/domains/cms/src/lib/cms.resolver.ts
+++ b/libs/api/domains/cms/src/lib/cms.resolver.ts
@@ -326,7 +326,7 @@ export class CmsResolver {
 
   @Directive(cacheControlDirective())
   @Query(() => Frontpage)
-  getFrontpage(@Args('input') input: GetFrontpageInput): Promise<Frontpage> {
+  getFrontpage(@Args('input') input: GetFrontpageInput): Promise<Frontpage | null> {
     return this.cmsElasticsearchService.getSingleDocumentTypeBySlug(
       getElasticsearchIndex(input.lang),
       { type: 'webFrontpage', slug: input.pageIdentifier },

--- a/libs/api/domains/cms/src/lib/cms.resolver.ts
+++ b/libs/api/domains/cms/src/lib/cms.resolver.ts
@@ -326,7 +326,9 @@ export class CmsResolver {
 
   @Directive(cacheControlDirective())
   @Query(() => Frontpage)
-  getFrontpage(@Args('input') input: GetFrontpageInput): Promise<Frontpage | null> {
+  getFrontpage(
+    @Args('input') input: GetFrontpageInput,
+  ): Promise<Frontpage | null> {
     return this.cmsElasticsearchService.getSingleDocumentTypeBySlug(
       getElasticsearchIndex(input.lang),
       { type: 'webFrontpage', slug: input.pageIdentifier },

--- a/libs/api/domains/cms/tsconfig.json
+++ b/libs/api/domains/cms/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
     "types": ["node", "jest"],
-    "strict": false
+    "strict": true
   },
   "include": [],
   "files": [],

--- a/libs/api/domains/cms/tsconfig.lib.json
+++ b/libs/api/domains/cms/tsconfig.lib.json
@@ -5,7 +5,7 @@
     "outDir": "../../../../dist/out-tsc",
     "declaration": true,
     "types": ["node"],
-    "strict": true
+    "strict": false
   },
   "exclude": ["**/*.spec.ts"],
   "include": ["**/*.ts"]


### PR DESCRIPTION
# \<Description\>
Forgot to enable strict in the tsConfig. Fixed an error introduced since first error pruning.
