### PR TITLE
fix(data-providers): Make sure family data provider fails when there is an error

### DIFF
--- a/libs/application/core/src/lib/messages.ts
+++ b/libs/application/core/src/lib/messages.ts
@@ -187,6 +187,11 @@ export const coreErrorMessages = defineMessages({
     defaultMessage: 'Úps! Eitthvað fór úrskeiðis við að sækja gögnin þín',
     description: 'Oops! Something went wrong when fetching your data',
   },
+  errorDataProviderDescription: {
+    id: 'application.system:core.error.dataProvider.description',
+    defaultMessage: 'Upp kom óvænt villa. Vinsamlegast reyndu aftur.',
+    description: 'An unexpected error occured. Please try again.',
+  },
   fileUpload: {
     id: 'application.system:core.error.file.upload',
     defaultMessage: 'Villa kom upp við að hlaða inn einni eða fleiri skrám.',

--- a/libs/application/data-providers/src/providers/FamilyInformationProvider.spec.ts
+++ b/libs/application/data-providers/src/providers/FamilyInformationProvider.spec.ts
@@ -1,0 +1,105 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+import { coreErrorMessages } from '@island.is/application/core'
+
+const defaultResult = [
+  {
+    fullName: 'Tester Successon',
+  },
+]
+
+class BasicSuccessDataProvider {
+  useGraphqlGateway() {
+    return Promise.resolve({
+      json: () =>
+        Promise.resolve({
+          data: {
+            nationalRegistryFamily: defaultResult,
+          },
+        }),
+    })
+  }
+}
+
+class BasicFailingDataProvider {
+  useGraphqlGateway() {
+    return Promise.reject()
+  }
+}
+
+describe('FamilyInformationProvider', () => {
+  beforeEach(() => {
+    jest.resetModules()
+  })
+
+  const trickEnvironmentCheckToThinkItIs = (type: string) => {
+    jest.mock('@island.is/shared/utils', () => ({
+      isRunningOnEnvironment: (environment: string) => environment === type,
+    }))
+  }
+
+  const letGraphqlQueryFromBaseClass = (type: 'succeed' | 'fail') => {
+    jest.mock('@island.is/application/core', () => ({
+      ...(jest.requireActual('@island.is/application/core') as any),
+      BasicDataProvider:
+        type === 'succeed'
+          ? BasicSuccessDataProvider
+          : BasicFailingDataProvider,
+    }))
+  }
+
+  it('should resolve to empty array on local environment when query fails', async () => {
+    // Mock dependencies before importing the provider
+    trickEnvironmentCheckToThinkItIs('local')
+    letGraphqlQueryFromBaseClass('fail')
+
+    const { FamilyInformationProvider } = require('./FamilyInformationProvider')
+
+    const instance = new FamilyInformationProvider()
+    const result = await instance.provide()
+
+    expect(result).toEqual([])
+  })
+
+  it('should resolve to response on local environment when query succeeds', async () => {
+    // Mock dependencies before importing the provider
+    trickEnvironmentCheckToThinkItIs('local')
+    letGraphqlQueryFromBaseClass('succeed')
+
+    const { FamilyInformationProvider } = require('./FamilyInformationProvider')
+
+    const instance = new FamilyInformationProvider()
+    const result = await instance.provide()
+
+    expect(result).toEqual(defaultResult)
+  })
+
+  it('should fail on non-local environments when query fails', async () => {
+    // Mock dependencies before importing the provider
+    trickEnvironmentCheckToThinkItIs('prod')
+    letGraphqlQueryFromBaseClass('fail')
+
+    const { FamilyInformationProvider } = require('./FamilyInformationProvider')
+    const instance = new FamilyInformationProvider()
+
+    try {
+      await instance.provide()
+    } catch (e) {
+      expect(e).toEqual({
+        reason: coreErrorMessages.errorDataProviderDescription,
+      })
+    }
+  })
+
+  it('should resolve to response on non-local environments when query succeeds', async () => {
+    // Mock dependencies before importing the provider
+    trickEnvironmentCheckToThinkItIs('prod')
+    letGraphqlQueryFromBaseClass('succeed')
+
+    const { FamilyInformationProvider } = require('./FamilyInformationProvider')
+    const instance = new FamilyInformationProvider()
+
+    const result = await instance.provide()
+
+    expect(result).toEqual(defaultResult)
+  })
+})

--- a/libs/application/data-providers/src/providers/FamilyInformationProvider.ts
+++ b/libs/application/data-providers/src/providers/FamilyInformationProvider.ts
@@ -2,10 +2,14 @@ import {
   BasicDataProvider,
   SuccessfulDataProviderResult,
   FailedDataProviderResult,
+  StaticText,
+  coreErrorMessages,
 } from '@island.is/application/core'
+import { isRunningOnEnvironment } from '@island.is/shared/utils'
 
-import { FamilyMember } from '@island.is/api/domains/national-registry'
+import type { FamilyMember } from '@island.is/api/domains/national-registry'
 
+const isLocalDevelopment = isRunningOnEnvironment('local')
 export class FamilyInformationProvider extends BasicDataProvider {
   type = 'FamilyInformationProvider'
 
@@ -35,16 +39,24 @@ export class FamilyInformationProvider extends BasicDataProvider {
   }
 
   handleError(error: Error | unknown) {
+    if (isLocalDevelopment) {
+      return Promise.resolve([])
+    }
+
     console.error('Provider error - FamilyInformation:', error)
-    return Promise.resolve([])
+    return Promise.reject({
+      reason: coreErrorMessages.errorDataProviderDescription,
+    })
   }
 
-  onProvideError(result: string): FailedDataProviderResult {
+  onProvideError(error: { reason: StaticText }): FailedDataProviderResult {
+    const { reason } = error
+
     return {
       date: new Date(),
-      reason: result,
+      reason,
       status: 'failure',
-      data: result,
+      data: [],
     }
   }
 


### PR DESCRIPTION
## What

Family data provider was not failing when there was an error in the query to fetch family members.

## Why

So that a user cannot start an application with incorrect state, without family members that may be required to correctly fill the application.

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/6312838/138335928-1b251fb7-c253-480a-ae04-addaa2690294.png)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
