### PR TITLE
feat(services-party-letter-registry-api): Added audit logs and authentication

### DIFF
--- a/apps/services/party-letter-registry-api/src/app/app.module.ts
+++ b/apps/services/party-letter-registry-api/src/app/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common'
 import { SequelizeModule } from '@nestjs/sequelize'
 
+import { AuthModule } from '@island.is/auth-nest-tools'
 import { AuditModule } from '@island.is/nest/audit'
 
 import { PartyLetterRegistryModule } from './modules/partyLetterRegistry/partyLetterRegistry.module'
@@ -9,6 +10,7 @@ import { environment } from '../environments'
 
 @Module({
   imports: [
+    AuthModule.register(environment.auth),
     AuditModule.forRoot(environment.audit),
     SequelizeModule.forRootAsync({
       useClass: SequelizeConfigService,

--- a/apps/services/party-letter-registry-api/src/app/app.module.ts
+++ b/apps/services/party-letter-registry-api/src/app/app.module.ts
@@ -1,10 +1,15 @@
 import { Module } from '@nestjs/common'
 import { SequelizeModule } from '@nestjs/sequelize'
+
+import { AuditModule } from '@island.is/nest/audit'
+
 import { PartyLetterRegistryModule } from './modules/partyLetterRegistry/partyLetterRegistry.module'
 import { SequelizeConfigService } from './sequelizeConfig.service'
+import { environment } from '../environments'
 
 @Module({
   imports: [
+    AuditModule.forRoot(environment.audit),
     SequelizeModule.forRootAsync({
       useClass: SequelizeConfigService,
     }),

--- a/apps/services/party-letter-registry-api/src/app/modules/partyLetterRegistry/e2e/create/create.spec.ts
+++ b/apps/services/party-letter-registry-api/src/app/modules/partyLetterRegistry/e2e/create/create.spec.ts
@@ -1,12 +1,26 @@
-import { setup } from '../../../../../../test/setup'
-import { errorExpectedStructure } from '../../../../../../test/testHelpers'
 import * as request from 'supertest'
 import { INestApplication } from '@nestjs/common'
+
+import { IdsUserGuard, MockAuthGuard } from '@island.is/auth-nest-tools'
+
+import { setup } from '../../../../../../test/setup'
+import { errorExpectedStructure } from '../../../../../../test/testHelpers'
 
 let app: INestApplication
 
 beforeAll(async () => {
-  app = await setup()
+  app = await setup({
+    override: (builder) => {
+      builder
+        .overrideGuard(IdsUserGuard)
+        .useValue(
+          new MockAuthGuard({
+            nationalId: '1234567890',
+          }),
+        )
+        .compile()
+    },
+  })
 })
 
 describe('CreatePartyLetterRegistry', () => {

--- a/apps/services/party-letter-registry-api/src/app/modules/partyLetterRegistry/e2e/findByManager/findByManager.spec.ts
+++ b/apps/services/party-letter-registry-api/src/app/modules/partyLetterRegistry/e2e/findByManager/findByManager.spec.ts
@@ -1,12 +1,26 @@
-import { setup } from '../../../../../../test/setup'
-import { errorExpectedStructure } from '../../../../../../test/testHelpers'
 import * as request from 'supertest'
 import { INestApplication } from '@nestjs/common'
+
+import { IdsUserGuard, MockAuthGuard } from '@island.is/auth-nest-tools'
+
+import { setup } from '../../../../../../test/setup'
+import { errorExpectedStructure } from '../../../../../../test/testHelpers'
 
 let app: INestApplication
 
 beforeAll(async () => {
-  app = await setup()
+  app = await setup({
+    override: (builder) => {
+      builder
+        .overrideGuard(IdsUserGuard)
+        .useValue(
+          new MockAuthGuard({
+            nationalId: '1234567890',
+          }),
+        )
+        .compile()
+    },
+  })
 })
 
 describe('FindByManagerPartyLetterRegistry', () => {

--- a/apps/services/party-letter-registry-api/src/app/modules/partyLetterRegistry/e2e/findByOwner/findByOwner.spec.ts
+++ b/apps/services/party-letter-registry-api/src/app/modules/partyLetterRegistry/e2e/findByOwner/findByOwner.spec.ts
@@ -1,12 +1,26 @@
-import { setup } from '../../../../../../test/setup'
-import { errorExpectedStructure } from '../../../../../../test/testHelpers'
 import * as request from 'supertest'
 import { INestApplication } from '@nestjs/common'
+
+import { IdsUserGuard, MockAuthGuard } from '@island.is/auth-nest-tools'
+
+import { setup } from '../../../../../../test/setup'
+import { errorExpectedStructure } from '../../../../../../test/testHelpers'
 
 let app: INestApplication
 
 beforeAll(async () => {
-  app = await setup()
+  app = await setup({
+    override: (builder) => {
+      builder
+        .overrideGuard(IdsUserGuard)
+        .useValue(
+          new MockAuthGuard({
+            nationalId: '1234567890',
+          }),
+        )
+        .compile()
+    },
+  })
 })
 
 describe('FindByOwnerPartyLetterRegistry', () => {

--- a/apps/services/party-letter-registry-api/src/app/modules/partyLetterRegistry/partyLetterRegistry.controller.ts
+++ b/apps/services/party-letter-registry-api/src/app/modules/partyLetterRegistry/partyLetterRegistry.controller.ts
@@ -14,6 +14,9 @@ import {
   ApiOkResponse,
   ApiTags,
 } from '@nestjs/swagger'
+
+import { Audit } from '@island.is/nest/audit'
+
 import { CreateDto } from './dto/create.dto'
 import { FindByManagerDto } from './dto/findByManager.dto'
 import { FindByOwnerDto } from './dto/findByOwner.dto'
@@ -72,6 +75,9 @@ export class PartyLetterRegistryController {
     type: CreateDto,
   })
   @Post()
+  @Audit<PartyLetterRegistry>({
+    resources: (partyLetterRegistry) => partyLetterRegistry.partyLetter,
+  })
   async create(@Body() input: CreateDto): Promise<PartyLetterRegistry> {
     return await this.partyLetterRegistryService.create(input)
   }

--- a/apps/services/party-letter-registry-api/src/app/modules/partyLetterRegistry/partyLetterRegistry.controller.ts
+++ b/apps/services/party-letter-registry-api/src/app/modules/partyLetterRegistry/partyLetterRegistry.controller.ts
@@ -1,3 +1,4 @@
+import { IdsUserGuard } from '@island.is/auth-nest-tools'
 import {
   Body,
   Controller,
@@ -5,6 +6,7 @@ import {
   NotFoundException,
   Post,
   Query,
+  UseGuards,
 } from '@nestjs/common'
 import {
   ApiBody,
@@ -18,6 +20,7 @@ import { FindByOwnerDto } from './dto/findByOwner.dto'
 import { PartyLetterRegistry } from './partyLetterRegistry.model'
 import { PartyLetterRegistryService } from './partyLetterRegistry.service'
 
+@UseGuards(IdsUserGuard)
 @Controller('party-letter-registry')
 @ApiTags('partyLetterRegistry')
 export class PartyLetterRegistryController {

--- a/apps/services/party-letter-registry-api/src/environments/environment.prod.ts
+++ b/apps/services/party-letter-registry-api/src/environments/environment.prod.ts
@@ -1,4 +1,8 @@
 export default {
+  auth: {
+    issuer: process.env.IDENTITY_SERVER_ISSUER_URL,
+    audience: '@island.is',
+  },
   audit: {
     defaultNamespace: '@island.is/party-letter-registry',
     groupName: process.env.AUDIT_GROUP_NAME,

--- a/apps/services/party-letter-registry-api/src/environments/environment.prod.ts
+++ b/apps/services/party-letter-registry-api/src/environments/environment.prod.ts
@@ -1,1 +1,7 @@
-export default {}
+export default {
+  audit: {
+    defaultNamespace: '@island.is/party-letter-registry',
+    groupName: process.env.AUDIT_GROUP_NAME,
+    serviceName: 'icelandic-names-registry-backend',
+  },
+}

--- a/apps/services/party-letter-registry-api/src/environments/environment.ts
+++ b/apps/services/party-letter-registry-api/src/environments/environment.ts
@@ -1,4 +1,8 @@
 export default {
+  auth: {
+    issuer: 'https://identity-server.dev01.devland.is',
+    audience: '@island.is',
+  },
   audit: {
     defaultNamespace: '@island.is/party-letter-registry',
   },

--- a/apps/services/party-letter-registry-api/src/environments/environment.ts
+++ b/apps/services/party-letter-registry-api/src/environments/environment.ts
@@ -1,1 +1,5 @@
-export default {}
+export default {
+  audit: {
+    defaultNamespace: '@island.is/party-letter-registry',
+  },
+}


### PR DESCRIPTION
# Adding audit logs and authentication to `party-letter-registry-api`

## What

Adding audit logs and authentication.
Authentication is only logged in user, no specific authorization.

## Why

To track user activity when creating new party letter.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
