### PR TITLE
fix(service-portal): Fix override of enabled modules when system route is defined

### DIFF
--- a/apps/service-portal/src/hooks/useNavigation/useNavigation.ts
+++ b/apps/service-portal/src/hooks/useNavigation/useNavigation.ts
@@ -21,7 +21,7 @@ const filterNavigationTree = (
         (Array.isArray(route.path) &&
           item.path &&
           route.path.includes(item.path)),
-    ) !== undefined || item.systemRoute === true
+    ) !== undefined
 
   // Filters out any children that do not have a module route defined
   item.children = item.children?.filter((child) => {


### PR DESCRIPTION
# Fix override of enabled modules when system route is defined

## What

Fix navigation when a system route is defined

## Why

This was overriding the cases when a feature was disabled from Config Cat.

## Screenshots / Gifs

![fixnavroutes](https://user-images.githubusercontent.com/5694851/117949774-00396500-b302-11eb-8e24-ddecaa37d907.gif)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
