### PR TITLE
chore(parental-leave): Temporarily remove sharing leave information with other parent

### DIFF
--- a/libs/application/templates/parental-leave/src/fields/Review/index.tsx
+++ b/libs/application/templates/parental-leave/src/fields/Review/index.tsx
@@ -606,64 +606,71 @@ const Review: FC<ReviewScreenProps> = ({
             </Box>
           </AccordionItem> */}
 
-          <AccordionItem
-            id="id_4"
-            label={formatMessage(
-              parentalLeaveFormMessages.shareInformation.subSection,
-            )}
-            startExpanded={allItemsExpanded}
-          >
-            <Box paddingY={4}>
-              <Box marginTop={1} marginBottom={2}>
-                <Text variant="h5">
-                  {formatMessage(
-                    parentalLeaveFormMessages.shareInformation.title,
-                  )}
-                </Text>
-              </Box>
-
-              {editable ? (
-                <RadioController
-                  id="shareInformationWithOtherParent"
-                  disabled={false}
-                  name="shareInformationWithOtherParent"
-                  error={
-                    (errors as RecordObject<string> | undefined)
-                      ?.shareInformationWithOtherParent
-                  }
-                  defaultValue={
-                    getValueViaPath(
-                      application.answers,
-                      'shareInformationWithOtherParent',
-                    ) as string[]
-                  }
-                  options={[
-                    {
-                      label: formatMessage(
-                        parentalLeaveFormMessages.shared.yesOptionLabel,
-                      ),
-                      value: YES,
-                    },
-                    {
-                      label: formatMessage(
-                        parentalLeaveFormMessages.shared.noOptionLabel,
-                      ),
-                      value: NO,
-                    },
-                  ]}
-                />
-              ) : (
-                <Text>
-                  {
-                    getValueViaPath(
-                      application.answers,
-                      'shareInformationWithOtherParent',
-                    ) as string[]
-                  }
-                </Text>
+          {/* TODO: Bring back this feature post v1 launch
+              Would also be good to combine it with the first accordion item
+              and make just one section for the other parent info, and sharing with the other parent
+              https://app.asana.com/0/1182378413629561/1200214178491339/f
+          */}
+          {/* {statefulOtherParentConfirmed === 'manual' && (
+            <AccordionItem
+              id="id_4"
+              label={formatMessage(
+                parentalLeaveFormMessages.shareInformation.subSection,
               )}
-            </Box>
-          </AccordionItem>
+              startExpanded={allItemsExpanded}
+            >
+              <Box paddingY={4}>
+                <Box marginTop={1} marginBottom={2}>
+                  <Text variant="h5">
+                    {formatMessage(
+                      parentalLeaveFormMessages.shareInformation.title,
+                    )}
+                  </Text>
+                </Box>
+
+                {editable ? (
+                  <RadioController
+                    id="shareInformationWithOtherParent"
+                    disabled={false}
+                    name="shareInformationWithOtherParent"
+                    error={
+                      (errors as RecordObject<string> | undefined)
+                        ?.shareInformationWithOtherParent
+                    }
+                    defaultValue={
+                      getValueViaPath(
+                        application.answers,
+                        'shareInformationWithOtherParent',
+                      ) as string[]
+                    }
+                    options={[
+                      {
+                        label: formatMessage(
+                          parentalLeaveFormMessages.shared.yesOptionLabel,
+                        ),
+                        value: YES,
+                      },
+                      {
+                        label: formatMessage(
+                          parentalLeaveFormMessages.shared.noOptionLabel,
+                        ),
+                        value: NO,
+                      },
+                    ]}
+                  />
+                ) : (
+                  <Text>
+                    {
+                      getValueViaPath(
+                        application.answers,
+                        'shareInformationWithOtherParent',
+                      ) as string[]
+                    }
+                  </Text>
+                )}
+              </Box>
+            </AccordionItem>
+          )} */}
         </Accordion>
       </Box>
     </div>

--- a/libs/application/templates/parental-leave/src/forms/ParentalLeaveForm.ts
+++ b/libs/application/templates/parental-leave/src/forms/ParentalLeaveForm.ts
@@ -743,31 +743,33 @@ export const ParentalLeaveForm: Form = buildForm({
         //   ],
         // }),
 
-        buildSubSection({
-          id: 'shareInformation',
-          title: parentalLeaveFormMessages.shareInformation.subSection,
-          condition: (answers) => answers.otherParent !== NO,
-          children: [
-            buildRadioField({
-              id: 'shareInformationWithOtherParent',
-              title: parentalLeaveFormMessages.shareInformation.title,
-              description:
-                parentalLeaveFormMessages.shareInformation.description,
-              emphasize: false,
-              largeButtons: true,
-              options: [
-                {
-                  label: parentalLeaveFormMessages.shareInformation.yesOption,
-                  value: YES,
-                },
-                {
-                  label: parentalLeaveFormMessages.shareInformation.noOption,
-                  value: NO,
-                },
-              ],
-            }),
-          ],
-        }),
+        // TODO: Bring back this feature post v1 launch
+        // https://app.asana.com/0/1182378413629561/1200214178491339/f
+        // buildSubSection({
+        //   id: 'shareInformation',
+        //   title: parentalLeaveFormMessages.shareInformation.subSection,
+        //   condition: (answers) => answers.otherParent !== NO,
+        //   children: [
+        //     buildRadioField({
+        //       id: 'shareInformationWithOtherParent',
+        //       title: parentalLeaveFormMessages.shareInformation.title,
+        //       description:
+        //         parentalLeaveFormMessages.shareInformation.description,
+        //       emphasize: false,
+        //       largeButtons: true,
+        //       options: [
+        //         {
+        //           label: parentalLeaveFormMessages.shareInformation.yesOption,
+        //           value: YES,
+        //         },
+        //         {
+        //           label: parentalLeaveFormMessages.shareInformation.noOption,
+        //           value: NO,
+        //         },
+        //       ],
+        //     }),
+        //   ],
+        // }),
       ],
     }),
     buildSection({


### PR DESCRIPTION
Temporarily comment out sharing leave information with other parent. 
We will work on this post v1 launch.

## Why

We have not built the functionality to combine to the information points (your leaves and the other parent)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
