### PR TITLE
feat(web): Select article footer and chat panel from array of organizations

### DIFF
--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -33,6 +33,7 @@ import { DigitalIcelandHeader } from './Themes/DigitalIcelandTheme'
 import { DefaultHeader } from './Themes/DefaultTheme'
 import getConfig from 'next/config'
 import { UtlendingastofnunHeader } from './Themes/UtlendingastofnunTheme'
+import { endpoints as chatPanelEndpoints } from '../../ChatPanel/config'
 
 interface NavigationData {
   title: string
@@ -76,28 +77,27 @@ const OrganizationHeader: React.FC<HeaderProps> = ({ organizationPage }) => {
 }
 
 interface FooterProps {
-  theme: string
-  organization?: Organization
+  organizations: Array<Organization>
 }
 
 export const OrganizationFooter: React.FC<FooterProps> = ({
-  theme,
-  organization,
+  organizations,
 }) => {
+  const footerEnabled = ['syslumenn']
+
+  const organization = organizations.find((x) => footerEnabled.includes(x.slug))
   if (!organization) return null
 
-  switch (theme) {
-    case 'syslumenn':
-      return (
-        <SyslumennFooter
-          title={organization.title}
-          logo={organization.logo?.url}
-          footerItems={organization.footerItems}
-        />
-      )
-    default:
-      return null
+  if (organization.slug === 'syslumenn') {
+    return (
+      <SyslumennFooter
+        title={organization.title}
+        logo={organization.logo?.url}
+        footerItems={organization.footerItems}
+      />
+    )
   }
+  return null
 }
 
 export const OrganizationChatPanel = ({
@@ -114,11 +114,13 @@ export const OrganizationChatPanel = ({
     return null
   }
 
-  if (slugs.includes('syslumenn')) {
-    return <ChatPanel endpoint={'syslumenn'} pushUp={pushUp} />
-  }
+  const chatEnabled = ['syslumenn']
 
-  return null
+  const slug = slugs.find((x) => chatEnabled.includes(x))
+
+  return !!slug ? (
+    <ChatPanel endpoint={slug as keyof typeof chatPanelEndpoints} pushUp={pushUp} />
+  ) : null
 }
 
 const SecondaryMenu = ({ linkGroup }: { linkGroup: LinkGroup }) => (
@@ -293,10 +295,7 @@ export const OrganizationWrapper: React.FC<WrapperProps> = ({
         )}
       </Main>
       {!minimal && (
-        <OrganizationFooter
-          theme={organizationPage.theme}
-          organization={organizationPage.organization}
-        />
+        <OrganizationFooter organizations={[organizationPage.organization]} />
       )}
       <OrganizationChatPanel slugs={[organizationPage?.slug]} />
     </>

--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -118,8 +118,11 @@ export const OrganizationChatPanel = ({
 
   const slug = slugs.find((x) => chatEnabled.includes(x))
 
-  return !!slug ? (
-    <ChatPanel endpoint={slug as keyof typeof chatPanelEndpoints} pushUp={pushUp} />
+  return slug ? (
+    <ChatPanel
+      endpoint={slug as keyof typeof chatPanelEndpoints}
+      pushUp={pushUp}
+    />
   ) : null
 }
 

--- a/apps/web/screens/Article.tsx
+++ b/apps/web/screens/Article.tsx
@@ -573,8 +573,7 @@ const ArticleScreen: Screen<ArticleProps> = ({ article, namespace }) => {
         pushUp={isVisible}
       />
       <OrganizationFooter
-        theme={article.organization[0]?.slug}
-        organization={article.organization[0] as Organization}
+        organizations={article.organization as Organization[]}
       />
     </>
   )


### PR DESCRIPTION
# Select article footer and chat panel from array of organizations

## What

Articles can have multiple organizations attached to it. This PR makes articles use the footer of the first organization in the array that has a configured footer.

## Why

Some articles were not displaying the Syslumenn header because another organization was element zero in the array.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
