### PR TITLE
fix(core): Use graphql context where appropriate

### DIFF
--- a/libs/auth-nest-tools/src/lib/current-user.decorator.ts
+++ b/libs/auth-nest-tools/src/lib/current-user.decorator.ts
@@ -3,27 +3,15 @@ import {
   ExecutionContext,
   UnauthorizedException,
 } from '@nestjs/common'
-import { GqlExecutionContext } from '@nestjs/graphql'
 import { logger } from '@island.is/logging'
 
 import { User } from './user'
 import { getRequest } from './getRequest'
 
-export const getCurrentUser = (
-  context: ExecutionContext & { contextType?: string },
-): User => {
-  const resolveUser = () => {
-    if (context.contextType === 'graphql') {
-      const ctx = GqlExecutionContext.create(context)
-      const { req } = ctx.getContext()
-      return req.user
-    } else {
-      const request = getRequest(context)
-      return request.user
-    }
-  }
+export const getCurrentUser = (context: ExecutionContext): User => {
+  const request = getRequest(context)
 
-  const user = resolveUser()
+  const user = request.user
   if (!user) {
     logger.warn(
       'No user authentication found. Did you forget to add IdsUserGuard?',

--- a/libs/auth-nest-tools/src/lib/current-user.decorator.ts
+++ b/libs/auth-nest-tools/src/lib/current-user.decorator.ts
@@ -3,15 +3,27 @@ import {
   ExecutionContext,
   UnauthorizedException,
 } from '@nestjs/common'
+import { GqlExecutionContext } from '@nestjs/graphql'
 import { logger } from '@island.is/logging'
 
 import { User } from './user'
 import { getRequest } from './getRequest'
 
-export const getCurrentUser = (context: ExecutionContext): User => {
-  const request = getRequest(context)
+export const getCurrentUser = (
+  context: ExecutionContext & { contextType?: string },
+): User => {
+  const resolveUser = () => {
+    if (context.contextType === 'graphql') {
+      const ctx = GqlExecutionContext.create(context)
+      const { req } = ctx.getContext()
+      return req.user
+    } else {
+      const request = getRequest(context)
+      return request.user
+    }
+  }
 
-  const user = request.user
+  const user = resolveUser()
   if (!user) {
     logger.warn(
       'No user authentication found. Did you forget to add IdsUserGuard?',

--- a/libs/auth-nest-tools/src/lib/getRequest.ts
+++ b/libs/auth-nest-tools/src/lib/getRequest.ts
@@ -1,14 +1,11 @@
 import { ExecutionContext } from '@nestjs/common'
 import { GqlExecutionContext } from '@nestjs/graphql'
 
-export const getRequest = (context: ExecutionContext) => {
-  const request = context.switchToHttp().getRequest()
-
-  if (request) {
-    return request
-  } else {
+export const getRequest = (context: ExecutionContext & { contextType?: string }) => {
+  if (context.contextType === 'graphql') {
     const ctx = GqlExecutionContext.create(context)
-
     return ctx.getContext().req
   }
+
+  return context.switchToHttp().getRequest()
 }

--- a/libs/auth-nest-tools/src/lib/getRequest.ts
+++ b/libs/auth-nest-tools/src/lib/getRequest.ts
@@ -1,7 +1,9 @@
 import { ExecutionContext } from '@nestjs/common'
 import { GqlExecutionContext } from '@nestjs/graphql'
 
-export const getRequest = (context: ExecutionContext & { contextType?: string }) => {
+export const getRequest = (
+  context: ExecutionContext & { contextType?: string },
+) => {
   if (context.contextType === 'graphql') {
     const ctx = GqlExecutionContext.create(context)
     return ctx.getContext().req


### PR DESCRIPTION
# Use graphql context where appropriate

## What

Use graphql context where appropriate

## Why

This would result in loosing the GraphQL context for nested resolvers,
meaning that this would not work:
```typescript
@ResolveField('address')
resolveAddress(@CurrentUser() user: User) {
  // throws an error due to the @CurrentUser decorator
}
```

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
