### PR TITLE
chore(judicial-system): Remove police case number from ruling pdf

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/rulingPdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/rulingPdf.ts
@@ -79,7 +79,9 @@ function constructRestrictionRulingPdf(
     .text(formatMessage(ruling.proceedingsHeading), { align: 'center' })
     .lineGap(30)
     .text(
-      `Mál nr. ${existingCase.courtCaseNumber} - LÖKE nr. ${existingCase.policeCaseNumber}`,
+      formatMessage(ruling.caseNumber, {
+        caseNumber: existingCase.courtCaseNumber,
+      }),
       { align: 'center' },
     )
     .fontSize(baseFontSize)
@@ -434,7 +436,9 @@ function constructInvestigationRulingPdf(
     .text(formatMessage(ruling.proceedingsHeading), { align: 'center' })
     .lineGap(30)
     .text(
-      `Mál nr. ${existingCase.courtCaseNumber} - LÖKE nr. ${existingCase.policeCaseNumber}`,
+      formatMessage(ruling.caseNumber, {
+        caseNumber: existingCase.courtCaseNumber,
+      }),
       { align: 'center' },
     )
     .fontSize(baseFontSize)

--- a/apps/judicial-system/backend/src/app/messages/rulingPdf.ts
+++ b/apps/judicial-system/backend/src/app/messages/rulingPdf.ts
@@ -6,6 +6,11 @@ export const ruling = {
     defaultMessage: 'Þingbók og úrskurður',
     description: 'Notaður sem fyrirsögn á þingbók.',
   }),
+  caseNumber: defineMessage({
+    id: 'judicial.system.backend:pdf.ruling.case_number',
+    defaultMessage: 'Mál nr. {caseNumber}',
+    description: 'Notað sem undirsögn á þingbók fyrir númer á máli',
+  }),
   intro: defineMessage({
     id: 'judicial.system.backend:pdf.ruling.into',
     defaultMessage:


### PR DESCRIPTION
# Remove police case number from ruling pdf

https://app.asana.com/0/1199153462262248/1201386801040005/f

## What

* Remove police case number from ruling pdf
* Add case number string to Contentful

## Screenshots / Gifs

Before:
![image](https://user-images.githubusercontent.com/5690487/142512112-f43a04a9-6894-4238-a8f4-695a9efecfbd.png)

After: 
<img width="291" alt="Screenshot 2021-11-18 at 23 14 06" src="https://user-images.githubusercontent.com/5690487/142512172-e0bb727a-7b0e-429a-a585-0ce7b4d75fd4.png">


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
