### PR TITLE
fix(ci): Avoid sending message on feature deploy

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -469,7 +469,7 @@ jobs:
 
   failure-notification:
     runs-on: ubuntu-20.04
-    if: failure() && needs.pre-checks.outputs.PRE_CHECK
+    if: failure() && needs.pre-checks.outputs.PRE_CHECK && needs.pre-checks.outputs.PRE_CHECK != "feature-deploy"
     needs:
       - pre-checks
       - prepare


### PR DESCRIPTION
Feature deployments should not send a message about failed builds to slack