### PR TITLE
feat(infra): NestJS interceptor for DataDog APM

### DIFF
--- a/libs/infra-nest-server/src/lib/infra/apm.interceptor.ts
+++ b/libs/infra-nest-server/src/lib/infra/apm.interceptor.ts
@@ -1,0 +1,23 @@
+import { CallHandler, ExecutionContext, NestInterceptor } from '@nestjs/common'
+import { from, Observable } from 'rxjs'
+import tracer from 'dd-trace'
+
+export class ApmInterceptor implements NestInterceptor {
+  async intercept(
+    executionContext: ExecutionContext,
+    next: CallHandler,
+  ): Promise<Observable<any>> {
+    const handlerClass = executionContext.getClass()
+    const handlerFn = executionContext.getHandler()
+
+    return from(
+      tracer.trace(
+        'nestjs.handler',
+        {
+          resource: `${handlerClass.name}#${handlerFn.name}`,
+        },
+        (span) => next.handle().toPromise(),
+      ),
+    )
+  }
+}

--- a/libs/infra-nest-server/src/lib/infra/infra.module.ts
+++ b/libs/infra-nest-server/src/lib/infra/infra.module.ts
@@ -1,6 +1,10 @@
-import { Module, DynamicModule, Type } from '@nestjs/common'
-import { InfraController } from './infra.controller'
+import { DynamicModule, Module, Type } from '@nestjs/common'
+import { APP_INTERCEPTOR } from '@nestjs/core'
+
 import { LoggingModule } from '@island.is/logging'
+
+import { InfraController } from './infra.controller'
+import { ApmInterceptor } from './apm.interceptor'
 
 interface InfraModuleOptions {
   appModule: Type<any>
@@ -8,6 +12,12 @@ interface InfraModuleOptions {
 
 @Module({
   controllers: [InfraController],
+  providers: [
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: ApmInterceptor,
+    },
+  ],
   imports: [LoggingModule],
 })
 export class InfraModule {


### PR DESCRIPTION
## What

NestJS interceptor which adds DataDog APM spans for NestJS request handlers and resolvers.

## Why

To have more visibility into which NestJS handlers are running and when.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
