### PR TITLE
Added initial version of party letter service

### DIFF
--- a/apps/services/party-letter-registry-api/.eslintrc
+++ b/apps/services/party-letter-registry-api/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../.eslintrc.json",
+  "rules": {},
+  "ignorePatterns": ["!**/*"]
+}

--- a/apps/services/party-letter-registry-api/.sequelizerc
+++ b/apps/services/party-letter-registry-api/.sequelizerc
@@ -1,0 +1,7 @@
+const path = require('path');
+
+module.exports = {
+  'config': path.resolve('sequelize.config.js'),
+  'seeders-path': path.resolve('seeders'),
+  'migrations-path': path.resolve('migrations')
+};

--- a/apps/services/party-letter-registry-api/README.md
+++ b/apps/services/party-letter-registry-api/README.md
@@ -1,0 +1,7 @@
+# Party letter Registry
+
+## About
+**This service needs to be accessed by users through another service providing appropriate authentication for getting this data**  
+The consuming application should validate that the requesting user is in managers  
+This service contains the political party letter registry.  
+The source of the data contained in this service is the Ministry of Justice and the party letter application currently contained within the application system.

--- a/apps/services/party-letter-registry-api/bin/startup.sql
+++ b/apps/services/party-letter-registry-api/bin/startup.sql
@@ -1,0 +1,15 @@
+\set db_user `echo $DEV_DB_USER`
+\set db_password `echo $DEV_DB_PASS`
+\set db_name `echo $DEV_DB_NAME`
+\set test_db_user `echo $TEST_DB_USER`
+\set test_db_password `echo $TEST_DB_PASS`
+\set test_db_name `echo $TEST_DB_NAME`
+
+CREATE DATABASE :db_name;
+CREATE DATABASE :test_db_name;
+
+CREATE USER :db_user WITH PASSWORD :'db_password';
+CREATE USER :test_db_user WITH PASSWORD :'test_db_password';
+
+GRANT ALL PRIVILEGES ON DATABASE :db_name TO :db_user;
+GRANT ALL PRIVILEGES ON DATABASE :test_db_name TO :test_db_user;

--- a/apps/services/party-letter-registry-api/docker-compose.base.yml
+++ b/apps/services/party-letter-registry-api/docker-compose.base.yml
@@ -1,0 +1,21 @@
+version: '3.3'
+
+services:
+  party_letter_registry:
+    image: postgres:11.6
+    container_name: party_letter_registry
+    networks:
+      - local
+    environment:
+      - POSTGRES_PASSWORD=XjFsvIrGyCCrdE
+      - TEST_DB_USER=test_db
+      - TEST_DB_PASS=test_db
+      - TEST_DB_NAME=test_db
+      - DEV_DB_USER=dev_db
+      - DEV_DB_PASS=dev_db
+      - DEV_DB_NAME=dev_db
+    volumes:
+      - ./bin/startup.sql:/docker-entrypoint-initdb.d/startup.sql
+
+networks:
+  local:

--- a/apps/services/party-letter-registry-api/docker-compose.ci.yml
+++ b/apps/services/party-letter-registry-api/docker-compose.ci.yml
@@ -1,0 +1,24 @@
+version: '3.3'
+
+services:
+  sut:
+    build:
+      context: .
+      dockerfile: ../../scripts/ci/Dockerfile.test
+      args:
+        DB_NAME: party_letter_registry
+        APP: party-letter-registry
+    networks:
+      - local
+    depends_on:
+      - party_letter_registry
+    environment:
+      - TEST_DB_USER=test_db
+      - TEST_DB_PASS=test_db
+      - TEST_DB_NAME=test_db
+      - DB_HOST=party_letter_registry
+    volumes:
+      - ../..:/code
+
+  party_letter_registry:
+    ports: []

--- a/apps/services/party-letter-registry-api/docker-compose.dev.yml
+++ b/apps/services/party-letter-registry-api/docker-compose.dev.yml
@@ -1,0 +1,6 @@
+version: '3.3'
+
+services:
+  party_letter_registry:
+    ports:
+      - 5432:5432

--- a/apps/services/party-letter-registry-api/jest.config.js
+++ b/apps/services/party-letter-registry-api/jest.config.js
@@ -1,0 +1,19 @@
+module.exports = {
+  displayName: 'party-letter-registry-api',
+  preset: '../../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsConfig: '<rootDir>/tsconfig.spec.json',
+    },
+  },
+  transform: {
+    '^.+\\.[tj]s$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'js', 'html', 'json'],
+  coverageDirectory:
+    '../../../../coverage/apps/services/party-letter-registry-api',
+  setupFiles: ['./test/environment.jest.ts'],
+  setupFilesAfterEnv: ['./test/setup.ts'],
+  globalSetup: './test/globalSetup.ts',
+  globalTeardown: './test/globalTeardown.ts',
+}

--- a/apps/services/party-letter-registry-api/migrations/20210514135724-party-letter-registry.js
+++ b/apps/services/party-letter-registry-api/migrations/20210514135724-party-letter-registry.js
@@ -1,0 +1,53 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const transaction = await queryInterface.sequelize.transaction()
+
+    // try is here to make sure this safely fails if index creation fails
+    try {
+      await queryInterface.createTable('party_letter_registry', {
+        id: {
+          type: Sequelize.INTEGER,
+          autoIncrement: true,
+          primaryKey: true,
+        },
+        party_letter: {
+          type: Sequelize.CHAR(2),
+          allowNull: false,
+          unique: true,
+        },
+        party_name: {
+          type: Sequelize.STRING,
+          allowNull: false,
+        },
+        owner: {
+          type: Sequelize.STRING,
+          allowNull: false,
+          unique: true,
+        },
+        managers: {
+          type: Sequelize.ARRAY(Sequelize.STRING),
+          allowNull: false,
+        },
+        created: {
+          type: Sequelize.DATE,
+          allowNull: false,
+        },
+        modified: {
+          type: Sequelize.DATE,
+          allowNull: false,
+        },
+      })
+      await queryInterface.addIndex('party_letter_registry', ['owner'])
+      transaction.commit()
+    } catch (err) {
+      await transaction.rollback()
+      throw err
+    }
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable('party_letter_registry')
+  },
+}

--- a/apps/services/party-letter-registry-api/seeders/20210514153818-e2e-tests.js
+++ b/apps/services/party-letter-registry-api/seeders/20210514153818-e2e-tests.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const createPartyLetterRegistry = require('../src/app/modules/partyLetterRegistry/e2e/create/seed.js')
+const findByOwnerPartyLetterRegistry = require('../src/app/modules/partyLetterRegistry/e2e/findByOwner/seed.js')
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const partyLetterRegistry = [
+      ...createPartyLetterRegistry.partyLetterRegistry,
+      ...findByOwnerPartyLetterRegistry.partyLetterRegistry,
+    ]
+
+    await queryInterface.bulkInsert(
+      'party_letter_registry',
+      partyLetterRegistry,
+    )
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('party_letter_registry')
+  },
+}

--- a/apps/services/party-letter-registry-api/seeders/20210514154039-development.js
+++ b/apps/services/party-letter-registry-api/seeders/20210514154039-development.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const { getGenericPartyLetterRegistry } = require('../test/seedHelpers')
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const partyLetterRegistry = [
+      getGenericPartyLetterRegistry(),
+      getGenericPartyLetterRegistry(),
+      getGenericPartyLetterRegistry(),
+    ]
+
+    await queryInterface.bulkInsert(
+      'party_letter_registry',
+      partyLetterRegistry,
+    )
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('party_letter_registry')
+  },
+}

--- a/apps/services/party-letter-registry-api/sequelize.config.d.ts
+++ b/apps/services/party-letter-registry-api/sequelize.config.d.ts
@@ -1,0 +1,17 @@
+import { Dialect } from 'sequelize/types'
+
+interface SequelizeConfig {
+  username: string
+  password: string
+  database: string
+  host: string
+  dialect: Dialect
+}
+
+declare namespace SequelizeConfig {
+  const production: SequelizeConfig
+  const test: SequelizeConfig
+  const development: SequelizeConfig
+}
+
+export = SequelizeConfig

--- a/apps/services/party-letter-registry-api/sequelize.config.js
+++ b/apps/services/party-letter-registry-api/sequelize.config.js
@@ -1,0 +1,24 @@
+/* eslint-env node */
+module.exports = {
+  development: {
+    username: 'dev_db',
+    password: 'dev_db',
+    database: 'dev_db',
+    host: 'localhost',
+    dialect: 'postgres',
+  },
+  test: {
+    username: 'test_db',
+    password: 'test_db',
+    database: 'test_db',
+    host: process.env.DB_HOST,
+    dialect: 'postgres',
+  },
+  production: {
+    username: process.env.DB_USER,
+    password: process.env.DB_PASS,
+    database: process.env.DB_NAME,
+    host: process.env.DB_HOST,
+    dialect: 'postgres',
+  },
+}

--- a/apps/services/party-letter-registry-api/src/app/app.module.ts
+++ b/apps/services/party-letter-registry-api/src/app/app.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common'
+import { SequelizeModule } from '@nestjs/sequelize'
+import { PartyLetterRegistryModule } from './modules/partyLetterRegistry/partyLetterRegistry.module'
+import { SequelizeConfigService } from './sequelizeConfig.service'
+
+@Module({
+  imports: [
+    SequelizeModule.forRootAsync({
+      useClass: SequelizeConfigService,
+    }),
+    PartyLetterRegistryModule,
+  ],
+})
+export class AppModule {}

--- a/apps/services/party-letter-registry-api/src/app/modules/partyLetterRegistry/dto/create.dto.ts
+++ b/apps/services/party-letter-registry-api/src/app/modules/partyLetterRegistry/dto/create.dto.ts
@@ -1,0 +1,17 @@
+import { IsArray, IsString, Length } from 'class-validator'
+import { IsNationalId } from '../validators/isNationalId.decorator'
+
+export class CreateDto {
+  @IsNationalId()
+  owner!: string
+
+  @Length(1, 2)
+  partyLetter!: string
+
+  @IsString()
+  partyName!: string
+
+  @IsArray()
+  @IsNationalId({ each: true })
+  managers!: string[]
+}

--- a/apps/services/party-letter-registry-api/src/app/modules/partyLetterRegistry/dto/findByOwner.dto.ts
+++ b/apps/services/party-letter-registry-api/src/app/modules/partyLetterRegistry/dto/findByOwner.dto.ts
@@ -1,0 +1,6 @@
+import { IsNationalId } from '../validators/isNationalId.decorator'
+
+export class FindByOwnerDto {
+  @IsNationalId()
+  owner!: string
+}

--- a/apps/services/party-letter-registry-api/src/app/modules/partyLetterRegistry/e2e/create/create.spec.ts
+++ b/apps/services/party-letter-registry-api/src/app/modules/partyLetterRegistry/e2e/create/create.spec.ts
@@ -1,0 +1,63 @@
+import { setup } from '../../../../../../test/setup'
+import { errorExpectedStructure } from '../../../../../../test/testHelpers'
+import * as request from 'supertest'
+import { INestApplication } from '@nestjs/common'
+
+let app: INestApplication
+
+beforeAll(async () => {
+  app = await setup()
+})
+
+describe('CreatePartyLetterRegistry', () => {
+  it('POST /party-letter-registry should return error when data is invalid', async () => {
+    const requestData = {
+      partyLetter: 'A',
+      partyName: 'The awesome party',
+      owner: '0000000002',
+      managers: ['0000000001'],
+    }
+    const response = await request(app.getHttpServer())
+      .post('/party-letter-registry')
+      .send(requestData)
+      .expect(400)
+
+    expect(response.body).toMatchObject({
+      ...errorExpectedStructure,
+      statusCode: 400,
+    })
+  })
+  it('POST /party-letter-registry should fail to assign an existing letter', async () => {
+    const nationalId = '0101305069'
+    const requestData = {
+      partyLetter: 'B',
+      partyName: 'The awesome party',
+      owner: nationalId,
+      managers: [nationalId],
+    }
+    const response = await request(app.getHttpServer())
+      .post('/party-letter-registry')
+      .send(requestData)
+      .expect(405)
+
+    expect(response.body).toMatchObject({
+      ...errorExpectedStructure,
+      statusCode: 405,
+    })
+  })
+  it('POST /party-letter-registry should create a new entry', async () => {
+    const nationalId = '0101303019'
+    const requestData = {
+      partyLetter: 'C',
+      partyName: 'The awesome party',
+      owner: nationalId,
+      managers: [nationalId],
+    }
+    const response = await request(app.getHttpServer())
+      .post('/party-letter-registry')
+      .send(requestData)
+      .expect(201)
+
+    expect(response.body).toMatchObject(requestData)
+  })
+})

--- a/apps/services/party-letter-registry-api/src/app/modules/partyLetterRegistry/e2e/create/seed.js
+++ b/apps/services/party-letter-registry-api/src/app/modules/partyLetterRegistry/e2e/create/seed.js
@@ -1,0 +1,12 @@
+const {
+  getGenericPartyLetterRegistry,
+} = require('../../../../../../test/seedHelpers')
+
+module.exports = {
+  partyLetterRegistry: [
+    {
+      ...getGenericPartyLetterRegistry(),
+      party_letter: 'B',
+    },
+  ],
+}

--- a/apps/services/party-letter-registry-api/src/app/modules/partyLetterRegistry/e2e/findByOwner/findByOwner.spec.ts
+++ b/apps/services/party-letter-registry-api/src/app/modules/partyLetterRegistry/e2e/findByOwner/findByOwner.spec.ts
@@ -1,0 +1,48 @@
+import { setup } from '../../../../../../test/setup'
+import { errorExpectedStructure } from '../../../../../../test/testHelpers'
+import * as request from 'supertest'
+import { INestApplication } from '@nestjs/common'
+
+let app: INestApplication
+
+beforeAll(async () => {
+  app = await setup()
+})
+
+describe('FindByOwnerPartyLetterRegistry', () => {
+  it('GET /party-letter-registry should return error when national id is invalid', async () => {
+    const nationalId = '0000000001'
+    const response = await request(app.getHttpServer())
+      .get(`/party-letter-registry?owner=${nationalId}`)
+      .send()
+      .expect(400)
+
+    expect(response.body).toMatchObject({
+      ...errorExpectedStructure,
+      statusCode: 400,
+    })
+  })
+  it('GET /party-letter-registry should return not found error when national owns no letters', async () => {
+    const nationalId = '0101303019'
+    const response = await request(app.getHttpServer())
+      .get(`/party-letter-registry?owner=${nationalId}`)
+      .send()
+      .expect(404)
+
+    expect(response.body).toMatchObject({
+      ...errorExpectedStructure,
+      statusCode: 404,
+    })
+  })
+  it('GET /party-letter-registry should return a party letter entry', async () => {
+    const nationalId = '0101302989'
+    const response = await request(app.getHttpServer())
+      .get(`/party-letter-registry?owner=${nationalId}`)
+      .send()
+      .expect(200)
+
+    expect(response.body).toMatchObject({
+      owner: nationalId,
+    })
+  })
+})

--- a/apps/services/party-letter-registry-api/src/app/modules/partyLetterRegistry/e2e/findByOwner/seed.js
+++ b/apps/services/party-letter-registry-api/src/app/modules/partyLetterRegistry/e2e/findByOwner/seed.js
@@ -1,0 +1,12 @@
+const {
+  getGenericPartyLetterRegistry,
+} = require('../../../../../../test/seedHelpers')
+
+module.exports = {
+  partyLetterRegistry: [
+    {
+      ...getGenericPartyLetterRegistry(),
+      owner: '0101302989',
+    },
+  ],
+}

--- a/apps/services/party-letter-registry-api/src/app/modules/partyLetterRegistry/partyLetterRegistry.controller.ts
+++ b/apps/services/party-letter-registry-api/src/app/modules/partyLetterRegistry/partyLetterRegistry.controller.ts
@@ -1,0 +1,37 @@
+import {
+  Body,
+  Controller,
+  Get,
+  NotFoundException,
+  Post,
+  Query,
+} from '@nestjs/common'
+import { CreateDto } from './dto/create.dto'
+import { FindByOwnerDto } from './dto/findByOwner.dto'
+import { PartyLetterRegistry } from './partyLetterRegistry.model'
+import { PartyLetterRegistryService } from './partyLetterRegistry.service'
+
+@Controller('party-letter-registry')
+export class PartyLetterRegistryController {
+  constructor (
+    private readonly partyLetterRegistryService: PartyLetterRegistryService,
+  ) {}
+
+  @Get()
+  async findByOwner (
+    @Query() { owner }: FindByOwnerDto,
+  ): Promise<PartyLetterRegistry> {
+    const resource = await this.partyLetterRegistryService.findByOwner(owner)
+
+    if (!resource) {
+      throw new NotFoundException("This resource doesn't exist")
+    }
+
+    return resource
+  }
+
+  @Post()
+  async create (@Body() input: CreateDto): Promise<PartyLetterRegistry> {
+    return await this.partyLetterRegistryService.create(input)
+  }
+}

--- a/apps/services/party-letter-registry-api/src/app/modules/partyLetterRegistry/partyLetterRegistry.model.ts
+++ b/apps/services/party-letter-registry-api/src/app/modules/partyLetterRegistry/partyLetterRegistry.model.ts
@@ -1,0 +1,62 @@
+import {
+  Column,
+  CreatedAt,
+  DataType,
+  Model,
+  Table,
+  UpdatedAt,
+} from 'sequelize-typescript'
+
+@Table({
+  tableName: 'party_letter_registry',
+  indexes: [
+    {
+      fields: ['owner'],
+    },
+  ],
+})
+export class PartyLetterRegistry extends Model<PartyLetterRegistry> {
+  @Column({
+    type: DataType.INTEGER,
+    primaryKey: true,
+    autoIncrement: true,
+  })
+  id!: string
+
+  @Column({
+    type: DataType.CHAR(2),
+    allowNull: false,
+    get () {
+      // this adds a space cause of char 2 we remove added spaces here
+      const value: string = ((this as unknown) as Model<
+        PartyLetterRegistry
+      >).getDataValue('partyLetter' as any)
+      return value.trim()
+    },
+  })
+  partyLetter!: string
+
+  @Column({
+    type: DataType.STRING,
+    allowNull: false,
+  })
+  partyName!: string
+
+  @Column({
+    type: DataType.STRING,
+    allowNull: false,
+  })
+  owner!: string
+
+  @Column({
+    type: DataType.ARRAY(DataType.STRING),
+    allowNull: false,
+  })
+  managers!: string[]
+
+  @CreatedAt
+  readonly created!: Date
+
+  @UpdatedAt
+  readonly modified!: Date
+}

--- a/apps/services/party-letter-registry-api/src/app/modules/partyLetterRegistry/partyLetterRegistry.module.ts
+++ b/apps/services/party-letter-registry-api/src/app/modules/partyLetterRegistry/partyLetterRegistry.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common'
+import { SequelizeModule } from '@nestjs/sequelize'
+import { PartyLetterRegistry } from './partyLetterRegistry.model'
+import { PartyLetterRegistryService } from './partyLetterRegistry.service'
+import { PartyLetterRegistryController } from './partyLetterRegistry.controller'
+
+@Module({
+  imports: [SequelizeModule.forFeature([PartyLetterRegistry])],
+  controllers: [PartyLetterRegistryController],
+  providers: [PartyLetterRegistryService],
+})
+export class PartyLetterRegistryModule {}

--- a/apps/services/party-letter-registry-api/src/app/modules/partyLetterRegistry/partyLetterRegistry.service.ts
+++ b/apps/services/party-letter-registry-api/src/app/modules/partyLetterRegistry/partyLetterRegistry.service.ts
@@ -1,0 +1,41 @@
+import { Inject, Injectable, MethodNotAllowedException } from '@nestjs/common'
+import { InjectModel } from '@nestjs/sequelize'
+import { UniqueConstraintError } from 'sequelize'
+import { Logger, LOGGER_PROVIDER } from '@island.is/logging'
+import { PartyLetterRegistry } from './partyLetterRegistry.model'
+import { CreateDto } from './dto/create.dto'
+
+@Injectable()
+export class PartyLetterRegistryService {
+  constructor (
+    @InjectModel(PartyLetterRegistry)
+    private partyLetterRegistryModel: typeof PartyLetterRegistry,
+    @Inject(LOGGER_PROVIDER)
+    private logger: Logger,
+  ) {}
+
+  findByOwner (owner: string) {
+    this.logger.debug(`Finding party letter for owner - "${owner}"`)
+    return this.partyLetterRegistryModel.findOne({
+      where: { owner },
+    })
+  }
+
+  create (input: CreateDto) {
+    return this.partyLetterRegistryModel
+      .create(input)
+      .catch((error: UniqueConstraintError) => {
+        switch (error.constructor) {
+          // we want to relay this specific error type to the client
+          case UniqueConstraintError: {
+            throw new MethodNotAllowedException(
+              error.errors.map((err) => err.message),
+            )
+          }
+          default: {
+            throw error
+          }
+        }
+      })
+  }
+}

--- a/apps/services/party-letter-registry-api/src/app/modules/partyLetterRegistry/validators/isNationalId.decorator.ts
+++ b/apps/services/party-letter-registry-api/src/app/modules/partyLetterRegistry/validators/isNationalId.decorator.ts
@@ -1,0 +1,23 @@
+import { registerDecorator, ValidationOptions } from 'class-validator'
+import { isPerson } from 'kennitala'
+
+export const IsNationalId = (validationOptions?: ValidationOptions) => {
+  return (object: Object, propertyName: string) => {
+    registerDecorator({
+      name: 'IsNationalId',
+      target: object.constructor,
+      propertyName: propertyName,
+      options: {
+        message: `${propertyName} contains an invalid national id for a person`,
+        ...validationOptions,
+      },
+      validator: {
+        validate(value: any) {
+          return (
+            typeof value === 'string' && isPerson(value) && value.length === 10
+          )
+        },
+      },
+    })
+  }
+}

--- a/apps/services/party-letter-registry-api/src/app/sequelizeConfig.service.ts
+++ b/apps/services/party-letter-registry-api/src/app/sequelizeConfig.service.ts
@@ -1,0 +1,51 @@
+import { Inject, Injectable } from '@nestjs/common'
+import {
+  SequelizeModuleOptions,
+  SequelizeOptionsFactory,
+} from '@nestjs/sequelize'
+import * as databaseConfig from '../../sequelize.config.js'
+import { Logger, LOGGER_PROVIDER } from '@island.is/logging'
+
+@Injectable()
+export class SequelizeConfigService implements SequelizeOptionsFactory {
+  constructor (
+    @Inject(LOGGER_PROVIDER)
+    private logger: Logger,
+  ) {}
+
+  createSequelizeOptions (): SequelizeModuleOptions {
+    let config
+    switch (process.env.NODE_ENV) {
+      case 'test':
+        config = databaseConfig.test
+        break
+      case 'production':
+        config = databaseConfig.production
+        break
+      default:
+        config = databaseConfig.development
+    }
+
+    return {
+      ...config,
+      define: {
+        underscored: true,
+        timestamps: true,
+        createdAt: 'created',
+        updatedAt: 'modified',
+      },
+      dialectOptions: {
+        useUTC: true,
+      },
+      pool: {
+        max: 5,
+        min: 0,
+        acquire: 30000,
+        idle: 10000,
+      },
+      logging: (message) => this.logger.debug(message),
+      autoLoadModels: true,
+      synchronize: false,
+    }
+  }
+}

--- a/apps/services/party-letter-registry-api/src/buildOpenApi.ts
+++ b/apps/services/party-letter-registry-api/src/buildOpenApi.ts
@@ -1,0 +1,10 @@
+import { buildOpenApi } from '@island.is/infra-nest-server'
+
+import { AppModule } from './app/app.module'
+import { openApi } from './openApi'
+
+buildOpenApi({
+  path: 'apps/services/party-letter-registry-api/src/openapi.yaml',
+  appModule: AppModule,
+  openApi,
+})

--- a/apps/services/party-letter-registry-api/src/environments/environment.prod.ts
+++ b/apps/services/party-letter-registry-api/src/environments/environment.prod.ts
@@ -1,0 +1,1 @@
+export default {}

--- a/apps/services/party-letter-registry-api/src/environments/environment.ts
+++ b/apps/services/party-letter-registry-api/src/environments/environment.ts
@@ -1,0 +1,1 @@
+export default {}

--- a/apps/services/party-letter-registry-api/src/environments/index.ts
+++ b/apps/services/party-letter-registry-api/src/environments/index.ts
@@ -1,0 +1,1 @@
+export { default as environment } from './environment'

--- a/apps/services/party-letter-registry-api/src/main.ts
+++ b/apps/services/party-letter-registry-api/src/main.ts
@@ -1,0 +1,12 @@
+import { bootstrap } from '@island.is/infra-nest-server'
+
+import { AppModule } from './app/app.module'
+import { openApi } from './openApi'
+
+bootstrap({
+  appModule: AppModule,
+  name: 'services-party-letter-registry-api',
+  openApi,
+  port: 4251,
+  swaggerPath: '',
+})

--- a/apps/services/party-letter-registry-api/src/openApi.ts
+++ b/apps/services/party-letter-registry-api/src/openApi.ts
@@ -1,0 +1,7 @@
+import { DocumentBuilder } from '@nestjs/swagger'
+
+export const openApi = new DocumentBuilder()
+  .setTitle('Party letter registry')
+  .setDescription('This api manages access to the party letter registry.')
+  .setVersion('1.0')
+  .build()

--- a/apps/services/party-letter-registry-api/test/environment.jest.ts
+++ b/apps/services/party-letter-registry-api/test/environment.jest.ts
@@ -1,0 +1,3 @@
+process.env.APPLICATION_DB_USER = 'test_db'
+process.env.APPLICATION_DB_PASS = 'test_db'
+process.env.APPLICATION_DB_NAME = 'test_db'

--- a/apps/services/party-letter-registry-api/test/globalSetup.ts
+++ b/apps/services/party-letter-registry-api/test/globalSetup.ts
@@ -1,0 +1,10 @@
+import { execSync } from 'child_process'
+
+const setup = async () => {
+  execSync('yarn nx run services-party-letter-registry-api:migrate --env test')
+  execSync(
+    'yarn nx run services-party-letter-registry-api:seed --env test --seed 20210514153818-e2e-tests.js',
+  )
+}
+
+export default setup

--- a/apps/services/party-letter-registry-api/test/globalTeardown.ts
+++ b/apps/services/party-letter-registry-api/test/globalTeardown.ts
@@ -1,0 +1,9 @@
+import { execSync } from 'child_process'
+
+const setup = async () => {
+  execSync(
+    'yarn nx run services-party-letter-registry-api:seed/undo --env test --seed 20210514153818-e2e-tests.js',
+  )
+}
+
+export default setup

--- a/apps/services/party-letter-registry-api/test/seedHelpers.js
+++ b/apps/services/party-letter-registry-api/test/seedHelpers.js
@@ -1,0 +1,16 @@
+const faker = require('faker')
+
+module.exports = {
+  getGenericPartyLetterRegistry: () => ({
+    party_letter: faker.random.alpha({ count: 1, uppercase: true }),
+    party_name: faker.company.companyName(),
+    owner: faker.phone.phoneNumber('##########'),
+    managers: [
+      faker.phone.phoneNumber('##########'),
+      faker.phone.phoneNumber('##########'),
+      faker.phone.phoneNumber('##########'),
+    ],
+    created: new Date(),
+    modified: new Date(),
+  }),
+}

--- a/apps/services/party-letter-registry-api/test/setup.ts
+++ b/apps/services/party-letter-registry-api/test/setup.ts
@@ -1,0 +1,46 @@
+import { testServer, TestServerOptions } from '@island.is/infra-nest-server'
+import { getConnectionToken } from '@nestjs/sequelize'
+import { INestApplication, Type } from '@nestjs/common'
+import { Sequelize } from 'sequelize-typescript'
+import { AppModule } from '../src/app/app.module'
+
+export let app: INestApplication
+let sequelize: Sequelize
+
+// needed for generic error validation
+expect.extend({
+  anyOf(value: any, classTypes: any[]) {
+    const types = classTypes.map((type) => type.name).join(', ')
+    const message = `expected to be any of type: ${types}`
+    for (let i = 0; i < classTypes.length; i++) {
+      if (value.constructor === classTypes[i]) {
+        return {
+          pass: true,
+          message: () => message,
+        }
+      }
+    }
+
+    return {
+      pass: false,
+      message: () => message,
+    }
+  },
+})
+
+export const setup = async (options?: Partial<TestServerOptions>) => {
+  app = await testServer({
+    appModule: AppModule,
+    ...options,
+  })
+  sequelize = await app.resolve(getConnectionToken() as Type<Sequelize>)
+
+  return app
+}
+
+afterAll(async () => {
+  if (app && sequelize) {
+    await app.close()
+    await sequelize.close()
+  }
+})

--- a/apps/services/party-letter-registry-api/test/testHelpers.ts
+++ b/apps/services/party-letter-registry-api/test/testHelpers.ts
@@ -1,0 +1,5 @@
+export const errorExpectedStructure = {
+  error: expect.any(String),
+  message: expect.anyOf([String, Array]),
+  statusCode: expect.any(Number),
+}

--- a/apps/services/party-letter-registry-api/tsconfig.app.json
+++ b/apps/services/party-letter-registry-api/tsconfig.app.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "types": ["node"]
+  },
+  "exclude": ["**/*.spec.ts", "test/**", "**/e2e/**"],
+  "include": ["**/*.ts"]
+}

--- a/apps/services/party-letter-registry-api/tsconfig.json
+++ b/apps/services/party-letter-registry-api/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "types": ["node", "jest", "./types"]
+  },
+  "include": [],
+  "files": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/apps/services/party-letter-registry-api/tsconfig.spec.json
+++ b/apps/services/party-letter-registry-api/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": ["**/*.spec.ts", "**/*.d.ts", "test/**.ts", "**/e2e/**.ts"]
+}

--- a/apps/services/party-letter-registry-api/types/index.d.ts
+++ b/apps/services/party-letter-registry-api/types/index.d.ts
@@ -1,0 +1,8 @@
+export {}
+declare global {
+  namespace jest {
+    interface Expect {
+      anyOf(input: any[])
+    }
+  }
+}

--- a/apps/services/party-letter-registry-api/webpack.config.js
+++ b/apps/services/party-letter-registry-api/webpack.config.js
@@ -1,0 +1,45 @@
+// Found in issue https://github.com/nrwl/nx/issues/2147
+const webpack = require('webpack')
+
+const swaggerPluginOptions = {
+  dtoFileNameSuffix: ['.dto.ts', '.model.ts'],
+  classValidatorShim: true,
+  introspectComments: true,
+}
+
+module.exports = (config) => {
+  const tsLoader = config.module.rules.find((rule) =>
+    rule.loader.includes('ts-loader'),
+  )
+
+  if (tsLoader) {
+    tsLoader.options.transpileOnly = false // required because if true, plugin can't work properly
+    tsLoader.options.getCustomTransformers = (program) => {
+      return {
+        before: [
+          require('@nestjs/swagger/plugin').before(
+            swaggerPluginOptions,
+            program,
+          ),
+        ],
+      }
+    }
+  }
+
+  config.plugins = [
+    ...(config.plugins || []),
+    new webpack.ProvidePlugin({
+      openapi: '@nestjs/swagger',
+    }),
+  ]
+
+  config.entry = {
+    ...config.entry,
+    buildOpenApi:
+      './apps/services/party-letter-registry-api/src/buildOpenApi.ts',
+  }
+  config.output.filename = '[name].js'
+  return {
+    ...config,
+  }
+}

--- a/nx.json
+++ b/nx.json
@@ -507,6 +507,9 @@
     "services-search-indexer": {
       "tags": []
     },
+    "services-party-letter-registry-api": {
+      "tags": []
+    },
     "services-user-profile": {
       "tags": []
     },

--- a/workspace.json
+++ b/workspace.json
@@ -6293,6 +6293,106 @@
         "docker-express": {}
       }
     },
+    "services-party-letter-registry-api": {
+      "root": "apps/services/party-letter-registry-api",
+      "sourceRoot": "apps/services/party-letter-registry-api/src",
+      "projectType": "application",
+      "prefix": "services-party-letter-registry-api",
+      "architect": {
+        "build": {
+          "builder": "@nrwl/node:build",
+          "outputs": ["{options.outputPath}"],
+          "options": {
+            "outputPath": "dist/apps/services/party-letter-registry-api",
+            "main": "apps/services/party-letter-registry-api/src/main.ts",
+            "tsConfig": "apps/services/party-letter-registry-api/tsconfig.app.json",
+            "webpackConfig": "apps/services/party-letter-registry-api/webpack.config.js"
+          },
+          "configurations": {
+            "production": {
+              "optimization": true,
+              "extractLicenses": true,
+              "inspect": false,
+              "fileReplacements": [
+                {
+                  "replace": "apps/services/party-letter-registry-api/src/environments/environment.ts",
+                  "with": "apps/services/party-letter-registry-api/src/environments/environment.prod.ts"
+                }
+              ]
+            }
+          }
+        },
+        "serve": {
+          "builder": "@nrwl/node:execute",
+          "options": {
+            "buildTarget": "services-party-letter-registry-api:build"
+          }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:eslint",
+          "options": {
+            "lintFilePatterns": [
+              "apps/services/party-letter-registry-api/**/*.ts"
+            ]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "outputs": ["coverage/apps/services/party-letter-registry-api"],
+          "options": {
+            "jestConfig": "apps/services/party-letter-registry-api/jest.config.js",
+            "passWithNoTests": true
+          }
+        },
+        "dev-services": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "command": "docker-compose -f docker-compose.base.yml -f docker-compose.dev.yml up -d --build",
+            "cwd": "apps/services/party-letter-registry-api"
+          }
+        },
+        "schemas/build-openapi": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "outputPath": "apps/services/party-letter-registry-api/src/openapi.yaml",
+            "commands": [
+              "nx run services-party-letter-registry-api:build",
+              "node dist/apps/services/party-letter-registry-api/buildOpenApi.js"
+            ],
+            "parallel": false
+          }
+        },
+        "migrate": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "command": "../../../node_modules/.bin/sequelize-cli db:migrate",
+            "cwd": "apps/services/party-letter-registry-api"
+          }
+        },
+        "seed": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "command": "../../../node_modules/.bin/sequelize-cli db:seed",
+            "cwd": "apps/services/party-letter-registry-api"
+          }
+        },
+        "seed/undo": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "command": "../../../node_modules/.bin/sequelize-cli db:seed:undo",
+            "cwd": "apps/services/party-letter-registry-api"
+          }
+        },
+        "migrate/generate": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "command": "../../../node_modules/.bin/sequelize-cli migration:generate --name $(whoami)",
+            "cwd": "apps/services/party-letter-registry-api"
+          }
+        },
+        "docker-express": {}
+      }
+    },
     "services-user-profile": {
       "root": "apps/services/user-profile",
       "sourceRoot": "apps/services/user-profile/src",


### PR DESCRIPTION
# \<Description\>

We want to keep a registry of party letters for applications that require a party letter to be assigned.
We also want to be able to assign new party letters to national ids in the application system.

What
- Added database config for party letter registry
-  Added tests
- Added api

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
