### PR TITLE
fix(service-portal): use proper translation namespaces for wip section

### DIFF
--- a/libs/service-portal/assets/src/screens/AssetsVehicles/AssetsVehicles.tsx
+++ b/libs/service-portal/assets/src/screens/AssetsVehicles/AssetsVehicles.tsx
@@ -8,7 +8,7 @@ import { defineMessage } from 'react-intl'
 import { useNamespaces } from '@island.is/localization'
 
 export const AssetsVehicles: ServicePortalModuleComponent = () => {
-  useNamespaces(['service.portal', 'sp.assets'])
+  useNamespaces(['sp.assets'])
 
   return (
     <InfoScreen
@@ -26,16 +26,15 @@ export const AssetsVehicles: ServicePortalModuleComponent = () => {
         items: [
           defineMessage({
             id: 'sp.assets:vehicles-inc-1',
-            defaultMessage:
-              'Yfirlit og hægt verður að greiða öll opinber gjöld',
+            defaultMessage: 'Ökutækin mín',
           }),
           defineMessage({
             id: 'sp.assets:vehicles-inc-2',
-            defaultMessage: 'Ganga frá skattskýrsla og sjá eldi skattskýrslur',
+            defaultMessage: 'Eignastöðuvottorð',
           }),
           defineMessage({
             id: 'sp.assets:vehicles-inc-3',
-            defaultMessage: 'Sjá yfirlit og ráðstafa séreignarsparnaði',
+            defaultMessage: 'Ökutækjaferill',
           }),
         ],
       }}

--- a/libs/service-portal/wip/src/screens/FinanceWIP/FinanceWIP.tsx
+++ b/libs/service-portal/wip/src/screens/FinanceWIP/FinanceWIP.tsx
@@ -7,22 +7,22 @@ import { defineMessage } from 'react-intl'
 import { useNamespaces } from '@island.is/localization'
 
 export const SettingsWIP: ServicePortalModuleComponent = () => {
-  useNamespaces('sp.finance')
+  useNamespaces('sp.wip')
 
   return (
     <InfoScreen
       title={defineMessage({
-        id: 'sp.finance:title',
+        id: 'sp.wip:finance-title',
         defaultMessage: 'Fjármál',
       })}
       intro={defineMessage({
-        id: 'sp.finance:wip-intro',
+        id: 'sp.wip:finance-intro',
         defaultMessage: `Hér eru upplýsingar um það sem kemur til með að koma inn undir
         fjármál á næstunni.`,
       })}
       externalHref="https://minarsidur.island.is/minar-sidur/fjarmal/fjarmal-stada-vid-rikissjod-og-stofnanir/"
       externalLinkTitle={defineMessage({
-        id: 'sp.finance:external-link-title',
+        id: 'sp.wip:external-link-title',
         defaultMessage: 'Fara á fjármál',
       })}
       figure="./assets/images/working.jpg"

--- a/libs/service-portal/wip/src/screens/SettingsWIP/SettingsWIP.tsx
+++ b/libs/service-portal/wip/src/screens/SettingsWIP/SettingsWIP.tsx
@@ -8,16 +8,16 @@ import { defineMessage } from 'react-intl'
 import { useNamespaces } from '@island.is/localization'
 
 export const SettingsWIP: ServicePortalModuleComponent = () => {
-  useNamespaces('sp.family')
+  useNamespaces('sp.wip')
 
   return (
     <InfoScreen
       title={defineMessage({
-        id: 'sp.family:settings-title',
+        id: 'sp.wip:settings-title',
         defaultMessage: 'Stillingar',
       })}
       intro={defineMessage({
-        id: 'sp.family:settings-intro',
+        id: 'sp.wip:settings-intro',
         defaultMessage: `Hér eru upplýsingar um það sem kemur til með að koma inn undir
         stillingar á næstunni.`,
       })}
@@ -25,23 +25,22 @@ export const SettingsWIP: ServicePortalModuleComponent = () => {
         title: m.incoming,
         items: [
           defineMessage({
-            id: 'sp.family:settings-inc-1',
-            defaultMessage:
-              'Yfirlit og hægt verður að greiða öll opinber gjöld',
+            id: 'sp.wip:settings-inc-1',
+            defaultMessage: 'Umboðs og aðgangsstýringarkerfi',
           }),
           defineMessage({
-            id: 'sp.family:settings-inc-2',
-            defaultMessage: 'Ganga frá skattskýrsla og sjá eldi skattskýrslur',
+            id: 'sp.wip:settings-inc-2',
+            defaultMessage: 'Stillingar fyrir tilkynningar',
           }),
           defineMessage({
-            id: 'sp.family:settings-inc-3',
-            defaultMessage: 'Sjá yfirlit og ráðstafa séreignarsparnaði',
+            id: 'sp.wip:settings-inc-3',
+            defaultMessage: 'Bankaupplýsingar',
           }),
         ],
       }}
       externalHref="https://minarsidur.island.is/minar-sidur/minn-adgangur/stillingar/"
       externalLinkTitle={defineMessage({
-        id: 'sp.family:settings-external-link-title',
+        id: 'sp.wip:settings-external-link-title',
         defaultMessage: 'Fara í stillingar',
       })}
       figure="./assets/images/working.jpg"


### PR DESCRIPTION
## What

Change the namespaces of a couple of translation strings.

## Why

Unable to properly change the translation strings because of misplaces namespaces. It would result in deprecating some strings I would rather not deprecate.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
