### PR TITLE
fix(web): Fix overflow problem on news slider

### DIFF
--- a/apps/web/components/Organization/Slice/LatestNewsSlice/LatestNewsSlice.tsx
+++ b/apps/web/components/Organization/Slice/LatestNewsSlice/LatestNewsSlice.tsx
@@ -18,7 +18,7 @@ export const LatestNewsSlice: React.FC<SliceProps> = ({
   fullWidth,
 }) => {
   return (
-    <section key={slice.id}>
+    <div key={slice.id} style={{ overflow: 'hidden' }}>
       <Section
         paddingTop={[8, 8, 6]}
         paddingBottom={[8, 8, 6]}
@@ -46,6 +46,6 @@ export const LatestNewsSlice: React.FC<SliceProps> = ({
           />
         )}
       </Section>
-    </section>
+    </div>
   )
 }


### PR DESCRIPTION
# Fix overflow problem on news slider

This fixes a visual problem with the news slider on organization pages. An `overflow: hidden` was missing.
