### PR TITLE
feat(delegation): fix breadcrumbs

### DIFF
--- a/apps/service-portal/src/components/ContentBreadcrumbs/ContentBreadcrumbs.tsx
+++ b/apps/service-portal/src/components/ContentBreadcrumbs/ContentBreadcrumbs.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react'
-import { Link, useLocation } from 'react-router-dom'
+import { Link, useLocation, matchPath } from 'react-router-dom'
 import {
   BreadcrumbsDeprecated as Breadcrumbs,
   Box,
@@ -30,8 +30,12 @@ const ContentBreadcrumbs: FC<{}> = () => {
   const { formatMessage } = useLocale()
   const items: ServicePortalNavigationItem[] = reduce(
     (acc, n) => {
-      if (n.path && location.pathname.includes(n.path)) return [...acc, n]
-      else return acc
+      const isPathActive = matchPath(location.pathname, n.path || '')
+      if (isPathActive) {
+        return [...acc, n]
+      } else {
+        return acc
+      }
     },
     {
       name: 'root',
@@ -48,7 +52,7 @@ const ContentBreadcrumbs: FC<{}> = () => {
         {items.map((item, index) =>
           item.path !== undefined ? (
             index === items.length - 1 ? (
-              <Tag key={index} variant="blue" outlined>
+              <Tag key={index} variant="blue" disabled outlined>
                 {formatMessage(item.name)}
               </Tag>
             ) : (

--- a/libs/service-portal/core/src/lib/messages.ts
+++ b/libs/service-portal/core/src/lib/messages.ts
@@ -423,6 +423,14 @@ export const m = defineMessages({
     id: 'service.portal:accessControl',
     defaultMessage: 'Aðgangsstýring',
   },
+  accessControlGrant: {
+    id: 'service.portal:accessControlGrant',
+    defaultMessage: 'Veita aðgang',
+  },
+  accessControlAccess: {
+    id: 'service.portal:accessControlAccess',
+    defaultMessage: 'Aðgangur',
+  },
   educationStudentAssessment: {
     id: 'service.portal:educationStudentAssessment',
     defaultMessage: 'Samræmd könnunarpróf',

--- a/libs/service-portal/core/src/lib/navigation/masterNavigation.ts
+++ b/libs/service-portal/core/src/lib/navigation/masterNavigation.ts
@@ -237,6 +237,16 @@ export const servicePortalMasterNavigation: ServicePortalNavigationItem[] = [
           {
             name: m.accessControl,
             path: ServicePortalPath.SettingsAccessControl,
+            children: [
+              {
+                name: m.accessControlGrant,
+                path: ServicePortalPath.SettingsAccessControlGrant,
+              },
+              {
+                name: m.accessControlAccess,
+                path: ServicePortalPath.SettingsAccessControlAccess,
+              },
+            ],
           },
         ],
       },

--- a/libs/service-portal/core/src/lib/navigation/paths.ts
+++ b/libs/service-portal/core/src/lib/navigation/paths.ts
@@ -15,7 +15,7 @@ export enum ServicePortalPath {
   SettingsRoot = '/stillingar',
   SettingsAccessControl = '/stillingar/adgangsstyring',
   SettingsAccessControlGrant = '/stillingar/adgangsstyring/veita',
-  SettingsAccessControlAccess = '/stillingar/adgangsstyring/:nationalId',
+  SettingsAccessControlAccess = '/stillingar/adgangsstyring/:nationalId(\\d+)',
   SettingsPersonalInformation = '/stillingar/personuupplysingar',
   SettingsPersonalInformationEditPhoneNumber = '/stillingar/personuupplysingar/breyta-simanumeri',
   SettingsPersonalInformationEditEmail = '/stillingar/personuupplysingar/breyta-netfangi',

--- a/libs/service-portal/settings/access-control/src/index.ts
+++ b/libs/service-portal/settings/access-control/src/index.ts
@@ -1,10 +1,10 @@
 import { lazy } from 'react'
-import { defineMessage } from 'react-intl'
 
 import {
   ServicePortalModule,
   ServicePortalPath,
   ServicePortalRoute,
+  m,
 } from '@island.is/service-portal/core'
 
 export const accessControlModule: ServicePortalModule = {
@@ -13,26 +13,17 @@ export const accessControlModule: ServicePortalModule = {
   routes: () => {
     const routes: ServicePortalRoute[] = [
       {
-        name: defineMessage({
-          id: 'service.portal.settings.accessControl:root-title',
-          defaultMessage: 'Aðgangsstýring',
-        }),
+        name: m.accessControl,
         path: ServicePortalPath.SettingsAccessControl,
         render: () => lazy(() => import('./screens/AccessControl')),
       },
       {
-        name: defineMessage({
-          id: 'service.portal.settings.accessControl:root-grant-ritle',
-          defaultMessage: 'Veita aðgang',
-        }),
+        name: m.accessControlGrant,
         path: ServicePortalPath.SettingsAccessControlGrant,
         render: () => lazy(() => import('./screens/GrantAccess')),
       },
       {
-        name: defineMessage({
-          id: 'service.portal.settings.accessControl:root-access-title',
-          defaultMessage: 'Aðgangur',
-        }),
+        name: m.accessControlAccess,
         path: ServicePortalPath.SettingsAccessControlAccess,
         render: () => lazy(() => import('./screens/Access')),
       },

--- a/libs/service-portal/settings/access-control/src/screens/AccessControl/AccessControl.tsx
+++ b/libs/service-portal/settings/access-control/src/screens/AccessControl/AccessControl.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { defineMessage } from 'react-intl'
 
 import { Box } from '@island.is/island-ui/core'
-import { IntroHeader } from '@island.is/service-portal/core'
+import { IntroHeader, m } from '@island.is/service-portal/core'
 
 import { Accesses } from './components'
 
@@ -10,10 +10,7 @@ function AccessControl(): JSX.Element {
   return (
     <Box>
       <IntroHeader
-        title={defineMessage({
-          id: 'service.portal.settings.accessControl:home-title',
-          defaultMessage: 'Aðgangsstýring',
-        })}
+        title={m.accessControl}
         intro={defineMessage({
           id: 'service.portal.settings.accessControl:home-intro',
           defaultMessage:

--- a/libs/service-portal/settings/access-control/src/screens/GrantAccess/GrantAccess.tsx
+++ b/libs/service-portal/settings/access-control/src/screens/GrantAccess/GrantAccess.tsx
@@ -16,7 +16,11 @@ import {
 } from '@island.is/island-ui/core'
 import { InputController } from '@island.is/shared/form-fields'
 import { Mutation, Query } from '@island.is/api/schema'
-import { IntroHeader, ServicePortalPath, m } from '@island.is/service-portal/core'
+import {
+  IntroHeader,
+  ServicePortalPath,
+  m,
+} from '@island.is/service-portal/core'
 import { useLocale } from '@island.is/localization'
 
 import { AuthDelegationsQuery } from '../AccessControl'

--- a/libs/service-portal/settings/access-control/src/screens/GrantAccess/GrantAccess.tsx
+++ b/libs/service-portal/settings/access-control/src/screens/GrantAccess/GrantAccess.tsx
@@ -16,7 +16,7 @@ import {
 } from '@island.is/island-ui/core'
 import { InputController } from '@island.is/shared/form-fields'
 import { Mutation, Query } from '@island.is/api/schema'
-import { IntroHeader, ServicePortalPath } from '@island.is/service-portal/core'
+import { IntroHeader, ServicePortalPath, m } from '@island.is/service-portal/core'
 import { useLocale } from '@island.is/localization'
 
 import { AuthDelegationsQuery } from '../AccessControl'
@@ -101,10 +101,7 @@ function GrantAccess() {
   return (
     <Box>
       <IntroHeader
-        title={defineMessage({
-          id: 'service.portal.settings.accessControl:grant-title',
-          defaultMessage: 'Veita aðgang',
-        })}
+        title={m.accessControlGrant}
         intro={defineMessage({
           id: 'service.portal.settings.accessControl:grant-intro',
           defaultMessage:


### PR DESCRIPTION
# Fix breadcrumbs

https://www.notion.so/Unable-to-select-from-bread-crumbs-e87205e51edd4aa8b92f8d967309caca

## What

* Fix breadcrumbs in general to support route params
* Add breadcrumbs for child routes of access-control

## Why

* Service portal didn't support route params before, and was leaving out breadcrumbs for those routes.

## Screenshots / Gifs

![bread](https://user-images.githubusercontent.com/5694851/131706538-ac03b656-d224-4bf2-a078-a6d7cf11f2f5.gif)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
