### PR TITLE
fix(judicial-system): Reduce the number of times we call Já's national registry API

### DIFF
--- a/apps/judicial-system/web/src/routes/Prosecutor/InvestigationRequest/Defendant/DefendantForm.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/InvestigationRequest/Defendant/DefendantForm.tsx
@@ -25,12 +25,12 @@ import { capitalize, caseTypes } from '@island.is/judicial-system/formatters'
 import DefenderInfo from '@island.is/judicial-system-web/src/components/DefenderInfo/DefenderInfo'
 import { isDefendantStepValidIC } from '@island.is/judicial-system-web/src/utils/validate'
 import { setAndSendToServer } from '@island.is/judicial-system-web/src/utils/formHelper'
+import useDefendants from '@island.is/judicial-system-web/src/utils/hooks/useDefendants'
 import { defendant as m } from '@island.is/judicial-system-web/messages'
 import * as constants from '@island.is/judicial-system-web/src/utils/constants'
 
 import LokeCaseNumber from '../../SharedComponents/LokeCaseNumber/LokeCaseNumber'
 import DefendantInfo from '../../SharedComponents/DefendantInfo/DefendantInfo'
-import useDefendants from '@island.is/judicial-system-web/src/utils/hooks/useDefendants'
 
 interface Props {
   workingCase: Case

--- a/apps/judicial-system/web/src/routes/Prosecutor/SharedComponents/DefendantInfo/DefendantInfo.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/SharedComponents/DefendantInfo/DefendantInfo.tsx
@@ -132,6 +132,7 @@ const DefendantInfo: React.FC<Props> = (props) => {
           maskPlaceholder={null}
           value={defendant.nationalId ?? ''}
           onChange={(evt) => {
+            setNationalIdErrorMessage('')
             setNationalIdNotFound(false)
             removeErrorMessageIfValid(
               ['empty', 'national-id'] as Validation[],
@@ -145,7 +146,7 @@ const DefendantInfo: React.FC<Props> = (props) => {
             })
           }}
           onBlur={async (evt) => {
-            if (person && person.items.length === 1 && !error) {
+            if (person?.items?.length === 1 && !error) {
               onChange(defendant.id, {
                 nationalId: evt.target.value,
                 name: person.items[0].name,
@@ -182,7 +183,7 @@ const DefendantInfo: React.FC<Props> = (props) => {
             required
           />
         </InputMask>
-        {nationalIdNotFound && (
+        {defendant.nationalId?.length === 11 && nationalIdNotFound && (
           <Text color="red600" variant="eyebrow" marginTop={1}>
             {formatMessage(core.nationalIdNotFoundInNationalRegistry)}
           </Text>

--- a/apps/judicial-system/web/src/utils/hooks/useNationalRegistry/index.tsx
+++ b/apps/judicial-system/web/src/utils/hooks/useNationalRegistry/index.tsx
@@ -1,14 +1,28 @@
+import { useMemo, useRef, useState } from 'react'
 import useSWR from 'swr'
 
 import { NationalRegistryResponse } from '@island.is/judicial-system-web/src/types'
 
 const useNationalRegistry = (nationalId?: string) => {
-  const fetcher = (url: string) => fetch(url).then((res) => res.json())
+  const [shouldFetch, setShouldFetch] = useState<boolean>(false)
+  const isMounted = useRef(false)
 
+  const fetcher = (url: string) => fetch(url).then((res) => res.json())
+  console.log(shouldFetch, nationalId?.replace('-', '').length === 10)
   const { data, error } = useSWR<NationalRegistryResponse>(
-    `/api/nationalRegistry/getByNationalId?nationalId=${nationalId}`,
+    shouldFetch && nationalId?.replace('-', '').length === 10
+      ? `/api/nationalRegistry/getByNationalId?nationalId=${nationalId}`
+      : null,
     fetcher,
   )
+
+  useMemo(() => {
+    if (isMounted.current) {
+      setShouldFetch(true)
+    } else {
+      isMounted.current = true
+    }
+  }, [nationalId])
 
   return {
     person: data,


### PR DESCRIPTION
# Reduce the number of times we call Já's national registry API

https://app.asana.com/0/1199153462262248/1200221568911085/f

## What

Stop calling the API on render and only call it when a national id is changed and is 10 digit long (excluding the hyphen).

## Why

We are paying per call to the API so we want to limit it as much as possible.

## Screenshots / Gifs


https://user-images.githubusercontent.com/3789875/153002884-0db2250b-e484-4ad5-8461-8228ee5d1902.mov



## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
