### PR TITLE
fix(parental-leave): missing tiles and wrong ids

### DIFF
--- a/libs/application/core/src/lib/formBuilders.ts
+++ b/libs/application/core/src/lib/formBuilders.ts
@@ -55,7 +55,7 @@ export function buildRepeater(data: {
 export function buildSection(data: {
   id?: string
   condition?: Condition
-  title: MessageDescriptor | string
+  title: FormText
   children: SectionChildren[]
 }): Section {
   return { ...data, type: FormItemTypes.SECTION }

--- a/libs/application/templates/parental-leave/src/forms/DraftRequiresAction.ts
+++ b/libs/application/templates/parental-leave/src/forms/DraftRequiresAction.ts
@@ -19,11 +19,11 @@ export const DraftRequiresAction: Form = buildForm({
   mode: FormModes.REJECTED,
   children: [
     buildSection({
-      id: 'Draft not approved, requires action',
-      title: '',
+      id: 'draftRequiresAction.section',
+      title: parentalLeaveFormMessages.draftFlow.draftNotApprovedTitle,
       children: [
         buildCustomField({
-          id: 'draftRequiresAction',
+          id: 'draftRequiresAction.field',
           title: parentalLeaveFormMessages.draftFlow.draftNotApprovedTitle,
           component: 'DraftRequiresAction',
         }),

--- a/libs/application/templates/parental-leave/src/forms/EditOrAddPeriods.ts
+++ b/libs/application/templates/parental-leave/src/forms/EditOrAddPeriods.ts
@@ -22,8 +22,8 @@ export const EditOrAddPeriods: Form = buildForm({
   mode: FormModes.EDITING,
   children: [
     buildSection({
-      id: 'editOrAddPeropds',
-      title: '',
+      id: 'editOrAddPeriods',
+      title: parentalLeaveFormMessages.leavePlan.title,
       children: [
         buildRepeater({
           id: 'periods',
@@ -91,7 +91,7 @@ export const EditOrAddPeriods: Form = buildForm({
           children: [
             buildCustomField({
               id: 'confirmationScreen',
-              title: '',
+              title: parentalLeaveFormMessages.confirmation.title,
               component: 'EditPeriodsReview',
             }),
             buildSubmitField({

--- a/libs/application/templates/parental-leave/src/forms/EditsInReview.ts
+++ b/libs/application/templates/parental-leave/src/forms/EditsInReview.ts
@@ -20,7 +20,7 @@ export const EditsInReview: Form = buildForm({
   children: [
     buildSection({
       id: 'review',
-      title: '',
+      title: parentalLeaveFormMessages.reviewScreen.titleInReview,
       children: [
         buildCustomField({
           id: 'EditsInReviewSteps',

--- a/libs/application/templates/parental-leave/src/forms/EditsRequireAction.ts
+++ b/libs/application/templates/parental-leave/src/forms/EditsRequireAction.ts
@@ -19,11 +19,11 @@ export const EditsRequireAction: Form = buildForm({
   mode: FormModes.REJECTED,
   children: [
     buildSection({
-      id: 'Edits not approved, require action',
-      title: '',
+      id: 'EditsRequireAction.section',
+      title: parentalLeaveFormMessages.editFlow.editsNotApprovedTitle,
       children: [
         buildCustomField({
-          id: 'editsRequireAction',
+          id: 'editsRequireAction.field',
           title: parentalLeaveFormMessages.editFlow.editsNotApprovedTitle,
           component: 'EditsRequireAction',
         }),

--- a/libs/application/templates/parental-leave/src/forms/EmployerApproval.ts
+++ b/libs/application/templates/parental-leave/src/forms/EmployerApproval.ts
@@ -30,7 +30,7 @@ export const EmployerApproval: Form = buildForm({
             buildCustomField(
               {
                 id: 'intro',
-                title: '',
+                title: employerFormMessages.reviewMultiTitle,
                 component: 'PeriodsRepeater',
               },
               {

--- a/libs/application/templates/parental-leave/src/forms/InReview.ts
+++ b/libs/application/templates/parental-leave/src/forms/InReview.ts
@@ -20,7 +20,10 @@ export const InReview: Form = buildForm({
   children: [
     buildSection({
       id: 'review',
-      title: '',
+      title: (application) =>
+        application.state === 'approved'
+          ? parentalLeaveFormMessages.reviewScreen.titleApproved
+          : parentalLeaveFormMessages.reviewScreen.titleInReview,
       children: [
         buildCustomField({
           id: 'InReviewSteps',

--- a/libs/application/templates/parental-leave/src/forms/OtherParentApproval.ts
+++ b/libs/application/templates/parental-leave/src/forms/OtherParentApproval.ts
@@ -28,7 +28,7 @@ export const OtherParentApproval: Form = buildForm({
           children: [
             buildDescriptionField({
               id: 'intro',
-              title: '',
+              title: otherParentApprovalFormMessages.multiTitle,
               description: otherParentApprovalFormMessages.introDescription,
             }),
             buildSubmitField({

--- a/libs/application/templates/parental-leave/src/forms/Prerequisites.ts
+++ b/libs/application/templates/parental-leave/src/forms/Prerequisites.ts
@@ -173,13 +173,6 @@ export const PrerequisitesForm: Form = buildForm({
               title: '',
               description: '',
             }),
-            // TODO: Custom component with a lot more explanation of why you may not see any children
-            // buildDescriptionField({
-            //   id: 'notEligible',
-            //   title: parentalLeaveFormMessages.selectChild.notEligibleTitle,
-            //   description:
-            //     parentalLeaveFormMessages.selectChild.notEligibleDescription,
-            // }),
           ],
         }),
       ],


### PR DESCRIPTION
## What

- https://app.asana.com/0/1182378413629561/1200409061590810

## Why

- So we have nice titles in the browser tabs while the step is active
