### PR TITLE
fix(endorsement-system-api): National registry soap prod config

### DIFF
--- a/apps/services/endorsements/api/src/environments/environment.ts
+++ b/apps/services/endorsements/api/src/environments/environment.ts
@@ -95,10 +95,10 @@ const prodConfig = {
     },
   },
   nationalRegistry: {
-    baseSoapUrl: 'https://localhost:8443',
+    baseSoapUrl: process.env.SOFFIA_SOAP_URL ?? '',
     user: process.env.SOFFIA_USER ?? '',
     password: process.env.SOFFIA_PASS ?? '',
-    host: 'soffiaprufa.skra.is',
+    host: process.env.SOFFIA_HOST_URL ?? '',
   },
   auth: {
     issuer: process.env.IDENTITY_SERVER_ISSUER_URL,


### PR DESCRIPTION
# ...
The National registry soap config was set to the dev config, causing errors on dev and staging.

This mistake was made in this pr https://github.com/island-is/island.is/pull/5752/

Errors:
https://app.datadoghq.eu/logs?query=service%3Aendorsement-system-api%20env%3Astaging%20-status%3A%28warn%20OR%20info%29&cols=host%2Cservice&event=AQAAAX2aKzhFL6ZXRQAAAABBWDJhSzBtT0FBQi11MGZyeUZzRkl3QVc&index=%2A&messageDisplay=inline&stream_sort=desc&from_ts=1638809302375&to_ts=1638982102375&live=true

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
