### PR TITLE
fix(system-e2e): Wrong target name on cypress dockerfile

### DIFF
--- a/scripts/ci/Dockerfile.cypress
+++ b/scripts/ci/Dockerfile.cypress
@@ -190,7 +190,7 @@ RUN echo  " node version:    $(node -v) \n" \
 
 ENTRYPOINT ["cypress", "run"]
 
-FROM cypress-included as cypress-output
+FROM cypress-included as output-cypress
 
 RUN apt-get install jq -y
 RUN addgroup runners && adduser runner && adduser runner runners


### PR DESCRIPTION
## What

Fix broken build

## Why

Because developers are usually not happy with broken build

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
