### PR TITLE
chore(READMEs): Normalize Júní code ownership naming

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -144,7 +144,7 @@ If your domain needs to expose fields in the GraphQL schema, make sure to export
 
 ## Code owners and maintainers
 
-- [Kosmos & Kaos](https://github.com/orgs/island-is/teams/kosmos-kaos/members): `libs/cms`, `libs/api/domains/content-search`
+- [Júní](https://github.com/orgs/island-is/teams/juni/members): `libs/cms`, `libs/api/domains/content-search`
 - [Aranja](https://github.com/orgs/island-is/teams/aranja/members): `libs/cms`, `libs/api/domains/application`, `libs/api/domains/content-search`
 - [Sendiráðið](https://github.com/orgs/island-is/teams/sendiradid/members): `libs/api/domains/documents`, `libs/api/domains/national-registry`
 - [Stefna](https://github.com/orgs/island-is/teams/stefna/members): `libs/api/domains/content-search`

--- a/apps/services/endorsements/api/README.md
+++ b/apps/services/endorsements/api/README.md
@@ -59,4 +59,4 @@ yarn test services-endorsements-api --skip-nx-cache
 
 ## Code owners and maintainers
 
-- [Júní, formerly Kosmos&Kaos](https://github.com/orgs/island-is/teams/kosmos-kaos/members)
+- [Júní](https://github.com/orgs/island-is/teams/juni/members)

--- a/apps/services/search-indexer/README.md
+++ b/apps/services/search-indexer/README.md
@@ -22,5 +22,5 @@ The indexer server currently has two endpoints:
 ## Code owners and maintainers
 
 - [Stefna](https://github.com/orgs/island-is/teams/stefna/members)
-- [Kosmos & Kaos](https://github.com/orgs/island-is/teams/kosmos-kaos/members)
+- [Júní](https://github.com/orgs/island-is/teams/juni/members)
 - [Aranja](https://github.com/orgs/island-is/teams/aranja/members)

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -73,5 +73,5 @@ creating subpages for the web.
 
 ## Code owners and maintainers
 
-- [Kosmos & Kaos](https://github.com/orgs/island-is/teams/kosmos-kaos/members)
+- [Júní](https://github.com/orgs/island-is/teams/juni/members)
 - [Aranja](https://github.com/orgs/island-is/teams/aranja/members)

--- a/handbook/misc/application-payment-guide.md
+++ b/handbook/misc/application-payment-guide.md
@@ -139,5 +139,5 @@ by talking to the Advania FJS developers.
 
 ## Code owners and maintainers
 
-- [Júní](https://github.com/orgs/island-is/teams/kosmos-kaos/members)
+- [Júní](https://github.com/orgs/island-is/teams/juni/members)
 - [Aranja](https://github.com/orgs/island-is/teams/aranja/members)

--- a/libs/application/templates/driving-license/src/forms/prerequisites/sectionFakeData.ts
+++ b/libs/application/templates/driving-license/src/forms/prerequisites/sectionFakeData.ts
@@ -32,7 +32,7 @@ export const sectionFakeData = buildSubSection({
             Öll önnur gögn eru ekki gervigögn og er þetta eingöngu gert
             til að hægt sé að prófa ferlið án þess að vera með tilheyrandi
             ökuréttindi í staging grunni RLS.
-          `.replace(/\s{2}/g, ''),
+          `.replace(/\s{1,}/g, ' '),
         }),
         buildRadioField({
           id: 'fakeData.useFakeData',

--- a/libs/application/templates/general-petition/README.md
+++ b/libs/application/templates/general-petition/README.md
@@ -62,4 +62,4 @@ RSK_API_PASSWORD
 
 ## Code owners and maintainers
 
-- [Kosmos & Kaos](https://github.com/orgs/island-is/teams/kosmos-kaos)
+- [Júní](https://github.com/orgs/island-is/teams/juni)

--- a/libs/clients/driving-license/README.md
+++ b/libs/clients/driving-license/README.md
@@ -67,4 +67,4 @@ export class SomeService {
 
 ## Code owners and maintainers
 
-- [Kosmos & Kaos](https://github.com/orgs/island-is/teams/kosmos-og-kaos/members)
+- [Júní](https://github.com/orgs/island-is/teams/juni/members)

--- a/libs/clients/syslumenn/README.md
+++ b/libs/clients/syslumenn/README.md
@@ -26,5 +26,5 @@ yarn nx run clients-syslumenn:schemas/external-openapi-generator
 
 ## Code owners and maintainers
 
-- [Kosmos & Kaos](https://github.com/orgs/island-is/teams/kosmos-og-kaos/members)
+- [Júní](https://github.com/orgs/island-is/teams/juni/members)
 - [Stefna](https://github.com/orgs/island-is/teams/stefna/members)

--- a/libs/cms/README.md
+++ b/libs/cms/README.md
@@ -58,5 +58,5 @@ You will need a `CONTENTFUL_MANAGEMENT_ACCESS_TOKEN` to run the script locally. 
 
 ## Code owners and maintainers
 
-- [Kosmos & Kaos](https://github.com/orgs/island-is/teams/kosmos-kaos/members)
+- [Júní](https://github.com/orgs/island-is/teams/juni/members)
 - [Aranja](https://github.com/orgs/island-is/teams/aranja/members)


### PR DESCRIPTION
## What
Rename all mentions of Kosmos & Kaos to Júní.

## Why

Kosmos & Kaos is now named Júní after merger

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
