### PR TITLE
feat(web): Organizations / Render new Contentful field External Links for Organization Page

### DIFF
--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -21,6 +21,8 @@ import {
   ProfileCard,
   Stack,
   Text,
+  Button,
+  Inline,
 } from '@island.is/island-ui/core'
 import NextLink from 'next/link'
 import {
@@ -126,6 +128,40 @@ export const OrganizationAlert: React.FC<AlertProps> = ({
             title: n('alertLinkTitle', 'Nánar'),
           }}
         />
+      </Box>
+    )
+  }
+  return null
+}
+
+interface ExternalLinksProps {
+  organizationPage: OrganizationPage
+}
+
+export const OrganizationExternalLinks: React.FC<ExternalLinksProps> = ({
+  organizationPage,
+}) => {
+  if (organizationPage.externalLinks) {
+    return (
+      <Box
+        display={['none', 'none', 'flex', 'flex']}
+        justifyContent="flexEnd"
+        marginBottom={4}
+      >
+        <Inline space={2}>
+          {organizationPage.externalLinks.map((link) => (
+            <Link href={link.url}>
+              <Button
+                colorScheme="light"
+                icon="open"
+                iconType="outline"
+                size="small"
+              >
+                {link.text}
+              </Button>
+            </Link>
+          ))}
+        </Inline>
       </Box>
     )
   }
@@ -385,6 +421,9 @@ export const OrganizationWrapper: React.FC<WrapperProps> = ({
                       }}
                     />
                   )}
+                  <OrganizationExternalLinks
+                    organizationPage={organizationPage}
+                  />
                   {pageDescription && (
                     <Box paddingTop={[2, 2, breadcrumbItems ? 5 : 0]}>
                       <Text variant="default">{pageDescription}</Text>

--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -149,8 +149,8 @@ export const OrganizationExternalLinks: React.FC<ExternalLinksProps> = ({
         marginBottom={4}
       >
         <Inline space={2}>
-          {organizationPage.externalLinks.map((link) => (
-            <Link href={link.url}>
+          {organizationPage.externalLinks.map((link, index) => (
+            <Link href={link.url} key={'organization-external-link-' + index}>
               <Button
                 colorScheme="light"
                 icon="open"

--- a/apps/web/screens/queries/Organization.tsx
+++ b/apps/web/screens/queries/Organization.tsx
@@ -111,6 +111,10 @@ export const GET_ORGANIZATION_PAGE_QUERY = gql`
         gradientStartColor
         gradientEndColor
       }
+      externalLinks {
+        text
+        url
+      }
     }
   }
   ${slices}

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -1930,6 +1930,9 @@ export interface IOrganizationPageFields {
 
   /** Theme Properties */
   themeProperties?: Record<string, any> | undefined
+
+  /** External Links */
+  externalLinks?: ILink[] | undefined
 }
 
 export interface IOrganizationPage extends Entry<IOrganizationPageFields> {

--- a/libs/cms/src/lib/models/organizationPage.model.ts
+++ b/libs/cms/src/lib/models/organizationPage.model.ts
@@ -3,6 +3,7 @@ import { Field, ObjectType, ID } from '@nestjs/graphql'
 import { IOrganizationPage } from '../generated/contentfulTypes'
 import { mapOrganization, Organization } from './organization.model'
 import { LinkGroup, mapLinkGroup } from './linkGroup.model'
+import { Link, mapLink } from './link.model'
 import { Image, mapImage } from './image.model'
 import { safelyMapSliceUnion, SliceUnion } from '../unions/slice.union'
 import { FooterItem, mapFooterItem } from './footerItem.model'
@@ -59,6 +60,9 @@ export class OrganizationPage {
 
   @Field(() => [SidebarCard])
   sidebarCards!: Array<SidebarCard>
+
+  @Field(() => [Link], { nullable: true })
+  externalLinks?: Array<Link>
 }
 
 export const mapOrganizationPage = ({
@@ -84,4 +88,5 @@ export const mapOrganizationPage = ({
   featuredImage: fields.featuredImage ? mapImage(fields.featuredImage) : null,
   footerItems: (fields.footerItems ?? []).map(mapFooterItem),
   sidebarCards: (fields.sidebarCards ?? []).map(mapSidebarCard),
+  externalLinks: (fields.externalLinks ?? []).map(mapLink),
 })


### PR DESCRIPTION
# Render new Contentful field External Links for Organization Page

## What

We've added a new field in Contentful to store links to external systems for Organizations, This PR updates the Contentful types accordingly and renders these links on the Organization home page.

## Why

Sjúkratryggingar provide information portals for users to use (Réttindagátt and Gagnagátt) and we need to show links to those on the Organization home page.

## Screenshots / Gifs

<img width="1732" alt="organization-home-external-links" src="https://user-images.githubusercontent.com/89025896/146556966-bd8f316f-693f-4e5f-a00d-21998731af1e.png">


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
