### PR TITLE
refactor(api): Adding license:verify scope for verify endpoint.

### DIFF
--- a/apps/service-portal/src/auth.ts
+++ b/apps/service-portal/src/auth.ts
@@ -53,7 +53,7 @@ if (userMocked) {
       ApiScope.financeSalary,
       ApiScope.internal,
       ApiScope.meDetails,
-      ApiScope.licenses,
+      ApiScope.licensesVerify,
     ],
     post_logout_redirect_uri: `${window.location.origin}`,
     userStorePrefix: 'sp.',

--- a/libs/api/domains/license-service/src/lib/graphql/main.resolver.ts
+++ b/libs/api/domains/license-service/src/lib/graphql/main.resolver.ts
@@ -7,7 +7,7 @@ import {
   Field,
   Mutation,
 } from '@nestjs/graphql'
-import { UseGuards } from '@nestjs/common'
+import { Scope, UseGuards } from '@nestjs/common'
 import type { User } from '@island.is/auth-nest-tools'
 import {
   IdsUserGuard,
@@ -154,6 +154,7 @@ export class MainResolver {
     return { pkpassQRCode }
   }
 
+  @Scopes(ApiScope.internal, ApiScope.licensesVerify)
   @Mutation(() => GenericPkPassVerification)
   @Audit()
   async verifyPkPass(

--- a/libs/api/domains/license-service/src/lib/graphql/main.resolver.ts
+++ b/libs/api/domains/license-service/src/lib/graphql/main.resolver.ts
@@ -7,7 +7,7 @@ import {
   Field,
   Mutation,
 } from '@nestjs/graphql'
-import { Scope, UseGuards } from '@nestjs/common'
+import { UseGuards } from '@nestjs/common'
 import type { User } from '@island.is/auth-nest-tools'
 import {
   IdsUserGuard,

--- a/libs/auth/scopes/src/lib/api.scope.ts
+++ b/libs/auth/scopes/src/lib/api.scope.ts
@@ -6,4 +6,5 @@ export enum ApiScope {
   internal = '@island.is/internal',
   meDetails = '@island.is/me:details',
   licenses = '@island.is/licenses',
+  licensesVerify = '@island.is/licenses:verify',
 }


### PR DESCRIPTION
## What

Creating a `@island.is/licenses:verify` scope on the verify endpoint in the GQL api.

## Why

To grant external clients access to the licenses verify endpoint. The scanner apps needs this to verify driver licenses and we don't won't to grant the client the internal scope.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
