### PR TITLE
chore(judicial-system): Switch registrar with type in last line of info card

### DIFF
--- a/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/SignedVerdictOverviewForm.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/SignedVerdictOverviewForm.tsx
@@ -289,20 +289,20 @@ const SignedVerdictOverviewForm: React.FC<Props> = (props) => {
               title: formatMessage(core.judge),
               value: workingCase.judge?.name,
             },
-            ...(workingCase.registrar
-              ? [
-                  {
-                    title: formatMessage(core.registrar),
-                    value: workingCase.registrar?.name,
-                  },
-                ]
-              : []),
             // Conditionally add this field based on case type
             ...(isInvestigationCase(workingCase.type)
               ? [
                   {
                     title: formatMessage(core.caseType),
                     value: capitalize(caseTypes[workingCase.type]),
+                  },
+                ]
+              : []),
+            ...(workingCase.registrar
+              ? [
+                  {
+                    title: formatMessage(core.registrar),
+                    value: workingCase.registrar?.name,
                   },
                 ]
               : []),


### PR DESCRIPTION
# Switch registrar with type in last line of info card

https://app.asana.com/0/1199153462262248/1201777996978512/f

## What

Switch registrar with type in last line of info card

## Why

Better readability

## Screenshots / Gifs

<img width="626" alt="Screen Shot 2022-02-15 at 15 50 21" src="https://user-images.githubusercontent.com/3789875/154098152-af5e5d60-38fd-4bb6-af65-6dee5094c199.png">


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
