### PR TITLE
fix(web): Fix event slice styles

### DIFF
--- a/apps/web/components/Organization/Slice/EventSlice/EventSlice.treat.ts
+++ b/apps/web/components/Organization/Slice/EventSlice/EventSlice.treat.ts
@@ -1,7 +1,7 @@
 import { style } from 'treat'
 
 export const wrapper = style({
-  padding: '50px 40px 30px 40px',
-  backgroundSize: 'cover',
-  backgroundPositionY: 'center',
+  padding: '50px 40px 30px 40px !important',
+  backgroundSize: 'cover !important',
+  backgroundPositionY: 'center !important',
 })

--- a/apps/web/components/Organization/Slice/EventSlice/EventSlice.tsx
+++ b/apps/web/components/Organization/Slice/EventSlice/EventSlice.tsx
@@ -24,7 +24,7 @@ export const EventSlice: React.FC<SliceProps> = ({ slice }) => {
       <Box
         className={styles.wrapper}
         style={{
-          background: `url(${slice.backgroundImage?.url}, rgb(31, 101, 251)`,
+          background: `url(${slice.backgroundImage?.url}), rgb(31, 101, 251)`,
         }}
       >
         <GridContainer>


### PR DESCRIPTION
# Fix event slice styles

Attach a link to issue if relevant

## What

Fixing CSS styles for the event slice.

## Why

The event slice does not render properly currently.

This was hot-fixed to the last release, but did not end up in the main branch, so we need to hot-fix again.
