### PR TITLE
fix(judicial-system): only display default value if there is a workingCase

### DIFF
--- a/apps/judicial-system/web/src/routes/Prosecutor/InvestigationRequest/Defendant/DefendantForm.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/InvestigationRequest/Defendant/DefendantForm.tsx
@@ -109,10 +109,14 @@ const DefendantForm: React.FC<Props> = (props) => {
                     updateCase,
                   )
                 }
-                defaultValue={{
-                  value: CaseType[workingCase.type],
-                  label: capitalize(ReadableCaseType[workingCase.type]),
-                }}
+                defaultValue={
+                  workingCase?.id
+                    ? {
+                        value: CaseType[workingCase.type],
+                        label: capitalize(ReadableCaseType[workingCase.type]),
+                      }
+                    : undefined
+                }
                 formatGroupLabel={() => (
                   <div
                     style={{


### PR DESCRIPTION
# Fixes missing placeholder

https://app.asana.com/0/1199153462262248/1200474750183715

## What

- Fixes a missing placeholder for R Cases select dropdown

## Why

- Bug

## Screenshots / Gifs

![Screenshot 2021-06-21 at 21 53 55](https://user-images.githubusercontent.com/17431581/122832657-37287080-d2db-11eb-9ca5-3ba113ff8ae0.jpg)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
