### PR TITLE
fix(api): license scope (#6811)

### DIFF
--- a/libs/api/domains/license-service/src/lib/graphql/main.resolver.ts
+++ b/libs/api/domains/license-service/src/lib/graphql/main.resolver.ts
@@ -74,7 +74,7 @@ export class VerifyPkPassInput {
 }
 
 @UseGuards(IdsUserGuard, ScopesGuard)
-@Scopes(ApiScope.licenses)
+@Scopes(ApiScope.internal)
 @Resolver()
 @Audit({ namespace: '@island.is/api/license-service' })
 export class MainResolver {

--- a/libs/service-portal/licenses/src/index.ts
+++ b/libs/service-portal/licenses/src/index.ts
@@ -18,14 +18,14 @@ export const licensesModule: ServicePortalModule = {
         defaultMessage: 'Þín skírteini',
       }),
       path: ServicePortalPath.LicensesRoot,
-      enabled: userInfo.scopes.includes(ApiScope.licenses),
+      enabled: userInfo.scopes.includes(ApiScope.internal),
       render: () =>
         lazy(() => import('./screens/LicensesOverview/LicensesOverview')),
     },
     {
       name: m.drivingLicense,
       path: ServicePortalPath.LicensesDrivingDetail,
-      enabled: userInfo.scopes.includes(ApiScope.licenses),
+      enabled: userInfo.scopes.includes(ApiScope.internal),
       render: () =>
         lazy(() =>
           import('./screens/DrivingLicenseDetail/DrivingLicenseDetail'),


### PR DESCRIPTION
Co-authored-by: kodiakhq[bot] <49736102+kodiakhq[bot]@users.noreply.github.com>

# Hotfix - Revert license scopes

PR: #6811 

App is failing when trying to display driving license. Revert for now. App will change later.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
