### PR TITLE
fix(service-portal): Fixing toast error handling in GrantAccess and typescript issues for delegations

### DIFF
--- a/libs/service-portal/settings/access-control/src/screens/Access/Access.tsx
+++ b/libs/service-portal/settings/access-control/src/screens/Access/Access.tsx
@@ -207,7 +207,7 @@ function Access() {
   return (
     <Box>
       <IntroHeader
-        title={authDelegation?.to.name || ''}
+        title={authDelegation?.to?.name || ''}
         intro={defineMessage({
           id: 'service.portal.settings.accessControl:access-intro',
           defaultMessage:

--- a/libs/service-portal/settings/access-control/src/screens/AccessControl/components/Accesses/Accesses.tsx
+++ b/libs/service-portal/settings/access-control/src/screens/AccessControl/components/Accesses/Accesses.tsx
@@ -70,17 +70,19 @@ function Accesses(): JSX.Element {
                 <EmptyImage width="100%" />
               </Box>
             ) : (
-              authDelegations.map((delegation) => (
-                <AccessCard
-                  key={delegation.id}
-                  title={delegation.to.name}
-                  validTo={delegation.validTo}
-                  description={kennitala.format(delegation.to.nationalId)}
-                  tags={delegation.scopes.map((scope) => scope.displayName)}
-                  href={`${pathname}/${delegation.id}`}
-                  group="Ísland.is"
-                />
-              ))
+              authDelegations.map((delegation) =>
+                delegation.to ? (
+                  <AccessCard
+                    key={delegation.id}
+                    title={delegation.to.name}
+                    validTo={delegation.validTo}
+                    description={kennitala.format(delegation.to.nationalId)}
+                    tags={delegation.scopes.map((scope) => scope.displayName)}
+                    href={`${pathname}/${delegation.id}`}
+                    group="Ísland.is"
+                  />
+                ) : undefined,
+              )
             )}
           </Stack>
         </GridColumn>

--- a/libs/service-portal/settings/access-control/src/screens/GrantAccess/GrantAccess.tsx
+++ b/libs/service-portal/settings/access-control/src/screens/GrantAccess/GrantAccess.tsx
@@ -51,6 +51,15 @@ const IdentityQuery = gql`
 `
 
 function GrantAccess() {
+  const noUserFoundToast = () => {
+    toast.error(
+      formatMessage({
+        id: 'service.portal.settings.accessControl:grant-identity-error',
+        defaultMessage: 'Enginn notandi fannst með þessa kennitölu.',
+      }),
+    )
+  }
+
   const [name, setName] = useState('')
   const { handleSubmit, control, errors, watch, reset } = useForm({
     mode: 'onChange',
@@ -64,13 +73,11 @@ function GrantAccess() {
   const [getIdentity, { data, loading: queryLoading }] = useLazyQuery<Query>(
     IdentityQuery,
     {
-      onError: (error) => {
-        toast.error(
-          formatMessage({
-            id: 'service.portal.settings.accessControl:grant-identity-error',
-            defaultMessage: 'Enginn notandi fannst með þessa kennitölu.',
-          }),
-        )
+      onError: noUserFoundToast,
+      onCompleted: (data) => {
+        if (!data.identity) {
+          noUserFoundToast()
+        }
       },
     },
   )

--- a/libs/shared/components/src/auth/UserMenu/UserDelegations.tsx
+++ b/libs/shared/components/src/auth/UserMenu/UserDelegations.tsx
@@ -62,11 +62,13 @@ export const UserDelegations = ({
     delegations.push(
       ...data.authActorDelegations
         .map((delegation) => ({
-          nationalId: delegation.from.nationalId,
-          name: delegation.from.name,
+          nationalId: delegation.from?.nationalId ?? '',
+          name: delegation.from?.name ?? '',
           isCurrent: false,
         }))
-        .filter(({ nationalId }) => nationalId !== currentNationalId),
+        .filter(
+          ({ nationalId }) => nationalId && nationalId !== currentNationalId,
+        ),
     )
   }
 


### PR DESCRIPTION
## What

When no identity is found the GQL returns null object so adding handling for `onComplete` if `identity` was not found to display the toast error message.

Fixing typescript compile errors when `to` and `from` fields on `delegation` are missing due to errors in `identity` service.
## Why

Fixing the regression when returning null instead of throwing error when identity was not found in the identity service.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
