### PR TITLE
feat(web): Use ReferenceLink for organization pages instead of hardcoded URLs

### DIFF
--- a/libs/api/domains/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/api/domains/cms/src/lib/generated/contentfulTypes.d.ts
@@ -1501,6 +1501,8 @@ export interface IMenuLinkFields {
     | ILifeEventPage
     | ILinkUrl
     | INews
+    | IOrganizationPage
+    | IOrganizationSubpage
     | IPage
     | IVidspyrnaFrontpage
     | IVidspyrnaPage
@@ -1539,6 +1541,8 @@ export interface IMenuLinkWithChildrenFields {
     | ILifeEventPage
     | ILinkUrl
     | INews
+    | IOrganizationPage
+    | IOrganizationSubpage
     | IPage
     | IVidspyrnaFrontpage
     | IVidspyrnaPage
@@ -1885,7 +1889,7 @@ export interface IOrganizationPageFields {
   description?: string | undefined
 
   /** Theme */
-  theme: 'default' | 'syslumenn' | 'digital_iceland'
+  theme: 'default' | 'default_with_image' | 'syslumenn' | 'digital_iceland'
 
   /** Slices */
   slices?:
@@ -1896,9 +1900,11 @@ export interface IOrganizationPageFields {
         | IFeaturedArticles
         | ISectionHeading
         | ILogoListSlice
+        | IOneColumnText
         | IStorySection
         | ITabSection
         | ITimeline
+        | ITwoColumnText
       )[]
     | undefined
 
@@ -1912,6 +1918,9 @@ export interface IOrganizationPageFields {
 
   /** Menu Links (DEPRECATED - DELETE AFTER 01-06-2021) */
   menuLinks?: ILinkGroup[] | undefined
+
+  /** Menu Links (test) */
+  menuItems?: IMenuLinkWithChildren[] | undefined
 
   /** Secondary Menu */
   secondaryMenu?: ILinkGroup | undefined

--- a/libs/api/domains/cms/src/lib/models/organizationPage.model.ts
+++ b/libs/api/domains/cms/src/lib/models/organizationPage.model.ts
@@ -12,6 +12,10 @@ import {
   OrganizationTheme,
 } from './organizationTheme.model'
 import { GenericTag, mapGenericTag } from './genericTag.model'
+import {
+  mapMenuLinkWithChildren,
+  MenuLinkWithChildren,
+} from './menuLinkWithChildren.model'
 
 @ObjectType()
 export class OrganizationPage {
@@ -45,6 +49,9 @@ export class OrganizationPage {
   @Field(() => [LinkGroup])
   menuLinks!: Array<LinkGroup>
 
+  @Field(() => [MenuLinkWithChildren])
+  menuItems!: Array<MenuLinkWithChildren>
+
   @Field(() => LinkGroup, { nullable: true })
   secondaryMenu!: LinkGroup | null
 
@@ -75,6 +82,7 @@ export const mapOrganizationPage = ({
   bottomSlices: (fields.bottomSlices ?? []).map(safelyMapSliceUnion),
   newsTag: fields.newsTag ? mapGenericTag(fields.newsTag) : null,
   menuLinks: (fields.menuLinks ?? []).map(mapLinkGroup),
+  menuItems: (fields.menuItems ?? []).map(mapMenuLinkWithChildren),
   secondaryMenu: fields.secondaryMenu
     ? mapLinkGroup(fields.secondaryMenu)
     : null,

--- a/libs/api/domains/cms/src/lib/unions/page.union.ts
+++ b/libs/api/domains/cms/src/lib/unions/page.union.ts
@@ -15,6 +15,8 @@ import {
   IArticleCategory,
   ILifeEventPage,
   INews,
+  IOrganizationPage,
+  IOrganizationSubpage,
   IPage,
   ISubArticle,
   IVidspyrnaFrontpage,
@@ -26,6 +28,14 @@ import {
   ArticleCategory,
   mapArticleCategory,
 } from '../models/articleCategory.model'
+import {
+  mapOrganizationPage,
+  OrganizationPage,
+} from '../models/organizationPage.model'
+import {
+  mapOrganizationSubpage,
+  OrganizationSubpage,
+} from '../models/organizationSubpage.model'
 
 export type PageTypes =
   | IArticle
@@ -37,6 +47,8 @@ export type PageTypes =
   | IVidspyrnaFrontpage
   | INews
   | IArticleCategory
+  | IOrganizationPage
+  | IOrganizationSubpage
 
 export const PageUnion = createUnionType({
   name: 'Page',
@@ -50,6 +62,8 @@ export const PageUnion = createUnionType({
     AdgerdirFrontpage,
     News,
     ArticleCategory,
+    OrganizationPage,
+    OrganizationSubpage,
   ],
   resolveType: (document) => document.typename, // typename is appended to request on indexing
 })
@@ -83,6 +97,12 @@ export const mapPageUnion = (page: PageTypes): typeof PageUnion => {
     }
     case 'articleCategory': {
       return mapArticleCategory(page as IArticleCategory)
+    }
+    case 'organizationPage': {
+      return mapOrganizationPage(page as IOrganizationPage)
+    }
+    case 'organizationSubpage': {
+      return mapOrganizationSubpage(page as IOrganizationSubpage)
     }
     default: {
       throw new ApolloError(`Can not map to page union: ${contentType}`)


### PR DESCRIPTION
# Use ReferenceLink for organization pages instead of hardcoded URLs

## What

This adds `organizationPage` and `organizationSubpage` to the `pageTypes` union and makes it possible to use the `ReferenceLink` type for organization pages.

This also creates a new field for organization page menu items, using this type instead of hardcoded URLs

## Why

More user friendly and less chances of broken links

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
