### PR TITLE
feat(core): Add className props to Text and Button, and margins* props to Divider

### DIFF
--- a/libs/island-ui/core/src/lib/Button/Button.tsx
+++ b/libs/island-ui/core/src/lib/Button/Button.tsx
@@ -69,6 +69,7 @@ export interface ButtonProps {
   title?: string
   inline?: boolean
   as?: As
+  className?: string
 }
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps & ButtonTypes>(
@@ -90,6 +91,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps & ButtonTypes>(
       nowrap,
       inline,
       as,
+      className,
       ...buttonProps
     },
     ref,
@@ -121,6 +123,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps & ButtonTypes>(
             [styles.isEmpty]: !children,
             [styles.loading]: loading,
           },
+          className,
         )}
         display={variant === 'text' ? 'inline' : inline ? 'inlineFlex' : 'flex'}
         disabled={disabled || loading}

--- a/libs/island-ui/core/src/lib/Divider/Divider.tsx
+++ b/libs/island-ui/core/src/lib/Divider/Divider.tsx
@@ -1,28 +1,19 @@
 import React from 'react'
+import { BoxProps } from '../Box/types'
 import { Box } from '../Box/Box'
-import * as styleRefs from './Divider.treat'
+import * as styles from './Divider.treat'
 
 export interface DividerProps {
-  weight?: keyof typeof styleRefs.weight
+  weight?: keyof typeof styles.weight
+  marginTop?: BoxProps['marginTop']
+  marginBottom?: BoxProps['marginBottom']
 }
 
-const defaultWeight = 'regular'
-
-export const Divider = ({ weight = defaultWeight }: DividerProps) => {
-  const styles = {
-    ...styleRefs,
-  }
-
-  return (
-    <Box position="relative">
-      <Box
-        position="absolute"
-        width="full"
-        className={[
-          styles.base,
-          styles.weight[weight] || styles.weight[defaultWeight],
-        ]}
-      />
-    </Box>
-  )
-}
+export const Divider = (props: DividerProps) => (
+  <Box
+    width="full"
+    className={[styles.base, styles.weight[props.weight || 'regular']]}
+    marginTop={props.marginTop}
+    marginBottom={props.marginBottom}
+  />
+)

--- a/libs/island-ui/core/src/lib/Text/Text.tsx
+++ b/libs/island-ui/core/src/lib/Text/Text.tsx
@@ -46,6 +46,7 @@ export interface TextProps {
   lineHeight?: keyof typeof lineHeightStyles
   title?: string
   strikethrough?: boolean
+  className?: string
 }
 
 type GetTextStylesProps = Pick<
@@ -58,24 +59,31 @@ type GetTextStylesProps = Pick<
   | 'strikethrough'
 >
 
-export const getTextStyles = ({
-  color,
-  truncate,
-  fontWeight,
-  lineHeight,
-  variant = 'default',
-  strikethrough,
-}: GetTextStylesProps) =>
-  cn(base, {
-    [variantStyles[variant!]]: variant,
-    [colors[color!]]: color,
-    [fontWeightStyles[fontWeight!]]: fontWeight,
-    [lineHeightStyles[lineHeight!]]: lineHeight,
-    [defaultFontWeights[variant!]]: variant && !fontWeight,
-    [defaultLineHeights[variant!]]: variant && !lineHeight,
-    [truncateStyle]: truncate,
-    [strikethroughStyle]: strikethrough,
-  })
+export const getTextStyles = (
+  {
+    color,
+    truncate,
+    fontWeight,
+    lineHeight,
+    variant = 'default',
+    strikethrough,
+  }: GetTextStylesProps,
+  className?: string,
+) =>
+  cn(
+    base,
+    {
+      [variantStyles[variant!]]: variant,
+      [colors[color!]]: color,
+      [fontWeightStyles[fontWeight!]]: fontWeight,
+      [lineHeightStyles[lineHeight!]]: lineHeight,
+      [defaultFontWeights[variant!]]: variant && !fontWeight,
+      [defaultLineHeights[variant!]]: variant && !lineHeight,
+      [truncateStyle]: truncate,
+      [strikethroughStyle]: strikethrough,
+    },
+    className,
+  )
 
 export const Text = forwardRef<HTMLElement, TextProps>(
   (
@@ -96,6 +104,7 @@ export const Text = forwardRef<HTMLElement, TextProps>(
       title,
       as = 'p',
       strikethrough,
+      className,
     },
     ref,
   ) => {
@@ -110,14 +119,17 @@ export const Text = forwardRef<HTMLElement, TextProps>(
         paddingTop={paddingTop}
         paddingBottom={paddingBottom}
         paddingY={paddingY}
-        className={getTextStyles({
-          color,
-          truncate,
-          fontWeight,
-          lineHeight,
-          variant,
-          strikethrough,
-        })}
+        className={getTextStyles(
+          {
+            color,
+            truncate,
+            fontWeight,
+            lineHeight,
+            variant,
+            strikethrough,
+          },
+          className,
+        )}
         ref={ref}
         title={title}
       >


### PR DESCRIPTION
Attempt to make meaningless div/Box wrappers needed less often to do simple custom layout/styling tweaks.

Also vertical-margin-collapse fix for the Divider component.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
