### PR TITLE
fix(application-system): use env variables when sending emails

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/children-residence-change/emailGenerators/applicationSubmitted.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/children-residence-change/emailGenerators/applicationSubmitted.ts
@@ -28,8 +28,8 @@ export const generateApplicationSubmittedEmail: AttachmentEmailTemplateGenerator
 
   return {
     from: {
-      name: 'Devland.is',
-      address: 'development@island.is',
+      name: process.env.EMAIL_FROM_NAME ?? '',
+      address: process.env.EMAIL_FROM ?? 'development@island.is',
     },
     to: [
       {

--- a/libs/application/template-api-modules/src/lib/modules/templates/children-residence-change/emailGenerators/transferRequested.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/children-residence-change/emailGenerators/transferRequested.ts
@@ -18,8 +18,8 @@ export const transferRequestedEmail: EmailTemplateGenerator = (props) => {
 
   return {
     from: {
-      name: 'Devland.is',
-      address: 'development@island.is',
+      name: process.env.EMAIL_FROM_NAME ?? '',
+      address: process.env.EMAIL_FROM ?? 'development@island.is',
     },
     to: [
       {

--- a/libs/application/template-api-modules/src/lib/modules/templates/document-provider-onboarding/emailGenerators/applicationApproved.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/document-provider-onboarding/emailGenerators/applicationApproved.ts
@@ -38,8 +38,8 @@ export const generateApplicationApprovedEmail: EmailTemplateGenerator = (
 
   return {
     from: {
-      name: 'Devland.is',
-      address: 'development@island.is',
+      name: process.env.EMAIL_FROM_NAME ?? '',
+      address: process.env.EMAIL_FROM ?? 'development@island.is',
     },
     to: [
       {

--- a/libs/application/template-api-modules/src/lib/modules/templates/document-provider-onboarding/emailGenerators/applicationRejected.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/document-provider-onboarding/emailGenerators/applicationRejected.ts
@@ -35,8 +35,8 @@ export const generateApplicationRejectedEmail: EmailTemplateGenerator = (
 
   return {
     from: {
-      name: 'Devland.is',
-      address: 'development@island.is',
+      name: process.env.EMAIL_FROM_NAME ?? '',
+      address: process.env.EMAIL_FROM ?? 'development@island.is',
     },
     to: [
       {

--- a/libs/application/template-api-modules/src/lib/modules/templates/document-provider-onboarding/emailGenerators/assignReviewerEmail.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/document-provider-onboarding/emailGenerators/assignReviewerEmail.ts
@@ -42,8 +42,8 @@ export const generateAssignReviewerEmail: AssignmentEmailTemplateGenerator = (
 
   return {
     from: {
-      name: 'Devland.is',
-      address: 'development@island.is',
+      name: process.env.EMAIL_FROM_NAME ?? '',
+      address: process.env.EMAIL_FROM ?? 'development@island.is',
     },
     to: [
       {

--- a/libs/application/templates/children-residence-change/src/forms/ChildrenResidenceChangeForm.ts
+++ b/libs/application/templates/children-residence-change/src/forms/ChildrenResidenceChangeForm.ts
@@ -97,7 +97,7 @@ export const ChildrenResidenceChangeForm: Form = buildForm({
               dataProviders: [
                 buildDataProviderItem({
                   id: 'nationalRegistry',
-                  type: 'DataProviderTypes.NationalRegistry',
+                  type: DataProviderTypes.NationalRegistry,
                   title: m.externalData.applicant.title,
                   subTitle: m.externalData.applicant.subTitle,
                 }),


### PR DESCRIPTION
# \<Description\>

Currently emails are not sending because `development@island.is` was hardcoded as a sender.
Fixing this issue for applications that are already in production.

We have a better solution for this that we will implement and release later.

## Why

- Emails are failing on production
