### PR TITLE
fix(as): Fix slider on mobile devices

### DIFF
--- a/libs/application/templates/funding-government-projects/src/fields/components/Slider/Slider.tsx
+++ b/libs/application/templates/funding-government-projects/src/fields/components/Slider/Slider.tsx
@@ -104,6 +104,7 @@ const Slider = ({
   const thumbStyle = {
     transform: `translateX(${dragX.current == null ? x : dragX.current}px)`,
     transition: isDragging ? 'none' : '',
+    touchAction: 'none',
   }
   const remainderStyle = {
     left: `${dragX.current == null ? x : dragX.current}px`,

--- a/libs/application/templates/parental-leave/src/fields/components/Slider/index.tsx
+++ b/libs/application/templates/parental-leave/src/fields/components/Slider/index.tsx
@@ -111,6 +111,7 @@ const Slider = ({
   const thumbStyle = {
     transform: `translateX(${dragX.current == null ? x : dragX.current}px)`,
     transition: isDragging ? 'none' : '',
+    touchAction: 'none',
   }
 
   const remainderStyle = {

--- a/libs/application/templates/public-debt-payment-plan/src/fields/components/Slider/Slider.tsx
+++ b/libs/application/templates/public-debt-payment-plan/src/fields/components/Slider/Slider.tsx
@@ -110,6 +110,7 @@ const Slider = ({
   const thumbStyle = {
     transform: `translateX(${dragX.current == null ? x : dragX.current}px)`,
     transition: isDragging ? 'none' : '',
+    touchAction: 'none',
   }
   const remainderStyle = {
     left: `${dragX.current == null ? x : dragX.current}px`,


### PR DESCRIPTION
## What

The Slider component in Parental Leave was using old-school touch events incorrectly. Refactored to use pointer events. That way the same code consistently supports all pointing devices.

The Slider component and useDrag are copied in a few places. Slider has additionally been modified here and there unfortunately and there is a rush to get this into the release.

So I didn't have a chance to refactor further. Hopefully someone gets a chance to do that.

## Why

This was breaking the parental leave application (and probably others) on mobile.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] ~I have made corresponding changes to the documentation~
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~ unfortunately not :(
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
