### PR TITLE
chore(judicial-system): Session bookings autofill is now markdown

### DIFF
--- a/apps/judicial-system/web/messages/InvestigationCases/Court/courtRecordForm.ts
+++ b/apps/judicial-system/web/messages/InvestigationCases/Court/courtRecordForm.ts
@@ -58,7 +58,7 @@ export const icCourtRecord = {
       },
       autofillAllPresent: {
         id:
-          'judicial.system.investigation_cases:court_record.session_bookings.autofill_all_present',
+          'judicial.system.investigation_cases:court_record.session_bookings.autofill_all_present#markdown',
         defaultMessage:
           'Sækjanda og verjanda varnaraðila er gefinn kostur á að tjá sig um kröfuna. Verjandi krefst þess að kröfunni verði hafnað.\n\nMálið er tekið til úrskurðar.\n\nÍ málinu er kveðinn upp úrskurður.',
         description:
@@ -82,7 +82,7 @@ export const icCourtRecord = {
       },
       autofillSpokeperson: {
         id:
-          'judicial.system.investigation_cases:court_record.session_bookings.autofill_spokeperson',
+          'judicial.system.investigation_cases:court_record.session_bookings.autofill_spokeperson#markdown',
         defaultMessage:
           'Dómari hefur fallist á að krafan hljóti meðferð fyrir dómi án þess að varnaraðili verði kvaddur/kvödd á dómþing, sbr. 1. mgr. 104. gr. laga nr. 88/2008.\n\nSækjanda og talsmanni varnaraðila er gefinn kostur á að tjá sig um kröfuna. Talsmaður varnaraðila mótmælir kröfunni og krefst þess að kröfunni verði hafnað en til vara að aðgerðinni verði markaður skemmri tími. Þá krefst talsmaður þóknunar fyrir sín störf.\n\nMálið er tekið til úrskurðar.\n\nÍ málinu er kveðinn upp úrskurður.',
         description:
@@ -90,7 +90,7 @@ export const icCourtRecord = {
       },
       autofillProsecutor: {
         id:
-          'judicial.system.investigation_cases:court_record.session_bookings.autofill_prosecutor',
+          'judicial.system.investigation_cases:court_record.session_bookings.autofill_prosecutor#markdown',
         defaultMessage:
           'Dómari hefur fallist á að krafan hljóti meðferð fyrir dómi án þess að varnaraðili verði kvaddur/kvödd á dómþing, sbr. 1. mgr. 104. gr. laga nr. 88/2008.\n\nSækjanda er gefinn kostur á að tjá sig um kröfuna.',
         description:
@@ -98,7 +98,7 @@ export const icCourtRecord = {
       },
       autofillRestrainingOrder: {
         id:
-          'judicial.system.investigation_cases:court_record.session_bookings.autofill_restraining_order',
+          'judicial.system.investigation_cases:court_record.session_bookings.autofill_restraining_order#markdown',
         defaultMessage:
           'Sækjanda, réttargæslumanni og verjanda varnaraðila  er gefinn kostur á að tjá sig um kröfuna. Verjandi krefst þess að kröfunni verði hafnað en til vara að nálgunnarbanni verði markaður skemmri tími. Þá krefjast verjandi og réttargæslumaður þóknunar sér til handa.\n\nMálið er tekið til úrskurðar.\n\nÍ málinu er kveðinn upp úrskurður.',
         description:
@@ -106,7 +106,7 @@ export const icCourtRecord = {
       },
       autofillAutopsy: {
         id:
-          'judicial.system.investigation_cases:court_record.session_bookings.autofill_autopsy',
+          'judicial.system.investigation_cases:court_record.session_bookings.autofill_autopsy#markdown',
         defaultMessage:
           'Ekki er sótt þing af hálfu varnaraðila.\n\nSækjanda er gefinn kostur á að tjá sig um kröfuna.\n\nMálið er tekið til úrskurðar.\n\nÍ málinu er kveðinn upp úrskurður.',
         description:

--- a/apps/judicial-system/web/messages/RestrictionCases/Court/courtRecordForm.ts
+++ b/apps/judicial-system/web/messages/RestrictionCases/Court/courtRecordForm.ts
@@ -74,7 +74,7 @@ export const rcCourtRecord = {
       },
       autofillPresentations: {
         id:
-          'judicial.system.restriction_cases:court_record.session_bookings.autofill_presentations',
+          'judicial.system.restriction_cases:court_record.session_bookings.autofill_presentations#markdown',
         defaultMessage:
           'Sækjandi ítrekar kröfu um gæsluvarðhald, reifar og rökstyður kröfuna og leggur málið í úrskurð með venjulegum fyrirvara.\n\nVerjandi {accused} ítrekar mótmæli hans, krefst þess að kröfunni verði hafnað, til vara að {accused} verði gert að sæta farbanni í stað gæsluvarðhalds, en til þrautavara að gæsluvarðhaldi verði markaður skemmri tími en krafist er og að {accused} verði ekki gert að sæta einangrun á meðan á gæsluvarðhaldi stendur. Verjandinn reifar og rökstyður mótmælin og leggur málið í úrskurð með venjulegum fyrirvara.',
         description:
@@ -82,7 +82,7 @@ export const rcCourtRecord = {
       },
       autofillPresentationsTravelBan: {
         id:
-          'judicial.system.restriction_cases:court_record.session_bookings.autofill_presentations_travel_ban',
+          'judicial.system.restriction_cases:court_record.session_bookings.autofill_presentations_travel_ban#markdown',
         defaultMessage:
           'Sækjanda og verjanda varnaraðila er gefinn kostur á að tjá sig um kröfuna. Verjandi krefst þess að kröfunni verði hafnað en til vara að farbanni verði markaður skemmri tími.\n\nMálið er tekið til úrskurðar.\n\nÍ málinu er kveðinn upp úrskurður.',
         description:


### PR DESCRIPTION
# Session bookings autofill is now markdown

Attach a link to issue if relevant

## What

Session bookings autofill is now markdown

## Why

These strings have newlines in them but they are not showing in CF. By marking them as #markdown, content editors have more control over their format in CF.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
