### PR TITLE
fix(feature-flags): Use nationalId as a user identifier

### DIFF
--- a/libs/feature-flags/src/lib/context.tsx
+++ b/libs/feature-flags/src/lib/context.tsx
@@ -24,11 +24,11 @@ export const FeatureFlagProvider: FC<FeatureFlagContextProviderProps> = ({
 
   const context = useMemo<FeatureFlagClient>(() => {
     const userAuth =
-      userInfo && userInfo.profile.sid !== undefined
+      userInfo && userInfo.profile.nationalId !== undefined
         ? {
-            id: userInfo.profile.sid,
+            id: userInfo.profile.nationalId,
             attributes: {
-              nationalId: userInfo.profile.nationalId as string,
+              nationalId: userInfo.profile.nationalId,
             },
           }
         : undefined


### PR DESCRIPTION
This commit was originally added to #release-9.1.0. This PR is for main.

## What

Use nationalId as a user identifier for ConfigCat feature flags.

## Why

This makes feature flags simpler, and allows us to do percentage based
feature rollouts more reliably.