### PR TITLE
chore(user-notification): removing worker health check

### DIFF
--- a/apps/services/user-notification/infra/user-notification.ts
+++ b/apps/services/user-notification/infra/user-notification.ts
@@ -40,5 +40,3 @@ export const userNotificationWorkerSetup = (): ServiceBuilder<'user-notification
       MAIN_QUEUE_NAME,
       DEAD_LETTER_QUEUE_NAME,
     })
-    .liveness('/liveness')
-    .readiness('/liveness')

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -1247,11 +1247,11 @@ user-notification-worker:
   healthCheck:
     liveness:
       initialDelaySeconds: 3
-      path: '/liveness'
+      path: '/'
       timeoutSeconds: 3
     readiness:
       initialDelaySeconds: 3
-      path: '/liveness'
+      path: '/'
       timeoutSeconds: 3
   image:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/services-user-notification'

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -1190,11 +1190,11 @@ user-notification-worker:
   healthCheck:
     liveness:
       initialDelaySeconds: 3
-      path: '/liveness'
+      path: '/'
       timeoutSeconds: 3
     readiness:
       initialDelaySeconds: 3
-      path: '/liveness'
+      path: '/'
       timeoutSeconds: 3
   image:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/services-user-notification'


### PR DESCRIPTION
## What

Removing the health checks for the notification worker

## Why

Because the worker service doesn't require it and is getting shut down over and over

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
