### PR TITLE
fix(island-ui): Tweak aria errors for form fields

### DIFF
--- a/libs/island-ui/contentful/src/lib/ContactUs/ContactUs.tsx
+++ b/libs/island-ui/contentful/src/lib/ContactUs/ContactUs.tsx
@@ -84,6 +84,7 @@ export const ContactUs: FC<ContactUsProps> = ({
                         <Input
                           name="name"
                           label={labelName}
+                          placeholder={labelName}
                           required
                           errorMessage={errors.name?.message}
                           ref={register({
@@ -112,6 +113,7 @@ export const ContactUs: FC<ContactUsProps> = ({
                     <Input
                       name="email"
                       label={labelEmail}
+                      placeholder={labelEmail}
                       required
                       errorMessage={errors.email?.message}
                       ref={register({
@@ -125,12 +127,14 @@ export const ContactUs: FC<ContactUsProps> = ({
                     <Input
                       name="subject"
                       label={labelSubject}
+                      placeholder={labelSubject}
                       errorMessage={errors.subject?.message}
                       ref={register({})}
                     />
                     <Input
                       name="message"
                       label={labelMessage}
+                      placeholder={labelMessage}
                       required
                       errorMessage={errors.message?.message}
                       textarea

--- a/libs/island-ui/core/src/lib/Checkbox/Checkbox.tsx
+++ b/libs/island-ui/core/src/lib/Checkbox/Checkbox.tsx
@@ -26,6 +26,11 @@ export interface CheckboxProps {
   subLabel?: string
 }
 
+interface AriaError {
+  'aria-invalid': boolean
+  'aria-describedby': string
+}
+
 export const Checkbox = ({
   label,
   subLabel,
@@ -43,10 +48,11 @@ export const Checkbox = ({
   backgroundColor,
   filled = false,
 }: CheckboxProps) => {
+  const errorId = `${id}-error`
   const ariaError = hasError
     ? {
         'aria-invalid': true,
-        'aria-describedby': id,
+        'aria-describedby': errorId,
       }
     : {}
 
@@ -70,7 +76,7 @@ export const Checkbox = ({
         onChange={onChange}
         value={value}
         checked={checked}
-        {...ariaError}
+        {...(ariaError as AriaError)}
       />
       <label
         className={cn(styles.label, {
@@ -117,7 +123,11 @@ export const Checkbox = ({
           </div>
         )}
         {hasError && errorMessage && (
-          <div className={styles.errorMessage} id={id}>
+          <div
+            id={errorId}
+            className={styles.errorMessage}
+            aria-live="assertive"
+          >
             {errorMessage}
           </div>
         )}

--- a/libs/island-ui/core/src/lib/IconRC/Icon.tsx
+++ b/libs/island-ui/core/src/lib/IconRC/Icon.tsx
@@ -20,6 +20,7 @@ export interface IconProps {
   size?: Size
   className?: string
   skipPlaceholderSize?: boolean
+  ariaHidden?: boolean
 }
 
 export interface SvgProps {
@@ -61,6 +62,7 @@ export const Icon = ({
   title,
   titleId,
   skipPlaceholderSize,
+  ariaHidden,
 }: IconProps) => {
   const path = iconMap[type][icon]
   const IconSvg = useMemo(() => React.lazy(() => import('./icons/' + path)), [
@@ -99,7 +101,12 @@ export const Icon = ({
         />
       }
     >
-      <IconSvg fill={colors[color]} color={colors[color]} {...optionalProps} />
+      <IconSvg
+        aria-hidden={ariaHidden}
+        fill={colors[color]}
+        color={colors[color]}
+        {...optionalProps}
+      />
     </Suspense>
   )
 }

--- a/libs/island-ui/core/src/lib/Input/Input.tsx
+++ b/libs/island-ui/core/src/lib/Input/Input.tsx
@@ -13,6 +13,11 @@ import { UseBoxStylesProps } from '../Box/useBoxStyles'
 
 export type InputBackgroundColor = 'white' | 'blue'
 
+interface AriaError {
+  'aria-invalid': boolean
+  'aria-describedby': string
+}
+
 interface InputComponentProps {
   name: string
   value?: string | number
@@ -127,10 +132,11 @@ export const Input = forwardRef(
     } = props
     const [hasFocus, setHasFocus] = useState(false)
     const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null)
+    const errorId = `${id}-error`
     const ariaError = hasError
       ? {
           'aria-invalid': true,
-          'aria-describedby': id,
+          'aria-describedby': errorId,
         }
       : {}
     const mergedRefs = useMergeRefs(inputRef, ref || null)
@@ -170,7 +176,12 @@ export const Input = forwardRef(
               })}
             >
               {label}
-              {required && <span className={styles.isRequiredStar}> *</span>}
+              {required && (
+                <span aria-hidden="true" className={styles.isRequiredStar}>
+                  {' '}
+                  *
+                </span>
+              )}
               {tooltip && (
                 <Box marginLeft={1} display="inlineBlock">
                   <Tooltip text={tooltip} />
@@ -224,8 +235,9 @@ export const Input = forwardRef(
                 }
               }}
               type={type}
-              {...ariaError}
+              {...(ariaError as AriaError)}
               {...inputProps}
+              {...(required && { 'aria-required': true })}
             />
           </Box>
           {hasError && !icon && (
@@ -233,6 +245,7 @@ export const Input = forwardRef(
               icon="warning"
               skipPlaceholderSize
               className={cn(styles.icon, styles.iconError)}
+              ariaHidden
             />
           )}
           {icon && (
@@ -243,13 +256,15 @@ export const Input = forwardRef(
               className={cn(styles.icon, {
                 [styles.iconError]: hasError,
               })}
+              ariaHidden
             />
           )}
         </Box>
         {hasError && errorMessage && (
           <div
+            id={errorId}
             className={styles.errorMessage}
-            id={id}
+            aria-live="assertive"
             data-testid="inputErrorMessage"
           >
             {errorMessage}

--- a/libs/island-ui/core/src/lib/RadioButton/RadioButton.tsx
+++ b/libs/island-ui/core/src/lib/RadioButton/RadioButton.tsx
@@ -21,6 +21,11 @@ export interface RadioButtonProps {
   subLabel?: string
 }
 
+interface AriaError {
+  'aria-invalid': boolean
+  'aria-describedby': string
+}
+
 export const RadioButton = ({
   label,
   subLabel,
@@ -36,10 +41,11 @@ export const RadioButton = ({
   large,
   filled = false,
 }: RadioButtonProps) => {
+  const errorId = `${id}-error`
   const ariaError = hasError
     ? {
         'aria-invalid': true,
-        'aria-describedby': id,
+        'aria-describedby': errorId,
       }
     : {}
   return (
@@ -58,7 +64,7 @@ export const RadioButton = ({
         onChange={onChange}
         value={value}
         checked={checked}
-        {...ariaError}
+        {...(ariaError as AriaError)}
       />
       <label
         className={cn(styles.label, {
@@ -101,7 +107,11 @@ export const RadioButton = ({
           </div>
         )}
         {hasError && errorMessage && (
-          <div className={styles.errorMessage} id={id}>
+          <div
+            id={errorId}
+            className={styles.errorMessage}
+            aria-live="assertive"
+          >
             {errorMessage}
           </div>
         )}

--- a/libs/island-ui/core/src/lib/Select/Select.tsx
+++ b/libs/island-ui/core/src/lib/Select/Select.tsx
@@ -24,6 +24,12 @@ export type Option = {
   value: string | number
   disabled?: boolean
 }
+
+interface AriaError {
+  'aria-invalid': boolean
+  'aria-describedby': string
+}
+
 export interface SelectProps {
   name: string
   id?: string
@@ -46,6 +52,7 @@ export interface SelectProps {
   size?: 'sm' | 'md'
   backgroundColor?: InputBackgroundColor
   required?: boolean
+  ariaError?: AriaError
 }
 
 export const Select = ({
@@ -67,6 +74,14 @@ export const Select = ({
   backgroundColor = 'white',
   required,
 }: SelectProps) => {
+  const errorId = `${id}-error`
+  const ariaError = hasError
+    ? {
+        'aria-invalid': true,
+        'aria-describedby': errorId,
+      }
+    : {}
+
   return (
     <div
       className={cn(styles.wrapper, styles.wrapperColor[backgroundColor])}
@@ -92,6 +107,7 @@ export const Select = ({
         isSearchable={isSearchable}
         size={size}
         required={required}
+        ariaError={ariaError as AriaError}
         components={{
           Control,
           Input,
@@ -105,7 +121,7 @@ export const Select = ({
         }}
       />
       {hasError && errorMessage && (
-        <div className={styles.errorMessage} id={id}>
+        <div id={errorId} className={styles.errorMessage} aria-live="assertive">
           {errorMessage}
         </div>
       )}
@@ -186,11 +202,13 @@ const Placeholder = (props: PlaceholderProps<Option>) => {
 const Input: ComponentType<InputProps> = (
   props: InputProps & { selectProps?: Props<Option> },
 ) => {
+  const ariaError = props?.selectProps?.ariaError
   const size = (props?.selectProps?.size || 'md') as SelectProps['size']
   return (
     <components.Input
       className={cn(styles.input, styles.inputSize[size!])}
       {...props}
+      {...ariaError}
     />
   )
 }
@@ -210,7 +228,10 @@ const Control = (props: ControlProps<Option>) => {
       >
         {props.selectProps.label}
         {props.selectProps.required && (
-          <span className={styles.isRequiredStar}> *</span>
+          <span aria-hidden="true" className={styles.isRequiredStar}>
+            {' '}
+            *
+          </span>
         )}
       </label>
       {props.children}


### PR DESCRIPTION
- Added `aria-live="assertive"` to form errors for screen readers to immediately notify the user of any error
- Made input fields have `aria-describedby` with the id of the displayed error
- Set `aria-hidden="true"` for asterisks (*) in required field labels
- Added `ariaHidden` as an optional prop for Icon component and set it to true in the Input/Select where it displays an alert icon
 
## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
