### PR TITLE
chore(web): add breadcrumb tag link back to news overview

### DIFF
--- a/apps/web/screens/Organization/NewsItem.tsx
+++ b/apps/web/screens/Organization/NewsItem.tsx
@@ -63,6 +63,14 @@ const NewsItem: Screen<NewsItemProps> = ({
     ? currentNavItem.primaryLink.text
     : n('newsTitle', 'Fréttir og tilkynningar')
 
+  const isNewsletter = newsItem?.genericTags?.some(
+    (x) => x.slug === 'frettabref',
+  )
+
+  const newsletterTitle = newsItem?.genericTags?.find(
+    (x) => x.slug === 'frettabref',
+  )?.title
+
   const breadCrumbs: BreadCrumbItem[] = [
     {
       title: 'Ísland.is',
@@ -77,10 +85,23 @@ const NewsItem: Screen<NewsItemProps> = ({
     ...(isOrganizationNews
       ? [
           {
+            isTag: true,
             title: newsOverviewTitle,
             href: linkResolver('organizationnewsoverview', [
               organizationPage.slug,
             ]).href,
+            typename: 'organizationnewsoverview',
+          },
+        ]
+      : []),
+    ...(isNewsletter
+      ? [
+          {
+            isTag: true,
+            title: newsletterTitle,
+            href:
+              linkResolver('organizationnewsoverview', [organizationPage.slug])
+                .href + '?tag=frettabref',
             typename: 'organizationnewsoverview',
           },
         ]


### PR DESCRIPTION
### What
Adds a link back to news overview in breadcrumbs.

### Why
Requested: https://app.asana.com/0/1199123945323117/1201539837995036

<img src="https://user-images.githubusercontent.com/8450096/149319510-c9322b72-c135-44df-9a19-56d87d617b71.png" width="300" />

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
