### PR TITLE
fix(license): Use two step method for downloading to bypass Chrome security standards

### DIFF
--- a/libs/api/domains/education/src/lib/s3.service.ts
+++ b/libs/api/domains/education/src/lib/s3.service.ts
@@ -54,11 +54,11 @@ export class S3Service {
 
     return promise
       .then((result) => {
-        const fiveSeconds = 5
+        const oneMinutePlus = 65 // leave extra 5 seconds for network delay
         return this.s3.getSignedUrlPromise('getObject', {
           Bucket: s3Location.bucket,
           Key: result.Key,
-          Expires: fiveSeconds,
+          Expires: oneMinutePlus,
         })
       })
       .catch((err) => {

--- a/libs/service-portal/education-license/src/index.ts
+++ b/libs/service-portal/education-license/src/index.ts
@@ -1,5 +1,4 @@
 import { lazy } from 'react'
-import { defineMessage } from 'react-intl'
 
 import {
   ServicePortalModule,

--- a/libs/service-portal/education-license/src/screens/EducationLicense/components/LicenseCards/LicenseCards.css.ts
+++ b/libs/service-portal/education-license/src/screens/EducationLicense/components/LicenseCards/LicenseCards.css.ts
@@ -1,0 +1,22 @@
+import { style } from '@vanilla-extract/css'
+import { theme, themeUtils } from '@island.is/island-ui/theme'
+
+export const modal = style({
+  position: 'relative',
+  maxWidth: `calc(100% - ${theme.spacing['6']}px)`,
+  maxHeight: `calc(100% - ${theme.spacing['6']}px)`,
+  margin: theme.spacing['3'],
+  borderRadius: theme.border.radius.large,
+  overflowY: 'auto',
+  boxShadow: '0px 4px 70px rgba(0, 97, 255, 0.1)',
+  ...themeUtils.responsiveStyle({
+    md: {
+      margin: `${theme.spacing['6']}px auto`,
+      maxHeight: `calc(100% - ${theme.spacing['12']}px)`,
+      width: '90%',
+    },
+    lg: {
+      width: 828,
+    },
+  }),
+})


### PR DESCRIPTION
## What

Use two step process for downloading, i.e.
1. first request an e-sealed documentation
2. download it

## Why

The previous implementation violates the Content Security Policy directive: "connect-src 'self'" which was newly set and started to break the downloads.

## Screenshots / Gifs

### Process
![fixfix](https://user-images.githubusercontent.com/5694851/143871019-60f30d6b-67a7-4c15-a818-d154f1cd70dc.gif)

### After the link runs out
![image](https://user-images.githubusercontent.com/5694851/143872021-312d7aa9-0774-4a0b-a89c-84b20c1f15f8.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
