### PR TITLE
feat(web): Organization Services page now has articles

### DIFF
--- a/apps/web/screens/Organization/Home.tsx
+++ b/apps/web/screens/Organization/Home.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import React from 'react'
-import { Button, NavigationItem, Text } from '@island.is/island-ui/core'
+import { NavigationItem } from '@island.is/island-ui/core'
 import { withMainLayout } from '@island.is/web/layouts/main'
 import {
   ContentLanguage,
@@ -28,7 +28,16 @@ interface HomeProps {
   namespace: Query['getNamespace']
 }
 
-const WITH_SEARCH = ['syslumenn', 'sjukratryggingar', 'utlendingastofnun']
+const WITH_SEARCH = [
+  'syslumenn',
+  'district-commissioner',
+
+  'sjukratryggingar',
+  'health-insurance-in-iceland',
+
+  'utlendingastofnun',
+  'directorate-of-immigration',
+]
 
 const Home: Screen<HomeProps> = ({ organizationPage, namespace }) => {
   const { disableSyslumennPage: disablePage } = publicRuntimeConfig

--- a/libs/cms/src/lib/environments/environment.ts
+++ b/libs/cms/src/lib/environments/environment.ts
@@ -12,6 +12,7 @@ export default {
     'vidspyrnaPage',
     'menu',
     'groupedMenu',
+    'organization',
     'organizationPage',
     'organizationSubpage',
     'supportQNA',
@@ -19,6 +20,7 @@ export default {
     'frontpage',
   ],
   nestedContentTypes: [
+    'organizationPage',
     'subArticle',
     'processEntry',
     'embeddedVideo',


### PR DESCRIPTION
# Organization Services page now has articles

https://stefna.atlassian.net/browse/ISLAND-839

## What

* Organization services page now has articles and english translations
* Updated the WITH_SEARCH constant to show the searchbox when the slug is in english

## Why

* Organization services page didn't load any articles
* The WITH_SEARCH constant did not support english slugs meaning that if you would toggle english on then the searchbox would go away

## Screenshots / Gifs

It previously looked like this
![image](https://user-images.githubusercontent.com/43557895/148369144-1cd97414-6c73-4d10-acd1-cbdcfca0d200.png)

Now after this change then contentful realizes that the english articles belong to this page and are shown
![image](https://user-images.githubusercontent.com/43557895/148369262-46291336-da14-406a-89b9-0eecfa2823a7.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
