### PR TITLE
fix(feature-flags): Use nationalId as a user identifier

### DIFF
--- a/libs/feature-flags/src/lib/context.tsx
+++ b/libs/feature-flags/src/lib/context.tsx
@@ -24,11 +24,11 @@ export const FeatureFlagProvider: FC<FeatureFlagContextProviderProps> = ({
 
   const context = useMemo<FeatureFlagClient>(() => {
     const userAuth =
-      userInfo && userInfo.profile.sid !== undefined
+      userInfo && userInfo.profile.nationalId !== undefined
         ? {
-            id: userInfo.profile.sid,
+            id: userInfo.profile.nationalId,
             attributes: {
-              nationalId: userInfo.profile.nationalId as string,
+              nationalId: userInfo.profile.nationalId,
             },
           }
         : undefined


### PR DESCRIPTION
## What

Use nationalId as a user identifier in configcat.

## Why

This makes feature flags simpler, and allows us to do percentage based
feature rollouts more reliably.

It also fixes a delegation feature flag which the service portal is sharing with the identity server.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
