### PR TITLE
fix(service-portal): Update plausible custom url detail pages to use absolute urls

### DIFF
--- a/libs/service-portal/core/src/hooks/usePlausibleDetailPageview/usePlausibleDetailPageview.ts
+++ b/libs/service-portal/core/src/hooks/usePlausibleDetailPageview/usePlausibleDetailPageview.ts
@@ -1,12 +1,17 @@
 import { useEffect } from 'react'
+import { ServicePortalPath } from '@island.is/service-portal/core'
 
 // Custom location helper for dynamic paths in service portal: https://plausible.io/docs/custom-locations
 export const PlausiblePageviewDetail = (page: string) => {
   useEffect(() => {
     const plausible = window && window.plausible
 
+    const pageOrigin = window.location.origin
+    const rootPath = ServicePortalPath.MinarSidurPath
+    const absoluteUrl = `${pageOrigin}${rootPath}${page}`
+
     if (plausible) {
-      plausible('pageview', { u: page })
+      plausible('pageview', { u: absoluteUrl })
     }
   }, [])
 }

--- a/libs/service-portal/core/src/lib/navigation/paths.ts
+++ b/libs/service-portal/core/src/lib/navigation/paths.ts
@@ -1,6 +1,7 @@
 export enum ServicePortalPath {
   // Mínar síður
   MinarSidurRoot = '/',
+  MinarSidurPath = '/minarsidur',
   MinarSidurSignInOidc = '/signin-oidc',
   MinarSidurSilentSignInOidc = '/silent/signin-oidc',
 


### PR DESCRIPTION
## What

Update plausible custom url detail pages to use absolute urls

## Why

The plausible custom location function requires the full url.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
