### PR TITLE
feat(audit): Updating audit to support auditing from auth object without nationalId.

### DIFF
--- a/libs/nest/audit/src/lib/audit.interceptor.spec.ts
+++ b/libs/nest/audit/src/lib/audit.interceptor.spec.ts
@@ -4,12 +4,12 @@ import { AuditService } from './audit.service'
 import { Test, TestingModule } from '@nestjs/testing'
 import { AuditInterceptor } from './audit.interceptor'
 import { Audit } from './audit.decorator'
-import { getCurrentUser } from '@island.is/auth-nest-tools'
+import { getCurrentAuth } from '@island.is/auth-nest-tools'
 import { of } from 'rxjs'
 import MockInstance = jest.MockInstance
 
 jest.mock('@island.is/auth-nest-tools', () => ({
-  getCurrentUser: jest.fn(),
+  getCurrentAuth: jest.fn(),
 }))
 
 const context: any = {
@@ -124,11 +124,11 @@ describe('AuditInterceptor', () => {
     context.getClass.mockReturnValue(MyClass)
     context.getHandler.mockReturnValue(MyClass.prototype.handler)
     const user = 'Test user'
-    const getCurrentUserMock = (getCurrentUser as unknown) as MockInstance<
+    const getCurrentAuthMock = (getCurrentAuth as unknown) as MockInstance<
       string,
       unknown[]
     >
-    getCurrentUserMock.mockReturnValue(user)
+    getCurrentAuthMock.mockReturnValue(user)
 
     // Act
     const observable = interceptor.intercept(context, next)

--- a/libs/nest/audit/src/lib/audit.interceptor.ts
+++ b/libs/nest/audit/src/lib/audit.interceptor.ts
@@ -9,7 +9,7 @@ import { tap } from 'rxjs/operators'
 import { AuditService, AuditTemplate } from './audit.service'
 import { Reflector } from '@nestjs/core'
 import { AUDIT_METADATA_KEY } from './audit.decorator'
-import { getCurrentUser } from '@island.is/auth-nest-tools'
+import { getCurrentAuth } from '@island.is/auth-nest-tools'
 
 @Injectable()
 export class AuditInterceptor implements NestInterceptor {
@@ -30,7 +30,7 @@ export class AuditInterceptor implements NestInterceptor {
       return next.handle()
     }
 
-    const user = getCurrentUser(context)
+    const user = getCurrentAuth(context)
     const template = {
       action: handler.name,
       ...decorators[0],

--- a/libs/nest/audit/src/lib/audit.service.spec.ts
+++ b/libs/nest/audit/src/lib/audit.service.spec.ts
@@ -1,13 +1,12 @@
+import { Test, TestingModule } from '@nestjs/testing'
 import { mock } from 'jest-mock-extended'
 
-import { Test, TestingModule } from '@nestjs/testing'
-
-import type { Logger } from '@island.is/logging'
 import { LOGGER_PROVIDER } from '@island.is/logging'
+import { AUDIT_OPTIONS } from '@island.is/nest/audit'
+import type { Logger } from '@island.is/logging'
+import type { Auth, User } from '@island.is/auth-nest-tools'
 
 import { AuditService } from './audit.service'
-import { AUDIT_OPTIONS } from '@island.is/nest/audit'
-import type { Auth, User } from '@island.is/auth-nest-tools'
 import SpyInstance = jest.SpyInstance
 
 jest.mock('@island.is/logging', () => {
@@ -72,7 +71,6 @@ describe('AuditService against Cloudwatch', () => {
   // Cleanup
   afterEach(() => {
     jest.restoreAllMocks()
-    //spy.mockReset()
   })
 
   it('should be defined', () => {

--- a/libs/nest/audit/src/lib/audit.service.ts
+++ b/libs/nest/audit/src/lib/audit.service.ts
@@ -1,16 +1,16 @@
 import winston from 'winston'
 import WinstonCloudWatch from 'winston-cloudwatch'
-import { format, TransformableInfo } from 'logform'
+import { TransformableInfo } from 'logform'
 import { createHash } from 'crypto'
 import { Inject, Injectable } from '@nestjs/common'
 import type { Logger } from '@island.is/logging'
 import { LOGGER_PROVIDER } from '@island.is/logging'
-import type { User } from '@island.is/auth-nest-tools'
+import type { Auth } from '@island.is/auth-nest-tools'
 import type { AuditOptions } from './audit.options'
 import { AUDIT_OPTIONS } from './audit.options'
 
 export interface AuditMessage {
-  user: User
+  user: Auth
   action: string
   namespace?: string
   resources?: string | string[]
@@ -18,7 +18,7 @@ export interface AuditMessage {
 }
 
 export type AuditTemplate<ResultType> = {
-  user: User
+  user: Auth
   action: string
   namespace?: string
   resources?: string | string[] | ((result: ResultType) => string | string[])


### PR DESCRIPTION
# ☝️

## What

When machine clients calls an API they by default don't have `nationalId` claim. This allows for audit logging also for machine clients without nationalId.

## Why

To support audit logging for machine clients.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
