### PR TITLE
fix(crc): overview description

### DIFF
--- a/libs/application/templates/children-residence-change/src/fields/Overview/index.tsx
+++ b/libs/application/templates/children-residence-change/src/fields/Overview/index.tsx
@@ -155,15 +155,21 @@ const Overview = ({
         fileSignatureState={fileSignatureState}
       />
       <Box>
-        <DescriptionText
-          text={m.contract.general.description}
-          format={{
-            otherParent:
-              parentKey === Roles.ParentA
-                ? parentB.fullName
-                : applicant.fullName,
-          }}
-        />
+        {parentKey === Roles.ParentA ? (
+          <DescriptionText
+            text={m.contract.general.description}
+            format={{
+              otherParent: parentB.fullName,
+            }}
+          />
+        ) : (
+          <DescriptionText
+            text={m.contract.general.parentBDescription}
+            format={{
+              otherParent: applicant.fullName,
+            }}
+          />
+        )}
       </Box>
       <Box marginTop={4}>
         <ContractOverview application={application} />

--- a/libs/application/templates/children-residence-change/src/lib/messages/contract.ts
+++ b/libs/application/templates/children-residence-change/src/lib/messages/contract.ts
@@ -14,6 +14,13 @@ export const contract = {
         'Hér er yfirlit yfir samning um breytt lögheimili. __Þú og {otherParent}__ þurfa að staðfesta með undirritun áður en umsóknin fer í afgreiðslu hjá sýslumanni.\\n\\nBreyting á lögheimili og þar með á greiðslu meðlags og barnabóta tekur gildi eftir að sýslumaður hefur staðfest samninginn.',
       description: 'Contract page description',
     },
+    parentBDescription: {
+      id:
+        'crc.application:section.contract.overview.parentBDescription#markdown',
+      defaultMessage:
+        'Hér er yfirlit yfir samning um breytt lögheimili og meðlag. __{otherParent}__ hefur nú þegar undrritað samningin og næst þarft þú að undirrita áður en umsóknin fer í afgreiðslu hjá sýslumanni.\\n\\nBreyting á lögheimili og þar með á greiðslu meðlags og barnabóta tekur gildi eftir að sýslumaður hefur staðfest samninginn.',
+      description: 'Contract page description for parent B',
+    },
   }),
   labels: defineMessages({
     childName: {


### PR DESCRIPTION
# \<Description\>

https://app.asana.com/0/1199733748699731/1200270543199448

## What

- Render different string for parent A and parent B

## Why

- We want to be able to display different text for depending on which parent is viewing the application

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
