### PR TITLE
fix(web)/functional download csv on open data sub page

### DIFF
--- a/apps/web/components/Charts/ChartsCard/ChartsCard.treat.ts
+++ b/apps/web/components/Charts/ChartsCard/ChartsCard.treat.ts
@@ -10,12 +10,9 @@ export const frameWrapper = style({
   minHeight: 124,
   textDecoration: 'none',
   position: 'relative',
-  borderRadius: 'large',
   overflow: 'visible',
   background: 'transparent',
   outline: 'none',
-  borderColor: 'purple100',
-  borderWidth: 'standard',
   ':hover': {
     textDecoration: 'none',
   },

--- a/apps/web/components/Charts/ChartsCard/ChartsCard.treat.ts
+++ b/apps/web/components/Charts/ChartsCard/ChartsCard.treat.ts
@@ -1,7 +1,7 @@
 import { style, styleMap } from 'treat'
 import { theme } from '@island.is/island-ui/theme'
 
-export const card = style({
+export const frameWrapper = style({
   display: 'flex',
   height: '646px',
   width: '100%',
@@ -10,7 +10,55 @@ export const card = style({
   minHeight: 124,
   textDecoration: 'none',
   position: 'relative',
+  borderRadius: 'large',
+  overflow: 'visible',
+  background: 'transparent',
+  outline: 'none',
+  borderColor: 'purple100',
+  borderWidth: 'standard',
   ':hover': {
     textDecoration: 'none',
   },
+})
+
+export const card = style({
+  display: 'flex',
+  flexDirection: 'column',
+  flexGrow: 1,
+  alignItems: 'stretch',
+  justifyContent: 'flexStart',
+})
+
+export const outerWrapper = style({
+  width: '100%',
+  minHeight: '156px',
+  borderTopLeftRadius: '8px',
+  borderTopRightRadius: '8px',
+  alignItems: 'center',
+  justifyContent: 'spaceBetween',
+})
+
+export const innerWrapper = style({
+  minHeight: '156px',
+  borderTopLeftRadius: '8px',
+  borderTopRightRadius: '8px',
+  paddingBottom: '24px',
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+})
+
+export const graphWrapper = style({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  width: '100%',
+  height: '100%',
+})
+
+export const graphParent = style({
+  justifyContent: 'center',
+  width: '80%',
+  height: '408px',
 })

--- a/apps/web/components/Charts/ChartsCard/ChartsCard.tsx
+++ b/apps/web/components/Charts/ChartsCard/ChartsCard.tsx
@@ -28,10 +28,10 @@ interface ChartCardDataProps {
 
 export interface ChartsCardsProps {
   data: ChartCardDataProps
-  blue?: boolean
+  subPage?: boolean
 }
 
-export const ChartsCard: React.FC<ChartsCardsProps> = ({ data, blue }) => {
+export const ChartsCard: React.FC<ChartsCardsProps> = ({ data, subPage }) => {
   const { graphTitle, graphDescription, organization, graph } = data
   const [ref, { width }] = useMeasure()
 
@@ -56,34 +56,12 @@ export const ChartsCard: React.FC<ChartsCardsProps> = ({ data, blue }) => {
   }
 
   const items = (
-    <Box
-      ref={ref}
-      display="flex"
-      style={{ flexDirection: 'column' }}
-      flexGrow={1}
-      flexDirection={shouldStack ? 'columnReverse' : 'row'}
-      alignItems="stretch"
-      justifyContent="flexStart"
-    >
+    <Box ref={ref} className={cn(styles.card)}>
       <Box
-        style={{
-          width: '100%',
-          minHeight: '156px',
-          borderTopLeftRadius: '8px',
-          borderTopRightRadius: '8px',
-        }}
-        background={blue ? 'blue100' : 'purple100'}
-        alignItems="center"
-        justifyContent="spaceBetween"
+        className={cn(styles.outerWrapper)}
+        background={subPage ? 'blue100' : 'purple100'}
       >
-        <Box
-          style={{
-            minHeight: '156px',
-            borderTopLeftRadius: '8px',
-            borderTopRightRadius: '8px',
-            paddingBottom: '24px',
-          }}
-        >
+        <Box className={cn(styles.innerWrapper)}>
           <Box padding={[2, 2, 4]}>
             {organization && (
               <Text variant="eyebrow" color="dark400">
@@ -97,23 +75,17 @@ export const ChartsCard: React.FC<ChartsCardsProps> = ({ data, blue }) => {
               <Text color="dark400">{graphDescription}</Text>
             )}
           </Box>
+
+          {subPage && (
+            <Box padding={[2, 2, 4]}>
+              <ExportCSVButton data={graph.data} />
+            </Box>
+          )}
         </Box>
-        {blue && (
-          <Box padding={[2, 2, 4]}>
-            <ExportCSVButton data={graph.data} />
-          </Box>
-        )}
       </Box>
 
-      <Box
-        display="flex"
-        justifyContent="center"
-        alignItems="center"
-        style={{ width: '100%', height: '100%' }}
-      >
-        <Box justifyContent="center" style={{ width: '80%', height: '408px' }}>
-          {children}
-        </Box>
+      <Box className={cn(styles.graphWrapper)}>
+        <Box className={cn(styles.graphParent)}>{children}</Box>
       </Box>
     </Box>
   )
@@ -122,20 +94,7 @@ export const ChartsCard: React.FC<ChartsCardsProps> = ({ data, blue }) => {
 }
 
 const FrameWrapper = ({ children }) => {
-  return (
-    <Box
-      className={cn(styles.card)}
-      position="relative"
-      borderRadius="large"
-      overflow="visible"
-      background="transparent"
-      outline="none"
-      borderColor="purple100"
-      borderWidth="standard"
-    >
-      {children}
-    </Box>
-  )
+  return <Box className={cn(styles.frameWrapper)}>{children}</Box>
 }
 
 export default ChartsCard

--- a/apps/web/components/Charts/ChartsCard/ChartsCard.tsx
+++ b/apps/web/components/Charts/ChartsCard/ChartsCard.tsx
@@ -94,7 +94,16 @@ export const ChartsCard: React.FC<ChartsCardsProps> = ({ data, subPage }) => {
 }
 
 const FrameWrapper = ({ children }) => {
-  return <Box className={cn(styles.frameWrapper)}>{children}</Box>
+  return (
+    <Box
+      className={cn(styles.frameWrapper)}
+      borderColor="purple100"
+      borderWidth="standard"
+      borderRadius="large"
+    >
+      {children}
+    </Box>
+  )
 }
 
 export default ChartsCard

--- a/apps/web/components/ExportCSVButton/ExportCSVButton.tsx
+++ b/apps/web/components/ExportCSVButton/ExportCSVButton.tsx
@@ -43,30 +43,29 @@ export interface ExportCSVButtonProps {
   data: string
 }
 
-export const ExportCSVButton: FC<ExportCSVButtonProps> = ({ data }) => {
+const useCsvExport = (data) => {
   const newdata = JSON.parse(data)
-  const useCsvExport = () => {
-    if (data) {
-      try {
-        const allFlat = newdata.map((obj) => [...forAll(obj)])
+  if (data) {
+    try {
+      const allFlat = newdata.map((obj) => [...forAll(obj)])
 
-        const csvContent = makeCsv(allFlat)
+      const csvContent = makeCsv(allFlat)
 
-        triggerDownload(`opin_gogn${new Date()}.csv`, csvContent)
-      } catch (e) {
-        console.log(e)
-      }
+      triggerDownload(`opin_gogn${new Date()}.csv`, csvContent)
+    } catch (e) {
+      console.log(e)
     }
-
-    return
   }
+}
+
+export const ExportCSVButton: FC<ExportCSVButtonProps> = ({ data }) => {
   return (
     <Box style={{ height: '48px' }}>
       <Button
         colorScheme="default"
         preTextIcon="download"
         iconType="filled"
-        onClick={() => useCsvExport}
+        onClick={() => useCsvExport(data)}
         preTextIconType="filled"
         size="small"
         type="button"

--- a/apps/web/screens/OpenDataSubPage/OpenDataSubPage.tsx
+++ b/apps/web/screens/OpenDataSubPage/OpenDataSubPage.tsx
@@ -148,7 +148,7 @@ const OpenDataSubPage: Screen = () => {
               <GridColumn span={'12/12'}>
                 {data.map((item, index) => (
                   <Box marginBottom={3} key={index}>
-                    <ChartsCard data={item} />
+                    <ChartsCard data={item} subPage />
                   </Box>
                 ))}
               </GridColumn>


### PR DESCRIPTION

## What

Download CSV

## Why

Users can now download csv data for graphs displayed on open data subpages

## Screenshots / Gifs

![Screenshot 2021-08-09 at 12 05 15](https://user-images.githubusercontent.com/42963845/128703397-cf744812-5bf6-4fc2-81e7-b33a2354412a.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
