### PR TITLE
chore(core): Update dockerfile node versions from 14.16 to 14.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you want to contribute to the repository, please make sure to follow [this gu
 
 ## Prerequisites
 
-- You have Node installed `^14.16.0` and Yarn at `^1.22.0`.
+- You have Node installed `^14.17.0` and Yarn at `^1.22.0`.
 - You have [Docker](https://docs.docker.com/desktop/) installed.
 - You have [direnv](https://direnv.net/) installed.
 - You have [Java](https://www.java.com/en/download/manual.jsp) `>= 1.8` installed (for schema generation).

--- a/scripts/ci/Dockerfile.cypress
+++ b/scripts/ci/Dockerfile.cypress
@@ -13,7 +13,7 @@ RUN apt-get update \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 RUN npm install -g n yarn
-RUN n install 14.16.0
+RUN n install 14.17.0
 
 # https://github.com/cypress-io/cypress-docker-images/blob/master/base/12.19.0/Dockerfile
 FROM node-base as cypress-base

--- a/scripts/ci/Dockerfile.test
+++ b/scripts/ci/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM node:14.16.0-alpine3.11
+FROM node:14.17.0-alpine3.11
 
 WORKDIR "/code"
 VOLUME ["/code"]

--- a/scripts/ci/Dockerfile.test
+++ b/scripts/ci/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM node:14.17.0-alpine3.11
+FROM node:14.17.0-alpine3.13
 
 WORKDIR "/code"
 VOLUME ["/code"]


### PR DESCRIPTION
## What

Update node versions from 14.16 to 14.17

## Why

Breaking CI since it is the new [minimum version](https://github.com/island-is/island.is/blob/main/package.json#L6).

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
