### PR TITLE
fix(web): Syslumenn auctions, now you can filter by date, instead of everything dissapearing when you use the datepicker

### DIFF
--- a/apps/web/screens/Organization/Syslumenn/Auctions.tsx
+++ b/apps/web/screens/Organization/Syslumenn/Auctions.tsx
@@ -381,6 +381,16 @@ const LOT_TYPES_OPTIONS: LotTypeOption[] = [
   },
 ]
 
+const sameDay = (d1: Date, d2: Date) => {
+  if (!d1 && !d2) return true
+  if (!d1 || !d2) return false
+  return (
+    d1.getDate() === d2.getDate() &&
+    d1.getFullYear() === d2.getFullYear() &&
+    d1.getMonth() === d2.getMonth()
+  )
+}
+
 const Auctions: Screen<AuctionsProps> = ({
   organizationPage,
   syslumennAuctions,
@@ -468,6 +478,9 @@ const Auctions: Screen<AuctionsProps> = ({
   }, [Router, setOfficeLocation])
 
   const filteredAuctions = syslumennAuctions.filter((auction) => {
+    const auctionDate = auction.auctionDate
+      ? new Date(auction.auctionDate)
+      : null
     return (
       // Filter by office
       (officeLocation.office
@@ -491,9 +504,7 @@ const Auctions: Screen<AuctionsProps> = ({
         ? auction.auctionType !== lotTypeOption.excludeAuctionType
         : true) &&
       // Filter by Date
-      (date
-        ? auction.auctionDate.startsWith(format(date, 'yyyy-MM-dd'))
-        : true) &&
+      (date ? sameDay(date, auctionDate) : true) &&
       // Filter by search query
       (auction.lotName?.toLowerCase().includes(query) ||
         auction.lotId?.toLowerCase().includes(query) ||


### PR DESCRIPTION
# Syslumenn auctions, now you can filter by date, instead of everything dissapearing when you use the datepicker

## What

* Currently the datepicker on the Syslumenn auctions page isn't filtering the auctions by date

## Why

* We want to fix this since the live version makes all auctions dissapear when you change the date filter

## Screenshots / Gifs

### Before
![image](https://user-images.githubusercontent.com/43557895/151539817-e40388ad-0a82-41b2-820c-5622d5b7d421.png)

### After
![image](https://user-images.githubusercontent.com/43557895/151540494-a4743829-2e19-4dd5-a1b2-64e790b92e1f.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
