### PR TITLE
chore(judicial-system): Put selectProsecutor component's text into Contentful

### DIFF
--- a/apps/judicial-system/web/messages/Core/selectProsecutor.ts
+++ b/apps/judicial-system/web/messages/Core/selectProsecutor.ts
@@ -1,0 +1,23 @@
+import { defineMessages } from 'react-intl'
+
+export const selectProsecutor = defineMessages({
+  heading: {
+    id: 'judicial.system.core:select_prosecutor.heading',
+    defaultMessage: 'Ákærandi',
+    description:
+      'Notaður sem titill fyrir "ákærandi" hlutann á óskir um fyrirtöku skrefi í öllum málstegundum.',
+  },
+  label: {
+    id: 'judicial.system.core:select_prosecutor.label',
+    defaultMessage: 'Veldu sækjanda',
+    description:
+      'Notaður sem titill í "Veldu sækjanda" textaboxi á óskir um fyrirtöku skrefi í öllum málstegundum.',
+  },
+  tooltip: {
+    id: 'judicial.system.core:select_prosecutor.tooltip',
+    defaultMessage:
+      'Sá ákærandi sem valinn er hér er skráður fyrir kröfunni í öllum upplýsingaskeytum og skjölum sem tengjast kröfunni, og flytur málið fyrir dómstólum fyrir hönd síns embættis.',
+    description:
+      'Notaður sem skýritexti fyrir "ákærandi" hlutann á óskir um fyrirtöku skrefi í öllum málstegundum.',
+  },
+})

--- a/apps/judicial-system/web/src/routes/Prosecutor/SharedComponents/SelectProsecutor/SelectProsecutor.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/SharedComponents/SelectProsecutor/SelectProsecutor.tsx
@@ -6,6 +6,8 @@ import type { Case } from '@island.is/judicial-system/types'
 import { ValueType } from 'react-select'
 import { Option } from '@island.is/island-ui/core'
 import { useCase } from '@island.is/judicial-system-web/src/utils/hooks'
+import { useIntl } from 'react-intl'
+import { selectProsecutor as m } from '@island.is/judicial-system-web/messages/Core/selectProsecutor'
 
 interface Props {
   workingCase: Case
@@ -16,6 +18,7 @@ interface Props {
 const SelectProsecutor: React.FC<Props> = (props) => {
   const { workingCase, setWorkingCase, prosecutors } = props
   const { updateCase } = useCase()
+  const { formatMessage } = useIntl()
 
   const defaultProsecutor = prosecutors?.find(
     (prosecutor: Option) => prosecutor.value === workingCase.prosecutor?.id,
@@ -24,15 +27,15 @@ const SelectProsecutor: React.FC<Props> = (props) => {
     <>
       <Box marginBottom={3}>
         <Text as="h3" variant="h3">
-          {`Ákærandi `}
+          {`${formatMessage(m.heading)} `}
           <Box component="span" data-testid="prosecutor-tooltip">
-            <Tooltip text="Sá saksóknari sem valinn er hér er skráður fyrir kröfunni í öllum upplýsingaskeytum og skjölum sem tengjast kröfunni, og flytur málið fyrir dómstólum fyrir hönd síns embættis." />
+            <Tooltip text={formatMessage(m.tooltip)} />
           </Box>
         </Text>
       </Box>
       <Select
         name="prosecutor"
-        label="Veldu saksóknara"
+        label={formatMessage(m.label)}
         defaultValue={defaultProsecutor}
         options={prosecutors}
         onChange={(selectedOption: ValueType<ReactSelectOption>) =>


### PR DESCRIPTION
# Put selectProsecutor component's text into Contentful with some minor changes

https://app.asana.com/0/1199153462262248/1199622062820286/f

## What

Put selectProsecutor component's text into Contentful with some minor changes

## Why

This comes from feedback from one of our users.

## Screenshots / Gifs

![Screen Shot 2021-10-07 at 11 15 18](https://user-images.githubusercontent.com/3789875/136373847-8856030c-170e-40ec-b8c2-b6872c2fe35d.png)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
