### PR TITLE
chore(ci): Disabling `npm audit` since it is hard to manage and not that helpful

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -87,8 +87,8 @@ jobs:
         if: steps.generated-files-cache.outputs.cache-hit != 'true'
         run: tar zcvf generated_files.tar.gz $(./scripts/ci/get-files-touched-by.sh yarn schemas --skip-cache | xargs realpath --relative-to $(pwd))
 
-      - name: Security audit Node modules
-        run: ./scripts/ci/20_security-audit.sh
+      # - name: Security audit Node modules
+      #   run: ./scripts/ci/20_security-audit.sh
 
       - name: License audit Node modules
         run: ./scripts/ci/20_license-audit.sh


### PR DESCRIPTION
# Disabling `npm audit`

It is very noisy and we cannot suppress individual packages 

## What

Get rid of it being in the critical path to delivery in favour of dependabot which is much more fine grained and is not blocking delivery pipelines.

## Why

Predictability

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
