### PR TITLE
fix(plausible): Normalize queries with lowercase

### DIFF
--- a/apps/web/screens/Search/Search.tsx
+++ b/apps/web/screens/Search/Search.tsx
@@ -101,7 +101,7 @@ const Search: Screen<CategoryProps> = ({
   // Submit the search query to plausible
   if (q) {
     plausibleCustomEvent('Search Query', {
-      query: q,
+      query: q.toLowerCase(),
       source: 'Web',
     })
   }

--- a/apps/web/screens/ServiceWeb/Search/ServiceSearch.tsx
+++ b/apps/web/screens/ServiceWeb/Search/ServiceSearch.tsx
@@ -93,7 +93,7 @@ const ServiceSearch: Screen<ServiceSearchProps> = ({
   // Submit the search query to plausible
   if (q) {
     plausibleCustomEvent('Search Query', {
-      query: q,
+      query: q.toLowerCase(),
       source: 'Service Web',
     })
   }


### PR DESCRIPTION
Forgot to normalize queries.
Some might say it would prove insightful to see when search queries are angry but data becomes that much more organized when standardized :stuck_out_tongue_closed_eyes: 

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
