### PR TITLE
fix(web): Article organization slug not changing on sync

### DIFF
--- a/libs/cms/src/lib/environments/environment.ts
+++ b/libs/cms/src/lib/environments/environment.ts
@@ -19,6 +19,7 @@ export default {
     'frontpage',
   ],
   nestedContentTypes: [
+    'organization',
     'subArticle',
     'processEntry',
     'embeddedVideo',


### PR DESCRIPTION
# Article organization slug not changing on sync

## What

* If an organization slug changes then articles that are referencing that organization still point to the old slug

## Why

* This fixes the problem regarding no articles showing up on the organization services page due to a change of organization slug (since articles will then keep pointing to the old slug)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
