### PR TITLE
fix(service-portal): missing data in detail view properties

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -102,6 +102,7 @@
 /apps/web/components/Regulations/                                                             @island-is/hugsmidjan
 /libs/api/domains/documents/                                                                  @island-is/hugsmidjan
 /libs/api/domains/finance/                                                                    @island-is/hugsmidjan
+/libs/api/domains/assets/                                                                     @island-is/hugsmidjan
 /libs/api/domains/license-service/                                                            @island-is/hugsmidjan
 /libs/api/domains/national-registry/                                                          @island-is/hugsmidjan
 /libs/clients/finance/                                                                        @island-is/hugsmidjan

--- a/libs/api/domains/assets/src/lib/api-domains-assets.service.ts
+++ b/libs/api/domains/assets/src/lib/api-domains-assets.service.ts
@@ -43,6 +43,10 @@ export class AssetsXRoadService {
       cursor: cursor,
     })
 
+    console.log(
+      'fasteignirResponsefasteignirResponsefasteignirResponse',
+      fasteignirResponse,
+    )
     if (fasteignirResponse) {
       return {
         paging: fasteignirResponse.paging,
@@ -68,6 +72,10 @@ export class AssetsXRoadService {
       auth,
     ).fasteignirGetFasteign({ fasteignanumer: getAssetString(assetId) })
 
+    console.log(
+      'singleFasteignResponsesingleFasteignResponsesingleFasteignResponse__ DETAIL__',
+      singleFasteignResponse,
+    )
     if (singleFasteignResponse) {
       return {
         propertyNumber: singleFasteignResponse.fasteignanumer,
@@ -117,12 +125,19 @@ export class AssetsXRoadService {
               propertyNumber: unit.fasteignanumer,
               unitOfUseNumber: unit.notkunareininganumer,
               address: {
-                displayShort: unit.stadfang?.birtingStutt,
-                display: unit.stadfang?.birting,
-                propertyNumber: unit.stadfang?.landeignarnumer,
-                municipality: unit.stadfang?.sveitarfelagBirting,
-                postNumber: unit.stadfang?.postnumer,
-                locationNumber: unit.stadfang?.stadfanganumer,
+                // This does not come from the service as the service is set up today. Needs to come from parent as things stand.
+                displayShort:
+                  singleFasteignResponse.sjalfgefidStadfang?.birtingStutt,
+                display: singleFasteignResponse.sjalfgefidStadfang?.birting,
+                propertyNumber:
+                  singleFasteignResponse.sjalfgefidStadfang?.landeignarnumer,
+                municipality:
+                  singleFasteignResponse.sjalfgefidStadfang
+                    ?.sveitarfelagBirting,
+                postNumber:
+                  singleFasteignResponse.sjalfgefidStadfang?.postnumer,
+                locationNumber:
+                  singleFasteignResponse.sjalfgefidStadfang?.stadfanganumer,
               },
               marking: unit.merking,
               usageDisplay: unit.notkunBirting,

--- a/libs/api/domains/assets/src/lib/api-domains-assets.service.ts
+++ b/libs/api/domains/assets/src/lib/api-domains-assets.service.ts
@@ -43,10 +43,6 @@ export class AssetsXRoadService {
       cursor: cursor,
     })
 
-    console.log(
-      'fasteignirResponsefasteignirResponsefasteignirResponse',
-      fasteignirResponse,
-    )
     if (fasteignirResponse) {
       return {
         paging: fasteignirResponse.paging,
@@ -72,10 +68,6 @@ export class AssetsXRoadService {
       auth,
     ).fasteignirGetFasteign({ fasteignanumer: getAssetString(assetId) })
 
-    console.log(
-      'singleFasteignResponsesingleFasteignResponsesingleFasteignResponse__ DETAIL__',
-      singleFasteignResponse,
-    )
     if (singleFasteignResponse) {
       return {
         propertyNumber: singleFasteignResponse.fasteignanumer,

--- a/libs/service-portal/assets/src/screens/RealEstateAssetDetail/RealEstateAssetDetail.tsx
+++ b/libs/service-portal/assets/src/screens/RealEstateAssetDetail/RealEstateAssetDetail.tsx
@@ -94,6 +94,63 @@ export const AssetsOverview: ServicePortalModuleComponent = () => {
     )
   }
 
+  console.log('assetData', assetData)
+  const test = {
+    fasteignanumer: 'F2084803',
+    sjalfgefidStadfang: {
+      stadfanganumer: 1033382,
+      landeignarnumer: 125400,
+      postnumer: 270,
+      sveitarfelagBirting: 'Mosfellsbær',
+      birting: 'Reykjalundur, 270 Mosfellsbær',
+      birtingStutt: 'Reykjalundur',
+    },
+    fasteignamat: {
+      gildandiFasteignamat: 1,
+      fyrirhugadFasteignamat: 1,
+      gildandiMannvirkjamat: 1,
+      fyrirhugadMannvirkjamat: 1,
+      gildandiLodarhlutamat: 147450000,
+      fyrirhugadLodarhlutamat: 151150000,
+      gildandiAr: 2021,
+      fyrirhugadAr: 2022,
+    },
+    thinglystirEigendur: {
+      thinglystirEigendur: [
+        {
+          nafn: 'Gervimaður Bandaríkin          ',
+          kennitala: '1',
+          eignarhlutfall: 1,
+          kaupdagur: '1944-05-30T00:00:00.000Z',
+          heimildBirting: 'Fleiri en ein eignarheimild',
+        },
+      ],
+    },
+    notkunareiningar: {
+      notkunareiningar: [
+        {
+          notkunareininganumer: '2084803',
+          fasteignanumer: '2084803',
+          merking: '010101',
+          notkunBirting: 'Vistheimili',
+          skyring: 'Vistheimili',
+          byggingararBirting: '1944-2000',
+          birtStaerd: 20613.6,
+          fasteignamat: {
+            gildandiFasteignamat: 1,
+            fyrirhugadFasteignamat: 1,
+            gildandiMannvirkjamat: 1,
+            fyrirhugadMannvirkjamat: 1,
+            gildandiLodarhlutamat: 147450000,
+            fyrirhugadLodarhlutamat: 151150000,
+            gildandiAr: 2021,
+            fyrirhugadAr: 2022,
+          },
+          brunabotamat: 1,
+        },
+      ],
+    },
+  }
   const paginateOwners =
     ownersQuery?.data?.assetsPropertyOwners.paging?.hasNextPage ||
     (assetData.registeredOwners?.paging?.hasNextPage &&

--- a/libs/service-portal/assets/src/screens/RealEstateAssetDetail/RealEstateAssetDetail.tsx
+++ b/libs/service-portal/assets/src/screens/RealEstateAssetDetail/RealEstateAssetDetail.tsx
@@ -94,63 +94,6 @@ export const AssetsOverview: ServicePortalModuleComponent = () => {
     )
   }
 
-  console.log('assetData', assetData)
-  const test = {
-    fasteignanumer: 'F2084803',
-    sjalfgefidStadfang: {
-      stadfanganumer: 1033382,
-      landeignarnumer: 125400,
-      postnumer: 270,
-      sveitarfelagBirting: 'Mosfellsbær',
-      birting: 'Reykjalundur, 270 Mosfellsbær',
-      birtingStutt: 'Reykjalundur',
-    },
-    fasteignamat: {
-      gildandiFasteignamat: 1,
-      fyrirhugadFasteignamat: 1,
-      gildandiMannvirkjamat: 1,
-      fyrirhugadMannvirkjamat: 1,
-      gildandiLodarhlutamat: 147450000,
-      fyrirhugadLodarhlutamat: 151150000,
-      gildandiAr: 2021,
-      fyrirhugadAr: 2022,
-    },
-    thinglystirEigendur: {
-      thinglystirEigendur: [
-        {
-          nafn: 'Gervimaður Bandaríkin          ',
-          kennitala: '1',
-          eignarhlutfall: 1,
-          kaupdagur: '1944-05-30T00:00:00.000Z',
-          heimildBirting: 'Fleiri en ein eignarheimild',
-        },
-      ],
-    },
-    notkunareiningar: {
-      notkunareiningar: [
-        {
-          notkunareininganumer: '2084803',
-          fasteignanumer: '2084803',
-          merking: '010101',
-          notkunBirting: 'Vistheimili',
-          skyring: 'Vistheimili',
-          byggingararBirting: '1944-2000',
-          birtStaerd: 20613.6,
-          fasteignamat: {
-            gildandiFasteignamat: 1,
-            fyrirhugadFasteignamat: 1,
-            gildandiMannvirkjamat: 1,
-            fyrirhugadMannvirkjamat: 1,
-            gildandiLodarhlutamat: 147450000,
-            fyrirhugadLodarhlutamat: 151150000,
-            gildandiAr: 2021,
-            fyrirhugadAr: 2022,
-          },
-          brunabotamat: 1,
-        },
-      ],
-    },
-  }
   const paginateOwners =
     ownersQuery?.data?.assetsPropertyOwners.paging?.hasNextPage ||
     (assetData.registeredOwners?.paging?.hasNextPage &&


### PR DESCRIPTION
## What

Missing data in detail view of properties: Staðfang & Sveitafélag

Bonus: Adding hugsmidjan as codeowners for the assets service.

## Why

Bugfixing

## Screenshots / Gifs

![Screenshot 2021-12-02 at 13 13 23](https://user-images.githubusercontent.com/24840451/144428988-8b89805d-3115-47de-9a08-54cf54e91831.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
