### PR TITLE
feat(island-ui): Add support for groups and custom group labels in Select component

### DIFF
--- a/libs/island-ui/core/src/lib/Select/Select.stories.tsx
+++ b/libs/island-ui/core/src/lib/Select/Select.stories.tsx
@@ -140,5 +140,46 @@ export const TempTest = () => (
       noOptionsMessage="Enginn valmöguleiki"
       backgroundColor="blue"
     />
+    <div style={{ height: 30 }} />
+    <Template
+      name="select"
+      label="With groups"
+      size="md"
+      placeholder="placeholder test"
+      menuIsOpen
+      formatGroupLabel={() => <p>Custom group label</p>}
+      options={[
+        {
+          label: 'Valmöguleiki 3',
+          value: '4',
+        },
+        {
+          label: 'Valmöguleiki 3',
+          value: '5',
+        },
+        {
+          label: 'Valmöguleiki 3',
+          value: '6',
+        },
+        {
+          label: 'group1',
+          options: [
+            {
+              label: 'Valmöguleiki 1',
+              value: '0',
+            },
+            {
+              label: 'Valmöguleiki 2',
+              value: '1',
+            },
+            {
+              label: 'Valmöguleiki 3',
+              value: '3',
+            },
+          ],
+        },
+      ]}
+      noOptionsMessage="Enginn valmöguleiki"
+    />
   </div>
 )

--- a/libs/island-ui/core/src/lib/Select/Select.tsx
+++ b/libs/island-ui/core/src/lib/Select/Select.tsx
@@ -1,4 +1,5 @@
 import React, { ComponentType } from 'react'
+import cn from 'classnames'
 import ReactSelect, {
   components,
   ValueType,
@@ -16,7 +17,7 @@ import ReactSelect, {
   OptionsType,
   GroupedOptionsType,
 } from 'react-select'
-import cn from 'classnames'
+import { formatGroupLabel } from 'react-select/src/builtins'
 import * as styles from './Select.treat'
 import { Icon } from '../IconRC/Icon'
 import { InputBackgroundColor } from '../Input/types'
@@ -34,9 +35,9 @@ interface AriaError {
 
 export interface SelectProps {
   name: string
+  options: OptionsType<Option> | GroupedOptionsType<Option> | undefined
   id?: string
   disabled?: boolean
-  options: OptionsType<Option> | GroupedOptionsType<Option> | undefined
   hasError?: boolean
   errorMessage?: string
   noOptionsMessage?: string
@@ -55,6 +56,7 @@ export interface SelectProps {
   backgroundColor?: InputBackgroundColor
   required?: boolean
   ariaError?: AriaError
+  formatGroupLabel?: formatGroupLabel<Option>
 }
 
 export const Select = ({
@@ -75,6 +77,7 @@ export const Select = ({
   size = 'md',
   backgroundColor = 'white',
   required,
+  formatGroupLabel,
 }: SelectProps) => {
   const errorId = `${id}-error`
   const ariaError = hasError
@@ -110,6 +113,7 @@ export const Select = ({
         size={size}
         required={required}
         ariaError={ariaError as AriaError}
+        formatGroupLabel={formatGroupLabel}
         components={{
           Control,
           Input,

--- a/libs/island-ui/core/src/lib/Select/Select.tsx
+++ b/libs/island-ui/core/src/lib/Select/Select.tsx
@@ -35,7 +35,7 @@ interface AriaError {
 
 export interface SelectProps {
   name: string
-  options: OptionsType<Option> | GroupedOptionsType<Option> | undefined
+  options: OptionsType<Option> | GroupedOptionsType<Option>
   id?: string
   disabled?: boolean
   hasError?: boolean

--- a/libs/island-ui/core/src/lib/Select/Select.tsx
+++ b/libs/island-ui/core/src/lib/Select/Select.tsx
@@ -13,6 +13,8 @@ import ReactSelect, {
   InputProps,
   ControlProps,
   Props,
+  OptionsType,
+  GroupedOptionsType,
 } from 'react-select'
 import cn from 'classnames'
 import * as styles from './Select.treat'
@@ -34,7 +36,7 @@ export interface SelectProps {
   name: string
   id?: string
   disabled?: boolean
-  options: ReadonlyArray<Option>
+  options: OptionsType<Option> | GroupedOptionsType<Option> | undefined
   hasError?: boolean
   errorMessage?: string
   noOptionsMessage?: string


### PR DESCRIPTION
# Add support for groups and custom group labels in Select component

https://app.asana.com/0/0/1200404779972597/f

## What

Add support for groups and custom group labels in Select component

## Why

The judicial-system project needs to use groups in one of their Select components.

## Screenshots / Gifs

![Screen Shot 2021-06-01 at 13 54 41](https://user-images.githubusercontent.com/3789875/120335366-f099b480-c2e0-11eb-9024-e3ef6f47d034.png)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
