### PR TITLE
feat(judicial-system): Add case file comments to overview screen for judges

### DIFF
--- a/apps/judicial-system/web/src/routes/Judge/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Judge/Overview/Overview.tsx
@@ -518,6 +518,21 @@ export const JudgeOverview: React.FC = () => {
                   </Text>
                 </div>
               )}
+              {features.includes(Feature.CASE_FILES) &&
+                workingCase.caseFilesComments && (
+                  <div className={styles.infoSection}>
+                    <Box marginBottom={1}>
+                      <Text variant="h3" as="h3">
+                        Athugasemdir vegna rannsóknargagna
+                      </Text>
+                    </Box>
+                    <Text>
+                      <span className={styles.breakSpaces}>
+                        {workingCase.caseFilesComments}
+                      </span>
+                    </Text>
+                  </div>
+                )}
               {features.includes(Feature.CASE_FILES) && (
                 <div className={styles.infoSection}>
                   <Box marginBottom={1}>

--- a/apps/judicial-system/web/src/routes/Prosecutor/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Overview/Overview.tsx
@@ -358,7 +358,7 @@ export const Overview: React.FC = () => {
                   !!workingCase.caseFilesComments && (
                     <AccordionItem
                       id="id_7"
-                      label="Athugasemdir vegna málsmeðferðar"
+                      label="Athugasemdir vegna rannsóknargagna"
                       labelVariant="h3"
                     >
                       <Text>


### PR DESCRIPTION
# Add case file comments to overview screen for judges

https://app.asana.com/0/1199153462262248/1200195763827515

## What

Add case file comments to overview screen for judges and fix typo on overview page for prosecutors where "Athugasemdir vegna málsmeðferðar" was the title for both comments and caseFileComments

## Why

Case file comments should be visible to the judge.

## Screenshots / Gifs

![Screen Shot 2021-04-23 at 14 30 25](https://user-images.githubusercontent.com/3789875/115886439-74d65d80-a440-11eb-9342-b84e7be320e8.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
