### PR TITLE
fix(judicial-system): wrong defaultMessage in translation string

### DIFF
--- a/apps/judicial-system/web/messages/reportForm.ts
+++ b/apps/judicial-system/web/messages/reportForm.ts
@@ -131,7 +131,7 @@ export const reportForm = {
       defaultValue: {
         id: 'judicial.system:form.reportForm.prosecutorOnly.input.defaultValue',
         defaultMessage:
-          'Er eitthvað sem þú vilt koma á framfæri við dómstólinn varðandi fyrirtökuna eða málsmeðferðina?',
+          'Beðið er um að krafan verði tekin fyrir án þess að þeir sem hún beinist að verði kvaddir á dómþingið.',
         description: 'Report form case procecutor only: Default value',
       },
     }),

--- a/apps/judicial-system/web/src/routes/Prosecutor/InvestigationRequest/PoliceReport/PoliceReportForm.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/InvestigationRequest/PoliceReport/PoliceReportForm.tsx
@@ -55,7 +55,7 @@ const PoliceReportForm: React.FC<Props> = (props) => {
         workingCase,
       )
     }
-  }, [autofill, workingCase.requestProsecutorOnlySession])
+  }, [autofill, workingCase, defaultProsecutorOnlySessionRequest])
 
   return (
     <>


### PR DESCRIPTION
# Fix wrong defaultMessage in translation string

https://app.asana.com/0/1199153462262248/1200530258163038

## What

- Changed the defaultMessage
- Fixed dependency array in useEffect

## Why

- Bug

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
