### PR TITLE
fix(judicial-system): Update state with new case files when uploading case files

### DIFF
--- a/apps/judicial-system/web/src/routes/Prosecutor/InvestigationRequest/CaseFiles/CaseFilesForm.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/InvestigationRequest/CaseFiles/CaseFilesForm.tsx
@@ -63,7 +63,7 @@ const CaseFilesForm: React.FC<Props> = (props) => {
     onChange,
     onRemove,
     onRetry,
-  } = useS3Upload(workingCase)
+  } = useS3Upload(workingCase, setWorkingCase)
   const { formatMessage } = useIntl()
   const { updateCase } = useCase()
 

--- a/apps/judicial-system/web/src/routes/Prosecutor/RestrictionRequest/StepFive/StepFiveForm.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/RestrictionRequest/StepFive/StepFiveForm.tsx
@@ -64,7 +64,7 @@ export const StepFiveForm: React.FC<Props> = (props) => {
     onChange,
     onRemove,
     onRetry,
-  } = useS3Upload(workingCase)
+  } = useS3Upload(workingCase, setWorkingCase)
   const { updateCase } = useCase()
 
   useEffect(() => {

--- a/apps/judicial-system/web/src/utils/hooks/useS3Upload.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useS3Upload.ts
@@ -9,11 +9,15 @@ import {
 } from '@island.is/judicial-system-web/graphql'
 import {
   Case,
+  CaseFile,
   PresignedPost,
   UploadPoliceCaseFileResponse,
 } from '@island.is/judicial-system/types'
 
-export const useS3Upload = (workingCase?: Case) => {
+export const useS3Upload = (
+  workingCase?: Case,
+  setWorkingCase?: React.Dispatch<React.SetStateAction<Case>>,
+) => {
   const [files, setFiles] = useState<UploadFile[]>([])
   const [uploadErrorMessage, setUploadErrorMessage] = useState<string>()
   const [allFilesUploaded, setAllFilesUploaded] = useState<boolean>(true)
@@ -197,6 +201,13 @@ export const useS3Upload = (workingCase?: Case) => {
           file.id = res.data.createFile.id
           file.status = 'done'
           updateFile(file)
+        })
+        .then(() => {
+          setWorkingCase &&
+            setWorkingCase({
+              ...workingCase,
+              caseFiles: [...(workingCase.caseFiles || []), file as CaseFile],
+            })
         })
         .catch((reason) => {
           // TODO: Log to sentry


### PR DESCRIPTION
# Update state with new case files when uploading case files

https://app.asana.com/0/1199153462262248/1201423192590376/f

## What

Update state with new case files when uploading case files

## Why

In the new setup where we use the FormProvider to fetch cases and not on every page, there is a regression. The regression is that when we upload case files, we are not setting the state with the uploaded case file. This means that the case files are not visible in the client until you refresh. 

## Screenshots / Gifs

### Before

https://user-images.githubusercontent.com/3789875/145425549-289341e3-391e-4beb-b606-b723b99703d7.mov

### After

https://user-images.githubusercontent.com/3789875/145425365-e70d3577-fca2-4129-84ca-26bce7c1ce98.mov

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
