### PR TITLE
feat(application-templates-driving-assessment-approval): updating translations

### DIFF
--- a/libs/application/templates/driving-assessment-approval/src/fields/Congratulations.tsx
+++ b/libs/application/templates/driving-assessment-approval/src/fields/Congratulations.tsx
@@ -26,7 +26,11 @@ export const Congratulations = ({ application }: PropTypes): JSX.Element => {
               application,
               formatMessage,
             )}`}
-            message=""
+            message={`${formatText(
+              m.finalAssessmentDescription,
+              application,
+              formatMessage,
+            )}`}
           />
         </ContentBlock>
       </Box>

--- a/libs/application/templates/driving-assessment-approval/src/lib/DrivingAssessmentApprovalTemplate.ts
+++ b/libs/application/templates/driving-assessment-approval/src/lib/DrivingAssessmentApprovalTemplate.ts
@@ -2,11 +2,8 @@ import {
   ApplicationTemplate,
   ApplicationTypes,
   ApplicationContext,
-  ApplicationRole,
   ApplicationStateSchema,
-  Application,
   DefaultEvents,
-  DefaultStateLifeCycle,
   ApplicationConfigurations,
 } from '@island.is/application/core'
 import * as z from 'zod'

--- a/libs/application/templates/driving-assessment-approval/src/lib/messages.ts
+++ b/libs/application/templates/driving-assessment-approval/src/lib/messages.ts
@@ -272,7 +272,8 @@ export const m = defineMessages({
   },
   finalAssessmentDescription: {
     id: 'dla.application:finalAssessmentDescription',
-    defaultMessage: 'Tölvupóstur hefur verið sendur á nemanda og honum tilkynnt að ökukennari hafi staðfest að akstursmat hafi farið fram. Nemandi getur nú sótt um fullnaðarskírteini.',
+    defaultMessage:
+      'Tölvupóstur hefur verið sendur á nemanda og honum tilkynnt að ökukennari hafi staðfest að akstursmat hafi farið fram. Nemandi getur nú sótt um fullnaðarskírteini.',
     description: 'Driving assessment received description.',
   },
 })

--- a/libs/application/templates/driving-assessment-approval/src/lib/messages.ts
+++ b/libs/application/templates/driving-assessment-approval/src/lib/messages.ts
@@ -266,8 +266,13 @@ export const m = defineMessages({
     description: 'I confirm that the student has passed the driving assessment',
   },
   finalAssessmentTitle: {
-    id: 'dla.application:',
-    defaultMessage: 'Akstursmat hefur verið staðfest',
+    id: 'dla.application:finalAssessmentTitle',
+    defaultMessage: 'Akstursmat móttekið',
     description: 'Driving assessment received.',
+  },
+  finalAssessmentDescription: {
+    id: 'dla.application:finalAssessmentDescription',
+    defaultMessage: 'Tölvupóstur hefur verið sendur á nemanda og honum tilkynnt að ökukennari hafi staðfest að akstursmat hafi farið fram. Nemandi getur nú sótt um fullnaðarskírteini.',
+    description: 'Driving assessment received description.',
   },
 })


### PR DESCRIPTION
updating translation string keys for Contentful and adding a description to the confirmation box

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
