### PR TITLE
fix(web): Featured Articles causing 500 error

### DIFF
--- a/libs/cms/src/lib/models/articleReference.ts
+++ b/libs/cms/src/lib/models/articleReference.ts
@@ -14,6 +14,7 @@ import { SystemMetadata } from '@island.is/shared/types'
 import { ArticleGroup, mapArticleGroup } from './articleGroup.model'
 import { mapOrganization, Organization } from './organization.model'
 import { ArticleCategory, mapArticleCategory } from './articleCategory.model'
+import { mapProcessEntry, ProcessEntry } from './processEntry.model'
 
 @ObjectType()
 export class ArticleReference {
@@ -37,6 +38,9 @@ export class ArticleReference {
 
   @Field(() => [Organization], { nullable: true })
   organization?: Array<Organization>
+
+  @Field(() => ProcessEntry, { nullable: true })
+  processEntry?: ProcessEntry | null
 }
 
 export const mapArticleReference = ({
@@ -55,4 +59,7 @@ export const mapArticleReference = ({
       (organization) => organization.fields?.title && organization.fields?.slug,
     )
     .map(mapOrganization),
+  processEntry: fields.processEntry
+    ? mapProcessEntry(fields.processEntry)
+    : null,
 })

--- a/libs/cms/src/lib/models/featuredArticles.model.ts
+++ b/libs/cms/src/lib/models/featuredArticles.model.ts
@@ -4,8 +4,8 @@ import { IFeaturedArticles } from '../generated/contentfulTypes'
 
 import { SystemMetadata } from 'api-cms-domain'
 import { Image, mapImage } from './image.model'
-import { Article, mapArticle } from './article.model'
 import { Link, mapLink } from './link.model'
+import { ArticleReference, mapArticleReference } from './articleReference'
 
 @ObjectType()
 export class FeaturedArticles {
@@ -18,8 +18,8 @@ export class FeaturedArticles {
   @Field(() => Image, { nullable: true })
   image?: Image | null
 
-  @Field(() => [Article])
-  articles?: Array<Article>
+  @Field(() => [ArticleReference])
+  articles?: Array<ArticleReference>
 
   @Field(() => Link, { nullable: true })
   link?: Link | null
@@ -33,6 +33,6 @@ export const mapFeaturedArticles = ({
   id: sys.id,
   title: fields.title ?? '',
   image: fields.image ? mapImage(fields.image) : null,
-  articles: (fields.articles ?? []).map(mapArticle),
+  articles: (fields.articles ?? []).map(mapArticleReference),
   link: fields.link ? mapLink(fields.link) : null,
 })


### PR DESCRIPTION
# Featured Articles causing 500 error

## What

* When adding a specific article to FeaturedArticles list in Contentful causes a 500 GraphQL error
* The error was likely caused due to article - subArticle circularity in the code
* This was fixed by changing the article model to a articleReference model in the code

## Why

* We want to fix this issue

## Screenshots / Gifs

https://user-images.githubusercontent.com/43557895/162018534-f05567f4-6c50-4bb4-b3a5-744be26c3186.mp4



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
