### PR TITLE
feat(metrics): add metrics module; add metrics to license-service

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -197,6 +197,7 @@
 - [Localization](libs/localization/README.md)
 - [Nest Modules](libs/nest/README.md)
   - [Audit Module](libs/nest/audit/README.md)
+  - [Metrics Module](libs/nest/metrics/README.md)
 - [NOVA SMS](libs/nova-sms/README.md)
 - [Plausible](libs/plausible/README.md)
 - [Regulations](libs/regulations/README.md)

--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -36,6 +36,7 @@ import { PartyLetterRegistryModule } from '@island.is/api/domains/party-letter-r
 import { LicenseServiceModule } from '@island.is/api/domains/license-service'
 import { AuditModule } from '@island.is/nest/audit'
 import { PaymentScheduleModule } from '@island.is/api/domains/payment-schedule'
+import { MetricsModule, MetricsOptions } from '@island.is/nest/metrics'
 
 import { maskOutFieldsMiddleware } from './graphql.middleware'
 
@@ -81,6 +82,7 @@ const autoSchemaFile = environment.production
       authPublicApi: environment.authPublicApi,
     }),
     AuditModule.forRoot(environment.audit),
+    MetricsModule.forRoot(environment.metrics),
     ContentSearchModule,
     CmsModule,
     DrivingLicenseModule.register({

--- a/apps/api/src/app/environments/environment.ts
+++ b/apps/api/src/app/environments/environment.ts
@@ -148,6 +148,12 @@ const devConfig = {
     username: process.env.PAYMENT_SCHEDULE_USER,
     password: process.env.PAYMENT_SCHEDULE_PASSWORD,
   },
+  metrics: {
+    path: process.env.METRICS_PATH,
+    port: process.env.METRICS_PORT,
+    protocol: process.env.METRICS_PROTOCOL,
+    prefix: 'islandis',
+  },
 }
 
 const prodConfig = {
@@ -284,6 +290,12 @@ const prodConfig = {
     xRoadClientId: process.env.XROAD_CLIENT_ID,
     username: process.env.PAYMENT_SCHEDULE_USER,
     password: process.env.PAYMENT_SCHEDULE_PASSWORD,
+  },
+  metrics: {
+    path: process.env.METRICS_PATH,
+    port: process.env.METRICS_PORT,
+    protocol: process.env.METRICS_PROTOCOL,
+    prefix: 'islandis',
   },
 }
 

--- a/libs/api/domains/license-service/src/lib/licenseService.module.ts
+++ b/libs/api/domains/license-service/src/lib/licenseService.module.ts
@@ -1,6 +1,7 @@
 import { Cache as CacheManager } from 'cache-manager'
 import { Module, DynamicModule, CacheModule } from '@nestjs/common'
 import { logger, LOGGER_PROVIDER } from '@island.is/logging'
+import { MetricsModule } from '@island.is/nest/metrics'
 
 import { LicenseServiceService } from './licenseService.service'
 
@@ -50,7 +51,7 @@ export class LicenseServiceModule {
   static register(config: Config): DynamicModule {
     return {
       module: LicenseServiceModule,
-      imports: [CacheModule.register()],
+      imports: [CacheModule.register(), MetricsModule.forRoot()],
       providers: [
         MainResolver,
         LicenseServiceService,

--- a/libs/nest/metrics/.eslintrc.json
+++ b/libs/nest/metrics/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "rules": {}
+}

--- a/libs/nest/metrics/README.md
+++ b/libs/nest/metrics/README.md
@@ -1,0 +1,3 @@
+# Metrics Module
+
+TODO.

--- a/libs/nest/metrics/jest.config.js
+++ b/libs/nest/metrics/jest.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  displayName: 'nest-metrics',
+  preset: '../../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsConfig: '<rootDir>/tsconfig.spec.json',
+    },
+  },
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../../coverage/libs/nest/metrics',
+}

--- a/libs/nest/metrics/src/index.ts
+++ b/libs/nest/metrics/src/index.ts
@@ -1,0 +1,3 @@
+export * from './lib/metrics.module'
+export * from './lib/metrics.options'
+export * from './lib/metrics.service'

--- a/libs/nest/metrics/src/lib/metrics.module.ts
+++ b/libs/nest/metrics/src/lib/metrics.module.ts
@@ -1,0 +1,23 @@
+import { DynamicModule, Global, Module } from '@nestjs/common'
+import { MetricsOptions, METRICS_OPTIONS } from './metrics.options'
+import { MetricsService } from './metrics.service'
+
+@Global()
+@Module({
+  controllers: [],
+  providers: [MetricsService],
+  exports: [MetricsService],
+})
+export class MetricsModule {
+  static forRoot(options: MetricsOptions): DynamicModule {
+    return {
+      module: MetricsModule,
+      providers: [
+        {
+          provide: METRICS_OPTIONS,
+          useValue: options,
+        },
+      ],
+    }
+  }
+}

--- a/libs/nest/metrics/src/lib/metrics.options.ts
+++ b/libs/nest/metrics/src/lib/metrics.options.ts
@@ -1,0 +1,8 @@
+export const METRICS_OPTIONS = 'METRICS_OPTIONS'
+
+export interface MetricsOptions {
+  path: string
+  port: string
+  protocol: string
+  prefix: string
+}

--- a/libs/nest/metrics/src/lib/metrics.service.ts
+++ b/libs/nest/metrics/src/lib/metrics.service.ts
@@ -1,0 +1,54 @@
+import StatsDClient, { ClientOptions, StatsD } from 'hot-shots'
+import { Inject, Injectable } from '@nestjs/common'
+import type { Logger } from '@island.is/logging'
+import { LOGGER_PROVIDER } from '@island.is/logging'
+
+import { MetricsOptions, METRICS_OPTIONS } from './metrics.options'
+
+type ProtocolType = ClientOptions['protocol']
+
+/** Type safe cast of env string into legal protocol */
+function parseProtocol(str?: string): ProtocolType {
+  if (!str) {
+    return undefined
+  }
+
+  const values: Record<Exclude<ProtocolType, undefined>, 1> = {
+    tcp: 1,
+    udp: 1,
+    uds: 1,
+    stream: 1,
+  }
+
+  return str in values ? (str as ProtocolType) : undefined
+}
+
+@Injectable()
+export class MetricsService {
+  private stats?: StatsD
+
+  constructor(
+    @Inject(LOGGER_PROVIDER)
+    private readonly logger: Logger,
+    @Inject(METRICS_OPTIONS)
+    private options: MetricsOptions,
+  ) {
+    const parsedPort = parseInt(options.port, 10) || undefined
+
+    this.stats = new StatsDClient({
+      path: options.path,
+      port: parsedPort,
+      protocol: parseProtocol(options.protocol),
+      prefix: options.prefix,
+      errorHandler: this.errorHandler,
+    })
+  }
+
+  private errorHandler(error: Error) {
+    this.logger.error(`Error from metrics service`, error)
+  }
+
+  increment(counter: string) {
+    this.stats?.increment(counter)
+  }
+}

--- a/libs/nest/metrics/tsconfig.json
+++ b/libs/nest/metrics/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/nest/metrics/tsconfig.lib.json
+++ b/libs/nest/metrics/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"],
+    "target": "es6"
+  },
+  "exclude": ["**/*.spec.ts"],
+  "include": ["**/*.ts"]
+}

--- a/libs/nest/metrics/tsconfig.spec.json
+++ b/libs/nest/metrics/tsconfig.spec.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.spec.js",
+    "**/*.spec.jsx",
+    "**/*.d.ts"
+  ]
+}

--- a/nx.json
+++ b/nx.json
@@ -510,6 +510,9 @@
     "nest-audit": {
       "tags": []
     },
+    "nest-metrics": {
+      "tags": []
+    },
     "nest-validators": {
       "tags": []
     },

--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
     "graphql-tag": "2.10.3",
     "graphql-type-json": "0.3.2",
     "handlebars": "4.7.7",
+    "hot-shots": "8.5.1",
     "http-proxy-middleware": "0.19.1",
     "hypher": "0.2.5",
     "identicon.js": "2.3.3",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -329,6 +329,7 @@
       "@island.is/logging": ["libs/logging/src/index.ts"],
       "@island.is/message-queue": ["libs/message-queue/src/index.ts"],
       "@island.is/nest/audit": ["libs/nest/audit/src/index.ts"],
+      "@island.is/nest/metrics": ["libs/nest/metrics/src/index.ts"],
       "@island.is/nest/validators": ["libs/nest/validators/src/index.ts"],
       "@island.is/nova-sms": ["libs/nova-sms/src/index.ts"],
       "@island.is/plausible": ["libs/plausible/src/index.ts"],

--- a/workspace.json
+++ b/workspace.json
@@ -5859,6 +5859,27 @@
         }
       }
     },
+    "nest-metrics": {
+      "root": "libs/nest/metrics",
+      "sourceRoot": "libs/nest/metrics/src",
+      "projectType": "library",
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:eslint",
+          "options": {
+            "lintFilePatterns": ["libs/nest/metrics/**/*.ts"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "outputs": ["coverage/libs/nest/metrics"],
+          "options": {
+            "jestConfig": "libs/nest/metrics/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
     "nest-validators": {
       "root": "libs/nest/validators",
       "sourceRoot": "libs/nest/validators/src",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9747,7 +9747,7 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
-bindings@^1.5.0:
+bindings@^1.3.0, bindings@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
   integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
@@ -16072,6 +16072,13 @@ hosted-git-info@3.0.8, hosted-git-info@^2.1.4, hosted-git-info@^3.0.6, hosted-gi
   dependencies:
     lru-cache "^6.0.0"
 
+hot-shots@8.5.1:
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/hot-shots/-/hot-shots-8.5.1.tgz#9cbf57a857288683458685ec73134163220b9c14"
+  integrity sha512-LHqIVuoFDdKvtn9nNAC16KgdiinVsPHKSNuGIMoFlAxFzHL782SaWgQ/MTuOkPbwgEEtEmOGaiBeH25UeL/gRA==
+  optionalDependencies:
+    unix-dgram "2.0.x"
+
 hpack.js@^2.1.6:
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/hpack.js/-/hpack.js-2.1.6.tgz#87774c0949e513f42e84575b3c45681fade2a0b2"
@@ -20252,6 +20259,11 @@ nan@^2.12.1:
   version "2.14.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
+
+nan@^2.13.2:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
+  integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
 
 nano-css@^5.2.1:
   version "5.3.1"
@@ -28072,6 +28084,14 @@ universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
+
+unix-dgram@2.0.x:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/unix-dgram/-/unix-dgram-2.0.4.tgz#14d4fc21e539742b8fb027de16eccd4e5503a344"
+  integrity sha512-7tpK6x7ls7J7pDrrAU63h93R0dVhRbPwiRRCawR10cl+2e1VOvF3bHlVJc6WI1dl/8qk5He673QU+Ogv7bPNaw==
+  dependencies:
+    bindings "^1.3.0"
+    nan "^2.13.2"
 
 unixify@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Adds a metrics module that allows API to collect metrics via StatsD.

WIP with some open questions:

1. Should we pass the API through [`hot-shots`](https://github.com/brightcove/hot-shots) or wrap individually?
2. How does this fit in with datadog, and are we exposing enough config for it to work as is?
3. How should v1 of "how we use metrics" look like? I.e. naming of counters/tracked things, how we differentiate between success/failure.
4. How do we test this locally?

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
