### PR TITLE
chore(core): Adding type to testServer override

### DIFF
--- a/apps/application-system/api/src/app/modules/application/e2e/application.spec.ts
+++ b/apps/application-system/api/src/app/modules/application/e2e/application.spec.ts
@@ -56,7 +56,7 @@ let server: request.SuperTest<request.Test>
 
 beforeAll(async () => {
   app = await setup({
-    override: (builder) => {
+    override: (builder) =>
       builder
         .overrideProvider(ContentfulRepository)
         .useClass(MockContentfulRepository)
@@ -68,9 +68,7 @@ beforeAll(async () => {
             nationalId,
             scope: [ApplicationScope.read, ApplicationScope.write],
           }),
-        )
-        .compile()
-    },
+        ),
   })
 
   server = request(app.getHttpServer())

--- a/apps/application-system/api/src/app/modules/payment/e2e/payment-callback.spec.ts
+++ b/apps/application-system/api/src/app/modules/payment/e2e/payment-callback.spec.ts
@@ -8,12 +8,7 @@ let app: INestApplication
 let server: request.SuperTest<request.Test>
 
 beforeAll(async () => {
-  app = await setup({
-    override: (builder) => {
-      builder.compile()
-    },
-  })
-
+  app = await setup()
   server = request(app.getHttpServer())
 })
 

--- a/apps/application-system/api/src/app/modules/payment/e2e/payment.spec.ts
+++ b/apps/application-system/api/src/app/modules/payment/e2e/payment.spec.ts
@@ -84,7 +84,7 @@ let server: request.SuperTest<request.Test>
 
 beforeAll(async () => {
   app = await setup({
-    override: (builder) => {
+    override: (builder) =>
       builder
         .overrideProvider(PaymentAPI)
         .useClass(MockPaymentApi)
@@ -96,9 +96,7 @@ beforeAll(async () => {
           }),
         )
         .overrideProvider(PaymentService)
-        .useClass(MockPaymentService)
-        .compile()
-    },
+        .useClass(MockPaymentService),
   })
 
   server = request(app.getHttpServer())

--- a/apps/download-service/src/app/modules/e2e/document.spec.ts
+++ b/apps/download-service/src/app/modules/e2e/document.spec.ts
@@ -6,12 +6,7 @@ let app: INestApplication
 let server: request.SuperTest<request.Test>
 
 beforeAll(async () => {
-  app = await setup({
-    override: (builder) => {
-      builder.compile()
-    },
-  })
-
+  app = await setup()
   server = request(app.getHttpServer())
 })
 

--- a/apps/reference-backend/src/app/modules/resource/e2e/resource.spec.ts
+++ b/apps/reference-backend/src/app/modules/resource/e2e/resource.spec.ts
@@ -7,14 +7,13 @@ let app: INestApplication
 
 beforeAll(async () => {
   app = await setup({
-    override: (builder) => {
+    override: (builder) =>
       builder.overrideGuard(IdsUserGuard).useValue(
         new MockAuthGuard({
           nationalId: '1234567890',
           scope: [],
         }),
-      )
-    },
+      ),
   })
 })
 

--- a/apps/services/documents/src/app/modules/document-provider/e2e/document-provider.spec.ts
+++ b/apps/services/documents/src/app/modules/document-provider/e2e/document-provider.spec.ts
@@ -48,16 +48,12 @@ const simpleOrg = {
 
 beforeAll(async () => {
   app = await setup({
-    override: (builder) => {
-      builder
-        .overrideGuard(IdsUserGuard)
-        .useValue(
-          new MockAuthGuard({
-            nationalId,
-          }),
-        )
-        .compile()
-    },
+    override: (builder) =>
+      builder.overrideGuard(IdsUserGuard).useValue(
+        new MockAuthGuard({
+          nationalId,
+        }),
+      ),
   })
 
   server = request(app.getHttpServer())

--- a/apps/services/endorsements/api/test/setup.ts
+++ b/apps/services/endorsements/api/test/setup.ts
@@ -49,17 +49,13 @@ export const getAuthenticatedApp = ({
   nationalId = '1234567890',
 }: SetupAuthInput): Promise<INestApplication> =>
   setup({
-    override: (builder) => {
-      builder
-        .overrideProvider(IdsUserGuard)
-        .useValue(
-          new MockAuthGuard({
-            nationalId,
-            scope,
-          }),
-        )
-        .compile()
-    },
+    override: (builder) =>
+      builder.overrideProvider(IdsUserGuard).useValue(
+        new MockAuthGuard({
+          nationalId,
+          scope,
+        }),
+      ),
   })
 
 afterAll(async () => {

--- a/apps/services/party-letter-registry-api/test/setup.ts
+++ b/apps/services/party-letter-registry-api/test/setup.ts
@@ -50,17 +50,13 @@ export const getAuthenticatedApp = ({
   nationalId = '1234567890',
 }: SetupAuthInput): Promise<INestApplication> =>
   setup({
-    override: (builder) => {
-      builder
-        .overrideProvider(IdsUserGuard)
-        .useValue(
-          new MockAuthGuard({
-            nationalId,
-            scope,
-          }),
-        )
-        .compile()
-    },
+    override: (builder) =>
+      builder.overrideProvider(IdsUserGuard).useValue(
+        new MockAuthGuard({
+          nationalId,
+          scope,
+        }),
+      ),
   })
 
 afterAll(async () => {

--- a/apps/services/temporary-voter-registry-api/test/setup.ts
+++ b/apps/services/temporary-voter-registry-api/test/setup.ts
@@ -49,17 +49,13 @@ export const getAuthenticatedApp = ({
   scope = [EndorsementsScope.main],
 }: SetupAuthInput): Promise<INestApplication> =>
   setup({
-    override: (builder) => {
-      builder
-        .overrideProvider(IdsUserGuard)
-        .useValue(
-          new MockAuthGuard({
-            nationalId,
-            scope,
-          }),
-        )
-        .compile()
-    },
+    override: (builder) =>
+      builder.overrideProvider(IdsUserGuard).useValue(
+        new MockAuthGuard({
+          nationalId,
+          scope,
+        }),
+      ),
   })
 
 afterAll(async () => {

--- a/apps/services/user-profile/src/app/user-profile/e2e/userProfile.spec.ts
+++ b/apps/services/user-profile/src/app/user-profile/e2e/userProfile.spec.ts
@@ -24,17 +24,13 @@ const mockProfile = {
 
 beforeAll(async () => {
   app = await setup({
-    override: (builder) => {
-      builder
-        .overrideGuard(IdsUserGuard)
-        .useValue(
-          new MockAuthGuard({
-            nationalId: mockProfile.nationalId,
-            scope: [UserProfileScope.read, UserProfileScope.write],
-          }),
-        )
-        .compile()
-    },
+    override: (builder) =>
+      builder.overrideGuard(IdsUserGuard).useValue(
+        new MockAuthGuard({
+          nationalId: mockProfile.nationalId,
+          scope: [UserProfileScope.read, UserProfileScope.write],
+        }),
+      ),
   })
 
   emailService = app.get<EmailService>(EmailService)

--- a/libs/infra-nest-server/src/lib/testServer.ts
+++ b/libs/infra-nest-server/src/lib/testServer.ts
@@ -5,7 +5,7 @@ import {
 } from '@island.is/auth-nest-tools'
 import { Type, ValidationPipe } from '@nestjs/common'
 import { InfraModule } from './infra/infra.module'
-import { Test } from '@nestjs/testing'
+import { Test, TestingModule } from '@nestjs/testing'
 import { TestingModuleBuilder } from '@nestjs/testing/testing-module.builder'
 
 export type TestServerOptions = {
@@ -18,15 +18,15 @@ export type TestServerOptions = {
   /**
    * Hook to override providers.
    */
-  override?: (builder: TestingModuleBuilder) => void
+  override?: (builder: TestingModuleBuilder) => TestingModuleBuilder
 }
 
 export const testServer = async (options: TestServerOptions) => {
-  const builder = Test.createTestingModule({
+  let builder = Test.createTestingModule({
     imports: [InfraModule.forRoot(options.appModule)],
   })
   if (options.override) {
-    options.override(builder)
+    builder = options.override(builder)
   }
 
   const moduleRef = await builder.compile()


### PR DESCRIPTION
## What

Adding type to override in testServer to stop test specs from being able to call `.compile()` and instead need to return the builder in override.

## Why

To stop specs implementation from double compiling the app.
Fixes #5146 

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
