### PR TITLE
fix(infra): Change the postgres image for the m1 chip

### DIFF
--- a/apps/air-discount-scheme/backend/docker-compose.yml
+++ b/apps/air-discount-scheme/backend/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   db_ads_backend:
-    image: public.ecr.aws/bitnami/postgresql:11.12.0
+    image: public.ecr.aws/docker/library/postgres:11.14-alpine
     container_name: db_ads_backend
     networks:
       - local

--- a/apps/application-system/api/docker-compose.yml
+++ b/apps/application-system/api/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   db_application_system:
-    image: public.ecr.aws/bitnami/postgresql:11.12.0
+    image: public.ecr.aws/docker/library/postgres:11.14-alpine
     container_name: db_application_system
     networks:
       - local

--- a/apps/financial-aid/backend/docker-compose.yml
+++ b/apps/financial-aid/backend/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   db_financial_aid:
-    image: public.ecr.aws/bitnami/postgresql:11.12.0
+    image: public.ecr.aws/docker/library/postgres:11.14-alpine
     container_name: db_financial_aid
     networks:
       - local

--- a/apps/gjafakort/application/docker-compose.yml
+++ b/apps/gjafakort/application/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   db_gjafakort_application:
-    image: public.ecr.aws/bitnami/postgresql:11.12.0
+    image: public.ecr.aws/docker/library/postgres:11.14-alpine
     container_name: db_gjafakort_application
     networks:
       - local

--- a/apps/icelandic-names-registry/backend/docker-compose.yml
+++ b/apps/icelandic-names-registry/backend/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   db_icelandic_names_registry:
-    image: public.ecr.aws/bitnami/postgresql:11.12.0
+    image: public.ecr.aws/docker/library/postgres:11.14-alpine
     container_name: db_icelandic_names_registry
     networks:
       - local

--- a/apps/judicial-system/backend/docker-compose.yml
+++ b/apps/judicial-system/backend/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   db_judicial_system:
-    image: public.ecr.aws/bitnami/postgresql:11.12.0
+    image: public.ecr.aws/docker/library/postgres:11.14-alpine
     container_name: db_judicial_system
     networks:
       - local

--- a/apps/reference-backend/docker-compose.yml
+++ b/apps/reference-backend/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   db_reference_backend:
-    image: public.ecr.aws/bitnami/postgresql:11.12.0
+    image: public.ecr.aws/docker/library/postgres:11.14-alpine
     container_name: db_reference_backend
     networks:
       - local

--- a/apps/services/auth-api/docker-compose.yml
+++ b/apps/services/auth-api/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   db_services_auth_api:
-    image: public.ecr.aws/bitnami/postgresql:11.12.0
+    image: public.ecr.aws/docker/library/postgres:11.14-alpine
     container_name: db_services_auth_api
     networks:
       - local

--- a/apps/services/documents/docker-compose.yml
+++ b/apps/services/documents/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   db_documents:
-    image: public.ecr.aws/bitnami/postgresql:11.12.0
+    image: public.ecr.aws/docker/library/postgres:11.14-alpine
     container_name: db_documents
     networks:
       - local

--- a/apps/services/endorsements/api/docker-compose.yml
+++ b/apps/services/endorsements/api/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   db_endorsements:
-    image: public.ecr.aws/bitnami/postgresql:11.12.0
+    image: public.ecr.aws/docker/library/postgres:11.14-alpine
     container_name: db_endorsements
     networks:
       - local

--- a/apps/services/user-profile/docker-compose.yml
+++ b/apps/services/user-profile/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   db_user_profile:
-    image: public.ecr.aws/bitnami/postgresql:11.12.0
+    image: public.ecr.aws/docker/library/postgres:11.14-alpine
     container_name: db_user_profile
     networks:
       - local

--- a/apps/skilavottord/ws/docker-compose.yml
+++ b/apps/skilavottord/ws/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   db_skilavottord_backend:
-    image: public.ecr.aws/bitnami/postgresql:11.12.0
+    image: public.ecr.aws/docker/library/postgres:11.14-alpine
     container_name: db_skilavottord_backend
     networks:
       - local

--- a/libs/testing/containers/src/lib/testing-containers.ts
+++ b/libs/testing/containers/src/lib/testing-containers.ts
@@ -5,7 +5,7 @@ let postgresContainer: StartedTestContainer
 export const startPostgres = async () => {
   const name = 'test_db'
   postgresContainer = await new GenericContainer(
-    'public.ecr.aws/bitnami/postgresql:11.12.0',
+    'public.ecr.aws/docker/library/postgres:11.14-alpine',
   )
     .withEnv('POSTGRES_DB', name)
     .withEnv('POSTGRES_USER', name)


### PR DESCRIPTION
## What

Change postgres docker image to one that supports ARM 64

## Why

So developers using apples new M1 chip are able to run tests

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
