### PR TITLE
feat(web): Project page default header image and text background

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Check node version
         run: |
           node -v
+          yarn --version
           ls -l `which node`
 
       - name: Checking out relevant branches
@@ -76,6 +77,7 @@ jobs:
           export GENERATED_FILES_KEY=${{ runner.os }}-$HASH-files-generated
           echo "GENERATED_FILES_KEY: $GENERATED_FILES_KEY"
           echo "::set-output name=generated-files-cache-key::$GENERATED_FILES_KEY"
+          yarn --version
 
       - name: Cache for NodeJS dependencies - host OS
         id: node-modules
@@ -102,6 +104,7 @@ jobs:
           source ./scripts/ci/00_prepare-base-tags.sh
           git checkout $GITHUB_SHA
           echo "BASE=$BASE" >> $GITHUB_ENV
+          yarn --version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HTML_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -144,6 +144,7 @@ jobs:
         if: steps.generated-files-cache.outputs.cache-hit != 'true'
         run: |
           node --version
+          yarn --version
           tar zcvf generated_files.tar.gz $(./scripts/ci/get-files-touched-by.sh yarn schemas --skip-cache | xargs realpath --relative-to $(pwd))
 
       # - name: Security audit Node modules

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -31,6 +31,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
+      - name: Check yarn version
+        run: |
+          yarn --version
+          ls -l `which node`
+
       - uses: actions/setup-node@v2
         with:
           node-version: '14'

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -31,12 +31,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-
-      - name: Check yarn version
-        run: |
-          yarn --version
-          ls -l `which node`
-
       - uses: actions/setup-node@v2
         with:
           node-version: '14'

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -144,7 +144,6 @@ jobs:
         if: steps.generated-files-cache.outputs.cache-hit != 'true'
         run: |
           node --version
-          yarn --version
           tar zcvf generated_files.tar.gz $(./scripts/ci/get-files-touched-by.sh yarn schemas --skip-cache | xargs realpath --relative-to $(pwd))
 
       # - name: Security audit Node modules

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -38,7 +38,6 @@ jobs:
       - name: Check node version
         run: |
           node -v
-          yarn --version
           ls -l `which node`
 
       - name: Checking out relevant branches
@@ -77,7 +76,6 @@ jobs:
           export GENERATED_FILES_KEY=${{ runner.os }}-$HASH-files-generated
           echo "GENERATED_FILES_KEY: $GENERATED_FILES_KEY"
           echo "::set-output name=generated-files-cache-key::$GENERATED_FILES_KEY"
-          yarn --version
 
       - name: Cache for NodeJS dependencies - host OS
         id: node-modules
@@ -104,7 +102,6 @@ jobs:
           source ./scripts/ci/00_prepare-base-tags.sh
           git checkout $GITHUB_SHA
           echo "BASE=$BASE" >> $GITHUB_ENV
-          yarn --version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HTML_URL: ${{ github.event.pull_request.html_url }}

--- a/apps/web/components/Project/Header/DefaultProjectHeader.css.ts
+++ b/apps/web/components/Project/Header/DefaultProjectHeader.css.ts
@@ -1,10 +1,41 @@
+import { themeUtils } from '@island.is/island-ui/theme'
 import { style } from '@vanilla-extract/css'
 
 export const headerBg = style({
-  height: 530,
-  marginTop: -130,
-  paddingTop: 130,
   background: 'linear-gradient(94.09deg, #0044B3 0%, #4783E4 100%)',
+  height: '300px',
+  order: 1,
+  ...themeUtils.responsiveStyle({
+    md: {
+      order: 0,
+      height: '400px',
+    },
+  }),
 })
 
-export const headerWrapper = style({})
+export const headerWrapper = style({
+  display: 'grid',
+  gridTemplateRows: '1fr 1fr',
+  height: 'fit-content',
+  ...themeUtils.responsiveStyle({
+    md: {
+      display: 'grid',
+      height: 400,
+      gridTemplateColumns: '1fr 1fr',
+    },
+  }),
+})
+
+export const headerImage = style({
+  height: '100%',
+  objectFit: 'cover',
+  width: '100%',
+  order: 0,
+  ...themeUtils.responsiveStyle({
+    md: {
+      order: 1,
+      height: '400px',
+      objectFit: 'cover',
+    },
+  }),
+})

--- a/apps/web/components/Project/Header/DefaultProjectHeader.css.ts
+++ b/apps/web/components/Project/Header/DefaultProjectHeader.css.ts
@@ -2,7 +2,6 @@ import { themeUtils } from '@island.is/island-ui/theme'
 import { style } from '@vanilla-extract/css'
 
 export const headerBg = style({
-  background: 'linear-gradient(94.09deg, #0044B3 0%, #4783E4 100%)',
   height: '300px',
   order: 1,
   ...themeUtils.responsiveStyle({

--- a/apps/web/components/Project/Header/DefaultProjectHeader.css.ts
+++ b/apps/web/components/Project/Header/DefaultProjectHeader.css.ts
@@ -2,7 +2,8 @@ import { themeUtils } from '@island.is/island-ui/theme'
 import { style } from '@vanilla-extract/css'
 
 export const headerBg = style({
-  height: '300px',
+  height: 'fit-content',
+  minHeight: '300px',
   order: 1,
   ...themeUtils.responsiveStyle({
     md: {
@@ -14,12 +15,12 @@ export const headerBg = style({
 
 export const headerWrapper = style({
   display: 'grid',
-  gridTemplateRows: '1fr 1fr',
-  height: 'fit-content',
+  gridTemplateRows: '2fr 3fr',
+  height: '500px',
   ...themeUtils.responsiveStyle({
     md: {
       display: 'grid',
-      height: 400,
+      height: '400px',
       gridTemplateColumns: '1fr 1fr',
     },
   }),
@@ -27,6 +28,7 @@ export const headerWrapper = style({
 
 export const headerImage = style({
   height: '100%',
+  maxHeight: '200px',
   objectFit: 'cover',
   width: '100%',
   order: 0,
@@ -34,6 +36,7 @@ export const headerImage = style({
     md: {
       order: 1,
       height: '400px',
+      maxHeight: '100%',
       objectFit: 'cover',
     },
   }),

--- a/apps/web/components/Project/Header/DefaultProjectHeader.tsx
+++ b/apps/web/components/Project/Header/DefaultProjectHeader.tsx
@@ -20,8 +20,11 @@ export const DefaultProjectHeader = ({
 }: DefaultProjectHeaderProps) => {
   const { linkResolver } = useLinkResolver()
 
+  const defaultImageIsProvided =
+    projectPage.defaultHeaderImage && projectPage.defaultHeaderImage.url
+
   return (
-    <Box className={styles.headerWrapper}>
+    <Box className={defaultImageIsProvided ? styles.headerWrapper : undefined}>
       <Box className={styles.headerBg}>
         <GridContainer>
           <GridRow>
@@ -47,7 +50,7 @@ export const DefaultProjectHeader = ({
           </GridRow>
         </GridContainer>
       </Box>
-      {projectPage.defaultHeaderImage && projectPage.defaultHeaderImage.url && (
+      {defaultImageIsProvided && (
         <img
           className={styles.headerImage}
           src={projectPage.defaultHeaderImage.url}

--- a/apps/web/components/Project/Header/DefaultProjectHeader.tsx
+++ b/apps/web/components/Project/Header/DefaultProjectHeader.tsx
@@ -21,30 +21,39 @@ export const DefaultProjectHeader = ({
   const { linkResolver } = useLinkResolver()
 
   return (
-    <Box className={styles.headerBg}>
-      <GridContainer>
-        <GridRow>
-          <GridColumn
-            span={['12/12', '12/12', '10/12', '7/12', '6/12']}
-            offset={['0', '0', '1/12', '1/12', '1/12']}
-          >
-            <Text variant="eyebrow" color="white" marginTop={5}>
-              Ísland.is
-            </Text>
-            <Link href={linkResolver('projectpage', [projectPage.slug]).href}>
-              <Text variant="h1" color="white" marginTop={2}>
-                {projectPage.title}
+    <Box className={styles.headerWrapper}>
+      <Box className={styles.headerBg}>
+        <GridContainer>
+          <GridRow>
+            <GridColumn
+              span={['12/12', '12/12', '10/12', '7/12', '6/12']}
+              offset={['0', '0', '1/12', '1/12', '1/12']}
+            >
+              <Text variant="eyebrow" color="white" marginTop={5}>
+                Ísland.is
               </Text>
-            </Link>
-            <Text variant="intro" color="white" marginTop={3}>
-              {projectPage.subtitle}
-            </Text>
-            <Text color="white" marginTop={3}>
-              {projectPage.intro}
-            </Text>
-          </GridColumn>
-        </GridRow>
-      </GridContainer>
+              <Link href={linkResolver('projectpage', [projectPage.slug]).href}>
+                <Text variant="h1" color="white" marginTop={2}>
+                  {projectPage.title}
+                </Text>
+              </Link>
+              <Text variant="intro" color="white" marginTop={3}>
+                {projectPage.subtitle}
+              </Text>
+              <Text color="white" marginTop={3}>
+                {projectPage.intro}
+              </Text>
+            </GridColumn>
+          </GridRow>
+        </GridContainer>
+      </Box>
+      {projectPage.defaultHeaderImage && projectPage.defaultHeaderImage.url && (
+        <img
+          className={styles.headerImage}
+          src={projectPage.defaultHeaderImage.url}
+          alt="header"
+        ></img>
+      )}
     </Box>
   )
 }

--- a/apps/web/components/Project/Header/DefaultProjectHeader.tsx
+++ b/apps/web/components/Project/Header/DefaultProjectHeader.tsx
@@ -11,6 +11,12 @@ import * as styles from './DefaultProjectHeader.css'
 import { ProjectPage } from '@island.is/web/graphql/schema'
 import { useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
 
+const getTextBackgroundColor = (projectPage: ProjectPage) => {
+  if (projectPage.defaultHeaderBackgroundColor)
+    return projectPage.defaultHeaderBackgroundColor
+  return 'linear-gradient(94.09deg, #0044B3 0%, #4783E4 100%)'
+}
+
 interface DefaultProjectHeaderProps {
   projectPage: ProjectPage
 }
@@ -23,9 +29,14 @@ export const DefaultProjectHeader = ({
   const defaultImageIsProvided =
     projectPage.defaultHeaderImage && projectPage.defaultHeaderImage.url
 
+  const textBackgroundColor = getTextBackgroundColor(projectPage)
+
   return (
     <Box className={defaultImageIsProvided ? styles.headerWrapper : undefined}>
-      <Box className={styles.headerBg}>
+      <Box
+        className={styles.headerBg}
+        style={{ background: textBackgroundColor }}
+      >
         <GridContainer>
           <GridRow>
             <GridColumn

--- a/apps/web/components/Project/Header/DefaultProjectHeader.tsx
+++ b/apps/web/components/Project/Header/DefaultProjectHeader.tsx
@@ -7,9 +7,9 @@ import {
   GridColumn,
   Link,
 } from '@island.is/island-ui/core'
-import * as styles from './DefaultProjectHeader.css'
 import { ProjectPage } from '@island.is/web/graphql/schema'
 import { useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
+import * as styles from './DefaultProjectHeader.css'
 
 const getTextBackgroundColor = (projectPage: ProjectPage) => {
   if (projectPage.defaultHeaderBackgroundColor)

--- a/apps/web/screens/Project/Project.tsx
+++ b/apps/web/screens/Project/Project.tsx
@@ -246,8 +246,6 @@ const ProjectPage: Screen<PageProps> = ({
     }
   }, [renderSlicesAsTabs, subpage, router.asPath])
 
-  console.log(projectPage)
-
   return (
     <>
       <HeadWithSocialSharing

--- a/apps/web/screens/Project/Project.tsx
+++ b/apps/web/screens/Project/Project.tsx
@@ -49,7 +49,7 @@ import slugify from '@sindresorhus/slugify'
 import { getStepOptionsFromUIConfiguration } from '../../components/StepperFSM/StepperFSMUtils'
 import StepperFSM from '../../components/StepperFSM/StepperFSM'
 
-const lightThemes = ['traveling-to-iceland', 'election', 'ukraine']
+const lightThemes = ['traveling-to-iceland', 'election', 'ukraine', 'default']
 
 const getThemeConfig = (
   theme: string,
@@ -245,6 +245,8 @@ const ProjectPage: Screen<PageProps> = ({
       setSelectedSliceTab(slice)
     }
   }, [renderSlicesAsTabs, subpage, router.asPath])
+
+  console.log(projectPage)
 
   return (
     <>

--- a/apps/web/screens/queries/Project.tsx
+++ b/apps/web/screens/queries/Project.tsx
@@ -76,6 +76,7 @@ export const GET_PROJECT_PAGE_QUERY = gql`
         width
         height
       }
+      defaultHeaderBackgroundColor
     }
   }
   ${slices}

--- a/apps/web/screens/queries/Project.tsx
+++ b/apps/web/screens/queries/Project.tsx
@@ -70,6 +70,12 @@ export const GET_PROJECT_PAGE_QUERY = gql`
         width
         height
       }
+      defaultHeaderImage {
+        url
+        contentType
+        width
+        height
+      }
     }
   }
   ${slices}

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -2206,6 +2206,9 @@ export interface IProjectPageFields {
 
   /** Featured Image */
   featuredImage?: Asset | undefined
+
+  /** Default Header Image */
+  defaultHeaderImage?: Asset | undefined
 }
 
 export interface IProjectPage extends Entry<IProjectPageFields> {

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -2209,6 +2209,9 @@ export interface IProjectPageFields {
 
   /** Default Header Image */
   defaultHeaderImage?: Asset | undefined
+
+  /** Default Header Background Color */
+  defaultHeaderBackgroundColor?: string | undefined
 }
 
 export interface IProjectPage extends Entry<IProjectPageFields> {

--- a/libs/cms/src/lib/models/projectPage.model.ts
+++ b/libs/cms/src/lib/models/projectPage.model.ts
@@ -55,6 +55,9 @@ export class ProjectPage {
 
   @Field(() => Image, { nullable: true })
   featuredImage!: Image | null
+
+  @Field(() => Image, { nullable: true })
+  defaultHeaderImage!: Image | null
 }
 
 export const mapProjectPage = ({ sys, fields }: IProjectPage): ProjectPage => ({
@@ -74,4 +77,7 @@ export const mapProjectPage = ({ sys, fields }: IProjectPage): ProjectPage => ({
   newsTag: fields.newsTag ? mapGenericTag(fields.newsTag) : null,
   projectSubpages: (fields.projectSubpages ?? []).map(mapProjectSubpage),
   featuredImage: fields.featuredImage ? mapImage(fields.featuredImage) : null,
+  defaultHeaderImage: fields.defaultHeaderImage
+    ? mapImage(fields.defaultHeaderImage)
+    : null,
 })

--- a/libs/cms/src/lib/models/projectPage.model.ts
+++ b/libs/cms/src/lib/models/projectPage.model.ts
@@ -58,6 +58,9 @@ export class ProjectPage {
 
   @Field(() => Image, { nullable: true })
   defaultHeaderImage!: Image | null
+
+  @Field()
+  defaultHeaderBackgroundColor!: string
 }
 
 export const mapProjectPage = ({ sys, fields }: IProjectPage): ProjectPage => ({
@@ -80,4 +83,5 @@ export const mapProjectPage = ({ sys, fields }: IProjectPage): ProjectPage => ({
   defaultHeaderImage: fields.defaultHeaderImage
     ? mapImage(fields.defaultHeaderImage)
     : null,
+  defaultHeaderBackgroundColor: fields.defaultHeaderBackgroundColor ?? '',
 })


### PR DESCRIPTION
# Project page default header image and text background

## What

* Added 2 new fields to Project pages in Contentful (default header image and background color)
* Rendered these fields when the default theme is selected for a given Project Page 

## Why

* We want to be able to change how the default header looks in Contentful

## Screenshots / Gifs

New look:
<img width="1668" alt="image" src="https://user-images.githubusercontent.com/43557895/160299120-6bfc4342-a36a-4c32-b364-f124f38d3f7b.png">


New look (mobile):
<img width="347" alt="image" src="https://user-images.githubusercontent.com/43557895/160299156-4c340a95-3e38-4d30-833c-b1cd7195ad9e.png">


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
