### PR TITLE
feat(web): Add resolver for articles field in FeaturedArticles slice.

### DIFF
--- a/libs/api/domains/cms/src/lib/cms.module.ts
+++ b/libs/api/domains/cms/src/lib/cms.module.ts
@@ -6,6 +6,7 @@ import {
   ArticleResolver,
   LatestNewsSliceResolver,
   AboutSubPageResolver,
+  FeaturedArticlesResolver,
 } from './cms.resolver'
 import { CmsContentfulService } from './cms.contentful.service'
 import { ContentfulRepository } from './contentful.repository'
@@ -23,6 +24,7 @@ import { CmsHealthIndicator } from './cms.health'
     ContentfulRepository,
     CmsHealthIndicator,
     LatestNewsSliceResolver,
+    FeaturedArticlesResolver,
     AboutSubPageResolver,
   ],
   exports: [ContentfulRepository, CmsHealthIndicator],

--- a/libs/api/domains/cms/src/lib/cms.resolver.ts
+++ b/libs/api/domains/cms/src/lib/cms.resolver.ts
@@ -78,6 +78,7 @@ import { Auction } from './models/auction.model'
 import { GetAuctionInput } from './dto/getAuction.input'
 import { Frontpage } from './models/frontpage.model'
 import { GetFrontpageInput } from './dto/getFrontpage.input'
+import { FeaturedArticles } from './models/featuredArticles.model'
 
 const { cacheTime } = environment
 
@@ -437,6 +438,21 @@ export class LatestNewsSliceResolver {
       input,
     )
     return newsList.items
+  }
+}
+
+@Resolver(() => FeaturedArticles)
+export class FeaturedArticlesResolver {
+  constructor(private cmsElasticsearchService: CmsElasticsearchService) {}
+
+  @ResolveField(() => [Article])
+  async articles(
+    @Parent() { articles: input }: FeaturedArticles,
+  ): Promise<Article[]> {
+    return await this.cmsElasticsearchService.getArticles(
+      getElasticsearchIndex(input.lang),
+      input,
+    )
   }
 }
 

--- a/libs/api/domains/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/api/domains/cms/src/lib/generated/contentfulTypes.d.ts
@@ -704,6 +704,9 @@ export interface IFeaturedArticlesFields {
 
   /** Organization */
   organization?: IOrganization | undefined
+
+  /** Article Count */
+  articleCount?: number | undefined
 }
 
 export interface IFeaturedArticles extends Entry<IFeaturedArticlesFields> {

--- a/libs/api/domains/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/api/domains/cms/src/lib/generated/contentfulTypes.d.ts
@@ -701,6 +701,9 @@ export interface IFeaturedArticlesFields {
 
   /** Application Label */
   applicationLabel: string
+
+  /** Organization */
+  organization?: IOrganization | undefined
 }
 
 export interface IFeaturedArticles extends Entry<IFeaturedArticlesFields> {

--- a/libs/api/domains/cms/src/lib/models/featuredArticles.model.ts
+++ b/libs/api/domains/cms/src/lib/models/featuredArticles.model.ts
@@ -39,7 +39,7 @@ export const mapFeaturedArticles = ({
   articles: {
     lang:
       sys.locale === 'is-IS' ? 'is' : (sys.locale as ElasticsearchIndexLocale),
-    size: 5,
+    size: fields.articleCount ?? 5,
     sort: SortField.POPULAR,
     organization: fields.organization?.fields.slug ?? '',
   },

--- a/libs/api/domains/cms/src/lib/models/featuredArticles.model.ts
+++ b/libs/api/domains/cms/src/lib/models/featuredArticles.model.ts
@@ -6,6 +6,9 @@ import { SystemMetadata } from 'api-cms-domain'
 import { Image, mapImage } from './image.model'
 import { Article, mapArticle } from './article.model'
 import { Link, mapLink } from './link.model'
+import { GetArticlesInput } from '../dto/getArticles.input'
+import { ElasticsearchIndexLocale } from '@island.is/content-search-index-manager'
+import { SortField } from '@island.is/content-search-toolkit'
 
 @ObjectType()
 export class FeaturedArticles {
@@ -19,7 +22,7 @@ export class FeaturedArticles {
   image?: Image | null
 
   @Field(() => [Article])
-  articles?: Array<Article>
+  articles!: GetArticlesInput
 
   @Field(() => Link, { nullable: true })
   link?: Link | null
@@ -33,6 +36,12 @@ export const mapFeaturedArticles = ({
   id: sys.id,
   title: fields.title ?? '',
   image: fields.image ? mapImage(fields.image) : null,
-  articles: (fields.articles ?? []).map(mapArticle),
+  articles: {
+    lang:
+      sys.locale === 'is-IS' ? 'is' : (sys.locale as ElasticsearchIndexLocale),
+    size: 5,
+    sort: SortField.POPULAR,
+    organization: fields.organization?.fields.slug ?? '',
+  },
   link: fields.link ? mapLink(fields.link) : null,
 })


### PR DESCRIPTION
# Add resolver for articles field in FeaturedArticles slice.

## What

This makes the articles field in the `FeaturedArticles` slice dynamically resolved. Instead of showing manually selected articles we show the 5 most popular ones.

## Why

Organizations want to show the most popular articles on their frontpages.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
