### PR TITLE
fix(application-template-driving-license): returning message descriptor on error

### DIFF
--- a/libs/application/templates/driving-license/src/dataProviders/FeeInfoProvider.ts
+++ b/libs/application/templates/driving-license/src/dataProviders/FeeInfoProvider.ts
@@ -4,6 +4,7 @@ import {
   FailedDataProviderResult,
 } from '@island.is/application/core'
 import { PaymentCatalogProvider } from '@island.is/application/data-providers'
+import { m } from '../lib/messages'
 
 const CHARGE_ITEM_CODES = ['AY110', 'AY114']
 
@@ -24,7 +25,7 @@ export class FeeInfoProvider extends PaymentCatalogProvider {
   onProvideError(result: string): FailedDataProviderResult {
     return {
       date: new Date(),
-      reason: result,
+      reason: m.errorDataProvider,
       status: 'failure',
       data: result,
     }


### PR DESCRIPTION
returning message descriptor on fee info provider when there's an error - right now the application gets destroyed if there's an error in FJS

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
