### PR TITLE
fix(dpac): Tweaks to data schema and company info screen

### DIFF
--- a/libs/application/templates/data-protection-complaint/src/fields/ComplaineeRepeater/ComplaineeRepeaterItem.tsx
+++ b/libs/application/templates/data-protection-complaint/src/fields/ComplaineeRepeater/ComplaineeRepeaterItem.tsx
@@ -82,6 +82,7 @@ export const ComplaineeRepeaterItem: FC<Props> = ({
           error={errors && getErrorViaPath(errors, nameField)}
           required
           backgroundColor="blue"
+          defaultValue=""
         />
         <InputController
           id={addressField}
@@ -94,6 +95,7 @@ export const ComplaineeRepeaterItem: FC<Props> = ({
           error={errors && getErrorViaPath(errors, addressField)}
           required
           backgroundColor="blue"
+          defaultValue=""
         />
         <InputController
           id={nationalIdField}
@@ -107,6 +109,7 @@ export const ComplaineeRepeaterItem: FC<Props> = ({
           error={errors && getErrorViaPath(errors, nationalIdField)}
           required
           backgroundColor="blue"
+          defaultValue=""
         />
       </Stack>
       <Text variant="h5" marginTop={4} marginBottom={2}>
@@ -125,7 +128,7 @@ export const ComplaineeRepeaterItem: FC<Props> = ({
         onSelect={handleOnSelect}
       />
       {isOpen && (
-        <Box padding={3} background="blue100">
+        <Box padding={3} background="blue100" borderRadius="large">
           <Box marginBottom={2}>
             <InputController
               id={countryOfOperationField}
@@ -136,6 +139,7 @@ export const ComplaineeRepeaterItem: FC<Props> = ({
                 formatMessage,
               )}
               error={errors && getErrorViaPath(errors, countryOfOperationField)}
+              defaultValue=""
             />
           </Box>
           <AlertMessage

--- a/libs/application/templates/data-protection-complaint/src/forms/ComplaintForm.ts
+++ b/libs/application/templates/data-protection-complaint/src/forms/ComplaintForm.ts
@@ -10,13 +10,11 @@ import {
   FormValue,
   buildSubSection,
   buildFileUploadField,
-  buildRepeater,
   buildCheckboxField,
   buildSubmitField,
   DefaultEvents,
   buildExternalDataProvider,
   buildDataProviderItem,
-  buildDescriptionField,
 } from '@island.is/application/core'
 import { FILE_SIZE_LIMIT, YES, NO, SubjectOfComplaint } from '../shared'
 import {

--- a/libs/application/templates/data-protection-complaint/src/lib/dataSchema.ts
+++ b/libs/application/templates/data-protection-complaint/src/lib/dataSchema.ts
@@ -17,6 +17,9 @@ const FileSchema = z.object({
   url: z.string().optional(),
 })
 
+// Validation on optional field: https://github.com/colinhacks/zod/issues/310
+const optionalEmail = z.string().email().optional().or(z.literal(''))
+
 export const DataProtectionComplaintSchema = z.object({
   externalData: z.object({
     nationalRegistry: z.object({
@@ -70,21 +73,25 @@ export const DataProtectionComplaintSchema = z.object({
     ]),
   }),
   applicant: z.object({
-    name: z.string().nonempty(error.required.defaultMessage),
-    nationalId: z.string().refine((x) => (x ? kennitala.isPerson(x) : false)),
-    address: z.string().nonempty(error.required.defaultMessage),
-    postalCode: z.string().nonempty(error.required.defaultMessage),
-    city: z.string().nonempty(error.required.defaultMessage),
-    email: z.string().email().optional(),
+    name: z.string().refine((x) => !!x, { params: error.required }),
+    nationalId: z.string().refine((x) => (x ? kennitala.isPerson(x) : false), {
+      params: error.nationalId,
+    }),
+    address: z.string().refine((x) => !!x, { params: error.required }),
+    postalCode: z.string().refine((x) => !!x, { params: error.required }),
+    city: z.string().refine((x) => !!x, { params: error.required }),
+    email: optionalEmail,
     phoneNumber: z.string().optional(),
   }),
   organizationOrInstitution: z.object({
-    name: z.string().nonempty(error.required.defaultMessage),
-    nationalId: z.string().refine((x) => (x ? kennitala.isCompany(x) : false)),
-    address: z.string().nonempty(error.required.defaultMessage),
-    postalCode: z.string().nonempty(error.required.defaultMessage),
-    city: z.string().nonempty(error.required.defaultMessage),
-    email: z.string().email().optional(),
+    name: z.string().refine((x) => !!x, { params: error.required }),
+    nationalId: z.string().refine((x) => (x ? kennitala.isCompany(x) : false), {
+      params: error.nationalId,
+    }),
+    address: z.string().refine((x) => !!x, { params: error.required }),
+    postalCode: z.string().refine((x) => !!x, { params: error.required }),
+    city: z.string().refine((x) => !!x, { params: error.required }),
+    email: optionalEmail,
     phoneNumber: z.string().optional(),
   }),
   commissions: z.object({
@@ -92,7 +99,7 @@ export const DataProtectionComplaintSchema = z.object({
     persons: z
       .array(
         z.object({
-          name: z.string().nonempty(error.required.defaultMessage),
+          name: z.string().refine((x) => !!x, { params: error.required }),
           nationalId: z
             .string()
             .refine((x) => (x ? kennitala.isPerson(x) : false)),
@@ -102,12 +109,14 @@ export const DataProtectionComplaintSchema = z.object({
   }),
   complainees: z.array(
     z.object({
-      name: z.string().nonempty(error.required.defaultMessage),
-      address: z.string().nonempty(error.required.defaultMessage),
+      name: z.string().refine((x) => !!x, { params: error.required }),
+      address: z.string().refine((x) => !!x, { params: error.required }),
       nationalId: z
         .string()
-        .refine((x) => (x ? kennitala.isValid(x) : false))
-        .optional(),
+        .nonempty(error.required.defaultMessage)
+        .refine((x) => (x ? kennitala.isValid(x) : false), {
+          params: error.nationalId,
+        }),
       operatesWithinEurope: z.enum([YES, NO]),
       countryOfOperation: z.string().optional(),
     }),

--- a/libs/application/templates/data-protection-complaint/src/lib/messages/error.ts
+++ b/libs/application/templates/data-protection-complaint/src/lib/messages/error.ts
@@ -50,6 +50,11 @@ export const error = defineMessages({
     defaultMessage: 'Lýsingin má vera 500 orð að hámarki',
     description: 'Error message when a word count has been reached',
   },
+  nationalId: {
+    id: 'dpac.application:error.nationalId',
+    defaultMessage: 'Kennitala er ekki á réttu sniðmáti',
+    description: 'Error message when a nationalId is incorrect',
+  },
 })
 
 export const errorCards = defineMessages({


### PR DESCRIPTION
# Tweaks to data schema and company info screen

https://app.clickup.com/t/1e0y6wq

## What

- Added border-radius to custom component in company info repeater
- Added `defaultValue=""` to input controllers so that correct error message is shown
- Added special error message for nationalId format
- Changed all usages of `.nonempty()` in data-schema to `.refine()`, so that correct error message is shown.

## Why

QA / Design requirement

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/16031201/133273549-b2dc4424-e8fc-47ea-a6c7-a0e6470d81dc.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
