### PR TITLE
chore(core): move aranja codeowners list to not overwrite precedence

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,8 +12,33 @@
 # Make sure that team names are correct or everything stops working.
 # Organisation name is @island-is, not @island.is
 
-
 /libs/api/domains/identity/                                                                   @island-is/core
+
+/apps/reference-next-app/                                                                     @island-is/aranja-core
+/libs/api/domains/translations/                                                               @island-is/aranja-core
+/libs/contentful-extensions/                                                                  @island-is/aranja-core @island-is/kosmos-kaos
+/libs/contentful-extensions/translation/                                                      @island-is/aranja-core
+/libs/localization/                                                                           @island-is/aranja-core
+/libs/utils/api/                                                                              @island-is/aranja-core
+/libs/utils/shared/                                                                           @island-is/aranja-core
+/libs/service-portal/settings/access-control                                                  @island-is/aranja-core @island-is/vice-versa
+
+/apps/application-system/                                                                     @island-is/aranja-applications
+/libs/api/domains/application/                                                                @island-is/aranja-applications
+/libs/application/core/                                                                       @island-is/aranja-applications
+/libs/application/data-providers/                                                             @island-is/aranja-applications
+/libs/application/graphql/                                                                    @island-is/aranja-applications
+/libs/application/ui-components/                                                              @island-is/aranja-applications
+/libs/application/ui-fields/                                                                  @island-is/aranja-applications
+/libs/application/ui-shell/                                                                   @island-is/aranja-applications
+/libs/application/template-api-modules/                                                       @island-is/aranja-applications
+/libs/application/template-loader/                                                            @island-is/aranja-applications
+/libs/application/templates/meta-application/                                                 @island-is/aranja-applications
+/libs/application/templates/parental-leave/                                                   @island-is/aranja-applications
+/libs/application/templates/reference-template/                                               @island-is/aranja-applications
+/libs/clients/vmst/                                                                           @island-is/aranja-applications
+/libs/shared/form-fields/                                                                     @island-is/aranja-applications
+/libs/api/domains/directorate-of-labour/                                                      @island-is/aranja-applications
 
 /apps/web*/                                                                                   @island-is/kosmos-kaos
 /apps/services/endorsements/                                                                  @island-is/kosmos-kaos
@@ -42,33 +67,6 @@
 /libs/application/templates/driving-license/                                                  @island-is/kosmos-kaos
 /libs/application/templates/driving-assessment-approval/                                      @island-is/kosmos-kaos
 /libs/application/template-api-modules/src/lib/modules/templates/driving-license-submission   @island-is/kosmos-kaos
-
-
-/apps/reference-next-app/                                                                     @island-is/aranja-core
-/libs/api/domains/translations/                                                               @island-is/aranja-core
-/libs/contentful-extensions/                                                                  @island-is/aranja-core @island-is/kosmos-kaos
-/libs/contentful-extensions/translation/                                                      @island-is/aranja-core
-/libs/localization/                                                                           @island-is/aranja-core
-/libs/utils/api/                                                                              @island-is/aranja-core
-/libs/utils/shared/                                                                           @island-is/aranja-core
-/libs/service-portal/settings/access-control                                                  @island-is/aranja-core @island-is/vice-versa
-
-/apps/application-system/                                                                     @island-is/aranja-applications
-/libs/api/domains/application/                                                                @island-is/aranja-applications
-/libs/application/core/                                                                       @island-is/aranja-applications
-/libs/application/data-providers/                                                             @island-is/aranja-applications
-/libs/application/graphql/                                                                    @island-is/aranja-applications
-/libs/application/ui-components/                                                              @island-is/aranja-applications
-/libs/application/ui-fields/                                                                  @island-is/aranja-applications
-/libs/application/ui-shell/                                                                   @island-is/aranja-applications
-/libs/application/template-api-modules/                                                       @island-is/aranja-applications
-/libs/application/template-loader/                                                            @island-is/aranja-applications
-/libs/application/templates/meta-application/                                                 @island-is/aranja-applications
-/libs/application/templates/parental-leave/                                                   @island-is/aranja-applications
-/libs/application/templates/reference-template/                                               @island-is/aranja-applications
-/libs/clients/vmst/                                                                           @island-is/aranja-applications
-/libs/shared/form-fields/                                                                     @island-is/aranja-applications
-/libs/api/domains/directorate-of-labour/                                                      @island-is/aranja-applications
 
 /libs/application/templates/family-matters/                                                   @island-is/kolibri-modern-family
 /apps/application-system/api/src/app/modules/application/files/                               @island-is/kolibri-modern-family


### PR DESCRIPTION
## What

- This PR https://github.com/island-is/island.is/pull/4333 was requesting code review from aranja-application while it was already defining its own code owner. I believe it's because of the order precedence.
- Move aranja codeowners on top (the important one here: `/libs/application/template-api-modules/`) so lines like `/libs/application/template-api-modules/src/lib/modules/templates/party-application/` or `/libs/application/template-api-modules/src/lib/modules/templates/party-letter/` are not "overwritten"