### PR TITLE
fix(judicial-system): Fixes prison email in partially accepted custody cases

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/notification/notification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/notification.service.ts
@@ -611,7 +611,8 @@ export class NotificationService {
 
     if (
       existingCase.type === CaseType.CUSTODY &&
-      existingCase.decision === CaseDecision.ACCEPTING
+      (existingCase.decision === CaseDecision.ACCEPTING ||
+        existingCase.decision === CaseDecision.ACCEPTING_PARTIALLY)
     ) {
       recipients.concat(
         await this.sendRulingEmailNotificationToPrison(existingCase),


### PR DESCRIPTION
# Fixes prison email in partially accepted custody cases

https://app.asana.com/0/1199153462262248/1201437594297195/f

## What

- Sends email to prison when custody cases are accepted partially.

## Why

This was a bug.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
