### PR TITLE
feat(judicial-system): Add fields to InfoCard in prosecutor flow

### DIFF
--- a/apps/judicial-system/web/src/routes/Prosecutor/InvestigationRequest/Overview/OverviewForm.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/InvestigationRequest/Overview/OverviewForm.tsx
@@ -53,6 +53,14 @@ const OverviewForm: React.FC<Props> = (props) => {
                 title: 'LÖKE málsnúmer',
                 value: workingCase.policeCaseNumber,
               },
+              ...(workingCase.courtCaseNumber
+                ? [
+                    {
+                      title: 'Málsnúmer héraðsdóms',
+                      value: workingCase.courtCaseNumber,
+                    },
+                  ]
+                : []),
               {
                 title: 'Krafa stofnuð',
                 value: formatDate(workingCase.created, 'P'),
@@ -64,6 +72,14 @@ const OverviewForm: React.FC<Props> = (props) => {
                   'Ekki skráð'
                 }`,
               },
+              ...(workingCase.judge
+                ? [
+                    {
+                      title: 'Dómari',
+                      value: `${workingCase.judge.name}, ${workingCase.judge.title}`,
+                    },
+                  ]
+                : []),
               {
                 title: formatMessage(requestCourtDate.heading),
                 value: `${capitalize(
@@ -74,6 +90,14 @@ const OverviewForm: React.FC<Props> = (props) => {
                   TIME_FORMAT,
                 )}`,
               },
+              ...(workingCase.registrar
+                ? [
+                    {
+                      title: 'Dómritari',
+                      value: `${workingCase.registrar.name}, ${workingCase.registrar.title}`,
+                    },
+                  ]
+                : []),
               {
                 title: 'Ákærandi',
                 value: `${workingCase.prosecutor?.name} ${workingCase.prosecutor?.title}`,
@@ -82,6 +106,16 @@ const OverviewForm: React.FC<Props> = (props) => {
                 title: 'Tegund kröfu',
                 value: capitalize(caseTypes[workingCase.type]),
               },
+              ...(workingCase.courtDate
+                ? [
+                    {
+                      title: 'Staðfestur fyrirtökutími',
+                      value: `${capitalize(
+                        formatDate(workingCase.courtDate, 'PPPP', true) ?? '',
+                      )} kl. ${formatDate(workingCase.courtDate, TIME_FORMAT)}`,
+                    },
+                  ]
+                : []),
             ]}
             defendants={workingCase.defendants ?? []}
             defender={{

--- a/apps/judicial-system/web/src/routes/Prosecutor/RestrictionRequest/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/RestrictionRequest/Overview/Overview.tsx
@@ -128,6 +128,14 @@ export const Overview: React.FC = () => {
                 title: 'LÖKE málsnúmer',
                 value: workingCase.policeCaseNumber,
               },
+              ...(workingCase.courtCaseNumber
+                ? [
+                    {
+                      title: 'Málsnúmer héraðsdóms',
+                      value: workingCase.courtCaseNumber,
+                    },
+                  ]
+                : []),
               {
                 title: 'Dómstóll',
                 value: workingCase.court?.name,
@@ -139,6 +147,14 @@ export const Overview: React.FC = () => {
                   'Ekki skráð'
                 }`,
               },
+              ...(workingCase.judge
+                ? [
+                    {
+                      title: 'Dómari',
+                      value: `${workingCase.judge.name}, ${workingCase.judge.title}`,
+                    },
+                  ]
+                : []),
               {
                 title: formatMessage(requestCourtDate.heading),
                 value: `${capitalize(
@@ -149,6 +165,14 @@ export const Overview: React.FC = () => {
                   TIME_FORMAT,
                 )}`,
               },
+              ...(workingCase.registrar
+                ? [
+                    {
+                      title: 'Dómritari',
+                      value: `${workingCase.registrar.name}, ${workingCase.registrar.title}`,
+                    },
+                  ]
+                : []),
               { title: 'Ákærandi', value: workingCase.prosecutor?.name },
               {
                 title: workingCase.parentCase
@@ -175,6 +199,16 @@ export const Overview: React.FC = () => {
                     )} kl. ${formatDate(workingCase.arrestDate, TIME_FORMAT)}`
                   : 'Var ekki skráður',
               },
+              ...(workingCase.courtDate
+                ? [
+                    {
+                      title: 'Staðfestur fyrirtökutími',
+                      value: `${capitalize(
+                        formatDate(workingCase.courtDate, 'PPPP', true) ?? '',
+                      )} kl. ${formatDate(workingCase.courtDate, TIME_FORMAT)}`,
+                    },
+                  ]
+                : []),
             ]}
             defendants={workingCase.defendants ?? []}
             defender={{


### PR DESCRIPTION
# Add fields to InfoCard in prosecutor flow

https://app.asana.com/0/1199153462262248/1201514576356758/f

## What

Add judge, registrar and court date to info card in prosecutor flow but only if these fields have been set.

## Why

For clarity

## Screenshots / Gifs

<img width="1401" alt="Screenshot 2022-01-24 at 15 05 52" src="https://user-images.githubusercontent.com/3789875/150808382-f040ea77-08b4-4907-835a-c04849e0cbd4.png">

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
