### PR TITLE
fix(judicial-system): Fix Case Info For Registrars

### DIFF
--- a/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.tsx
+++ b/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.tsx
@@ -4,7 +4,7 @@ import { useIntl } from 'react-intl'
 import { Box, Text } from '@island.is/island-ui/core'
 import { core } from '@island.is/judicial-system-web/messages'
 import { capitalize } from '@island.is/judicial-system/formatters'
-import { Case, UserRole } from '@island.is/judicial-system/types'
+import { Case, courtRoles, UserRole } from '@island.is/judicial-system/types'
 
 interface Props {
   workingCase: Case
@@ -37,15 +37,16 @@ const CaseInfo: React.FC<Props> = ({
       <Box marginBottom={1}>
         <Text variant="h2" as="h2">
           {formatMessage(core.caseNumber, {
-            caseNumber:
-              userRole === UserRole.JUDGE
+            caseNumber: userRole
+              ? courtRoles.includes(userRole)
                 ? workingCase.courtCaseNumber
-                : workingCase.policeCaseNumber,
+                : workingCase.policeCaseNumber
+              : '',
           })}
         </Text>
       </Box>
       {userRole ? (
-        userRole === UserRole.JUDGE ? (
+        courtRoles.includes(userRole) ? (
           <>
             <Text fontWeight="semiBold">{`${formatMessage(core.prosecutor)}: ${
               workingCase.prosecutor?.institution?.name


### PR DESCRIPTION
# Fix Case Info For Registrars

https://app.asana.com/0/1199153462262248/1201927207988736/f

## What

- Fixes case info display for registrars.

## Why

Bug

## Screenshots / Gifs

### Looked like this:

<img width="773" alt="image" src="https://user-images.githubusercontent.com/795382/158182867-ce1b986f-c241-46aa-a76b-edf50b2b4d59.png">

### Looks like this now:

<img width="771" alt="image" src="https://user-images.githubusercontent.com/795382/158182501-bfaaf16d-f813-4947-ac63-7c75aefc9f76.png">

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
