### PR TITLE
chore(ci): Skip flaky application-system-form-e2e test

### DIFF
--- a/workspace.json
+++ b/workspace.json
@@ -1903,7 +1903,7 @@
             }
           }
         },
-        "e2e-ci": {
+        "e2e-ci-skip": {
           "builder": "@nrwl/workspace:run-commands",
           "options": {
             "command": "yarn e2e-ci -n application-system-form-e2e -t react -p 4242 -d dist/apps/application-system/form -c"


### PR DESCRIPTION
## What

See title.

## Why

This test is super flaky, not providing value at the moment and not much activity in creating this type of e2e tests.

We need to have a less flaky CI, at least for this release cycle. Would be great to revert this when we start creating this type of e2e tests and have a way to fix the actual issue (`nx run application-system-form:build:production` exiting with status code 1 and no logs).