### PR TITLE
fix(application-templates-party-application-api): Party application accepted screen

### DIFF
--- a/libs/application/templates/party-application/src/lib/PartyApplicationTemplate.ts
+++ b/libs/application/templates/party-application/src/lib/PartyApplicationTemplate.ts
@@ -194,7 +194,6 @@ const PartyApplicationTemplate: ApplicationTemplate<
       },
       [States.IN_REVIEW]: {
         entry: 'assignToSupremeCourt',
-        exit: 'clearAssignees',
         meta: {
           name: 'In Review',
           progress: 0.9,
@@ -241,6 +240,7 @@ const PartyApplicationTemplate: ApplicationTemplate<
         },
       },
       [States.APPROVED]: {
+        entry: 'assignToSupremeCourt',
         meta: {
           name: States.APPROVED,
           progress: 1,
@@ -284,13 +284,6 @@ const PartyApplicationTemplate: ApplicationTemplate<
           },
         }
       }),
-      clearAssignees: assign((context) => ({
-        ...context,
-        application: {
-          ...context.application,
-          assignees: [],
-        },
-      })),
     },
   },
   mapUserToRole(
@@ -301,8 +294,10 @@ const PartyApplicationTemplate: ApplicationTemplate<
       return Roles.ASSIGNEE
     } else if (application.applicant === nationalId) {
       return Roles.APPLICANT
-    } else if (application.state === States.COLLECT_ENDORSEMENTS) {
-      // TODO: Maybe display collection as closed in final state for signaturee
+    } else if (
+      application.state === States.COLLECT_ENDORSEMENTS ||
+      application.state === States.REJECTED
+    ) {
       // everyone can be signaturee if they are not the applicant
       return Roles.SIGNATUREE
     } else {


### PR DESCRIPTION
# Party application accepted screen

People can't endorse lists once they have been rejected

## What

- Allowed people to endorse rejected lists
- Made application not clear assignees when leaving states

## Why

- Clearing assignees prevents admins from accessing list

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
