### PR TITLE
fix(judicial-system): Fix form stepper navigation

### DIFF
--- a/apps/judicial-system/web/src/components/PageLayout/utils/index.ts
+++ b/apps/judicial-system/web/src/components/PageLayout/utils/index.ts
@@ -12,6 +12,7 @@ import {
   getCustodyAndTravelBanProsecutorSection,
   getExtenstionSections,
   getInvestigationCaseCourtSections,
+  getInvestigationCaseExtenstionSections,
   getInvestigationCaseProsecutorSection,
 } from '@island.is/judicial-system-web/src/utils/sections'
 
@@ -102,7 +103,12 @@ export const getSections = (
         workingCase,
       ),
     },
-    getExtenstionSections(workingCase || ({} as Case), activeSubSection),
+    isRestrictionCase(workingCase?.type)
+      ? getExtenstionSections(workingCase || ({} as Case), activeSubSection)
+      : getInvestigationCaseExtenstionSections(
+          workingCase || ({} as Case),
+          activeSubSection,
+        ),
     getCourtSections(workingCase || ({} as Case), user, activeSubSection),
   ]
 }

--- a/apps/judicial-system/web/src/utils/mocks.ts
+++ b/apps/judicial-system/web/src/utils/mocks.ts
@@ -9,7 +9,6 @@ import {
   CaseType,
   InstitutionType,
   UserRole,
-  Case,
 } from '@island.is/judicial-system/types'
 import type { UpdateCase, User } from '@island.is/judicial-system/types'
 import { CaseQuery } from '@island.is/judicial-system-web/graphql'

--- a/apps/judicial-system/web/src/utils/sections.ts
+++ b/apps/judicial-system/web/src/utils/sections.ts
@@ -13,6 +13,7 @@ import {
   isOverviewStepValidRC,
   isPoliceDemandsStepValidIC,
   isPoliceDemandsStepValidRC,
+  isPoliceReportStepValidIC,
   isPoliceReportStepValidRC,
   isRulingStepOneValidIC,
   isRulingStepOneValidRC,
@@ -402,6 +403,77 @@ export const getExtenstionSections = (
           isPoliceDemandsStepValidRC(workingCase) &&
           isPoliceReportStepValidRC(workingCase)
             ? `${Constants.STEP_SIX_ROUTE}/${id}`
+            : undefined,
+      },
+    ],
+  }
+}
+
+export const getInvestigationCaseExtenstionSections = (
+  workingCase: Case,
+  activeSubSection?: number,
+): Section => {
+  const { id } = workingCase
+
+  return {
+    name: 'Krafa um framlengingu',
+    children: [
+      {
+        type: 'SUB_SECTION',
+        name: 'Varnaraðili',
+        href: `${Constants.IC_DEFENDANT_ROUTE}/${id}`,
+      },
+      {
+        type: 'SUB_SECTION',
+        name: 'Óskir um fyrirtöku',
+        href:
+          (activeSubSection && activeSubSection > 1) ||
+          isDefendantStepValidIC(workingCase)
+            ? `${Constants.IC_HEARING_ARRANGEMENTS_ROUTE}/${id}`
+            : undefined,
+      },
+      {
+        type: 'SUB_SECTION',
+        name: 'Dómkröfur og lagagrundvöllur',
+        href:
+          (activeSubSection && activeSubSection > 2) ||
+          (isDefendantStepValidIC(workingCase) &&
+            isHearingArrangementsStepValidIC(workingCase))
+            ? `${Constants.IC_POLICE_DEMANDS_ROUTE}/${id}`
+            : undefined,
+      },
+      {
+        type: 'SUB_SECTION',
+        name: 'Greinargerð',
+        href:
+          (activeSubSection && activeSubSection > 3) ||
+          (isDefendantStepValidIC(workingCase) &&
+            isHearingArrangementsStepValidIC(workingCase) &&
+            isPoliceDemandsStepValidIC(workingCase))
+            ? `${Constants.IC_POLICE_REPORT_ROUTE}/${id}`
+            : undefined,
+      },
+      {
+        type: 'SUB_SECTION',
+        name: 'Rannsóknargögn',
+        href:
+          (activeSubSection && activeSubSection > 4) ||
+          (isDefendantStepValidIC(workingCase) &&
+            isHearingArrangementsStepValidIC(workingCase) &&
+            isPoliceDemandsStepValidIC(workingCase) &&
+            isPoliceReportStepValidIC(workingCase))
+            ? `${Constants.IC_CASE_FILES_ROUTE}/${id}`
+            : undefined,
+      },
+      {
+        type: 'SUB_SECTION',
+        name: 'Yfirlit kröfu',
+        href:
+          isDefendantStepValidIC(workingCase) &&
+          isHearingArrangementsStepValidIC(workingCase) &&
+          isPoliceDemandsStepValidIC(workingCase) &&
+          isPoliceReportStepValidIC(workingCase)
+            ? `${Constants.IC_POLICE_CONFIRMATION_ROUTE}/${id}`
             : undefined,
       },
     ],


### PR DESCRIPTION
# Fix form stepper navigation

https://app.asana.com/0/1199153462262248/1201634243867910/f

## What

In extended investigation cases, the form stepper would use travel ban urls. 

## Why

It's a bug

## Screenshots / Gifs

https://user-images.githubusercontent.com/3789875/149126571-e5923234-f73d-4ab5-9f66-be077906f301.mov

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
