### PR TITLE
fix(web): Timeline with no future causes errors

### DIFF
--- a/apps/web/components/Organization/Slice/TimelineSlice/TimelineSlice.tsx
+++ b/apps/web/components/Organization/Slice/TimelineSlice/TimelineSlice.tsx
@@ -180,8 +180,11 @@ export const TimelineSlice: React.FC<SliceProps> = ({ slice }) => {
       .map((x, idx) =>
         x.year >= today.getFullYear() && x.month >= today.getMonth() ? idx : 0,
       )
-      .filter((x) => x >= 0)
+      .filter((x) => x > 0)
 
+    if (futureMonths.length === 0) {
+      return 0
+    }
     return Math.min(...futureMonths)
   })
 

--- a/apps/web/components/Organization/Slice/TimelineSlice/TimelineSlice.tsx
+++ b/apps/web/components/Organization/Slice/TimelineSlice/TimelineSlice.tsx
@@ -180,7 +180,7 @@ export const TimelineSlice: React.FC<SliceProps> = ({ slice }) => {
       .map((x, idx) =>
         x.year >= today.getFullYear() && x.month >= today.getMonth() ? idx : 0,
       )
-      .filter((x) => x > 0)
+      .filter((x) => x >= 0)
 
     return Math.min(...futureMonths)
   })


### PR DESCRIPTION
The English website for `/en/o/digital-iceland` is throwing 500 errors
https://island.is/en/o/digital-iceland

When getting months for future, it cannot find anything in this future. Fallback of index `0` given but then the filter filters out with `>0`, sometimes giving it nothing to return

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
