### PR TITLE
feat(web): Organization searchbox, show loading icon while typing, enabled english search and improved keyboard navigation

### DIFF
--- a/apps/web/components/Organization/SearchBox/SearchBox.tsx
+++ b/apps/web/components/Organization/SearchBox/SearchBox.tsx
@@ -1,5 +1,11 @@
 import React, { useEffect, useState } from 'react'
-import { Box, AsyncSearch, Text, Button } from '@island.is/island-ui/core'
+import {
+  Box,
+  AsyncSearch,
+  Text,
+  Button,
+  AsyncSearchOption,
+} from '@island.is/island-ui/core'
 import { useLazyQuery } from '@apollo/client'
 import {
   Query,
@@ -10,6 +16,10 @@ import { GET_ORGANIZATION_SERVICES_QUERY } from '@island.is/web/screens/queries'
 import { LinkType, useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
 import { useRouter } from 'next/router'
 import { useDebounce } from 'react-use'
+
+interface AsyncSearchOptionWithIsArticleField extends AsyncSearchOption {
+  isArticle: boolean
+}
 
 interface SearchBoxProps {
   organizationPage: Query['getOrganizationPage']
@@ -25,13 +35,16 @@ export const SearchBox = ({
   searchAllText,
 }: SearchBoxProps) => {
   const { linkResolver } = useLinkResolver()
-  const Router = useRouter()
+  const router = useRouter()
 
   const [value, setValue] = useState('')
   const [options, setOptions] = useState([])
-  const [isLoading, setIsLoading] = useState<boolean>(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [waitingForNextPageToLoad, setWaitingForNextPageToLoad] = useState(
+    false,
+  )
 
-  const [fetch, { data }] = useLazyQuery<Query, QueryGetArticlesArgs>(
+  const [fetch, { data, loading }] = useLazyQuery<Query, QueryGetArticlesArgs>(
     GET_ORGANIZATION_SERVICES_QUERY,
   )
 
@@ -41,16 +54,15 @@ export const SearchBox = ({
         fetch({
           variables: {
             input: {
-              lang: 'is',
+              lang: router.asPath.includes('/en/') ? 'en' : 'is',
               organization: organizationPage.slug,
               size: 500,
               sort: SortField.Popular,
             },
           },
         })
-
-        setIsLoading(false)
       }
+      setIsLoading(false)
     },
     300,
     [value],
@@ -59,16 +71,17 @@ export const SearchBox = ({
   const items = data?.getArticles?.map((item, index) => ({
     label: item.title,
     value: item.slug,
+    isArticle: true,
     component: ({ active }) => {
       return (
         <Box
-          key={index}
+          key={`article-${item.id ?? ''}-${index}`}
           cursor="pointer"
           outline="none"
           paddingX={2}
           paddingY={1}
           role="button"
-          background={active ? 'white' : 'blue100'}
+          background={active ? 'blue100' : 'white'}
           onClick={() => {
             setOptions([])
           }}
@@ -84,7 +97,35 @@ export const SearchBox = ({
     setOptions([])
   }
 
-  useEffect(() => {
+  const handleOptionSelect = (
+    selectedItem: AsyncSearchOptionWithIsArticleField,
+    value: string,
+  ) => {
+    setOptions([])
+    if (!value) return
+    setWaitingForNextPageToLoad(true)
+
+    let pathname: string
+    let searchAll = false
+
+    if (selectedItem && selectedItem?.isArticle) {
+      const newValue = selectedItem.value
+      pathname = linkResolver('Article' as LinkType, [newValue]).href
+      setValue(selectedItem.label)
+    } else {
+      pathname = linkResolver('search').href
+      searchAll = true
+    }
+
+    router
+      .push({
+        pathname,
+        query: searchAll ? { q: value } : {},
+      })
+      .then(() => window.scrollTo(0, 0))
+  }
+
+  const updateOptions = () => {
     const newOpts = items
       ? items
           .filter(
@@ -101,19 +142,27 @@ export const SearchBox = ({
     setOptions(
       newOpts.length
         ? newOpts.concat({
-            label: 'searchAll',
+            label: value,
             value: '',
-            component: () => (
-              <Box padding={2}>
+            isArticle: false,
+            component: ({ active }) => (
+              <Box
+                padding={2}
+                background={active ? 'blue100' : 'white'}
+                cursor="pointer"
+              >
                 <Button
                   type="button"
                   variant="text"
-                  onClick={() =>
-                    Router.push({
-                      pathname: linkResolver('search').href,
-                      query: { q: value },
-                    })
-                  }
+                  onClick={() => {
+                    setWaitingForNextPageToLoad(true)
+                    router
+                      .push({
+                        pathname: linkResolver('search').href,
+                        query: { q: value },
+                      })
+                      .then(() => window.scrollTo(0, 0))
+                  }}
                 >
                   {searchAllText}
                 </Button>
@@ -122,15 +171,40 @@ export const SearchBox = ({
           })
         : [
             {
+              label: value,
+              value: '',
+              isArticle: false,
               component: () => (
                 <Box padding={2} disabled>
                   <Text as="span">{noResultsText}</Text>
+                  <Box cursor="pointer">
+                    <Button
+                      type="button"
+                      variant="text"
+                      onClick={() => {
+                        setWaitingForNextPageToLoad(true)
+                        router
+                          .push({
+                            pathname: linkResolver('search').href,
+                            query: { q: value },
+                          })
+                          .then(() => window.scrollTo(0, 0))
+                      }}
+                    >
+                      {searchAllText}
+                    </Button>
+                  </Box>
                 </Box>
               ),
             },
           ],
     )
-  }, [value])
+  }
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(updateOptions, [value, loading, data])
+
+  const busy = loading || isLoading || waitingForNextPageToLoad
 
   return (
     <Box marginTop={3}>
@@ -140,36 +214,25 @@ export const SearchBox = ({
         key="island-organization"
         placeholder={placeholder}
         options={options}
-        loading={isLoading}
+        loading={busy}
         initialInputValue={''}
         inputValue={value}
-        onInputValueChange={(value) => {
-          setIsLoading(true)
-          setValue(value)
+        onInputValueChange={(newValue) => {
+          setIsLoading(newValue !== value)
+          setValue(newValue ?? '')
         }}
         closeMenuOnSubmit
         onSubmit={(value, selectedOption) => {
-          setOptions([])
-
-          value &&
-            Router.push({
-              pathname: selectedOption
-                ? linkResolver('Article' as LinkType, [selectedOption.value])
-                    .href
-                : linkResolver('search').href,
-              query: { q: value },
-            })
+          handleOptionSelect(
+            selectedOption as AsyncSearchOptionWithIsArticleField,
+            value,
+          )
         }}
         onChange={(i, option) => {
-          setOptions([])
-
-          value &&
-            Router.push({
-              pathname: linkResolver('Article' as LinkType, [
-                option.selectedItem.value,
-              ]).href,
-              query: { q: value.toLowerCase() },
-            })
+          handleOptionSelect(
+            option.selectedItem as AsyncSearchOptionWithIsArticleField,
+            value,
+          )
         }}
       />
     </Box>


### PR DESCRIPTION
# Iteration on PR 5767

## What

* Enable keyboard navigation via the searchbox on organization home pages (arrow keys, enter and tab)

## Why

* Before this change you could not press enter to search
* Before this change you could not use the arrow keys to cycle through search results
* Before this change you could not click on the magnifying glass to search

## Screenshots / Gifs

Here we see the searchbox on island.is/s/syslumenn right now (the search icon does not work):
https://user-images.githubusercontent.com/43557895/148384421-2ea5d148-fa7d-4386-a72d-27f71f9ca647.mp4

Here's what this change looks like, now you can click the search icon, use the arrow keys and enter to navigate:
https://user-images.githubusercontent.com/43557895/148385068-54a1f68c-f2b8-41f5-ac63-0d673d5a74cb.mp4

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
