### PR TITLE
fix(regulations/web): HOTFIX)Prevent over-extending index titles

### DIFF
--- a/apps/web/components/Regulations/useRegulationIndexer.ts
+++ b/apps/web/components/Regulations/useRegulationIndexer.ts
@@ -81,12 +81,18 @@ const insertIds = (
   idPrefix = '',
 ): HTMLText =>
   html.replace(
-    / class="(section|chapter|article)__title"\s*>(([^<]+)[^]+?)<\/h\d/g,
-    (htmlSnippet: string, _type: string, title: string, shortTitle: string) => {
+    / class="(section|chapter|article)__title"\s*>(([^<]+)(?:.[^/][^]*?)?)<\/[hH]\d/g,
+    (
+      htmlSnippet: string,
+      _type: string,
+      longTitle: string,
+      shortTitle: string,
+    ) => {
       const type = _type as ItemType
-      const id = idPrefix + shortTitle.toLocaleLowerCase().replace(/\s/g, '')
+      const id = idPrefix + shortTitle.toLowerCase().replace(/\s/g, '')
+      const title = longTitle.replace(/<[^]+?>/g, '').trim()
       flatIndex.push({
-        title: title.replace(/<[^]+?>/g, '').trim(),
+        title,
         type,
         id,
       })


### PR DESCRIPTION
## Why

Some Regulation text-bodies trigger a bug in the TOC/index generator, resulting in a wall of titles.

This affects at least two very recent regulations.

<img width="706" alt="image" src="https://user-images.githubusercontent.com/86827/143050380-81226729-02bf-44ec-85ec-2feb6267737f.png">

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
