### PR TITLE
fix(web): Fix organization subpage query to fetch assets

### DIFF
--- a/apps/web/screens/queries/Organization.tsx
+++ b/apps/web/screens/queries/Organization.tsx
@@ -112,7 +112,7 @@ export const GET_ORGANIZATION_SUBPAGE_QUERY = gql`
       title
       slug
       description {
-        ...HtmlFields
+        ...AllSlices
       }
       links {
         text


### PR DESCRIPTION
# Fix organization subpage query to fetch assets

## What

This fixes images and attachments not appearing on the subpages.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
