### PR TITLE
fix(API): Fix missing graphql type for delegations

### DIFF
--- a/libs/api/domains/auth/src/lib/models/delegation.model.ts
+++ b/libs/api/domains/auth/src/lib/models/delegation.model.ts
@@ -17,6 +17,10 @@ import { DelegationScope } from './delegationScope.model'
 registerEnumType(DelegationProvider, { name: 'AuthDelegationProvider' })
 registerEnumType(DelegationType, { name: 'AuthDelegationType' })
 
+const exhaustiveCheck = (param: never) => {
+  throw new Error(`Missing interfaceType ${param}`)
+}
+
 @InterfaceType('AuthDelegation', {
   resolveType(delegation: Delegation) {
     switch (delegation.type) {
@@ -28,11 +32,9 @@ registerEnumType(DelegationType, { name: 'AuthDelegationType' })
         return PersonalRepresentativeDelegation
       case DelegationType.Custom:
         return CustomDelegation
+      default:
+        exhaustiveCheck(delegation.type)
     }
-    const exhaustiveCheck = (param: never) => {
-      throw new Error(`Missing interfaceType ${param}`)
-    }
-    exhaustiveCheck(delegation.type)
   },
 })
 export abstract class Delegation {

--- a/libs/api/domains/auth/src/lib/models/delegation.model.ts
+++ b/libs/api/domains/auth/src/lib/models/delegation.model.ts
@@ -24,9 +24,15 @@ registerEnumType(DelegationType, { name: 'AuthDelegationType' })
         return LegalGuardianDelegation
       case DelegationType.ProcurationHolder:
         return ProcuringHolderDelegation
+      case DelegationType.PersonalRepresentative:
+        return PersonalRepresentativeDelegation
       case DelegationType.Custom:
         return CustomDelegation
     }
+    const exhaustiveCheck = (param: never) => {
+      throw new Error(`Missing interfaceType ${param}`)
+    }
+    exhaustiveCheck(delegation.type)
   },
 })
 export abstract class Delegation {
@@ -55,6 +61,11 @@ export class LegalGuardianDelegation extends Delegation {}
   implements: Delegation,
 })
 export class ProcuringHolderDelegation extends Delegation {}
+
+@ObjectType('AuthPersonalRepresentativeDelegation', {
+  implements: Delegation,
+})
+export class PersonalRepresentativeDelegation extends Delegation {}
 
 @ObjectType('AuthCustomDelegation', {
   implements: Delegation,


### PR DESCRIPTION
Adds type for Personal Representative delegations.

Adds exhaustive type checking to ensure user get build errors when
adding new types to delegationType enum without adding new type.

## What

New PersonalRepresentative delegation did not work with GraphQL since it was missing type.
This adds a new type.

In addition a exhaustive check was added do ensure this issue does not repeat.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
