### PR TITLE
fix(ui): fix content jumps for checkbox toggle

### DIFF
--- a/libs/island-ui/core/src/lib/Checkbox/Checkbox.treat.ts
+++ b/libs/island-ui/core/src/lib/Checkbox/Checkbox.treat.ts
@@ -101,3 +101,8 @@ export const tooltipLargeContainer = style({
   marginLeft: 'auto',
   paddingLeft: theme.spacing[2],
 })
+
+export const fixJumpingContentFromFontWeightToggle = style({
+  visibility: 'hidden',
+  height: 0,
+})

--- a/libs/island-ui/core/src/lib/Checkbox/Checkbox.tsx
+++ b/libs/island-ui/core/src/lib/Checkbox/Checkbox.tsx
@@ -108,7 +108,10 @@ export const Checkbox = ({
           >
             {label}
           </Text>
-          <div className={styles.fixJumpingContentFromFontWeightToggle}>
+          <div
+            aria-hidden="true"
+            className={styles.fixJumpingContentFromFontWeightToggle}
+          >
             <Text as="span" variant={labelVariant} fontWeight="semiBold">
               {label}
             </Text>

--- a/libs/island-ui/core/src/lib/Checkbox/Checkbox.tsx
+++ b/libs/island-ui/core/src/lib/Checkbox/Checkbox.tsx
@@ -108,6 +108,11 @@ export const Checkbox = ({
           >
             {label}
           </Text>
+          <div className={styles.fixJumpingContentFromFontWeightToggle}>
+            <Text as="span" variant={labelVariant} fontWeight="semiBold">
+              {label}
+            </Text>
+          </div>
           {subLabel && large && (
             <Text
               as="span"

--- a/libs/shared/form-fields/src/lib/CheckboxController/CheckboxController.spec.tsx
+++ b/libs/shared/form-fields/src/lib/CheckboxController/CheckboxController.spec.tsx
@@ -19,8 +19,8 @@ describe('CheckboxController', () => {
         <CheckboxController id="values" options={options} />
       </Wrapper>,
     )
-    expect(screen.getByText('some checkbox')).toBeInTheDocument()
-    expect(screen.getByText('another checkbox')).toBeInTheDocument()
+    expect(screen.getAllByText('some checkbox')[0]).toBeInTheDocument()
+    expect(screen.getAllByText('another checkbox')[0]).toBeInTheDocument()
   })
 
   it('should render an error message', () => {


### PR DESCRIPTION
# Fix content jumps for checkbox toggle

Fixes: https://github.com/island-is/island.is/issues/4027
Implements: https://www.notion.so/Please-go-over-UI-of-scope-selection-e5ee740a78944dd0b6d97eb162ac0ea6

## What

Make semibold text occupy space in order to avoid content jumps

## Screenshots / Gifs

### Before

![before](https://user-images.githubusercontent.com/5694851/131841218-421f99ad-f359-486b-bef9-fe767215b280.gif)


### After

![after](https://user-images.githubusercontent.com/5694851/131841207-26dae81f-53f9-415d-b14e-2cbc9f3d9331.gif)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
