### PR TITLE
feat(auth-public-api): Removing /public for service to let ingress configure

### DIFF
--- a/apps/services/auth-public-api/src/app/modules/delegations/delegations.controller.ts
+++ b/apps/services/auth-public-api/src/app/modules/delegations/delegations.controller.ts
@@ -32,6 +32,7 @@ import {
   CurrentActor,
   CurrentUser,
   ActorScopes,
+  AuthMiddlewareOptions,
 } from '@island.is/auth-nest-tools'
 import type { User } from '@island.is/auth-nest-tools'
 import { AuthScope } from '@island.is/auth/scopes'
@@ -90,13 +91,15 @@ export class DelegationsController {
   @Get()
   @ApiOkResponse({ type: [DelegationDTO] })
   @Audit<DelegationDTO[]>({
-    resources: (delegations) => delegations.map((delegation) => delegation.id),
+    resources: (delegations) =>
+      delegations.map((delegation) => delegation.id ?? ''),
   })
   async findAllTo(@CurrentActor() user: User): Promise<DelegationDTO[]> {
     return this.delegationsService.findAllTo(
       user,
       environment.nationalRegistry.xroad.clientId ?? '',
-      environment.nationalRegistry.authMiddlewareOptions,
+      environment.nationalRegistry
+        .authMiddlewareOptions as AuthMiddlewareOptions,
     )
   }
 
@@ -104,7 +107,7 @@ export class DelegationsController {
   @Post()
   @ApiCreatedResponse({ type: DelegationDTO })
   @Audit<DelegationDTO>({
-    resources: (delegation) => delegation?.id,
+    resources: (delegation) => delegation?.id ?? '',
   })
   create(
     @CurrentUser() user: User,
@@ -119,7 +122,8 @@ export class DelegationsController {
     return this.delegationsService.create(
       user,
       environment.nationalRegistry.xroad.clientId ?? '',
-      environment.nationalRegistry.authMiddlewareOptions,
+      environment.nationalRegistry
+        .authMiddlewareOptions as AuthMiddlewareOptions,
       delegation,
     )
   }
@@ -138,12 +142,12 @@ export class DelegationsController {
       )
     }
 
-    return this.auditService.auditPromise<DelegationDTO>(
+    return this.auditService.auditPromise<DelegationDTO | null>(
       {
         user,
         namespace,
         action: 'update',
-        resources: (delegation) => delegation?.id,
+        resources: (delegation) => delegation?.id ?? '',
         meta: { fields: Object.keys(delegation) },
       },
       this.delegationsService.update(user.nationalId, delegation, toNationalId),
@@ -190,7 +194,7 @@ export class DelegationsController {
   @Get('custom/findone/:id')
   @ApiOkResponse({ type: DelegationDTO })
   @Audit<DelegationDTO>({
-    resources: (delegation) => delegation?.id,
+    resources: (delegation) => delegation?.id ?? '',
   })
   findOne(
     @CurrentUser() user: User,
@@ -203,7 +207,7 @@ export class DelegationsController {
   @Get('custom/findone/to/:nationalId')
   @ApiOkResponse({ type: DelegationDTO })
   @Audit<DelegationDTO>({
-    resources: (delegation) => delegation?.id,
+    resources: (delegation) => delegation?.id ?? '',
   })
   async findOneTo(
     @CurrentUser() user: User,
@@ -226,7 +230,8 @@ export class DelegationsController {
   @Get('custom/to')
   @ApiOkResponse({ type: [DelegationDTO] })
   @Audit<DelegationDTO[]>({
-    resources: (delegations) => delegations.map((delegation) => delegation?.id),
+    resources: (delegations) =>
+      delegations.map((delegation) => delegation?.id ?? ''),
   })
   async findAllCustomTo(
     @CurrentUser() user: User,
@@ -239,7 +244,8 @@ export class DelegationsController {
   @ApiQuery({ name: 'is-valid', required: false })
   @ApiOkResponse({ type: [DelegationDTO] })
   @Audit<DelegationDTO[]>({
-    resources: (delegations) => delegations.map((delegation) => delegation?.id),
+    resources: (delegations) =>
+      delegations.map((delegation) => delegation?.id ?? ''),
   })
   async findAllCustomFrom(
     @CurrentUser() user: User,

--- a/apps/services/auth-public-api/src/app/modules/delegations/delegations.controller.ts
+++ b/apps/services/auth-public-api/src/app/modules/delegations/delegations.controller.ts
@@ -43,7 +43,7 @@ const namespace = '@island.is/auth-public-api/delegations'
 
 @UseGuards(IdsUserGuard, ScopesGuard)
 @ApiTags('delegations')
-@Controller('public/v1/delegations')
+@Controller('v1/delegations')
 @Audit({ namespace })
 export class DelegationsController {
   constructor(

--- a/apps/services/auth-public-api/src/app/modules/delegations/test/integration/delegations.controller.spec.ts
+++ b/apps/services/auth-public-api/src/app/modules/delegations/test/integration/delegations.controller.spec.ts
@@ -76,7 +76,7 @@ describe('DelegationsController with auth', () => {
 
       // Act
       const response = await request(app.getHttpServer())
-        .post('/public/v1/delegations')
+        .post('/v1/delegations')
         .send(payload)
 
       // Assert
@@ -125,7 +125,7 @@ describe('DelegationsController without auth', () => {
 
       // Act
       const response = await request(app.getHttpServer())
-        .post('/public/v1/delegations')
+        .post('/v1/delegations')
         .send(payload)
 
       // Assert

--- a/apps/services/auth-public-api/src/app/modules/resources/api-scope.controller.ts
+++ b/apps/services/auth-public-api/src/app/modules/resources/api-scope.controller.ts
@@ -10,7 +10,7 @@ import { ApiOkResponse, ApiTags } from '@nestjs/swagger'
 import type { User } from '@island.is/auth-nest-tools'
 @UseGuards(IdsUserGuard, ScopesGuard)
 @ApiTags('api-scope')
-@Controller('public/v1/api-scope')
+@Controller('v1/api-scope')
 export class ApiScopeController {
   constructor(private readonly resourcesService: ResourcesService) {}
 

--- a/apps/services/auth-public-api/src/app/modules/resources/identity-resources.controller.ts
+++ b/apps/services/auth-public-api/src/app/modules/resources/identity-resources.controller.ts
@@ -11,7 +11,7 @@ import type { User } from '@island.is/auth-nest-tools'
 
 @UseGuards(IdsUserGuard, ScopesGuard)
 @ApiTags('api-scope')
-@Controller('public/v1/identity-resources')
+@Controller('v1/identity-resources')
 export class IdentityResourcesController {
   constructor(private readonly resourcesService: ResourcesService) {}
 

--- a/apps/services/auth-public-api/src/app/modules/translation/translation.controller.ts
+++ b/apps/services/auth-public-api/src/app/modules/translation/translation.controller.ts
@@ -5,7 +5,7 @@ import { IdsAuthGuard, Scopes, ScopesGuard } from '@island.is/auth-nest-tools'
 
 @UseGuards(IdsAuthGuard, ScopesGuard)
 @ApiTags('translation')
-@Controller('public/v1/translations')
+@Controller('v1/translations')
 export class TranslationController {
   constructor(private readonly translationService: TranslationService) {}
 

--- a/apps/services/auth-public-api/src/openApi.ts
+++ b/apps/services/auth-public-api/src/openApi.ts
@@ -2,7 +2,10 @@ import { DocumentBuilder } from '@nestjs/swagger'
 
 export const openApi = new DocumentBuilder()
   .setTitle('IdentityServer Public Api')
-  .setDescription('Public Api for IdentityServer.')
+  .setDescription(
+    'Public API for IdentityServer.\n\n\nThe swagger document can be downloaded by appending `-json` to the last path segment.',
+  )
+  .addServer(process.env.PUBLIC_URL ?? 'http://localhost:3370')
   .setVersion('1.0')
   .addTag('auth-public-api')
   .build()


### PR DESCRIPTION
## What

Removing `/public` from controllers paths in `auth-public-api`.
Adding server option to the OpenAPI document.

## Why

To open for the Swagger UI and OpenAPI document for auth-public-api.
First attempt of testing the Ingress rewrite-target rule, which will be configured manually against the dev kubernetes cluster before configuring the Helm charts.
https://github.com/kubernetes/ingress-nginx/blob/main/docs/examples/rewrite/README.md#rewrite-target

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
