### PR TITLE
fix(ids): HOTFIX Revert user profile integration

### DIFF
--- a/apps/services/auth-api/src/app/modules/user-profile/user-profile.controller.spec.ts
+++ b/apps/services/auth-api/src/app/modules/user-profile/user-profile.controller.spec.ts
@@ -149,7 +149,7 @@ describe('UserProfileController', () => {
 
         // Assert
         expect(res.body).toEqual({})
-        expect(errorLog).toHaveBeenCalledTimes(2)
+        expect(errorLog).toHaveBeenCalledTimes(1)
       })
 
       it('with full registries should return all claims', async () => {
@@ -181,17 +181,17 @@ describe('UserProfileController', () => {
             postalCode: domicile.postnumer,
             locality: domicile.stadur,
           },
-          email: userProfile.email,
-          emailVerified: userProfile.emailVerified,
+          // email: userProfile.email,
+          // emailVerified: userProfile.emailVerified,
           familyName: individual.kenninafn,
           gender: 'male',
           givenName: individual.eiginnafn,
-          locale: userProfile.locale,
+          // locale: userProfile.locale,
           middleName: individual.millinafn,
           name: individual.nafn,
-          phoneNumber: userProfile.mobilePhoneNumber,
-          phoneNumberVerified: userProfile.mobilePhoneNumberVerified,
-          picture: userProfile.profileImageUrl,
+          // phoneNumber: userProfile.mobilePhoneNumber,
+          // phoneNumberVerified: userProfile.mobilePhoneNumberVerified,
+          // picture: userProfile.profileImageUrl,
         }
 
         // Act

--- a/libs/auth-api-lib/src/lib/services/user-profile.service.ts
+++ b/libs/auth-api-lib/src/lib/services/user-profile.service.ts
@@ -44,7 +44,9 @@ export class UserProfileService {
   async getIndividualUserProfileClaims(auth: User): Promise<UserProfileDTO> {
     const [nationalRegistryClaims, userProfileClaims] = await Promise.all([
       this.getClaimsFromNationalRegistry(auth).catch(this.handleError),
-      this.getClaimsFromUserProfile(auth).catch(this.handleError),
+      // REVERTED for release/14.3.0
+      // this.getClaimsFromUserProfile(auth).catch(this.handleError),
+      {},
     ])
     return { ...nationalRegistryClaims, ...userProfileClaims }
   }


### PR DESCRIPTION
## What

Revert user profile integration in auth-api.

## Why

Because it doesn't work on staging/prod and sometimes slows down auth by around 3 seconds.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
