### PR TITLE
feat(web): Add breadcrumb to auction single view

### DIFF
--- a/apps/web/hooks/useLinkResolver/useLinkResolver.tsx
+++ b/apps/web/hooks/useLinkResolver/useLinkResolver.tsx
@@ -85,6 +85,10 @@ export const routesTemplate = {
     is: '/stofnanir/[organization]/frett',
     en: '/en/organizations/[organization]/news',
   },
+  auctions: {
+    is: '/stofnanir/syslumenn/uppbod',
+    en: '',
+  },
   auction: {
     is: '/stofnanir/syslumenn/uppbod/[id]',
     en: '',

--- a/apps/web/screens/Organization/Syslumenn/Auction.tsx
+++ b/apps/web/screens/Organization/Syslumenn/Auction.tsx
@@ -77,6 +77,10 @@ const Auction: Screen<AuctionProps> = ({
           title: organizationPage.title,
           href: linkResolver('organizationpage', [organizationPage.slug]).href,
         },
+        {
+          title: n('auctions', 'Uppboð'),
+          href: linkResolver('auctions').href,
+        },
       ]}
       navigationData={{
         title: n('navigationTitle', 'Efnisyfirlit'),

--- a/apps/web/screens/Organization/Syslumenn/Auction.tsx
+++ b/apps/web/screens/Organization/Syslumenn/Auction.tsx
@@ -62,7 +62,7 @@ const Auction: Screen<AuctionProps> = ({
 
   return (
     <OrganizationWrapper
-      pageTitle={`${auction.title} ${format(date, 'e. MMMM yyyy')}`}
+      pageTitle={`${auction.title} ${format(date, 'd. MMMM yyyy')}`}
       organizationPage={organizationPage}
       breadcrumbItems={[
         {


### PR DESCRIPTION
# Add breadcrumb to auction single view

## What

On single auction view, the last breadcrumb linking back to the overview, was missing.
Also fix date format on auction title

## Screenshots / Gifs
![image](https://user-images.githubusercontent.com/8808850/114583533-35a25280-9c71-11eb-9af8-8288202ce377.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
