### PR TITLE
feat(web): Project page default header visual changes

### DIFF
--- a/apps/web/components/Project/Header/DefaultProjectHeader.css.ts
+++ b/apps/web/components/Project/Header/DefaultProjectHeader.css.ts
@@ -3,7 +3,7 @@ import { style } from '@vanilla-extract/css'
 
 export const headerBg = style({
   height: 'fit-content',
-  minHeight: '300px',
+  minHeight: '200px',
   order: 1,
   ...themeUtils.responsiveStyle({
     md: {
@@ -15,12 +15,12 @@ export const headerBg = style({
 
 export const headerWrapper = style({
   display: 'grid',
-  minHeight: '500px',
+  minHeight: '300px',
   height: 'fit-content',
   ...themeUtils.responsiveStyle({
     md: {
       gridTemplateColumns: '1fr 1fr',
-      gridTemplateRows: '1fr',
+      gridTemplateRows: 'min-content',
     },
   }),
 })
@@ -34,7 +34,7 @@ export const headerImage = style({
   ...themeUtils.responsiveStyle({
     md: {
       order: 1,
-      maxHeight: '100%',
+      maxHeight: 'fit-content',
     },
   }),
 })

--- a/apps/web/components/Project/Header/DefaultProjectHeader.css.ts
+++ b/apps/web/components/Project/Header/DefaultProjectHeader.css.ts
@@ -6,7 +6,7 @@ export const headerBg = style({
   minHeight: '200px',
   order: 1,
   ...themeUtils.responsiveStyle({
-    md: {
+    lg: {
       order: 0,
       minHeight: '100%',
     },
@@ -17,8 +17,9 @@ export const headerWrapper = style({
   display: 'grid',
   minHeight: '300px',
   height: 'fit-content',
+  maxHeight: 'min-content',
   ...themeUtils.responsiveStyle({
-    md: {
+    lg: {
       gridTemplateColumns: '1fr 1fr',
       gridTemplateRows: 'min-content',
     },
@@ -27,14 +28,22 @@ export const headerWrapper = style({
 
 export const headerImage = style({
   height: '100%',
-  maxHeight: '200px',
   width: '100%',
   objectFit: 'cover',
   order: 0,
   ...themeUtils.responsiveStyle({
+    xs: {
+      maxHeight: '200px',
+    },
+    sm: {
+      maxHeight: '200px',
+    },
     md: {
+      maxHeight: '200px',
+    },
+    lg: {
       order: 1,
-      maxHeight: 'fit-content',
+      maxHeight: '300px',
     },
   }),
 })

--- a/apps/web/components/Project/Header/DefaultProjectHeader.tsx
+++ b/apps/web/components/Project/Header/DefaultProjectHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useRef } from 'react'
 import {
   Box,
   Text,
@@ -37,11 +37,11 @@ export const DefaultProjectHeader = ({
 
   const { width } = useWindowSize()
 
-  const isBelowLarge = !(width < theme.breakpoints.lg)
+  const isBelowLarge = width < theme.breakpoints.lg
 
   console.log(textRef.current?.getBoundingClientRect())
 
-  const maxImageHeight = isBelowLarge
+  const maxImageHeight = !isBelowLarge
     ? textRef.current?.getBoundingClientRect()?.height ?? undefined
     : undefined
 

--- a/apps/web/components/Project/Header/DefaultProjectHeader.tsx
+++ b/apps/web/components/Project/Header/DefaultProjectHeader.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 import {
   Box,
   Text,
@@ -10,6 +10,8 @@ import {
 import { ProjectPage } from '@island.is/web/graphql/schema'
 import { useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
 import * as styles from './DefaultProjectHeader.css'
+import { useWindowSize } from '@island.is/web/hooks/useViewport'
+import { theme } from '@island.is/island-ui/theme'
 
 const getTextBackgroundColor = (projectPage: ProjectPage) => {
   if (projectPage.defaultHeaderBackgroundColor)
@@ -31,45 +33,65 @@ export const DefaultProjectHeader = ({
 
   const textBackgroundColor = getTextBackgroundColor(projectPage)
 
+  const textRef = useRef<HTMLDivElement | null>(null)
+
+  const { width } = useWindowSize()
+
+  const isBelowLarge = !(width < theme.breakpoints.lg)
+
+  console.log(textRef.current?.getBoundingClientRect())
+
+  const maxImageHeight = isBelowLarge
+    ? textRef.current?.getBoundingClientRect()?.height ?? undefined
+    : undefined
+
   return (
     <Box className={defaultImageIsProvided ? styles.headerWrapper : undefined}>
-      <Box
+      <div
         className={styles.headerBg}
         style={{ background: textBackgroundColor }}
+        ref={textRef}
       >
         <GridContainer>
-          <GridRow align="flexEnd">
-            <GridColumn
-              paddingTop={5}
-              span={[
-                '12/12',
-                '12/12',
-                defaultImageIsProvided ? '10/12' : '12/12',
-                defaultImageIsProvided ? '10/12' : '12/12',
-                defaultImageIsProvided ? '8/12' : '12/12',
-              ]}
-            >
-              <Text variant="eyebrow" color="white" marginTop={5}>
-                Ísland.is
-              </Text>
-              <Link href={linkResolver('projectpage', [projectPage.slug]).href}>
-                <Text variant="h1" color="white" marginTop={2}>
-                  {projectPage.title}
+          <div ref={textRef}>
+            <GridRow align="flexEnd">
+              <GridColumn
+                paddingTop={5}
+                span={[
+                  '12/12',
+                  '12/12',
+                  defaultImageIsProvided ? '10/12' : '12/12',
+                  defaultImageIsProvided ? '10/12' : '12/12',
+                  defaultImageIsProvided ? '8/12' : '12/12',
+                ]}
+              >
+                <Text variant="eyebrow" color="white" marginTop={5}>
+                  Ísland.is
                 </Text>
-              </Link>
-              <Text variant="intro" color="white" marginTop={3}>
-                {projectPage.subtitle}
-              </Text>
-              <Text color="white" marginTop={3}>
-                {projectPage.intro}
-              </Text>
-            </GridColumn>
-          </GridRow>
+                <Link
+                  href={linkResolver('projectpage', [projectPage.slug]).href}
+                >
+                  <Text variant="h1" color="white" marginTop={2}>
+                    {projectPage.title}
+                  </Text>
+                </Link>
+                <Text variant="intro" color="white" marginTop={3}>
+                  {projectPage.subtitle}
+                </Text>
+                <Text color="white" marginTop={3} marginBottom={3}>
+                  {projectPage.intro}
+                </Text>
+              </GridColumn>
+            </GridRow>
+          </div>
         </GridContainer>
-      </Box>
+      </div>
       {defaultImageIsProvided && (
         <img
           className={styles.headerImage}
+          style={{
+            maxHeight: maxImageHeight,
+          }}
           src={projectPage.defaultHeaderImage.url}
           alt="header"
         ></img>


### PR DESCRIPTION
# Project page default header visual changes

## What

* Minor visual changes for the default header of Project pages

## Why

* The header's height used to be too large

## Screenshots / Gifs

### Before
![image](https://user-images.githubusercontent.com/43557895/162737398-7c2f7533-813d-4f74-a09a-8c701f109656.png)

### After
![image](https://user-images.githubusercontent.com/43557895/162737497-647f2db4-f70a-4b6b-8411-4322c79683eb.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
