### PR TITLE
fix(dpac): removing termsAgreement from application

### DIFF
--- a/libs/application/templates/data-protection-complaint/src/forms/ComplaintForm.ts
+++ b/libs/application/templates/data-protection-complaint/src/forms/ComplaintForm.ts
@@ -629,13 +629,12 @@ export const ComplaintForm: Form = buildForm({
               component: 'ComplaintOverview',
             }),
             buildSubmitField({
-              id: 'overview.termsAgreement',
+              id: 'overview.sendApplication',
               title: '',
-              placement: 'screen',
               actions: [
                 {
                   event: DefaultEvents.SUBMIT,
-                  name: overview.labels.termsAgreement,
+                  name: overview.labels.sendApplication,
                   type: 'primary',
                 },
               ],

--- a/libs/application/templates/data-protection-complaint/src/lib/dataSchema.ts
+++ b/libs/application/templates/data-protection-complaint/src/lib/dataSchema.ts
@@ -137,9 +137,6 @@ export const DataProtectionComplaintSchema = z.object({
 
     documents: z.array(FileSchema),
   }),
-  overview: z.object({
-    termsAgreement: z.string().refine((x) => x === DefaultEvents.SUBMIT),
-  }),
 })
 
 export type DataProtectionComplaint = z.TypeOf<

--- a/libs/application/templates/data-protection-complaint/src/lib/messages/overview.ts
+++ b/libs/application/templates/data-protection-complaint/src/lib/messages/overview.ts
@@ -19,11 +19,10 @@ export const overview = {
     },
   }),
   labels: defineMessage({
-    termsAgreement: {
-      id: 'dpac.application:section.overview.labels.termsAgreement',
-      defaultMessage:
-        'Ég samþykki að Persónuvernd hefur leyfi til þess að nota persónuupplýsingar til meðferðar á þessari umsókn.',
-      description: 'Terms agreement label',
+    sendApplication: {
+      id: 'dpac.application:section.overview.labels.sendApplication',
+      defaultMessage: 'Senda',
+      description: 'Send button on overview screen',
     },
     delimitationAccordionTitle: {
       id: 'dpac.application:section.overview.labels.delimitationAccordionTitle',


### PR DESCRIPTION
# Removing termsAgreement from application

[1e0y719](https://app.clickup.com/t/1e0y719)

## What

Removing termsAgreement from application.

## Why

Stakeholder asked to remove checkbox, there was no need for termsAgreemant after that.

## Screenshots / Gifs

![Screenshot 2021-12-06 at 11 36 42](https://user-images.githubusercontent.com/39527334/144840996-3c216925-3cb0-416f-8495-ee29547c2b1e.png)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
