### PR TITLE
feat(service-portal): hotfix removal of education degree page from service-portal

### DIFF
--- a/apps/service-portal/src/store/modules.ts
+++ b/apps/service-portal/src/store/modules.ts
@@ -29,7 +29,6 @@ export type ModuleKeys =
   | 'finance'
   | 'settings'
   | 'education'
-  | 'educationDegree'
   | 'educationLicense'
   | 'educationCareer'
   | 'educationStudentAssessment'
@@ -38,7 +37,6 @@ export type ModuleKeys =
 export const featureFlaggedModules: ModuleKeys[] = [
   'documentProvider',
   'education',
-  'educationDegree',
   'educationLicense',
   'educationCareer',
   'educationStudentAssessment',
@@ -52,7 +50,6 @@ export const modules: Record<ModuleKeys, ServicePortalModule> = {
   finance: financeModule,
   settings: settingsModule,
   education: educationModule,
-  educationDegree: educationDegreeModule,
   educationLicense: educationLicenseModule,
   educationCareer: educationCareerModule,
   educationStudentAssessment: educationStudentAssessmentModule,

--- a/libs/service-portal/core/src/lib/navigation/masterNavigation.ts
+++ b/libs/service-portal/core/src/lib/navigation/masterNavigation.ts
@@ -73,6 +73,35 @@ export const servicePortalMasterNavigation: ServicePortalNavigationItem[] = [
           icon: 'people',
         },
       },
+
+      // Menntun
+      {
+        name: defineMessage({
+          id: 'service.portal:education',
+          defaultMessage: 'Menntun',
+        }),
+        path: ServicePortalPath.EducationRoot,
+        icon: {
+          type: 'outline',
+          icon: 'school',
+        },
+        children: [
+          {
+            name: defineMessage({
+              id: 'service.portal:educationLicense',
+              defaultMessage: 'Starfsleyfi',
+            }),
+            path: ServicePortalPath.EducationLicense,
+          },
+          {
+            name: defineMessage({
+              id: 'service.portal:educationCareer',
+              defaultMessage: 'Námsferill',
+            }),
+            path: ServicePortalPath.EducationCareer,
+          },
+        ],
+      },
       {
         name: defineMessage({
           id: 'service.portal:document-provider',
@@ -163,42 +192,6 @@ export const servicePortalMasterNavigation: ServicePortalNavigationItem[] = [
           type: 'outline',
           icon: 'cellular',
         },
-      },
-
-      // Menntun
-      {
-        name: defineMessage({
-          id: 'service.portal:education',
-          defaultMessage: 'Menntun',
-        }),
-        path: ServicePortalPath.EducationRoot,
-        icon: {
-          type: 'outline',
-          icon: 'school',
-        },
-        children: [
-          {
-            name: defineMessage({
-              id: 'service.portal:educationDegree',
-              defaultMessage: 'Prófskírteini',
-            }),
-            path: ServicePortalPath.EducationDegree,
-          },
-          {
-            name: defineMessage({
-              id: 'service.portal:educationLicense',
-              defaultMessage: 'Starfsleyfi',
-            }),
-            path: ServicePortalPath.EducationLicense,
-          },
-          {
-            name: defineMessage({
-              id: 'service.portal:educationCareer',
-              defaultMessage: 'Námsferill',
-            }),
-            path: ServicePortalPath.EducationCareer,
-          },
-        ],
       },
 
       // Fasteignir

--- a/libs/service-portal/education/src/screens/EducationOverview/EducationOverview.tsx
+++ b/libs/service-portal/education/src/screens/EducationOverview/EducationOverview.tsx
@@ -23,25 +23,6 @@ export const EducationOverview: ServicePortalModuleComponent = () => {
       navigation={[
         {
           title: defineMessage({
-            id: 'sp.education:degree-title',
-            defaultMessage: 'Prófskírteini',
-          }),
-          intro: defineMessage({
-            id: 'sp.education:degree-intro',
-            defaultMessage:
-              'Hér getur þú fundið yfirlit yfir prófskírteini og lokapróf á öllum námsstigum.',
-          }),
-          image: './assets/images/educationDegree.svg',
-          link: {
-            title: defineMessage({
-              id: 'sp.education:degree-link-title',
-              defaultMessage: 'Skoða prófskírteinin mín',
-            }),
-            href: ServicePortalPath.EducationDegree,
-          },
-        },
-        {
-          title: defineMessage({
             id: 'sp.education:license-title',
             defaultMessage: 'Starfsleyfi',
           }),


### PR DESCRIPTION
# Remove education degree page

We want to remove the education degree page from the service portal, and remove it from the latest section.

This is a cherry-pick of #3431 on top of release 8.0.0

## Why
Education degree page is not production ready

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
