### PR TITLE
chore(user-notification): Fix error detection from firebase-admin

### DIFF
--- a/apps/services/user-notification/src/app/modules/notifications/notificationDispatch.service.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/notificationDispatch.service.ts
@@ -28,8 +28,8 @@ const isTokenError = (e: firebaseAdmin.FirebaseError): boolean => {
   // ideal since technically it might change at any time without notice.
   return (
     (e.code === 'messaging/invalid-argument' &&
-      Boolean(e.message.match(/invalid.+token/gi))) ||
-    e.code === 'messaging/unregistered'
+      e.message.includes('not a valid FCM registration token')) ||
+    e.code === 'messaging/registration-token-not-registered'
   )
 }
 


### PR DESCRIPTION
Fix error detection from firebase-admin

Firebase error documentation is rather poor.
When firebase returns an error on sending a push notification we must decide based on the response if the error is caused by an issue with the push token or not.
If we decide incorrectly that the issue is not with the token when it actually is the tokens fault, the message will end up in the sqs dead-letter-queue, which we'd rather avoid.

This change is based on errors we're seeing in datadog.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
