### PR TITLE
chore: Allow all white space characters in strings and comments

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,6 +31,14 @@
             ]
           }
         ],
+        "no-irregular-whitespace": [
+          "error",
+          {
+            "skipStrings": true,
+            "skipComments": true,
+            "skipTemplates": true
+          }
+        ],
         "local-rules/disallow-kennitalas": 1
       }
     },


### PR DESCRIPTION
## What

Expand ESLint recommended config's default white space rules to not error on fancy spaces inside template strings and comments.

## Why

Custom white spaces have valid use-cases and are perfectly safe to display as part of the on-screen UI

The default rule already allows custom white space characters inside old-school strings, but as soon as we either turn those strings into template literals or move them into a code-comment, ESLint throws a  fit.

...which is surprising, and annoying.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new warnings
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
