### PR TITLE
fix(fa): Spouse email - name instead of number

### DIFF
--- a/libs/financial-aid/shared/src/lib/formatters.ts
+++ b/libs/financial-aid/shared/src/lib/formatters.ts
@@ -315,9 +315,9 @@ export const getApplicantEmailDataFromEventType = (
           header: `Þú þarft að skila inn gögnum fyrir umsókn maka þíns um fjárhagsaðstoð hjá ${municipality.name}`,
           content: `Maki þinn hefur sótt um fjárhagsaðstoð fyrir ${
             getPeriod.month
-          } mánuð. Svo hægt sé að klára umsóknina þurfum við að fá þig til að hlaða upp tekju- og skattagögnum til að reikna út fjárhagsaðstoð til útgreiðslu í byrjun ${nextMonth(
-            createdDate.getMonth(),
-          )}.`,
+          } mánuð. Svo hægt sé að klára umsóknina þurfum við að fá þig til að hlaða upp tekju- og skattagögnum til að reikna út fjárhagsaðstoð til útgreiðslu í byrjun ${
+            months[nextMonth(createdDate.getMonth())]
+          }.`,
           applicationChange: 'Umsókn bíður eftir gögnum frá maka',
           applicationMonth: getPeriod.month,
           applicationYear: getPeriod.year,


### PR DESCRIPTION
# ...
https://app.asana.com/0/1201498198362488/1201405795061494

## What
Displays month name instead of number in spouse email

## Why
Clearer copy


## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
