### PR TITLE
chore(codeowners): add aranja-app as codeowners for native apps

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -58,6 +58,8 @@
 /libs/clients/vmst/                                                                           @island-is/aranja-applications
 /libs/shared/form-fields/                                                                     @island-is/aranja-applications
 
+/apps/native/                                                                                 @island-is/aranja-app
+
 /libs/application/templates/family-matters/                                                   @island-is/kolibri-modern-family
 /apps/application-system/api/src/app/modules/application/files/                               @island-is/kolibri-modern-family
 /libs/application/template-api-modules/src/lib/modules/templates/children-residence-change    @island-is/kolibri-modern-family


### PR DESCRIPTION
# Aranja App team as codeowners for /apps/native

Attach a link to issue if relevant

## What

Update codeowners

## Why

Missing codeowners

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
