### PR TITLE
fix(island-ui): fix datepicker without label

### DIFF
--- a/libs/island-ui/core/src/lib/DatePicker/DatePicker.css.ts
+++ b/libs/island-ui/core/src/lib/DatePicker/DatePicker.css.ts
@@ -134,6 +134,47 @@ export const increaseButton = style({
   },
 })
 
+export const popper = style({
+  marginTop: '0',
+  right: '0',
+  width: '100%',
+  top: '65px !important',
+  transform: 'none !important',
+  margin: '0 !important',
+  ...themeUtils.responsiveStyle({
+    md: {
+      top: '70px !important',
+    },
+  }),
+})
+
+export const popperSmall = style({
+  top: '51px !important',
+  ...themeUtils.responsiveStyle({
+    md: {
+      top: '57px !important',
+    },
+  }),
+})
+
+export const popperSmallWithoutLabel = style({
+  top: '42px !important',
+  ...themeUtils.responsiveStyle({
+    md: {
+      top: '42px !important',
+    },
+  }),
+})
+
+export const popperWithoutLabel = style({
+  top: '52px !important',
+  ...themeUtils.responsiveStyle({
+    md: {
+      top: '52px !important',
+    },
+  }),
+})
+
 // Overwrite default ReactDatepicker styles
 globalStyle(`${root}.island-ui-datepicker .react-datepicker`, {
   display: 'block',
@@ -161,29 +202,6 @@ globalStyle(
     borderBottom: 'none',
   },
 )
-
-globalStyle(`${root}.island-ui-datepicker .react-datepicker-popper`, {
-  marginTop: '0',
-  right: '0',
-  width: '100%',
-  top: '65px !important',
-  transform: 'none !important',
-  margin: '0 !important',
-  ...themeUtils.responsiveStyle({
-    md: {
-      top: '70px !important',
-    },
-  }),
-})
-
-globalStyle(`${root}${small}.island-ui-datepicker .react-datepicker-popper`, {
-  top: '51px !important',
-  ...themeUtils.responsiveStyle({
-    md: {
-      top: '57px !important',
-    },
-  }),
-})
 
 globalStyle(`${root}.island-ui-datepicker .react-datepicker__month-container`, {
   float: 'none',

--- a/libs/island-ui/core/src/lib/DatePicker/DatePicker.stories.tsx
+++ b/libs/island-ui/core/src/lib/DatePicker/DatePicker.stories.tsx
@@ -154,3 +154,26 @@ export const Disabled = () => (
     </Wrap>
   </>
 )
+
+export const WithoutLabel = () => (
+  <Wrap>
+    <DatePicker
+      label=""
+      placeholderText="Pick a date"
+      selected={new Date()}
+      handleChange={(date: Date) => console.log(date)}
+    />
+  </Wrap>
+)
+
+export const SmallWithoutLabel = () => (
+  <Wrap>
+    <DatePicker
+      label=""
+      size="sm"
+      placeholderText="Pick a date"
+      selected={new Date()}
+      handleChange={(date: Date) => console.log(date)}
+    />
+  </Wrap>
+)

--- a/libs/island-ui/core/src/lib/DatePicker/DatePicker.tsx
+++ b/libs/island-ui/core/src/lib/DatePicker/DatePicker.tsx
@@ -84,6 +84,11 @@ export const DatePicker: React.FC<DatePickerProps> = ({
         })}
       >
         <ReactDatePicker
+          popperClassName={cn(styles.popper, {
+            [styles.popperSmall]: size === 'sm',
+            [styles.popperSmallWithoutLabel]: size === 'sm' && !label,
+            [styles.popperWithoutLabel]: size === 'md' && !label,
+          })}
           id={id}
           disabled={disabled}
           selected={selected ?? startDate}


### PR DESCRIPTION
# ...

[@island.is/island-ui: Datepicker needs to check if label is in order to place popper](https://github.com/island-is/island.is/issues/5226)

## What

Refactor datepicker popper to use className instead of globalStyles and fix datepicker without label, it shouldn't happen, but it is possible to add empty string as a label.

## Why

Because it breaks datepicker when there is no label for it

## Screenshots / Gifs

### default datepicker with label
![Screenshot 2022-01-07 at 11 13 12](https://user-images.githubusercontent.com/26793642/148537277-7ada51d2-ab76-4606-a43e-2d352157f9d8.png)

### default datepicker without label
![Screenshot 2022-01-07 at 11 12 49](https://user-images.githubusercontent.com/26793642/148537361-4fd126ee-8891-4393-9458-861c93d1ecc5.png)

### small datepicker with label
![Screenshot 2022-01-07 at 11 13 28](https://user-images.githubusercontent.com/26793642/148537330-bf42ada4-23e3-4dee-8c49-41a46e97f83c.png)

### small datepicker without label
![Screenshot 2022-01-07 at 11 12 12](https://user-images.githubusercontent.com/26793642/148537385-6b755172-2a0c-4696-8f6b-253cd0c9085f.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
