### PR TITLE
fix(regulations/web): remove cacheOptions from RegulationsService

### DIFF
--- a/libs/clients/regulations/src/lib/regulations.ts
+++ b/libs/clients/regulations/src/lib/regulations.ts
@@ -26,7 +26,6 @@ export const REGULATIONS_OPTIONS = 'REGULATIONS_OPTIONS'
 
 export interface RegulationsServiceOptions {
   url: string
-  ttl?: number
 }
 
 export class RegulationsService extends RESTDataSource {
@@ -65,11 +64,9 @@ export class RegulationsService extends RESTDataSource {
       isCustomDiff,
       earlierDate,
     })
-    const ttl = this.options.ttl ?? 600 // defaults to 10 minutes
-
     const response = await this.get<
       Regulation | RegulationDiff | RegulationRedirect | null
-    >(url, { cacheOptions: { ttl } })
+    >(url)
     return response
   }
 
@@ -80,9 +77,6 @@ export class RegulationsService extends RESTDataSource {
     page = page && page > 1 ? page : undefined
     const response = await this.get<RegulationSearchResults | null>(
       `regulations/${type}${page ? '?page=' + page : ''}`,
-      {
-        cacheOptions: { ttl: this.options.ttl ?? 600 }, // defaults to 10 minutes
-      },
     )
     return response
   }
@@ -102,27 +96,17 @@ export class RegulationsService extends RESTDataSource {
       // Strip away empty params
       // Object.fromEntries(Object.entries({ q, rn, year, yearTo, ch, iA, iR, page }).filter((val) => val))
       pickBy({ q, rn, year, yearTo, ch, iA, iR, page }, identity),
-      {
-        cacheOptions: { ttl: this.options.ttl ?? 600 }, // defaults to 10 minutes
-      },
     )
     return response
   }
 
   async getRegulationsYears(): Promise<RegulationYears | null> {
-    const response = await this.get<RegulationYears | null>(`years`, {
-      cacheOptions: { ttl: this.options.ttl ?? 600 }, // defaults to 10 minutes
-    })
+    const response = await this.get<RegulationYears | null>(`years`)
     return response
   }
 
   async getRegulationsMinistries(): Promise<RegulationMinistryList | null> {
-    const response = await this.get<RegulationMinistryList | null>(
-      `ministries`,
-      {
-        cacheOptions: { ttl: this.options.ttl ?? 600 }, // defaults to 10 minutes
-      },
-    )
+    const response = await this.get<RegulationMinistryList | null>(`ministries`)
     return response
   }
 
@@ -131,9 +115,6 @@ export class RegulationsService extends RESTDataSource {
   ): Promise<RegulationLawChapterTree | null> {
     const response = await this.get<RegulationLawChapterTree | null>(
       `lawchapters${tree ? '/tree' : ''}`,
-      {
-        cacheOptions: { ttl: this.options.ttl ?? 600 }, // defaults to 10 minutes
-      },
     )
     return response
   }


### PR DESCRIPTION
## Why

Graphql caching is behaving strangely, these requests are being cached in too many places.

Regulation data and search results are getting cached for days on end, resulting in badly outdated information.

FWIW, The up-stream API sets nicely behaved HTTP Cache-Control headers.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
