### PR TITLE
fix(financial-aid): Moving filtering of applications from client to backend

### DIFF
--- a/apps/financial-aid/api/src/app/modules/application/application.resolver.ts
+++ b/apps/financial-aid/api/src/app/modules/application/application.resolver.ts
@@ -19,7 +19,7 @@ import {
 } from './dto'
 import { JwtGraphQlAuthGuard } from '@island.is/financial-aid/auth'
 
-import { ApplicationInput } from './dto'
+import { ApplicationInput, ApplicationsInput } from './dto'
 
 import {
   Application,
@@ -37,11 +37,13 @@ export class ApplicationResolver {
 
   @Query(() => [ApplicationModel], { nullable: false })
   applications(
+    @Args('input', { type: () => ApplicationsInput })
+    input: ApplicationsInput,
     @Context('dataSources') { backendApi }: { backendApi: BackendAPI },
   ): Promise<Application[]> {
     this.logger.debug('Getting all applications')
 
-    return backendApi.getApplications()
+    return backendApi.getApplications(input.stateUrl)
   }
 
   @Query(() => ApplicationModel, { nullable: false })

--- a/apps/financial-aid/api/src/app/modules/application/application.resolver.ts
+++ b/apps/financial-aid/api/src/app/modules/application/application.resolver.ts
@@ -19,7 +19,7 @@ import {
 } from './dto'
 import { JwtGraphQlAuthGuard } from '@island.is/financial-aid/auth'
 
-import { ApplicationInput, ApplicationsInput } from './dto'
+import { ApplicationInput, AllApplicationInput } from './dto'
 
 import {
   Application,
@@ -37,8 +37,8 @@ export class ApplicationResolver {
 
   @Query(() => [ApplicationModel], { nullable: false })
   applications(
-    @Args('input', { type: () => ApplicationsInput })
-    input: ApplicationsInput,
+    @Args('input', { type: () => AllApplicationInput })
+    input: AllApplicationInput,
     @Context('dataSources') { backendApi }: { backendApi: BackendAPI },
   ): Promise<Application[]> {
     this.logger.debug('Getting all applications')

--- a/apps/financial-aid/api/src/app/modules/application/dto/allApplications.input.ts
+++ b/apps/financial-aid/api/src/app/modules/application/dto/allApplications.input.ts
@@ -4,7 +4,7 @@ import { Field, InputType } from '@nestjs/graphql'
 import { ApplicationStateUrl } from '@island.is/financial-aid/shared/lib'
 
 @InputType()
-export class ApplicationsInput {
+export class AllApplicationInput {
   @Allow()
   @Field(() => String)
   readonly stateUrl!: ApplicationStateUrl

--- a/apps/financial-aid/api/src/app/modules/application/dto/applications.input.ts
+++ b/apps/financial-aid/api/src/app/modules/application/dto/applications.input.ts
@@ -1,0 +1,11 @@
+import { Allow } from 'class-validator'
+
+import { Field, InputType } from '@nestjs/graphql'
+import { ApplicationStateUrl } from '@island.is/financial-aid/shared/lib'
+
+@InputType()
+export class ApplicationsInput {
+  @Allow()
+  @Field(() => String)
+  readonly stateUrl!: ApplicationStateUrl
+}

--- a/apps/financial-aid/api/src/app/modules/application/dto/index.ts
+++ b/apps/financial-aid/api/src/app/modules/application/dto/index.ts
@@ -1,5 +1,5 @@
 export { CreateApplicationInput } from './createApplication.input'
 export { ApplicationInput } from './application.input'
-export { ApplicationsInput } from './applications.input'
+export { AllApplicationInput } from './allApplications.input'
 export { UpdateApplicationInput } from './updateApplication.input'
 export { CreateApplicationEventInput } from './createApplicationEvent.input'

--- a/apps/financial-aid/api/src/app/modules/application/dto/index.ts
+++ b/apps/financial-aid/api/src/app/modules/application/dto/index.ts
@@ -1,4 +1,5 @@
 export { CreateApplicationInput } from './createApplication.input'
 export { ApplicationInput } from './application.input'
+export { ApplicationsInput } from './applications.input'
 export { UpdateApplicationInput } from './updateApplication.input'
 export { CreateApplicationEventInput } from './createApplicationEvent.input'

--- a/apps/financial-aid/api/src/services/backend.ts
+++ b/apps/financial-aid/api/src/services/backend.ts
@@ -13,6 +13,7 @@ import {
   CreateApplicationEvent,
   ApplicationFilters,
   CreateFilesResponse,
+  ApplicationStateUrl,
 } from '@island.is/financial-aid/shared/lib'
 
 import { environment } from '../environments'
@@ -27,8 +28,8 @@ class BackendAPI extends RESTDataSource {
     req.headers.set('cookie', this.context.req.headers.cookie)
   }
 
-  getApplications(): Promise<Application[]> {
-    return this.get('applications')
+  getApplications(stateUrl: ApplicationStateUrl): Promise<Application[]> {
+    return this.get(`applications/${stateUrl}`)
   }
 
   getApplication(id: string): Promise<Application> {

--- a/apps/financial-aid/api/src/services/backend.ts
+++ b/apps/financial-aid/api/src/services/backend.ts
@@ -29,7 +29,7 @@ class BackendAPI extends RESTDataSource {
   }
 
   getApplications(stateUrl: ApplicationStateUrl): Promise<Application[]> {
-    return this.get(`applications/${stateUrl}`)
+    return this.get(`allApplications/${stateUrl}`)
   }
 
   getApplication(id: string): Promise<Application> {

--- a/apps/financial-aid/backend/src/app/modules/application/application.controller.ts
+++ b/apps/financial-aid/backend/src/app/modules/application/application.controller.ts
@@ -36,7 +36,10 @@ import {
 
 import { ApplicationGuard } from '../../guards/application.guard'
 
-import type { User } from '@island.is/financial-aid/shared/lib'
+import type {
+  ApplicationStateUrl,
+  User,
+} from '@island.is/financial-aid/shared/lib'
 
 import {
   ApplicationFilters,
@@ -63,14 +66,16 @@ export class ApplicationController {
 
   @UseGuards(JwtAuthGuard, RolesGuard)
   @RolesRules(RolesRule.VEITA)
-  @Get('applications')
+  @Get('applications/:stateUrl')
   @ApiOkResponse({
     type: ApplicationModel,
     isArray: true,
     description: 'Gets all existing applications',
   })
-  getAll(): Promise<ApplicationModel[]> {
-    return this.applicationService.getAll()
+  getAll(
+    @Param('stateUrl') stateUrl: ApplicationStateUrl,
+  ): Promise<ApplicationModel[]> {
+    return this.applicationService.getAll(stateUrl)
   }
 
   @UseGuards(JwtAuthGuard, ApplicationGuard)

--- a/apps/financial-aid/backend/src/app/modules/application/application.controller.ts
+++ b/apps/financial-aid/backend/src/app/modules/application/application.controller.ts
@@ -66,7 +66,7 @@ export class ApplicationController {
 
   @UseGuards(JwtAuthGuard, RolesGuard)
   @RolesRules(RolesRule.VEITA)
-  @Get('applications/:stateUrl')
+  @Get('allApplications/:stateUrl')
   @ApiOkResponse({
     type: ApplicationModel,
     isArray: true,

--- a/apps/financial-aid/backend/src/app/modules/application/application.service.ts
+++ b/apps/financial-aid/backend/src/app/modules/application/application.service.ts
@@ -14,6 +14,8 @@ import {
   ApplicationEventType,
   ApplicationFilters,
   ApplicationState,
+  ApplicationStateUrl,
+  getStateFromUrl,
   User,
 } from '@island.is/financial-aid/shared/lib'
 import { FileService } from '../file'
@@ -67,8 +69,11 @@ export class ApplicationService {
     })
   }
 
-  async getAll(): Promise<ApplicationModel[]> {
+  async getAll(stateUrl: ApplicationStateUrl): Promise<ApplicationModel[]> {
     return this.applicationModel.findAll({
+      where: {
+        state: { [Op.in]: getStateFromUrl[stateUrl] },
+      },
       order: [['modified', 'DESC']],
       include: [{ model: StaffModel, as: 'staff' }],
     })
@@ -174,6 +179,7 @@ export class ApplicationService {
     if (update.state === ApplicationState.NEW) {
       update.staffId = null
     }
+
     const [
       numberOfAffectedRows,
       [updatedApplication],

--- a/apps/financial-aid/web-veita/graphql/sharedGql.ts
+++ b/apps/financial-aid/web-veita/graphql/sharedGql.ts
@@ -132,7 +132,7 @@ export const UpdateApplicationMutation = gql`
   }
 `
 export const GetApplicationsQuery = gql`
-  query GetApplicationsQuery($input: ApplicationsInput!) {
+  query GetApplicationsQuery($input: AllApplicationInput!) {
     applications(input: $input) {
       id
       nationalId

--- a/apps/financial-aid/web-veita/graphql/sharedGql.ts
+++ b/apps/financial-aid/web-veita/graphql/sharedGql.ts
@@ -45,7 +45,7 @@ applicationEvents {
 `
 
 export const GetApplicationQuery = gql`
-  query GetFinancialAidApplicationQuery($input: ApplicationInput!) {
+  query GetApplicationQuery($input: ApplicationInput!) {
     application(input: $input) {
       id
       nationalId
@@ -132,8 +132,8 @@ export const UpdateApplicationMutation = gql`
   }
 `
 export const GetApplicationsQuery = gql`
-  query GetApplicationQuery {
-    applications {
+  query GetApplicationsQuery($input: ApplicationsInput!) {
+    applications(input: $input) {
       id
       nationalId
       name

--- a/apps/financial-aid/web-veita/src/routes/ApplicationsOverview/applicationsOverview.tsx
+++ b/apps/financial-aid/web-veita/src/routes/ApplicationsOverview/applicationsOverview.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useContext } from 'react'
-import { Text, Box } from '@island.is/island-ui/core'
+import { Text, Box, Link } from '@island.is/island-ui/core'
 import { useRouter } from 'next/router'
 import { useQuery } from '@apollo/client'
 import {
@@ -11,6 +11,7 @@ import {
 import {
   ApplicationState,
   Application,
+  ApplicationStateUrl,
 } from '@island.is/financial-aid/shared/lib'
 
 import { GetApplicationsQuery } from '@island.is/financial-aid-web/veita/graphql/sharedGql'
@@ -39,6 +40,9 @@ export const ApplicationsOverview = () => {
   const { data, error, loading } = useQuery<ApplicationsProvider>(
     GetApplicationsQuery,
     {
+      variables: {
+        input: { stateUrl: router.pathname.substring(1) },
+      },
       fetchPolicy: 'no-cache',
       errorPolicy: 'all',
     },
@@ -52,11 +56,7 @@ export const ApplicationsOverview = () => {
 
   useEffect(() => {
     if (data?.applications) {
-      setApplications(
-        data.applications.filter((item) =>
-          currentNavigationItem?.applicationState.includes(item?.state),
-        ),
-      )
+      setApplications(data.applications)
     }
   }, [data, router])
 

--- a/apps/financial-aid/web-veita/src/utils/navigation.ts
+++ b/apps/financial-aid/web-veita/src/utils/navigation.ts
@@ -1,9 +1,12 @@
-import { ApplicationState } from '@island.is/financial-aid/shared/lib'
+import {
+  ApplicationState,
+  ApplicationStateUrl,
+} from '@island.is/financial-aid/shared/lib'
 
 export const navigationItems = [
   {
     label: 'Ný mál',
-    link: '/nymal',
+    link: `/${ApplicationStateUrl.NEW}`,
     applicationState: [ApplicationState.NEW],
     headers: [
       { title: 'Nafn' },
@@ -15,7 +18,7 @@ export const navigationItems = [
   },
   {
     label: 'Mál í vinnslu',
-    link: '/vinnslu',
+    link: `/${ApplicationStateUrl.INPROGRESS}`,
     applicationState: [
       ApplicationState.INPROGRESS,
       ApplicationState.DATANEEDED,
@@ -30,7 +33,7 @@ export const navigationItems = [
   },
   {
     label: 'Afgreidd mál',
-    link: '/afgreidd',
+    link: `/${ApplicationStateUrl.PROCESSED}`,
     applicationState: [ApplicationState.APPROVED, ApplicationState.REJECTED],
     headers: [
       { title: 'Nafn' },

--- a/libs/financial-aid/shared/src/lib/enums.ts
+++ b/libs/financial-aid/shared/src/lib/enums.ts
@@ -22,6 +22,12 @@ export enum ApplicationState {
   APPROVED = 'Approved',
 }
 
+export enum ApplicationStateUrl {
+  NEW = 'nymal',
+  INPROGRESS = 'vinnslu',
+  PROCESSED = 'afgreidd',
+}
+
 export enum ApplicationEventType {
   NEW = 'New',
   INPROGRESS = 'InProgress',

--- a/libs/financial-aid/shared/src/lib/formatters.ts
+++ b/libs/financial-aid/shared/src/lib/formatters.ts
@@ -3,6 +3,7 @@ import {
   ApplicationState,
   Employment,
   ApplicationEventType,
+  ApplicationStateUrl,
 } from './enums'
 import type { KeyMapping } from './types'
 
@@ -28,6 +29,15 @@ export const getState: KeyMapping<ApplicationState, string> = {
   InProgress: 'Í vinnslu',
   Rejected: 'Synjað',
   Approved: 'Samþykkt',
+}
+
+export const getStateFromUrl: KeyMapping<
+  ApplicationStateUrl,
+  ApplicationState[]
+> = {
+  nymal: [ApplicationState.NEW],
+  vinnslu: [ApplicationState.INPROGRESS, ApplicationState.DATANEEDED],
+  afgreidd: [ApplicationState.REJECTED, ApplicationState.APPROVED],
 }
 
 export const getEventType: KeyMapping<


### PR DESCRIPTION
# Moving filtering of applications from client to backend

https://app.asana.com/0/1201017282841966/1201079906615276

## What

Added a enum ApplicationStateUrl 
When getting all applications, takes input that is ApplicationStateUrl 
Filters in backend instead of client 
When routing between tables, we get the newest

## Why

Put the filter rather on the backend than in client

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
