### PR TITLE
feat(services-user-profile): Remove email/sms verification in POST /userProfile

### DIFF
--- a/apps/services/user-profile/src/app/user-profile/e2e/userProfile.spec.ts
+++ b/apps/services/user-profile/src/app/user-profile/e2e/userProfile.spec.ts
@@ -78,41 +78,6 @@ describe('User profile API', () => {
       expect(response.body.id).toBeTruthy()
     })
 
-    it('POST /userProfile should register userProfile and create verification', async () => {
-      // Act
-      await request(app.getHttpServer())
-        .post('/emailVerification/')
-        .send({
-          nationalId: mockProfile.nationalId,
-          email: mockProfile.email,
-        })
-        .expect(204)
-
-      const verification = await EmailVerification.findOne({
-        where: { nationalId: mockProfile.nationalId },
-      })
-
-      const spy = jest
-        .spyOn(emailService, 'sendEmail')
-        .mockImplementation(() => Promise.resolve('user'))
-      const response = await request(app.getHttpServer())
-        .post('/userProfile')
-        .send({ ...mockProfile, emailCode: verification.hash })
-        .expect(201)
-      expect(spy).toHaveBeenCalled()
-      expect(response.body.id).toBeTruthy()
-
-      // Assert
-      expect(response.body.emailStatus).toEqual(DataStatus.VERIFIED)
-      expect(verification.nationalId).toEqual(mockProfile.nationalId)
-      expect(response.body).toEqual(
-        expect.objectContaining({ nationalId: verification.nationalId }),
-      )
-      expect(response.body).toEqual(
-        expect.objectContaining({ email: verification.email }),
-      )
-    })
-
     it('POST /userProfile should return conflict on existing nationalId', async () => {
       // Act
       await request(app.getHttpServer())

--- a/apps/services/user-profile/src/app/user-profile/userProfile.controller.ts
+++ b/apps/services/user-profile/src/app/user-profile/userProfile.controller.ts
@@ -114,43 +114,6 @@ export class UserProfileController {
       )
     }
 
-    if (userProfileDto.email) {
-      const emailVerified = await this.verificationService.confirmEmail(
-        { hash: userProfileDto.emailCode },
-        user.nationalId,
-      )
-
-      if (emailVerified.confirmed) {
-        await this.verificationService.removeEmailVerification(
-          userProfileDto.nationalId,
-        )
-        userProfileDto = {
-          ...userProfileDto,
-          emailStatus: DataStatus.VERIFIED,
-          emailVerified: emailVerified.confirmed,
-        }
-      }
-    }
-
-    if (userProfileDto.mobilePhoneNumber) {
-      const phoneVerified = await this.verificationService.confirmSms(
-        { code: userProfileDto.smsCode },
-        user.nationalId,
-      )
-
-      if (phoneVerified.confirmed) {
-        await this.verificationService.removeSmsVerification(
-          userProfileDto.nationalId,
-        )
-
-        userProfileDto = {
-          ...userProfileDto,
-          emailStatus: DataStatus.VERIFIED,
-          mobilePhoneNumberVerified: phoneVerified.confirmed,
-        }
-      }
-    }
-
     const userProfile = await this.userProfileService.create(userProfileDto)
     this.auditService.audit({
       auth: user,


### PR DESCRIPTION
## What

Remove code which is realistically never be used. The `userProfile.controller.ts:create()` function can only run if the calling user is not registered in the database. However, when a user is registering their email/phone they will always already have an account registered. Thus, in practice, a user will never have a registered email when signing up. At least, the email/phone will never be confirmed at registration.

## Why

Remove complexity and chance for exploitability. No tests cover e.g. sms verification portion of the `POST /userProfile` endpoint. Instead of writing tests for it (which can easily be mocked) I suggest we remove code which can never happen in the real world.

## Note
I'm not 💯  sure the relevant code is unused in all cases. Please correct me 🙂

## Checklist:

- [x] I have performed a self-review of my own code
- [x] ~I have made corresponding changes to the documentation~
- [x] My changes generate no new warnings
- [x] ~I have added tests that prove my fix is effective or that my feature works~
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
