### PR TITLE
feat(web): Project page featured description

### DIFF
--- a/apps/web/components/Project/Header/DefaultProjectHeader.tsx
+++ b/apps/web/components/Project/Header/DefaultProjectHeader.tsx
@@ -41,7 +41,13 @@ export const DefaultProjectHeader = ({
           <GridRow align="flexEnd">
             <GridColumn
               paddingTop={5}
-              span={['12/12', '12/12', '10/12', '10/12', '8/12']}
+              span={[
+                '12/12',
+                '12/12',
+                defaultImageIsProvided ? '10/12' : '12/12',
+                defaultImageIsProvided ? '10/12' : '12/12',
+                defaultImageIsProvided ? '8/12' : '12/12',
+              ]}
             >
               <Text variant="eyebrow" color="white" marginTop={5}>
                 Ísland.is

--- a/apps/web/screens/Project/Project.tsx
+++ b/apps/web/screens/Project/Project.tsx
@@ -252,7 +252,7 @@ const ProjectPage: Screen<PageProps> = ({
       {projectPage.id === '7GtuCCd7MEZhZKe0oXcHdb' && <UkraineChatPanel />}
       <HeadWithSocialSharing
         title={`${projectPage.title} | Ísland.is`}
-        description={projectPage.intro}
+        description={projectPage.featuredDescription || projectPage.intro}
         imageUrl={projectPage.featuredImage?.url}
         imageContentType={projectPage.featuredImage?.contentType}
         imageWidth={projectPage.featuredImage?.width?.toString()}

--- a/apps/web/screens/queries/Project.tsx
+++ b/apps/web/screens/queries/Project.tsx
@@ -9,6 +9,7 @@ export const GET_PROJECT_PAGE_QUERY = gql`
       slug
       theme
       sidebar
+      featuredDescription
       sidebarLinks {
         primaryLink {
           text

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -2215,6 +2215,9 @@ export interface IProjectPageFields {
 
   /** Default Header Background Color */
   defaultHeaderBackgroundColor?: string | undefined
+
+  /** Featured Description */
+  featuredDescription?: string | undefined
 }
 
 export interface IProjectPage extends Entry<IProjectPageFields> {

--- a/libs/cms/src/lib/models/projectPage.model.ts
+++ b/libs/cms/src/lib/models/projectPage.model.ts
@@ -61,27 +61,35 @@ export class ProjectPage {
 
   @Field()
   defaultHeaderBackgroundColor!: string
+
+  @Field()
+  featuredDescription!: string
 }
 
-export const mapProjectPage = ({ sys, fields }: IProjectPage): ProjectPage => ({
-  id: sys.id,
-  title: fields.title ?? '',
-  slug: fields.slug ?? '',
-  theme: fields.theme ?? 'default',
-  sidebar: fields.sidebar ?? false,
-  sidebarLinks: (fields.sidebarLinks ?? []).map(mapLinkGroup),
-  subtitle: fields.subtitle ?? '',
-  intro: fields.intro ?? '',
-  content: fields.content
-    ? mapDocument(fields.content, sys.id + ':content')
-    : [],
-  stepper: fields.stepper ? mapStepper(fields.stepper) : null,
-  slices: (fields.slices ?? []).map(safelyMapSliceUnion),
-  newsTag: fields.newsTag ? mapGenericTag(fields.newsTag) : null,
-  projectSubpages: (fields.projectSubpages ?? []).map(mapProjectSubpage),
-  featuredImage: fields.featuredImage ? mapImage(fields.featuredImage) : null,
-  defaultHeaderImage: fields.defaultHeaderImage
-    ? mapImage(fields.defaultHeaderImage)
-    : null,
-  defaultHeaderBackgroundColor: fields.defaultHeaderBackgroundColor ?? '',
-})
+export const mapProjectPage = ({ sys, fields }: IProjectPage): ProjectPage => {
+  return {
+    id: sys.id,
+    title: fields.title ?? '',
+    slug: fields.slug ?? '',
+    theme: fields.theme ?? 'default',
+    sidebar: fields.sidebar ?? false,
+    sidebarLinks: (fields.sidebarLinks ?? []).map(mapLinkGroup),
+    subtitle: fields.subtitle ?? '',
+    intro: fields.intro ?? '',
+    content: fields.content
+      ? mapDocument(fields.content, sys.id + ':content')
+      : [],
+    stepper: fields.stepper ? mapStepper(fields.stepper) : null,
+    slices: (fields.slices ?? []).map(safelyMapSliceUnion),
+    newsTag: fields.newsTag ? mapGenericTag(fields.newsTag) : null,
+    projectSubpages: (fields.projectSubpages ?? [])
+      .filter((p) => p.fields?.title)
+      .map(mapProjectSubpage),
+    featuredImage: fields.featuredImage ? mapImage(fields.featuredImage) : null,
+    defaultHeaderImage: fields.defaultHeaderImage
+      ? mapImage(fields.defaultHeaderImage)
+      : null,
+    defaultHeaderBackgroundColor: fields.defaultHeaderBackgroundColor ?? '',
+    featuredDescription: fields.featuredDescription ?? '',
+  }
+}

--- a/libs/cms/src/lib/models/projectPage.model.ts
+++ b/libs/cms/src/lib/models/projectPage.model.ts
@@ -66,30 +66,28 @@ export class ProjectPage {
   featuredDescription!: string
 }
 
-export const mapProjectPage = ({ sys, fields }: IProjectPage): ProjectPage => {
-  return {
-    id: sys.id,
-    title: fields.title ?? '',
-    slug: fields.slug ?? '',
-    theme: fields.theme ?? 'default',
-    sidebar: fields.sidebar ?? false,
-    sidebarLinks: (fields.sidebarLinks ?? []).map(mapLinkGroup),
-    subtitle: fields.subtitle ?? '',
-    intro: fields.intro ?? '',
-    content: fields.content
-      ? mapDocument(fields.content, sys.id + ':content')
-      : [],
-    stepper: fields.stepper ? mapStepper(fields.stepper) : null,
-    slices: (fields.slices ?? []).map(safelyMapSliceUnion),
-    newsTag: fields.newsTag ? mapGenericTag(fields.newsTag) : null,
-    projectSubpages: (fields.projectSubpages ?? [])
-      .filter((p) => p.fields?.title)
-      .map(mapProjectSubpage),
-    featuredImage: fields.featuredImage ? mapImage(fields.featuredImage) : null,
-    defaultHeaderImage: fields.defaultHeaderImage
-      ? mapImage(fields.defaultHeaderImage)
-      : null,
-    defaultHeaderBackgroundColor: fields.defaultHeaderBackgroundColor ?? '',
-    featuredDescription: fields.featuredDescription ?? '',
-  }
-}
+export const mapProjectPage = ({ sys, fields }: IProjectPage): ProjectPage => ({
+  id: sys.id,
+  title: fields.title ?? '',
+  slug: fields.slug ?? '',
+  theme: fields.theme ?? 'default',
+  sidebar: fields.sidebar ?? false,
+  sidebarLinks: (fields.sidebarLinks ?? []).map(mapLinkGroup),
+  subtitle: fields.subtitle ?? '',
+  intro: fields.intro ?? '',
+  content: fields.content
+    ? mapDocument(fields.content, sys.id + ':content')
+    : [],
+  stepper: fields.stepper ? mapStepper(fields.stepper) : null,
+  slices: (fields.slices ?? []).map(safelyMapSliceUnion),
+  newsTag: fields.newsTag ? mapGenericTag(fields.newsTag) : null,
+  projectSubpages: (fields.projectSubpages ?? [])
+    .filter((p) => p.fields?.title)
+    .map(mapProjectSubpage),
+  featuredImage: fields.featuredImage ? mapImage(fields.featuredImage) : null,
+  defaultHeaderImage: fields.defaultHeaderImage
+    ? mapImage(fields.defaultHeaderImage)
+    : null,
+  defaultHeaderBackgroundColor: fields.defaultHeaderBackgroundColor ?? '',
+  featuredDescription: fields.featuredDescription ?? '',
+})


### PR DESCRIPTION
# Project page featured description

## What

* Added a new field in Contentful that allows you to edit what text gets shown when you share a link to Project page
* Added a fail-safe to the project subpage mapping

## Why

* We want to be able to customize the text shown when you share a link to a project page (without using the intro text)
* If you delete a project subpage in Contentful and forget to remove the reference in the Project page then you would get a 500 error

## Screenshots / Gifs

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
