### PR TITLE
fix(judicial-system): Use 'Kærði/a' instead of 'Varnaraðili' in restriction cases PDF

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/rulingPdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/rulingPdf.ts
@@ -317,7 +317,11 @@ function constructRestrictionRulingPdf(
     )
     .text(' ')
     .text(
-      `${formatAppeal(existingCase.accusedAppealDecision, 'Varnaraðili')} ${
+      `${formatAppeal(
+        existingCase.accusedAppealDecision,
+        capitalize(formatAccusedByGender(existingCase.accusedGender)),
+        existingCase.accusedGender,
+      )} ${
         existingCase.accusedAppealDecision === CaseAppealDecision.APPEAL
           ? existingCase.accusedAppealAnnouncement ?? ''
           : ''


### PR DESCRIPTION
# Use 'Kærði/a' instead of 'Varnaraðili' in restriction cases PDF

https://app.asana.com/0/1199153462262248/1201061586055548/f

## What

Use 'Kærði/a' instead of 'Varnaraðili' in restriction cases PDF

## Screenshots / Gifs

![Screen Shot 2021-10-05 at 09 42 26](https://user-images.githubusercontent.com/3789875/135999623-c1d1acc1-4be6-4ace-b558-a61c3ed70222.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
