### PR TITLE
chore(codeowners): Simplify aranja teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,8 +12,7 @@
 # that are developed by others teams, we first list down the team working on the core and
 # further below the other team working on other part of the project.
 /apps/web*/                                                                                   @island-is/kosmos-kaos
-/libs/application/                                                                            @island-is/aranja-applications
-/libs/contentful-extensions/                                                                  @island-is/aranja-core @island-is/kosmos-kaos
+/libs/contentful-extensions/                                                                  @island-is/kosmos-kaos
 /libs/service-portal/                                                                         @island-is/hugsmidjan
 
 /*                                                                                            @island-is/core
@@ -46,7 +45,7 @@
 /libs/application/templates/driving-license/                                                  @island-is/kosmos-kaos
 /libs/application/templates/driving-assessment-approval/                                      @island-is/kosmos-kaos
 /libs/application/template-api-modules/src/lib/modules/templates/driving-license-submission   @island-is/kosmos-kaos
-/apps/application-system/api/src/app/modules/payment                                          @island-is/kosmos-kaos @island-is/aranja-applications
+/apps/application-system/api/src/app/modules/payment                                          @island-is/kosmos-kaos
 /libs/api/domains/driving-license/                                                            @island-is/kosmos-kaos
 /libs/api/domains/education/                                                                  @island-is/kosmos-kaos
 /libs/application/templates/general-petition/                                                 @island-is/kosmos-kaos
@@ -57,19 +56,11 @@
 /libs/air-discount-scheme/                                                                    @island-is/kosmos-kaos
 /libs/application/templates/p-sign/                                                           @island-is/kosmos-kaos
 
-/apps/reference-next-app/                                                                     @island-is/aranja-core
-/libs/cms-translations/                                                                       @island-is/aranja-core
-/libs/contentful-extensions/translation/                                                      @island-is/aranja-core
-/libs/clients/auth-public-api/                                                                @island-is/aranja-core
-/libs/clients/middlewares/                                                                    @island-is/aranja-core
-/libs/localization/                                                                           @island-is/aranja-core
-/libs/service-portal/settings/access-control                                                  @island-is/aranja-core @island-is/vice-versa
-
-/apps/application-system/                                                                     @island-is/aranja-applications
-/libs/api/domains/application/                                                                @island-is/aranja-applications
-/libs/clients/vmst/                                                                           @island-is/aranja-applications
-/libs/shared/form-fields/                                                                     @island-is/aranja-applications
-/libs/api/domains/directorate-of-labour/                                                      @island-is/aranja-applications
+/libs/clients/auth-public-api/                                                                @island-is/aranja
+/libs/clients/middlewares/                                                                    @island-is/aranja
+/libs/service-portal/settings/access-control                                                  @island-is/aranja
+/libs/clients/vmst/                                                                           @island-is/aranja
+/libs/api/domains/directorate-of-labour/                                                      @island-is/aranja
 
 /apps/application-system/api/src/app/modules/application/files/                               @island-is/kolibri-modern-family
 /libs/application/templates/family-matters/                                                   @island-is/kolibri-modern-family
@@ -165,10 +156,10 @@ infra/                                                                          
 
 /apps/services/auth-api/                                                                      @island-is/fuglar
 /apps/services/auth-admin-api/                                                                @island-is/fuglar
-/apps/services/auth-public-api/                                                               @island-is/fuglar @island-is/aranja-core
+/apps/services/auth-public-api/                                                               @island-is/fuglar @island-is/aranja
 /apps/auth-admin-web/                                                                         @island-is/fuglar
 /apps/auth-admin-web-e2e/                                                                     @island-is/fuglar
-/libs/auth-api-lib/                                                                           @island-is/fuglar @island-is/aranja-core
-/libs/auth-nest-tools/                                                                        @island-is/fuglar @island-is/aranja-core
+/libs/auth-api-lib/                                                                           @island-is/fuglar @island-is/aranja
+/libs/auth-nest-tools/                                                                        @island-is/fuglar @island-is/aranja
 
 /apps/services/personal-representative/                                                       @island-is/programm


### PR DESCRIPTION
## What

Simplify codeowners for aranja-related projects.

* Disconnect the application system from Aranja. Core will handle code reviews until a new code owner is found.
* Remove aranja codeownership from some other libs which we're not maintaining anymore.
* Aranja owns authentication folders and some parental leave folders (until another team takes over).
* Simplify to a single Aranja team to match internal structure.

## Why

To clean up github org.