### PR TITLE
Adds cookie name to env

### DIFF
--- a/apps/financial-aid/api/src/environments/environment.ts
+++ b/apps/financial-aid/api/src/environments/environment.ts
@@ -8,7 +8,7 @@ const prodConfig = {
   production: true,
   identityServerAuth: {
     issuer: process.env.IDENTITY_SERVER_DOMAIN ?? '',
-    audience: '@sambandid.is',
+    audience: '@samband.is',
   },
   backend: {
     url: process.env.BACKEND_URL,
@@ -19,7 +19,7 @@ const devConfig = {
   production: false,
   identityServerAuth: {
     issuer: 'https://identity-server.dev01.devland.is',
-    audience: '@sambandid.is',
+    audience: '@samband.is',
   },
   backend: {
     url: 'http://localhost:3344',

--- a/apps/financial-aid/backend/src/environments/environment.ts
+++ b/apps/financial-aid/backend/src/environments/environment.ts
@@ -19,7 +19,7 @@ const prodConfig = {
   },
   identityServerAuth: {
     issuer: process.env.IDENTITY_SERVER_DOMAIN ?? '',
-    audience: '@sambandid.is',
+    audience: '@samband.is',
   },
   emailOptions: {
     useTestAccount: false,
@@ -40,7 +40,7 @@ const devConfig = {
   },
   identityServerAuth: {
     issuer: 'https://identity-server.dev01.devland.is',
-    audience: '@sambandid.is',
+    audience: '@samband.is',
   },
   emailOptions: {
     useTestAccount: (process.env.EMAIL_USE_TEST_ACCOUNT ?? 'true') === 'true',

--- a/libs/financial-aid/shared/src/lib/environment/environment.ts
+++ b/libs/financial-aid/shared/src/lib/environment/environment.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  idsCookieName: process.env.idsCookieName ?? 'next-auth.session-token',
+}

--- a/libs/financial-aid/shared/src/lib/identityProvider.ts
+++ b/libs/financial-aid/shared/src/lib/identityProvider.ts
@@ -1,5 +1,7 @@
+import { environment } from './environment/environment'
+
 export const IDENTITY_SERVER_SESSION_TOKEN_COOKIE_NAME =
-  'next-auth.session-token'
+  environment.idsCookieName
 
 export const identityServerId = 'identity-server'
 


### PR DESCRIPTION
# ...
Reads cookie name from env, since next-auth sets different name for it in deployed environment and it is not configurable through the lib
## What


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
