### PR TITLE
refactor(application-templates-driving-license): address & type fixes in email generator

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/driving-license-submission/emailGenerators/drivingLicenseSubmittedEmail.spec.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/driving-license-submission/emailGenerators/drivingLicenseSubmittedEmail.spec.ts
@@ -8,6 +8,7 @@ import {
   createApplication,
   createCurrentUser,
 } from '@island.is/testing/fixtures'
+import { faker } from '@island.is/shared/mocking'
 
 import { generateDrivingLicenseSubmittedEmail } from './drivingLicenseSubmittedEmail'
 import { EmailComplete, EmailHeader, EmailRequirements } from './EmailUi'
@@ -26,6 +27,7 @@ const application = createApplication({
       a: 'no',
       b: 'yes',
     },
+    email: faker.internet.email(),
   },
   applicant: user.nationalId,
   assignees: [],


### PR DESCRIPTION
## What

A few sanity fixes and addressing the issue where an applicant does not have an email set

## Why

To make it more clear that we need to add an email option into the application if we want people to receive emails

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
