### PR TITLE
feat(application-system): WIP Allow organisations to make requests to application system

### DIFF
--- a/apps/application-system/api/src/environments/environment.ts
+++ b/apps/application-system/api/src/environments/environment.ts
@@ -21,6 +21,7 @@ const devConfig = {
   auth: {
     issuer: 'https://identity-server.dev01.devland.is',
     audience: '@island.is',
+    allowXRoadClientHeaderAuthentication: true,
   },
   templateApi: {
     clientLocationOrigin: 'http://localhost:4242/umsoknir',

--- a/libs/auth-nest-tools/src/lib/auth.module.ts
+++ b/libs/auth-nest-tools/src/lib/auth.module.ts
@@ -4,6 +4,7 @@ import { JwtStrategy } from './jwt.strategy'
 export interface AuthConfig {
   audience: string
   issuer: string
+  allowXRoadClientHeaderAuthentication?: true
 }
 
 @Module({})

--- a/libs/auth-nest-tools/src/lib/jwt.strategy.utils.spec.ts
+++ b/libs/auth-nest-tools/src/lib/jwt.strategy.utils.spec.ts
@@ -1,0 +1,30 @@
+/* eslint-disable local-rules/disallow-kennitalas */
+
+import { parseNationalIdFromXRoadClient } from './jwt.strategy.utils'
+
+describe('parseNationalIdFromXRoadClient', () => {
+  it('should return null when no national id is present', () => {
+    expect(parseNationalIdFromXRoadClient('')).toBe(null)
+    expect(parseNationalIdFromXRoadClient('asdf')).toBe(null)
+    expect(parseNationalIdFromXRoadClient('IS/GOV/missing')).toBe(null)
+    expect(parseNationalIdFromXRoadClient('IS/GOV/123456789/missing')).toBe(
+      null,
+    )
+  })
+
+  it('should return national id when present', () => {
+    expect(
+      parseNationalIdFromXRoadClient('IS/GOV/1111111119/institution'),
+    ).toBe('1111111119')
+
+    expect(
+      parseNationalIdFromXRoadClient('IS/GOV/1811921519/institution'),
+    ).toBe('1811921519')
+  })
+
+  it('should return null when invalid national id is present', () => {
+    expect(
+      parseNationalIdFromXRoadClient('IS/GOV/9111111119/institution'),
+    ).toBe(null)
+  })
+})

--- a/libs/auth-nest-tools/src/lib/jwt.strategy.utils.ts
+++ b/libs/auth-nest-tools/src/lib/jwt.strategy.utils.ts
@@ -1,0 +1,53 @@
+import { Request } from 'express'
+import * as kennitala from 'kennitala'
+import { isNumericCharacter } from '@island.is/shared/utils'
+
+/**
+ * Returns the first occurance of a valid kennitala, if found, null otherwise
+ * TODO: also parse numeric id of length 5 on dev/staging environments
+ *
+ * @param xRoadClient Example IS/GOV/1122334560/something
+ * @returns Example 1122334560
+ */
+export const parseNationalIdFromXRoadClient = (
+  xRoadClient: string,
+): string | null => {
+  const characters = xRoadClient.split('')
+  const candidates: string[] = []
+
+  let currentCandidateIndex = 0
+  let lastCharacterWasNumeric = false
+
+  for (const character of characters) {
+    if (isNumericCharacter(character)) {
+      if (candidates[currentCandidateIndex] === undefined) {
+        candidates[currentCandidateIndex] = ''
+      }
+
+      candidates[currentCandidateIndex] += character
+      lastCharacterWasNumeric = true
+    } else {
+      if (lastCharacterWasNumeric) {
+        currentCandidateIndex += 1
+      }
+
+      lastCharacterWasNumeric = false
+    }
+  }
+
+  return (
+    candidates.find(
+      (candidate) => candidate.length === 10 && kennitala.isValid(candidate),
+    ) ?? null
+  )
+}
+
+export const parseXRoadClientNationalIdFromRequest = (
+  request: Request,
+): string | null => {
+  const xRoadClient = request.headers['x-road-client'] as string | undefined
+
+  return typeof xRoadClient === 'string'
+    ? parseNationalIdFromXRoadClient(xRoadClient)
+    : null
+}

--- a/libs/shared/utils/src/index.ts
+++ b/libs/shared/utils/src/index.ts
@@ -4,3 +4,4 @@
  */
 export { getStaticEnv } from './lib/getStaticEnv'
 export { isRunningOnEnvironment } from './lib/isRunningOnEnvironment'
+export { isNumericCharacter } from './lib/string'

--- a/libs/shared/utils/src/lib/string.ts
+++ b/libs/shared/utils/src/lib/string.ts
@@ -1,0 +1,12 @@
+/**
+ * Checks if provided character is a numeric character
+ */
+export const isNumericCharacter = (character: string): boolean => {
+  const possibleNumber = parseFloat(character)
+
+  if (isNaN(possibleNumber)) {
+    return false
+  }
+
+  return isFinite(possibleNumber)
+}


### PR DESCRIPTION
## What

In order for an institution to make requests to the application system we need to:
- Create a connection between their x-road server (handled by the institution) and our x-road server (handled by Andes)
- When this connection has been established the institution can make a request to the application-system

When the request hits the application system:
- A new client is created for the institution by an IDP admin and the client is given the applications:read and/or :write scopes
- Headers are forwarded so we can make use of `X-Road-Client` to know which institution is making the request
- We modify the code where the user object is generated to also read national id from `X-Road-Client` when the request is coming through x-road
- The request hits the application just like any other authenticated request coming from a user through GraphQL
- An application template can map the institution national id to a role depending on the current state and the institution can fire events and/or edit data

If we see that we need more advanced request handlers we can implement them in the future.

## Why

For institution to be able to make requests to the application system (for example to advance from a state where the user is waiting for their approval or rejection)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
