### PR TITLE
feat(access-control): use identity for delegations

### DIFF
--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common'
 import { GraphQLModule } from '@nestjs/graphql'
 import { TerminusModule } from '@nestjs/terminus'
 import responseCachePlugin from 'apollo-server-plugin-response-cache'
+
 import { AuthModule as AuthDomainModule } from '@island.is/api/domains/auth'
 import { ContentSearchModule } from '@island.is/api/domains/content-search'
 import { CmsModule } from '@island.is/api/domains/cms'
@@ -67,7 +68,17 @@ const autoSchemaFile = environment.production
         }),
       ],
     }),
-    AuthDomainModule.register(environment.authPublicApi),
+    AuthDomainModule.register({
+      identity: {
+        nationalRegistry: {
+          baseSoapUrl: environment.nationalRegistry.baseSoapUrl,
+          user: environment.nationalRegistry.user,
+          password: environment.nationalRegistry.password,
+          host: environment.nationalRegistry.host,
+        },
+      },
+      authPublicApi: environment.authPublicApi,
+    }),
     AuditModule.forRoot(environment.audit),
     ContentSearchModule,
     CmsModule,

--- a/apps/service-portal/src/components/UserDelegations/UserDelegations.tsx
+++ b/apps/service-portal/src/components/UserDelegations/UserDelegations.tsx
@@ -42,8 +42,8 @@ export const UserDelegations = ({ onSwitch }: UserDelegationsProps) => {
 
   let delegations: Delegation[] = data.authActorDelegations.map(
     (delegation) => ({
-      nationalId: delegation.fromNationalId,
-      name: delegation.fromName,
+      nationalId: delegation.from.nationalId,
+      name: delegation.from.name,
     }),
   )
 

--- a/libs/api/domains/auth/src/lib/auth.module.ts
+++ b/libs/api/domains/auth/src/lib/auth.module.ts
@@ -4,6 +4,10 @@ import {
   AuthPublicApiClientModule,
   AuthPublicApiClientModuleConfig,
 } from '@island.is/clients/auth-public-api'
+import {
+  IdentityModule,
+  Config as IdentityConfig,
+} from '@island.is/api/domains/identity'
 
 import {
   ApiScopeResolver,
@@ -12,7 +16,10 @@ import {
 } from './resolvers'
 import { AuthService } from './auth.service'
 
-export type Config = AuthPublicApiClientModuleConfig
+export type Config = {
+  authPublicApi: AuthPublicApiClientModuleConfig
+  identity: IdentityConfig
+}
 
 @Module({
   providers: [
@@ -26,7 +33,10 @@ export class AuthModule {
   static register(config: Config): DynamicModule {
     return {
       module: AuthModule,
-      imports: [AuthPublicApiClientModule.register(config)],
+      imports: [
+        AuthPublicApiClientModule.register(config.authPublicApi),
+        IdentityModule.register(config.identity),
+      ],
     }
   }
 }

--- a/libs/api/domains/auth/src/lib/models/delegation.model.ts
+++ b/libs/api/domains/auth/src/lib/models/delegation.model.ts
@@ -10,6 +10,7 @@ import {
   DelegationProvider,
   DelegationType,
 } from '@island.is/clients/auth-public-api'
+import { Identity } from '@island.is/api/domains/identity'
 
 import { DelegationScope } from './delegationScope.model'
 
@@ -32,17 +33,11 @@ export abstract class Delegation {
   @Field(() => ID)
   id?: string
 
-  @Field()
-  toNationalId!: string
+  @Field(() => Identity)
+  from!: Identity
 
-  @Field()
-  fromNationalId!: string
-
-  @Field()
-  fromName!: string
-
-  @Field()
-  toName!: string
+  @Field(() => Identity)
+  to!: Identity
 
   @Field(() => DelegationType)
   type!: DelegationType

--- a/libs/api/domains/auth/src/lib/resolvers/delegation.resolver.ts
+++ b/libs/api/domains/auth/src/lib/resolvers/delegation.resolver.ts
@@ -8,6 +8,7 @@ import {
   Resolver,
 } from '@nestjs/graphql'
 import { UseGuards } from '@nestjs/common'
+import * as kennitala from 'kennitala'
 
 import { CurrentUser, IdsUserGuard } from '@island.is/auth-nest-tools'
 import { Identity, IdentityService } from '@island.is/api/domains/identity'
@@ -115,11 +116,27 @@ export class DelegationResolver {
 
   @ResolveField('to', () => Identity)
   resolveTo(@Parent() delegation: DelegationDTO): Promise<Identity | null> {
+    if (kennitala.isCompany(delegation.toNationalId)) {
+      // XXX: temp until rsk gets implemented
+      return Promise.resolve({
+        nationalId: delegation.toNationalId,
+        name: delegation.toName,
+        type: 'company',
+      } as Identity)
+    }
     return this.identityService.getIdentity(delegation.toNationalId)
   }
 
   @ResolveField('from', () => Identity)
   resolveFrom(@Parent() delegation: DelegationDTO): Promise<Identity | null> {
+    if (kennitala.isCompany(delegation.fromNationalId)) {
+      // XXX: temp until rsk gets implemented
+      return Promise.resolve({
+        nationalId: delegation.fromNationalId,
+        name: delegation.fromName,
+        type: 'company',
+      } as Identity)
+    }
     return this.identityService.getIdentity(delegation.fromNationalId)
   }
 }

--- a/libs/api/domains/auth/src/lib/resolvers/delegation.resolver.ts
+++ b/libs/api/domains/auth/src/lib/resolvers/delegation.resolver.ts
@@ -10,6 +10,7 @@ import {
 import { UseGuards } from '@nestjs/common'
 
 import { CurrentUser, IdsUserGuard } from '@island.is/auth-nest-tools'
+import { Identity, IdentityService } from '@island.is/api/domains/identity'
 import type { User } from '@island.is/auth-nest-tools'
 import type { DelegationDTO } from '@island.is/clients/auth-public-api'
 
@@ -38,7 +39,10 @@ const ignore404 = (e: Response) => {
 @Resolver(() => LegalGuardianDelegation)
 @Resolver(() => ProcuringHolderDelegation)
 export class DelegationResolver {
-  constructor(private authService: AuthService) {}
+  constructor(
+    private authService: AuthService,
+    private identityService: IdentityService,
+  ) {}
 
   @Query(() => [Delegation], { name: 'authActorDelegations' })
   getActorDelegations(@CurrentUser() user: User): Promise<DelegationDTO[]> {
@@ -107,5 +111,15 @@ export class DelegationResolver {
   @ResolveField('id', () => ID)
   resolveId(@Parent() delegation: DelegationDTO): string {
     return `${delegation.fromNationalId}-${delegation.toNationalId}`
+  }
+
+  @ResolveField('to', () => Identity)
+  resolveTo(@Parent() delegation: DelegationDTO): Promise<Identity | null> {
+    return this.identityService.getIdentity(delegation.toNationalId)
+  }
+
+  @ResolveField('from', () => Identity)
+  resolveFrom(@Parent() delegation: DelegationDTO): Promise<Identity | null> {
+    return this.identityService.getIdentity(delegation.fromNationalId)
   }
 }

--- a/libs/api/domains/auth/src/lib/resolvers/delegation.resolver.ts
+++ b/libs/api/domains/auth/src/lib/resolvers/delegation.resolver.ts
@@ -81,11 +81,6 @@ export class DelegationResolver {
       .catch(ignore404)
     if (!delegation) {
       delegation = await this.authService.createDelegation(user, input)
-    } else if (delegation.toName !== input.name) {
-      return this.authService.updateDelegation(
-        user,
-        input as UpdateDelegationInput,
-      )
     }
 
     return delegation

--- a/libs/api/domains/identity/src/index.ts
+++ b/libs/api/domains/identity/src/index.ts
@@ -1,1 +1,3 @@
-export { IdentityModule } from './lib/identity.module'
+export { IdentityModule, Config } from './lib/identity.module'
+export { Identity } from './lib/models'
+export { IdentityService } from './lib/identity.service'

--- a/libs/api/domains/identity/src/lib/identity.module.ts
+++ b/libs/api/domains/identity/src/lib/identity.module.ts
@@ -2,9 +2,11 @@ import { Module, DynamicModule } from '@nestjs/common'
 
 import { NationalRegistryModule } from '@island.is/api/domains/national-registry'
 import { NationalRegistryConfig } from '@island.is/clients/national-registry-v1'
-import { IdentityResolver } from './identity.resolver'
 
-type Config = {
+import { IdentityResolver } from './identity.resolver'
+import { IdentityService } from './identity.service'
+
+export type Config = {
   nationalRegistry: NationalRegistryConfig
 }
 
@@ -13,8 +15,13 @@ export class IdentityModule {
   static register(config: Config): DynamicModule {
     return {
       module: IdentityModule,
-      imports: [NationalRegistryModule.register(config)],
-      providers: [IdentityResolver],
+      imports: [
+        NationalRegistryModule.register({
+          nationalRegistry: config.nationalRegistry,
+        }),
+      ],
+      providers: [IdentityResolver, IdentityService],
+      exports: [IdentityService],
     }
   }
 }

--- a/libs/api/domains/identity/src/lib/identity.service.ts
+++ b/libs/api/domains/identity/src/lib/identity.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common'
+import * as kennitala from 'kennitala'
+
+import {
+  NationalRegistryService,
+  NationalRegistryUser,
+} from '@island.is/api/domains/national-registry'
+
+import { IdentityType } from './identity.type'
+import { Identity } from './models'
+
+@Injectable()
+export class IdentityService {
+  constructor(
+    private nationalRegistryService: NationalRegistryService,
+  ) {}
+
+  async getIdentity(nationalId: string): Promise<Identity | null> {
+    if (kennitala.isCompany(nationalId)) {
+      return Promise.resolve(null)
+    }
+
+    const person = await this.nationalRegistryService.getUser(nationalId)
+    return {
+      ...person,
+      type: IdentityType.Person,
+    } as Identity
+  }
+}

--- a/libs/api/domains/identity/src/lib/identity.service.ts
+++ b/libs/api/domains/identity/src/lib/identity.service.ts
@@ -11,9 +11,7 @@ import { Identity } from './models'
 
 @Injectable()
 export class IdentityService {
-  constructor(
-    private nationalRegistryService: NationalRegistryService,
-  ) {}
+  constructor(private nationalRegistryService: NationalRegistryService) {}
 
   async getIdentity(nationalId: string): Promise<Identity | null> {
     if (kennitala.isCompany(nationalId)) {

--- a/libs/api/domains/identity/src/lib/identity.service.ts
+++ b/libs/api/domains/identity/src/lib/identity.service.ts
@@ -15,7 +15,7 @@ export class IdentityService {
 
   async getIdentity(nationalId: string): Promise<Identity | null> {
     if (kennitala.isCompany(nationalId)) {
-      return Promise.resolve(null)
+      return null
     }
 
     const person = await this.nationalRegistryService.getUser(nationalId)

--- a/libs/island-ui/core/src/lib/Input/Input.tsx
+++ b/libs/island-ui/core/src/lib/Input/Input.tsx
@@ -69,6 +69,7 @@ export const Input = forwardRef(
       backgroundColor = 'white',
       onFocus,
       onBlur,
+      readOnly,
       onClick,
       onKeyDown,
       textarea,
@@ -183,6 +184,7 @@ export const Input = forwardRef(
                   onBlur(e)
                 }
               }}
+              readOnly={readOnly}
               type={type}
               {...(ariaError as AriaError)}
               {...inputProps}

--- a/libs/island-ui/core/src/lib/Input/types.ts
+++ b/libs/island-ui/core/src/lib/Input/types.ts
@@ -19,6 +19,7 @@ export interface InputComponentProps {
   className?: string
   disabled?: boolean
   required?: boolean
+  readOnly?: boolean
   placeholder?: string
   autoFocus?: boolean
   maxLength?: number

--- a/libs/service-portal/graphql/src/lib/queries/getActorDelegations.ts
+++ b/libs/service-portal/graphql/src/lib/queries/getActorDelegations.ts
@@ -3,8 +3,10 @@ import { gql } from '@apollo/client'
 export const ACTOR_DELEGATIONS = gql`
   query ActorDelegations {
     authActorDelegations {
-      fromNationalId
-      fromName
+      from {
+        nationalId
+        name
+      }
     }
   }
 `

--- a/libs/service-portal/settings/access-control/src/screens/Access/Access.tsx
+++ b/libs/service-portal/settings/access-control/src/screens/Access/Access.tsx
@@ -74,9 +74,13 @@ const AuthDelegationQuery = gql`
     authDelegation(input: $input) {
       id
       type
-      toName
-      toNationalId
-      fromNationalId
+      to {
+        nationalId
+        name
+      }
+      from {
+        nationalId
+      }
       ... on AuthCustomDelegation {
         scopes {
           id
@@ -93,7 +97,9 @@ const UpdateAuthDelegationMutation = gql`
   mutation UpdateAuthDelegationMutation($input: UpdateAuthDelegationInput!) {
     updateAuthDelegation(input: $input) {
       id
-      fromNationalId
+      from {
+        nationalId
+      }
       ... on AuthCustomDelegation {
         scopes {
           id
@@ -201,7 +207,7 @@ function Access() {
   return (
     <Box>
       <IntroHeader
-        title={authDelegation?.toName || ''}
+        title={authDelegation?.to.name || ''}
         intro={defineMessage({
           id: 'service.portal.settings.accessControl:access-intro',
           defaultMessage:

--- a/libs/service-portal/settings/access-control/src/screens/AccessControl/components/Accesses/Accesses.tsx
+++ b/libs/service-portal/settings/access-control/src/screens/AccessControl/components/Accesses/Accesses.tsx
@@ -22,8 +22,10 @@ export const AuthDelegationsQuery = gql`
     authDelegations {
       id
       type
-      toNationalId
-      toName
+      to {
+        nationalId
+        name
+      }
       ... on AuthCustomDelegation {
         validTo
         scopes {
@@ -74,11 +76,11 @@ function Accesses(): JSX.Element {
               authDelegations.map((delegation) => (
                 <AccessCard
                   key={delegation.id}
-                  title={delegation.toName}
+                  title={delegation.to.name}
                   validTo={delegation.validTo}
-                  description={delegation.toNationalId}
+                  description={delegation.to.nationalId}
                   tags={delegation.scopes.map((scope) => scope.displayName)}
-                  href={`${pathname}/${delegation.toNationalId}`}
+                  href={`${pathname}/${delegation.to.nationalId}`}
                   group="Ísland.is"
                 />
               ))

--- a/libs/service-portal/settings/access-control/src/screens/GrantAccess/GrantAccess.tsx
+++ b/libs/service-portal/settings/access-control/src/screens/GrantAccess/GrantAccess.tsx
@@ -167,19 +167,10 @@ function GrantAccess() {
               control={control}
               name="name"
               defaultValue=""
-              rules={{
-                required: {
-                  value: true,
-                  message: formatMessage({
-                    id:
-                      'service.portal.settings.accessControl:grant-required-name',
-                    defaultMessage: 'Skylda er að fylla út aðgangshafa',
-                  }),
-                },
-              }}
               render={({ onChange, value, name }) => (
                 <Input
                   name={name}
+                  readOnly={true}
                   label={formatMessage({
                     id:
                       'service.portal.settings.accessControl:grant-label-user',

--- a/libs/service-portal/settings/access-control/src/screens/GrantAccess/GrantAccess.tsx
+++ b/libs/service-portal/settings/access-control/src/screens/GrantAccess/GrantAccess.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react'
 import { gql, useMutation, useLazyQuery } from '@apollo/client'
-import { useForm, Controller } from 'react-hook-form'
+import { useForm, Controller, ValidationRules } from 'react-hook-form'
 import { useHistory } from 'react-router-dom'
 import { defineMessage } from 'react-intl'
 import * as kennitala from 'kennitala'
@@ -14,6 +14,7 @@ import {
   GridColumn,
   toast,
 } from '@island.is/island-ui/core'
+import { InputController } from '@island.is/shared/form-fields'
 import { Mutation, Query } from '@island.is/api/schema'
 import { IntroHeader, ServicePortalPath } from '@island.is/service-portal/core'
 import { useLocale } from '@island.is/localization'
@@ -57,7 +58,7 @@ function GrantAccess() {
   const requestDelegation = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) => {
-    const value = e.target.value
+    const value = e.target.value.replace('-', '').trim()
     if (value.length === 10 && kennitala.isValid(value)) {
       getIdentity({ variables: { input: { nationalId: value } } })
       if (identity?.nationalId === value) {
@@ -120,52 +121,46 @@ function GrantAccess() {
             </Text>
           </GridColumn>
           <GridColumn paddingBottom={2} span={['12/12', '12/12', '6/12']}>
-            <Controller
+            <InputController
               control={control}
-              name="toNationalId"
+              id="toNationalId"
               defaultValue=""
-              rules={{
-                required: {
-                  value: true,
-                  message: formatMessage({
-                    id:
-                      'service.portal.settings.accessControl:grant-required-ssn',
-                    defaultMessage: 'Skylda er að fylla út kennitölu',
-                  }),
-                },
-                validate: {
-                  value: (value) => {
-                    if (!kennitala.isValid(value)) {
-                      return formatMessage({
-                        id:
-                          'service.portal.settings.accessControl:grant-invalid-ssn',
-                        defaultMessage: 'Kennitalan er ekki gild kennitala',
-                      })
-                    }
+              rules={
+                {
+                  required: {
+                    value: true,
+                    message: formatMessage({
+                      id:
+                        'service.portal.settings.accessControl:grant-required-ssn',
+                      defaultMessage: 'Skylda er að fylla út kennitölu',
+                    }),
                   },
-                },
+                  validate: {
+                    value: (value: number) => {
+                      if (!kennitala.isValid(value)) {
+                        return formatMessage({
+                          id:
+                            'service.portal.settings.accessControl:grant-invalid-ssn',
+                          defaultMessage: 'Kennitalan er ekki gild kennitala',
+                        })
+                      }
+                    },
+                  },
+                } as ValidationRules
+              }
+              type="tel"
+              format="######-####"
+              label={formatMessage({
+                id: 'global:nationalId',
+                defaultMessage: 'Kennitala',
+              })}
+              placeholder={formatMessage({
+                id: 'global:nationalId',
+                defaultMessage: 'Kennitala',
+              })}
+              onChange={(value) => {
+                requestDelegation(value)
               }}
-              render={({ onChange, value, name }) => (
-                <Input
-                  name={name}
-                  type="number"
-                  label={formatMessage({
-                    id: 'global:nationalId',
-                    defaultMessage: 'Kennitala',
-                  })}
-                  placeholder={formatMessage({
-                    id: 'global:nationalId',
-                    defaultMessage: 'Kennitala',
-                  })}
-                  value={value}
-                  hasError={errors.toNationalId}
-                  errorMessage={errors.toNationalId?.message}
-                  onChange={(value) => {
-                    onChange(value)
-                    requestDelegation(value)
-                  }}
-                />
-              )}
             />
           </GridColumn>
           <GridColumn paddingBottom={2} span={['12/12', '12/12', '6/12']}>

--- a/libs/service-portal/settings/access-control/src/screens/GrantAccess/GrantAccess.tsx
+++ b/libs/service-portal/settings/access-control/src/screens/GrantAccess/GrantAccess.tsx
@@ -61,9 +61,10 @@ function GrantAccess() {
   ) => {
     const value = e.target.value.replace('-', '').trim()
     if (value.length === 10 && kennitala.isValid(value)) {
-      getIdentity({ variables: { input: { nationalId: value } } })
-      if (identity?.nationalId === value) {
-        setValue('name', identity.name)
+      if (kennitala.isCompany(value)) {
+        setValue('name', value)
+      } else {
+        getIdentity({ variables: { input: { nationalId: value } } })
       }
     } else {
       setValue('name', '')

--- a/libs/service-portal/settings/access-control/src/screens/GrantAccess/GrantAccess.tsx
+++ b/libs/service-portal/settings/access-control/src/screens/GrantAccess/GrantAccess.tsx
@@ -43,7 +43,7 @@ const IdentityQuery = gql`
 `
 
 function GrantAccess() {
-  const { handleSubmit, control, errors, setValue } = useForm()
+  const { handleSubmit, control, errors, setValue, watch } = useForm()
   const [createAuthDelegation, { loading }] = useMutation<Mutation>(
     CreateAuthDelegationMutation,
     {
@@ -54,6 +54,7 @@ function GrantAccess() {
   const { identity } = data || {}
   const { formatMessage } = useLocale()
   const history = useHistory()
+  const watchToNationalId = watch('toNationalId')
 
   const requestDelegation = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
@@ -70,10 +71,10 @@ function GrantAccess() {
   }
 
   useEffect(() => {
-    if (identity) {
+    if (identity && identity.nationalId === watchToNationalId) {
       setValue('name', identity.name)
     }
-  }, [identity, setValue])
+  }, [identity, setValue, watchToNationalId])
 
   const onSubmit = handleSubmit(async ({ toNationalId, name }) => {
     try {

--- a/libs/shared/form-fields/src/lib/InputController/InputController.tsx
+++ b/libs/shared/form-fields/src/lib/InputController/InputController.tsx
@@ -1,12 +1,14 @@
 import React, { FC } from 'react'
 import { Input, InputBackgroundColor } from '@island.is/island-ui/core'
-import { Controller } from 'react-hook-form'
+import { Controller, Control, ValidationRules } from 'react-hook-form'
 import NumberFormat, { FormatInputValueFunction } from 'react-number-format'
 
 interface Props {
   autoFocus?: boolean
   defaultValue?: string
   disabled?: boolean
+  control?: Control
+  rules?: ValidationRules
   error?: string
   id: string
   label?: string
@@ -41,6 +43,8 @@ export const InputController: FC<Props> = ({
   label,
   name = id,
   placeholder,
+  control,
+  rules,
   backgroundColor,
   textarea,
   currency,
@@ -165,6 +169,8 @@ export const InputController: FC<Props> = ({
   return (
     <Controller
       name={name}
+      control={control}
+      rules={rules}
       {...(defaultValue !== undefined && { defaultValue })}
       render={renderChildInput}
     />


### PR DESCRIPTION
# Use Identity type instead of from / to for delegations

## What

Use Identity type instead of from / to for delegations

## Why

From* and To* name should be readonly and should just come from rsk or national-registry

## Screenshots / Gifs

![identity](https://user-images.githubusercontent.com/5694851/124131096-fe249480-da6e-11eb-90f1-632ecb11678f.gif)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
