### PR TITLE
feat(parental-leave): Be able to fully use rights

### DIFF
--- a/libs/api/domains/directorate-of-labour/src/dto/getParentalLeavesEstimatedPaymentPlan.input.ts
+++ b/libs/api/domains/directorate-of-labour/src/dto/getParentalLeavesEstimatedPaymentPlan.input.ts
@@ -1,4 +1,4 @@
-import { Field, Float, InputType } from '@nestjs/graphql'
+import { Field, InputType } from '@nestjs/graphql'
 import { IsString, IsNumber, IsBoolean, IsArray } from 'class-validator'
 
 @InputType()
@@ -11,9 +11,9 @@ class Period {
   @IsString()
   to!: string
 
-  @Field(() => Float)
+  @Field(() => String)
   @IsNumber()
-  ratio!: number // Ratio of usage in period.
+  ratio!: string // Ratio of usage in period.
 
   @Field(() => Boolean)
   @IsBoolean()

--- a/libs/api/domains/directorate-of-labour/src/lib/directorate-of-labour.repository.ts
+++ b/libs/api/domains/directorate-of-labour/src/lib/directorate-of-labour.repository.ts
@@ -206,7 +206,7 @@ export class DirectorateOfLabourRepository {
         period: {
           from: '01-01-2020',
           to: '01-01-2020',
-          ratio: 0.8,
+          ratio: '0.8',
           approved: true,
           paid: true,
         },

--- a/libs/api/domains/directorate-of-labour/src/models/parentalLeavePeriod.model.ts
+++ b/libs/api/domains/directorate-of-labour/src/models/parentalLeavePeriod.model.ts
@@ -1,4 +1,4 @@
-import { Field, ObjectType, Float } from '@nestjs/graphql'
+import { Field, ObjectType } from '@nestjs/graphql'
 
 @ObjectType()
 export class ParentalLeavePeriod {
@@ -8,8 +8,8 @@ export class ParentalLeavePeriod {
   @Field(() => String)
   to!: string
 
-  @Field(() => Float)
-  ratio!: number
+  @Field(() => String)
+  ratio!: string
 
   @Field(() => Boolean)
   approved!: boolean

--- a/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/parental-leave.service.spec.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/parental-leave.service.spec.ts
@@ -2,6 +2,7 @@ import { Test } from '@nestjs/testing'
 import { ConfigService } from '@nestjs/config'
 import get from 'lodash/get'
 import set from 'lodash/set'
+import addDays from 'date-fns/addDays'
 
 import {
   Application,
@@ -9,11 +10,20 @@ import {
   ApplicationTypes,
 } from '@island.is/application/core'
 import { logger, LOGGER_PROVIDER } from '@island.is/logging'
-import { ParentalLeaveApi } from '@island.is/clients/vmst'
+import {
+  ParentalLeaveApi,
+  Period as VmstPeriod,
+  ParentalLeaveGetPeriodLengthRequest,
+  ParentalLeaveGetPeriodEndDateRequest,
+  PeriodLengthResponse,
+  PeriodEndDateResponse,
+} from '@island.is/clients/vmst'
 import {
   StartDateOptions,
   YES,
   NO,
+  Period,
+  calculatePeriodLength,
 } from '@island.is/application/templates/parental-leave'
 import { EmailService } from '@island.is/email-service'
 
@@ -121,17 +131,54 @@ describe('ParentalLeaveService', () => {
               Promise.resolve({
                 id: '1337',
               }),
-            parentalLeaveGetPeriodLength: () =>
+            parentalLeaveGetPeriodLength: ({
+              startDate,
+              endDate,
+              percentage,
+            }: ParentalLeaveGetPeriodLengthRequest): Promise<PeriodLengthResponse> =>
               Promise.resolve({
-                periodLength: 225,
+                periodLength:
+                  startDate && endDate
+                    ? calculatePeriodLength(
+                        startDate,
+                        endDate,
+                        Number(percentage) / 100,
+                      )
+                    : 0,
               }),
-            parentalLeaveGetPeriodEndDate: ({ length }: { length: string }) =>
-              Promise.resolve({
-                periodEndDate:
-                  Number(length) === 45
-                    ? new Date('2022-01-01T00:00:00')
-                    : new Date('2021-11-16T00:00:00.000Z'),
-              }),
+            parentalLeaveGetPeriodEndDate: ({
+              startDate,
+              percentage,
+              length,
+            }: ParentalLeaveGetPeriodEndDateRequest): Promise<PeriodEndDateResponse> => {
+              if (!startDate) {
+                throw new Error(
+                  'parentalLeaveGetPeriodEndDate: missing start date',
+                )
+              }
+
+              const ratio = Number(percentage) / 100
+              const goalLength = Number(length)
+              let calculatedLength = 0
+              let currentDate = startDate
+
+              while (calculatedLength <= goalLength) {
+                const nextDate = addDays(currentDate, 1)
+                calculatedLength = calculatePeriodLength(
+                  startDate,
+                  nextDate,
+                  ratio,
+                )
+
+                if (calculatedLength <= goalLength) {
+                  currentDate = nextDate
+                }
+              }
+
+              return Promise.resolve({
+                periodEndDate: currentDate,
+              })
+            },
           })),
         },
         {
@@ -166,7 +213,7 @@ describe('ParentalLeaveService', () => {
         {
           from: '2021-05-17',
           to: '2021-11-16',
-          ratio: 100,
+          ratio: '100',
           approved: false,
           paid: false,
           rightsCodePeriod: null,
@@ -174,7 +221,7 @@ describe('ParentalLeaveService', () => {
         {
           from: '2021-11-17',
           to: '2022-01-01',
-          ratio: 100,
+          ratio: '100',
           approved: false,
           paid: false,
           rightsCodePeriod: apiConstants.rights.receivingRightsId,
@@ -201,7 +248,7 @@ describe('ParentalLeaveService', () => {
         {
           from: 'date_of_birth',
           to: '2021-11-16',
-          ratio: 100,
+          ratio: '100',
           approved: false,
           paid: false,
           rightsCodePeriod: null,
@@ -209,12 +256,53 @@ describe('ParentalLeaveService', () => {
         {
           from: '2021-11-17',
           to: '2022-01-01',
-          ratio: 100,
+          ratio: '100',
           approved: false,
           paid: false,
           rightsCodePeriod: apiConstants.rights.receivingRightsId,
         },
       ])
+    })
+
+    it('should change period ratio to D<number_of_days> when using .daysToUse', async () => {
+      const application = createApplication()
+
+      const startDate = new Date(2022, 9, 10)
+      const endDate = new Date(2023, 0, 9)
+      const ratio = 0.59
+
+      const originalPeriods: Period[] = [
+        {
+          startDate: startDate.toISOString().split('T')[0],
+          endDate: endDate.toISOString().split('T')[0],
+          ratio: `${ratio * 100}`,
+          firstPeriodStart: StartDateOptions.ESTIMATED_DATE_OF_BIRTH,
+          daysToUse: calculatePeriodLength(
+            startDate,
+            endDate,
+            ratio,
+          ).toString(),
+        },
+      ]
+
+      set(application.answers, 'periods', originalPeriods)
+
+      const expectedPeriods: VmstPeriod[] = [
+        {
+          approved: false,
+          from: originalPeriods[0].startDate,
+          to: originalPeriods[0].endDate,
+          paid: false,
+          ratio: `D${originalPeriods[0].daysToUse}`,
+          rightsCodePeriod: null,
+        },
+      ]
+      const res = await parentalLeaveService.createPeriodsDTO(
+        application,
+        nationalId,
+      )
+
+      expect(res).toEqual(expectedPeriods)
     })
   })
 

--- a/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/parental-leave.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/parental-leave.service.ts
@@ -26,10 +26,7 @@ import {
   generateApplicationApprovedByEmployerEmail,
   generateApplicationApprovedByEmployerToEmployerEmail,
 } from './emailGenerators'
-import {
-  getEmployer,
-  transformApplicationToParentalLeaveDTO,
-} from './parental-leave.utils'
+import { transformApplicationToParentalLeaveDTO } from './parental-leave.utils'
 import { apiConstants } from './constants'
 
 interface VMSTError {
@@ -154,8 +151,15 @@ export class ParentalLeaveService {
       firstPeriodStart === StartDateOptions.ACTUAL_DATE_OF_BIRTH
     let numberOfDaysAlreadySpent = 0
 
+    const getRatio = (
+      ratio: string,
+      length: string,
+      shouldUseLength: boolean,
+    ) => (shouldUseLength ? `D${length}` : ratio)
+
     for (const [index, period] of answers.entries()) {
       const isFirstPeriod = index === 0
+      const isUsingNumberOfDays = period.daysToUse !== undefined
 
       // If a period doesn't have both startDate or endDate we skip it
       if (!isFirstPeriod && (!period.startDate || !period.endDate)) {
@@ -164,17 +168,25 @@ export class ParentalLeaveService {
 
       const startDate = new Date(period.startDate)
       const endDate = new Date(period.endDate)
-      const getPeriodLength = await this.parentalLeaveApi.parentalLeaveGetPeriodLength(
-        { nationalRegistryId, startDate, endDate, percentage: period.ratio },
-      )
 
-      if (getPeriodLength.periodLength === undefined) {
-        throw new Error(
-          `Could not calculate length of period from ${period.startDate} to ${period.endDate}`,
+      let periodLength = 0
+
+      if (isUsingNumberOfDays) {
+        periodLength = Number(period.daysToUse)
+      } else {
+        const getPeriodLength = await this.parentalLeaveApi.parentalLeaveGetPeriodLength(
+          { nationalRegistryId, startDate, endDate, percentage: period.ratio },
         )
+
+        if (getPeriodLength.periodLength === undefined) {
+          throw new Error(
+            `Could not calculate length of period from ${period.startDate} to ${period.endDate}`,
+          )
+        }
+
+        periodLength = Number(getPeriodLength.periodLength ?? 0)
       }
 
-      const periodLength = Number(getPeriodLength.periodLength ?? 0)
       const numberOfDaysSpentAfterPeriod =
         numberOfDaysAlreadySpent + periodLength
 
@@ -200,7 +212,11 @@ export class ParentalLeaveService {
               ? apiConstants.actualDateOfBirth
               : period.startDate,
           to: period.endDate,
-          ratio: Number(period.ratio),
+          ratio: getRatio(
+            period.ratio,
+            periodLength.toString(),
+            isUsingNumberOfDays,
+          ),
           approved: false,
           paid: false,
           rightsCodePeriod: null,
@@ -213,7 +229,11 @@ export class ParentalLeaveService {
               ? apiConstants.actualDateOfBirth
               : period.startDate,
           to: period.endDate,
-          ratio: Number(period.ratio),
+          ratio: getRatio(
+            period.ratio,
+            periodLength.toString(),
+            isUsingNumberOfDays,
+          ),
           approved: false,
           paid: false,
           rightsCodePeriod: apiConstants.rights.receivingRightsId,
@@ -247,7 +267,11 @@ export class ParentalLeaveService {
               ? apiConstants.actualDateOfBirth
               : period.startDate,
           to: format(getNormalPeriodEndDate.periodEndDate, df),
-          ratio: Number(period.ratio),
+          ratio: getRatio(
+            period.ratio,
+            daysLeftOfPersonalRights.toString(),
+            isUsingNumberOfDays,
+          ),
           approved: false,
           paid: false,
           rightsCodePeriod: null,
@@ -279,7 +303,11 @@ export class ParentalLeaveService {
         periods.push({
           from: format(transferredPeriodStartDate, df),
           to: format(getTransferredPeriodEndDate.periodEndDate, df),
-          ratio: Number(period.ratio),
+          ratio: getRatio(
+            period.ratio,
+            lengthOfPeriodUsingTransferredDays.toString(),
+            isUsingNumberOfDays,
+          ),
           approved: false,
           paid: false,
           rightsCodePeriod: apiConstants.rights.receivingRightsId,

--- a/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/parental-leave.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/parental-leave.service.ts
@@ -155,7 +155,7 @@ export class ParentalLeaveService {
       ratio: string,
       length: string,
       shouldUseLength: boolean,
-    ) => (shouldUseLength ? `D${length}` : ratio)
+    ) => (shouldUseLength ? `D${length}` : `${ratio}`)
 
     for (const [index, period] of answers.entries()) {
       const isFirstPeriod = index === 0

--- a/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/parental-leave.utils.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/parental-leave.utils.ts
@@ -193,7 +193,7 @@ export const answerToPeriodsDTO = (answers: AnswerPeriod[]) => {
     periods = answers.map((period) => ({
       from: period.startDate,
       to: period.endDate,
-      ratio: Number(period.ratio),
+      ratio: period.ratio,
       approved: false,
       paid: false,
       rightsCodePeriod: null,

--- a/libs/application/templates/parental-leave/src/fields/PeriodPercentage/PeriodPercentage.tsx
+++ b/libs/application/templates/parental-leave/src/fields/PeriodPercentage/PeriodPercentage.tsx
@@ -114,7 +114,10 @@ export const PeriodPercentage: FC<PeriodPercentageField> = ({
 
       options.splice(0, 0, {
         value: max,
-        label: `Full nýting (tæp ${maxPercentage}%)`,
+        label: formatMessage(
+          parentalLeaveFormMessages.duration.fullyUsedRatio,
+          { maxPercentage: max },
+        ),
       })
     }
 

--- a/libs/application/templates/parental-leave/src/fields/PeriodPercentage/PeriodPercentage.tsx
+++ b/libs/application/templates/parental-leave/src/fields/PeriodPercentage/PeriodPercentage.tsx
@@ -104,7 +104,10 @@ export const PeriodPercentage: FC<PeriodPercentageField> = ({
       maxPercentage / 100,
     )
 
-    if (periodLengthWithMaxPercentage < remainingRights) {
+    if (
+      periodLengthWithMaxPercentage < remainingRights &&
+      maxPercentage < 100
+    ) {
       setCanChooseRemainingDays(true)
       const max = `${maxPercentage + 1}`
       setMaxPercentageValue(max)

--- a/libs/application/templates/parental-leave/src/index.ts
+++ b/libs/application/templates/parental-leave/src/index.ts
@@ -7,5 +7,6 @@ export const getFields = () => import('./fields/')
 export default ParentalLeaveTemplate
 
 export * from './lib/parentalLeaveUtils'
+export { calculatePeriodLength } from './lib/directorateOfLabour.utils'
 export * from './constants'
 export * from './types'

--- a/libs/application/templates/parental-leave/src/lib/directorateOfLabour.utils.ts
+++ b/libs/application/templates/parental-leave/src/lib/directorateOfLabour.utils.ts
@@ -95,10 +95,15 @@ export const calculateExistingNumberOfDays = (periods: ParentalLeavePeriod[]) =>
     .reduce((acc, cur) => {
       const from = new Date(cur.from)
       const to = new Date(cur.to)
-      const days = calculateNumberOfDaysForOnePeriod(from, to)
-      const daysWithRatio = Math.round((days * cur.ratio) / 100)
 
-      return acc + daysWithRatio
+      if (cur.ratio.toString().startsWith('D')) {
+        const [, rawDays] = cur.ratio.toString().split('D')[1]
+
+        return acc + Number(rawDays)
+      }
+      const ratio = Number(cur.ratio)
+
+      return acc + calculatePeriodLength(from, to, ratio / 100)
     }, 0)
 
 /**

--- a/libs/application/templates/parental-leave/src/lib/messages.ts
+++ b/libs/application/templates/parental-leave/src/lib/messages.ts
@@ -904,6 +904,11 @@ export const parentalLeaveFormMessages: MessageDir = {
         'Fyrir svona langt tímabil fást greiðslur að hlutfalli af hámarksréttindum þínum: ',
       description: 'For this length of time you will get payments up to',
     },
+    fullyUsedRatio: {
+      id: 'pl.application:duration.ratio.fullyUse',
+      defaultMessage: 'Full nýting (tæp {maxPercentage}%)',
+      description: 'Fully use rights {percentage}',
+    },
   }),
 
   employer: defineMessages({

--- a/libs/application/templates/parental-leave/src/lib/parentalLeaveUtils.ts
+++ b/libs/application/templates/parental-leave/src/lib/parentalLeaveUtils.ts
@@ -675,7 +675,9 @@ export const calculateDaysUsedByPeriods = (periods: Period[]) =>
       const end = parseISO(period.endDate)
       const percentage = Number(period.ratio) / 100
 
-      const calculatedLength = calculatePeriodLength(start, end, percentage)
+      const calculatedLength = period.daysToUse
+        ? Number(period.daysToUse)
+        : calculatePeriodLength(start, end, percentage)
 
       return total + calculatedLength
     }, 0),

--- a/libs/application/templates/parental-leave/src/types.ts
+++ b/libs/application/templates/parental-leave/src/types.ts
@@ -8,6 +8,7 @@ export interface Period {
   ratio: string
   firstPeriodStart?: string
   useLength?: YesOrNo
+  daysToUse?: string
   rawIndex?: number
 }
 

--- a/libs/clients/vmst/src/clientConfig.yaml
+++ b/libs/clients/vmst/src/clientConfig.yaml
@@ -439,8 +439,8 @@ components:
           type: string
           minLength: 1
         ratio:
-          type: number
-          format: float
+          type: string
+          minLength: 1
         approved:
           type: boolean
         paid:


### PR DESCRIPTION
## What

For certain periods greater than remaining rights it is not always possible to fully use all days since there can be a remainder of days from spreading rights over some amount of months with a certain percentage.

By specifying that the user wishes to fully use days the VMST API will make sure to use all the remaining rights.

This is done by prefixing the ratio with `D` so the API will process it as days to use rather than a ratio to use for each month within the period.

## Why

So that there won't be some days left when the user means to use all of them for a single period.

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/6312838/149663834-b9645113-8fd1-472b-aa03-3def42415119.png)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
