### PR TITLE
feat(judicial-system): Route judges to signed verdict overview instead of the list of requests after signing a verdict

### DIFF
--- a/apps/judicial-system/web/src/components/SigningModal/SigningModal.tsx
+++ b/apps/judicial-system/web/src/components/SigningModal/SigningModal.tsx
@@ -162,11 +162,11 @@ const SigningModal: React.FC<SigningModalProps> = ({
       }
       handlePrimaryButtonClick={() => {
         window.open(Constants.FEEDBACK_FORM_URL, '_blank')
-        router.push(Constants.REQUEST_LIST_ROUTE)
+        router.push(`${Constants.SIGNED_VERDICT_OVERVIEW}/${workingCase.id}`)
       }}
       handleSecondaryButtonClick={async () => {
         if (rulingSignatureConfirmationResponse?.documentSigned === true) {
-          router.push(Constants.REQUEST_LIST_ROUTE)
+          router.push(`${Constants.SIGNED_VERDICT_OVERVIEW}/${workingCase.id}`)
         } else {
           setModalVisible(false)
         }

--- a/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/Components/Accused/AccusedAppealDatePicker.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/Components/Accused/AccusedAppealDatePicker.tsx
@@ -59,8 +59,7 @@ const AccusedAppealDatePicker: React.FC<Props> = (props) => {
             onClick={() => setAccusedAppealDate(appealDate)}
             disabled={!appealDate}
           >
-            `$
-            {capitalize(
+            {`${capitalize(
               isRestrictionCase(workingCase.type)
                 ? formatMessage(core.accused, {
                     suffix:
@@ -77,12 +76,11 @@ const AccusedAppealDatePicker: React.FC<Props> = (props) => {
                         ? 'ar'
                         : 'i',
                   }),
-            )}{' '}
-            $
-            {workingCase.defendants && workingCase.defendants.length > 1
-              ? 'kæra'
-              : 'kærir'}{' '}
-            `
+            )} ${
+              workingCase.defendants && workingCase.defendants.length > 1
+                ? 'kæra'
+                : 'kærir'
+            }`}
           </Button>
         </Box>
       </div>


### PR DESCRIPTION
# Route judges to signed verdict overview instead of the list of requests after signing a verdict

https://app.asana.com/0/1199153462262248/1201514576356808/f

## What

Route judges to signed verdict overview instead of the list of requests after signing a verdict

## Why

Better UX

## Screenshots / Gifs


https://user-images.githubusercontent.com/3789875/150959729-c6446f84-2fbb-4c7b-94cd-84fdb756ad77.mov



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
