### PR TITLE
fix(as): Reads email from env values

### DIFF
--- a/apps/application-system/api/src/environments/environment.prod.ts
+++ b/apps/application-system/api/src/environments/environment.prod.ts
@@ -23,6 +23,10 @@ export default {
         region: process.env.EMAIL_REGION,
       },
     },
+    email: {
+      sender: process.env.EMAIL_FROM_NAME,
+      address: process.env.EMAIL_FROM,
+    },
     jwtSecret: process.env.AUTH_JWT_SECRET,
     xRoadBasePathWithEnv: process.env.XROAD_BASE_PATH_WITH_ENV ?? '',
     baseApiUrl,

--- a/apps/application-system/api/src/environments/environment.ts
+++ b/apps/application-system/api/src/environments/environment.ts
@@ -28,6 +28,10 @@ export default {
     emailOptions: {
       useTestAccount: true,
     },
+    email: {
+      sender: 'Devland.is',
+      address: 'development@island.is',
+    },
     jwtSecret: 'supersecret',
     xRoadBasePathWithEnv: process.env.XROAD_BASE_PATH_WITH_ENV ?? '',
     baseApiUrl,

--- a/libs/application/template-api-modules/src/lib/modules/shared/shared.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/shared/shared.service.ts
@@ -32,10 +32,10 @@ export class SharedTemplateApiService {
       'clientLocationOrigin',
     ) as string
 
-    const email = getConfigValue(this.configService, 'email') as {
-      sender: string
-      address: string
-    }
+    const email = getConfigValue(
+      this.configService,
+      'email',
+    ) as BaseTemplateAPIModuleConfig['email']
 
     const template = templateGenerator({
       application,
@@ -64,10 +64,10 @@ export class SharedTemplateApiService {
       'clientLocationOrigin',
     ) as string
 
-    const email = getConfigValue(this.configService, 'email') as {
-      sender: string
-      address: string
-    }
+    const email = getConfigValue(
+      this.configService,
+      'email',
+    ) as BaseTemplateAPIModuleConfig['email']
 
     const assignLink = `${clientLocationOrigin}/tengjast-umsokn?token=${token}`
 
@@ -98,10 +98,10 @@ export class SharedTemplateApiService {
       'clientLocationOrigin',
     ) as string
 
-    const email = getConfigValue(this.configService, 'email') as {
-      sender: string
-      address: string
-    }
+    const email = getConfigValue(
+      this.configService,
+      'email',
+    ) as BaseTemplateAPIModuleConfig['email']
 
     const template = templateGenerator(
       {

--- a/libs/application/template-api-modules/src/lib/modules/shared/shared.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/shared/shared.service.ts
@@ -32,11 +32,17 @@ export class SharedTemplateApiService {
       'clientLocationOrigin',
     ) as string
 
+    const email = getConfigValue(this.configService, 'email') as {
+      sender: string
+      address: string
+    }
+
     const template = templateGenerator({
       application,
       options: {
         clientLocationOrigin,
         locale,
+        email,
       },
     })
 
@@ -58,6 +64,11 @@ export class SharedTemplateApiService {
       'clientLocationOrigin',
     ) as string
 
+    const email = getConfigValue(this.configService, 'email') as {
+      sender: string
+      address: string
+    }
+
     const assignLink = `${clientLocationOrigin}/tengjast-umsokn?token=${token}`
 
     const template = templateGenerator(
@@ -66,6 +77,7 @@ export class SharedTemplateApiService {
         options: {
           clientLocationOrigin,
           locale,
+          email,
         },
       },
       assignLink,
@@ -78,7 +90,7 @@ export class SharedTemplateApiService {
     templateGenerator: AttachmentEmailTemplateGenerator,
     application: Application,
     fileContent: string,
-    email: string,
+    recipientEmail: string,
     locale = 'is',
   ) {
     const clientLocationOrigin = getConfigValue(
@@ -86,16 +98,22 @@ export class SharedTemplateApiService {
       'clientLocationOrigin',
     ) as string
 
+    const email = getConfigValue(this.configService, 'email') as {
+      sender: string
+      address: string
+    }
+
     const template = templateGenerator(
       {
         application,
         options: {
           clientLocationOrigin,
           locale,
+          email,
         },
       },
       fileContent,
-      email,
+      recipientEmail,
     )
 
     return this.emailService.sendEmail(template)

--- a/libs/application/template-api-modules/src/lib/modules/templates/children-residence-change/emailGenerators/applicationSubmitted.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/children-residence-change/emailGenerators/applicationSubmitted.ts
@@ -5,11 +5,11 @@ import { AttachmentEmailTemplateGenerator } from '../../../../types'
 export const generateApplicationSubmittedEmail: AttachmentEmailTemplateGenerator = (
   props,
   fileContent,
-  email,
+  recipientEmail,
 ) => {
   const {
     application,
-    options: { clientLocationOrigin },
+    options: { clientLocationOrigin, email },
   } = props
   const applicationSlug = getSlugFromType(application.typeId) as string
   const applicationLink = `${clientLocationOrigin}/${applicationSlug}/${application.id}`
@@ -28,13 +28,13 @@ export const generateApplicationSubmittedEmail: AttachmentEmailTemplateGenerator
 
   return {
     from: {
-      name: 'Devland.is',
-      address: 'development@island.is',
+      name: email.sender,
+      address: email.address,
     },
     to: [
       {
         name: '',
-        address: email,
+        address: recipientEmail,
       },
     ],
     subject,

--- a/libs/application/template-api-modules/src/lib/modules/templates/children-residence-change/emailGenerators/transferRequested.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/children-residence-change/emailGenerators/transferRequested.ts
@@ -5,7 +5,7 @@ import { EmailTemplateGenerator } from '../../../../types'
 export const transferRequestedEmail: EmailTemplateGenerator = (props) => {
   const application = (props.application as unknown) as CRCApplication
   const {
-    options: { clientLocationOrigin },
+    options: { clientLocationOrigin, email },
   } = props
   const applicationSlug = getSlugFromType(application.typeId) as string
   const applicationLink = `${clientLocationOrigin}/${applicationSlug}/${application.id}`
@@ -20,8 +20,8 @@ export const transferRequestedEmail: EmailTemplateGenerator = (props) => {
 
   return {
     from: {
-      name: 'Devland.is',
-      address: 'development@island.is',
+      name: email.sender,
+      address: email.address,
     },
     to: [
       {

--- a/libs/application/template-api-modules/src/lib/modules/templates/document-provider-onboarding/emailGenerators/applicationApproved.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/document-provider-onboarding/emailGenerators/applicationApproved.ts
@@ -9,7 +9,7 @@ export const generateApplicationApprovedEmail: EmailTemplateGenerator = (
 ) => {
   const {
     application,
-    options: { locale, clientLocationOrigin },
+    options: { locale, clientLocationOrigin, email },
   } = props
 
   const applicantEmail = get(application.answers, 'applicant.email')
@@ -38,8 +38,8 @@ export const generateApplicationApprovedEmail: EmailTemplateGenerator = (
 
   return {
     from: {
-      name: 'Devland.is',
-      address: 'development@island.is',
+      name: email.sender,
+      address: email.address,
     },
     to: [
       {

--- a/libs/application/template-api-modules/src/lib/modules/templates/document-provider-onboarding/emailGenerators/applicationRejected.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/document-provider-onboarding/emailGenerators/applicationRejected.ts
@@ -8,7 +8,7 @@ export const generateApplicationRejectedEmail: EmailTemplateGenerator = (
 ) => {
   const {
     application,
-    options: { locale },
+    options: { email, locale },
   } = props
 
   const applicantEmail = get(application.answers, 'applicant.email')
@@ -35,8 +35,8 @@ export const generateApplicationRejectedEmail: EmailTemplateGenerator = (
 
   return {
     from: {
-      name: 'Devland.is',
-      address: 'development@island.is',
+      name: email.sender,
+      address: email.address,
     },
     to: [
       {

--- a/libs/application/template-api-modules/src/lib/modules/templates/document-provider-onboarding/emailGenerators/assignReviewerEmail.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/document-provider-onboarding/emailGenerators/assignReviewerEmail.ts
@@ -8,11 +8,11 @@ export const generateAssignReviewerEmail: AssignmentEmailTemplateGenerator = (
 ) => {
   const {
     application,
-    options: { locale },
+    options: { email, locale },
   } = props
   const applicantNationalId = get(application.answers, 'applicant.nationalId')
   const applicantName = get(application.answers, 'applicant.name')
-  const email = process.env.DOCUMENT_PROVIDER_ONBOARDING_REVIEWER
+  const emailRecipient = process.env.DOCUMENT_PROVIDER_ONBOARDING_REVIEWER
 
   const subject =
     locale === 'is'
@@ -42,13 +42,13 @@ export const generateAssignReviewerEmail: AssignmentEmailTemplateGenerator = (
 
   return {
     from: {
-      name: 'Devland.is',
-      address: 'development@island.is',
+      name: email.sender,
+      address: email.address,
     },
     to: [
       {
         name: '',
-        address: email as string,
+        address: emailRecipient as string,
       },
     ],
     subject,

--- a/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/emailGenerators/applicationApproved.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/emailGenerators/applicationApproved.ts
@@ -8,7 +8,7 @@ export const generateApplicationApprovedEmail: EmailTemplateGenerator = (
 ) => {
   const {
     application,
-    options: { locale },
+    options: { email, locale },
   } = props
 
   const applicantEmail = get(application.answers, 'applicant.email')
@@ -37,8 +37,8 @@ export const generateApplicationApprovedEmail: EmailTemplateGenerator = (
 
   return {
     from: {
-      name: 'Devland.is',
-      address: 'development@island.is',
+      name: email.sender,
+      address: email.address,
     },
     to: [
       {

--- a/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/emailGenerators/assignEmployerEmail.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/emailGenerators/assignEmployerEmail.ts
@@ -9,7 +9,7 @@ export const generateAssignEmployerApplicationEmail: AssignmentEmailTemplateGene
 ) => {
   const {
     application,
-    options: { locale },
+    options: { email, locale },
   } = props
 
   const employerEmail = get(application.answers, 'employer.email')
@@ -40,8 +40,8 @@ export const generateAssignEmployerApplicationEmail: AssignmentEmailTemplateGene
 
   return {
     from: {
-      name: 'Devland.is',
-      address: 'development@island.is',
+      name: email.sender,
+      address: email.address,
     },
     to: [
       {

--- a/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/emailGenerators/assignOtherParentEmail.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/emailGenerators/assignOtherParentEmail.ts
@@ -9,7 +9,7 @@ export const generateAssignOtherParentApplicationEmail: AssignmentEmailTemplateG
 ) => {
   const {
     application,
-    options: { locale },
+    options: { email, locale },
   } = props
 
   const applicantEmail = get(application.answers, 'person.email')
@@ -41,8 +41,8 @@ export const generateAssignOtherParentApplicationEmail: AssignmentEmailTemplateG
 
   return {
     from: {
-      name: 'Devland.is',
-      address: 'development@island.is',
+      name: email.sender,
+      address: email.address,
     },
     to: [
       {

--- a/libs/application/template-api-modules/src/lib/modules/templates/reference-template/emailGenerators/applicationApproved.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/reference-template/emailGenerators/applicationApproved.ts
@@ -8,7 +8,7 @@ export const generateApplicationApprovedEmail: EmailTemplateGenerator = (
 ) => {
   const {
     application,
-    options: { locale },
+    options: { email, locale },
   } = props
 
   const applicantEmail = get(application.answers, 'person.email')
@@ -37,8 +37,8 @@ export const generateApplicationApprovedEmail: EmailTemplateGenerator = (
 
   return {
     from: {
-      name: 'Devland.is',
-      address: 'development@island.is',
+      name: email.sender,
+      address: email.address,
     },
     to: [
       {

--- a/libs/application/template-api-modules/src/lib/types/index.ts
+++ b/libs/application/template-api-modules/src/lib/types/index.ts
@@ -28,7 +28,6 @@ export interface BaseTemplateAPIModuleConfig {
     password: string
   }
 }
-
 export interface TemplateApiModuleActionProps {
   application: Application
   authorization: string

--- a/libs/application/template-api-modules/src/lib/types/index.ts
+++ b/libs/application/template-api-modules/src/lib/types/index.ts
@@ -17,6 +17,10 @@ export interface BaseTemplateAPIModuleConfig {
     username: string
     password: string
   }
+  email: {
+    sender: string
+    address: string
+  }
   presignBucket: string
   smsOptions: {
     url: string
@@ -35,6 +39,7 @@ export interface EmailTemplateGeneratorProps {
   options: {
     clientLocationOrigin: string
     locale: string // TODO union / enum
+    email: { sender: string; address: string }
   }
 }
 


### PR DESCRIPTION
# \<Description\>
Reads email sender name and email address from environment variables instead of hard coding them.

## Why
There is a different value white listed for sending email's on production then on dev and staging. This means that the current implementation with hard coding the email address would always be blocked on production.


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
