### PR TITLE
feat(parental-leave): add button to print overview

### DIFF
--- a/libs/application/templates/parental-leave/src/fields/Review/Review.css.ts
+++ b/libs/application/templates/parental-leave/src/fields/Review/Review.css.ts
@@ -1,0 +1,27 @@
+import { style } from '@vanilla-extract/css'
+
+import { theme } from '@island.is/island-ui/theme'
+
+// currently its not possible to add custom button to the header
+// so I am using position absolute and some constants
+const SMALL_SCREEN_TOP = -108
+const XSMALL_SCREEN_TOP = -132
+const MEDIUM_SCREEN_TOP = -146
+
+export const printButton = style({
+  top: XSMALL_SCREEN_TOP,
+  right: 12,
+  '@media': {
+    // subtitle breaks into 2 lines
+    [`screen and (min-width: 500px)`]: {
+      top: SMALL_SCREEN_TOP,
+    },
+    [`screen and (min-width: ${theme.breakpoints.md}px)`]: {
+      top: MEDIUM_SCREEN_TOP,
+    },
+    // subtitle breaks into 2 lines
+    [`screen and (min-width: 932px)`]: {
+      top: -theme.spacing[15],
+    },
+  },
+})

--- a/libs/application/templates/parental-leave/src/fields/Review/Review.tsx
+++ b/libs/application/templates/parental-leave/src/fields/Review/Review.tsx
@@ -10,7 +10,13 @@ import {
   RecordObject,
   Field,
 } from '@island.is/application/core'
-import { Box, GridColumn, GridRow, Stack } from '@island.is/island-ui/core'
+import {
+  Box,
+  Button,
+  GridColumn,
+  GridRow,
+  Stack,
+} from '@island.is/island-ui/core'
 import {
   InputController,
   RadioController,
@@ -59,6 +65,8 @@ import { usePrivatePensionFund as usePrivatePensionFundOptions } from '../../hoo
 import { usePensionFund as usePensionFundOptions } from '../../hooks/usePensionFund'
 import { useStatefulAnswers } from '../../hooks/useStatefulAnswers'
 import { getSelectOptionLabel } from '../../lib/parentalLeaveClientUtils'
+
+import * as styles from './Review.css'
 
 type ValidOtherParentAnswer = typeof NO | typeof MANUAL | undefined
 
@@ -164,6 +172,16 @@ export const Review: FC<ReviewScreenProps> = ({
 
   return (
     <>
+      <Box className={styles.printButton} position="absolute">
+        <Button
+          variant="utility"
+          icon="print"
+          onClick={(e) => {
+            e.preventDefault()
+            window.print()
+          }}
+        />
+      </Box>
       <ReviewGroup
         isEditable={editable}
         canCloseEdit={groupHasNoErrors([


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Option to print parental leave form overview.

## Why

Specify why you need to achieve this

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/26793642/160384482-065d13d4-a0d6-4653-8708-3240b55a7d83.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
