### PR TITLE
fix(web): Fix padding on event slice with client-side render

### DIFF
--- a/apps/web/components/Organization/Slice/EventSlice/EventSlice.treat.ts
+++ b/apps/web/components/Organization/Slice/EventSlice/EventSlice.treat.ts
@@ -1,7 +1,7 @@
 import { style } from 'treat'
 
 export const wrapper = style({
-  padding: '50px 40px 30px 40px',
+  padding: '50px 40px 30px 40px !important',
   backgroundSize: 'cover !important',
   backgroundPositionY: 'center !important',
 })


### PR DESCRIPTION
# Fix padding on event slice with client-side render
## What

The event slice doesn't get the right padding when client side rendered as the CSS is ordered differently. Very annoying.

## Screenshots / Gifs

Should not look like this.

![image](https://user-images.githubusercontent.com/3607456/124935895-984b8600-dff5-11eb-8436-48b3c1d68e34.png)
