### PR TITLE
fix(application-system-api): use server side feature flag for deciding v1/v2 driving license service

### DIFF
--- a/apps/application-system/api/jest.config.js
+++ b/apps/application-system/api/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   setupFiles: ['./test/environment.jest.ts'],
   setupFilesAfterEnv: ['./test/setup.ts'],
   moduleFileExtensions: ['ts', 'js', 'html', 'json'],
+  testEnvironment: 'node',
   globals: {
     'ts-jest': {
       tsConfig: '<rootDir>/tsconfig.spec.json',

--- a/apps/application-system/api/src/environments/environment.ts
+++ b/apps/application-system/api/src/environments/environment.ts
@@ -1,3 +1,4 @@
+import { ServerSideFeatureClient } from '@island.is/feature-flags'
 import { Environment } from './environment.interface'
 
 const devConfig = {
@@ -186,7 +187,11 @@ const prodConfig = {
         xroadClientId: process.env.XROAD_CLIENT_ID,
         xroadBaseUrl: process.env.XROAD_BASE_PATH,
         xroadPathV1: process.env.XROAD_DRIVING_LICENSE_PATH,
-        xroadPathV2: process.env.XROAD_DRIVING_LICENSE_V2_PATH,
+        xroadPathV2: ServerSideFeatureClient.isOn(
+          'driving-license-use-v1-endpoint-for-v2-comms',
+        )
+          ? process.env.XROAD_DRIVING_LICENSE_PATH
+          : process.env.XROAD_DRIVING_LICENSE_V2_PATH,
       },
     },
     paymentOptions: {


### PR DESCRIPTION
This got updated for api domains, but we missed it for this one

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
