### PR TITLE
fix(service-portal): General petition admin overview of locked lists and csv fix

### DIFF
--- a/libs/service-portal/endorsements/src/lib/messages.ts
+++ b/libs/service-portal/endorsements/src/lib/messages.ts
@@ -80,6 +80,11 @@ export const m: MessageDir = {
       defaultMessage: 'Lokaða meðmælendalista',
       description: 'Petitions intro text bullet',
     },
+    bullet3Admin: {
+      id: 'sp.petitions:intro-bullet2-admin',
+      defaultMessage: 'Læsta meðmælendalista',
+      description: 'Petitions intro text bullet',
+    },
     petitionListsIown: {
       id: 'sp.petitions:petition-lists-i-own',
       defaultMessage: 'Listar stofnaðir af mér',
@@ -94,6 +99,11 @@ export const m: MessageDir = {
       id: 'sp.petitions:petition-lists-closed',
       defaultMessage: 'Lokaðir listar',
       description: 'Section title for closed petition lists',
+    },
+    petitionListsLocked: {
+      id: 'sp.petitions:petition-lists-locked',
+      defaultMessage: 'Læstir listar',
+      description: 'Section title for locked petition lists',
     },
     petitionListsSignedByMe: {
       id: 'sp.petitions:petition-lists-signed-by-me',

--- a/libs/service-portal/endorsements/src/screens/PetitionsAdmin/PetitionsAdmin.tsx
+++ b/libs/service-portal/endorsements/src/screens/PetitionsAdmin/PetitionsAdmin.tsx
@@ -32,12 +32,17 @@ const PetitionsAdmin = () => {
   const openLists = allPetitionLists?.filter((list) => {
     return (
       new Date(list.openedDate) <= new Date() &&
-      new Date() <= new Date(list.closedDate)
+      new Date() <= new Date(list.closedDate) &&
+      !list.adminLock
     )
   })
 
   const closedLists = allPetitionLists?.filter((list) => {
-    return new Date() >= new Date(list.closedDate)
+    return new Date() >= new Date(list.closedDate) && !list.adminLock
+  })
+
+  const lockedLists = allPetitionLists?.filter((list) => {
+    return list.adminLock === true
   })
 
   return (
@@ -55,6 +60,7 @@ const PetitionsAdmin = () => {
         <BulletList type="ul">
           <Bullet>{formatMessage(m.petition.bullet1Admin)}</Bullet>
           <Bullet>{formatMessage(m.petition.bullet2Admin)}</Bullet>
+          <Bullet>{formatMessage(m.petition.bullet3Admin)}</Bullet>
         </BulletList>
       </Box>
 
@@ -110,6 +116,49 @@ const PetitionsAdmin = () => {
 
             <Stack space={4}>
               {closedLists.map((list: any) => {
+                return (
+                  <Link
+                    style={{ textDecoration: 'none' }}
+                    key={list.id}
+                    to={{
+                      pathname: ServicePortalPath.PetitionListAdmin.replace(
+                        ':listId',
+                        list.id,
+                      ),
+                      state: { listId: list.id },
+                    }}
+                  >
+                    <ActionCard
+                      backgroundColor="blue"
+                      heading={list.title}
+                      text={
+                        formatMessage(m.petition.listPeriod) +
+                        ' ' +
+                        formatDate(list.openedDate) +
+                        ' - ' +
+                        formatDate(list.closedDate)
+                      }
+                      cta={{
+                        label: formatMessage(m.petition.editList),
+                        variant: 'text',
+                        icon: 'arrowForward',
+                      }}
+                    />
+                  </Link>
+                )
+              })}
+            </Stack>
+          </>
+        )}
+
+        {lockedLists && lockedLists.length > 0 && (
+          <>
+            <Text as="p" variant="h3" marginBottom={3} marginTop={7}>
+              {formatMessage(m.petition.petitionListsLocked)}
+            </Text>
+
+            <Stack space={4}>
+              {lockedLists.map((list: any) => {
                 return (
                   <Link
                     style={{ textDecoration: 'none' }}

--- a/libs/service-portal/endorsements/src/screens/PetitionsTable/PetitionsTable.tsx
+++ b/libs/service-portal/endorsements/src/screens/PetitionsTable/PetitionsTable.tsx
@@ -89,7 +89,7 @@ const PetitionsTable = (data: any) => {
         </Text>
         {data.isViewTypeEdit && (
           <ExportAsCSV
-            data={mapToCSVFile(listOfPetitions) as object[]}
+            data={mapToCSVFile(data.petitions?.data) as object[]}
             filename="Meðmælalisti"
             title="Sækja lista"
             variant="text"

--- a/libs/service-portal/endorsements/src/screens/queries.ts
+++ b/libs/service-portal/endorsements/src/screens/queries.ts
@@ -87,6 +87,7 @@ const GetAllEndorsementsLists = gql`
         description
         closedDate
         openedDate
+        adminLock
       }
     }
   }


### PR DESCRIPTION
Admin now has overview over what lists have been locked by admin. And CSV downloads all petitions belonging a given list not just currently paginated endorsements.

![Screenshot 2021-11-19 at 15 09 03](https://user-images.githubusercontent.com/42963845/142649825-d1bd8a98-1acb-4053-b249-64ac60bd80fd.png)


- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
