### PR TITLE
fix(p-sign-application): Adding prefix to base64 string 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,6 +56,7 @@
 /apps/air-discount-scheme/                                                                    @island-is/kosmos-kaos
 /libs/air-discount-scheme/                                                                    @island-is/kosmos-kaos
 /libs/application/templates/p-sign/                                                           @island-is/kosmos-kaos
+/libs/application/template-api-modules/src/lib/modules/templates/p-sign-submission   @island-is/kosmos-kaos
 
 /libs/clients/auth-public-api/                                                                @island-is/aranja
 /libs/clients/middlewares/                                                                    @island-is/aranja

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,7 +56,7 @@
 /apps/air-discount-scheme/                                                                    @island-is/kosmos-kaos
 /libs/air-discount-scheme/                                                                    @island-is/kosmos-kaos
 /libs/application/templates/p-sign/                                                           @island-is/kosmos-kaos
-/libs/application/template-api-modules/src/lib/modules/templates/p-sign-submission   @island-is/kosmos-kaos
+/libs/application/template-api-modules/src/lib/modules/templates/p-sign-submission            @island-is/kosmos-kaos
 
 /libs/clients/auth-public-api/                                                                @island-is/aranja
 /libs/clients/middlewares/                                                                    @island-is/aranja

--- a/libs/application/template-api-modules/src/lib/modules/templates/p-sign-submission/p-sign-submission.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/p-sign-submission/p-sign-submission.service.ts
@@ -144,7 +144,6 @@ export class PSignSubmissionService {
       })
       .promise()
     const fileContent = file.Body as Buffer
-
-    return fileContent?.toString('base64') || ''
+    return `data:image/jpeg;base64,${fileContent?.toString('base64')}` || ''
   }
 }


### PR DESCRIPTION
Base 64 prefix was missing and adding codeowners.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
