### PR TITLE
fix(judicial-system): Ignores white-spaces in empty attendees field

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/rulingPdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/rulingPdf.ts
@@ -102,7 +102,7 @@ function constructRestrictionRulingPdf(
     })
   }
 
-  if (existingCase.courtAttendees) {
+  if (existingCase.courtAttendees?.trim()) {
     doc
       .text(' ')
       .font('Times-Bold')
@@ -455,7 +455,7 @@ function constructInvestigationRulingPdf(
     })
   }
 
-  if (existingCase.courtAttendees) {
+  if (existingCase.courtAttendees?.trim()) {
     doc
       .text(' ')
       .font('Times-Bold')


### PR DESCRIPTION
# Ignores white-spaces in empty attendees field

https://app.asana.com/0/1199153462262248/1200879471149033

## What

Fix to☝️ 

## Why

Bug

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
