### PR TITLE
fix(judicial-system): Only display isolation demand for custody cases

### DIFF
--- a/apps/judicial-system/web/src/routes/Prosecutor/RestrictionRequest/StepThree/StepThreeForm.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/RestrictionRequest/StepThree/StepThreeForm.tsx
@@ -85,7 +85,7 @@ const StepThreeForm: React.FC<Props> = (props) => {
             )}
           </Box>
           <BlueBox>
-            <Box marginBottom={3}>
+            <Box marginBottom={workingCase.type === CaseType.CUSTODY ? 3 : 0}>
               <DateTime
                 name="reqValidToDate"
                 datepickerLabel={`${
@@ -114,25 +114,27 @@ const StepThreeForm: React.FC<Props> = (props) => {
                 blueBox={false}
               />
             </Box>
-            <Checkbox
-              name="isIsolation"
-              label={formatMessage(rcDemands.sections.demands.isolation)}
-              tooltip={formatMessage(rcDemands.sections.demands.tooltip)}
-              checked={workingCase.requestedCustodyRestrictions?.includes(
-                CaseCustodyRestrictions.ISOLATION,
-              )}
-              onChange={() =>
-                setCheckboxAndSendToServer(
-                  'requestedCustodyRestrictions',
-                  'ISOLATION',
-                  workingCase,
-                  setWorkingCase,
-                  updateCase,
-                )
-              }
-              large
-              filled
-            />
+            {workingCase.type === CaseType.CUSTODY && (
+              <Checkbox
+                name="isIsolation"
+                label={formatMessage(rcDemands.sections.demands.isolation)}
+                tooltip={formatMessage(rcDemands.sections.demands.tooltip)}
+                checked={workingCase.requestedCustodyRestrictions?.includes(
+                  CaseCustodyRestrictions.ISOLATION,
+                )}
+                onChange={() =>
+                  setCheckboxAndSendToServer(
+                    'requestedCustodyRestrictions',
+                    'ISOLATION',
+                    workingCase,
+                    setWorkingCase,
+                    updateCase,
+                  )
+                }
+                large
+                filled
+              />
+            )}
           </BlueBox>
         </Box>
         <Box component="section" marginBottom={7}>


### PR DESCRIPTION
# Only display isolation demand for custody cases

https://app.asana.com/0/1199153462262248/1201371123228010/f

## What

Only display isolation demand for custody cases

## Why

Fix, isolation demand does not apply for travel ban case type

## Screenshots / Gifs

Before:
![image](https://user-images.githubusercontent.com/5690487/141986090-3b204b86-b7f9-4177-a807-3efd6bab5bde.png)

After:
<img width="1069" alt="Screenshot 2021-11-16 at 12 33 02" src="https://user-images.githubusercontent.com/5690487/141986113-b5dca292-f717-4b7d-a2a9-bbe221187ec4.png">


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
