### PR TITLE
feat(judicial-system): Style changes to comments

### DIFF
--- a/apps/judicial-system/web/src/routes/Judge/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Judge/Overview/Overview.tsx
@@ -509,7 +509,7 @@ export const JudgeOverview: React.FC = () => {
                     </Text>
                   </Box>
                   {workingCase.comments && (
-                    <>
+                    <Box marginBottom={workingCase.caseFilesComments ? 3 : 0}>
                       <Box marginBottom={1}>
                         <Text variant="h4" as="h3" color="blue400">
                           Athugasemdir vegna málsmeðferðar
@@ -520,11 +520,11 @@ export const JudgeOverview: React.FC = () => {
                           {workingCase.comments}
                         </span>
                       </Text>
-                    </>
+                    </Box>
                   )}
                   {features.includes(Feature.CASE_FILES) &&
                     workingCase.caseFilesComments && (
-                      <Box marginTop={3}>
+                      <>
                         <Box marginBottom={1}>
                           <Text variant="h4" as="h3" color="blue400">
                             Athugasemdir vegna rannsóknargagna
@@ -535,7 +535,7 @@ export const JudgeOverview: React.FC = () => {
                             {workingCase.caseFilesComments}
                           </span>
                         </Text>
-                      </Box>
+                      </>
                     )}
                 </div>
               )}

--- a/apps/judicial-system/web/src/routes/Judge/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Judge/Overview/Overview.tsx
@@ -501,35 +501,45 @@ export const JudgeOverview: React.FC = () => {
                   )}
                 </div>
               )}
-              {workingCase.comments && (
+              {(workingCase.comments || workingCase.caseFilesComments) && (
                 <div className={styles.infoSection}>
-                  <Box marginBottom={1}>
+                  <Box marginBottom={2}>
                     <Text variant="h3" as="h3">
-                      Athugasemdir vegna málsmeðferðar
+                      Athugasemdir
                     </Text>
                   </Box>
-                  <Text>
-                    <span className={styles.breakSpaces}>
-                      {workingCase.comments}
-                    </span>
-                  </Text>
+                  {workingCase.comments && (
+                    <>
+                      <Box marginBottom={1}>
+                        <Text variant="h4" as="h3" color="blue400">
+                          Athugasemdir vegna málsmeðferðar
+                        </Text>
+                      </Box>
+                      <Text>
+                        <span className={styles.breakSpaces}>
+                          {workingCase.comments}
+                        </span>
+                      </Text>
+                    </>
+                  )}
+                  {features.includes(Feature.CASE_FILES) &&
+                    workingCase.caseFilesComments && (
+                      <Box marginTop={3}>
+                        <Box marginBottom={1}>
+                          <Text variant="h4" as="h3" color="blue400">
+                            Athugasemdir vegna rannsóknargagna
+                          </Text>
+                        </Box>
+                        <Text>
+                          <span className={styles.breakSpaces}>
+                            {workingCase.caseFilesComments}
+                          </span>
+                        </Text>
+                      </Box>
+                    )}
                 </div>
               )}
-              {features.includes(Feature.CASE_FILES) &&
-                workingCase.caseFilesComments && (
-                  <div className={styles.infoSection}>
-                    <Box marginBottom={1}>
-                      <Text variant="h3" as="h3">
-                        Athugasemdir vegna rannsóknargagna
-                      </Text>
-                    </Box>
-                    <Text>
-                      <span className={styles.breakSpaces}>
-                        {workingCase.caseFilesComments}
-                      </span>
-                    </Text>
-                  </div>
-                )}
+
               {features.includes(Feature.CASE_FILES) && (
                 <div className={styles.infoSection}>
                   <Box marginBottom={1}>

--- a/apps/judicial-system/web/src/routes/Prosecutor/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Overview/Overview.tsx
@@ -327,17 +327,41 @@ export const Overview: React.FC = () => {
                     </Box>
                   )}
                 </AccordionItem>
-                <AccordionItem
-                  id="id_5"
-                  label="Athugasemdir vegna málsmeðferðar"
-                  labelVariant="h3"
-                >
-                  <Text>
-                    <span className={styles.breakSpaces}>
-                      {workingCase.comments}
-                    </span>
-                  </Text>
-                </AccordionItem>
+                {(workingCase.comments || workingCase.caseFilesComments) && (
+                  <AccordionItem
+                    id="id_5"
+                    label="Athugasemdir"
+                    labelVariant="h3"
+                  >
+                    {workingCase.comments && (
+                      <Box marginBottom={workingCase.caseFilesComments ? 3 : 0}>
+                        <Box marginBottom={1}>
+                          <Text variant="h4" as="h4">
+                            Athugasemdir vegna málsmeðferðar
+                          </Text>
+                        </Box>
+                        <Text>
+                          <span className={styles.breakSpaces}>
+                            {workingCase.comments}
+                          </span>
+                        </Text>
+                      </Box>
+                    )}
+                    {features.includes(Feature.CASE_FILES) &&
+                      !!workingCase.caseFilesComments && (
+                        <>
+                          <Text variant="h4" as="h4">
+                            Athugasemdir vegna málsmeðferðar
+                          </Text>
+                          <Text>
+                            <span className={styles.breakSpaces}>
+                              {workingCase.caseFilesComments}
+                            </span>
+                          </Text>
+                        </>
+                      )}
+                  </AccordionItem>
+                )}
                 {features.includes(Feature.CASE_FILES) && (
                   <AccordionItem
                     id="id_6"
@@ -354,20 +378,6 @@ export const Overview: React.FC = () => {
                     </Box>
                   </AccordionItem>
                 )}
-                {features.includes(Feature.CASE_FILES) &&
-                  !!workingCase.caseFilesComments && (
-                    <AccordionItem
-                      id="id_7"
-                      label="Athugasemdir vegna rannsóknargagna"
-                      labelVariant="h3"
-                    >
-                      <Text>
-                        <span className={styles.breakSpaces}>
-                          {workingCase.caseFilesComments}
-                        </span>
-                      </Text>
-                    </AccordionItem>
-                  )}
               </Accordion>
             </Box>
             <Box className={styles.prosecutorContainer}>

--- a/apps/judicial-system/web/src/routes/Prosecutor/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Overview/Overview.tsx
@@ -351,7 +351,7 @@ export const Overview: React.FC = () => {
                       !!workingCase.caseFilesComments && (
                         <>
                           <Text variant="h4" as="h4">
-                            Athugasemdir vegna málsmeðferðar
+                            Athugasemdir vegna rannsóknargagna
                           </Text>
                           <Text>
                             <span className={styles.breakSpaces}>


### PR DESCRIPTION
# Style changes to comments

https://app.asana.com/0/1199153462262248/1200221197332081

## What

Style changes to comments

## Why

Instead of having two accordion items for comments, combine them into one which makes the UI cleaner.

## Screenshots / Gifs

### Prosecutor
![Screen Shot 2021-04-29 at 15 24 49](https://user-images.githubusercontent.com/3789875/116576416-0f321780-a8ff-11eb-88e3-0a4153f5c9de.png)


### Judge 
![Screen Shot 2021-04-29 at 15 24 02](https://user-images.githubusercontent.com/3789875/116576273-ef9aef00-a8fe-11eb-9bda-d154307adcac.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
