### PR TITLE
fix(ci): docker image re-tagging should work when re-running the CI jobs

### DIFF
--- a/libs/logging/src/lib/logging.ts
+++ b/libs/logging/src/lib/logging.ts
@@ -1,7 +1,6 @@
 import { createLogger, format, LoggerOptions, transports } from 'winston'
 import { utilities } from 'nest-winston'
 
-import { SentryTransport } from './transports'
 import { maskNationalIdFormatter } from './formatters'
 
 // Default log settings for debug mode
@@ -24,7 +23,7 @@ if (process.env.NODE_ENV === 'production') {
   )
 }
 
-const logTransports = [new transports.Console(), new SentryTransport()]
+const logTransports = [new transports.Console()]
 
 export const logger = createLogger({
   level: logLevel,

--- a/libs/logging/src/lib/logging.ts
+++ b/libs/logging/src/lib/logging.ts
@@ -1,6 +1,7 @@
 import { createLogger, format, LoggerOptions, transports } from 'winston'
 import { utilities } from 'nest-winston'
 
+import { SentryTransport } from './transports'
 import { maskNationalIdFormatter } from './formatters'
 
 // Default log settings for debug mode
@@ -23,7 +24,7 @@ if (process.env.NODE_ENV === 'production') {
   )
 }
 
-const logTransports = [new transports.Console()]
+const logTransports = [new transports.Console(), new SentryTransport()]
 
 export const logger = createLogger({
   level: logLevel,

--- a/scripts/ci/_retag.sh
+++ b/scripts/ci/_retag.sh
@@ -5,4 +5,10 @@ set -euo pipefail
 # This is a script to re-tag a Docker image without pulling the pushing the image but rather directly in the registry.
 
 MANIFEST=$(aws ecr batch-get-image --repository-name "$IMAGE" --image-ids imageTag="$LAST_GOOD_BUILD_DOCKER_TAG" --query 'images[].imageManifest' --output text)
-aws ecr put-image --repository-name "$IMAGE" --image-tag "$DOCKER_TAG" --image-manifest "$MANIFEST"
+#now checking if tag already exits by picking up the version number from the response
+EXISTING_TAG=$(aws ecr batch-get-image --repository-name "$IMAGE" --image-ids imageTag="$DOCKER_TAG" --query 'images[].imageManifest' --output text | jq -r '.schemaVersion')
+if [[ "$EXISTING_TAG" != "2" ]]; then
+  aws ecr put-image --repository-name "$IMAGE" --image-tag "$DOCKER_TAG" --image-manifest "$MANIFEST"
+else
+  echo "Tag $DOCKER_TAG already existed for image $IAMGE. Hopefully this is a re-run in which case it should be ok."
+fi


### PR DESCRIPTION
Fixes #6770 
# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
