### PR TITLE
feat(web): Ability to have explicit redirect links

### DIFF
--- a/apps/web/pages/_error.tsx
+++ b/apps/web/pages/_error.tsx
@@ -86,7 +86,10 @@ class ErrorPage extends React.Component<ErrorPageProps> {
 
         // Found an URL content type that contained this
         // path (which has a page assigned to it) so we redirect to that page
-        const url = linkResolver(type as LinkType, [slug], locale).href
+        const url =
+          type === 'explicitRedirect'
+            ? slug
+            : linkResolver(type as LinkType, [slug], locale).href
         if (!process.browser) {
           res.writeHead(302, { Location: url })
           res.end()
@@ -171,6 +174,13 @@ const getRedirectProps = async ({
       },
     })
     .then((response) => response.data)
+
+  if (!getUrl?.page && getUrl?.explicitRedirect) {
+    return {
+      slug: getUrl.explicitRedirect,
+      type: 'explicitRedirect',
+    }
+  }
 
   return getUrl?.page ?? null
 }

--- a/apps/web/screens/queries/Url.tsx
+++ b/apps/web/screens/queries/Url.tsx
@@ -10,6 +10,7 @@ export const GET_URL_QUERY = gql`
         slug
         type
       }
+      explicitRedirect
     }
   }
 `

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -3189,7 +3189,7 @@ export interface IUrlFields {
   title?: string | undefined
 
   /** Page */
-  page:
+  page?:
     | IAboutSubPage
     | IArticle
     | IArticleCategory
@@ -3197,9 +3197,13 @@ export interface IUrlFields {
     | INews
     | IVidspyrnaFrontpage
     | IVidspyrnaPage
+    | undefined
 
   /** Urls list */
   urlsList: string[]
+
+  /** Explicit Redirect */
+  explicitRedirect?: string | undefined
 }
 
 export interface IUrl extends Entry<IUrlFields> {

--- a/libs/cms/src/lib/models/url.model.ts
+++ b/libs/cms/src/lib/models/url.model.ts
@@ -15,11 +15,15 @@ export class Url {
 
   @Field(() => [String])
   urlsList!: Array<string>
+
+  @Field(() => String, { nullable: true })
+  explicitRedirect?: string
 }
 
 export const mapUrl = ({ fields, sys }: IUrl): Url => ({
   id: sys.id,
   title: fields.title ?? '',
   page: fields.page ? mapReferenceLink(fields.page) : null,
+  explicitRedirect: fields.explicitRedirect ?? '',
   urlsList: fields.urlsList ?? [],
 })


### PR DESCRIPTION
## What

Allowing a fallback redirect with the `explicitRedirect` on 404redirects (url) in contentful.

## Why

We're refactoring our content models. In that effort we wish to remove `aboutSubPage` but it is still being used for 404redirects. The superseding `organizationSubPage` does not store slugs in the same way as `aboutSubPage`.
One solution is to simply allow explicit redirects as a fallback if `page` is not provided.

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
