### PR TITLE
feat(web): Syslumenn auctions, show respondents and petitioners for ships and real estate

### DIFF
--- a/apps/web/screens/Organization/Syslumenn/Auctions.tsx
+++ b/apps/web/screens/Organization/Syslumenn/Auctions.tsx
@@ -538,16 +538,17 @@ const Auctions: Screen<AuctionsProps> = ({
         auctionContainsVakaKeyword(auction))
     )
   }
-  const getExtraInfo = (auction: SyslumennAuction) => {
+  const getWhereAuctionTakesPlaceAndExtraInfo = (auction: SyslumennAuction) => {
     if (auctionAtVaka(auction)) {
       return (
         <div>
           <Text paddingBottom={1}>
             {n('auctionTakesPlaceAt', 'Staðsetning uppboðs')}:{' '}
-            {n(
-              'auctionTakesPlaceAtVaka',
-              'Uppboð verður haldið í aðstöðu Vöku hf., Héðinsgötu 1 - 3.',
-            )}
+            {auction.auctionTakesPlaceAt ??
+              n(
+                'auctionTakesPlaceAtVaka',
+                'Uppboð verður haldið í aðstöðu Vöku hf., Héðinsgötu 1 - 3.',
+              )}
           </Text>
           <Text variant="small">
             {n(
@@ -578,6 +579,15 @@ const Auctions: Screen<AuctionsProps> = ({
             'Framhald uppboðs fasteignarinnar verður háð á fasteigninni sjálfri.',
           )}
         </Text>
+      )
+    } else {
+      return (
+        auction.auctionTakesPlaceAt && (
+          <Text paddingBottom={1}>
+            {n('auctionTakesPlaceAt', 'Staðsetning uppboðs')}:{' '}
+            {auction.auctionTakesPlaceAt}
+          </Text>
+        )
       )
     }
   }
@@ -802,11 +812,7 @@ const Auctions: Screen<AuctionsProps> = ({
                   )}
 
                   {/* Auction extra info */}
-                  {getExtraInfo(auction)}
-
-                  {auction.auctionTakesPlaceAt && (
-                    <Text>Uppboðsstaður: {auction.auctionTakesPlaceAt}</Text>
-                  )}
+                  {getWhereAuctionTakesPlaceAndExtraInfo(auction)}
 
                   {/* Respondents */}
                   {auctionRespondents &&

--- a/apps/web/screens/Organization/Syslumenn/Auctions.tsx
+++ b/apps/web/screens/Organization/Syslumenn/Auctions.tsx
@@ -520,7 +520,7 @@ const Auctions: Screen<AuctionsProps> = ({
   const capitalAreaOffice = n(
     'auctionCapitalAreaOffice',
     'Sýslumaðurinn á höfuðborgarsvæðinu',
-  )
+  ) as string
   const auctionContainsVakaKeyword = (auction: SyslumennAuction) => {
     return vakaAuctionKeywords.some((keyword) => {
       return (
@@ -538,7 +538,9 @@ const Auctions: Screen<AuctionsProps> = ({
         auctionContainsVakaKeyword(auction))
     )
   }
-  const getWhereAuctionTakesPlaceAndExtraInfo = (auction: SyslumennAuction) => {
+  const renderWhereAuctionTakesPlaceAndExtraInfo = (
+    auction: SyslumennAuction,
+  ) => {
     if (auctionAtVaka(auction)) {
       return (
         <div>
@@ -590,6 +592,41 @@ const Auctions: Screen<AuctionsProps> = ({
         )
       )
     }
+  }
+
+  const renderRespondents = (auction: SyslumennAuction, auctionRespondents) => {
+    if (!auctionRespondents) return null
+
+    if (auction.lotType === LOT_TYPES.REAL_ESTATE) {
+      return (
+        <Text paddingTop={2} paddingBottom={1}>
+          {auctionRespondents.length > 1
+            ? n('auctionRealEstateRespondentsPlural', 'Þinglýstir eigendur')
+            : n('auctionRealEstateRespondentsSingle', 'Þinglýstur eigandi')}
+          : {auctionRespondents.join(', ')}
+        </Text>
+      )
+    }
+
+    if (auction.lotType === LOT_TYPES.SHIP) {
+      return (
+        <Text paddingTop={2} paddingBottom={1}>
+          {auctionRespondents.length > 1
+            ? n('auctionShipRespondentsPlural', 'Gerðarþolar')
+            : n('auctionShipRespondentsSingle', 'Gerðarþoli')}
+          : {auctionRespondents.join(', ')}
+        </Text>
+      )
+    }
+
+    return (
+      <Text paddingTop={2} paddingBottom={1}>
+        {auctionRespondents.length > 1
+          ? n('auctionRespondentsPlural', 'Gerðarþolar')
+          : n('auctionRespondentsSingle', 'Gerðarþoli')}
+        : {auctionRespondents.join(', ')}
+      </Text>
+    )
   }
 
   return (
@@ -812,41 +849,22 @@ const Auctions: Screen<AuctionsProps> = ({
                   )}
 
                   {/* Auction extra info */}
-                  {getWhereAuctionTakesPlaceAndExtraInfo(auction)}
+                  {renderWhereAuctionTakesPlaceAndExtraInfo(auction)}
 
                   {/* Respondents */}
-                  {auctionRespondents &&
-                  auction.lotType === LOT_TYPES.REAL_ESTATE ? (
-                    <Text paddingTop={2} paddingBottom={1}>
-                      {auctionRespondents.length > 1
-                        ? n(
-                            'auctionRealEstateRespondentsPlural',
-                            'Þinglýstir eigendur',
-                          )
-                        : n(
-                            'auctionRealEstateRespondentsSingle',
-                            'Þinglýstur eigandi',
-                          )}
-                      : {auctionRespondents.join(', ')}
-                    </Text>
-                  ) : (
-                    <Text paddingTop={2} paddingBottom={1}>
-                      {auctionRespondents.length > 1
-                        ? n('auctionRespondentsPlural', 'Gerðarþolar')
-                        : n('auctionRespondentsSingle', 'Gerðarþoli')}
-                      : {auctionRespondents.join(', ')}
-                    </Text>
-                  )}
+                  {renderRespondents(auction, auctionRespondents)}
 
                   {/* Petitioners */}
-                  {auctionPetitioners && (
-                    <Text paddingBottom={1}>
-                      {auctionPetitioners.length > 1
-                        ? n('auctionPetitionersPlural', 'Gerðarbeiðendur')
-                        : n('auctionPetitionersSingle', 'Gerðarbeiðandi')}
-                      : {auctionPetitioners.join(', ')}
-                    </Text>
-                  )}
+                  {auctionPetitioners &&
+                    (auction.lotType === LOT_TYPES.REAL_ESTATE ||
+                      auction.lotType === LOT_TYPES.SHIP) && (
+                      <Text paddingBottom={1}>
+                        {auctionPetitioners.length > 1
+                          ? n('auctionPetitionersPlural', 'Gerðarbeiðendur')
+                          : n('auctionPetitionersSingle', 'Gerðarbeiðandi')}
+                        : {auctionPetitioners.join(', ')}
+                      </Text>
+                    )}
 
                   <Box
                     alignItems="flexEnd"

--- a/apps/web/screens/Organization/Syslumenn/Auctions.tsx
+++ b/apps/web/screens/Organization/Syslumenn/Auctions.tsx
@@ -538,7 +538,7 @@ const Auctions: Screen<AuctionsProps> = ({
         auctionContainsVakaKeyword(auction))
     )
   }
-  const getAuctionTakesPlaceAtAndExtraInfo = (auction: SyslumennAuction) => {
+  const getExtraInfo = (auction: SyslumennAuction) => {
     if (auctionAtVaka(auction)) {
       return (
         <div>
@@ -801,30 +801,46 @@ const Auctions: Screen<AuctionsProps> = ({
                     />
                   )}
 
-                  {/* Auction takes place at & auction extra info */}
-                  {getAuctionTakesPlaceAtAndExtraInfo(auction)}
+                  {/* Auction extra info */}
+                  {getExtraInfo(auction)}
+
+                  {auction.auctionTakesPlaceAt && (
+                    <Text>Uppboðsstaður: {auction.auctionTakesPlaceAt}</Text>
+                  )}
 
                   {/* Respondents */}
                   {auctionRespondents &&
-                    auction.lotType === LOT_TYPES.REAL_ESTATE && (
-                      <Text paddingTop={2} paddingBottom={1}>
-                        {auctionRespondents.length > 1
-                          ? n('auctionRespondentsPlural', 'Þinglýstir eigendur')
-                          : n('auctionRespondentsSingle', 'Þinglýstur eigandi')}
-                        : {auctionRespondents.join(', ')}
-                      </Text>
-                    )}
+                  auction.lotType === LOT_TYPES.REAL_ESTATE ? (
+                    <Text paddingTop={2} paddingBottom={1}>
+                      {auctionRespondents.length > 1
+                        ? n(
+                            'auctionRealEstateRespondentsPlural',
+                            'Þinglýstir eigendur',
+                          )
+                        : n(
+                            'auctionRealEstateRespondentsSingle',
+                            'Þinglýstur eigandi',
+                          )}
+                      : {auctionRespondents.join(', ')}
+                    </Text>
+                  ) : (
+                    <Text paddingTop={2} paddingBottom={1}>
+                      {auctionRespondents.length > 1
+                        ? n('auctionRespondentsPlural', 'Gerðarþolar')
+                        : n('auctionRespondentsSingle', 'Gerðarþoli')}
+                      : {auctionRespondents.join(', ')}
+                    </Text>
+                  )}
 
                   {/* Petitioners */}
-                  {auctionPetitioners &&
-                    auction.lotType === LOT_TYPES.REAL_ESTATE && (
-                      <Text paddingBottom={1}>
-                        {auctionPetitioners.length > 1
-                          ? n('auctionPetitionersPlural', 'Gerðarbeiðendur')
-                          : n('auctionPetitionersSingle', 'Gerðarbeiðandi')}
-                        : {auctionPetitioners.join(', ')}
-                      </Text>
-                    )}
+                  {auctionPetitioners && (
+                    <Text paddingBottom={1}>
+                      {auctionPetitioners.length > 1
+                        ? n('auctionPetitionersPlural', 'Gerðarbeiðendur')
+                        : n('auctionPetitionersSingle', 'Gerðarbeiðandi')}
+                      : {auctionPetitioners.join(', ')}
+                    </Text>
+                  )}
 
                   <Box
                     alignItems="flexEnd"

--- a/apps/web/screens/Organization/Syslumenn/Auctions.tsx
+++ b/apps/web/screens/Organization/Syslumenn/Auctions.tsx
@@ -594,7 +594,10 @@ const Auctions: Screen<AuctionsProps> = ({
     }
   }
 
-  const renderRespondents = (auction: SyslumennAuction, auctionRespondents) => {
+  const renderRespondents = (
+    auction: SyslumennAuction,
+    auctionRespondents: string[],
+  ) => {
     if (!auctionRespondents) return null
 
     if (auction.lotType === LOT_TYPES.REAL_ESTATE) {
@@ -619,14 +622,7 @@ const Auctions: Screen<AuctionsProps> = ({
       )
     }
 
-    return (
-      <Text paddingTop={2} paddingBottom={1}>
-        {auctionRespondents.length > 1
-          ? n('auctionRespondentsPlural', 'Gerðarþolar')
-          : n('auctionRespondentsSingle', 'Gerðarþoli')}
-        : {auctionRespondents.join(', ')}
-      </Text>
-    )
+    return null
   }
 
   return (

--- a/apps/web/screens/queries/Organization.tsx
+++ b/apps/web/screens/queries/Organization.tsx
@@ -210,6 +210,7 @@ export const GET_SYSLUMENN_AUCTIONS_QUERY = gql`
       auctionTime
       petitioners
       respondent
+      auctionTakesPlaceAt
     }
   }
 `

--- a/libs/api/domains/syslumenn/src/lib/models/syslumennAuction.ts
+++ b/libs/api/domains/syslumenn/src/lib/models/syslumennAuction.ts
@@ -34,4 +34,7 @@ export class SyslumennAuction {
 
   @Field({ nullable: true })
   respondent?: string
+
+  @Field({ nullable: true })
+  auctionTakesPlaceAt?: string
 }

--- a/libs/clients/syslumenn/src/lib/syslumennClient.types.ts
+++ b/libs/clients/syslumenn/src/lib/syslumennClient.types.ts
@@ -10,6 +10,7 @@ export interface SyslumennAuction {
   auctionTime: string
   petitioners: string
   respondent: string
+  auctionTakesPlaceAt: string
 }
 
 export interface DataUploadResponse {

--- a/libs/clients/syslumenn/src/lib/syslumennClient.utils.ts
+++ b/libs/clients/syslumenn/src/lib/syslumennClient.utils.ts
@@ -72,7 +72,7 @@ export const mapSyslumennAuction = (auction: Uppbod): SyslumennAuction => ({
   office: auction.embaetti ?? '',
   location: auction.starfsstod ?? '',
   auctionType: auction.tegund ?? '',
-  lotType: auction.andlag ?? '',
+  lotType: auction?.andlag?.trim() ?? '',
   lotName: auction.andlagHeiti ?? '',
   lotId: auction.fastanumer ?? '',
   lotItems: auction.lausafjarmunir ?? '',
@@ -80,6 +80,7 @@ export const mapSyslumennAuction = (auction: Uppbod): SyslumennAuction => ({
   auctionTime: auction.klukkan ?? '',
   petitioners: auction.gerdarbeidendur ?? '',
   respondent: auction.gerdartholar ?? '',
+  auctionTakesPlaceAt: auction.uppbodStadur ?? '',
 })
 
 export const mapOperatingLicense = (


### PR DESCRIPTION
# Syslumenn auctions, show respondents and petitioners for both ships and real estate

## What

* Respondents and petitioners were only showing up for real estate auctions
* Show where the auction takes place if that data is available

## Why

* We want to show the respondents and petitioners for both ships and real estates
* Recently, a new field `uppbodStadur` was added to Syslumenn API, to contain information about where the auction takes place. This field is currently always empty, but soon it will be fully implemented in the Syslumenn API. Therefore, in this PR, we are rendering this field in the view if it has a value.

## Screenshots

### Before

<img width="813" alt="ship-auction-before" src="https://user-images.githubusercontent.com/1277384/149323539-8a7dbe6f-5d35-4c1d-a855-a38797703a37.png">

### After

![ship-auction-after](https://user-images.githubusercontent.com/1277384/149323813-7d63c053-0442-43ac-8c76-41b443c426c7.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
