### PR TITLE
fix(build): Preventing collision of config keys from different sections

### DIFF
--- a/infra/src/dsl/env.spec.ts
+++ b/infra/src/dsl/env.spec.ts
@@ -33,7 +33,7 @@ describe('Env variable', () => {
     ])
   })
 
-  it('Should not allow to collide with secrets', () => {
+  it('Should not allow to collision of secrets and env variables', () => {
     const sut = service('api').env({
       A: 'B',
     }).secrets({
@@ -44,6 +44,24 @@ describe('Env variable', () => {
       new UberChart(Staging),
     ) as SerializeErrors
     
-    expect(serviceDef.errors).toStrictEqual(['Error'])
+    expect(serviceDef.errors).toStrictEqual(['Collisions for environment or secrets for key A'])
+  })
+
+  it('Should not allow collision of secrets and env variables in init containers', () => {
+    const sut = service('api').initContainer({
+      envs: {
+        A: 'B',
+      },
+      secrets: {
+        A: 'somesecret'
+      },
+      containers: [{command: 'go'}]
+    })
+    const serviceDef = serializeService(
+      sut,
+      new UberChart(Staging),
+    ) as SerializeErrors
+    
+    expect(serviceDef.errors).toStrictEqual(['Collisions for environment or secrets for key A'])
   })
 })

--- a/infra/src/dsl/env.spec.ts
+++ b/infra/src/dsl/env.spec.ts
@@ -32,4 +32,18 @@ describe('Env variable', () => {
       'Missing settings for service api in env staging. Keys of missing settings: B',
     ])
   })
+
+  it('Should not allow to collide with secrets', () => {
+    const sut = service('api').env({
+      A: 'B',
+    }).secrets({
+      A: 'somesecret'
+    })
+    const serviceDef = serializeService(
+      sut,
+      new UberChart(Staging),
+    ) as SerializeErrors
+    
+    expect(serviceDef.errors).toStrictEqual(['Error'])
+  })
 })

--- a/infra/src/dsl/map-to-values.ts
+++ b/infra/src/dsl/map-to-values.ts
@@ -33,6 +33,13 @@ export const serializeService: SerializeMethod = (
   uberChart: UberChartType,
 ) => {
   let allErrors: string[] = []
+  const mergeObject = (target: any, source: any) => {
+    const targetKeys = Object.keys(target)
+    return (
+      Object.keys(source).findIndex((srcKey) => targetKeys.includes(srcKey)) ===
+      -1
+    )
+  }
   const addToErrors = (errors: string[]) => {
     allErrors.push(...errors)
   }

--- a/infra/src/dsl/map-to-values.ts
+++ b/infra/src/dsl/map-to-values.ts
@@ -33,6 +33,9 @@ export const serializeService: SerializeMethod = (
   uberChart: UberChartType,
 ) => {
   let allErrors: string[] = []
+  const addToErrors = (errors: string[]) => {
+    allErrors.push(...errors)
+  }
   const serviceDef = service.serviceDef
   const {
     grantNamespaces,
@@ -103,7 +106,7 @@ export const serializeService: SerializeMethod = (
       uberChart,
       serviceDef.extraAttributes,
     )
-    allErrors = allErrors.concat(errors)
+    addToErrors(errors)
     result.extra = envs
   }
 
@@ -119,7 +122,7 @@ export const serializeService: SerializeMethod = (
       uberChart,
       serviceDef.env,
     )
-    allErrors = allErrors.concat(errors)
+    addToErrors(errors)
     result.env = { ...result.env, ...envs }
   }
 
@@ -134,7 +137,7 @@ export const serializeService: SerializeMethod = (
     secrets: featureSecrets,
   } = addFeaturesConfig(serviceDef.features, uberChart, service)
   result.env = { ...result.env, ...featureEnvs }
-  allErrors = allErrors.concat(featureErrors)
+  addToErrors(featureErrors)
   result.secrets = { ...result.secrets, ...featureSecrets }
 
   // service account
@@ -170,7 +173,7 @@ export const serializeService: SerializeMethod = (
           uberChart,
           serviceDef.initContainers.envs,
         )
-        allErrors = allErrors.concat(errors)
+        addToErrors(errors)
         result.initContainer.env = { ...result.initContainer.env, ...envs }
       }
       if (typeof serviceDef.initContainers.secrets !== 'undefined') {
@@ -189,8 +192,8 @@ export const serializeService: SerializeMethod = (
           ...result.initContainer.secrets,
           ...secrets,
         }
-        allErrors = allErrors.concat(envErros)
-        allErrors = allErrors.concat(secretErrors)
+        addToErrors(envErros)
+        addToErrors(secretErrors)
       }
       if (serviceDef.initContainers.features) {
         const {
@@ -207,14 +210,14 @@ export const serializeService: SerializeMethod = (
           ...result.initContainer.env,
           ...featureEnvs,
         }
-        allErrors = allErrors.concat(featureErrors)
+        addToErrors(featureErrors)
         result.initContainer.secrets = {
           ...result.initContainer.secrets,
           ...featureSecrets,
         }
       }
     } else {
-      allErrors.push('No containers to run defined in initContainers')
+      addToErrors(['No containers to run defined in initContainers'])
     }
   }
 
@@ -234,7 +237,7 @@ export const serializeService: SerializeMethod = (
             [`${ingressName}-alb`]: ingress,
           }
         } catch (e) {
-          allErrors.push(e.message)
+          addToErrors([e.message])
           return acc
         }
       },
@@ -252,8 +255,8 @@ export const serializeService: SerializeMethod = (
 
     result.env = { ...result.env, ...env }
     result.secrets = { ...result.secrets, ...secrets }
-    allErrors = allErrors.concat(envErros)
-    allErrors = allErrors.concat(secretErrors)
+    addToErrors(envErros)
+    addToErrors(secretErrors)
   }
 
   return allErrors.length === 0

--- a/infra/src/dsl/map-to-values.ts
+++ b/infra/src/dsl/map-to-values.ts
@@ -34,8 +34,12 @@ export const serializeService: SerializeMethod = (
 ) => {
   let allErrors: string[] = []
   const checkCollisions = (target: any, source: any) => {
-    const targetKeys = Object.keys(target)    
-    addToErrors(Object.keys(source).filter((srcKey) => targetKeys.includes(srcKey)).map(key => `Collisions for environment or secrets for key ${key}`))
+    const targetKeys = Object.keys(target)
+    addToErrors(
+      Object.keys(source)
+        .filter((srcKey) => targetKeys.includes(srcKey))
+        .map((key) => `Collisions for environment or secrets for key ${key}`),
+    )
   }
   const mergeObjects = (target: any, source: any) => {
     checkCollisions(target, source)
@@ -136,7 +140,7 @@ export const serializeService: SerializeMethod = (
 
   // secrets
   if (Object.keys(serviceDef.secrets).length > 0) {
-    result.secrets = serviceDef.secrets
+    result.secrets = { ...serviceDef.secrets }
   }
 
   const {

--- a/infra/src/dsl/postgres.spec.ts
+++ b/infra/src/dsl/postgres.spec.ts
@@ -45,10 +45,10 @@ describe('Postgres', () => {
 
     it('Env and secret variables already defined', () => {
       expect(result.errors).toEqual([
-        'You have already defined an environment variable DB_USER which is interfering with the Postgres definion',
-        'You have already defined an environment variable DB_NAME which is interfering with the Postgres definion',
-        'You have already defined an environment variable DB_HOST which is interfering with the Postgres definion',
-        'You have already defined a secret variable DB_PASS which is interfering with the Postgres definion',
+        'Collisions for environment or secrets for key DB_USER',
+        'Collisions for environment or secrets for key DB_NAME',
+        'Collisions for environment or secrets for key DB_HOST',
+        'Collisions for environment or secrets for key DB_PASS',
       ])
     })
   })


### PR DESCRIPTION
# ...

Secrets and env variables all end up as environment variables and thus share the same name space. Since these are coming from different parts of the code, added a bit of checks to validate there are no collisions.

## What

Avoid weird deployment errors.


## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
