### PR TITLE
feat(service-portal): Hotfix. Empty state for status transactions.

### DIFF
--- a/libs/service-portal/core/src/lib/navigation/masterNavigation.ts
+++ b/libs/service-portal/core/src/lib/navigation/masterNavigation.ts
@@ -156,7 +156,7 @@ export const servicePortalMasterNavigation: ServicePortalNavigationItem[] = [
       // Fjarmal
       {
         name: m.finance,
-        path: ServicePortalPath.FinanceStatus,
+        path: ServicePortalPath.FinanceRoot,
         children: [
           {
             name: m.financeStatus,
@@ -216,7 +216,7 @@ export const servicePortalMasterNavigation: ServicePortalNavigationItem[] = [
       // Fjármál
       {
         name: m.finance,
-        path: ServicePortalPath.FinanceRoot,
+        path: ServicePortalPath.FinanceWIP,
         systemRoute: true,
         icon: {
           type: 'outline',

--- a/libs/service-portal/core/src/lib/navigation/paths.ts
+++ b/libs/service-portal/core/src/lib/navigation/paths.ts
@@ -42,6 +42,7 @@ export enum ServicePortalPath {
   FinanceVehicles = 'https://mitt.samgongustofa.is/',
   FinancePayments = '/greidslur',
   FinanceExternal = 'https://minarsidur.island.is/minar-sidur/fjarmal/fjarmal-stada-vid-rikissjod-og-stofnanir/',
+  FinanceWIP = '/fjarmal-annad',
 
   // Electronic Documents
   ElectronicDocumentsRoot = '/postholf',

--- a/libs/service-portal/finance/src/index.ts
+++ b/libs/service-portal/finance/src/index.ts
@@ -14,12 +14,12 @@ export const financeModule: ServicePortalModule = {
   widgets: () => [],
   routes: () => {
     const routes: ServicePortalRoute[] = [
-      // {
-      //   name: m.finance,
-      //   path: ServicePortalPath.FinanceRoot,
-      //   render: () =>
-      //     lazy(() => import('./screens/FinanceOverview/FinanceOverview')),
-      // },
+      {
+        name: m.finance,
+        path: ServicePortalPath.FinanceRoot,
+        render: () =>
+          lazy(() => import('./screens/FinanceOverview/FinanceOverview')),
+      },
       {
         name: m.financeStatus,
         path: ServicePortalPath.FinanceStatus,

--- a/libs/service-portal/finance/src/screens/FinanceStatus/FinanceStatus.tsx
+++ b/libs/service-portal/finance/src/screens/FinanceStatus/FinanceStatus.tsx
@@ -114,6 +114,32 @@ const FinanceStatus: ServicePortalModuleComponent = () => {
               />
             </Box>
           )}
+          {!loading &&
+            !error &&
+            (financeStatusData?.organizations?.length === 0 ||
+              financeStatusData?.organizations === null) && (
+              <Box marginTop={2}>
+                <T.Table>
+                  <ExpandHeader
+                    data={[
+                      { value: formatMessage(m.feeCategory) },
+                      { value: formatMessage(m.guardian) },
+                      { value: formatMessage(m.status), align: 'right' },
+                    ]}
+                  />
+                  <T.Body>
+                    <ExpandRow
+                      last
+                      data={[
+                        { value: formatMessage(m.total) },
+                        { value: '' },
+                        { value: getChargeTypeTotal(), align: 'right' },
+                      ]}
+                    />
+                  </T.Body>
+                </T.Table>
+              </Box>
+            )}
           {financeStatusData?.organizations?.length > 0 ? (
             <>
               <Hidden print={true}>

--- a/libs/service-portal/wip/src/index.ts
+++ b/libs/service-portal/wip/src/index.ts
@@ -15,7 +15,7 @@ export const wipModule: ServicePortalModule = {
     },
     {
       name: 'Fjármál',
-      path: ServicePortalPath.FinanceRoot,
+      path: ServicePortalPath.FinanceWIP,
       render: () => lazy(() => import('./screens/FinanceWIP/FinanceWIP')),
     },
   ],


### PR DESCRIPTION
## What

Hotfix for: https://github.com/island-is/island.is/pull/5108

* Add an empty state for the user when there are no "Status transactions"
* Fix breadcrumbs on the finance module

## Why

* Empty state on status transactions is now totally empty
* The finance breadcrumbs are a little bit wonky because of the WIP finance that users who are not within the feature flag see. Changed the setup a bit.

## Screenshots / Gifs

![Screenshot 2021-09-28 at 09 07 07](https://user-images.githubusercontent.com/24840451/135058808-560df93a-8f0b-468e-aed7-bd41477425df.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
