### PR TITLE
fix(application-system): update button text in application list

### DIFF
--- a/apps/application-system/form/src/routes/Applications.tsx
+++ b/apps/application-system/form/src/routes/Applications.tsx
@@ -144,7 +144,9 @@ export const Applications: FC = () => {
                       heading={application.name || application.typeId}
                       text={application.stateDescription}
                       cta={{
-                        label: formatMessage(coreMessages.buttonNext),
+                        label: isCompleted
+                          ? formatMessage(coreMessages.cardButtonComplete)
+                          : formatMessage(coreMessages.cardButtonInProgress),
                         variant: 'ghost',
                         size: 'small',
                         icon: undefined,

--- a/libs/application/core/src/lib/messages.ts
+++ b/libs/application/core/src/lib/messages.ts
@@ -31,6 +31,16 @@ export const coreMessages = defineMessages({
     defaultMessage: 'Breyta',
     description: 'Edit button for review screen and so on',
   },
+  cardButtonInProgress: {
+    id: 'application:card.button.inProgress',
+    defaultMessage: 'Opna umsókn',
+    description: 'Button label when application is in progress',
+  },
+  cardButtonComplete: {
+    id: 'application:card.button.complete',
+    defaultMessage: 'Skoða yfirlit',
+    description: 'Button label when application is complete',
+  },
   externalDataTitle: {
     id: 'application.system:externalData.title',
     defaultMessage: 'Eftirfarandi gögn verða sótt rafrænt með þínu samþykki',


### PR DESCRIPTION
# Button text in application list

Currently we are displaying different text in the application list buttons

## What

- Added new translation strings
- Updated the application list component to display the same text as in Mínar síður

### Note

- I will push translations to Contentful once this gets merged to `main`

## Why

- We want to have this unified

## Screenshots / Gifs

![Screenshot 2021-05-26 at 16 31 54](https://user-images.githubusercontent.com/17431581/119697623-eb032100-be3f-11eb-9179-596bb863ec46.jpg)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
