### PR TITLE
ci: Retry if cache fails

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -1,0 +1,83 @@
+# You can use this composite action if you want retry functionality with your
+# caching action. Because composite actions currently do not have the
+# continue-on-error feature we need a second step to check the output of the
+# cache action to determine if it ran successfully.
+#
+# Example:
+#
+# jobs:
+#   my-job:
+#     steps:
+#     - name: Cache node modules
+#       id: node-modules
+#       continue-on-error: true
+#       uses: ./.github/actions/cache
+#       with:
+#         path: node_modules
+#         key: ${{ steps.calculate_node_modules_hash.outputs.node-modules-hash }}-yarn
+#     - name: Check cache status
+#       run: '[[ "${{ steps.node-modules.outputs.status }}" != "failure" ]] || exit 1'
+#
+name: 'Cache'
+description: 'Cache with retry'
+inputs:
+  path:
+    required: true
+  key:
+    required: true
+  retry:
+    required: false
+    default: 2
+outputs:
+  status:
+    value: ${{ steps.computed_outputs.outputs.status }}
+  cache-hit:
+    value: ${{ steps.computed_outputs.outputs.cache-hit }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Cache try number one
+      id: cache_try_number_one
+      uses: island-is/cache@v0.1
+      with:
+        path: ${{ inputs.path }}
+        key: ${{ inputs.key }}
+
+    - name: Cache try number two
+      id: cache_try_number_two
+      if: always() && inputs.retry > 0 && steps.cache_try_number_one.outputs.cache-hit == ''
+      uses: island-is/cache@v0.1
+      with:
+        path: ${{ inputs.path }}
+        key: ${{ inputs.key }}
+
+    - name: Cache try number three
+      id: cache_try_number_three
+      if: always() && inputs.retry > 1 && steps.cache_try_number_one.outputs.cache-hit == '' && steps.cache_try_number_two.outputs.cache-hit == ''
+      uses: island-is/cache@v0.1
+      with:
+        path: ${{ inputs.path }}
+        key: ${{ inputs.key }}
+
+    - name: Gather outputs
+      id: computed_outputs
+      if: always()
+      shell: bash
+      run: |
+        if [[ "${{ steps.cache_try_number_one.outputs.cache-hit }}" != "" ]] || \
+           [[ "${{ steps.cache_try_number_two.outputs.cache-hit }}" != "" ]] || \
+           [[ "${{ steps.cache_try_number_three.outputs.cache-hit }}" != "" ]]
+        then
+          echo "::set-output name=status::success"
+        else
+          echo "::set-output name=status::failure"
+        fi
+
+        if [[ "${{ steps.cache_try_number_one.outputs.cache-hit }}" == "true" ]] || \
+           [[ "${{ steps.cache_try_number_two.outputs.cache-hit }}" == "true" ]] || \
+           [[ "${{ steps.cache_try_number_three.outputs.cache-hit }}" == "true" ]]
+        then
+          echo "::set-output name=cache-hit::true"
+        else
+          echo "::set-output name=cache-hit::false"
+        fi

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -64,20 +64,29 @@ jobs:
 
       - name: Cache for NodeJS dependencies - host OS
         id: node-modules
-        uses: island-is/cache@v0.1
+        continue-on-error: true
+        uses: ./.github/actions/cache
         with:
           path: node_modules
           key: ${{ steps.calculate_node_modules_hash.outputs.node-modules-hash }}-yarn
+
+      - name: Check cache status
+        run: '[[ "${{ steps.node-modules.outputs.status }}" != "failure" ]] || exit 1'
 
       - name: Building NodeJS dependencies
         if: steps.node-modules.outputs.cache-hit != 'true'
         run: ./scripts/ci/10_prepare-host-deps.sh
 
       - name: Cache for cypress
-        uses: island-is/cache@v0.1
+        id: cypress
+        continue-on-error: true
+        uses: ./.github/actions/cache
         with:
           path: ~/.cache/Cypress
           key: cypress-cache-${{ steps.calculate_node_modules_hash.outputs.node-modules-hash }}
+
+      - name: Check cache status
+        run: '[[ "${{ steps.cypress.outputs.status }}" != "failure" ]] || exit 1'
 
       - name: Verify cypress
         id: cypress-check
@@ -90,10 +99,14 @@ jobs:
 
       - name: Cache for generated files
         id: generated-files-cache
-        uses: island-is/cache@v0.1
+        continue-on-error: true
+        uses: ./.github/actions/cache
         with:
           path: generated_files.tar.gz
           key: ${{ steps.calculate_generated_files_cache_key.outputs.generated-files-cache-key }}
+
+      - name: Check cache status
+        run: '[[ "${{ steps.generated-files-cache.outputs.status }}" != "failure" ]] || exit 1'
 
       - name: Generate schemas
         if: steps.generated-files-cache.outputs.cache-hit != 'true'
@@ -190,22 +203,37 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Cache for NodeJS dependencies - host OS
-        uses: island-is/cache@v0.1
+        id: node-modules
+        continue-on-error: true
+        uses: ./.github/actions/cache
         with:
           path: node_modules
           key: ${{ needs.prepare.outputs.node-modules-hash }}-yarn
 
+      - name: Check cache status
+        run: '[[ "${{ steps.node-modules.outputs.status }}" != "failure" ]] || exit 1'
+
       - name: Cache for cypress
-        uses: island-is/cache@v0.1
+        id: cypress
+        continue-on-error: true
+        uses: ./.github/actions/cache
         with:
           path: ~/.cache/Cypress
           key: cypress-cache-${{ needs.prepare.outputs.node-modules-hash }}
 
+      - name: Check cache status
+        run: '[[ "${{ steps.cypress.outputs.status }}" != "failure" ]] || exit 1'
+
       - name: Cache for generated files
-        uses: island-is/cache@v0.1
+        id: generated-files-cache
+        continue-on-error: true
+        uses: ./.github/actions/cache
         with:
           path: generated_files.tar.gz
           key: ${{ needs.prepare.outputs.generated-files-cache-key }}
+
+      - name: Check cache status
+        run: '[[ "${{ steps.generated-files-cache.outputs.status }}" != "failure" ]] || exit 1'
 
       - name: Untar generated files
         run: tar zxvf generated_files.tar.gz
@@ -225,10 +253,13 @@ jobs:
       - uses: actions/checkout@v2
       - name: Cache for NodeJS dependencies - host OS
         id: node-modules
-        uses: island-is/cache@v0.1
+        continue-on-error: true
+        uses: ./.github/actions/cache
         with:
           path: node_modules
           key: ${{ needs.prepare.outputs.node-modules-hash }}-yarn
+      - name: Check cache status
+        run: '[[ "${{ steps.node-modules.outputs.status }}" != "failure" ]] || exit 1'
       - name: Linting workspace
         run: ./scripts/ci/20_lint-workspace.sh
       - name: Run ShellCheck
@@ -246,10 +277,13 @@ jobs:
       - uses: actions/checkout@v2
       - name: Cache for NodeJS dependencies - host OS
         id: node-modules
-        uses: island-is/cache@v0.1
+        continue-on-error: true
+        uses: ./.github/actions/cache
         with:
           path: node_modules
           key: ${{ needs.prepare.outputs.node-modules-hash }}-yarn
+      - name: Check cache status
+        run: '[[ "${{ steps.node-modules.outputs.status }}" != "failure" ]] || exit 1'
       - name: Check formatting
         run: ./scripts/ci/20_check-formatting.sh
 
@@ -270,16 +304,26 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Cache for NodeJS dependencies - host OS
-        uses: island-is/cache@v0.1
+        id: node-modules
+        continue-on-error: true
+        uses: ./.github/actions/cache
         with:
           path: node_modules
           key: ${{ needs.prepare.outputs.node-modules-hash }}-yarn
 
+      - name: Check cache status
+        run: '[[ "${{ steps.node-modules.outputs.status }}" != "failure" ]] || exit 1'
+
       - name: Cache for generated files
-        uses: island-is/cache@v0.1
+        id: generated-files-cache
+        continue-on-error: true
+        uses: ./.github/actions/cache
         with:
           path: generated_files.tar.gz
           key: ${{ needs.prepare.outputs.generated-files-cache-key }}
+
+      - name: Check cache status
+        run: '[[ "${{ steps.generated-files-cache.outputs.status }}" != "failure" ]] || exit 1'
 
       - name: Untar generated files
         run: tar zxvf generated_files.tar.gz
@@ -303,16 +347,26 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Cache for NodeJS dependencies - host OS
-        uses: island-is/cache@v0.1
+        id: node-modules
+        continue-on-error: true
+        uses: ./.github/actions/cache
         with:
           path: node_modules
           key: ${{ needs.prepare.outputs.node-modules-hash }}-yarn
 
+      - name: Check cache status
+        run: '[[ "${{ steps.node-modules.outputs.status }}" != "failure" ]] || exit 1'
+
       - name: Cache for generated files
-        uses: island-is/cache@v0.1
+        id: generated-files-cache
+        continue-on-error: true
+        uses: ./.github/actions/cache
         with:
           path: generated_files.tar.gz
           key: ${{ needs.prepare.outputs.generated-files-cache-key }}
+
+      - name: Check cache status
+        run: '[[ "${{ steps.generated-files-cache.outputs.status }}" != "failure" ]] || exit 1'
 
       - name: Untar generated files
         run: tar zxvf generated_files.tar.gz

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -220,17 +220,25 @@ jobs:
 
       - name: Cache for NodeJS dependencies - Docker layer
         id: cache-deps
-        uses: island-is/cache@v0.1
+        continue-on-error: true
+        uses: ./.github/actions/cache
         with:
           path: cache
           key: ${{ steps.calculate_node_modules_hash.outputs.node-modules-hash }}-docker-deps
 
+      - name: Check cache status
+        run: '[[ "${{ steps.cache-deps.outputs.status }}" != "failure" ]] || exit 1'
+
       - name: Cache for NodeJS dependencies - Docker layer
         id: cache-deps-base
-        uses: island-is/cache@v0.1
+        continue-on-error: true
+        uses: ./.github/actions/cache
         with:
           path: cache_output
           key: ${{ steps.calculate_node_modules_hash.outputs.node-modules-hash }}-docker-output-base
+
+      - name: Check cache status
+        run: '[[ "${{ steps.cache-deps-base.outputs.status }}" != "failure" ]] || exit 1'
 
       - name: Building NodeJS dependencies
         if: steps.cache-deps.outputs.cache-hit != 'true' || steps.cache-deps-base.outputs.cache-hit != 'true'
@@ -238,10 +246,14 @@ jobs:
 
       - name: Cache for NodeJS dependencies - host OS
         id: node-modules
-        uses: island-is/cache@v0.1
+        continue-on-error: true
+        uses: ./.github/actions/cache
         with:
           path: node_modules
           key: ${{ steps.calculate_node_modules_hash.outputs.node-modules-hash }}-yarn
+
+      - name: Check cache status
+        run: '[[ "${{ steps.node-modules.outputs.status }}" != "failure" ]] || exit 1'
 
       - name: Building NodeJS dependencies
         if: steps.node-modules.outputs.cache-hit != 'true'
@@ -252,10 +264,14 @@ jobs:
 
       - name: Cache for generated files
         id: generated-files-cache
-        uses: island-is/cache@v0.1
+        continue-on-error: true
+        uses: ./.github/actions/cache
         with:
           path: generated_files.tar.gz
           key: ${{ steps.calculate_generated_files_cache_key.outputs.generated-files-cache-key }}
+
+      - name: Check cache status
+        run: '[[ "${{ steps.generated-files-cache.outputs.status }}" != "failure" ]] || exit 1'
 
       - name: Generate schemas
         if: steps.generated-files-cache.outputs.cache-hit != 'true'
@@ -356,11 +372,16 @@ jobs:
       - uses: actions/checkout@v2
         if: steps.gather.outcome == 'success'
       - name: Cache for generated files
+        id: generated-files-cache
         if: steps.gather.outcome == 'success'
-        uses: island-is/cache@v0.1
+        continue-on-error: true
+        uses: ./.github/actions/cache
         with:
           path: generated_files.tar.gz
           key: ${{ needs.prepare.outputs.generated-files-cache-key }}
+
+      - name: Check cache status
+        run: '[[ "${{ steps.generated-files-cache.outputs.status }}" != "failure" ]] || exit 1'
 
       - name: Untar generated files
         if: steps.gather.outcome == 'success'
@@ -368,18 +389,27 @@ jobs:
 
       - name: Cache for dependencies Docker layer
         if: steps.gather.outcome == 'success'
-        id: cache-deps
-        uses: island-is/cache@v0.1
+        id: cache-deps-base
+        continue-on-error: true
+        uses: ./.github/actions/cache
         with:
           path: cache_output
           key: ${{ needs.prepare.outputs.node-modules-hash }}-docker-output-base
 
+      - name: Check cache status
+        run: '[[ "${{ steps.cache-deps-base.outputs.status }}" != "failure" ]] || exit 1'
+
       - name: Cache for NodeJS dependencies - Docker layer
+        id: cache-deps
         if: steps.gather.outcome == 'success'
-        uses: island-is/cache@v0.1
+        continue-on-error: true
+        uses: ./.github/actions/cache
         with:
           path: cache
           key: ${{ needs.prepare.outputs.node-modules-hash }}-docker-deps
+
+      - name: Check cache status
+        run: '[[ "${{ steps.cache-deps.outputs.status }}" != "failure" ]] || exit 1'
 
       - name: Docker login to ECR repo
         if: steps.gather.outcome == 'success'


### PR DESCRIPTION
island-is/infrastructure#1017

## What

Bake in retry mechanism for the cache actions in our CI

It's not ideal that we need a second step after the cache action to check if it failed or not but composite actions do not yet support continue-on-error.

## Why

Because our cache action was failing with 500 every now and then.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
