### PR TITLE
fix(auth-nest-tools): Use x-orginal-forwarded-for for ip in audit logs

### DIFF
--- a/libs/auth-nest-tools/src/lib/jwt.strategy.ts
+++ b/libs/auth-nest-tools/src/lib/jwt.strategy.ts
@@ -54,7 +54,11 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
         nationalId: actor.nationalId,
         scope: this.parseScopes(actor.scope),
       },
-      ip: String(request.headers['x-real-ip']) ?? request.ip,
+      ip: String(
+        request.headers['x-original-forwarded-for'] ??
+          request.headers['x-real-ip'] ??
+          request.ip,
+      ),
       userAgent: request.headers['user-agent'],
     }
   }


### PR DESCRIPTION
island-is/infrastructure#1003

## What

Use correct source ip of client in audit logs.
X-Real-Ip has either 127.0.0.1 or cloudfront ip

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
