### PR TITLE
fix(public-debt-payment-plan): Add "does not require answer" on screens with no questions

### DIFF
--- a/libs/application/templates/public-debt-payment-plan/src/forms/BetaTestSection.ts
+++ b/libs/application/templates/public-debt-payment-plan/src/forms/BetaTestSection.ts
@@ -11,6 +11,7 @@ export const betaTestSection = buildSection({
         id: 'betaTest.section.textField',
         title: betaTest.title,
         component: 'DescriptionWithLink',
+        doesNotRequireAnswer: true,
       },
       {
         descriptionFirstPart: betaTest.descriptionFirstPart,

--- a/libs/application/templates/public-debt-payment-plan/src/forms/PaymentPlanForm.ts
+++ b/libs/application/templates/public-debt-payment-plan/src/forms/PaymentPlanForm.ts
@@ -123,6 +123,7 @@ export const PaymentPlanForm: Form = buildForm({
               id: 'prerequisitesErrorModal',
               component: 'PrerequisitesErrorModal',
               title: '',
+              doesNotRequireAnswer: true,
             }),
           ],
           condition: (_formValue, externalData) => {

--- a/libs/application/ui-shell/src/components/FormExternalDataProvider.tsx
+++ b/libs/application/ui-shell/src/components/FormExternalDataProvider.tsx
@@ -24,7 +24,10 @@ import {
   coreErrorMessages,
   StaticText,
 } from '@island.is/application/core'
-import { UPDATE_APPLICATION_EXTERNAL_DATA } from '@island.is/application/graphql'
+import {
+  UPDATE_APPLICATION_EXTERNAL_DATA,
+  UPDATE_APPLICATION,
+} from '@island.is/application/graphql'
 import { useLocale } from '@island.is/localization'
 
 import { ExternalDataProviderScreen } from '../types'
@@ -121,6 +124,7 @@ const FormExternalDataProvider: FC<{
 }) => {
   const { formatMessage, lang: locale } = useLocale()
   const { setValue, clearErrors } = useFormContext()
+  const [updateApplication] = useMutation(UPDATE_APPLICATION)
   const [updateExternalData] = useMutation(UPDATE_APPLICATION_EXTERNAL_DATA, {
     onCompleted(responseData: UpdateApplicationExternalDataResponse) {
       addExternalData(getExternalDataFromResponse(responseData))
@@ -153,6 +157,17 @@ const FormExternalDataProvider: FC<{
                 id,
                 type,
               })),
+            },
+            locale,
+          },
+        })
+
+        // Update checkbox value in application
+        await updateApplication({
+          variables: {
+            input: {
+              id: applicationId,
+              answers: { [id as string]: checked },
             },
             locale,
           },


### PR DESCRIPTION
# Add "does not require answer" on screens with no questions

https://app.clickup.com/t/1m99t96

## What

After refresh the application was always at the starting point. 
Same as here: https://github.com/island-is/island.is/pull/5719


## Why

Users want the application to return to the same spot after refresh

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
