### PR TITLE
fix(application-templates-party-application-api): Fix for party application states

### DIFF
--- a/libs/application/templates/party-application/src/lib/PartyApplicationTemplate.ts
+++ b/libs/application/templates/party-application/src/lib/PartyApplicationTemplate.ts
@@ -194,7 +194,6 @@ const PartyApplicationTemplate: ApplicationTemplate<
       },
       [States.IN_REVIEW]: {
         entry: 'assignToSupremeCourt',
-        exit: 'clearAssignees',
         meta: {
           name: 'In Review',
           progress: 0.9,
@@ -241,6 +240,7 @@ const PartyApplicationTemplate: ApplicationTemplate<
         },
       },
       [States.APPROVED]: {
+        entry: 'assignToSupremeCourt',
         meta: {
           name: States.APPROVED,
           progress: 1,
@@ -284,13 +284,6 @@ const PartyApplicationTemplate: ApplicationTemplate<
           },
         }
       }),
-      clearAssignees: assign((context) => ({
-        ...context,
-        application: {
-          ...context.application,
-          assignees: [],
-        },
-      })),
     },
   },
   mapUserToRole(
@@ -301,8 +294,10 @@ const PartyApplicationTemplate: ApplicationTemplate<
       return Roles.ASSIGNEE
     } else if (application.applicant === nationalId) {
       return Roles.APPLICANT
-    } else if (application.state === States.COLLECT_ENDORSEMENTS) {
-      // TODO: Maybe display collection as closed in final state for signaturee
+    } else if (
+      application.state === States.COLLECT_ENDORSEMENTS ||
+      application.state === States.REJECTED
+    ) {
       // everyone can be signaturee if they are not the applicant
       return Roles.SIGNATUREE
     } else {


### PR DESCRIPTION
# Fix for party application states

Currently admins can't access lists once they are accepted

## What

- Added correct role when list is accepted
- Made assignees not get removed when entering new state

## Screenshots / Gifs

<img width="631" alt="Screenshot 2021-09-09 at 16 58 25" src="https://user-images.githubusercontent.com/6640435/132729839-d23ae926-616f-45f9-8972-8546cd28690f.png">

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
