### PR TITLE
fix(judicial-system): Use correct route when leaving the defendant screen in investigation cases

### DIFF
--- a/apps/judicial-system/web/src/components/AccordionItems/PoliceRequestAccordionItem/PoliceRequestAccordionItem.tsx
+++ b/apps/judicial-system/web/src/components/AccordionItems/PoliceRequestAccordionItem/PoliceRequestAccordionItem.tsx
@@ -41,9 +41,11 @@ const PoliceRequestAccordionItem: React.FC<Props> = ({
     >
       <Box marginBottom={2}>
         <Text variant="h4" as="h4">
-          {formatMessage(core.defendant, {
-            suffix: (workingCase.defendants ?? []).length > 1 ? 'ar' : 'i',
-          })}
+          {capitalize(
+            formatMessage(core.defendant, {
+              suffix: (workingCase.defendants ?? []).length > 1 ? 'ar' : 'i',
+            }),
+          )}
         </Text>
       </Box>
       {workingCase.defendants &&

--- a/apps/judicial-system/web/src/routes/Prosecutor/InvestigationRequest/Defendant/Defendant.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/InvestigationRequest/Defendant/Defendant.tsx
@@ -51,9 +51,11 @@ const Defendant = () => {
           })
         }
       })
-      router.push(`${constants.STEP_TWO_ROUTE}/${createdCase.id}`)
+      router.push(
+        `${constants.IC_HEARING_ARRANGEMENTS_ROUTE}/${createdCase.id}`,
+      )
     } else {
-      router.push(`${constants.STEP_TWO_ROUTE}/${theCase.id}`)
+      router.push(`${constants.IC_HEARING_ARRANGEMENTS_ROUTE}/${theCase.id}`)
     }
   }
 


### PR DESCRIPTION
# Use correct route when leaving the defendant screen in investigation cases

https://app.asana.com/0/1199153462262248/1201256841519082/f

## What

Use correct route when leaving the defendant screen in investigation cases

## Why

It's a bug

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
