### PR TITLE
feat(fa): When creating municipality being able to use existing admin

### DIFF
--- a/apps/financial-aid/api/src/app/modules/municipality/dto/createMunicipality.input.ts
+++ b/apps/financial-aid/api/src/app/modules/municipality/dto/createMunicipality.input.ts
@@ -1,7 +1,7 @@
 import { Allow } from 'class-validator'
 
 import { Field, InputType } from '@nestjs/graphql'
-import { CreateStaffInput } from '../../staff'
+import { CreateStaffInput } from '../../staff/dto'
 
 @InputType()
 export class CreateMunicipalityInput {
@@ -15,5 +15,5 @@ export class CreateMunicipalityInput {
 
   @Allow()
   @Field()
-  readonly admin!: CreateStaffInput
+  readonly admin?: CreateStaffInput
 }

--- a/apps/financial-aid/api/src/app/modules/municipality/dto/createMunicipality.input.ts
+++ b/apps/financial-aid/api/src/app/modules/municipality/dto/createMunicipality.input.ts
@@ -14,6 +14,6 @@ export class CreateMunicipalityInput {
   readonly municipalityId!: string
 
   @Allow()
-  @Field()
+  @Field({ nullable: true })
   readonly admin?: CreateStaffInput
 }

--- a/apps/financial-aid/api/src/app/modules/municipality/municipality.resolver.ts
+++ b/apps/financial-aid/api/src/app/modules/municipality/municipality.resolver.ts
@@ -71,7 +71,7 @@ export class MunicipalityResolver {
     @Args('input', { type: () => CreateMunicipalityInput })
     input: CreateMunicipalityInput,
     @Context('dataSources') { backendApi }: { backendApi: BackendAPI },
-  ): Promise<MunicipalityModel> {
+  ): Promise<Municipality> {
     const { admin, ...createMunicipality } = input
     this.logger.debug('Creating municipality')
     return backendApi.createMunicipality(createMunicipality, admin)

--- a/apps/financial-aid/api/src/app/modules/staff/staff.resolver.ts
+++ b/apps/financial-aid/api/src/app/modules/staff/staff.resolver.ts
@@ -38,6 +38,14 @@ export class StaffResolver {
   }
 
   @Query(() => [StaffModel])
+  admins(
+    @Context('dataSources') { backendApi }: { backendApi: BackendAPI },
+  ): Promise<Staff[]> {
+    this.logger.debug(`Getting all admins`)
+    return backendApi.getAdmins()
+  }
+
+  @Query(() => [StaffModel])
   supervisors(
     @Context('dataSources') { backendApi }: { backendApi: BackendAPI },
   ): Promise<Staff[]> {

--- a/apps/financial-aid/api/src/services/backend.ts
+++ b/apps/financial-aid/api/src/services/backend.ts
@@ -71,7 +71,7 @@ class BackendAPI extends RESTDataSource {
 
   createMunicipality(
     createMunicipality: CreateMunicipality,
-    createAdmin: CreateStaff,
+    createAdmin?: CreateStaff,
   ): Promise<Municipality> {
     return this.post('municipality', {
       municipalityInput: createMunicipality,

--- a/apps/financial-aid/api/src/services/backend.ts
+++ b/apps/financial-aid/api/src/services/backend.ts
@@ -161,6 +161,10 @@ class BackendAPI extends RESTDataSource {
     return this.get('staff/supervisors')
   }
 
+  getAdmins(): Promise<Staff[]> {
+    return this.get('staff/admins')
+  }
+
   updateStaff(id: string, updateStaff: UpdateStaff): Promise<Staff> {
     return this.put(`staff/id/${id}`, updateStaff)
   }

--- a/apps/financial-aid/backend/src/app/modules/municipality/municipality.controller.ts
+++ b/apps/financial-aid/backend/src/app/modules/municipality/municipality.controller.ts
@@ -75,7 +75,7 @@ export class MunicipalityController {
     @Body()
     input: {
       municipalityInput: CreateMunicipalityDto
-      adminInput: CreateStaffDto
+      adminInput?: CreateStaffDto
     },
   ): Promise<MunicipalityModel> {
     return this.municipalityService.create(

--- a/apps/financial-aid/backend/src/app/modules/municipality/municipality.service.ts
+++ b/apps/financial-aid/backend/src/app/modules/municipality/municipality.service.ts
@@ -140,6 +140,10 @@ export class MunicipalityService {
                 transaction: t,
               })
             })
+        } else {
+          return this.municipalityModel.create(municipality, {
+            transaction: t,
+          })
         }
       })
     })

--- a/apps/financial-aid/backend/src/app/modules/municipality/municipality.service.ts
+++ b/apps/financial-aid/backend/src/app/modules/municipality/municipality.service.ts
@@ -124,21 +124,23 @@ export class MunicipalityService {
           AidType.COHABITATION,
         )
 
-        return await this.staffService
-          .createStaff(
-            admin,
-            {
-              municipalityId: municipality.municipalityId,
-              municipalityName: municipality.name,
-            },
-            t,
-            true,
-          )
-          .then(() => {
-            return this.municipalityModel.create(municipality, {
-              transaction: t,
+        if (admin) {
+          return await this.staffService
+            .createStaff(
+              admin,
+              {
+                municipalityId: municipality.municipalityId,
+                municipalityName: municipality.name,
+              },
+              t,
+              true,
+            )
+            .then(() => {
+              return this.municipalityModel.create(municipality, {
+                transaction: t,
+              })
             })
-          })
+        }
       })
     })
   }

--- a/apps/financial-aid/backend/src/app/modules/staff/staff.controller.ts
+++ b/apps/financial-aid/backend/src/app/modules/staff/staff.controller.ts
@@ -132,6 +132,16 @@ export class StaffController {
   }
 
   @StaffRolesRules(StaffRole.SUPERADMIN)
+  @Get('admins')
+  @ApiOkResponse({
+    type: [StaffModel],
+    description: 'Gets admins',
+  })
+  async getAdmins(): Promise<StaffModel[]> {
+    return this.staffService.getAdmins()
+  }
+
+  @StaffRolesRules(StaffRole.SUPERADMIN)
   @Get('supervisors')
   @ApiOkResponse({
     type: [StaffModel],

--- a/apps/financial-aid/backend/src/app/modules/staff/staff.service.ts
+++ b/apps/financial-aid/backend/src/app/modules/staff/staff.service.ts
@@ -172,6 +172,7 @@ export class StaffService {
     return await this.staffModel.count({
       where: {
         municipalityIds: { [Op.contains]: [municipalityId] },
+        roles: { [Op.contains]: [StaffRole.ADMIN] },
       },
     })
   }

--- a/apps/financial-aid/backend/src/app/modules/staff/staff.service.ts
+++ b/apps/financial-aid/backend/src/app/modules/staff/staff.service.ts
@@ -185,6 +185,14 @@ export class StaffService {
     })
   }
 
+  async getAdmins(): Promise<StaffModel[]> {
+    return await this.staffModel.findAll({
+      where: {
+        roles: { [Op.contains]: [StaffRole.ADMIN] },
+      },
+    })
+  }
+
   async getSupervisors(): Promise<StaffModel[]> {
     return await this.staffModel.findAll({
       where: {

--- a/apps/financial-aid/backend/src/app/modules/staff/test/numberOfUsersForMunicipality.spec.ts
+++ b/apps/financial-aid/backend/src/app/modules/staff/test/numberOfUsersForMunicipality.spec.ts
@@ -3,6 +3,7 @@ import { uuid } from 'uuidv4'
 
 import { createTestingStaffModule } from './createTestingStaffModule'
 import { Op } from 'sequelize'
+import { StaffRole } from '@island.is/financial-aid/shared/lib'
 
 interface Then {
   result: Number
@@ -46,6 +47,7 @@ describe('StaffController - Get number of users for municipality', () => {
       expect(mockNumberOfUsers).toHaveBeenCalledWith({
         where: {
           municipalityIds: { [Op.contains]: [municipalityId] },
+          roles: { [Op.contains]: [StaffRole.ADMIN] },
         },
       })
     })

--- a/apps/financial-aid/web-veita/graphql/sharedGql.ts
+++ b/apps/financial-aid/web-veita/graphql/sharedGql.ts
@@ -496,6 +496,15 @@ export const AdminUsersQuery = gql`
   }
 `
 
+export const AllAdminsQuery = gql`
+  query allAdminsQuery {
+    admins {
+      id
+      name
+    }
+  }
+`
+
 export const SupervisorsQuery = gql`
   query supervisorsQuery {
     supervisors {

--- a/apps/financial-aid/web-veita/graphql/sharedGql.ts
+++ b/apps/financial-aid/web-veita/graphql/sharedGql.ts
@@ -501,6 +501,7 @@ export const AllAdminsQuery = gql`
     admins {
       id
       name
+      municipalityIds
     }
   }
 `

--- a/apps/financial-aid/web-veita/graphql/sharedGql.ts
+++ b/apps/financial-aid/web-veita/graphql/sharedGql.ts
@@ -378,6 +378,7 @@ export const MunicipalityMutation = gql`
   mutation MunicipalityMutation($input: CreateMunicipalityInput!) {
     createMunicipality(input: $input) {
       id
+      municipalityId
     }
   }
 `

--- a/apps/financial-aid/web-veita/src/components/NewMunicipalityModal/NewMunicipalityModal.tsx
+++ b/apps/financial-aid/web-veita/src/components/NewMunicipalityModal/NewMunicipalityModal.tsx
@@ -12,6 +12,12 @@ interface Props {
   setIsVisible: React.Dispatch<React.SetStateAction<boolean>>
   activeMunicipalitiesCodes?: number[]
   onMunicipalityCreated: () => void
+  allAdmins?: [
+    {
+      id: string
+      name: string
+    },
+  ]
 }
 
 interface newMunicipalityModalState {
@@ -28,7 +34,10 @@ const NewMunicipalityModal = ({
   setIsVisible,
   activeMunicipalitiesCodes,
   onMunicipalityCreated,
+  allAdmins,
 }: Props) => {
+  console.log('newMunibla ', allAdmins)
+
   const selectServiceCenter = serviceCenters
     .filter(
       (el) =>
@@ -131,6 +140,11 @@ const NewMunicipalityModal = ({
 
       <Text marginBottom={2} variant="h4">
         Stjórnandi
+      </Text>
+      <Text marginBottom={2} variant="small">
+        Þú getur valið núverandi stjórnanda eða bætt við nýjum. <br />
+        Stjórnandi fær sendan tölvupóst með hlekk til að skrá sig inn með
+        rafrænum skilríkjum.
       </Text>
       <Box marginBottom={2}>
         <Input

--- a/apps/financial-aid/web-veita/src/components/NewMunicipalityModal/NewMunicipalityModal.tsx
+++ b/apps/financial-aid/web-veita/src/components/NewMunicipalityModal/NewMunicipalityModal.tsx
@@ -146,6 +146,36 @@ const NewMunicipalityModal = ({
         Stjórnandi fær sendan tölvupóst með hlekk til að skrá sig inn með
         rafrænum skilríkjum.
       </Text>
+
+      {allAdmins && (
+        <Box marginBottom={3}>
+          <Select
+            label="Leita að stjórnanda"
+            name="selectAdmin"
+            noOptionsMessage="Enginn valmöguleiki"
+            options={allAdmins.map((el) => {
+              return { label: el.name, value: el.id }
+            })}
+            placeholder="Veldu tegund"
+            hasError={
+              state.hasError &&
+              !state.serviceCenter.label &&
+              !state.serviceCenter.value
+            }
+            errorMessage="Þú þarft að velja stjórnanda"
+            // hasError={state.hasError && }
+            value={state.serviceCenter}
+            onChange={(option) => {
+              setState({
+                ...state,
+                serviceCenter: option as Option,
+                hasError: false,
+              })
+            }}
+          />
+        </Box>
+      )}
+
       <Box marginBottom={2}>
         <Input
           label="Kennitala"

--- a/apps/financial-aid/web-veita/src/routes/Municipalities/municipalities.tsx
+++ b/apps/financial-aid/web-veita/src/routes/Municipalities/municipalities.tsx
@@ -111,7 +111,9 @@ export const Municipalities = () => {
           variant="ghost"
           onClick={() => {
             setIsModalVisible(true)
-            getAdmins()
+            if (!dataAdmins?.admins) {
+              getAdmins()
+            }
           }}
         >
           Nýtt sveitarfélag

--- a/apps/financial-aid/web-veita/src/routes/Municipalities/municipalities.tsx
+++ b/apps/financial-aid/web-veita/src/routes/Municipalities/municipalities.tsx
@@ -20,10 +20,15 @@ import * as tableStyles from '../../sharedStyles/Table.css'
 import * as headerStyles from '../../sharedStyles/Header.css'
 import cn from 'classnames'
 
-import { Municipality, Routes } from '@island.is/financial-aid/shared/lib'
+import {
+  Municipality,
+  Routes,
+  Staff,
+} from '@island.is/financial-aid/shared/lib'
 import {
   MunicipalityActivityMutation,
   MunicipalitiesQuery,
+  AllAdminsQuery,
 } from '@island.is/financial-aid-web/veita/graphql'
 import { useRouter } from 'next/router'
 
@@ -35,9 +40,20 @@ export const Municipalities = () => {
     errorPolicy: 'all',
   })
 
+  const [getAdmins, { data: dataAdmins }] = useLazyQuery<{
+    admins: [
+      {
+        id: string
+        name: string
+      },
+    ]
+  }>(AllAdminsQuery, {
+    fetchPolicy: 'no-cache',
+    errorPolicy: 'all',
+  })
+
   const [isModalVisible, setIsModalVisible] = useState(false)
   const router = useRouter()
-
   useEffect(() => {
     getMunicipalities()
   }, [])
@@ -93,7 +109,10 @@ export const Municipalities = () => {
           size="small"
           icon="add"
           variant="ghost"
-          onClick={() => setIsModalVisible(true)}
+          onClick={() => {
+            setIsModalVisible(true)
+            getAdmins()
+          }}
         >
           Nýtt sveitarfélag
         </Button>
@@ -174,6 +193,7 @@ export const Municipalities = () => {
           parseInt(el.municipalityId),
         )}
         onMunicipalityCreated={refreshList}
+        allAdmins={dataAdmins?.admins}
       />
     </LoadingContainer>
   )

--- a/apps/financial-aid/web-veita/src/routes/Municipalities/municipalities.tsx
+++ b/apps/financial-aid/web-veita/src/routes/Municipalities/municipalities.tsx
@@ -16,14 +16,11 @@ import {
   ToastContainer,
   toast,
 } from '@island.is/island-ui/core'
-import * as tableStyles from '../../sharedStyles/Table.css'
-import * as headerStyles from '../../sharedStyles/Header.css'
-import cn from 'classnames'
 
 import {
   Municipality,
   Routes,
-  Staff,
+  UpdateAdmin,
 } from '@island.is/financial-aid/shared/lib'
 import {
   MunicipalityActivityMutation,
@@ -31,6 +28,10 @@ import {
   AllAdminsQuery,
 } from '@island.is/financial-aid-web/veita/graphql'
 import { useRouter } from 'next/router'
+
+import * as tableStyles from '../../sharedStyles/Table.css'
+import * as headerStyles from '../../sharedStyles/Header.css'
+import cn from 'classnames'
 
 export const Municipalities = () => {
   const [getMunicipalities, { data, error, loading }] = useLazyQuery<{
@@ -40,13 +41,11 @@ export const Municipalities = () => {
     errorPolicy: 'all',
   })
 
-  const [getAdmins, { data: dataAdmins }] = useLazyQuery<{
-    admins: [
-      {
-        id: string
-        name: string
-      },
-    ]
+  const [
+    getAdmins,
+    { data: dataAdmins, error: errorAdmins, loading: loadingAdmins },
+  ] = useLazyQuery<{
+    admins: UpdateAdmin[]
   }>(AllAdminsQuery, {
     fetchPolicy: 'no-cache',
     errorPolicy: 'all',
@@ -196,6 +195,7 @@ export const Municipalities = () => {
         )}
         onMunicipalityCreated={refreshList}
         allAdmins={dataAdmins?.admins}
+        loadingAdmins={loadingAdmins}
       />
     </LoadingContainer>
   )


### PR DESCRIPTION
# ... 👍🏼 

https://app.asana.com/0/1202037685216853/1202025307775313

## What

- Making create admin when creating muni optional 
- Adding to new muni modal the option of picking out an existing admin
- If selected existing admin, after creating muni update admin 
- When getting number of users only admin user

## Why

- Because we want to be able to update admin instead of creating 
- Requested


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
