### PR TITLE
chore(web): font preloading

### DIFF
--- a/apps/web/layouts/main.tsx
+++ b/apps/web/layouts/main.tsx
@@ -180,10 +180,29 @@ const Layout: NextComponentType<
     JSON.stringify(alertBannerContent),
   )}`
 
+  const preloadedFonts = [
+    '/fonts/ibm-plex-sans-v7-latin-300.woff2',
+    '/fonts/ibm-plex-sans-v7-latin-regular.woff2',
+    '/fonts/ibm-plex-sans-v7-latin-italic.woff2',
+    '/fonts/ibm-plex-sans-v7-latin-500.woff2',
+    '/fonts/ibm-plex-sans-v7-latin-600.woff2',
+  ]
+
   return (
     <GlobalContextProvider namespace={namespace}>
       <Page component="div">
         <Head>
+          {preloadedFonts.map((href, index) => {
+            return (
+              <link
+                rel="preload"
+                href={href}
+                as="font"
+                type="font/woff2"
+                crossOrigin="true"
+              />
+            )
+          })}
           <link
             rel="apple-touch-icon"
             sizes="180x180"
@@ -204,16 +223,13 @@ const Layout: NextComponentType<
           <link rel="manifest" href="/site.webmanifest" />
           <meta name="msapplication-TileColor" content="#da532c" />
           <meta name="theme-color" content="#ffffff" />
-
           <title>{n('title')}</title>
-
           <meta name="title" content={n('title')} key="title" />
           <meta
             name="description"
             content={n('description')}
             key="description"
           />
-
           <meta property="og:title" content={n('title')} key="ogTitle" />
           <meta
             property="og:description"
@@ -229,7 +245,6 @@ const Layout: NextComponentType<
           />
           <meta property="og:image:width" content="1200" key="ogImageWidth" />
           <meta property="og:image:height" content="630" key="ogImageHeight" />
-
           <meta
             property="twitter:card"
             content="summary_large_image"


### PR DESCRIPTION
## What

Preload fonts, trying to reduce largest contentful paint

![image](https://user-images.githubusercontent.com/8450096/117448885-d281a400-af2e-11eb-9eba-a8f47dbf4705.png)

## Why

Trying to improve the lighthouse score

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
