### PR TITLE
chore(application-templates-parental-leave): Skip requests in Children data provider if mocking data

### DIFF
--- a/libs/application/templates/parental-leave/src/dataProviders/Children/Children.ts
+++ b/libs/application/templates/parental-leave/src/dataProviders/Children/Children.ts
@@ -108,13 +108,6 @@ export class Children extends BasicDataProvider {
     customTemplateFindQuery: CustomTemplateFindQuery,
     pregnancyStatus?: PregnancyStatus | null,
   ): Promise<ChildrenWithoutRightsAndExistingApplications> {
-    const useMockData =
-      getValueViaPath(application.answers, 'useMockData', NO) === YES
-
-    if (useMockData && !isRunningOnProduction) {
-      return getChildrenFromMockData(application)
-    }
-
     // Applications where this parent is applicant
     const applicationsWhereApplicant = (
       await customTemplateFindQuery({
@@ -172,6 +165,14 @@ export class Children extends BasicDataProvider {
     application: Application,
     customTemplateFindQuery: CustomTemplateFindQuery,
   ): Promise<ChildrenAndExistingApplications> {
+    const useMockData =
+      getValueViaPath(application.answers, 'useMockData', NO) === YES
+    const shouldUseMockData = useMockData && !isRunningOnProduction
+
+    if (shouldUseMockData) {
+      return getChildrenFromMockData(application)
+    }
+
     const parentalLeavesAndPregnancyStatus = await this.queryParentalLeavesAndPregnancyStatus()
 
     const {


### PR DESCRIPTION
# \<Description\>

## What

Skipping all requests in data provider if mocking data

## Why

Some of them may fail because you are not expecting a baby so that the data provider will not return mocked data

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
