### PR TITLE
feat(web): Organization published material page - default ordering

### DIFF
--- a/apps/web/screens/Organization/PublishedMaterial/PublishedMaterial.tsx
+++ b/apps/web/screens/Organization/PublishedMaterial/PublishedMaterial.tsx
@@ -74,7 +74,7 @@ const PublishedMaterial: Screen<PublishedMaterialProps> = ({
   const [searchValue, setSearchValue] = useState('')
   const [ordering, setOrdering] = useState<Ordering>({
     field: 'releaseDate',
-    order: 'asc',
+    order: 'desc',
   })
   const n = useNamespace(namespace)
 
@@ -82,25 +82,24 @@ const PublishedMaterial: Screen<PublishedMaterialProps> = ({
   useLocalLinkTypeResolver()
   const { activeLocale } = useI18n()
 
-  const pageUrl = `${organizationPage.slug}/${router.asPath.split('/').pop()}`
-
   const navList: NavigationItem[] = organizationPage.menuLinks.map(
     ({ primaryLink, childrenLinks }) => ({
       title: primaryLink.text,
       href: primaryLink.url,
       active:
-        primaryLink.url.includes(pageUrl) ||
-        childrenLinks.some((link) => link.url.includes(pageUrl)),
+        primaryLink.url === router.asPath ||
+        childrenLinks.some((link) => link.url === router.asPath),
       items: childrenLinks.map(({ text, url }) => ({
         title: text,
         href: url,
-        active: url.includes(pageUrl),
+        active: url === router.asPath,
       })),
     }),
   )
 
-  const [isTyping, setIsTyping] = useState(false)
+  // The page number is 1-based meaning that page 1 is the first page
   const [page, setPage] = useState(1)
+  const [isTyping, setIsTyping] = useState(false)
   const [parameters, setParameters] = useState<Record<string, string[]>>({})
   const [queryVariables, setQueryVariables] = useState({
     variables: {
@@ -227,7 +226,7 @@ const PublishedMaterial: Screen<PublishedMaterialProps> = ({
       isSelected: ordering.field === 'title.sort' && ordering.order === 'desc',
     },
     {
-      title: n('orderByReleaseDateDescending', 'Útgáfudagur (nýjast)'),
+      title: n('orderByReleaseDateDescending', 'Útgáfudagur (nýtt)'),
       onClick: () =>
         setOrdering({
           field: 'releaseDate',
@@ -236,7 +235,7 @@ const PublishedMaterial: Screen<PublishedMaterialProps> = ({
       isSelected: ordering.field === 'releaseDate' && ordering.order === 'desc',
     },
     {
-      title: n('orderByReleaseDateAscending', 'Útgáfudagur (elsta)'),
+      title: n('orderByReleaseDateAscending', 'Útgáfudagur (gamalt)'),
       onClick: () =>
         setOrdering({
           field: 'releaseDate',

--- a/libs/cms/src/lib/cms.elasticsearch.service.ts
+++ b/libs/cms/src/lib/cms.elasticsearch.service.ts
@@ -237,7 +237,7 @@ export class CmsElasticsearchService {
     {
       organizationSlug,
       searchString,
-      page = 1,
+      page = 1, // The page number is 1-based meaning that page 1 is the first page
       size = 10,
       tags,
       tagGroups,

--- a/libs/cms/src/lib/dto/getPublishedMaterial.input.ts
+++ b/libs/cms/src/lib/dto/getPublishedMaterial.input.ts
@@ -18,6 +18,7 @@ export class GetPublishedMaterialInput {
   @Field(() => Int, { nullable: true })
   @IsInt()
   @IsOptional()
+  // The page number is 1-based meaning that page 1 is the first page
   page?: number
 
   @Field({ nullable: true })


### PR DESCRIPTION
# Organization published material page - default ordering

## What

* Changed the default ordering on the Organization published material page
* Only show a menu link as active if it's a direct match
* Added comments indicating that the page number is 1-based

## Why

* The default ordering used to be the ascending release date which is not what users expect
* Menu links are active if there is a prefix match which is not ideal
* A colleague recommended that I'd add comments to indicate that the page number is 1-based since that's not at all obvious

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
