### PR TITLE
feat(web): Contact link for the organization contact banner on the service web

### DIFF
--- a/apps/web/screens/ServiceWeb/SubPage/SubPage.tsx
+++ b/apps/web/screens/ServiceWeb/SubPage/SubPage.tsx
@@ -245,12 +245,12 @@ const SubPage: Screen<SubPageProps> = ({
                               <GridColumn>
                                 {(question.relatedLinks ?? []).map(
                                   ({ text, url }, index) => (
-                                    <GridRow marginTop={2}>
+                                    <GridRow marginTop={2} key={index}>
                                       <Link
                                         underline="small"
                                         underlineVisibility="hover"
                                         href={url}
-                                        key={index}
+                                       
                                       >
                                         {text}
                                       </Link>
@@ -260,7 +260,7 @@ const SubPage: Screen<SubPageProps> = ({
                               </GridColumn>
                             </Box>
                           )}
-                          {institutionSlugBelongsToMannaudstorg && (
+                          {question.contactLink && (
                             <Box
                               marginTop={
                                 question.relatedLinks?.length > 0 ? 0 : 4
@@ -268,7 +268,7 @@ const SubPage: Screen<SubPageProps> = ({
                             >
                               <OrganizationContactBanner
                                 organizationLogoUrl={organization.logo?.url}
-                                contactLink="https://gatt.fjs.is/plugins/servlet/desk/portal/11/create/127"
+                                contactLink={question.contactLink}
                                 headerText={o(
                                   'serviceWebOrganizationContactBannerHeaderTitle',
                                   'Finnurðu ekki það sem þig vantar?',

--- a/apps/web/screens/ServiceWeb/SubPage/SubPage.tsx
+++ b/apps/web/screens/ServiceWeb/SubPage/SubPage.tsx
@@ -250,7 +250,6 @@ const SubPage: Screen<SubPageProps> = ({
                                         underline="small"
                                         underlineVisibility="hover"
                                         href={url}
-                                       
                                       >
                                         {text}
                                       </Link>

--- a/apps/web/screens/queries/ServiceWeb.ts
+++ b/apps/web/screens/queries/ServiceWeb.ts
@@ -55,6 +55,7 @@ export const GET_SUPPORT_QNAS_IN_CATEGORY = gql`
         url
         text
       }
+      contactLink
     }
   }
   ${slices}

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -2778,6 +2778,9 @@ export interface ISupportQnaFields {
 
   /** Related links */
   relatedLinks?: (ILink | ISupportQna)[] | undefined
+
+  /** Contact Link */
+  contactLink?: string | undefined
 }
 
 /** Helpdesk support questions and answer */

--- a/libs/cms/src/lib/models/supportQNA.model.ts
+++ b/libs/cms/src/lib/models/supportQNA.model.ts
@@ -39,6 +39,9 @@ export class SupportQNA {
 
   @Field(() => [Link])
   relatedLinks?: Link[]
+
+  @Field()
+  contactLink?: string
 }
 
 export const mapSupportQNA = ({ fields, sys }: ISupportQna): SupportQNA => ({
@@ -63,6 +66,7 @@ export const mapSupportQNA = ({ fields, sys }: ISupportQna): SupportQNA => ({
         return mapLink(convertSupportQnAToLink(supportQnA))
       })
     : [],
+  contactLink: fields.contactLink ?? ''
 })
 
 const convertSupportQnAToLink = (supportQnA: ISupportQna) => {

--- a/libs/cms/src/lib/models/supportQNA.model.ts
+++ b/libs/cms/src/lib/models/supportQNA.model.ts
@@ -66,7 +66,7 @@ export const mapSupportQNA = ({ fields, sys }: ISupportQna): SupportQNA => ({
         return mapLink(convertSupportQnAToLink(supportQnA))
       })
     : [],
-  contactLink: fields.contactLink ?? ''
+  contactLink: fields.contactLink ?? '',
 })
 
 const convertSupportQnAToLink = (supportQnA: ISupportQna) => {


### PR DESCRIPTION
# Contact link for the organization contact banner on the service web

## What

* Added a Contact link for the organization contact banner on the service web

## Why

* Previously it was hardcoded in

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
