### PR TITLE
fix(parental-leave): Request rights were missing proper initialization

### DIFF
--- a/libs/application/templates/parental-leave/src/fields/Rights/RequestRightsRadio.tsx
+++ b/libs/application/templates/parental-leave/src/fields/Rights/RequestRightsRadio.tsx
@@ -9,14 +9,12 @@ import {
   RadioField,
 } from '@island.is/application/core'
 import { RadioFormField } from '@island.is/application/ui-fields'
-import {
-  NO,
-  YES,
-  YesOrNo,
-  getApplicationAnswers,
-} from '@island.is/application/templates/parental-leave'
+
+import { getApplicationAnswers } from '../../lib/parentalLeaveUtils'
 import { parentalLeaveFormMessages } from '../../lib/messages'
 import { maxDaysToGiveOrReceive } from '../../config'
+import { NO, YES } from '../../constants'
+import { YesOrNo } from '../../types'
 
 interface RequestRightsRadioProps extends FieldBaseProps {
   field: RadioField

--- a/libs/application/templates/parental-leave/src/fields/Rights/RequestRightsRadio.tsx
+++ b/libs/application/templates/parental-leave/src/fields/Rights/RequestRightsRadio.tsx
@@ -5,14 +5,18 @@ import {
   FieldBaseProps,
   FieldComponents,
   FieldTypes,
+  getErrorViaPath,
   RadioField,
 } from '@island.is/application/core'
 import { RadioFormField } from '@island.is/application/ui-fields'
-
+import {
+  NO,
+  YES,
+  YesOrNo,
+  getApplicationAnswers,
+} from '@island.is/application/templates/parental-leave'
 import { parentalLeaveFormMessages } from '../../lib/messages'
-import { NO, YES } from '../../constants'
 import { maxDaysToGiveOrReceive } from '../../config'
-import { YesOrNo } from '../../types'
 
 interface RequestRightsRadioProps extends FieldBaseProps {
   field: RadioField
@@ -21,9 +25,13 @@ interface RequestRightsRadioProps extends FieldBaseProps {
 const RequestRightsRadio = ({
   field,
   application,
+  errors,
 }: RequestRightsRadioProps) => {
+  const { isRequestingRights } = getApplicationAnswers(application.answers)
   const { register } = useFormContext()
-  const [radio, setRadio] = useState<YesOrNo | undefined>(undefined)
+  const [radio, setRadio] = useState<YesOrNo | undefined>(
+    isRequestingRights ?? undefined,
+  )
 
   return (
     <>
@@ -49,6 +57,9 @@ const RequestRightsRadio = ({
             },
           ],
         }}
+        error={
+          errors && getErrorViaPath(errors, `${field.id}.isRequestingRights`)
+        }
       />
 
       <input


### PR DESCRIPTION
## What

Initialize requestDays with existing answer.
Add error to the field if either radio option is not selected.

## Why

If applicant left the application and returned later. Navigated to previous steps and back again through RequestRights, without changing it value, it resulted in the error state `requestDays: 0, isRequesting: "yes"`.

If the applicant was going through new application and no value is selected in RequestRights and he clicked "Áfram" nothing happened and no error was shown. Now the forms highlights the fields with error message.

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/54210288/134364193-9af88a86-eb97-4f00-906e-8e0a2b3e9c03.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
