### PR TITLE
fix(application-template-driving-assessment): fixing an undefined value in the student lookup

### DIFF
--- a/libs/application/templates/driving-assessment-approval/src/fields/StudentLookupField.tsx
+++ b/libs/application/templates/driving-assessment-approval/src/fields/StudentLookupField.tsx
@@ -26,7 +26,7 @@ interface Props extends FieldBaseProps {
 }
 
 interface ExpectedStudent {
-  nationalId: string
+  nationalId?: string
 }
 
 export const StudentLookupField: FC<Props> = ({ error, application }) => {
@@ -35,7 +35,7 @@ export const StudentLookupField: FC<Props> = ({ error, application }) => {
     name: 'student.nationalId',
     // FYI the watch value is not queried unless the value changes after rendering.
     // see react hook form's docs for useWatch for further info.
-    defaultValue: student.nationalId,
+    defaultValue: student?.nationalId,
   })
 
   const { formatMessage } = useLocale()


### PR DESCRIPTION
When the teacher hasn't filled out a student nationalId, the lookup will crash and burn. This should address and fix that issue.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
