### PR TITLE
fix(parental-leave): Fixes duration slider events not called (#4233)

### DIFF
--- a/libs/application/templates/parental-leave/src/fields/Duration/index.tsx
+++ b/libs/application/templates/parental-leave/src/fields/Duration/index.tsx
@@ -11,7 +11,7 @@ import {
   FieldBaseProps,
   getValueViaPath,
 } from '@island.is/application/core'
-import { Box, Text, Tooltip } from '@island.is/island-ui/core'
+import { Box, Text } from '@island.is/island-ui/core'
 import { theme } from '@island.is/island-ui/theme'
 import { useLocale } from '@island.is/localization'
 import { FieldDescription } from '@island.is/shared/form-fields'
@@ -122,11 +122,15 @@ const Duration: FC<FieldBaseProps> = ({ field, application }) => {
             <Text variant="h4" as="span">
               {formatMessage(parentalLeaveFormMessages.duration.paymentsRatio)}
               &nbsp;&nbsp;
-              <Tooltip
+              {/* 
+                Remove for first release
+                https://app.asana.com/0/1182378413629561/1200472736049963/f
+               */}
+              {/* <Tooltip
                 text={formatMessage(
                   parentalLeaveFormMessages.paymentPlan.description,
                 )}
-              />
+              /> */}
             </Text>
           </Box>
 

--- a/libs/application/templates/parental-leave/src/fields/components/Slider/index.tsx
+++ b/libs/application/templates/parental-leave/src/fields/components/Slider/index.tsx
@@ -183,12 +183,16 @@ const Slider = ({
     switch (event.key) {
       case 'ArrowLeft':
         if (currentIndex > min) {
-          onChange(currentIndex - step)
+          const index = currentIndex - step
+          onChange(index)
+          onChangeEnd?.(index)
         }
         break
       case 'ArrowRight':
         if (currentIndex < max) {
-          onChange(currentIndex + step)
+          const index = currentIndex + step
+          onChange(index)
+          onChangeEnd?.(index)
         }
         break
     }
@@ -201,7 +205,8 @@ const Slider = ({
     const rect = event.currentTarget.getBoundingClientRect()
     const percentClicked = event.nativeEvent.offsetX / rect.width
     const newIndex = Math.max(min, index + roundByNum(percentClicked, step))
-    onChange && onChange(newIndex)
+    onChange?.(newIndex)
+    onChangeEnd?.(newIndex)
   }
 
   return (


### PR DESCRIPTION
Merging #4233 into the release branch

* Fixes the duration slider so that it calculates the percentage when the track is clicked and when the keyboard arrow keys are used.
* Removes Slider tooltip for this release
