### PR TITLE
feat(web): Service web related links visual update

### DIFF
--- a/apps/web/screens/ServiceWeb/SubPage/SubPage.tsx
+++ b/apps/web/screens/ServiceWeb/SubPage/SubPage.tsx
@@ -237,27 +237,27 @@ const SubPage: Screen<SubPageProps> = ({
                               marginTop={6}
                               marginBottom={2}
                             >
-                              <Text fontWeight="semiBold">
-                                {o(
-                                  'serviceWebRelatedMaterialHeaderTitle',
-                                  'Tengt efni',
-                                )}
-                              </Text>
-                              <GridColumn>
+                              <Stack space={[1, 1, 2]}>
+                                <Text variant="eyebrow" as="h3">
+                                  {o(
+                                    'serviceWebRelatedMaterialHeaderTitle',
+                                    'Tengt efni',
+                                  )}
+                                </Text>
                                 {(question.relatedLinks ?? []).map(
                                   ({ text, url }, index) => (
-                                    <GridRow marginTop={2} key={index}>
-                                      <Link
-                                        underline="small"
-                                        underlineVisibility="hover"
-                                        href={url}
-                                      >
+                                    <Link
+                                      key={index}
+                                      href={url}
+                                      underline="normal"
+                                    >
+                                      <Text key={url} as="span">
                                         {text}
-                                      </Link>
-                                    </GridRow>
+                                      </Text>
+                                    </Link>
                                   ),
                                 )}
-                              </GridColumn>
+                              </Stack>
                             </Box>
                           )}
                           {question.contactLink && (


### PR DESCRIPTION
# Service web related links visual update

## What

* Changed how the related links on the service web look

## Why

* For consistency

## Screenshots / Gifs
Previous look
![Screenshot 2022-03-21 at 21 41 52](https://user-images.githubusercontent.com/43557895/159368462-7acb6b29-17be-4ca6-9eec-86ee8110f07c.png)

Current look
![Screenshot 2022-03-21 at 21 43 05](https://user-images.githubusercontent.com/43557895/159368563-0d8be8b5-07c2-4372-b7f5-cdc9f132ac1f.png)

The new look is more similar to the sidebar on Articles
![Screenshot 2022-03-21 at 21 44 53](https://user-images.githubusercontent.com/43557895/159368777-a5db4597-05c4-4a98-aec8-cf01a2ab7324.png)



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
