### PR TITLE
fix(cms): Add CONTENTFUL_HOST values to CMS env

### DIFF
--- a/apps/services/user-notification/infra/user-notification.ts
+++ b/apps/services/user-notification/infra/user-notification.ts
@@ -57,6 +57,11 @@ export const userNotificationWorkerSetup = (services: {
         staging: 'is.island.app.staging',
         prod: 'is.island.app',
       },
+      CONTENTFUL_HOST: {
+        dev: 'preview.contentful.com',
+        staging: 'cdn.contentful.com',
+        prod: 'cdn.contentful.com',
+      },
     })
     .secrets({
       FIREBASE_CREDENTIALS: '/k8s/user-notification/firestore-credentials',

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -1575,6 +1575,7 @@ user-notification-worker:
     - 'node'
   enabled: true
   env:
+    CONTENTFUL_HOST: 'preview.contentful.com'
     DEAD_LETTER_QUEUE_NAME: 'user-notification-failure'
     IDENTITY_SERVER_PATH: 'https://identity-server.dev01.devland.is'
     MAIN_QUEUE_NAME: 'user-notification'

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -1470,6 +1470,7 @@ user-notification-worker:
     - 'node'
   enabled: true
   env:
+    CONTENTFUL_HOST: 'cdn.contentful.com'
     DEAD_LETTER_QUEUE_NAME: 'user-notification-failure'
     IDENTITY_SERVER_PATH: 'https://innskra.island.is'
     MAIN_QUEUE_NAME: 'user-notification'

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -1469,6 +1469,7 @@ user-notification-worker:
     - 'node'
   enabled: true
   env:
+    CONTENTFUL_HOST: 'cdn.contentful.com'
     DEAD_LETTER_QUEUE_NAME: 'user-notification-failure'
     IDENTITY_SERVER_PATH: 'https://identity-server.staging01.devland.is'
     MAIN_QUEUE_NAME: 'user-notification'


### PR DESCRIPTION
## What
Fix Hnipp not sending notifications

## Why
Contentful was throwing "Invalid Access Token" errors. Through debugging, it was realized that the cms service was sending production access key to `preview.contentful.com` instead of `cdn.contentful.com`. This PR adds the correct contentful hosts in dev, staging, and prod.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
