### PR TITLE
feat(api-domains-driving-license): adding the reason for rejection from RLS

### DIFF
--- a/libs/api/domains/driving-license/src/lib/drivingLicense.service.ts
+++ b/libs/api/domains/driving-license/src/lib/drivingLicense.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common'
+import { Inject, Injectable } from '@nestjs/common'
 import type { User } from '@island.is/auth-nest-tools'
 import {
   TeachingRightsStatus,
@@ -13,8 +13,11 @@ import {
   QualityPhotoResult,
   DrivingLicenseApplicationType,
   NewTemporaryDrivingLicenseInput,
+  ApplicationEligibilityRequirement,
 } from './drivingLicense.type'
 import {
+  CanApplyErrorCodeBFull,
+  CanApplyErrorCodeBTemporary,
   DriversLicense,
   DrivingAssessment,
   DrivingLicenseApi,
@@ -27,10 +30,15 @@ import {
 import sortTeachers from './util/sortTeachers'
 import { StudentAssessment } from '..'
 import { FetchError } from '@island.is/clients/middlewares'
+import { LOGGER_PROVIDER } from '@island.is/logging'
+import type { Logger } from '@island.is/logging'
 
 @Injectable()
 export class DrivingLicenseService {
-  constructor(private readonly drivingLicenseApi: DrivingLicenseApi) {}
+  constructor(
+    @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
+    private readonly drivingLicenseApi: DrivingLicenseApi,
+  ) {}
 
   async getDrivingLicense(
     nationalId: User['nationalId'],
@@ -124,34 +132,34 @@ export class DrivingLicenseService {
 
     const canApply = await this.canApplyFor(nationalId, type)
 
-    const requirements = []
-
-    if (type === 'B-full') {
-      requirements.push(
-        {
-          key: RequirementKey.drivingAssessmentMissing,
-          requirementMet:
-            (assessmentResult?.created?.getTime() ?? 0) >
-            Date.now() - DRIVING_ASSESSMENT_MAX_AGE,
-        },
-        {
-          key: RequirementKey.drivingSchoolMissing,
-          requirementMet: hasFinishedSchool,
-        },
-      )
-    } else if (type === 'B-temp') {
-      requirements.push({
-        key: RequirementKey.localResidency,
-        requirementMet: true,
-      })
-    } else {
-      throw new Error('unknown type')
-    }
-
-    requirements.push({
-      key: RequirementKey.deniedByService,
-      requirementMet: canApply,
-    })
+    const requirements: ApplicationEligibilityRequirement[] = [
+      ...(type === 'B-full'
+        ? [
+            {
+              key: RequirementKey.drivingAssessmentMissing,
+              requirementMet:
+                (assessmentResult?.created?.getTime() ?? 0) >
+                Date.now() - DRIVING_ASSESSMENT_MAX_AGE,
+            },
+            {
+              key: RequirementKey.drivingSchoolMissing,
+              requirementMet: hasFinishedSchool,
+            },
+          ]
+        : []),
+      ...(type === 'B-temp'
+        ? [
+            {
+              key: RequirementKey.localResidency,
+              requirementMet: true,
+            },
+          ]
+        : []),
+      {
+        key: this.canApplyErrorCodeToRequirementKey(canApply.errorCode),
+        requirementMet: canApply.result,
+      },
+    ]
 
     // only eligible if we dont find an unmet requirement
     const isEligible = !requirements.find(
@@ -161,6 +169,40 @@ export class DrivingLicenseService {
     return {
       requirements,
       isEligible,
+    }
+  }
+
+  private canApplyErrorCodeToRequirementKey(
+    errorCode?: CanApplyErrorCodeBFull | CanApplyErrorCodeBTemporary,
+  ): RequirementKey {
+    if (errorCode === undefined) {
+      return RequirementKey.deniedByService
+    }
+
+    switch (errorCode) {
+      case 'HAS_DEPRIVATION':
+        return RequirementKey.hasDeprivation
+      case 'HAS_NO_PHOTO':
+        return RequirementKey.hasNoPhoto
+      case 'HAS_NO_SIGNATURE':
+        return RequirementKey.hasNoSignature
+      case 'HAS_POINTS':
+        return RequirementKey.hasPoints
+      case 'NO_LICENSE_FOUND':
+        return RequirementKey.noLicenseFound
+      case 'NO_TEMP_LICENSE':
+        return RequirementKey.noTempLicense
+      case 'PERSON_NOT_17_YEARS_OLD':
+        return RequirementKey.personNot17YearsOld
+      case 'PERSON_NOT_FOUND_IN_NATIONAL_REGISTRY':
+        return RequirementKey.personNotFoundInNationalRegistry
+      default:
+        this.logger.warn(
+          '[api-domains-driving-license] unhandled can apply error code',
+          errorCode,
+        )
+
+        return RequirementKey.deniedByService
     }
   }
 

--- a/libs/api/domains/driving-license/src/lib/drivingLicense.spec.ts
+++ b/libs/api/domains/driving-license/src/lib/drivingLicense.spec.ts
@@ -10,6 +10,8 @@ import {
 } from './__mock-data__/requestHandlers'
 import { startMocking } from '@island.is/shared/mocking'
 import { createLogger } from 'winston'
+import { logger, LOGGER_PROVIDER } from '@island.is/logging'
+import { Logger } from '@nestjs/common'
 
 startMocking(requestHandlers)
 
@@ -32,7 +34,16 @@ describe('DrivingLicenseService', () => {
           },
         }),
       ],
-      providers: [DrivingLicenseService, { provide: 'CONFIG', useValue: {} }],
+      providers: [
+        DrivingLicenseService,
+        { provide: 'CONFIG', useValue: {} },
+        {
+          provide: LOGGER_PROVIDER,
+          useValue: {
+            warn: () => undefined,
+          },
+        },
+      ],
     }).compile()
 
     service = module.get(DrivingLicenseService)

--- a/libs/api/domains/driving-license/src/lib/drivingLicense.type.ts
+++ b/libs/api/domains/driving-license/src/lib/drivingLicense.type.ts
@@ -52,6 +52,14 @@ export enum RequirementKey {
   drivingSchoolMissing = 'DrivingSchoolMissing',
   deniedByService = 'DeniedByService',
   localResidency = 'LocalResidency',
+  noTempLicense = 'NoTempLicense',
+  noLicenseFound = 'NoLicenseFound',
+  personNot17YearsOld = 'PersonNot17YearsOld',
+  hasNoPhoto = 'HasNoPhoto',
+  hasNoSignature = 'HasNoSignature',
+  personNotFoundInNationalRegistry = 'PersonNotFoundInNationalRegistry',
+  hasDeprivation = 'HasDeprivation',
+  hasPoints = 'HasPoints',
 }
 
 export interface ApplicationEligibilityRequirement {

--- a/libs/application/templates/driving-license/src/fields/EligibilitySummary/extractReasons.ts
+++ b/libs/application/templates/driving-license/src/fields/EligibilitySummary/extractReasons.ts
@@ -44,6 +44,12 @@ const requirementKeyToStep = (key: string, isRequirementMet: boolean): Step => {
         title: m.requirementUnmetLocalResidencyTitle,
         description: m.requirementUnmetLocalResidencyDescription,
       }
+    case RequirementKey.NoTempLicense:
+      return {
+        ...step,
+        title: m.requirementUnmetDeniedByServiceTitle,
+        description: m.requirementUnmetNoTempLicenseDescription,
+      }
     default:
       throw new Error('Unknown requirement reason - should not happen')
   }

--- a/libs/application/templates/driving-license/src/fields/EligibilitySummary/extractReasons.ts
+++ b/libs/application/templates/driving-license/src/fields/EligibilitySummary/extractReasons.ts
@@ -1,54 +1,70 @@
-import { m } from '../../lib/messages'
+import { MessageDescriptor } from 'react-intl'
+import { m, requirementsMessages } from '../../lib/messages'
 import { ApplicationEligibility, RequirementKey } from '../../types/schema'
 import { ReviewSectionState, Step } from './ReviewSection'
 
 export const extractReasons = (eligibility: ApplicationEligibility): Step[] => {
-  return eligibility.requirements.map(({ key, requirementMet }) =>
-    requirementKeyToStep(key, requirementMet),
-  )
+  return eligibility.requirements.map(({ key, requirementMet }) => ({
+    ...requirementKeyToStep(key, requirementMet),
+    state: requirementMet
+      ? ReviewSectionState.complete
+      : ReviewSectionState.requiresAction,
+  }))
+}
+
+const getDeniedByServiceMessageDescription = (
+  key: RequirementKey,
+): MessageDescriptor => {
+  switch (key) {
+    case RequirementKey.NoLicenseFound:
+    case RequirementKey.NoTempLicense:
+      return requirementsMessages.invalidLicense
+    case RequirementKey.HasDeprivation:
+    case RequirementKey.HasPoints:
+      return requirementsMessages.hasPointsOrDeprivation
+    default:
+      return requirementsMessages.rlsDefaultDeniedDescription
+  }
 }
 
 // TODO: we need a better way of getting the translated string in here, outside
 // of react. Possibly we should just make a more flexible results screen.
 // This string ends up being used as the paramejter displayed as the error message
 // for the failed dataprovider
-const requirementKeyToStep = (key: string, isRequirementMet: boolean): Step => {
-  const step = {
-    state: isRequirementMet
-      ? ReviewSectionState.complete
-      : ReviewSectionState.requiresAction,
-  }
-
+const requirementKeyToStep = (
+  key: RequirementKey,
+  requirementMet: boolean,
+): Omit<Step, 'state'> => {
   switch (key) {
     case RequirementKey.DrivingSchoolMissing:
       return {
-        ...step,
-        title: m.requirementUnmetDrivingSchoolTitle,
-        description: m.requirementUnmetDrivingSchoolDescription,
+        title: requirementsMessages.drivingSchoolTitle,
+        description: requirementsMessages.drivingSchoolDescription,
       }
     case RequirementKey.DrivingAssessmentMissing:
       return {
-        ...step,
-        title: m.requirementUnmetDrivingAssessmentTitle,
-        description: m.requirementUnmetDrivingAssessmentDescription,
+        title: requirementsMessages.drivingAssessmentTitle,
+        description: requirementsMessages.drivingAssessmentDescription,
       }
     case RequirementKey.DeniedByService:
+    case RequirementKey.HasNoPhoto:
+    case RequirementKey.HasDeprivation:
+    case RequirementKey.HasNoSignature:
+    case RequirementKey.HasPoints:
+    case RequirementKey.NoLicenseFound:
+    case RequirementKey.PersonNot17YearsOld:
+    case RequirementKey.PersonNotFoundInNationalRegistry:
+    case RequirementKey.NoTempLicense:
       return {
-        ...step,
-        title: m.requirementUnmetDeniedByServiceTitle,
-        description: m.requirementUnmetDeniedByServiceDescription,
+        title: requirementsMessages.rlsTitle,
+        description: requirementMet
+          ? requirementsMessages.rlsAcceptedDescription
+          : getDeniedByServiceMessageDescription(key),
       }
     case RequirementKey.LocalResidency:
       return {
-        ...step,
-        title: m.requirementUnmetLocalResidencyTitle,
-        description: m.requirementUnmetLocalResidencyDescription,
-      }
-    case RequirementKey.NoTempLicense:
-      return {
-        ...step,
-        title: m.requirementUnmetDeniedByServiceTitle,
-        description: m.requirementUnmetNoTempLicenseDescription,
+        title: requirementsMessages.localResidencyTitle,
+        description: requirementsMessages.localResidencyDescription,
       }
     default:
       throw new Error('Unknown requirement reason - should not happen')

--- a/libs/application/templates/driving-license/src/lib/messages.ts
+++ b/libs/application/templates/driving-license/src/lib/messages.ts
@@ -362,56 +362,6 @@ export const m = defineMessages({
     defaultMessage: 'Greiðsla',
     description: 'Cost',
   },
-  requirementUnmetDrivingAssessmentTitle: {
-    id: 'dl.application:requirementunmet.drivingassessmenttitle',
-    defaultMessage: 'Akstursmat',
-    description: 'requirement unmet assessment',
-  },
-  requirementUnmetDrivingAssessmentDescription: {
-    id: 'dl.application:requirementunmet.drivingassessmentdescription',
-    defaultMessage:
-      'Ef þú ert búinn að fara í akstursmat hjá ökukennara biddu hann um að staðfesta það rafrænt.',
-    description: 'requirement unmet assessment',
-  },
-  requirementUnmetDrivingSchoolTitle: {
-    id: 'dl.application:requirementunmet.drivingschooltitle',
-    defaultMessage: 'Ökuskóli 3',
-    description: 'requirement unmet driving school',
-  },
-  requirementUnmetDrivingSchoolDescription: {
-    id: 'dl.application:requirementunmet.drivingschooldescription',
-    defaultMessage:
-      'Umsækjandi þarf að hafa klárað Ökuskóla 3 til að fá fullnaðarskírteini.',
-    description: 'requirement unmet driving school',
-  },
-  requirementUnmetDeniedByServiceTitle: {
-    id: 'dl.application:requirementunmet.deniedbyservicetitle',
-    defaultMessage: 'Ökuskírteinaskrá',
-    description: 'requirement unmet api returned false',
-  },
-  requirementUnmetDeniedByServiceDescription: {
-    id: 'dl.application:requirementunmet.deniedbyservicedescription',
-    defaultMessage:
-      'Vinsamlega hafðu samband við næsta sýslumannsembætti til að fá frekari upplýsingar.',
-    description: 'requirement unmet api returned false',
-  },
-  requirementUnmetNoTempLicenseDescription: {
-    id: 'dl.application:requirementunmet.notemplicensedescription',
-    defaultMessage:
-      'Bráðabirgðaskírteini er ekki til staðar. Vinsamlega hafðu samband við næsta sýslumannsembætti til að fá frekari upplýsingar.',
-    description: 'requirement unmet api returned NO_TEMP_LICENSE',
-  },
-  requirementUnmetLocalResidencyTitle: {
-    id: 'dl.application:requirementunmet.localResidencyTitle',
-    defaultMessage: 'Búseta á Íslandi',
-    description: 'requirement unmet api returned false',
-  },
-  requirementUnmetLocalResidencyDescription: {
-    id: 'dl.application:requirementunmet.localResidencyDescription',
-    defaultMessage:
-      'Þú þarft að hafa búið að minnsta kosti 180 daga af síðustu 365 dögum á Íslandi til að geta sótt um ökuskírteini.',
-    description: 'requirement unmet api returned false',
-  },
   errorDataProvider: {
     id: 'dl.application:error.dataProvider',
     defaultMessage: 'Reyndu aftur síðar',
@@ -721,5 +671,71 @@ export const m = defineMessages({
     defaultMessage: 'Leiðbeiningar',
     description:
       'Title of the section that explains the next steps when they have a driving license in a different country',
+  },
+})
+
+export const requirementsMessages = defineMessages({
+  rlsAcceptedDescription: {
+    id: 'dl.application:requirementunmet.accepted',
+    defaultMessage: 'Þú uppfyllir þær kröfur sem gerðar eru',
+    description: 'RLS / driving license api approves of the applicant',
+  },
+  rlsDefaultDeniedDescription: {
+    id: 'dl.application:requirementunmet.deniedbyservicedescription',
+    defaultMessage:
+      'Vinsamlega hafðu samband við næsta sýslumannsembætti til að fá frekari upplýsingar.',
+    description:
+      'requirement unmet api returned false for an unspecified reason',
+  },
+  invalidLicense: {
+    id: 'dl.application:requirementunmet.invalidlicense',
+    defaultMessage:
+      'Bráðabirgðaskírteini er ekki til staðar. Vinsamlega hafðu samband við næsta sýslumannsembætti til að fá frekari upplýsingar.',
+    description:
+      'requirement unmet api returned NO_TEMP_LICENSE / NO_LICENSE_FOUND',
+  },
+  hasPointsOrDeprivation: {
+    id: 'dl.application:requirementunmet.haspointsordeprivation',
+    defaultMessage:
+      'Þú ert með punkta eða sviptingu. Vinsamlega hafðu samband við næsta sýslumannsembætti til að fá frekari upplýsingar.',
+    description: 'requirement unmet api returned HAS_DEPRIVATION / HAS_POINTS',
+  },
+  drivingAssessmentTitle: {
+    id: 'dl.application:requirementunmet.drivingassessmenttitle',
+    defaultMessage: 'Akstursmat',
+    description: 'requirement unmet assessment',
+  },
+  drivingAssessmentDescription: {
+    id: 'dl.application:requirementunmet.drivingassessmentdescription',
+    defaultMessage:
+      'Ef þú ert búinn að fara í akstursmat hjá ökukennara biddu hann um að staðfesta það rafrænt.',
+    description: 'requirement unmet assessment',
+  },
+  drivingSchoolTitle: {
+    id: 'dl.application:requirementunmet.drivingschooltitle',
+    defaultMessage: 'Ökuskóli 3',
+    description: 'requirement unmet driving school',
+  },
+  drivingSchoolDescription: {
+    id: 'dl.application:requirementunmet.drivingschooldescription',
+    defaultMessage:
+      'Umsækjandi þarf að hafa klárað Ökuskóla 3 til að fá fullnaðarskírteini.',
+    description: 'requirement unmet driving school',
+  },
+  rlsTitle: {
+    id: 'dl.application:requirementunmet.deniedbyservicetitle',
+    defaultMessage: 'Ökuskírteinaskrá',
+    description: 'requirement unmet api returned false',
+  },
+  localResidencyTitle: {
+    id: 'dl.application:requirementunmet.localResidencyTitle',
+    defaultMessage: 'Búseta á Íslandi',
+    description: 'requirement unmet api returned false',
+  },
+  localResidencyDescription: {
+    id: 'dl.application:requirementunmet.localResidencyDescription',
+    defaultMessage:
+      'Þú þarft að hafa búið að minnsta kosti 180 daga af síðustu 365 dögum á Íslandi til að geta sótt um ökuskírteini.',
+    description: 'requirement unmet api returned false',
   },
 })

--- a/libs/application/templates/driving-license/src/lib/messages.ts
+++ b/libs/application/templates/driving-license/src/lib/messages.ts
@@ -395,6 +395,12 @@ export const m = defineMessages({
       'Vinsamlega hafðu samband við næsta sýslumannsembætti til að fá frekari upplýsingar.',
     description: 'requirement unmet api returned false',
   },
+  requirementUnmetNoTempLicenseDescription: {
+    id: 'dl.application:requirementunmet.notemplicensedescription',
+    defaultMessage:
+      'Bráðabirgðaskírteini er ekki til staðar. Vinsamlega hafðu samband við næsta sýslumannsembætti til að fá frekari upplýsingar.',
+    description: 'requirement unmet api returned NO_TEMP_LICENSE',
+  },
   requirementUnmetLocalResidencyTitle: {
     id: 'dl.application:requirementunmet.localResidencyTitle',
     defaultMessage: 'Búseta á Íslandi',

--- a/libs/clients/driving-license/src/lib/drivingLicenseApi.service.ts
+++ b/libs/clients/driving-license/src/lib/drivingLicenseApi.service.ts
@@ -1,8 +1,18 @@
 import { Injectable } from '@nestjs/common'
-import { DrivingAssessment, Juristiction, QualityPhoto } from '..'
+import {
+  CanApplyErrorCodeBFull,
+  CanApplyForCategoryResult,
+  DrivingAssessment,
+  Juristiction,
+  QualityPhoto,
+} from '..'
 import { ApiV1, EmbaettiDto } from '../v1'
 import { ApiV2, DRIVING_LICENSE_API_VERSION_V2, Rettindi } from '../v2'
-import { DriversLicense, Teacher } from './drivingLicenseApi.types'
+import {
+  CanApplyErrorCodeBTemporary,
+  DriversLicense,
+  Teacher,
+} from './drivingLicenseApi.types'
 import { handleCreateResponse } from './utils/handleCreateResponse'
 
 const DRIVING_LICENSE_SUCCESSFUL_RESPONSE_VALUE = ''
@@ -116,8 +126,8 @@ export class DrivingLicenseApi {
   public async getCanApplyForCategoryFull(params: {
     category: string
     nationalId: string
-  }) {
-    const canApplyResult = await this.v2.apiOkuskirteiniKennitalaCanapplyforCategoryFullGet(
+  }): Promise<CanApplyForCategoryResult<CanApplyErrorCodeBFull>> {
+    const response = await this.v2.apiOkuskirteiniKennitalaCanapplyforCategoryFullGet(
       {
         apiVersion: DRIVING_LICENSE_API_VERSION_V2,
         kennitala: params.nationalId,
@@ -125,18 +135,29 @@ export class DrivingLicenseApi {
       },
     )
 
-    // TODO: Use error codes from v2 api
-    return !!canApplyResult.result
+    return {
+      result: !!response.result,
+      errorCode: response.errorCode
+        ? (response.errorCode as CanApplyErrorCodeBFull)
+        : undefined,
+    }
   }
 
-  public async getCanApplyForCategoryTemporary(params: { nationalId: string }) {
-    const canApplyResult = await this.v1.apiOkuskirteiniKennitalaCanapplyforTemporaryGet(
+  public async getCanApplyForCategoryTemporary(params: {
+    nationalId: string
+  }): Promise<CanApplyForCategoryResult<CanApplyErrorCodeBTemporary>> {
+    const response = await this.v1.apiOkuskirteiniKennitalaCanapplyforTemporaryGet(
       {
         kennitala: params.nationalId,
       },
     )
 
-    return !!canApplyResult.result
+    return {
+      result: !!response.result,
+      errorCode: response.errorCode
+        ? (response.errorCode as CanApplyErrorCodeBTemporary)
+        : undefined,
+    }
   }
 
   public async postCreateDrivingAssessment(params: {

--- a/libs/clients/driving-license/src/lib/drivingLicenseApi.types.ts
+++ b/libs/clients/driving-license/src/lib/drivingLicenseApi.types.ts
@@ -36,3 +36,23 @@ export interface DrivingAssessment {
 export interface QualityPhoto {
   data: string
 }
+
+export type CanApplyErrorCodeBTemporary =
+  | 'PERSON_NOT_FOUND_IN_NATIONAL_REGISTRY'
+  | 'NO_LICENSE_FOUND'
+  | 'PERSON_NOT_17_YEARS_OLD'
+  | 'HAS_DEPRIVATION'
+  | 'HAS_NO_PHOTO'
+  | 'HAS_NO_SIGNATURE'
+
+export type CanApplyErrorCodeBFull =
+  | 'HAS_POINTS'
+  | 'NO_TEMP_LICENSE'
+  | 'HAS_DEPRIVATION'
+
+export interface CanApplyForCategoryResult<
+  T extends CanApplyErrorCodeBFull | CanApplyErrorCodeBTemporary
+> {
+  result: boolean
+  errorCode?: T | undefined
+}


### PR DESCRIPTION
## What

This adds a reason for why RLS will not let people move forward in the application

## Why

People who are applying and get the generic notice that people need to contact Syslumenn, will now get a user-friendly message indicating what the error may be.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
