### PR TITLE
fix(user-profile): Only create islykill settings if email OR tel is in input

### DIFF
--- a/libs/api/domains/user-profile/src/lib/userProfile.service.ts
+++ b/libs/api/domains/user-profile/src/lib/userProfile.service.ts
@@ -96,7 +96,7 @@ export class UserProfileService {
       user,
     )
 
-    if (feature) {
+    if (feature && (input.email || input.mobilePhoneNumber)) {
       await this.islyklarService
         .createIslykillSettings(user.nationalId, {
           email: input.email,


### PR DESCRIPTION
## What

Only create islykill settings if `email` OR `mobile` is in input

## Why

IF islykill fails when creating a user with only `locale` or `documentNotifications` an error will be thrown. And that error will not have any relevance for a user with only `locale` or `documentNotifications` in the input

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
