### PR TITLE
fix(auth): hide loading indicator if delegation request fails

### DIFF
--- a/apps/service-portal/src/components/UserDelegations/UserDelegations.tsx
+++ b/apps/service-portal/src/components/UserDelegations/UserDelegations.tsx
@@ -21,12 +21,12 @@ interface Delegation {
 export const UserDelegations = ({ onSwitch }: UserDelegationsProps) => {
   const { formatMessage } = useLocale()
   const { userInfo, switchUser } = useAuth()
-  const { data } = useActorDelegationsQuery()
+  const { data, error, loading } = useActorDelegationsQuery()
   const currentNationalId = userInfo?.profile.nationalId as string
   const actor = userInfo?.profile.actor
 
-  // Loading or no delegations.
-  if (!data || data.authActorDelegations.length === 0) {
+  // Loading.
+  if (loading) {
     return (
       <Stack space={1}>
         <Text variant="h5" as="h5" marginBottom={1}>
@@ -38,6 +38,11 @@ export const UserDelegations = ({ onSwitch }: UserDelegationsProps) => {
         <SkeletonLoader display="block" height={59} borderRadius="large" />
       </Stack>
     )
+  }
+
+  // Error or no data.
+  if (error || !data || data.authActorDelegations.length === 0) {
+    return null
   }
 
   let delegations: Delegation[] = data.authActorDelegations.map(


### PR DESCRIPTION
## What

Hide loading indicator if delegation request fails.

## Why

The loading indicator would be forever visible if the request fails.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] ~I have made corresponding changes to the documentation~
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
