### PR TITLE
feat(api): Add audit logs to domains consuming 3rd party services

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,9 +37,6 @@
     {
       "files": ["*.ts", "*.tsx"],
       "extends": ["plugin:@nrwl/nx/typescript"],
-      "parserOptions": {
-        "project": "./tsconfig.*?.json"
-      },
       "rules": {
         "@typescript-eslint/no-extra-semi": "off",
         "@typescript-eslint/explicit-member-accessibility": "off",

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -177,7 +177,7 @@ jobs:
       CYPRESS_PROJECT_ID: 4q7jz8
       CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
       API_MOCKS: 'true'
-      NODE_OPTIONS: --max-old-space-size=8192
+      NODE_OPTIONS: --max-old-space-size=4096
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare.outputs.E2E_CHUNKS) }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -177,7 +177,7 @@ jobs:
       CYPRESS_PROJECT_ID: 4q7jz8
       CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
       API_MOCKS: 'true'
-      NODE_OPTIONS: --max-old-space-size=4096
+      NODE_OPTIONS: --max-old-space-size=8192
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare.outputs.E2E_CHUNKS) }}

--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -31,6 +31,7 @@ import { ApiDomainsPaymentModule } from '@island.is/api/domains/payment'
 import { TemporaryVoterRegistryModule } from '@island.is/api/domains/temporary-voter-registry'
 import { PartyLetterRegistryModule } from '@island.is/api/domains/party-letter-registry'
 import { LicenseServiceModule } from '@island.is/api/domains/license-service'
+import { AuditModule } from '@island.is/nest/audit'
 
 const debug = process.env.NODE_ENV === 'development'
 const playground = debug || process.env.GQL_PLAYGROUND_ENABLED === 'true'
@@ -60,6 +61,7 @@ const autoSchemaFile = environment.production
       ],
     }),
     AuthDomainModule.register(environment.authPublicApi),
+    AuditModule.forRoot(environment.audit),
     ContentSearchModule,
     CmsModule,
     DrivingLicenseModule.register({

--- a/apps/api/src/app/environments/environment.ts
+++ b/apps/api/src/app/environments/environment.ts
@@ -121,6 +121,9 @@ const devConfig = {
   partyLetterRegistry: {
     baseApiUrl: 'http://localhost:4251',
   },
+  audit: {
+    defaultNamespace: '@island.is/api',
+  },
 }
 
 const prodConfig = {
@@ -233,6 +236,11 @@ const prodConfig = {
   },
   partyLetterRegistry: {
     baseApiUrl: process.env.PARTY_LETTER_REGISTRY_BASE_API_URL,
+  },
+  audit: {
+    defaultNamespace: '@island.is/api',
+    groupName: process.env.AUDIT_GROUP_NAME,
+    serviceName: 'api',
   },
 }
 

--- a/libs/api/domains/document-provider/src/lib/document-provider.resolver.ts
+++ b/libs/api/domains/document-provider/src/lib/document-provider.resolver.ts
@@ -31,11 +31,17 @@ import {
 } from './dto'
 import { UpdateOrganisationInput } from './dto/updateOrganisation.input'
 import { AdminGuard } from './utils/admin.guard'
+import { AuditService } from '@island.is/nest/audit'
+
+const namespace = '@island.is/api/document-provider'
 
 @UseGuards(IdsUserGuard, ScopesGuard)
 @Resolver()
 export class DocumentProviderResolver {
-  constructor(private documentProviderService: DocumentProviderService) {}
+  constructor(
+    private documentProviderService: DocumentProviderService,
+    private readonly auditService: AuditService,
+  ) {}
 
   @UseGuards(AdminGuard)
   @Query(() => [Organisation])
@@ -196,10 +202,18 @@ export class DocumentProviderResolver {
       `createTestProvider: user: ${user.nationalId}, organisation: ${input.nationalId}, clientName: ${input.clientName}`,
     )
 
-    return this.documentProviderService.createProviderOnTest(
-      input.nationalId,
-      input.clientName,
-      user,
+    return this.auditService.auditPromise(
+      {
+        user,
+        namespace,
+        action: 'createTestProvider',
+        resources: input.nationalId,
+      },
+      this.documentProviderService.createProviderOnTest(
+        input.nationalId,
+        input.clientName,
+        user,
+      ),
     )
   }
 
@@ -212,10 +226,19 @@ export class DocumentProviderResolver {
       `updateTestEndpoint: user: ${user.nationalId}, organisation: ${input.nationalId}, endpoint: ${input.endpoint}`,
     )
 
-    return this.documentProviderService.updateEndpointOnTest(
-      input.endpoint,
-      input.providerId,
-      input.xroad || false,
+    return this.auditService.auditPromise(
+      {
+        user,
+        namespace,
+        action: 'updateTestEndpoint',
+        resources: input.nationalId,
+        meta: { fields: Object.keys(input) },
+      },
+      this.documentProviderService.updateEndpointOnTest(
+        input.endpoint,
+        input.providerId,
+        input.xroad || false,
+      ),
     )
   }
 
@@ -228,10 +251,18 @@ export class DocumentProviderResolver {
       `runEndpointTests: user: ${user.nationalId}, organisation: ${input.nationalId}, recipient: ${input.recipient}, documentId: ${input.recipient}, providerId: ${input.providerId}`,
     )
 
-    return this.documentProviderService.runEndpointTests(
-      input.recipient,
-      input.documentId,
-      input.providerId,
+    return this.auditService.auditPromise(
+      {
+        user,
+        namespace,
+        action: 'runEndpointTests',
+        resources: input.nationalId,
+      },
+      this.documentProviderService.runEndpointTests(
+        input.recipient,
+        input.documentId,
+        input.providerId,
+      ),
     )
   }
 
@@ -244,10 +275,18 @@ export class DocumentProviderResolver {
       `createTestProvider: user: ${user.nationalId}, organisation: ${input.nationalId}, clientName: ${input.clientName}`,
     )
 
-    return this.documentProviderService.createProvider(
-      input.nationalId,
-      input.clientName,
-      user,
+    return this.auditService.auditPromise(
+      {
+        user,
+        namespace,
+        action: 'createProvider',
+        resources: input.nationalId,
+      },
+      this.documentProviderService.createProvider(
+        input.nationalId,
+        input.clientName,
+        user,
+      ),
     )
   }
 
@@ -260,11 +299,20 @@ export class DocumentProviderResolver {
       `updateTestEndpoint: user: ${user.nationalId}, organisation: ${input.nationalId}, endpoint: ${input.endpoint}`,
     )
 
-    return this.documentProviderService.updateEndpoint(
-      input.endpoint,
-      input.providerId,
-      input.xroad || false,
-      user,
+    return this.auditService.auditPromise(
+      {
+        user,
+        namespace,
+        action: 'updateEndpoint',
+        resources: input.nationalId,
+        meta: { fields: Object.keys(input) },
+      },
+      this.documentProviderService.updateEndpoint(
+        input.endpoint,
+        input.providerId,
+        input.xroad || false,
+        user,
+      ),
     )
   }
 

--- a/libs/api/domains/education/src/lib/graphql/main.resolver.ts
+++ b/libs/api/domains/education/src/lib/graphql/main.resolver.ts
@@ -8,6 +8,7 @@ import {
   ScopesGuard,
   CurrentUser,
 } from '@island.is/auth-nest-tools'
+import { AuditService } from '@island.is/nest/audit'
 
 import { EducationService } from '../education.service'
 import {
@@ -17,14 +18,27 @@ import {
 } from './license'
 import { ExamFamilyOverview, ExamResult } from './grade'
 
+const namespace = '@island.is/api/education'
+
 @UseGuards(IdsUserGuard, ScopesGuard)
 @Resolver()
 export class MainResolver {
-  constructor(private readonly educationService: EducationService) {}
+  constructor(
+    private readonly educationService: EducationService,
+    private readonly auditService: AuditService,
+  ) {}
 
   @Query(() => [EducationLicense])
   educationLicense(@CurrentUser() user: User): Promise<EducationLicense[]> {
-    return this.educationService.getLicenses(user.nationalId)
+    return this.auditService.auditPromise<EducationLicense[]>(
+      {
+        user,
+        namespace,
+        action: 'educationLicense',
+        resources: (licenses) => licenses.map((license) => license.id),
+      },
+      this.educationService.getLicenses(user.nationalId),
+    )
   }
 
   @Mutation(() => EducationSignedLicense, { nullable: true })
@@ -40,6 +54,14 @@ export class MainResolver {
     if (url === null) {
       throw new ApolloError('Could not create a download link')
     }
+
+    this.auditService.audit({
+      user,
+      namespace,
+      action: 'fetchEducationSignedicenseUrl',
+      resources: input.licenseId,
+    })
+
     return { url }
   }
 
@@ -47,7 +69,15 @@ export class MainResolver {
   educationExamFamilyOverviews(
     @CurrentUser() user: User,
   ): Promise<ExamFamilyOverview[]> {
-    return this.educationService.getExamFamilyOverviews(user.nationalId)
+    return this.auditService.auditPromise<ExamFamilyOverview[]>(
+      {
+        user,
+        namespace,
+        action: 'educationExamFamilyOverviews',
+        resources: (results) => results.map((result) => result.nationalId),
+      },
+      this.educationService.getExamFamilyOverviews(user.nationalId),
+    )
   }
 
   @Query(() => ExamResult)
@@ -62,6 +92,14 @@ export class MainResolver {
     if (!familyMember) {
       throw new ApolloError('The requested nationalId is not a part of family')
     }
-    return this.educationService.getExamResult(familyMember)
+    return this.auditService.auditPromise(
+      {
+        user,
+        namespace,
+        action: 'educationExamResult',
+        resources: nationalId,
+      },
+      this.educationService.getExamResult(familyMember),
+    )
   }
 }

--- a/libs/api/domains/health-insurance/src/lib/graphql/healthInsurance.resolver.ts
+++ b/libs/api/domains/health-insurance/src/lib/graphql/healthInsurance.resolver.ts
@@ -7,16 +7,18 @@ import {
   ScopesGuard,
   CurrentUser,
 } from '@island.is/auth-nest-tools'
+import { AuditService } from '@island.is/nest/audit'
 
-// import { VistaSkjalModel } from './models'
 import { HealthInsuranceService } from '../healthInsurance.service'
-// import { VistaSkjalInput } from '@island.is/health-insurance'
+
+const namespace = '@island.is/api/health-insurance'
 
 @UseGuards(IdsUserGuard, ScopesGuard)
 @Resolver(() => String)
 export class HealthInsuranceResolver {
   constructor(
     private readonly healthInsuranceService: HealthInsuranceService,
+    private readonly auditService: AuditService,
   ) {}
 
   @Query(() => String, {
@@ -32,8 +34,14 @@ export class HealthInsuranceResolver {
   healthInsuranceIsHealthInsured(
     @CurrentUser() user: AuthUser,
   ): Promise<boolean> {
-    return this.healthInsuranceService.isHealthInsured(user.nationalId)
-    // return this.healthInsuranceService.isHealthInsured('0101006070') // TODO cleanup
+    return this.auditService.auditPromise(
+      {
+        user,
+        namespace,
+        action: 'healthInsuranceIsHealthInsured',
+      },
+      this.healthInsuranceService.isHealthInsured(user.nationalId),
+    )
   }
 
   @Query(() => [Number], {
@@ -42,19 +50,14 @@ export class HealthInsuranceResolver {
   healthInsuranceGetPendingApplication(
     @CurrentUser() user: AuthUser,
   ): Promise<number[]> {
-    return this.healthInsuranceService.getPendingApplication(user.nationalId)
-    // return this.healthInsuranceService.getPendingApplication('0101006070') // TODO cleanup
+    return this.auditService.auditPromise<number[]>(
+      {
+        user,
+        namespace,
+        action: 'healthInsuranceGetPendingApplication',
+        resources: (results) => results.map(String),
+      },
+      this.healthInsuranceService.getPendingApplication(user.nationalId),
+    )
   }
-
-  // TODO remove so this function will not be public exposed
-  // @Mutation(() => VistaSkjalModel, {
-  //   name: 'healthInsuranceApplyInsurance',
-  // })
-  // async healthInsuranceApplyInsurance(
-  //   @Args({ name: 'inputs', type: () => VistaSkjalInput })
-  //   inputs: VistaSkjalInput,
-  //   @CurrentUser() user: AuthUser,
-  // ): Promise<VistaSkjalModel> {
-  //   return this.healthInsuranceService.applyInsurance(inputs, user.nationalId)
-  // }
 }

--- a/libs/api/domains/national-registry-x-road/src/lib/nationalRegistryXRoad.resolver.ts
+++ b/libs/api/domains/national-registry-x-road/src/lib/nationalRegistryXRoad.resolver.ts
@@ -1,5 +1,5 @@
+import { UseGuards } from '@nestjs/common'
 import { Resolver, Query, ResolveField, Parent, Context } from '@nestjs/graphql'
-import { NationalRegistryXRoadService } from './nationalRegistryXRoad.service'
 import type { User } from '@island.is/auth-nest-tools'
 import {
   CurrentUser,
@@ -7,11 +7,14 @@ import {
   IdsUserGuard,
   ScopesGuard,
 } from '@island.is/auth-nest-tools'
-import { UseGuards } from '@nestjs/common'
+import { Audit } from '@island.is/nest/audit'
+
 import { NationalRegistryPerson } from '../models/nationalRegistryPerson.model'
+import { NationalRegistryXRoadService } from './nationalRegistryXRoad.service'
 
 @UseGuards(IdsAuthGuard, IdsUserGuard, ScopesGuard)
 @Resolver(() => NationalRegistryPerson)
+@Audit({ namespace: '@island.is/api/national-registry-x-road' })
 export class NationalRegistryXRoadResolver {
   constructor(
     private nationalRegistryXRoadService: NationalRegistryXRoadService,
@@ -20,6 +23,7 @@ export class NationalRegistryXRoadResolver {
   @Query(() => NationalRegistryPerson, {
     name: 'nationalRegistryUserV2',
   })
+  @Audit()
   async nationalRegistryPersons(
     @CurrentUser() user: User,
   ): Promise<NationalRegistryPerson | undefined> {
@@ -30,6 +34,7 @@ export class NationalRegistryXRoadResolver {
   }
 
   @ResolveField('children', () => [NationalRegistryPerson])
+  @Audit()
   async resolveChildren(
     @Context('req') { user }: { user: User },
     @Parent() person: NationalRegistryPerson,

--- a/libs/api/domains/national-registry/src/lib/graphql/familyMember.resolver.ts
+++ b/libs/api/domains/national-registry/src/lib/graphql/familyMember.resolver.ts
@@ -7,6 +7,7 @@ import {
   ScopesGuard,
   CurrentUser,
 } from '@island.is/auth-nest-tools'
+import { Audit } from '@island.is/nest/audit'
 
 import { NationalRegistryFamilyMember } from './models'
 import { NationalRegistryService } from '../nationalRegistry.service'
@@ -14,6 +15,7 @@ import { FamilyMember } from '../types'
 
 @UseGuards(IdsUserGuard, ScopesGuard)
 @Resolver(() => NationalRegistryFamilyMember)
+@Audit({ namespace: '@island.is/api/national-registry' })
 export class FamilyMemberResolver {
   constructor(
     private readonly nationalRegistryService: NationalRegistryService,
@@ -23,6 +25,7 @@ export class FamilyMemberResolver {
     name: 'nationalRegistryFamily',
     nullable: true,
   })
+  @Audit()
   getMyFamily(@CurrentUser() user: AuthUser): Promise<FamilyMember[]> {
     return this.nationalRegistryService.getFamily(user.nationalId)
   }

--- a/libs/api/domains/national-registry/src/lib/graphql/user.resolver.ts
+++ b/libs/api/domains/national-registry/src/lib/graphql/user.resolver.ts
@@ -8,6 +8,7 @@ import {
   ScopesGuard,
   CurrentUser,
 } from '@island.is/auth-nest-tools'
+import { Audit } from '@island.is/nest/audit'
 
 import { NationalRegistryUser, Citizenship } from './models'
 import { NationalRegistryService } from '../nationalRegistry.service'
@@ -15,6 +16,7 @@ import { User } from '../types'
 
 @UseGuards(IdsUserGuard, ScopesGuard)
 @Resolver(() => NationalRegistryUser)
+@Audit({ namespace: '@island.is/api/national-registry' })
 export class UserResolver {
   constructor(
     private readonly nationalRegistryService: NationalRegistryService,
@@ -24,6 +26,7 @@ export class UserResolver {
     name: 'nationalRegistryUser',
     nullable: true,
   })
+  @Audit()
   user(@CurrentUser() user: AuthUser): Promise<User> {
     return this.nationalRegistryService.getUser(user.nationalId)
   }

--- a/libs/api/domains/rsk/src/lib/api-domains-rsk.resolver.ts
+++ b/libs/api/domains/rsk/src/lib/api-domains-rsk.resolver.ts
@@ -1,6 +1,5 @@
 import { Query, Resolver } from '@nestjs/graphql'
 import { UseGuards } from '@nestjs/common'
-
 import type { User } from '@island.is/auth-nest-tools'
 import {
   IdsUserGuard,
@@ -8,14 +7,18 @@ import {
   CurrentUser,
 } from '@island.is/auth-nest-tools'
 import { RSKService } from '@island.is/clients/rsk/v1'
+import { Audit } from '@island.is/nest/audit'
+
 import { CurrentUserCompanies } from './models/currentUserCompanies.model'
 
 @UseGuards(IdsUserGuard, ScopesGuard)
 @Resolver()
+@Audit({ namespace: '@island.is/api/rsk' })
 export class RSKResolver {
   constructor(private RSKService: RSKService) {}
 
   @Query(() => [CurrentUserCompanies])
+  @Audit()
   async rskCurrentUserCompanies(@CurrentUser() user: User) {
     return this.RSKService.getCompaniesByNationalId(user.nationalId)
   }


### PR DESCRIPTION
# Adding audit logs to GQL api domains that consumes 3rd party services with sensitive data

## What

As part of the authentication and delegation system we are adding audit logs to our services and
our GQL api domains that read sensitive data from 3rd party service providers.

## Why

To audit which user is reading what data.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
