### PR TITLE
fix(judicial-system): Only autofill ruling on initial render

### DIFF
--- a/apps/judicial-system/web/src/components/RulingInput/RulingInput.tsx
+++ b/apps/judicial-system/web/src/components/RulingInput/RulingInput.tsx
@@ -37,7 +37,7 @@ const RulingInput: React.FC<Props> = (props) => {
     ) {
       autofill('ruling', workingCase.parentCase.ruling, workingCase)
     }
-  }, [workingCase, autofill, formatMessage])
+  }, [])
 
   return (
     <Input


### PR DESCRIPTION
# Only autofill ruling on initial render

https://app.asana.com/0/1199153462262248/1201423192590376/f

## What

Only autofill ruling on initial render. We were autofilling every time workingCase changed, making it impossible to edit the autofilled ruling

## Why

This is a bug. This fixes a broken e2e test.

## Screenshots / Gifs

### Before

https://user-images.githubusercontent.com/3789875/145368031-5a5ffcb0-aab5-4c4a-a511-168d1d0060a2.mov

### After 

https://user-images.githubusercontent.com/3789875/145367691-1072e3bb-3536-4898-be25-d39e0984f0a5.mov

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
