### PR TITLE
fix(ads): Patch null-values from national registry propagating to DB

### DIFF
--- a/apps/air-discount-scheme/backend/src/app/modules/flight/flight.controller.ts
+++ b/apps/air-discount-scheme/backend/src/app/modules/flight/flight.controller.ts
@@ -242,6 +242,13 @@ export class PublicFlightController {
             custodianInfo &&
             this.flightService.isADSPostalCode(custodianInfo.postalcode)
           ) {
+            // Overview breaks when postalcode is null
+            // On rare occasions the national registry has no
+            // info on children. This is a patch for the overview screen
+            // to function properly on those occasions
+            if (!user.postalcode) {
+              user.postalcode = custodianInfo.postalcode
+            }
             meetsADSRequirements = true
             break
           }


### PR DESCRIPTION
## What
Admin overview having problems with null values in `user_info -> postalCode`.
![image-20220404111314845](https://user-images.githubusercontent.com/77672665/161559178-42b20eda-4def-4365-afab-d6a7b1ca7e79.png)

Problems patched with devops via
```sql
UPDATE flight                                                                            
SET user_info = jsonb_set(user_info, '{postalCode}', '0', false)
WHERE user_info -> 'postalCode'::text = 'null';
```

Now patching future null insertions with this patch.

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
