### PR TITLE
chore(ui-core): Add arrow down to icon map

### DIFF
--- a/libs/island-ui/core/src/lib/IconRC/iconMap.ts
+++ b/libs/island-ui/core/src/lib/IconRC/iconMap.ts
@@ -5,6 +5,7 @@ export type Icon =
   | 'arrowForward'
   | 'arrowBack'
   | 'arrowUp'
+  | 'arrowDown'
   | 'attach'
   | 'business'
   | 'calendar'


### PR DESCRIPTION
# \<Add arrow down to icon map\>

## What

Arrow down added to iconMap Icon type

## Why

The icon exists as an asset but was missing in the type

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
