### PR TITLE
feat(ctao): Attachments in overview

### DIFF
--- a/libs/application/templates/complaints-to-althingi-ombudsman/src/fields/ComplaintOverview/ComplainedFor.tsx
+++ b/libs/application/templates/complaints-to-althingi-ombudsman/src/fields/ComplaintOverview/ComplainedFor.tsx
@@ -45,13 +45,13 @@ export const ComplainedFor: FC<Props> = ({
     {complainedForType === ComplainedForTypes.SOMEONEELSE && (
       <ReviewGroup>
         <GridRow>
-          <GridColumn span={'4/12'}>
+          <GridColumn span={['12/12', '12/12', '6/12']}>
             <ValueLine
               value={complainedFor.name}
               label={complainedForMessages.labels.name}
             />
           </GridColumn>
-          <GridColumn span={'6/12'}>
+          <GridColumn span={['12/12', '12/12', '6/12']}>
             <ValueLine
               value={complainedFor.ssn}
               label={complainedForMessages.labels.ssn}
@@ -59,13 +59,13 @@ export const ComplainedFor: FC<Props> = ({
           </GridColumn>
         </GridRow>
         <GridRow>
-          <GridColumn span={'4/12'}>
+          <GridColumn span={['12/12', '12/12', '6/12']}>
             <ValueLine
               value={complainedFor.address}
               label={complainedForMessages.labels.address}
             />
           </GridColumn>
-          <GridColumn span={'6/12'}>
+          <GridColumn span={['12/12', '12/12', '6/12']}>
             <ValueLine
               value={complainedFor.city}
               label={complainedForMessages.labels.city}
@@ -73,13 +73,13 @@ export const ComplainedFor: FC<Props> = ({
           </GridColumn>
         </GridRow>
         <GridRow>
-          <GridColumn span={'4/12'}>
+          <GridColumn span={['12/12', '12/12', '6/12']}>
             <ValueLine
               value={complainedFor.postcode}
               label={complainedForMessages.labels.postcode}
             />
           </GridColumn>
-          <GridColumn span={'6/12'}>
+          <GridColumn span={['12/12', '12/12', '6/12']}>
             <ValueLine
               value={complainedFor.phone}
               label={complainedForMessages.labels.phone}
@@ -87,7 +87,7 @@ export const ComplainedFor: FC<Props> = ({
           </GridColumn>
         </GridRow>
         <GridRow>
-          <GridColumn span={'4/12'}>
+          <GridColumn span={['12/12', '12/12', '6/12']}>
             <ValueLine
               value={complainedFor.email}
               label={complainedForMessages.labels.email}

--- a/libs/application/templates/complaints-to-althingi-ombudsman/src/fields/ComplaintOverview/ComplainedFor.tsx
+++ b/libs/application/templates/complaints-to-althingi-ombudsman/src/fields/ComplaintOverview/ComplainedFor.tsx
@@ -33,6 +33,12 @@ export const ComplainedFor: FC<Props> = ({
             label={complaintOverview.labels.complainedForConnection}
             value={connection}
           />
+          {complainedFor.powerOfAttorney && (
+            <ValueLine
+              label={complaintOverview.labels.powerOfAttorney}
+              value={complainedFor.powerOfAttorney.name}
+            />
+          )}
         </>
       )}
     </ReviewGroup>

--- a/libs/application/templates/complaints-to-althingi-ombudsman/src/fields/ComplaintOverview/ComplainedFor.tsx
+++ b/libs/application/templates/complaints-to-althingi-ombudsman/src/fields/ComplaintOverview/ComplainedFor.tsx
@@ -36,7 +36,9 @@ export const ComplainedFor: FC<Props> = ({
           {complainedFor.powerOfAttorney && (
             <ValueLine
               label={complaintOverview.labels.powerOfAttorney}
-              value={complainedFor.powerOfAttorney.name}
+              value={complainedFor.powerOfAttorney
+                ?.map((x) => x.name)
+                .join(', ')}
             />
           )}
         </>

--- a/libs/application/templates/complaints-to-althingi-ombudsman/src/fields/ComplaintOverview/Complainee.tsx
+++ b/libs/application/templates/complaints-to-althingi-ombudsman/src/fields/ComplaintOverview/Complainee.tsx
@@ -21,13 +21,13 @@ export const Complainee: FC<Props> = ({ type, name }) => {
   return (
     <ReviewGroup>
       <GridRow>
-        <GridColumn span={'4/12'}>
+        <GridColumn span={['12/12', '12/12', '6/12']}>
           <ValueLine
             label={complaintOverview.labels.complainee}
             value={complainee}
           />
         </GridColumn>
-        <GridColumn span={'6/12'}>
+        <GridColumn span={['12/12', '12/12', '6/12']}>
           <ValueLine
             label={complaintOverview.labels.complaineeName}
             value={name}

--- a/libs/application/templates/complaints-to-althingi-ombudsman/src/fields/ComplaintOverview/ComplaintOverview.tsx
+++ b/libs/application/templates/complaints-to-althingi-ombudsman/src/fields/ComplaintOverview/ComplaintOverview.tsx
@@ -75,7 +75,6 @@ export const ComplaintOverview: FC<FieldBaseProps> = ({ application }) => {
         />
       </ReviewGroup>
       <ReviewGroup isLast>
-        <Text variant="h5"></Text>
         <ValueLine
           label={complaintOverview.labels.attachments}
           value={attachmentsText}

--- a/libs/application/templates/complaints-to-althingi-ombudsman/src/fields/ComplaintOverview/ComplaintOverview.tsx
+++ b/libs/application/templates/complaints-to-althingi-ombudsman/src/fields/ComplaintOverview/ComplaintOverview.tsx
@@ -13,9 +13,9 @@ export const ComplaintOverview: FC<FieldBaseProps> = ({ application }) => {
   const answers = (application as any).answers as ComplaintsToAlthingiOmbudsman
   const { name, ssn, phone, email, address } = answers.information
   const attachmentsText =
-    answers.attachments.documents.length === 0
-      ? complaintOverview.general.noAttachments
-      : answers.attachments.documents.map((x) => x.name).join(', ')
+    answers.attachments.documents && answers.attachments.documents.length > 0
+      ? answers.attachments.documents?.map((x) => x.name).join(', ')
+      : complaintOverview.general.noAttachments
 
   return (
     <Box component="section" paddingTop={6}>

--- a/libs/application/templates/complaints-to-althingi-ombudsman/src/fields/ComplaintOverview/ComplaintOverview.tsx
+++ b/libs/application/templates/complaints-to-althingi-ombudsman/src/fields/ComplaintOverview/ComplaintOverview.tsx
@@ -17,7 +17,7 @@ export const ComplaintOverview: FC<FieldBaseProps> = ({ application }) => {
     <Box component="section" paddingTop={6}>
       <ReviewGroup>
         <GridRow>
-          <GridColumn span={'4/12'}>
+          <GridColumn span={['12/12', '12/12', '6/12']}>
             <ValueLine
               value={`${name}, ${ssn}, ${phone}, ${email}`}
               label={complaintOverview.labels.nationalRegistry}
@@ -27,13 +27,13 @@ export const ComplaintOverview: FC<FieldBaseProps> = ({ application }) => {
       </ReviewGroup>
       <ReviewGroup>
         <GridRow>
-          <GridColumn span={'4/12'}>
+          <GridColumn span={['12/12', '12/12', '6/12']}>
             <ValueLine
               value={name}
               label={information.aboutTheComplainer.name}
             />
           </GridColumn>
-          <GridColumn span={'6/12'}>
+          <GridColumn span={['12/12', '12/12', '6/12']}>
             <ValueLine
               value={address}
               label={information.aboutTheComplainer.address}
@@ -41,13 +41,13 @@ export const ComplaintOverview: FC<FieldBaseProps> = ({ application }) => {
           </GridColumn>
         </GridRow>
         <GridRow>
-          <GridColumn span={'4/12'}>
+          <GridColumn span={['12/12', '12/12', '6/12']}>
             <ValueLine
               value={phone}
               label={information.aboutTheComplainer.phone}
             />
           </GridColumn>
-          <GridColumn span={'6/12'}>
+          <GridColumn span={['12/12', '12/12', '6/12']}>
             <ValueLine
               value={email}
               label={information.aboutTheComplainer.email}

--- a/libs/application/templates/complaints-to-althingi-ombudsman/src/fields/ComplaintOverview/ComplaintOverview.tsx
+++ b/libs/application/templates/complaints-to-althingi-ombudsman/src/fields/ComplaintOverview/ComplaintOverview.tsx
@@ -71,11 +71,14 @@ export const ComplaintOverview: FC<FieldBaseProps> = ({ application }) => {
         />
       </ReviewGroup>
       <ReviewGroup isLast>
-        <Text variant="h5">Fylgiskjöl</Text>
+        <Text variant="h5"></Text>
+        <ValueLine
+          label={complaintOverview.labels.attachments}
+          value={
+            answers.attachments.documents?.map((x) => x.name).join(', ') ?? ''
+          }
+        />
       </ReviewGroup>
-      {/* 
-        6. Staðfesting og rafræn undirritun
-      */}
     </Box>
   )
 }

--- a/libs/application/templates/complaints-to-althingi-ombudsman/src/fields/ComplaintOverview/ComplaintOverview.tsx
+++ b/libs/application/templates/complaints-to-althingi-ombudsman/src/fields/ComplaintOverview/ComplaintOverview.tsx
@@ -12,6 +12,10 @@ import { yesNoMessageMapper } from '../../utils'
 export const ComplaintOverview: FC<FieldBaseProps> = ({ application }) => {
   const answers = (application as any).answers as ComplaintsToAlthingiOmbudsman
   const { name, ssn, phone, email, address } = answers.information
+  const attachmentsText =
+    answers.attachments.documents.length === 0
+      ? complaintOverview.general.noAttachments
+      : answers.attachments.documents.map((x) => x.name).join(', ')
 
   return (
     <Box component="section" paddingTop={6}>
@@ -74,9 +78,7 @@ export const ComplaintOverview: FC<FieldBaseProps> = ({ application }) => {
         <Text variant="h5"></Text>
         <ValueLine
           label={complaintOverview.labels.attachments}
-          value={
-            answers.attachments.documents?.map((x) => x.name).join(', ') ?? ''
-          }
+          value={attachmentsText}
         />
       </ReviewGroup>
     </Box>

--- a/libs/application/templates/complaints-to-althingi-ombudsman/src/forms/ComplaintsToAlthingiOmbudsmanApplication.ts
+++ b/libs/application/templates/complaints-to-althingi-ombudsman/src/forms/ComplaintsToAlthingiOmbudsmanApplication.ts
@@ -462,7 +462,7 @@ export const ComplaintsToAlthingiOmbudsmanApplication: Form = buildForm({
       title: section.attachments,
       children: [
         buildFileUploadField({
-          id: 'attachments.fileUpload',
+          id: 'attachments.documents',
           title: attachments.title,
           introduction: attachments.introduction,
           uploadHeader: attachments.uploadHeader,

--- a/libs/application/templates/complaints-to-althingi-ombudsman/src/lib/dataSchema.ts
+++ b/libs/application/templates/complaints-to-althingi-ombudsman/src/lib/dataSchema.ts
@@ -10,6 +10,12 @@ import {
 } from '../shared'
 import { error } from './messages/error'
 
+const FileSchema = z.object({
+  name: z.string(),
+  key: z.string(),
+  url: z.string().optional(),
+})
+
 export const ComplaintsToAlthingiOmbudsmanSchema = z.object({
   approveExternalData: z.boolean().refine((v) => v, { params: error.required }),
   information: z.object({
@@ -58,6 +64,7 @@ export const ComplaintsToAlthingiOmbudsmanSchema = z.object({
     email: z.string(),
     phone: z.string(),
     connection: z.string(),
+    powerOfAttorney: FileSchema.optional(),
   }),
   complaintDescription: z.object({
     decisionDate: z.string().optional(), // TODO: Validate this block
@@ -71,6 +78,7 @@ export const ComplaintsToAlthingiOmbudsmanSchema = z.object({
       }),
   }),
   courtActionAnswer: z.enum([YES, NO]),
+  attachments: z.object({ documents: z.array(FileSchema).optional() }),
 })
 
 export type ComplaintsToAlthingiOmbudsman = z.TypeOf<

--- a/libs/application/templates/complaints-to-althingi-ombudsman/src/lib/dataSchema.ts
+++ b/libs/application/templates/complaints-to-althingi-ombudsman/src/lib/dataSchema.ts
@@ -64,7 +64,7 @@ export const ComplaintsToAlthingiOmbudsmanSchema = z.object({
     email: z.string(),
     phone: z.string(),
     connection: z.string(),
-    powerOfAttorney: FileSchema.optional(),
+    powerOfAttorney: z.array(FileSchema).optional(),
   }),
   complaintDescription: z.object({
     decisionDate: z.string().optional(), // TODO: Validate this block
@@ -78,7 +78,7 @@ export const ComplaintsToAlthingiOmbudsmanSchema = z.object({
       }),
   }),
   courtActionAnswer: z.enum([YES, NO]),
-  attachments: z.object({ documents: z.array(FileSchema) }),
+  attachments: z.object({ documents: z.array(FileSchema).optional() }),
 })
 
 export type ComplaintsToAlthingiOmbudsman = z.TypeOf<

--- a/libs/application/templates/complaints-to-althingi-ombudsman/src/lib/dataSchema.ts
+++ b/libs/application/templates/complaints-to-althingi-ombudsman/src/lib/dataSchema.ts
@@ -78,7 +78,7 @@ export const ComplaintsToAlthingiOmbudsmanSchema = z.object({
       }),
   }),
   courtActionAnswer: z.enum([YES, NO]),
-  attachments: z.object({ documents: z.array(FileSchema).optional() }),
+  attachments: z.object({ documents: z.array(FileSchema) }),
 })
 
 export type ComplaintsToAlthingiOmbudsman = z.TypeOf<

--- a/libs/application/templates/complaints-to-althingi-ombudsman/src/lib/messages/overview.ts
+++ b/libs/application/templates/complaints-to-althingi-ombudsman/src/lib/messages/overview.ts
@@ -1,6 +1,14 @@
 import { defineMessages } from 'react-intl'
 
 export const complaintOverview = {
+  general: defineMessages({
+    noAttachments: {
+      id: 'ctao.application:overview.noAttachments',
+      defaultMessage: 'Engin fylgiskjöl',
+      description:
+        'Fallback text to display in overview when there are no attachments',
+    },
+  }),
   labels: defineMessages({
     nationalRegistry: {
       id: 'ctao.application:overview.label.nationalRegistry',

--- a/libs/application/templates/complaints-to-althingi-ombudsman/src/lib/messages/overview.ts
+++ b/libs/application/templates/complaints-to-althingi-ombudsman/src/lib/messages/overview.ts
@@ -32,5 +32,15 @@ export const complaintOverview = {
       defaultMessage: 'Lagt fyrir dómstóla',
       description: 'Label for the court action answer',
     },
+    powerOfAttorney: {
+      id: 'ctao.application:overview.label.powerOfAttorney',
+      defaultMessage: 'Umboð frá kvörtunaraðila',
+      description: 'Label for power of attorney',
+    },
+    attachments: {
+      id: 'ctao.application:overview.label.attachments',
+      defaultMessage: 'Fylgiskjöl',
+      description: 'Label for attachments',
+    },
   }),
 }


### PR DESCRIPTION
# Show attachments in overview

https://app.clickup.com/t/nbduny

## What

Show attachments in overview plus minor mobile overview adjustments

## Why

So that the user can see what documents are attached to the application

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/35707048/125620564-9e3a7f5a-3b8e-4345-9fb5-990043b94968.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
