### PR TITLE
fix(air-discount-scheme): Included swagger distribution files in esbuild

### DIFF
--- a/apps/air-discount-scheme/backend/esbuild.json
+++ b/apps/air-discount-scheme/backend/esbuild.json
@@ -13,7 +13,7 @@
     "@nestjs/microservices/microservices-module",
     "apollo-server-fastify",
     "@elastic/elasticsearch",
-    "@nestjs/swagger",
+    "fastify-swagger",
     "@nestjs/mongoose",
     "@nestjs/typeorm",
     "dd-trace",
@@ -26,7 +26,9 @@
     "atob",
     "logform",
     "pg-native",
-    "form-data"
+    "form-data",
+    "swagger-ui-express",
+    "swagger-ui-dist"
   ],
   "keepNames": true
 }


### PR DESCRIPTION
Reverting #5135 
Adding swagger distribution files instead to work with `fastify-swagger`

## Screenshots
Top: feature-deploy of this PR
Bottom: current main with #5135

![image](https://user-images.githubusercontent.com/77672665/135304591-9b91efd2-fcb7-488a-94db-6e67cb5c943a.png)

This PR on dev via feature-deploy
![image](https://user-images.githubusercontent.com/77672665/135304873-b317479b-4114-4de0-959a-e3e5e6ab7d8f.png)


## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
