### PR TITLE
feat(web): Change header background for Utlendingastofnun

### DIFF
--- a/apps/web/components/Organization/Wrapper/Themes/UtlendingastofnunTheme/UtlendingastofnunHeader.treat.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/UtlendingastofnunTheme/UtlendingastofnunHeader.treat.ts
@@ -13,9 +13,8 @@ export const headerContainer = style({
   height: 385,
   ...themeUtils.responsiveStyle({
     lg: {
-      background: `url('https://images.ctfassets.net/8k0h54kbe6bj/5LpuUMoH5JrsmG0dn6ncNh/dd569ad88510a0d1a1590110f0c36899/image_65_shutterstock.png')`,
+      background: `url('https://images.ctfassets.net/8k0h54kbe6bj/1UwZEiLUXwiy0qyMcFQztZ/1f74ca98866e4ad7e85c45c58bf64568/image_65_shutterstock__1_.png')`,
       backgroundRepeat: 'no-repeat !important',
-      backgroundPosition: '-48px 0 !important',
     },
   }),
 })


### PR DESCRIPTION
# Change header background for Utlendingastofnun

## What

This makes the Utl. header a bit darker.

## Why

Designers want to try this.

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/3607456/120216666-d7343200-c226-11eb-83a1-f5fbc8c88e8c.png)
