### PR TITLE
feat(island-ui): Add secondary CTA option to Action Card

### DIFF
--- a/libs/island-ui/core/src/lib/ActionCard/ActionCard.stories.tsx
+++ b/libs/island-ui/core/src/lib/ActionCard/ActionCard.stories.tsx
@@ -17,6 +17,7 @@ export const Default = () => (
     cta={{ label: 'Click me' }}
   />
 )
+
 export const Unavailable = () => (
   <ActionCard
     heading="Default"
@@ -34,7 +35,8 @@ export const SecondaryCTA = () => (
   <ActionCard
     heading="Hello"
     text="This is the text"
-    cta={{ label: 'Click me', variant: 'text' }}
+    cta={{ label: 'Click me' }}
+    secondaryCta={{ label: 'Click me' }}
   />
 )
 

--- a/libs/island-ui/core/src/lib/ActionCard/ActionCard.tsx
+++ b/libs/island-ui/core/src/lib/ActionCard/ActionCard.tsx
@@ -13,7 +13,7 @@ import { Icon } from '../IconRC/Icon'
 
 type ActionCardProps = {
   date?: string
-  heading: string
+  heading?: string
   text?: string
   tag?: {
     label: string
@@ -24,6 +24,11 @@ type ActionCardProps = {
     label: string
     variant?: ButtonTypes['variant']
     size?: ButtonSizes
+    icon?: 'arrowForward'
+    onClick?: () => void
+  }
+  secondaryCta?: {
+    label: string
     icon?: 'arrowForward'
     onClick?: () => void
   }
@@ -68,6 +73,7 @@ export const ActionCard: React.FC<ActionCardProps> = ({
   heading,
   text,
   cta: _cta,
+  secondaryCta,
   tag: _tag,
   unavailable: _unavailable,
   progressMeter: _progressMeter,
@@ -130,16 +136,37 @@ export const ActionCard: React.FC<ActionCardProps> = ({
 
   const renderDefault = () => {
     const hasCTA = cta.label && !progressMeter.active
+    const hasSecondaryCTA =
+      hasCTA && secondaryCta?.label && !progressMeter.active
 
     return (
       <>
         {!date && renderTag()}
 
         {!!hasCTA && (
-          <Box paddingTop={tag.label ? 'gutter' : 0}>
-            <Button variant={cta.variant} size="small" onClick={cta.onClick}>
-              {cta.label}
-            </Button>
+          <Box
+            paddingTop={tag.label ? 'gutter' : 0}
+            display="flex"
+            justifyContent={['flexStart', 'flexEnd']}
+            alignItems="center"
+            flexDirection="row"
+          >
+            {hasSecondaryCTA && (
+              <Box paddingRight={4} paddingLeft={2}>
+                <Button
+                  variant="text"
+                  onClick={secondaryCta?.onClick}
+                  icon={'document'}
+                >
+                  {secondaryCta?.label}
+                </Button>
+              </Box>
+            )}
+            <Box>
+              <Button variant={cta.variant} size="small" onClick={cta.onClick}>
+                {cta.label}
+              </Button>
+            </Box>
           </Box>
         )}
       </>
@@ -199,13 +226,14 @@ export const ActionCard: React.FC<ActionCardProps> = ({
       >
         <Box>
           <Text variant="h3">{heading}</Text>
-          <Text paddingTop={1}>{text}</Text>
+          <Text paddingTop={!!heading ? 1 : 0}>{text}</Text>
         </Box>
 
         <Box
           display="flex"
           alignItems={['flexStart', 'flexEnd']}
           flexDirection="column"
+          flexShrink={0}
           marginTop={['gutter', 0]}
           marginLeft={[0, 'auto']}
         >

--- a/libs/island-ui/core/src/lib/ActionCard/ActionCard.tsx
+++ b/libs/island-ui/core/src/lib/ActionCard/ActionCard.tsx
@@ -226,7 +226,7 @@ export const ActionCard: React.FC<ActionCardProps> = ({
       >
         <Box>
           <Text variant="h3">{heading}</Text>
-          <Text paddingTop={!!heading ? 1 : 0}>{text}</Text>
+          <Text paddingTop={heading ? 1 : 0}>{text}</Text>
         </Box>
 
         <Box

--- a/libs/island-ui/core/src/lib/IconRC/iconMap.ts
+++ b/libs/island-ui/core/src/lib/IconRC/iconMap.ts
@@ -23,6 +23,7 @@ export type Icon =
   | 'closeCircle'
   | 'close'
   | 'copy'
+  | 'document'
   | 'documents'
   | 'download'
   | 'ellipse'
@@ -80,6 +81,7 @@ export default {
     closeCircle: 'CloseCircle',
     close: 'Close',
     copy: 'Copy',
+    document: 'Document',
     documents: 'Documents',
     download: 'Download',
     ellipse: 'Ellipse',
@@ -136,6 +138,7 @@ export default {
     closeCircle: 'CloseCircleOutline',
     close: 'Close',
     copy: 'CopyOutline',
+    document: 'DocumentOutline',
     documents: 'DocumentsOutline',
     download: 'DownloadOutline',
     ellipse: 'EllipseOutline',

--- a/libs/island-ui/core/src/lib/IconRC/icons/Document.tsx
+++ b/libs/island-ui/core/src/lib/IconRC/icons/Document.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react'
+import { SvgProps as SVGRProps } from '../Icon'
+
+const SvgDocument = ({
+  title,
+  titleId,
+  ...props
+}: React.SVGProps<SVGSVGElement> & SVGRProps) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className="document_svg__ionicon"
+      viewBox="0 0 512 512"
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path d="M428 224H288a48 48 0 01-48-48V36a4 4 0 00-4-4h-92a64 64 0 00-64 64v320a64 64 0 0064 64h224a64 64 0 0064-64V228a4 4 0 00-4-4z" />
+      <path d="M419.22 188.59L275.41 44.78a2 2 0 00-3.41 1.41V176a16 16 0 0016 16h129.81a2 2 0 001.41-3.41z" />
+    </svg>
+  )
+}
+
+export default SvgDocument

--- a/libs/island-ui/core/src/lib/IconRC/icons/DocumentOutline.tsx
+++ b/libs/island-ui/core/src/lib/IconRC/icons/DocumentOutline.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react'
+import { SvgProps as SVGRProps } from '../Icon'
+
+const SvgDocumentOutline = ({
+  title,
+  titleId,
+  ...props
+}: React.SVGProps<SVGSVGElement> & SVGRProps) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className="document-outline_svg__ionicon"
+      viewBox="0 0 512 512"
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path
+        d="M416 221.25V416a48 48 0 01-48 48H144a48 48 0 01-48-48V96a48 48 0 0148-48h98.75a32 32 0 0122.62 9.37l141.26 141.26a32 32 0 019.37 22.62z"
+        fill="none"
+        stroke="currentColor"
+        strokeLinejoin="round"
+        strokeWidth={32}
+      />
+      <path
+        d="M256 56v120a32 32 0 0032 32h120"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={32}
+      />
+    </svg>
+  )
+}
+
+export default SvgDocumentOutline


### PR DESCRIPTION
# Add secondary CTA option to Action Card

## What

This adds the option for a secondary CTA on Action Cards.

## Why

We need something like this for a list of applications that have both a digital version (primary) and a PDF (secondary).

Designers think this should be a part of the core library.

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/3607456/116431816-a469d900-a837-11eb-81f2-abfbb680ede0.png)

![image](https://user-images.githubusercontent.com/3607456/116431876-b3e92200-a837-11eb-9f0f-c8bfd07a166d.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
