### PR TITLE
fix(fa): Status page aid amount calculation

### DIFF
--- a/apps/financial-aid/web-osk/graphql/sharedGql.ts
+++ b/apps/financial-aid/web-osk/graphql/sharedGql.ts
@@ -67,6 +67,7 @@ export const ApplicationQuery = gql`
       modified
       municipalityCode
       spouseNationalId
+      familyStatus
       applicationEvents {
         id
         applicationId

--- a/apps/financial-aid/web-osk/src/components/Estimation/Estimation.tsx
+++ b/apps/financial-aid/web-osk/src/components/Estimation/Estimation.tsx
@@ -8,6 +8,7 @@ import {
   MartialStatusType,
   martialStatusTypeFromMartialCode,
   estimatedBreakDown,
+  showSpouseData,
 } from '@island.is/financial-aid/shared/lib'
 
 import { AppContext } from '@island.is/financial-aid-web/osk/src/components/AppProvider/AppProvider'
@@ -24,15 +25,32 @@ const Estimation = ({
   homeCircumstances,
   usePersonalTaxCredit,
 }: Props) => {
-  const { municipality, nationalRegistryData } = useContext(AppContext)
+  const { municipality, nationalRegistryData, myApplication } = useContext(
+    AppContext,
+  )
+
+  const getAidType = () => {
+    switch (true) {
+      case nationalRegistryData?.spouse?.maritalStatus != undefined:
+        return (
+          martialStatusTypeFromMartialCode(
+            nationalRegistryData?.spouse?.maritalStatus,
+          ) === MartialStatusType.SINGLE
+        )
+      case myApplication?.familyStatus != undefined:
+        if (myApplication?.familyStatus) {
+          return !showSpouseData[myApplication.familyStatus]
+        }
+      case myApplication?.spouseNationalId != undefined:
+        return false
+    }
+  }
 
   const aidAmount = useMemo(() => {
     if (municipality && homeCircumstances) {
       return aidCalculator(
         homeCircumstances,
-        martialStatusTypeFromMartialCode(
-          nationalRegistryData?.spouse?.maritalStatus,
-        ) === MartialStatusType.SINGLE
+        getAidType()
           ? municipality.individualAid
           : municipality.cohabitationAid,
       )


### PR DESCRIPTION
# ... ☝🏼 

https://app.asana.com/0/1202024607727436/1201995298577458

## What

- When applicant is married the aid amount calculated differently from veita to osk 
- We were using national registry, which we dont retrieve when logged into status page osk 
- Added family status to my application to use to decide between individual or cohabitation 

## Why

- Necessary that osk and veita provide the same information 


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
