### PR TITLE
fix(fa): Hot fix when application created without municipality code

### DIFF
--- a/apps/financial-aid/web-osk/src/utils/hooks/useApplication.ts
+++ b/apps/financial-aid/web-osk/src/utils/hooks/useApplication.ts
@@ -18,7 +18,7 @@ const useApplication = () => {
     { loading: isCreatingApplication },
   ] = useMutation(CreateApplicationMutation)
 
-  const { nationalRegistryData } = useContext(AppContext)
+  const { nationalRegistryData, municipality } = useContext(AppContext)
 
   const formatFiles = (files: UploadFile[], type: FileType) => {
     return files.map((f) => {
@@ -73,7 +73,9 @@ const useApplication = () => {
               streetName: nationalRegistryData?.address.streetName,
               postalCode: nationalRegistryData?.address.postalCode,
               city: nationalRegistryData?.address.city,
-              municipalityCode: nationalRegistryData?.address.municipalityCode,
+              municipalityCode:
+                nationalRegistryData?.address.municipalityCode ||
+                municipality?.municipalityId,
               directTaxPayments: form?.directTaxPayments,
             },
           },


### PR DESCRIPTION
# ... ☝🏼 

https://app.asana.com/0/1201849781730850/1201873101852414

## What

- If national registry isn't available but municipality information is stored, use that when creating application 

## Why
- Application are created without municipality code and that is necessary for application

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
