### PR TITLE
fix(auth-public-api): Fix validTo to allow null in swagger.

### DIFF
--- a/libs/auth-api-lib/src/lib/entities/dto/delegation-scope.dto.ts
+++ b/libs/auth-api-lib/src/lib/entities/dto/delegation-scope.dto.ts
@@ -51,7 +51,8 @@ export class DelegationScopeDTO {
   @ApiProperty()
   validFrom!: Date
 
+  @IsOptional()
   @IsDateString()
-  @ApiProperty()
-  validTo!: Date
+  @ApiPropertyOptional({ nullable: true })
+  validTo?: Date | null
 }

--- a/libs/auth-api-lib/src/lib/entities/dto/delegation.dto.ts
+++ b/libs/auth-api-lib/src/lib/entities/dto/delegation.dto.ts
@@ -49,7 +49,7 @@ export class DelegationDTO {
 
   @IsOptional()
   @IsDateString()
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({ nullable: true })
   validTo?: Date | null
 
   @ApiProperty({ enum: DelegationType, enumName: 'DelegationType' })


### PR DESCRIPTION
## What

Fixing a validTo regression as I removed nullable: true from swagger decorator.

## Why

This cause the GQL api to use default date value as 01-01-1970.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
