### PR TITLE
feat(island-ui): add smaller padding on icon buttons to match other

### DIFF
--- a/libs/island-ui/core/src/lib/Button/Button.css.ts
+++ b/libs/island-ui/core/src/lib/Button/Button.css.ts
@@ -168,6 +168,14 @@ export const padding = styleVariants({
       },
     }),
   },
+  icon: {
+    padding: '12px 16px',
+    ...themeUtils.responsiveStyle({
+      md: {
+        padding: '12px 16px',
+      },
+    }),
+  },
 })
 
 export const circleSizes = styleVariants({

--- a/libs/island-ui/core/src/lib/Button/Button.tsx
+++ b/libs/island-ui/core/src/lib/Button/Button.tsx
@@ -125,6 +125,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps & ButtonTypes>(
             [styles.isEmpty]: !children,
             [styles.loading]: loading,
           },
+          icon && variant !== 'text' && !circle && styles.padding.icon,
         )}
         display={variant === 'text' ? 'inline' : inline ? 'inlineFlex' : 'flex'}
         disabled={disabled || loading}


### PR DESCRIPTION
# ...

Smaller padding added on buttons that have icons

## What

Smaller padding added on buttons that have icons

## Why

Buttons with icons were 52px and other buttons 48px. Fixed the padding on buttons with icons so they look the same

## Screenshots / Gifs

![Screenshot 2022-01-11 at 15 45 51](https://user-images.githubusercontent.com/19873770/149109318-e1edde6c-0aac-4fcd-88e6-16bdf677ca18.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
