### PR TITLE
fix(service-portal): My children age restriction

### DIFF
--- a/libs/api/domains/national-registry/src/lib/nationalRegistry.service.ts
+++ b/libs/api/domains/national-registry/src/lib/nationalRegistry.service.ts
@@ -92,7 +92,10 @@ export class NationalRegistryService {
 
     const members = myChildren
       .filter((familyChild) => {
-        return familyChild.Barn !== nationalId
+        const isNotUser = familyChild.Barn !== nationalId
+        const isUnderEighteen = kennitala.info(familyChild.Barn).age < 18
+
+        return isNotUser && isUnderEighteen
       })
       .map((familyChild) => ({
         fullName: familyChild.FulltNafn,


### PR DESCRIPTION
## What

Exclude children over 18 from natreg getmychildren service

## Why

User should not get the info of their children when they are regarded as adults by the law. The service can on some occasions return children over 18, so we need to remove them.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
