### PR TITLE
chore(judicial-system): Validate conclusion and decision on courtRecord screen instead of ruling

### DIFF
--- a/apps/judicial-system/web-e2e/src/integration/Court/InvestigationCases/courtRecord.spec.ts
+++ b/apps/judicial-system/web-e2e/src/integration/Court/InvestigationCases/courtRecord.spec.ts
@@ -2,6 +2,7 @@ import faker from 'faker'
 
 import {
   Case,
+  CaseDecision,
   CaseType,
   SessionArrangements,
 } from '@island.is/judicial-system/types'
@@ -168,6 +169,42 @@ describe(`${IC_COURT_RECORD_ROUTE}/:id`, () => {
     cy.getByTestid('inputErrorMessage').should('not.exist')
   })
 
+  it('should not allow users to continue if conclusion is not set', () => {
+    const caseData = makeInvestigationCase()
+
+    const caseDataAddition: Case = {
+      ...caseData,
+      prosecutor: makeProsecutor(),
+      courtDate: '2021-12-16T10:50:04.033Z',
+      decision: CaseDecision.ACCEPTING,
+    }
+
+    cy.stubAPIResponses()
+    cy.visit(`${IC_COURT_RECORD_ROUTE}/test_id_stadfest`)
+
+    intercept(caseDataAddition)
+
+    cy.getByTestid('continueButton').should('not.exist')
+  })
+
+  it('should not allow users to continue if decision is not set', () => {
+    const caseData = makeInvestigationCase()
+
+    const caseDataAddition: Case = {
+      ...caseData,
+      prosecutor: makeProsecutor(),
+      courtDate: '2021-12-16T10:50:04.033Z',
+      conclusion: faker.lorem.words(5),
+    }
+
+    cy.stubAPIResponses()
+    cy.visit(`${IC_COURT_RECORD_ROUTE}/test_id_stadfest`)
+
+    intercept(caseDataAddition)
+
+    cy.getByTestid('continueButton').should('not.exist')
+  })
+
   it('should navigate to the next step when all input data is valid and the continue button is clicked', () => {
     const caseData = makeInvestigationCase()
 
@@ -175,6 +212,8 @@ describe(`${IC_COURT_RECORD_ROUTE}/:id`, () => {
       ...caseData,
       prosecutor: makeProsecutor(),
       courtDate: '2021-12-16T10:50:04.033Z',
+      decision: CaseDecision.ACCEPTING,
+      conclusion: faker.lorem.words(5),
     }
 
     cy.stubAPIResponses()

--- a/apps/judicial-system/web-e2e/src/integration/Court/RestrictionCases/courtRecord.spec.ts
+++ b/apps/judicial-system/web-e2e/src/integration/Court/RestrictionCases/courtRecord.spec.ts
@@ -1,3 +1,5 @@
+import faker from 'faker'
+
 import { Case, CaseDecision, CaseType } from '@island.is/judicial-system/types'
 import {
   makeCustodyCase,
@@ -107,6 +109,7 @@ describe(`${COURT_RECORD_ROUTE}/:id`, () => {
       prosecutor: makeProsecutor(),
       decision: CaseDecision.ACCEPTING,
       courtDate: '2020-09-16T19:50:08.033Z',
+      conclusion: faker.lorem.words(5),
     }
 
     cy.visit(`${COURT_RECORD_ROUTE}/test_id_stadfest`)
@@ -122,6 +125,42 @@ describe(`${COURT_RECORD_ROUTE}/:id`, () => {
     cy.getByTestid('continueButton').should('not.be.disabled')
   })
 
+  it('should not allow users to continue if conclusion is not set', () => {
+    const caseData = makeCustodyCase()
+
+    const caseDataAddition: Case = {
+      ...caseData,
+      prosecutor: makeProsecutor(),
+      courtDate: '2021-12-16T10:50:04.033Z',
+      decision: CaseDecision.ACCEPTING,
+    }
+
+    cy.stubAPIResponses()
+    cy.visit(`${COURT_RECORD_ROUTE}/test_id_stadfest`)
+
+    intercept(caseDataAddition)
+
+    cy.getByTestid('continueButton').should('not.exist')
+  })
+
+  it('should not allow users to continue if decision is not set', () => {
+    const caseData = makeCustodyCase()
+
+    const caseDataAddition: Case = {
+      ...caseData,
+      prosecutor: makeProsecutor(),
+      courtDate: '2021-12-16T10:50:04.033Z',
+      conclusion: faker.lorem.words(5),
+    }
+
+    cy.stubAPIResponses()
+    cy.visit(`${COURT_RECORD_ROUTE}/test_id_stadfest`)
+
+    intercept(caseDataAddition)
+
+    cy.getByTestid('continueButton').should('not.exist')
+  })
+
   it('should navigate to the next step when all input data is valid and the continue button is clicked', () => {
     const caseData = makeCustodyCase()
 
@@ -130,6 +169,7 @@ describe(`${COURT_RECORD_ROUTE}/:id`, () => {
       prosecutor: makeProsecutor(),
       decision: CaseDecision.ACCEPTING,
       courtDate: '2020-09-16T19:50:08.033Z',
+      conclusion: faker.lorem.words(5),
     }
 
     cy.visit(`${COURT_RECORD_ROUTE}/test_id_stadfest`)

--- a/apps/judicial-system/web/messages/InvestigationCases/Court/courtRecordForm.ts
+++ b/apps/judicial-system/web/messages/InvestigationCases/Court/courtRecordForm.ts
@@ -340,7 +340,7 @@ export const icCourtRecord = {
   nextButtonInfo: {
     id: 'judicial.system.investigation_cases:court_record.next_button_info',
     defaultMessage:
-      'Ekki er hægt að halda áfram fyrr en búið er að setja lyktir máls og úrskurðarorð',
+      'Til að halda áfram þarf að skrá lyktir máls og skrifa úrskurðarorð á skjánum Úrskurður.',
     description:
       'Notaður sem texti í info panel sem kemur í staðinn fyrir Áfram takk þegar ekki er búið að setja lyktir máls eða úrskurðarorð',
   },

--- a/apps/judicial-system/web/messages/InvestigationCases/Court/courtRecordForm.ts
+++ b/apps/judicial-system/web/messages/InvestigationCases/Court/courtRecordForm.ts
@@ -337,4 +337,11 @@ export const icCourtRecord = {
       },
     }),
   },
+  nextButtonInfo: {
+    id: 'judicial.system.investigation_cases:court_record.next_button_info',
+    defaultMessage:
+      'Ekki er hægt að halda áfram fyrr en búið er að setja lyktir máls og úrskurðarorð',
+    description:
+      'Notaður sem texti í info panel sem kemur í staðinn fyrir Áfram takk þegar ekki er búið að setja lyktir máls eða úrskurðarorð',
+  },
 }

--- a/apps/judicial-system/web/messages/RestrictionCases/Court/courtRecordForm.ts
+++ b/apps/judicial-system/web/messages/RestrictionCases/Court/courtRecordForm.ts
@@ -274,7 +274,7 @@ export const rcCourtRecord = {
   nextButtonInfo: {
     id: 'judicial.system.restriction_cases:court_record.next_button_info',
     defaultMessage:
-      'Ekki er hægt að halda áfram fyrr en búið er að setja lyktir máls og úrskurðarorð',
+      'Til að halda áfram þarf að skrá lyktir máls og skrifa úrskurðarorð á skjánum Úrskurður.',
     description:
       'Notaður sem texti í info panel sem kemur í staðinn fyrir Áfram takk þegar ekki er búið að setja lyktir máls eða úrskurðarorð',
   },

--- a/apps/judicial-system/web/messages/RestrictionCases/Court/courtRecordForm.ts
+++ b/apps/judicial-system/web/messages/RestrictionCases/Court/courtRecordForm.ts
@@ -271,4 +271,11 @@ export const rcCourtRecord = {
       },
     }),
   },
+  nextButtonInfo: {
+    id: 'judicial.system.restriction_cases:court_record.next_button_info',
+    defaultMessage:
+      'Ekki er hægt að halda áfram fyrr en búið er að setja lyktir máls og úrskurðarorð',
+    description:
+      'Notaður sem texti í info panel sem kemur í staðinn fyrir Áfram takk þegar ekki er búið að setja lyktir máls eða úrskurðarorð',
+  },
 }

--- a/apps/judicial-system/web/src/routes/Court/InvestigationRequest/CourtRecord/CourtRecordForm.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationRequest/CourtRecord/CourtRecordForm.tsx
@@ -742,6 +742,12 @@ const CourtRecordForm: React.FC<Props> = (props) => {
           nextIsLoading={isLoading}
           nextUrl={`${Constants.IC_CONFIRMATION_ROUTE}/${workingCase.id}`}
           nextIsDisabled={!isCourtRecordStepValidIC(workingCase)}
+          hideNextButton={!workingCase.decision || !workingCase.conclusion}
+          infoBoxText={
+            !workingCase.decision || !workingCase.conclusion
+              ? formatMessage(m.nextButtonInfo)
+              : ''
+          }
         />
       </FormContentContainer>
     </>

--- a/apps/judicial-system/web/src/routes/Court/InvestigationRequest/Ruling/RulingForm.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationRequest/Ruling/RulingForm.tsx
@@ -46,7 +46,6 @@ const RulingForm: React.FC<Props> = (props) => {
   const [courtCaseFactsEM, setCourtCaseFactsEM] = useState<string>('')
   const [courtLegalArgumentsEM, setCourtLegalArgumentsEM] = useState<string>('')
   const [prosecutorDemandsEM, setProsecutorDemandsEM] = useState<string>('')
-  const [conclusionEM, setConclusionEM] = useState<string>('')
   const [introductionEM, setIntroductionEM] = useState<string>('')
 
   return (
@@ -275,10 +274,7 @@ const RulingForm: React.FC<Props> = (props) => {
         <Box component="section" marginBottom={5}>
           <Box marginBottom={3}>
             <Text as="h3" variant="h3">
-              {`${formatMessage(m.sections.decision.title)} `}
-              <Text as="span" fontWeight="semiBold" color="red600">
-                *
-              </Text>
+              {formatMessage(m.sections.decision.title)}
             </Text>
           </Box>
           <Box marginBottom={5}>
@@ -309,29 +305,23 @@ const RulingForm: React.FC<Props> = (props) => {
               removeTabsValidateAndSet(
                 'conclusion',
                 event.target.value,
-                ['empty'],
+                [],
                 workingCase,
                 setWorkingCase,
-                conclusionEM,
-                setConclusionEM,
               )
             }
             onBlur={(event) =>
               validateAndSendToServer(
                 'conclusion',
                 event.target.value,
-                ['empty'],
+                [],
                 workingCase,
                 updateCase,
-                setConclusionEM,
               )
             }
-            hasError={conclusionEM !== ''}
-            errorMessage={conclusionEM}
             rows={7}
             autoExpand={{ on: true, maxHeight: 300 }}
             textarea
-            required
           />
         </Box>
         <Box marginBottom={10}>

--- a/apps/judicial-system/web/src/routes/Court/RestrictionRequest/CourtRecord/CourtRecord.tsx
+++ b/apps/judicial-system/web/src/routes/Court/RestrictionRequest/CourtRecord/CourtRecord.tsx
@@ -984,6 +984,12 @@ export const CourtRecord: React.FC = () => {
           previousUrl={`${Constants.RULING_ROUTE}/${workingCase.id}`}
           nextUrl={`${Constants.CONFIRMATION_ROUTE}/${id}`}
           nextIsDisabled={!isCourtRecordStepValidRC(workingCase)}
+          hideNextButton={!workingCase.decision || !workingCase.conclusion}
+          infoBoxText={
+            !workingCase.decision || !workingCase.conclusion
+              ? formatMessage(m.nextButtonInfo)
+              : ''
+          }
         />
       </FormContentContainer>
     </PageLayout>

--- a/apps/judicial-system/web/src/routes/Court/RestrictionRequest/Ruling/Ruling.tsx
+++ b/apps/judicial-system/web/src/routes/Court/RestrictionRequest/Ruling/Ruling.tsx
@@ -486,10 +486,7 @@ export const Ruling: React.FC = () => {
         <Box component="section" marginBottom={5}>
           <Box marginBottom={3}>
             <Text as="h3" variant="h3">
-              {`${formatMessage(m.sections.decision.title)} `}
-              <Text as="span" fontWeight="semiBold" color="red600">
-                *
-              </Text>
+              {formatMessage(m.sections.decision.title)}
             </Text>
           </Box>
           <Box marginBottom={5}>

--- a/apps/judicial-system/web/src/routes/Court/RestrictionRequest/Ruling/Ruling.tsx
+++ b/apps/judicial-system/web/src/routes/Court/RestrictionRequest/Ruling/Ruling.tsx
@@ -78,9 +78,6 @@ export const Ruling: React.FC = () => {
     prosecutorDemandsErrorMessage,
     setProsecutorDemandsMessage,
   ] = useState<string>('')
-  const [conclusionErrorMessage, setConclusionErrorMessage] = useState<string>(
-    '',
-  )
 
   const router = useRouter()
   const id = router.query.id
@@ -665,27 +662,21 @@ export const Ruling: React.FC = () => {
               removeTabsValidateAndSet(
                 'conclusion',
                 event.target.value,
-                ['empty'],
+                [],
                 workingCase,
                 setWorkingCase,
-                conclusionErrorMessage,
-                setConclusionErrorMessage,
               )
             }
             onBlur={(event) =>
               validateAndSendToServer(
                 'conclusion',
                 event.target.value,
-                ['empty'],
+                [],
                 workingCase,
                 updateCase,
-                setConclusionErrorMessage,
               )
             }
-            hasError={conclusionErrorMessage !== ''}
-            errorMessage={conclusionErrorMessage}
             textarea
-            required
             rows={7}
             autoExpand={{ on: true, maxHeight: 300 }}
           />

--- a/apps/judicial-system/web/src/utils/validate.ts
+++ b/apps/judicial-system/web/src/utils/validate.ts
@@ -213,9 +213,7 @@ export const isRulingValidRC = (workingCase: Case) => {
     validate(workingCase.prosecutorDemands || '', 'empty').isValid &&
     validate(workingCase.courtCaseFacts || '', 'empty').isValid &&
     validate(workingCase.courtLegalArguments || '', 'empty').isValid &&
-    validate(workingCase.decision || '', 'empty').isValid &&
-    validate(workingCase.ruling || '', 'empty').isValid &&
-    validate(workingCase.conclusion || '', 'empty').isValid
+    validate(workingCase.ruling || '', 'empty').isValid
   )
 }
 
@@ -224,9 +222,7 @@ export const isRulingValidIC = (workingCase: Case) => {
     validate(workingCase.prosecutorDemands || '', 'empty').isValid &&
     validate(workingCase.courtCaseFacts || '', 'empty').isValid &&
     validate(workingCase.courtLegalArguments || '', 'empty').isValid &&
-    validate(workingCase.decision || '', 'empty').isValid &&
-    validate(workingCase.ruling || '', 'empty').isValid &&
-    validate(workingCase.conclusion || '', 'empty').isValid
+    validate(workingCase.ruling || '', 'empty').isValid
   )
 }
 
@@ -238,7 +234,9 @@ export const isCourtRecordStepValidRC = (workingCase: Case) => {
     workingCase.accusedAppealDecision &&
     workingCase.prosecutorAppealDecision &&
     validate(workingCase.courtEndTime || '', 'empty').isValid &&
-    validate(workingCase.courtEndTime || '', 'date-format').isValid
+    validate(workingCase.courtEndTime || '', 'date-format').isValid &&
+    validate(workingCase.decision || '', 'empty').isValid &&
+    validate(workingCase.conclusion || '', 'empty').isValid
   )
 }
 
@@ -250,7 +248,9 @@ export const isCourtRecordStepValidIC = (workingCase: Case) => {
     workingCase.accusedAppealDecision &&
     workingCase.prosecutorAppealDecision &&
     validate(workingCase.courtEndTime || '', 'empty').isValid &&
-    validate(workingCase.courtEndTime || '', 'date-format').isValid
+    validate(workingCase.courtEndTime || '', 'date-format').isValid &&
+    validate(workingCase.decision || '', 'empty').isValid &&
+    validate(workingCase.conclusion || '', 'empty').isValid
   )
 }
 


### PR DESCRIPTION
# Validate conclusion and decision on courtRecord screen instead of ruling

https://app.asana.com/0/1199153462262248/1201935511632243/f

## What

Validate conclusion and decision on courtRecord screen instead of ruling

## Why

Users want to be able to start working on the court record before making these decisions.

## Screenshots / Gifs

![screencapture-localhost-4200-domur-rannsoknarheimild-thingbok-9b8a0926-aab1-4b44-90b6-44530550ad2c-2022-03-11-11_26_13](https://user-images.githubusercontent.com/3789875/157858394-743f6c76-55cb-4530-bbe6-bc8773bdd31f.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
