### PR TITLE
fix(endorsement-system-api): limiting queries to national registry

### DIFF
--- a/apps/services/endorsements/api/infra/endorsement-system-scripts-update-metadata.ts
+++ b/apps/services/endorsements/api/infra/endorsement-system-scripts-update-metadata.ts
@@ -14,7 +14,6 @@ export const serviceSetup = (services: {
     .namespace('endorsement-system')
     .image('services-endorsements-api')
     .env({
-      MAX_CONCURRENT: '2',
       TEMPORARY_VOTER_REGISTRY_API_URL: ref(
         (h) => `http://${h.svc(services.servicesTemporaryVoterRegistryApi)}`,
       ),

--- a/apps/services/endorsements/api/infra/endorsement-system-scripts-update-metadata.ts
+++ b/apps/services/endorsements/api/infra/endorsement-system-scripts-update-metadata.ts
@@ -29,7 +29,7 @@ export const serviceSetup = (services: {
     .command('node')
     .args('--tls-min-v1.0', 'updateMetadata.js')
     .extraAttributes({
-      dev: { schedule: '1 */1 * * *' },
-      staging: { schedule: '1 */1 * * *' },
-      prod: { schedule: '1 */1 * * *' },
+      dev: { schedule: '1 */6 * * *' },
+      staging: { schedule: '1 */6 * * *' },
+      prod: { schedule: '1 */6 * * *' },
     })

--- a/apps/services/endorsements/api/migrations/20210909175011-arnorhs.js
+++ b/apps/services/endorsements/api/migrations/20210909175011-arnorhs.js
@@ -1,0 +1,66 @@
+'use strict'
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      const newMetadataFields = [
+        {
+          field: 'fullName',
+        },
+        {
+          field: 'signedTags',
+        },
+        {
+          field: 'address',
+        },
+      ]
+
+      // add correct metadata fields for existing partyLetter lists
+      await queryInterface.bulkUpdate(
+        'endorsement_list',
+        {
+          endorsement_metadata: JSON.stringify(newMetadataFields),
+        },
+        {
+          tags: {
+            [Sequelize.Op.overlap]: queryInterface.sequelize.cast(
+              ['partyLetter2021'],
+              'varchar[]',
+            ),
+          },
+        },
+        { transaction: t },
+      )
+
+      // add correct metadata fields for existing partyApplication lists
+      await queryInterface.bulkUpdate(
+        'endorsement_list',
+        {
+          endorsement_metadata: JSON.stringify([
+            ...newMetadataFields,
+            {
+              field: 'voterRegion',
+              keepUpToDate: true,
+            },
+          ]),
+        },
+        {
+          tags: {
+            [Sequelize.Op.overlap]: queryInterface.sequelize.cast(
+              [
+                'partyApplicationNordausturkjordaemi2021',
+                'partyApplicationNordvesturkjordaemi2021',
+                'partyApplicationReykjavikurkjordaemiNordur2021',
+                'partyApplicationReykjavikurkjordaemiSudur2021',
+                'partyApplicationSudurkjordaemi2021',
+                'partyApplicationSudvesturkjordaemi2021',
+              ],
+              'varchar[]',
+            ),
+          },
+        },
+        { transaction: t },
+      )
+    })
+  },
+}

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -459,7 +459,6 @@ endorsement-system-scripts-update-metadata:
     DB_HOST: dev-vidspyrna-aurora-1.c6cxecmrvlpq.eu-west-1.rds.amazonaws.com
     DB_NAME: services_endorsements_api
     DB_USER: services_endorsements_api
-    MAX_CONCURRENT: '2'
     TEMPORARY_VOTER_REGISTRY_API_URL: >-
       http://web-temporary-voter-registry-api.temporary-voter-registry.svc.cluster.local
   grantNamespaces:

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -482,7 +482,7 @@ endorsement-system-scripts-update-metadata:
     default: 2
     max: 3
     min: 2
-  schedule: 1 */1 * * *
+  schedule: 1 */6 * * *
   secrets:
     CONFIGCAT_SDK_KEY: /k8s/configcat/CONFIGCAT_SDK_KEY
     DB_PASS: /k8s/services-endorsements-api/DB_PASSWORD

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -449,7 +449,6 @@ endorsement-system-scripts-update-metadata:
     DB_HOST: prod-vidspyrna-aurora.cluster-cneim47t7wpr.eu-west-1.rds.amazonaws.com
     DB_NAME: services_endorsements_api
     DB_USER: services_endorsements_api
-    MAX_CONCURRENT: '2'
     TEMPORARY_VOTER_REGISTRY_API_URL: >-
       http://web-temporary-voter-registry-api.temporary-voter-registry.svc.cluster.local
   grantNamespaces:

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -472,7 +472,7 @@ endorsement-system-scripts-update-metadata:
     default: 2
     max: 10
     min: 2
-  schedule: 1 */1 * * *
+  schedule: 1 */6 * * *
   secrets:
     CONFIGCAT_SDK_KEY: /k8s/configcat/CONFIGCAT_SDK_KEY
     DB_PASS: /k8s/services-endorsements-api/DB_PASSWORD

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -470,7 +470,7 @@ endorsement-system-scripts-update-metadata:
     default: 2
     max: 3
     min: 2
-  schedule: 1 */1 * * *
+  schedule: 1 */6 * * *
   secrets:
     CONFIGCAT_SDK_KEY: /k8s/configcat/CONFIGCAT_SDK_KEY
     DB_PASS: /k8s/services-endorsements-api/DB_PASSWORD

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -447,7 +447,6 @@ endorsement-system-scripts-update-metadata:
     DB_HOST: staging-vidspyrna-aurora-2.cxg4o2lgih4t.eu-west-1.rds.amazonaws.com
     DB_NAME: services_endorsements_api
     DB_USER: services_endorsements_api
-    MAX_CONCURRENT: '2'
     TEMPORARY_VOTER_REGISTRY_API_URL: >-
       http://web-temporary-voter-registry-api.temporary-voter-registry.svc.cluster.local
   grantNamespaces:


### PR DESCRIPTION
Updating meta data only for the temporary voter registry

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
