### PR TITLE
fix(parental-leave): Send an empty true date of birth

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/parental-leave.utils.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/parental-leave.utils.ts
@@ -230,7 +230,7 @@ export const transformApplicationToParentalLeaveDTO = (
     expectedDateOfBirth: selectedChild.expectedDateOfBirth,
     // TODO: get true date of birth, not expected
     // will get it from a new Þjóðskrá API (returns children in custody of a national registry id)
-    dateOfBirth: selectedChild.expectedDateOfBirth,
+    dateOfBirth: '',
     email,
     phoneNumber,
     paymentInfo: {

--- a/libs/clients/vmst/src/clientConfig.yaml
+++ b/libs/clients/vmst/src/clientConfig.yaml
@@ -316,7 +316,6 @@ components:
         - applicationId
         - applicant
         - expectedDateOfBirth
-        - dateOfBirth
         - email
         - phoneNumber
         - paymentInfo
@@ -340,7 +339,6 @@ components:
           minLength: 1
         dateOfBirth:
           type: string
-          minLength: 1
         email:
           type: string
           minLength: 1
@@ -491,8 +489,8 @@ components:
           type: integer
           format: int32
         transferableMonths:
-          type: integer
-          format: int32
+          type: number
+          format: float
     EstimatedPaymentPlan:
       type: object
       additionalProperties: false


### PR DESCRIPTION
## What

The API only supports `dateOfBirth` when children have been born. We do not have this data at the moment and will revist when we do.

Will revisit this field in another PR where integrating custody API from Þjóðskrá as well as connecting estimated dates of birth to national registry ids of born children.

## Why

So that we do not get an error when sending applications for unborn children.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
