### PR TITLE
fix(dpo): fix single provider statistics - unauthorized

### DIFF
--- a/libs/api/domains/document-provider/src/lib/document-provider.resolver.ts
+++ b/libs/api/domains/document-provider/src/lib/document-provider.resolver.ts
@@ -272,8 +272,10 @@ export class DocumentProviderResolver {
   @Query(() => ProviderStatistics)
   async getStatisticsTotal(
     @Args('input', { nullable: true }) input: StatisticsInput,
+    @CurrentUser() user: User,
   ): Promise<ProviderStatistics> {
     return this.documentProviderService.getStatisticsTotal(
+      user,
       input?.organisationId,
       input?.fromDate,
       input?.toDate,

--- a/libs/api/domains/document-provider/src/lib/document-provider.service.ts
+++ b/libs/api/domains/document-provider/src/lib/document-provider.service.ts
@@ -380,21 +380,20 @@ export class DocumentProviderService {
   //-------------------- STATISTICS --------------------------
 
   async getStatisticsTotal(
+    authorization: Auth,
     organisationId?: string,
     fromDate?: string,
     toDate?: string,
-    authorization?: string,
   ): Promise<ProviderStatistics> {
     let providers = undefined
 
     // Get external provider ids if organisationId is included
     if (organisationId) {
-      const orgProviders = await this.organisationsApi.organisationControllerGetOrganisationsProviders(
-        {
-          id: organisationId,
-          authorization,
-        },
-      )
+      const orgProviders = await this.organisationsApiWithAuth(
+        authorization!,
+      ).organisationControllerGetOrganisationsProviders({
+        id: organisationId,
+      })
 
       // Filter out null values and only set providers if organisation has external providers
       if (orgProviders) {

--- a/libs/api/domains/document-provider/src/lib/document-provider.service.ts
+++ b/libs/api/domains/document-provider/src/lib/document-provider.service.ts
@@ -390,7 +390,7 @@ export class DocumentProviderService {
     // Get external provider ids if organisationId is included
     if (organisationId) {
       const orgProviders = await this.organisationsApiWithAuth(
-        authorization!,
+        authorization,
       ).organisationControllerGetOrganisationsProviders({
         id: organisationId,
       })


### PR DESCRIPTION
# Fix single provider statistics - unauthorized

## What

Failed to load statistics for single provider. The reason was that the authentication token was not forwarded to the services-layer.

## Why

Bugfix

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
