### PR TITLE
feat(web): Add missing children links to services screen nav list

### DIFF
--- a/apps/web/screens/Organization/Services.tsx
+++ b/apps/web/screens/Organization/Services.tsx
@@ -80,6 +80,10 @@ const ServicesPage: Screen<ServicesPageProps> = ({
       title: primaryLink.text,
       href: primaryLink.url,
       active: primaryLink.url === `/s/${organizationPage.slug}/thjonusta`,
+      items: childrenLinks.map(({ text, url }) => ({
+        title: text,
+        href: url,
+      })),
     }),
   )
 


### PR DESCRIPTION
# Add missing children links to services screen nav list

## What
The services screen was missing implementation of children links in nav list.

## Why
Requested by Sýslumenn webmaster

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/8808850/130247323-15735f48-9e48-4a1c-8e2c-6bf1d1520e05.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
