### PR TITLE
fix(web/island-ui): move global styles from Text

### DIFF
--- a/libs/island-ui/core/src/lib/BulletList/BulletList.css.ts
+++ b/libs/island-ui/core/src/lib/BulletList/BulletList.css.ts
@@ -1,9 +1,11 @@
-import { style } from '@vanilla-extract/css'
+import { globalStyle, style } from '@vanilla-extract/css'
 import { theme } from '@island.is/island-ui/theme'
 
 export const container = style({
   counterReset: 'section',
 })
+
+export const content = style({})
 
 export const bullet = style({
   display: 'inline-block',
@@ -36,4 +38,18 @@ export const icon = style({
     backgroundColor: theme.color.red400,
     borderRadius: '50%',
   },
+})
+
+globalStyle(`${content} a`, {
+  cursor: 'pointer',
+  color: theme.color.blue400,
+  textDecoration: 'none',
+  boxShadow: `inset 0 -2px 0 0 currentColor`,
+  transition: 'color .2s, box-shadow .2s',
+  paddingBottom: 4,
+})
+
+globalStyle(`${content} a:hover`, {
+  color: theme.color.blueberry400,
+  boxShadow: `inset 0 -2px 0 0 ${theme.color.blueberry400}`,
 })

--- a/libs/island-ui/core/src/lib/BulletList/BulletList.tsx
+++ b/libs/island-ui/core/src/lib/BulletList/BulletList.tsx
@@ -14,7 +14,7 @@ const BulletListContext = createContext<BulletListContextValue>({
   type: 'ul',
 })
 
-export const Bullet: FC<{}> = ({ children }) => {
+export const Bullet: FC = ({ children }) => {
   const { type } = useContext(BulletListContext)
 
   return (
@@ -29,7 +29,7 @@ export const Bullet: FC<{}> = ({ children }) => {
             {type === 'ul' && <span className={styles.icon} />}
           </span>
         </Box>
-        <Box>{children}</Box>
+        <Box className={styles.content}>{children}</Box>
       </Box>
     </Text>
   )

--- a/libs/island-ui/core/src/lib/Footer/Footer.tsx
+++ b/libs/island-ui/core/src/lib/Footer/Footer.tsx
@@ -163,7 +163,7 @@ export const Footer = ({
                   <LinkContext.Provider
                     value={{
                       linkRenderer: (href, children) => (
-                        <Link href={href} color="blue400" underline="normal">
+                        <Link href={href} color="blue600" underline="normal">
                           {children}
                         </Link>
                       ),

--- a/libs/island-ui/core/src/lib/Text/Text.css.ts
+++ b/libs/island-ui/core/src/lib/Text/Text.css.ts
@@ -182,20 +182,6 @@ globalStyle(`${base} mark`, {
   fontWeight: theme.typography.regular,
 })
 
-globalStyle(`${base} a`, {
-  cursor: 'pointer',
-  color: theme.color.blue400,
-  transition: 'color .2s, box-shadow .2s',
-  textDecoration: 'none',
-  boxShadow: `inset 0 -1px 0 0 ${theme.color.blue400}`,
-})
-
-globalStyle(`${base} a:hover`, {
-  color: theme.color.blueberry400,
-  boxShadow: `inset 0 -2px 0 0 ${theme.color.blueberry400}`,
-  textDecoration: 'none',
-})
-
 globalStyle(`${base} a svg path`, {
   transition: 'fill .2s, box-shadow .2s',
   fill: theme.color.blue400,


### PR DESCRIPTION
Moving these global styles from `Text` to `BulletList` where they were meant to be used. Reverting https://github.com/island-is/island.is/commit/c2c6acbad2cbe3ed7ff69637acb576601b89f14f#diff-c3cce377b28f0326bd8b5aa4331dcadb6d7cc4858a07d9648a9c303948b54e26R178-R190

BulletList was using the old `Typography` component. When it switched to `Text` it lost the global style for `a` elements. But this caused all links within `Text` to become underlined. This moves the needed styles to BulletList only.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
