### PR TITLE
feat(judicial-system): Inform court if case is appealed in court on signed verdict overview page

### DIFF
--- a/apps/judicial-system/web/messages/Core/signedVerdictOverview.ts
+++ b/apps/judicial-system/web/messages/Core/signedVerdictOverview.ts
@@ -5,14 +5,14 @@ export const signedVerdictOverview = defineMessages({
   accusedAppealed: {
     id: 'judicial.system.core:signed_verdict_overview.accused_appealed',
     defaultMessage:
-      '{genderedAccused} hefur kært úrskurðinn í þinghaldi sem lauk kl. {courtEndTime}',
+      '{genderedAccused} hefur kært úrskurðinn í þinghaldi sem lauk {courtEndTime}',
     description:
       'Notaður sem upplýsingatexti sem útskýrir að kærði kærði úrskurðinn í þinghaldi á yfirlitsskjá afgreiddra mála.',
   },
   prosecutorAppealed: {
     id: 'judicial.system.core:signed_verdict_overview.prosecutor_appealed',
     defaultMessage:
-      'Sækjandi hefur kært úrskurðinn í þinghaldi sem lauk kl. {courtEndTime}',
+      'Sækjandi hefur kært úrskurðinn í þinghaldi sem lauk {courtEndTime}',
     description:
       'Notaður sem upplýsingatexti sem útskýrir að sækjandi kærði úrskurðinn í þinghaldi á yfirlitsskjá afgreiddra mála.',
   },

--- a/apps/judicial-system/web/messages/Core/signedVerdictOverview.ts
+++ b/apps/judicial-system/web/messages/Core/signedVerdictOverview.ts
@@ -1,0 +1,19 @@
+import { defineMessages } from 'react-intl'
+
+// Strings on signed verdict overview screen
+export const signedVerdictOverview = defineMessages({
+  accusedAppealed: {
+    id: 'judicial.system.core:signed_verdict_overview.accused_appealed',
+    defaultMessage:
+      '{genderedAccused} hefur kært úrskurðinn í þinghaldi sem lauk kl. {courtEndTime}',
+    description:
+      'Notaður sem upplýsingatexti sem útskýrir að kærði kærði úrskurðinn í þinghaldi á yfirlitsskjá afgreiddra mála.',
+  },
+  prosecutorAppealed: {
+    id: 'judicial.system.core:signed_verdict_overview.prosecutor_appealed',
+    defaultMessage:
+      'Sækjandi hefur kært úrskurðinn í þinghaldi sem lauk kl. {courtEndTime}',
+    description:
+      'Notaður sem upplýsingatexti sem útskýrir að sækjandi kærði úrskurðinn í þinghaldi á yfirlitsskjá afgreiddra mála.',
+  },
+})

--- a/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/Components/AppealSection/AppealSection.spec.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/Components/AppealSection/AppealSection.spec.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { render, screen } from '@testing-library/react'
 import AppealSection from './AppealSection'
 import { CaseState, CaseType } from '@island.is/judicial-system/types'
+import { LocaleProvider } from '@island.is/localization'
+import { MockedProvider } from '@apollo/client/testing'
 
 describe('Appeal section component', () => {
   const baseWorkingCase = {
@@ -16,15 +18,19 @@ describe('Appeal section component', () => {
 
   test('should say when a case is no longer appealable', async () => {
     render(
-      <AppealSection
-        workingCase={{
-          ...baseWorkingCase,
-          isAppealDeadlineExpired: true,
-          rulingDate: '2020-09-16T19:50:00.000Z',
-        }}
-        setAccusedAppealDate={() => null}
-        setProsecutorAppealDate={() => null}
-      />,
+      <MockedProvider>
+        <LocaleProvider locale="is" messages={{}}>
+          <AppealSection
+            workingCase={{
+              ...baseWorkingCase,
+              isAppealDeadlineExpired: true,
+              rulingDate: '2020-09-16T19:50:00.000Z',
+            }}
+            setAccusedAppealDate={() => null}
+            setProsecutorAppealDate={() => null}
+          />
+        </LocaleProvider>
+      </MockedProvider>,
     )
 
     expect(
@@ -36,11 +42,15 @@ describe('Appeal section component', () => {
 
   test('should not show the "Accused appeals" button if the accused cannot appeal', async () => {
     render(
-      <AppealSection
-        workingCase={baseWorkingCase}
-        setAccusedAppealDate={() => null}
-        setProsecutorAppealDate={() => null}
-      />,
+      <MockedProvider>
+        <LocaleProvider locale="is" messages={{}}>
+          <AppealSection
+            workingCase={baseWorkingCase}
+            setAccusedAppealDate={() => null}
+            setProsecutorAppealDate={() => null}
+          />
+        </LocaleProvider>
+      </MockedProvider>,
     )
 
     expect(
@@ -50,11 +60,15 @@ describe('Appeal section component', () => {
 
   test('should not show the "Prosecutor appeals" button if the prosecutor cannot appeal', async () => {
     render(
-      <AppealSection
-        workingCase={baseWorkingCase}
-        setAccusedAppealDate={() => null}
-        setProsecutorAppealDate={() => null}
-      />,
+      <MockedProvider>
+        <LocaleProvider locale="is" messages={{}}>
+          <AppealSection
+            workingCase={baseWorkingCase}
+            setAccusedAppealDate={() => null}
+            setProsecutorAppealDate={() => null}
+          />
+        </LocaleProvider>
+      </MockedProvider>,
     )
 
     expect(

--- a/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/Components/AppealSection/AppealSection.treat.ts
+++ b/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/Components/AppealSection/AppealSection.treat.ts
@@ -3,7 +3,7 @@ import { style } from 'treat'
 
 export const appealContainer = style({
   height: 112,
-  marginBottom: theme.spacing[3],
+  marginBottom: theme.spacing[2],
 })
 
 export const appealInnerWrapper = style({

--- a/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/Components/AppealSection/AppealSection.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/Components/AppealSection/AppealSection.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { useIntl } from 'react-intl'
 import { AnimatePresence } from 'framer-motion'
 import { Box, Text } from '@island.is/island-ui/core'
 import { getAppealEndDate } from '@island.is/judicial-system-web/src/utils/stepHelper'
@@ -11,7 +12,12 @@ import ProsecutorAppealInfo from '../Prosecutor/ProsecutorAppealInfo'
 import AccusedAppealDatePicker from '../Accused/AccusedAppealDatePicker'
 import { useEffectOnce } from 'react-use'
 import ProsecutorAppealDatePicker from '../Prosecutor/ProsecutorAppealDatePicker'
-import { formatAccusedByGender } from '@island.is/judicial-system/formatters'
+import {
+  capitalize,
+  formatAccusedByGender,
+  formatDate,
+} from '@island.is/judicial-system/formatters'
+import { signedVerdictOverview } from '@island.is/judicial-system-web/messages/Core/signedVerdictOverview'
 
 interface Props {
   workingCase: Case
@@ -29,6 +35,7 @@ const AppealSection: React.FC<Props> = (props) => {
     withdrawAccusedAppealDate,
     withdrawProsecutorAppealDate,
   } = props
+  const { formatMessage } = useIntl()
 
   const [isInitialMount, setIsInitialMount] = useState<boolean>(true)
 
@@ -67,7 +74,12 @@ const AppealSection: React.FC<Props> = (props) => {
         <div className={styles.appealContainer}>
           <BlueBox>
             <InfoBox
-              text="Sakborningur kærði úrskurðinn í þinghaldi"
+              text={formatMessage(signedVerdictOverview.accusedAppealed, {
+                genderedAccused: capitalize(
+                  formatAccusedByGender(workingCase.accusedGender),
+                ),
+                courtEndTime: formatDate(workingCase.courtEndTime, 'p'),
+              })}
               fluid
               light
             />
@@ -77,7 +89,16 @@ const AppealSection: React.FC<Props> = (props) => {
       {workingCase.prosecutorAppealDecision === CaseAppealDecision.APPEAL && (
         <div className={styles.appealContainer}>
           <BlueBox>
-            <InfoBox text="Sækjandi kærði úrskurðinn í þinghaldi" fluid light />
+            <InfoBox
+              text={formatMessage(signedVerdictOverview.prosecutorAppealed, {
+                genderedAccused: capitalize(
+                  formatAccusedByGender(workingCase.accusedGender),
+                ),
+                courtEndTime: formatDate(workingCase.courtEndTime, 'p'),
+              })}
+              fluid
+              light
+            />
           </BlueBox>
         </div>
       )}

--- a/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/Components/AppealSection/AppealSection.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/Components/AppealSection/AppealSection.tsx
@@ -78,7 +78,10 @@ const AppealSection: React.FC<Props> = (props) => {
                 genderedAccused: capitalize(
                   formatAccusedByGender(workingCase.accusedGender),
                 ),
-                courtEndTime: formatDate(workingCase.courtEndTime, 'p'),
+                courtEndTime: `${formatDate(
+                  workingCase.courtEndTime,
+                  'PP',
+                )} kl. ${formatDate(workingCase.courtEndTime, 'p')}`,
               })}
               fluid
               light
@@ -94,7 +97,10 @@ const AppealSection: React.FC<Props> = (props) => {
                 genderedAccused: capitalize(
                   formatAccusedByGender(workingCase.accusedGender),
                 ),
-                courtEndTime: formatDate(workingCase.courtEndTime, 'p'),
+                courtEndTime: `${formatDate(
+                  workingCase.courtEndTime,
+                  'PP',
+                )} kl. ${formatDate(workingCase.courtEndTime, 'p')}`,
               })}
               fluid
               light

--- a/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/Components/AppealSection/AppealSection.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/Components/AppealSection/AppealSection.tsx
@@ -11,6 +11,7 @@ import ProsecutorAppealInfo from '../Prosecutor/ProsecutorAppealInfo'
 import AccusedAppealDatePicker from '../Accused/AccusedAppealDatePicker'
 import { useEffectOnce } from 'react-use'
 import ProsecutorAppealDatePicker from '../Prosecutor/ProsecutorAppealDatePicker'
+import { formatAccusedByGender } from '@island.is/judicial-system/formatters'
 
 interface Props {
   workingCase: Case
@@ -59,6 +60,24 @@ const AppealSection: React.FC<Props> = (props) => {
               fluid
               light
             />
+          </BlueBox>
+        </div>
+      )}
+      {workingCase.accusedAppealDecision === CaseAppealDecision.APPEAL && (
+        <div className={styles.appealContainer}>
+          <BlueBox>
+            <InfoBox
+              text="Sakborningur kærði úrskurðinn í þinghaldi"
+              fluid
+              light
+            />
+          </BlueBox>
+        </div>
+      )}
+      {workingCase.prosecutorAppealDecision === CaseAppealDecision.APPEAL && (
+        <div className={styles.appealContainer}>
+          <BlueBox>
+            <InfoBox text="Sækjandi kærði úrskurðinn í þinghaldi" fluid light />
           </BlueBox>
         </div>
       )}

--- a/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/SignedVerdictOverviewForm.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/SignedVerdictOverviewForm.tsx
@@ -42,6 +42,7 @@ import AppealSection from './Components/AppealSection/AppealSection'
 import { useInstitution } from '@island.is/judicial-system-web/src/utils/hooks'
 import { ValueType } from 'react-select/src/types'
 import { ReactSelectOption } from '@island.is/judicial-system-web/src/types'
+import InfoBox from '@island.is/judicial-system-web/src/shared-components/InfoBox/InfoBox'
 
 interface Props {
   workingCase: Case
@@ -288,7 +289,9 @@ const SignedVerdictOverviewForm: React.FC<Props> = (props) => {
         />
       </Box>
       {(workingCase.accusedAppealDecision === CaseAppealDecision.POSTPONE ||
-        workingCase.prosecutorAppealDecision === CaseAppealDecision.POSTPONE) &&
+        workingCase.accusedAppealDecision === CaseAppealDecision.APPEAL ||
+        workingCase.prosecutorAppealDecision === CaseAppealDecision.POSTPONE ||
+        workingCase.prosecutorAppealDecision === CaseAppealDecision.APPEAL) &&
         workingCase.rulingDate &&
         (user?.role === UserRole.JUDGE ||
           user?.role === UserRole.REGISTRAR) && (


### PR DESCRIPTION
# Inform court if case is appealed in court on signed verdict overview page

https://app.asana.com/0/1199153462262248/1200339992478442

## What

Inform court if case is appealed in court on signed verdict overview page

## Why

We inform the court if a case is appealed after a verdict so it makes sense to do so also if the case is appealed in court.

## Screenshots / Gifs

![Screen Shot 2021-09-01 at 10 44 43](https://user-images.githubusercontent.com/3789875/131658943-07cb9f41-8140-4378-9b77-829a874af3f8.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
