### PR TITLE
fix(judicial-system): Add noNationalId to extended case's defendants

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/case/case.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/case.service.ts
@@ -819,6 +819,7 @@ export class CaseService {
               this.defendantService.create(
                 caseId,
                 {
+                  noNationalId: defendant.noNationalId,
                   nationalId: defendant.nationalId,
                   name: defendant.name,
                   gender: defendant.gender,


### PR DESCRIPTION
# Add noNationalId to extended case's defendants

https://app.asana.com/0/1199153462262248/1201899370258140/f

## What

Add noNationalId to extended case's defendants

## Why

It's a bug

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
