### PR TITLE
fix(api): Fixing possbile null and undefined values in auth and identity domains

### DIFF
--- a/libs/api/domains/auth/src/lib/resolvers/delegation.resolver.ts
+++ b/libs/api/domains/auth/src/lib/resolvers/delegation.resolver.ts
@@ -126,6 +126,10 @@ export class DelegationResolver {
 
   @ResolveField('validTo', () => Date, { nullable: true })
   resolveValidTo(@Parent() delegation: DelegationDTO): Date | undefined {
+    if (!delegation.validTo) {
+      return undefined
+    }
+
     return delegation.scopes?.every(
       (scope) => scope.validTo?.toString() === delegation.validTo?.toString(),
     )

--- a/libs/api/domains/identity/src/lib/identity.service.ts
+++ b/libs/api/domains/identity/src/lib/identity.service.ts
@@ -22,6 +22,11 @@ export class IdentityService {
       user,
       nationalId,
     )
+
+    if (!person) {
+      return null
+    }
+
     return {
       nationalId: person.nationalId,
       name: person.fullName,


### PR DESCRIPTION

## What

When person is not found in Þjóðskrá the person is null which causes a error. This returns null instead.
The validTo date can be null from the OpenAPI spec so checking for falsy value and returning undefined if it is.

## Why

To avoid the errors otherwise caused.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
