### PR TITLE
feat(application-templates-driving-license): Enable fake data at the beginning of the application flow

### DIFF
--- a/libs/application/templates/driving-license/src/dataProviders/EligibilityProvider.ts
+++ b/libs/application/templates/driving-license/src/dataProviders/EligibilityProvider.ts
@@ -1,15 +1,39 @@
 import {
   BasicDataProvider,
+  Application,
   SuccessfulDataProviderResult,
   FailedDataProviderResult,
 } from '@island.is/application/core'
 import { m } from '../lib/messages'
-import { ApplicationEligibilityRequirement } from '@island.is/api/schema'
+import { DrivingLicenseFakeData, YES } from '../lib/constants'
+import { ApplicationEligibility, RequirementKey } from '../types/schema'
 
 export class EligibilityProvider extends BasicDataProvider {
   type = 'EligibilityProvider'
 
-  async provide(): Promise<ApplicationEligibilityRequirement> {
+  async provide(application: Application): Promise<ApplicationEligibility> {
+    const fakeData = application.answers.fakeData as DrivingLicenseFakeData | undefined
+
+    if (fakeData?.useFakeData === YES) {
+      return {
+        isEligible: true,
+        requirements: [
+          {
+            key: RequirementKey.DrivingAssessmentMissing,
+            requirementMet: true,
+          },
+          {
+            key: RequirementKey.DrivingSchoolMissing,
+            requirementMet: true,
+          },
+          {
+            key: RequirementKey.DeniedByService,
+            requirementMet: true,
+          },
+        ],
+      }
+    }
+
     const query = `
       query EligibilityQuery($drivingLicenseType: String!) {
         drivingLicenseApplicationEligibility(type: $drivingLicenseType) {

--- a/libs/application/templates/driving-license/src/dataProviders/EligibilityProvider.ts
+++ b/libs/application/templates/driving-license/src/dataProviders/EligibilityProvider.ts
@@ -12,7 +12,9 @@ export class EligibilityProvider extends BasicDataProvider {
   type = 'EligibilityProvider'
 
   async provide(application: Application): Promise<ApplicationEligibility> {
-    const fakeData = application.answers.fakeData as DrivingLicenseFakeData | undefined
+    const fakeData = application.answers.fakeData as
+      | DrivingLicenseFakeData
+      | undefined
 
     if (fakeData?.useFakeData === YES) {
       return {

--- a/libs/application/templates/driving-license/src/dataProviders/QualityPhotoProvider.ts
+++ b/libs/application/templates/driving-license/src/dataProviders/QualityPhotoProvider.ts
@@ -11,7 +11,9 @@ export class QualityPhotoProvider extends BasicDataProvider {
   type = 'QualityPhotoProvider'
 
   async provide(application: Application) {
-    const fakeData = application.answers.fakeData as DrivingLicenseFakeData | undefined
+    const fakeData = application.answers.fakeData as
+      | DrivingLicenseFakeData
+      | undefined
 
     if (fakeData?.useFakeData === YES) {
       return {

--- a/libs/application/templates/driving-license/src/dataProviders/QualityPhotoProvider.ts
+++ b/libs/application/templates/driving-license/src/dataProviders/QualityPhotoProvider.ts
@@ -2,13 +2,27 @@ import {
   BasicDataProvider,
   SuccessfulDataProviderResult,
   FailedDataProviderResult,
+  Application,
 } from '@island.is/application/core'
+import { DrivingLicenseFakeData, YES } from '../lib/constants'
 import { m } from '../lib/messages'
 
 export class QualityPhotoProvider extends BasicDataProvider {
   type = 'QualityPhotoProvider'
 
-  async provide() {
+  async provide(application: Application) {
+    const fakeData = application.answers.fakeData as DrivingLicenseFakeData | undefined
+
+    if (fakeData?.useFakeData === YES) {
+      return {
+        success: fakeData.qualityPhoto === YES,
+        qualityPhoto:
+          fakeData.qualityPhoto === YES
+            ? `data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAQEBAQEBAQEBAQGBgUGBggHBwcHCAwJCQkJCQwTDA4MDA4MExEUEA8QFBEeFxUVFx4iHRsdIiolJSo0MjRERFwBBAQEBAQEBAQEBAYGBQYGCAcHBwcIDAkJCQkJDBMMDgwMDgwTERQQDxAUER4XFRUXHiIdGx0iKiUlKjQyNEREXP/CABEIAAIAAgMBIgACEQEDEQH/xAAUAAEAAAAAAAAAAAAAAAAAAAAH/9oACAEBAAAAAHP/xAAUAQEAAAAAAAAAAAAAAAAAAAAH/9oACAECEAAAADv/xAAUAQEAAAAAAAAAAAAAAAAAAAAG/9oACAEDEAAAAHn/xAAZEAABBQAAAAAAAAAAAAAAAAAAAgMTU5H/2gAIAQEAAT8AjbrTh//EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQIBAT8Af//EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQMBAT8Af//Z`
+            : null,
+      }
+    }
+
     const query = `
         query HasQualityPhoto {
           qualityPhoto {
@@ -34,8 +48,20 @@ export class QualityPhotoProvider extends BasicDataProvider {
 
     return {
       success: !!response.data.qualityPhoto?.success,
-      qualityPhoto: response.data.qualityPhoto?.qualityPhoto,
+      qualityPhoto: this.toDataUri(response.data.qualityPhoto?.qualityPhoto),
     }
+  }
+
+  toDataUri(qualityPhoto?: string) {
+    if (!qualityPhoto) {
+      return null
+    }
+
+    // TODO: Not sure why we need to do this - was in the UI but doesnt match normal base64 encoded jpegs
+    return `data:image/jpeg;base64,${qualityPhoto.substr(
+      1,
+      qualityPhoto.length - 2,
+    )}`
   }
 
   onProvideError(): FailedDataProviderResult {

--- a/libs/application/templates/driving-license/src/fields/QualityPhoto/QualityPhoto.tsx
+++ b/libs/application/templates/driving-license/src/fields/QualityPhoto/QualityPhoto.tsx
@@ -28,8 +28,7 @@ const Photo: FC<QualityPhotoData> = ({
     return null
   }
 
-  const src =
-    'data:image/jpg;base64,' + qualityPhoto.substr(1, qualityPhoto.length - 2)
+  const src = qualityPhoto
   return (
     <img
       alt={formatText(m.qualityPhotoAltText, application, formatMessage) || ''}

--- a/libs/application/templates/driving-license/src/lib/constants.ts
+++ b/libs/application/templates/driving-license/src/lib/constants.ts
@@ -11,3 +11,15 @@ export enum States {
   DONE = 'done',
   PAYMENT = 'payment',
 }
+
+export const YES = 'yes'
+export const NO = 'no'
+
+type FakeCurrentLicense = 'none' | 'temp'
+type YesOrNo = 'yes' | 'no'
+
+export interface DrivingLicenseFakeData {
+  useFakeData?: YesOrNo
+  qualityPhoto?: YesOrNo
+  currentLicense?: FakeCurrentLicense
+}

--- a/libs/application/templates/driving-license/src/lib/messages.ts
+++ b/libs/application/templates/driving-license/src/lib/messages.ts
@@ -308,7 +308,7 @@ export const m = defineMessages({
   },
   applicationQualityPhotoTitle: {
     id: 'dl.application:applicationQualityPhotoTitle',
-    defaultMessage: 'Passamynd',
+    defaultMessage: 'Ljósmynd',
     description: 'title for quality photo section',
   },
   qualityPhotoTitle: {


### PR DESCRIPTION
Mock data for driving license application itself.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
