### PR TITLE
fix(service-portal): logo not visible in sidebar on safari (#6316)

### DIFF
--- a/apps/service-portal/src/components/Sidebar/Sidebar.tsx
+++ b/apps/service-portal/src/components/Sidebar/Sidebar.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useEffect, useState } from 'react'
-import { Box, Stack, Logo, FocusableBox, Icon } from '@island.is/island-ui/core'
+import { Box, Stack, Logo, Icon } from '@island.is/island-ui/core'
 import { ActionType } from '../../store/actions'
 import { ServicePortalPath } from '@island.is/service-portal/core'
 import { Link } from 'react-router-dom'
@@ -57,17 +57,15 @@ export const Sidebar: FC<{}> = () => {
           className={collapsed && styles.logoCollapsed}
           paddingBottom={8}
           paddingTop={3}
+          height="full"
           paddingLeft={collapsed ? 0 : 4}
         >
           <Link to={ServicePortalPath.MinarSidurRoot}>
-            <FocusableBox component="div">
-              <Logo
-                width={collapsed ? 24 : 136}
-                height={22}
-                iconOnly={collapsed}
-                id="sidebar"
-              />
-            </FocusableBox>
+            {collapsed ? (
+              <Logo width={24} height={22} iconOnly id="sidebar-collapsed" />
+            ) : (
+              <Logo width={136} height={22} id="sidebar" />
+            )}
           </Link>
         </Box>
         <Box>


### PR DESCRIPTION
* fix: logo not visible in sidebar

* fix: remove clutter

# commit:  28fa35c87a97a474c1c61d92c14b8079f58dc08f
# PR:  #6316

## What & Why

HOTFIX 🔥  - No logo displayed in Service Portal in Safari

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
