### PR TITLE
fix(judicial-system): Set isolationTo datepicker to disabled if isolation is not selected

### DIFF
--- a/apps/judicial-system/web/src/routes/Court/RestrictionRequest/Ruling/StepOne/RulingStepOne.tsx
+++ b/apps/judicial-system/web/src/routes/Court/RestrictionRequest/Ruling/StepOne/RulingStepOne.tsx
@@ -397,6 +397,11 @@ export const RulingStepOne: React.FC = () => {
                     <DateTime
                       name="isolationToDate"
                       datepickerLabel="Einangrun til"
+                      disabled={
+                        !workingCase.custodyRestrictions?.includes(
+                          CaseCustodyRestrictions.ISOLATION,
+                        )
+                      }
                       selectedDate={
                         workingCase.isolationToDate
                           ? new Date(workingCase.isolationToDate)


### PR DESCRIPTION
# Set isolationTo datepicker to disabled if isolation is not selected

https://app.asana.com/0/1199153462262248/1201017048880137/f

## What

Set isolationTo datepicker to disabled if isolation is not selected

## Why

It's a bug

## Screenshots / Gifs


https://user-images.githubusercontent.com/3789875/136040474-8d9cc833-070d-4acf-86de-224d749e2dcd.mov



## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
