### PR TITLE
chore(syslumenn-api): CodeOwners / Add CodeOwners of refactored Syslumenn Client

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -134,6 +134,7 @@
 /libs/content-search-indexer/                                                                 @island-is/stefna @island-is/kosmos-kaos
 /libs/api/domains/content-search/                                                             @island-is/stefna @island-is/kosmos-kaos
 /libs/api/domains/syslumenn/                                                                  @island-is/stefna
+/libs/clients/syslumenn/                                                                      @island-is/stefna @island-is/kosmos-kaos
 
 /libs/island-ui/                                                                              @island-is/island-ui
 

--- a/libs/clients/syslumenn/README.md
+++ b/libs/clients/syslumenn/README.md
@@ -25,3 +25,4 @@ yarn nx run clients-syslumenn:schemas/external-openapi-generator
 ## Code owners and maintainers
 
 - [Kosmos & Kaos](https://github.com/orgs/island-is/teams/kosmos-og-kaos/members)
+- [Stefna](https://github.com/orgs/island-is/teams/stefna/members)


### PR DESCRIPTION
# CodeOwners / Add CodeOwners for refactored Syslumenn Client

## What

Adding @island-is/kosmos-kaos and @island-is/stefna as code owners of recently refactored Syslumenn Client.

## Why

In PR #5973 the Syslumenn Client was refactored and moved from `/libs/api/domains/syslumenn/` to `/libs/clients/syslumenn/`, but the CodeOwners definition was not updated accordingly.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
