### PR TITLE
feat(nest-config): Add support for optional configs

### DIFF
--- a/libs/nest/config/README.md
+++ b/libs/nest/config/README.md
@@ -145,6 +145,51 @@ SomeModule is not configured. Validation failed with the following errors:
 
 ## Advanced functionality
 
+### Optional config
+
+If you have module that can depend on a config optionally it can use the `isConfigured` property to check if the config is provided. Then in the module's imports you import the config definition with `registerOptional()`. This allows for a complete config to be optional, but if some property is provided all of the required properties need to be provided.
+
+{% hint style="warning" %}
+Only optional configs should be imported in the module itself. Required config should be loaded in the root module using the `ConfigModule.forRoot(...)`
+{% endhint %}
+
+Checking if config is provided:
+
+```ts
+import { Inject } from '@nestjs/common'
+import { ConfigType, OtherConfig } from '@island.is/nest/config'
+import { SomeModuleConfig } from './someModule.config'
+
+export class SomeClientService {
+  constructor(
+    @Inject(SomeModuleConfig.Key)
+    private config: ConfigType<typeof SomeModuleConfig>,
+    @Inject(OtherConfig.Key)
+    private otherConfig: ConfigType<typeof OtherConfig>,
+  ) {
+    this.someProp = otherConfig.isConfigured
+      ? otherConfig.someProp
+      : 'Some default behaviour'
+  }
+}
+```
+
+Add the config as optional in the module.
+
+```ts
+import { ConfigModule } from '@island.is/nest/config'
+import { SomeModuleConfig } from './someModule.config'
+import { SomeClientService } from './someClient.service'
+
+@Module({
+  // SomeModuleConfig is imported in the root module
+  imports: [OtherConfig.registerOptional()],
+  provides: [SomeClientService],
+  exports: [SomeClientService],
+})
+export class SomeClientModule {}
+```
+
 ### Server side features
 
 If you're working on server-side functionality or integrations which needs to be on main, but it's not ready for staging or production, you can use [Server-Side Feature Flags](https://docs.devland.is/technical-overview/devops/service-setup#server-side-feature-flags) to disable the functionality. In these cases, entire module configurations may be missing which would crash configuration loading.

--- a/libs/nest/config/src/lib/ConfigurationLoader.ts
+++ b/libs/nest/config/src/lib/ConfigurationLoader.ts
@@ -38,7 +38,7 @@ export class ConfigurationLoader<T> implements EnvLoader {
       return this.handleResult(result)
     } catch (err) {
       // Loader crashed. If there are reported issues, throw those instead.
-      return this.handleResult(undefined, err)
+      return this.handleResult(undefined, err as Error)
     }
   }
 

--- a/libs/nest/config/src/lib/ConfigurationLoader.ts
+++ b/libs/nest/config/src/lib/ConfigurationLoader.ts
@@ -1,14 +1,15 @@
 import { ZodError } from 'zod'
+
 import { ServerSideFeatureClient } from '@island.is/feature-flags'
 import { logger } from '@island.is/logging'
 
-import { ConfigDefinition, Configuration, EnvLoader } from './types'
-import { InvalidConfiguration } from './InvalidConfiguration'
 import {
   ConfigurationError,
   ConfigurationValidationError,
 } from './ConfigurationError'
+import { InvalidConfiguration } from './InvalidConfiguration'
 import { Issues, IssueType } from './Issues'
+import { ConfigDefinition, Configuration, EnvLoader } from './types'
 
 export class ConfigurationLoader<T> implements EnvLoader {
   private allowDevFallback = process.env.NODE_ENV !== 'production'

--- a/libs/nest/config/src/lib/ConfigurationLoader.ts
+++ b/libs/nest/config/src/lib/ConfigurationLoader.ts
@@ -47,6 +47,12 @@ export class ConfigurationLoader<T> implements EnvLoader {
       throw new ConfigurationError(this.formatConfigurationError())
     }
 
+    if (this.issues.hasMissingIssue && this.definition.optional) {
+      return new InvalidConfiguration(
+        this.formatConfigurationError(),
+      ) as Configuration<T>
+    }
+
     // Only throw missing issue in production
     if (this.issues.hasMissingIssue && !this.allowDevFallback) {
       throw new ConfigurationError(this.formatConfigurationError())

--- a/libs/nest/config/src/lib/InvalidConfiguration.ts
+++ b/libs/nest/config/src/lib/InvalidConfiguration.ts
@@ -25,11 +25,11 @@ export class InvalidConfiguration {
   constructor(errorMessage: string) {
     return new Proxy(this, {
       get(target, prop) {
-        console.log(`Getting ${String(prop)}`, target)
         if (
           prop in target ||
           InvalidConfiguration.allowedMembers.includes(String(prop))
         ) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           return (target as any)[prop]
         }
         throw new ConfigurationError(errorMessage)

--- a/libs/nest/config/src/lib/InvalidConfiguration.ts
+++ b/libs/nest/config/src/lib/InvalidConfiguration.ts
@@ -25,6 +25,7 @@ export class InvalidConfiguration {
   constructor(errorMessage: string) {
     return new Proxy(this, {
       get(target, prop) {
+        console.log(`Getting ${String(prop)}`, target)
         if (
           prop in target ||
           InvalidConfiguration.allowedMembers.includes(String(prop))

--- a/libs/nest/config/src/lib/defineConfig.ts
+++ b/libs/nest/config/src/lib/defineConfig.ts
@@ -1,4 +1,4 @@
-import { registerAs } from '@nestjs/config'
+import { ConfigModule, registerAs } from '@nestjs/config'
 import { ConfigDefinition, ConfigFactory } from './types'
 import { ConfigurationLoader } from './ConfigurationLoader'
 
@@ -6,7 +6,26 @@ export const defineConfig = <T extends Record<string, any>>(
   definition: ConfigDefinition<T>,
 ): ConfigFactory<T> => {
   const loader = new ConfigurationLoader<T>(definition)
-  return registerAs(definition.name, () => {
+  const factory = registerAs(definition.name, () => {
     return loader.load()
-  })
+  }) as ConfigFactory<T>
+
+  factory.optional = () => {
+    const cloneDefinition = Object.assign(
+      {},
+      {
+        ...definition,
+        optional: true,
+      },
+    )
+
+    const cloneLoader = new ConfigurationLoader<T>(cloneDefinition)
+    return registerAs(cloneDefinition.name, () =>
+      cloneLoader.load(),
+    ) as ConfigFactory<T>
+  }
+
+  factory.registerOptional = () => ConfigModule.forFeature(factory.optional())
+
+  return factory
 }

--- a/libs/nest/config/src/lib/defineConfig.ts
+++ b/libs/nest/config/src/lib/defineConfig.ts
@@ -3,6 +3,7 @@ import { ConfigModule, registerAs } from '@nestjs/config'
 import { ConfigurationLoader } from './ConfigurationLoader'
 import { ConfigDefinition, ConfigFactory } from './types'
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const defineConfig = <T extends Record<string, any>>(
   definition: ConfigDefinition<T>,
 ): ConfigFactory<T> => {

--- a/libs/nest/config/src/lib/defineConfig.ts
+++ b/libs/nest/config/src/lib/defineConfig.ts
@@ -1,6 +1,7 @@
 import { ConfigModule, registerAs } from '@nestjs/config'
-import { ConfigDefinition, ConfigFactory } from './types'
+
 import { ConfigurationLoader } from './ConfigurationLoader'
+import { ConfigDefinition, ConfigFactory } from './types'
 
 export const defineConfig = <T extends Record<string, any>>(
   definition: ConfigDefinition<T>,

--- a/libs/nest/config/src/lib/e2e/config.module.spec.ts
+++ b/libs/nest/config/src/lib/e2e/config.module.spec.ts
@@ -7,6 +7,7 @@ import {
 import { logger } from '@island.is/logging'
 
 import { defineConfig, ConfigModule, ConfigType, ConfigFactory } from '../..'
+import { Module } from '@nestjs/common'
 
 async function testInjection<T extends ConfigFactory>(config: T) {
   const moduleRef = await Test.createTestingModule({
@@ -261,6 +262,77 @@ describe('Config definitions', () => {
       )
     })
 
+    it('should work if globally optional', () => {
+      // Arrange
+      const config = defineConfig({
+        name: 'test',
+        optional: true,
+        load: () => ({
+          test: 'value',
+        }),
+      })
+
+      // Act
+      const result = testInjection(config)
+
+      // Assert
+      return expect(result).resolves.toEqual({
+        isConfigured: true,
+        test: 'value',
+      })
+    })
+
+    it('should work if registered optional', async () => {
+      // Arrange
+      const config = defineConfig({
+        name: 'test',
+        load: () => ({
+          test: 'value',
+        }),
+      })
+
+      // Act
+      const moduleRef = await Test.createTestingModule({
+        imports: [
+          ConfigModule.forRoot({ isGlobal: true, load: [] }),
+          config.registerOptional(),
+        ],
+      }).compile()
+
+      // Assert
+      expect(moduleRef.get<ConfigType<typeof config>>(config.KEY)).toEqual({
+        isConfigured: true,
+        test: 'value',
+      })
+    })
+
+    it('should throw an error if optional config is used not fully provided', async () => {
+      // Arrange
+      const config = defineConfig({
+        name: 'test',
+        load: (env) => ({
+          test: env.required('CONFIG_TEST'),
+        }),
+      })
+
+      // Act
+      const moduleRef = await Test.createTestingModule({
+        imports: [
+          ConfigModule.forRoot({ isGlobal: true, load: [config.optional()] }),
+        ],
+      }).compile()
+
+      // Assert
+      expect(() => {
+        const conf = moduleRef.get<ConfigType<typeof config>>(config.KEY)
+
+        // Accessing the property cause the error to be thrown
+        conf.test
+      }).toThrow(
+        'Failed loading configuration for test:\n- CONFIG_TEST missing',
+      )
+    })
+
     it('should throw a friendly error if validation fails', async () => {
       // Arrange
       process.env.CONFIG_TEST1 = 'asdf'
@@ -452,6 +524,67 @@ describe('Config definitions', () => {
 
         // Assert
         return expect(result).rejects.toThrow(
+          'Failed loading configuration for test:\n- CONFIG_TEST missing',
+        )
+      })
+
+      it('should throw an error when required in root and optional in nested module and not provided', async () => {
+        // Arrange
+        const config = defineConfig({
+          name: 'test',
+          load: (env) => ({
+            test: env.required('CONFIG_TEST'),
+          }),
+        })
+
+        @Module({
+          imports: [config.registerOptional()],
+        })
+        class NestedModule {}
+
+        // Act
+        const act = () =>
+          Test.createTestingModule({
+            imports: [
+              ConfigModule.forRoot({ isGlobal: true, load: [config] }),
+              NestedModule,
+            ],
+          }).compile()
+
+        // Assert
+        return expect(act).rejects.toThrow(
+          'Failed loading configuration for test:\n- CONFIG_TEST missing',
+        )
+      })
+
+      it('should throw an error when optional in root and required in nested module and not provided', async () => {
+        // Arrange
+        const config = defineConfig({
+          name: 'test',
+          load: (env) => ({
+            test: env.required('CONFIG_TEST'),
+          }),
+        })
+
+        @Module({
+          imports: [ConfigModule.forFeature(config)],
+        })
+        class NestedModule {}
+
+        // Act
+        const act = () =>
+          Test.createTestingModule({
+            imports: [
+              ConfigModule.forRoot({
+                isGlobal: true,
+                load: [config.optional()],
+              }),
+              NestedModule,
+            ],
+          }).compile()
+
+        // Assert
+        return expect(act).rejects.toThrow(
           'Failed loading configuration for test:\n- CONFIG_TEST missing',
         )
       })

--- a/libs/nest/config/src/lib/e2e/config.module.spec.ts
+++ b/libs/nest/config/src/lib/e2e/config.module.spec.ts
@@ -1,13 +1,14 @@
+import { Module } from '@nestjs/common'
 import { Test } from '@nestjs/testing'
 import * as z from 'zod'
+
 import {
   ServerSideFeatureClient,
   ServerSideFeatureNames,
 } from '@island.is/feature-flags'
 import { logger } from '@island.is/logging'
 
-import { defineConfig, ConfigModule, ConfigType, ConfigFactory } from '../..'
-import { Module } from '@nestjs/common'
+import { ConfigFactory, ConfigModule, ConfigType, defineConfig } from '../..'
 
 async function testInjection<T extends ConfigFactory>(config: T) {
   const moduleRef = await Test.createTestingModule({

--- a/libs/nest/config/src/lib/types.ts
+++ b/libs/nest/config/src/lib/types.ts
@@ -1,27 +1,36 @@
 import { ZodType } from 'zod'
 import { ServerSideFeatureNames } from '@island.is/feature-flags'
+import { DynamicModule } from '@nestjs/common'
 
 export interface EnvLoader {
   required(envVariable: string, devFallback?: string): string
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   requiredJSON<T = any>(envVariable: string, devFallback?: T): T
 
   optional(envVariable: string, devFallback?: string): string | undefined
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   optionalJSON<T = any>(envVariable: string, devFallback?: T): T | undefined
 }
 
 export type Configuration<T> = T & { isConfigured: boolean }
 
 export type ConfigFactory<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   T extends Record<string, any> = Record<string, any>
-> = (() => Configuration<T>) & { KEY: string }
+> = (() => Configuration<T>) & {
+  KEY: string
+  optional: () => ConfigFactory<T>
+  registerOptional: () => DynamicModule
+}
 
 export type ConfigType<T extends ConfigFactory> = ReturnType<T>
 
 export interface ConfigDefinition<T> {
   name: string
   schema?: ZodType<T>
+  optional?: boolean
   serverSideFeature?: ServerSideFeatureNames
   load: (env: EnvLoader) => T
 }

--- a/libs/nest/config/src/lib/types.ts
+++ b/libs/nest/config/src/lib/types.ts
@@ -1,6 +1,7 @@
-import { ZodType } from 'zod'
-import { ServerSideFeatureNames } from '@island.is/feature-flags'
 import { DynamicModule } from '@nestjs/common'
+import { ZodType } from 'zod'
+
+import { ServerSideFeatureNames } from '@island.is/feature-flags'
 
 export interface EnvLoader {
   required(envVariable: string, devFallback?: string): string


### PR DESCRIPTION
# Add support for optional configs

## What

This adds support for optional configs. So module can register config type to be optional, and handle it using the `isConfigured` property.

## Why

This was inspired when I was going to add token exchange for the `NationalRegistryClientModule` but other apps like Air Discount Scheme so changing the `NationalRegistryClientModule`  to require client credentials in config would have broken ADS. 

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
