### PR TITLE
fix(judicial-system): Layout changes to the conclusion modal

### DIFF
--- a/apps/judicial-system/web/src/routes/Judge/Overview/Components/ConclusionDraft.tsx
+++ b/apps/judicial-system/web/src/routes/Judge/Overview/Components/ConclusionDraft.tsx
@@ -17,7 +17,9 @@ const ConclusionDraft: React.FC<Props> = (props) => {
     <>
       <Box marginBottom={2}>
         <Text>
-          {`Hér er hægt að skrifa drög að niðurstöðu í málinu. Endanlegur frágangur niðurstöðu og úrskurðar fer fram í þinghaldi\n\nAthugið að drögin vistast sjálfkrafa.`}
+          Hér er hægt að skrifa drög að niðurstöðu í málinu. Endanlegur
+          frágangur niðurstöðu og úrskurðar fer fram í þinghaldi. Athugið að
+          drögin vistast sjálfkrafa.
         </Text>
       </Box>
       <Box marginBottom={3}>
@@ -33,6 +35,7 @@ const ConclusionDraft: React.FC<Props> = (props) => {
         workingCase={workingCase}
         setWorkingCase={setWorkingCase}
         isRequired={false}
+        rows={12}
       />
     </>
   )

--- a/apps/judicial-system/web/src/shared-components/Modal/Modal.treat.ts
+++ b/apps/judicial-system/web/src/shared-components/Modal/Modal.treat.ts
@@ -20,7 +20,7 @@ export const modalContainer = style({
   background: theme.color.white,
   maxWidth: '40vw',
   maxHeight: '90vh',
-  overflowY: 'scroll',
+  overflowY: 'auto',
   borderRadius: theme.border.radius.standard,
 })
 

--- a/apps/judicial-system/web/src/shared-components/RulingInput/RulingInput.tsx
+++ b/apps/judicial-system/web/src/shared-components/RulingInput/RulingInput.tsx
@@ -11,10 +11,11 @@ interface Props {
   workingCase: Case
   setWorkingCase: React.Dispatch<React.SetStateAction<Case | undefined>>
   isRequired: boolean
+  rows?: number
 }
 
 const RulingInput: React.FC<Props> = (props) => {
-  const { workingCase, setWorkingCase, isRequired } = props
+  const { workingCase, setWorkingCase, isRequired, rows } = props
   const { updateCase } = useCase()
   const [rulingErrorMessage, setRulingErrorMessage] = useState('')
 
@@ -25,7 +26,7 @@ const RulingInput: React.FC<Props> = (props) => {
       label="Efni úrskurðar"
       placeholder="Hver er niðurstaðan að mati dómara?"
       defaultValue={workingCase.ruling}
-      rows={16}
+      rows={rows ?? 16}
       errorMessage={rulingErrorMessage}
       hasError={rulingErrorMessage !== ''}
       required={isRequired}


### PR DESCRIPTION
# Layout changes to the conclusion modal

https://app.asana.com/0/1199153462262248/1200162824002549

## What

Layout changes to the conclusion modal

## Why

We want to do everything we can to prevent users to have to scroll the modal window.

## Screenshots / Gifs

![Screen Shot 2021-05-05 at 15 06 39](https://user-images.githubusercontent.com/3789875/117163764-81997080-adb3-11eb-8e1d-751fac8be638.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
