### PR TITLE
fix(template-api-modules-driving-license): re-adding the return statement

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/driving-license-submission/driving-license-submission.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/driving-license-submission/driving-license-submission.service.ts
@@ -40,6 +40,8 @@ export class DrivingLicenseSubmissionService {
     if (!response.paymentUrl) {
       throw new Error('paymentUrl missing in response')
     }
+
+    return response
   }
 
   async submitApplication({


### PR DESCRIPTION
re-adding the return statement I idiotically removed when trying to fix the consistency of the action

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
