### PR TITLE
fix(charts): wrong env link to chart

### DIFF
--- a/apps/application-system/api/infra/application-system-api.ts
+++ b/apps/application-system/api/infra/application-system-api.ts
@@ -142,9 +142,9 @@ export const serviceSetup = (services: {
         '/k8s/application-system-api/PAYMENT_XROAD_PROVIDER_ID',
       PAYMENT_USERNAME: '/k8s/application-system-api/PAYMENT_USER',
       PAYMENT_PASSWORD: '/k8s/application-system-api/PAYMENT_PASSWORD',
-      CALLBACK_BASE_URL:
+      PAYMENT_BASE_CALLBACK_URL:
         '/k8s/application-system-api/PAYMENT_BASE_CALLBACK_URL',
-      CALLBACK_ADDITION_URL:
+      PAYMENT_ADDITION_CALLBACK_URL:
         '/k8s/application-system-api/PAYMENT_ADDITION_CALLBACK_URL',
       ARK_BASE_URL: '/k8s/application-system-api/ARK_ENDPOINT',
     })

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -200,8 +200,6 @@ application-system-api:
   secrets:
     ARK_BASE_URL: /k8s/application-system-api/ARK_ENDPOINT
     AUTH_JWT_SECRET: /k8s/application-system/api/AUTH_JWT_SECRET
-    CALLBACK_ADDITION_URL: /k8s/application-system-api/PAYMENT_ADDITION_CALLBACK_URL
-    CALLBACK_BASE_URL: /k8s/application-system-api/PAYMENT_BASE_CALLBACK_URL
     CONFIGCAT_SDK_KEY: /k8s/configcat/CONFIGCAT_SDK_KEY
     CONTENTFUL_ACCESS_TOKEN: /k8s/api/CONTENTFUL_ACCESS_TOKEN
     DB_PASS: /k8s/application-system/api/DB_PASSWORD
@@ -217,6 +215,8 @@ application-system-api:
     HEALTH_INSURANCE_XROAD_WSDLURL: /k8s/application-system-api/HEALTH_INSURANCE_XROAD_WSDLURL
     NOVA_PASSWORD: /k8s/application-system/api/NOVA_PASSWORD
     NOVA_URL: /k8s/application-system-api/NOVA_URL
+    PAYMENT_ADDITION_CALLBACK_URL: /k8s/application-system-api/PAYMENT_ADDITION_CALLBACK_URL
+    PAYMENT_BASE_CALLBACK_URL: /k8s/application-system-api/PAYMENT_BASE_CALLBACK_URL
     PAYMENT_PASSWORD: /k8s/application-system-api/PAYMENT_PASSWORD
     PAYMENT_USERNAME: /k8s/application-system-api/PAYMENT_USER
     PAYMENT_XROAD_PROVIDER_ID: /k8s/application-system-api/PAYMENT_XROAD_PROVIDER_ID

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -198,8 +198,6 @@ application-system-api:
   secrets:
     ARK_BASE_URL: /k8s/application-system-api/ARK_ENDPOINT
     AUTH_JWT_SECRET: /k8s/application-system/api/AUTH_JWT_SECRET
-    CALLBACK_ADDITION_URL: /k8s/application-system-api/PAYMENT_ADDITION_CALLBACK_URL
-    CALLBACK_BASE_URL: /k8s/application-system-api/PAYMENT_BASE_CALLBACK_URL
     CONFIGCAT_SDK_KEY: /k8s/configcat/CONFIGCAT_SDK_KEY
     CONTENTFUL_ACCESS_TOKEN: /k8s/api/CONTENTFUL_ACCESS_TOKEN
     DB_PASS: /k8s/application-system/api/DB_PASSWORD
@@ -215,6 +213,8 @@ application-system-api:
     HEALTH_INSURANCE_XROAD_WSDLURL: /k8s/application-system-api/HEALTH_INSURANCE_XROAD_WSDLURL
     NOVA_PASSWORD: /k8s/application-system/api/NOVA_PASSWORD
     NOVA_URL: /k8s/application-system-api/NOVA_URL
+    PAYMENT_ADDITION_CALLBACK_URL: /k8s/application-system-api/PAYMENT_ADDITION_CALLBACK_URL
+    PAYMENT_BASE_CALLBACK_URL: /k8s/application-system-api/PAYMENT_BASE_CALLBACK_URL
     PAYMENT_PASSWORD: /k8s/application-system-api/PAYMENT_PASSWORD
     PAYMENT_USERNAME: /k8s/application-system-api/PAYMENT_USER
     PAYMENT_XROAD_PROVIDER_ID: /k8s/application-system-api/PAYMENT_XROAD_PROVIDER_ID

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -196,8 +196,6 @@ application-system-api:
   secrets:
     ARK_BASE_URL: /k8s/application-system-api/ARK_ENDPOINT
     AUTH_JWT_SECRET: /k8s/application-system/api/AUTH_JWT_SECRET
-    CALLBACK_ADDITION_URL: /k8s/application-system-api/PAYMENT_ADDITION_CALLBACK_URL
-    CALLBACK_BASE_URL: /k8s/application-system-api/PAYMENT_BASE_CALLBACK_URL
     CONFIGCAT_SDK_KEY: /k8s/configcat/CONFIGCAT_SDK_KEY
     CONTENTFUL_ACCESS_TOKEN: /k8s/api/CONTENTFUL_ACCESS_TOKEN
     DB_PASS: /k8s/application-system/api/DB_PASSWORD
@@ -213,6 +211,8 @@ application-system-api:
     HEALTH_INSURANCE_XROAD_WSDLURL: /k8s/application-system-api/HEALTH_INSURANCE_XROAD_WSDLURL
     NOVA_PASSWORD: /k8s/application-system/api/NOVA_PASSWORD
     NOVA_URL: /k8s/application-system-api/NOVA_URL
+    PAYMENT_ADDITION_CALLBACK_URL: /k8s/application-system-api/PAYMENT_ADDITION_CALLBACK_URL
+    PAYMENT_BASE_CALLBACK_URL: /k8s/application-system-api/PAYMENT_BASE_CALLBACK_URL
     PAYMENT_PASSWORD: /k8s/application-system-api/PAYMENT_PASSWORD
     PAYMENT_USERNAME: /k8s/application-system-api/PAYMENT_USER
     PAYMENT_XROAD_PROVIDER_ID: /k8s/application-system-api/PAYMENT_XROAD_PROVIDER_ID


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

API ENV calls these like this:
 ```
callbackAdditionUrl: process.env.PAYMENT_ADDITION_CALLBACK_URL,
  callbackBaseUrl: `process.env.PAYMENT_BASE_CALLBACK_URL
```
application-system-api calls them like this:
```
callbackBaseUrl: process.env.PAYMENT_BASE_CALLBACK_URL,
callbackAdditionUrl: process.env.PAYMENT_ADDITION_CALLBACK_URL,

```

## Screenshots / Gifs



Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
