### PR TITLE
feat(core): Feature flag library for Nest APIs

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -210,6 +210,7 @@
 - [Nest Modules](libs/nest/README.md)
   - [Audit Module](libs/nest/audit/README.md)
   - [Nest Config](libs/nest/config/README.md)
+  - [Nest Feature Flags](libs/nest/feature-flags/README.md)
   - [Nest Sequelize Cursor Pagination](libs/nest/pagination/README.md)
   - [Problem Module](libs/nest/problem/README.md)
 - [Next Ids Auth Lib](libs/next-ids-auth/README.md)

--- a/jest.config.js
+++ b/jest.config.js
@@ -153,6 +153,7 @@ module.exports = {
     '<rootDir>/libs/judicial-system/types',
     '<rootDir>/libs/nest/audit',
     '<rootDir>/libs/nest/config',
+    '<rootDir>/libs/nest/feature-flags',
     '<rootDir>/libs/nest/problem',
     '<rootDir>/libs/react/feature-flags',
     '<rootDir>/libs/service-portal/applications',

--- a/libs/feature-flags/README.md
+++ b/libs/feature-flags/README.md
@@ -5,7 +5,7 @@ This library is a low-level wrapper for whatever feature flag service **Island.i
 For high-level libraries, check out the following:
 
 - [`@island.is/react/feature-flags`](../react/feature-flags/README.md)
-- `@island.is/nest/feature-flags` (...coming soon)
+- [`@island.is/nest/feature-flags`](../nest/feature-flags/README.md)
 
 {% hint style="warning" %}
 Feature flagging is a way to soft launch a "beta ready" feature to a specific

--- a/libs/feature-flags/src/lib/configcat.ts
+++ b/libs/feature-flags/src/lib/configcat.ts
@@ -32,6 +32,10 @@ export class Client implements FeatureFlagClient {
     }
   }
 
+  dispose() {
+    this.configcat.dispose()
+  }
+
   async getValue(
     key: string,
     defaultValue: boolean | string,

--- a/libs/feature-flags/src/lib/types.ts
+++ b/libs/feature-flags/src/lib/types.ts
@@ -13,6 +13,8 @@ export interface FeatureFlagClient {
     defaultValue: boolean | string,
     user?: FeatureFlagUser,
   ): Promise<boolean | string>
+
+  dispose(): void
 }
 
 export interface FeatureFlagClientProps {

--- a/libs/infra-nest-server/src/lib/buildOpenApi.ts
+++ b/libs/infra-nest-server/src/lib/buildOpenApi.ts
@@ -24,7 +24,15 @@ export const buildOpenApi = async ({
     })
     const document = SwaggerModule.createDocument(app, openApi)
 
-    return writeFileSync(path, yaml.dump(document, { noRefs: true }))
+    writeFileSync(path, yaml.dump(document, { noRefs: true }))
+
+    // Shut down everything so the process ends.
+    await app.close()
+
+    // Unfortunately, the above is not enough sometimes because of this bug:
+    // https://github.com/configcat/common-js/issues/36
+    // TODO: Remove this when it's been fixed.
+    process.exit(0)
   } catch (e) {
     logger.error('Error while creating openapi.yaml', { message: e.message })
   }

--- a/libs/nest/feature-flags/.eslintrc.json
+++ b/libs/nest/feature-flags/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "rules": {}
+}

--- a/libs/nest/feature-flags/README.md
+++ b/libs/nest/feature-flags/README.md
@@ -1,0 +1,112 @@
+# Nest Feature Flags
+
+A Nest module which wraps our low level [feature flagging library](../../feature-flags/README.md) with some handy nest utilities.
+
+## Setup
+
+To use the FeatureFlag module you first need to load its configuration in your app module and make sure CONFIGCAT_SDK_KEY is set in your production environment.
+
+```tsx
+import { Module } from '@nestjs/common'
+import { ConfigModule } from '@island.is/nest/config'
+import { FeatureFlagConfig } from '@island.is/nest/feature-flags'
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      load: [FeatureFlagConfig],
+    }),
+  ],
+})
+export class AppModule {}
+```
+
+Then you can import it anywhere you need one of its exports:
+
+```tsx
+import { Module } from '@nestjs/common'
+import { FeatureFlagModule } from '@island.is/nest/feature-flags'
+
+@Module({
+  imports: [FeatureFlagModule],
+})
+export class SomeModule {}
+```
+
+## FeatureFlagService
+
+The service wraps getValue with support for our server-side [User objects](../../auth-nest-tools/README.md) for checking if they have access to a feature.
+
+```tsx
+import { FeatureFlagService, Features } from '@island.is/nest/feature-flags'
+import { User } from '@island.is/auth-nest-tools'
+
+export class YourService {
+  constructor(private readonly featureFlagService: FeatureFlagService) {}
+
+  maybeDoSomething(user: User) {
+    const canDoSomething = this.featureFlagService.getValue(
+      Features.someFeature,
+      false,
+      user,
+    )
+
+    if (canDoIt) {
+      return this.doSomething()
+    }
+  }
+}
+```
+
+## FeatureFlagGuard
+
+If your feature has new API endpoints, you can use the FeatureFlagGuard to disable them completely:
+
+```tsx
+import { Controller, Get, UseGuards } from '@nestjs/common'
+import {
+  FeatureFlagGuard,
+  FeatureFlag,
+  Features,
+} from '@island.is/nest/feature-flags'
+
+@UseGuards(IdsUserGuard, FeatureFlagGuard)
+@Controller('some')
+export class SomeController {
+  @Get()
+  @FeatureFlag(Features.someFeature)
+  getSomething() {
+    // Will only reach here if someFeature is turned on, either globally or for the authenticated user.
+  }
+}
+```
+
+The guard works both for GraphQL resolvers as well as REST controllers.
+
+{% hint style="warning" %}
+The FeatureFlagGuard MUST be listed after IdsUserGuard in the `@UseGuards()` decorator if you want it to support user-specific feature flags.
+{% endhint %}
+
+## FeatureFlagClient
+
+If you need access to the low level client and getValue functions, you can dependency inject it like this:
+
+```tsx
+import { Inject } from '@nestjs/common'
+import {
+  FeatureFlagClient,
+  FEATURE_FLAG_CLIENT,
+} from '@island.is/nest/feature-flags'
+
+export class YourService {
+  constructor(
+    @Inject(FEATURE_FLAG_CLIENT)
+    private readonly client: FeatureFlagClient,
+  ) {}
+}
+```
+
+## Running unit tests
+
+Run `nx test nest-feature-flags` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/nest/feature-flags/README.md
+++ b/libs/nest/feature-flags/README.md
@@ -45,8 +45,8 @@ import { User } from '@island.is/auth-nest-tools'
 export class YourService {
   constructor(private readonly featureFlagService: FeatureFlagService) {}
 
-  maybeDoSomething(user: User) {
-    const canDoSomething = this.featureFlagService.getValue(
+  async maybeDoSomething(user: User) {
+    const canDoSomething = await this.featureFlagService.getValue(
       Features.someFeature,
       false,
       user,

--- a/libs/nest/feature-flags/jest.config.js
+++ b/libs/nest/feature-flags/jest.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  displayName: 'nest-feature-flags',
+  preset: '../../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsConfig: '<rootDir>/tsconfig.spec.json',
+    },
+  },
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../../coverage/libs/nest/feature-flags',
+}

--- a/libs/nest/feature-flags/src/index.ts
+++ b/libs/nest/feature-flags/src/index.ts
@@ -1,0 +1,9 @@
+export * from './lib/feature-flag.module'
+export * from './lib/feature-flag.service'
+export * from './lib/feature-flag.config'
+export { FEATURE_FLAG_CLIENT } from './lib/feature-flag.client'
+export * from './lib/feature-flag.decorator'
+export * from './lib/feature-flag.guard'
+
+export { Features } from '@island.is/feature-flags'
+export type { FeatureFlagClient } from '@island.is/feature-flags'

--- a/libs/nest/feature-flags/src/lib/feature-flag.client.ts
+++ b/libs/nest/feature-flags/src/lib/feature-flag.client.ts
@@ -1,0 +1,14 @@
+import { ConfigType } from '@island.is/nest/config'
+import { createClient } from '@island.is/feature-flags'
+
+import { FeatureFlagConfig } from './feature-flag.config'
+
+export const FEATURE_FLAG_CLIENT = 'FeatureFlagClient'
+
+export const FeatureFlagClientProvider = {
+  provide: FEATURE_FLAG_CLIENT,
+  inject: [FeatureFlagConfig.KEY],
+  useFactory({ sdkKey }: ConfigType<typeof FeatureFlagConfig>) {
+    return createClient({ sdkKey })
+  },
+}

--- a/libs/nest/feature-flags/src/lib/feature-flag.config.ts
+++ b/libs/nest/feature-flags/src/lib/feature-flag.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@island.is/nest/config'
+
+export const FeatureFlagConfig = defineConfig({
+  name: 'FeatureFlag',
+  load: (env) => ({
+    sdkKey: env.required(
+      'CONFIGCAT_SDK_KEY',
+      'YcfYCOwBTUeI04mWOWpPdA/KgCHhUk0_k2BdiKMaNh3qA',
+    ),
+  }),
+})

--- a/libs/nest/feature-flags/src/lib/feature-flag.decorator.ts
+++ b/libs/nest/feature-flags/src/lib/feature-flag.decorator.ts
@@ -1,0 +1,7 @@
+import { SetMetadata } from '@nestjs/common'
+import { Features } from '@island.is/feature-flags'
+
+export const FEATURE_FLAG_KEY = 'featureFlag'
+
+export const FeatureFlag = (featureFlag: Features) =>
+  SetMetadata(FEATURE_FLAG_KEY, featureFlag)

--- a/libs/nest/feature-flags/src/lib/feature-flag.guard.spec.ts
+++ b/libs/nest/feature-flags/src/lib/feature-flag.guard.spec.ts
@@ -1,0 +1,127 @@
+import request from 'supertest'
+import { Controller, Get, INestApplication, UseGuards } from '@nestjs/common'
+import { Test } from '@nestjs/testing'
+import { ConfigModule } from '@island.is/nest/config'
+import { IdsUserGuard, MockAuthGuard } from '@island.is/auth-nest-tools'
+import { createCurrentUser } from '@island.is/testing/fixtures'
+
+import {
+  FeatureFlagGuard,
+  FeatureFlag,
+  Features,
+  FeatureFlagModule,
+  FeatureFlagConfig,
+  FEATURE_FLAG_CLIENT,
+} from '../'
+import { GraphQLModule, Query, Resolver } from '@nestjs/graphql'
+
+const testUser = createCurrentUser()
+const testFeature = 'test' as Features
+
+@UseGuards(IdsUserGuard, FeatureFlagGuard)
+@Controller('rest')
+export class TestController {
+  @Get()
+  @FeatureFlag(testFeature)
+  getSomething() {
+    // Will only reach here if someFeature is turned on, either globally or for the authenticated user.
+  }
+}
+
+@UseGuards(IdsUserGuard, FeatureFlagGuard)
+@Resolver()
+export class TestResolver {
+  @Query(() => Boolean, { nullable: true })
+  @FeatureFlag(testFeature)
+  getSomething() {
+    // Will only reach here if someFeature is turned on, either globally or for the authenticated user.
+  }
+}
+
+describe('FeatureFlagGuard', () => {
+  let app: INestApplication
+  const featureFlagClient = {
+    getValue: jest.fn(),
+  }
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [TestController],
+      providers: [TestResolver],
+      imports: [
+        FeatureFlagModule,
+        GraphQLModule.forRoot({ autoSchemaFile: true, path: '/graphql' }),
+        ConfigModule.forRoot({ isGlobal: true, load: [FeatureFlagConfig] }),
+      ],
+    })
+      .overrideProvider(FEATURE_FLAG_CLIENT)
+      .useValue(featureFlagClient)
+      .overrideGuard(IdsUserGuard)
+      .useValue(new MockAuthGuard(testUser))
+      .compile()
+
+    app = moduleRef.createNestApplication()
+    await app.init()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('guards controller if feature is disabled', () => {
+    // Arrange
+    featureFlagClient.getValue.mockResolvedValue(false)
+
+    // Act
+    return request(app.getHttpServer()).get('/rest').expect(403)
+  })
+
+  it('allows controller if feature is enabled', async () => {
+    // Arrange
+    featureFlagClient.getValue.mockResolvedValue(true)
+
+    // Act
+    return request(app.getHttpServer()).get('/rest').expect(200)
+  })
+
+  it('passes user details to getValue', async () => {
+    // Act
+    await request(app.getHttpServer()).get('/rest')
+
+    // Assert
+    expect(featureFlagClient.getValue).toHaveBeenCalledWith(
+      testFeature,
+      false,
+      {
+        id: testUser.nationalId,
+      },
+    )
+  })
+
+  it('guards resolver if feature is disabled', async () => {
+    // Arrange
+    featureFlagClient.getValue.mockResolvedValue(false)
+
+    // Act
+    const response = await request(app.getHttpServer())
+      .get('/graphql')
+      .query({ query: '{ getSomething }' })
+
+    // Assert
+    expect(response.body).toMatchObject({
+      data: { getSomething: null },
+      errors: [{ message: 'Forbidden resource' }],
+    })
+  })
+
+  it('allows resolver if feature is enabled', async () => {
+    // Arrange
+    featureFlagClient.getValue.mockResolvedValue(true)
+
+    // Act
+    return request(app.getHttpServer())
+      .get('/graphql')
+      .query({ query: '{ getSomething }' })
+      .expect(200)
+  })
+})

--- a/libs/nest/feature-flags/src/lib/feature-flag.guard.ts
+++ b/libs/nest/feature-flags/src/lib/feature-flag.guard.ts
@@ -1,0 +1,33 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common'
+import { Reflector } from '@nestjs/core'
+import { getRequest } from '@island.is/auth-nest-tools'
+import { Features } from '@island.is/feature-flags'
+
+import { FeatureFlagService } from './feature-flag.service'
+import { FEATURE_FLAG_KEY } from './feature-flag.decorator'
+
+@Injectable()
+export class FeatureFlagGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly featureFlagService: FeatureFlagService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const featureFlag = this.reflector.get<Features | undefined>(
+      FEATURE_FLAG_KEY,
+      context.getHandler(),
+    )
+    if (!featureFlag) {
+      return true
+    }
+
+    const request = getRequest(context)
+    const value = await this.featureFlagService.getValue(
+      featureFlag,
+      false,
+      request.user,
+    )
+    return !!value
+  }
+}

--- a/libs/nest/feature-flags/src/lib/feature-flag.module.ts
+++ b/libs/nest/feature-flags/src/lib/feature-flag.module.ts
@@ -1,5 +1,10 @@
-import { Module } from '@nestjs/common'
-import { FeatureFlagClientProvider } from './feature-flag.client'
+import { Inject, Module } from '@nestjs/common'
+import { FeatureFlagClient } from '@island.is/feature-flags'
+
+import {
+  FEATURE_FLAG_CLIENT,
+  FeatureFlagClientProvider,
+} from './feature-flag.client'
 import { FeatureFlagService } from './feature-flag.service'
 
 @Module({
@@ -7,4 +12,13 @@ import { FeatureFlagService } from './feature-flag.service'
   providers: [FeatureFlagClientProvider, FeatureFlagService],
   exports: [FeatureFlagClientProvider, FeatureFlagService],
 })
-export class FeatureFlagModule {}
+export class FeatureFlagModule {
+  constructor(
+    @Inject(FEATURE_FLAG_CLIENT)
+    private readonly client: FeatureFlagClient,
+  ) {}
+
+  onApplicationShutdown() {
+    this.client.dispose()
+  }
+}

--- a/libs/nest/feature-flags/src/lib/feature-flag.module.ts
+++ b/libs/nest/feature-flags/src/lib/feature-flag.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common'
+import { FeatureFlagClientProvider } from './feature-flag.client'
+import { FeatureFlagService } from './feature-flag.service'
+
+@Module({
+  controllers: [],
+  providers: [FeatureFlagClientProvider, FeatureFlagService],
+  exports: [FeatureFlagClientProvider, FeatureFlagService],
+})
+export class FeatureFlagModule {}

--- a/libs/nest/feature-flags/src/lib/feature-flag.service.ts
+++ b/libs/nest/feature-flags/src/lib/feature-flag.service.ts
@@ -1,0 +1,17 @@
+import { Inject } from '@nestjs/common'
+import type { User } from '@island.is/auth-nest-tools'
+import { Features, FeatureFlagClient } from '@island.is/feature-flags'
+
+import { FEATURE_FLAG_CLIENT } from './feature-flag.client'
+
+export class FeatureFlagService {
+  constructor(
+    @Inject(FEATURE_FLAG_CLIENT)
+    private readonly client: FeatureFlagClient,
+  ) {}
+
+  getValue(feature: Features, defaultValue: boolean | string, user?: User) {
+    const featureFlagUser = user && { id: user.nationalId }
+    return this.client.getValue(feature, defaultValue, featureFlagUser)
+  }
+}

--- a/libs/nest/feature-flags/tsconfig.json
+++ b/libs/nest/feature-flags/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/nest/feature-flags/tsconfig.lib.json
+++ b/libs/nest/feature-flags/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"],
+    "target": "es6"
+  },
+  "exclude": ["**/*.spec.ts"],
+  "include": ["**/*.ts"]
+}

--- a/libs/nest/feature-flags/tsconfig.spec.json
+++ b/libs/nest/feature-flags/tsconfig.spec.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.spec.js",
+    "**/*.spec.jsx",
+    "**/*.d.ts"
+  ]
+}

--- a/libs/react/feature-flags/src/lib/context.tsx
+++ b/libs/react/feature-flags/src/lib/context.tsx
@@ -8,6 +8,8 @@ import { useAuth } from '@island.is/auth/react'
 
 const FeatureFlagContext = createContext<FeatureFlagClient>({
   getValue: (_, defaultValue) => Promise.resolve(defaultValue),
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  dispose() {},
 })
 
 export interface FeatureFlagContextProviderProps {
@@ -45,6 +47,7 @@ export const FeatureFlagProvider: FC<FeatureFlagContextProviderProps> = ({
       ) {
         return featureFlagClient.getValue(key, defaultValue, user)
       },
+      dispose: () => featureFlagClient.dispose(),
     }
   }, [featureFlagClient, userInfo, userProp])
 
@@ -76,6 +79,8 @@ export const MockedFeatureFlagProvider: FC<MockedFeatureFlagProviderProps> = ({
       getValue: async (key, defaultValue) => {
         return cleanFlags[key] ?? defaultValue
       },
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      dispose() {},
     }
   }, [flags])
 

--- a/nx.json
+++ b/nx.json
@@ -534,6 +534,9 @@
     "nest-config": {
       "tags": []
     },
+    "nest-feature-flags": {
+      "tags": []
+    },
     "nest-pagination": {
       "tags": []
     },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -350,6 +350,7 @@
       "@island.is/message-queue": ["libs/message-queue/src/index.ts"],
       "@island.is/nest/audit": ["libs/nest/audit/src/index.ts"],
       "@island.is/nest/config": ["libs/nest/config/src/index.ts"],
+      "@island.is/nest/feature-flags": ["libs/nest/feature-flags/src/index.ts"],
       "@island.is/nest/pagination": ["libs/nest/pagination/src/index.ts"],
       "@island.is/nest/problem": ["libs/nest/problem/src/index.ts"],
       "@island.is/nest/validators": ["libs/nest/validators/src/index.ts"],

--- a/workspace.json
+++ b/workspace.json
@@ -6212,6 +6212,27 @@
         }
       }
     },
+    "nest-feature-flags": {
+      "root": "libs/nest/feature-flags",
+      "sourceRoot": "libs/nest/feature-flags/src",
+      "projectType": "library",
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:eslint",
+          "options": {
+            "lintFilePatterns": ["libs/nest/feature-flags/**/*.ts"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "outputs": ["coverage/libs/nest/feature-flags"],
+          "options": {
+            "jestConfig": "libs/nest/feature-flags/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
     "nest-pagination": {
       "root": "libs/nest/pagination",
       "sourceRoot": "libs/nest/pagination/src",


### PR DESCRIPTION
## What

A feature flag library for our APIs. Wraps the low level API to provide support for our user objects, consistent with the `@island.is/react/feature-flags` library.

Also includes a NestJS guard to wrap entire endpoints and resolvers behind feature flags.

[Readme](https://github.com/island-is/island.is/blob/nest-feature-flag/libs/nest/feature-flags/README.md)

## Why

To make it easier to use feature flags in our APIs.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
