### PR TITLE
feat(fa): Super admin can make existing user as admin

### DIFF
--- a/apps/financial-aid/api/src/app/modules/municipality/models/municipality.model.ts
+++ b/apps/financial-aid/api/src/app/modules/municipality/models/municipality.model.ts
@@ -39,4 +39,7 @@ export class MunicipalityModel implements Municipality {
 
   @Field(() => [StaffModel], { nullable: true })
   readonly adminUsers?: StaffModel[]
+
+  @Field(() => [StaffModel], { nullable: true })
+  readonly allAdminUsers?: StaffModel[]
 }

--- a/apps/financial-aid/api/src/app/modules/municipality/municipality.resolver.ts
+++ b/apps/financial-aid/api/src/app/modules/municipality/municipality.resolver.ts
@@ -105,19 +105,26 @@ export class MunicipalityResolver {
     this.logger.debug(
       `Getting number of users for ${municipality.municipalityId}`,
     )
-
     return backendApi.getNumberOfStaffForMunicipality(
       municipality.municipalityId,
     )
   }
 
-  @ResolveField('adminUsers', () => [StaffModel])
+  @ResolveField('adminUsers')
   adminUsers(
     @Parent() municipality: MunicipalityModel,
     @Context('dataSources') { backendApi }: { backendApi: BackendAPI },
   ): Promise<Staff[]> {
     this.logger.debug(`Getting admin users for ${municipality.municipalityId}`)
-
     return backendApi.getAdminUsers(municipality.municipalityId)
+  }
+
+  @ResolveField('allAdminUsers')
+  allAdminUsers(
+    @Parent() municipality: MunicipalityModel,
+    @Context('dataSources') { backendApi }: { backendApi: BackendAPI },
+  ): Promise<Staff[]> {
+    this.logger.debug(`Getting admin users for ${municipality.municipalityId}`)
+    return backendApi.getAllAdminUsers(municipality.municipalityId)
   }
 }

--- a/apps/financial-aid/api/src/app/modules/municipality/municipality.resolver.ts
+++ b/apps/financial-aid/api/src/app/modules/municipality/municipality.resolver.ts
@@ -71,7 +71,7 @@ export class MunicipalityResolver {
     @Args('input', { type: () => CreateMunicipalityInput })
     input: CreateMunicipalityInput,
     @Context('dataSources') { backendApi }: { backendApi: BackendAPI },
-  ): Promise<MunicipalityModel> {
+  ): Promise<Municipality> {
     const { admin, ...createMunicipality } = input
     this.logger.debug('Creating municipality')
     return backendApi.createMunicipality(createMunicipality, admin)

--- a/apps/financial-aid/api/src/services/backend.ts
+++ b/apps/financial-aid/api/src/services/backend.ts
@@ -156,6 +156,9 @@ class BackendAPI extends RESTDataSource {
   getAdminUsers(municipalityId: string): Promise<Staff[]> {
     return this.get(`staff/users/${municipalityId}`)
   }
+  getAllAdminUsers(municipalityId: string): Promise<Staff[]> {
+    return this.get(`staff/allAdminUsers/${municipalityId}`)
+  }
 
   getSupervisors(): Promise<Staff[]> {
     return this.get('staff/supervisors')

--- a/apps/financial-aid/backend/src/app/modules/staff/staff.controller.ts
+++ b/apps/financial-aid/backend/src/app/modules/staff/staff.controller.ts
@@ -132,6 +132,18 @@ export class StaffController {
   }
 
   @StaffRolesRules(StaffRole.SUPERADMIN)
+  @Get('allAdminUsers/:municipalityId')
+  @ApiOkResponse({
+    type: [StaffModel],
+    description: 'Gets admin users by municipality id',
+  })
+  async allAdminUsers(
+    @Param('municipalityId') municipalityId: string,
+  ): Promise<StaffModel[]> {
+    return this.staffService.allAdminUsers(municipalityId)
+  }
+
+  @StaffRolesRules(StaffRole.SUPERADMIN)
   @Get('supervisors')
   @ApiOkResponse({
     type: [StaffModel],

--- a/apps/financial-aid/backend/src/app/modules/staff/staff.service.ts
+++ b/apps/financial-aid/backend/src/app/modules/staff/staff.service.ts
@@ -185,6 +185,19 @@ export class StaffService {
     })
   }
 
+  async allAdminUsers(municipalityId: string): Promise<StaffModel[]> {
+    return await this.staffModel.findAll({
+      where: {
+        [Op.not]: {
+          municipalityIds: {
+            [Op.contains]: [municipalityId],
+          },
+        },
+        roles: { [Op.contains]: [StaffRole.ADMIN] },
+      },
+    })
+  }
+
   async getSupervisors(): Promise<StaffModel[]> {
     return await this.staffModel.findAll({
       where: {

--- a/apps/financial-aid/web-veita/graphql/sharedGql.ts
+++ b/apps/financial-aid/web-veita/graphql/sharedGql.ts
@@ -459,6 +459,13 @@ export const MunicipalityQuery = gql`
         active
         id
       }
+      allAdminUsers {
+        name
+        nationalId
+        email
+        active
+        id
+      }
       individualAid {
         ownPlace
         registeredRenting

--- a/apps/financial-aid/web-veita/graphql/sharedGql.ts
+++ b/apps/financial-aid/web-veita/graphql/sharedGql.ts
@@ -461,10 +461,8 @@ export const MunicipalityQuery = gql`
       }
       allAdminUsers {
         name
-        nationalId
-        email
-        active
         id
+        municipalityIds
       }
       individualAid {
         ownPlace

--- a/apps/financial-aid/web-veita/src/components/MultiSelection/MultiSelection.css.ts
+++ b/apps/financial-aid/web-veita/src/components/MultiSelection/MultiSelection.css.ts
@@ -6,3 +6,9 @@ export const tags = style({
   marginRight: theme.spacing[2],
   borderRadius: theme.spacing[1],
 })
+
+export const selectionAdminContainer = style({
+  display: 'grid',
+  gridTemplateColumns: 'auto max-content',
+  columnGap: theme.spacing[3],
+})

--- a/apps/financial-aid/web-veita/src/components/MultiSelection/MultiSelectionAdmins.tsx
+++ b/apps/financial-aid/web-veita/src/components/MultiSelection/MultiSelectionAdmins.tsx
@@ -2,13 +2,14 @@ import React, { useState } from 'react'
 import { Box, Select, Button } from '@island.is/island-ui/core'
 import {
   ReactSelectOption,
-  Staff,
   UpdateAdmin,
 } from '@island.is/financial-aid/shared/lib'
 import { ValueType } from 'react-select'
 
 import { useStaff } from '@island.is/financial-aid-web/veita/src/utils/useStaff'
 import { useRouter } from 'next/router'
+
+import * as styles from './MultiSelection.css'
 
 interface Props {
   admins: UpdateAdmin[]
@@ -42,27 +43,32 @@ const MultiSelectionAdmin = ({ admins, onUpdate }: Props) => {
     })
   }
   return (
-    <Box display="block" marginBottom={3}>
-      <Box marginBottom={3}>
-        <Select
-          label="Leita að stjórnanda"
-          name="selectMunicipality"
-          noOptionsMessage="Enginn valmöguleiki"
-          options={admins.map((el) => {
-            return { label: el.name, value: el.id }
-          })}
-          placeholder="Veldu stjórnanda"
-          onChange={(option: ValueType<ReactSelectOption>) => {
-            const { value } = option as ReactSelectOption
-            setSelected(admins.find((el) => value === el.id))
-          }}
-          errorMessage="Verður að velja að minnsta kosti 1 sveitarfélag"
-          // hasError={hasError && municipalityIds.length === 0}
-        />
+    <Box marginBottom={7} className={styles.selectionAdminContainer}>
+      <Select
+        label="Leita að stjórnanda"
+        name="selectMunicipality"
+        noOptionsMessage="Enginn valmöguleiki"
+        options={admins.map((el) => {
+          return { label: el.name, value: el.id }
+        })}
+        placeholder="Veldu stjórnanda"
+        onChange={(option: ValueType<ReactSelectOption>) => {
+          const { value } = option as ReactSelectOption
+          setSelected(admins.find((el) => value === el.id))
+        }}
+        size="sm"
+      />
+      <Box display="flex" alignItems="center">
+        <Button
+          size="small"
+          icon="add"
+          variant="ghost"
+          onClick={onSubmitUpdate}
+          disabled={!selected}
+        >
+          Bæta við
+        </Button>
       </Box>
-      <Button size="small" icon="add" variant="ghost" onClick={onSubmitUpdate}>
-        Bæta við
-      </Button>
     </Box>
   )
 }

--- a/apps/financial-aid/web-veita/src/components/MultiSelection/MultiSelectionAdmins.tsx
+++ b/apps/financial-aid/web-veita/src/components/MultiSelection/MultiSelectionAdmins.tsx
@@ -45,13 +45,13 @@ const MultiSelectionAdmin = ({ admins, onUpdate }: Props) => {
     <Box display="block" marginBottom={3}>
       <Box marginBottom={3}>
         <Select
-          label="Stjórnendur"
+          label="Leita að stjórnanda"
           name="selectMunicipality"
           noOptionsMessage="Enginn valmöguleiki"
           options={admins.map((el) => {
             return { label: el.name, value: el.id }
           })}
-          placeholder="Leita að stjórnanda"
+          placeholder="Veldu stjórnanda"
           onChange={(option: ValueType<ReactSelectOption>) => {
             const { value } = option as ReactSelectOption
             setSelected(admins.find((el) => value === el.id))

--- a/apps/financial-aid/web-veita/src/components/MultiSelection/MultiSelectionAdmins.tsx
+++ b/apps/financial-aid/web-veita/src/components/MultiSelection/MultiSelectionAdmins.tsx
@@ -1,25 +1,23 @@
 import React, { useState } from 'react'
 import { Box, Select, Button } from '@island.is/island-ui/core'
-import { ReactSelectOption } from '@island.is/financial-aid/shared/lib'
+import {
+  ReactSelectOption,
+  Staff,
+  UpdateAdmin,
+} from '@island.is/financial-aid/shared/lib'
 import { ValueType } from 'react-select'
 
-import { useStaff } from '../../utils/useStaff'
+import { useStaff } from '@island.is/financial-aid-web/veita/src/utils/useStaff'
 import { useRouter } from 'next/router'
-
-interface UpdateAdmin {
-  id: string
-  name: string
-  municipalityIds: string[]
-}
 
 interface Props {
   admins: UpdateAdmin[]
+  onUpdate: () => void
 }
 
-const MultiSelectionAdmin = ({ admins }: Props) => {
+const MultiSelectionAdmin = ({ admins, onUpdate }: Props) => {
   const router = useRouter()
   const [selected, setSelected] = useState<UpdateAdmin>()
-  console.log(selected)
 
   const { updateInfo } = useStaff()
   const onSubmitUpdate = async () => {
@@ -39,38 +37,32 @@ const MultiSelectionAdmin = ({ admins }: Props) => {
       selected?.municipalityIds && newMuni
         ? [...selected?.municipalityIds, newMuni]
         : undefined,
-    )
+    ).then(() => {
+      onUpdate()
+    })
   }
-
-  console.log(admins)
   return (
     <Box display="block" marginBottom={3}>
       <Box marginBottom={3}>
-        <Button
-          size="small"
-          icon="add"
-          variant="ghost"
-          onClick={onSubmitUpdate}
-        >
-          Bæta við stjórnanda
-        </Button>
+        <Select
+          label="Stjórnendur"
+          name="selectMunicipality"
+          noOptionsMessage="Enginn valmöguleiki"
+          options={admins.map((el) => {
+            return { label: el.name, value: el.id }
+          })}
+          placeholder="Leita að stjórnanda"
+          onChange={(option: ValueType<ReactSelectOption>) => {
+            const { value } = option as ReactSelectOption
+            setSelected(admins.find((el) => value === el.id))
+          }}
+          errorMessage="Verður að velja að minnsta kosti 1 sveitarfélag"
+          // hasError={hasError && municipalityIds.length === 0}
+        />
       </Box>
-
-      <Select
-        label="Stjórnendur"
-        name="selectMunicipality"
-        noOptionsMessage="Enginn valmöguleiki"
-        options={admins.map((el) => {
-          return { label: el.name, value: el.id }
-        })}
-        placeholder="Leita að stjórnanda"
-        onChange={(option: ValueType<ReactSelectOption>) => {
-          const { value } = option as ReactSelectOption
-          setSelected(admins.find((el) => value === el.id))
-        }}
-        errorMessage="Verður að velja að minnsta kosti 1 sveitarfélag"
-        // hasError={hasError && municipalityIds.length === 0}
-      />
+      <Button size="small" icon="add" variant="ghost" onClick={onSubmitUpdate}>
+        Bæta við
+      </Button>
     </Box>
   )
 }

--- a/apps/financial-aid/web-veita/src/components/MultiSelection/MultiSelectionAdmins.tsx
+++ b/apps/financial-aid/web-veita/src/components/MultiSelection/MultiSelectionAdmins.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react'
+import { Box, Select, Button } from '@island.is/island-ui/core'
+import { ReactSelectOption } from '@island.is/financial-aid/shared/lib'
+import { ValueType } from 'react-select'
+
+import { useStaff } from '../../utils/useStaff'
+import { useRouter } from 'next/router'
+
+interface UpdateAdmin {
+  id: string
+  name: string
+  municipalityIds: string[]
+}
+
+interface Props {
+  admins: UpdateAdmin[]
+}
+
+const MultiSelectionAdmin = ({ admins }: Props) => {
+  const router = useRouter()
+  const [selected, setSelected] = useState<UpdateAdmin>()
+  console.log(selected)
+
+  const { updateInfo } = useStaff()
+  const onSubmitUpdate = async () => {
+    const newMuni = router?.query?.id?.toString()
+
+    if (!selected && !newMuni) {
+      return
+    }
+    await updateInfo(
+      selected?.id,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      selected?.municipalityIds && newMuni
+        ? [...selected?.municipalityIds, newMuni]
+        : undefined,
+    )
+  }
+
+  console.log(admins)
+  return (
+    <Box display="block" marginBottom={3}>
+      <Box marginBottom={3}>
+        <Button
+          size="small"
+          icon="add"
+          variant="ghost"
+          onClick={onSubmitUpdate}
+        >
+          Bæta við stjórnanda
+        </Button>
+      </Box>
+
+      <Select
+        label="Stjórnendur"
+        name="selectMunicipality"
+        noOptionsMessage="Enginn valmöguleiki"
+        options={admins.map((el) => {
+          return { label: el.name, value: el.id }
+        })}
+        placeholder="Leita að stjórnanda"
+        onChange={(option: ValueType<ReactSelectOption>) => {
+          const { value } = option as ReactSelectOption
+          setSelected(admins.find((el) => value === el.id))
+        }}
+        errorMessage="Verður að velja að minnsta kosti 1 sveitarfélag"
+        // hasError={hasError && municipalityIds.length === 0}
+      />
+    </Box>
+  )
+}
+
+export default MultiSelectionAdmin

--- a/apps/financial-aid/web-veita/src/components/MultiSelection/MultiSelectionMunicipality.tsx
+++ b/apps/financial-aid/web-veita/src/components/MultiSelection/MultiSelectionMunicipality.tsx
@@ -23,7 +23,7 @@ type Props<T> = {
   state: CreateUpdateStaff<T>
 }
 
-const MultiSelection = <T extends unknown>({
+const MultiSelectionMunicipality = <T extends unknown>({
   selectionUpdate,
   state,
 }: Props<T>) => {
@@ -83,4 +83,4 @@ const MultiSelection = <T extends unknown>({
   )
 }
 
-export default MultiSelection
+export default MultiSelectionMunicipality

--- a/apps/financial-aid/web-veita/src/components/NewUserModal/NewUserModal.tsx
+++ b/apps/financial-aid/web-veita/src/components/NewUserModal/NewUserModal.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { Box, Checkbox, Input, Text } from '@island.is/island-ui/core'
 import {
   ActionModal,
-  MultiSelection,
+  MultiSelectionMunicipality,
 } from '@island.is/financial-aid-web/veita/src/components'
 import { StaffMutation } from '@island.is/financial-aid-web/veita/graphql'
 import { ApolloError, useMutation } from '@apollo/client'
@@ -11,7 +11,7 @@ import cn from 'classnames'
 import {
   CreateUpdateStaff,
   selectionType,
-} from '@island.is/financial-aid-web/veita/src/components/MultiSelection/MultiSelection'
+} from '@island.is/financial-aid-web/veita/src/components/MultiSelection/MultiSelectionMunicipality'
 import { useRouter } from 'next/router'
 
 interface Props {
@@ -192,7 +192,7 @@ const NewUserModal = ({
       {predefinedRoles.length === 0 && (
         <>
           <Box display="block" marginBottom={[3, 3, 5]}>
-            <MultiSelection
+            <MultiSelectionMunicipality
               selectionUpdate={(
                 value: string,
                 label: string,

--- a/apps/financial-aid/web-veita/src/components/Profile/EmployeeProfile.tsx
+++ b/apps/financial-aid/web-veita/src/components/Profile/EmployeeProfile.tsx
@@ -17,11 +17,11 @@ import {
   Staff,
   StaffRole,
 } from '@island.is/financial-aid/shared/lib'
-import { MultiSelection } from '@island.is/financial-aid-web/veita/src/components'
+import { MultiSelectionMunicipality } from '@island.is/financial-aid-web/veita/src/components'
 
 import { useStaff } from '@island.is/financial-aid-web/veita/src/utils/useStaff'
 import { AdminContext } from '@island.is/financial-aid-web/veita/src/components/AdminProvider/AdminProvider'
-import { CreateUpdateStaff } from '../MultiSelection/MultiSelection'
+import { CreateUpdateStaff } from '@island.is/financial-aid-web/veita/src/components/MultiSelection/MultiSelectionMunicipality'
 
 import cn from 'classnames'
 import * as styles from './Profile.css'
@@ -215,7 +215,7 @@ const EmployeeProfile = ({ user }: EmployeeProfileProps) => {
             marginBottom={[3, 3, 5]}
           >
             <Box display="block" marginTop={3} marginBottom={[3, 3, 5]}>
-              <MultiSelection
+              <MultiSelectionMunicipality
                 selectionUpdate={(
                   value: string,
                   label: string,

--- a/apps/financial-aid/web-veita/src/components/Profile/MunicipalityProfile.tsx
+++ b/apps/financial-aid/web-veita/src/components/Profile/MunicipalityProfile.tsx
@@ -20,6 +20,7 @@ import {
   TextTableItem,
   ActivationButtonTableItem,
   NewUserModal,
+  MultiSelectionAdmin,
 } from '@island.is/financial-aid-web/veita/src/components'
 import { useStaff } from '@island.is/financial-aid-web/veita/src/utils/useStaff'
 import { useLazyQuery } from '@apollo/client'
@@ -203,6 +204,10 @@ const MunicipalityProfile = ({
             <Text as="h3" variant="h3" color="dark300">
               Stjórnendur
             </Text>
+          </Box>
+
+          <Box>
+            <MultiSelectionAdmin admins={municipality.allAdminUsers} />
           </Box>
 
           <div className={`${tableStyles.smallTableWrapper} hideScrollBar`}>

--- a/apps/financial-aid/web-veita/src/components/Profile/MunicipalityProfile.tsx
+++ b/apps/financial-aid/web-veita/src/components/Profile/MunicipalityProfile.tsx
@@ -171,7 +171,7 @@ const MunicipalityProfile = ({
               variant="ghost"
               onClick={() => setIsModalVisible(true)}
             >
-              Bæta við stjórnanda
+              Nýr stjórnandi
             </Button>
           </Box>
 
@@ -199,17 +199,18 @@ const MunicipalityProfile = ({
             </button>
           </Box>
         </Box>
-        <Box marginBottom={7}>
-          <Box marginBottom={3} className={`contentUp delay-50`}>
+        <Box marginBottom={7} className={`contentUp delay-50`}>
+          <Box marginBottom={3}>
             <Text as="h3" variant="h3" color="dark300">
               Stjórnendur
             </Text>
           </Box>
-
           <Box>
-            <MultiSelectionAdmin admins={municipality.allAdminUsers} />
+            <MultiSelectionAdmin
+              admins={municipality.allAdminUsers}
+              onUpdate={refreshList}
+            />
           </Box>
-
           <div className={`${tableStyles.smallTableWrapper} hideScrollBar`}>
             <table
               className={cn({

--- a/apps/financial-aid/web-veita/src/components/Profile/MunicipalityProfile.tsx
+++ b/apps/financial-aid/web-veita/src/components/Profile/MunicipalityProfile.tsx
@@ -205,12 +205,6 @@ const MunicipalityProfile = ({
               Stjórnendur
             </Text>
           </Box>
-          <Box>
-            <MultiSelectionAdmin
-              admins={municipality.allAdminUsers}
-              onUpdate={refreshList}
-            />
-          </Box>
           <div className={`${tableStyles.smallTableWrapper} hideScrollBar`}>
             <table
               className={cn({
@@ -277,12 +271,23 @@ const MunicipalityProfile = ({
           </div>
         </Box>
 
-        <Box>
-          <Box marginBottom={3} className={`contentUp delay-100`}>
-            <Text as="h3" variant="h3" color="dark300">
-              Grunnupphæðir
-            </Text>
-          </Box>
+        <Box marginBottom={3} className={`contentUp delay-100`}>
+          {municipality?.allAdminUsers && (
+            <>
+              <Text as="h3" variant="h3" color="dark300" marginBottom={3}>
+                Bæta við stjórnanda úr lista
+              </Text>
+
+              <MultiSelectionAdmin
+                admins={municipality.allAdminUsers}
+                onUpdate={refreshList}
+              />
+            </>
+          )}
+
+          <Text as="h3" variant="h3" color="dark300">
+            Grunnupphæðir
+          </Text>
           <div className={`${tableStyles.smallTableWrapper} hideScrollBar`}>
             <table
               className={cn({

--- a/apps/financial-aid/web-veita/src/components/Profile/MunicipalityProfile.tsx
+++ b/apps/financial-aid/web-veita/src/components/Profile/MunicipalityProfile.tsx
@@ -170,7 +170,7 @@ const MunicipalityProfile = ({
               variant="ghost"
               onClick={() => setIsModalVisible(true)}
             >
-              Nýr stjórnandi
+              Bæta við stjórnanda
             </Button>
           </Box>
 

--- a/apps/financial-aid/web-veita/src/components/index.ts
+++ b/apps/financial-aid/web-veita/src/components/index.ts
@@ -47,5 +47,6 @@ export { default as NewMunicipalityModal } from './NewMunicipalityModal/NewMunic
 export { default as MunicipalityProfile } from './Profile/MunicipalityProfile'
 export { default as CollapsibleProfileUnit } from './ProfileUnit/CollapsibleProfileUnit'
 export { default as PrintableFiles } from './PrintableFiles/PrintableFiles'
-export { default as MultiSelection } from './MultiSelection/MultiSelection'
+export { default as MultiSelectionMunicipality } from './MultiSelection/MultiSelectionMunicipality'
 export { default as SelectedMunicipality } from './SelectedMunicipality/SelectedMunicipality'
+export { default as MultiSelectionAdmin } from './MultiSelection/MultiSelectionAdmins'

--- a/libs/financial-aid/shared/src/lib/interfaces.ts
+++ b/libs/financial-aid/shared/src/lib/interfaces.ts
@@ -162,6 +162,7 @@ export interface Municipality {
   rulesHomepage?: string
   numberOfUsers?: number
   adminUsers?: Staff[]
+  allAdminUsers?: Staff[]
 }
 
 export interface UpdateMunicipalityActivity {

--- a/libs/financial-aid/shared/src/lib/interfaces.ts
+++ b/libs/financial-aid/shared/src/lib/interfaces.ts
@@ -150,6 +150,12 @@ export interface ApplicationEvent {
   staffName?: string
 }
 
+export interface UpdateAdmin {
+  id: string
+  name: string
+  municipalityIds: string[]
+}
+
 export interface Municipality {
   id: string
   name: string
@@ -162,7 +168,7 @@ export interface Municipality {
   rulesHomepage?: string
   numberOfUsers?: number
   adminUsers?: Staff[]
-  allAdminUsers?: Staff[]
+  allAdminUsers?: UpdateAdmin[]
 }
 
 export interface UpdateMunicipalityActivity {


### PR DESCRIPTION
# Super admin can make existing user as admin to municipality 

https://app.asana.com/0/1202037685216853/1202025307775315

## What

- Created new endpoint where getting all admins that are not in municipality 
- Added select option where you can pick admin that are not in municipality 

## Why

- Needed feature for super admin and convenient 

## Screenshots / Gifs

![Screenshot 2022-04-08 at 13 34 16](https://user-images.githubusercontent.com/62568905/162447319-b5b145c3-b4c7-4868-a8c4-be99d57a4e30.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
