### PR TITLE
fix(judicial-system): Hide travelBanTo when a judge is dismissing a case

### DIFF
--- a/apps/judicial-system/web/src/routes/Court/RestrictionRequest/Ruling/StepOne/RulingStepOne.tsx
+++ b/apps/judicial-system/web/src/routes/Court/RestrictionRequest/Ruling/StepOne/RulingStepOne.tsx
@@ -324,7 +324,8 @@ export const RulingStepOne: React.FC = () => {
               />
             </Box>
             {workingCase.decision &&
-              workingCase.decision !== CaseDecision.REJECTING && (
+              workingCase.decision !== CaseDecision.REJECTING &&
+              workingCase.decision !== CaseDecision.DISMISSING && (
                 <Box
                   component="section"
                   marginBottom={7}


### PR DESCRIPTION
# Hide travelBanTo when a judge is dismissing a case

https://app.asana.com/0/1199153462262248/1201193958986290/f

## What

Hide travelBanTo when a judge is dismissing a case

## Why

It's a bug


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
