### PR TITLE
fix(judicial-system): Fixes case info on hearing arrangements screen in restriction cases

### DIFF
--- a/apps/judicial-system/web/src/routes/Prosecutor/RestrictionRequest/StepTwo/StepTwoForm.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/RestrictionRequest/StepTwo/StepTwoForm.tsx
@@ -62,7 +62,7 @@ const StepTwoForm: React.FC<Props> = (props) => {
           </Text>
         </Box>
         <Box component="section" marginBottom={7}>
-          <CaseInfo workingCase={workingCase} />
+          <CaseInfo workingCase={workingCase} userRole={user?.role} />
         </Box>
         <Box component="section" marginBottom={5}>
           <BlueBox>


### PR DESCRIPTION
# Fixes case info on hearing arrangements screen in restriction cases

https://app.asana.com/0/1199153462262248/1201927207988736/f

## What

- Fixes case info for prosecutors on the hearing arrangements screen in restriction cases.

## Why

Bug

## Screenshots / Gifs

### Before:

<img width="962" alt="image" src="https://user-images.githubusercontent.com/795382/158207513-f646167b-b38b-4c77-a8dd-0b015801c134.png">

### After:

<img width="764" alt="image" src="https://user-images.githubusercontent.com/795382/158207604-3b4e3faa-8355-461c-9243-f515903b9676.png">

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
