### PR TITLE
fix(fa): Add error message when national id is already in use

### DIFF
--- a/apps/financial-aid/web-veita/src/components/NewUserModal/NewUserModal.tsx
+++ b/apps/financial-aid/web-veita/src/components/NewUserModal/NewUserModal.tsx
@@ -21,8 +21,8 @@ interface newUsersModalState {
   staffName: string
   staffEmail: string
   hasError: boolean
-  hasNationalIdError: boolean
   hasSubmitError: boolean
+  errorMessage: string
   roles: StaffRole[]
 }
 
@@ -41,7 +41,7 @@ const NewUserModal = ({
     staffEmail: '',
     hasError: false,
     hasSubmitError: false,
-    hasNationalIdError: false,
+    errorMessage: '',
     roles: predefinedRoles,
   })
   const [createStaff] = useMutation(StaffMutation)
@@ -88,9 +88,11 @@ const NewUserModal = ({
       setState({
         ...state,
         hasSubmitError: true,
-        hasNationalIdError:
+        errorMessage:
           (e as ApolloError).graphQLErrors[0]?.extensions?.response.status ===
-          400,
+          400
+            ? 'Mögulega er notandi með þessa kennitölu til nú þegar'
+            : 'Eitthvað fór úrskeiðis, vinsamlega reynið aftur síðar',
       })
     }
   }
@@ -101,11 +103,7 @@ const NewUserModal = ({
       setIsVisible={setIsVisible}
       header={'Nýr notandi'}
       hasError={state.hasSubmitError}
-      errorMessage={
-        state.hasNationalIdError
-          ? 'Mögulega er notandi með þessa kennitölu til nú þegar'
-          : 'Eitthvað fór úrskeiðis, vinsamlega reynið aftur síðar'
-      }
+      errorMessage={state.errorMessage}
       submitButtonText={'Stofna notanda'}
       onSubmit={submit}
     >

--- a/apps/financial-aid/web-veita/src/components/NewUserModal/NewUserModal.tsx
+++ b/apps/financial-aid/web-veita/src/components/NewUserModal/NewUserModal.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { Box, Checkbox, Input, Text } from '@island.is/island-ui/core'
 import { ActionModal } from '@island.is/financial-aid-web/veita/src/components'
 import { StaffMutation } from '@island.is/financial-aid-web/veita/graphql'
-import { useMutation } from '@apollo/client'
+import { ApolloError, useMutation } from '@apollo/client'
 import { isEmailValid, StaffRole } from '@island.is/financial-aid/shared/lib'
 import cn from 'classnames'
 
@@ -21,6 +21,7 @@ interface newUsersModalState {
   staffName: string
   staffEmail: string
   hasError: boolean
+  hasNationalIdError: boolean
   hasSubmitError: boolean
   roles: StaffRole[]
 }
@@ -40,6 +41,7 @@ const NewUserModal = ({
     staffEmail: '',
     hasError: false,
     hasSubmitError: false,
+    hasNationalIdError: false,
     roles: predefinedRoles,
   })
   const [createStaff] = useMutation(StaffMutation)
@@ -83,7 +85,13 @@ const NewUserModal = ({
         onStaffCreated()
       })
     } catch (e) {
-      setState({ ...state, hasSubmitError: true })
+      setState({
+        ...state,
+        hasSubmitError: true,
+        hasNationalIdError:
+          (e as ApolloError).graphQLErrors[0]?.extensions?.response.status ===
+          400,
+      })
     }
   }
 
@@ -93,7 +101,11 @@ const NewUserModal = ({
       setIsVisible={setIsVisible}
       header={'Nýr notandi'}
       hasError={state.hasSubmitError}
-      errorMessage={'Eitthvað fór úrskeiðis, vinsamlega reynið aftur síðar'}
+      errorMessage={
+        state.hasNationalIdError
+          ? 'Mögulega er notandi með þessa kennitölu til nú þegar'
+          : 'Eitthvað fór úrskeiðis, vinsamlega reynið aftur síðar'
+      }
       submitButtonText={'Stofna notanda'}
       onSubmit={submit}
     >

--- a/apps/financial-aid/web-veita/src/components/NewUserModal/NewUserModal.tsx
+++ b/apps/financial-aid/web-veita/src/components/NewUserModal/NewUserModal.tsx
@@ -21,8 +21,7 @@ interface newUsersModalState {
   staffName: string
   staffEmail: string
   hasError: boolean
-  hasSubmitError: boolean
-  errorMessage: string
+  errorMessage?: string
   roles: StaffRole[]
 }
 
@@ -40,8 +39,7 @@ const NewUserModal = ({
     staffName: '',
     staffEmail: '',
     hasError: false,
-    hasSubmitError: false,
-    errorMessage: '',
+    errorMessage: undefined,
     roles: predefinedRoles,
   })
   const [createStaff] = useMutation(StaffMutation)
@@ -87,7 +85,6 @@ const NewUserModal = ({
     } catch (e) {
       setState({
         ...state,
-        hasSubmitError: true,
         errorMessage:
           (e as ApolloError).graphQLErrors[0]?.extensions?.response.status ===
           400
@@ -102,7 +99,7 @@ const NewUserModal = ({
       isVisible={isVisible}
       setIsVisible={setIsVisible}
       header={'Nýr notandi'}
-      hasError={state.hasSubmitError}
+      hasError={state.errorMessage !== undefined}
       errorMessage={state.errorMessage}
       submitButtonText={'Stofna notanda'}
       onSubmit={submit}


### PR DESCRIPTION
# ... 👆

https://app.asana.com/0/1201849781730850/1201814168458673

## What

Check if the national id is already in use and display error message about that.

## Why

So the user know what the error is about.

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/43727721/155138390-fdc1520e-b716-4cad-a604-a75e054dc1cf.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
