### PR TITLE
fix(service-porta-education): preventing siblings from being able to see each others' grades

### DIFF
--- a/libs/api/domains/education/src/lib/education.service.ts
+++ b/libs/api/domains/education/src/lib/education.service.ts
@@ -67,8 +67,10 @@ export class EducationService {
   }
 
   private isChild(familyMember: ISLFjolskyldan): boolean {
-    return !['1', '2', '7'].includes(familyMember.Kyn) &&
+    return (
+      !['1', '2', '7'].includes(familyMember.Kyn) &&
       kennitala.info(familyMember.Kennitala).age < ADULT_AGE_LIMIT
+    )
   }
 
   async getFamily(nationalId: string): Promise<ISLFjolskyldan[]> {
@@ -79,10 +81,11 @@ export class EducationService {
       return []
     }
 
-    return family
-      .filter((familyMember) =>
-        familyMember === myself || this.isChild(familyMember) && !this.isChild(myself)
-      )
+    return family.filter(
+      (familyMember) =>
+        familyMember === myself ||
+        (this.isChild(familyMember) && !this.isChild(myself)),
+    )
   }
 
   async getExamFamilyOverviews(


### PR DESCRIPTION
## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
