### PR TITLE
fix(parental-leave): Fixes to duration slider screen

### DIFF
--- a/libs/application/core/src/lib/formUtils.ts
+++ b/libs/application/core/src/lib/formUtils.ts
@@ -41,7 +41,7 @@ export function getValueViaPath(
 ): unknown | undefined {
   // Errors from dataSchema with array of object looks like e.g. `{ 'periods[1].startDate': 'error message' }`
   if (path.match(/.\[\d\]\../g) && !containsArray(obj)) {
-    return obj?.[path]
+    return obj?.[path] || defaultValue
   }
 
   // For the rest of the case, we are into e.g. `personalAllowance.usePersonalAllowance`

--- a/libs/application/core/src/lib/formUtils.ts
+++ b/libs/application/core/src/lib/formUtils.ts
@@ -41,7 +41,7 @@ export function getValueViaPath(
 ): unknown | undefined {
   // Errors from dataSchema with array of object looks like e.g. `{ 'periods[1].startDate': 'error message' }`
   if (path.match(/.\[\d\]\../g) && !containsArray(obj)) {
-    return obj?.[path] || defaultValue
+    return obj?.[path] ?? defaultValue
   }
 
   // For the rest of the case, we are into e.g. `personalAllowance.usePersonalAllowance`

--- a/libs/application/templates/parental-leave/src/config.ts
+++ b/libs/application/templates/parental-leave/src/config.ts
@@ -4,5 +4,5 @@ export const minMonths = 5
 export const maxMonths = 7
 export const minPeriodDays = 14
 export const usageMinMonths = 1
-export const usageMaxMonths = 18
+export const usageMaxMonths = 24
 export const daysInMonth = 30

--- a/libs/application/templates/parental-leave/src/lib/answerValidators.spec.ts
+++ b/libs/application/templates/parental-leave/src/lib/answerValidators.spec.ts
@@ -117,15 +117,4 @@ describe('answerValidators', () => {
       path: 'periods[0].ratio',
     })
   })
-
-  it('should return error if the period selected is more than the allowed period', () => {
-    const startDate = '2021-01-29'
-    const endDate = '2021-08-16'
-    const newAnswers = [{ startDate, endDate }]
-
-    expect(answerValidators['periods'](newAnswers, application)).toStrictEqual({
-      message: `You cannot apply for a period longer than the allowed period of 6 months.`,
-      path: 'periods[0].endDate',
-    })
-  })
 })

--- a/libs/application/templates/parental-leave/src/lib/answerValidators.ts
+++ b/libs/application/templates/parental-leave/src/lib/answerValidators.ts
@@ -178,18 +178,6 @@ export const answerValidators: Record<string, AnswerValidator> = {
         )
       }
 
-      // We check if the endDate is inside the allowed range of days/months
-      if (
-        (!startDate &&
-          differenceInDays(parseISO(endDate), parseISO(dob)) > days) ||
-        differenceInDays(parseISO(endDate), parseISO(startDate)) > days
-      ) {
-        return buildError(
-          `You cannot apply for a period longer than the allowed period of ${months} months.`,
-          field,
-        )
-      }
-
       // We check if the start date is within the allowed period
       if (
         differenceInMonths(parseISO(endDate), parseISO(dob)) > usageMaxMonths


### PR DESCRIPTION
This PR fixes 2 issues and updates 1 value:
1. Allow the user to move the duration slider beyond 6 months
2. Resolve an error if the user refreshes while on the duration slider screen.
3. Change the maxMonths value to 24

Notes:
On the duration slider screen, we can't determine if the user will spread their leave beyond 6 months with a percent ratio lower than 100. So we will take out the check `"if the endDate is inside the allowed range of days/months"` for now.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
