### PR TITLE
feat(web): Organization meta title

### DIFF
--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -85,10 +85,13 @@ export const OrganizationWrapper: React.FC<WrapperProps> = ({
     }),
   )
 
+  const metaTitleSuffix =
+    pageTitle !== organizationPage.title ? ` | ${organizationPage.title}` : ''
+
   return (
     <>
       <HeadWithSocialSharing
-        title={pageTitle}
+        title={`${pageTitle}${metaTitleSuffix}`}
         description={pageDescription}
         imageUrl={pageFeaturedImage?.url}
         imageContentType={pageFeaturedImage?.contentType}

--- a/apps/web/screens/Organization/NewsItem.tsx
+++ b/apps/web/screens/Organization/NewsItem.tsx
@@ -81,13 +81,6 @@ const NewsItem: Screen<NewsItemProps> = ({
 
   return (
     <>
-      <HeadWithSocialSharing
-        title={`${newsItem.title} | Sýslumenn | Ísland.is`}
-        description={newsItem.intro}
-        imageUrl={newsItem.image?.url}
-        imageWidth={newsItem.image?.width.toString()}
-        imageHeight={newsItem.image?.height.toString()}
-      />
       <OrganizationWrapper
         pageTitle={organizationPage.title}
         organizationPage={organizationPage}
@@ -99,6 +92,13 @@ const NewsItem: Screen<NewsItemProps> = ({
       >
         <NewsArticle newsItem={newsItem} namespace={namespace} />
       </OrganizationWrapper>
+      <HeadWithSocialSharing
+        title={`${newsItem.title} | ${organizationPage.title}`}
+        description={newsItem.intro}
+        imageUrl={newsItem.image?.url}
+        imageWidth={newsItem.image?.width.toString()}
+        imageHeight={newsItem.image?.height.toString()}
+      />
     </>
   )
 }

--- a/apps/web/screens/Organization/NewsList.tsx
+++ b/apps/web/screens/Organization/NewsList.tsx
@@ -209,11 +209,8 @@ const NewsList: Screen<NewsListProps> = ({
 
   return (
     <>
-      <Head>
-        <title>{n('pageTitle')} | Ísland.is</title>
-      </Head>
       <OrganizationWrapper
-        pageTitle={organizationPage.title}
+        pageTitle={n('newsTitle', 'Fréttir og tilkynningar')}
         organizationPage={organizationPage}
         breadcrumbItems={breadCrumbs}
         sidebarContent={sidebar}

--- a/apps/web/screens/Organization/Syslumenn/Auction.tsx
+++ b/apps/web/screens/Organization/Syslumenn/Auction.tsx
@@ -62,7 +62,7 @@ const Auction: Screen<AuctionProps> = ({
 
   return (
     <OrganizationWrapper
-      pageTitle={n('singleAuction', 'Uppboð')}
+      pageTitle={`${auction.title} ${format(date, 'e. MMMM yyyy')}`}
       organizationPage={organizationPage}
       breadcrumbItems={[
         {


### PR DESCRIPTION
# Organization meta title

Organization title used as meta title suffix on organization subpages. 

## What

Example: _Fréttir og tilkynningar | Sýslumenn_

## Why

Keep consistancy on meta title usages. On single article it is _Article name | Ísland.is_

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
