### PR TITLE
fix(application): Redis cluster not starting on dev when password not supplied WIP

### DIFF
--- a/apps/application-system/api/docker-compose.dev.yml
+++ b/apps/application-system/api/docker-compose.dev.yml
@@ -12,6 +12,7 @@ services:
     sysctls:
       net.core.somaxconn: '511'
     environment:
+      - ALLOW_EMPTY_PASSWORD=yes
       - IP=0.0.0.0
     ports:
       - '7000-7005:7000-7005'


### PR DESCRIPTION
# Allow empty password on docker compose in dev application

Attach a link to issue if relevant

## What

Allow empty password in order to start redis on dev.

## Why

Redis wasnt starting.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
