### PR TITLE
Index process entry

### DIFF
--- a/libs/api/domains/content-search/src/lib/enums/searchableTags.ts
+++ b/libs/api/domains/content-search/src/lib/enums/searchableTags.ts
@@ -2,6 +2,7 @@ import { registerEnumType } from '@nestjs/graphql'
 
 export enum SearchableTags {
   category = 'category',
+  processentry = 'processentry',
 }
 
 registerEnumType(SearchableTags, { name: 'SearchableTags' })

--- a/libs/cms/src/lib/search/importers/article.service.ts
+++ b/libs/cms/src/lib/search/importers/article.service.ts
@@ -131,6 +131,11 @@ export class ArticleSyncService implements CmsSyncProvider<IArticle> {
                 value: entry.fields?.category?.fields?.title,
                 type: 'category',
               },
+              {
+                key: entry.fields?.processEntry ? 'true' : 'false',
+                value: entry.fields?.processEntry ? 'Yes' : 'No',
+                type: 'processentry',
+              },
               ...(mapped.otherCategories ?? []).map((x) => ({
                 key: x.slug,
                 value: x.title,


### PR DESCRIPTION

## What

Adding possibility to search in articles in Contentful that have process entry. Articles that have process entry are applications. 

## Why

We have a special Application screen in the mobile app where we want to have the possibility to search in articles that have process entry. We also need to list out all applications.

## Checklist:

- [ x ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x ] Formatting passes locally with my changes
- [ x ] I have rebased against main before asking for a review
