### PR TITLE
feat(fa): When access to one municipality default will select one  

### DIFF
--- a/apps/financial-aid/web-veita/src/components/MultiSelection/MultiSelection.tsx
+++ b/apps/financial-aid/web-veita/src/components/MultiSelection/MultiSelection.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useContext, useEffect } from 'react'
 import { Box, Select, Text, Icon } from '@island.is/island-ui/core'
 import {
   ReactSelectOption,
@@ -6,7 +6,7 @@ import {
 } from '@island.is/financial-aid/shared/lib'
 import { isString } from 'lodash'
 import { ValueType } from 'react-select'
-import { mapMuniToOption } from '@island.is/financial-aid-web/veita/src/utils/formHelper'
+import { AdminContext } from '@island.is/financial-aid-web/veita/src/components/AdminProvider/AdminProvider'
 
 import * as styles from './MultiSelection.css'
 
@@ -27,7 +27,37 @@ const MultiSelection = <T extends unknown>({
   selectionUpdate,
   state,
 }: Props<T>) => {
+  const { municipality } = useContext(AdminContext)
+
+  useEffect(() => {
+    if (municipality && municipality.length === 1) {
+      selectionUpdate(
+        municipality[0].municipalityId,
+        municipality[0].name,
+        'add',
+      )
+    }
+  }, [municipality])
+
+  if (municipality.length === 1) {
+    return <></>
+  }
+
   const { municipalityIds, hasError } = state
+
+  const mapMuniToOption = (filterArr: string[], active: boolean) => {
+    const { municipality } = useContext(AdminContext)
+
+    return municipality
+      .filter((el) =>
+        active
+          ? filterArr.includes(el.municipalityId)
+          : !filterArr.includes(el.municipalityId),
+      )
+      .map((el) => {
+        return { label: el.name, value: el.municipalityId }
+      })
+  }
 
   return (
     <Box display="block">

--- a/apps/financial-aid/web-veita/src/utils/formHelper.ts
+++ b/apps/financial-aid/web-veita/src/utils/formHelper.ts
@@ -1,11 +1,9 @@
-import { useContext } from 'react'
 import differenceInMinutes from 'date-fns/differenceInMinutes'
 import differenceInHours from 'date-fns/differenceInHours'
 import differenceInDays from 'date-fns/differenceInDays'
 import differenceInYears from 'date-fns/differenceInYears'
 import differenceInWeeks from 'date-fns/differenceInWeeks'
 import { ApplicationState } from '@island.is/financial-aid/shared/lib'
-import { AdminContext } from '@island.is/financial-aid-web/veita/src/components/AdminProvider/AdminProvider'
 
 export const isPluralInIcelandic = (value: number): boolean =>
   value % 10 !== 1 || value % 100 === 11
@@ -62,18 +60,4 @@ export const getTagByState = (state: ApplicationState) => {
     case ApplicationState.DATANEEDED:
       return 'outDatedOrDenied'
   }
-}
-
-export const mapMuniToOption = (filterArr: string[], active: boolean) => {
-  const { municipality } = useContext(AdminContext)
-
-  return municipality
-    .filter((el) =>
-      active
-        ? filterArr.includes(el.municipalityId)
-        : !filterArr.includes(el.municipalityId),
-    )
-    .map((el) => {
-      return { label: el.name, value: el.municipalityId }
-    })
 }


### PR DESCRIPTION
# ... ☝🏼 

https://app.asana.com/0/1202037685216853/1202088096213725

## What

- Checks if admin has access to one muni 
- if so then add municipality ids to the one 
- moved mapping function to component

## Why

- select with one selection is just wrong


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
