### PR TITLE
fix(services-endorsement-api): Fix for national registry environment

### DIFF
--- a/apps/services/endorsements/api/src/app/modules/endorsementMetadata/endorsementMetadata.module.ts
+++ b/apps/services/endorsements/api/src/app/modules/endorsementMetadata/endorsementMetadata.module.ts
@@ -1,7 +1,10 @@
 import { Module } from '@nestjs/common'
 import { EndorsementMetadataService } from './endorsementMetadata.service'
 import { NationalRegistryService } from './providers/nationalRegistry.service'
-import { NationalRegistryApi } from '@island.is/clients/national-registry'
+import {
+  NationalRegistryApi,
+  NationalRegistryConfig,
+} from '@island.is/clients/national-registry'
 import { environment } from '../../../environments/environment'
 import { NationalRegistryApiMock } from './providers/mock/nationalRegistryApiMock'
 
@@ -13,7 +16,8 @@ import { NationalRegistryApiMock } from './providers/mock/nationalRegistryApiMoc
       provide: NationalRegistryApi,
       useFactory: async () =>
         await NationalRegistryApi.instanciateClass(
-          environment.metadataProviser.nationalRegistry,
+          environment.metadataProviser
+            .nationalRegistry as NationalRegistryConfig,
         ),
       // This exists cause mocking soap with msw is out of scope for this project
       ...(environment.apiMock


### PR DESCRIPTION
# \<Description\>

Environment dev file getting swapped out for environment prod file is breaking the build.

## What

- Added `as NationalRegistryConfig`

## Why

- To suppress type issue

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
