### PR TITLE
fix(services-search-indexer): Reduce bulk import chunk size

### DIFF
--- a/libs/content-search-toolkit/src/services/elastic.service.ts
+++ b/libs/content-search-toolkit/src/services/elastic.service.ts
@@ -107,7 +107,7 @@ export class ElasticService {
   async bulkRequest(index: string, requests: Record<string, unknown>[]) {
     try {
       // elasticsearch does not like big requests (above 5mb) so we limit the size to X entries just in case
-      const chunkSize = 100 // this has to be an even number
+      const chunkSize = 20 // this has to be an even number
       const client = await this.getClient()
       let requestChunk = requests.splice(-chunkSize, chunkSize)
       while (requestChunk.length) {


### PR DESCRIPTION
# Reduce bulk import chunk size

Bulk import is failing due to large payload size

## What

- Reduce chunk size to a value that is unlikely to cause further issues

## Why

- Allow search indexer to continue to work normally

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
