### PR TITLE
chore(judicial-system): Description in requestPDF

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/requestPdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/requestPdf.ts
@@ -297,10 +297,16 @@ function constructInvestigationRequestPdf(
           : caseTypes[theCase.type],
       ),
     )
-    .text(theCase.description ?? formatMessage(m.description.noDescription), {
-      lineGap: 6,
-      paragraphGap: 0,
-    })
+
+  if (theCase.description && theCase.description.trim()) {
+    doc
+      .font('Helvetica')
+      .fontSize(baseFontSize)
+      .lineGap(4)
+      .text(theCase.description)
+  }
+
+  doc
     .text(' ')
     .font('Helvetica-Bold')
     .fontSize(mediumFontSize)

--- a/apps/judicial-system/backend/src/app/messages/requestPdf.ts
+++ b/apps/judicial-system/backend/src/app/messages/requestPdf.ts
@@ -72,13 +72,6 @@ export const restrictionRequest = {
       defaultMessage: 'Efni kröfu',
       description: 'Notaður sem texti fyrir titil fyrir efni kröfu í kröfu PDF',
     },
-    noDescription: {
-      id:
-        'judicial.system.backend:pdf.restriction_request.description.no_description',
-      defaultMessage: 'Efni kröfu ekki skráð',
-      description:
-        'Notaður sem texti þegar efni kröfu eru ekki skráðar í kröfu PDF',
-    },
   }),
   demands: defineMessages({
     heading: {


### PR DESCRIPTION
# Description in requestPDF

https://app.asana.com/0/1199153462262248/1201614149125822/f

## What

Only show description in requestPDF if the description has been set and does not contain only spaces.

## Why

This field is optional.

## Screenshots / Gifs

### Description is set

<img width="620" alt="Screenshot 2022-01-26 at 10 37 17" src="https://user-images.githubusercontent.com/3789875/151149036-49699b0e-416c-4a16-b482-e220afb99897.png">

### Description is not set or the description is set to one space

<img width="624" alt="Screenshot 2022-01-26 at 10 37 42" src="https://user-images.githubusercontent.com/3789875/151149043-57eb9a1e-93fd-4750-806e-a298a531b6df.png">


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
