### PR TITLE
chore(judicial-system): Iterate request pdf

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/requestPdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/requestPdf.ts
@@ -244,15 +244,18 @@ function constructInvestigationRequestPdf(
     .lineGap(4)
     .text(`Kennitala: ${formatNationalId(existingCase.accusedNationalId)}`)
     .text(`Fullt nafn: ${existingCase.accusedName}`)
-    .text(`Lögheimili: ${existingCase.accusedAddress}`)
-    .text(
+    .text(`Lögheimili/dvalarstaður: ${existingCase.accusedAddress}`)
+
+  if (existingCase.defenderName) {
+    doc.text(
       formatMessage(m.baseInfo.defender, {
         defenderName:
-          existingCase.defenderName && !existingCase.defenderIsSpokesperson
-            ? existingCase.defenderName
-            : formatMessage(m.baseInfo.noDefender),
+          !existingCase.defenderIsSpokesperson && existingCase.defenderName,
       }),
     )
+  }
+
+  doc
     .text(' ')
     .font('Helvetica-Bold')
     .fontSize(mediumFontSize)

--- a/apps/judicial-system/backend/src/app/formatters/requestPdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/requestPdf.ts
@@ -42,7 +42,9 @@ function constructRestrictionRequestPdf(
 
   const title = formatMessage(m.heading, {
     caseType:
-      existingCase.type === CaseType.CUSTODY ? 'gæsluvarðhald' : 'farbann',
+      existingCase.type === CaseType.CUSTODY
+        ? formatMessage(m.caseType.custody)
+        : formatMessage(m.caseType.travelBan),
   })
 
   if (doc.info) {
@@ -70,7 +72,9 @@ function constructRestrictionRequestPdf(
       { align: 'center' },
     )
     .lineGap(40)
-    .text(`Dómstóll: ${existingCase.court?.name}`, { align: 'center' })
+    .text(`${formatMessage(m.baseInfo.court)} ${existingCase.court?.name}`, {
+      align: 'center',
+    })
     .font('Helvetica-Bold')
     .fontSize(mediumFontSize)
     .lineGap(8)
@@ -97,10 +101,10 @@ function constructRestrictionRequestPdf(
     .font('Helvetica-Bold')
     .fontSize(mediumFontSize)
     .lineGap(8)
-    .text('Dómkröfur')
+    .text(formatMessage(m.demands.heading))
     .font('Helvetica')
     .fontSize(baseFontSize)
-    .text(existingCase.demands ?? 'Dómkröfur ekki skráðar', {
+    .text(existingCase.demands ?? formatMessage(m.demands.noDemands), {
       lineGap: 6,
       paragraphGap: 0,
     })
@@ -108,10 +112,10 @@ function constructRestrictionRequestPdf(
     .font('Helvetica-Bold')
     .fontSize(mediumFontSize)
     .lineGap(8)
-    .text('Lagaákvæði sem brot varða við')
+    .text(formatMessage(m.lawsBroken.heading))
     .font('Helvetica')
     .fontSize(baseFontSize)
-    .text(existingCase.lawsBroken ?? 'Lagaákvæði ekki skráð', {
+    .text(existingCase.lawsBroken ?? formatMessage(m.lawsBroken.noLawsBroken), {
       lineGap: 6,
       paragraphGap: 0,
     })
@@ -119,7 +123,7 @@ function constructRestrictionRequestPdf(
     .font('Helvetica-Bold')
     .fontSize(mediumFontSize)
     .lineGap(8)
-    .text('Lagaákvæði sem krafan er byggð á')
+    .text(formatMessage(m.legalBasis.heading))
     .font('Helvetica')
     .fontSize(baseFontSize)
     .text(
@@ -137,7 +141,7 @@ function constructRestrictionRequestPdf(
     .fontSize(mediumFontSize)
     .lineGap(8)
     .text(
-      `Takmarkanir og tilhögun ${
+      `${formatMessage(m.baseInfo.restrictions)} ${
         existingCase.type === CaseType.CUSTODY ? 'gæslu' : 'farbanns'
       }`,
       {},
@@ -164,10 +168,13 @@ function constructRestrictionRequestPdf(
     .text(formatMessage(m.factsAndArguments.facts))
     .font('Helvetica')
     .fontSize(baseFontSize)
-    .text(existingCase.caseFacts ?? 'Málsatvik ekki skráð', {
-      lineGap: 6,
-      paragraphGap: 0,
-    })
+    .text(
+      existingCase.caseFacts ?? formatMessage(m.factsAndArguments.noFacts),
+      {
+        lineGap: 6,
+        paragraphGap: 0,
+      },
+    )
     .text(' ')
     .font('Helvetica-Bold')
     .fontSize(mediumFontSize)
@@ -175,16 +182,21 @@ function constructRestrictionRequestPdf(
     .text(formatMessage(m.factsAndArguments.arguments))
     .font('Helvetica')
     .fontSize(baseFontSize)
-    .text(existingCase.legalArguments ?? 'Lagarök ekki skráð', {
-      lineGap: 6,
-      paragraphGap: 0,
-    })
+    .text(
+      existingCase.legalArguments ??
+        formatMessage(m.factsAndArguments.noArguments),
+      {
+        lineGap: 6,
+        paragraphGap: 0,
+      },
+    )
     .text(' ')
     .font('Helvetica-Bold')
     .text(
-      `${existingCase.prosecutor?.name ?? 'Saksóknari ekki skráður'} ${
-        existingCase.prosecutor?.title ?? ''
-      }`,
+      `${
+        existingCase.prosecutor?.name ??
+        formatMessage(m.prosecutor.noProsecutor)
+      } ${existingCase.prosecutor?.title ?? ''}`,
     )
 
   setPageNumbers(doc)
@@ -209,8 +221,12 @@ function constructInvestigationRequestPdf(
     bufferPages: true,
   })
 
+  const title = formatMessage(m.heading, {
+    caseType: formatMessage(m.caseType.investigate),
+  })
+
   if (doc.info) {
-    doc.info['Title'] = 'Krafa um rannsóknarheimild'
+    doc.info['Title'] = title
   }
 
   const stream = doc.pipe(new streamBuffers.WritableStreamBuffer())
@@ -219,7 +235,7 @@ function constructInvestigationRequestPdf(
     .font('Helvetica-Bold')
     .fontSize(hugeFontSize)
     .lineGap(8)
-    .text('Krafa um rannsóknarheimild', { align: 'center' })
+    .text(title, { align: 'center' })
     .font('Helvetica')
     .fontSize(largeFontSize)
     .text(
@@ -234,7 +250,9 @@ function constructInvestigationRequestPdf(
       { align: 'center' },
     )
     .lineGap(40)
-    .text(`Dómstóll: ${existingCase.court?.name}`, { align: 'center' })
+    .text(`${formatMessage(m.baseInfo.court)} ${existingCase.court?.name}`, {
+      align: 'center',
+    })
     .font('Helvetica-Bold')
     .fontSize(largeFontSize)
     .lineGap(8)
@@ -242,9 +260,13 @@ function constructInvestigationRequestPdf(
     .font('Helvetica')
     .fontSize(baseFontSize)
     .lineGap(4)
-    .text(`Kennitala: ${formatNationalId(existingCase.accusedNationalId)}`)
-    .text(`Fullt nafn: ${existingCase.accusedName}`)
-    .text(`Lögheimili/dvalarstaður: ${existingCase.accusedAddress}`)
+    .text(
+      `${formatMessage(m.baseInfo.nationalId)} ${formatNationalId(
+        existingCase.accusedNationalId,
+      )}`,
+    )
+    .text(`${formatMessage(m.baseInfo.fullName)} ${existingCase.accusedName}`)
+    .text(`${formatMessage(m.baseInfo.address)} ${existingCase.accusedAddress}`)
 
   if (existingCase.defenderName) {
     doc.text(
@@ -260,12 +282,26 @@ function constructInvestigationRequestPdf(
     .font('Helvetica-Bold')
     .fontSize(mediumFontSize)
     .lineGap(8)
-    .text('Efni kröfu')
+    .text(formatMessage(m.description.heading))
     .font('Helvetica')
     .fontSize(baseFontSize)
     .lineGap(4)
     .text(capitalize(caseTypes[existingCase.type]))
-    .text(existingCase.description ?? 'Efni kröfu ekki skráð', {
+    .text(
+      existingCase.description ?? formatMessage(m.description.noDescription),
+      {
+        lineGap: 6,
+        paragraphGap: 0,
+      },
+    )
+    .text(' ')
+    .font('Helvetica-Bold')
+    .fontSize(mediumFontSize)
+    .lineGap(8)
+    .text(formatMessage(m.demands.heading))
+    .font('Helvetica')
+    .fontSize(baseFontSize)
+    .text(existingCase.demands ?? formatMessage(m.demands.noDemands), {
       lineGap: 6,
       paragraphGap: 0,
     })
@@ -273,10 +309,10 @@ function constructInvestigationRequestPdf(
     .font('Helvetica-Bold')
     .fontSize(mediumFontSize)
     .lineGap(8)
-    .text('Dómkröfur')
+    .text(formatMessage(m.lawsBroken.heading))
     .font('Helvetica')
     .fontSize(baseFontSize)
-    .text(existingCase.demands ?? 'Dómkröfur ekki skráðar', {
+    .text(existingCase.lawsBroken ?? formatMessage(m.lawsBroken.noLawsBroken), {
       lineGap: 6,
       paragraphGap: 0,
     })
@@ -284,21 +320,10 @@ function constructInvestigationRequestPdf(
     .font('Helvetica-Bold')
     .fontSize(mediumFontSize)
     .lineGap(8)
-    .text('Lagaákvæði sem brot varða við')
+    .text(formatMessage(m.legalBasis.heading))
     .font('Helvetica')
     .fontSize(baseFontSize)
-    .text(existingCase.lawsBroken ?? 'Lagaákvæði ekki skráð', {
-      lineGap: 6,
-      paragraphGap: 0,
-    })
-    .text(' ')
-    .font('Helvetica-Bold')
-    .fontSize(mediumFontSize)
-    .lineGap(8)
-    .text('Lagaákvæði sem krafan er byggð á')
-    .font('Helvetica')
-    .fontSize(baseFontSize)
-    .text(existingCase.legalBasis ?? 'Lagaákvæði ekki skráð', {
+    .text(existingCase.legalBasis ?? formatMessage(m.legalBasis.noLegalBasis), {
       lineGap: 6,
       paragraphGap: 0,
     })
@@ -306,26 +331,33 @@ function constructInvestigationRequestPdf(
     .font('Helvetica-Bold')
     .fontSize(largeFontSize)
     .lineGap(8)
-    .text('Greinargerð um málsatvik og lagarök')
+    .text(formatMessage(m.factsAndArguments.heading))
     .fontSize(mediumFontSize)
-    .text('Málsatvik')
+    .text(formatMessage(m.factsAndArguments.facts))
     .font('Helvetica')
     .fontSize(baseFontSize)
-    .text(existingCase.caseFacts ?? 'Málsatvik ekki skráð', {
-      lineGap: 6,
-      paragraphGap: 0,
-    })
+    .text(
+      existingCase.caseFacts ?? formatMessage(m.factsAndArguments.noFacts),
+      {
+        lineGap: 6,
+        paragraphGap: 0,
+      },
+    )
     .text(' ')
     .font('Helvetica-Bold')
     .fontSize(mediumFontSize)
     .lineGap(8)
-    .text('Lagarök')
+    .text(formatMessage(m.factsAndArguments.arguments))
     .font('Helvetica')
     .fontSize(baseFontSize)
-    .text(existingCase.legalArguments ?? 'Lagarök ekki skráð', {
-      lineGap: 6,
-      paragraphGap: 0,
-    })
+    .text(
+      existingCase.legalArguments ??
+        formatMessage(m.factsAndArguments.noArguments),
+      {
+        lineGap: 6,
+        paragraphGap: 0,
+      },
+    )
     .text(' ')
 
   if (existingCase.requestProsecutorOnlySession) {
@@ -333,7 +365,7 @@ function constructInvestigationRequestPdf(
       .font('Helvetica-Bold')
       .fontSize(mediumFontSize)
       .lineGap(8)
-      .text('Beiðni um dómþing að varnaraðila fjarstöddum')
+      .text(formatMessage(m.requestProsecutorOnlySession))
       .font('Helvetica')
       .fontSize(baseFontSize)
       .text(existingCase.prosecutorOnlySessionRequest ?? '', {
@@ -346,9 +378,10 @@ function constructInvestigationRequestPdf(
   doc
     .font('Helvetica-Bold')
     .text(
-      `${existingCase.prosecutor?.name ?? 'Saksóknari ekki skráður'} ${
-        existingCase.prosecutor?.title ?? ''
-      }`,
+      `${
+        existingCase.prosecutor?.name ??
+        formatMessage(m.prosecutor.noProsecutor)
+      } ${existingCase.prosecutor?.title ?? ''}`,
     )
 
   setPageNumbers(doc)

--- a/apps/judicial-system/backend/src/app/messages/requestPdf.ts
+++ b/apps/judicial-system/backend/src/app/messages/requestPdf.ts
@@ -1,6 +1,27 @@
 import { defineMessage, defineMessages } from '@formatjs/intl'
 
 export const restrictionRequest = {
+  caseType: defineMessages({
+    custody: {
+      id: 'judicial.system.backend:pdf.restriction_request.case_type.custody',
+      defaultMessage: 'gæsluvarðhald',
+      description:
+        'Notaður sem texti fyrir týpu gæsluvarðhald á kröfu í kröfu PDF',
+    },
+    travelBan: {
+      id:
+        'judicial.system.backend:pdf.restriction_request.case_type.travel_ban',
+      defaultMessage: 'farbann',
+      description: 'Notaður sem texti fyrir týpu farbann á kröfu í kröfu PDF',
+    },
+    investigate: {
+      id:
+        'judicial.system.backend:pdf.restriction_request.case_type.investigate',
+      defaultMessage: 'rannsóknarheimild',
+      description:
+        'Notaður sem texti fyrir týpu rannsóknarheimild á kröfu í kröfu PDF',
+    },
+  }),
   heading: defineMessage({
     id: 'judicial.system.backend:pdf.restriction_request.heading',
     defaultMessage: 'Krafa um {caseType}',
@@ -18,6 +39,18 @@ export const restrictionRequest = {
       defaultMessage: 'Grunnupplýsingar',
       description:
         'Notaður sem texti fyrir titill fyrir grunnupplýsingar í kröfu PDF',
+    },
+    court: {
+      id: 'judicial.system.backend:pdf.restriction_request.base_info.court',
+      defaultMessage: 'Dómstóll:',
+      description: 'Notaður sem texti fyrir dómstól í kröfu PDF',
+    },
+    restrictions: {
+      id:
+        'judicial.system.backend:pdf.restriction_request.base_info.restrictions',
+      defaultMessage: 'Takmarkanir og tilhögun',
+      description:
+        'Notaður sem texti fyrir takmarkanir og tilhögun í kröfu PDF',
     },
     nationalId: {
       id:
@@ -54,28 +87,80 @@ export const restrictionRequest = {
         'Notaður sem texti þegar enginn verjandi er skráður í kröfu PDF',
     },
   }),
+  description: defineMessages({
+    heading: {
+      id: 'judicial.system.backend:pdf.restriction_request.description.heading',
+      defaultMessage: 'Efni kröfu',
+      description: 'Notaður sem texti fyrir titil fyrir efni kröfu í kröfu PDF',
+    },
+    noDescription: {
+      id:
+        'judicial.system.backend:pdf.restriction_request.description.no_description',
+      defaultMessage: 'Efni kröfu ekki skráð',
+      description:
+        'Notaður sem texti þegar efni kröfu eru ekki skráðar í kröfu PDF',
+    },
+  }),
+  demands: defineMessages({
+    heading: {
+      id: 'judicial.system.backend:pdf.restriction_request.demands.heading',
+      defaultMessage: 'Dómkröfur',
+      description: 'Notaður sem texti fyrir titil fyrir dómkröfur í kröfu PDF',
+    },
+    noDemands: {
+      id: 'judicial.system.backend:pdf.restriction_request.demands.no_demands',
+      defaultMessage: 'Dómkröfur ekki skráðar',
+      description:
+        'Notaður sem texti þegar engar dómkröfur eru skráðar í kröfu PDF',
+    },
+  }),
+  lawsBroken: defineMessages({
+    heading: {
+      id: 'judicial.system.backend:pdf.restriction_request.laws_broken.heading',
+      defaultMessage: 'Lagaákvæði sem brot varða við',
+      description:
+        'Notaður sem texti fyrir titil fyrir lagaákvæði sem brot varða við í kröfu PDF',
+    },
+    noLawsBroken: {
+      id:
+        'judicial.system.backend:pdf.restriction_request.laws_broken.no_laws_broken',
+      defaultMessage: 'Lagaákvæði ekki skráð',
+      description:
+        'Notaður sem texti þegar engin lagaákvæði eru skráðar í kröfu PDF',
+    },
+  }),
+  legalBasis: defineMessage({
+    heading: {
+      id: 'judicial.system.backend:pdf.restriction_request.legal_basis.heading',
+      defaultMessage: 'Lagaákvæði sem krafan er byggð á',
+      description:
+        'Notaður sem texti fyrir lagaákvæði sem krafan er byggð á í kröfu PDF',
+    },
+    noLegalBasis: {
+      id:
+        'judicial.system.backend:pdf.restriction_request.legal_basis.no_legal_basis',
+      defaultMessage: 'Lagaákvæði ekki skráð',
+      description:
+        'Notaður sem texti þegar engin lagaákvæði eru skráðar í kröfu PDF',
+    },
+  }),
   courtClaim: defineMessage({
     id: 'judicial.system.backend:pdf.restriction_request.court_claim',
     defaultMessage: 'Dómkröfur',
     description: 'Notaður sem texti fyrir dómkröfur í kröfu PDF',
-  }),
-  lawsBroken: defineMessage({
-    id: 'judicial.system.backend:pdf.restriction_request.laws_broken',
-    defaultMessage: 'Lagaákvæði sem brot varða við',
-    description:
-      'Notaður sem texti fyrir lagaákvæði sem brot varða við í kröfu PDF',
-  }),
-  legalBasis: defineMessage({
-    id: 'judicial.system.backend:pdf.restriction_request.legal_basis',
-    defaultMessage: 'Lagaákvæði sem krafan er byggð á',
-    description:
-      'Notaður sem texti fyrir lagaákvæði sem krafan er byggð á í kröfu PDF',
   }),
   restrictions: defineMessage({
     id: 'judicial.system.backend:pdf.restriction_request.restrictions',
     defaultMessage: 'Takmarkanir og tilhögun {caseType}',
     description:
       'Notaður sem texti fyrir takmarkanir og tilhögun í kröfu PDF þar sem {caseType} mála týpan.',
+  }),
+  requestProsecutorOnlySession: defineMessage({
+    id:
+      'judicial.system.backend:pdf.restriction_request.request_prosecutor_only_session',
+    defaultMessage: 'Beiðni um dómþing að varnaraðila fjarstöddum',
+    description:
+      'Notaður sem texti fyrir beiðni um dómþing að varnaraðila fjarstöddum í kröfu PDF',
   }),
   factsAndArguments: defineMessages({
     heading: {
@@ -96,6 +181,29 @@ export const restrictionRequest = {
         'judicial.system.backend:pdf.restriction_request.facts_and_arguments.arguments',
       defaultMessage: 'Lagarök',
       description: 'Notaður sem texti fyrir titill fyrir lagarök í kröfu PDF',
+    },
+    noFacts: {
+      id:
+        'judicial.system.backend:pdf.restriction_request.facts_and_arguments.no_facts',
+      defaultMessage: 'Málsatvik ekki skráð',
+      description:
+        'Notaður sem texti þegar engin málsatvik eru skráða í kröfu PDF',
+    },
+    noArguments: {
+      id:
+        'judicial.system.backend:pdf.restriction_request.facts_and_arguments.no_arguments',
+      defaultMessage: 'Lagarök ekki skráð',
+      description:
+        'Notaður sem texti þegar engin lagarök eru skráða í kröfu PDF',
+    },
+  }),
+  prosecutor: defineMessage({
+    noProsecutor: {
+      id:
+        'judicial.system.backend:pdf.restriction_request.prosecutor.noProsecutor',
+      defaultMessage: 'Saksóknari ekki skráður',
+      description:
+        'Notaður sem texti þegar engin saksóknari er skráður í kröfu PDF',
     },
   }),
 }

--- a/apps/judicial-system/web/src/utils/useFormHelper.ts
+++ b/apps/judicial-system/web/src/utils/useFormHelper.ts
@@ -94,6 +94,7 @@ export const useCaseFormHelper = (
   }
 
   return {
+    isValid,
     setField,
     validateAndSendToServer,
     setAndSendToServer,


### PR DESCRIPTION
# Iterate request pdf

https://app.asana.com/0/1199153462262248/1201261137719276/f

## What

- Remove defender section if no defender chosen
- Move all strings in requestPdf to Contentful
- Minor string changes
- Minor bug fix where isValid export was missing from useFormHelper

## Why

Iteration on request Pdf

## Screenshots / Gifs

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
