### PR TITLE
chore(island-ui): Replace deprecated Icon with IconRC in Checkbox and AlertBanner

### DIFF
--- a/libs/island-ui/core/src/lib/AlertBanner/AlertBanner.tsx
+++ b/libs/island-ui/core/src/lib/AlertBanner/AlertBanner.tsx
@@ -3,7 +3,7 @@ import { Colors } from '@island.is/island-ui/theme'
 
 import { Box } from '../Box/Box'
 import * as styles from './AlertBanner.css'
-import { Icon, IconTypes } from '../Icon/Icon'
+import { Icon, IconMapIcon } from '../IconRC/Icon'
 import { Text } from '../Text/Text'
 import { LinkContext } from '../context/LinkContext/LinkContext'
 import { Link } from '../Link/Link'
@@ -19,7 +19,7 @@ type VariantStyle = {
   background: Colors
   borderColor: Colors
   iconColor?: Colors
-  icon?: IconTypes
+  icon?: IconMapIcon
 }
 
 type VariantStyles = {
@@ -35,25 +35,25 @@ const variantStyles: VariantStyles = {
     background: 'red100',
     borderColor: 'red200',
     iconColor: 'red400',
-    icon: 'alert',
+    icon: 'warning',
   },
   info: {
     background: 'blue100',
     borderColor: 'blue200',
     iconColor: 'blue400',
-    icon: 'info',
+    icon: 'informationCircle',
   },
   success: {
     background: 'mint100',
     borderColor: 'mint200',
     iconColor: 'mint400',
-    icon: 'check',
+    icon: 'checkmark',
   },
   warning: {
     background: 'yellow200',
     borderColor: 'yellow400',
     iconColor: 'yellow600',
-    icon: 'alert',
+    icon: 'warning',
   },
 }
 
@@ -109,7 +109,7 @@ export const AlertBanner: FC<AlertBannerProps> = ({
           marginRight={[0, 0, 0, 2]}
           marginBottom={[2, 2, 2, 0]}
         >
-          <Icon type={variant.icon} color={variant.iconColor} />
+          <Icon icon={variant.icon} color={variant.iconColor} />
         </Box>
       )}
       {title && (
@@ -163,7 +163,7 @@ export const AlertBanner: FC<AlertBannerProps> = ({
               }
             }}
           >
-            <Icon type="close" color="dark400" width={14} />
+            <Icon icon="close" color="dark400" />
           </button>
         </Box>
       )}

--- a/libs/island-ui/core/src/lib/Checkbox/Checkbox.tsx
+++ b/libs/island-ui/core/src/lib/Checkbox/Checkbox.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import cn from 'classnames'
 import { Text } from '../Text/Text'
-import { Icon } from '../Icon/Icon'
+import { Icon } from '../IconRC/Icon'
 import { Tooltip } from '../Tooltip/Tooltip'
 import { Box } from '../Box/Box'
 import { InputBackgroundColor } from '../Input/types'
@@ -94,11 +94,7 @@ export const Checkbox = ({
             [styles.checkboxDisabled]: disabled,
           })}
         >
-          <Icon
-            type="check"
-            width={styles.checkMarkWidth}
-            color={checked ? 'white' : 'transparent'}
-          />
+          <Icon icon="checkmark" color={checked ? 'white' : 'transparent'} />
         </div>
         <span className={styles.labelText}>
           <Text


### PR DESCRIPTION
# Replace deprecated Icon with IconRC in Checkbox and AlertBanner components 

## What

Replace deprecated Icon with IconRC in Checkbox and AlertBanner components

## Why

Using deprecated components should be avoided. Also, using them gives an annoying warning in the console.

## Screenshots / Gifs

<img width="986" alt="Screenshot 2022-02-18 at 11 03 08" src="https://user-images.githubusercontent.com/3789875/154670752-55844e14-78c3-469c-9455-33fb36635a7a.png">

<img width="207" alt="Screenshot 2022-02-18 at 11 04 14" src="https://user-images.githubusercontent.com/3789875/154670927-65c2b5a3-f5ed-4356-b632-0905e1fc88c4.png">

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
