### PR TITLE
fix(judicial-system): Investigation case pdf header fix

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/requestPdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/requestPdf.ts
@@ -5,7 +5,6 @@ import { CaseType } from '@island.is/judicial-system/types'
 import {
   caseTypes,
   formatRequestedCustodyRestrictions,
-  formatGender,
   formatNationalId,
   capitalize,
   formatDate,
@@ -196,6 +195,7 @@ function constructRestrictionRequestPdf(
 
 function constructInvestigationRequestPdf(
   existingCase: Case,
+  formatMessage?: FormatMessage,
 ): streamBuffers.WritableStreamBuffer {
   const doc = new PDFDocument({
     size: 'A4',
@@ -221,18 +221,32 @@ function constructInvestigationRequestPdf(
     .text('Krafa um rannsóknarheimild', { align: 'center' })
     .font('Helvetica')
     .fontSize(18)
-    .text(`LÖKE málsnúmer: ${existingCase.policeCaseNumber}`, {
-      align: 'center',
-    })
+    .text(
+      formatMessage(m.district, {
+        district:
+          existingCase.prosecutor?.institution?.name ??
+          formatMessage(m.noDistrict),
+      }),
+      {
+        align: 'center',
+      },
+    )
     .fontSize(16)
     .text(
-      `Embætti: ${existingCase.prosecutor?.institution?.name ?? 'Ekki skráð'}`,
+      `${formatDate(existingCase.created, 'PPP')} - ${formatMessage(
+        m.caseNumber,
+        {
+          caseNumber: existingCase.policeCaseNumber,
+        },
+      )}`,
       {
         align: 'center',
       },
     )
     .lineGap(40)
-    .text(`Dómstóll: ${existingCase.court?.name}`, { align: 'center' })
+    .text(formatMessage(m.court, { court: existingCase.court?.name }), {
+      align: 'center',
+    })
     .font('Helvetica-Bold')
     .fontSize(18)
     .lineGap(8)
@@ -242,7 +256,6 @@ function constructInvestigationRequestPdf(
     .lineGap(4)
     .text(`Kennitala: ${formatNationalId(existingCase.accusedNationalId)}`)
     .text(`Fullt nafn: ${existingCase.accusedName}`)
-    .text(`Kyn: ${formatGender(existingCase.accusedGender)}`)
     .text(`Lögheimili: ${existingCase.accusedAddress}`)
     .text(
       `Verjandi sakbornings: ${
@@ -360,7 +373,7 @@ function constructRequestPdf(
   return existingCase.type === CaseType.CUSTODY ||
     existingCase.type === CaseType.TRAVEL_BAN
     ? constructRestrictionRequestPdf(existingCase, formatMessage)
-    : constructInvestigationRequestPdf(existingCase)
+    : constructInvestigationRequestPdf(existingCase, formatMessage)
 }
 
 export async function getRequestPdfAsString(


### PR DESCRIPTION
# Investigation case pdf header fix

https://app.asana.com/0/1199153462262248/1200844715490175

## What

Change the layout of the header in investigation case pdfs to match the header in restriction case pdfs

## Why

It looks better. Note that this is only a layout change, the actual copy can be changed in Contentful.

## Screenshots / Gifs

![Screen Shot 2021-08-25 at 10 24 24](https://user-images.githubusercontent.com/3789875/130774068-2eebe001-3d5a-42da-955c-374a71762070.png)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
