### PR TITLE
feat(island-ui): Add a createable ReactSelect component

### DIFF
--- a/libs/island-ui/core/src/lib/Select/Components/index.tsx
+++ b/libs/island-ui/core/src/lib/Select/Components/index.tsx
@@ -1,0 +1,173 @@
+import React, { ComponentType } from 'react'
+import cn from 'classnames'
+import {
+  components,
+  MenuProps,
+  OptionProps,
+  OptionsType,
+  GroupedOptionsType,
+  ActionMeta,
+  ValueType,
+  IndicatorContainerProps,
+  ControlProps,
+  InputProps,
+  PlaceholderProps,
+  ValueContainerProps,
+  SingleValueProps,
+  IndicatorProps,
+  Props,
+} from 'react-select'
+import { formatGroupLabel } from 'react-select/src/builtins'
+import { AriaError, InputBackgroundColor } from '../../Input/types'
+import { Icon } from '../../IconRC/Icon'
+import * as styles from '../Select.css'
+
+export type ReactSelectOption = {
+  label: string
+  value: string | number
+  disabled?: boolean
+}
+
+export interface SelectProps {
+  name: string
+  options:
+    | OptionsType<ReactSelectOption>
+    | GroupedOptionsType<ReactSelectOption>
+  id?: string
+  disabled?: boolean
+  hasError?: boolean
+  errorMessage?: string
+  noOptionsMessage?: string
+  onChange?: ((
+    value: ValueType<ReactSelectOption>,
+    actionMeta: ActionMeta<ReactSelectOption>,
+  ) => void) &
+    ((
+      value: ValueType<ReactSelectOption>,
+      action: ActionMeta<ReactSelectOption>,
+    ) => void)
+  label?: string
+  value?: ValueType<ReactSelectOption>
+  placeholder?: string
+  defaultValue?: ReactSelectOption
+  icon?: string
+  isSearchable?: boolean
+  size?: 'sm' | 'md'
+  backgroundColor?: InputBackgroundColor
+  required?: boolean
+  ariaError?: AriaError
+  formatGroupLabel?: formatGroupLabel<ReactSelectOption>
+}
+
+export const Menu = (props: MenuProps<ReactSelectOption>) => (
+  <components.Menu className={styles.menu} {...props} />
+)
+
+export const Option = (props: OptionProps<ReactSelectOption>) => {
+  const size: SelectProps['size'] = props.selectProps.size || 'md'
+  return (
+    <components.Option
+      className={cn(styles.option, styles.optionSizes[size!])}
+      {...props}
+    />
+  )
+}
+
+export const IndicatorsContainer = (
+  props: IndicatorContainerProps<ReactSelectOption>,
+) => (
+  <components.IndicatorsContainer
+    className={styles.indicatorsContainer}
+    {...props}
+  />
+)
+
+export const DropdownIndicator = (props: IndicatorProps<ReactSelectOption>) => {
+  const { icon, hasError } = props.selectProps
+
+  return (
+    <components.DropdownIndicator
+      className={styles.dropdownIndicator}
+      {...props}
+    >
+      <Icon
+        icon={icon}
+        size="large"
+        color={hasError ? 'red600' : 'blue400'}
+        className={styles.icon}
+      />
+    </components.DropdownIndicator>
+  )
+}
+
+export const SingleValue = (props: SingleValueProps<ReactSelectOption>) => {
+  const size: SelectProps['size'] = props.selectProps.size || 'md'
+  return (
+    <components.SingleValue
+      className={cn(styles.singleValue, styles.singleValueSizes[size!])}
+      {...props}
+    />
+  )
+}
+
+export const ValueContainer = (
+  props: ValueContainerProps<ReactSelectOption>,
+) => <components.ValueContainer className={styles.valueContainer} {...props} />
+
+export const Placeholder = (props: PlaceholderProps<ReactSelectOption>) => {
+  const size: SelectProps['size'] = props.selectProps.size || 'md'
+  return (
+    <components.Placeholder
+      className={cn(
+        styles.placeholder,
+        styles.placeholderPadding,
+        styles.placeholderSizes[size!],
+      )}
+      {...props}
+    />
+  )
+}
+
+export const Input: ComponentType<InputProps> = (
+  props: InputProps & { selectProps?: Props<ReactSelectOption> },
+) => {
+  const ariaError = props?.selectProps?.ariaError
+  const size = (props?.selectProps?.size || 'md') as SelectProps['size']
+  return (
+    <components.Input
+      className={cn(styles.input, styles.inputSize[size!])}
+      {...props}
+      {...ariaError}
+    />
+  )
+}
+
+export const Control = (props: ControlProps<ReactSelectOption>) => {
+  const size: SelectProps['size'] = props.selectProps.size || 'md'
+  return (
+    <components.Control
+      className={cn(styles.container, styles.containerSizes[size!], {
+        [styles.hasError]: props.selectProps.hasError,
+      })}
+      {...props}
+    >
+      <label
+        htmlFor={props.selectProps.name}
+        className={cn(styles.label, styles.labelSizes[size!])}
+      >
+        {props.selectProps.label}
+        {props.selectProps.required && (
+          <span aria-hidden="true" className={styles.isRequiredStar}>
+            {' '}
+            *
+          </span>
+        )}
+      </label>
+      {props.children}
+    </components.Control>
+  )
+}
+
+export const customStyles = {
+  indicatorSeparator: () => ({}),
+}

--- a/libs/island-ui/core/src/lib/Select/Components/index.tsx
+++ b/libs/island-ui/core/src/lib/Select/Components/index.tsx
@@ -75,12 +75,18 @@ export const Option = (props: OptionProps<ReactSelectOption>) => {
 
 export const IndicatorsContainer = (
   props: IndicatorContainerProps<ReactSelectOption>,
-) => (
-  <components.IndicatorsContainer
-    className={styles.indicatorsContainer}
-    {...props}
-  />
-)
+) => {
+  const { icon } = props.selectProps
+
+  return (
+    <components.IndicatorsContainer
+      className={cn(styles.indicatorsContainer, {
+        [styles.dontRotateIconOnOpen]: icon !== 'chevronDown',
+      })}
+      {...props}
+    />
+  )
+}
 
 export const DropdownIndicator = (props: IndicatorProps<ReactSelectOption>) => {
   const { icon, hasError } = props.selectProps

--- a/libs/island-ui/core/src/lib/Select/Components/index.tsx
+++ b/libs/island-ui/core/src/lib/Select/Components/index.tsx
@@ -4,10 +4,6 @@ import {
   components,
   MenuProps,
   OptionProps,
-  OptionsType,
-  GroupedOptionsType,
-  ActionMeta,
-  ValueType,
   IndicatorContainerProps,
   ControlProps,
   InputProps,
@@ -17,48 +13,9 @@ import {
   IndicatorProps,
   Props,
 } from 'react-select'
-import { formatGroupLabel } from 'react-select/src/builtins'
-import { AriaError, InputBackgroundColor } from '../../Input/types'
 import { Icon } from '../../IconRC/Icon'
 import * as styles from '../Select.css'
-
-export type ReactSelectOption = {
-  label: string
-  value: string | number
-  disabled?: boolean
-}
-
-export interface SelectProps {
-  name: string
-  options:
-    | OptionsType<ReactSelectOption>
-    | GroupedOptionsType<ReactSelectOption>
-  id?: string
-  disabled?: boolean
-  hasError?: boolean
-  errorMessage?: string
-  noOptionsMessage?: string
-  onChange?: ((
-    value: ValueType<ReactSelectOption>,
-    actionMeta: ActionMeta<ReactSelectOption>,
-  ) => void) &
-    ((
-      value: ValueType<ReactSelectOption>,
-      action: ActionMeta<ReactSelectOption>,
-    ) => void)
-  label?: string
-  value?: ValueType<ReactSelectOption>
-  placeholder?: string
-  defaultValue?: ReactSelectOption
-  icon?: string
-  isSearchable?: boolean
-  isCreatable?: boolean
-  size?: 'sm' | 'md'
-  backgroundColor?: InputBackgroundColor
-  required?: boolean
-  ariaError?: AriaError
-  formatGroupLabel?: formatGroupLabel<ReactSelectOption>
-}
+import { SelectProps, Option as ReactSelectOption } from '../Select'
 
 export const Menu = (props: MenuProps<ReactSelectOption>) => (
   <components.Menu className={styles.menu} {...props} />

--- a/libs/island-ui/core/src/lib/Select/Components/index.tsx
+++ b/libs/island-ui/core/src/lib/Select/Components/index.tsx
@@ -52,6 +52,7 @@ export interface SelectProps {
   defaultValue?: ReactSelectOption
   icon?: string
   isSearchable?: boolean
+  isCreatable?: boolean
   size?: 'sm' | 'md'
   backgroundColor?: InputBackgroundColor
   required?: boolean

--- a/libs/island-ui/core/src/lib/Select/Select.css.ts
+++ b/libs/island-ui/core/src/lib/Select/Select.css.ts
@@ -217,6 +217,7 @@ export const singleValueSizes = styleVariants(
 )
 export const indicatorsContainer = style(
   {
+    cursor: 'pointer',
     selectors: {
       [`${wrapper} &`]: {
         height: '100%',

--- a/libs/island-ui/core/src/lib/Select/Select.css.ts
+++ b/libs/island-ui/core/src/lib/Select/Select.css.ts
@@ -288,10 +288,19 @@ export const optionSizes = styleVariants({
   md: wrapMedia(inputMixins.inputSizes.md, `${wrapper} &`),
 })
 
+export const dontRotateIconOnOpen = style({})
+
 globalStyle(
   `${wrapper} .island-select__control${container}.island-select__control--menu-is-open ${indicatorsContainer}`,
   {
     transform: 'rotateX(180deg)',
+  },
+)
+
+globalStyle(
+  `${wrapper} .island-select__control${container}.island-select__control--menu-is-open ${indicatorsContainer}${dontRotateIconOnOpen}`,
+  {
+    transform: 'rotateX(0)',
   },
 )
 

--- a/libs/island-ui/core/src/lib/Select/Select.css.ts
+++ b/libs/island-ui/core/src/lib/Select/Select.css.ts
@@ -292,16 +292,9 @@ export const optionSizes = styleVariants({
 export const dontRotateIconOnOpen = style({})
 
 globalStyle(
-  `${wrapper} .island-select__control${container}.island-select__control--menu-is-open ${indicatorsContainer}`,
+  `${wrapper} .island-select__control${container}.island-select__control--menu-is-open ${indicatorsContainer}:not(${dontRotateIconOnOpen})`,
   {
     transform: 'rotateX(180deg)',
-  },
-)
-
-globalStyle(
-  `${wrapper} .island-select__control${container}.island-select__control--menu-is-open ${indicatorsContainer}${dontRotateIconOnOpen}`,
-  {
-    transform: 'rotateX(0)',
   },
 )
 

--- a/libs/island-ui/core/src/lib/Select/Select.tsx
+++ b/libs/island-ui/core/src/lib/Select/Select.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import cn from 'classnames'
 import ReactSelect from 'react-select'
+import CreatableReactSelect from 'react-select/creatable'
 import {
   Option,
   Menu,
@@ -36,6 +37,7 @@ export const Select = ({
   defaultValue,
   icon = 'chevronDown',
   isSearchable = true,
+  isCreatable = false,
   size = 'md',
   backgroundColor = 'white',
   required,
@@ -48,8 +50,59 @@ export const Select = ({
         'aria-describedby': errorId,
       }
     : {}
+  const [currentValue, setCurrentValue] = React.useState('')
 
-  return (
+  return isCreatable ? (
+    <div
+      className={cn(styles.wrapper, styles.wrapperColor[backgroundColor])}
+      data-testid={`creatable-select-${name}`}
+    >
+      <CreatableReactSelect
+        instanceId={id}
+        noOptionsMessage={() => noOptionsMessage || null}
+        id={id}
+        name={name}
+        isDisabled={disabled}
+        options={options}
+        styles={customStyles}
+        classNamePrefix="island-select"
+        onChange={onChange}
+        label={label}
+        value={value}
+        icon={icon}
+        placeholder={placeholder}
+        defaultValue={defaultValue}
+        isOptionDisabled={(option) => !!option.disabled}
+        hasError={hasError}
+        isSearchable={isSearchable}
+        size={size}
+        required={required}
+        ariaError={ariaError as AriaError}
+        formatGroupLabel={formatGroupLabel}
+        formatCreateLabel={() => currentValue}
+        createOptionPosition="first"
+        onInputChange={(inputValue) => setCurrentValue(inputValue)}
+        components={{
+          Control,
+          Input,
+          Placeholder,
+          ValueContainer,
+          SingleValue,
+          DropdownIndicator,
+          IndicatorsContainer,
+          Menu,
+          Option,
+        }}
+        isClearable
+        backspaceRemovesValue
+      />
+      {hasError && errorMessage && (
+        <div id={errorId} className={styles.errorMessage} aria-live="assertive">
+          {errorMessage}
+        </div>
+      )}
+    </div>
+  ) : (
     <div
       className={cn(styles.wrapper, styles.wrapperColor[backgroundColor])}
       data-testid={`select-${name}`}

--- a/libs/island-ui/core/src/lib/Select/Select.tsx
+++ b/libs/island-ui/core/src/lib/Select/Select.tsx
@@ -1,62 +1,24 @@
-import React, { ComponentType } from 'react'
+import React from 'react'
 import cn from 'classnames'
-import ReactSelect, {
-  components,
-  ValueType,
-  ActionMeta,
-  MenuProps,
-  OptionProps,
-  IndicatorContainerProps,
-  IndicatorProps,
-  SingleValueProps,
-  ValueContainerProps,
-  PlaceholderProps,
-  InputProps,
-  ControlProps,
-  Props,
-  OptionsType,
-  GroupedOptionsType,
-} from 'react-select'
-import { formatGroupLabel } from 'react-select/src/builtins'
+import ReactSelect from 'react-select'
+import {
+  Option,
+  Menu,
+  SelectProps,
+  IndicatorsContainer,
+  Control,
+  DropdownIndicator,
+  Input,
+  Placeholder,
+  SingleValue,
+  ValueContainer,
+  customStyles,
+} from './Components'
 import * as styles from './Select.css'
-import { Icon } from '../IconRC/Icon'
-import { InputBackgroundColor } from '../Input/types'
-
-export type Option = {
-  label: string
-  value: string | number
-  disabled?: boolean
-}
 
 interface AriaError {
   'aria-invalid': boolean
   'aria-describedby': string
-}
-
-export interface SelectProps {
-  name: string
-  options: OptionsType<Option> | GroupedOptionsType<Option>
-  id?: string
-  disabled?: boolean
-  hasError?: boolean
-  errorMessage?: string
-  noOptionsMessage?: string
-  onChange?: ((
-    value: ValueType<Option>,
-    actionMeta: ActionMeta<Option>,
-  ) => void) &
-    ((value: ValueType<Option>, action: ActionMeta<Option>) => void)
-  label?: string
-  value?: ValueType<Option>
-  placeholder?: string
-  defaultValue?: Option
-  icon?: string
-  isSearchable?: boolean
-  size?: 'sm' | 'md'
-  backgroundColor?: InputBackgroundColor
-  required?: boolean
-  ariaError?: AriaError
-  formatGroupLabel?: formatGroupLabel<Option>
 }
 
 export const Select = ({
@@ -132,115 +94,5 @@ export const Select = ({
         </div>
       )}
     </div>
-  )
-}
-
-const customStyles = {
-  indicatorSeparator: () => ({}),
-}
-
-const Menu = (props: MenuProps<Option>) => (
-  <components.Menu className={styles.menu} {...props} />
-)
-const Option = (props: OptionProps<Option>) => {
-  const size: SelectProps['size'] = props.selectProps.size || 'md'
-  return (
-    <components.Option
-      className={cn(styles.option, styles.optionSizes[size!])}
-      {...props}
-    />
-  )
-}
-
-const IndicatorsContainer = (props: IndicatorContainerProps<Option>) => (
-  <components.IndicatorsContainer
-    className={styles.indicatorsContainer}
-    {...props}
-  />
-)
-
-const DropdownIndicator = (props: IndicatorProps<Option>) => {
-  const { icon, hasError } = props.selectProps
-
-  return (
-    <components.DropdownIndicator
-      className={styles.dropdownIndicator}
-      {...props}
-    >
-      <Icon
-        icon={icon}
-        size="large"
-        color={hasError ? 'red600' : 'blue400'}
-        className={styles.icon}
-      />
-    </components.DropdownIndicator>
-  )
-}
-
-const SingleValue = (props: SingleValueProps<Option>) => {
-  const size: SelectProps['size'] = props.selectProps.size || 'md'
-  return (
-    <components.SingleValue
-      className={cn(styles.singleValue, styles.singleValueSizes[size!])}
-      {...props}
-    />
-  )
-}
-
-const ValueContainer = (props: ValueContainerProps<Option>) => (
-  <components.ValueContainer className={styles.valueContainer} {...props} />
-)
-
-const Placeholder = (props: PlaceholderProps<Option>) => {
-  const size: SelectProps['size'] = props.selectProps.size || 'md'
-  return (
-    <components.Placeholder
-      className={cn(
-        styles.placeholder,
-        styles.placeholderPadding,
-        styles.placeholderSizes[size!],
-      )}
-      {...props}
-    />
-  )
-}
-
-const Input: ComponentType<InputProps> = (
-  props: InputProps & { selectProps?: Props<Option> },
-) => {
-  const ariaError = props?.selectProps?.ariaError
-  const size = (props?.selectProps?.size || 'md') as SelectProps['size']
-  return (
-    <components.Input
-      className={cn(styles.input, styles.inputSize[size!])}
-      {...props}
-      {...ariaError}
-    />
-  )
-}
-
-const Control = (props: ControlProps<Option>) => {
-  const size: SelectProps['size'] = props.selectProps.size || 'md'
-  return (
-    <components.Control
-      className={cn(styles.container, styles.containerSizes[size!], {
-        [styles.hasError]: props.selectProps.hasError,
-      })}
-      {...props}
-    >
-      <label
-        htmlFor={props.selectProps.name}
-        className={cn(styles.label, styles.labelSizes[size!])}
-      >
-        {props.selectProps.label}
-        {props.selectProps.required && (
-          <span aria-hidden="true" className={styles.isRequiredStar}>
-            {' '}
-            *
-          </span>
-        )}
-      </label>
-      {props.children}
-    </components.Control>
   )
 }

--- a/libs/island-ui/core/src/lib/Select/Select.tsx
+++ b/libs/island-ui/core/src/lib/Select/Select.tsx
@@ -1,11 +1,16 @@
 import React from 'react'
 import cn from 'classnames'
-import ReactSelect from 'react-select'
+import ReactSelect, {
+  OptionsType,
+  GroupedOptionsType,
+  ActionMeta,
+  ValueType,
+} from 'react-select'
 import CreatableReactSelect from 'react-select/creatable'
+import { formatGroupLabel } from 'react-select/src/builtins'
 import {
   Option,
   Menu,
-  SelectProps,
   IndicatorsContainer,
   Control,
   DropdownIndicator,
@@ -15,11 +20,45 @@ import {
   ValueContainer,
   customStyles,
 } from './Components'
+import { InputBackgroundColor } from '../Input/types'
 import * as styles from './Select.css'
 
 interface AriaError {
   'aria-invalid': boolean
   'aria-describedby': string
+}
+
+export type Option = {
+  label: string
+  value: string | number
+  disabled?: boolean
+}
+
+export interface SelectProps {
+  name: string
+  options: OptionsType<Option> | GroupedOptionsType<Option>
+  id?: string
+  disabled?: boolean
+  hasError?: boolean
+  errorMessage?: string
+  noOptionsMessage?: string
+  onChange?: ((
+    value: ValueType<Option>,
+    actionMeta: ActionMeta<Option>,
+  ) => void) &
+    ((value: ValueType<Option>, action: ActionMeta<Option>) => void)
+  label?: string
+  value?: ValueType<Option>
+  placeholder?: string
+  defaultValue?: Option
+  icon?: string
+  isSearchable?: boolean
+  isCreatable?: boolean
+  size?: 'sm' | 'md'
+  backgroundColor?: InputBackgroundColor
+  required?: boolean
+  ariaError?: AriaError
+  formatGroupLabel?: formatGroupLabel<Option>
 }
 
 export const Select = ({


### PR DESCRIPTION
# Add a createable ReactSelect component

## What

Add a createable ReactSelect component into island-ui. 

To create a createable ReactSelect component, you'd pass down a `isCreateable` prop (default set to false) to the existing Select component and it will render a creatable version of that component. I also added a fix for a minor bug where we were rotating the icon, no matter what the icon was. I think it only makes sense to rotate the icon if it's set to chevronDown (default).

## Why

The judicial-system project needs a createable ReactSelect component.

## Screenshots / Gifs


https://user-images.githubusercontent.com/3789875/144438203-5b5cf3f0-1fe3-43f8-82f2-f6b5ecfca3cd.mov

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
