### PR TITLE
fix(application-template-driving-license): fixing event sent for aborting the payment flow

### DIFF
--- a/libs/application/templates/driving-license/src/fields/PaymentPending/PaymentPending.tsx
+++ b/libs/application/templates/driving-license/src/fields/PaymentPending/PaymentPending.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useEffect } from 'react'
 import {
   CustomField,
+  DefaultEvents,
   FieldBaseProps,
   getValueViaPath,
 } from '@island.is/application/core'
@@ -25,6 +26,7 @@ export const PaymentPending: FC<Props> = (props) => {
   const [submitBack, { error: backError }] = useSubmitApplication({
     application,
     refetch,
+    event: DefaultEvents.ABORT,
   })
 
   const fromRedirect = isComingFromRedirect()
@@ -76,6 +78,7 @@ const PollingForPayment: FC<Props> = ({ error, application, refetch }) => {
   const [submitApplication, { error: submitError }] = useSubmitApplication({
     application,
     refetch,
+    event: DefaultEvents.SUBMIT,
   })
 
   // automatically go to done state if payment has been fulfilled

--- a/libs/application/templates/driving-license/src/fields/PaymentPending/hooks/useSubmitApplication.ts
+++ b/libs/application/templates/driving-license/src/fields/PaymentPending/hooks/useSubmitApplication.ts
@@ -6,7 +6,7 @@ export interface UseSubmitApplication {
   (params: {
     application: Application
     refetch: (() => void) | undefined
-    event?: DefaultEvents
+    event: DefaultEvents
   }): MutationTuple<
     void,
     {
@@ -22,7 +22,7 @@ export interface UseSubmitApplication {
 export const useSubmitApplication: UseSubmitApplication = ({
   application,
   refetch,
-  event = DefaultEvents.SUBMIT,
+  event,
 }) => {
   return useMutation(SUBMIT_APPLICATION, {
     onError: (e) => console.error(e.message),


### PR DESCRIPTION
zendesk issue: 15293 -- regression introduced in #6117

## What

fixing event sent for aborting the payment flow

## Why

so people without a payment url are not redirected as if the application was sent successfully

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
