### PR TITLE
feat(service-portal): Set default filter of inbox to 3 months in future

### DIFF
--- a/libs/service-portal/documents/src/screens/Overview/Overview.tsx
+++ b/libs/service-portal/documents/src/screens/Overview/Overview.tsx
@@ -37,7 +37,7 @@ import isAfter from 'date-fns/isAfter'
 import isBefore from 'date-fns/isBefore'
 import isEqual from 'lodash/isEqual'
 import isWithinInterval from 'date-fns/isWithinInterval'
-import startOfTomorrow from 'date-fns/startOfTomorrow'
+import addMonths from 'date-fns/addMonths'
 import * as Sentry from '@sentry/react'
 import * as styles from './Overview.css'
 
@@ -67,7 +67,7 @@ const getFilteredDocuments = (
   const { dateFrom, dateTo, activeCategory, searchQuery } = filterValues
   let filteredDocuments = documents.filter((document) => {
     const minDate = dateFrom || new Date('1900-01-01')
-    const maxDate = dateTo || startOfTomorrow()
+    const maxDate = dateTo || addMonths(new Date(), 3)
     return isWithinInterval(new Date(document.date), {
       start: isBefore(maxDate, minDate) ? maxDate : minDate,
       end: isAfter(minDate, maxDate) ? minDate : maxDate,


### PR DESCRIPTION
## What

Set default filter of inbox to 3 months in future

## Why

Users cannot see documents when they are sent with a date that surpasses today's date.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
