### PR TITLE
feat: Loading Input

### DIFF
--- a/libs/island-ui/core/src/lib/Input/Input.css.ts
+++ b/libs/island-ui/core/src/lib/Input/Input.css.ts
@@ -1,4 +1,4 @@
-import { style, styleVariants } from '@vanilla-extract/css'
+import { keyframes, style, styleVariants } from '@vanilla-extract/css'
 import { Theme, theme, themeUtils } from '@island.is/island-ui/theme'
 import * as mixins from './Input.mixins'
 import omit from 'lodash/omit'
@@ -103,9 +103,29 @@ export const fixedFocusState = style({
   },
 })
 
+export const spinner = style({
+  width: 24,
+  height: 24,
+  marginBottom: -3,
+  border: `3px solid ${theme.color.blue200}`,
+  borderBottomColor: theme.color.blue400,
+  animationName: keyframes({
+    from: {
+      transform: 'rotate(0deg)',
+    },
+    to: {
+      transform: 'rotate(360deg)',
+    },
+  }),
+  animationDuration: '1.5s',
+  animationIterationCount: 'infinite',
+  animationTimingFunction: 'linear',
+})
+
 export const icon = style({
   width: 24,
   height: 24,
+  flexShrink: 0,
   marginBottom: -3,
   color: theme.color.blue400,
   ...themeUtils.responsiveStyle({

--- a/libs/island-ui/core/src/lib/Input/Input.tsx
+++ b/libs/island-ui/core/src/lib/Input/Input.tsx
@@ -79,6 +79,7 @@ export const Input = forwardRef(
       size = 'md',
       fixedFocusState,
       autoExpand,
+      loading,
       ...inputProps
     } = props
     const [hasFocus, setHasFocus] = useState(false)
@@ -242,7 +243,14 @@ export const Input = forwardRef(
               {...(required && { 'aria-required': true })}
             />
           </Box>
-          {hasError && !icon && (
+          {loading && (
+            <Box
+              className={styles.spinner}
+              flexShrink={0}
+              borderRadius="circle"
+            />
+          )}
+          {!loading && hasError && !icon && (
             <Icon
               icon="warning"
               skipPlaceholderSize
@@ -250,7 +258,7 @@ export const Input = forwardRef(
               ariaHidden
             />
           )}
-          {icon && (
+          {!loading && icon && (
             <Icon
               icon={icon}
               type={iconType}

--- a/libs/island-ui/core/src/lib/Input/types.ts
+++ b/libs/island-ui/core/src/lib/Input/types.ts
@@ -62,4 +62,5 @@ export interface InputProps extends InputComponentProps {
   backgroundColor?: ResponsiveProp<InputBackgroundColor>
   textarea?: boolean
   maxLength?: number
+  loading?: boolean
 }

--- a/libs/shared/form-fields/src/lib/InputController/InputController.tsx
+++ b/libs/shared/form-fields/src/lib/InputController/InputController.tsx
@@ -28,8 +28,8 @@ interface Props {
   required?: boolean
   readOnly?: boolean
   maxLength?: number
+  loading?: boolean
   size?: 'xs' | 'sm' | 'md'
-  autoComplete?: 'off' | 'on'
 }
 
 interface ChildParams {
@@ -62,8 +62,8 @@ export const InputController: FC<Props> = ({
   required,
   readOnly,
   maxLength,
+  loading,
   size = 'md',
-  autoComplete,
 }) => {
   function renderChildInput(c: ChildParams) {
     const { value, onChange, ...props } = c
@@ -85,7 +85,7 @@ export const InputController: FC<Props> = ({
           value={value}
           format={format}
           maxLength={maxLength}
-          autoComplete={autoComplete}
+          loading={loading}
           onChange={(
             e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
           ) => {
@@ -118,7 +118,7 @@ export const InputController: FC<Props> = ({
           value={value}
           format={format}
           maxLength={maxLength}
-          autoComplete={autoComplete}
+          loading={loading}
           onChange={(
             e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
           ) => {
@@ -151,7 +151,7 @@ export const InputController: FC<Props> = ({
           value={value}
           format={format}
           maxLength={maxLength}
-          autoComplete={autoComplete}
+          loading={loading}
           onChange={(
             e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
           ) => {
@@ -186,7 +186,7 @@ export const InputController: FC<Props> = ({
           textarea={textarea}
           type={type}
           maxLength={maxLength}
-          autoComplete={autoComplete}
+          loading={loading}
           onChange={(e) => {
             onChange(e.target.value)
             if (onInputChange) {

--- a/libs/shared/form-fields/src/lib/InputController/InputController.tsx
+++ b/libs/shared/form-fields/src/lib/InputController/InputController.tsx
@@ -30,6 +30,7 @@ interface Props {
   maxLength?: number
   loading?: boolean
   size?: 'xs' | 'sm' | 'md'
+  autoComplete?: 'off' | 'on'
 }
 
 interface ChildParams {
@@ -64,6 +65,7 @@ export const InputController: FC<Props> = ({
   maxLength,
   loading,
   size = 'md',
+  autoComplete,
 }) => {
   function renderChildInput(c: ChildParams) {
     const { value, onChange, ...props } = c
@@ -85,6 +87,7 @@ export const InputController: FC<Props> = ({
           value={value}
           format={format}
           maxLength={maxLength}
+          autoComplete={autoComplete}
           loading={loading}
           onChange={(
             e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
@@ -118,6 +121,7 @@ export const InputController: FC<Props> = ({
           value={value}
           format={format}
           maxLength={maxLength}
+          autoComplete={autoComplete}
           loading={loading}
           onChange={(
             e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
@@ -151,6 +155,7 @@ export const InputController: FC<Props> = ({
           value={value}
           format={format}
           maxLength={maxLength}
+          autoComplete={autoComplete}
           loading={loading}
           onChange={(
             e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
@@ -186,6 +191,7 @@ export const InputController: FC<Props> = ({
           textarea={textarea}
           type={type}
           maxLength={maxLength}
+          autoComplete={autoComplete}
           loading={loading}
           onChange={(e) => {
             onChange(e.target.value)


### PR DESCRIPTION
# Loading Input

## What

Show loading indicator inside input field for better async UX

## Why

Async actions based on input have no standard loading indicator like buttons, this should allow for a more consistent UX

## Screenshots / Gifs

![2022-04-11 09 41 50](https://user-images.githubusercontent.com/5655741/162712619-448e2430-512a-48c5-98f8-66f0ec53ba00.gif)
![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/5655741/162714884-69622a68-32e1-4528-a17e-b96a5bcd9eaf.gif)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
