### PR TITLE
fix(gjafakort-api): allowing a null packageId in giftcard detail object

### DIFF
--- a/apps/gjafakort/api/src/domains/users/typeDefs.ts
+++ b/apps/gjafakort/api/src/domains/users/typeDefs.ts
@@ -8,7 +8,7 @@ export default gql`
   }
 
   type GiftDetail {
-    packageId: String!
+    packageId: String
     from: String
     greeting: Greeting
     personalMessage: String

--- a/apps/gjafakort/api/src/services/yay.ts
+++ b/apps/gjafakort/api/src/services/yay.ts
@@ -14,7 +14,7 @@ interface GiftCard {
   statusId: number
   indentifier: string
   giftDetail: {
-    packageId: string
+    packageId: string | null
     from: string
     greeting: {
       greetingType: number


### PR DESCRIPTION
## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
