### PR TITLE
fix(crc): hide mock data section

### DIFF
--- a/libs/application/templates/family-matters/children-residence-change/src/forms/ChildrenResidenceChangeForm.ts
+++ b/libs/application/templates/family-matters/children-residence-change/src/forms/ChildrenResidenceChangeForm.ts
@@ -10,10 +10,7 @@ import {
   buildMultiField,
   buildSubmitField,
   DefaultEvents,
-  buildRadioField,
-  Comparators,
 } from '@island.is/application/core'
-import { isRunningOnEnvironment } from '@island.is/utils/shared'
 import { DataProviderTypes } from '@island.is/application/templates/children-residence-change'
 import Logo from '@island.is/application/templates/family-matters-core/assets/Logo'
 import { selectDurationInputs } from '../fields/Duration'
@@ -21,7 +18,6 @@ import { confirmContractIds } from '../fields/Overview'
 import { contactInfoIds } from '../fields/ContactInfo'
 import * as m from '../lib/messages'
 import { ExternalData } from '@island.is/application/templates/family-matters-core/types'
-import { Answers } from '../types'
 import { hasChildren } from '../lib/utils'
 
 const soleCustodyField = () => {
@@ -48,14 +44,17 @@ const noChildrenFoundField = () => {
   })
 }
 
-const shouldUseMocks = (answers: Answers): boolean => {
-  if (answers.useMocks && answers.useMocks === 'yes') {
-    return true
-  }
-  return false
-}
+// TODO: Added by Kolibri - 2021-07-05 - Revisit mockdata implementation to prevent
+// Continue and Back button from being displayed on production
 
-const shouldRenderMockDataSubSection = !isRunningOnEnvironment('production')
+// const shouldUseMocks = (answers: Answers): boolean => {
+//   if (answers.useMocks && answers.useMocks === 'yes') {
+//     return true
+//   }
+//   return false
+// }
+
+// const shouldRenderMockDataSubSection = !isRunningOnEnvironment('production')
 
 export const ChildrenResidenceChangeForm: Form = buildForm({
   id: 'ChildrenResidenceChangeFormDraft',
@@ -63,72 +62,72 @@ export const ChildrenResidenceChangeForm: Form = buildForm({
   logo: Logo,
   mode: FormModes.APPLYING,
   children: [
-    buildSection({
-      id: 'mockData',
-      title: 'Mock data',
-      condition: () => shouldRenderMockDataSubSection,
-      children: [
-        buildSubSection({
-          id: 'useMocks',
-          title: 'Nota gervigögn?',
-          children: [
-            buildRadioField({
-              id: 'useMocks',
-              title: 'Nota gervigögn',
-              options: [
-                {
-                  value: 'yes',
-                  label: 'Já',
-                },
-                {
-                  value: 'no',
-                  label: 'Nei',
-                },
-              ],
-            }),
-          ],
-        }),
-        buildSubSection({
-          id: 'applicantMock',
-          title: 'Umsækjandi',
-          condition: (answers) =>
-            shouldUseMocks((answers as unknown) as Answers),
-          children: [
-            buildCustomField({
-              id: 'mockData.applicant',
-              title: 'Mock Umsækjandi',
-              component: 'ApplicantMock',
-            }),
-          ],
-        }),
-        buildSubSection({
-          id: 'parentMock',
-          title: 'Foreldrar',
-          condition: (answers) =>
-            shouldUseMocks((answers as unknown) as Answers),
-          children: [
-            buildCustomField({
-              id: 'mockData.parents',
-              title: 'Mock Foreldrar',
-              component: 'ParentMock',
-            }),
-          ],
-        }),
-        buildSubSection({
-          id: 'childrenMock',
-          title: 'Börn',
-          condition: (answers) =>
-            shouldUseMocks((answers as unknown) as Answers),
-          children: [
-            buildCustomField({
-              id: 'mockData.children',
-              title: 'Mock Börn',
-              component: 'ChildrenMock',
-            }),
-          ],
-        }),
-      ],
-    }),
+    // buildSection({
+    //   id: 'mockData',
+    //   title: 'Mock data',
+    //   condition: () => shouldRenderMockDataSubSection,
+    //   children: [
+    //     buildSubSection({
+    //       id: 'useMocks',
+    //       title: 'Nota gervigögn?',
+    //       children: [
+    //         buildRadioField({
+    //           id: 'useMocks',
+    //           title: 'Nota gervigögn',
+    //           options: [
+    //             {
+    //               value: 'yes',
+    //               label: 'Já',
+    //             },
+    //             {
+    //               value: 'no',
+    //               label: 'Nei',
+    //             },
+    //           ],
+    //         }),
+    //       ],
+    //     }),
+    //     buildSubSection({
+    //       id: 'applicantMock',
+    //       title: 'Umsækjandi',
+    //       condition: (answers) =>
+    //         shouldUseMocks((answers as unknown) as Answers),
+    //       children: [
+    //         buildCustomField({
+    //           id: 'mockData.applicant',
+    //           title: 'Mock Umsækjandi',
+    //           component: 'ApplicantMock',
+    //         }),
+    //       ],
+    //     }),
+    //     buildSubSection({
+    //       id: 'parentMock',
+    //       title: 'Foreldrar',
+    //       condition: (answers) =>
+    //         shouldUseMocks((answers as unknown) as Answers),
+    //       children: [
+    //         buildCustomField({
+    //           id: 'mockData.parents',
+    //           title: 'Mock Foreldrar',
+    //           component: 'ParentMock',
+    //         }),
+    //       ],
+    //     }),
+    //     buildSubSection({
+    //       id: 'childrenMock',
+    //       title: 'Börn',
+    //       condition: (answers) =>
+    //         shouldUseMocks((answers as unknown) as Answers),
+    //       children: [
+    //         buildCustomField({
+    //           id: 'mockData.children',
+    //           title: 'Mock Börn',
+    //           component: 'ChildrenMock',
+    //         }),
+    //       ],
+    //     }),
+    //   ],
+    // }),
     buildSection({
       id: 'backgroundInformation',
       title: m.section.backgroundInformation,
@@ -136,8 +135,8 @@ export const ChildrenResidenceChangeForm: Form = buildForm({
         buildSubSection({
           id: 'externalData',
           title: m.externalData.general.sectionTitle,
-          condition: (answers) =>
-            !shouldUseMocks((answers as unknown) as Answers),
+          // condition: (answers) =>
+          //   !shouldUseMocks((answers as unknown) as Answers),
           children: [
             buildExternalDataProvider({
               title: m.externalData.general.pageTitle,
@@ -170,43 +169,43 @@ export const ChildrenResidenceChangeForm: Form = buildForm({
             soleCustodyField(),
           ],
         }),
-        buildSubSection({
-          id: 'externalData',
-          title: m.externalData.general.sectionTitle,
-          condition: (answers) =>
-            shouldUseMocks((answers as unknown) as Answers),
-          children: [
-            buildExternalDataProvider({
-              title: m.externalData.general.pageTitle,
-              id: 'approveExternalData',
-              subTitle: m.externalData.general.subTitle,
-              description: m.externalData.general.description,
-              checkboxLabel: m.externalData.general.checkboxLabel,
-              dataProviders: [
-                buildDataProviderItem({
-                  id: 'nationalRegistry',
-                  type: DataProviderTypes.MockNationalRegistry,
-                  title: m.externalData.applicant.title,
-                  subTitle: m.externalData.applicant.subTitle,
-                }),
-                buildDataProviderItem({
-                  id: '',
-                  type: '',
-                  title: m.externalData.children.title,
-                  subTitle: m.externalData.children.subTitle,
-                }),
-                buildDataProviderItem({
-                  id: 'userProfile',
-                  type: DataProviderTypes.UserProfile,
-                  title: '',
-                  subTitle: '',
-                }),
-              ],
-            }),
-            noChildrenFoundField(),
-            soleCustodyField(),
-          ],
-        }),
+        // buildSubSection({
+        //   id: 'externalData',
+        //   title: m.externalData.general.sectionTitle,
+        //   condition: (answers) =>
+        //     shouldUseMocks((answers as unknown) as Answers),
+        //   children: [
+        //     buildExternalDataProvider({
+        //       title: m.externalData.general.pageTitle,
+        //       id: 'approveExternalData',
+        //       subTitle: m.externalData.general.subTitle,
+        //       description: m.externalData.general.description,
+        //       checkboxLabel: m.externalData.general.checkboxLabel,
+        //       dataProviders: [
+        //         buildDataProviderItem({
+        //           id: 'nationalRegistry',
+        //           type: DataProviderTypes.MockNationalRegistry,
+        //           title: m.externalData.applicant.title,
+        //           subTitle: m.externalData.applicant.subTitle,
+        //         }),
+        //         buildDataProviderItem({
+        //           id: '',
+        //           type: '',
+        //           title: m.externalData.children.title,
+        //           subTitle: m.externalData.children.subTitle,
+        //         }),
+        //         buildDataProviderItem({
+        //           id: 'userProfile',
+        //           type: DataProviderTypes.UserProfile,
+        //           title: '',
+        //           subTitle: '',
+        //         }),
+        //       ],
+        //     }),
+        //     noChildrenFoundField(),
+        //     soleCustodyField(),
+        //   ],
+        // }),
         buildSubSection({
           id: 'selectChildInCustody',
           title: m.selectChildren.general.sectionTitle,


### PR DESCRIPTION
Hotfix hiding mock data section so we don't display the `Continue` and `Back` buttons in places where they shouldn't be present.