### PR TITLE
fix(accident-notification): Fix edge case for when accident wasnt fatal

### DIFF
--- a/libs/application/templates/accident-notification/src/utils/hasMissingDocuments.ts
+++ b/libs/application/templates/accident-notification/src/utils/hasMissingDocuments.ts
@@ -4,7 +4,7 @@ import {
   MessageFormatter,
 } from '@island.is/application/core'
 import { AttachmentsEnum, FileType, WhoIsTheNotificationForEnum } from '..'
-import { YES } from '../constants'
+import { YES, NO } from '../constants'
 import { AccidentNotification } from '../lib/dataSchema'
 import { attachments } from '../lib/messages'
 
@@ -24,6 +24,9 @@ export const hasReceivedProxyDocument = (answers: FormValue) => {
 }
 
 export const hasReceivedPoliceReport = (answers: FormValue) => {
+  const wasTheAccidentFatal = answers.wasTheAccidentFatal
+  // if accident wasn't fatal the police report isnt required
+  if (wasTheAccidentFatal === NO) return true
   return includesAttachment(answers, 'PoliceReport')
 }
 


### PR DESCRIPTION
# fix case for when accident wasnt fatal

Attach a link to issue if relevant

## What

Only check police report when accident was fatal

## Why

Current implementation results in a bug.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
