### PR TITLE
feat(api): Create endorsement system domain

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,11 +17,12 @@
 /apps/endorsement-system/                                                                     @island-is/kosmos-kaos
 /apps/icelandic-names-registry*/                                                              @island-is/kosmos-kaos
 /libs/api/domains/cms/                                                                        @island-is/kosmos-kaos @island-is/aranja
+/libs/api/domains/endorsement-system                                                          @island-is/kosmos-kaos
+/libs/api/domains/icelandic-names-registry/                                                   @island-is/kosmos-kaos
 /libs/application/templates/party-letter/                                                     @island-is/kosmos-kaos
 /libs/application/templates/party-application/                                                @island-is/kosmos-kaos
 /libs/clients/rsk/                                                                            @island-is/kosmos-kaos
 /libs/clients/zendesk/                                                                        @island-is/kosmos-kaos
-/libs/api/domains/icelandic-names-registry/                                                   @island-is/kosmos-kaos
 /libs/icelandic-names-registry/                                                               @island-is/kosmos-kaos
 
 /*/gjafakort/                                                                                 @island-is/kosmos-kaos

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -110,6 +110,7 @@
     - [Document Provider API](libs/api/domains/document-provider/README.md)
     - [API Domains Driving License](libs/api/domains/driving-license/README.md)
     - [API Domains Education](libs/api/domains/education/README.md)
+    - [API Domains Endorsement System](libs/api/domains/endorsement-system/README.md)
     - [API Domains Health Insurance](libs/api/domains/health-insurance/README.md)
     - [API Domains Rsk](libs/api/domains/rsk/README.md)
     - [API Domains Translations](libs/api/domains/translations/README.md)

--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -148,13 +148,9 @@ const autoSchemaFile = environment.production
       url: environment.rskDomain.url,
       username: environment.rskDomain.username,
     }),
-    ...(environment.endorsementSystem.isEnabled
-      ? [
-          EndorsementSystemModule.register({
-            baseApiUrl: environment.endorsementSystem.baseApiUrl,
-          }),
-        ]
-      : []),
+    EndorsementSystemModule.register({
+      baseApiUrl: environment.endorsementSystem.baseApiUrl,
+    }),
   ],
 })
 export class AppModule {}

--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -22,6 +22,7 @@ import { ApiCatalogueModule } from '@island.is/api/domains/api-catalogue'
 import { DocumentProviderModule } from '@island.is/api/domains/document-provider'
 import { SyslumennModule } from '@island.is/api/domains/syslumenn'
 import { RSKModule } from '@island.is/api/domains/rsk'
+import { EndorsementSystemModule } from '@island.is/api/domains/endorsement-system'
 
 const debug = process.env.NODE_ENV === 'development'
 const playground = debug || process.env.GQL_PLAYGROUND_ENABLED === 'true'
@@ -147,6 +148,13 @@ const autoSchemaFile = environment.production
       url: environment.rskDomain.url,
       username: environment.rskDomain.username,
     }),
+    ...(environment.endorsementSystem.isEnabled
+      ? [
+          EndorsementSystemModule.register({
+            baseApiUrl: environment.endorsementSystem.baseApiUrl,
+          }),
+        ]
+      : []),
   ],
 })
 export class AppModule {}

--- a/apps/api/src/app/environments/environment.prod.ts
+++ b/apps/api/src/app/environments/environment.prod.ts
@@ -79,7 +79,6 @@ export default {
     backendUrl: process.env.ICELANDIC_NAMES_REGISTRY_BACKEND_URL,
   },
   endorsementSystem: {
-    isEnabled: process.env.ENDORSEMENT_SYSTEM_IS_ENABLED ?? false,
     baseApiUrl: process.env.ENDORSEMENT_SYSTEM_BASE_API_URL,
   },
 }

--- a/apps/api/src/app/environments/environment.prod.ts
+++ b/apps/api/src/app/environments/environment.prod.ts
@@ -78,4 +78,8 @@ export default {
   icelandicNamesRegistry: {
     backendUrl: process.env.ICELANDIC_NAMES_REGISTRY_BACKEND_URL,
   },
+  endorsementSystem: {
+    isEnabled: process.env.ENDORSEMENT_SYSTEM_IS_ENABLED ?? false,
+    baseApiUrl: process.env.ENDORSEMENT_SYSTEM_BASE_API_URL,
+  },
 }

--- a/apps/api/src/app/environments/environment.ts
+++ b/apps/api/src/app/environments/environment.ts
@@ -83,4 +83,8 @@ export default {
   icelandicNamesRegistry: {
     backendUrl: 'http://localhost:4239',
   },
+  endorsementSystem: {
+    isEnabled: true,
+    baseApiUrl: 'http://localhost:4246',
+  },
 }

--- a/apps/api/src/app/environments/environment.ts
+++ b/apps/api/src/app/environments/environment.ts
@@ -84,7 +84,6 @@ export default {
     backendUrl: 'http://localhost:4239',
   },
   endorsementSystem: {
-    isEnabled: true,
     baseApiUrl: 'http://localhost:4246',
   },
 }

--- a/apps/endorsement-system/src/app/modules/endorsement/endorsement.controller.ts
+++ b/apps/endorsement-system/src/app/modules/endorsement/endorsement.controller.ts
@@ -10,7 +10,6 @@ import {
 import { ApiTags } from '@nestjs/swagger'
 import { Endorsement } from './endorsement.model'
 import { EndorsementService } from './endorsement.service'
-import * as faker from 'faker'
 
 @ApiTags('endorsement')
 @Controller('endorsement-list/:listId/endorsement')

--- a/apps/endorsement-system/src/app/modules/endorsement/endorsement.model.ts
+++ b/apps/endorsement-system/src/app/modules/endorsement/endorsement.model.ts
@@ -1,3 +1,4 @@
+import { ApiProperty } from '@nestjs/swagger'
 import {
   BelongsTo,
   Column,
@@ -9,7 +10,7 @@ import {
   UpdatedAt,
 } from 'sequelize-typescript'
 import { EndorsementList } from '../endorsementList/endorsementList.model'
-import { EndorsementMetaData } from '../endorsementMetadata/endorsementMetadata.service'
+import { EndorsementMetadata } from '../endorsementMetadata/endorsementMetadata.model'
 @Table({
   tableName: 'endorsement',
   indexes: [
@@ -47,11 +48,17 @@ export class Endorsement extends Model<Endorsement> {
     type: DataType.JSONB,
     allowNull: false,
   })
-  meta!: EndorsementMetaData
+  meta!: EndorsementMetadata
 
+  @ApiProperty({
+    type: String,
+  })
   @CreatedAt
   readonly created!: Date
 
+  @ApiProperty({
+    type: String,
+  })
   @UpdatedAt
   readonly modified!: Date
 }

--- a/apps/endorsement-system/src/app/modules/endorsementList/dto/endorsementList.dto.ts
+++ b/apps/endorsement-system/src/app/modules/endorsementList/dto/endorsementList.dto.ts
@@ -15,7 +15,7 @@ export class EndorsementListDto {
 
   @IsOptional()
   @IsString()
-  description = ''
+  description?: string = ''
 
   @IsOptional()
   @IsArray()

--- a/apps/endorsement-system/src/app/modules/endorsementList/dto/validationRule.dto.ts
+++ b/apps/endorsement-system/src/app/modules/endorsementList/dto/validationRule.dto.ts
@@ -1,4 +1,4 @@
-import { IsEnum, IsObject, IsOptional, IsString } from 'class-validator'
+import { IsEnum, IsObject, IsOptional } from 'class-validator'
 import { IsEndorsementValidator } from '../../endorsementValidator/endorsementValidator.decorator'
 import { ValidationRule } from '../../endorsementValidator/endorsementValidator.service'
 export class ValidationRuleDto {
@@ -8,5 +8,5 @@ export class ValidationRuleDto {
   @IsOptional()
   @IsObject()
   @IsEndorsementValidator()
-  value?: string
+  value?: object
 }

--- a/apps/endorsement-system/src/app/modules/endorsementList/endorsementList.controller.ts
+++ b/apps/endorsement-system/src/app/modules/endorsementList/endorsementList.controller.ts
@@ -26,6 +26,7 @@ export class EndorsementListController {
   async findLists(
     @Query() { tag }: FindEndorsementListByTagDto,
   ): Promise<EndorsementList[]> {
+    console.log('Hit!', tag)
     // TODO: Add dto for tags here?
     // TODO: Add pagination
     return await this.endorsementListService.findListsByTag(tag)

--- a/apps/endorsement-system/src/app/modules/endorsementList/endorsementList.controller.ts
+++ b/apps/endorsement-system/src/app/modules/endorsementList/endorsementList.controller.ts
@@ -26,7 +26,6 @@ export class EndorsementListController {
   async findLists(
     @Query() { tag }: FindEndorsementListByTagDto,
   ): Promise<EndorsementList[]> {
-    console.log('Hit!', tag)
     // TODO: Add dto for tags here?
     // TODO: Add pagination
     return await this.endorsementListService.findListsByTag(tag)

--- a/apps/endorsement-system/src/app/modules/endorsementList/endorsementList.model.ts
+++ b/apps/endorsement-system/src/app/modules/endorsementList/endorsementList.model.ts
@@ -1,3 +1,4 @@
+import { ApiProperty } from '@nestjs/swagger'
 import {
   Column,
   CreatedAt,
@@ -37,11 +38,19 @@ export class EndorsementList extends Model<EndorsementList> {
   })
   title!: string
 
+  @ApiProperty({
+    type: String,
+    nullable: true,
+  })
   @Column({
     type: DataType.TEXT,
   })
   description!: string | null
 
+  @ApiProperty({
+    type: String,
+    nullable: true,
+  })
   @Column({
     type: DataType.DATE,
   })
@@ -70,11 +79,17 @@ export class EndorsementList extends Model<EndorsementList> {
   owner!: string
 
   @HasMany(() => Endorsement)
-  readonly endorsements!: Endorsement[]
+  readonly endorsements?: Endorsement[]
 
+  @ApiProperty({
+    type: String,
+  })
   @CreatedAt
   readonly created!: Date
 
+  @ApiProperty({
+    type: String,
+  })
   @UpdatedAt
   readonly modified!: Date
 }

--- a/apps/endorsement-system/src/app/modules/endorsementMetadata/endorsementMetadata.model.ts
+++ b/apps/endorsement-system/src/app/modules/endorsementMetadata/endorsementMetadata.model.ts
@@ -1,0 +1,4 @@
+export class EndorsementMetadata {
+  fullName!: string
+  address!: any
+}

--- a/apps/endorsement-system/src/app/modules/endorsementMetadata/endorsementMetadata.service.ts
+++ b/apps/endorsement-system/src/app/modules/endorsementMetadata/endorsementMetadata.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common'
+import { EndorsementMetadata } from './endorsementMetadata.model'
 import {
   NationalRegistryResponse,
   NationalRegistryService,
@@ -16,9 +17,6 @@ type MetadataProviderField = {
 }
 type MetadataProviderService = {
   [providerKey in EndorsementMetaField]: MetadataProvider
-}
-export type EndorsementMetaData = {
-  [key in EndorsementMetaField]?: any
 }
 export interface MetadataProvider {
   metadataKey: string
@@ -95,7 +93,7 @@ export class EndorsementMetadataService {
   mapProviderDataToFields(
     fields: EndorsementMetaField[],
     providerData: MetadataProviderResponse,
-  ): EndorsementMetaData {
+  ): EndorsementMetadata {
     return fields.reduce(
       (metadata, fieldName) => ({
         ...metadata,
@@ -103,14 +101,14 @@ export class EndorsementMetadataService {
           providerData,
         ),
       }),
-      {},
+      {} as EndorsementMetadata,
     )
   }
 
   pruneMetadataFields(
-    allMetadataFields: EndorsementMetaData,
+    allMetadataFields: EndorsementMetadata,
     fieldsToKeep: EndorsementMetaField[],
-  ): EndorsementMetaData {
+  ): EndorsementMetadata {
     // some meta fields are only required for validation and should not be persisted, we remove them here
     return Object.entries(allMetadataFields).reduce(
       (metadata, [metadataKey, metadataValue]) =>
@@ -120,11 +118,11 @@ export class EndorsementMetadataService {
               [metadataKey]: metadataValue,
             }
           : metadata,
-      {},
+      {} as EndorsementMetadata,
     )
   }
 
-  async getMetadata(input: MetadataInput): Promise<EndorsementMetaData> {
+  async getMetadata(input: MetadataInput): Promise<EndorsementMetadata> {
     const requiredProviders = this.findProvidersByRequestedMetadataFields(
       input.fields,
     )

--- a/apps/endorsement-system/src/main.ts
+++ b/apps/endorsement-system/src/main.ts
@@ -6,4 +6,5 @@ bootstrap({
   appModule: AppModule,
   name: 'endorsement-system',
   openApi,
+  port: 4246,
 })

--- a/apps/endorsement-system/src/openApi.ts
+++ b/apps/endorsement-system/src/openApi.ts
@@ -1,7 +1,7 @@
 import { DocumentBuilder } from '@nestjs/swagger'
 
 export const openApi = new DocumentBuilder()
-  .setTitle('Endorsement system')
+  .setTitle('EndorsementSystem')
   .setDescription(
     'This API manages non-digital endorsements collected by systems within island.is.',
   )

--- a/apps/endorsement-system/webpack.config.js
+++ b/apps/endorsement-system/webpack.config.js
@@ -33,5 +33,13 @@ module.exports = (config) => {
     }),
   ]
 
-  return config
+  const basePath = 'apps/endorsement-system/src'
+  config.entry = {
+    ...config.entry,
+    buildOpenApi: './apps/endorsement-system/src/buildOpenApi.ts',
+  }
+  config.output.filename = '[name].js'
+  return {
+    ...config,
+  }
 }

--- a/libs/api/domains/endorsement-system/.eslintrc
+++ b/libs/api/domains/endorsement-system/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../../.eslintrc.json",
+  "rules": {},
+  "ignorePatterns": ["!**/*"]
+}

--- a/libs/api/domains/endorsement-system/README.md
+++ b/libs/api/domains/endorsement-system/README.md
@@ -1,0 +1,15 @@
+# api-domains-endorsement-system
+
+This library routes requests to the endorsement system app.
+
+## Generate types and api clients
+
+This library uses types and api clients from the endorsement system generated via [openapi generator](https://openapi-generator.tech/).  
+To generate api clients and types first run:  
+`yarn nx run endorsement-system:schemas/build-openapi` (build fresh openapi schema in endorsement system app)  
+Then run:  
+`yarn nx run api-domains-endorsement-system:schemas/openapi-generator` (creates clients and types inside this domain)
+
+## Running unit tests
+
+Run `ng test api-domains-endorsement-system` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/api/domains/endorsement-system/README.md
+++ b/libs/api/domains/endorsement-system/README.md
@@ -1,4 +1,4 @@
-# api-domains-endorsement-system
+# API Domains Endorsement System
 
 This library routes requests to the endorsement system app.
 

--- a/libs/api/domains/endorsement-system/jest.config.js
+++ b/libs/api/domains/endorsement-system/jest.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  preset: '../../../../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html'],
+  coverageDirectory: '../../../../coverage/libs/api/domains/application',
+  globals: { 'ts-jest': { tsConfig: '<rootDir>/tsconfig.spec.json' } },
+  displayName: 'api-domains-application',
+}

--- a/libs/api/domains/endorsement-system/src/index.ts
+++ b/libs/api/domains/endorsement-system/src/index.ts
@@ -1,0 +1,2 @@
+export * from './lib/endorsementSystem.module'
+export * from './lib/endorsementSystem.resolver'

--- a/libs/api/domains/endorsement-system/src/lib/dto/createEndorsementList.input.ts
+++ b/libs/api/domains/endorsement-system/src/lib/dto/createEndorsementList.input.ts
@@ -1,0 +1,41 @@
+import { Field, InputType, registerEnumType } from '@nestjs/graphql'
+import { IsEnum, IsOptional, IsString, ValidateNested } from 'class-validator'
+import { Type } from 'class-transformer'
+import {
+  EndorsementListDtoEndorsementMetaEnum,
+  EndorsementListDtoTagsEnum,
+} from '../../../gen/fetch'
+import { ValidationRuleInput } from './validationRule.input'
+
+registerEnumType(EndorsementListDtoEndorsementMetaEnum, {
+  name: 'EndorsementListDtoEndorsementMetaEnum',
+})
+
+registerEnumType(EndorsementListDtoTagsEnum, {
+  name: 'EndorsementListDtoTagsEnum',
+})
+
+@InputType()
+export class CreateEndorsementListDto {
+  @Field()
+  @IsString()
+  title!: string
+
+  @Field()
+  @IsOptional()
+  @IsString()
+  description?: string
+
+  @Field(() => [EndorsementListDtoEndorsementMetaEnum])
+  @IsEnum(EndorsementListDtoEndorsementMetaEnum, { each: true })
+  endorsementMeta!: EndorsementListDtoEndorsementMetaEnum[]
+
+  @Field(() => [EndorsementListDtoTagsEnum])
+  @IsEnum(EndorsementListDtoTagsEnum, { each: true })
+  tags!: EndorsementListDtoTagsEnum[]
+
+  @Field(() => [ValidationRuleInput])
+  @ValidateNested({ each: true })
+  @Type(() => ValidationRuleInput)
+  validationRules!: ValidationRuleInput[]
+}

--- a/libs/api/domains/endorsement-system/src/lib/dto/findEndorsementList.input.ts
+++ b/libs/api/domains/endorsement-system/src/lib/dto/findEndorsementList.input.ts
@@ -1,0 +1,9 @@
+import { Field, InputType } from '@nestjs/graphql'
+import { IsUUID } from 'class-validator'
+
+@InputType()
+export class FindEndorsementListInput {
+  @Field()
+  @IsUUID(4)
+  listId!: string
+}

--- a/libs/api/domains/endorsement-system/src/lib/dto/findEndorsementListsByTag.dto.ts
+++ b/libs/api/domains/endorsement-system/src/lib/dto/findEndorsementListsByTag.dto.ts
@@ -1,0 +1,14 @@
+import { Field, InputType, registerEnumType } from '@nestjs/graphql'
+import { IsEnum } from 'class-validator'
+import { EndorsementListControllerFindListsTagEnum } from '../../../gen/fetch/apis/EndorsementListApi'
+
+registerEnumType(EndorsementListControllerFindListsTagEnum, {
+  name: 'EndorsementListControllerFindListsTagEnum',
+})
+
+@InputType()
+export class FindEndorsementListByTagDto {
+  @Field(() => EndorsementListControllerFindListsTagEnum)
+  @IsEnum(EndorsementListControllerFindListsTagEnum)
+  tag!: EndorsementListControllerFindListsTagEnum
+}

--- a/libs/api/domains/endorsement-system/src/lib/dto/validationRule.input.ts
+++ b/libs/api/domains/endorsement-system/src/lib/dto/validationRule.input.ts
@@ -1,0 +1,15 @@
+import { Field, InputType } from '@nestjs/graphql'
+import { IsEnum, IsOptional } from 'class-validator'
+import { ValidationRuleDtoTypeEnum } from '../../../gen/fetch'
+import graphqlTypeJson from 'graphql-type-json'
+
+@InputType()
+export class ValidationRuleInput {
+  @Field(() => ValidationRuleDtoTypeEnum)
+  @IsEnum(ValidationRuleDtoTypeEnum)
+  type!: ValidationRuleDtoTypeEnum
+
+  @Field(() => graphqlTypeJson)
+  @IsOptional()
+  value?: object
+}

--- a/libs/api/domains/endorsement-system/src/lib/endorsementSystem.module.ts
+++ b/libs/api/domains/endorsement-system/src/lib/endorsementSystem.module.ts
@@ -1,0 +1,47 @@
+import { Module, DynamicModule } from '@nestjs/common'
+import fetch from 'isomorphic-fetch'
+import { EndorsementSystemResolver } from './endorsementSystem.resolver'
+import { EndorsementSystemService } from './endorsementSystem.service'
+import {
+  EndorsementApi,
+  Configuration,
+  EndorsementListApi,
+} from '../../gen/fetch'
+
+export interface Config {
+  baseApiUrl: string
+}
+
+@Module({})
+export class EndorsementSystemModule {
+  static register(config: Config): DynamicModule {
+    return {
+      module: EndorsementSystemModule,
+      providers: [
+        EndorsementSystemResolver,
+        EndorsementSystemService,
+        {
+          provide: EndorsementApi,
+          useFactory: async () =>
+            new EndorsementApi(
+              new Configuration({
+                fetchApi: fetch,
+                basePath: config.baseApiUrl,
+              }),
+            ),
+        },
+        {
+          provide: EndorsementListApi,
+          useFactory: async () =>
+            new EndorsementListApi(
+              new Configuration({
+                fetchApi: fetch,
+                basePath: config.baseApiUrl,
+              }),
+            ),
+        },
+      ],
+      exports: [],
+    }
+  }
+}

--- a/libs/api/domains/endorsement-system/src/lib/endorsementSystem.resolver.ts
+++ b/libs/api/domains/endorsement-system/src/lib/endorsementSystem.resolver.ts
@@ -1,0 +1,85 @@
+import { Args, Query, Resolver, Mutation } from '@nestjs/graphql'
+import { IdsAuthGuard, ScopesGuard } from '@island.is/auth-nest-tools'
+import { UseGuards } from '@nestjs/common'
+import { Endorsement } from './models/endorsement.model'
+import { EndorsementSystemService } from './endorsementSystem.service'
+import { FindEndorsementListInput } from './dto/findEndorsementList.input'
+import { EndorsementList } from './models/endorsementList.model'
+import { FindEndorsementListByTagDto } from './dto/findEndorsementListsByTag.dto'
+import { CreateEndorsementListDto } from './dto/createEndorsementList.input'
+
+// @UseGuards(IdsAuthGuard, ScopesGuard)
+@Resolver('EndorsementSystemResolver')
+export class EndorsementSystemResolver {
+  constructor(private endorsementSystemService: EndorsementSystemService) {}
+
+  // endorsement
+  @Query(() => Endorsement, { nullable: true })
+  async endorsementSystemGetSingleEndorsement(
+    @Args('input') input: FindEndorsementListInput,
+  ): Promise<Endorsement> {
+    return await this.endorsementSystemService.endorsementControllerFindOne(
+      input,
+    )
+  }
+
+  @Mutation(() => Endorsement)
+  async endorsementSystemEndorseList(
+    @Args('input') input: FindEndorsementListInput,
+  ): Promise<Endorsement> {
+    return await this.endorsementSystemService.endorsementControllerCreate(
+      input,
+    )
+  }
+
+  @Mutation(() => Boolean)
+  async endorsementSystemUnendorseList(
+    @Args('input') input: FindEndorsementListInput,
+  ): Promise<boolean> {
+    return await this.endorsementSystemService.endorsementControllerDelete(
+      input,
+    )
+  }
+
+  // Endorsement list
+  @Query(() => [EndorsementList])
+  async endorsementSystemFindEndorsementLists(
+    @Args('input') input: FindEndorsementListByTagDto,
+  ): Promise<EndorsementList[]> {
+    return await this.endorsementSystemService.endorsementListControllerFindLists(
+      input,
+    )
+  }
+
+  @Query(() => EndorsementList, { nullable: true })
+  async endorsementSystemGetSingleEndorsementList(
+    @Args('input') input: FindEndorsementListInput,
+  ): Promise<EndorsementList> {
+    return await this.endorsementSystemService.endorsementListControllerFindOne(
+      input,
+    )
+  }
+
+  @Query(() => [Endorsement])
+  async endorsementSystemUserEndorsements(): Promise<Endorsement[]> {
+    return await this.endorsementSystemService.endorsementListControllerFindEndorsements()
+  }
+
+  @Mutation(() => EndorsementList)
+  async endorsementSystemCloseEndorsementList(
+    @Args('input') input: FindEndorsementListInput,
+  ): Promise<EndorsementList> {
+    return await this.endorsementSystemService.endorsementListControllerClose(
+      input,
+    )
+  }
+
+  @Mutation(() => EndorsementList)
+  async endorsementSystemCreateEndorsementList(
+    @Args('input') input: CreateEndorsementListDto,
+  ): Promise<EndorsementList> {
+    return await this.endorsementSystemService.endorsementListControllerCreate({
+      endorsementListDto: input,
+    })
+  }
+}

--- a/libs/api/domains/endorsement-system/src/lib/endorsementSystem.service.ts
+++ b/libs/api/domains/endorsement-system/src/lib/endorsementSystem.service.ts
@@ -1,0 +1,99 @@
+import { Injectable } from '@nestjs/common'
+import { logger } from '@island.is/logging'
+import { ApolloError } from 'apollo-server-express'
+import {
+  EndorsementApi,
+  EndorsementListApi,
+  EndorsementControllerCreateRequest,
+  EndorsementControllerDeleteRequest,
+  EndorsementControllerFindOneRequest,
+  EndorsementListControllerCloseRequest,
+  EndorsementListControllerCreateRequest,
+  EndorsementListControllerFindListsRequest,
+  EndorsementListControllerFindOneRequest,
+} from '../../gen/fetch'
+
+const handleError = async (error: any) => {
+  logger.error(JSON.stringify(error))
+
+  if (error.json) {
+    console.log('inside if')
+    const json = await error.json()
+
+    logger.error(json)
+
+    console.log('About to run apollo error', json)
+    throw new ApolloError(JSON.stringify(json), error.status)
+  }
+
+  throw new ApolloError('Failed to resolve request', error.status)
+}
+
+@Injectable()
+export class EndorsementSystemService {
+  constructor(
+    private readonly endorsementApi: EndorsementApi,
+    private readonly endorsementListApi: EndorsementListApi,
+  ) {}
+
+  // Endorsement endpoints
+  async endorsementControllerFindOne(
+    input: EndorsementControllerFindOneRequest,
+  ) {
+    return await this.endorsementApi
+      .endorsementControllerFindOne(input)
+      .catch(handleError)
+  }
+
+  async endorsementControllerCreate(input: EndorsementControllerCreateRequest) {
+    return await this.endorsementApi
+      .endorsementControllerCreate(input)
+      .catch(handleError)
+  }
+
+  async endorsementControllerDelete(input: EndorsementControllerDeleteRequest) {
+    const result = await this.endorsementApi
+      .endorsementControllerDelete(input)
+      .catch(handleError)
+    return Boolean(result)
+  }
+
+  // Endorsement list endpoints
+  async endorsementListControllerFindLists(
+    input: EndorsementListControllerFindListsRequest,
+  ) {
+    return await this.endorsementListApi
+      .endorsementListControllerFindLists(input)
+      .catch(handleError)
+  }
+
+  async endorsementListControllerFindEndorsements() {
+    return await this.endorsementListApi
+      .endorsementListControllerFindEndorsements()
+      .catch(handleError)
+  }
+
+  async endorsementListControllerFindOne(
+    input: EndorsementListControllerFindOneRequest,
+  ) {
+    return await this.endorsementListApi
+      .endorsementListControllerFindOne(input)
+      .catch(handleError)
+  }
+
+  async endorsementListControllerClose(
+    input: EndorsementListControllerCloseRequest,
+  ) {
+    return await this.endorsementListApi
+      .endorsementListControllerClose(input)
+      .catch(handleError)
+  }
+
+  async endorsementListControllerCreate(
+    endorsementList: EndorsementListControllerCreateRequest,
+  ) {
+    return await this.endorsementListApi
+      .endorsementListControllerCreate(endorsementList)
+      .catch(handleError)
+  }
+}

--- a/libs/api/domains/endorsement-system/src/lib/endorsementSystem.service.ts
+++ b/libs/api/domains/endorsement-system/src/lib/endorsementSystem.service.ts
@@ -17,12 +17,10 @@ const handleError = async (error: any) => {
   logger.error(JSON.stringify(error))
 
   if (error.json) {
-    console.log('inside if')
     const json = await error.json()
 
     logger.error(json)
 
-    console.log('About to run apollo error', json)
     throw new ApolloError(JSON.stringify(json), error.status)
   }
 

--- a/libs/api/domains/endorsement-system/src/lib/models/endorsement.model.ts
+++ b/libs/api/domains/endorsement-system/src/lib/models/endorsement.model.ts
@@ -1,0 +1,23 @@
+import { Field, ObjectType, ID } from '@nestjs/graphql'
+import { EndorsementMetadata } from './endorsementMetadata.model'
+
+@ObjectType()
+export class Endorsement {
+  @Field(() => ID)
+  id!: string
+
+  @Field()
+  endorser!: string
+
+  @Field()
+  endorsementListId!: string
+
+  @Field(() => EndorsementMetadata)
+  meta!: EndorsementMetadata
+
+  @Field()
+  created!: string
+
+  @Field()
+  modified!: string
+}

--- a/libs/api/domains/endorsement-system/src/lib/models/endorsementList.model.ts
+++ b/libs/api/domains/endorsement-system/src/lib/models/endorsementList.model.ts
@@ -41,7 +41,7 @@ export class EndorsementList {
   owner!: string
 
   @Field(() => [Endorsement])
-  endorsements!: Endorsement[]
+  endorsements?: Endorsement[]
 
   @Field()
   created!: string

--- a/libs/api/domains/endorsement-system/src/lib/models/endorsementList.model.ts
+++ b/libs/api/domains/endorsement-system/src/lib/models/endorsementList.model.ts
@@ -1,0 +1,51 @@
+import { Field, ObjectType, ID, registerEnumType } from '@nestjs/graphql'
+import {
+  EndorsementListEndorsementMetaEnum,
+  EndorsementListTagsEnum,
+} from '../../../gen/fetch'
+import { Endorsement } from './endorsement.model'
+import { ValidationRule } from './validationRule.model'
+
+registerEnumType(EndorsementListEndorsementMetaEnum, {
+  name: 'EndorsementListEndorsementMetaEnum',
+})
+
+registerEnumType(EndorsementListTagsEnum, {
+  name: 'EndorsementListTagsEnum',
+})
+
+@ObjectType()
+export class EndorsementList {
+  @Field(() => ID)
+  id!: string
+
+  @Field()
+  title!: string
+
+  @Field({ nullable: true })
+  description!: string | null
+
+  @Field({ nullable: true })
+  closedDate!: string | null
+
+  @Field(() => [EndorsementListEndorsementMetaEnum])
+  endorsementMeta!: EndorsementListEndorsementMetaEnum[]
+
+  @Field(() => [EndorsementListTagsEnum])
+  tags!: EndorsementListTagsEnum[]
+
+  @Field(() => [ValidationRule])
+  validationRules!: ValidationRule[]
+
+  @Field()
+  owner!: string
+
+  @Field(() => [Endorsement])
+  endorsements!: Endorsement[]
+
+  @Field()
+  created!: string
+
+  @Field()
+  modified!: string
+}

--- a/libs/api/domains/endorsement-system/src/lib/models/endorsementMetadata.model.ts
+++ b/libs/api/domains/endorsement-system/src/lib/models/endorsementMetadata.model.ts
@@ -1,0 +1,11 @@
+import { Field, ObjectType } from '@nestjs/graphql'
+import graphqlTypeJson from 'graphql-type-json'
+
+@ObjectType()
+export class EndorsementMetadata {
+  @Field({ nullable: true })
+  fullName!: string | null
+
+  @Field(() => graphqlTypeJson, { nullable: true })
+  address!: object | null
+}

--- a/libs/api/domains/endorsement-system/src/lib/models/validationRule.model.ts
+++ b/libs/api/domains/endorsement-system/src/lib/models/validationRule.model.ts
@@ -1,0 +1,20 @@
+import { Field, ObjectType, registerEnumType } from '@nestjs/graphql'
+import { IsEnum, IsObject, IsOptional } from 'class-validator'
+import { ValidationRuleDtoTypeEnum } from '../../../gen/fetch'
+import graphqlTypeJson from 'graphql-type-json'
+
+registerEnumType(ValidationRuleDtoTypeEnum, {
+  name: 'ValidationRuleDtoTypeEnum',
+})
+
+@ObjectType()
+export class ValidationRule {
+  @Field(() => ValidationRuleDtoTypeEnum)
+  @IsEnum(ValidationRuleDtoTypeEnum)
+  type!: ValidationRuleDtoTypeEnum
+
+  @Field(() => graphqlTypeJson)
+  @IsOptional()
+  @IsObject()
+  value?: object
+}

--- a/libs/api/domains/endorsement-system/tsconfig.json
+++ b/libs/api/domains/endorsement-system/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node", "jest"],
+    "target": "es6",
+    "strict": true
+  },
+  "include": [],
+  "files": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/api/domains/endorsement-system/tsconfig.lib.json
+++ b/libs/api/domains/endorsement-system/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["**/*.spec.ts"],
+  "include": ["**/*.ts"]
+}

--- a/libs/api/domains/endorsement-system/tsconfig.spec.json
+++ b/libs/api/domains/endorsement-system/tsconfig.spec.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.spec.js",
+    "**/*.spec.jsx",
+    "**/*.d.ts"
+  ]
+}

--- a/nx.json
+++ b/nx.json
@@ -94,6 +94,9 @@
     "api-domains-education": {
       "tags": []
     },
+    "api-domains-endorsement-system": {
+      "tags": []
+    },
     "api-domains-file-upload": {
       "tags": []
     },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -68,6 +68,9 @@
       "@island.is/api/domains/education": [
         "libs/api/domains/education/src/index.ts"
       ],
+      "@island.is/api/domains/endorsement-system": [
+        "libs/api/domains/endorsement-system/src/index.ts"
+      ],
       "@island.is/api/domains/file-upload": [
         "libs/api/domains/file-upload/src/index.ts"
       ],

--- a/workspace.json
+++ b/workspace.json
@@ -970,6 +970,43 @@
         }
       }
     },
+    "api-domains-endorsement-system": {
+      "root": "libs/api/domains/endorsement-system",
+      "sourceRoot": "libs/api/domains/endorsement-system/src",
+      "projectType": "library",
+      "schematics": {},
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:lint",
+          "options": {
+            "linter": "eslint",
+            "tsConfig": [
+              "libs/api/domains/endorsement-system/tsconfig.lib.json",
+              "libs/api/domains/endorsement-system/tsconfig.spec.json"
+            ],
+            "exclude": [
+              "**/node_modules/**",
+              "!libs/api/domains/endorsement-system/**/*"
+            ]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/api/domains/endorsement-system/jest.config.js",
+            "passWithNoTests": true
+          },
+          "outputs": ["coverage/libs/api/domains/endorsement-system"]
+        },
+        "schemas/openapi-generator": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "outputPath": "libs/api/domains/endorsement-system/gen/fetch",
+            "command": "yarn openapi-generator -o libs/api/domains/endorsement-system/gen/fetch -i apps/endorsement-system/src/openapi.yaml --additional-properties=enumPropertyNaming=original"
+          }
+        }
+      }
+    },
     "api-domains-file-upload": {
       "root": "libs/api/domains/file-upload",
       "sourceRoot": "libs/api/domains/file-upload/src",
@@ -2964,7 +3001,11 @@
           "builder": "@nrwl/workspace:run-commands",
           "options": {
             "outputPath": "apps/endorsement-system/src/openapi.yaml",
-            "command": "yarn ts-node -P apps/endorsement-system/tsconfig.app.json apps/endorsement-system/src/buildOpenApi.ts"
+            "commands": [
+              "yarn build endorsement-system",
+              "yarn ts-node -P apps/endorsement-system/tsconfig.app.json dist/apps/endorsement-system/buildOpenApi.js"
+            ],
+            "parallel": false
           }
         },
         "migrate": {


### PR DESCRIPTION
# \<Description\>

We need access to the endorsement system through the central API.

## What

- Added endpoints from endorsement app to api
- Added decorators to endorsement system to get better openapi generation

## Why

- To allow integration into other systems within island.is

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Formatting passes locally with my changes
