### PR TITLE
fix(dev): Revert docker image for redis cluster

### DIFF
--- a/apps/air-discount-scheme/backend/docker-compose.dev.yml
+++ b/apps/air-discount-scheme/backend/docker-compose.dev.yml
@@ -7,7 +7,7 @@ services:
 
   redis-cluster:
     container_name: ads_redis_cluster
-    image: public.ecr.aws/bitnami/redis-cluster:5.0.12
+    image: grokzen/redis-cluster:5.0.6
     privileged: true
     sysctls:
       net.core.somaxconn: '511'

--- a/apps/application-system/api/docker-compose.dev.yml
+++ b/apps/application-system/api/docker-compose.dev.yml
@@ -7,7 +7,7 @@ services:
 
   redis-cluster:
     container_name: redis_cluster
-    image: public.ecr.aws/bitnami/redis-cluster:5.0.12
+    image: grokzen/redis-cluster:5.0.6
     privileged: true
     sysctls:
       net.core.somaxconn: '511'

--- a/apps/gjafakort/application/docker-compose.dev.yml
+++ b/apps/gjafakort/application/docker-compose.dev.yml
@@ -7,7 +7,7 @@ services:
 
   redis_cluster:
     container_name: redis_cluster
-    image: public.ecr.aws/bitnami/redis-cluster:5.0.12
+    image: grokzen/redis-cluster:5.0.6
     privileged: true
     sysctls:
       net.core.somaxconn: '511'


### PR DESCRIPTION
The one on public ecr doesn't seem to be compatible with the one we
were using. No need to change them since this is not running in ci.
