### PR TITLE
fix: Add missing `useNamespaceStrict()` `RetVal` typing action

### DIFF
--- a/apps/web/hooks/useNamespace.ts
+++ b/apps/web/hooks/useNamespace.ts
@@ -5,12 +5,18 @@ export type NamespaceMessages = Readonly<
   Record<string, NamespaceValues | undefined | null>
 >
 
+type RetVal<Value, Fallback> = Value extends Nully
+  ? Fallback
+  : Value extends Exclude<Value, Nully>
+  ? Value
+  : Exclude<Value, Nully> | Fallback
+
 export type NamespaceGetter<M extends NamespaceMessages> = {
-  <K extends keyof M>(key: K, fallback?: Nully): M[K] extends Nully ? K : M[K]
-  <K extends keyof M, F extends NamespaceValues>(
-    key: K,
-    fallback: F,
-  ): M[K] extends Nully ? F : M[K]
+  <K extends keyof M>(key: K, fallback?: Nully): RetVal<M[K], K>
+  <K extends keyof M, F extends NamespaceValues>(key: K, fallback: F): RetVal<
+    M[K],
+    F
+  >
   /** @deprecated
    * Sloppy fallback version (based on the assumption that this is somehow desirable/practical)
    */


### PR DESCRIPTION
## What

Adds a crucial bit to `useNamespaceStrict()`'s `RetVal` typing that didn't make it over from the feature-branch from which this feature was cherry picked.

(Test/spec file compilation only succeeded because Jest runs in non-strict mode. We **MUST** fix this issue.)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
