### PR TITLE
fix(ids): Only return actor delegations which the client can sign in as

### DIFF
--- a/apps/services/auth-public-api/src/app/modules/delegations/actorDelegations.controller.spec.ts
+++ b/apps/services/auth-public-api/src/app/modules/delegations/actorDelegations.controller.spec.ts
@@ -3,6 +3,7 @@ import request from 'supertest'
 
 import {
   ApiScope,
+  Client,
   Delegation,
   DelegationDTO,
   DelegationScope,
@@ -30,18 +31,25 @@ import {
   PersonalRepresentativeRightType,
   PersonalRepresentativeType,
 } from '@island.is/auth-api-lib/personal-representative'
+import { RskProcuringClient } from '@island.is/clients/rsk/procuring'
+import { EinstaklingarApi } from '@island.is/clients/national-registry-v2'
+import { ResponseSimple } from '@island.is/clients/rsk/procuring'
 
 const today = new Date('2021-11-12')
-const client = createClient({ clientId: '@island.is/webapp' })
+const client = createClient({
+  clientId: '@island.is/webapp',
+  supportsDelegation: true,
+  supportsLegalGuardians: true,
+  supportsProcuringHolders: true,
+  supportsPersonalRepresentatives: true,
+})
 const user = createCurrentUser({
   nationalId: '1122334455',
   scope: [AuthScope.actorDelegations, Scopes[0].name],
   client: client.clientId,
 })
 const userName = 'Tester Tests'
-const nationalRegistryUser = createNationalRegistryUser({
-  kennitala: '6677889900',
-})
+const nationalRegistryUser = createNationalRegistryUser()
 
 beforeAll(() => {
   jest.useFakeTimers('modern').setSystemTime(today.getTime())
@@ -53,6 +61,7 @@ describe('ActorDelegationsController', () => {
     let server: request.SuperTest<request.Test>
     let delegationModel: typeof Delegation
     let apiScopeModel: typeof ApiScope
+    let clientModel: typeof Client
 
     beforeAll(async () => {
       // TestApp setup with auth and database
@@ -70,6 +79,19 @@ describe('ActorDelegationsController', () => {
       // Get reference on Delegation and ApiScope models to seed DB
       delegationModel = app.get<typeof Delegation>(getModelToken(Delegation))
       apiScopeModel = app.get<typeof ApiScope>(getModelToken(ApiScope))
+      clientModel = app.get<typeof Client>(getModelToken(Client))
+    })
+
+    beforeEach(() => {
+      return clientModel.update(
+        {
+          supportsDelegation: true,
+          supportsLegalGuardians: true,
+          supportsProcuringHolders: true,
+          supportsPersonalRepresentatives: true,
+        },
+        { where: { clientId: client.clientId } },
+      )
     })
 
     afterAll(async () => {
@@ -188,23 +210,61 @@ describe('ActorDelegationsController', () => {
         })
       })
 
-      it('should not return delegation when all the scopes are no longer allowed for delegation', async () => {
+      describe('when scope is no longer allowed for delegation', () => {
+        beforeAll(() => {
+          return apiScopeModel.update(
+            { allowExplicitDelegationGrant: false } as ApiScope,
+            { where: { name: Scopes[1].name } },
+          )
+        })
+        afterAll(() => {
+          return apiScopeModel.update(
+            { allowExplicitDelegationGrant: true } as ApiScope,
+            { where: { name: Scopes[1].name } },
+          )
+        })
+
+        it('should not return delegation', async () => {
+          // Arrange
+          await delegationModel.create(
+            createDelegation({
+              fromNationalId: nationalRegistryUser.kennitala,
+              toNationalId: user.nationalId,
+              scopes: [Scopes[1].name],
+              today,
+            }),
+            {
+              include: [{ model: DelegationScope, as: 'delegationScopes' }],
+            },
+          )
+          const expectedModels: DelegationDTO[] = []
+
+          // Act
+          const res = await server.get(`${path}${query}`)
+
+          // Assert
+          expect(res.status).toEqual(200)
+          expect(res.body).toHaveLength(0)
+          expectMatchingObject(res.body, expectedModels)
+        })
+      })
+
+      it('should not return delegation when client does not support custom delegations', async () => {
         // Arrange
         await delegationModel.create(
           createDelegation({
             fromNationalId: nationalRegistryUser.kennitala,
             toNationalId: user.nationalId,
-            scopes: [Scopes[1].name],
+            scopes: [Scopes[0].name],
             today,
           }),
           {
             include: [{ model: DelegationScope, as: 'delegationScopes' }],
           },
         )
-        // Disable the scope for delegation after it has been used in delegation
-        await apiScopeModel.update(
-          { allowExplicitDelegationGrant: false } as ApiScope,
-          { where: { name: Scopes[1].name } },
+        await clientModel.update(
+          { supportsDelegation: false },
+          { where: { clientId: client.clientId } },
         )
         const expectedModels: DelegationDTO[] = []
 
@@ -215,12 +275,6 @@ describe('ActorDelegationsController', () => {
         expect(res.status).toEqual(200)
         expect(res.body).toHaveLength(0)
         expectMatchingObject(res.body, expectedModels)
-
-        // Clean up
-        await apiScopeModel.update(
-          { allowExplicitDelegationGrant: true } as ApiScope,
-          { where: { name: Scopes[1].name } },
-        )
       })
 
       it('should not return scopes in delegation that are no longer allowed for delegation', async () => {
@@ -257,14 +311,110 @@ describe('ActorDelegationsController', () => {
         expectMatchingObject(res.body, expectedModels)
       })
 
+      describe('with legal guardian delegations', () => {
+        let getForsja: jest.SpyInstance
+        beforeAll(() => {
+          const client = app.get(EinstaklingarApi)
+          getForsja = jest
+            .spyOn(client, 'einstaklingarGetForsja')
+            .mockResolvedValue([nationalRegistryUser.kennitala])
+        })
+
+        afterAll(() => {
+          getForsja.mockRestore()
+        })
+
+        it('should return delegations', async () => {
+          // Arrange
+          const expectedDelegation = {
+            fromName: nationalRegistryUser.nafn,
+            fromNationalId: nationalRegistryUser.kennitala,
+            provider: 'thjodskra',
+            toNationalId: user.nationalId,
+            type: 'LegalGuardian',
+          }
+          // Act
+          const res = await server.get(`${path}${query}`)
+
+          // Assert
+          expect(res.status).toEqual(200)
+          expect(res.body).toHaveLength(1)
+          expect(res.body[0]).toEqual(expectedDelegation)
+        })
+
+        it('should not return delegations when client does not support legal guardian delegations', async () => {
+          // Arrange
+          await clientModel.update(
+            { supportsLegalGuardians: false },
+            { where: { clientId: client.clientId } },
+          )
+
+          // Act
+          const res = await server.get(`${path}${query}`)
+
+          // Assert
+          expect(res.status).toEqual(200)
+          expect(res.body).toHaveLength(0)
+        })
+      })
+
+      describe('with procuring delegations', () => {
+        let getSimple: jest.SpyInstance
+        beforeAll(() => {
+          const client = app.get(RskProcuringClient)
+          getSimple = jest.spyOn(client, 'getSimple').mockResolvedValue({
+            companies: [
+              {
+                nationalId: nationalRegistryUser.kennitala,
+                name: nationalRegistryUser.nafn,
+              },
+            ],
+          } as ResponseSimple)
+        })
+
+        afterAll(() => {
+          getSimple.mockRestore()
+        })
+
+        it('should return delegations', async () => {
+          // Arrange
+          const expectedDelegation = {
+            fromName: nationalRegistryUser.nafn,
+            fromNationalId: nationalRegistryUser.kennitala,
+            provider: 'fyrirtaekjaskra',
+            toNationalId: user.nationalId,
+            type: 'ProcurationHolder',
+          }
+          // Act
+          const res = await server.get(`${path}${query}`)
+
+          // Assert
+          expect(res.status).toEqual(200)
+          expect(res.body).toHaveLength(1)
+          expect(res.body[0]).toEqual(expectedDelegation)
+        })
+
+        it('should not return delegations when client does not support legal guardian delegations', async () => {
+          // Arrange
+          await clientModel.update(
+            { supportsProcuringHolders: false },
+            { where: { clientId: client.clientId } },
+          )
+
+          // Act
+          const res = await server.get(`${path}${query}`)
+
+          // Assert
+          expect(res.status).toEqual(200)
+          expect(res.body).toHaveLength(0)
+        })
+      })
+
       describe('when user is a personal representative with one representee', () => {
         let prModel: typeof PersonalRepresentative
         let prRightsModel: typeof PersonalRepresentativeRight
         let prRightTypeModel: typeof PersonalRepresentativeRightType
         let prTypeModel: typeof PersonalRepresentativeType
-
-        let response: request.Response
-        let body: DelegationDTO[]
 
         beforeAll(async () => {
           prTypeModel = app.get<typeof PersonalRepresentativeType>(
@@ -303,43 +453,67 @@ describe('ActorDelegationsController', () => {
             rightTypeCode: prRightType.code,
             personalRepresentativeId: pr.id,
           })
-
-          response = await server.get(`${path}${query}`)
-          body = response.body
         })
 
-        it('should have a an OK return status', () => {
-          expect(response.status).toEqual(200)
+        describe('when fetched', () => {
+          let response: request.Response
+          let body: DelegationDTO[]
+
+          beforeAll(async () => {
+            response = await server.get(`${path}${query}`)
+            body = response.body
+          })
+
+          it('should have a an OK return status', () => {
+            expect(response.status).toEqual(200)
+          })
+
+          it('should return a single entity', () => {
+            expect(body.length).toEqual(1)
+          })
+
+          it('should have the nationalId of the user as the representer', () => {
+            expect(
+              body.some((d) => d.toNationalId === user.nationalId),
+            ).toBeTruthy()
+          })
+
+          it('should have the nationalId of the correct representee', () => {
+            expect(
+              body.some(
+                (d) => d.fromNationalId === nationalRegistryUser.kennitala,
+              ),
+            ).toBeTruthy()
+          })
+
+          it('should have the name of the correct representee', () => {
+            expect(
+              body.some((d) => d.fromName === nationalRegistryUser.nafn),
+            ).toBeTruthy()
+          })
+
+          it('should have the delegation type claim of PersonalRepresentative', () => {
+            expect(
+              body.some(
+                (d) => d.type === DelegationType.PersonalRepresentative,
+              ),
+            ).toBeTruthy()
+          })
         })
 
-        it('should return a single entity', () => {
-          expect(body.length).toEqual(1)
-        })
+        it('should not return delegations when client does not support personal representative delegations', async () => {
+          // Prepare
+          await clientModel.update(
+            { supportsPersonalRepresentatives: false },
+            { where: { clientId: client.clientId } },
+          )
 
-        it('should have the nationalId of the user as the representer', () => {
-          expect(
-            body.some((d) => d.toNationalId === user.nationalId),
-          ).toBeTruthy()
-        })
+          // Act
+          const res = await server.get(`${path}${query}`)
 
-        it('should have the nationalId of the correct representee', () => {
-          expect(
-            body.some(
-              (d) => d.fromNationalId === nationalRegistryUser.kennitala,
-            ),
-          ).toBeTruthy()
-        })
-
-        it('should have the name of the correct representee', () => {
-          expect(
-            body.some((d) => d.fromName === nationalRegistryUser.nafn),
-          ).toBeTruthy()
-        })
-
-        it('should have the delegation type claim of PersonalRepresentative', () => {
-          expect(
-            body.some((d) => d.type === DelegationType.PersonalRepresentative),
-          ).toBeTruthy()
+          // Assert
+          expect(res.status).toEqual(200)
+          expect(res.body).toHaveLength(0)
         })
 
         afterAll(async () => {

--- a/apps/services/auth-public-api/test/fixtures/client.fixture.ts
+++ b/apps/services/auth-public-api/test/fixtures/client.fixture.ts
@@ -3,7 +3,13 @@ import { Client } from '@island.is/auth-api-lib'
 
 export type CreateClient = Pick<
   Client,
-  'clientId' | 'nationalId' | 'clientType'
+  | 'clientId'
+  | 'nationalId'
+  | 'clientType'
+  | 'supportsDelegation'
+  | 'supportsLegalGuardians'
+  | 'supportsProcuringHolders'
+  | 'supportsPersonalRepresentatives'
 >
 
 const createRandomClient = (): CreateClient => {
@@ -11,6 +17,10 @@ const createRandomClient = (): CreateClient => {
     clientId: faker.random.word(),
     nationalId: faker.datatype.string(10),
     clientType: 'web',
+    supportsDelegation: false,
+    supportsLegalGuardians: false,
+    supportsProcuringHolders: false,
+    supportsPersonalRepresentatives: false,
   }
 }
 

--- a/libs/clients/rsk/procuring/src/index.ts
+++ b/libs/clients/rsk/procuring/src/index.ts
@@ -1,3 +1,4 @@
 export { RskProcuringClientModule } from './lib/RskProcuringClientModule'
 export { RskProcuringClientConfig } from './lib/RskProcuringClientConfig'
 export { RskProcuringClient } from './lib/RskProcuringClient'
+export { ResponseSimple } from '../gen/fetch/models'


### PR DESCRIPTION
## What

Change actorDelegations controller to only return delegations which the active client can sign in with.

## Why

To minimise transfer of sensitive information to clients.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] ~I have made corresponding changes to the documentation~
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
