### PR TITLE
fix(application-templates-party-application): Fix admin overview

### DIFF
--- a/libs/application/templates/party-application/src/fields/SupremeCourtOverview/index.tsx
+++ b/libs/application/templates/party-application/src/fields/SupremeCourtOverview/index.tsx
@@ -14,7 +14,7 @@ import format from 'date-fns/format'
 import { format as formatKennitala } from 'kennitala'
 import orderBy from 'lodash/orderBy'
 
-const mapToCSVFile = (endorsements: Endorsement[], constituency: string) => {
+const mapToCSVFile = (endorsements: Endorsement[], regionNumber: number) => {
   return endorsements.map((endorsement) => {
     return {
       Kennitala: formatKennitala(endorsement.endorser),
@@ -24,7 +24,9 @@ const mapToCSVFile = (endorsements: Endorsement[], constituency: string) => {
       Póstnúmer: endorsement.meta.address.postalCode ?? '',
       Borg: endorsement.meta.address.city ?? '',
       'Meðmæli í vafa':
-        constituency !== endorsement.meta.voterRegion ? 'X' : '',
+        regionNumber !== endorsement.meta.voterRegion.voterRegionNumber
+          ? 'X'
+          : '',
       'Meðmæli á pappír': endorsement.meta.bulkEndorsement ? 'X' : '',
     }
   })
@@ -44,7 +46,7 @@ const SupremeCourtOverview: FC<FieldBaseProps> = ({ application }) => {
   const endorsementListId = (externalData?.createEndorsementList.data as any).id
   const { endorsements } = useEndorsements(endorsementListId, false)
   const constituency =
-    constituencyMapper[answers.constituency as EndorsementListTags].region_name
+    constituencyMapper[answers.constituency as EndorsementListTags]
 
   return (
     <Box>
@@ -54,13 +56,13 @@ const SupremeCourtOverview: FC<FieldBaseProps> = ({ application }) => {
           <Text variant="h5">
             {formatMessage(m.supremeCourt.partyNameLabel)}
           </Text>
-          <Text>{answers.partyName}</Text>
+          <Text>{partyLetterRegistry.partyName}</Text>
         </Box>
         <Box width="half">
           <Text variant="h5">
             {formatMessage(m.supremeCourt.partyLetterLabel)}
           </Text>
-          <Text>{answers.partyLetter}</Text>
+          <Text>{partyLetterRegistry.partyLetter}</Text>
         </Box>
       </Box>
       <Box display="flex" marginBottom={5}>
@@ -95,12 +97,12 @@ const SupremeCourtOverview: FC<FieldBaseProps> = ({ application }) => {
                 data={
                   mapToCSVFile(
                     orderBy(endorsements, 'created', 'desc'),
-                    constituency,
+                    constituency.region_number,
                   ) as object[]
                 }
                 filename={csvFileName(
-                  partyLetterRegistry?.partyLetter,
-                  partyLetterRegistry?.partyName,
+                  partyLetterRegistry.partyLetter,
+                  partyLetterRegistry.partyName,
                 )}
                 title={formatMessage(m.supremeCourt.csvButton)}
               />
@@ -111,7 +113,7 @@ const SupremeCourtOverview: FC<FieldBaseProps> = ({ application }) => {
           <Text variant="h5">
             {formatMessage(m.supremeCourt.constituencyLabel)}
           </Text>
-          <Text>{constituency}</Text>
+          <Text>{constituency.region_name}</Text>
         </Box>
       </Box>
     </Box>

--- a/libs/application/templates/party-application/src/lib/PartyApplicationTemplate.ts
+++ b/libs/application/templates/party-application/src/lib/PartyApplicationTemplate.ts
@@ -262,6 +262,7 @@ const PartyApplicationTemplate: ApplicationTemplate<
                 },
                 { event: DefaultEvents.REJECT, name: 'Hafna', type: 'reject' },
               ],
+              read: 'all',
               write: 'all',
             },
             {


### PR DESCRIPTION
# Fix admin overview

Currently admins of the party application don't see the party name and get wrong info in exports.

## What

- Made admin page use external data fields
- Fixed constituency validation logic 

## Screenshots / Gifs

![Screenshot 2021-09-08 at 15 59 02](https://user-images.githubusercontent.com/6640435/132543894-b9c73764-7142-4927-84d5-2fee725fea22.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
