### PR TITLE
fix(judicial-system): demands prefill parameter fix

### DIFF
--- a/apps/judicial-system/web/messages/InvestigationCases/Prosecutor/demandsForm.ts
+++ b/apps/judicial-system/web/messages/InvestigationCases/Prosecutor/demandsForm.ts
@@ -69,7 +69,7 @@ export const icDemands = {
           id:
             'judicial.system.investigation_cases:police_demands.demands.prefill.phone_tapping2',
           defaultMessage:
-            'Þess er krafist að {court} úrskurði að {insitution} sé heimilt að hlusta og hljóðrita símtöl úr og í símanúmerin [###-####] auk annara símanúmera sem {accused}, hefur í notkun og umráð yfir, frá og með [DD.MM.ÁÁ] til og með [DD.MM.ÁÁ], og jafnframt sé heimilt að nema sms sendingar, þar með taldar sms sendingar á lesanlegu formi, sem sendar eru eða mótteknar með símanúmerunum á sama tíma og hlusta og hljóðrita samtöl við talhólf greindra númera og símtækja á sama tíma.',
+            'Þess er krafist að {court} úrskurði að {institution} sé heimilt að hlusta og hljóðrita símtöl úr og í símanúmerin [###-####] auk annara símanúmera sem {accused}, hefur í notkun og umráð yfir, frá og með [DD.MM.ÁÁ] til og með [DD.MM.ÁÁ], og jafnframt sé heimilt að nema sms sendingar, þar með taldar sms sendingar á lesanlegu formi, sem sendar eru eða mótteknar með símanúmerunum á sama tíma og hlusta og hljóðrita samtöl við talhólf greindra númera og símtækja á sama tíma.',
           description: 'Sjálfgefinn dómkröfutexti fyrir símhlerun',
         },
         teleCommunications: {

--- a/apps/judicial-system/web/src/routes/Prosecutor/InvestigationRequest/PoliceDemands/PoliceDemandsForm.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/InvestigationRequest/PoliceDemands/PoliceDemandsForm.tsx
@@ -67,7 +67,13 @@ const courtClaimPrefill: Partial<
   [CaseType.ELECTRONIC_DATA_DISCOVERY_INVESTIGATION]: {
     text:
       icDemands.sections.demands.prefill.electronicDataDiscoveryInvestigation,
-    format: { court: true, institution: true, address: true, year: true },
+    format: {
+      court: true,
+      institution: true,
+      accused: true,
+      address: true,
+      year: true,
+    },
   },
 }
 
@@ -146,7 +152,7 @@ const PoliceDemandsForm: React.FC<Props> = (props) => {
                 live: workingCase.defendants.length,
               }),
               ...(courtClaim.format?.year && {
-                institution: new Date().getFullYear(),
+                year: new Date().getFullYear(),
               }),
             })
           : ''


### PR DESCRIPTION
[Asana task](https://app.asana.com/0/1199153462262248/1201855983978493/f)

## What

fix paramenters provided to the demandsForm strings

## Why

- If some parameter is missing when calling `formatMessage` it will default to not swithing out any of the paramenters, bit weird. 

## Screenshots / Gifs

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
