### PR TITLE
feat(web): Asset link https prefix

### DIFF
--- a/libs/island-ui/contentful/src/lib/AssetLink/AssetLink.tsx
+++ b/libs/island-ui/contentful/src/lib/AssetLink/AssetLink.tsx
@@ -10,7 +10,7 @@ export const AssetLink: FC<AssetLinkProps> = ({ title, url, children }) => {
   const parts = url.split('.')
   const extension = parts[parts.length - 1].toUpperCase()
 
-  const secureUrl = `${url.startsWith('//')  ? 'https:' : ''}${url}`
+  const secureUrl = `${url.startsWith('//') ? 'https:' : ''}${url}`
 
   return (
     <FocusableBox href={secureUrl} border="standard" borderRadius="large">

--- a/libs/island-ui/contentful/src/lib/AssetLink/AssetLink.tsx
+++ b/libs/island-ui/contentful/src/lib/AssetLink/AssetLink.tsx
@@ -10,8 +10,10 @@ export const AssetLink: FC<AssetLinkProps> = ({ title, url, children }) => {
   const parts = url.split('.')
   const extension = parts[parts.length - 1].toUpperCase()
 
+  const secureUrl = `${url.startsWith('//')  ? 'https:' : ''}${url}`
+
   return (
-    <FocusableBox href={url} border="standard" borderRadius="large">
+    <FocusableBox href={secureUrl} border="standard" borderRadius="large">
       <LinkCard background="white" tag={extension}>
         {title || children}
       </LinkCard>


### PR DESCRIPTION
# Asset link https prefix

## What

* Added a https prefix to asset links

## Why

* We can't link to a .docx file since the browser blocks unsecure connections
* It was weird for people to open a pdf file which would open up as an http link

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
