### PR TITLE
fix(ads): ADS national registry hotfix and logging

### DIFF
--- a/apps/air-discount-scheme/backend/src/environments/environment.ts
+++ b/apps/air-discount-scheme/backend/src/environments/environment.ts
@@ -11,13 +11,6 @@ const devConfig = {
     password: process.env.NATIONAL_REGISTRY_PASSWORD,
     authMiddlewareOptions: {
       forwardUserInfo: false,
-      tokenExchangeOptions: {
-        issuer: 'https://identity-server.dev01.devland.is',
-        clientId: '@vegagerdin.is/clients/air-discount-scheme',
-        clientSecret: process.env.VEGAGERDIN_IDS_CLIENTS_SECRET,
-        scope: 'openid profile @skra.is/individuals',
-        requestActorToken: false,
-      },
     },
   },
   airlineApiKeys: {
@@ -58,13 +51,6 @@ const prodConfig = {
     password: process.env.NATIONAL_REGISTRY_PASSWORD,
     authMiddlewareOptions: {
       forwardUserInfo: false,
-      tokenExchangeOptions: {
-        issuer: process.env.IDENTITY_SERVER_ISSUER_URL,
-        clientId: '@vegagerdin.is/clients/air-discount-scheme',
-        clientSecret: process.env.VEGAGERDIN_IDS_CLIENTS_SECRET,
-        scope: 'openid profile @skra.is/individuals',
-        requestActorToken: false,
-      },
     },
   },
   airlineApiKeys: {

--- a/libs/clients/national-registry/v2/src/lib/nationalRegistryClient.config.ts
+++ b/libs/clients/national-registry/v2/src/lib/nationalRegistryClient.config.ts
@@ -5,6 +5,7 @@ const schema = z.object({
   xRoadServicePath: z.string(),
   fetch: z.object({
     timeout: z.number().int(),
+    logErrorResponseBody: z.boolean(),
   }),
   redis: z.object({
     nodes: z.array(z.string()),
@@ -23,6 +24,8 @@ export const NationalRegistryClientConfig = defineConfig({
       ),
       fetch: {
         timeout: env.optionalJSON('XROAD_NATIONAL_REGISTRY_TIMEOUT') ?? 10000,
+        logErrorResponseBody:
+          env.optionalJSON('XROAD_NATIONAL_REGISTRY_LOG_ERRORS') ?? false,
       },
       redis: {
         nodes: env.optionalJSON('XROAD_NATIONAL_REGISTRY_REDIS_NODES') ?? [],


### PR DESCRIPTION
## What

Disable token exchange for ADS. It is currently 100% redundant since the client already has the scope required to talk to National Registry. It may be causing problems due to clock drift and NBF validation.

Also add a configuration to increase logging of national registry errors.

## Why

To figure out why ADS has been broken all day.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] ~I have made corresponding changes to the documentation~
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
