### PR TITLE
fix(api): race condition when fetching url or qrcode (#6852)

### DIFF
--- a/libs/api/domains/license-service/src/lib/graphql/genericLicense.model.ts
+++ b/libs/api/domains/license-service/src/lib/graphql/genericLicense.model.ts
@@ -109,6 +109,10 @@ export class GenericUserLicense {
 export class GenericPkPass {
   @Field(() => String)
   pkpassUrl!: string
+}
+
+@ObjectType()
+export class GenericPkPassQrCode {
   @Field(() => String)
   pkpassQRCode!: string
 }

--- a/libs/api/domains/license-service/src/lib/graphql/main.resolver.ts
+++ b/libs/api/domains/license-service/src/lib/graphql/main.resolver.ts
@@ -21,6 +21,7 @@ import { Audit } from '@island.is/nest/audit'
 import { LicenseServiceService } from '../licenseService.service'
 import {
   GenericPkPass,
+  GenericPkPassQrCode,
   GenericPkPassVerification,
   GenericUserLicense,
 } from './genericLicense.model'
@@ -126,16 +127,31 @@ export class MainResolver {
     locale: Locale = 'is',
     @Args('input') input: GeneratePkPassInput,
   ): Promise<GenericPkPass> {
+    const { pkpassUrl } = await this.licenseServiceService.generatePkPass(
+      user.nationalId,
+      locale,
+      input.licenseType,
+    )
+    return { pkpassUrl }
+  }
+
+  @Mutation(() => GenericPkPassQrCode)
+  @Audit()
+  async generatePkPassQrCode(
+    @CurrentUser() user: User,
+    @Args('locale', { type: () => String, nullable: true })
+    locale: Locale = 'is',
+    @Args('input') input: GeneratePkPassInput,
+  ): Promise<GenericPkPassQrCode> {
     const {
-      pkpassUrl,
       pkpassQRCode,
-    } = await this.licenseServiceService.generatePkPass(
+    } = await this.licenseServiceService.generatePkPassQrCode(
       user.nationalId,
       locale,
       input.licenseType,
     )
 
-    return { pkpassUrl, pkpassQRCode }
+    return { pkpassQRCode }
   }
 
   @Mutation(() => GenericPkPassVerification)

--- a/libs/api/domains/license-service/src/lib/licenseService.service.ts
+++ b/libs/api/domains/license-service/src/lib/licenseService.service.ts
@@ -224,7 +224,6 @@ export class LicenseServiceService {
     licenseType: GenericLicenseType,
   ) {
     let pkpassUrl: string | null = null
-    let pkpassQRCode: string | null = null
 
     const licenseService = await this.genericLicenseFactory(
       licenseType,
@@ -233,7 +232,6 @@ export class LicenseServiceService {
 
     if (licenseService) {
       pkpassUrl = await licenseService.getPkPassUrl(nationalId)
-      pkpassQRCode = await licenseService.getPkPassQRCode(nationalId)
     } else {
       throw new Error(`${licenseType} not supported`)
     }
@@ -243,14 +241,33 @@ export class LicenseServiceService {
         `Unable to get pkpass url for ${licenseType} for nationalId ${nationalId}`,
       )
     }
+    return { pkpassUrl }
+  }
 
+  async generatePkPassQrCode(
+    nationalId: User['nationalId'],
+    locale: Locale,
+    licenseType: GenericLicenseType,
+  ) {
+    let pkpassQRCode: string | null = null
+
+    const licenseService = await this.genericLicenseFactory(
+      licenseType,
+      this.cacheManager,
+    )
+
+    if (licenseService) {
+      pkpassQRCode = await licenseService.getPkPassQRCode(nationalId)
+    } else {
+      throw new Error(`${licenseType} not supported`)
+    }
     if (!pkpassQRCode) {
       throw new Error(
         `Unable to get pkpass qr code for ${licenseType} for nationalId ${nationalId}`,
       )
     }
 
-    return { pkpassUrl, pkpassQRCode }
+    return { pkpassQRCode }
   }
 
   async verifyPkPass(

--- a/libs/service-portal/graphql/src/lib/mutations/createPkPass.ts
+++ b/libs/service-portal/graphql/src/lib/mutations/createPkPass.ts
@@ -4,6 +4,13 @@ export const CREATE_PK_PASS = gql`
   mutation generatePkPass($input: GeneratePkPassInput!) {
     generatePkPass(input: $input) {
       pkpassUrl
+    }
+  }
+`
+
+export const CREATE_PK_PASS_QR_CODE = gql`
+  mutation generatePkPassQrCode($input: GeneratePkPassInput!) {
+    generatePkPassQrCode(input: $input) {
       pkpassQRCode
     }
   }


### PR DESCRIPTION
# HOTFIX 🔥  - Split up when fetching data for driving license

## What


SEE: #6852 

Race condition was made by fetching pkpass two times in a row. 
Either pkpass url or qrcode was expired.


## Why

BUG 🐛 

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
