### PR TITLE
chore(core): Rename user to auth for dependents of Audit library

### DIFF
--- a/apps/application-system/api/src/app/modules/application/application.controller.ts
+++ b/apps/application-system/api/src/app/modules/application/application.controller.ts
@@ -282,7 +282,7 @@ export class ApplicationController {
     )
 
     this.auditService.audit({
-      user,
+      auth: user,
       action: 'create',
       resources: updatedApplication.id,
       meta: { type: application.typeId },
@@ -425,7 +425,7 @@ export class ApplicationController {
     )
 
     this.auditService.audit({
-      user,
+      auth: user,
       action: 'update',
       resources: updatedApplication.id,
       meta: { fields: Object.keys(newAnswers) },
@@ -492,7 +492,7 @@ export class ApplicationController {
     }
 
     this.auditService.audit({
-      user,
+      auth: user,
       action: 'updateExternalData',
       resources: updatedApplication.id,
       meta: { providers: externalDataDto },
@@ -574,7 +574,7 @@ export class ApplicationController {
     )
 
     this.auditService.audit({
-      user,
+      auth: user,
       action: 'submitApplication',
       resources: existingApplication.id,
       meta: {
@@ -812,7 +812,7 @@ export class ApplicationController {
     })
 
     this.auditService.audit({
-      user,
+      auth: user,
       action: 'addAttachment',
       resources: updatedApplication.id,
       meta: {
@@ -853,7 +853,7 @@ export class ApplicationController {
     )
 
     this.auditService.audit({
-      user,
+      auth: user,
       action: 'deleteAttachment',
       resources: updatedApplication.id,
       meta: {
@@ -889,7 +889,7 @@ export class ApplicationController {
     )
 
     this.auditService.audit({
-      user,
+      auth: user,
       action: 'generatePdf',
       resources: existingApplication.id,
       meta: { type: input.type },
@@ -927,7 +927,7 @@ export class ApplicationController {
     )
 
     this.auditService.audit({
-      user,
+      auth: user,
       action: 'requestFileSignature',
       resources: existingApplication.id,
       meta: { type: input.type },
@@ -963,7 +963,7 @@ export class ApplicationController {
     )
 
     this.auditService.audit({
-      user,
+      auth: user,
       action: 'uploadSignedFile',
       resources: existingApplication.id,
       meta: { type: input.type },
@@ -999,7 +999,7 @@ export class ApplicationController {
     )
 
     this.auditService.audit({
-      user,
+      auth: user,
       action: 'getPresignedUrl',
       resources: existingApplication.id,
       meta: { type },

--- a/apps/application-system/api/src/app/modules/payment/payment.controller.ts
+++ b/apps/application-system/api/src/app/modules/payment/payment.controller.ts
@@ -30,7 +30,6 @@ import { InjectModel } from '@nestjs/sequelize'
 import { Payment } from './payment.model'
 import { PaymentService } from './payment.service'
 import { PaymentStatusResponseDto } from './dto/paymentStatusResponse.dto'
-import { isUuid } from 'uuidv4'
 import { CreateChargeInput } from './dto/createChargeInput.dto'
 import { PaymentAPI } from '@island.is/clients/payment'
 
@@ -87,7 +86,7 @@ export class PaymentController {
     const chargeResult = await this.paymentService.createCharge(payment, user)
 
     this.auditService.audit({
-      user,
+      auth: user,
       action: 'createCharge',
       resources: paymentDto.application_id as string,
       meta: { applicationId: paymentDto.application_id, id: payment.id },

--- a/apps/financial-aid/backend/src/app/modules/application/application.controller.ts
+++ b/apps/financial-aid/backend/src/app/modules/application/application.controller.ts
@@ -114,7 +114,7 @@ export class ApplicationController {
     )
 
     this.auditService.audit({
-      user,
+      auth: user,
       action: 'findByNationalId',
       resources: applications.map((application) => application.id),
     })
@@ -172,7 +172,7 @@ export class ApplicationController {
     this.logger.debug(`Application controller: Getting application by id ${id}`)
 
     this.auditService.audit({
-      user,
+      auth: user,
       action: 'getApplication',
       resources: application.id,
     })

--- a/apps/icelandic-names-registry/backend/src/app/modules/icelandic-name/icelandic-name.controller.ts
+++ b/apps/icelandic-names-registry/backend/src/app/modules/icelandic-name/icelandic-name.controller.ts
@@ -113,7 +113,7 @@ export class IcelandicNameController {
     }
 
     this.auditService.audit({
-      user,
+      auth: user,
       action: 'updateNameById',
       resources: `${id}`,
       meta: { fields: Object.keys(body) },
@@ -142,7 +142,7 @@ export class IcelandicNameController {
   ): Promise<IcelandicName> {
     return this.auditService.auditPromise<IcelandicName>(
       {
-        user,
+        auth: user,
         action: 'createName',
         resources: (name) => `${name.id}`,
       },
@@ -173,7 +173,7 @@ export class IcelandicNameController {
     }
 
     this.auditService.audit({
-      user,
+      auth: user,
       action: 'deleteById',
       resources: `${id}`,
     })

--- a/apps/services/auth-admin-api/src/app/modules/access/access.controller.ts
+++ b/apps/services/auth-admin-api/src/app/modules/access/access.controller.ts
@@ -124,7 +124,7 @@ export class AccessController {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'udpate',
         namespace,
         resources: nationalId,
@@ -148,7 +148,7 @@ export class AccessController {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'delete',
         namespace,
         resources: nationalId,

--- a/apps/services/auth-admin-api/src/app/modules/clients/client-allowed-scope.controller.ts
+++ b/apps/services/auth-admin-api/src/app/modules/clients/client-allowed-scope.controller.ts
@@ -77,7 +77,7 @@ export class ClientAllowedScopeController {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'delete',
         namespace,
         resources: clientId,

--- a/apps/services/auth-admin-api/src/app/modules/clients/client-claim.controller.ts
+++ b/apps/services/auth-admin-api/src/app/modules/clients/client-claim.controller.ts
@@ -65,7 +65,7 @@ export class ClientClaimController {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'delete',
         namespace,
         resources: `${clientId}/${claimType}/${claimValue}`,

--- a/apps/services/auth-admin-api/src/app/modules/clients/client-grant-type.controller.ts
+++ b/apps/services/auth-admin-api/src/app/modules/clients/client-grant-type.controller.ts
@@ -65,7 +65,7 @@ export class ClientGrantTypeController {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'delete',
         namespace,
         resources: clientId,

--- a/apps/services/auth-admin-api/src/app/modules/clients/client-post-logout-redirect-uri.controller.ts
+++ b/apps/services/auth-admin-api/src/app/modules/clients/client-post-logout-redirect-uri.controller.ts
@@ -65,7 +65,7 @@ export class ClientPostLogoutRedirectUriController {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'delete',
         namespace,
         resources: clientId,

--- a/apps/services/auth-admin-api/src/app/modules/clients/client-secret.controller.ts
+++ b/apps/services/auth-admin-api/src/app/modules/clients/client-secret.controller.ts
@@ -64,7 +64,7 @@ export class ClientSecretController {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'delete',
         namespace,
         resources: clientSecret.clientId,

--- a/apps/services/auth-admin-api/src/app/modules/clients/clients.controller.ts
+++ b/apps/services/auth-admin-api/src/app/modules/clients/clients.controller.ts
@@ -134,7 +134,7 @@ export class ClientsController {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'update',
         namespace,
         resources: id,
@@ -158,7 +158,7 @@ export class ClientsController {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'delete',
         namespace,
         resources: id,

--- a/apps/services/auth-admin-api/src/app/modules/clients/cors.controller.ts
+++ b/apps/services/auth-admin-api/src/app/modules/clients/cors.controller.ts
@@ -65,7 +65,7 @@ export class CorsController {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'delete',
         namespace,
         resources: clientId,

--- a/apps/services/auth-admin-api/src/app/modules/clients/idp-restriction.controller.ts
+++ b/apps/services/auth-admin-api/src/app/modules/clients/idp-restriction.controller.ts
@@ -67,7 +67,7 @@ export class IdpRestrictionController {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'delete',
         namespace,
         resources: clientId,

--- a/apps/services/auth-admin-api/src/app/modules/clients/redirect-uri.controller.ts
+++ b/apps/services/auth-admin-api/src/app/modules/clients/redirect-uri.controller.ts
@@ -65,7 +65,7 @@ export class RedirectUriController {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'delete',
         namespace,
         resources: clientId,

--- a/apps/services/auth-admin-api/src/app/modules/grant-types/grant-types.controller.ts
+++ b/apps/services/auth-admin-api/src/app/modules/grant-types/grant-types.controller.ts
@@ -157,7 +157,7 @@ export class GrantTypeController {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'updateGrantType',
         namespace,
         resources: name,
@@ -180,7 +180,7 @@ export class GrantTypeController {
     }
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'deleteGrantType',
         namespace,
         resources: name,

--- a/apps/services/auth-admin-api/src/app/modules/idp-provider/idp-provider.controller.ts
+++ b/apps/services/auth-admin-api/src/app/modules/idp-provider/idp-provider.controller.ts
@@ -121,7 +121,7 @@ export class IdpProviderController {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'delete',
         namespace,
         resources: name,
@@ -148,7 +148,7 @@ export class IdpProviderController {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'update',
         namespace,
         resources: name,

--- a/apps/services/auth-admin-api/src/app/modules/personal-representative/personal-representative.controller.ts
+++ b/apps/services/auth-admin-api/src/app/modules/personal-representative/personal-representative.controller.ts
@@ -114,7 +114,7 @@ export class PersonalRepresentativeController {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'deleteScopePermission',
         namespace,
         resources: id,

--- a/apps/services/auth-admin-api/src/app/modules/resources/resources.controller.ts
+++ b/apps/services/auth-admin-api/src/app/modules/resources/resources.controller.ts
@@ -313,7 +313,7 @@ export class ResourcesController {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'updateIdentityResource',
         namespace,
         resources: name,
@@ -336,7 +336,7 @@ export class ResourcesController {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'deleteIdentityResource',
         namespace,
         resources: name,
@@ -459,7 +459,7 @@ export class ResourcesController {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'updateApiScope',
         namespace,
         resources: name,
@@ -484,7 +484,7 @@ export class ResourcesController {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'updateApiResource',
         namespace,
         resources: name,
@@ -508,7 +508,7 @@ export class ResourcesController {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'deleteApiScope',
         namespace,
         resources: name,
@@ -531,7 +531,7 @@ export class ResourcesController {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'deleteApiResource',
         namespace,
         resources: name,
@@ -564,7 +564,7 @@ export class ResourcesController {
   ): Promise<number> {
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'removeResourceUserClaim',
         namespace,
         resources: `${identityResourceName}/${claimName}`,
@@ -598,7 +598,7 @@ export class ResourcesController {
   ): Promise<number> {
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'removeApiScopeUserClaim',
         namespace,
         resources: `${apiScopeName}/${claimName}`,
@@ -667,7 +667,7 @@ export class ResourcesController {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'removeApiResourceUserClaim',
         namespace,
         resources: `${apiResourceName}/${claimName}`,
@@ -711,7 +711,7 @@ export class ResourcesController {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'removeApiResourceSecret',
         namespace,
         resources: apiSecret.apiResourceName,
@@ -758,7 +758,7 @@ export class ResourcesController {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'removeApiResourceAllowedScope',
         namespace,
         resources: `${apiResourceName}/${scopeName}`,
@@ -799,7 +799,7 @@ export class ResourcesController {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'removeApiScopeFromApiResourceScope',
         namespace,
         resources: scopeName,
@@ -863,7 +863,7 @@ export class ResourcesController {
   ): Promise<[number, ApiScopeGroup[]]> {
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         namespace,
         action: 'updateApiScopeGroup',
         resources: id,
@@ -885,7 +885,7 @@ export class ResourcesController {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         namespace,
         action: 'deleteApiScopeGroup',
         resources: id,
@@ -945,7 +945,7 @@ export class ResourcesController {
   ): Promise<[number, Domain[]]> {
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         namespace,
         action: 'updateDomain',
         resources: name,
@@ -968,7 +968,7 @@ export class ResourcesController {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         namespace,
         action: 'deleteDomain',
         resources: name,

--- a/apps/services/auth-admin-api/src/app/modules/translation/translation.controller.ts
+++ b/apps/services/auth-admin-api/src/app/modules/translation/translation.controller.ts
@@ -154,7 +154,7 @@ export class TranslationController {
   ): Promise<Language> {
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'updateLanguage',
         namespace,
         resources: language.isoKey,
@@ -174,7 +174,7 @@ export class TranslationController {
   ): Promise<number> {
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'deleteLanguage',
         namespace,
         resources: isoKey,
@@ -244,7 +244,7 @@ export class TranslationController {
   ): Promise<Translation> {
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'udpateTranslation',
         namespace,
         resources: `${translation.language}/${translation.className}/${translation.property}/${translation.key}`,
@@ -263,7 +263,7 @@ export class TranslationController {
   ): Promise<number> {
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'deleteTranslation',
         namespace,
         resources: `${translation.language}/${translation.className}/${translation.property}/${translation.key}`,

--- a/apps/services/auth-public-api/src/app/modules/delegations/meDelegations.controller.ts
+++ b/apps/services/auth-public-api/src/app/modules/delegations/meDelegations.controller.ts
@@ -241,7 +241,7 @@ export class MeDelegationsController {
 
     return this.auditService.auditPromise<DelegationDTO | null>(
       {
-        user,
+        auth: user,
         namespace,
         action: 'update',
         resources: (delegation) => delegation?.id ?? '',
@@ -265,7 +265,7 @@ export class MeDelegationsController {
   ): Promise<void> {
     await this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         namespace,
         action: 'deleteFrom',
         resources: delegationId,

--- a/apps/services/documents/src/app/modules/document-provider/controllers/organisation.controller.ts
+++ b/apps/services/documents/src/app/modules/document-provider/controllers/organisation.controller.ts
@@ -122,7 +122,7 @@ export class OrganisationController {
     }
 
     this.auditService.audit({
-      user,
+      auth: user,
       namespace,
       action: 'updateOrganisation',
       resources: id,
@@ -186,7 +186,7 @@ export class OrganisationController {
     }
 
     this.auditService.audit({
-      user,
+      auth: user,
       namespace,
       action: 'updateAdministrativeContact',
       resources: administrativeContactId,
@@ -240,7 +240,7 @@ export class OrganisationController {
     }
 
     this.auditService.audit({
-      user,
+      auth: user,
       namespace,
       action: 'updateTechnicalContact',
       resources: technicalContactId,
@@ -292,7 +292,7 @@ export class OrganisationController {
     }
 
     this.auditService.audit({
-      user,
+      auth: user,
       namespace,
       action: 'updateHelpdesk',
       resources: helpdeskId,

--- a/apps/services/documents/src/app/modules/document-provider/controllers/provider.controller.ts
+++ b/apps/services/documents/src/app/modules/document-provider/controllers/provider.controller.ts
@@ -126,7 +126,7 @@ export class ProviderController {
     }
 
     this.auditService.audit({
-      user,
+      auth: user,
       namespace,
       action: 'updateProvider',
       resources: id,

--- a/apps/services/endorsements/api/src/app/modules/endorsement/endorsement.controller.ts
+++ b/apps/services/endorsements/api/src/app/modules/endorsement/endorsement.controller.ts
@@ -1,6 +1,5 @@
 import {
   BypassAuth,
-  CurrentAuth,
   CurrentUser,
   Scopes,
   ScopesGuard,
@@ -200,7 +199,7 @@ export class EndorsementController {
   ): Promise<undefined> {
     // we pass audit manually since we need to use the request parameter since we don't return the endorsement list
     this.auditService.audit({
-      user,
+      auth: user,
       resources: endorsementList.id,
       namespace: auditNamespace,
       action: 'delete',

--- a/apps/services/endorsements/api/src/app/modules/endorsementList/endorsementList.controller.ts
+++ b/apps/services/endorsements/api/src/app/modules/endorsementList/endorsementList.controller.ts
@@ -339,7 +339,7 @@ export class EndorsementListController {
   @ApiParam({ name: 'listId', type: 'string' })
   @BypassAuth()
   @Get(':listId/ownerInfo')
-  async getOwnerInfo(@Param('listId') listId: string): Promise<String> {
+  async getOwnerInfo(@Param('listId') listId: string): Promise<string> {
     return await this.endorsementListService.getOwnerInfo(listId)
   }
 

--- a/apps/services/personal-representative/src/app/modules/personalRepresentatives/personalRepresentatives.controller.ts
+++ b/apps/services/personal-representative/src/app/modules/personalRepresentatives/personalRepresentatives.controller.ts
@@ -189,7 +189,7 @@ export class PersonalRepresentativesController {
     }
     return await this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'deletePersonalRepresentative',
         namespace,
         resources: id,
@@ -241,7 +241,7 @@ export class PersonalRepresentativesController {
     if (currentContract && currentContract.id) {
       await this.auditService.auditPromise(
         {
-          user,
+          auth: user,
           action: 'deleteExistingPersonalRepresentative',
           namespace,
           resources: personalRepresentative.nationalIdRepresentedPerson,
@@ -253,7 +253,7 @@ export class PersonalRepresentativesController {
     // Create a new personal representative
     return await this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'createPersonalRepresentative',
         namespace,
         resources: personalRepresentative.nationalIdRepresentedPerson,

--- a/apps/services/personal-representative/src/app/modules/rightTypes/rightTypes.controller.ts
+++ b/apps/services/personal-representative/src/app/modules/rightTypes/rightTypes.controller.ts
@@ -111,7 +111,7 @@ export class RightTypesController {
     // delete right type
     return await this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'deletePersonalRepresentativeRightType',
         namespace,
         resources: code,
@@ -136,7 +136,7 @@ export class RightTypesController {
     // Create a new right type
     return await this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'createPersonalRepresentativeRightType',
         namespace,
         resources: rightType.code,
@@ -167,7 +167,7 @@ export class RightTypesController {
     // Update right type
     const result = await this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'updatePersonalRepresentativeRightType',
         namespace,
         resources: rightType.code,

--- a/apps/services/user-profile/src/app/user-profile/userProfile.controller.ts
+++ b/apps/services/user-profile/src/app/user-profile/userProfile.controller.ts
@@ -136,7 +136,7 @@ export class UserProfileController {
 
     const userProfile = await this.userProfileService.create(userProfileDto)
     this.auditService.audit({
-      user,
+      auth: user,
       action: 'create',
       resources: userProfileDto.nationalId,
       meta: { fields: Object.keys(userProfileDto) },
@@ -206,7 +206,7 @@ export class UserProfileController {
       )
     }
     this.auditService.audit({
-      user,
+      auth: user,
       action: 'update',
       resources: updatedUserProfile.nationalId,
       meta: { fields: updatedFields },
@@ -274,7 +274,7 @@ export class UserProfileController {
 
     return await this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'confirmEmail',
         resources: profile.nationalId,
       },
@@ -308,7 +308,7 @@ export class UserProfileController {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         action: 'confirmSms',
         resources: nationalId,
       },

--- a/libs/api/domains/document-provider/src/lib/document-provider.resolver.ts
+++ b/libs/api/domains/document-provider/src/lib/document-provider.resolver.ts
@@ -204,7 +204,7 @@ export class DocumentProviderResolver {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         namespace,
         action: 'createTestProvider',
         resources: input.nationalId,
@@ -228,7 +228,7 @@ export class DocumentProviderResolver {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         namespace,
         action: 'updateTestEndpoint',
         resources: input.nationalId,
@@ -253,7 +253,7 @@ export class DocumentProviderResolver {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         namespace,
         action: 'runEndpointTests',
         resources: input.nationalId,
@@ -277,7 +277,7 @@ export class DocumentProviderResolver {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         namespace,
         action: 'createProvider',
         resources: input.nationalId,
@@ -301,7 +301,7 @@ export class DocumentProviderResolver {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         namespace,
         action: 'updateEndpoint',
         resources: input.nationalId,

--- a/libs/api/domains/documents/src/lib/document.resolver.ts
+++ b/libs/api/domains/documents/src/lib/document.resolver.ts
@@ -33,7 +33,7 @@ export class DocumentResolver {
   ): Promise<DocumentDetails> {
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         namespace: '@island.is/api/document',
         action: 'getDocument',
         resources: input.id,

--- a/libs/api/domains/driving-license/src/lib/graphql/main.resolver.ts
+++ b/libs/api/domains/driving-license/src/lib/graphql/main.resolver.ts
@@ -38,7 +38,7 @@ export class MainResolver {
   drivingLicense(@CurrentUser() user: User) {
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         namespace,
         action: 'drivingLicense',
         resources: user.nationalId,
@@ -56,7 +56,7 @@ export class MainResolver {
   drivingLicenseTeachingRights(@CurrentUser() user: User) {
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         namespace,
         action: 'drivingLicenseTeachingRights',
         resources: user.nationalId,
@@ -75,7 +75,7 @@ export class MainResolver {
     )
 
     this.auditService.audit({
-      user,
+      auth: user,
       namespace,
       action: 'drivingLicenseStudentInformation',
       resources: nationalId,

--- a/libs/api/domains/education/src/lib/graphql/main.resolver.ts
+++ b/libs/api/domains/education/src/lib/graphql/main.resolver.ts
@@ -35,7 +35,7 @@ export class MainResolver {
   educationLicense(@CurrentUser() user: User): Promise<EducationLicense[]> {
     return this.auditService.auditPromise<EducationLicense[]>(
       {
-        user,
+        auth: user,
         namespace,
         action: 'educationLicense',
         resources: (licenses) => licenses.map((license) => license.id),
@@ -60,7 +60,7 @@ export class MainResolver {
     }
 
     this.auditService.audit({
-      user,
+      auth: user,
       namespace,
       action: 'fetchEducationSignedicenseUrl',
       resources: input.licenseId,
@@ -76,7 +76,7 @@ export class MainResolver {
   ): Promise<ExamFamilyOverview[]> {
     return this.auditService.auditPromise<ExamFamilyOverview[]>(
       {
-        user,
+        auth: user,
         namespace,
         action: 'educationExamFamilyOverviews',
         resources: (results) => results.map((result) => result.nationalId),
@@ -100,7 +100,7 @@ export class MainResolver {
 
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         namespace,
         action: 'educationExamResult',
         resources: familyMember.Kennitala,

--- a/libs/api/domains/health-insurance/src/lib/graphql/healthInsurance.resolver.ts
+++ b/libs/api/domains/health-insurance/src/lib/graphql/healthInsurance.resolver.ts
@@ -41,7 +41,7 @@ export class HealthInsuranceResolver {
   ): Promise<boolean> {
     return this.auditService.auditPromise(
       {
-        user,
+        auth: user,
         namespace,
         action: 'healthInsuranceIsHealthInsured',
       },
@@ -61,7 +61,7 @@ export class HealthInsuranceResolver {
   ): Promise<number[]> {
     return this.auditService.auditPromise<number[]>(
       {
-        user,
+        auth: user,
         namespace,
         action: 'healthInsuranceGetPendingApplication',
         resources: (results) => results.map(String),

--- a/libs/nest/audit/README.md
+++ b/libs/nest/audit/README.md
@@ -61,7 +61,7 @@ Then you can create audit records like this:
 ```typescript
 // uses the default namespace: '@island.is/apiName',
 this.auditService.audit({
-  user,
+  auth: user,
   action: 'findAll',
 })
 ```
@@ -71,7 +71,7 @@ You can set custom namespace, resources and metadata like this:
 ```typescript
 const stuff = await this.stuffService.getStuff()
 this.auditService.audit({
-  user,
+  auth: user,
   namespace: '@island.is/overridden',
   action: 'findAll',
   resources: stuff.map((s) => s.id),
@@ -84,7 +84,7 @@ If you are auditing an async action, you can wrap it like this:
 ```typescript
 return this.auditService.auditPromise(
   {
-    user,
+    auth: user,
     action: 'findAll',
     resources: (stuff) => stuff.map((s) => s.id),
     meta: (stuff) => ({ count: stuff.length }),

--- a/libs/nest/audit/src/lib/audit.interceptor.spec.ts
+++ b/libs/nest/audit/src/lib/audit.interceptor.spec.ts
@@ -12,6 +12,7 @@ jest.mock('@island.is/auth-nest-tools', () => ({
   getCurrentAuth: jest.fn(),
 }))
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const context: any = {
   getHandler: jest.fn(),
   getClass: jest.fn(),
@@ -123,12 +124,12 @@ describe('AuditInterceptor', () => {
     }
     context.getClass.mockReturnValue(MyClass)
     context.getHandler.mockReturnValue(MyClass.prototype.handler)
-    const user = 'Test user'
+    const auth = 'Test user'
     const getCurrentAuthMock = (getCurrentAuth as unknown) as MockInstance<
       string,
       unknown[]
     >
-    getCurrentAuthMock.mockReturnValue(user)
+    getCurrentAuthMock.mockReturnValue(auth)
 
     // Act
     const observable = interceptor.intercept(context, next)
@@ -137,7 +138,7 @@ describe('AuditInterceptor', () => {
     // Assert
     expect(auditService.auditPromise).toHaveBeenCalledWith(
       expect.objectContaining({
-        user,
+        auth,
       }),
       expect.anything(),
     )

--- a/libs/nest/audit/src/lib/audit.interceptor.ts
+++ b/libs/nest/audit/src/lib/audit.interceptor.ts
@@ -30,7 +30,7 @@ export class AuditInterceptor implements NestInterceptor {
       return next.handle()
     }
 
-    const user = getCurrentAuth(context)
+    const auth = getCurrentAuth(context)
     const template = {
       action: handler.name,
       ...decorators[0],
@@ -42,7 +42,7 @@ export class AuditInterceptor implements NestInterceptor {
         this.auditService.auditPromise(
           {
             ...template,
-            user,
+            auth,
           },
           Promise.resolve(result),
         )

--- a/libs/nest/audit/src/lib/audit.service.spec.ts
+++ b/libs/nest/audit/src/lib/audit.service.spec.ts
@@ -27,7 +27,7 @@ jest.mock('winston-cloudwatch', () => {
 
 const defaultNamespace = '@test.is'
 
-const user: User = {
+const auth: User = {
   nationalId: '1234567890',
   actor: {
     nationalId: '2234567890',
@@ -86,7 +86,7 @@ describe('AuditService against Cloudwatch', () => {
 
     // Act
     service.audit({
-      user,
+      auth,
       namespace,
       action,
       resources,
@@ -95,14 +95,14 @@ describe('AuditService against Cloudwatch', () => {
 
     // Assert
     expect(spy).toHaveBeenCalledWith({
-      actor: user.actor?.nationalId,
-      subject: user.nationalId,
-      client: [user.client],
+      actor: auth.actor?.nationalId,
+      subject: auth.nationalId,
+      client: [auth.client],
       action: `${namespace}#${action}`,
       resources,
       meta,
-      ip: user.ip,
-      userAgent: user.userAgent,
+      ip: auth.ip,
+      userAgent: auth.userAgent,
     })
   })
 
@@ -112,18 +112,18 @@ describe('AuditService against Cloudwatch', () => {
 
     // Act
     service.audit({
-      user,
+      auth,
       action,
     })
 
     // Assert
     expect(spy).toHaveBeenCalledWith({
-      actor: user.actor?.nationalId,
-      subject: user.nationalId,
-      client: [user.client],
+      actor: auth.actor?.nationalId,
+      subject: auth.nationalId,
+      client: [auth.client],
       action: `${defaultNamespace}#${action}`,
-      ip: user.ip,
-      userAgent: user.userAgent,
+      ip: auth.ip,
+      userAgent: auth.userAgent,
     })
   })
 
@@ -134,7 +134,7 @@ describe('AuditService against Cloudwatch', () => {
     // Act and assert
     expect(() => {
       service.audit({
-        user,
+        auth,
         namespace: '',
         action,
       })
@@ -154,7 +154,7 @@ describe('AuditService against Cloudwatch', () => {
 
     // Act
     service.audit({
-      user: auth,
+      auth,
       action,
     })
 
@@ -176,7 +176,7 @@ describe('AuditService against Cloudwatch', () => {
     // Act
     await service.auditPromise(
       {
-        user,
+        auth,
         action,
         resources: (result) => result,
         meta: (result) => ({
@@ -188,14 +188,14 @@ describe('AuditService against Cloudwatch', () => {
 
     // Assert
     expect(spy).toHaveBeenCalledWith({
-      actor: user.actor?.nationalId,
-      subject: user.nationalId,
-      client: [user.client],
+      actor: auth.actor?.nationalId,
+      subject: auth.nationalId,
+      client: [auth.client],
       action: `${defaultNamespace}#${action}`,
       resources,
       meta,
-      ip: user.ip,
-      userAgent: user.userAgent,
+      ip: auth.ip,
+      userAgent: auth.userAgent,
     })
   })
 })
@@ -234,7 +234,7 @@ describe('AuditService in development', () => {
 
     // Act
     service.audit({
-      user,
+      auth,
       namespace,
       action,
       resources,
@@ -244,14 +244,14 @@ describe('AuditService in development', () => {
     // Assert
     expect(spy).toHaveBeenCalledWith({
       message: 'Audit record',
-      actor: user.actor?.nationalId,
-      subject: user.nationalId,
-      client: [user.client],
+      actor: auth.actor?.nationalId,
+      subject: auth.nationalId,
+      client: [auth.client],
       action: `${namespace}#${action}`,
       resources,
       meta,
-      ip: user.ip,
-      userAgent: user.userAgent,
+      ip: auth.ip,
+      userAgent: auth.userAgent,
     })
   })
 })

--- a/libs/nest/audit/src/lib/audit.service.ts
+++ b/libs/nest/audit/src/lib/audit.service.ts
@@ -10,7 +10,7 @@ import type { AuditOptions } from './audit.options'
 import { AUDIT_OPTIONS } from './audit.options'
 
 export interface AuditMessage {
-  user: Auth
+  auth: Auth
   action: string
   namespace?: string
   resources?: string | string[]
@@ -18,7 +18,7 @@ export interface AuditMessage {
 }
 
 export type AuditTemplate<ResultType> = {
-  user: Auth
+  auth: Auth
   action: string
   namespace?: string
   resources?: string | string[] | ((result: ResultType) => string | string[])
@@ -81,7 +81,7 @@ export class AuditService {
   }
 
   private formatMessage({
-    user,
+    auth,
     namespace = this.defaultNamespace,
     action,
     resources,
@@ -93,15 +93,15 @@ export class AuditService {
       )
     }
     const message = {
-      subject: user.nationalId,
-      actor: user.actor ? user.actor.nationalId : user.nationalId,
-      client: [user.client],
+      subject: auth.nationalId,
+      actor: auth.actor ? auth.actor.nationalId : auth.nationalId,
+      client: [auth.client],
       action: `${namespace}#${action}`,
       resources:
         resources && (typeof resources === 'string' ? [resources] : resources),
       meta,
-      ip: user.ip,
-      userAgent: user.userAgent,
+      ip: auth.ip,
+      userAgent: auth.userAgent,
     }
 
     return this.useDevLogger ? { message: 'Audit record', ...message } : message
@@ -121,7 +121,7 @@ export class AuditService {
   ): Promise<ResultType> {
     return promise.then((result) => {
       const message: AuditMessage = {
-        user: template.user,
+        auth: template.auth,
         action: template.action,
         namespace: template.namespace,
         resources: this.unwrap(template.resources, result),


### PR DESCRIPTION
# ☝️

## What

Renaming `user`-> `auth` in the `Audit` library after changing to the `Auth` object from the `User` object.
Updating all dependents using the `AuditService` to rename the variable.

## Why

Follow up PR of #6165 for nicer variable naming.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
