### PR TITLE
fix: Aafgp - set ready for prod flag

### DIFF
--- a/libs/application/templates/funding-government-projects/src/lib/FundingGovernmentProjectsTemplate.ts
+++ b/libs/application/templates/funding-government-projects/src/lib/FundingGovernmentProjectsTemplate.ts
@@ -37,7 +37,8 @@ const FundingGovernmentProjectsTemplate: ApplicationTemplate<
   FundingGovernmentProjectsEvent
 > = {
   type: ApplicationTypes.FUNDING_GOVERNMENT_PROJECTS,
-  name: 'Umsókn um fjármögnun ríkisverkefnis',
+  name: application.name,
+  readyForProduction: true,
   translationNamespaces: [
     ApplicationConfigurations.FundingGovernmentProjects.translation,
   ],


### PR DESCRIPTION
Application for funding government projects is missing the ready for production flag.
Also translation added for application name.