### PR TITLE
fix(judicial-system): prosecutorDemands not being validated on rulingStepOne screen

### DIFF
--- a/apps/judicial-system/web/src/routes/Court/InvestigationRequest/CourtRecord/CourtRecordForm.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationRequest/CourtRecord/CourtRecordForm.tsx
@@ -54,9 +54,6 @@ const CourtRecordForm: React.FC<Props> = (props) => {
     courtLocation: {
       validations: ['empty'],
     },
-    prosecutorDemands: {
-      validations: ['empty'],
-    },
     litigationPresentations: {
       validations: ['empty'],
     },

--- a/apps/judicial-system/web/src/routes/Court/InvestigationRequest/Ruling/StepOne/RulingStepOneForm.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationRequest/Ruling/StepOne/RulingStepOneForm.tsx
@@ -49,6 +49,9 @@ const RulingStepOneForm: React.FC<Props> = (props) => {
   const [prosecutorDemandsEM, setProsecutorDemandsEM] = useState('')
 
   const validations: FormSettings = {
+    prosecutorDemands: {
+      validations: ['empty'],
+    },
     ruling: {
       validations: ['empty'],
     },

--- a/apps/judicial-system/web/src/utils/validate.ts
+++ b/apps/judicial-system/web/src/utils/validate.ts
@@ -180,7 +180,6 @@ export const isCourtRecordStepValidIC = (workingCase: Case) => {
   return (
     validate(workingCase.courtStartDate || '', 'date-format').isValid &&
     validate(workingCase.courtLocation || '', 'empty').isValid &&
-    validate(workingCase.prosecutorDemands || '', 'empty').isValid &&
     validate(workingCase.litigationPresentations || '', 'empty').isValid
   )
 }
@@ -197,6 +196,7 @@ export const isRulingStepOneValidRC = (workingCase: Case) => {
 
 export const isRulingStepOneValidIC = (workingCase: Case) => {
   return (
+    validate(workingCase.prosecutorDemands || '', 'empty').isValid &&
     validate(workingCase.courtCaseFacts || '', 'empty').isValid &&
     validate(workingCase.courtLegalArguments || '', 'empty').isValid &&
     validate(workingCase.decision || '', 'empty').isValid &&


### PR DESCRIPTION
# prosecutorDemands not being validated on rulingStepOne screen

Attach a link to issue if relevant

## What

Fixes a bug where prosecutorDemands were not being validated on rulingStepOne screen. This is a regression from https://app.asana.com/0/1199153462262248/1201312869487978/f. We forgot to move the validations in investigation cases

## Why

It's a bug

## Screenshots / Gifs

### Before

https://user-images.githubusercontent.com/3789875/143410680-fae2ec60-f5ae-444c-acee-78b8e8613b5e.mov

### After

https://user-images.githubusercontent.com/3789875/143410532-4f103869-66d7-44e9-8954-a00ba3607a3b.mov

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
