### PR TITLE
fix(ads-backend): Add missing color* externals

### DIFF
--- a/apps/air-discount-scheme/backend/esbuild.json
+++ b/apps/air-discount-scheme/backend/esbuild.json
@@ -2,6 +2,8 @@
   "platform": "node",
   "external": [
     "fsevents",
+    "color-convert",
+    "color-string",
     "@nestjs/microservices",
     "class-transformer",
     "cache-manager",


### PR DESCRIPTION
## What

Add missing external dependencies

## Why

To make air-discount-scheme-backend run

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
