### PR TITLE
fix(content-search-toolkit): Aggregations removed from ranking metrics

### DIFF
--- a/libs/content-search-toolkit/src/queries/rankEvaluation.ts
+++ b/libs/content-search-toolkit/src/queries/rankEvaluation.ts
@@ -26,7 +26,7 @@ export const rankEvaluationQuery = ({
       {
         id: 'search_query',
         template: {
-          source: searchQuery({ queryString: '{{query_string}}' }),
+          source: searchQuery({ queryString: '{{query_string}}' }, false),
         },
       },
     ],

--- a/libs/content-search-toolkit/src/queries/search.ts
+++ b/libs/content-search-toolkit/src/queries/search.ts
@@ -4,16 +4,19 @@ import { TagQuery, tagQuery } from './tagQuery'
 import { typeAggregationQuery } from './typeAggregation'
 import { processAggregationQuery } from './processAggregation'
 
-export const searchQuery = ({
-  queryString,
-  size = 10,
-  page = 1,
-  types = [],
-  tags = [],
-  countTag = [],
-  countTypes = false,
-  countProcessEntry = false,
-}: SearchInput) => {
+export const searchQuery = (
+  {
+    queryString,
+    size = 10,
+    page = 1,
+    types = [],
+    tags = [],
+    countTag = [],
+    countTypes = false,
+    countProcessEntry = false,
+  }: SearchInput,
+  aggregate = true,
+) => {
   const should = []
   const must: TagQuery[] = []
   let minimumShouldMatch = 1
@@ -52,20 +55,22 @@ export const searchQuery = ({
 
   const aggregation = { aggs: {} }
 
-  if (countTag) {
-    // set the tag aggregation as the only aggregation
-    aggregation.aggs = tagAggregationQueryFragment(countTag).aggs
-  }
+  if (aggregate) {
+    if (countTag) {
+      // set the tag aggregation as the only aggregation
+      aggregation.aggs = tagAggregationQueryFragment(countTag).aggs
+    }
 
-  if (countTypes) {
-    // add tag aggregation, handle if there is already an existing aggregation
-    aggregation.aggs = { ...aggregation.aggs, ...typeAggregationQuery().aggs }
-  }
+    if (countTypes) {
+      // add tag aggregation, handle if there is already an existing aggregation
+      aggregation.aggs = { ...aggregation.aggs, ...typeAggregationQuery().aggs }
+    }
 
-  if (countProcessEntry) {
-    aggregation.aggs = {
-      ...aggregation.aggs,
-      ...processAggregationQuery().aggs,
+    if (countProcessEntry) {
+      aggregation.aggs = {
+        ...aggregation.aggs,
+        ...processAggregationQuery().aggs,
+      }
     }
   }
 


### PR DESCRIPTION
## What

Ranking metrics should not receive aggregations.
Was causing errors when accidentally introduced to aggregates.
More aggregations have been introduced and they're simply hitting the ranking evaluations by default.
Simple solution: flag for aggregations.

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
