### PR TITLE
fix(web): Fix sýslumenn auction date format

### DIFF
--- a/apps/web/screens/Organization/Syslumenn/Auction.tsx
+++ b/apps/web/screens/Organization/Syslumenn/Auction.tsx
@@ -91,7 +91,7 @@ const Auction: Screen<AuctionProps> = ({
           {auction.title}
         </Text>
         <Text variant="h3" as="h3" marginBottom={2}>
-          {format(date, 'e. MMMM yyyy')}
+          {format(date, 'd. MMMM yyyy')}
         </Text>
         <Box marginBottom={4}>
           <Tag disabled>{auction.organization.title}</Tag>


### PR DESCRIPTION
# Fix auction date format

## What

Date format for auction view on sýslumenn page is wrong and displays wrong dates in title.

## Screenshots / Gifs

The date of the example auction is 14.04.21

**List view:**
![image](https://user-images.githubusercontent.com/8808850/114585669-6a170e00-9c73-11eb-89dc-f14a4422a731.png)

**Single view**
Before:
![image](https://user-images.githubusercontent.com/8808850/114585613-59ff2e80-9c73-11eb-834f-6a9f84553f47.png)

After:
![image](https://user-images.githubusercontent.com/8808850/114585822-916ddb00-9c73-11eb-9ed3-ab9998fc7185.png)



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
