### PR TITLE
feat(island-ui): Add properties to Profile Card and change card border

### DIFF
--- a/libs/island-ui/core/src/lib/ProfileCard/ProfileCard.tsx
+++ b/libs/island-ui/core/src/lib/ProfileCard/ProfileCard.tsx
@@ -1,6 +1,8 @@
 import React, { FC } from 'react'
 import { Box } from '../Box/Box'
-import { Typography } from '../Typography/Typography'
+import { Button } from '../Button/Button'
+import { Link } from '../Link/Link'
+import { Text } from '../Text/Text'
 import * as styles from './ProfileCard.treat'
 
 /**
@@ -23,6 +25,17 @@ export interface ProfileCardProps {
    * 100% height
    */
   heightFull?: boolean
+  /**
+   * Size of description and link
+   */
+  size?: 'small' | 'default'
+  /**
+   * Link at the bottom of card
+   */
+  link?: {
+    url: string
+    text: string
+  }
 }
 
 export const ProfileCard: FC<ProfileCardProps> = ({
@@ -30,6 +43,8 @@ export const ProfileCard: FC<ProfileCardProps> = ({
   title,
   description,
   heightFull,
+  size = 'default',
+  link,
 }) => {
   const conditionalProps: { height?: 'full' } = {}
   if (heightFull) {
@@ -40,7 +55,8 @@ export const ProfileCard: FC<ProfileCardProps> = ({
       borderRadius="large"
       overflow="hidden"
       background="white"
-      boxShadow="subtle"
+      borderWidth="standard"
+      borderColor="blue200"
       {...conditionalProps}
     >
       {image && (
@@ -51,11 +67,26 @@ export const ProfileCard: FC<ProfileCardProps> = ({
       )}
       <Box padding={3}>
         {title && (
-          <Typography variant="h4" marginBottom={1}>
+          <Text variant="h4" marginBottom={1}>
             {title}
-          </Typography>
+          </Text>
         )}
-        {description && <Typography variant="p">{description}</Typography>}
+        {description && <Text variant={size}>{description}</Text>}
+        {link && (
+          <Box paddingTop={2}>
+            <Link href={link.url}>
+              <Button
+                icon="arrowForward"
+                iconType="filled"
+                type="button"
+                variant="text"
+                size={size}
+              >
+                {link.text}
+              </Button>
+            </Link>
+          </Box>
+        )}
       </Box>
     </Box>
   )


### PR DESCRIPTION
# Add properties to Profile Card and change card border

## What

- Change border style from shadow to solid
- Add option for link at bottom of card
- Add option for making the content smaller

## Why

We need this to implement a new design.

This is done in cooperation with Helgi Páll from K&K.

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/3607456/117443292-7a936f00-af27-11eb-8e41-cfc5cb966fb9.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
