### PR TITLE
fix(services-endorsements-api): Removed owner validation

### DIFF
--- a/apps/services/endorsements/api/src/app/modules/endorsementList/e2e/openEndorsementList/openEndorsementList.spec.ts
+++ b/apps/services/endorsements/api/src/app/modules/endorsementList/e2e/openEndorsementList/openEndorsementList.spec.ts
@@ -35,21 +35,6 @@ describe('openEndorsementList', () => {
       statusCode: 404,
     })
   })
-  it(`PUT /endorsement-list/:listId/open should not be able to open endorsement lists for others`, async () => {
-    const app = await getAuthenticatedApp({
-      nationalId: authNationalId,
-      scope: [EndorsementsScope.main],
-    })
-    const response = await request(app.getHttpServer())
-      .put('/endorsement-list/9c0b4106-4213-43be-a6b2-ff324f4ba017/open')
-      .send()
-      .expect(405)
-
-    expect(response.body).toMatchObject({
-      ...errorExpectedStructure,
-      statusCode: 405,
-    })
-  })
   it(`PUT /endorsement-list/:listId/open should open existing closed endorsement list`, async () => {
     const app = await getAuthenticatedApp({
       nationalId: authNationalId,

--- a/apps/services/endorsements/api/src/app/modules/endorsementList/endorsementList.controller.ts
+++ b/apps/services/endorsements/api/src/app/modules/endorsementList/endorsementList.controller.ts
@@ -132,7 +132,6 @@ export class EndorsementListController {
       'listId',
       new ParseUUIDPipe({ version: '4' }),
       EndorsementListByIdPipe,
-      IsEndorsementListOwnerValidationPipe,
     )
     endorsementList: EndorsementList,
   ): Promise<EndorsementList> {


### PR DESCRIPTION
# Removed owner validation

Fix for Ministry of justice can't open list

## What

- Removed owner validation for open

## Why

- Allow Ministry of justice to open list

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
