### PR TITLE
feat(web): Syslumenn / Remove outdated temporary alert

### DIFF
--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -1,12 +1,10 @@
 import React, { ReactNode, useMemo } from 'react'
 import {
   Image,
-  Namespace,
   Organization,
   OrganizationPage,
 } from '@island.is/web/graphql/schema'
 import {
-  AlertBanner,
   Box,
   BreadCrumbItem,
   Breadcrumbs,
@@ -46,7 +44,6 @@ import {
 import { endpoints as chatPanelEndpoints } from '../../ChatPanel/config'
 import { useRouter } from 'next/router'
 import * as styles from './OrganizationWrapper.css'
-import { useNamespace } from '@island.is/web/hooks'
 
 interface NavigationData {
   title: string
@@ -67,7 +64,6 @@ interface WrapperProps {
   stickySidebar?: boolean
   minimal?: boolean
   showSecondaryMenu?: boolean
-  namespace: Namespace
   showExternalLinks: boolean
 }
 
@@ -91,47 +87,6 @@ const OrganizationHeader: React.FC<HeaderProps> = ({ organizationPage }) => {
     default:
       return <DefaultHeader organizationPage={organizationPage} />
   }
-}
-
-interface AlertProps {
-  organizationPage: OrganizationPage
-  namespace: Namespace
-}
-
-export const OrganizationAlert: React.FC<AlertProps> = ({
-  organizationPage,
-  namespace,
-}) => {
-  /**
-   * The following code was added as a quick fix in order to get the message out to
-   * users ASAP. After December 14th 2021, the PR that added this code can be reverted.
-   */
-  const n = useNamespace(namespace)
-  const alertEndDate = new Date(2021, 11, 14) // Dec. 14th 2021
-  const withinAlertTimeframe = new Date() < alertEndDate
-  if (organizationPage.slug === 'syslumenn' && withinAlertTimeframe) {
-    return (
-      <Box paddingTop={[3, 4, 8]} paddingX={[3, 3, 6]}>
-        <AlertBanner
-          variant={n('alertVariant', 'info')}
-          title={n('alertTitle', 'Lokað er hjá sýslumönnum 13. desember')}
-          description={n(
-            'alertDescription',
-            'Skrifstofur embætta sýslumanna um land allt verða lokaðar mánudaginn 13. desember vegna uppfærslu tölvukerfa.',
-          )}
-          dismissable={false}
-          link={{
-            href: n(
-              'alertLinkHref',
-              'https://island.is/s/syslumenn/frett/lokad-hja-syslumonnum-13-desember',
-            ),
-            title: n('alertLinkTitle', 'Nánar'),
-          }}
-        />
-      </Box>
-    )
-  }
-  return null
 }
 
 interface ExternalLinksProps {
@@ -299,7 +254,6 @@ export const OrganizationWrapper: React.FC<WrapperProps> = ({
   children,
   minimal = false,
   showSecondaryMenu = true,
-  namespace,
   showExternalLinks = false,
 }) => {
   const router = useRouter()
@@ -333,16 +287,6 @@ export const OrganizationWrapper: React.FC<WrapperProps> = ({
       />
       <OrganizationHeader organizationPage={organizationPage} />
       <Main>
-        <GridContainer>
-          <GridRow>
-            <GridColumn span={['12/12', '12/12', '12/12', '12/12', '11/12']}>
-              <OrganizationAlert
-                organizationPage={organizationPage}
-                namespace={namespace}
-              />
-            </GridColumn>
-          </GridRow>
-        </GridContainer>
         {!minimal && (
           <SidebarLayout
             paddingTop={[2, 2, 9]}

--- a/apps/web/screens/Organization/Home.tsx
+++ b/apps/web/screens/Organization/Home.tsx
@@ -59,7 +59,6 @@ const Home: Screen<HomeProps> = ({ organizationPage, namespace }) => {
       organizationPage={organizationPage}
       pageFeaturedImage={organizationPage.featuredImage}
       fullWidthContent={true}
-      namespace={namespace}
       navigationData={{
         title: n('navigationTitle', 'Efnisyfirlit'),
         items: navList,


### PR DESCRIPTION
# Syslumenn / Remove outdated temporary alert

## What

Removing an alert message that was temporarily added last month (see PR #5942), where Syslumenn needed to show a certain message on their Organization page to Users, with short notice. This message is now outdated and therefor we're removing it.

Note: Ideally the merge commit of the before mentioned PR should simply have been reverted, but there were some conflicts when doing the revert. Since these are only a handful of lines in only two files, I manually removed the lines added in the original PR.

## Why

This code we're removing here was added with that in mind to simply remove it once the message was outdated.

## Screenshots / Gifs

For screenshots of the alter message begin removed, see screenshots in PR #5942 where this alert message was added.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
