### PR TITLE
feat(web): Add new field signupUrl to Email Signup Contentful model

### DIFF
--- a/apps/web/screens/queries/fragments.ts
+++ b/apps/web/screens/queries/fragments.ts
@@ -45,6 +45,7 @@ export const slices = gql`
     description
     inputLabel
     buttonText
+    signupUrl
   }
 
   fragment StoryFields on StorySlice {

--- a/libs/api/domains/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/api/domains/cms/src/lib/generated/contentfulTypes.d.ts
@@ -1438,6 +1438,9 @@ export interface IMailingListSignupFields {
 
   /** Submit button text */
   buttonText: string
+
+  /** Signup URL */
+  signupUrl: string
 }
 
 export interface IMailingListSignup extends Entry<IMailingListSignupFields> {
@@ -1965,6 +1968,7 @@ export interface IOrganizationSubpageFields {
         | IAccordionSlice
         | IContactUs
         | IDistricts
+        | IMailingListSignup
         | IOffices
         | IOneColumnText
         | ITeamList

--- a/libs/api/domains/cms/src/lib/models/mailingListSignupSlice.model.ts
+++ b/libs/api/domains/cms/src/lib/models/mailingListSignupSlice.model.ts
@@ -18,6 +18,9 @@ export class MailingListSignupSlice {
 
   @Field()
   buttonText!: string
+
+  @Field()
+  signupUrl!: string
 }
 
 export const mapMailingListSignup = ({
@@ -30,4 +33,5 @@ export const mapMailingListSignup = ({
   description: fields.description ?? '',
   inputLabel: fields.inputLabel ?? '',
   buttonText: fields.buttonText ?? '',
+  signupUrl: fields.signupUrl ?? '',
 })


### PR DESCRIPTION
# Add new field signupUrl to Email Signup Contentful model

## What

Add a new field `signupUrl` to Contentful type `MailingListSignup`.

## Why

So that Contentful types reflect the corresponding content model in Contentful. The corresponding content model in Contentful is named `Email Signup`. In an upcoming Pull Request, we'll use this new field to set mailing list signup URLs via Contentful.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
