### PR TITLE
fix(infra): Exclude user-notification try 2

### DIFF
--- a/infra/src/dsl/feature-values.spec.ts
+++ b/infra/src/dsl/feature-values.spec.ts
@@ -21,6 +21,7 @@ const Dev: EnvironmentConfig = {
 describe('Feature-deployment support', () => {
   const dependencyA = service('service-a').namespace('A')
   const dependencyB = service('service-b')
+  const dependencyC = service('service-c')
   const apiService: ServiceBuilder<'graphql'> = service('graphql')
     .env({
       A: ref((h) => `${h.svc(dependencyA)}`),
@@ -46,7 +47,8 @@ describe('Feature-deployment support', () => {
   const values = generateYamlForFeature(
     chart,
     [apiService, dependencyA, dependencyB],
-    dependencyA,
+    [dependencyA, dependencyC],
+    [dependencyC],
   )
 
   it('dynamic service name generation', () => {

--- a/infra/src/dsl/serialize-to-yaml.ts
+++ b/infra/src/dsl/serialize-to-yaml.ts
@@ -119,15 +119,17 @@ export const getDependantServices = (
 export const generateYamlForFeature = (
   uberChart: UberChart,
   habitat: Service[],
-  ...services: Service[]
+  services: Service[],
+  excludedServices: Service[] = [],
 ) => {
   const feature = uberChart.env.feature
   if (typeof feature !== 'undefined') {
+    const excludedServiceNames = excludedServices.map((f) => f.serviceDef.name)
     const featureSpecificServices = getDependantServices(
       uberChart,
       habitat,
       ...services,
-    )
+    ).filter((f) => !excludedServiceNames.includes(f.serviceDef.name))
     const namespace = `feature-${feature}`
     featureSpecificServices.forEach((s) => {
       s.serviceDef.namespace = namespace

--- a/infra/src/feature-env.ts
+++ b/infra/src/feature-env.ts
@@ -68,14 +68,10 @@ const parseArguments = (argv: Arguments) => {
   const ch = new UberChart({ ...Envs[env], feature: feature })
 
   const habitat = charts[chart][env]
-  const excludedFeatureDeploymentNames = ExcludedFeatureDeploymentServices.map(
-    (f) => f.serviceDef.name,
-  )
 
   const affectedServices = habitat
     .concat(FeatureDeploymentServices)
     .filter((h) => images?.includes(h.serviceDef.image ?? h.serviceDef.name))
-    .filter((h) => !excludedFeatureDeploymentNames.includes(h.serviceDef.name))
   return { ch, habitat, affectedServices }
 }
 
@@ -107,7 +103,8 @@ yargs(hideBin(process.argv))
       const featureYaml = generateYamlForFeature(
         ch,
         habitat,
-        ...affectedServices,
+        affectedServices.slice(),
+        ExcludedFeatureDeploymentServices,
       )
       await writeToOutput(dumpYaml(ch, featureYaml), argv.output)
     },
@@ -121,7 +118,8 @@ yargs(hideBin(process.argv))
       const featureYaml = generateYamlForFeature(
         ch,
         habitat,
-        ...affectedServices,
+        affectedServices.slice(),
+        ExcludedFeatureDeploymentServices,
       )
       await writeToOutput(buildComment(featureYaml.services), argv.output)
     },


### PR DESCRIPTION
## What

Feature service exclude was not working because they were excluded before the dependent services were calculated

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
