### PR TITLE
fix(service-portal): remove labels on family member cards

### DIFF
--- a/libs/service-portal/family/src/components/FamilyMemberCard/FamilyMemberCard.tsx
+++ b/libs/service-portal/family/src/components/FamilyMemberCard/FamilyMemberCard.tsx
@@ -9,7 +9,6 @@ import {
 import React, { FC } from 'react'
 import { Link } from 'react-router-dom'
 import * as styles from './FamilyMemberCard.treat'
-import { defineMessage } from 'react-intl'
 
 interface Props {
   title: string
@@ -21,26 +20,9 @@ interface Props {
 export const FamilyMemberCard: FC<Props> = ({
   title,
   nationalId,
-  familyRelation,
   currentUser,
 }) => {
   const { formatMessage } = useLocale()
-
-  const familyRelationLabel =
-    familyRelation === 'child'
-      ? defineMessage({
-          id: 'sp.family:child',
-          defaultMessage: 'Barn',
-        })
-      : familyRelation === 'spouse'
-      ? defineMessage({
-          id: 'sp.family:spouse',
-          defaultMessage: 'Maki',
-        })
-      : defineMessage({
-          id: 'sp.family:family-member',
-          defaultMessage: 'Fjölskyldumeðlimur',
-        })
 
   return (
     <Box
@@ -67,11 +49,6 @@ export const FamilyMemberCard: FC<Props> = ({
           </Text>
         </Box>
         <div>
-          {familyRelation && (
-            <Text variant="eyebrow" color="purple400">
-              {formatMessage(familyRelationLabel)}
-            </Text>
-          )}
           <Box marginBottom={nationalId ? 1 : 0}>
             <Text variant="h3" as="h3" color="dark400">
               {title}


### PR DESCRIPTION
## What

Remove family relation display on family member cards

## Why

Occasionally the user will get an incorrect family relation displayed.

## Screenshots / Gifs

![Screenshot 2021-09-09 at 10 39 17](https://user-images.githubusercontent.com/24840451/132671869-3df5529b-4b3a-4bfa-ac06-1c7222230698.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
