### PR TITLE
chore(j-s): Travel Ban Cleanup

### DIFF
--- a/apps/judicial-system/backend/migrations/20220405091349-update-case.js
+++ b/apps/judicial-system/backend/migrations/20220405091349-update-case.js
@@ -1,0 +1,69 @@
+'use strict'
+
+module.exports = {
+  up: (queryInterface) => {
+    return queryInterface.sequelize.transaction((transaction) =>
+      queryInterface
+        .renameColumn(
+          'case',
+          'requested_custody_restrictions',
+          'requested_custody_restrictions_old',
+          { transaction },
+        )
+        .then(() =>
+          queryInterface.sequelize.query(
+            `ALTER TYPE enum_case_custody_restrictions RENAME TO enum_case_custody_restrictions_old;
+             CREATE TYPE enum_case_custody_restrictions AS ENUM (
+               'NECESSITIES',
+               'ISOLATION',
+               'VISITAION',
+               'COMMUNICATION',
+               'MEDIA',
+               'ALTERNATIVE_TRAVEL_BAN_REQUIRE_NOTIFICATION',
+               'WORKBAN');`,
+            { transaction },
+          ),
+        )
+        .then(() =>
+          queryInterface.sequelize.query(
+            'ALTER TABLE "case" ADD COLUMN requested_custody_restrictions enum_case_custody_restrictions[]',
+            { transaction },
+          ),
+        )
+        .then(() =>
+          queryInterface.sequelize.query(
+            `UPDATE "case"
+               SET requested_custody_restrictions=(
+                 SELECT ARRAY(
+                   SELECT UNNEST(requested_custody_restrictions_old)
+                   EXCEPT SELECT UNNEST('{ALTERNATIVE_TRAVEL_BAN_CONFISCATE_PASSPORT}'::enum_case_custody_restrictions_old[])
+                 )::VARCHAR[]::enum_case_custody_restrictions[]
+               )
+               WHERE requested_custody_restrictions_old IS NOT NULL`,
+            { transaction },
+          ),
+        )
+        .then(() =>
+          queryInterface.removeColumn(
+            'case',
+            'requested_custody_restrictions_old',
+            { transaction },
+          ),
+        )
+        .then(() =>
+          queryInterface.sequelize.query(
+            `DROP TYPE enum_case_custody_restrictions_old`,
+            { transaction },
+          ),
+        ),
+    )
+  },
+
+  down: (queryInterface) => {
+    // ALTER TYPE ... ADD cannot run inside a transaction block
+    return queryInterface.sequelize.query(
+      `ALTER TYPE "enum_case_custody_restrictions"
+       ADD VALUE 'ALTERNATIVE_TRAVEL_BAN_CONFISCATE_PASSPORT'`,
+    )
+  },
+}


### PR DESCRIPTION
# Travel Ban Cleanup

https://app.asana.com/0/1199153462262248/1201960036639141/f

## What

- Removes the restriction option ALTERNATIVE_TRAVEL_BAN_CONFISCATE_PASSPORT from the database.

## Why

The removed option is no longer used and not referenced in code.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
