### PR TITLE
fix(react-auth): Use history.replace in oidc-signin callback page

### DIFF
--- a/libs/auth/react/src/lib/Authenticator/OidcSignIn.tsx
+++ b/libs/auth/react/src/lib/Authenticator/OidcSignIn.tsx
@@ -23,7 +23,7 @@ export const OidcSignIn = ({ authDispatch }: Props): ReactElement => {
       authDispatch({ type: ActionType.SIGNIN_SUCCESS, payload: user })
 
       const url = typeof user.state === 'string' ? user.state : '/'
-      history.push(url)
+      history.replace(url)
     } catch (error) {
       if (error.error === 'login_required') {
         // If trying to switch delegations and the IDS session is expired, we'll


### PR DESCRIPTION
https://islandis.slack.com/archives/C01C7C3M2J3/p1645446634932849

## What

Don't create a navigation entry in the browser history on the oidc-signin callback page. This page is just to handle arguments from the IDP. It is single use and should not be visited again.

## Why

So user's don't accidentally end up on an error page when navigating back and forth.

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/115094/155032072-0dd94130-f9f0-417c-8756-f3c1f6a0c074.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] ~I have made corresponding changes to the documentation~
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
