### PR TITLE
chore(core): Remove next-transpile-modules

### DIFF
--- a/apps/auth-admin-web/next.config.js
+++ b/apps/auth-admin-web/next.config.js
@@ -2,64 +2,50 @@ const withTreat = require('next-treat')()
 const withHealthcheckConfig = require('./next-modules/withHealthcheckConfig')
 const { createSecureHeaders } = require('next-secure-headers')
 
-/* eslint-disable @typescript-eslint/no-var-requires */
-
-// These modules need to be transpiled for IE11 support. This is not ideal,
-// we should aim to drop IE11 support, or only use dependencies that have
-// ES5 code (optionally plus ES6 module syntax).
-const transpileModules = [
-  'templite', // used by rosetta.
-  '@sindresorhus/slugify',
-  '@sindresorhus/transliterate', // Used by slugify.
-  'escape-string-regexp', // Used by slugify.
-]
-const withTM = require('next-transpile-modules')(transpileModules)
 const { NEXT_PUBLIC_BACKEND_URL } = 'http://localhost:4200/backend'
 
 module.exports = withTreat(
-  withTM(
-    withHealthcheckConfig({
-      basePath: '/admin',
-      cssModules: false,
-      serverRuntimeConfig: {
-        // Will only be available on the server side
-        // Requests made by the server are internal request made directly to the api hostname
-        backendUrl: NEXT_PUBLIC_BACKEND_URL,
-      },
-      publicRuntimeConfig: {
-        backendUrl: '',
-      },
-      env: {
-        API_MOCKS: process.env.API_MOCKS || '',
-      },
-      async headers() {
-        return [
-          {
-            source: '/(.*)',
-            headers: createSecureHeaders({
-              contentSecurityPolicy: {
-                directives: {
-                  defaultSrc: "'self'",
-                  objectSrc: "'none'",
-                  frameSrc: "'none'",
-                  baseURI: "'self'",
-                  styleSrc: ["'self' 'unsafe-inline'"],
-                  scriptSrc: ["'self'"],
-                  connectSrc: ["'self'"],
-                },
+  withHealthcheckConfig({
+    basePath: '/admin',
+    cssModules: false,
+    serverRuntimeConfig: {
+      // Will only be available on the server side
+      // Requests made by the server are internal request made directly to the api hostname
+      backendUrl: NEXT_PUBLIC_BACKEND_URL,
+    },
+    publicRuntimeConfig: {
+      backendUrl: '',
+    },
+    env: {
+      API_MOCKS: process.env.API_MOCKS || '',
+    },
+    async headers() {
+      return [
+        {
+          source: '/(.*)',
+          headers: createSecureHeaders({
+            contentSecurityPolicy: {
+              directives: {
+                defaultSrc: "'self'",
+                objectSrc: "'none'",
+                frameSrc: "'none'",
+                baseURI: "'self'",
+                styleSrc: ["'self' 'unsafe-inline'"],
+                scriptSrc: ["'self'"],
+                connectSrc: ["'self'"],
               },
-              forceHTTPSRedirect: [
-                true,
-                { maxAge: 60 * 60 * 24 * 4, includeSubDomains: true },
-              ],
-              nosniff: 'nosniff',
-              frameGuard: 'deny',
-              referrerPolicy: 'no-referrer',
-            }),
-          },
-        ]
-      },
-      poweredByHeader: false,
-    }),
-  ),
+            },
+            forceHTTPSRedirect: [
+              true,
+              { maxAge: 60 * 60 * 24 * 4, includeSubDomains: true },
+            ],
+            nosniff: 'nosniff',
+            frameGuard: 'deny',
+            referrerPolicy: 'no-referrer',
+          }),
+        },
+      ]
+    },
+    poweredByHeader: false,
+  }),
 )

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -5,16 +5,6 @@ const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
 const StatoscopeWebpackPlugin = require('@statoscope/ui-webpack')
 const { DuplicatesPlugin } = require('inspectpack/plugin')
 
-// These modules need to be transpiled for IE11 support. This is not ideal,
-// we should aim to drop IE11 support, or only use dependencies that have
-// ES5 code (optionally plus ES6 module syntax).
-const transpileModules = [
-  'templite', // used by rosetta.
-  '@sindresorhus/slugify',
-  '@sindresorhus/transliterate', // Used by slugify.
-  'escape-string-regexp', // Used by slugify.
-]
-const withTM = require('next-transpile-modules')(transpileModules)
 const { API_URL = 'http://localhost:4444', SENTRY_DSN } = process.env
 const graphqlPath = '/api/graphql'
 const {
@@ -24,81 +14,79 @@ const {
 } = process.env
 
 module.exports = withTreat(
-  withTM(
-    withHealthcheckConfig({
-      webpack: (config, { isServer }) => {
-        if (!isServer) {
-          config.resolve.alias['@sentry/node'] = '@sentry/browser'
-        }
+  withHealthcheckConfig({
+    webpack: (config, { isServer }) => {
+      if (!isServer) {
+        config.resolve.alias['@sentry/node'] = '@sentry/browser'
+      }
 
-        if (process.env.ANALYZE === 'true' && !isServer) {
-          config.plugins.push(
-            new DuplicatesPlugin({
-              emitErrors: false,
-              verbose: true,
-            }),
-          )
+      if (process.env.ANALYZE === 'true' && !isServer) {
+        config.plugins.push(
+          new DuplicatesPlugin({
+            emitErrors: false,
+            verbose: true,
+          }),
+        )
 
-          config.plugins.push(
-            new StatoscopeWebpackPlugin({
-              saveTo: 'dist/apps/web/statoscope.html',
-              saveStatsTo: 'dist/apps/web/stats.json',
-              statsOptions: { all: true, source: false },
-            }),
-          )
+        config.plugins.push(
+          new StatoscopeWebpackPlugin({
+            saveTo: 'dist/apps/web/statoscope.html',
+            saveStatsTo: 'dist/apps/web/stats.json',
+            statsOptions: { all: true, source: false },
+          }),
+        )
 
-          config.plugins.push(
-            new BundleAnalyzerPlugin({
-              analyzerMode: 'static',
-              reportFilename: isServer
-                ? '../analyze/server.html'
-                : './analyze/client.html',
-            }),
-          )
-        }
+        config.plugins.push(
+          new BundleAnalyzerPlugin({
+            analyzerMode: 'static',
+            reportFilename: isServer
+              ? '../analyze/server.html'
+              : './analyze/client.html',
+          }),
+        )
+      }
 
-        const modules = path.resolve(__dirname, '../..', 'node_modules')
+      const modules = path.resolve(__dirname, '../..', 'node_modules')
 
-        config.resolve.alias = {
-          ...(config.resolve.alias || {}),
-          '@babel/runtime': path.resolve(modules, '@babel/runtime'),
-          'bn.js': path.resolve(modules, 'bn.js'),
-          'date-fns': path.resolve(modules, 'date-fns'),
-          'es-abstract': path.resolve(modules, 'es-abstract'),
-          'escape-string-regexp': path.resolve(modules, 'escape-string-regexp'),
-          'readable-stream': path.resolve(modules, 'readable-stream'),
-          'react-popper': path.resolve(modules, 'react-popper'),
-          inherits: path.resolve(modules, 'inherits'),
-          'graphql-tag': path.resolve(modules, 'graphql-tag'),
-          'safe-buffer': path.resolve(modules, 'safe-buffer'),
-          scheduler: path.resolve(modules, 'scheduler'),
-        }
+      config.resolve.alias = {
+        ...(config.resolve.alias || {}),
+        '@babel/runtime': path.resolve(modules, '@babel/runtime'),
+        'bn.js': path.resolve(modules, 'bn.js'),
+        'date-fns': path.resolve(modules, 'date-fns'),
+        'es-abstract': path.resolve(modules, 'es-abstract'),
+        'escape-string-regexp': path.resolve(modules, 'escape-string-regexp'),
+        'readable-stream': path.resolve(modules, 'readable-stream'),
+        'react-popper': path.resolve(modules, 'react-popper'),
+        inherits: path.resolve(modules, 'inherits'),
+        'graphql-tag': path.resolve(modules, 'graphql-tag'),
+        'safe-buffer': path.resolve(modules, 'safe-buffer'),
+        scheduler: path.resolve(modules, 'scheduler'),
+      }
 
-        return config
-      },
+      return config
+    },
 
-      cssModules: false,
+    cssModules: false,
 
-      serverRuntimeConfig: {
-        // Will only be available on the server side
-        // Requests made by the server are internal request made directly to the api hostname
-        graphqlUrl: API_URL,
-        graphqlEndpoint: graphqlPath,
-      },
+    serverRuntimeConfig: {
+      // Will only be available on the server side
+      // Requests made by the server are internal request made directly to the api hostname
+      graphqlUrl: API_URL,
+      graphqlEndpoint: graphqlPath,
+    },
 
-      publicRuntimeConfig: {
-        // Will be available on both server and client
-        graphqlUrl: '',
-        graphqlEndpoint: graphqlPath,
-        SENTRY_DSN,
-        disableApiCatalog: DISABLE_API_CATALOGUE,
-        disableSyslumennPage: DISABLE_SYSLUMENN_PAGE,
-        disableOrganizationChatbot: DISABLE_ORGANIZATION_CHATBOT,
-      },
+    publicRuntimeConfig: {
+      // Will be available on both server and client
+      graphqlUrl: '',
+      graphqlEndpoint: graphqlPath,
+      SENTRY_DSN,
+      disableApiCatalog: DISABLE_API_CATALOGUE,
+      disableSyslumennPage: DISABLE_SYSLUMENN_PAGE,
+      disableOrganizationChatbot: DISABLE_ORGANIZATION_CHATBOT,
+    },
 
-      env: {
-        API_MOCKS: process.env.API_MOCKS || '',
-      },
-    }),
-  ),
+    env: {
+      API_MOCKS: process.env.API_MOCKS || '',
+    },
+  }),
 )

--- a/package.json
+++ b/package.json
@@ -385,7 +385,6 @@
     "jest-transform-stub": "2.0.0",
     "license-checker": "25.0.1",
     "next-secure-headers": "2.1.0",
-    "next-transpile-modules": "4.1.0",
     "prettier": "2.2.1",
     "quicktype": "15.0.258",
     "sequelize-cli": "5.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20490,14 +20490,6 @@ next-tick@~1.0.0:
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
   integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
 
-next-transpile-modules@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/next-transpile-modules/-/next-transpile-modules-4.1.0.tgz#b2d4bd29f3d4179014f7615720f360fdeec67ff7"
-  integrity sha512-brb9S2Dq7l01fV0fdZw1pO2cWMu7fFTclIV2nccmX2Jzwtz1c9iScPMqGyWP6/wglOPOColoJlHzOrSG6cnEIQ==
-  dependencies:
-    micromatch "^4.0.2"
-    slash "^3.0.0"
-
 next-treat@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/next-treat/-/next-treat-1.3.0.tgz#f380ffbfb6f353fe5d9acb25b2ad4128190a402a"


### PR DESCRIPTION
## What

Removing `next-transpile-module`.

## Why

The [Technical Direction](https://docs.devland.is/technical-overview/technical-direction#accessibility) states that the webs should be tested for browsers with more than 1% usage in Iceland, according to StatsCounter.

And over the last year, Sept 2020 - Sept 2021 IE has 0.56% usage.
![image](https://user-images.githubusercontent.com/54210288/138442269-eaf98262-bb70-49a3-9521-e2c9431d9c52.png)

Also the usage of `next-transpile-modules` breaks in Nx 13.
And only two projects were using it:
* web
* auth-admin-web

### auth-admin-web
This web is only used by island.is staff and ops. There is no one using IE11 in that group.

### web
Is already broken in IE11 so `next-transpile-modules` is not adding any functionality.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
