### PR TITLE
feat(island-ui): Add zIndex to useBoxStyles

### DIFF
--- a/apps/judicial-system/web/src/shared-components/DropdownMenu/DropdownMenu.tsx
+++ b/apps/judicial-system/web/src/shared-components/DropdownMenu/DropdownMenu.tsx
@@ -45,7 +45,7 @@ export const DropdownMenu = ({
     display: 'flex',
     flexDirection: 'column',
     borderRadius: 'large',
-    zIndex: 1,
+    zIndex: 10,
   })
   const menuItemBoxStyle = useBoxStyles({
     component: 'button',

--- a/apps/judicial-system/web/src/shared-components/DropdownMenu/DropdownMenu.tsx
+++ b/apps/judicial-system/web/src/shared-components/DropdownMenu/DropdownMenu.tsx
@@ -45,6 +45,7 @@ export const DropdownMenu = ({
     display: 'flex',
     flexDirection: 'column',
     borderRadius: 'large',
+    zIndex: 1,
   })
   const menuItemBoxStyle = useBoxStyles({
     component: 'button',

--- a/libs/island-ui/core/src/lib/Box/useBoxStyles.treat.ts
+++ b/libs/island-ui/core/src/lib/Box/useBoxStyles.treat.ts
@@ -589,7 +589,15 @@ export const opacity = styleMap({
 })
 
 export const zIndex = styleMap({
-  1: { zIndex: 1 },
+  10: { zIndex: 10 },
+  20: { zIndex: 20 },
+  30: { zIndex: 30 },
+  40: { zIndex: 40 },
+  50: { zIndex: 50 },
+  60: { zIndex: 60 },
+  70: { zIndex: 70 },
+  80: { zIndex: 80 },
+  90: { zIndex: 90 },
 })
 
 export const printHidden = style({

--- a/libs/island-ui/core/src/lib/Box/useBoxStyles.treat.ts
+++ b/libs/island-ui/core/src/lib/Box/useBoxStyles.treat.ts
@@ -588,6 +588,10 @@ export const opacity = styleMap({
   1: { opacity: 1 },
 })
 
+export const zIndex = styleMap({
+  1: { zIndex: 1 },
+})
+
 export const printHidden = style({
   '@media': {
     print: {

--- a/libs/island-ui/core/src/lib/Box/useBoxStyles.ts
+++ b/libs/island-ui/core/src/lib/Box/useBoxStyles.ts
@@ -69,6 +69,7 @@ export interface UseBoxStylesProps {
   opacity?: keyof typeof styleRefs.opacity
   printHidden?: boolean
   className?: Parameters<typeof classnames>[0]
+  zIndex?: keyof typeof styleRefs.zIndex
 }
 
 export const useBoxStyles = ({
@@ -127,6 +128,7 @@ export const useBoxStyles = ({
   opacity,
   printHidden,
   className,
+  zIndex,
 }: UseBoxStylesProps) => {
   const resetStyles = { ...resetStyleRefs }
   const styles = { ...styleRefs }
@@ -313,5 +315,6 @@ export const useBoxStyles = ({
     styles.opacity[opacity!],
     printHidden && styles.printHidden,
     className,
+    styles.zIndex[zIndex!],
   )
 }


### PR DESCRIPTION
# Add zIndex to useBoxStyles

## What

Add the ability to use zIndex: 1 in useBoxStyles

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
