### PR TITLE
chore(web): Remove chatbot from covid pages

### DIFF
--- a/apps/web/screens/Adgerdir/Article.tsx
+++ b/apps/web/screens/Adgerdir/Article.tsx
@@ -19,7 +19,7 @@ import {
   QueryGetAdgerdirTagsArgs,
 } from '@island.is/api/schema'
 import { withMainLayout } from '@island.is/web/layouts/main'
-import { HeadWithSocialSharing, ChatPanel } from '@island.is/web/components'
+import { HeadWithSocialSharing } from '@island.is/web/components'
 import AdgerdirArticles from './components/AdgerdirArticles/AdgerdirArticles'
 import { Tag } from './components/UI/Tag/Tag'
 import { ProcessEntry } from './components/UI/ProcessEntry/ProcessEntry'

--- a/apps/web/screens/Adgerdir/Article.tsx
+++ b/apps/web/screens/Adgerdir/Article.tsx
@@ -172,7 +172,6 @@ const AdgerdirArticle: Screen<AdgerdirArticleProps> = ({
           </ContentBlock>
         </Box>
       </ColorSchemeContext.Provider>
-      <ChatPanel endpoint="covid-island" />
     </>
   )
 }

--- a/apps/web/screens/Adgerdir/Home.tsx
+++ b/apps/web/screens/Adgerdir/Home.tsx
@@ -17,7 +17,6 @@ import { Slice as SliceType } from '@island.is/island-ui/contentful'
 import {
   RichText,
   HeadWithSocialSharing,
-  ChatPanel,
   Header,
   Main,
 } from '@island.is/web/components'

--- a/apps/web/screens/Adgerdir/Home.tsx
+++ b/apps/web/screens/Adgerdir/Home.tsx
@@ -253,7 +253,6 @@ const Home: Screen<HomeProps> = ({
             })}
           </Stack>
         </Box>
-        <ChatPanel endpoint="covid-island" />
       </Main>
     </>
   )


### PR DESCRIPTION
Removes the chatbot on the covid pages. It is about to be taken down so it would no longer be functional on the page. Requested by Fríða from Stafrænt Ísland.