### PR TITLE
fix(auth-api): Handle integration errors better

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -154,11 +154,11 @@ infra/                                                                          
 /libs/application/templates/parental-leave/                                                         @island-is/deloitte
 /libs/application/template-api-modules/src/lib/modules/templates/parental-leave/                    @island-is/deloitte
 
-/apps/services/auth-api/                                                                            @island-is/fuglar
-/apps/services/auth-admin-api/                                                                      @island-is/fuglar
+/apps/services/auth-api/                                                                            @island-is/fuglar @island-is/aranja
+/apps/services/auth-admin-api/                                                                      @island-is/fuglar @island-is/aranja
 /apps/services/auth-public-api/                                                                     @island-is/fuglar @island-is/aranja
-/apps/auth-admin-web/                                                                               @island-is/fuglar
-/apps/auth-admin-web-e2e/                                                                           @island-is/fuglar
+/apps/auth-admin-web/                                                                               @island-is/fuglar @island-is/aranja
+/apps/auth-admin-web-e2e/                                                                           @island-is/fuglar @island-is/aranja
 /libs/auth-api-lib/                                                                                 @island-is/fuglar @island-is/aranja
 /libs/auth-nest-tools/                                                                              @island-is/fuglar @island-is/aranja
 

--- a/apps/services/auth-api/src/app/modules/user-profile/user-profile.controller.spec.ts
+++ b/apps/services/auth-api/src/app/modules/user-profile/user-profile.controller.spec.ts
@@ -1,7 +1,10 @@
 import request from 'supertest'
 import * as faker from 'faker'
 
-import { EinstaklingarApi } from '@island.is/clients/national-registry-v2'
+import {
+  EinstaklingarApi,
+  Einstaklingsupplysingar,
+} from '@island.is/clients/national-registry-v2'
 import {
   GetCompanyApi,
   ResponseCompanyDetailed,
@@ -23,6 +26,16 @@ import { Logger, LOGGER_PROVIDER } from '@island.is/logging'
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function mocked<T extends (...args: any) => any>(value: T) {
   return (value as unknown) as jest.Mock<ReturnType<T>, Parameters<T>>
+}
+
+const mockNationalRegistry = (
+  einstaklingarApi: EinstaklingarApi,
+  data: Einstaklingsupplysingar,
+) => {
+  mocked(einstaklingarApi.einstaklingarGetEinstaklingurRaw).mockResolvedValue({
+    value: () => Promise.resolve(data),
+    raw: { status: 200 } as Response,
+  })
 }
 
 function createCompany(): ResponseCompanyDetailed {
@@ -77,11 +90,46 @@ describe('UserProfileController', () => {
 
     describe('GET /user-profile', () => {
       it('with empty registries should return no claims', async () => {
+        // Arrange
+        const errorLog = jest
+          .spyOn(app.get<Logger>(LOGGER_PROVIDER), 'error')
+          .mockImplementation()
+        mocked(
+          app.get(UserProfileApi).userProfileControllerFindOneByNationalId,
+        ).mockRejectedValue({ status: 404 })
+        mocked(
+          app.get(EinstaklingarApi).einstaklingarGetEinstaklingurRaw,
+        ).mockRejectedValue({ status: 404 })
+
         // Act
         const res = await server.get(path).expect(200)
 
         // Assert
         expect(res.body).toEqual({})
+        expect(errorLog).toHaveBeenCalledTimes(0)
+      })
+
+      it('with 204 response from natreg should return no claims', async () => {
+        // Arrange
+        const errorLog = jest
+          .spyOn(app.get<Logger>(LOGGER_PROVIDER), 'error')
+          .mockImplementation()
+        mocked(
+          app.get(UserProfileApi).userProfileControllerFindOneByNationalId,
+        ).mockRejectedValue({ status: 404 })
+        mocked(
+          app.get(EinstaklingarApi).einstaklingarGetEinstaklingurRaw,
+        ).mockResolvedValue({
+          value: () => Promise.reject('JSON ERROR'),
+          raw: { status: 204 } as Response,
+        })
+
+        // Act
+        const res = await server.get(path).expect(200)
+
+        // Assert
+        expect(res.body).toEqual({})
+        expect(errorLog).toHaveBeenCalledTimes(0)
       })
 
       it('with failing registries should log and return no claims', async () => {
@@ -91,10 +139,10 @@ describe('UserProfileController', () => {
           .mockImplementation()
         mocked(
           app.get(UserProfileApi).userProfileControllerFindOneByNationalId,
-        ).mockRejectedValue(new Error('test error 1'))
+        ).mockRejectedValue(new Error('500'))
         mocked(
-          app.get(EinstaklingarApi).einstaklingarGetEinstaklingur,
-        ).mockRejectedValue(new Error('test error 2'))
+          app.get(EinstaklingarApi).einstaklingarGetEinstaklingurRaw,
+        ).mockRejectedValue(new Error('500'))
 
         // Act
         const res = await server.get(path).expect(200)
@@ -113,9 +161,7 @@ describe('UserProfileController', () => {
         mocked(
           app.get(UserProfileApi).userProfileControllerFindOneByNationalId,
         ).mockResolvedValue(userProfile)
-        mocked(
-          app.get(EinstaklingarApi).einstaklingarGetEinstaklingur,
-        ).mockResolvedValue(individual)
+        mockNationalRegistry(app.get(EinstaklingarApi), individual)
 
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const domicile = individual.logheimili!
@@ -129,7 +175,7 @@ describe('UserProfileController', () => {
             streetAddress: address.heiti,
           },
           birthdate: individual.faedingardagur.toISOString().split('T')[0],
-          domicile: {
+          legalDomicile: {
             formatted: `${domicile.heiti}\n${domicile.postnumer} ${domicile.stadur}\nÍsland`,
             streetAddress: domicile.heiti,
             postalCode: domicile.postnumer,
@@ -159,9 +205,7 @@ describe('UserProfileController', () => {
         // Arrange
         const individual = createNationalRegistryUser()
         individual.adsetur = null
-        mocked(
-          app.get(EinstaklingarApi).einstaklingarGetEinstaklingur,
-        ).mockResolvedValue(individual)
+        mockNationalRegistry(app.get(EinstaklingarApi), individual)
 
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const domicile = individual.logheimili!
@@ -185,9 +229,7 @@ describe('UserProfileController', () => {
         // Arrange
         const individual = createNationalRegistryUser()
         individual.kynkodi = faker.random.arrayElement(['2', '4'])
-        mocked(
-          app.get(EinstaklingarApi).einstaklingarGetEinstaklingur,
-        ).mockResolvedValue(individual)
+        mockNationalRegistry(app.get(EinstaklingarApi), individual)
         const expected = {
           gender: 'female',
         }
@@ -203,9 +245,7 @@ describe('UserProfileController', () => {
         // Arrange
         const individual = createNationalRegistryUser()
         individual.kynkodi = faker.random.arrayElement(['7', '8'])
-        mocked(
-          app.get(EinstaklingarApi).einstaklingarGetEinstaklingur,
-        ).mockResolvedValue(individual)
+        mockNationalRegistry(app.get(EinstaklingarApi), individual)
         const expected = {
           gender: 'non-binary',
         }

--- a/apps/services/auth-api/src/app/modules/user-profile/user-profile.controller.ts
+++ b/apps/services/auth-api/src/app/modules/user-profile/user-profile.controller.ts
@@ -36,6 +36,6 @@ export class UserProfileController {
   async individualUserProfile(
     @CurrentUser() user: User,
   ): Promise<UserProfileDTO> {
-    return this.userProfileService.getIndividualUserProfileClaims(user)
+    return this.userProfileService.getUserProfileClaims(user)
   }
 }

--- a/apps/services/auth-api/test/setup.ts
+++ b/apps/services/auth-api/test/setup.ts
@@ -18,6 +18,7 @@ import { AppModule } from '../src/app/app.module'
 class MockEinstaklingarApi {
   withMiddleware = () => this
   einstaklingarGetEinstaklingur = jest.fn().mockResolvedValue({})
+  einstaklingarGetEinstaklingurRaw = jest.fn().mockResolvedValue({})
   einstaklingarGetForsja = jest.fn().mockResolvedValue([])
 }
 

--- a/libs/auth-api-lib/src/lib/entities/dto/user-profile.dto.ts
+++ b/libs/auth-api-lib/src/lib/entities/dto/user-profile.dto.ts
@@ -44,5 +44,5 @@ export class UserProfileDTO {
   address?: AddressDTO
 
   @ApiPropertyOptional()
-  domicile?: AddressDTO
+  legalDomicile?: AddressDTO
 }

--- a/libs/clients/national-registry/v2/src/index.ts
+++ b/libs/clients/national-registry/v2/src/index.ts
@@ -1,3 +1,6 @@
 export { NationalRegistryClientModule } from './lib/nationalRegistryClient.module'
 export { NationalRegistryClientConfig } from './lib/nationalRegistryClient.config'
+export { NationalRegistryClientService } from './lib/nationalRegistryClient.service'
+export { IndividualDto } from './lib/types/individual.dto'
+export { AddressDto } from './lib/types/address.dto'
 export * from '../gen/fetch'

--- a/libs/clients/national-registry/v2/src/lib/nationalRegistryClient.module.ts
+++ b/libs/clients/national-registry/v2/src/lib/nationalRegistryClient.module.ts
@@ -4,10 +4,11 @@ import { IdsClientConfig } from '@island.is/nest/config'
 
 import { ApiConfiguration } from './apiConfiguration'
 import { exportedApis } from './apis'
+import { NationalRegistryClientService } from './nationalRegistryClient.service'
 
 @Module({
   imports: [IdsClientConfig.registerOptional()],
-  providers: [ApiConfiguration, ...exportedApis],
-  exports: exportedApis,
+  providers: [ApiConfiguration, NationalRegistryClientService, ...exportedApis],
+  exports: [NationalRegistryClientService, ...exportedApis],
 })
 export class NationalRegistryClientModule {}

--- a/libs/clients/national-registry/v2/src/lib/nationalRegistryClient.service.ts
+++ b/libs/clients/national-registry/v2/src/lib/nationalRegistryClient.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common'
+
+import { FetchError } from '@island.is/clients/middlewares'
+
+import { EinstaklingarApi } from '../../gen/fetch'
+import { formatIndividualDto, IndividualDto } from './types/individual.dto'
+
+@Injectable()
+export class NationalRegistryClientService {
+  constructor(private individualApi: EinstaklingarApi) {}
+
+  async getIndividual(nationalId: string): Promise<IndividualDto | null> {
+    const response = await this.individualApi
+      .einstaklingarGetEinstaklingurRaw({
+        id: nationalId,
+      })
+      .catch(this.handleError)
+
+    const individual =
+      response === null || response.raw.status === 204
+        ? null
+        : await response.value()
+
+    return formatIndividualDto(individual)
+  }
+
+  private handleError(error: FetchError): null {
+    if (error.status === 404) {
+      return null
+    }
+    throw error
+  }
+}

--- a/libs/clients/national-registry/v2/src/lib/types/address.dto.ts
+++ b/libs/clients/national-registry/v2/src/lib/types/address.dto.ts
@@ -1,0 +1,23 @@
+import { Heimilisfang } from '../../../gen/fetch'
+
+export interface AddressDto {
+  streetAddress: string
+  postalCode: string | null
+  locality: string | null
+  municipalityNumber: string | null
+}
+
+export function formatAddressDto(
+  address: Heimilisfang | null | undefined,
+): AddressDto | null {
+  if (address == null) {
+    return null
+  }
+
+  return {
+    streetAddress: address.heiti,
+    postalCode: address.postnumer ?? null,
+    locality: address.stadur ?? null,
+    municipalityNumber: address.sveitarfelagsnumer ?? null,
+  }
+}

--- a/libs/clients/national-registry/v2/src/lib/types/individual.dto.ts
+++ b/libs/clients/national-registry/v2/src/lib/types/individual.dto.ts
@@ -1,0 +1,37 @@
+import { AddressDto, formatAddressDto } from './address.dto'
+import { Einstaklingsupplysingar } from '../../../gen/fetch'
+
+export interface IndividualDto {
+  nationalId: string
+  name: string
+  givenName: string | null
+  middleName: string | null
+  familyName: string | null
+  fullName: string | null
+  genderCode: string
+  exceptionFromDirectMarketing: boolean
+  birthdate: Date
+  legalDomicile: AddressDto | null
+  residence: AddressDto | null
+}
+
+export function formatIndividualDto(
+  individual: Einstaklingsupplysingar | null | undefined,
+): IndividualDto | null {
+  if (individual == null) {
+    return null
+  }
+  return {
+    nationalId: individual.kennitala,
+    name: individual.nafn,
+    givenName: individual.eiginnafn ?? null,
+    middleName: individual.millinafn ?? null,
+    familyName: individual.kenninafn ?? null,
+    fullName: individual.fulltNafn ?? null,
+    genderCode: individual.kynkodi,
+    exceptionFromDirectMarketing: individual.bannmerking,
+    birthdate: individual.faedingardagur,
+    legalDomicile: formatAddressDto(individual.logheimili),
+    residence: formatAddressDto(individual.adsetur),
+  }
+}


### PR DESCRIPTION
## What

Handle error responses better in the new IDS / Auth API integrations.

* Handle 404 responses from Company Registry, National Registry and User Profile Service.
* Handle empty National Registry 204 responses with new shared code and client service.

## Why

So we can add more user claims in IDS.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
