### PR TITLE
fix(island-ui): RadioButton error state

### DIFF
--- a/libs/island-ui/core/src/lib/RadioButton/RadioButton.treat.ts
+++ b/libs/island-ui/core/src/lib/RadioButton/RadioButton.treat.ts
@@ -48,14 +48,6 @@ export const largeLabel = style({
     },
   },
 })
-export const labelWithError = style({
-  padding: `${theme.spacing[3]}px ${theme.spacing[2]}px 0 ${theme.spacing[3]}px`,
-  '@media': {
-    [`screen and (min-width: ${theme.breakpoints.sm}px)`]: {
-      padding: `${theme.spacing[3]}px ${theme.spacing[3]}px 0 ${theme.spacing[3]}px`,
-    },
-  },
-})
 export const radioButtonDisabled = style({
   background: 'transparent',
   borderColor: theme.color.blue200,

--- a/libs/island-ui/core/src/lib/RadioButton/RadioButton.tsx
+++ b/libs/island-ui/core/src/lib/RadioButton/RadioButton.tsx
@@ -84,7 +84,6 @@ export const RadioButton = ({
       />
       <label
         className={cn(styles.label, {
-          [styles.labelWithError]: hasError,
           [styles.radioButtonLabelDisabled]: disabled,
           [styles.largeLabel]: large,
         })}


### PR DESCRIPTION
# Fix RadioButton error state

## What

Removed `RadioButton` error style that was left behind after changes in this PR https://github.com/island-is/island.is/pull/4625
The class was setting `padding-bottom: 0` on the label when it had an error, when the padding should just stay the same.

## Why

QA

## Screenshots / Gifs

### Before
![image](https://user-images.githubusercontent.com/16031201/133242365-af11274d-d8ce-42a4-a72c-ad5189160b55.png)

### After
![image](https://user-images.githubusercontent.com/16031201/133242392-e4acb1f6-e99a-41cc-b4ee-61c319e30263.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
