### PR TITLE
fix(web): Add OG image and description to project pages

### DIFF
--- a/apps/web/screens/Project/Project.tsx
+++ b/apps/web/screens/Project/Project.tsx
@@ -21,8 +21,8 @@ import {
   Section,
   Stepper,
   EntryProjectHeader,
+  HeadWithSocialSharing,
 } from '@island.is/web/components'
-import Head from 'next/head'
 import {
   GridColumn,
   GridContainer,
@@ -99,9 +99,14 @@ const ProjectPage: Screen<PageProps> = ({ projectPage, news, namespace }) => {
 
   return (
     <>
-      <Head>
-        <title>{projectPage.title} | Ísland.is</title>
-      </Head>
+      <HeadWithSocialSharing
+        title={`${projectPage.title} | Ísland.is`}
+        description={projectPage.intro}
+        imageUrl={projectPage.featuredImage?.url}
+        imageContentType={projectPage.featuredImage?.contentType}
+        imageWidth={projectPage.featuredImage?.width?.toString()}
+        imageHeight={projectPage.featuredImage?.height?.toString()}
+      />
       <ProjectHeader projectPage={projectPage} />
       <ProjectWrapper
         withSidebar={projectPage.sidebar}

--- a/apps/web/screens/queries/Project.tsx
+++ b/apps/web/screens/queries/Project.tsx
@@ -50,6 +50,12 @@ export const GET_PROJECT_PAGE_QUERY = gql`
           ...AllSlices
         }
       }
+      featuredImage {
+        url
+        contentType
+        width
+        height
+      }
     }
   }
   ${slices}

--- a/libs/api/domains/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/api/domains/cms/src/lib/generated/contentfulTypes.d.ts
@@ -2390,6 +2390,9 @@ export interface IProjectPageFields {
 
   /** Project Subpages */
   projectSubpages?: IProjectSubpage[] | undefined
+
+  /** Featured Image */
+  featuredImage?: Asset | undefined
 }
 
 export interface IProjectPage extends Entry<IProjectPageFields> {

--- a/libs/api/domains/cms/src/lib/models/projectPage.model.ts
+++ b/libs/api/domains/cms/src/lib/models/projectPage.model.ts
@@ -10,6 +10,7 @@ import { GenericTag, mapGenericTag } from './genericTag.model'
 import { Link, mapLink } from './link.model'
 import { mapProjectSubpage, ProjectSubpage } from './projectSubpage.model'
 import { mapStepper, Stepper } from './stepper.model'
+import { mapImage, Image } from './image.model'
 
 @ObjectType()
 export class ProjectPage {
@@ -51,6 +52,9 @@ export class ProjectPage {
 
   @Field(() => [ProjectSubpage])
   projectSubpages!: Array<ProjectSubpage>
+
+  @Field(() => Image, { nullable: true })
+  featuredImage!: Image | null
 }
 
 export const mapProjectPage = ({ sys, fields }: IProjectPage): ProjectPage => ({
@@ -69,4 +73,5 @@ export const mapProjectPage = ({ sys, fields }: IProjectPage): ProjectPage => ({
   slices: (fields.slices ?? []).map(safelyMapSliceUnion),
   newsTag: fields.newsTag ? mapGenericTag(fields.newsTag) : null,
   projectSubpages: (fields.projectSubpages ?? []).map(mapProjectSubpage),
+  featuredImage: fields.featuredImage ? mapImage(fields.featuredImage) : null,
 })


### PR DESCRIPTION
# Add OG image and description to project pages

## What

Add OG image and description to project pages for sharing on social media.

## Why

People want to use it for island.is/entry

## Screenshots / Gifs

![Screenshot from 2021-07-07 18-38-17](https://user-images.githubusercontent.com/3607456/124812023-a4cad280-df52-11eb-89ea-6c3546c98207.png)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
