### PR TITLE
feat(web): Project subpage, same tab selected on refresh

### DIFF
--- a/apps/web/screens/Project/Project.tsx
+++ b/apps/web/screens/Project/Project.tsx
@@ -291,7 +291,7 @@ const ProjectPage: Screen<PageProps> = ({ projectPage, news, namespace }) => {
         )}
         {renderSlicesAsTabs && !!subpage && subpage.slices.length > 1 && (
           <TableOfContents
-            tableOfContentsTitle="Undirkaflar"
+            tableOfContentsTitle={n('tableOfContentsTitle', 'Undirkaflar')}
             headings={subpage.slices.map((slice) => ({
               headingId: slice.id,
               headingTitle: (slice as OneColumnText).title,


### PR DESCRIPTION
# Project subpage, have the same tab selected on refresh

## What

* When you refresh the page then the browser will always select the first tab on a project subpage.
* This change makes it so that the selected tab is stored in the url, meaning that when you refresh the page now the tab you had selected stays selected.

## Why

* We want to fix this so that users can share links to a selected tab and also so that you don't lose the selected tab on refresh

## Screenshots / Gifs

Previously if you would refresh the page while on this tab, then the first tab would get selected
![image](https://user-images.githubusercontent.com/43557895/149970283-02f60d3c-c3d5-4b61-aea0-0ba83a2fb2c2.png)

![image](https://user-images.githubusercontent.com/43557895/149970472-6f510e03-71b6-48a9-b0fe-08f978d4661a.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
