### PR TITLE
fix(api-domains-education): Prevent the national IDs from showing up in URLs

### DIFF
--- a/libs/api/domains/education/src/lib/education.service.ts
+++ b/libs/api/domains/education/src/lib/education.service.ts
@@ -64,7 +64,7 @@ export class EducationService {
     })
   }
 
-  private isChild(familyMember: ISLFjolskyldan): boolean {
+  public isChild(familyMember: ISLFjolskyldan): boolean {
     return (
       !['1', '2', '7'].includes(familyMember.Kyn) &&
       kennitala.info(familyMember.Kennitala).age < ADULT_AGE_LIMIT

--- a/libs/api/domains/education/src/lib/education.spec.ts
+++ b/libs/api/domains/education/src/lib/education.spec.ts
@@ -54,7 +54,7 @@ describe('EducationService', () => {
     })
   })
 
-  describe('MyFamily for an adult', () => {
+  describe('getFamily() for an adult', () => {
     let family: ISLFjolskyldan[]
     beforeEach(async () => {
       family = await service.getFamily('0910819979')
@@ -81,7 +81,7 @@ describe('EducationService', () => {
     })
   })
 
-  describe('MyFamily for a child', () => {
+  describe('getFamily() for a child', () => {
     let family: ISLFjolskyldan[]
     beforeEach(async () => {
       family = await service.getFamily('2407134110')
@@ -95,6 +95,18 @@ describe('EducationService', () => {
       expect(
         family.find(({ Kennitala }) => Kennitala === '2407134110'),
       ).not.toBeUndefined()
+    })
+  })
+
+  describe('isChild()', () => {
+    it('recognizes children as children', async () => {
+      const person = (await service.getFamily('2407134110'))[0]
+      expect(await service.isChild(person)).toStrictEqual(true)
+    })
+
+    it("doesn't recognize adults as children", async () => {
+      const person = (await service.getFamily('0910819979'))[0]
+      expect(await service.isChild(person)).toStrictEqual(false)
     })
   })
 })

--- a/libs/api/domains/education/src/lib/education.spec.ts
+++ b/libs/api/domains/education/src/lib/education.spec.ts
@@ -1,0 +1,100 @@
+import { Test } from '@nestjs/testing'
+import { EducationService } from './education.service'
+import { LoggingModule } from '@island.is/logging'
+import type { Config } from './education.module'
+import { MyFamilyMock } from './mock-data/my-family'
+import {
+  ISLFjolskyldan,
+  NationalRegistryApi,
+} from '@island.is/clients/national-registry-v1'
+import { MMSApi } from '@island.is/clients/mms'
+import { S3Service } from './s3.service'
+import Soap from 'soap'
+
+const config = {
+  fileDownloadBucket: '',
+  xroad: { baseUrl: '', clientId: '', services: { license: '', grade: '' } },
+} as Config
+
+describe('EducationService', () => {
+  let service: EducationService
+  let nationalRegistryService: NationalRegistryApi
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      imports: [LoggingModule],
+      providers: [
+        S3Service,
+        {
+          provide: NationalRegistryApi,
+          useFactory: async () =>
+            new NationalRegistryApi({} as Soap.Client, 'xx', 'yy'),
+        },
+        {
+          provide: MMSApi,
+          useFactory: async () => new MMSApi(config.xroad),
+        },
+        EducationService,
+        { provide: 'CONFIG', useValue: config },
+      ],
+    }).compile()
+
+    nationalRegistryService = module.get(NationalRegistryApi)
+
+    jest
+      .spyOn(nationalRegistryService, 'getMyFamily')
+      .mockImplementation(async () => MyFamilyMock as ISLFjolskyldan[])
+
+    service = module.get(EducationService)
+  })
+
+  describe('Module', () => {
+    it('should be defined', () => {
+      expect(service).toBeTruthy()
+    })
+  })
+
+  describe('MyFamily for an adult', () => {
+    let family: ISLFjolskyldan[]
+    beforeEach(async () => {
+      family = await service.getFamily('0910819979')
+    })
+
+    it('should not return the spouse', async () => {
+      expect(
+        family.find(({ Kennitala }) => Kennitala === '1809789929'),
+      ).toBeUndefined()
+    })
+
+    it('should return yourself', async () => {
+      expect(
+        family.find(({ Kennitala }) => Kennitala === '0910819979'),
+      ).not.toBeUndefined()
+    })
+
+    it('should return consistantly ordered results', async () => {
+      expect(family.map(({ Kennitala }) => Kennitala)).toStrictEqual([
+        '0910819979',
+        '2407134110',
+        '3108168330',
+      ])
+    })
+  })
+
+  describe('MyFamily for a child', () => {
+    let family: ISLFjolskyldan[]
+    beforeEach(async () => {
+      family = await service.getFamily('2407134110')
+    })
+
+    it('should not return other family members', async () => {
+      expect(family).toHaveLength(1)
+    })
+
+    it('should return yourself', async () => {
+      expect(
+        family.find(({ Kennitala }) => Kennitala === '2407134110'),
+      ).not.toBeUndefined()
+    })
+  })
+})

--- a/libs/api/domains/education/src/lib/education.type.ts
+++ b/libs/api/domains/education/src/lib/education.type.ts
@@ -12,6 +12,7 @@ export interface ExamFamilyOverview {
   organizationType: string
   organizationName: string
   yearInterval: string
+  familyIndex: number
 }
 
 interface Grade {

--- a/libs/api/domains/education/src/lib/graphql/grade/examFamilyOverview.model.ts
+++ b/libs/api/domains/education/src/lib/graphql/grade/examFamilyOverview.model.ts
@@ -1,4 +1,4 @@
-import { Field, ObjectType, ID } from '@nestjs/graphql'
+import { Field, ObjectType, ID, Int } from '@nestjs/graphql'
 
 @ObjectType('EducationExamFamilyOverview')
 export class ExamFamilyOverview {
@@ -19,4 +19,7 @@ export class ExamFamilyOverview {
 
   @Field(() => String)
   yearInterval!: string
+
+  @Field(() => Int)
+  familyIndex!: number
 }

--- a/libs/api/domains/education/src/lib/graphql/main.resolver.ts
+++ b/libs/api/domains/education/src/lib/graphql/main.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Query, Mutation, Resolver } from '@nestjs/graphql'
+import { Args, Query, Mutation, Resolver, Int } from '@nestjs/graphql'
 import { UseGuards } from '@nestjs/common'
 import { ApolloError } from 'apollo-server-express'
 
@@ -83,21 +83,21 @@ export class MainResolver {
   @Query(() => ExamResult)
   async educationExamResult(
     @CurrentUser() user: User,
-    @Args('nationalId') nationalId: string,
+    @Args('familyIndex', { type: () => Int }) familyIndex: number,
   ): Promise<ExamResult> {
     const family = await this.educationService.getFamily(user.nationalId)
-    const familyMember = family.find(
-      (familyMember) => familyMember.Kennitala === nationalId,
-    )
+    const familyMember = family[familyIndex]
+
     if (!familyMember) {
       throw new ApolloError('The requested nationalId is not a part of family')
     }
+
     return this.auditService.auditPromise(
       {
         user,
         namespace,
         action: 'educationExamResult',
-        resources: nationalId,
+        resources: familyMember.Kennitala,
       },
       this.educationService.getExamResult(familyMember),
     )

--- a/libs/api/domains/education/src/lib/mock-data/my-family.ts
+++ b/libs/api/domains/education/src/lib/mock-data/my-family.ts
@@ -1,0 +1,63 @@
+import { ISLFjolskyldan } from '@island.is/clients/national-registry-v1'
+
+// Note: this family is generated from a real family, but the names and
+// national IDs have been changed to protect the identity of said family.
+// Extra note: it would be nice to have more family cases to test.
+export const MyFamilyMock = [
+  {
+    attributes: {
+      'diffgr:id': 'ISLFjolskyldan2',
+      'msdata:rowOrder': '1',
+      'diffgr:hasChanges': 'inserted',
+    },
+    Kennitala: '0910819979',
+    Nafn: 'Arfón Heyrir Sogurðsson',
+    Fjolsknr: '1809789929',
+    Kyn: '1',
+    Kynheiti: 'Karl',
+    Faedingardagur: '9.10.1981 00:00:00',
+    MakiBarn: '',
+  },
+  {
+    attributes: {
+      'diffgr:id': 'ISLFjolskyldan4',
+      'msdata:rowOrder': '3',
+      'diffgr:hasChanges': 'inserted',
+    },
+    Kennitala: '3108168330',
+    Nafn: 'Salbör Arfónsdóttir',
+    Fjolsknr: '1809789929',
+    Kyn: '4',
+    Kynheiti: 'Stúlka',
+    Faedingardagur: '31.8.2016 00:00:00',
+    MakiBarn: '',
+  },
+  {
+    attributes: {
+      'diffgr:id': 'ISLFjolskyldan3',
+      'msdata:rowOrder': '2',
+      'diffgr:hasChanges': 'inserted',
+    },
+    Kennitala: '2407134110',
+    Nafn: 'Glóa Arfónsdóttir',
+    Fjolsknr: '1809789929',
+    Kyn: '4',
+    Kynheiti: 'Stúlka',
+    Faedingardagur: '24.7.2013 00:00:00',
+    MakiBarn: '',
+  },
+  {
+    attributes: {
+      'diffgr:id': 'ISLFjolskyldan1',
+      'msdata:rowOrder': '0',
+      'diffgr:hasChanges': 'inserted',
+    },
+    Kennitala: '1809789929',
+    Nafn: 'Helfa Hreiðursdóttir',
+    Fjolsknr: '1809789929',
+    Kyn: '2',
+    Kynheiti: 'Kona',
+    Faedingardagur: '18.9.1978 00:00:00',
+    MakiBarn: '',
+  },
+] as ISLFjolskyldan[]

--- a/libs/service-portal/core/src/lib/navigation/paths.ts
+++ b/libs/service-portal/core/src/lib/navigation/paths.ts
@@ -54,7 +54,7 @@ export enum ServicePortalPath {
   EducationRoot = '/menntun',
   EducationDegree = '/menntun/profgradur',
   EducationCareer = '/menntun/namsferill',
-  EducationStudentAssessment = '/menntun/namsferill/:nationalId/samraemd-prof',
+  EducationStudentAssessment = '/menntun/namsferill/:familyIndex/samraemd-prof',
   EducationExternal = 'https://minarsidur.island.is/minar-sidur/menntun/namsferill/',
 
   // Education License

--- a/libs/service-portal/education-career/src/screens/EducationCareer/components/CareerCards/CareerCards.tsx
+++ b/libs/service-portal/education-career/src/screens/EducationCareer/components/CareerCards/CareerCards.tsx
@@ -8,7 +8,6 @@ import {
   ServicePortalPath,
   EducationCard,
   EmptyState,
-  m,
 } from '@island.is/service-portal/core'
 import * as styles from './CareerCards.treat'
 import { defineMessage } from 'react-intl'
@@ -23,6 +22,7 @@ const EducationExamFamilyOverviewsQuery = gql`
       organizationType
       organizationName
       yearInterval
+      familyIndex
     }
   }
 `
@@ -51,8 +51,8 @@ const CareerCards = () => {
             CTA={
               <Link
                 to={ServicePortalPath.EducationStudentAssessment.replace(
-                  ':nationalId',
-                  member.nationalId,
+                  ':familyIndex',
+                  member.familyIndex.toString(),
                 )}
                 className={styles.link}
               >

--- a/libs/service-portal/education-student-assessment/src/screens/EducationStudentAssessment/components/StudentAssessmentTable/StudentAssessmentTable.tsx
+++ b/libs/service-portal/education-student-assessment/src/screens/EducationStudentAssessment/components/StudentAssessmentTable/StudentAssessmentTable.tsx
@@ -13,8 +13,8 @@ import { gql, useQuery } from '@apollo/client'
 import { Query } from '@island.is/api/schema'
 
 const EducationExamResultQuery = gql`
-  query EducationExamResultQuery($nationalId: String!) {
-    educationExamResult(nationalId: $nationalId) {
+  query EducationExamResultQuery($familyIndex: Int!) {
+    educationExamResult(familyIndex: $familyIndex) {
       id
       fullName
       grades {
@@ -74,12 +74,12 @@ type DataField = Pick<
 >
 
 const StudentAssessmentTable = () => {
-  const { nationalId } = useParams<{ nationalId: string }>()
+  const { familyIndex } = useParams<{ familyIndex: string }>()
   const { data, loading: queryLoading, error } = useQuery<Query>(
     EducationExamResultQuery,
     {
       variables: {
-        nationalId,
+        familyIndex: parseInt(familyIndex, 10),
       },
     },
   )


### PR DESCRIPTION
The national IDs are showing up in analytics applications, and possibly even some other places since they are presented as part of the URLs and used in navigation.

This change should make it so we access them by index within your visible family members, when you can see more than a single one. This affects both the showing of URLs in the service portal's education part, as well as the way these things are presented.

I also added a few tests for the case of visibility between different family members and for the ordering

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
