### PR TITLE
fix(judicial-system): Limits client ingress to specific api sub paths

### DIFF
--- a/apps/judicial-system/api/infra/judicial-system-api.ts
+++ b/apps/judicial-system/api/infra/judicial-system-api.ts
@@ -49,7 +49,7 @@ export const serviceSetup = (services: {
           staging: 'judicial-system',
           prod: 'rettarvorslugatt.island.is',
         },
-        paths: ['/api'],
+        paths: ['/api/graphql', '/api/auth', '/api/case', '/api/feature'],
       },
     })
     .grantNamespaces('nginx-ingress-external')

--- a/apps/judicial-system/web/proxy.config.json
+++ b/apps/judicial-system/web/proxy.config.json
@@ -6,5 +6,13 @@
   "/api/auth": {
     "target": "http://localhost:3333",
     "secure": false
+  },
+  "/api/case": {
+    "target": "http://localhost:3333",
+    "secure": false
+  },
+  "/api/feature": {
+    "target": "http://localhost:3333",
+    "secure": false
   }
 }


### PR DESCRIPTION
# Limits client ingress to specific api sub paths

https://app.asana.com/0/1199153462262248/1200221568911085/f

## What

- Fixes client ingress to make Next api routes accessible in AWS environments.
- Fixes client proxy settings to make /api/case and /api/feature routes accessible in local dev.

## Why

Bug

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
