### PR TITLE
fix(judicial-system): Remove custody time boundaries if past case was rejected

### DIFF
--- a/apps/judicial-system/web/src/routes/Shared/DetentionRequests/PastDetentionRequests.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/DetentionRequests/PastDetentionRequests.tsx
@@ -125,14 +125,18 @@ const PastDetentionRequests: React.FC<Props> = (props) => {
               rulingDate: string
               custodyEndDate: string
               courtEndTime: string
+              state: CaseState
             }
           }
         }) => {
           const rulingDate = row.row.original.rulingDate
           const custodyEndDate = row.row.original.custodyEndDate
           const courtEndDate = row.row.original.courtEndTime
+          const state = row.row.original.state
 
-          if (rulingDate) {
+          if (state === CaseState.REJECTED) {
+            return null
+          } else if (rulingDate) {
             return `${formatDate(parseISO(rulingDate), 'd.M.y')} - ${formatDate(
               parseISO(custodyEndDate),
               'd.M.y',


### PR DESCRIPTION
# Remove custody time boundaries if past case was rejected

https://app.asana.com/0/1199153462262248/1200214145052850

## What

Remove custody time boundaries if past case was rejected

## Why

It doesn't make sense to show to and from dates for rejected custody requests

## Screenshots / Gifs

![Screen Shot 2021-04-21 at 13 30 20](https://user-images.githubusercontent.com/3789875/115562136-bb438500-a2a5-11eb-9731-2fb0c62af955.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
