### PR TITLE
feat(application-templates-party-application): Move emails to environment variables

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/party-application/emailGenerators/assignSupremeCourtEmail.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/party-application/emailGenerators/assignSupremeCourtEmail.ts
@@ -10,7 +10,8 @@ export const generateAssignSupremeCourtApplicationEmail: AssignmentEmailTemplate
     options: { email },
   } = props
 
-  const supremeCourtEmail = 'sigridur@kosmosogkaos.is'
+  const supremeCourtEmail =
+    process.env.PARTY_APPLICATION_SUBMISSION_DESTINATION_EMAIL ?? ''
   const { partyLetter, partyName } = application.externalData
     .partyLetterRegistry?.data as any
 
@@ -33,7 +34,7 @@ export const generateAssignSupremeCourtApplicationEmail: AssignmentEmailTemplate
     to: [
       {
         name: '',
-        address: supremeCourtEmail as string,
+        address: supremeCourtEmail,
       },
     ],
     subject,

--- a/libs/application/template-api-modules/src/lib/modules/templates/party-letter/emailGenerators/assignToMinistryOfJustice.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/party-letter/emailGenerators/assignToMinistryOfJustice.ts
@@ -10,7 +10,8 @@ export const generateAssignMinistryOfJusticeApplicationEmail: AssignmentEmailTem
     options: { email },
   } = props
 
-  const ministryOfJusticeEmail = 'postur@dmr.is'
+  const ministryOfJusticeEmail =
+    process.env.PARTY_LETTER_SUBMISSION_DESTINATION_EMAIL ?? ''
 
   const subject = 'Meðmæli með listabókstaf'
   const body = dedent(`
@@ -30,7 +31,7 @@ export const generateAssignMinistryOfJusticeApplicationEmail: AssignmentEmailTem
     to: [
       {
         name: '',
-        address: ministryOfJusticeEmail as string,
+        address: ministryOfJusticeEmail,
       },
     ],
     subject,


### PR DESCRIPTION
# Move emails to environment variables

Currently emails are hardcoded and can't be properly tested in deployment environments

## What

- Made emails use environment variables

## Why

- Allow for testing in dev and staging

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
