### PR TITLE
fix(endorsement-system-api): create endorsement on list gets fullName from national registry v1 and skips metadata steps

### DIFF
--- a/apps/services/endorsements/api/src/app/modules/endorsement/e2e/bulkCreateEndorsement/bulkCreateEndorsement.spec.ts
+++ b/apps/services/endorsements/api/src/app/modules/endorsement/e2e/bulkCreateEndorsement/bulkCreateEndorsement.spec.ts
@@ -4,7 +4,7 @@ import { authNationalId } from './seed'
 import { getAuthenticatedApp } from '../../../../../../test/setup'
 import {
   errorExpectedStructure,
-  metaDataResponse,
+  bulkMetaDataResponse,
 } from '../../../../../../test/testHelpers'
 
 describe('bulkCreateEndorsement', () => {
@@ -48,7 +48,7 @@ describe('bulkCreateEndorsement', () => {
         expect.objectContaining({
           // lets make sure metadata got correctly populated
           meta: {
-            ...metaDataResponse,
+            ...bulkMetaDataResponse,
             bulkEndorsement: true,
           },
         }),
@@ -113,7 +113,7 @@ describe('bulkCreateEndorsement', () => {
           endorsementListId: listId,
           // lets make sure metadata got correctly populated
           meta: {
-            ...metaDataResponse,
+            ...bulkMetaDataResponse,
             bulkEndorsement: true,
           },
         }),

--- a/apps/services/endorsements/api/src/app/modules/endorsement/e2e/createEndorsement/createEndorsement.spec.ts
+++ b/apps/services/endorsements/api/src/app/modules/endorsement/e2e/createEndorsement/createEndorsement.spec.ts
@@ -67,26 +67,6 @@ describe('createEndorsement', () => {
       statusCode: 405,
     })
   })
-  it(`POST /endorsement-list/:listId/endorsement should fail to create endorsement when conflicts within tags`, async () => {
-    const app = await getAuthenticatedApp({
-      nationalId: authNationalId,
-      scope: [EndorsementsScope.main],
-    })
-    const endorsementBody = {
-      showName: true,
-    }
-    const response = await request(app.getHttpServer())
-      .post(
-        `/endorsement-list/9c0b4106-4213-43be-a6b2-ff324f4ba0c5/endorsement`,
-      )
-      .send(endorsementBody)
-      .expect(400)
-
-    expect(response.body).toMatchObject({
-      ...errorExpectedStructure,
-      statusCode: 400,
-    })
-  })
   it(`POST /endorsement-list/:listId/endorsement should create a new endorsement and populate metadata`, async () => {
     const app = await getAuthenticatedApp({
       nationalId: authNationalId,

--- a/apps/services/endorsements/api/src/app/modules/endorsement/endorsement.controller.ts
+++ b/apps/services/endorsements/api/src/app/modules/endorsement/endorsement.controller.ts
@@ -174,14 +174,11 @@ export class EndorsementController {
     @Body() endorsement: EndorsementDto,
     @CurrentUser() user: User,
   ): Promise<Endorsement> {
-    return await this.endorsementService.createEndorsementOnList(
-      {
-        nationalId: user.nationalId,
-        endorsementList,
-        showName: endorsement.showName,
-      },
-      user,
-    )
+    return await this.endorsementService.createEndorsementOnList({
+      nationalId: user.nationalId,
+      endorsementList,
+      showName: endorsement.showName,
+    })
   }
 
   @ApiOperation({

--- a/apps/services/endorsements/api/test/testHelpers.ts
+++ b/apps/services/endorsements/api/test/testHelpers.ts
@@ -6,15 +6,4 @@ export const errorExpectedStructure = {
 
 export const metaDataResponse = {
   fullName: expect.any(String),
-  address: {
-    streetAddress: expect.any(String),
-    city: expect.any(String),
-    postalCode: expect.any(String),
-  },
-  bulkEndorsement: expect.any(Boolean),
-  showName: expect.any(Boolean),
-  voterRegion: {
-    voterRegionNumber: expect.any(Number),
-    voterRegionName: expect.any(String),
-  },
 }

--- a/apps/services/endorsements/api/test/testHelpers.ts
+++ b/apps/services/endorsements/api/test/testHelpers.ts
@@ -4,6 +4,21 @@ export const errorExpectedStructure = {
   statusCode: expect.any(Number),
 }
 
+export const bulkMetaDataResponse = {
+  fullName: expect.any(String),
+  address: {
+    streetAddress: expect.any(String),
+    city: expect.any(String),
+    postalCode: expect.any(String),
+  },
+  bulkEndorsement: expect.any(Boolean),
+  showName: expect.any(Boolean),
+  voterRegion: {
+    voterRegionNumber: expect.any(Number),
+    voterRegionName: expect.any(String),
+  },
+}
+
 export const metaDataResponse = {
   fullName: expect.any(String),
 }


### PR DESCRIPTION
Use national Registry v1 since xroad connection is causing errors

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
