### PR TITLE
fix(user-notification): Change to default swagger path

### DIFF
--- a/apps/services/user-notification/src/main.ts
+++ b/apps/services/user-notification/src/main.ts
@@ -20,6 +20,5 @@ if (argv.job === 'worker') {
     appModule: AppModule,
     name: 'services-user-notifications',
     openApi,
-    swaggerPath: '',
   })
 }


### PR DESCRIPTION
The openapi json schema path is generated by adding '-json' to the
swagger path. By having the swagger path on the root the openapi schema
is hosted on /-json which doesn't make any sense