### PR TITLE
fix(fa): Allow longer text on comments

### DIFF
--- a/apps/financial-aid/backend/migrations/20220406124843-update-applications-comments.js
+++ b/apps/financial-aid/backend/migrations/20220406124843-update-applications-comments.js
@@ -1,0 +1,49 @@
+'use strict'
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction((t) =>
+      Promise.all([
+        queryInterface.changeColumn(
+          'applications',
+          'home_circumstances_custom',
+          {
+            type: Sequelize.TEXT,
+          },
+          { transaction: t },
+        ),
+        queryInterface.changeColumn(
+          'applications',
+          'employment_custom',
+          {
+            type: Sequelize.TEXT,
+          },
+          { transaction: t },
+        ),
+      ]),
+    )
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction((t) =>
+      Promise.all([
+        queryInterface.changeColumn(
+          'applications',
+          'home_circumstances_custom',
+          {
+            type: Sequelize.STRING,
+          },
+          { transaction: t },
+        ),
+        queryInterface.changeColumn(
+          'applications',
+          'employment_custom',
+          {
+            type: Sequelize.STRING,
+          },
+          { transaction: t },
+        ),
+      ]),
+    )
+  },
+}

--- a/apps/financial-aid/backend/src/app/modules/application/models/application.model.ts
+++ b/apps/financial-aid/backend/src/app/modules/application/models/application.model.ts
@@ -86,7 +86,7 @@ export class ApplicationModel extends Model<Application> {
   homeCircumstances: HomeCircumstances
 
   @Column({
-    type: DataType.STRING,
+    type: DataType.TEXT,
     allowNull: true,
   })
   @ApiProperty()
@@ -101,7 +101,7 @@ export class ApplicationModel extends Model<Application> {
   employment: Employment
 
   @Column({
-    type: DataType.STRING,
+    type: DataType.TEXT,
     allowNull: true,
   })
   @ApiProperty()


### PR DESCRIPTION
# ... 👆

https://app.asana.com/0/1202037685216853/1202055368844795

## What

Change comment fields type from STRING to TEXT.

## Why

So the user can have long long texts.

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/43727721/161995334-f6b1b014-2a22-4493-9e4f-93c0de5623df.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
