### PR TITLE
chore(judicial-system): Put strings in ruling accordion into CF

### DIFF
--- a/apps/judicial-system/web/messages/Core/rulingAccordion.ts
+++ b/apps/judicial-system/web/messages/Core/rulingAccordion.ts
@@ -1,7 +1,29 @@
-import { defineMessages } from 'react-intl'
+import { defineMessage, defineMessages } from 'react-intl'
 
 export const rulingAccordion = {
+  title: defineMessage({
+    id: 'judicial.system.core:ruling_accordion.title',
+    defaultMessage: 'Úrskurður Héraðsdóms',
+    description:
+      'Notaður sem titill fyrir úrskurðar fellilista í öllum málategundum.',
+  }),
   sections: {
+    courtLegalArguments: defineMessages({
+      title: {
+        id: 'judicial.system.core:ruling_accordion.court_legal_arguments.title',
+        defaultMessage: 'Lagarök',
+        description:
+          'Notaður sem titill fyrir "Lagarök" hlutanum í úrskurðar fellilista í öllum málategundum.',
+      },
+    }),
+    courtCaseFacts: defineMessages({
+      title: {
+        id: 'judicial.system.core:ruling_accordion.court_case_facts.title',
+        defaultMessage: 'Málsatvik',
+        description:
+          'Notaður sem titill fyrir "Málsatvik" hlutanum í úrskurðar fellilista í öllum málategundum.',
+      },
+    }),
     appealDecision: defineMessages({
       disclaimer: {
         id: 'judicial.system.core:ruling_accordion.appeal_decision.disclaimer',
@@ -9,6 +31,38 @@ export const rulingAccordion = {
           'Dómari leiðbeinir málsaðilum um rétt þeirra til að kæra úrskurð þennan til Landsréttar innan þriggja sólarhringa.',
         description:
           'Notaður sem texti í "Ákvörðun um kæru" hlutanum í úrskurðar fellilista í öllum málategundum.',
+      },
+    }),
+    requestProsecutorOnlySession: defineMessages({
+      title: {
+        id:
+          'judicial.system.core:ruling_accordion.request_prosecutor_only_session.title',
+        defaultMessage: 'Beiðni um dómþing að varnaraðila fjarstöddum',
+        description:
+          'Notaður sem titill fyrir "Beiðni um dómþing að varnaraðila fjarstöddum" hlutanum í úrskurðar fellilista í öllum málategundum.',
+      },
+    }),
+    ruling: defineMessages({
+      title: {
+        id: 'judicial.system.core:ruling_accordion.ruling.title',
+        defaultMessage: 'Niðurstaða',
+        description:
+          'Notaður sem titill fyrir "Niðurstaða" hlutanum í úrskurðar fellilista í öllum málategundum.',
+      },
+    }),
+    conclusion: defineMessages({
+      title: {
+        id: 'judicial.system.core:ruling_accordion.conclusion.title',
+        defaultMessage: 'Úrskurðarorð',
+        description:
+          'Notaður sem titill fyrir "Úrskurðarorð" hlutanum í úrskurðar fellilista í öllum málategundum.',
+      },
+      disclaimer: {
+        id: 'judicial.system.core:ruling_accordion.conclusion.disclaimer',
+        defaultMessage:
+          'Úrskurðarorðið er lesið í heyranda hljóði fyrir viðstadda.',
+        description:
+          'Notaður sem texti undir "Úrskurðarorð" hlutanum í úrskurðar fellilista í gæslu- og farbannsmálum og í rannsóknarheimildum þar sem fyrirtaka er ekki haldin í fjarfundi.',
       },
     }),
   },

--- a/apps/judicial-system/web/messages/InvestigationCases/Court/rulingStepOne.ts
+++ b/apps/judicial-system/web/messages/InvestigationCases/Court/rulingStepOne.ts
@@ -3,6 +3,13 @@ import { defineMessages } from 'react-intl'
 export const icRulingStepOne = {
   sections: {
     courtCaseFacts: defineMessages({
+      title: {
+        id:
+          'judicial.system.investigation_cases:ruling_step_one.court_case_facts.title',
+        defaultMessage: 'Greinargerð um málsatvik',
+        description:
+          'Notaður sem titill fyrir "greinargerð um málsatvik" hlutann á úrskurðar skrefi í rannsóknarheimildum.',
+      },
       tooltip: {
         id:
           'judicial.system.investigation_cases:ruling_step_one.court_case_facts.tooltip',
@@ -13,6 +20,13 @@ export const icRulingStepOne = {
       },
     }),
     courtLegalArguments: defineMessages({
+      title: {
+        id:
+          'judicial.system.investigation_cases:ruling_step_one.court_legal_arguments.title',
+        defaultMessage: 'Greinargerð um lagarök',
+        description:
+          'Notaður sem titill fyrir "Greinargerð um lagarök" hlutann á úrskurðar skrefi í rannsóknarheimildum.',
+      },
       tooltip: {
         id:
           'judicial.system.investigation_cases:ruling_step_one.court_legal_arguments.tooltip',

--- a/apps/judicial-system/web/messages/RestrictionCases/Court/rulingStepOne.tsx
+++ b/apps/judicial-system/web/messages/RestrictionCases/Court/rulingStepOne.tsx
@@ -3,6 +3,13 @@ import { defineMessages } from 'react-intl'
 export const rcRulingStepOne = {
   sections: {
     courtCaseFacts: defineMessages({
+      title: {
+        id:
+          'judicial.system.restriction_cases:ruling_step_one.court_case_facts.title',
+        defaultMessage: 'Greinargerð um málsatvik',
+        description:
+          'Notaður sem titill fyrir "greinargerð um málsatvik" hlutann á úrskurðar skrefi í gæsluvarðhalds- og farbannsmálum.',
+      },
       tooltip: {
         id:
           'judicial.system.restriction_cases:ruling_step_one.court_case_facts.tooltip',
@@ -13,6 +20,13 @@ export const rcRulingStepOne = {
       },
     }),
     courtLegalArguments: defineMessages({
+      title: {
+        id:
+          'judicial.system.restriction_cases:ruling_step_one.court_legal_arguments.title',
+        defaultMessage: 'Greinargerð um lagarök',
+        description:
+          'Notaður sem titill fyrir "Greinargerð um lagarök" hlutann á úrskurðar skrefi í gæsluvarðhalds- og farbannsmálum.',
+      },
       tooltip: {
         id:
           'judicial.system.restriction_cases:ruling_step_one.court_legal_arguments.tooltip',

--- a/apps/judicial-system/web/src/routes/Court/InvestigationRequest/Confirmation/ConfirmationForm.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationRequest/Confirmation/ConfirmationForm.tsx
@@ -58,7 +58,7 @@ const Confirmation: React.FC<Props> = (props) => {
           <Accordion>
             <PoliceRequestAccordionItem workingCase={workingCase} />
             <CourtRecordAccordionItem workingCase={workingCase} />
-            <RulingAccordionItem workingCase={workingCase} />
+            <RulingAccordionItem workingCase={workingCase} startExpanded />
           </Accordion>
         </Box>
         <Box marginBottom={3}>

--- a/apps/judicial-system/web/src/routes/Court/InvestigationRequest/Ruling/StepOne/RulingStepOneForm.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationRequest/Ruling/StepOne/RulingStepOneForm.tsx
@@ -29,7 +29,7 @@ import {
   validateAndSendToServer,
 } from '@island.is/judicial-system-web/src/utils/formHelper'
 import { useCase } from '@island.is/judicial-system-web/src/utils/hooks'
-import { icRulingStepOne } from '@island.is/judicial-system-web/messages'
+import { icRulingStepOne as m } from '@island.is/judicial-system-web/messages'
 
 interface Props {
   workingCase: Case
@@ -98,11 +98,9 @@ const RulingStepOneForm: React.FC<Props> = (props) => {
         <Box component="section" marginBottom={5}>
           <Box marginBottom={3}>
             <Text as="h3" variant="h3">
-              Greinargerð um málsatvik{' '}
+              {formatMessage(m.sections.courtCaseFacts.title)}{' '}
               <Tooltip
-                text={formatMessage(
-                  icRulingStepOne.sections.courtCaseFacts.tooltip,
-                )}
+                text={formatMessage(m.sections.courtCaseFacts.tooltip)}
               />
             </Text>
           </Box>
@@ -145,11 +143,9 @@ const RulingStepOneForm: React.FC<Props> = (props) => {
         <Box component="section" marginBottom={5}>
           <Box marginBottom={3}>
             <Text as="h3" variant="h3">
-              Greinargerð um lagarök{' '}
+              {formatMessage(m.sections.courtLegalArguments.title)}{' '}
               <Tooltip
-                text={formatMessage(
-                  icRulingStepOne.sections.courtLegalArguments.tooltip,
-                )}
+                text={formatMessage(m.sections.courtLegalArguments.tooltip)}
               />
             </Text>
           </Box>
@@ -205,9 +201,7 @@ const RulingStepOneForm: React.FC<Props> = (props) => {
               acceptedLabelText="Krafa samþykkt"
               rejectedLabelText="Kröfu hafnað"
               partiallyAcceptedLabelText="Krafa tekin til greina að hluta"
-              dismissLabelText={formatMessage(
-                icRulingStepOne.sections.decision.dismissLabel,
-              )}
+              dismissLabelText={formatMessage(m.sections.decision.dismissLabel)}
             />
           </Box>
         </Box>

--- a/apps/judicial-system/web/src/routes/Court/RestrictionRequest/Confirmation/Confirmation.tsx
+++ b/apps/judicial-system/web/src/routes/Court/RestrictionRequest/Confirmation/Confirmation.tsx
@@ -130,7 +130,7 @@ export const Confirmation: React.FC = () => {
               <Accordion>
                 <PoliceRequestAccordionItem workingCase={workingCase} />
                 <CourtRecordAccordionItem workingCase={workingCase} />
-                <RulingAccordionItem workingCase={workingCase} />
+                <RulingAccordionItem workingCase={workingCase} startExpanded />
               </Accordion>
             </Box>
             <Box marginBottom={3}>

--- a/apps/judicial-system/web/src/routes/Court/RestrictionRequest/Ruling/StepOne/RulingStepOne.tsx
+++ b/apps/judicial-system/web/src/routes/Court/RestrictionRequest/Ruling/StepOne/RulingStepOne.tsx
@@ -50,7 +50,7 @@ import { useRouter } from 'next/router'
 import DateTime from '@island.is/judicial-system-web/src/shared-components/DateTime/DateTime'
 import { useCase } from '@island.is/judicial-system-web/src/utils/hooks'
 import { UserContext } from '@island.is/judicial-system-web/src/shared-components/UserProvider/UserProvider'
-import { rcRulingStepOne } from '@island.is/judicial-system-web/messages'
+import { rcRulingStepOne as m } from '@island.is/judicial-system-web/messages'
 
 export const RulingStepOne: React.FC = () => {
   const [workingCase, setWorkingCase] = useState<Case>()
@@ -188,11 +188,9 @@ export const RulingStepOne: React.FC = () => {
             <Box component="section" marginBottom={5}>
               <Box marginBottom={3}>
                 <Text as="h3" variant="h3">
-                  Greinargerð um málsatvik{' '}
+                  {formatMessage(m.sections.courtCaseFacts.title)}{' '}
                   <Tooltip
-                    text={formatMessage(
-                      rcRulingStepOne.sections.courtCaseFacts.tooltip,
-                    )}
+                    text={formatMessage(m.sections.courtCaseFacts.tooltip)}
                   />
                 </Text>
               </Box>
@@ -235,11 +233,9 @@ export const RulingStepOne: React.FC = () => {
             <Box component="section" marginBottom={5}>
               <Box marginBottom={3}>
                 <Text as="h3" variant="h3">
-                  Greinargerð um lagarök{' '}
+                  {formatMessage(m.sections.courtLegalArguments.title)}{' '}
                   <Tooltip
-                    text={formatMessage(
-                      rcRulingStepOne.sections.courtLegalArguments.tooltip,
-                    )}
+                    text={formatMessage(m.sections.courtLegalArguments.tooltip)}
                   />
                 </Text>
               </Box>
@@ -304,7 +300,7 @@ export const RulingStepOne: React.FC = () => {
                   } hafnað`}
                   partiallyAcceptedLabelText="Kröfu um gæsluvarðhald hafnað en úrskurðað í farbann"
                   dismissLabelText={formatMessage(
-                    rcRulingStepOne.sections.decision.dismissLabel,
+                    m.sections.decision.dismissLabel,
                     {
                       caseType:
                         workingCase.type === CaseType.CUSTODY

--- a/apps/judicial-system/web/src/shared-components/AccordionItems/RulingAccordionItem/RulingAccordionItem.tsx
+++ b/apps/judicial-system/web/src/shared-components/AccordionItems/RulingAccordionItem/RulingAccordionItem.tsx
@@ -25,9 +25,13 @@ import * as style from './RulingAccordionItem.treat'
 
 interface Props {
   workingCase: Case
+  startExpanded?: boolean
 }
 
-const RulingAccordionItem: React.FC<Props> = ({ workingCase }: Props) => {
+const RulingAccordionItem: React.FC<Props> = ({
+  workingCase,
+  startExpanded,
+}: Props) => {
   const { user } = useContext(UserContext)
   const { formatMessage } = useIntl()
 
@@ -47,16 +51,17 @@ const RulingAccordionItem: React.FC<Props> = ({ workingCase }: Props) => {
       id="id_3"
       label="Úrskurður Héraðsdóms Reykjavíkur"
       labelVariant="h3"
+      startExpanded={startExpanded}
     >
       <Box component="section" marginBottom={5}>
         <Box marginBottom={2}>
           <Text as="h4" variant="h4">
-            Úrskurður Héraðsdóms
+            {formatMessage(m.title)}
           </Text>
         </Box>
         <Box marginBottom={1}>
           <Text variant="eyebrow" color="blue400">
-            Greinargerð um málsatvik
+            {formatMessage(m.sections.courtCaseFacts.title)}
           </Text>
         </Box>
         <Box marginBottom={2}>
@@ -64,7 +69,7 @@ const RulingAccordionItem: React.FC<Props> = ({ workingCase }: Props) => {
         </Box>
         <Box marginBottom={1}>
           <Text variant="eyebrow" color="blue400">
-            Greinargerð um lagarök
+            {formatMessage(m.sections.courtLegalArguments.title)}
           </Text>
         </Box>
         <Box marginBottom={2}>
@@ -75,7 +80,7 @@ const RulingAccordionItem: React.FC<Props> = ({ workingCase }: Props) => {
             <Box marginY={2}>
               <Box marginBottom={1}>
                 <Text variant="eyebrow" color="blue400">
-                  Beiðni um dómþing að varnaraðila fjarstöddum
+                  {formatMessage(m.sections.requestProsecutorOnlySession.title)}
                 </Text>
               </Box>
               <Text>{workingCase.prosecutorOnlySessionRequest}</Text>
@@ -83,7 +88,7 @@ const RulingAccordionItem: React.FC<Props> = ({ workingCase }: Props) => {
           )}
         <Box marginBottom={5}>
           <Text variant="eyebrow" color="blue400">
-            Niðurstaða
+            {formatMessage(m.sections.ruling.title)}
           </Text>
           <Text>
             <span className={style.breakSpaces}>{workingCase.ruling}</span>
@@ -93,7 +98,7 @@ const RulingAccordionItem: React.FC<Props> = ({ workingCase }: Props) => {
       <Box component="section" marginBottom={7}>
         <Box marginBottom={2}>
           <Text as="h4" variant="h4">
-            Úrskurðarorð
+            {formatMessage(m.sections.conclusion.title)}
           </Text>
         </Box>
         <Box marginBottom={3}>
@@ -111,9 +116,7 @@ const RulingAccordionItem: React.FC<Props> = ({ workingCase }: Props) => {
         {(isRestrictionCase(workingCase.type) ||
           workingCase.sessionArrangements !==
             SessionArrangements.REMOTE_SESSION) && (
-          <Text>
-            Úrskurðarorðið er lesið í heyranda hljóði fyrir viðstadda.
-          </Text>
+          <Text>{formatMessage(m.sections.conclusion.disclaimer)}</Text>
         )}
       </Box>
       <Box component="section" marginBottom={3}>


### PR DESCRIPTION
# Put strings in ruling accordion into CF

Attach a link to issue if relevant

## What

Put strings in ruling accordion into CF and make it start expanded.

## Screenshots / Gifs

![screencapture-localhost-4200-domur-stadfesta-27e13c5d-455c-447b-9e2c-c784a20162f3-2021-10-13-08_56_11](https://user-images.githubusercontent.com/3789875/137164377-319fde85-bd48-4183-9a6e-9930107a1225.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
