### PR TITLE
fix(dpo): Make Organisation api model fields nullable where nullable

### DIFF
--- a/libs/api/domains/document-provider/src/lib/models/organisation.model.ts
+++ b/libs/api/domains/document-provider/src/lib/models/organisation.model.ts
@@ -14,14 +14,14 @@ export class Organisation {
   @Field(() => String)
   name!: string
 
-  @Field(() => String)
-  address!: string
+  @Field(() => String, { nullable: true })
+  address?: string
 
-  @Field(() => String)
-  email!: string
+  @Field(() => String, { nullable: true })
+  email?: string
 
-  @Field(() => String)
-  phoneNumber!: string
+  @Field(() => String, { nullable: true })
+  phoneNumber?: string
 
   @Field(() => Date)
   created!: Date


### PR DESCRIPTION
# Make Organisation api model fields nullable where nullable

## What

Make Organisation api model fields nullable where nullable

## Why

To display manually inserted objects

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
