### PR TITLE
feat(web): Syslumenn / Alert quick fix

### DIFF
--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -2,10 +2,12 @@ import React, { ReactNode } from 'react'
 import {
   Image,
   LinkGroup,
+  Namespace,
   Organization,
   OrganizationPage,
 } from '@island.is/web/graphql/schema'
 import {
+  AlertBanner,
   Box,
   BreadCrumbItem,
   Breadcrumbs,
@@ -43,6 +45,7 @@ import {
 import { endpoints as chatPanelEndpoints } from '../../ChatPanel/config'
 import { useRouter } from 'next/router'
 import * as styles from './OrganizationWrapper.css'
+import { useNamespace } from '@island.is/web/hooks'
 
 interface NavigationData {
   title: string
@@ -63,6 +66,7 @@ interface WrapperProps {
   stickySidebar?: boolean
   minimal?: boolean
   showSecondaryMenu?: boolean
+  namespace: Namespace
 }
 
 interface HeaderProps {
@@ -85,6 +89,43 @@ const OrganizationHeader: React.FC<HeaderProps> = ({ organizationPage }) => {
     default:
       return <DefaultHeader organizationPage={organizationPage} />
   }
+}
+
+interface AlertProps {
+  organizationPage: OrganizationPage
+  namespace: Namespace
+}
+
+export const OrganizationAlert: React.FC<AlertProps> = ({
+  organizationPage,
+  namespace,
+}) => {
+  const n = useNamespace(namespace)
+  const alertEndDate = new Date(2021, 11, 14) // Dec. 14th 2021
+  const withinAlertTimeframe = new Date() < alertEndDate
+  if (organizationPage.slug === 'syslumenn' && withinAlertTimeframe) {
+    return (
+      <Box paddingTop={[3, 4, 8]} paddingX={[3, 3, 6]}>
+        <AlertBanner
+          variant={n('alertVariant', 'info')}
+          title={n('alertTitle', 'Lokað er hjá sýslumönnum 13. desember')}
+          description={n(
+            'alertDescription',
+            'Skrifstofur embætta sýslumanna um land allt verða lokaðar mánudaginn 13. desember vegna uppfærslu tölvukerfa.',
+          )}
+          dismissable={false}
+          link={{
+            href: n(
+              'alertLinkHref',
+              'https://island.is/s/syslumenn/frett/lokad-hja-syslumonnum-13-desember',
+            ),
+            title: n('alertLinkTitle', 'Nánar'),
+          }}
+        />
+      </Box>
+    )
+  }
+  return null
 }
 
 interface FooterProps {
@@ -202,6 +243,7 @@ export const OrganizationWrapper: React.FC<WrapperProps> = ({
   children,
   minimal = false,
   showSecondaryMenu = true,
+  namespace,
 }) => {
   const Router = useRouter()
 
@@ -229,6 +271,16 @@ export const OrganizationWrapper: React.FC<WrapperProps> = ({
       />
       <OrganizationHeader organizationPage={organizationPage} />
       <Main>
+        <GridContainer>
+          <GridRow>
+            <GridColumn span={['12/12', '12/12', '12/12', '12/12', '11/12']}>
+              <OrganizationAlert
+                organizationPage={organizationPage}
+                namespace={namespace}
+              />
+            </GridColumn>
+          </GridRow>
+        </GridContainer>
         {!minimal && (
           <SidebarLayout
             paddingTop={[2, 2, 9]}

--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -100,6 +100,10 @@ export const OrganizationAlert: React.FC<AlertProps> = ({
   organizationPage,
   namespace,
 }) => {
+  /**
+   * The following code was added as a quick fix in order to get the message out to
+   * users ASAP. After December 14th 2021, the PR that added this code can be reverted.
+   */
   const n = useNamespace(namespace)
   const alertEndDate = new Date(2021, 11, 14) // Dec. 14th 2021
   const withinAlertTimeframe = new Date() < alertEndDate

--- a/apps/web/screens/Organization/Home.tsx
+++ b/apps/web/screens/Organization/Home.tsx
@@ -58,6 +58,7 @@ const Home: Screen<HomeProps> = ({ organizationPage, namespace }) => {
       organizationPage={organizationPage}
       pageFeaturedImage={organizationPage.featuredImage}
       fullWidthContent={true}
+      namespace={namespace}
       navigationData={{
         title: n('navigationTitle', 'Efnisyfirlit'),
         items: navList,


### PR DESCRIPTION
# Syslumenn / Alert quick fix

## What

We've been asked to show this message to users via an alert on all Syslumenn pages, implemented as a quick fix, in order to get this live ASAP. The message disappears after December 13th. Then we will simply revert this PR to get rid of this quick fix in future releases.

## Why

Syslumenn offices will be closed on Monday December 13th.

## Screenshots / Gifs

### Desktop
![syslumenn-alert-desktop](https://user-images.githubusercontent.com/1277384/145412537-18293a55-cc91-4bec-ab2c-f48550cd6602.png)

### Mobile
![syslumenn-alert-mobile](https://user-images.githubusercontent.com/1277384/145412579-aa7ef060-82eb-4b33-ba81-59d9d1a8fba1.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
