### PR TITLE
fix(giftcard-web): Preventing crash when user views a giftcard without a sender

### DIFF
--- a/apps/gjafakort/web/screens/User/components/Barcode/Barcode.tsx
+++ b/apps/gjafakort/web/screens/User/components/Barcode/Barcode.tsx
@@ -180,9 +180,11 @@ function Barcode({ shouldPoll: initialPolling }: PropTypes) {
                 <Typography variant="h3">
                   {formatNumber(giftCard.amount)} kr.
                 </Typography>
-                <Typography variant="p">
-                  {t.fromPrefix} {giftCard.giftDetail.from}
-                </Typography>
+                {giftCard.giftDetail && (
+                  <Typography variant="p">
+                    {t.fromPrefix} {giftCard.giftDetail.from}
+                  </Typography>
+                )}
               </Box>
               <Button
                 noWrap


### PR DESCRIPTION

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
