### PR TITLE
fix(judicial-system): PDFs now use a font size variable

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/casefilesPdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/casefilesPdf.ts
@@ -3,7 +3,12 @@ import streamBuffers from 'stream-buffers'
 
 import { environment } from '../../environments'
 import { Case } from '../modules/case/models'
-import { setPageNumbers } from './pdfHelpers'
+import {
+  baseFontSize,
+  hugeFontSize,
+  largeFontSize,
+  setPageNumbers,
+} from './pdfHelpers'
 import { writeFile } from './writeFile'
 
 function constructCasefilesPdf(
@@ -28,18 +33,18 @@ function constructCasefilesPdf(
 
   doc
     .font('Helvetica-Bold')
-    .fontSize(26)
+    .fontSize(hugeFontSize)
     .lineGap(8)
     .text('Rannsóknargögn', { align: 'center' })
     .font('Helvetica')
-    .fontSize(18)
+    .fontSize(largeFontSize)
     .lineGap(40)
     .text(
       `Mál nr. ${existingCase.courtCaseNumber} - LÖKE nr. ${existingCase.policeCaseNumber}`,
       { align: 'center' },
     )
     .lineGap(8)
-    .fontSize(12)
+    .fontSize(baseFontSize)
     .list(existingCase.caseFiles?.map((file) => file.name) ?? [], {
       listType: 'numbered',
     })

--- a/apps/judicial-system/backend/src/app/formatters/custodyNoticePdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/custodyNoticePdf.ts
@@ -9,7 +9,13 @@ import {
 
 import { environment } from '../../environments'
 import { Case } from '../modules/case/models'
-import { setPageNumbers } from './pdfHelpers'
+import {
+  baseFontSize,
+  hugeFontSize,
+  largeFontSize,
+  mediumFontSize,
+  setPageNumbers,
+} from './pdfHelpers'
 import { writeFile } from './writeFile'
 
 export async function getCustodyNoticePdfAsString(
@@ -34,10 +40,10 @@ export async function getCustodyNoticePdfAsString(
 
   doc
     .font('Helvetica-Bold')
-    .fontSize(26)
+    .fontSize(hugeFontSize)
     .lineGap(8)
     .text('Vistunarseðill', { align: 'center' })
-    .fontSize(18)
+    .fontSize(largeFontSize)
     .text('Úrskurður um gæsluvarðhald', { align: 'center' })
     .font('Helvetica')
     .text(
@@ -51,10 +57,10 @@ export async function getCustodyNoticePdfAsString(
     })
     .text(' ')
     .font('Helvetica-Bold')
-    .fontSize(14)
+    .fontSize(mediumFontSize)
     .lineGap(8)
     .text('Sakborningur')
-    .fontSize(12)
+    .fontSize(baseFontSize)
     .text(existingCase.accusedName ?? 'Nafn ekki skráð')
     .font('Helvetica')
     .text(`kt. ${formatNationalId(existingCase.accusedNationalId)}`)
@@ -62,11 +68,11 @@ export async function getCustodyNoticePdfAsString(
     .text(' ')
     .text(' ')
     .font('Helvetica-Bold')
-    .fontSize(14)
+    .fontSize(mediumFontSize)
     .lineGap(8)
     .text('Úrskurður um gæsluvarðhald')
     .font('Helvetica')
-    .fontSize(12)
+    .fontSize(baseFontSize)
     .text(
       `${existingCase.court?.name}, ${formatDate(
         existingCase.courtStartDate,
@@ -132,11 +138,11 @@ export async function getCustodyNoticePdfAsString(
       .text(' ')
       .text(' ')
       .font('Helvetica-Bold')
-      .fontSize(14)
+      .fontSize(mediumFontSize)
       .lineGap(8)
       .text('Tilhögun gæsluvarðhalds')
       .font('Helvetica')
-      .fontSize(12)
+      .fontSize(baseFontSize)
       .text(custodyRestrictions, {
         lineGap: 6,
         paragraphGap: 0,

--- a/apps/judicial-system/backend/src/app/formatters/pdfHelpers.ts
+++ b/apps/judicial-system/backend/src/app/formatters/pdfHelpers.ts
@@ -1,3 +1,9 @@
+export const baseFontSize = 11
+export const mediumFontSize = 14
+export const mediumPlusFontSize = 16
+export const largeFontSize = 18
+export const hugeFontSize = 26
+
 export function setPageNumbers(doc: PDFKit.PDFDocument) {
   const pages = doc.bufferedPageRange()
   for (let i = 0; i < pages.count; i++) {

--- a/apps/judicial-system/backend/src/app/formatters/requestPdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/requestPdf.ts
@@ -15,7 +15,14 @@ import { environment } from '../../environments'
 import { restrictionRequest as m } from '../messages'
 import { Case } from '../modules/case/models'
 import { formatCustodyProvisions } from './formatters'
-import { setPageNumbers } from './pdfHelpers'
+import {
+  baseFontSize,
+  hugeFontSize,
+  largeFontSize,
+  mediumFontSize,
+  mediumPlusFontSize,
+  setPageNumbers,
+} from './pdfHelpers'
 import { writeFile } from './writeFile'
 
 function constructRestrictionRequestPdf(
@@ -46,16 +53,16 @@ function constructRestrictionRequestPdf(
 
   doc
     .font('Helvetica-Bold')
-    .fontSize(26)
+    .fontSize(hugeFontSize)
     .lineGap(8)
     .text(title, { align: 'center' })
     .font('Helvetica')
-    .fontSize(18)
+    .fontSize(largeFontSize)
     .text(
       existingCase.prosecutor?.institution?.name ?? formatMessage(m.noDistrict),
       { align: 'center' },
     )
-    .fontSize(16)
+    .fontSize(mediumPlusFontSize)
     .text(
       `${formatDate(existingCase.created, 'PPP')} - Mál nr. ${
         existingCase.policeCaseNumber
@@ -65,11 +72,11 @@ function constructRestrictionRequestPdf(
     .lineGap(40)
     .text(`Dómstóll: ${existingCase.court?.name}`, { align: 'center' })
     .font('Helvetica-Bold')
-    .fontSize(14)
+    .fontSize(mediumFontSize)
     .lineGap(8)
     .text(formatMessage(m.baseInfo.heading))
     .font('Helvetica')
-    .fontSize(12)
+    .fontSize(baseFontSize)
     .lineGap(4)
     .text(
       `${formatMessage(m.baseInfo.nationalId)} ${formatNationalId(
@@ -88,33 +95,33 @@ function constructRestrictionRequestPdf(
     )
     .text(' ')
     .font('Helvetica-Bold')
-    .fontSize(14)
+    .fontSize(mediumFontSize)
     .lineGap(8)
     .text('Dómkröfur')
     .font('Helvetica')
-    .fontSize(12)
+    .fontSize(baseFontSize)
     .text(existingCase.demands ?? 'Dómkröfur ekki skráðar', {
       lineGap: 6,
       paragraphGap: 0,
     })
     .text(' ')
     .font('Helvetica-Bold')
-    .fontSize(14)
+    .fontSize(mediumFontSize)
     .lineGap(8)
     .text('Lagaákvæði sem brot varða við')
     .font('Helvetica')
-    .fontSize(12)
+    .fontSize(baseFontSize)
     .text(existingCase.lawsBroken ?? 'Lagaákvæði ekki skráð', {
       lineGap: 6,
       paragraphGap: 0,
     })
     .text(' ')
     .font('Helvetica-Bold')
-    .fontSize(14)
+    .fontSize(mediumFontSize)
     .lineGap(8)
     .text('Lagaákvæði sem krafan er byggð á')
     .font('Helvetica')
-    .fontSize(12)
+    .fontSize(baseFontSize)
     .text(
       formatCustodyProvisions(
         existingCase.custodyProvisions,
@@ -127,7 +134,7 @@ function constructRestrictionRequestPdf(
     )
     .text(' ')
     .font('Helvetica-Bold')
-    .fontSize(14)
+    .fontSize(mediumFontSize)
     .lineGap(8)
     .text(
       `Takmarkanir og tilhögun ${
@@ -136,7 +143,7 @@ function constructRestrictionRequestPdf(
       {},
     )
     .font('Helvetica')
-    .fontSize(12)
+    .fontSize(baseFontSize)
     .text(
       `${formatRequestedCustodyRestrictions(
         existingCase.type,
@@ -150,24 +157,24 @@ function constructRestrictionRequestPdf(
     )
     .text(' ')
     .font('Helvetica-Bold')
-    .fontSize(18)
+    .fontSize(largeFontSize)
     .lineGap(8)
     .text(formatMessage(m.factsAndArguments.heading))
-    .fontSize(14)
+    .fontSize(mediumFontSize)
     .text(formatMessage(m.factsAndArguments.facts))
     .font('Helvetica')
-    .fontSize(12)
+    .fontSize(baseFontSize)
     .text(existingCase.caseFacts ?? 'Málsatvik ekki skráð', {
       lineGap: 6,
       paragraphGap: 0,
     })
     .text(' ')
     .font('Helvetica-Bold')
-    .fontSize(14)
+    .fontSize(mediumFontSize)
     .lineGap(8)
     .text(formatMessage(m.factsAndArguments.arguments))
     .font('Helvetica')
-    .fontSize(12)
+    .fontSize(baseFontSize)
     .text(existingCase.legalArguments ?? 'Lagarök ekki skráð', {
       lineGap: 6,
       paragraphGap: 0,
@@ -210,16 +217,16 @@ function constructInvestigationRequestPdf(
 
   doc
     .font('Helvetica-Bold')
-    .fontSize(26)
+    .fontSize(hugeFontSize)
     .lineGap(8)
     .text('Krafa um rannsóknarheimild', { align: 'center' })
     .font('Helvetica')
-    .fontSize(18)
+    .fontSize(largeFontSize)
     .text(
       existingCase.prosecutor?.institution?.name ?? formatMessage(m.noDistrict),
       { align: 'center' },
     )
-    .fontSize(16)
+    .fontSize(mediumPlusFontSize)
     .text(
       `${formatDate(existingCase.created, 'PPP')} - Mál nr. ${
         existingCase.policeCaseNumber
@@ -229,11 +236,11 @@ function constructInvestigationRequestPdf(
     .lineGap(40)
     .text(`Dómstóll: ${existingCase.court?.name}`, { align: 'center' })
     .font('Helvetica-Bold')
-    .fontSize(18)
+    .fontSize(mediumFontSize)
     .lineGap(8)
     .text(formatMessage(m.baseInfo.heading))
     .font('Helvetica')
-    .fontSize(12)
+    .fontSize(baseFontSize)
     .lineGap(4)
     .text(`Kennitala: ${formatNationalId(existingCase.accusedNationalId)}`)
     .text(`Fullt nafn: ${existingCase.accusedName}`)
@@ -248,11 +255,11 @@ function constructInvestigationRequestPdf(
     )
     .text(' ')
     .font('Helvetica-Bold')
-    .fontSize(14)
+    .fontSize(mediumFontSize)
     .lineGap(8)
     .text('Efni kröfu')
     .font('Helvetica')
-    .fontSize(12)
+    .fontSize(baseFontSize)
     .lineGap(4)
     .text(capitalize(caseTypes[existingCase.type]))
     .text(existingCase.description ?? 'Efni kröfu ekki skráð', {
@@ -261,57 +268,57 @@ function constructInvestigationRequestPdf(
     })
     .text(' ')
     .font('Helvetica-Bold')
-    .fontSize(14)
+    .fontSize(mediumFontSize)
     .lineGap(8)
     .text('Dómkröfur')
     .font('Helvetica')
-    .fontSize(12)
+    .fontSize(baseFontSize)
     .text(existingCase.demands ?? 'Dómkröfur ekki skráðar', {
       lineGap: 6,
       paragraphGap: 0,
     })
     .text(' ')
     .font('Helvetica-Bold')
-    .fontSize(14)
+    .fontSize(mediumFontSize)
     .lineGap(8)
     .text('Lagaákvæði sem brot varða við')
     .font('Helvetica')
-    .fontSize(12)
+    .fontSize(baseFontSize)
     .text(existingCase.lawsBroken ?? 'Lagaákvæði ekki skráð', {
       lineGap: 6,
       paragraphGap: 0,
     })
     .text(' ')
     .font('Helvetica-Bold')
-    .fontSize(14)
+    .fontSize(mediumFontSize)
     .lineGap(8)
     .text('Lagaákvæði sem krafan er byggð á')
     .font('Helvetica')
-    .fontSize(12)
+    .fontSize(baseFontSize)
     .text(existingCase.legalBasis ?? 'Lagaákvæði ekki skráð', {
       lineGap: 6,
       paragraphGap: 0,
     })
     .text(' ')
     .font('Helvetica-Bold')
-    .fontSize(18)
+    .fontSize(largeFontSize)
     .lineGap(8)
     .text('Greinargerð um málsatvik og lagarök')
-    .fontSize(14)
+    .fontSize(mediumFontSize)
     .text('Málsatvik')
     .font('Helvetica')
-    .fontSize(12)
+    .fontSize(baseFontSize)
     .text(existingCase.caseFacts ?? 'Málsatvik ekki skráð', {
       lineGap: 6,
       paragraphGap: 0,
     })
     .text(' ')
     .font('Helvetica-Bold')
-    .fontSize(14)
+    .fontSize(mediumFontSize)
     .lineGap(8)
     .text('Lagarök')
     .font('Helvetica')
-    .fontSize(12)
+    .fontSize(baseFontSize)
     .text(existingCase.legalArguments ?? 'Lagarök ekki skráð', {
       lineGap: 6,
       paragraphGap: 0,
@@ -321,11 +328,11 @@ function constructInvestigationRequestPdf(
   if (existingCase.requestProsecutorOnlySession) {
     doc
       .font('Helvetica-Bold')
-      .fontSize(14)
+      .fontSize(mediumFontSize)
       .lineGap(8)
       .text('Beiðni um dómþing að varnaraðila fjarstöddum')
       .font('Helvetica')
-      .fontSize(12)
+      .fontSize(baseFontSize)
       .text(existingCase.prosecutorOnlySessionRequest ?? '', {
         lineGap: 6,
         paragraphGap: 0,

--- a/apps/judicial-system/backend/src/app/formatters/rulingPdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/rulingPdf.ts
@@ -26,7 +26,12 @@ import {
 import { environment } from '../../environments'
 import { Case } from '../modules/case/models'
 import { core, ruling } from '../messages'
-import { setPageNumbers } from './pdfHelpers'
+import {
+  baseFontSize,
+  mediumFontSize,
+  largeFontSize,
+  setPageNumbers,
+} from './pdfHelpers'
 import { writeFile } from './writeFile'
 import { skjaldarmerki } from './skjaldarmerki'
 
@@ -68,12 +73,12 @@ function constructRestrictionRulingPdf(
 
   doc
     .font('Times-Roman')
-    .fontSize(18)
+    .fontSize(largeFontSize)
     .lineGap(4)
     .text(existingCase.court?.name ?? formatMessage(core.missing.court), {
       align: 'center',
     })
-    .fontSize(14)
+    .fontSize(mediumFontSize)
     .lineGap(2)
     .text(formatMessage(ruling.proceedingsHeading), { align: 'center' })
     .lineGap(30)
@@ -81,7 +86,7 @@ function constructRestrictionRulingPdf(
       `Mál nr. ${existingCase.courtCaseNumber} - LÖKE nr. ${existingCase.policeCaseNumber}`,
       { align: 'center' },
     )
-    .fontSize(11)
+    .fontSize(baseFontSize)
     .lineGap(1)
     .text(
       formatMessage(ruling.intro, {
@@ -215,20 +220,20 @@ function constructRestrictionRulingPdf(
     .lineGap(3)
     .text(' ')
     .text(' ')
-    .fontSize(14)
+    .fontSize(mediumFontSize)
     .lineGap(16)
     .text(formatMessage(ruling.rulingHeading), { align: 'center' })
 
   if (shortVersion) {
     doc
-      .fontSize(11)
+      .fontSize(baseFontSize)
       .lineGap(1)
       .text(formatMessage(ruling.rulingShortVersionPlaceholder), {
         align: 'center',
       })
   } else {
     doc
-      .fontSize(11)
+      .fontSize(baseFontSize)
       .lineGap(1)
       .font('Times-Bold')
       .text(formatMessage(ruling.courtDemandsHeading))
@@ -274,10 +279,10 @@ function constructRestrictionRulingPdf(
     .lineGap(3)
     .text(' ')
     .text(' ')
-    .fontSize(14)
+    .fontSize(mediumFontSize)
     .lineGap(16)
     .text(formatMessage(ruling.rulingTextHeading), { align: 'center' })
-    .fontSize(11)
+    .fontSize(baseFontSize)
     .lineGap(1)
     .text(existingCase.conclusion ?? formatMessage(core.missing.rulingText), {
       align: 'center',
@@ -439,12 +444,12 @@ function constructInvestigationRulingPdf(
 
   doc
     .font('Times-Roman')
-    .fontSize(18)
+    .fontSize(largeFontSize)
     .lineGap(4)
     .text(existingCase.court?.name ?? formatMessage(core.missing.court), {
       align: 'center',
     })
-    .fontSize(14)
+    .fontSize(mediumFontSize)
     .lineGap(2)
     .text(formatMessage(ruling.proceedingsHeading), { align: 'center' })
     .lineGap(30)
@@ -452,7 +457,7 @@ function constructInvestigationRulingPdf(
       `Mál nr. ${existingCase.courtCaseNumber} - LÖKE nr. ${existingCase.policeCaseNumber}`,
       { align: 'center' },
     )
-    .fontSize(11)
+    .fontSize(baseFontSize)
     .lineGap(1)
     .text(
       formatMessage(ruling.intro, {
@@ -501,7 +506,7 @@ function constructInvestigationRulingPdf(
     .text(formatMessage(ruling.demandsHeading))
     .text(' ')
     .font('Times-Roman')
-    .fontSize(12)
+    .fontSize(baseFontSize)
     .text(
       existingCase.prosecutorDemands ?? formatMessage(core.missing.demands),
       {
@@ -588,20 +593,20 @@ function constructInvestigationRulingPdf(
     .lineGap(3)
     .text(' ')
     .text(' ')
-    .fontSize(14)
+    .fontSize(mediumFontSize)
     .lineGap(16)
     .text(formatMessage(ruling.rulingHeading), { align: 'center' })
 
   if (shortVersion) {
     doc
-      .fontSize(11)
+      .fontSize(baseFontSize)
       .lineGap(1)
       .text(formatMessage(ruling.rulingShortVersionPlaceholder), {
         align: 'center',
       })
   } else {
     doc
-      .fontSize(11)
+      .fontSize(baseFontSize)
       .lineGap(1)
       .font('Times-Bold')
       .text(formatMessage(ruling.courtDemandsHeading))
@@ -647,10 +652,10 @@ function constructInvestigationRulingPdf(
     .lineGap(3)
     .text(' ')
     .text(' ')
-    .fontSize(14)
+    .fontSize(mediumFontSize)
     .lineGap(16)
     .text(formatMessage(ruling.rulingTextHeading), { align: 'center' })
-    .fontSize(11)
+    .fontSize(baseFontSize)
     .lineGap(1)
     .text(existingCase.conclusion ?? formatMessage(core.missing.rulingText), {
       align: 'center',


### PR DESCRIPTION
# PDFs now use a font size variable

https://app.asana.com/0/1199153462262248/1201085301643289/f

## What

The demands text in investigation case's court record pdf was set to font-size: 12 while other text was set to font-size: 11. After inspecting other PDFs I noticed that some PDFs used 11 as body text font size while others used 12. All PDFs should look the same and the best way to do that is to reuse font size variables between PDFs. 

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
