### PR TITLE
fix(parental-leave): remove invalid periods before adding new periods

### DIFF
--- a/libs/application/core/src/types/Form.ts
+++ b/libs/application/core/src/types/Form.ts
@@ -6,7 +6,7 @@ import type { BoxProps } from '@island.is/island-ui/core/types'
 import { Field, RecordObject } from '@island.is/application/core'
 
 import { Condition } from './Condition'
-import { Application } from './Application'
+import { Application, FormValue } from './Application'
 
 export type BeforeSubmitCallback = () => Promise<[true, null] | [false, string]>
 
@@ -140,7 +140,7 @@ export interface FieldBaseProps {
 
 export type RepeaterProps = {
   application: Application
-  expandRepeater: () => void
+  expandRepeater: (answers?: FormValue) => void
   error?: string
   repeater: Repeater
   removeRepeaterItem: (index: number) => void

--- a/libs/application/templates/meta-application/src/fields/DataRepeater/index.tsx
+++ b/libs/application/templates/meta-application/src/fields/DataRepeater/index.tsx
@@ -14,7 +14,8 @@ const DataRepeater: FC<RepeaterProps> = ({ expandRepeater, application }) => {
       <Box marginY={3}>
         <DataTable application={application} />
       </Box>
-      <Button onClick={expandRepeater}>
+
+      <Button onClick={() => expandRepeater()}>
         {formatText(m.dataAdd, application, formatMessage)}
       </Button>
     </>

--- a/libs/application/templates/parental-leave/src/fields/index.ts
+++ b/libs/application/templates/parental-leave/src/fields/index.ts
@@ -1,6 +1,6 @@
 export { Duration } from './Duration/Duration'
 export { default as FirstPeriodStart } from './FirstPeriodStart'
-export { default as PeriodsRepeater } from './PeriodsRepeater'
+export { PeriodsRepeater } from './PeriodsRepeater/PeriodsRepeater'
 export { default as PaymentSchedule } from './PaymentSchedule'
 export { default as PaymentScheduleInformation } from './PaymentSchedule/InformationScreen'
 export { default as SalaryScreen } from './PaymentSchedule/SalaryScreen'

--- a/libs/application/templates/reference-template/src/fields/CustomRepeater.tsx
+++ b/libs/application/templates/reference-template/src/fields/CustomRepeater.tsx
@@ -11,7 +11,7 @@ const CustomRepeater: FC<RepeaterProps> = ({ expandRepeater }) => {
         important as it initiates that subflow to generate more nested items.
       </Text>
 
-      <Button onClick={expandRepeater}>Expand repeater</Button>
+      <Button onClick={() => expandRepeater()}>Expand repeater</Button>
     </>
   )
 }

--- a/libs/application/ui-shell/src/components/FormRepeater.tsx
+++ b/libs/application/ui-shell/src/components/FormRepeater.tsx
@@ -4,6 +4,7 @@ import {
   getValueViaPath,
   Application,
   RecordObject,
+  FormValue,
 } from '@island.is/application/core'
 
 import { useFields } from '../context/FieldContext'
@@ -15,7 +16,7 @@ const FormRepeater: FC<{
   application: Application
   repeater: RepeaterScreen
   errors: RecordObject
-  expandRepeater: () => void
+  expandRepeater: (answers?: FormValue) => void
   onRemoveRepeaterItem: (newRepeaterItems: RepeaterItems) => Promise<unknown>
 }> = ({
   application,

--- a/libs/application/ui-shell/src/components/Screen.tsx
+++ b/libs/application/ui-shell/src/components/Screen.tsx
@@ -60,7 +60,7 @@ type ScreenProps = {
   answerAndGoToNextScreen(answers: FormValue): void
   answerQuestions(answers: FormValue): void
   dataSchema: Schema
-  expandRepeater(): void
+  expandRepeater(answers?: FormValue): void
   mode?: FormModes
   numberOfScreens: number
   prevScreen(): void

--- a/libs/application/ui-shell/src/lib/FormShell.tsx
+++ b/libs/application/ui-shell/src/lib/FormShell.tsx
@@ -125,8 +125,8 @@ export const FormShell: FC<{
                       dispatch({ type: ActionTypes.ANSWER, payload })
                     }
                     dataSchema={dataSchema}
-                    expandRepeater={() =>
-                      dispatch({ type: ActionTypes.EXPAND_REPEATER })
+                    expandRepeater={(payload) =>
+                      dispatch({ type: ActionTypes.EXPAND_REPEATER, payload })
                     }
                     answerAndGoToNextScreen={(payload) =>
                       dispatch({

--- a/libs/application/ui-shell/src/reducer/ApplicationFormReducer.ts
+++ b/libs/application/ui-shell/src/reducer/ApplicationFormReducer.ts
@@ -121,15 +121,27 @@ const answerAndGoNextScreen = (
   return { ...newState, activeScreen, historyReason: 'navigate' }
 }
 
-function expandRepeater(state: ApplicationUIState): ApplicationUIState {
-  const { activeScreen, form, screens, application } = state
+function expandRepeater(
+  state: ApplicationUIState,
+  updatedAnswers?: FormValue,
+): ApplicationUIState {
+  const updatedState = {
+    ...state,
+    application: {
+      ...state.application,
+      answers: updatedAnswers ?? state.application.answers,
+    },
+  }
+
+  const { activeScreen, form, screens, application } = updatedState
   const repeater = screens[activeScreen]
 
   if (!repeater || repeater.type !== FormItemTypes.REPEATER) {
-    return state
+    return updatedState
   }
 
   const { answers, externalData } = application
+
   const repeaterValues = getValueViaPath(
     answers ?? {},
     repeater.id,
@@ -144,11 +156,13 @@ function expandRepeater(state: ApplicationUIState): ApplicationUIState {
   const newScreens = convertFormToScreens(form, newAnswers, externalData)
 
   return {
-    ...state,
+    ...updatedState,
     screens: newScreens,
     activeScreen: moveToScreen(
       newScreens,
-      state.activeScreen + repeaterValues.length * repeater.children.length + 1,
+      updatedState.activeScreen +
+        repeaterValues.length * repeater.children.length +
+        1,
       true,
     ),
     historyReason: 'navigate',
@@ -207,7 +221,7 @@ export const ApplicationReducer = (
       return addNewAnswersToState(state, action.payload)
 
     case ActionTypes.EXPAND_REPEATER:
-      return expandRepeater(state)
+      return expandRepeater(state, action.payload)
 
     case ActionTypes.GO_TO_SCREEN:
       return goToSpecificScreen(state, action.payload)


### PR DESCRIPTION
## What

- When the user refreshes the page or goes back and forth the creation of periods is broken. The period is not showing but the JSON object is created with only a `startDate` or and `endDate` or a `ratio`.
- Before creating a new period, we make sure the previous are valid, and we remove the invalid ones if it exists