### PR TITLE
fix(parental-leave): Fix duplicate string id

### DIFF
--- a/libs/application/templates/parental-leave/src/lib/messages.ts
+++ b/libs/application/templates/parental-leave/src/lib/messages.ts
@@ -972,7 +972,7 @@ export const parentalLeaveFormMessages: MessageDir = {
       description: 'Your application was not approved',
     },
     draftNotApprovedOtherParentDesc: {
-      id: 'pl.application:draftFlow.requiresAction.employerDesc',
+      id: 'pl.application:draftFlow.requiresAction.otherParentDesc',
       defaultMessage: 'The other parent did not approve your request.',
       description: 'The other parent did not approve your request.',
     },


### PR DESCRIPTION
Fixes a duplicate string id.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
