### PR TITLE
fix(application-templates-driving-license): fix license selection

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/driving-license-submission/driving-license-submission.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/driving-license-submission/driving-license-submission.service.ts
@@ -6,7 +6,7 @@ import {
 
 import { SharedTemplateApiService } from '../../shared'
 import { TemplateApiModuleActionProps } from '../../../types'
-import { FormValue } from '@island.is/application/core'
+import { FormValue, getValueViaPath } from '@island.is/application/core'
 import {
   generateDrivingLicenseSubmittedEmail,
   generateDrivingAssessmentApprovalEmail,
@@ -27,7 +27,12 @@ export class DrivingLicenseSubmissionService {
     application: { id, answers },
     auth,
   }: TemplateApiModuleActionProps) {
-    const applicationFor = answers.applicationFor || 'B-full'
+    const applicationFor = getValueViaPath<'B-full' | 'B-temp'>(
+      answers,
+      'applicationFor',
+      'B-full',
+    )
+
     const chargeItemCode = applicationFor === 'B-full' ? 'AY110' : 'AY114'
 
     const response = await this.sharedTemplateAPIService.createCharge(

--- a/libs/application/templates/driving-license/src/dataProviders/CurrentLicenseProvider.ts
+++ b/libs/application/templates/driving-license/src/dataProviders/CurrentLicenseProvider.ts
@@ -3,21 +3,25 @@ import {
   Application,
   SuccessfulDataProviderResult,
   FailedDataProviderResult,
+  getValueViaPath,
 } from '@island.is/application/core'
 import { m } from '../lib/messages'
 import { DrivingLicenseFakeData, YES } from '../lib/constants'
 import { Eligibility } from '../types/schema'
 
+export interface CurrentLicenseProviderResult {
+  currentLicense: Eligibility['name'] | null
+}
 export class CurrentLicenseProvider extends BasicDataProvider {
   type = 'CurrentLicenseProvider'
 
   async provide(
     application: Application,
-  ): Promise<{ currentLicense: Eligibility['name'] | null }> {
-    const fakeData = application.answers.fakeData as
-      | DrivingLicenseFakeData
-      | undefined
-
+  ): Promise<CurrentLicenseProviderResult> {
+    const fakeData = getValueViaPath<DrivingLicenseFakeData>(
+      application.answers,
+      'fakeData',
+    )
     if (fakeData?.useFakeData === YES) {
       return {
         currentLicense: fakeData.currentLicense === 'temp' ? 'B' : null,
@@ -62,11 +66,12 @@ export class CurrentLicenseProvider extends BasicDataProvider {
       date: new Date(),
       reason: m.errorDataProvider,
       status: 'failure',
-      data: {},
     }
   }
 
-  onProvideSuccess(result: object): SuccessfulDataProviderResult {
+  onProvideSuccess(
+    result: CurrentLicenseProviderResult,
+  ): SuccessfulDataProviderResult {
     return { date: new Date(), status: 'success', data: result }
   }
 }

--- a/libs/application/templates/driving-license/src/forms/application.ts
+++ b/libs/application/templates/driving-license/src/forms/application.ts
@@ -35,6 +35,7 @@ import {
   B_TEMP,
 } from '../shared/constants'
 import { hasYes } from '../utils'
+import { CurrentLicenseProviderResult } from '../dataProviders/CurrentLicenseProvider'
 
 const allowFakeCondition = (result = YES) => (answers: FormValue) =>
   getValueViaPath(answers, 'fakeData.useFakeData') === result
@@ -251,21 +252,31 @@ export const getApplication = (
                 description: '',
                 space: 0,
                 largeButtons: true,
-                options: [
-                  {
-                    label: m.applicationForTempLicenseTitle,
-                    subLabel:
-                      m.applicationForTempLicenseDescription.defaultMessage,
-                    value: B_TEMP,
-                  },
-                  {
-                    label: m.applicationForFullLicenseTitle,
-                    subLabel:
-                      m.applicationForFullLicenseDescription.defaultMessage,
-                    value: B_FULL,
-                    disabled: true,
-                  },
-                ],
+                options: (app) => {
+                  const {
+                    currentLicense,
+                  } = getValueViaPath<CurrentLicenseProviderResult>(
+                    app.externalData,
+                    'currentLicense.data',
+                  ) ?? { currentLicense: null }
+
+                  return [
+                    {
+                      label: m.applicationForTempLicenseTitle,
+                      subLabel:
+                        m.applicationForTempLicenseDescription.defaultMessage,
+                      value: B_TEMP,
+                      disabled: !!currentLicense,
+                    },
+                    {
+                      label: m.applicationForFullLicenseTitle,
+                      subLabel:
+                        m.applicationForFullLicenseDescription.defaultMessage,
+                      value: B_FULL,
+                      disabled: !currentLicense,
+                    },
+                  ]
+                },
               }),
             ],
           }),


### PR DESCRIPTION
## What

when license selection is available, allow both types depending on the current license
tiny typing cleanup in submission step

## Why

To allow full-license application flow, when testing the new license flow

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
