### PR TITLE
fix(national-registry): Extends timout period

### DIFF
--- a/libs/api/domains/national-registry-x-road/src/lib/nationalRegistryXRoad.module.ts
+++ b/libs/api/domains/national-registry-x-road/src/lib/nationalRegistryXRoad.module.ts
@@ -38,6 +38,9 @@ export class NationalRegistryXRoadModule {
             config.xRoadTjodskraApiPath,
           ),
           xRoadClient: config.xRoadClientId,
+          fetch: {
+            timeout: 20000,
+          },
         }),
       ],
       exports: [NationalRegistryXRoadService],


### PR DESCRIPTION
# ...
Extends timeout for national registry api since it is timing out on prod


## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
