### PR TITLE
chore(judicial-system): Stop sending signed ruling to court if it is already in S3

### DIFF
--- a/apps/judicial-system/backend/src/app/messages/notifications.ts
+++ b/apps/judicial-system/backend/src/app/messages/notifications.ts
@@ -48,12 +48,13 @@ export const notifications = {
       description:
         'Notaður sem texti í pósti til sækjanda vegna undirritunar úrskúrðar ef ekki tókst að vista úrskurð í AWS S3',
     },
-    courtBodyAttachment: {
+    courtBody: {
       id:
         'judicial.system.backend:notifications.signed_ruling.court_body_attachment',
-      defaultMessage: 'Ekki tókst að vista meðfylgjandi skjal í Auði.',
+      defaultMessage:
+        'Ekki tókst að vista þingbók og/eða úrskurð í máli {courtCaseNumber} í Auði.<br /><br />Skjöl málsins eru aðengileg á {linkStart}yfirlitssíðu málsins í Réttarvörslugátt{linkEnd}.',
       description:
-        'Notaður sem texti í pósti til dómara og dómritara vegna undirritunar úrskúrðar ef ekki tókst að vista úrskurð í Auði',
+        'Notaður sem texti í pósti til dómara og dómritara vegna undirritunar úrskúrðar ef ekki tókst að vista þingbók eða úrskurð í Auði',
     },
     defenderBodyAttachment: {
       id:

--- a/apps/judicial-system/backend/src/app/modules/case/case.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/case.service.ts
@@ -180,7 +180,10 @@ export class CaseService {
     }
   }
 
-  private async uploadCourtRecordPdfToCourt(theCase: Case, pdf: string) {
+  private async uploadCourtRecordPdfToCourt(
+    theCase: Case,
+    pdf: string,
+  ): Promise<boolean> {
     try {
       this.logger.debug(
         `Uploading court record pdf to court for case ${theCase.id}`,
@@ -199,12 +202,16 @@ export class CaseService {
         }),
         buffer,
       )
+
+      return true
     } catch (error) {
       // Log and ignore this error. The court record can be uploaded manually.
       this.logger.error(
         `Failed to upload court record pdf to court for case ${theCase.id}`,
         { error },
       )
+
+      return false
     }
   }
 
@@ -272,16 +279,107 @@ export class CaseService {
     }
   }
 
+  private sendEmailToProsecutor(
+    theCase: Case,
+    rulingUploadedToS3: boolean,
+    rulingAttachment: { filename: string; content: string; encoding: string },
+  ) {
+    return this.sendEmail(
+      {
+        name: theCase.prosecutor?.name ?? '',
+        address: theCase.prosecutor?.email ?? '',
+      },
+      rulingUploadedToS3
+        ? this.formatMessage(m.signedRuling.prosecutorBodyS3, {
+            courtCaseNumber: theCase.courtCaseNumber,
+            courtName: theCase.court?.name?.replace('dómur', 'dómi'),
+            linkStart: `<a href="${environment.deepLinks.completedCaseOverviewUrl}${theCase.id}">`,
+            linkEnd: '</a>',
+          })
+        : this.formatMessage(m.signedRuling.prosecutorBodyAttachment, {
+            courtName: theCase.court?.name,
+            courtCaseNumber: theCase.courtCaseNumber,
+            linkStart: `<a href="${environment.deepLinks.completedCaseOverviewUrl}${theCase.id}">`,
+            linkEnd: '</a>',
+          }),
+      theCase.courtCaseNumber,
+      rulingUploadedToS3 ? undefined : [rulingAttachment],
+    )
+  }
+
+  private sendEmailToCourt(
+    theCase: Case,
+    rulingUploadedToCourt: boolean,
+    rulingAttachment: { filename: string; content: string; encoding: string },
+  ) {
+    const recipients = [
+      {
+        name: theCase.judge?.name ?? '',
+        address: theCase.judge?.email ?? '',
+      },
+    ]
+    if (theCase.registrar) {
+      recipients.push({
+        name: theCase.registrar?.name ?? '',
+        address: theCase.registrar?.email ?? '',
+      })
+    }
+
+    return this.sendEmail(
+      recipients,
+      this.formatMessage(m.signedRuling.courtBody, {
+        courtCaseNumber: theCase.courtCaseNumber,
+        linkStart: `<a href="${environment.deepLinks.completedCaseOverviewUrl}${theCase.id}">`,
+        linkEnd: '</a>',
+      }),
+      theCase.courtCaseNumber,
+      rulingUploadedToCourt ? undefined : [rulingAttachment],
+    )
+  }
+
+  private sendEmailToDefender(
+    courtRecordPdf: undefined,
+    theCase: Case,
+    rulingAttachment: { filename: string; content: string; encoding: string },
+  ) {
+    const attachments = courtRecordPdf
+      ? [
+          {
+            filename: this.formatMessage(m.signedRuling.courtRecordAttachment, {
+              courtCaseNumber: theCase.courtCaseNumber,
+            }),
+            content: courtRecordPdf,
+            encoding: 'binary',
+          },
+          rulingAttachment,
+        ]
+      : [rulingAttachment]
+
+    return this.sendEmail(
+      {
+        name: theCase.defenderName ?? '',
+        address: theCase.defenderEmail ?? '',
+      },
+      this.formatMessage(m.signedRuling.defenderBodyAttachment, {
+        courtName: theCase.court?.name,
+        courtCaseNumber: theCase.courtCaseNumber,
+      }),
+      theCase.courtCaseNumber,
+      attachments,
+    )
+  }
+
   private async sendRulingAsSignedPdf(
     theCase: Case,
     signedRulingPdf: string,
   ): Promise<void> {
-    let uploadedToS3 = false
-    let uploadedToCourt = false
+    let rulingUploadedToS3 = false
+    let rulingUploadedToCourt = false
+    let courtRecordUploadedToCourt = false
 
     const uploadPromises = [
       this.uploadSignedRulingPdfToS3(theCase, signedRulingPdf).then((res) => {
-        uploadedToS3 = res
+        rulingUploadedToS3 = res
       }),
     ]
 
@@ -295,14 +393,19 @@ export class CaseService {
       uploadPromises.push(
         this.uploadSignedRulingPdfToCourt(theCase, signedRulingPdf).then(
           (res) => {
-            uploadedToCourt = res
+            rulingUploadedToCourt = res
           },
         ),
         this.uploadCaseFilesPdfToCourt(theCase),
         getCourtRecordPdfAsString(theCase, this.formatMessage)
           .then((pdf) => {
             courtRecordPdf = pdf
-            return this.uploadCourtRecordPdfToCourt(theCase, courtRecordPdf)
+            return this.uploadCourtRecordPdfToCourt(
+              theCase,
+              courtRecordPdf,
+            ).then((res) => {
+              courtRecordUploadedToCourt = res
+            })
           })
           .catch((reason) => {
             // Log and ignore this error. The court record can be uploaded manually.
@@ -325,50 +428,12 @@ export class CaseService {
     }
 
     const emailPromises = [
-      this.sendEmail(
-        {
-          name: theCase.prosecutor?.name ?? '',
-          address: theCase.prosecutor?.email ?? '',
-        },
-        uploadedToS3
-          ? this.formatMessage(m.signedRuling.prosecutorBodyS3, {
-              courtCaseNumber: theCase.courtCaseNumber,
-              courtName: theCase.court?.name?.replace('dómur', 'dómi'),
-              linkStart: `<a href="${environment.deepLinks.completedCaseOverviewUrl}${theCase.id}">`,
-              linkEnd: '</a>',
-            })
-          : this.formatMessage(m.signedRuling.prosecutorBodyAttachment, {
-              courtName: theCase.court?.name,
-              courtCaseNumber: theCase.courtCaseNumber,
-              linkStart: `<a href="${environment.deepLinks.completedCaseOverviewUrl}${theCase.id}">`,
-              linkEnd: '</a>',
-            }),
-        theCase.courtCaseNumber,
-        uploadedToS3 ? undefined : [rulingAttachment],
-      ),
+      this.sendEmailToProsecutor(theCase, rulingUploadedToS3, rulingAttachment),
     ]
 
-    if (!uploadedToCourt) {
-      const recipients = [
-        {
-          name: theCase.judge?.name ?? '',
-          address: theCase.judge?.email ?? '',
-        },
-      ]
-      if (theCase.registrar) {
-        recipients.push({
-          name: theCase.registrar?.name ?? '',
-          address: theCase.registrar?.email ?? '',
-        })
-      }
-
+    if (!rulingUploadedToCourt || !courtRecordUploadedToCourt) {
       emailPromises.push(
-        this.sendEmail(
-          recipients,
-          this.formatMessage(m.signedRuling.courtBodyAttachment),
-          theCase.courtCaseNumber,
-          [rulingAttachment],
-        ),
+        this.sendEmailToCourt(theCase, rulingUploadedToCourt, rulingAttachment),
       )
     }
 
@@ -380,35 +445,8 @@ export class CaseService {
           SessionArrangements.ALL_PRESENT_SPOKESPERSON &&
           theCase.defenderIsSpokesperson))
     ) {
-      const attachments = courtRecordPdf
-        ? [
-            {
-              filename: this.formatMessage(
-                m.signedRuling.courtRecordAttachment,
-                {
-                  courtCaseNumber: theCase.courtCaseNumber,
-                },
-              ),
-              content: courtRecordPdf,
-              encoding: 'binary',
-            },
-            rulingAttachment,
-          ]
-        : [rulingAttachment]
-
       emailPromises.push(
-        this.sendEmail(
-          {
-            name: theCase.defenderName ?? '',
-            address: theCase.defenderEmail,
-          },
-          this.formatMessage(m.signedRuling.defenderBodyAttachment, {
-            courtName: theCase.court?.name,
-            courtCaseNumber: theCase.courtCaseNumber,
-          }),
-          theCase.courtCaseNumber,
-          attachments,
-        ),
+        this.sendEmailToDefender(courtRecordPdf, theCase, rulingAttachment),
       )
     }
 


### PR DESCRIPTION
# Stop sending signed ruling to court if it is already in S3

https://app.asana.com/0/1199153462262248/1201835567438802/f

## What

👆 

## Why

Increased security.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
