### PR TITLE
fix(services-endorsements-api): Metadata type

### DIFF
--- a/apps/services/endorsements/api/src/app/modules/endorsementMetadata/endorsementMetadata.model.ts
+++ b/apps/services/endorsements/api/src/app/modules/endorsementMetadata/endorsementMetadata.model.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger'
 import { EndorsementTag } from '../endorsementList/constants'
+import { TemporaryVoterRegistryResponse } from './providers/temporaryVoterRegistry/temporaryVoterRegistry.service'
 
 export class EndorsementMetadata {
   @ApiProperty()
@@ -16,4 +17,7 @@ export class EndorsementMetadata {
 
   @ApiProperty({ enum: EndorsementTag, isArray: true })
   signedTags!: EndorsementTag[]
+
+  @ApiProperty()
+  voterRegion!: TemporaryVoterRegistryResponse
 }

--- a/apps/services/endorsements/api/src/app/modules/endorsementMetadata/endorsementMetadata.model.ts
+++ b/apps/services/endorsements/api/src/app/modules/endorsementMetadata/endorsementMetadata.model.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger'
 import { EndorsementTag } from '../endorsementList/constants'
-import { TemporaryVoterRegistryResponse } from './providers/temporaryVoterRegistry/temporaryVoterRegistry.service'
+import type { TemporaryVoterRegistryResponse } from './providers/temporaryVoterRegistry/temporaryVoterRegistry.service'
 
 export class EndorsementMetadata {
   @ApiProperty()

--- a/apps/services/endorsements/api/src/app/modules/endorsementMetadata/providers/temporaryVoterRegistry/temporaryVoterRegistry.service.ts
+++ b/apps/services/endorsements/api/src/app/modules/endorsementMetadata/providers/temporaryVoterRegistry/temporaryVoterRegistry.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common'
+import { Injectable } from '@nestjs/common'
 import { MetadataProvider } from '../../types'
 import { TemporaryVoterRegistryApi } from './gen/fetch'
 

--- a/libs/api/domains/endorsement-system/src/lib/models/endorsementMetadata.model.ts
+++ b/libs/api/domains/endorsement-system/src/lib/models/endorsementMetadata.model.ts
@@ -18,4 +18,7 @@ export class EndorsementMetadata {
 
   @Field(() => [EndorsementMetadataSignedTagsEnum], { nullable: true })
   signedTags!: EndorsementMetadataSignedTagsEnum[] | null
+
+  @Field(() => graphqlTypeJson, { nullable: true })
+  voterRegion!: object | null
 }


### PR DESCRIPTION
# Fix metadata type

Voter region metadata field is not being exported properly from the endorsement system and domain

## What

- Added `voterRegion` to exported metadata field types

## Why

- To make the field accessible via the graphql api

## Screenshots / Gifs
<img width="1594" alt="Screenshot 2021-06-22 at 08 47 37" src="https://user-images.githubusercontent.com/6640435/122894319-9c5d7f80-d336-11eb-9356-938ef3b8e2a0.png">


## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
