### PR TITLE
fix(api): move driving license xroad path into env

### DIFF
--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -177,6 +177,7 @@ const autoSchemaFile = environment.production
       xroad: {
         xroadBaseUrl: environment.xroad.baseUrl,
         xroadClientId: environment.xroad.clientId,
+        xroadPath: environment.drivingLicense.xroadPath,
         drivingLicenseSecret: environment.drivingLicense.secret,
       },
     }),

--- a/apps/api/src/app/environments/environment.ts
+++ b/apps/api/src/app/environments/environment.ts
@@ -12,7 +12,9 @@ const devConfig = {
   },
   drivingLicense: {
     secret: process.env.DRIVING_LICENSE_SECRET,
-    xroadPath: process.env.DRIVING_LICENSE_XROAD_PATH ?? 'r1/IS-DEV/GOV/10005/Logreglan-Protected/RafraentOkuskirteini-v1',
+    xroadPath:
+      process.env.DRIVING_LICENSE_XROAD_PATH ??
+      'r1/IS-DEV/GOV/10005/Logreglan-Protected/RafraentOkuskirteini-v1',
   },
   education: {
     xroadLicenseServiceId: 'IS-DEV/EDU/10020/MMS-Protected/license-api-v1',

--- a/apps/api/src/app/environments/environment.ts
+++ b/apps/api/src/app/environments/environment.ts
@@ -12,6 +12,7 @@ const devConfig = {
   },
   drivingLicense: {
     secret: process.env.DRIVING_LICENSE_SECRET,
+    xroadPath: process.env.DRIVING_LICENSE_XROAD_PATH ?? 'r1/IS-DEV/GOV/10005/Logreglan-Protected/RafraentOkuskirteini-v1',
   },
   education: {
     xroadLicenseServiceId: 'IS-DEV/EDU/10020/MMS-Protected/license-api-v1',
@@ -122,6 +123,7 @@ const prodConfig = {
   },
   drivingLicense: {
     secret: process.env.DRIVING_LICENSE_SECRET,
+    xroadPath: process.env.DRIVING_LICENSE_XROAD_PATH,
   },
   education: {
     xroadLicenseServiceId: process.env.XROAD_MMS_LICENSE_SERVICE_ID,

--- a/libs/api/domains/license-service/src/lib/client/driving-license-client/drivingLicenseService.api.ts
+++ b/libs/api/domains/license-service/src/lib/client/driving-license-client/drivingLicenseService.api.ts
@@ -12,7 +12,12 @@ export class LicenseServiceApi {
   private readonly xroadPath: string
   private readonly secret: string
 
-  constructor(xroadBaseUrl: string, xroadClientId: string, xroadPath: string, secret: string) {
+  constructor(
+    xroadBaseUrl: string,
+    xroadClientId: string,
+    xroadPath: string,
+    secret: string,
+  ) {
     this.xroadApiUrl = xroadBaseUrl
     this.xroadClientId = xroadClientId
     this.xroadPath = xroadPath

--- a/libs/api/domains/license-service/src/lib/client/driving-license-client/drivingLicenseService.api.ts
+++ b/libs/api/domains/license-service/src/lib/client/driving-license-client/drivingLicenseService.api.ts
@@ -9,11 +9,13 @@ import { GenericDrivingLicenseResponse } from './genericDrivingLicense.type'
 export class LicenseServiceApi {
   private readonly xroadApiUrl: string
   private readonly xroadClientId: string
+  private readonly xroadPath: string
   private readonly secret: string
 
-  constructor(xroadBaseUrl: string, xroadClientId: string, secret: string) {
+  constructor(xroadBaseUrl: string, xroadClientId: string, xroadPath: string, secret: string) {
     this.xroadApiUrl = xroadBaseUrl
     this.xroadClientId = xroadClientId
+    this.xroadPath = xroadPath
     this.secret = secret
   }
 
@@ -71,12 +73,8 @@ export class LicenseServiceApi {
   async getGenericDrivingLicense(
     nationalId: User['nationalId'],
   ): Promise<GenericDrivingLicenseResponse[] | null> {
-    // TODO(osk) Move into env
-    const xroadDrivingLicensePath =
-      'r1/IS-DEV/GOV/10005/Logreglan-Protected/RafraentOkuskirteini-v1'
-
     const response = await this.requestApi(
-      `${xroadDrivingLicensePath}/api/Okuskirteini/${nationalId}`,
+      `${this.xroadPath}/api/Okuskirteini/${nationalId}`,
     )
 
     // TODO(osk) should this throw or return null? What's the general pattern

--- a/libs/api/domains/license-service/src/lib/licenseService.module.ts
+++ b/libs/api/domains/license-service/src/lib/licenseService.module.ts
@@ -10,6 +10,7 @@ export interface Config {
   xroad: {
     xroadBaseUrl: string
     xroadClientId: string
+    xroadPath: string
     drivingLicenseSecret: string
   }
 }
@@ -28,6 +29,7 @@ export class LicenseServiceModule {
             new LicenseServiceApi(
               config.xroad.xroadBaseUrl,
               config.xroad.xroadClientId,
+              config.xroad.xroadPath,
               config.xroad.drivingLicenseSecret,
             ),
         },


### PR DESCRIPTION
# Move driving license xroad path into env

## What

Move xroad path for RLS driving license service into env var `DRIVING_LICENSE_XROAD_PATH`.

## Why

Path was mistakenly left hard-coded in first version.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] ~I have made corresponding changes to the documentation~
- [ ] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
