### PR TITLE
feat(fa): Autofill spouse email

### DIFF
--- a/apps/financial-aid/api/src/app/modules/user/spouseModel.model.ts
+++ b/apps/financial-aid/api/src/app/modules/user/spouseModel.model.ts
@@ -10,5 +10,8 @@ export class SpouseModel implements Spouse {
   readonly hasFiles!: boolean
 
   @Field()
-  readonly spouseName?: string
+  readonly applicantName?: string
+
+  @Field()
+  readonly applicantSpouseEmail?: string
 }

--- a/apps/financial-aid/backend/src/app/modules/application/application.service.ts
+++ b/apps/financial-aid/backend/src/app/modules/application/application.service.ts
@@ -77,12 +77,14 @@ export class ApplicationService {
         )
       : false
 
-    const spouseName = application ? application.name : ''
+    const applicantName = application ? application.name : ''
+    const applicantSpouseEmail = application ? application.spouseEmail : ''
 
     return {
       hasPartnerApplied: Boolean(application),
       hasFiles: Boolean(files),
-      spouseName: spouseName,
+      applicantName: applicantName,
+      applicantSpouseEmail: applicantSpouseEmail,
     }
   }
 

--- a/apps/financial-aid/backend/src/app/modules/application/models/spouse.response.ts
+++ b/apps/financial-aid/backend/src/app/modules/application/models/spouse.response.ts
@@ -8,5 +8,8 @@ export class SpouseResponse {
   hasFiles: boolean
 
   @ApiProperty()
-  spouseName?: string
+  applicantName?: string
+
+  @ApiProperty()
+  applicantSpouseEmail?: string
 }

--- a/apps/financial-aid/backend/src/app/modules/application/test/spouse.spec.ts
+++ b/apps/financial-aid/backend/src/app/modules/application/test/spouse.spec.ts
@@ -68,7 +68,7 @@ describe('ApplicationController - Spouse', () => {
     const expected: SpouseResponse = {
       hasPartnerApplied: false,
       hasFiles: false,
-      spouseName: '',
+      applicantName: '',
     }
 
     beforeEach(async () => {
@@ -89,14 +89,14 @@ describe('ApplicationController - Spouse', () => {
     const spouse: SpouseResponse = {
       hasPartnerApplied: true,
       hasFiles: true,
-      spouseName: 'Name',
+      applicantName: 'Name',
     }
 
     beforeEach(async () => {
       const mockSpouse = mockApplicationModel.findOne as jest.Mock
       mockSpouse.mockReturnValueOnce({
         id: uuid(),
-        name: spouse.spouseName,
+        name: spouse.applicantName,
       } as ApplicationModel)
       const mockFiles = mockFileService.getApplicationFilesByType as jest.Mock
       mockFiles.mockReturnValueOnce({} as ApplicationFileModel)
@@ -115,14 +115,14 @@ describe('ApplicationController - Spouse', () => {
     const spouse: SpouseResponse = {
       hasPartnerApplied: true,
       hasFiles: false,
-      spouseName: 'Name',
+      applicantName: 'Name',
     }
 
     beforeEach(async () => {
       const mockSpouse = mockApplicationModel.findOne as jest.Mock
       mockSpouse.mockReturnValueOnce({
         id: uuid(),
-        name: spouse.spouseName,
+        name: spouse.applicantName,
       } as ApplicationModel)
       const mockFiles = mockFileService.getApplicationFilesByType as jest.Mock
       mockFiles.mockReturnValueOnce(undefined)

--- a/apps/financial-aid/web-osk/graphql/sharedGql.ts
+++ b/apps/financial-aid/web-osk/graphql/sharedGql.ts
@@ -35,7 +35,8 @@ export const CurrentUserQuery = gql`
       spouse {
         hasPartnerApplied
         hasFiles
-        spouseName
+        applicantName
+        applicantSpouseEmail
       }
       currentApplicationId
     }

--- a/apps/financial-aid/web-osk/src/components/FormProvider/FormProvider.tsx
+++ b/apps/financial-aid/web-osk/src/components/FormProvider/FormProvider.tsx
@@ -29,6 +29,7 @@ export interface Form {
   ledger?: string
   accountNumber?: string
   emailAddress?: string
+  emailEdited: boolean
   interview?: boolean
   submitted: boolean
   section?: Array<string>
@@ -45,6 +46,7 @@ export const initialState = {
   taxReturnFiles: [],
   taxReturnFromRskFile: [],
   otherFiles: [],
+  emailEdited: false
 }
 
 interface FormProvider {
@@ -84,6 +86,7 @@ const FormProvider = ({ children }: Props) => {
       incomeFiles: [],
       taxReturnFiles: [],
       otherFiles: [],
+      emailEdited: false
     })
   }
 

--- a/apps/financial-aid/web-osk/src/routes/application/ContactInfo/contactInfo.tsx
+++ b/apps/financial-aid/web-osk/src/routes/application/ContactInfo/contactInfo.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react'
+import React, { useState, useContext, useEffect } from 'react'
 import { Text, Input, Box } from '@island.is/island-ui/core'
 
 import {
@@ -13,9 +13,11 @@ import {
   NavigationProps,
   isEmailValid,
 } from '@island.is/financial-aid/shared/lib'
+import { AppContext } from '@island.is/financial-aid-web/osk/src/components/AppProvider/AppProvider'
 
 const ContactInfo = () => {
   const router = useRouter()
+  const { user } = useContext(AppContext)
 
   const { form, updateForm } = useContext(FormContext)
   const [hasError, setHasError] = useState(false)
@@ -44,6 +46,12 @@ const ContactInfo = () => {
     }
   }
 
+  useEffect(() => {
+    if (user?.spouse?.applicantSpouseEmail && (!form.emailEdited || form.emailAddress === '')) {
+      updateForm({ ...form, emailAddress: user?.spouse?.applicantSpouseEmail, emailEdited: true })
+    }
+  }, [])
+
   return (
     <>
       <ContentContainer>
@@ -66,8 +74,7 @@ const ContactInfo = () => {
             value={form?.emailAddress}
             onChange={(event) => {
               setHasError(false)
-
-              updateForm({ ...form, emailAddress: event.target.value })
+              updateForm({ ...form, emailAddress: event.target.value, emailEdited: true })
             }}
             backgroundColor="blue"
             errorMessage="Athugaðu hvort netfang sé rétt slegið inn"
@@ -85,7 +92,6 @@ const ContactInfo = () => {
             value={form?.phoneNumber}
             onChange={(event) => {
               setHasError(false)
-
               updateForm({ ...form, phoneNumber: event.target.value })
             }}
             backgroundColor="blue"

--- a/libs/financial-aid/shared/src/lib/interfaces.ts
+++ b/libs/financial-aid/shared/src/lib/interfaces.ts
@@ -290,7 +290,8 @@ export interface GetSignedUrlForId {
 export interface Spouse {
   hasPartnerApplied: boolean
   hasFiles: boolean
-  spouseName?: string
+  applicantName?: string
+  applicantSpouseEmail?: string
 }
 
 export interface UpdateApplicationTableResponseType {


### PR DESCRIPTION
# ... 👆

https://app.asana.com/0/1201722624788165/1201785888802173

## What

When an applicant fills out the form and selects that he has a spouse, the spouse email is required. Then when the spouse fills out the form we want the email field to be autofilled with the email that the applicant already entered.

## Why

Better UX.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
