### PR TITLE
feat(web): Highlight active item in secondary menu on organization pages

### DIFF
--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -35,6 +35,7 @@ import { DefaultHeader } from './Themes/DefaultTheme'
 import getConfig from 'next/config'
 import { UtlendingastofnunHeader } from './Themes/UtlendingastofnunTheme'
 import { endpoints as chatPanelEndpoints } from '../../ChatPanel/config'
+import { useRouter } from 'next/router'
 
 interface NavigationData {
   title: string
@@ -127,7 +128,13 @@ export const OrganizationChatPanel = ({
   ) : null
 }
 
-const SecondaryMenu = ({ linkGroup }: { linkGroup: LinkGroup }) => (
+const SecondaryMenu = ({
+  title,
+  items,
+}: {
+  title: string
+  items: NavigationItem[]
+}) => (
   <Box
     background="purple100"
     borderRadius="large"
@@ -136,12 +143,16 @@ const SecondaryMenu = ({ linkGroup }: { linkGroup: LinkGroup }) => (
   >
     <Stack space={[1, 1, 2]}>
       <Text variant="eyebrow" as="h2">
-        {linkGroup.name}
+        {title}
       </Text>
-      {linkGroup.childrenLinks.map((link) => (
-        <Link key={link.url} href={link.url} underline="normal">
-          <Text key={link.url} as="span">
-            {link.text}
+      {items.map((link) => (
+        <Link key={link.href} href={link.href} underline="normal">
+          <Text
+            key={link.href}
+            as="span"
+            variant={link.active ? 'h5' : 'default'}
+          >
+            {link.title}
           </Text>
         </Link>
       ))}
@@ -163,11 +174,13 @@ export const OrganizationWrapper: React.FC<WrapperProps> = ({
   children,
   minimal = false,
 }) => {
+  const Router = useRouter()
+
   const secondaryNavList: NavigationItem[] =
     organizationPage.secondaryMenu?.childrenLinks.map(({ text, url }) => ({
       title: text,
       href: url,
-      active: text === pageTitle,
+      active: Router.asPath === url,
     })) ?? []
 
   const metaTitleSuffix =
@@ -209,7 +222,10 @@ export const OrganizationWrapper: React.FC<WrapperProps> = ({
                   }}
                 />
                 {organizationPage.secondaryMenu && (
-                  <SecondaryMenu linkGroup={organizationPage.secondaryMenu} />
+                  <SecondaryMenu
+                    title={organizationPage.secondaryMenu.name}
+                    items={secondaryNavList}
+                  />
                 )}
                 {organizationPage.sidebarCards.map((card) => (
                   <ProfileCard

--- a/apps/web/screens/Organization/NewsList.tsx
+++ b/apps/web/screens/Organization/NewsList.tsx
@@ -75,12 +75,16 @@ const NewsList: Screen<NewsListProps> = ({
   const { getMonthByIndex } = useDateUtils()
   const n = useNamespace(namespace)
 
-  const currentNavItem = organizationPage.menuLinks.find(
-    ({ primaryLink }) => primaryLink.url === Router.asPath,
-  )
+  const currentNavItem =
+    organizationPage.menuLinks.find(
+      ({ primaryLink }) => primaryLink.url === Router.asPath,
+    )?.primaryLink ??
+    organizationPage.secondaryMenu?.childrenLinks.find(
+      ({ url }) => url === Router.asPath,
+    )
 
   const newsTitle =
-    currentNavItem?.primaryLink.text ??
+    currentNavItem?.text ??
     newsList[0]?.genericTags.find((x) => x.slug === selectedTag).title ??
     n('newsTitle', 'Fréttir og tilkynningar')
 


### PR DESCRIPTION
# Highlight active item in secondary menu on organization pages

## What

Secondary menu items are now bold if active. News list searches for title to use in secondary menu as well.

## Why

It is expected behavior for links

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/3607456/119020519-d9c49b00-b98d-11eb-819f-97277586dfe2.png)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
