### PR TITLE
fix(island-ui): Align input box with visual box

### DIFF
--- a/libs/island-ui/core/src/lib/Checkbox/Checkbox.treat.ts
+++ b/libs/island-ui/core/src/lib/Checkbox/Checkbox.treat.ts
@@ -26,7 +26,8 @@ export const input = style({
   left: 0,
   opacity: 0,
   position: 'absolute',
-  top: 0,
+  top: '50%',
+  transform: 'translateY(-50%)',
   width: checkboxSize,
 })
 export const label = style({


### PR DESCRIPTION
# Fix input alignment with visual box

## What

Align the input box with the visual box

## Why

After setting alignSelf to center the input box and the visual checkbox did not align anymore. 

## Screenshots / Gifs

Before:
![Screenshot 2021-04-16 at 17 08 45](https://user-images.githubusercontent.com/64913954/115045701-0bea6500-9ed7-11eb-9360-4660cb4f7b5b.png)

After:
![Screenshot 2021-04-16 at 17 10 28](https://user-images.githubusercontent.com/64913954/115045706-0d1b9200-9ed7-11eb-9ff8-277e6c9e552a.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
