### PR TITLE
feat(personal-rep-ids-admin): Add permission type to scope connector

### DIFF
--- a/apps/auth-admin-web/components/Resource/forms/ApiScopePersonalRepresentativePermissionsForm.tsx
+++ b/apps/auth-admin-web/components/Resource/forms/ApiScopePersonalRepresentativePermissionsForm.tsx
@@ -156,6 +156,12 @@ const ApiScopePersonalRepresentativePermissionsForm = (props: Props) => {
                     title={localization.buttons['add'].helpText}
                   />
                 </div>
+                <div className="personal-representative-permissions-form__selected__description">
+                  {
+                    permissionTypes?.find((pt) => pt.code === selectedItem)
+                      ?.description
+                  }
+                </div>
               </div>
             </form>
 
@@ -167,7 +173,10 @@ const ApiScopePersonalRepresentativePermissionsForm = (props: Props) => {
                     key={permission.rightTypeCode}
                     className="personal-representative-permissions-form__container__list__item"
                   >
-                    <div className="list-value">{permission.rightTypeCode}</div>
+                    <div className="list-name">{permission.rightTypeCode}</div>
+                    <div className="list-value">
+                      {permission.rightType.description}
+                    </div>
                     <div className="list-remove">
                       <button
                         onClick={() => deleteScopePermission(permission.id)}

--- a/apps/auth-admin-web/entities/models/personal-representative-scope-permission.model.ts
+++ b/apps/auth-admin-web/entities/models/personal-representative-scope-permission.model.ts
@@ -1,6 +1,9 @@
+import { PersonalRepresentativePermissionType } from './personal-representative-permission-type.model'
+
 export type ScopePermission = {
   id: string
   rightTypeCode: string
+  rightType: PersonalRepresentativePermissionType
   apiScopeName: string
   created: string
   modified: string

--- a/apps/auth-admin-web/styles/_FormLayout.scss
+++ b/apps/auth-admin-web/styles/_FormLayout.scss
@@ -237,6 +237,14 @@
     }
   }
 
+  &__selected__description {
+    flex-direction: row;
+    text-align: left;
+    align-items: flex-start;
+    width: 100%;
+    padding: 8px 8px 24px 8px;
+  }
+
   &__container__checkbox__field,
   &__container__radio__field {
     input[type='checkbox'],

--- a/libs/auth-api-lib/src/lib/personal-representative/services/personal-representative-scope-permission.service.ts
+++ b/libs/auth-api-lib/src/lib/personal-representative/services/personal-representative-scope-permission.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common'
 import { InjectModel } from '@nestjs/sequelize'
 import { PersonalRepresentativeScopePermission } from '../entities/models/personal-representative-scope-permission.model'
 import { PersonalRepresentativeScopePermissionDTO } from '../entities/dto/personal-representative-scope-permission.dto'
+import { PersonalRepresentativeRightType } from '../entities/models/personal-representative-right-type.model'
 
 @Injectable()
 export class PersonalRepresentativeScopePermissionService {
@@ -15,6 +16,12 @@ export class PersonalRepresentativeScopePermissionService {
   ): Promise<PersonalRepresentativeScopePermission[] | null> {
     return this.prScopePermissionModel.findAll({
       where: { apiScopeName },
+      include: [
+        {
+          model: PersonalRepresentativeRightType,
+          required: true,
+        },
+      ],
     })
   }
 


### PR DESCRIPTION
# Add permission type description
When connecting scope to right type in personal representative permission in the IDS Admin the description for the permission type was not shown. It is now shown both for selected type and for active scope permissions (see screenshot)

## Screenshots / Gifs
<img width="636" alt="image" src="https://user-images.githubusercontent.com/85297370/161259306-6c73f681-af0f-42dc-923b-48697c8fb80b.png">
## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
