### PR TITLE
fix(skilavottord): use request.auth instead of cookies

### DIFF
--- a/apps/skilavottord/ws/src/app/modules/auth/auth.guard.ts
+++ b/apps/skilavottord/ws/src/app/modules/auth/auth.guard.ts
@@ -42,15 +42,12 @@ export class AuthGuard implements CanActivate {
   }
 
   private decodeSession(request: GraphQLContext['req']): Partial<User> {
-    const sessionToken = request.cookies
-      ? request.cookies['next-auth.session-token']
-      : null
-
-    if (!sessionToken) {
+    const accessToken = request.auth.authorization.replace('Bearer ', '')
+    if (!accessToken) {
       throw new AuthenticationError('Invalid user')
     }
 
-    const decodedToken = decode(sessionToken) as Partial<User>
+    const decodedToken = decode(accessToken) as Partial<User>
 
     return {
       name: decodedToken.name,


### PR DESCRIPTION
# Fix auth

## What

Use request.auth instead of cookies

## Why

The cookies differ from prod to localhost

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
