### PR TITLE
fix(download-service): hotfix-download service auth and timeout extend

### DIFF
--- a/apps/download-service/src/app/modules/documents/document.controller.ts
+++ b/apps/download-service/src/app/modules/documents/document.controller.ts
@@ -42,6 +42,11 @@ export class DocumentController {
       authenticationType: 'HIGH',
     })
 
+    if (!rawDocumentDTO) {
+      res.end()
+      return
+    }
+
     const pdf = rawDocumentDTO.content ?? ''
 
     const stream = new ReadableStreamBuffer({
@@ -62,5 +67,6 @@ export class DocumentController {
 
     stream.pipe(res)
     stream.stop()
+    return
   }
 }

--- a/apps/download-service/src/app/modules/documents/dto/getDocument.dto.ts
+++ b/apps/download-service/src/app/modules/documents/dto/getDocument.dto.ts
@@ -8,5 +8,5 @@ export class GetDocumentDto {
 
   @IsJWT()
   @ApiProperty()
-  readonly token!: string
+  readonly __accessToken!: string
 }

--- a/libs/clients/documents/src/lib/documents.module.ts
+++ b/libs/clients/documents/src/lib/documents.module.ts
@@ -14,11 +14,7 @@ export class DocumentsClientModule {
   static register(config: DocumentClientConfig): DynamicModule {
     return {
       module: DocumentsClientModule,
-      imports: [
-        HttpModule.register({
-          timeout: 10000,
-        }),
-      ],
+      imports: [HttpModule.register({})],
       providers: [
         DocumentClient,
         {

--- a/libs/clients/documents/src/lib/documents.module.ts
+++ b/libs/clients/documents/src/lib/documents.module.ts
@@ -14,7 +14,11 @@ export class DocumentsClientModule {
   static register(config: DocumentClientConfig): DynamicModule {
     return {
       module: DocumentsClientModule,
-      imports: [HttpModule.register({})],
+      imports: [
+        HttpModule.register({
+          timeout: 30000,
+        }),
+      ],
       providers: [
         DocumentClient,
         {


### PR DESCRIPTION
# Download service auth and timeout remove


## What

Increasing the timeout to 30s , added exeption handling on the document client.
Body token was incorrect in controller after auth changes from [#3149](https://github.com/island-is/island.is/pull/3419)

## Why

Some document requests are taking longer than 10s to respond and thus returning an unhandled error which was causing problems for the app. 

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
