### PR TITLE
feat(web): Syslumenn - Operating licenses paginated by Syslumenn webservice

### DIFF
--- a/apps/web/screens/Organization/Syslumenn/OperatingLicenses.tsx
+++ b/apps/web/screens/Organization/Syslumenn/OperatingLicenses.tsx
@@ -39,12 +39,12 @@ import { useDateUtils } from '@island.is/web/i18n/useDateUtils'
 type SearchState = {
   currentTerm: string
   results: OperatingLicense[]
-  currentPageNumber: number,
-  hasNextPage: boolean,
-  totalCount: number,
-  isLoadingFirstPage: boolean,
-  isLoadingNextPage: boolean,
-  hasError: boolean,
+  currentPageNumber: number
+  hasNextPage: boolean
+  totalCount: number
+  isLoadingFirstPage: boolean
+  isLoadingNextPage: boolean
+  hasError: boolean
 }
 
 const SEARCH_REDUCER_ACTION_TYPES = {
@@ -58,14 +58,16 @@ const SEARCH_REDUCER_ACTION_TYPES = {
 const searchReducer = (state: SearchState, action): SearchState => {
   switch (action.type) {
     case SEARCH_REDUCER_ACTION_TYPES.START_LOADING_FIRST_PAGE:
-      return { ...state,
+      return {
+        ...state,
         currentTerm: action.currentTerm,
         currentPageNumber: action.currentPageNumber,
         isLoadingFirstPage: true,
         hasError: false,
       }
     case SEARCH_REDUCER_ACTION_TYPES.START_LOADING_NEXT_PAGE:
-      return { ...state,
+      return {
+        ...state,
         currentTerm: action.currentTerm,
         currentPageNumber: action.currentPageNumber,
         isLoadingNextPage: true,
@@ -73,16 +75,19 @@ const searchReducer = (state: SearchState, action): SearchState => {
       }
     case SEARCH_REDUCER_ACTION_TYPES.SEARCH_SUCCESS_FIRST_PAGE:
       // Request-Response matching based on current search term and current page number.
-      if (action.searchQuery === state.currentTerm && action.currentPageNumber === state.currentPageNumber) {
-        return { ...state,
+      if (
+        action.searchQuery === state.currentTerm &&
+        action.currentPageNumber === state.currentPageNumber
+      ) {
+        return {
+          ...state,
           results: action.results,
           hasNextPage: action.hasNextPage,
           totalCount: action.totalCount,
           isLoadingFirstPage: false,
           hasError: false,
         }
-      }
-      else {
+      } else {
         // Request-Response mismatch. Ignore outdated action.
         return state
       }
@@ -90,29 +95,34 @@ const searchReducer = (state: SearchState, action): SearchState => {
     case SEARCH_REDUCER_ACTION_TYPES.SEARCH_SUCCESS_NEXT_PAGE:
       // Request-Response matching, based on current search term and current page.
       // TODO: BUG, trailing space in search string, makes loading hang. (Potentially fixed by trimming the values before comparing for request-response match)
-      if (action.searchQuery === state.currentTerm && action.currentPageNumber === state.currentPageNumber) {
-        return { ...state,
-          results: [ ...state.results, ...action.results],
+      if (
+        action.searchQuery === state.currentTerm &&
+        action.currentPageNumber === state.currentPageNumber
+      ) {
+        return {
+          ...state,
+          results: [...state.results, ...action.results],
           hasNextPage: action.hasNextPage,
           totalCount: action.totalCount,
           isLoadingNextPage: false,
           hasError: false,
         }
-      }
-      else {
+      } else {
         // Request-Response mismatch. Ignore outdated action.
         return state
       }
     case SEARCH_REDUCER_ACTION_TYPES.SEARCH_ERROR:
       console.error(action.error)
-      return { ...state,
+      return {
+        ...state,
         hasError: true,
         isLoadingFirstPage: false,
         isLoadingNextPage: false,
       }
     default: {
       console.error('Unhandled search reducer action type.')
-      return { ...state,
+      return {
+        ...state,
         hasError: true,
         isLoadingFirstPage: false,
         isLoadingNextPage: false,
@@ -120,7 +130,6 @@ const searchReducer = (state: SearchState, action): SearchState => {
     }
   }
 }
-
 
 interface OperatingLicensesProps {
   organizationPage: Query['getOrganizationPage']
@@ -133,7 +142,7 @@ const DEBOUNCE_TIMER = 400
 // TODO: Find an appropriate page size.
 const PAGE_SIZE = 10
 
-const useSearch = ( term: string, currentPageNumber: number ): SearchState => {
+const useSearch = (term: string, currentPageNumber: number): SearchState => {
   const [state, dispatch] = useReducer(searchReducer, {
     currentTerm: term,
     results: [],
@@ -152,18 +161,15 @@ const useSearch = ( term: string, currentPageNumber: number ): SearchState => {
       dispatch({
         type: SEARCH_REDUCER_ACTION_TYPES.START_LOADING_FIRST_PAGE,
         currentTerm: term,
-        currentPageNumber: currentPageNumber
+        currentPageNumber: currentPageNumber,
       })
-    }
-    else
-    {
+    } else {
       dispatch({
         type: SEARCH_REDUCER_ACTION_TYPES.START_LOADING_NEXT_PAGE,
         currentTerm: term,
-        currentPageNumber: currentPageNumber
+        currentPageNumber: currentPageNumber,
       })
     }
-
 
     const thisTimerId = (timer.current = setTimeout(async () => {
       client
@@ -177,37 +183,39 @@ const useSearch = ( term: string, currentPageNumber: number ): SearchState => {
             },
           },
         })
-        .then(({ data: { getOperatingLicenses: { results, paginationInfo, searchQuery} }}) => {
-          if (paginationInfo.pageNumber === 1)
-          {
-            // First page
-            dispatch({
-              type: SEARCH_REDUCER_ACTION_TYPES.SEARCH_SUCCESS_FIRST_PAGE,
-              results,
-              currentPageNumber: paginationInfo.pageNumber,
-              hasNextPage: paginationInfo.hasNext,
-              totalCount: paginationInfo.totalCount,
-              searchQuery: searchQuery ?? '',
-            })
-          }
-          else
-          {
-            // Next pages
-            dispatch({
-              type: SEARCH_REDUCER_ACTION_TYPES.SEARCH_SUCCESS_NEXT_PAGE,
-              results,
-              currentPageNumber: paginationInfo.pageNumber,
-              hasNextPage: paginationInfo.hasNext,
-              totalCount: paginationInfo.totalCount,
-              searchQuery: searchQuery ?? '',
-            })
-          }
-
-        })
+        .then(
+          ({
+            data: {
+              getOperatingLicenses: { results, paginationInfo, searchQuery },
+            },
+          }) => {
+            if (paginationInfo.pageNumber === 1) {
+              // First page
+              dispatch({
+                type: SEARCH_REDUCER_ACTION_TYPES.SEARCH_SUCCESS_FIRST_PAGE,
+                results,
+                currentPageNumber: paginationInfo.pageNumber,
+                hasNextPage: paginationInfo.hasNext,
+                totalCount: paginationInfo.totalCount,
+                searchQuery: searchQuery ?? '',
+              })
+            } else {
+              // Next pages
+              dispatch({
+                type: SEARCH_REDUCER_ACTION_TYPES.SEARCH_SUCCESS_NEXT_PAGE,
+                results,
+                currentPageNumber: paginationInfo.pageNumber,
+                hasNextPage: paginationInfo.hasNext,
+                totalCount: paginationInfo.totalCount,
+                searchQuery: searchQuery ?? '',
+              })
+            }
+          },
+        )
         .catch((error) => {
           dispatch({
             type: SEARCH_REDUCER_ACTION_TYPES.SEARCH_ERROR,
-            error
+            error,
           })
         })
     }, DEBOUNCE_TIMER))
@@ -286,9 +294,7 @@ const OperatingLicenses: Screen<OperatingLicensesProps> = ({
           {subpage.title}
         </Text>
       </Box>
-      <Box
-        marginBottom={3}
-      >
+      <Box marginBottom={3}>
         <Input
           name="operatingLicenseSearchInput"
           placeholder={n('operatingLicensesFilterSearch', 'Leita')}
@@ -302,19 +308,25 @@ const OperatingLicenses: Screen<OperatingLicensesProps> = ({
           paddingTop={1}
           textAlign="center"
           style={{
-            visibility: search.isLoadingFirstPage ? 'visible' : 'hidden'
+            visibility: search.isLoadingFirstPage ? 'visible' : 'hidden',
           }}
         >
-          <LoadingDots/>
+          <LoadingDots />
         </Box>
       </Box>
-      {!search.isLoadingFirstPage && !search.isLoadingNextPage && !search.hasError && search.results.length === 0 &&
-        <Box display="flex" marginTop={4} justifyContent="center">
-          <Text variant="h3">
-            {n('operatingLicensesNoSearchResults', 'Engin rekstrarleyfi fundust.')}
-          </Text>
-        </Box>
-      }
+      {!search.isLoadingFirstPage &&
+        !search.isLoadingNextPage &&
+        !search.hasError &&
+        search.results.length === 0 && (
+          <Box display="flex" marginTop={4} justifyContent="center">
+            <Text variant="h3">
+              {n(
+                'operatingLicensesNoSearchResults',
+                'Engin rekstrarleyfi fundust.',
+              )}
+            </Text>
+          </Box>
+        )}
       {search.results.map((operatingLicense, index) => {
         return (
           <Box
@@ -326,7 +338,9 @@ const OperatingLicenses: Screen<OperatingLicensesProps> = ({
             paddingX={4}
           >
             <Text variant="h4" color="blue400" marginBottom={1}>
-              {operatingLicense.name ? operatingLicense.name : operatingLicense.location}
+              {operatingLicense.name
+                ? operatingLicense.name
+                : operatingLicense.location}
             </Text>
             <GridRow>
               <GridColumn span={['12/12', '12/12', '12/12']}>
@@ -339,7 +353,10 @@ const OperatingLicenses: Screen<OperatingLicensesProps> = ({
                 {operatingLicense.validUntil && (
                   <Text>
                     Gildir til{' '}
-                    {format(new Date(operatingLicense.validUntil), 'd. MMMM yyyy')}
+                    {format(
+                      new Date(operatingLicense.validUntil),
+                      'd. MMMM yyyy',
+                    )}
                   </Text>
                 )}
                 <Text>{operatingLicense.type}</Text>
@@ -351,13 +368,16 @@ const OperatingLicenses: Screen<OperatingLicensesProps> = ({
           </Box>
         )
       })}
-      {search.hasError &&
+      {search.hasError && (
         <AlertBanner
           title={n('operatingLicensesErrorTitle', 'Villa')}
-          description={n('operatingLicensesErrorDescription', 'Villa kom upp við að sækja rekstrarleyfi.')}
+          description={n(
+            'operatingLicensesErrorDescription',
+            'Villa kom upp við að sækja rekstrarleyfi.',
+          )}
           variant="error"
         />
-      }
+      )}
       <Box
         display="flex"
         justifyContent="center"
@@ -365,10 +385,10 @@ const OperatingLicenses: Screen<OperatingLicensesProps> = ({
         paddingBottom={2}
         textAlign="center"
         style={{
-          visibility: search.isLoadingNextPage ? 'visible' : 'hidden'
+          visibility: search.isLoadingNextPage ? 'visible' : 'hidden',
         }}
       >
-        <LoadingDots/>
+        <LoadingDots />
       </Box>
       <Box
         display="flex"

--- a/apps/web/screens/Organization/Syslumenn/OperatingLicenses.tsx
+++ b/apps/web/screens/Organization/Syslumenn/OperatingLicenses.tsx
@@ -2,11 +2,13 @@
 import React, { useEffect, useState, useRef, useReducer } from 'react'
 import { useApolloClient } from '@apollo/client/react'
 import {
+  AlertBanner,
   Box,
   Button,
   GridColumn,
   GridRow,
   Input,
+  LoadingDots,
   NavigationItem,
   Text,
 } from '@island.is/island-ui/core'
@@ -55,7 +57,10 @@ const SEARCH_REDUCER_ACTION_TYPES = {
 const searchReducer = (state: SearchState, action): SearchState => {
   switch (action.type) {
     case SEARCH_REDUCER_ACTION_TYPES.START_LOADING:
-      return { ...state, isLoading: true }
+      return { ...state,
+        isLoading: true,
+        hasError: false,
+      }
     case SEARCH_REDUCER_ACTION_TYPES.SEARCH_SUCCESS_FIRST_PAGE:
       // TODO: Do Request-Response matching
       return { ...state,
@@ -64,6 +69,7 @@ const searchReducer = (state: SearchState, action): SearchState => {
         hasNextPage: action.hasNextPage,
         totalCount: action.totalCount,
         isLoading: false,
+        hasError: false,
       }
     case SEARCH_REDUCER_ACTION_TYPES.SEARCH_SUCCESS_NEXT_PAGE:
       return { ...state,
@@ -72,13 +78,20 @@ const searchReducer = (state: SearchState, action): SearchState => {
         hasNextPage: action.hasNextPage,
         totalCount: action.totalCount,
         isLoading: false,
+        hasError: false,
       }
     case SEARCH_REDUCER_ACTION_TYPES.SEARCH_ERROR:
       console.error(action.error)
-      return { ...state, hasError: true, isLoading: false }
+      return { ...state,
+        hasError: true,
+        isLoading: false
+      }
     default: {
       console.error('Unhandled search reducer action type.')
-      return { ...state, hasError: true, isLoading: false }
+      return { ...state,
+        hasError: true,
+        isLoading: false
+      }
     }
   }
 }
@@ -206,10 +219,8 @@ const OperatingLicenses: Screen<OperatingLicensesProps> = ({
   }
 
   const onLoadMore = () => {
-    // TODO: Implement some loading animation.
     setCurrentPageNumber(currentPageNumber + 1)
   }
-
 
   return (
     <OrganizationWrapper
@@ -236,7 +247,6 @@ const OperatingLicenses: Screen<OperatingLicensesProps> = ({
           {subpage.title}
         </Text>
       </Box>
-      {richText(subpage.description as SliceType[])}
       <Box
         background="blue100"
         borderRadius="large"
@@ -247,18 +257,13 @@ const OperatingLicenses: Screen<OperatingLicensesProps> = ({
       >
         <Input
           name="operatingLicenseSearchInput"
-          placeholder={n('filterSearch', 'Leita')}
+          placeholder={n('operatingLicensesFilterSearch', 'Leita')}
           backgroundColor={['blue', 'blue', 'white']}
           size="sm"
           icon="search"
           iconType="outline"
           onChange={(event) => onSearch(event.target.value)}
         />
-        {search.isLoading ? 'LOADING...' : 'DONE'}
-        <br></br>
-        {search.results.length + " / " + search.totalCount}
-        <br></br>
-        {search.hasError && 'ERROR!!!'}
       </Box>
       {search.results.map((operatingLicense, index) => {
         return (
@@ -296,6 +301,25 @@ const OperatingLicenses: Screen<OperatingLicensesProps> = ({
           </Box>
         )
       })}
+      {search.hasError &&
+        <AlertBanner
+          title={n('operatingLicensesErrorTitle', 'Villa')}
+          description={n('operatingLicensesErrorDescription', 'Villa kom upp við að sækja rekstrarleyfi.')}
+          variant="error"
+        />
+      }
+      <Box
+        display="flex"
+        justifyContent="center"
+        // TODO: Fix the UI so that id does not shift when pushing the "Load more" button.
+        paddingTop={2}
+        paddingBottom={2}
+        textAlign="center"
+      >
+        {search.isLoading &&
+          <LoadingDots />
+        }
+      </Box>
       <Box
         display="flex"
         justifyContent="center"
@@ -303,8 +327,11 @@ const OperatingLicenses: Screen<OperatingLicensesProps> = ({
         textAlign="center"
       >
         {search.hasNextPage && (
-          <Button onClick={() => onLoadMore()}>
-            {n('seeMore', 'Sjá meira') } (
+          <Button
+            onClick={() => onLoadMore()}
+            disabled={search.isLoading}
+          >
+            {n('operatingLicensesSeeMore', 'Sjá fleiri')} (
             {search.totalCount - search.results.length})
           </Button>
         )}

--- a/apps/web/screens/Organization/Syslumenn/OperatingLicenses.tsx
+++ b/apps/web/screens/Organization/Syslumenn/OperatingLicenses.tsx
@@ -56,7 +56,6 @@ const SEARCH_REDUCER_ACTION_TYPES = {
 }
 
 const searchReducer = (state: SearchState, action): SearchState => {
-  // TODO: Refactor this switch statement to if statements, altering the state and returning it in the end.
   switch (action.type) {
     case SEARCH_REDUCER_ACTION_TYPES.START_LOADING_FIRST_PAGE:
       return { ...state,
@@ -138,8 +137,6 @@ const useSearch = ( term: string, currentPageNumber: number ): SearchState => {
   const [state, dispatch] = useReducer(searchReducer, {
     currentTerm: term,
     results: [],
-    // TODO: Only show loading dots on initial load and next page load.
-    // TODO: The reload icon in the search bar disappears before the results have been fully loaded. It's not in sync with the loading dots that are shown depending on the same boolean variable.
     currentPageNumber: currentPageNumber,
     hasNextPage: false,
     totalCount: 0,
@@ -208,7 +205,6 @@ const useSearch = ( term: string, currentPageNumber: number ): SearchState => {
 
         })
         .catch((error) => {
-          // TODO: Test the error handling by producing an error, e.g. by commenting out the Authenitication call in the client.
           dispatch({
             type: SEARCH_REDUCER_ACTION_TYPES.SEARCH_ERROR,
             error

--- a/apps/web/screens/Organization/Syslumenn/OperatingLicenses.tsx
+++ b/apps/web/screens/Organization/Syslumenn/OperatingLicenses.tsx
@@ -94,7 +94,6 @@ const searchReducer = (state: SearchState, action): SearchState => {
 
     case SEARCH_REDUCER_ACTION_TYPES.SEARCH_SUCCESS_NEXT_PAGE:
       // Request-Response matching, based on current search term and current page.
-      // TODO: BUG, trailing space in search string, makes loading hang. (Potentially fixed by trimming the values before comparing for request-response match)
       if (
         action.searchQuery === state.currentTerm &&
         action.currentPageNumber === state.currentPageNumber

--- a/apps/web/screens/Organization/Syslumenn/OperatingLicenses.tsx
+++ b/apps/web/screens/Organization/Syslumenn/OperatingLicenses.tsx
@@ -248,12 +248,7 @@ const OperatingLicenses: Screen<OperatingLicensesProps> = ({
         </Text>
       </Box>
       <Box
-        background="blue100"
-        borderRadius="large"
-        paddingX={4}
-        paddingY={3}
-        marginTop={4}
-        marginBottom={4}
+        marginBottom={6}
       >
         <Input
           name="operatingLicenseSearchInput"

--- a/apps/web/screens/Organization/Syslumenn/OperatingLicenses.tsx
+++ b/apps/web/screens/Organization/Syslumenn/OperatingLicenses.tsx
@@ -260,6 +260,13 @@ const OperatingLicenses: Screen<OperatingLicensesProps> = ({
           onChange={(event) => onSearch(event.target.value)}
         />
       </Box>
+      {!search.isLoading && !search.hasError && search.results.length === 0 &&
+        <Box display="flex" marginTop={4} justifyContent="center">
+          <Text variant="h3">
+            {n('operatingLicensesNoSearchResults', 'Engin rekstrarleyfi fundust.')}
+          </Text>
+        </Box>
+      }
       {search.results.map((operatingLicense, index) => {
         return (
           <Box

--- a/apps/web/screens/Organization/Syslumenn/OperatingLicenses.tsx
+++ b/apps/web/screens/Organization/Syslumenn/OperatingLicenses.tsx
@@ -13,7 +13,7 @@ import { withMainLayout } from '@island.is/web/layouts/main'
 import {
   ContentLanguage,
   Query,
-  QueryGetHomestaysArgs,
+  QueryGetOperatingLicensesArgs,
   QueryGetNamespaceArgs,
   QueryGetOrganizationPageArgs,
   QueryGetOrganizationSubpageArgs,
@@ -39,6 +39,8 @@ interface OperatingLicensesProps {
   operatingLicenses: Query['getOperatingLicenses']
   namespace: Query['getNamespace']
 }
+
+const PAGE_SIZE = 30
 
 const OperatingLicenses: Screen<OperatingLicensesProps> = ({
   organizationPage,
@@ -74,7 +76,7 @@ const OperatingLicenses: Screen<OperatingLicensesProps> = ({
 
   const setQuery = (query: string) => _setQuery(query.toLowerCase())
 
-  const filteredItems = operatingLicenses
+  const filteredItems = operatingLicenses.results
     .filter(
       (homestay) =>
         homestay.name?.toLowerCase().includes(query) ||
@@ -212,8 +214,14 @@ OperatingLicenses.getInitialProps = async ({ apolloClient, locale, query }) => {
         },
       },
     }),
-    apolloClient.query<Query, QueryGetHomestaysArgs>({
+    apolloClient.query<Query, QueryGetOperatingLicensesArgs>({
       query: GET_OPERATING_LICENSES_QUERY,
+      variables: {
+        input: {
+          pageNumber: 1,
+          pageSize: PAGE_SIZE,
+        },
+      },
     }),
     apolloClient
       .query<Query, QueryGetNamespaceArgs>({

--- a/apps/web/screens/queries/Organization.tsx
+++ b/apps/web/screens/queries/Organization.tsx
@@ -211,18 +211,29 @@ export const GET_SYSLUMENN_AUCTIONS_QUERY = gql`
 `
 
 export const GET_OPERATING_LICENSES_QUERY = gql`
-  query GetOperatingLicenses {
-    getOperatingLicenses {
-      location
-      name
-      street
-      postalCode
-      validUntil
-      type
-      category
-      issuedBy
-      licenseHolder
-      licenseNumber
+  query GetOperatingLicenses($input: GetOperatingLicensesInput!) {
+    getOperatingLicenses(input: $input) {
+      paginationInfo {
+        pageSize
+        pageNumber
+        totalCount
+        totalPages
+        currentPage
+        hasNext
+        hasPrevious
+      }
+      results {
+        location
+        name
+        street
+        postalCode
+        validUntil
+        type
+        category
+        issuedBy
+        licenseHolder
+        licenseNumber
+      }
     }
   }
 `

--- a/apps/web/screens/queries/Organization.tsx
+++ b/apps/web/screens/queries/Organization.tsx
@@ -222,6 +222,7 @@ export const GET_OPERATING_LICENSES_QUERY = gql`
         hasNext
         hasPrevious
       }
+      searchQuery
       results {
         location
         name

--- a/libs/api/domains/syslumenn/src/lib/client/models/paginatedOperatingLicenses.ts
+++ b/libs/api/domains/syslumenn/src/lib/client/models/paginatedOperatingLicenses.ts
@@ -1,0 +1,7 @@
+import { IOperatingLicense } from './operatingLicense'
+import { IPaginationInfo } from './paginationInfo'
+
+export interface IPaginatedOperatingLicenses {
+  paginationInfo: IPaginationInfo
+  results: IOperatingLicense[]
+}

--- a/libs/api/domains/syslumenn/src/lib/client/models/paginatedOperatingLicenses.ts
+++ b/libs/api/domains/syslumenn/src/lib/client/models/paginatedOperatingLicenses.ts
@@ -2,6 +2,7 @@ import { IOperatingLicense } from './operatingLicense'
 import { IPaginationInfo } from './paginationInfo'
 
 export interface IPaginatedOperatingLicenses {
+  searchQuery: string
   paginationInfo: IPaginationInfo
   results: IOperatingLicense[]
 }

--- a/libs/api/domains/syslumenn/src/lib/client/models/paginationInfo.ts
+++ b/libs/api/domains/syslumenn/src/lib/client/models/paginationInfo.ts
@@ -1,0 +1,9 @@
+export interface IPaginationInfo {
+  PageSize?: number
+  PageNumber?: number
+  TotalCount?: number
+  TotalPages?: number
+  CurrentPage?: number
+  HasNext?: boolean
+  HasPrevious?: boolean
+}

--- a/libs/api/domains/syslumenn/src/lib/client/syslumenn.client.ts
+++ b/libs/api/domains/syslumenn/src/lib/client/syslumenn.client.ts
@@ -100,6 +100,7 @@ export class SyslumennClient {
 
     const paginatedOperatingLicenses: IPaginatedOperatingLicenses = {
       paginationInfo: JSON.parse(response.headers['x-pagination']),
+      searchQuery: decodeURIComponent(response.headers['x-searchby']),
       results: response.data,
     }
 

--- a/libs/api/domains/syslumenn/src/lib/client/syslumenn.client.ts
+++ b/libs/api/domains/syslumenn/src/lib/client/syslumenn.client.ts
@@ -98,9 +98,10 @@ export class SyslumennClient {
       })
       .toPromise()
 
-
     // TODO: BUG workaround. Currently the Syslumenn Webservice encodes whitespaces as '+' instead of '%20'. Until that has been addressed, we work around the bug.
-    const searchQueryBugWorkaround = decodeURIComponent((response.headers['x-searchby'] ?? '').replace('+', '%20'))
+    const searchQueryBugWorkaround = decodeURIComponent(
+      (response.headers['x-searchby'] ?? '').replace('+', '%20'),
+    )
 
     const paginatedOperatingLicenses: IPaginatedOperatingLicenses = {
       paginationInfo: JSON.parse(response.headers['x-pagination']),

--- a/libs/api/domains/syslumenn/src/lib/client/syslumenn.client.ts
+++ b/libs/api/domains/syslumenn/src/lib/client/syslumenn.client.ts
@@ -100,7 +100,7 @@ export class SyslumennClient {
 
     const paginatedOperatingLicenses: IPaginatedOperatingLicenses = {
       paginationInfo: JSON.parse(response.headers['x-pagination']),
-      searchQuery: decodeURIComponent(response.headers['x-searchby']),
+      searchQuery: decodeURIComponent(response.headers['x-searchby'] ?? ''),
       results: response.data,
     }
 

--- a/libs/api/domains/syslumenn/src/lib/client/syslumenn.client.ts
+++ b/libs/api/domains/syslumenn/src/lib/client/syslumenn.client.ts
@@ -98,9 +98,13 @@ export class SyslumennClient {
       })
       .toPromise()
 
+
+    // TODO: BUG workaround. Currently the Syslumenn Webservice encodes whitespaces as '+' instead of '%20'. Until that has been addressed, we work around the bug.
+    const searchQueryBugWorkaround = decodeURIComponent((response.headers['x-searchby'] ?? '').replace('+', '%20'))
+
     const paginatedOperatingLicenses: IPaginatedOperatingLicenses = {
       paginationInfo: JSON.parse(response.headers['x-pagination']),
-      searchQuery: decodeURIComponent(response.headers['x-searchby'] ?? ''),
+      searchQuery: searchQueryBugWorkaround,
       results: response.data,
     }
 

--- a/libs/api/domains/syslumenn/src/lib/dto/getOperatingLicenses.input.ts
+++ b/libs/api/domains/syslumenn/src/lib/dto/getOperatingLicenses.input.ts
@@ -1,0 +1,20 @@
+import { IsNumber, IsString, IsOptional } from 'class-validator'
+import { Field, InputType } from '@nestjs/graphql'
+
+@InputType()
+export class GetOperatingLicensesInput {
+  @Field({ nullable: true })
+  @IsString()
+  @IsOptional()
+  searchBy?: string
+
+  @Field({ nullable: true })
+  @IsNumber()
+  @IsOptional()
+  pageNumber?: number
+
+  @Field({ nullable: true })
+  @IsNumber()
+  @IsOptional()
+  pageSize?: number
+}

--- a/libs/api/domains/syslumenn/src/lib/models/paginatedOperatingLicenses.ts
+++ b/libs/api/domains/syslumenn/src/lib/models/paginatedOperatingLicenses.ts
@@ -8,6 +8,9 @@ export class PaginatedOperatingLicenses {
   @Field({ nullable: true })
   paginationInfo?: PaginationInfo
 
+  @Field({ nullable: true })
+  searchQuery?: string
+
   @Field(() => [OperatingLicense])
   results?: OperatingLicense[]
 }
@@ -16,5 +19,6 @@ export const mapPaginatedOperatingLicenses = (
   paginatedOperatingLicenses: IPaginatedOperatingLicenses,
 ): PaginatedOperatingLicenses => ({
   paginationInfo: mapPaginationInfo(paginatedOperatingLicenses.paginationInfo),
+  searchQuery: paginatedOperatingLicenses.searchQuery,
   results: (paginatedOperatingLicenses.results ?? []).map(mapOperatingLicense),
 })

--- a/libs/api/domains/syslumenn/src/lib/models/paginatedOperatingLicenses.ts
+++ b/libs/api/domains/syslumenn/src/lib/models/paginatedOperatingLicenses.ts
@@ -1,0 +1,20 @@
+import { Field, ObjectType } from '@nestjs/graphql'
+import { IPaginatedOperatingLicenses } from '../client/models/paginatedOperatingLicenses'
+import { OperatingLicense, mapOperatingLicense } from './operatingLicense'
+import { PaginationInfo, mapPaginationInfo } from './paginationInfo'
+
+@ObjectType()
+export class PaginatedOperatingLicenses {
+  @Field({ nullable: true })
+  paginationInfo?: PaginationInfo
+
+  @Field(() => [OperatingLicense])
+  results?: OperatingLicense[]
+}
+
+export const mapPaginatedOperatingLicenses = (
+  paginatedOperatingLicenses: IPaginatedOperatingLicenses,
+): PaginatedOperatingLicenses => ({
+  paginationInfo: mapPaginationInfo(paginatedOperatingLicenses.paginationInfo),
+  results: (paginatedOperatingLicenses.results ?? []).map(mapOperatingLicense),
+})

--- a/libs/api/domains/syslumenn/src/lib/models/paginationInfo.ts
+++ b/libs/api/domains/syslumenn/src/lib/models/paginationInfo.ts
@@ -1,0 +1,38 @@
+import { Field, ObjectType } from '@nestjs/graphql'
+import { IPaginationInfo } from '../client/models/paginationInfo'
+
+@ObjectType()
+export class PaginationInfo {
+  @Field({ nullable: true })
+  pageSize?: number
+
+  @Field({ nullable: true })
+  pageNumber?: number
+
+  @Field({ nullable: true })
+  totalCount?: number
+
+  @Field({ nullable: true })
+  totalPages?: number
+
+  @Field({ nullable: true })
+  currentPage?: number
+
+  @Field({ nullable: true })
+  hasNext?: boolean
+
+  @Field({ nullable: true })
+  hasPrevious?: boolean
+}
+
+export const mapPaginationInfo = (
+  paginationInfo: IPaginationInfo,
+): PaginationInfo => ({
+  pageSize: paginationInfo.PageSize,
+  pageNumber: paginationInfo.PageNumber,
+  totalCount: paginationInfo.TotalCount,
+  totalPages: paginationInfo.TotalPages,
+  currentPage: paginationInfo.CurrentPage,
+  hasNext: paginationInfo.HasNext,
+  hasPrevious: paginationInfo.HasPrevious,
+})

--- a/libs/api/domains/syslumenn/src/lib/syslumenn.resolver.ts
+++ b/libs/api/domains/syslumenn/src/lib/syslumenn.resolver.ts
@@ -1,9 +1,10 @@
 import { Args, Directive, Query, Resolver } from '@nestjs/graphql'
 import { GetHomestaysInput } from './dto/getHomestays.input'
+import { GetOperatingLicensesInput } from './dto/getOperatingLicenses.input'
 import { Homestay } from './models/homestay'
 import { SyslumennAuction } from './models/syslumennAuction'
 import { SyslumennService } from './syslumenn.service'
-import { OperatingLicense } from './models/operatingLicense'
+import { PaginatedOperatingLicenses } from './models/paginatedOperatingLicenses'
 
 const cacheTime = process.env.CACHE_TIME || 300
 
@@ -26,8 +27,14 @@ export class SyslumennResolver {
   }
 
   @Directive(cacheControlDirective())
-  @Query(() => [OperatingLicense])
-  getOperatingLicenses(): Promise<OperatingLicense[]> {
-    return this.syslumennService.getOperatingLicenses()
+  @Query(() => PaginatedOperatingLicenses)
+  getOperatingLicenses(
+    @Args('input') input: GetOperatingLicensesInput,
+  ): Promise<PaginatedOperatingLicenses> {
+    return this.syslumennService.getOperatingLicenses(
+      input.searchBy,
+      input.pageNumber,
+      input.pageSize,
+    )
   }
 }

--- a/libs/api/domains/syslumenn/src/lib/syslumenn.service.ts
+++ b/libs/api/domains/syslumenn/src/lib/syslumenn.service.ts
@@ -7,9 +7,9 @@ import {
 import { Injectable } from '@nestjs/common'
 import { Person, Attachment, DataUploadResponse } from './models/dataUpload'
 import {
-  OperatingLicense,
-  mapOperatingLicense,
-} from './models/operatingLicense'
+  PaginatedOperatingLicenses,
+  mapPaginatedOperatingLicenses,
+} from './models/paginatedOperatingLicenses'
 
 @Injectable()
 export class SyslumennService {
@@ -27,10 +27,18 @@ export class SyslumennService {
     return (syslumennAuctions ?? []).map(mapSyslumennAuction)
   }
 
-  async getOperatingLicenses(): Promise<OperatingLicense[]> {
-    const operatingLicenses = await this.syslumennClient.getOperatingLicenses()
+  async getOperatingLicenses(
+    searchQuery?: string,
+    pageNumber?: number,
+    pageSize?: number,
+  ): Promise<PaginatedOperatingLicenses> {
+    const paginatedOperatingLicenses = await this.syslumennClient.getOperatingLicenses(
+      searchQuery,
+      pageNumber,
+      pageSize,
+    )
 
-    return (operatingLicenses ?? []).map(mapOperatingLicense)
+    return mapPaginatedOperatingLicenses(paginatedOperatingLicenses)
   }
 
   async uploadData(


### PR DESCRIPTION
# Syslumenn - Operating licenses paginated by Syslumenn webservice

## What

Instead of fetching all Operating licences in one call to Syslumenn webservice we now get Operating licences paginated from the Syslumenn webservice. It follows that the Syslumenn webservice will now handle any search or filtering of the data.
In addition to this, we've iterated on the UI/UX. 

## Why

It turned out that the previous approach for fetching Operating licenses (and is currently used for Homestays and Auctions) where we fetch all data in a single call to Syslumenn webservice was not a good approach due to the number of Operating licences, i.e. the size of the data. Instead, the Syslumenn webservice has now added support for paginating Operating licenses which we now utilise.

## Screenshots / Gifs

![syslumenn-operating-licenses-paginated](https://user-images.githubusercontent.com/1277384/135427139-73af1702-fcaf-4f03-bd01-41a3b6f23da4.png)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
