### PR TITLE
feat(ctao): Add new data provider field for notifications

### DIFF
--- a/libs/application/templates/complaints-to-althingi-ombudsman/src/forms/ComplaintsToAlthingiOmbudsmanApplication.ts
+++ b/libs/application/templates/complaints-to-althingi-ombudsman/src/forms/ComplaintsToAlthingiOmbudsmanApplication.ts
@@ -68,6 +68,12 @@ export const ComplaintsToAlthingiOmbudsmanApplication: Form = buildForm({
               title: dataProvider.userProfileTitle,
               subTitle: dataProvider.userProfileSubTitle,
             }),
+            buildDataProviderItem({
+              id: 'notification',
+              type: undefined,
+              title: dataProvider.notificationTitle,
+              subTitle: dataProvider.notificationSubTitle,
+            }),
           ],
         }),
       ],

--- a/libs/application/templates/complaints-to-althingi-ombudsman/src/lib/messages/dataProvider.ts
+++ b/libs/application/templates/complaints-to-althingi-ombudsman/src/lib/messages/dataProvider.ts
@@ -37,4 +37,15 @@ export const dataProvider = defineMessages({
       'Símanúmer, netfang. Upplýsingar um símanúmer eða netfang er hægt að uppfæra á vefsíðu island.is ef þess þarf.',
     description: 'User Profile Subtitle',
   },
+  notificationTitle: {
+    id: 'ctao.application:dataProvider.notificationTitle',
+    defaultMessage: 'Samþykki fyrir tilkynningar',
+    description: 'Approval of notifications',
+  },
+  notificationSubTitle: {
+    id: 'ctao.application:dataProvider.notificationSubTitle',
+    defaultMessage: 'Send verða til þín skilaboð um stöðu mála osfrv.',
+    description:
+      'Notifications will be sent regarding the status of your application',
+  },
 })


### PR DESCRIPTION
# Add new data provider field for notifications

Attach a link to issue if relevant

## What

Add new data provider field for notifications

## Why

Needed in order to approve notifications to the applicant.

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/2814693/130447864-d785ab74-3f73-4afb-adde-2bdbbf31c319.png)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
