### PR TITLE
fix(judicial-system): Fixes court fallback email

### DIFF
--- a/apps/judicial-system/backend/src/app/messages/notifications.ts
+++ b/apps/judicial-system/backend/src/app/messages/notifications.ts
@@ -49,8 +49,7 @@ export const notifications = {
         'Notaður sem texti í pósti til sækjanda vegna undirritunar úrskúrðar ef ekki tókst að vista úrskurð í AWS S3',
     },
     courtBody: {
-      id:
-        'judicial.system.backend:notifications.signed_ruling.court_body_attachment',
+      id: 'judicial.system.backend:notifications.signed_ruling.court_body',
       defaultMessage:
         'Ekki tókst að vista þingbók og/eða úrskurð í máli {courtCaseNumber} í Auði.<br /><br />Skjöl málsins eru aðengileg á {linkStart}yfirlitssíðu málsins í Réttarvörslugátt{linkEnd}.',
       description:

--- a/apps/judicial-system/backend/src/app/modules/case/case.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/case.service.ts
@@ -318,7 +318,7 @@ export class CaseService {
 
   private sendEmailToCourt(
     theCase: Case,
-    rulingUploadedToCourt: boolean,
+    rulingUploadedToS3: boolean,
     rulingAttachment: { filename: string; content: string; encoding: string },
   ) {
     const recipients = [
@@ -342,7 +342,7 @@ export class CaseService {
         linkEnd: '</a>',
       }),
       theCase.courtCaseNumber,
-      rulingUploadedToCourt ? undefined : [rulingAttachment],
+      rulingUploadedToS3 ? undefined : [rulingAttachment],
     )
   }
 
@@ -444,7 +444,7 @@ export class CaseService {
 
     if (!rulingUploadedToCourt || !courtRecordUploadedToCourt) {
       emailPromises.push(
-        this.sendEmailToCourt(theCase, rulingUploadedToCourt, rulingAttachment),
+        this.sendEmailToCourt(theCase, rulingUploadedToS3, rulingAttachment),
       )
     }
 


### PR DESCRIPTION
# Fixes court fallback email

https://app.asana.com/0/1199153462262248/1201835567438802/f

## What

- Fixes reference to the Contentful string for the email body.
- Only sends the signed ruling as an attachment if it was not uploaded to S3.

## Why

Bug

## Screenshots / Gifs

<img width="1617" alt="image" src="https://user-images.githubusercontent.com/795382/157281595-2735f49c-aa87-44e1-8d2a-a0592f3216ca.png">

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
