### PR TITLE
fix: Release/8.1 ic application s3 fix

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/institution-collaboration/institution-collaboration.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/institution-collaboration/institution-collaboration.service.ts
@@ -25,7 +25,7 @@ export class InstitutionCollaborationService {
   ) {}
 
   async sendApplication({ application }: TemplateApiModuleActionProps) {
-    const attachments = this.prepareAttachments(application)
+    const attachments = await this.prepareAttachments(application)
 
     await this.sharedTemplateAPIService.sendEmail(
       (props) =>
@@ -53,9 +53,9 @@ export class InstitutionCollaborationService {
   }
 
   // Generating signedUrls for mail attachments
-  private prepareAttachments(
+  private async prepareAttachments(
     application: Application,
-  ): InstitutionAttachment[] {
+  ): Promise<InstitutionAttachment[]> {
     const attachments = getValueViaPath(
       application.answers,
       'attachments',
@@ -64,11 +64,14 @@ export class InstitutionCollaborationService {
     if (!hasattachments) {
       return []
     }
-    return attachments.map(({ key, name }) => {
+
+    return Promise.all(attachments.map(async ({ key, name }) => {
       const url = (application.attachments as {
         [key: string]: string
       })[key]
-      return { name, url: this.fileStorageService.generateSignedUrl(url) }
-    })
+      const signedUrl = await this.fileStorageService.generateSignedUrl(url)
+      return { name, url: signedUrl }
+    }))
+
   }
 }

--- a/libs/application/template-api-modules/src/lib/modules/templates/institution-collaboration/institution-collaboration.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/institution-collaboration/institution-collaboration.service.ts
@@ -65,13 +65,14 @@ export class InstitutionCollaborationService {
       return []
     }
 
-    return Promise.all(attachments.map(async ({ key, name }) => {
-      const url = (application.attachments as {
-        [key: string]: string
-      })[key]
-      const signedUrl = await this.fileStorageService.generateSignedUrl(url)
-      return { name, url: signedUrl }
-    }))
-
+    return Promise.all(
+      attachments.map(async ({ key, name }) => {
+        const url = (application.attachments as {
+          [key: string]: string
+        })[key]
+        const signedUrl = await this.fileStorageService.generateSignedUrl(url)
+        return { name, url: signedUrl }
+      }),
+    )
   }
 }

--- a/libs/application/templates/institution-collaboration/src/forms/application.ts
+++ b/libs/application/templates/institution-collaboration/src/forms/application.ts
@@ -15,7 +15,7 @@ import { institutionApplicationMessages as m } from '../lib/messages'
 import { YES, FILE_SIZE_LIMIT } from '../constants'
 
 export const application: Form = buildForm({
-  id: 'InstitutionCollaborationDraftForm',
+  id: 'InstitutionCollaborationApplicationForm',
   title: m.applicant.formName,
   mode: FormModes.APPLYING,
   children: [

--- a/libs/file-storage/src/lib/file-storage.service.ts
+++ b/libs/file-storage/src/lib/file-storage.service.ts
@@ -47,11 +47,19 @@ export class FileStorageService {
     })
   }
 
-  public generateSignedUrl(url: string): string {
+  public generateSignedUrl(url: string): Promise<string> {
     const { bucket, key } = AmazonS3URI(url)
     const params = { Bucket: bucket, Expires: SIGNED_GET_EXPIRES, Key: key }
 
-    return this.s3.getSignedUrl('getObject', params)
+    return new Promise((resolve, reject) => {
+      this.s3.getSignedUrl('getObject',params, (err, signedUrl) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve(signedUrl)
+        }
+      })
+    })
   }
 
   async copyObjectFromUploadBucket(

--- a/libs/file-storage/src/lib/file-storage.service.ts
+++ b/libs/file-storage/src/lib/file-storage.service.ts
@@ -52,7 +52,7 @@ export class FileStorageService {
     const params = { Bucket: bucket, Expires: SIGNED_GET_EXPIRES, Key: key }
 
     return new Promise((resolve, reject) => {
-      this.s3.getSignedUrl('getObject',params, (err, signedUrl) => {
+      this.s3.getSignedUrl('getObject', params, (err, signedUrl) => {
         if (err) {
           reject(err)
         } else {


### PR DESCRIPTION
# Updated generateSignedUrl method
Ic Using asynchronous method instead of synchronous

##What
Changed s3.getSignedUrl method, using asynchronous overload instead of synchronous.

## Why
Attempting to fix issues when generating signedUrl on staging.

## Screenshots / Gifs
Attach Screenshots / Gifs to help reviewers understand the scope of the pull request


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
