### PR TITLE
fix(application-system): Checkbox value not registering in application

### DIFF
--- a/libs/application/ui-shell/src/components/FormExternalDataProvider.tsx
+++ b/libs/application/ui-shell/src/components/FormExternalDataProvider.tsx
@@ -24,7 +24,10 @@ import {
   coreErrorMessages,
   StaticText,
 } from '@island.is/application/core'
-import { UPDATE_APPLICATION_EXTERNAL_DATA } from '@island.is/application/graphql'
+import {
+  UPDATE_APPLICATION_EXTERNAL_DATA,
+  UPDATE_APPLICATION,
+} from '@island.is/application/graphql'
 import { useLocale } from '@island.is/localization'
 
 import { ExternalDataProviderScreen } from '../types'
@@ -121,6 +124,7 @@ const FormExternalDataProvider: FC<{
 }) => {
   const { formatMessage, lang: locale } = useLocale()
   const { setValue, clearErrors } = useFormContext()
+  const [updateApplication] = useMutation(UPDATE_APPLICATION)
   const [updateExternalData] = useMutation(UPDATE_APPLICATION_EXTERNAL_DATA, {
     onCompleted(responseData: UpdateApplicationExternalDataResponse) {
       addExternalData(getExternalDataFromResponse(responseData))
@@ -153,6 +157,17 @@ const FormExternalDataProvider: FC<{
                 id,
                 type,
               })),
+            },
+            locale,
+          },
+        })
+
+        // Update checkbox value in application
+        await updateApplication({
+          variables: {
+            input: {
+              id: applicationId,
+              answers: { [id as string]: checked },
             },
             locale,
           },


### PR DESCRIPTION
# Checkbox value not registering in application

Attach a link to issue if relevant

## What

Fixing issue where the checkbox value wasn't saved to the application state. Resulting in an unanswered question that resulted in the application always going back to the dataprovider screen on refresh in at least three applications I tested.

## Why

It's really annoying for the user to have to go back to the start of the application every time they refresh.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
