### PR TITLE
hotfix(service-portal): logo not visible in sidebar on safari

### DIFF
--- a/apps/service-portal/src/components/Sidebar/Sidebar.tsx
+++ b/apps/service-portal/src/components/Sidebar/Sidebar.tsx
@@ -1,8 +1,8 @@
 import React, { FC, useEffect, useState } from 'react'
-import { Box, Stack, Logo, FocusableBox, Icon } from '@island.is/island-ui/core'
+import { Box, Stack, Logo, Icon } from '@island.is/island-ui/core'
 import { ActionType } from '../../store/actions'
 import { ServicePortalPath } from '@island.is/service-portal/core'
-import { Link, useLocation } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import { useStore } from '../../store/stateProvider'
 import ModuleNavigation from './ModuleNavigation'
 import useNavigation from '../../hooks/useNavigation/useNavigation'
@@ -11,7 +11,6 @@ import cn from 'classnames'
 import { useWindowSize } from 'react-use'
 import { theme } from '@island.is/island-ui/theme'
 import { useListDocuments } from '@island.is/service-portal/graphql'
-import { fixSvgUrls } from '../../utils/fixes'
 
 export const Sidebar: FC<{}> = () => {
   const navigation = useNavigation()
@@ -21,14 +20,6 @@ export const Sidebar: FC<{}> = () => {
   const isTablet = width < theme.breakpoints.lg && width >= theme.breakpoints.md
   const isMobile = width < theme.breakpoints.md
   const { unreadCounter } = useListDocuments('')
-  const location = useLocation()
-
-  // useEffect(() => {
-  //   // Fixes the island.is logo and other SVGs not appearing on
-  //   // Mobile Safari, when a <base> tag exists in index.html.
-  //   const url = window.location.origin + location.pathname
-  //   if (sidebarState === 'open') fixSvgUrls(url)
-  // }, [location, sidebarState])
 
   useEffect(() => {
     if (isTablet) {

--- a/apps/service-portal/src/components/Sidebar/Sidebar.tsx
+++ b/apps/service-portal/src/components/Sidebar/Sidebar.tsx
@@ -2,7 +2,7 @@ import React, { FC, useEffect, useState } from 'react'
 import { Box, Stack, Logo, FocusableBox, Icon } from '@island.is/island-ui/core'
 import { ActionType } from '../../store/actions'
 import { ServicePortalPath } from '@island.is/service-portal/core'
-import { Link } from 'react-router-dom'
+import { Link, useLocation } from 'react-router-dom'
 import { useStore } from '../../store/stateProvider'
 import ModuleNavigation from './ModuleNavigation'
 import useNavigation from '../../hooks/useNavigation/useNavigation'
@@ -11,6 +11,7 @@ import cn from 'classnames'
 import { useWindowSize } from 'react-use'
 import { theme } from '@island.is/island-ui/theme'
 import { useListDocuments } from '@island.is/service-portal/graphql'
+import { fixSvgUrls } from '../../utils/fixes'
 
 export const Sidebar: FC<{}> = () => {
   const navigation = useNavigation()
@@ -20,6 +21,14 @@ export const Sidebar: FC<{}> = () => {
   const isTablet = width < theme.breakpoints.lg && width >= theme.breakpoints.md
   const isMobile = width < theme.breakpoints.md
   const { unreadCounter } = useListDocuments('')
+  const location = useLocation()
+
+  // useEffect(() => {
+  //   // Fixes the island.is logo and other SVGs not appearing on
+  //   // Mobile Safari, when a <base> tag exists in index.html.
+  //   const url = window.location.origin + location.pathname
+  //   if (sidebarState === 'open') fixSvgUrls(url)
+  // }, [location, sidebarState])
 
   useEffect(() => {
     if (isTablet) {
@@ -57,17 +66,15 @@ export const Sidebar: FC<{}> = () => {
           className={collapsed && styles.logoCollapsed}
           paddingBottom={8}
           paddingTop={3}
+          height="full"
           paddingLeft={collapsed ? 0 : 4}
         >
           <Link to={ServicePortalPath.MinarSidurRoot}>
-            <FocusableBox component="div">
-              <Logo
-                width={collapsed ? 24 : 136}
-                height={22}
-                iconOnly={collapsed}
-                id="sidebar"
-              />
-            </FocusableBox>
+            {collapsed ? (
+              <Logo width={24} height={22} iconOnly id="sidebar-collapsed" />
+            ) : (
+              <Logo width={136} height={22} id="sidebar" />
+            )}
           </Link>
         </Box>
         <Box>


### PR DESCRIPTION
# Logo not visible in Safari browser!

## What

No height given on logo container. Logo was not displaying in Safari browsers.

## Why

🐞 

## Screenshots / Gifs


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
