### PR TITLE
fix(judicial-system): Autofill prosecutorDemands on ruling screen for court users

### DIFF
--- a/apps/judicial-system/web/src/routes/Court/InvestigationRequest/CourtRecord/CourtRecord.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationRequest/CourtRecord/CourtRecord.tsx
@@ -94,10 +94,6 @@ const CourtRecord = () => {
         autofill('courtAttendees', defaultCourtAttendees(theCase), theCase)
       }
 
-      if (theCase.demands) {
-        autofill('prosecutorDemands', theCase.demands, theCase)
-      }
-
       if (theCase.type === CaseType.RESTRAINING_ORDER) {
         autofill(
           'sessionBookings',

--- a/apps/judicial-system/web/src/routes/Court/InvestigationRequest/Ruling/Ruling.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationRequest/Ruling/Ruling.tsx
@@ -28,6 +28,10 @@ const Ruling = () => {
 
   useEffect(() => {
     if (isCaseUpToDate) {
+      if (workingCase.demands) {
+        autofill('prosecutorDemands', workingCase.demands, workingCase)
+      }
+
       if (workingCase.caseFacts) {
         autofill('courtCaseFacts', workingCase.caseFacts, workingCase)
       }


### PR DESCRIPTION
# Autofill prosecutorDemands on ruling screen for court users

https://app.asana.com/0/1199153462262248/1201835567438764/f

## What

Autofill prosecutorDemands on ruling screen for court users

## Why

This was still being done on the courtRecord screen in investigation cases and that was a bug.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
