### PR TITLE
fix(services-endorsements-api): Fix minAgeAtDate age check

### DIFF
--- a/apps/services/endorsements/api/src/app/modules/endorsementValidator/validators/minAgeByDate/minAgeByDateValidator.service.ts
+++ b/apps/services/endorsements/api/src/app/modules/endorsementValidator/validators/minAgeByDate/minAgeByDateValidator.service.ts
@@ -29,10 +29,10 @@ export class MinAgeByDateValidatorService implements ValidatorService {
     const eventYear = eventDate.getFullYear()
     const birthdayYear = birthdayDate.getFullYear()
 
-    // if my birthday in the event year is before the event date we subtract 1 year
+    // if my birthday in the event year is after the event date we subtract 1 year
     birthdayDate.setFullYear(eventYear)
     const birthdayEqualizer = Number(
-      birthdayDate.getTime() <= eventDate.getTime(),
+      birthdayDate.getTime() >= eventDate.getTime(),
     )
     let ageAtDate = eventYear - birthdayYear - birthdayEqualizer
 


### PR DESCRIPTION
# Made minAgeAtDate validation check age after event date

Currently we remove one year if birthday is before event date, this should happen if birthday is after event date.

## What

- Turned the check arrow around
- Updated comments to reflect this

## Why

- This is the intended behaviour

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (unable to fulfill due to missing test data)
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
