### PR TITLE
chore(user-notification): disable fetch client circuit breaker

### DIFF
--- a/apps/services/user-notification/src/app/modules/notifications/notifications.module.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/notifications.module.ts
@@ -55,6 +55,7 @@ import * as userProfile from '@island.is/clients/user-profile'
             basePath: environment.userProfileServiceBasePath,
             fetchApi: createEnhancedFetch({
               name: 'services-user-notification',
+              circuitBreaker: false,
               autoAuth: {
                 issuer: environment.identityServerPath,
                 clientId: environment.notificationsClientId,


### PR DESCRIPTION
Requests from user-notification worker to user-profile service are super
slow and are triggering the fetch-client circuit breaker, so we're
disabling it (for now) while debugging

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
