### PR TITLE
fix: infrastructure settings missing for cross-namespace comms

### DIFF
--- a/apps/services/endorsements/api/infra/endorsement-system-api.ts
+++ b/apps/services/endorsements/api/infra/endorsement-system-api.ts
@@ -35,6 +35,6 @@ export const serviceSetup = (services: {
       SOFFIA_USER: settings.SOFFIA_USER,
       SOFFIA_PASS: settings.SOFFIA_PASS,
     })
-    .grantNamespaces('islandis')
+    .grantNamespaces('islandis', 'application-system')
     .liveness('/liveness')
     .readiness('/liveness')

--- a/apps/services/party-letter-registry-api/infra/party-letter-registry-api.ts
+++ b/apps/services/party-letter-registry-api/infra/party-letter-registry-api.ts
@@ -21,6 +21,6 @@ export const serviceSetup = (): ServiceBuilder<'party-letter-registry-api'> =>
       ],
       postgres: postgresInfo,
     })
-    .grantNamespaces('islandis')
+    .grantNamespaces('islandis', 'application-system')
     .liveness('/liveness')
     .readiness('/liveness')

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -386,6 +386,7 @@ endorsement-system-api:
       http://web-temporary-voter-registry-api.temporary-voter-registry.svc.cluster.local
   grantNamespaces:
     - islandis
+    - application-system
   grantNamespacesEnabled: true
   healthCheck:
     liveness:
@@ -541,6 +542,7 @@ party-letter-registry-api:
     DB_USER: services_party_letter_registry_api
   grantNamespaces:
     - islandis
+    - application-system
   grantNamespacesEnabled: true
   healthCheck:
     liveness:

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -378,6 +378,7 @@ endorsement-system-api:
       http://web-temporary-voter-registry-api.temporary-voter-registry.svc.cluster.local
   grantNamespaces:
     - islandis
+    - application-system
   grantNamespacesEnabled: true
   healthCheck:
     liveness:
@@ -526,6 +527,7 @@ party-letter-registry-api:
     DB_USER: services_party_letter_registry_api
   grantNamespaces:
     - islandis
+    - application-system
   grantNamespacesEnabled: true
   healthCheck:
     liveness:

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -376,6 +376,7 @@ endorsement-system-api:
       http://web-temporary-voter-registry-api.temporary-voter-registry.svc.cluster.local
   grantNamespaces:
     - islandis
+    - application-system
   grantNamespacesEnabled: true
   healthCheck:
     liveness:
@@ -525,6 +526,7 @@ party-letter-registry-api:
     DB_USER: services_party_letter_registry_api
   grantNamespaces:
     - islandis
+    - application-system
   grantNamespacesEnabled: true
   healthCheck:
     liveness:


### PR DESCRIPTION
Fix we already applied on release/9.2.0