### PR TITLE
feat(web): Sýslumenn published material page override

### DIFF
--- a/apps/web/pages/s/syslumenn/utgefid-efni/index.ts
+++ b/apps/web/pages/s/syslumenn/utgefid-efni/index.ts
@@ -1,5 +1,3 @@
-import '@island.is/api/mocks'
-
 import withApollo from '@island.is/web/graphql/withApollo'
 import { withLocale } from '@island.is/web/i18n'
 import subPage from '@island.is/web/screens/Organization/SubPage'

--- a/apps/web/pages/s/syslumenn/utgefid-efni/index.ts
+++ b/apps/web/pages/s/syslumenn/utgefid-efni/index.ts
@@ -1,0 +1,15 @@
+import '@island.is/api/mocks'
+
+import withApollo from '@island.is/web/graphql/withApollo'
+import { withLocale } from '@island.is/web/i18n'
+import subPage from '@island.is/web/screens/Organization/SubPage'
+
+/**
+ * This page was added since syslumenn have already set up their published material
+ * by creating an organization subpage filled with accordions and file links.
+ *
+ * That page has the same slug as the new generic published material page for organizations.
+ *
+ * This page will be removed in the future if syslumenn want to utilize the new generic published material page instead
+ */
+export default withApollo(withLocale('is')(subPage))

--- a/apps/web/pages/s/syslumenn/utgefid-efni/index.ts
+++ b/apps/web/pages/s/syslumenn/utgefid-efni/index.ts
@@ -5,11 +5,7 @@ import { withLocale } from '@island.is/web/i18n'
 import subPage from '@island.is/web/screens/Organization/SubPage'
 
 /**
- * This page was added since syslumenn have already set up their published material
- * by creating an organization subpage filled with accordions and file links.
- *
- * That page has the same slug as the new generic published material page for organizations.
- *
- * This page will be removed in the future if syslumenn want to utilize the new generic published material page instead
+ * This page was added since syslumenn have a custom published material page set up in Contentful.
+ * That page has the same slug as the new generic published material page for organizations, so that's why we explicitly added this route.
  */
 export default withApollo(withLocale('is')(subPage))

--- a/apps/web/screens/Organization/SubPage.tsx
+++ b/apps/web/screens/Organization/SubPage.tsx
@@ -38,6 +38,7 @@ import getConfig from 'next/config'
 import { Namespace } from '@island.is/api/schema'
 import useContentfulId from '@island.is/web/hooks/useContentfulId'
 import { richText, SliceType } from '@island.is/island-ui/contentful'
+import { ParsedUrlQuery } from 'querystring'
 
 const { publicRuntimeConfig } = getConfig()
 
@@ -189,7 +190,8 @@ const renderSlices = (
   }
 }
 
-SubPage.getInitialProps = async ({ apolloClient, locale, query }) => {
+SubPage.getInitialProps = async ({ apolloClient, locale, query, pathname }) => {
+  populateQueryFromPathname(query, pathname)
   const [
     {
       data: { getOrganizationPage },
@@ -245,6 +247,24 @@ SubPage.getInitialProps = async ({ apolloClient, locale, query }) => {
     namespace,
     showSearchInHeader: false,
     ...getThemeConfig(getOrganizationPage.theme),
+  }
+}
+
+/**
+ * This function was added since syslumenn have already set up their published material
+ * by creating an organization subpage filled with accordions and file links.
+ *
+ * That page has the same slug as the new generic published material page for organizations.
+ *
+ * This will be removed in the future if syslumenn want to utilize the new generic published material page instead
+ */
+const populateQueryFromPathname = (query: ParsedUrlQuery, pathname: string) => {
+  const path = pathname?.split('/') ?? []
+  const slug = path?.[path.length - 2]
+  const subSlug = path.pop()
+  if (slug === 'syslumenn' && subSlug === 'utgefid-efni') {
+    query.slug = 'syslumenn'
+    query.subSlug = 'utgefid-efni'
   }
 }
 

--- a/apps/web/screens/Organization/SubPage.tsx
+++ b/apps/web/screens/Organization/SubPage.tsx
@@ -259,7 +259,7 @@ const getSlugAndSubSlug = (query: ParsedUrlQuery, pathname: string) => {
     slug = path[path.length - 2]
   }
   if (!subSlug && path.length > 0) {
-    // The subslug is the last index in the path, i.e. "utgefid-efn" in the case of "/s/syslumenn/utgefid-efni"
+    // The subslug is the last index in the path, i.e. "utgefid-efni" in the case of "/s/syslumenn/utgefid-efni"
     subSlug = path.pop()
   }
 

--- a/apps/web/screens/Organization/SubPage.tsx
+++ b/apps/web/screens/Organization/SubPage.tsx
@@ -191,7 +191,7 @@ const renderSlices = (
 }
 
 SubPage.getInitialProps = async ({ apolloClient, locale, query, pathname }) => {
-  if (!query.slug && !query.subSlug) populateQueryFromPathname(query, pathname)
+  const { slug, subSlug } = getSlugAndSubSlug(query, pathname)
   const [
     {
       data: { getOrganizationPage },
@@ -205,7 +205,7 @@ SubPage.getInitialProps = async ({ apolloClient, locale, query, pathname }) => {
       query: GET_ORGANIZATION_PAGE_QUERY,
       variables: {
         input: {
-          slug: query.slug as string,
+          slug: slug as string,
           lang: locale as ContentLanguage,
         },
       },
@@ -214,8 +214,8 @@ SubPage.getInitialProps = async ({ apolloClient, locale, query, pathname }) => {
       query: GET_ORGANIZATION_SUBPAGE_QUERY,
       variables: {
         input: {
-          organizationSlug: query.slug as string,
-          slug: query.subSlug as string,
+          organizationSlug: slug as string,
+          slug: subSlug as string,
           lang: locale as ContentLanguage,
         },
       },
@@ -250,12 +250,20 @@ SubPage.getInitialProps = async ({ apolloClient, locale, query, pathname }) => {
   }
 }
 
-const populateQueryFromPathname = (query: ParsedUrlQuery, pathname: string) => {
+const getSlugAndSubSlug = (query: ParsedUrlQuery, pathname: string) => {
   const path = pathname?.split('/') ?? []
-  const slug = path?.[path.length - 2]
-  const subSlug = path.pop()
-  query.slug = slug
-  query.subSlug = subSlug
+  let { slug, subSlug } = query
+
+  if (!slug && path.length >= 2) {
+    // The slug is the next-last index in the path, i.e. "syslumenn" in the case of "/s/syslumenn/utgefid-efni"
+    slug = path[path.length - 2]
+  }
+  if (!subSlug && path.length > 0) {
+    // The subslug is the last index in the path, i.e. "utgefid-efn" in the case of "/s/syslumenn/utgefid-efni"
+    subSlug = path.pop()
+  }
+
+  return { slug, subSlug }
 }
 
 export default withMainLayout(SubPage)

--- a/apps/web/screens/Organization/SubPage.tsx
+++ b/apps/web/screens/Organization/SubPage.tsx
@@ -191,7 +191,7 @@ const renderSlices = (
 }
 
 SubPage.getInitialProps = async ({ apolloClient, locale, query, pathname }) => {
-  populateQueryFromPathname(query, pathname)
+  if (!query.slug && !query.subSlug) populateQueryFromPathname(query, pathname)
   const [
     {
       data: { getOrganizationPage },
@@ -250,22 +250,12 @@ SubPage.getInitialProps = async ({ apolloClient, locale, query, pathname }) => {
   }
 }
 
-/**
- * This function was added since syslumenn have already set up their published material
- * by creating an organization subpage filled with accordions and file links.
- *
- * That page has the same slug as the new generic published material page for organizations.
- *
- * This will be removed in the future if syslumenn want to utilize the new generic published material page instead
- */
 const populateQueryFromPathname = (query: ParsedUrlQuery, pathname: string) => {
   const path = pathname?.split('/') ?? []
   const slug = path?.[path.length - 2]
   const subSlug = path.pop()
-  if (slug === 'syslumenn' && subSlug === 'utgefid-efni') {
-    query.slug = 'syslumenn'
-    query.subSlug = 'utgefid-efni'
-  }
+  query.slug = slug
+  query.subSlug = subSlug
 }
 
 export default withMainLayout(SubPage)


### PR DESCRIPTION
# Sýslumenn published material page override

## What

* Sýslumenn already have an organization subpage that uses the same slug as the generic published material page, meaning that the new generic published material page appears instead of the old page, which is not ideal.
* So the change was to specifically check if the user was on the syslumenn utgefid-efni page and override the generic published material page with the syslumenn published material page
* This will be removed in the future if syslumenn want to utilize the new generic published material page instead

## Screenshots / Gifs

### Before
Here we can see the new generic published material page that appears instead of the old syslumenn org page since they share the same slug
![Screenshot 2022-04-11 at 14 06 47](https://user-images.githubusercontent.com/43557895/162757481-5ecd97d0-3f89-4ca2-88c4-ee8a663bd145.png)

### After 
Here is the page we want to see
![Screenshot 2022-04-11 at 14 08 43](https://user-images.githubusercontent.com/43557895/162757874-c9e7a92f-11f1-46ea-9929-646703af10ac.png)



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
