### PR TITLE
fix(ci): Use temporary published version of island-is/cache

### DIFF
--- a/.github/actions/unit-test/action.yml
+++ b/.github/actions/unit-test/action.yml
@@ -11,13 +11,13 @@ runs:
   using: 'composite'
   steps:
     - name: Cache for NodeJS dependencies - host OS
-      uses: ./cache/
+      uses: island-is/cache@v0.1
       with:
         path: node_modules
         key: ${{ inputs.node-modules-hash }}-yarn
 
     - name: Cache for generated files
-      uses: ./cache/
+      uses: island-is/cache@v0.1
       with:
         path: generated_files.tar.gz
         key: ${{ inputs.generated-files-cache-key }}

--- a/.github/workflows/config-values.yaml
+++ b/.github/workflows/config-values.yaml
@@ -45,14 +45,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/checkout@v2
-        with:
-          repository: 'island-is/cache'
-          path: 'cache/'
-
       - name: Cache for NodeJS dependencies
         id: node-modules
-        uses: ./cache/
+        uses: island-is/cache@v0.1
         with:
           path: infra/node_modules
           key: ${{ runner.os }}-${{ hashFiles('infra/yarn.lock') }}-infra
@@ -78,15 +73,10 @@ jobs:
       matrix: ${{ fromJson(needs.prepare.outputs.ENVS) }}
     steps:
       - uses: actions/checkout@v2
-
-      - uses: actions/checkout@v2
-        with:
-          repository: 'island-is/cache'
-          path: 'cache/'
-
+      
       - name: Cache for NodeJS dependencies
         id: node-modules
-        uses: ./cache/
+        uses: island-is/cache@v0.1
         with:
           path: infra/node_modules
           key: ${{ runner.os }}-${{ hashFiles('infra/yarn.lock') }}-infra

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -31,10 +31,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: actions/checkout@v2
-        with:
-          repository: 'island-is/cache'
-          path: 'cache/'
 
       - run: |
           echo "HEAD=$GITHUB_SHA" >> $GITHUB_ENV
@@ -60,7 +56,7 @@ jobs:
 
       - name: Cache for NodeJS dependencies - host OS
         id: node-modules
-        uses: ./cache/
+        uses: island-is/cache@v0.1
         with:
           path: node_modules
           key: ${{ steps.calculate_node_modules_hash.outputs.node-modules-hash }}-yarn
@@ -70,7 +66,7 @@ jobs:
         run: ./scripts/ci/10_prepare-host-deps.sh
 
       - name: Cache for cypress
-        uses: ./cache/
+        uses: island-is/cache@v0.1
         with:
           path: ~/.cache/Cypress
           key: cypress-cache-${{ steps.calculate_node_modules_hash.outputs.node-modules-hash }}
@@ -86,7 +82,7 @@ jobs:
 
       - name: Cache for generated files
         id: generated-files-cache
-        uses: ./cache/
+        uses: island-is/cache@v0.1
         with:
           path: generated_files.tar.gz
           key: ${{ steps.calculate_generated_files_cache_key.outputs.generated-files-cache-key }}
@@ -154,10 +150,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: actions/checkout@v2
-        with:
-          repository: 'island-is/cache'
-          path: 'cache/'
 
       - uses: ./.github/actions/unit-test
         with:
@@ -183,25 +175,21 @@ jobs:
       matrix: ${{ fromJson(needs.prepare.outputs.E2E_CHUNKS) }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/checkout@v2
-        with:
-          repository: 'island-is/cache'
-          path: 'cache/'
 
       - name: Cache for NodeJS dependencies - host OS
-        uses: ./cache
+        uses: island-is/cache@v0.1
         with:
           path: node_modules
           key: ${{ needs.prepare.outputs.node-modules-hash }}-yarn
 
       - name: Cache for cypress
-        uses: ./cache
+        uses: island-is/cache@v0.1
         with:
           path: ~/.cache/Cypress
           key: cypress-cache-${{ needs.prepare.outputs.node-modules-hash }}
 
       - name: Cache for generated files
-        uses: ./cache
+        uses: island-is/cache@v0.1
         with:
           path: generated_files.tar.gz
           key: ${{ needs.prepare.outputs.generated-files-cache-key }}
@@ -222,13 +210,9 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/checkout@v2
-        with:
-          repository: 'island-is/cache'
-          path: 'cache/'
       - name: Cache for NodeJS dependencies - host OS
         id: node-modules
-        uses: ./cache
+        uses: island-is/cache@v0.1
         with:
           path: node_modules
           key: ${{ needs.prepare.outputs.node-modules-hash }}-yarn
@@ -247,13 +231,9 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/checkout@v2
-        with:
-          repository: 'island-is/cache'
-          path: 'cache/'
       - name: Cache for NodeJS dependencies - host OS
         id: node-modules
-        uses: ./cache
+        uses: island-is/cache@v0.1
         with:
           path: node_modules
           key: ${{ needs.prepare.outputs.node-modules-hash }}-yarn
@@ -275,19 +255,15 @@ jobs:
       matrix: ${{ fromJson(needs.prepare.outputs.LINT_CHUNKS) }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/checkout@v2
-        with:
-          repository: 'island-is/cache'
-          path: 'cache/'
 
       - name: Cache for NodeJS dependencies - host OS
-        uses: ./cache
+        uses: island-is/cache@v0.1
         with:
           path: node_modules
           key: ${{ needs.prepare.outputs.node-modules-hash }}-yarn
 
       - name: Cache for generated files
-        uses: ./cache
+        uses: island-is/cache@v0.1
         with:
           path: generated_files.tar.gz
           key: ${{ needs.prepare.outputs.generated-files-cache-key }}
@@ -312,19 +288,15 @@ jobs:
     if: needs.prepare.outputs.BUILD_CHUNKS
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/checkout@v2
-        with:
-          repository: 'island-is/cache'
-          path: 'cache/'
 
       - name: Cache for NodeJS dependencies - host OS
-        uses: ./cache
+        uses: island-is/cache@v0.1
         with:
           path: node_modules
           key: ${{ needs.prepare.outputs.node-modules-hash }}-yarn
 
       - name: Cache for generated files
-        uses: ./cache
+        uses: island-is/cache@v0.1
         with:
           path: generated_files.tar.gz
           key: ${{ needs.prepare.outputs.generated-files-cache-key }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -126,10 +126,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: actions/checkout@v2
-        with:
-          repository: 'island-is/cache'
-          path: 'cache/'
 
       - name: Cleanup disk space
         run: |
@@ -216,14 +212,14 @@ jobs:
 
       - name: Cache for NodeJS dependencies - Docker layer
         id: cache-deps
-        uses: ./cache/
+        uses: island-is/cache@v0.1
         with:
           path: cache
           key: ${{ steps.calculate_node_modules_hash.outputs.node-modules-hash }}-docker-deps
 
       - name: Cache for NodeJS dependencies - Docker layer
         id: cache-deps-base
-        uses: ./cache/
+        uses: island-is/cache@v0.1
         with:
           path: cache_output
           key: ${{ steps.calculate_node_modules_hash.outputs.node-modules-hash }}-docker-output-base
@@ -234,7 +230,7 @@ jobs:
 
       - name: Cache for NodeJS dependencies - host OS
         id: node-modules
-        uses: ./cache/
+        uses: island-is/cache@v0.1
         with:
           path: node_modules
           key: ${{ steps.calculate_node_modules_hash.outputs.node-modules-hash }}-yarn
@@ -248,7 +244,7 @@ jobs:
 
       - name: Cache for generated files
         id: generated-files-cache
-        uses: ./cache/
+        uses: island-is/cache@v0.1
         with:
           path: generated_files.tar.gz
           key: ${{ steps.calculate_generated_files_cache_key.outputs.generated-files-cache-key }}
@@ -308,10 +304,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: actions/checkout@v2
-        with:
-          repository: 'island-is/cache'
-          path: 'cache/'
 
       - uses: ./.github/actions/unit-test
         with:
@@ -346,14 +338,9 @@ jobs:
         continue-on-error: true
       - uses: actions/checkout@v2
         if: steps.gather.outcome == 'success'
-      - uses: actions/checkout@v2
-        if: steps.gather.outcome == 'success'
-        with:
-          repository: 'island-is/cache'
-          path: 'cache/'
       - name: Cache for generated files
         if: steps.gather.outcome == 'success'
-        uses: ./cache/
+        uses: island-is/cache@v0.1
         with:
           path: generated_files.tar.gz
           key: ${{ needs.prepare.outputs.generated-files-cache-key }}
@@ -365,14 +352,14 @@ jobs:
       - name: Cache for dependencies Docker layer
         if: steps.gather.outcome == 'success'
         id: cache-deps
-        uses: ./cache/
+        uses: island-is/cache@v0.1
         with:
           path: cache_output
           key: ${{ needs.prepare.outputs.node-modules-hash }}-docker-output-base
 
       - name: Cache for NodeJS dependencies - Docker layer
         if: steps.gather.outcome == 'success'
-        uses: ./cache/
+        uses: island-is/cache@v0.1
         with:
           path: cache
           key: ${{ needs.prepare.outputs.node-modules-hash }}-docker-deps


### PR DESCRIPTION
To maybe get rid of API rate limiting... This should be temporary until either https://github.com/actions/toolkit/pull/947 or https://github.com/actions/cache/pull/679 are accepted and released