### PR TITLE
fix(api): Adding nullable true for resolve fields in auth domain.

### DIFF
--- a/libs/api/domains/auth/src/lib/resolvers/delegation.resolver.ts
+++ b/libs/api/domains/auth/src/lib/resolvers/delegation.resolver.ts
@@ -92,7 +92,7 @@ export class DelegationResolver {
     return this.meDelegationsService.deleteDelegation(user, input)
   }
 
-  @ResolveField('to', () => Identity)
+  @ResolveField('to', () => Identity, { nullable: true })
   resolveTo(
     @Parent() delegation: DelegationDTO,
     @CurrentUser() user: User,
@@ -108,7 +108,7 @@ export class DelegationResolver {
     return this.identityService.getIdentity(delegation.toNationalId, user)
   }
 
-  @ResolveField('from', () => Identity)
+  @ResolveField('from', () => Identity, { nullable: true })
   resolveFrom(
     @Parent() delegation: DelegationDTO,
     @CurrentUser() user: User,


### PR DESCRIPTION
## What

Fields can be null if no result is found in NationalRegistry, or the service is offline.

## Why

Missing nullable config for GQL schema.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
