### PR TITLE
feat(application-templates-party-application): Init and start commands

### DIFF
--- a/libs/application/templates/party-application/README.md
+++ b/libs/application/templates/party-application/README.md
@@ -1,3 +1,65 @@
 # Party Application
 
-This application allows political parties to announce candidacy
+This application allows governmental parties to apply to take part in the upcoming elections.
+
+## Setup
+
+Application System setup: [Setup](https://docs.devland.is/apps/application-system)
+
+### Additional setup
+
+There are additional steps required to run this template locally
+
+### National Registry Provider
+
+Prerequisites
+
+- You have `kubectl` installed
+  - `brew install kubectl`
+- You have [AWS Secrets](../../../../handbook/repository/aws-secrets.md) configured
+
+1. Make sure the following environment variables are set:
+
+```bash
+SOFFIA_PASS
+SOFFIA_USER
+```
+
+- A good way to get environment variables is to run `yarn get-secrets service-portal`
+
+2. Get kubeconfig
+
+- Export aws variables `aws eks update-kubeconfig --name dev-cluster01`
+
+3. Socat Þjóðskrá
+
+- Run `kubectl port-forward svc/socat-soffia 8443:443 -n socat`
+- Keep this process running while running the project
+
+### Current user companies provider
+
+Make sure the following environment variable is set
+
+```bash
+RSK_API_PASSWORD
+```
+
+- A good way to get environment variables is to run `yarn get-secrets service-portal`
+
+## Running project locally
+
+To docker environment run (this only needs to be run once):
+
+```bash
+yarn nx run application-templates-party-application:init
+```
+
+To start all required services:
+
+```bash
+yarn nx run application-templates-party-application:start
+```
+
+## Code owners and maintainers
+
+- [Kosmos & Kaos](https://github.com/orgs/island-is/teams/kosmos-kaos)

--- a/libs/application/templates/party-letter/README.md
+++ b/libs/application/templates/party-letter/README.md
@@ -46,6 +46,20 @@ RSK_API_PASSWORD
 
 - A good way to get environment variables is to run `yarn get-secrets service-portal`
 
+## Running project locally
+
+To docker environment run (this only needs to be run once):
+
+```bash
+yarn nx run application-templates-party-letter:init
+```
+
+To start all required services:
+
+```bash
+yarn nx run application-templates-party-letter:start
+```
+
 ## Code owners and maintainers
 
 - [Kosmos & Kaos](https://github.com/orgs/island-is/teams/kosmos-kaos)

--- a/workspace.json
+++ b/workspace.json
@@ -2512,6 +2512,34 @@
             "command": "yarn ts-node -P libs/localization/tsconfig.lib.json libs/localization/scripts/extract 'libs/application/party-application/src/lib/messages.ts'"
           }
         },
+        "init": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "commands": [
+              "yarn nx run application-system-api:dev-services",
+              "yarn nx run application-system-api:migrate",
+              "yarn nx run services-party-letter-registry-api:migrate",
+              "yarn nx run services-temporary-voter-registry-api:migrate",
+              "yarn nx run services-endorsements-api:migrate"
+            ],
+            "parallel": false
+          }
+        },
+        "start": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "commands": [
+              "kubectl port-forward svc/socat-soffia 8443:443 -n socat &",
+              "yarn start application-system-api &",
+              "yarn start application-system-form &",
+              "yarn start services-party-letter-registry-api &",
+              "yarn start services-temporary-voter-registry-api &",
+              "yarn start services-endorsements-api &",
+              "yarn start api &"
+            ],
+            "parallel": true
+          }
+        },
         "schemas/codegen": {
           "builder": "@nrwl/workspace:run-commands",
           "options": {
@@ -2569,6 +2597,34 @@
           "builder": "@nrwl/workspace:run-commands",
           "options": {
             "command": "yarn ts-node -P libs/localization/tsconfig.lib.json libs/localization/scripts/extract 'libs/application/templates/party-letter/src/lib/messages.ts'"
+          }
+        },
+        "init": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "commands": [
+              "yarn nx run application-system-api:dev-services",
+              "yarn nx run application-system-api:migrate",
+              "yarn nx run services-party-letter-registry-api:migrate",
+              "yarn nx run services-temporary-voter-registry-api:migrate",
+              "yarn nx run services-endorsements-api:migrate"
+            ],
+            "parallel": false
+          }
+        },
+        "start": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "commands": [
+              "kubectl port-forward svc/socat-soffia 8443:443 -n socat &",
+              "yarn start application-system-api &",
+              "yarn start application-system-form &",
+              "yarn start services-party-letter-registry-api &",
+              "yarn start services-temporary-voter-registry-api &",
+              "yarn start services-endorsements-api &",
+              "yarn start api &"
+            ],
+            "parallel": true
           }
         },
         "schemas/codegen": {


### PR DESCRIPTION
# Init and start commands

Currently you have to run multiple commands to init and start developing the `application-templates-party-application` and `application-templates-party-letter` application system templates.
This adds easy to execute commands to get those templates up and running for development.

## What

- Added init and start commands

## Why

- Reduce barrier of entry when working on these templates

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
