### PR TITLE
feat(web): Hyperlink support for organization page and subpage

### DIFF
--- a/libs/cms/src/lib/search/importers/organizationSubpage.service.ts
+++ b/libs/cms/src/lib/search/importers/organizationSubpage.service.ts
@@ -5,17 +5,24 @@ import { Entry } from 'contentful'
 import { IOrganizationSubpage } from '../../generated/contentfulTypes'
 import { CmsSyncProvider, processSyncDataInput } from '../cmsSync.service'
 import { mapOrganizationSubpage } from '../../models/organizationSubpage.model'
-import { extractStringsFromObject } from './utils'
+import { extractStringsFromObject, removeField } from './utils'
 
 @Injectable()
 export class OrganizationSubpageSyncService
   implements CmsSyncProvider<IOrganizationSubpage> {
   processSyncData(entries: processSyncDataInput<IOrganizationSubpage>) {
-    return entries.filter(
+    const data = entries.filter(
       (entry: Entry<any>): entry is IOrganizationSubpage =>
         entry.sys.contentType.sys.id === 'organizationSubpage' &&
         !!entry.fields.title,
     )
+
+    data.forEach((entry) => {
+      // Remove the parent field in case there's a nested article underneath to prevent circularity
+      removeField(entry.fields.description, 'parent')
+    })
+
+    return data
   }
 
   doMapping(entries: IOrganizationSubpage[]) {

--- a/libs/cms/src/lib/search/importers/utils.ts
+++ b/libs/cms/src/lib/search/importers/utils.ts
@@ -115,3 +115,17 @@ export const removeEntryHyperlinkFields = (node: any) => {
     }
   }
 }
+
+export const removeField = (node: any, fieldToRemove: string) => {
+  if (!node || typeof node !== 'object') {
+    return
+  }
+
+  for (const field of Object.keys(node)) {
+    if (field === fieldToRemove) {
+      delete node[field]
+    } else {
+      removeField(node[field], fieldToRemove)
+    }
+  }
+}

--- a/libs/island-ui/contentful/src/lib/RichTextRC/defaultRenderNode.tsx
+++ b/libs/island-ui/contentful/src/lib/RichTextRC/defaultRenderNode.tsx
@@ -163,8 +163,34 @@ export const defaultRenderNode: RenderNode = {
         return entry.fields.url ? (
           <Hyperlink href={entry.fields.url}>{children}</Hyperlink>
         ) : null
+      case 'organizationPage': {
+        const prefix = getOrganizationPrefix(entry.sys?.locale)
+        return entry.fields.slug ? (
+          <Hyperlink href={`/${prefix}/${entry.fields.slug}`}>
+            {children}
+          </Hyperlink>
+        ) : null
+      }
+      case 'organizationSubpage': {
+        const prefix = getOrganizationPrefix(entry.sys?.locale)
+        return entry.fields.slug &&
+          entry.fields.organizationPage?.fields?.slug ? (
+          <Hyperlink
+            href={`/${prefix}/${entry.fields.organizationPage.fields.slug}/${entry.fields.slug}`}
+          >
+            {children}
+          </Hyperlink>
+        ) : null
+      }
       default:
         return null
     }
   },
+}
+
+const getOrganizationPrefix = (locale: string) => {
+  if (locale && !locale.includes('is')) {
+    return 'o'
+  }
+  return 's'
 }


### PR DESCRIPTION
# Hyperlink support for organization page and subpage

## What

* Added hyperlink support, now you can link to an organization page or organization subpage entry which will automatically provide the link

## Why

* Previously you had to hardcode in a url instead of linking to an entry which might cause issues later on if the page you link to changes it's url in the future

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
