### PR TITLE
feat(fa): Creating staff added many muni

### DIFF
--- a/apps/financial-aid/api/src/app/modules/staff/dto/createStaff.input.ts
+++ b/apps/financial-aid/api/src/app/modules/staff/dto/createStaff.input.ts
@@ -27,6 +27,6 @@ export class CreateStaffInput implements CreateStaff {
   readonly municipalityName?: string
 
   @Allow()
-  @Field({ nullable: true })
-  readonly municipalityId?: string
+  @Field(() => [String], { nullable: true })
+  readonly municipalityIds?: string[]
 }

--- a/apps/financial-aid/backend/src/app/modules/staff/dto/createStaff.dto.ts
+++ b/apps/financial-aid/backend/src/app/modules/staff/dto/createStaff.dto.ts
@@ -25,9 +25,9 @@ export class CreateStaffDto {
   readonly roles!: StaffRole[]
 
   @IsOptional()
-  @IsString()
+  @IsArray()
   @ApiProperty()
-  readonly municipalityId: string
+  readonly municipalityIds: string[]
 
   @IsOptional()
   @IsString()

--- a/apps/financial-aid/backend/src/app/modules/staff/staff.controller.ts
+++ b/apps/financial-aid/backend/src/app/modules/staff/staff.controller.ts
@@ -110,7 +110,7 @@ export class StaffController {
       createStaffInput,
       {
         municipalityId:
-          createStaffInput.municipalityId ?? staff.municipalityIds[0],
+          createStaffInput.municipalityIds[0] ?? staff.municipalityIds[0],
         municipalityName:
           createStaffInput.municipalityName ?? staff.municipalityName,
       },

--- a/apps/financial-aid/backend/src/app/modules/staff/staff.service.ts
+++ b/apps/financial-aid/backend/src/app/modules/staff/staff.service.ts
@@ -144,7 +144,9 @@ export class StaffService {
         {
           nationalId: input.nationalId,
           name: input.name,
-          municipalityIds: [municipality.municipalityId],
+          municipalityIds: isFirstStaffForMunicipality
+            ? [municipality.municipalityId]
+            : input.municipalityIds,
           email: input.email,
           roles: input.roles,
           active: true,

--- a/apps/financial-aid/backend/src/app/modules/staff/test/createStaff.spec.ts
+++ b/apps/financial-aid/backend/src/app/modules/staff/test/createStaff.spec.ts
@@ -40,13 +40,12 @@ describe('StaffController - createStaff', () => {
   })
 
   describe('database query', () => {
-    const id = uuid()
     const input: CreateStaffDto = {
       name: 'Im a test',
       nationalId: '0000000000',
       email: 'test@test.test',
       roles: [StaffRole.EMPLOYEE],
-      municipalityId: '10',
+      municipalityIds: ['10'],
       municipalityName: 'Island',
     }
     const staff: Staff = {
@@ -71,7 +70,7 @@ describe('StaffController - createStaff', () => {
         {
           nationalId: input.nationalId,
           name: input.name,
-          municipalityIds: [input.municipalityId],
+          municipalityIds: input.municipalityIds,
           email: input.email,
           roles: input.roles,
           active: true,
@@ -89,7 +88,7 @@ describe('StaffController - createStaff', () => {
       nationalId: '0000000000',
       email: 'test@test.test',
       roles: [StaffRole.EMPLOYEE],
-      municipalityId: undefined,
+      municipalityIds: ['10'],
       municipalityName: undefined,
     }
     const staff: Staff = {
@@ -132,7 +131,7 @@ describe('StaffController - createStaff', () => {
       nationalId: '0000000000',
       email: 'test@test.test',
       roles: [StaffRole.EMPLOYEE],
-      municipalityId: '10',
+      municipalityIds: ['10'],
       municipalityName: 'A place',
     }
     const staff: Staff = {
@@ -164,7 +163,7 @@ describe('StaffController - createStaff', () => {
       nationalId: '0000000000',
       email: 'test@test.test',
       roles: [StaffRole.EMPLOYEE],
-      municipalityId: '',
+      municipalityIds: [],
       municipalityName: '',
     }
     const staff: Staff = {

--- a/apps/financial-aid/web-veita/src/components/AdminProvider/AdminProvider.tsx
+++ b/apps/financial-aid/web-veita/src/components/AdminProvider/AdminProvider.tsx
@@ -12,14 +12,14 @@ interface AdminProvider {
   isAuthenticated?: boolean
   admin?: User
   setAdmin?: React.Dispatch<React.SetStateAction<User | undefined>>
-  municipality?: Municipality[]
+  municipality: Municipality[]
 }
 
 interface PageProps {
   children: ReactNode
 }
 
-export const AdminContext = createContext<AdminProvider>({})
+export const AdminContext = createContext<AdminProvider>({ municipality: [] })
 
 const AdminProvider = ({ children }: PageProps) => {
   const [session] = useSession()

--- a/apps/financial-aid/web-veita/src/components/AdminProvider/AdminProvider.tsx
+++ b/apps/financial-aid/web-veita/src/components/AdminProvider/AdminProvider.tsx
@@ -12,14 +12,14 @@ interface AdminProvider {
   isAuthenticated?: boolean
   admin?: User
   setAdmin?: React.Dispatch<React.SetStateAction<User | undefined>>
-  municipality: Municipality[]
+  municipality?: Municipality[]
 }
 
 interface PageProps {
   children: ReactNode
 }
 
-export const AdminContext = createContext<AdminProvider>({ municipality: [] })
+export const AdminContext = createContext<AdminProvider>({})
 
 const AdminProvider = ({ children }: PageProps) => {
   const [session] = useSession()

--- a/apps/financial-aid/web-veita/src/components/MultiSelection/MultiSelection.tsx
+++ b/apps/financial-aid/web-veita/src/components/MultiSelection/MultiSelection.tsx
@@ -1,46 +1,48 @@
 import React from 'react'
-import { Box, Option, Select, Text, Icon } from '@island.is/island-ui/core'
-import { ReactSelectOption } from '@island.is/financial-aid/shared/lib'
-import { newUsersModalState } from '../NewUserModal/NewUserModal'
-import { EmployeeProfileInfo } from '../Profile/EmployeeProfile'
+import { Box, Select, Text, Icon } from '@island.is/island-ui/core'
+import {
+  ReactSelectOption,
+  StaffRole,
+} from '@island.is/financial-aid/shared/lib'
 import { isString } from 'lodash'
 import { ValueType } from 'react-select'
+import { mapMuniToOption } from '@island.is/financial-aid-web/veita/src/utils/formHelper'
+
 import * as styles from './MultiSelection.css'
 
-interface Props {
-  options: Option[]
-  active: Option[]
-  onSelected: (value: ValueType<ReactSelectOption>) => void
-  unSelected: (value: string, name: string) => void
-  setState:
-    | React.Dispatch<React.SetStateAction<newUsersModalState>>
-    | React.Dispatch<React.SetStateAction<EmployeeProfileInfo>>
-  state: newUsersModalState | EmployeeProfileInfo
+export type CreateUpdateStaff<T> = {
   hasError: boolean
-  // | Pick<EmployeeProfileInfo, 'municipalityIds' | 'serviceCenter'>
+  roles: StaffRole[]
+  municipalityIds: string[]
+} & T
+
+type Props<T> = {
+  selectionUpdate: any
+  state: CreateUpdateStaff<T>
+  hasError: boolean
 }
 
-const MultiSelection = ({
-  options,
-  active,
-  onSelected,
-  unSelected,
-  setState,
+const MultiSelection = <T extends unknown>({
+  selectionUpdate,
   state,
   hasError,
-}: Props) => {
+}: Props<T>) => {
+  const { municipalityIds } = state
+
   return (
     <Box display="block">
       <Text as="h2" variant="h3" color="dark300" marginBottom={3}>
         Sveitarfélög notanda
       </Text>
       <Box marginBottom={2}>
-        {active.map((muni, index) => {
+        {mapMuniToOption(municipalityIds, true).map((muni, index) => {
           return (
             <button
               key={'muni-tags-' + index}
               className={styles.tags}
-              onClick={() => unSelected(muni.value as string, muni.label)}
+              onClick={() => {
+                selectionUpdate(muni.value, 'remove')
+              }}
             >
               <Box display="flex" alignItems="center" padding={1}>
                 <Box marginRight={1}>
@@ -60,9 +62,14 @@ const MultiSelection = ({
         label="Sveitarfélög"
         name="selectMunicipality"
         noOptionsMessage="Enginn valmöguleiki"
-        options={options}
+        options={mapMuniToOption(municipalityIds, false)}
         placeholder="Veldu tegund"
-        onChange={onSelected}
+        onChange={(option: ValueType<ReactSelectOption>) => {
+          const { value } = option as ReactSelectOption
+          if (value && isString(value)) {
+            selectionUpdate(value, 'add')
+          }
+        }}
         backgroundColor="blue"
         errorMessage="Verður að haka við sveitarfélag"
         hasError={hasError}

--- a/apps/financial-aid/web-veita/src/components/MultiSelection/MultiSelection.tsx
+++ b/apps/financial-aid/web-veita/src/components/MultiSelection/MultiSelection.tsx
@@ -19,7 +19,7 @@ export type CreateUpdateStaff<T> = {
 export type selectionType = 'add' | 'remove'
 
 type Props<T> = {
-  selectionUpdate: (value: string, type: 'add' | 'remove') => void
+  selectionUpdate: (value: string, type: selectionType) => void
   state: CreateUpdateStaff<T>
   hasError: boolean
 }

--- a/apps/financial-aid/web-veita/src/components/MultiSelection/MultiSelection.tsx
+++ b/apps/financial-aid/web-veita/src/components/MultiSelection/MultiSelection.tsx
@@ -16,8 +16,10 @@ export type CreateUpdateStaff<T> = {
   municipalityIds: string[]
 } & T
 
+export type selectionType = 'add' | 'remove'
+
 type Props<T> = {
-  selectionUpdate: any
+  selectionUpdate: (value: string, type: 'add' | 'remove') => void
   state: CreateUpdateStaff<T>
   hasError: boolean
 }

--- a/apps/financial-aid/web-veita/src/components/MultiSelection/MultiSelection.tsx
+++ b/apps/financial-aid/web-veita/src/components/MultiSelection/MultiSelection.tsx
@@ -1,20 +1,39 @@
 import React from 'react'
 import { Box, Option, Select, Text, Icon } from '@island.is/island-ui/core'
-import * as styles from './MultiSelection.css'
-
-import { ValueType } from 'react-select'
 import { ReactSelectOption } from '@island.is/financial-aid/shared/lib'
+import { newUsersModalState } from '../NewUserModal/NewUserModal'
+import { EmployeeProfileInfo } from '../Profile/EmployeeProfile'
+import { isString } from 'lodash'
+import { ValueType } from 'react-select'
+import * as styles from './MultiSelection.css'
 
 interface Props {
   options: Option[]
   active: Option[]
   onSelected: (value: ValueType<ReactSelectOption>) => void
   unSelected: (value: string, name: string) => void
+  setState:
+    | React.Dispatch<React.SetStateAction<newUsersModalState>>
+    | React.Dispatch<React.SetStateAction<EmployeeProfileInfo>>
+  state: newUsersModalState | EmployeeProfileInfo
+  hasError: boolean
+  // | Pick<EmployeeProfileInfo, 'municipalityIds' | 'serviceCenter'>
 }
 
-const MultiSelection = ({ options, active, onSelected, unSelected }: Props) => {
+const MultiSelection = ({
+  options,
+  active,
+  onSelected,
+  unSelected,
+  setState,
+  state,
+  hasError,
+}: Props) => {
   return (
     <Box display="block">
+      <Text as="h2" variant="h3" color="dark300" marginBottom={3}>
+        Sveitarfélög notanda
+      </Text>
       <Box marginBottom={2}>
         {active.map((muni, index) => {
           return (
@@ -45,6 +64,8 @@ const MultiSelection = ({ options, active, onSelected, unSelected }: Props) => {
         placeholder="Veldu tegund"
         onChange={onSelected}
         backgroundColor="blue"
+        errorMessage="Verður að haka við sveitarfélag"
+        hasError={hasError}
       />
     </Box>
   )

--- a/apps/financial-aid/web-veita/src/components/MultiSelection/MultiSelection.tsx
+++ b/apps/financial-aid/web-veita/src/components/MultiSelection/MultiSelection.tsx
@@ -33,7 +33,12 @@ const MultiSelection = <T extends unknown>({
 
   return (
     <Box display="block">
-      <Text as="h2" variant="h3" color="dark300" marginBottom={3}>
+      <Text
+        fontWeight="semiBold"
+        color="dark300"
+        variant="small"
+        marginBottom={2}
+      >
         Sveitarfélög notanda
       </Text>
       <Box marginBottom={2}>
@@ -73,7 +78,7 @@ const MultiSelection = <T extends unknown>({
           }
         }}
         backgroundColor="blue"
-        errorMessage="Verður að haka við sveitarfélag"
+        errorMessage="Verður að velja að minnsta kosti 1 sveitarfélag"
         hasError={hasError}
       />
     </Box>

--- a/apps/financial-aid/web-veita/src/components/NewUserModal/NewUserModal.tsx
+++ b/apps/financial-aid/web-veita/src/components/NewUserModal/NewUserModal.tsx
@@ -8,7 +8,10 @@ import { StaffMutation } from '@island.is/financial-aid-web/veita/graphql'
 import { ApolloError, useMutation } from '@apollo/client'
 import { isEmailValid, StaffRole } from '@island.is/financial-aid/shared/lib'
 import cn from 'classnames'
-import { CreateUpdateStaff } from '@island.is/financial-aid-web/veita/src/components/MultiSelection/MultiSelection'
+import {
+  CreateUpdateStaff,
+  selectionType,
+} from '@island.is/financial-aid-web/veita/src/components/MultiSelection/MultiSelection'
 
 interface Props {
   isVisible: boolean
@@ -174,7 +177,7 @@ const NewUserModal = ({
         <>
           <Box display="block" marginBottom={[3, 3, 5]}>
             <MultiSelection
-              selectionUpdate={(value: string, type: 'add' | 'remove') => {
+              selectionUpdate={(value: string, type: selectionType) => {
                 if (type === 'add') {
                   setState({
                     ...state,

--- a/apps/financial-aid/web-veita/src/components/NewUserModal/NewUserModal.tsx
+++ b/apps/financial-aid/web-veita/src/components/NewUserModal/NewUserModal.tsx
@@ -169,7 +169,7 @@ const NewUserModal = ({
           }
         />
       </Box>
-      <Text marginBottom={5} variant="small">
+      <Text marginBottom={3} variant="small">
         Notandi fær sendan tölvupóst með hlekk til að skrá sig inn með rafrænum
         skilríkjum.
       </Text>

--- a/apps/financial-aid/web-veita/src/components/Profile/EmployeeProfile.tsx
+++ b/apps/financial-aid/web-veita/src/components/Profile/EmployeeProfile.tsx
@@ -33,7 +33,6 @@ type EmployeeProfileInfo = CreateUpdateStaff<{
   nationalId?: string
   nickname?: string
   email?: string
-  errorMessage?: string
 }>
 
 const EmployeeProfile = ({ user }: EmployeeProfileProps) => {

--- a/apps/financial-aid/web-veita/src/components/Profile/EmployeeProfile.tsx
+++ b/apps/financial-aid/web-veita/src/components/Profile/EmployeeProfile.tsx
@@ -1,4 +1,6 @@
 import React, { useContext, useState } from 'react'
+import { isString } from 'lodash'
+import { ValueType } from 'react-select'
 import {
   Box,
   Divider,
@@ -10,9 +12,6 @@ import {
   Option,
 } from '@island.is/island-ui/core'
 
-import * as styles from './Profile.css'
-
-import * as headerStyles from '@island.is/financial-aid-web/veita/src/components/ApplicationHeader/ApplicationHeader.css'
 import {
   InputType,
   isEmailValid,
@@ -20,19 +19,21 @@ import {
   Staff,
   StaffRole,
 } from '@island.is/financial-aid/shared/lib'
+import { MultiSelection } from '@island.is/financial-aid-web/veita/src/components'
 
-import cn from 'classnames'
 import { useStaff } from '@island.is/financial-aid-web/veita/src/utils/useStaff'
 import { AdminContext } from '@island.is/financial-aid-web/veita/src/components/AdminProvider/AdminProvider'
-import MultiSelection from '../MultiSelection/MultiSelection'
-import { isString } from 'lodash'
-import { ValueType } from 'react-select'
+import { mapMuniToOption } from '@island.is/financial-aid-web/veita/src/utils/formHelper'
+
+import cn from 'classnames'
+import * as styles from './Profile.css'
+import * as headerStyles from '@island.is/financial-aid-web/veita/src/components/ApplicationHeader/ApplicationHeader.css'
 
 interface EmployeeProfileProps {
   user: Staff
 }
 
-interface EmployeeProfileInfo {
+export interface EmployeeProfileInfo {
   nationalId: string
   email?: string
   nickname?: string
@@ -43,22 +44,10 @@ interface EmployeeProfileInfo {
 }
 
 const EmployeeProfile = ({ user }: EmployeeProfileProps) => {
-  const { admin, municipality } = useContext(AdminContext)
+  const { admin } = useContext(AdminContext)
 
   const isLoggedInUser = (staff: Staff) =>
     admin?.nationalId === staff.nationalId
-
-  const mapToOption = (filterArr: string[], active: boolean) => {
-    return municipality
-      .filter((el) =>
-        active
-          ? filterArr.includes(el.municipalityId)
-          : !filterArr.includes(el.municipalityId),
-      )
-      .map((el) => {
-        return { label: el.name, value: el.municipalityId }
-      })
-  }
 
   const [state, setState] = useState<EmployeeProfileInfo>({
     nationalId: user.nationalId,
@@ -67,7 +56,7 @@ const EmployeeProfile = ({ user }: EmployeeProfileProps) => {
     hasError: false,
     roles: user.roles,
     municipalityIds: user.municipalityIds,
-    serviceCenter: mapToOption(user.municipalityIds, false),
+    serviceCenter: mapMuniToOption(user.municipalityIds, false),
   })
 
   const { changeUserActivity, staffActivationLoading, updateInfo } = useStaff()
@@ -220,12 +209,11 @@ const EmployeeProfile = ({ user }: EmployeeProfileProps) => {
             marginBottom={[3, 3, 5]}
           >
             <Box display="block" marginTop={3} marginBottom={[3, 3, 5]}>
-              <Text as="h2" variant="h3" color="dark300" marginBottom={3}>
-                Sveitarfélög notanda
-              </Text>
               <MultiSelection
                 options={state.serviceCenter}
-                active={mapToOption(state.municipalityIds, true)}
+                active={mapMuniToOption(state.municipalityIds, true)}
+                setState={setState}
+                state={state}
                 onSelected={(option: ValueType<ReactSelectOption>) => {
                   const { value } = option as ReactSelectOption
                   if (value && isString(value)) {

--- a/apps/financial-aid/web-veita/src/components/index.ts
+++ b/apps/financial-aid/web-veita/src/components/index.ts
@@ -47,3 +47,4 @@ export { default as NewMunicipalityModal } from './NewMunicipalityModal/NewMunic
 export { default as MunicipalityProfile } from './Profile/MunicipalityProfile'
 export { default as CollapsibleProfileUnit } from './ProfileUnit/CollapsibleProfileUnit'
 export { default as PrintableFiles } from './PrintableFiles/PrintableFiles'
+export { default as MultiSelection } from './MultiSelection/MultiSelection'

--- a/apps/financial-aid/web-veita/src/utils/formHelper.ts
+++ b/apps/financial-aid/web-veita/src/utils/formHelper.ts
@@ -6,6 +6,8 @@ import differenceInWeeks from 'date-fns/differenceInWeeks'
 
 import { serviceCenters } from '@island.is/financial-aid/shared/data'
 import { ApplicationState } from '@island.is/financial-aid/shared/lib'
+import { useContext } from 'react'
+import { AdminContext } from '../components/AdminProvider/AdminProvider'
 
 export const isPluralInIcelandic = (value: number): boolean =>
   value % 10 !== 1 || value % 100 === 11
@@ -62,4 +64,18 @@ export const getTagByState = (state: ApplicationState) => {
     case ApplicationState.DATANEEDED:
       return 'outDatedOrDenied'
   }
+}
+
+export const mapMuniToOption = (filterArr: string[], active: boolean) => {
+  const { municipality } = useContext(AdminContext)
+
+  return municipality
+    .filter((el) =>
+      active
+        ? filterArr.includes(el.municipalityId)
+        : !filterArr.includes(el.municipalityId),
+    )
+    .map((el) => {
+      return { label: el.name, value: el.municipalityId }
+    })
 }

--- a/apps/financial-aid/web-veita/src/utils/formHelper.ts
+++ b/apps/financial-aid/web-veita/src/utils/formHelper.ts
@@ -3,11 +3,9 @@ import differenceInHours from 'date-fns/differenceInHours'
 import differenceInDays from 'date-fns/differenceInDays'
 import differenceInYears from 'date-fns/differenceInYears'
 import differenceInWeeks from 'date-fns/differenceInWeeks'
-
-import { serviceCenters } from '@island.is/financial-aid/shared/data'
 import { ApplicationState } from '@island.is/financial-aid/shared/lib'
 import { useContext } from 'react'
-import { AdminContext } from '../components/AdminProvider/AdminProvider'
+import { AdminContext } from '@island.is/financial-aid-web/veita/src/components/AdminProvider/AdminProvider'
 
 export const isPluralInIcelandic = (value: number): boolean =>
   value % 10 !== 1 || value % 100 === 11

--- a/apps/financial-aid/web-veita/src/utils/useLogOut.ts
+++ b/apps/financial-aid/web-veita/src/utils/useLogOut.ts
@@ -11,6 +11,7 @@ export const useLogOut = () => {
 
   const logOut = () => {
     setAdmin && setAdmin(undefined)
+    sessionStorage.clear()
     signOut({
       callbackUrl: signOutUrl(window, session?.idToken),
     })

--- a/apps/financial-aid/web-veita/src/utils/useMunicipalities.ts
+++ b/apps/financial-aid/web-veita/src/utils/useMunicipalities.ts
@@ -41,7 +41,7 @@ const MunicipalityQuery = gql`
 export const useMunicipalities = () => {
   const storageKey = 'currentMunicipalities'
 
-  const [municipality, setScopedMunicipality] = useState<Municipality[]>()
+  const [municipality, setScopedMunicipality] = useState<Municipality[]>([])
 
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<Error | undefined>(undefined)

--- a/libs/financial-aid/shared/src/lib/interfaces.ts
+++ b/libs/financial-aid/shared/src/lib/interfaces.ts
@@ -365,7 +365,7 @@ export interface CreateStaff {
   nationalId: string
   roles: StaffRole[]
   municipalityName?: string
-  municipalityId?: string
+  municipalityIds?: string[]
 }
 
 export interface CreateStaffMunicipality {


### PR DESCRIPTION
# When creating staff admin is allowed to select muni that admin has access to

https://app.asana.com/0/1202037685216853/1201234405372285

## What

- Added when logged out to clear session storage
- Adding to create staff municipalityIds 
- Refactoring multiselection component
- Refactoring types employ and new user modal for multiselection component
- Added type CreateUpdateStaff that employee and new user modal have in common
- Added error state if municipality ids is empty 
- Tested updated

## Why

- to start with a clean slate 
- needed to update create
- multiselection a bit cluttered

## Screenshots / Gifs
![Screenshot 2022-04-06 at 17 18 41](https://user-images.githubusercontent.com/62568905/162031601-f68bfc9b-54c0-43d4-a2a3-6a3e818c48ef.png)
![Screenshot 2022-04-06 at 17 18 16](https://user-images.githubusercontent.com/62568905/162031621-21c2327e-e30b-4661-9ba5-f1e8cd44b91d.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
