### PR TITLE
fix(judicial-system): Judge overview file fix

### DIFF
--- a/apps/judicial-system/web/src/routes/Judge/Overview/Overview.spec.tsx
+++ b/apps/judicial-system/web/src/routes/Judge/Overview/Overview.spec.tsx
@@ -87,7 +87,7 @@ describe('/domari-krafa with an ID', () => {
     expect(await screen.findByText('c-lið 1. mgr. 95. gr.')).toBeInTheDocument()
   })
 
-  test('should not allow case files to be opened unless a judge has been set', async () => {
+  test('should not show the "Open file" button if a judge has not been set', async () => {
     // Arrange
     const useRouter = jest.spyOn(require('next/router'), 'useRouter')
     useRouter.mockImplementation(() => ({
@@ -111,5 +111,59 @@ describe('/domari-krafa with an ID', () => {
 
     // Assert
     expect(screen.queryAllByRole('button', { name: 'Opna' })).toHaveLength(0)
+  })
+
+  test('should not show the "Open file" button if the currently logged in judge is not the judge that is assigned to the case', async () => {
+    // Arrange
+    const useRouter = jest.spyOn(require('next/router'), 'useRouter')
+    useRouter.mockImplementation(() => ({
+      query: { id: 'test_id_4' },
+    }))
+
+    render(
+      <MockedProvider
+        mocks={[...mockCaseQueries, ...mockJudgeQuery]}
+        addTypename={false}
+      >
+        <UserProvider>
+          <Overview />
+        </UserProvider>
+      </MockedProvider>,
+    )
+
+    userEvent.click(
+      await screen.findByRole('button', { name: 'Rannsóknargögn (2)' }),
+    )
+
+    // Assert
+    expect(screen.queryAllByRole('button', { name: 'Opna' })).toHaveLength(0)
+  })
+
+  test('should show the "Open file" button if the currently logged in judge is the same as is assigned to the case', async () => {
+    // Arrange
+    const useRouter = jest.spyOn(require('next/router'), 'useRouter')
+    useRouter.mockImplementation(() => ({
+      query: { id: 'test_id_5' },
+    }))
+
+    render(
+      <MockedProvider
+        mocks={[...mockCaseQueries, ...mockJudgeQuery]}
+        addTypename={false}
+      >
+        <UserProvider>
+          <Overview />
+        </UserProvider>
+      </MockedProvider>,
+    )
+
+    userEvent.click(
+      await screen.findByRole('button', { name: 'Rannsóknargögn (2)' }),
+    )
+
+    // Assert
+    expect(await screen.findAllByRole('button', { name: 'Opna' })).toHaveLength(
+      2,
+    )
   })
 })

--- a/apps/judicial-system/web/src/routes/Judge/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Judge/Overview/Overview.tsx
@@ -464,21 +464,19 @@ export const JudgeOverview: React.FC = () => {
                     }`}
                   </Text>
                 </Box>
-                <Text>
-                  {formatRequestedCustodyRestrictions(
-                    workingCase.type,
-                    workingCase.requestedCustodyRestrictions,
-                    workingCase.requestedOtherRestrictions,
-                  )
-                    .split('\n')
-                    .map((requestedCustodyRestriction, index) => {
-                      return (
-                        <div key={index}>
-                          <Text>{requestedCustodyRestriction}</Text>
-                        </div>
-                      )
-                    })}
-                </Text>
+                {formatRequestedCustodyRestrictions(
+                  workingCase.type,
+                  workingCase.requestedCustodyRestrictions,
+                  workingCase.requestedOtherRestrictions,
+                )
+                  .split('\n')
+                  .map((requestedCustodyRestriction, index) => {
+                    return (
+                      <div key={index}>
+                        <Text>{requestedCustodyRestriction}</Text>
+                      </div>
+                    )
+                  })}
               </div>
               {(workingCase.caseFacts || workingCase.legalArguments) && (
                 <div className={styles.infoSection}>

--- a/apps/judicial-system/web/src/routes/Judge/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Judge/Overview/Overview.tsx
@@ -58,6 +58,7 @@ import { CreateCustodyCourtCaseMutation } from '@island.is/judicial-system-web/s
 import { FeatureContext } from '@island.is/judicial-system-web/src/shared-components/FeatureProvider/FeatureProvider'
 import * as styles from './Overview.treat'
 import useFileList from '@island.is/judicial-system-web/src/utils/hooks/useFileList'
+import { UserContext } from '@island.is/judicial-system-web/src/shared-components/UserProvider/UserProvider'
 
 interface CaseData {
   case?: Case
@@ -82,6 +83,8 @@ export const JudgeOverview: React.FC = () => {
   const [showCreateCustodyCourtCase, setShowCreateCustodyCourtCase] = useState(
     false,
   )
+  const { user } = useContext(UserContext)
+
   const { handleOpenFile } = useFileList({
     caseId: workingCase?.id,
   })
@@ -536,7 +539,10 @@ export const JudgeOverview: React.FC = () => {
                   >
                     <CaseFileList
                       files={workingCase.files}
-                      canOpenFiles={workingCase.judge !== null}
+                      canOpenFiles={
+                        workingCase.judge !== null &&
+                        workingCase.judge?.id === user?.id
+                      }
                       onOpen={handleOpenFile}
                     />
                   </AccordionCard>

--- a/apps/judicial-system/web/src/utils/mocks.ts
+++ b/apps/judicial-system/web/src/utils/mocks.ts
@@ -36,6 +36,16 @@ export const mockJudge = {
   },
 } as User
 
+export const mockJudgeBatman = {
+  id: 'judge_2',
+  role: UserRole.JUDGE,
+  name: 'Batman',
+  title: 'héraðsdómari',
+  institution: {
+    name: 'Héraðsdómur Reykjavíkur',
+  },
+} as User
+
 export const mockRegistrar = {
   id: 'registrar_1',
   role: UserRole.REGISTRAR,
@@ -236,9 +246,25 @@ const testCase4 = {
   accusedAppealAnnouncement: null,
   prosecutorAppealDecision: null,
   prosecutorAppealAnnouncement: null,
-  judge: null,
+  judge: mockJudgeBatman,
   defenderName: 'Saul Goodman',
   defenderEmail: 'saul@goodman.com',
+  files: [
+    {
+      id: 'fc96b11c-f750-4867-b767-c5e562a54f09',
+      name: 'Screen Recording 2021-04-09 at 14.39.51.mov',
+      size: 4991527,
+      created: '2021-04-12T13:55:28.131Z',
+      __typename: 'File',
+    },
+    {
+      id: '997a2b8c-c3ea-46af-8764-087af21ba00a',
+      name: 'Screen Shot 2021-04-09 at 14.01.30.png',
+      size: 125293,
+      created: '2021-04-12T13:55:24.311Z',
+      __typename: 'File',
+    },
+  ],
 }
 
 const testCase5 = {
@@ -300,27 +326,6 @@ const testCase5 = {
       name: 'Screen Shot 2021-04-09 at 14.01.30.png',
       size: 125293,
       created: '2021-04-12T13:55:24.311Z',
-      __typename: 'File',
-    },
-    {
-      id: '58d53f9c-b70b-4b5a-a578-03e95102a981',
-      name: 'Screen Shot 2021-04-09 at 13.33.05.png',
-      size: 51454,
-      created: '2021-04-12T13:55:24.076Z',
-      __typename: 'File',
-    },
-    {
-      id: '0fcff6d7-3e2e-4933-87d9-f3eacdb4caed',
-      name: 'Screen Shot 2021-04-09 at 13.40.53.png',
-      size: 67077,
-      created: '2021-04-12T13:55:24.069Z',
-      __typename: 'File',
-    },
-    {
-      id: 'c63982e8-e548-445f-b9ea-580606e3de44',
-      name: 'Screen Shot 2021-04-09 at 08.48.06.png',
-      size: 50160,
-      created: '2021-04-12T13:55:24.055Z',
       __typename: 'File',
     },
   ],


### PR DESCRIPTION
# Don't show "Open" button in files overview for judges unless the currently signed in judge is assigned to the case

https://app.asana.com/0/1199153462262248/1199986469006836

## What

Remove 'Open' button from judge files overview if the currently logged in judge is not the assigned judge on that case

## Why

Only the judge assigned to a case should be able to see case files for that case.

TODO: div decendant in p

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
