### PR TITLE
chore(core): Improving e2e in CI

### DIFF
--- a/scripts/e2e-ci.js
+++ b/scripts/e2e-ci.js
@@ -164,7 +164,7 @@ const main = async () => {
 
     if (serveChild) {
       console.log('Clean up serve process...')
-      let killed = serveChild.kill('SIGINT')
+      let killed = serveChild.kill('SIGTERM')
       console.log(`Child process cleaned up successfully: ${killed}`)
     }
   } catch (err) {

--- a/scripts/e2e-ci.js
+++ b/scripts/e2e-ci.js
@@ -164,7 +164,7 @@ const main = async () => {
 
     if (serveChild) {
       console.log('Clean up serve process...')
-      let killed = serveChild.kill('SIGTERM')
+      let killed = serveChild.kill()
       console.log(`Child process cleaned up successfully: ${killed}`)
     }
   } catch (err) {
@@ -172,6 +172,7 @@ const main = async () => {
     console.log(err)
   }
 
+  console.log(`Exiting main process with code ${exitCode}`)
   process.exit(exitCode)
 }
 

--- a/scripts/schemas.js
+++ b/scripts/schemas.js
@@ -1,6 +1,6 @@
 const { stat, writeFile } = require('fs')
-const { spawn } = require('child_process')
 const { promisify } = require('util')
+const { exec } = require('./utils')
 
 /**
  * Because get-files-touched-by.sh cannot get files from nx cache
@@ -24,21 +24,6 @@ const TARGETS = [
   'schemas/build-graphql-schema', // Output api.graphql based on graphql app modules
   'schemas/codegen', // Output clients schemas (*.d.ts) based on codegen.yml
 ]
-
-const exec = (command) => {
-  return new Promise((resolve, reject) => {
-    const cmd = spawn(command, { stdio: 'inherit', shell: true })
-    cmd.on('exit', (exitCode) => {
-      if (exitCode === 0) {
-        resolve()
-      } else {
-        const error = new Error('Command exited with non-zero exit code.')
-        error.code = exitCode
-        reject(error)
-      }
-    })
-  })
-}
 
 const fileExists = async (path) =>
   !!(await promisify(stat)(path).catch((_) => false))

--- a/scripts/static-serve.js
+++ b/scripts/static-serve.js
@@ -34,7 +34,7 @@ const argv = yargs
 app.use(argv['base-path'], express.static(path.join(process.cwd(), argv.dist)))
 
 // Setup server shutdown signal from parent
-process.on('SIGTERM', () => {
+process.on('SIGINT', () => {
   console.log('Shutting down server...')
   server.close()
   console.log('Exiting process...')

--- a/scripts/static-serve.js
+++ b/scripts/static-serve.js
@@ -33,14 +33,6 @@ const argv = yargs
 // Set the path for static file serve
 app.use(argv['base-path'], express.static(path.join(process.cwd(), argv.dist)))
 
-// Setup server shutdown signal from parent
-process.on('SIGTERM', () => {
-  console.log('Shutting down server...')
-  server.close()
-  console.log('Exiting process...')
-  process.exit()
-})
-
 // Create base path to contain * to return index.html for all sub-paths
 // to let client handle routing.
 const basePath =

--- a/scripts/static-serve.js
+++ b/scripts/static-serve.js
@@ -34,7 +34,7 @@ const argv = yargs
 app.use(argv['base-path'], express.static(path.join(process.cwd(), argv.dist)))
 
 // Setup server shutdown signal from parent
-process.on('SIGINT', () => {
+process.on('SIGTERM', () => {
   console.log('Shutting down server...')
   server.close()
   console.log('Exiting process...')

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,0 +1,29 @@
+const { spawn } = require('child_process')
+
+/**
+ * Wraps child_process.spawn with more user friendly interface
+ * and to be async using Promise.
+ * @param {string} command
+ * @param {Object} options Same options as defined for `child_process.spawn()`
+ * @returns Promise
+ */
+exports.exec = (command, options) => {
+  return new Promise((resolve, reject) => {
+    console.log(options)
+    const cmd = spawn(command, {
+      stdio: 'inherit',
+      shell: true,
+      ...options,
+    })
+
+    cmd.on('exit', (exitCode) => {
+      if (exitCode === 0) {
+        resolve()
+      } else {
+        const error = new Error('Command exited with non-zero exit code.')
+        error.code = exitCode
+        reject(error)
+      }
+    })
+  })
+}

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -9,7 +9,6 @@ const { spawn } = require('child_process')
  */
 exports.exec = (command, options) => {
   return new Promise((resolve, reject) => {
-    console.log(options)
     const cmd = spawn(command, {
       stdio: 'inherit',
       shell: true,


### PR DESCRIPTION
# Improving e2e in CI 

Improving e2e-ci by using only spawn for child process, and piping otput to stdout for better debugging in CI.

## What

e2e test are sometimes flaky and recently we saw e2e test for `web` hanging for 25min without any useful logs.

## Why

To be able to debug flaky e2e tests in CI with more output logs.


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
