### PR TITLE
chore(application-system,service-portal): remove non used dev config

### DIFF
--- a/apps/application-system/api/webpack.config.js
+++ b/apps/application-system/api/webpack.config.js
@@ -7,9 +7,5 @@ module.exports = (config) => {
   config.stats.chunks = false
   config.stats.modules = false
 
-  if (process.env.NODE_ENV === 'development') {
-    config.devServer.noInfo = true
-  }
-
   return config
 }

--- a/apps/application-system/form/webpack.config.js
+++ b/apps/application-system/form/webpack.config.js
@@ -9,10 +9,6 @@ module.exports = (config) => {
   config.stats.chunks = false
   config.stats.modules = false
 
-  if (process.env.NODE_ENV === 'development') {
-    config.devServer.noInfo = true
-  }
-
   return {
     ...config,
     node: {

--- a/apps/service-portal/webpack.config.js
+++ b/apps/service-portal/webpack.config.js
@@ -9,10 +9,6 @@ module.exports = (config) => {
   config.stats.chunks = false
   config.stats.modules = false
 
-  if (process.env.NODE_ENV === 'development') {
-    config.devServer.noInfo = true
-  }
-
   return {
     ...config,
     node: {


### PR DESCRIPTION
## What

- Not working when using `NODE_ENV=development`, I believe it can be safely removed