### PR TITLE
chore(application-system-api): Enabling redis cluster in CI for application-system-api

### DIFF
--- a/apps/application-system/api/docker-compose.base.yml
+++ b/apps/application-system/api/docker-compose.base.yml
@@ -20,6 +20,8 @@ services:
   redis_cluster:
     container_name: redis_cluster
     image: grokzen/redis-cluster:5.0.6
+    networks:
+      - local
     privileged: true
     sysctls:
       net.core.somaxconn: '511'

--- a/apps/application-system/api/docker-compose.base.yml
+++ b/apps/application-system/api/docker-compose.base.yml
@@ -17,5 +17,14 @@ services:
     volumes:
       - ./bin/startup.sql:/docker-entrypoint-initdb.d/startup.sql
 
+  redis_cluster:
+    container_name: redis_cluster
+    image: grokzen/redis-cluster:5.0.6
+    privileged: true
+    sysctls:
+      net.core.somaxconn: '511'
+    environment:
+      - IP=0.0.0.0
+
 networks:
   local:

--- a/apps/application-system/api/docker-compose.base.yml
+++ b/apps/application-system/api/docker-compose.base.yml
@@ -25,8 +25,6 @@ services:
     privileged: true
     sysctls:
       net.core.somaxconn: '511'
-    environment:
-      - IP=0.0.0.0
 
 networks:
   local:

--- a/apps/application-system/api/docker-compose.ci.yml
+++ b/apps/application-system/api/docker-compose.ci.yml
@@ -12,6 +12,7 @@ services:
       - local
     depends_on:
       - db_application_system
+      - redis_cluster
     environment:
       - TEST_DB_USER=test_db
       - TEST_DB_PASS=test_db

--- a/apps/application-system/api/docker-compose.ci.yml
+++ b/apps/application-system/api/docker-compose.ci.yml
@@ -17,8 +17,12 @@ services:
       - TEST_DB_PASS=test_db
       - TEST_DB_NAME=test_db
       - DB_HOST=db_application_system
+      - REDIS_NODES=redis_cluster:7000,redis_cluster:7001,redis_cluster:7002,redis_cluster:7003,redis_cluster:7004,redis_cluster:7005
     volumes:
       - ../../..:/code
 
   db_application_system:
+    ports: []
+
+  redis_cluster:
     ports: []

--- a/apps/application-system/api/docker-compose.dev.yml
+++ b/apps/application-system/api/docker-compose.dev.yml
@@ -5,13 +5,6 @@ services:
     ports:
       - 5432:5432
 
-  redis-cluster:
-    container_name: redis_cluster
-    image: grokzen/redis-cluster:5.0.6
-    privileged: true
-    sysctls:
-      net.core.somaxconn: '511'
-    environment:
-      - IP=0.0.0.0
+  redis_cluster:
     ports:
       - '7000-7005:7000-7005'

--- a/apps/application-system/api/docker-compose.dev.yml
+++ b/apps/application-system/api/docker-compose.dev.yml
@@ -6,5 +6,7 @@ services:
       - 5432:5432
 
   redis_cluster:
+    environment:
+      - IP=0.0.0.0
     ports:
       - '7000-7005:7000-7005'

--- a/apps/application-system/api/src/environments/environment.ts
+++ b/apps/application-system/api/src/environments/environment.ts
@@ -6,14 +6,10 @@ const devConfig = {
   name: 'local',
   baseApiUrl: 'http://localhost:4444',
   redis: {
-    urls: [
-      'localhost:7000',
-      'localhost:7001',
-      'localhost:7002',
-      'localhost:7003',
-      'localhost:7004',
-      'localhost:7005',
-    ],
+    urls: (
+      process.env.REDIS_NODES ??
+      'localhost:7000,localhost:7001,localhost:7002,localhost:7003,localhost:7004,localhost:7005'
+    ).split(','),
   },
   audit: {
     defaultNamespace: '@island.is/applications',
@@ -108,7 +104,9 @@ const prodConfig = {
   name: process.env.name,
   baseApiUrl: process.env.GRAPHQL_API_URL,
   redis: {
-    urls: [process.env.REDIS_URL_NODE_01],
+    urls: (process.env.REDIS_NODES ?? process.env.REDIS_URL_NODE_01)?.split(
+      ',',
+    ),
   },
   audit: {
     defaultNamespace: '@island.is/applications',


### PR DESCRIPTION
## What

Adding `redis_cluster` to the `docker-compose` setup for `application-system-api`.

## Why

In the upgraded Nx repo [branch](https://github.com/island-is/island.is/tree/core/upgrade-nx) it breaks the test that the app is unable to connect to the redis cluster.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
