### PR TITLE
feat(judicial-system): case files strings to contentful

### DIFF
--- a/apps/judicial-system/web/messages/caseFiles.ts
+++ b/apps/judicial-system/web/messages/caseFiles.ts
@@ -1,0 +1,64 @@
+import { defineMessage, defineMessages } from 'react-intl'
+
+// Strings for select court component
+export const caseFiles = {
+  heading: defineMessage({
+    id: 'judicial.system:component.caseFiles.heading',
+    defaultMessage: 'Rannsóknargögn',
+    description: 'Case files component: Heading',
+  }),
+  description: defineMessages({
+    heading: {
+      id: 'judicial.system:component.caseFiles.description.heading',
+      defaultMessage: 'Meðferð gagna',
+      description: 'Case files component description: Heading',
+    },
+    list: {
+      id: 'judicial.system:component.caseFiles.description.list#markdown',
+      defaultMessage:
+        '- Hér er hægt að hlaða upp rannsóknargögnum til að sýna dómara.\\n\\n- Gögnin eru eingöngu aðgengileg dómara í málinu og aðgengi að þeim lokast þegar dómari hefur úrskurðað.\\n\\n- Gögnin verða ekki lögð fyrir eða flutt í málakerfi dómstóls nema annar hvor aðilinn kæri úrskurðinn.',
+      description: 'Case files component description: List',
+    },
+  }),
+  files: defineMessages({
+    heading: {
+      id: 'judicial.system:component.caseFiles.files.heading',
+      defaultMessage: 'Rannsóknargögn',
+      description: 'Case files component files: Heading',
+    },
+    label: {
+      id: 'judicial.system:component.caseFiles.files.label',
+      defaultMessage: 'Dragðu skjöl hingað til að hlaða upp',
+      description: 'Case files component files: Label',
+    },
+    buttonLabel: {
+      id: 'judicial.system:component.caseFiles.files.buttonLabel',
+      defaultMessage: 'Velja skjöl til að hlaða upp',
+      description: 'Case files component files: Button label',
+    },
+  }),
+  comments: defineMessages({
+    heading: {
+      id: 'judicial.system:component.caseFiles.comments.heading',
+      defaultMessage: 'Athugasemdir vegna rannsóknargagna',
+      description: 'Case files component comments: Heading',
+    },
+    tooltip: {
+      id: 'judicial.system:component.caseFiles.comments.tooltip',
+      defaultMessage:
+        'Hér er hægt að skrá athugasemdir til dómara og dómritara varðandi rannsóknargögnin.',
+      description: 'Case files component comments: Tooltip',
+    },
+    label: {
+      id: 'judicial.system:component.caseFiles.comments.label',
+      defaultMessage: 'Skilaboð',
+      description: 'Case files component comments: Label',
+    },
+    placeholder: {
+      id: 'judicial.system:component.caseFiles.comments.placeholder',
+      defaultMessage:
+        'Er eitthvað sem þú vilt koma á framfæri við dómstólinn varðandi gögnin?',
+      description: 'Case files component comments: Placeholder',
+    },
+  }),
+}

--- a/apps/judicial-system/web/messages/index.ts
+++ b/apps/judicial-system/web/messages/index.ts
@@ -1,3 +1,4 @@
+export * from './caseFiles'
 export * from './defendantInfo'
 export * from './defenderInfo'
 export * from './login'

--- a/apps/judicial-system/web/messages/requestCourtDate.ts
+++ b/apps/judicial-system/web/messages/requestCourtDate.ts
@@ -15,13 +15,13 @@ export const requestCourtDate = {
   }),
   dateInput: defineMessage({
     timeLabel: {
-      id: 'judicial.system:component.selectCourt.select.timeLabel',
+      id: 'judicial.system:component.requestCourtDate.select.timeLabel',
       defaultMessage: 'Ósk um tíma (kk:mm)',
       description: 'Request court date component date input: Time Label',
     },
   }),
   courtDate: defineMessage({
-    id: 'judicial.system:component.selectCourt.select.timeLabel',
+    id: 'judicial.system:component.requestCourtDate.courtDate',
     defaultMessage: 'Fyrirtökudegi og tíma hefur verið úthlutað',
     description: 'Request court date component set court date: Text',
   }),

--- a/apps/judicial-system/web/src/routes/Prosecutor/InvestigationRequest/CaseFiles/CaseFilesForm.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/InvestigationRequest/CaseFiles/CaseFilesForm.tsx
@@ -1,11 +1,10 @@
 import React from 'react'
+import { useIntl } from 'react-intl'
 import {
   Text,
   Box,
   ContentBlock,
   InputFileUpload,
-  BulletList,
-  Bullet,
   Input,
   Tooltip,
 } from '@island.is/island-ui/core'
@@ -19,8 +18,10 @@ import {
   FormContentContainer,
   FormFooter,
 } from '@island.is/judicial-system-web/src/shared-components'
+import { caseFiles as m } from '@island.is/judicial-system-web/messages'
 import { removeTabsValidateAndSet } from '@island.is/judicial-system-web/src/utils/formHelper'
 import { parseString } from '@island.is/judicial-system-web/src/utils/formatters'
+import MarkdownWrapper from '@island.is/judicial-system-web/src/shared-components/MarkdownWrapper/MarkdownWrapper'
 
 interface Props {
   workingCase: Case
@@ -37,6 +38,7 @@ const CaseFilesForm: React.FC<Props> = (props) => {
     onRemove,
     onRetry,
   } = useS3Upload(workingCase)
+  const { formatMessage } = useIntl()
   const { updateCase } = useCase()
 
   return (
@@ -44,44 +46,31 @@ const CaseFilesForm: React.FC<Props> = (props) => {
       <FormContentContainer>
         <Box marginBottom={7}>
           <Text as="h1" variant="h1">
-            Rannsóknargögn
+            {formatMessage(m.heading)}
           </Text>
         </Box>
         <Box marginBottom={5}>
           <Box marginBottom={3}>
             <Text as="h3" variant="h3">
-              Meðferð gagna
+              {formatMessage(m.description.heading)}
             </Text>
           </Box>
-          <BulletList type="ul">
-            <Bullet>
-              Hér er hægt að hlaða upp rannsóknargögnum til að sýna dómara.
-            </Bullet>
-            <Box marginTop={1}>
-              <Bullet>
-                Gögnin eru eingöngu aðgengileg dómara í málinu og aðgengi að
-                þeim lokast þegar dómari hefur úrskurðað.
-              </Bullet>
-            </Box>
-            <Box marginTop={1}>
-              <Bullet>
-                Gögnin verða ekki lögð fyrir eða flutt í málakerfi dómstóls nema
-                annar hvor aðilinn kæri úrskurðinn.
-              </Bullet>
-            </Box>
-          </BulletList>
+          <MarkdownWrapper
+            text={m.description.list}
+            textProps={{ marginBottom: 0 }}
+          />
         </Box>
         <Box marginBottom={3}>
           <Text variant="h3" as="h3">
-            Rannsóknargögn
+            {formatMessage(m.files.heading)}
           </Text>
         </Box>
         <Box marginBottom={5}>
           <ContentBlock>
             <InputFileUpload
               fileList={files}
-              header="Dragðu skjöl hingað til að hlaða upp"
-              buttonLabel="Velja skjöl til að hlaða upp"
+              header={formatMessage(m.files.label)}
+              buttonLabel={formatMessage(m.files.buttonLabel)}
               onChange={onChange}
               onRemove={onRemove}
               onRetry={onRetry}
@@ -93,19 +82,19 @@ const CaseFilesForm: React.FC<Props> = (props) => {
         <Box>
           <Box marginBottom={3}>
             <Text variant="h3" as="h3">
-              Athugasemdir vegna rannsóknargagna{' '}
+              {formatMessage(m.comments.heading)}{' '}
               <Tooltip
                 placement="right"
                 as="span"
-                text="Hér er hægt að skrá athugasemdir til dómara og dómritara varðandi rannsóknargögnin."
+                text={formatMessage(m.comments.tooltip)}
               />
             </Text>
           </Box>
           <Box marginBottom={10}>
             <Input
               name="caseFilesComments"
-              label="Skilaboð"
-              placeholder="Er eitthvað sem þú vilt koma á framfæri við dómstólinn varðandi gögnin?"
+              label={formatMessage(m.comments.label)}
+              placeholder={formatMessage(m.comments.placeholder)}
               defaultValue={workingCase?.caseFilesComments}
               onChange={(event) =>
                 removeTabsValidateAndSet(

--- a/apps/judicial-system/web/src/routes/Prosecutor/RestrictionRequest/StepFive/StepFiveForm.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/RestrictionRequest/StepFive/StepFiveForm.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useIntl } from 'react-intl'
 import {
   Text,
   Box,
@@ -19,8 +20,10 @@ import {
   FormContentContainer,
   FormFooter,
 } from '@island.is/judicial-system-web/src/shared-components'
+import { caseFiles as m } from '@island.is/judicial-system-web/messages'
 import { removeTabsValidateAndSet } from '@island.is/judicial-system-web/src/utils/formHelper'
 import { parseString } from '@island.is/judicial-system-web/src/utils/formatters'
+import MarkdownWrapper from '@island.is/judicial-system-web/src/shared-components/MarkdownWrapper/MarkdownWrapper'
 
 interface Props {
   workingCase: Case
@@ -29,6 +32,7 @@ interface Props {
 
 export const StepFiveForm: React.FC<Props> = (props) => {
   const { workingCase, setWorkingCase } = props
+  const { formatMessage } = useIntl()
 
   const {
     files,
@@ -44,44 +48,31 @@ export const StepFiveForm: React.FC<Props> = (props) => {
       <FormContentContainer>
         <Box marginBottom={7}>
           <Text as="h1" variant="h1">
-            Rannsóknargögn
+            {formatMessage(m.heading)}
           </Text>
         </Box>
         <Box marginBottom={5}>
           <Box marginBottom={3}>
             <Text as="h3" variant="h3">
-              Meðferð gagna
+              {formatMessage(m.description.heading)}
             </Text>
           </Box>
-          <BulletList type="ul">
-            <Bullet>
-              Hér er hægt að hlaða upp rannsóknargögnum til að sýna dómara.
-            </Bullet>
-            <Box marginTop={1}>
-              <Bullet>
-                Gögnin eru eingöngu aðgengileg dómara í málinu og aðgengi að
-                þeim lokast þegar dómari hefur úrskurðað.
-              </Bullet>
-            </Box>
-            <Box marginTop={1}>
-              <Bullet>
-                Gögnin verða ekki lögð fyrir eða flutt í málakerfi dómstóls nema
-                annar hvor aðilinn kæri úrskurðinn.
-              </Bullet>
-            </Box>
-          </BulletList>
+          <MarkdownWrapper
+            text={m.description.list}
+            textProps={{ marginBottom: 0 }}
+          />
         </Box>
         <Box marginBottom={3}>
           <Text variant="h3" as="h3">
-            Rannsóknargögn
+            {formatMessage(m.files.heading)}
           </Text>
         </Box>
         <Box marginBottom={10}>
           <ContentBlock>
             <InputFileUpload
               fileList={files}
-              header="Dragðu skjöl hingað til að hlaða upp"
-              buttonLabel="Velja skjöl til að hlaða upp"
+              header={formatMessage(m.files.label)}
+              buttonLabel={formatMessage(m.files.buttonLabel)}
               onChange={onChange}
               onRemove={onRemove}
               onRetry={onRetry}
@@ -93,19 +84,19 @@ export const StepFiveForm: React.FC<Props> = (props) => {
         <Box>
           <Box marginBottom={3}>
             <Text variant="h3" as="h3">
-              Athugasemdir vegna rannsóknargagna{' '}
+              {formatMessage(m.comments.heading)}{' '}
               <Tooltip
                 placement="right"
                 as="span"
-                text="Hér er hægt að skrá athugasemdir til dómara og dómritara varðandi rannsóknargögnin."
+                text={formatMessage(m.comments.tooltip)}
               />
             </Text>
           </Box>
           <Box marginBottom={10}>
             <Input
               name="caseFilesComments"
-              label="Skilaboð"
-              placeholder="Er eitthvað sem þú vilt koma á framfæri við dómstólinn varðandi gögnin?"
+              label={formatMessage(m.comments.label)}
+              placeholder={formatMessage(m.comments.placeholder)}
               defaultValue={workingCase?.caseFilesComments}
               onChange={(event) =>
                 removeTabsValidateAndSet(

--- a/apps/judicial-system/web/src/routes/Prosecutor/RestrictionRequest/StepFive/StepFiveForm.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/RestrictionRequest/StepFive/StepFiveForm.tsx
@@ -5,8 +5,6 @@ import {
   Box,
   ContentBlock,
   InputFileUpload,
-  BulletList,
-  Bullet,
   Input,
   Tooltip,
 } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/shared-components/MarkdownWrapper/MarkdownWrapper.treat.ts
+++ b/apps/judicial-system/web/src/shared-components/MarkdownWrapper/MarkdownWrapper.treat.ts
@@ -1,0 +1,47 @@
+import { theme } from '@island.is/island-ui/theme'
+import { style, globalStyle } from 'treat'
+
+const mediumBoxShadow = `inset 0 -2px 0 0 currentColor`
+const smallBoxShadow = `inset 0 -1px 0 0 currentColor`
+const activeBoxShadow = `inset 0 -2px 0 0 ${theme.color.mint400}`
+
+const linkStyle = {
+  color: theme.color.blue400,
+  fontWeight: theme.typography.semiBold,
+  paddingBottom: 4,
+  textDecoration: 'none',
+  boxShadow: smallBoxShadow,
+  transition: 'color .2s, box-shadow .2s',
+}
+
+const linkHoverStyle = {
+  color: theme.color.blueberry600,
+  boxShadow: mediumBoxShadow,
+}
+
+const linkFocusStyle = {
+  color: theme.color.dark400,
+  boxShadow: smallBoxShadow,
+  background: theme.color.mint400,
+}
+
+const linkActiveStyle = {
+  color: theme.color.blueberry600,
+  boxShadow: activeBoxShadow,
+}
+
+// Creates an empty container to target
+export const paragraphContainer = style({})
+// We need both global styles inside the paragraphContainer and a specific link
+// style for standalone links or links within other elements than <p>
+globalStyle(`${paragraphContainer} a`, linkStyle)
+globalStyle(`${paragraphContainer} a:hover`, linkHoverStyle)
+globalStyle(`${paragraphContainer} a:focus`, linkFocusStyle)
+globalStyle(`${paragraphContainer} a:active`, linkActiveStyle)
+
+export const link = style({
+  ...linkStyle,
+  ':hover': linkHoverStyle,
+  ':focus': linkFocusStyle,
+  ':active': linkActiveStyle,
+})

--- a/apps/judicial-system/web/src/shared-components/MarkdownWrapper/MarkdownWrapper.tsx
+++ b/apps/judicial-system/web/src/shared-components/MarkdownWrapper/MarkdownWrapper.tsx
@@ -1,0 +1,98 @@
+import React, { ReactNode } from 'react'
+import Markdown from 'markdown-to-jsx'
+import { MessageDescriptor, useIntl } from 'react-intl'
+import {
+  Box,
+  Text,
+  BulletList,
+  Bullet,
+  Link,
+  TextProps,
+} from '@island.is/island-ui/core'
+import * as styles from './MarkdownWrapper.treat'
+
+const BulletListBox = ({ children }: { children: ReactNode }) => {
+  return (
+    <Box marginBottom={3}>
+      <BulletList space={2}>{children}</BulletList>
+    </Box>
+  )
+}
+
+const TextComponent = ({ children, ...props }: { children: ReactNode }) => {
+  return (
+    <Box className={styles.paragraphContainer}>
+      <Text {...props}>{children}</Text>
+    </Box>
+  )
+}
+
+const LinkComponent = ({
+  children,
+  href,
+}: {
+  children: ReactNode
+  href: string
+}) => {
+  return (
+    <Link href={href} className={styles.link}>
+      {children}
+    </Link>
+  )
+}
+
+interface Props {
+  text: MessageDescriptor
+  format?: { [key: string]: string | number }
+  textProps?: TextProps
+}
+
+const headingOverride = {
+  component: Text,
+  props: {
+    variant: 'h4',
+    marginBottom: 1,
+  },
+}
+
+const DescriptionText = ({ text, format, textProps }: Props) => {
+  const { formatMessage } = useIntl()
+  const markdown = formatMessage(text, format)
+  // markdown-to-jsx is able to handle this in most cases but when using 'formatMessage'
+  // it does not work for some reason. That is the reason for this special handling here.
+  // We will take a look at this later with the localization team.
+  const formattedMarkdown = markdown.replace(/&#39;/g, '&apos;')
+  console.log('bla', formattedMarkdown.replace(/\\n\\n/g, ' \\n '))
+  return (
+    <Markdown
+      options={{
+        forceBlock: true,
+        overrides: {
+          p: {
+            component: TextComponent,
+            props: textProps,
+          },
+          span: {
+            component: TextComponent,
+            props: textProps,
+          },
+          h1: headingOverride,
+          h2: headingOverride,
+          h3: headingOverride,
+          h4: headingOverride,
+          a: { component: LinkComponent },
+          ul: {
+            component: BulletListBox,
+          },
+          li: {
+            component: Bullet,
+          },
+        },
+      }}
+    >
+      {formattedMarkdown}
+    </Markdown>
+  )
+}
+
+export default DescriptionText

--- a/apps/judicial-system/web/src/shared-components/MarkdownWrapper/MarkdownWrapper.tsx
+++ b/apps/judicial-system/web/src/shared-components/MarkdownWrapper/MarkdownWrapper.tsx
@@ -62,7 +62,6 @@ const DescriptionText = ({ text, format, textProps }: Props) => {
   // it does not work for some reason. That is the reason for this special handling here.
   // We will take a look at this later with the localization team.
   const formattedMarkdown = markdown.replace(/&#39;/g, '&apos;')
-  console.log('bla', formattedMarkdown.replace(/\\n\\n/g, ' \\n '))
   return (
     <Markdown
       options={{


### PR DESCRIPTION
# Case files strings

https://app.asana.com/0/1199153462262248/1200501166205913

## What

- Added strings for case files
- Added an initial MarkdownWrapper component

### Note

https://docs.devland.is/libs/localization#markdown-support

## Why

- We want to be able to control strings through Contentful

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
