### PR TITLE
feat(application-core/ui-fields): add props to buildRadioField

### DIFF
--- a/libs/application/core/src/types/Fields.ts
+++ b/libs/application/core/src/types/Fields.ts
@@ -38,6 +38,7 @@ export interface Option {
   tooltip?: FormText
   excludeOthers?: boolean
   illustration?: React.FC
+  disabled?: boolean
 }
 
 interface SelectOption {

--- a/libs/application/ui-fields/src/lib/RadioFormField/RadioFormField.tsx
+++ b/libs/application/ui-fields/src/lib/RadioFormField/RadioFormField.tsx
@@ -35,6 +35,7 @@ export const RadioFormField: FC<Props> = ({
     options,
     width,
     largeButtons,
+    backgroundColor,
   } = field
   const { formatMessage } = useLocale()
 
@@ -60,6 +61,7 @@ export const RadioFormField: FC<Props> = ({
       <Box marginTop={3}>
         <RadioController
           largeButtons={largeButtons}
+          backgroundColor={backgroundColor}
           id={id}
           disabled={disabled}
           error={error}

--- a/libs/shared/form-fields/src/lib/RadioController/RadioController.tsx
+++ b/libs/shared/form-fields/src/lib/RadioController/RadioController.tsx
@@ -16,6 +16,7 @@ interface Option {
   tooltip?: React.ReactNode
   excludeOthers?: boolean
   illustration?: React.FC
+  disabled?: boolean
 }
 
 interface Props {
@@ -75,7 +76,7 @@ export const RadioController: FC<Props> = ({
                 label={option.label}
                 subLabel={option.subLabel}
                 value={option.value}
-                disabled={disabled}
+                disabled={disabled || option.disabled}
                 hasError={error !== undefined}
                 backgroundColor={backgroundColor}
                 illustration={option.illustration}


### PR DESCRIPTION
## What

- Added the option to disable a single radio option. You can still disable the whole thing as before as well.
- Added the missing prop `backgroundColor` to `RadioController` inside `RadioFormField`

## Why

Needed to be able to set a single radio option as disabled. Also could not set the background white since the prop was missing in `RadioFormField`

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/8450096/135071157-fb77f11a-7467-42ed-b18e-b2cb6374a758.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
