### PR TITLE
fix(air-discount-scheme-web): remove no longer used props from Footer

### DIFF
--- a/apps/air-discount-scheme/web/components/AppLayout/AppLayout.tsx
+++ b/apps/air-discount-scheme/web/components/AppLayout/AppLayout.tsx
@@ -46,8 +46,6 @@ export const AppLayout: NextComponentType<
   isAuthenticated,
   footerUpperMenu,
   footerLowerMenu,
-  footerMiddleMenu,
-  footerTagsMenu,
   namespace,
   routeKey,
   localeKey,
@@ -73,7 +71,6 @@ export const AppLayout: NextComponentType<
     .filter(noEmptyOrHash)
     .map(mapLocalLinks)
   const footerMiddleMenuFiltered = [] // footerMiddleMenu.filter(noEmptyOrHash)
-  const footerTagsMenuFiltered = [] // footerTagsMenu.filter(noEmptyOrHash)
 
   return (
     <UserContext.Provider value={{ isAuthenticated, user, setUser }}>
@@ -131,11 +128,8 @@ export const AppLayout: NextComponentType<
           topLinksContact={[]}
           bottomLinks={footerLowerMenuFiltered}
           middleLinks={footerMiddleMenuFiltered}
-          tagLinks={footerTagsMenuFiltered}
           middleLinksTitle={namespace.footerMiddleLabel}
-          tagLinksTitle={namespace.footerRightLabel}
           showMiddleLinks={footerMiddleMenuFiltered.length > 0}
-          showTagLinks={footerTagsMenuFiltered.length > 0}
           languageSwitchLink={languageRoute}
           languageSwitchOnClick={() => {
             switchLanguage(null, nextLanguage)


### PR DESCRIPTION
Remove no longer used props from `Footer`

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
