### PR TITLE
fix(driving-license-application): Driving instructor name from answers for B-temp

### DIFF
--- a/libs/application/templates/driving-license/src/dataProviders/TeachersProvider.ts
+++ b/libs/application/templates/driving-license/src/dataProviders/TeachersProvider.ts
@@ -14,6 +14,7 @@ export class TeachersProvider extends BasicDataProvider {
       query DrivingLicenseTeachers {
         drivingLicenseTeachers {
           name
+          nationalId
         }
       }
     `

--- a/libs/application/templates/driving-license/src/forms/draft/subSectionSummary.ts
+++ b/libs/application/templates/driving-license/src/forms/draft/subSectionSummary.ts
@@ -8,8 +8,9 @@ import {
   DefaultEvents,
   StaticText,
   buildSubSection,
+  getValueViaPath,
 } from '@island.is/application/core'
-import { NationalRegistryUser, UserProfile } from '../../types/schema'
+import { NationalRegistryUser, Teacher, UserProfile } from '../../types/schema'
 import { m } from '../../lib/messages'
 import { format as formatKennitala } from 'kennitala'
 import { StudentAssessment } from '@island.is/api/schema'
@@ -97,8 +98,22 @@ export const subSectionSummary = buildSubSection({
         buildKeyValueField({
           label: m.overviewTeacher,
           width: 'half',
-          value: ({ externalData: { studentAssessment } }) =>
-            (studentAssessment.data as StudentAssessment).teacherName,
+          value: ({
+            externalData: {
+              studentAssessment,
+              teachers: { data },
+            },
+            answers,
+          }) => {
+            if (answers.applicationFor === B_TEMP) {
+              const teacher = (data as Teacher[]).find(
+                ({ nationalId }) =>
+                  getValueViaPath(answers, 'drivingInstructor') === nationalId,
+              )
+              return teacher?.name
+            }
+            return (studentAssessment.data as StudentAssessment).teacherName
+          },
         }),
         buildDividerField({
           condition: (answers) => hasYes(answers?.healthDeclaration || []),

--- a/libs/application/templates/driving-license/src/forms/draft/subSectionTempInfo.ts
+++ b/libs/application/templates/driving-license/src/forms/draft/subSectionTempInfo.ts
@@ -94,8 +94,8 @@ export const subSectionTempInfo = buildSubSection({
               teachers: { data },
             },
           }) => {
-            return (data as Teacher[]).map(({ name }) => ({
-              value: name,
+            return (data as Teacher[]).map(({ name, nationalId }) => ({
+              value: nationalId,
               label: name,
             }))
           },


### PR DESCRIPTION
B-temp applications have do not require driving assessment so instructor name needed to be the name from the drivingInstructor answers 
The driving instructor was also being saved as name and submitted instead of as the national id of the instructor.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
