### PR TITLE
ci(core): Disable Cypress video recording

### DIFF
--- a/apps/air-discount-scheme/web-e2e/cypress.json
+++ b/apps/air-discount-scheme/web-e2e/cypress.json
@@ -7,7 +7,7 @@
   "supportFile": "./src/support/index.ts",
   "pageLoadTimeout": 240000,
   "responseTimeout": 120000,
-  "video": true,
+  "video": false,
   "videosFolder": "../../../dist/cypress/apps/air-discount-scheme/web-e2e/videos",
   "screenshotsFolder": "../../../dist/cypress/apps/air-discount-scheme/web-e2e/screenshots",
   "chromeWebSecurity": false

--- a/apps/application-system/form-e2e/cypress.json
+++ b/apps/application-system/form-e2e/cypress.json
@@ -5,7 +5,7 @@
   "modifyObstructiveCode": false,
   "pluginsFile": "./src/plugins/index",
   "supportFile": "./src/support/index.ts",
-  "video": true,
+  "video": false,
   "requestTimeout": 20000,
   "videosFolder": "../../../dist/cypress/apps/application-system/form-e2e/videos",
   "screenshotsFolder": "../../../dist/cypress/apps/application-system/form-e2e/screenshots",

--- a/apps/auth-admin-web-e2e/cypress.json
+++ b/apps/auth-admin-web-e2e/cypress.json
@@ -7,7 +7,7 @@
   "supportFile": "./src/support/index.ts",
   "pageLoadTimeout": 240000,
   "responseTimeout": 120000,
-  "video": true,
+  "video": false,
   "videosFolder": "../../dist/cypress/apps/auth-admin-web-e2e/videos",
   "screenshotsFolder": "../../dist/cypress/apps/auth-admin-web-e2e/screenshots",
   "chromeWebSecurity": false

--- a/apps/gjafakort/web-e2e/cypress.json
+++ b/apps/gjafakort/web-e2e/cypress.json
@@ -7,7 +7,7 @@
   "supportFile": "./src/support/index.ts",
   "pageLoadTimeout": 240000,
   "responseTimeout": 120000,
-  "video": true,
+  "video": false,
   "videosFolder": "../../../dist/cypress/apps/gjafakort/web-e2e/videos",
   "screenshotsFolder": "../../../dist/cypress/apps/gjafakort/web-e2e/screenshots",
   "chromeWebSecurity": false

--- a/apps/judicial-system/web-e2e/cypress.json
+++ b/apps/judicial-system/web-e2e/cypress.json
@@ -5,7 +5,7 @@
   "modifyObstructiveCode": false,
   "pluginsFile": "./src/plugins/index",
   "supportFile": "./src/support/index.ts",
-  "video": true,
+  "video": false,
   "videosFolder": "../../../dist/cypress/apps/judicial-system/web-e2e/videos",
   "screenshotsFolder": "../../../dist/cypress/apps/judicial-system/web-e2e/screenshots",
   "chromeWebSecurity": false,

--- a/apps/service-portal-e2e/cypress.json
+++ b/apps/service-portal-e2e/cypress.json
@@ -5,7 +5,7 @@
   "modifyObstructiveCode": false,
   "pluginsFile": "./src/plugins/index",
   "supportFile": "./src/support/index.ts",
-  "video": true,
+  "video": false,
   "videosFolder": "../../dist/cypress/apps/service-portal-e2e/videos",
   "screenshotsFolder": "../../dist/cypress/apps/service-portal-e2e/screenshots",
   "chromeWebSecurity": false

--- a/apps/skilavottord/web-e2e/cypress.json
+++ b/apps/skilavottord/web-e2e/cypress.json
@@ -7,7 +7,7 @@
   "supportFile": "./src/support/index.ts",
   "pageLoadTimeout": 240000,
   "responseTimeout": 120000,
-  "video": true,
+  "video": false,
   "videosFolder": "../../../dist/cypress/apps/skilavottord/web-e2e/videos",
   "screenshotsFolder": "../../../dist/cypress/apps/skilavottord/web-e2e/screenshots",
   "chromeWebSecurity": false

--- a/apps/system-e2e/cypress.json
+++ b/apps/system-e2e/cypress.json
@@ -5,7 +5,7 @@
   "modifyObstructiveCode": false,
   "pluginsFile": "./src/plugins/index",
   "supportFile": "./src/support/index.ts",
-  "video": true,
+  "video": false,
   "pageLoadTimeout": 240000,
   "responseTimeout": 120000,
   "videosFolder": "../../dist/cypress/apps/web-e2e/videos",

--- a/apps/web-e2e/cypress.json
+++ b/apps/web-e2e/cypress.json
@@ -5,7 +5,7 @@
   "modifyObstructiveCode": false,
   "pluginsFile": "./src/plugins/index",
   "supportFile": "./src/support/index.ts",
-  "video": true,
+  "video": false,
   "pageLoadTimeout": 240000,
   "responseTimeout": 120000,
   "videosFolder": "../../dist/cypress/apps/web-e2e/videos",


### PR DESCRIPTION
# Disable Cypress video recording

It seems that the Cypress video record processing can make our e2e test hang.

https://github.com/cypress-io/cypress/issues/6695#issuecomment-852811773

## What

Test if the video recording process is making our e2e test able to hang.

## Why

To improve developer experince with the CI pipeline.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
