### PR TITLE
feat(license-service): map status code from verifyPkpass API (#5010)

### DIFF
--- a/libs/api/domains/license-service/src/lib/client/driving-license-client/drivingLicenseService.api.ts
+++ b/libs/api/domains/license-service/src/lib/client/driving-license-client/drivingLicenseService.api.ts
@@ -397,6 +397,7 @@ export class GenericDrivingLicenseApi
     if (!res.ok) {
       const responseErrors: PkPassServiceErrorResponse = {}
       try {
+        // Service returns 400 for invalid data with details in the body
         const json = await res.json()
         responseErrors.message = json?.message ?? undefined
         responseErrors.status = json?.status ?? undefined
@@ -405,14 +406,22 @@ export class GenericDrivingLicenseApi
         // noop
       }
 
-      this.logger.warn(
-        'Expected 200 status for pkpass verify drivers license service',
-        {
+      // If we don't have a status in the body and a non-200 response, log it
+      if (!responseErrors.status) {
+        let message =
+          'Expected 200 status or 400 status with info in message for pkpass verify drivers license service'
+
+        if (res.status === 400) {
+          message =
+            'Expected 400 status with info in message for pkpass verify drivers license service'
+        }
+
+        this.logger.warn(message, {
           status: res.status,
           statusText: res.statusText,
           ...responseErrors,
-        },
-      )
+        })
+      }
 
       return {
         valid: false,
@@ -481,9 +490,15 @@ export class GenericDrivingLicenseApi
         // noop
       }
 
+      // Is there a status code from the service?
+      const serviceErrorStatus = result.error.serviceError?.status
+
+      // Use status code, or http status code from serivce, or "0" for unknown
+      const status = serviceErrorStatus ?? (result.error.statusCode || 0)
+
       error = {
-        status: (result.error.statusCode || 0).toString(),
-        message: result.error.serviceError?.message ?? 'Unknown error',
+        status: status.toString(),
+        message: result.error.serviceError?.message || 'Unknown error',
         data,
       }
     }

--- a/libs/api/domains/license-service/src/lib/client/driving-license-client/genericDrivingLicense.type.ts
+++ b/libs/api/domains/license-service/src/lib/client/driving-license-client/genericDrivingLicense.type.ts
@@ -75,25 +75,51 @@ export interface PkPassServiceDriversLicenseResponse {
   status: number
 }
 
+/**
+ * Driving licenses are verified against SmartSolution API
+ * https://app.gitbook.com/@smartsolutions/s/smart-solutions-drivers-license/verify-drivers-license
+ */
+
+export type PkPassServiceVerifyDriversLicenseStatusCode =
+  /** License OK */
+  | 1
+  /** License expired */
+  | 2
+  /** No license info found */
+  | 3
+  /** Request contains some field errors */
+  | 4
+  /** Unknown error */
+  | 99
+
+/** Data for a response with errors */
 export interface PkPassServiceErrorResponse {
   message?: string
-  status?: number
+  status?: PkPassServiceVerifyDriversLicenseStatusCode
   data?: unknown
 }
 
+/** Data for a successful response */
 export interface PkPassServiceVerifyDriversLicenseResponse {
   message: string
   data?: {
     kennitala?: string
   }
-  status: number
+  status: PkPassServiceVerifyDriversLicenseStatusCode
 }
 
+/** Wrapper for error passed along to clients */
 export interface PkPassVerifyError {
+  /**
+   * HTTP status code from the service.
+   * Needed while `status` was always the same, use `serviceError.status` for
+   * error reported by API.
+   */
   statusCode: number
   serviceError?: PkPassServiceErrorResponse
 }
 
+/** Wrapper for data passed along to clients */
 export interface PkPassVerifyResult {
   valid: boolean
   error?: PkPassVerifyError

--- a/libs/api/domains/license-service/src/lib/licenceService.type.ts
+++ b/libs/api/domains/license-service/src/lib/licenceService.type.ts
@@ -102,11 +102,22 @@ export type GenericUserLicense = {
 }
 
 export type PkPassVerificationError = {
+  /**
+   * Generic placeholder for a status code, could be the HTTP status code, code
+   * from API, or empty string. Semantics need to be defined per license type
+   */
   status: string
+
+  /**
+   * Generic placeholder for a status message, from API, or empty "Unknown error".
+   * Semantics need to be defined per license type
+   */
   message: string
-  // data is used to pass along the error from originator, e.g. SmartSolution
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  data?: any
+
+  /**
+   * data is used to pass along the error from originator, e.g. SmartSolution
+   */
+  data?: string
 }
 
 export type PkPassVerification = {


### PR DESCRIPTION
* feat(license-service): map status code from verifyPkpass API result to client

* feat(license-service): skip logging if 400 error with status in message

* Update libs/api/domains/license-service/src/lib/licenceService.type.ts

Co-authored-by: Már Örlygsson <mar.nospam@anomy.net>

* Update libs/api/domains/license-service/src/lib/licenceService.type.ts

Co-authored-by: Már Örlygsson <mar.nospam@anomy.net>

* Update libs/api/domains/license-service/src/lib/licenceService.type.ts

Co-authored-by: Már Örlygsson <mar.nospam@anomy.net>

* Update libs/api/domains/license-service/src/lib/licenceService.type.ts

Co-authored-by: Már Örlygsson <mar.nospam@anomy.net>

* Update libs/api/domains/license-service/src/lib/client/driving-license-client/drivingLicenseService.api.ts

Co-authored-by: Már Örlygsson <mar.nospam@anomy.net>

* fix: types

Co-authored-by: Már Örlygsson <mar.nospam@anomy.net>
Co-authored-by: kodiakhq[bot] <49736102+kodiakhq[bot]@users.noreply.github.com>

# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
