### PR TITLE
fix(judicial-system): Fix: Add court permission to step validation

### DIFF
--- a/apps/judicial-system/web/src/components/PageLayout/PageLayout.tsx
+++ b/apps/judicial-system/web/src/components/PageLayout/PageLayout.tsx
@@ -46,6 +46,7 @@ const PageLayout: React.FC<PageProps> = ({
     { dismissedTitle: formatMessage(signedVerdictOverview.dismissedTitle) },
     workingCase,
     activeSubSection,
+    user,
   )
 
   return children ? (

--- a/apps/judicial-system/web/src/components/PageLayout/utils/index.ts
+++ b/apps/judicial-system/web/src/components/PageLayout/utils/index.ts
@@ -5,6 +5,7 @@ import {
   CaseType,
   isInvestigationCase,
   isRestrictionCase,
+  User,
 } from '@island.is/judicial-system/types'
 import {
   getCourtSections,
@@ -76,6 +77,7 @@ export const getSections = (
   translationStrings: TranslationStrings,
   workingCase?: Case,
   activeSubSection?: number,
+  user?: User,
 ) => {
   return [
     isRestrictionCase(workingCase?.type)
@@ -88,9 +90,10 @@ export const getSections = (
           activeSubSection,
         ),
     isRestrictionCase(workingCase?.type)
-      ? getCourtSections(workingCase || ({} as Case), activeSubSection)
+      ? getCourtSections(workingCase || ({} as Case), user, activeSubSection)
       : getInvestigationCaseCourtSections(
           workingCase || ({} as Case),
+          user,
           activeSubSection,
         ),
     {
@@ -100,6 +103,6 @@ export const getSections = (
       ),
     },
     getExtenstionSections(workingCase || ({} as Case), activeSubSection),
-    getCourtSections(workingCase || ({} as Case), activeSubSection),
+    getCourtSections(workingCase || ({} as Case), user, activeSubSection),
   ]
 }

--- a/apps/judicial-system/web/src/routes/Shared/Requests/Requests.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/Requests/Requests.tsx
@@ -147,10 +147,10 @@ export const Requests: React.FC = () => {
       routeTo = `${Constants.SIGNED_VERDICT_OVERVIEW}/${caseToOpen.id}`
     } else if (role === UserRole.JUDGE || role === UserRole.REGISTRAR) {
       if (isRestrictionCase(caseToOpen.type)) {
-        routeTo = findLastValidStep(getCourtSections(caseToOpen)).href
+        routeTo = findLastValidStep(getCourtSections(caseToOpen, user)).href
       } else {
         routeTo = findLastValidStep(
-          getInvestigationCaseCourtSections(caseToOpen),
+          getInvestigationCaseCourtSections(caseToOpen, user),
         ).href
       }
     } else {

--- a/apps/judicial-system/web/src/utils/sections.ts
+++ b/apps/judicial-system/web/src/utils/sections.ts
@@ -279,7 +279,8 @@ export const getCourtSections = (
         name: 'Fyrirtökutími',
         href:
           (activeSubSection && activeSubSection > 1) ||
-          isOverviewStepValidRC(workingCase)
+          (hasCourtPermission(workingCase, user) &&
+            isOverviewStepValidRC(workingCase))
             ? `${Constants.HEARING_ARRANGEMENTS_ROUTE}/${id}`
             : undefined,
       },

--- a/apps/judicial-system/web/src/utils/sections.ts
+++ b/apps/judicial-system/web/src/utils/sections.ts
@@ -1,4 +1,4 @@
-import { Case, CaseType } from '@island.is/judicial-system/types'
+import { Case, CaseType, User } from '@island.is/judicial-system/types'
 import * as Constants from '@island.is/judicial-system-web/src/utils/constants'
 import {
   isAccusedStepValidRC,
@@ -27,6 +27,12 @@ interface Section {
     name: string
     href: string | undefined
   }[]
+}
+
+const hasCourtPermission = (workingCase: Case, user?: User) => {
+  return (
+    user?.id === workingCase.judge?.id || user?.id === workingCase.registrar?.id
+  )
 }
 
 export const findLastValidStep = (section: Section) => {
@@ -177,6 +183,7 @@ export const getInvestigationCaseProsecutorSection = (
 
 export const getInvestigationCaseCourtSections = (
   workingCase: Case,
+  user?: User,
   activeSubSection?: number,
 ): Section => {
   const { id } = workingCase
@@ -194,7 +201,8 @@ export const getInvestigationCaseCourtSections = (
         name: 'Fyrirtökutími',
         href:
           (activeSubSection && activeSubSection > 1) ||
-          isOverviewStepValidIC(workingCase)
+          (hasCourtPermission(workingCase, user) &&
+            isOverviewStepValidIC(workingCase))
             ? `${Constants.IC_COURT_HEARING_ARRANGEMENTS_ROUTE}/${id}`
             : undefined,
       },
@@ -203,7 +211,8 @@ export const getInvestigationCaseCourtSections = (
         name: 'Þingbók',
         href:
           (activeSubSection && activeSubSection > 2) ||
-          (isOverviewStepValidIC(workingCase) &&
+          (hasCourtPermission(workingCase, user) &&
+            isOverviewStepValidIC(workingCase) &&
             isCourtHearingArrangementsStepValidIC(workingCase))
             ? `${Constants.IC_COURT_RECORD_ROUTE}/${id}`
             : undefined,
@@ -213,7 +222,8 @@ export const getInvestigationCaseCourtSections = (
         name: 'Úrskurður',
         href:
           (activeSubSection && activeSubSection > 3) ||
-          (isOverviewStepValidIC(workingCase) &&
+          (hasCourtPermission(workingCase, user) &&
+            isOverviewStepValidIC(workingCase) &&
             isCourtHearingArrangementsStepValidIC(workingCase) &&
             isCourtRecordStepValidIC(workingCase))
             ? `${Constants.IC_RULING_STEP_ONE_ROUTE}/${id}`
@@ -224,7 +234,8 @@ export const getInvestigationCaseCourtSections = (
         name: 'Úrskurðarorð',
         href:
           (activeSubSection && activeSubSection > 4) ||
-          (isOverviewStepValidIC(workingCase) &&
+          (hasCourtPermission(workingCase, user) &&
+            isOverviewStepValidIC(workingCase) &&
             isCourtHearingArrangementsStepValidIC(workingCase) &&
             isCourtRecordStepValidIC(workingCase) &&
             isRulingStepOneValidIC(workingCase))
@@ -235,6 +246,7 @@ export const getInvestigationCaseCourtSections = (
         type: 'SUB_SECTION',
         name: 'Yfirlit úrskurðar',
         href:
+          hasCourtPermission(workingCase, user) &&
           isOverviewStepValidIC(workingCase) &&
           isCourtHearingArrangementsStepValidIC(workingCase) &&
           isCourtRecordStepValidIC(workingCase) &&
@@ -249,6 +261,7 @@ export const getInvestigationCaseCourtSections = (
 
 export const getCourtSections = (
   workingCase: Case,
+  user?: User,
   activeSubSection?: number,
 ): Section => {
   const { id } = workingCase
@@ -275,7 +288,8 @@ export const getCourtSections = (
         name: 'Þingbók',
         href:
           (activeSubSection && activeSubSection > 2) ||
-          (isOverviewStepValidRC(workingCase) &&
+          (hasCourtPermission(workingCase, user) &&
+            isOverviewStepValidRC(workingCase) &&
             isCourtHearingArrangemenstStepValidRC(workingCase))
             ? `${Constants.COURT_RECORD_ROUTE}/${id}`
             : undefined,
@@ -285,7 +299,8 @@ export const getCourtSections = (
         name: 'Úrskurður',
         href:
           (activeSubSection && activeSubSection > 3) ||
-          (isOverviewStepValidRC(workingCase) &&
+          (hasCourtPermission(workingCase, user) &&
+            isOverviewStepValidRC(workingCase) &&
             isCourtHearingArrangemenstStepValidRC(workingCase) &&
             isCourtRecordStepValidRC(workingCase))
             ? `${Constants.RULING_STEP_ONE_ROUTE}/${id}`
@@ -296,7 +311,8 @@ export const getCourtSections = (
         name: 'Úrskurðarorð',
         href:
           (activeSubSection && activeSubSection > 4) ||
-          (isOverviewStepValidRC(workingCase) &&
+          (hasCourtPermission(workingCase, user) &&
+            isOverviewStepValidRC(workingCase) &&
             isCourtHearingArrangemenstStepValidRC(workingCase) &&
             isCourtRecordStepValidRC(workingCase) &&
             isRulingStepOneValidRC(workingCase))
@@ -307,6 +323,7 @@ export const getCourtSections = (
         type: 'SUB_SECTION',
         name: 'Yfirlit úrskurðar',
         href:
+          hasCourtPermission(workingCase, user) &&
           isOverviewStepValidRC(workingCase) &&
           isCourtHearingArrangemenstStepValidRC(workingCase) &&
           isCourtRecordStepValidRC(workingCase) &&


### PR DESCRIPTION
# Fix: Add court permission to step validation

https://app.asana.com/0/1199153462262248/1201408210753231/f

## What

Fix: validate that court(judge or registrar) has permission to open on valid court steps

## Why

For security reasons court (judge or registrar) needs permission to open a case


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
