### PR TITLE
fix: Updated the LinkResolver to prepend '/s' to the aboutPage type

### DIFF
--- a/apps/web/hooks/useLinkResolver/useLinkResolver.ts
+++ b/apps/web/hooks/useLinkResolver/useLinkResolver.ts
@@ -30,7 +30,7 @@ Keys in routesTemplate should ideally match lowercased __typename of graphql api
 */
 export const routesTemplate = {
   aboutsubpage: {
-    is: '/stafraent-island/[slug]',
+    is: '/s/stafraent-island/[slug]',
     en: '',
   },
   page: {


### PR DESCRIPTION
## Why
The contact link on the frontpage got its resolved slug as `/stafraent-island/hafa-samband` from the linkResolver's `aboutPage` rule. A 404 redirect can't be written for `/stafraent-island/hafa-samband` in contentful since the page type is `aboutPage` and resolves back to itself.

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
