### PR TITLE
fix(judicial-system): Strips dash from national id and format national id when displayed

### DIFF
--- a/apps/judicial-system/web/src/components/AccordionItems/PoliceRequestAccordionItem/PoliceRequestAccordionItem.tsx
+++ b/apps/judicial-system/web/src/components/AccordionItems/PoliceRequestAccordionItem/PoliceRequestAccordionItem.tsx
@@ -8,6 +8,7 @@ import {
   formatDate,
   TIME_FORMAT,
   formatRequestCaseType,
+  formatNationalId,
 } from '@island.is/judicial-system/formatters'
 import { CaseType, isRestrictionCase } from '@island.is/judicial-system/types'
 import type {
@@ -52,7 +53,9 @@ const PoliceRequestAccordionItem: React.FC<Props> = ({
         workingCase.defendants.map((defendant, index) => (
           <Box key={index}>
             <Box marginBottom={1}>
-              <Text>Kennitala: {defendant.nationalId}</Text>
+              <Text>
+                Kennitala: {formatNationalId(defendant.nationalId ?? '')}
+              </Text>
             </Box>
             <Box marginBottom={1}>
               <Text>Fullt nafn: {defendant.name}</Text>

--- a/apps/judicial-system/web/src/routes/Prosecutor/InvestigationRequest/Defendant/Defendant.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/InvestigationRequest/Defendant/Defendant.tsx
@@ -34,26 +34,39 @@ const Defendant = () => {
     if (!theCase.id) {
       const createdCase = await createCase(theCase)
 
-      workingCase.defendants?.forEach(async (defendant, index) => {
-        if (index === 0) {
-          await updateDefendant(createdCase.id, createdCase.defendants[0].id, {
-            gender: defendant.gender,
-            name: defendant.name,
-            address: defendant.address,
-            nationalId: defendant.nationalId,
-          })
-        } else {
-          await createDefendant(createdCase.id, {
-            gender: defendant.gender,
-            name: defendant.name,
-            address: defendant.address,
-            nationalId: defendant.nationalId,
-          })
-        }
-      })
-      router.push(
-        `${constants.IC_HEARING_ARRANGEMENTS_ROUTE}/${createdCase.id}`,
-      )
+      if (createdCase) {
+        workingCase.defendants?.forEach(async (defendant, index) => {
+          if (
+            index === 0 &&
+            createdCase.defendants &&
+            createdCase.defendants.length > 0
+          ) {
+            await updateDefendant(
+              createdCase.id,
+              createdCase.defendants[0].id,
+              {
+                gender: defendant.gender,
+                name: defendant.name,
+                address: defendant.address,
+                nationalId: defendant.nationalId,
+              },
+            )
+          } else {
+            await createDefendant(createdCase.id, {
+              gender: defendant.gender,
+              name: defendant.name,
+              address: defendant.address,
+              nationalId: defendant.nationalId,
+            })
+          }
+        })
+        router.push(
+          `${constants.IC_HEARING_ARRANGEMENTS_ROUTE}/${createdCase.id}`,
+        )
+      } else {
+        // TODO handle error
+        return
+      }
     } else {
       router.push(`${constants.IC_HEARING_ARRANGEMENTS_ROUTE}/${theCase.id}`)
     }

--- a/apps/judicial-system/web/src/routes/Prosecutor/InvestigationRequest/PoliceDemands/PoliceDemandsForm.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/InvestigationRequest/PoliceDemands/PoliceDemandsForm.tsx
@@ -9,6 +9,7 @@ import {
 } from '@island.is/judicial-system-web/src/components'
 import { CaseType } from '@island.is/judicial-system/types'
 import type { Case } from '@island.is/judicial-system/types'
+import { formatNationalId } from '@island.is/judicial-system/formatters'
 import {
   removeTabsValidateAndSet,
   validateAndSendToServer,
@@ -84,7 +85,9 @@ const PoliceDemandsForm: React.FC<Props> = (props) => {
                 accusedName: workingCase.defendants
                   .map(
                     (defendant) =>
-                      `${defendant.name} kt. ${defendant.nationalId}`,
+                      `${defendant.name} kt. ${formatNationalId(
+                        defendant.nationalId ?? '',
+                      )}`,
                   )
                   .toString()
                   .replace(/,/g, ', '),

--- a/apps/judicial-system/web/src/routes/Shared/Requests/ActiveRequests.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/Requests/ActiveRequests.tsx
@@ -7,14 +7,17 @@ import parseISO from 'date-fns/parseISO'
 
 import { Box, Text, Tag, Icon, Button } from '@island.is/island-ui/core'
 import { CaseState, UserRole } from '@island.is/judicial-system/types'
-import { insertAt } from '@island.is/judicial-system-web/src/utils/formatters'
 import { UserContext } from '@island.is/judicial-system-web/src/components/UserProvider/UserProvider'
 import {
   directionType,
   sortableTableColumn,
   SortConfig,
 } from '@island.is/judicial-system-web/src/types'
-import { capitalize, caseTypes } from '@island.is/judicial-system/formatters'
+import {
+  capitalize,
+  caseTypes,
+  formatNationalId,
+} from '@island.is/judicial-system/formatters'
 import { core, requests } from '@island.is/judicial-system-web/messages'
 import type { Case } from '@island.is/judicial-system/types'
 
@@ -227,11 +230,7 @@ const ActiveRequests: React.FC<Props> = (props) => {
                       <Text as="span" variant="small" color="dark400">
                         {`kt. ${
                           c.defendants[0].nationalId
-                            ? insertAt(
-                                c.defendants[0].nationalId.replace('-', ''),
-                                '-',
-                                6,
-                              )
+                            ? formatNationalId(c.defendants[0].nationalId)
                             : '-'
                         }`}
                       </Text>

--- a/apps/judicial-system/web/src/routes/Shared/Requests/PastRequests.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/Requests/PastRequests.tsx
@@ -18,9 +18,9 @@ import {
   capitalize,
   caseTypes,
   formatDate,
+  formatNationalId,
 } from '@island.is/judicial-system/formatters'
 import { Table } from '@island.is/judicial-system-web/src/components'
-import { insertAt } from '@island.is/judicial-system-web/src/utils/formatters'
 import { core, requests } from '@island.is/judicial-system-web/messages'
 
 import { getAppealDate, mapCaseStateToTagVariant } from './utils'
@@ -81,13 +81,8 @@ const PastRequests: React.FC<Props> = (props) => {
                 <Text as="span" variant="small" color="dark400">
                   {`kt. ${
                     row.row.original.defendants[0].nationalId
-                      ? insertAt(
-                          row.row.original.defendants[0].nationalId.replace(
-                            '-',
-                            '',
-                          ),
-                          '-',
-                          6,
+                      ? formatNationalId(
+                          row.row.original.defendants[0].nationalId,
                         )
                       : '-'
                   }`}

--- a/apps/judicial-system/web/src/utils/hooks/useDefendants/index.tsx
+++ b/apps/judicial-system/web/src/utils/hooks/useDefendants/index.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from '@apollo/client'
-import { Defendant, UpdateDefendant } from '@island.is/judicial-system/types'
+import { UpdateDefendant } from '@island.is/judicial-system/types'
 
 import { CreateDefendantMutation } from './createDefendantGql'
 import { DeleteDefendantMutation } from './deleteDefendantGql'
@@ -63,7 +63,16 @@ const useDefendants = () => {
     updateDefendant: UpdateDefendant,
   ) => {
     return updateDefendantMutation({
-      variables: { input: { caseId, defendantId, ...updateDefendant } },
+      variables: {
+        input: {
+          caseId,
+          defendantId,
+          name: updateDefendant.name,
+          address: updateDefendant.address,
+          nationalId: updateDefendant.nationalId?.replace('-', ''),
+          gender: updateDefendant.gender,
+        },
+      },
     })
   }
 


### PR DESCRIPTION
# Strips dash from national id and format national id when displayed

https://app.asana.com/0/1199153462262248/1201256841519082/f

## What

- Strip dash from national id before updating.
- Adds national id formatting where missing.

## Why

This was a bug.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
