### PR TITLE
chore(core): Adding resolution for dicer to version 0.3.0 (#4403)

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -3,7 +3,8 @@
     "workspace.json": "*",
     "package.json": {
       "dependencies": "*",
-      "devDependencies": "*"
+      "devDependencies": "*",
+      "resolutions": "*"
     },
     "nx.json": "*",
     "tsconfig.base.json": "*"

--- a/package.json
+++ b/package.json
@@ -446,6 +446,7 @@
     "css-what": "5.0.1",
     "glob-parent": "5.1.2",
     "trim-newlines": "3.0.1",
-    "normalize-url": "4.5.1"
+    "normalize-url": "4.5.1",
+    "dicer": "0.3.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11858,15 +11858,7 @@ dfa@^1.2.0:
   resolved "https://registry.yarnpkg.com/dfa/-/dfa-1.2.0.tgz#96ac3204e2d29c49ea5b57af8d92c2ae12790657"
   integrity sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==
 
-dicer@0.2.5:
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/dicer/-/dicer-0.2.5.tgz#5996c086bb33218c812c090bddc09cd12facb70f"
-  integrity sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=
-  dependencies:
-    readable-stream "1.1.x"
-    streamsearch "0.1.2"
-
-dicer@0.3.0:
+dicer@0.2.5, dicer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/dicer/-/dicer-0.3.0.tgz#eacd98b3bfbf92e8ab5c2fdb71aaac44bb06b872"
   integrity sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==


### PR DESCRIPTION
* Adding resolution for dicer to version 0.3.0, solving the deprecated buffer warning.

* Adding resolutions to nx.json to trigger affacted change.