### PR TITLE
feat(api): Use natreg over x-road in identity domain

### DIFF
--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -70,11 +70,11 @@ const autoSchemaFile = environment.production
     }),
     AuthDomainModule.register({
       identity: {
-        nationalRegistry: {
-          baseSoapUrl: environment.nationalRegistry.baseSoapUrl,
-          user: environment.nationalRegistry.user,
-          password: environment.nationalRegistry.password,
-          host: environment.nationalRegistry.host,
+        nationalRegistryXRoad: {
+          xRoadBasePathWithEnv: environment.nationalRegistryXRoad.url,
+          xRoadTjodskraMemberCode: environment.nationalRegistryXRoad.memberCode,
+          xRoadTjodskraApiPath: environment.nationalRegistryXRoad.apiPath,
+          xRoadClientId: environment.nationalRegistryXRoad.clientId,
         },
       },
       authPublicApi: environment.authPublicApi,
@@ -165,11 +165,11 @@ const autoSchemaFile = environment.production
     CommunicationsModule,
     ApiCatalogueModule,
     IdentityModule.register({
-      nationalRegistry: {
-        baseSoapUrl: environment.nationalRegistry.baseSoapUrl,
-        user: environment.nationalRegistry.user,
-        password: environment.nationalRegistry.password,
-        host: environment.nationalRegistry.host,
+      nationalRegistryXRoad: {
+        xRoadBasePathWithEnv: environment.nationalRegistryXRoad.url,
+        xRoadTjodskraMemberCode: environment.nationalRegistryXRoad.memberCode,
+        xRoadTjodskraApiPath: environment.nationalRegistryXRoad.apiPath,
+        xRoadClientId: environment.nationalRegistryXRoad.clientId,
       },
     }),
     AuthModule.register(environment.auth),

--- a/libs/api/domains/auth/src/lib/resolvers/delegation.resolver.ts
+++ b/libs/api/domains/auth/src/lib/resolvers/delegation.resolver.ts
@@ -110,7 +110,10 @@ export class DelegationResolver {
   }
 
   @ResolveField('to', () => Identity)
-  resolveTo(@Parent() delegation: DelegationDTO, @CurrentUser() user: User): Promise<Identity | null> {
+  resolveTo(
+    @Parent() delegation: DelegationDTO,
+    @CurrentUser() user: User,
+  ): Promise<Identity | null> {
     if (kennitala.isCompany(delegation.toNationalId)) {
       // XXX: temp until rsk gets implemented
       return Promise.resolve({
@@ -123,7 +126,10 @@ export class DelegationResolver {
   }
 
   @ResolveField('from', () => Identity)
-  resolveFrom(@Parent() delegation: DelegationDTO, @CurrentUser() user: User): Promise<Identity | null> {
+  resolveFrom(
+    @Parent() delegation: DelegationDTO,
+    @CurrentUser() user: User,
+  ): Promise<Identity | null> {
     if (kennitala.isCompany(delegation.fromNationalId)) {
       // XXX: temp until rsk gets implemented
       return Promise.resolve({

--- a/libs/api/domains/auth/src/lib/resolvers/delegation.resolver.ts
+++ b/libs/api/domains/auth/src/lib/resolvers/delegation.resolver.ts
@@ -110,7 +110,7 @@ export class DelegationResolver {
   }
 
   @ResolveField('to', () => Identity)
-  resolveTo(@Parent() delegation: DelegationDTO): Promise<Identity | null> {
+  resolveTo(@Parent() delegation: DelegationDTO, @CurrentUser() user: User): Promise<Identity | null> {
     if (kennitala.isCompany(delegation.toNationalId)) {
       // XXX: temp until rsk gets implemented
       return Promise.resolve({
@@ -119,11 +119,11 @@ export class DelegationResolver {
         type: 'company',
       } as Identity)
     }
-    return this.identityService.getIdentity(delegation.toNationalId)
+    return this.identityService.getIdentity(delegation.toNationalId, user)
   }
 
   @ResolveField('from', () => Identity)
-  resolveFrom(@Parent() delegation: DelegationDTO): Promise<Identity | null> {
+  resolveFrom(@Parent() delegation: DelegationDTO, @CurrentUser() user: User): Promise<Identity | null> {
     if (kennitala.isCompany(delegation.fromNationalId)) {
       // XXX: temp until rsk gets implemented
       return Promise.resolve({
@@ -132,6 +132,6 @@ export class DelegationResolver {
         type: 'company',
       } as Identity)
     }
-    return this.identityService.getIdentity(delegation.fromNationalId)
+    return this.identityService.getIdentity(delegation.fromNationalId, user)
   }
 }

--- a/libs/api/domains/auth/src/lib/resolvers/delegation.resolver.ts
+++ b/libs/api/domains/auth/src/lib/resolvers/delegation.resolver.ts
@@ -36,9 +36,7 @@ const ignore404 = (e: Response) => {
 }
 
 @UseGuards(IdsUserGuard)
-@Resolver(() => CustomDelegation)
-@Resolver(() => LegalGuardianDelegation)
-@Resolver(() => ProcuringHolderDelegation)
+@Resolver(() => Delegation)
 export class DelegationResolver {
   constructor(
     private authService: AuthService,

--- a/libs/api/domains/identity/src/lib/identity.module.ts
+++ b/libs/api/domains/identity/src/lib/identity.module.ts
@@ -1,13 +1,15 @@
 import { Module, DynamicModule } from '@nestjs/common'
 
-import { NationalRegistryModule } from '@island.is/api/domains/national-registry'
-import { NationalRegistryConfig } from '@island.is/clients/national-registry-v1'
+import {
+  NationalRegistryXRoadConfig,
+  NationalRegistryXRoadModule,
+} from '@island.is/api/domains/national-registry-x-road'
 
 import { IdentityResolver } from './identity.resolver'
 import { IdentityService } from './identity.service'
 
 export type Config = {
-  nationalRegistry: NationalRegistryConfig
+  nationalRegistryXRoad: NationalRegistryXRoadConfig
 }
 
 @Module({})
@@ -16,9 +18,7 @@ export class IdentityModule {
     return {
       module: IdentityModule,
       imports: [
-        NationalRegistryModule.register({
-          nationalRegistry: config.nationalRegistry,
-        }),
+        NationalRegistryXRoadModule.register(config.nationalRegistryXRoad),
       ],
       providers: [IdentityResolver, IdentityService],
       exports: [IdentityService],

--- a/libs/api/domains/identity/src/lib/identity.resolver.ts
+++ b/libs/api/domains/identity/src/lib/identity.resolver.ts
@@ -14,8 +14,7 @@ import { IdentityService } from './identity.service'
 import { Identity, IdentityPerson, IdentityCompany } from './models'
 
 @UseGuards(IdsUserGuard)
-@Resolver(() => IdentityPerson)
-@Resolver(() => IdentityCompany)
+@Resolver(() => Identity)
 export class IdentityResolver {
   constructor(private identityService: IdentityService) {}
 

--- a/libs/api/domains/identity/src/lib/identity.resolver.ts
+++ b/libs/api/domains/identity/src/lib/identity.resolver.ts
@@ -25,7 +25,7 @@ export class IdentityResolver {
     @Args('input', { nullable: true }) input: IdentityInput,
   ): Promise<Identity | null> {
     const nationalId = input?.nationalId || user.nationalId
-    return this.identityService.getIdentity(nationalId)
+    return this.identityService.getIdentity(nationalId, user)
   }
 
   @ResolveField('name', () => String)

--- a/libs/api/domains/identity/src/lib/identity.resolver.ts
+++ b/libs/api/domains/identity/src/lib/identity.resolver.ts
@@ -27,13 +27,4 @@ export class IdentityResolver {
     const nationalId = input?.nationalId || user.nationalId
     return this.identityService.getIdentity(nationalId, user)
   }
-
-  @ResolveField('name', () => String)
-  resolveName(@Parent() identity: Identity & NationalRegistryUser): string {
-    if (identity.type === IdentityType.Person) {
-      return identity.fullName
-    }
-    // TODO: need to handle companies
-    return 'unknown'
-  }
 }

--- a/libs/api/domains/identity/src/lib/identity.service.ts
+++ b/libs/api/domains/identity/src/lib/identity.service.ts
@@ -1,26 +1,35 @@
 import { Injectable } from '@nestjs/common'
 import * as kennitala from 'kennitala'
 
-import {
-  NationalRegistryService,
-  NationalRegistryUser,
-} from '@island.is/api/domains/national-registry'
+import { User } from '@island.is/auth-nest-tools'
+import { NationalRegistryXRoadService } from '@island.is/api/domains/national-registry-x-road'
 
 import { IdentityType } from './identity.type'
 import { Identity } from './models'
 
 @Injectable()
 export class IdentityService {
-  constructor(private nationalRegistryService: NationalRegistryService) {}
+  constructor(
+    private nationalRegistryXRoadService: NationalRegistryXRoadService,
+  ) {}
 
-  async getIdentity(nationalId: string): Promise<Identity | null> {
+  async getIdentity(nationalId: string, user: User): Promise<Identity | null> {
     if (kennitala.isCompany(nationalId)) {
       return null
     }
 
-    const person = await this.nationalRegistryService.getUser(nationalId)
+    const person = await this.nationalRegistryXRoadService.getNationalRegistryPerson(
+      nationalId,
+      user.authorization,
+    )
     return {
-      ...person,
+      nationalId: person.nationalId,
+      name: person.fullName,
+      address: person.address && {
+        streetAddress: person.address.streetName,
+        postalCode: person.address.postalCode,
+        city: person.address.city,
+      },
       type: IdentityType.Person,
     } as Identity
   }

--- a/libs/api/domains/national-registry-x-road/src/index.ts
+++ b/libs/api/domains/national-registry-x-road/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/nationalRegistryXRoad.module'
+export * from './lib/nationalRegistryXRoad.service'

--- a/libs/api/domains/national-registry-x-road/src/lib/nationalRegistryXRoad.module.ts
+++ b/libs/api/domains/national-registry-x-road/src/lib/nationalRegistryXRoad.module.ts
@@ -40,7 +40,7 @@ export class NationalRegistryXRoadModule {
           xRoadClient: config.xRoadClientId,
         }),
       ],
-      exports: [],
+      exports: [NationalRegistryXRoadService],
     }
   }
 }


### PR DESCRIPTION
## What

Move identity domain to use the new national registry service over x-road. 

## Why

This is to embrace the future and provide consistent delegations in all our environments.

Delegation API requests would call both the old Natreg API and the new Natreg API (in different layers). But the two api's have quite different data on dev, causing a lot of issues.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] ~I have made corresponding changes to the documentation~
- [x] ~My changes generate no new warnings~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
