### PR TITLE
chore(core): enable eslint in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,1 @@
-{
-  "eslint.enable": false
-}
+{}


### PR DESCRIPTION
## What

Not sure why it has been disabled in the first place? Any reasons why it shouldn't be enable?

## Why

- Improve DX to catch error straight from their IDEs