### PR TITLE
fix(fa): Adding service to decouple the dependency on api-domains for National Registry

### DIFF
--- a/apps/financial-aid/api/src/app/modules/municipalityNationalRegistryModule/municipalityNationalRegistry.resolver.ts
+++ b/apps/financial-aid/api/src/app/modules/municipalityNationalRegistryModule/municipalityNationalRegistry.resolver.ts
@@ -9,9 +9,9 @@ import {
   ScopesGuard,
 } from '@island.is/auth-nest-tools'
 import { Audit } from '@island.is/nest/audit'
-import { NationalRegistryXRoadService } from '@island.is/api/domains/national-registry-x-road'
 import { Person } from './models/person.model'
 import { UserSpouse } from './models/userSpouse.model'
+import { MunicipalityNationalRegistryService } from './municipalityNationalRegistry.service'
 
 @UseGuards(IdsAuthGuard, IdsUserGuard, ScopesGuard)
 @Scopes('@samband.is/internal')
@@ -19,7 +19,7 @@ import { UserSpouse } from './models/userSpouse.model'
 @Audit({ namespace: '@island.is/api/national-registry-x-road' })
 export class MunicipalityNationalRegistryResolver {
   constructor(
-    private nationalRegistryXRoadService: NationalRegistryXRoadService,
+    private municipalityNationalRegistryService: MunicipalityNationalRegistryService,
   ) {}
 
   @Query(() => Person, {
@@ -30,7 +30,7 @@ export class MunicipalityNationalRegistryResolver {
   async nationalRegistryPersons(
     @CurrentUser() user: User,
   ): Promise<Person | undefined> {
-    return this.nationalRegistryXRoadService.getNationalRegistryPerson(
+    return this.municipalityNationalRegistryService.getNationalRegistryPerson(
       user,
       user.nationalId,
     )
@@ -42,7 +42,7 @@ export class MunicipalityNationalRegistryResolver {
     @Context('req') { user }: { user: User },
     @Parent() person: Person,
   ): Promise<UserSpouse | undefined> {
-    return await this.nationalRegistryXRoadService
+    return await this.municipalityNationalRegistryService
       .getSpouse(user, person.nationalId)
       .then((res) => {
         return res

--- a/apps/financial-aid/api/src/app/modules/municipalityNationalRegistryModule/municipalityNationalRegistry.service.ts
+++ b/apps/financial-aid/api/src/app/modules/municipalityNationalRegistryModule/municipalityNationalRegistry.service.ts
@@ -1,0 +1,78 @@
+import { Inject, Injectable } from '@nestjs/common'
+
+import { Auth, AuthMiddleware, User } from '@island.is/auth-nest-tools'
+import { FetchError } from '@island.is/clients/middlewares'
+import { EinstaklingarApi } from '@island.is/clients/national-registry-v2'
+import { LOGGER_PROVIDER } from '@island.is/logging'
+import type { Logger } from '@island.is/logging'
+import { NationalRegistryClientPerson } from '@island.is/shared/types'
+
+import { Person } from './models/person.model'
+import { UserSpouse } from './models/userSpouse.model'
+
+@Injectable()
+export class MunicipalityNationalRegistryService {
+  constructor(
+    private nationalRegistryApi: EinstaklingarApi,
+    @Inject(LOGGER_PROVIDER)
+    private logger: Logger,
+  ) {}
+
+  nationalRegistryApiWithAuth(auth: Auth) {
+    return this.nationalRegistryApi.withMiddleware(new AuthMiddleware(auth))
+  }
+
+  private handle404(error: FetchError) {
+    if (error.status === 404) {
+      return undefined
+    }
+    throw error
+  }
+
+  async getNationalRegistryPerson(
+    user: User,
+    nationalId: string,
+  ): Promise<Person | undefined> {
+    const response = await this.nationalRegistryApiWithAuth(user)
+      .einstaklingarGetEinstaklingurRaw({ id: nationalId })
+      .catch(this.handle404)
+
+    // 2022-03-08: For some reason, the API now returns "204 No Content" when nationalId doesn't exist.
+    // Should remove this after they've fixed their API to return "404 Not Found".
+    const person: NationalRegistryClientPerson | undefined =
+      response === undefined || response.raw.status === 204
+        ? undefined
+        : await response.value()
+
+    return (
+      person && {
+        nationalId: person.kennitala,
+        fullName: person.nafn,
+        address: person.logheimili && {
+          streetName: person.logheimili.heiti,
+          postalCode: person.logheimili.postnumer,
+          city: person.logheimili.stadur,
+          municipalityCode: person.logheimili.sveitarfelagsnumer,
+        },
+        genderCode: person.kynkodi,
+      }
+    )
+  }
+
+  async getSpouse(
+    user: User,
+    nationalId: string,
+  ): Promise<UserSpouse | undefined> {
+    const spouse = await this.nationalRegistryApiWithAuth(user)
+      .einstaklingarGetHjuskapur({ id: nationalId })
+      .catch(this.handle404)
+
+    return (
+      spouse && {
+        nationalId: spouse.kennitalaMaka,
+        name: spouse.nafnMaka,
+        maritalStatus: spouse.hjuskaparkodi,
+      }
+    )
+  }
+}

--- a/apps/financial-aid/api/src/app/modules/municipalityNationalRegistryModule/municipalityNationalRegistryModule.module.ts
+++ b/apps/financial-aid/api/src/app/modules/municipalityNationalRegistryModule/municipalityNationalRegistryModule.module.ts
@@ -1,10 +1,15 @@
 import { Module } from '@nestjs/common'
 
+import { NationalRegistryClientModule } from '@island.is/clients/national-registry-v2'
+
 import { MunicipalityNationalRegistryResolver } from './municipalityNationalRegistry.resolver'
-import { NationalRegistryXRoadModule } from '@island.is/api/domains/national-registry-x-road'
+import { MunicipalityNationalRegistryService } from './municipalityNationalRegistry.service'
 
 @Module({
-  imports: [NationalRegistryXRoadModule],
-  providers: [MunicipalityNationalRegistryResolver],
+  imports: [NationalRegistryClientModule],
+  providers: [
+    MunicipalityNationalRegistryResolver,
+    MunicipalityNationalRegistryService,
+  ],
 })
 export class MunicipalityNationalRegistryModule {}


### PR DESCRIPTION
## What

Adding service class that uses the `NationalRegistryClientModule` in financial-aid instead of using the `api/domains/nationalRegistryXroadModule`. 

## Why

After the `api/domains/nationalRegistryXroadModule` was refactored to use token exchange or client credentials to communicate with Þjóðskrá, it broke the Financial Aid GraphQL communications with Þjóðskrá.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
