### PR TITLE
fix(judicial-system): Only create resentExplanation if the case is received

### DIFF
--- a/apps/judicial-system/web/src/routes/Prosecutor/InvestigationRequest/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/InvestigationRequest/Overview/Overview.tsx
@@ -76,14 +76,17 @@ export const Overview: React.FC = () => {
       setModalText(formatMessage(m.sections.modal.notificationNotSent))
     }
 
-    updateCase(workingCase.id, {
-      caseResentExplanation: createCaseResentExplanation(
-        workingCase,
-        caseResentExplanation,
-      ),
-    })
+    if (workingCase.state === CaseState.RECEIVED) {
+      updateCase(workingCase.id, {
+        caseResentExplanation: createCaseResentExplanation(
+          workingCase,
+          caseResentExplanation,
+        ),
+      })
 
-    setResendCaseModalVisible(false)
+      setResendCaseModalVisible(false)
+    }
+
     setModalVisible(true)
   }
 

--- a/apps/judicial-system/web/src/routes/Prosecutor/RestrictionRequest/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/RestrictionRequest/Overview/Overview.tsx
@@ -93,14 +93,17 @@ export const Overview: React.FC = () => {
       setModalText(formatMessage(rcOverview.sections.modal.notificationNotSent))
     }
 
-    updateCase(workingCase.id, {
-      caseResentExplanation: createCaseResentExplanation(
-        workingCase,
-        caseResentExplanation,
-      ),
-    })
+    if (workingCase.state === CaseState.RECEIVED) {
+      updateCase(workingCase.id, {
+        caseResentExplanation: createCaseResentExplanation(
+          workingCase,
+          caseResentExplanation,
+        ),
+      })
 
-    setResendCaseModalVisible(false)
+      setResendCaseModalVisible(false)
+    }
+
     setModalVisible(true)
   }
 


### PR DESCRIPTION
# Only create resentExplanation if the case is received

https://app.asana.com/0/1199153462262248/1201337986358791/f

## What

Only create resentExplanation if the case is received

## Why

You can only write a resent explanation if the case is received but we were creating one either way.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
