### PR TITLE
fix(auth): Improve signin error handling

### DIFF
--- a/libs/auth/react/src/lib/Authenticator/Authenticator.treat.ts
+++ b/libs/auth/react/src/lib/Authenticator/Authenticator.treat.ts
@@ -1,7 +1,7 @@
 import { style } from 'treat'
 import { theme } from '@island.is/island-ui/theme'
 
-export const wrapper = style({
+export const fullScreen = style({
   height: '100vh',
   backgroundColor: theme.color.blue100,
 })

--- a/libs/auth/react/src/lib/Authenticator/Authenticator.tsx
+++ b/libs/auth/react/src/lib/Authenticator/Authenticator.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useCallback, useEffect, useMemo, useReducer } from 'react'
 import { Route, Switch, useHistory } from 'react-router-dom'
-import { User } from 'oidc-client'
+import type { History } from 'history'
+import type { User } from 'oidc-client'
 
 import OidcSignIn from './OidcSignIn'
 import OidcSilentSignIn from './OidcSilentSignIn'
@@ -8,6 +9,7 @@ import { getAuthSettings, getUserManager } from '../userManager'
 import { ActionType, initialState, reducer } from './Authenticator.state'
 import { AuthContext } from './AuthContext'
 import { CheckAuth } from './CheckAuth'
+import { AuthSettings } from '../AuthSettings'
 
 interface Props {
   /**
@@ -16,6 +18,14 @@ interface Props {
    * Default: true
    */
   autoLogin?: boolean
+}
+
+const getReturnUrl = (history: History, { redirectPath }: AuthSettings) => {
+  const returnUrl = history.location.pathname + history.location.search
+  if (redirectPath && returnUrl.startsWith(redirectPath)) {
+    return '/'
+  }
+  return returnUrl
 }
 
 export const Authenticator: FC<Props> = ({ children, autoLogin = true }) => {
@@ -31,11 +41,11 @@ export const Authenticator: FC<Props> = ({ children, autoLogin = true }) => {
         type: ActionType.SIGNIN_START,
       })
       return userManager.signinRedirect({
-        state: history.location.pathname + history.location.search,
+        state: getReturnUrl(history, authSettings),
       })
       // Nothing more happens here since browser will redirect to IDS.
     },
-    [dispatch, userManager, history],
+    [dispatch, userManager, authSettings, history],
   )
 
   const signInSilent = useCallback(
@@ -72,12 +82,12 @@ export const Authenticator: FC<Props> = ({ children, autoLogin = true }) => {
         type: ActionType.SIGNIN_START,
       })
       return userManager.signinRedirect({
-        state: history.location.pathname + history.location.search,
+        state: getReturnUrl(history, authSettings),
         ...args,
       })
       // Nothing more happens here since browser will redirect to IDS.
     },
-    [userManager, dispatch],
+    [userManager, dispatch, history, authSettings],
   )
 
   const signOut = useCallback(
@@ -125,6 +135,12 @@ export const Authenticator: FC<Props> = ({ children, autoLogin = true }) => {
   )
 
   useEffect(() => {
+    // Only add events when we have userInfo, to avoid race conditions with
+    // oidc hooks.
+    if (state.userInfo === null) {
+      return
+    }
+
     // This is raised when a new user state has been loaded with a silent login.
     const userLoaded = (user: User) => {
       dispatch({
@@ -149,7 +165,7 @@ export const Authenticator: FC<Props> = ({ children, autoLogin = true }) => {
       userManager.events.removeUserLoaded(userLoaded)
       userManager.events.removeUserSignedOut(userSignedOut)
     }
-  }, [dispatch, userManager, signIn, autoLogin])
+  }, [dispatch, userManager, signIn, autoLogin, state.userInfo === null])
 
   const context = useMemo(
     () => ({

--- a/libs/auth/react/src/lib/Authenticator/AuthenticatorErrorScreen.tsx
+++ b/libs/auth/react/src/lib/Authenticator/AuthenticatorErrorScreen.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { useHistory } from 'react-router-dom'
+import { Box, Stack, Text, Button } from '@island.is/island-ui/core'
+import * as styles from './Authenticator.treat'
+
+// This screen is unfortunately not translated because at this point we don't
+// have a user locale, nor an access token to fetch translations.
+const AuthenticatorErrorScreen = () => {
+  const history = useHistory()
+
+  return (
+    <Box
+      display="flex"
+      justifyContent="center"
+      alignItems="center"
+      className={styles.fullScreen}
+    >
+      <Stack space={2} align="center">
+        <Text as="h1" variant="h2">
+          Óvænt villa
+        </Text>
+        <Text variant="intro">Innskráning mistókst.</Text>
+        <Button variant="primary" onClick={() => history.replace('/')}>
+          Reyna aftur
+        </Button>
+      </Stack>
+    </Box>
+  )
+}
+
+export default AuthenticatorErrorScreen

--- a/libs/auth/react/src/lib/Authenticator/AuthenticatorLoadingScreen.tsx
+++ b/libs/auth/react/src/lib/Authenticator/AuthenticatorLoadingScreen.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Box, LoadingIcon } from '@island.is/island-ui/core'
-import * as styles from './AuthenticatorLoadingScreen.treat'
+import * as styles from './Authenticator.treat'
 
 const AuthenticatorLoadingScreen = () => {
   return (
@@ -8,7 +8,7 @@ const AuthenticatorLoadingScreen = () => {
       display="flex"
       justifyContent="center"
       alignItems="center"
-      className={styles.wrapper}
+      className={styles.fullScreen}
       role="progressbar"
       aria-valuetext="Er að vinna í innskráningu"
     >

--- a/libs/auth/react/src/lib/Authenticator/OidcSignIn.tsx
+++ b/libs/auth/react/src/lib/Authenticator/OidcSignIn.tsx
@@ -1,6 +1,7 @@
-import React, { ReactElement, useEffect } from 'react'
+import React, { ReactElement, useEffect, useState } from 'react'
 import { useHistory } from 'react-router-dom'
 import AuthenticatorLoadingScreen from './AuthenticatorLoadingScreen'
+import AuthenticatorErrorScreen from './AuthenticatorErrorScreen'
 import { getUserManager } from '../userManager'
 import { ActionType, AuthDispatch } from './Authenticator.state'
 
@@ -10,6 +11,7 @@ interface Props {
 
 export const OidcSignIn = ({ authDispatch }: Props): ReactElement => {
   const history = useHistory()
+  const [hasError, setHasError] = useState(false)
 
   const init = async function init() {
     const userManager = getUserManager()
@@ -23,8 +25,8 @@ export const OidcSignIn = ({ authDispatch }: Props): ReactElement => {
       const url = typeof user.state === 'string' ? user.state : '/'
       history.push(url)
     } catch (error) {
-      console.error(error)
-      window.location.replace(window.location.origin)
+      console.error('Error in oidc callback', error)
+      setHasError(true)
     }
   }
 
@@ -32,7 +34,11 @@ export const OidcSignIn = ({ authDispatch }: Props): ReactElement => {
     init()
   }, [])
 
-  return <AuthenticatorLoadingScreen />
+  return hasError ? (
+    <AuthenticatorErrorScreen />
+  ) : (
+    <AuthenticatorLoadingScreen />
+  )
 }
 
 export default OidcSignIn


### PR DESCRIPTION
## What

* Render an error screen if the OIDC callback has an error from the IDS.
* Avoid race conditions in redirects during error callbacks.
* Never pass the OIDC callback url as a return url for IDS.

## Why

Better error handling. Spotted when an IDS regression caused strange client behaviour.

## Screenshots / Gifs

In case of an error during IDS login:

![image](https://user-images.githubusercontent.com/115094/123185138-bdcc8180-d484-11eb-8372-3b41c14e4b67.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
