### PR TITLE
fix(island-ui): gridcolumn classname

### DIFF
--- a/libs/island-ui/core/src/lib/Grid/GridColumn/GridColumn.css.ts
+++ b/libs/island-ui/core/src/lib/Grid/GridColumn/GridColumn.css.ts
@@ -140,7 +140,7 @@ const makeOrder = (breakpoint: Breakpoint) =>
     mapValues(order, (order) =>
       themeUtils.responsiveStyle({ [breakpoint]: { order } }),
     ),
-    `order_${breakpoint}:${order}`,
+    `order_${breakpoint}`,
   ) as Orders
 
 export const orderXs = makeOrder('xs')


### PR DESCRIPTION
## What

Remove object from gridcolumn classname on order class.

## Why

When developing locally, `[object_Object]` will be added to the order classname in gridColumn.
As a result of the `orderRange` "object from the const `order`. Thus you can not really use the order property while developing on localhost.

I did not see any reason for the order object to be placed as a part of the `order_` class.

## Screenshots / Gifs

![Screenshot 2021-11-17 at 14 25 44](https://user-images.githubusercontent.com/24840451/142219901-5491a7f6-807c-46c4-9c11-ce2813292e26.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
