### PR TITLE
fix(web): fix double footer

### DIFF
--- a/libs/island-ui/core/src/lib/Navigation/Navigation.tsx
+++ b/libs/island-ui/core/src/lib/Navigation/Navigation.tsx
@@ -360,7 +360,6 @@ const MobileButton = ({ title, colorScheme }: MobileButtonProps) => {
         style={{ top: '50%', transform: 'translateY(-50%)' }}
       >
         <FocusableBox
-          component="button"
           aria-controls={`OpenNavigationDialog`}
           background={colorSchemeColors[colorScheme]['dividerColor']}
           className={styles.dropdownIcon}


### PR DESCRIPTION
https://island.is/s/stafraent-island is showing two footers for whatever reason. I'm not sure what the cause is but it seems to have something to do with `reakit/MenuButton` and nesting another button there within causing strange things to happen. For now this seems to "fix" it... 

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
