### PR TITLE
feat(island-ui): NewsletterSignup - Add message and styling for success state

### DIFF
--- a/apps/web/screens/AboutPage/RenderForm.tsx
+++ b/apps/web/screens/AboutPage/RenderForm.tsx
@@ -140,7 +140,8 @@ export const RenderForm: React.FC<{
     <form onSubmit={formik.handleSubmit}>
       <NewsletterSignup
         id="email"
-        heading={headingByStatus}
+        name="email"
+        heading={heading}
         text={textByStatus}
         placeholder=""
         label={inputLabel}
@@ -149,6 +150,11 @@ export const RenderForm: React.FC<{
         onChange={formik.handleChange}
         onSubmit={formik.handleSubmit}
         value={formik.values.email}
+        successTitle={n('formThankYou', 'Skráning tókst. Takk fyrir.')}
+        successMessage={n(
+          'formCheckYourEmail',
+          'Þú þarft að fara í pósthólfið þitt og samþykkja umsóknina',
+        )}
         errorMessage={formatMessage(status.message)}
         state={status.type || 'default'}
       />

--- a/libs/island-ui/core/src/lib/NewsletterSignup/NewsletterSignup.stories.tsx
+++ b/libs/island-ui/core/src/lib/NewsletterSignup/NewsletterSignup.stories.tsx
@@ -39,3 +39,39 @@ export const BlueVariant = () => {
     />
   )
 }
+
+export const errorState = () => {
+  return (
+    <NewsletterSignup
+      heading="Vertu með"
+      id="newsletter-3"
+      text="Skráðu þig á póstlista Stafræns Íslands og fylgstu með því nýjast í
+          stafrænni opinberri þjónustu."
+      buttonText="Skrá mig"
+      placeholder="Settu inn netfangið þitt"
+      label="Netfang"
+      onChange={() => console.log('change')}
+      value="example@example.com"
+      state="error"
+      errorMessage="Skráning tókst ekki."
+    />
+  )
+}
+
+export const successState = () => {
+  return (
+    <NewsletterSignup
+      heading="Vertu með"
+      id="newsletter-4"
+      text="Skráðu þig á póstlista Stafræns Íslands og fylgstu með því nýjast í
+          stafrænni opinberri þjónustu."
+      buttonText="Skrá mig"
+      placeholder="Settu inn netfangið þitt"
+      label="Netfang"
+      onChange={() => console.log('change')}
+      value="example@example.com"
+      state="success"
+      successMessage="Skráning tókst!"
+    />
+  )
+}

--- a/libs/island-ui/core/src/lib/NewsletterSignup/NewsletterSignup.stories.tsx
+++ b/libs/island-ui/core/src/lib/NewsletterSignup/NewsletterSignup.stories.tsx
@@ -18,6 +18,10 @@ export const Default = () => {
       placeholder="Settu inn netfangið þitt"
       label="Netfang"
       onChange={() => console.log('change')}
+      onSubmit={() => console.log('submit')}
+      successTitle="Skráning tókst!"
+      successMessage="Tölvupóstur hefur verið sendur á jon@jonsbakari.is til staðfestingar. Takk fyrir."
+      errorMessage="Skráning tókst ekki"
       value=""
     />
   )
@@ -35,6 +39,10 @@ export const BlueVariant = () => {
       label="Netfang"
       variant="blue"
       onChange={() => console.log('change')}
+      onSubmit={() => console.log('submit')}
+      successTitle="Skráning tókst!"
+      successMessage="Tölvupóstur hefur verið sendur á jon@jonsbakari.is til staðfestingar. Takk fyrir."
+      errorMessage="Skráning tókst ekki"
       value=""
     />
   )
@@ -52,9 +60,12 @@ export const errorState = () => {
       label="Netfang"
       variant="blue"
       onChange={() => console.log('change')}
+      onSubmit={() => console.log('submit')}
       value="example@example.com"
       state="error"
-      errorMessage="Skráning tókst ekki."
+      successTitle="Skráning tókst!"
+      successMessage="Tölvupóstur hefur verið sendur á jon@jonsbakari.is til staðfestingar. Takk fyrir."
+      errorMessage="Skráning tókst ekki"
     />
   )
 }
@@ -71,10 +82,12 @@ export const successState = () => {
       label="Netfang"
       variant="blue"
       onChange={() => console.log('change')}
+      onSubmit={() => console.log('submit')}
       value="example@example.com"
       state="success"
       successTitle="Skráning tókst!"
-      successMessage="Tölvupóstur heufr veirð sendur á jon@jonsbakari.is til staðfestingar. Takk fyrir."
+      successMessage="Tölvupóstur hefur verið sendur á jon@jonsbakari.is til staðfestingar. Takk fyrir."
+      errorMessage="Skráning tókst ekki"
     />
   )
 }

--- a/libs/island-ui/core/src/lib/NewsletterSignup/NewsletterSignup.stories.tsx
+++ b/libs/island-ui/core/src/lib/NewsletterSignup/NewsletterSignup.stories.tsx
@@ -50,6 +50,7 @@ export const errorState = () => {
       buttonText="Skrá mig"
       placeholder="Settu inn netfangið þitt"
       label="Netfang"
+      variant="blue"
       onChange={() => console.log('change')}
       value="example@example.com"
       state="error"
@@ -68,10 +69,12 @@ export const successState = () => {
       buttonText="Skrá mig"
       placeholder="Settu inn netfangið þitt"
       label="Netfang"
+      variant="blue"
       onChange={() => console.log('change')}
       value="example@example.com"
       state="success"
-      successMessage="Skráning tókst!"
+      successTitle="Skráning tókst!"
+      successMessage="Tölvupóstur heufr veirð sendur á jon@jonsbakari.is til staðfestingar. Takk fyrir."
     />
   )
 }

--- a/libs/island-ui/core/src/lib/NewsletterSignup/NewsletterSignup.treat.ts
+++ b/libs/island-ui/core/src/lib/NewsletterSignup/NewsletterSignup.treat.ts
@@ -21,3 +21,7 @@ export const variants = styleMap({
     backgroundColor: theme.color.blue100,
   },
 })
+
+export const successBox = style({
+  maxWidth: 400,
+})

--- a/libs/island-ui/core/src/lib/NewsletterSignup/NewsletterSignup.tsx
+++ b/libs/island-ui/core/src/lib/NewsletterSignup/NewsletterSignup.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Typography } from '../Typography/Typography'
+import { Text } from '../Text/Text'
 import { Input } from '../Input/Input'
 import { Button } from '../Button/Button'
 
@@ -17,7 +17,7 @@ interface MessageProps {
 }
 
 const Message = ({ state, successMessage, errorMessage }: MessageProps) => (
-  <Typography
+  <Text
     variant="eyebrow"
     fontWeight="medium"
     color={
@@ -29,7 +29,7 @@ const Message = ({ state, successMessage, errorMessage }: MessageProps) => (
   >
     {(state === 'success' && successMessage) ||
       (state === 'error' && errorMessage)}
-  </Typography>
+  </Text>
 )
 
 interface Props {
@@ -67,12 +67,12 @@ export const NewsletterSignup: React.FC<Props> = ({
 }) => {
   return (
     <Box className={styles.variants[variant]}>
-      <Typography variant="h3" as="h3" color="blue400" paddingBottom={1}>
+      <Text variant="h3" as="h3" color="blue400" paddingBottom={1}>
         {heading}
-      </Typography>
-      <Typography variant="p" paddingBottom={3}>
+      </Text>
+      <Text variant="default" paddingBottom={3}>
         {text}
-      </Typography>
+      </Text>
       <Box display="flex" flexDirection={['column', 'column', 'row']}>
         <Box className={styles.inputWrap}>
           <Input

--- a/libs/island-ui/core/src/lib/NewsletterSignup/NewsletterSignup.tsx
+++ b/libs/island-ui/core/src/lib/NewsletterSignup/NewsletterSignup.tsx
@@ -5,9 +5,32 @@ import { Button } from '../Button/Button'
 
 import * as styles from './NewsletterSignup.treat'
 import { Box } from '../Box/Box'
+import { Hidden } from '../Hidden/Hidden'
 
 type ColorVariant = 'white' | 'blue'
 type State = 'default' | 'error' | 'success'
+
+interface MessageProps {
+  state: State
+  successMessage?: string
+  errorMessage?: string
+}
+
+const Message = ({ state, successMessage, errorMessage }: MessageProps) => (
+  <Typography
+    variant="eyebrow"
+    fontWeight="medium"
+    color={
+      (state === 'success' && 'blue400') ||
+      (state === 'error' && 'red600') ||
+      undefined
+    }
+    paddingTop={1}
+  >
+    {(state === 'success' && successMessage) ||
+      (state === 'error' && errorMessage)}
+  </Typography>
+)
 
 interface Props {
   heading: string
@@ -19,6 +42,7 @@ interface Props {
   variant?: ColorVariant
   state?: State
   errorMessage?: string
+  successMessage?: string
   onChange: (
     event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) => void
@@ -39,6 +63,7 @@ export const NewsletterSignup: React.FC<Props> = ({
   onSubmit,
   value,
   errorMessage,
+  successMessage,
 }) => {
   return (
     <Box className={styles.variants[variant]}>
@@ -56,11 +81,21 @@ export const NewsletterSignup: React.FC<Props> = ({
             value={value}
             placeholder={placeholder}
             label={label}
+            type="email"
             backgroundColor={variant === 'white' ? 'blue' : 'white'}
             hasError={state === 'error'}
-            errorMessage={errorMessage}
+            icon={state === 'success' ? 'checkmarkCircle' : undefined}
             onChange={onChange}
           />
+          <Hidden above="sm">
+            {(state === 'success' || state === 'error') && (
+              <Message
+                state={state}
+                successMessage={successMessage}
+                errorMessage={errorMessage}
+              />
+            )}
+          </Hidden>
         </Box>
         <Box
           display="flex"
@@ -76,6 +111,15 @@ export const NewsletterSignup: React.FC<Props> = ({
           </Box>
         </Box>
       </Box>
+      <Hidden below="md">
+        {(state === 'success' || state === 'error') && (
+          <Message
+            state={state}
+            successMessage={successMessage}
+            errorMessage={errorMessage}
+          />
+        )}
+      </Hidden>
     </Box>
   )
 }

--- a/libs/island-ui/core/src/lib/NewsletterSignup/NewsletterSignup.tsx
+++ b/libs/island-ui/core/src/lib/NewsletterSignup/NewsletterSignup.tsx
@@ -6,29 +6,18 @@ import { Button } from '../Button/Button'
 import * as styles from './NewsletterSignup.treat'
 import { Box } from '../Box/Box'
 import { Hidden } from '../Hidden/Hidden'
+import { AlertMessage } from '../AlertMessage/AlertMessage'
 
 type ColorVariant = 'white' | 'blue'
 type State = 'default' | 'error' | 'success'
 
-interface MessageProps {
-  state: State
-  successMessage?: string
+interface ErrorMessageProps {
   errorMessage?: string
 }
 
-const Message = ({ state, successMessage, errorMessage }: MessageProps) => (
-  <Text
-    variant="eyebrow"
-    fontWeight="medium"
-    color={
-      (state === 'success' && 'blue400') ||
-      (state === 'error' && 'red600') ||
-      undefined
-    }
-    paddingTop={1}
-  >
-    {(state === 'success' && successMessage) ||
-      (state === 'error' && errorMessage)}
+const ErrorMessage = ({ errorMessage }: ErrorMessageProps) => (
+  <Text variant="eyebrow" fontWeight="medium" color="red600" paddingTop={1}>
+    {errorMessage}
   </Text>
 )
 
@@ -42,8 +31,9 @@ interface Props {
   buttonText: string
   variant?: ColorVariant
   state?: State
-  errorMessage?: string
-  successMessage?: string
+  errorMessage: string
+  successTitle: string
+  successMessage: string
   onChange: (
     event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) => void
@@ -65,6 +55,7 @@ export const NewsletterSignup: React.FC<Props> = ({
   onSubmit,
   value,
   errorMessage,
+  successTitle,
   successMessage,
 }) => {
   return (
@@ -72,54 +63,55 @@ export const NewsletterSignup: React.FC<Props> = ({
       <Text variant="h3" as="h3" color="blue400" paddingBottom={1}>
         {heading}
       </Text>
-      <Text variant="default" paddingBottom={3}>
-        {text}
-      </Text>
-      <Box display="flex" flexDirection={['column', 'column', 'row']}>
-        <Box className={styles.inputWrap}>
-          <Input
-            id={id}
-            name={name}
-            value={value}
-            placeholder={placeholder}
-            label={label}
-            type="email"
-            hasError={state === 'error'}
-            icon={state === 'success' ? 'checkmark' : undefined}
-            onChange={onChange}
+      {state === 'success' ? (
+        <Box className={styles.successBox} marginTop={2}>
+          <AlertMessage
+            type="success"
+            title={successTitle}
+            message={successMessage}
           />
-          <Hidden above="sm">
-            {(state === 'success' || state === 'error') && (
-              <Message
-                state={state}
-                successMessage={successMessage}
-                errorMessage={errorMessage}
-              />
-            )}
-          </Hidden>
         </Box>
-        <Box
-          display="flex"
-          alignItems="center"
-          className={styles.buttonWrap}
-          paddingTop={[3, 2, 0]}
-          marginLeft={[0, 0, 8]}
-        >
-          <Box>
-            <Button as="span" onClick={onSubmit} variant="text">
-              {buttonText}
-            </Button>
+      ) : (
+        <Box>
+          <Text variant="default" paddingBottom={3}>
+            {text}
+          </Text>
+          <Box display="flex" flexDirection={['column', 'column', 'row']}>
+            <Box className={styles.inputWrap}>
+              <Input
+                id={id}
+                name={name}
+                value={value}
+                placeholder={placeholder}
+                label={label}
+                type="email"
+                hasError={state === 'error'}
+                onChange={onChange}
+              />
+              <Hidden above="sm">
+                {state === 'error' && (
+                  <ErrorMessage errorMessage={errorMessage} />
+                )}
+              </Hidden>
+            </Box>
+            <Box
+              display="flex"
+              alignItems="center"
+              className={styles.buttonWrap}
+              paddingTop={[3, 2, 0]}
+              marginLeft={[0, 0, 8]}
+            >
+              <Box>
+                <Button as="span" onClick={onSubmit} variant="text">
+                  {buttonText}
+                </Button>
+              </Box>
+            </Box>
           </Box>
         </Box>
-      </Box>
+      )}
       <Hidden below="md">
-        {(state === 'success' || state === 'error') && (
-          <Message
-            state={state}
-            successMessage={successMessage}
-            errorMessage={errorMessage}
-          />
-        )}
+        {state === 'error' && <ErrorMessage errorMessage={errorMessage} />}
       </Hidden>
     </Box>
   )

--- a/libs/island-ui/core/src/lib/NewsletterSignup/NewsletterSignup.tsx
+++ b/libs/island-ui/core/src/lib/NewsletterSignup/NewsletterSignup.tsx
@@ -82,7 +82,6 @@ export const NewsletterSignup: React.FC<Props> = ({
             placeholder={placeholder}
             label={label}
             type="email"
-            backgroundColor={variant === 'white' ? 'blue' : 'white'}
             hasError={state === 'error'}
             icon={state === 'success' ? 'checkmarkCircle' : undefined}
             onChange={onChange}

--- a/libs/island-ui/core/src/lib/NewsletterSignup/NewsletterSignup.tsx
+++ b/libs/island-ui/core/src/lib/NewsletterSignup/NewsletterSignup.tsx
@@ -85,7 +85,7 @@ export const NewsletterSignup: React.FC<Props> = ({
             label={label}
             type="email"
             hasError={state === 'error'}
-            icon={state === 'success' ? 'checkmarkCircle' : undefined}
+            icon={state === 'success' ? 'checkmark' : undefined}
             onChange={onChange}
           />
           <Hidden above="sm">

--- a/libs/island-ui/core/src/lib/NewsletterSignup/NewsletterSignup.tsx
+++ b/libs/island-ui/core/src/lib/NewsletterSignup/NewsletterSignup.tsx
@@ -36,6 +36,7 @@ interface Props {
   heading: string
   text: string
   id?: string
+  name?: string
   placeholder: string
   label: string
   buttonText: string
@@ -54,6 +55,7 @@ export const NewsletterSignup: React.FC<Props> = ({
   heading,
   text,
   id = 'newsletter',
+  name = 'newsletter',
   placeholder,
   label,
   buttonText,
@@ -77,7 +79,7 @@ export const NewsletterSignup: React.FC<Props> = ({
         <Box className={styles.inputWrap}>
           <Input
             id={id}
-            name={id}
+            name={name}
             value={value}
             placeholder={placeholder}
             label={label}


### PR DESCRIPTION
# NewsletterSignup - Add message and styling for success state

## What

Add message and styling for the state `success` of `NewsletterSignup`.

Implemented by design from Helgi at K&K.

## Why

Previous version of `NewsletterSignup` did not have any handling implemented for the success state.

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/3607456/119024062-3629b980-b992-11eb-9e79-a2f40a053883.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
