### PR TITLE
fix: Schema generation more reliable

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -26,13 +26,15 @@
           "schemas/openapi-generator",
           "schemas/build-graphql-schema",
           "schemas/codegen"
-        ]
+        ],
+        "cacheDirectory": ".cache/nx"
       }
     },
     "docker-test": {
       "runner": "@nrwl/workspace/tasks-runners/default",
       "options": {
-        "cacheableOperations": []
+        "cacheableOperations": [],
+        "cacheDirectory": ".cache/nx"
       }
     }
   },

--- a/scripts/schemas.js
+++ b/scripts/schemas.js
@@ -40,9 +40,12 @@ const main = async () => {
 
     try {
       await exec(
-        `nx run-many --target=${target} --all --with-deps --parallel --maxParallel=6 ${
-          skipCache ? '--skip-nx-cache' : ''
-        }`,
+        `nx run-many --target=${target} --all --with-deps --parallel --maxParallel=6 $NX_OPTIONS`,
+        {
+          env: skipCache
+            ? { ...process.env, NX_OPTIONS: '--skip-nx-cache' }
+            : process.env,
+        },
       )
     } catch (err) {
       console.error(`Error running command: ${err.message}`)

--- a/workspace.json
+++ b/workspace.json
@@ -2455,9 +2455,9 @@
           "builder": "@nrwl/workspace:run-commands",
           "options": {
             "commands": [
-              "nx run services-endorsements-api:schemas/external-openapi-generator",
-              "nx run services-endorsements-api:schemas/build-openapi",
-              "nx run application-templates-party-application:schemas/openapi-generator"
+              "nx run services-endorsements-api:schemas/external-openapi-generator $NX_OPTIONS",
+              "nx run services-endorsements-api:schemas/build-openapi $NX_OPTIONS",
+              "nx run application-templates-party-application:schemas/openapi-generator $NX_OPTIONS"
             ],
             "parallel": false
           }
@@ -2514,10 +2514,10 @@
           "builder": "@nrwl/workspace:run-commands",
           "options": {
             "commands": [
-              "nx run services-endorsements-api:schemas/external-openapi-generator",
-              "nx run services-endorsements-api:schemas/build-openapi",
-              "nx run services-party-letter-registry-api:schemas/build-openapi",
-              "nx run application-templates-party-letter:schemas/openapi-generator"
+              "nx run services-endorsements-api:schemas/external-openapi-generator $NX_OPTIONS",
+              "nx run services-endorsements-api:schemas/build-openapi $NX_OPTIONS",
+              "nx run services-party-letter-registry-api:schemas/build-openapi $NX_OPTIONS",
+              "nx run application-templates-party-letter:schemas/openapi-generator $NX_OPTIONS"
             ],
             "parallel": false
           }
@@ -7225,8 +7225,8 @@
           "builder": "@nrwl/workspace:run-commands",
           "options": {
             "commands": [
-              "nx run services-temporary-voter-registry-api:schemas/build-openapi",
-              "nx run services-endorsements-api:schemas/openapi-generator"
+              "nx run services-temporary-voter-registry-api:schemas/build-openapi $NX_OPTIONS",
+              "nx run services-endorsements-api:schemas/openapi-generator $NX_OPTIONS"
             ],
             "parallel": false
           }


### PR DESCRIPTION

Fixes #4533 

## What

Schema generation was sometimes failing unpredictably which I think was a combination of two things which are fixed with this PR:
  * Default NX cache is stored under `node_modules/.cache` which gets stored in the GitHub Actions cache as part of the node_modules cache we create
  * The flag `--skip-nx-cache` was not propagated in nested `nx run ...` executions
I suspect these two things in combination created situations where parts of the schema were retrieved from a cache where they should have been generated.

## Why

Consistent, clean schema generation.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
