### PR TITLE
chore(parental-leave): Make sure all periods have a default value for firstPeriodStart

### DIFF
--- a/libs/application/templates/parental-leave/src/fields/PeriodPercentage/PeriodPercentage.tsx
+++ b/libs/application/templates/parental-leave/src/fields/PeriodPercentage/PeriodPercentage.tsx
@@ -24,6 +24,7 @@ import {
 import { parentalLeaveFormMessages, errorMessages } from '../../lib/messages'
 import { getApplicationAnswers } from '../../lib/parentalLeaveUtils'
 import { useRemainingRights } from '../../hooks/useRemainingRights'
+import { StartDateOptions } from '../../constants'
 
 type FieldBaseAndCustomField = FieldBaseProps & CustomField
 
@@ -37,7 +38,7 @@ export const PeriodPercentage: FC<PeriodPercentageField> = ({
   errors,
 }) => {
   const { formatMessage } = useLocale()
-  const { setError } = useFormContext()
+  const { setError, register } = useFormContext()
   const { description } = field
   const { rawPeriods } = getApplicationAnswers(application.answers)
   const currentIndex = extractRepeaterIndexFromField(field)
@@ -124,6 +125,14 @@ export const PeriodPercentage: FC<PeriodPercentageField> = ({
           defaultValue: null,
         }}
       />
+      {currentPeriod.firstPeriodStart === undefined && (
+        <input
+          type="hidden"
+          ref={register}
+          name={`periods[${currentIndex}].firstPeriodStart`}
+          value={StartDateOptions.SPECIFIC_DATE}
+        />
+      )}
     </>
   )
 }


### PR DESCRIPTION
## What

When creating the first period the user is asked to select when it should start, on:
- Estimated date of birth
- Real date of birth
- Specific date

For all other periods they can only start on specific dates.

This PR makes sure that all of the periods created after the first period get a default value for `firstPeriodStart` to equal `specificDate`

## Why

If the user deletes the first period they may get a validation error that the first period is missing a value for `firstPeriodStart`. By having a default value on all periods we will not run into this situation.

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/6312838/137480563-48f8a399-007c-4703-a2ed-0290daf49f84.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
