### PR TITLE
fix(judicial-system): Fixes defendant heading in request pdf

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/requestPdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/requestPdf.ts
@@ -77,7 +77,14 @@ function constructRestrictionRequestPdf(
     .font('Helvetica-Bold')
     .fontSize(mediumFontSize)
     .lineGap(8)
-    .text(formatMessage(m.baseInfo.heading))
+    .text(
+      capitalize(
+        formatMessage(core.defendant, {
+          suffix:
+            theCase.defendants && theCase.defendants.length > 1 ? 'ar' : 'i',
+        }),
+      ),
+    )
     .font('Helvetica')
     .fontSize(baseFontSize)
     .lineGap(4)
@@ -235,7 +242,14 @@ function constructInvestigationRequestPdf(
     .font('Helvetica-Bold')
     .fontSize(largeFontSize)
     .lineGap(8)
-    .text(formatMessage(m.baseInfo.heading))
+    .text(
+      capitalize(
+        formatMessage(core.defendant, {
+          suffix:
+            theCase.defendants && theCase.defendants.length > 1 ? 'ar' : 'i',
+        }),
+      ),
+    )
     .font('Helvetica')
     .fontSize(baseFontSize)
     .lineGap(4)


### PR DESCRIPTION
# Fixes defendant heading in request pdf

https://app.asana.com/0/0/1201706705525298/f

## What

- Uses plural heading when more than one defendant.

## Why

Bug

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
