### PR TITLE
fix(skilavottord): use cookies to get user info from session token

### DIFF
--- a/apps/skilavottord/web/components/Header/Header.tsx
+++ b/apps/skilavottord/web/components/Header/Header.tsx
@@ -93,7 +93,7 @@ export const Header: FC = () => {
       language={activeLocale}
       switchLanguage={() => switchLanguage(nextLanguage)}
       userName={loading ? '' : user?.name ?? session?.user.name ?? ''}
-      authenticated={true || isAuthenticated}
+      authenticated={isAuthenticated}
       onLogout={logout}
     />
   )

--- a/apps/skilavottord/ws/src/environments/environment.ts
+++ b/apps/skilavottord/ws/src/environments/environment.ts
@@ -6,6 +6,7 @@ const devConfig = {
   auth: {
     issuer: 'https://identity-server.staging01.devland.is',
     audience: '@urvinnslusjodur.is/skilavottord',
+    nextAuthCookieName: 'next-auth.session-token',
   },
   samgongustofa: {
     soapUrl:
@@ -42,6 +43,7 @@ const prodConfig = {
   auth: {
     issuer: process.env.IDENTITY_SERVER_ISSUER_URL,
     audience: '@urvinnslusjodur.is/skilavottord',
+    nextAuthCookieName: '__Secure-next-auth.session-token',
   },
   samgongustofa: {
     soapUrl: process.env.SAMGONGUSTOFA_SOAP_URL,


### PR DESCRIPTION
# Fix user name in auth

## What

Use cookies to get user info from session token

## Why

The access token doesn't include user information (other than nationalId)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
