### PR TITLE
feat(web): Syslumenn auctions - Improved filters and UI

### DIFF
--- a/apps/web/screens/Organization/Syslumenn/Auctions.tsx
+++ b/apps/web/screens/Organization/Syslumenn/Auctions.tsx
@@ -490,8 +490,10 @@ const Auctions: Screen<AuctionsProps> = ({
         auction.lotId?.toLowerCase().includes(query) ||
         auction.lotItems?.toLowerCase().includes(query) ||
         auction.office?.toLowerCase().includes(query) ||
-        auction.location?.toLowerCase().includes(query))
-    )
+        auction.location?.toLowerCase().includes(query) ||
+        (auction.lotType === LOT_TYPES.REAL_ESTATE && auction.respondent?.toLowerCase().includes(query)) ||
+        (auction.lotType === LOT_TYPES.REAL_ESTATE && auction.petitioners?.toLowerCase().includes(query)))
+      )
   })
 
   return (
@@ -627,6 +629,8 @@ const Auctions: Screen<AuctionsProps> = ({
           !error &&
           filteredAuctions.slice(0, showCount).map((auction) => {
             const auctionDate = new Date(auction.auctionDate)
+            const auctionPetitioners = auction.petitioners?.split(',')
+            const auctionRespondents = auction.respondent?.split(',')
 
             return (
               <Box
@@ -666,6 +670,22 @@ const Auctions: Screen<AuctionsProps> = ({
                         linkText={auction.lotId}
                         href={`https://www.skra.is/default.aspx?pageid=d5db1b6d-0650-11e6-943c-005056851dd2&selector=streetname&streetname=${auction.lotId}&submitbutton=Leita`}
                       />
+                    )}
+
+                  {/* Real Estate respondents */}
+                  {auctionRespondents &&
+                    auction.lotType === LOT_TYPES.REAL_ESTATE && (
+                      <Text paddingTop={2} paddingBottom={1}>
+                        {auctionRespondents. length > 1 ? 'Þinglýstir eigendur' : 'Þinglýstur eigandi'}: {auctionRespondents.join(', ')}
+                      </Text>
+                    )}
+
+                  {/* Real Estate petitioners */}
+                  {auctionPetitioners &&
+                    auction.lotType === LOT_TYPES.REAL_ESTATE && (
+                      <Text paddingBottom={1}>
+                        {auctionPetitioners.length > 1 ? 'Gerðarbeiðendur' : 'Gerðarbeiðandi'}: {auctionPetitioners.join(', ')}
+                      </Text>
                     )}
 
                   {/* Vehicle link */}

--- a/apps/web/screens/Organization/Syslumenn/Auctions.tsx
+++ b/apps/web/screens/Organization/Syslumenn/Auctions.tsx
@@ -278,7 +278,7 @@ const LOT_TYPES = {
 const AUCTION_TYPES = {
   START: 'Byrjun uppboðs',
   CONTINUATION: 'Framhald uppboðs',
-  SOLD: 'Sölu lokið'
+  SOLD: 'Sölu lokið',
 }
 
 interface LotTypeOption {
@@ -510,9 +510,11 @@ const Auctions: Screen<AuctionsProps> = ({
         auction.lotItems?.toLowerCase().includes(query) ||
         auction.office?.toLowerCase().includes(query) ||
         auction.location?.toLowerCase().includes(query) ||
-        (auction.lotType === LOT_TYPES.REAL_ESTATE && auction.respondent?.toLowerCase().includes(query)) ||
-        (auction.lotType === LOT_TYPES.REAL_ESTATE && auction.petitioners?.toLowerCase().includes(query)))
-      )
+        (auction.lotType === LOT_TYPES.REAL_ESTATE &&
+          auction.respondent?.toLowerCase().includes(query)) ||
+        (auction.lotType === LOT_TYPES.REAL_ESTATE &&
+          auction.petitioners?.toLowerCase().includes(query)))
+    )
   })
 
   return (
@@ -695,7 +697,10 @@ const Auctions: Screen<AuctionsProps> = ({
                   {auctionRespondents &&
                     auction.lotType === LOT_TYPES.REAL_ESTATE && (
                       <Text paddingTop={2} paddingBottom={1}>
-                        {auctionRespondents. length > 1 ? 'Þinglýstir eigendur' : 'Þinglýstur eigandi'}: {auctionRespondents.join(', ')}
+                        {auctionRespondents.length > 1
+                          ? 'Þinglýstir eigendur'
+                          : 'Þinglýstur eigandi'}
+                        : {auctionRespondents.join(', ')}
                       </Text>
                     )}
 
@@ -703,7 +708,10 @@ const Auctions: Screen<AuctionsProps> = ({
                   {auctionPetitioners &&
                     auction.lotType === LOT_TYPES.REAL_ESTATE && (
                       <Text paddingBottom={1}>
-                        {auctionPetitioners.length > 1 ? 'Gerðarbeiðendur' : 'Gerðarbeiðandi'}: {auctionPetitioners.join(', ')}
+                        {auctionPetitioners.length > 1
+                          ? 'Gerðarbeiðendur'
+                          : 'Gerðarbeiðandi'}
+                        : {auctionPetitioners.join(', ')}
                       </Text>
                     )}
 

--- a/apps/web/screens/Organization/Syslumenn/Auctions.tsx
+++ b/apps/web/screens/Organization/Syslumenn/Auctions.tsx
@@ -289,8 +289,8 @@ interface LotTypeOption {
 
 const LOT_TYPES_OPTIONS: LotTypeOption[] = [
   {
-    filterLabel: 'Allar tegundir',
-    value: 'allar-tegundir',
+    filterLabel: 'Öll opin mál',
+    value: 'oll-opin-mal',
     lotType: '',
     auctionType: '',
   },
@@ -359,6 +359,12 @@ const LOT_TYPES_OPTIONS: LotTypeOption[] = [
     value: 'krofurettindi',
     lotType: LOT_TYPES.CLAIMS,
     auctionType: '',
+  },
+  {
+    filterLabel: 'Sölu lokið',
+    value: 'solu-lokid',
+    lotType: '',
+    auctionType: 'Sölu lokið',
   },
 ]
 

--- a/apps/web/screens/Organization/Syslumenn/Auctions.tsx
+++ b/apps/web/screens/Organization/Syslumenn/Auctions.tsx
@@ -39,8 +39,6 @@ import getConfig from 'next/config'
 import { useQuery } from '@apollo/client'
 import { useDateUtils } from '@island.is/web/i18n/useDateUtils'
 import { useRouter } from 'next/router'
-import format from 'date-fns/format'
-import { LottieOptions } from '@island.is/web/libs/react-lottie/types'
 import { theme } from '@island.is/island-ui/theme'
 
 const { publicRuntimeConfig } = getConfig()
@@ -397,6 +395,7 @@ const Auctions: Screen<AuctionsProps> = ({
   const { linkResolver } = useLinkResolver()
   const { format } = useDateUtils()
   const Router = useRouter()
+  const auctionDataFetched = new Date()
 
   const pageUrl = Router.pathname
 
@@ -461,8 +460,6 @@ const Auctions: Screen<AuctionsProps> = ({
       input: {},
     },
   })
-
-  // TODO: Fix input focus bug, where after after initial load of the page and first key-up on the Input, the Input looses focus.
 
   useEffect(() => {
     const hashString = window.location.hash.replace('#', '')
@@ -613,7 +610,7 @@ const Auctions: Screen<AuctionsProps> = ({
         <GridRow>
           <GridColumn
             paddingTop={[2, 2, 0]}
-            paddingBottom={[4, 4, 6]}
+            paddingBottom={[1, 1, 1]}
             span="12/12"
           >
             <Input
@@ -628,6 +625,16 @@ const Auctions: Screen<AuctionsProps> = ({
           </GridColumn>
         </GridRow>
       </GridContainer>
+      <Box
+        display="flex"
+        alignItems="flexEnd"
+        flexDirection="column"
+        paddingBottom={3}
+      >
+        <Text variant="small">
+          Gögn sótt: {format(auctionDataFetched, "d. MMM yyyy 'kl.' hh:mm")}
+        </Text>
+      </Box>
       <Box
         borderTopWidth="standard"
         borderColor="standard"

--- a/apps/web/screens/Organization/Syslumenn/Auctions.tsx
+++ b/apps/web/screens/Organization/Syslumenn/Auctions.tsx
@@ -121,12 +121,6 @@ const OFFICE_LOCATIONS: OfficeLocation[] = [
     location: 'Patreksfjörður',
   },
   {
-    filterLabel: ' - Bolungavík',
-    slugValue: 'syslumadurinn-a-vestfjordum-bolungarvik',
-    office: 'Sýslumaðurinn á Vestfjörðum',
-    location: 'Bolungavík',
-  },
-  {
     filterLabel: ' - Ísafjörður',
     slugValue: 'syslumadurinn-a-vestfjordum-isafjordur',
     office: 'Sýslumaðurinn á Vestfjörðum',

--- a/apps/web/screens/Organization/Syslumenn/Auctions.tsx
+++ b/apps/web/screens/Organization/Syslumenn/Auctions.tsx
@@ -278,6 +278,7 @@ const LOT_TYPES = {
 const AUCTION_TYPES = {
   START: 'Byrjun uppboðs',
   CONTINUATION: 'Framhald uppboðs',
+  SOLD: 'Sölu lokið'
 }
 
 interface LotTypeOption {
@@ -285,6 +286,7 @@ interface LotTypeOption {
   value: string
   lotType: string
   auctionType: string
+  excludeAuctionType: string
 }
 
 const LOT_TYPES_OPTIONS: LotTypeOption[] = [
@@ -293,78 +295,91 @@ const LOT_TYPES_OPTIONS: LotTypeOption[] = [
     value: 'oll-opin-mal',
     lotType: '',
     auctionType: '',
+    excludeAuctionType: AUCTION_TYPES.SOLD,
   },
   {
     filterLabel: `${LOT_TYPES.REAL_ESTATE} - ${AUCTION_TYPES.START}`,
     value: 'fasteign-byrjun',
     lotType: LOT_TYPES.REAL_ESTATE,
     auctionType: AUCTION_TYPES.START,
+    excludeAuctionType: '',
   },
   {
     filterLabel: `${LOT_TYPES.REAL_ESTATE} - ${AUCTION_TYPES.CONTINUATION}`,
     value: 'fasteign-framhald',
     lotType: LOT_TYPES.REAL_ESTATE,
     auctionType: AUCTION_TYPES.CONTINUATION,
+    excludeAuctionType: '',
   },
   {
     filterLabel: LOT_TYPES.VEHICLE,
     value: 'okutaeki',
     lotType: LOT_TYPES.VEHICLE,
     auctionType: '',
+    excludeAuctionType: '',
   },
   {
     filterLabel: LOT_TYPES.AIRCRAFT,
     value: 'loftfar',
     lotType: LOT_TYPES.AIRCRAFT,
     auctionType: '...',
+    excludeAuctionType: '',
   },
   {
     filterLabel: LOT_TYPES.SHIP,
     value: 'skip',
     lotType: LOT_TYPES.SHIP,
     auctionType: '',
+    excludeAuctionType: '',
   },
   {
     filterLabel: LOT_TYPES.LIQUID_ASSETS,
     value: 'lausafjarmunir',
     lotType: LOT_TYPES.LIQUID_ASSETS,
     auctionType: '',
+    excludeAuctionType: '',
   },
   {
     filterLabel: LOT_TYPES.SHAREHOLDING,
     value: 'hlutafjareign',
     lotType: LOT_TYPES.SHAREHOLDING,
     auctionType: '',
+    excludeAuctionType: '',
   },
   {
     filterLabel: LOT_TYPES.SHAREHOLDING_PLC,
     value: 'hlutafjareign-i-einkahlutafelagi',
     lotType: LOT_TYPES.SHAREHOLDING_PLC,
     auctionType: '',
+    excludeAuctionType: '',
   },
   {
     filterLabel: LOT_TYPES.SHAREHOLDING_LLC,
     value: 'hlutafjareign-i-hlutafelagi',
     lotType: LOT_TYPES.SHAREHOLDING_LLC,
     auctionType: '',
+    excludeAuctionType: '',
   },
   {
     filterLabel: LOT_TYPES.STOCKS,
     value: 'verdbref',
     lotType: LOT_TYPES.STOCKS,
     auctionType: '...',
+    excludeAuctionType: '',
   },
   {
     filterLabel: LOT_TYPES.CLAIMS,
     value: 'krofurettindi',
     lotType: LOT_TYPES.CLAIMS,
     auctionType: '',
+    excludeAuctionType: '',
   },
   {
-    filterLabel: 'Sölu lokið',
+    filterLabel: AUCTION_TYPES.SOLD,
     value: 'solu-lokid',
     lotType: '',
-    auctionType: 'Sölu lokið',
+    auctionType: AUCTION_TYPES.SOLD,
+    excludeAuctionType: '',
   },
 ]
 
@@ -480,6 +495,10 @@ const Auctions: Screen<AuctionsProps> = ({
       // Filter by auction type
       (lotTypeOption.auctionType
         ? auction.auctionType === lotTypeOption.auctionType
+        : true) &&
+      // Filter out excluded auction type
+      (lotTypeOption.excludeAuctionType
+        ? auction.auctionType !== lotTypeOption.excludeAuctionType
         : true) &&
       // Filter by Date
       (date


### PR DESCRIPTION
# Syslumenn auctions - Improved filters and UI

## What

- Show real estate respondents and petitioners in UI
- Add filter for auction type "Sale closed".
- Update filter "All open auctions" to hide auctions of type "Sale closed".
- Show timestamp when data was fetched.
- Remove office location Bolungarvik

## Why

For improved UI/UX.

## Screenshots / Gifs

![syslumenn-auctions-improved-ui-ux](https://user-images.githubusercontent.com/1277384/132689205-c1bd3055-7663-4b54-a74e-b38539dc8a8c.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
