### PR TITLE
feat(web): Organization published material, request-response matching

### DIFF
--- a/apps/web/screens/Organization/PublishedMaterial/PublishedMaterial.tsx
+++ b/apps/web/screens/Organization/PublishedMaterial/PublishedMaterial.tsx
@@ -50,6 +50,7 @@ import {
   getGenericTagGroupHierarchy,
   getInitialParameters,
   Ordering,
+  responseInputMatchesRequestInput,
 } from './utils'
 import { OrderByItem } from './components/OrderByItem'
 import { useSelect } from 'downshift'
@@ -114,6 +115,11 @@ const PublishedMaterial: Screen<PublishedMaterialProps> = ({
         sort: ordering,
       },
     },
+  })
+  const [publishedMaterialData, setPublishedMaterialData] = useState({
+    total: 0,
+    items: [],
+    input: {},
   })
 
   const { data, loading, fetchMore } = useQuery<
@@ -257,6 +263,14 @@ const PublishedMaterial: Screen<PublishedMaterialProps> = ({
   useEffect(() => {
     if (selectedItem?.onClick) selectedItem.onClick()
   }, [selectedItem])
+
+  useEffect(() => {
+    const responseInput = data?.getPublishedMaterial?.input ?? {}
+    const requestInput = queryVariables.variables.input
+    if (responseInputMatchesRequestInput(responseInput, requestInput)) {
+      setPublishedMaterialData(data?.getPublishedMaterial)
+    }
+  }, [data?.getPublishedMaterial, queryVariables.variables.input])
 
   const orderByButtonRef = useRef<HTMLDivElement | null>(null)
 
@@ -412,7 +426,7 @@ const PublishedMaterial: Screen<PublishedMaterialProps> = ({
               </GridRow>
             </GridColumn>
           </GridRow>
-          {(data?.getPublishedMaterial.items ?? []).map((item, index) => {
+          {(publishedMaterialData?.items ?? []).map((item, index) => {
             return (
               <GridRow
                 key={`${item.id}-${index}`}

--- a/apps/web/screens/Organization/PublishedMaterial/utils.ts
+++ b/apps/web/screens/Organization/PublishedMaterial/utils.ts
@@ -1,9 +1,4 @@
-import {
-  GenericTag,
-  GenericTagGroup,
-  GetPublishedMaterialInput,
-  GetPublishedMaterialObject,
-} from '@island.is/web/graphql/schema'
+import { GenericTag, GenericTagGroup } from '@island.is/web/graphql/schema'
 
 export interface Ordering {
   field: 'title.sort' | 'releaseDate'
@@ -86,62 +81,4 @@ export const getGenericTagGroupHierarchy = (
   })
 
   return hierarchy
-}
-
-export const responseInputMatchesRequestInput = (
-  responseInput: Partial<Omit<GetPublishedMaterialObject, '__typename'>>,
-  requestInput: GetPublishedMaterialInput,
-) => {
-  if (responseInput?.lang !== requestInput.lang) {
-    return false
-  }
-  if (responseInput?.organizationSlug !== requestInput.organizationSlug) {
-    return false
-  }
-  if (responseInput?.page !== requestInput.page) {
-    return false
-  }
-  if (responseInput?.searchString !== requestInput.searchString) {
-    return false
-  }
-  if (responseInput?.size !== requestInput.size) {
-    return false
-  }
-
-  const responseInputSort = responseInput?.sort ?? {}
-
-  for (const key in Object.keys(responseInputSort)) {
-    for (const subKey in Object.keys(responseInputSort[key] ?? {})) {
-      if (responseInput[key][subKey] !== requestInput[key]?.[subKey]) {
-        return false
-      }
-    }
-  }
-
-  const responseTagGroups = responseInput?.tagGroups ?? {}
-
-  for (const key in Object.keys(responseTagGroups)) {
-    if (!responseTagGroups[key]?.length) {
-      continue
-    }
-    for (let i = 0; i < responseTagGroups[key].length; i += 1) {
-      if (
-        responseTagGroups?.[key]?.[i] !== requestInput.tagGroups?.[key]?.[i]
-      ) {
-        return false
-      }
-    }
-  }
-
-  if (responseInput?.tags?.length !== requestInput.tags.length) {
-    return false
-  }
-
-  for (let i = 0; i < responseInput.tags.length; i += 1) {
-    if (responseInput.tags[i] !== requestInput.tags[i]) {
-      return false
-    }
-  }
-
-  return true
 }

--- a/apps/web/screens/Organization/PublishedMaterial/utils.ts
+++ b/apps/web/screens/Organization/PublishedMaterial/utils.ts
@@ -1,4 +1,9 @@
-import { GenericTag, GenericTagGroup } from '@island.is/web/graphql/schema'
+import {
+  GenericTag,
+  GenericTagGroup,
+  GetPublishedMaterialInput,
+  GetPublishedMaterialObject,
+} from '@island.is/web/graphql/schema'
 
 export interface Ordering {
   field: 'title.sort' | 'releaseDate'
@@ -81,4 +86,62 @@ export const getGenericTagGroupHierarchy = (
   })
 
   return hierarchy
+}
+
+export const responseInputMatchesRequestInput = (
+  responseInput: Partial<Omit<GetPublishedMaterialObject, '__typename'>>,
+  requestInput: GetPublishedMaterialInput,
+) => {
+  if (responseInput?.lang !== requestInput.lang) {
+    return false
+  }
+  if (responseInput?.organizationSlug !== requestInput.organizationSlug) {
+    return false
+  }
+  if (responseInput?.page !== requestInput.page) {
+    return false
+  }
+  if (responseInput?.searchString !== requestInput.searchString) {
+    return false
+  }
+  if (responseInput?.size !== requestInput.size) {
+    return false
+  }
+
+  const responseInputSort = responseInput?.sort ?? {}
+
+  for (const key in Object.keys(responseInputSort)) {
+    for (const subKey in Object.keys(responseInputSort[key] ?? {})) {
+      if (responseInput[key][subKey] !== requestInput[key]?.[subKey]) {
+        return false
+      }
+    }
+  }
+
+  const responseTagGroups = responseInput?.tagGroups ?? {}
+
+  for (const key in Object.keys(responseTagGroups)) {
+    if (!responseTagGroups[key]?.length) {
+      continue
+    }
+    for (let i = 0; i < responseTagGroups[key].length; i += 1) {
+      if (
+        responseTagGroups?.[key]?.[i] !== requestInput.tagGroups?.[key]?.[i]
+      ) {
+        return false
+      }
+    }
+  }
+
+  if (responseInput?.tags?.length !== requestInput.tags.length) {
+    return false
+  }
+
+  for (let i = 0; i < responseInput.tags.length; i += 1) {
+    if (responseInput.tags[i] !== requestInput.tags[i]) {
+      return false
+    }
+  }
+
+  return true
 }

--- a/apps/web/screens/queries/PublishedMaterial.ts
+++ b/apps/web/screens/queries/PublishedMaterial.ts
@@ -3,6 +3,16 @@ import gql from 'graphql-tag'
 export const GET_PUBLISHED_MATERIAL_QUERY = gql`
   query GetPublishedMaterial($input: GetPublishedMaterialInput!) {
     getPublishedMaterial(input: $input) {
+      input {
+        lang
+        size
+        page
+        organizationSlug
+        searchString
+        tags
+        tagGroups
+        sort
+      }
       total
       items {
         id

--- a/apps/web/screens/queries/PublishedMaterial.ts
+++ b/apps/web/screens/queries/PublishedMaterial.ts
@@ -3,16 +3,7 @@ import gql from 'graphql-tag'
 export const GET_PUBLISHED_MATERIAL_QUERY = gql`
   query GetPublishedMaterial($input: GetPublishedMaterialInput!) {
     getPublishedMaterial(input: $input) {
-      input {
-        lang
-        size
-        page
-        organizationSlug
-        searchString
-        tags
-        tagGroups
-        sort
-      }
+      hash
       total
       items {
         id

--- a/libs/cms/src/lib/cms.elasticsearch.service.ts
+++ b/libs/cms/src/lib/cms.elasticsearch.service.ts
@@ -234,7 +234,9 @@ export class CmsElasticsearchService {
 
   async getPublishedMaterial(
     index: string,
-    {
+    input: GetPublishedMaterialInput,
+  ): Promise<EnhancedAssetSearchResult> {
+    const {
       organizationSlug,
       searchString,
       page = 1, // The page number is 1-based meaning that page 1 is the first page
@@ -242,8 +244,8 @@ export class CmsElasticsearchService {
       tags,
       tagGroups,
       sort,
-    }: GetPublishedMaterialInput,
-  ): Promise<EnhancedAssetSearchResult> {
+    } = input
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const must: Record<string, any>[] = [
       {
@@ -318,6 +320,9 @@ export class CmsElasticsearchService {
       items: enhancedAssetResponse.body.hits.hits.map((item) =>
         JSON.parse(item._source.response ?? '{}'),
       ),
+
+      // Also return the input so we can match the response to the request that was made
+      input,
     }
   }
 }

--- a/libs/cms/src/lib/cms.elasticsearch.service.ts
+++ b/libs/cms/src/lib/cms.elasticsearch.service.ts
@@ -244,6 +244,7 @@ export class CmsElasticsearchService {
       tags,
       tagGroups,
       sort,
+      hash = 0,
     } = input
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -320,9 +321,7 @@ export class CmsElasticsearchService {
       items: enhancedAssetResponse.body.hits.hits.map((item) =>
         JSON.parse(item._source.response ?? '{}'),
       ),
-
-      // Also return the input so we can match the response to the request that was made
-      input,
+      hash, // Also return the input hash so we can match the response to the request that was made
     }
   }
 }

--- a/libs/cms/src/lib/dto/getPublishedMaterial.input.ts
+++ b/libs/cms/src/lib/dto/getPublishedMaterial.input.ts
@@ -1,13 +1,8 @@
 import { ElasticsearchIndexLocale } from '@island.is/content-search-index-manager'
 import { SortDirection } from '@island.is/content-search-toolkit'
-import { Field, InputType, Int, ObjectType } from '@nestjs/graphql'
+import { Field, InputType, Int } from '@nestjs/graphql'
 import { IsInt, IsOptional, IsString } from 'class-validator'
 import GraphQLJSON from 'graphql-type-json'
-
-/**
- * We need to make sure that these two classes have the same fields,
- * one is used for input and the other one is used for output in order to do request-response matching
- */
 
 @InputType()
 export class GetPublishedMaterialInput {
@@ -43,40 +38,10 @@ export class GetPublishedMaterialInput {
 
   @Field(() => GraphQLJSON)
   sort!: { field: 'title.sort' | 'releaseDate'; order: SortDirection }
-}
-
-@ObjectType()
-export class GetPublishedMaterialObject {
-  @Field(() => String)
-  @IsString()
-  lang: ElasticsearchIndexLocale = 'is'
 
   @Field(() => Int, { nullable: true })
   @IsInt()
   @IsOptional()
-  size?: number
-
-  @Field(() => Int, { nullable: true })
-  @IsInt()
-  @IsOptional()
-  // The page number is 1-based meaning that page 1 is the first page
-  page?: number
-
-  @Field({ nullable: true })
-  @IsString()
-  @IsOptional()
-  organizationSlug?: string
-
-  @Field(() => String)
-  @IsString()
-  searchString = ''
-
-  @Field(() => [String])
-  tags!: string[]
-
-  @Field(() => GraphQLJSON)
-  tagGroups!: Record<string, string[]>
-
-  @Field(() => GraphQLJSON)
-  sort!: { field: 'title.sort' | 'releaseDate'; order: SortDirection }
+  // The unique hash for this input (used to match the response with a request)
+  hash?: number
 }

--- a/libs/cms/src/lib/dto/getPublishedMaterial.input.ts
+++ b/libs/cms/src/lib/dto/getPublishedMaterial.input.ts
@@ -1,11 +1,52 @@
 import { ElasticsearchIndexLocale } from '@island.is/content-search-index-manager'
 import { SortDirection } from '@island.is/content-search-toolkit'
-import { Field, InputType, Int } from '@nestjs/graphql'
+import { Field, InputType, Int, ObjectType } from '@nestjs/graphql'
 import { IsInt, IsOptional, IsString } from 'class-validator'
 import GraphQLJSON from 'graphql-type-json'
 
+/**
+ * We need to make sure that these two classes have the same fields,
+ * one is used for input and the other one is used for output in order to do request-response matching
+ */
+
 @InputType()
 export class GetPublishedMaterialInput {
+  @Field(() => String)
+  @IsString()
+  lang: ElasticsearchIndexLocale = 'is'
+
+  @Field(() => Int, { nullable: true })
+  @IsInt()
+  @IsOptional()
+  size?: number
+
+  @Field(() => Int, { nullable: true })
+  @IsInt()
+  @IsOptional()
+  // The page number is 1-based meaning that page 1 is the first page
+  page?: number
+
+  @Field({ nullable: true })
+  @IsString()
+  @IsOptional()
+  organizationSlug?: string
+
+  @Field(() => String)
+  @IsString()
+  searchString = ''
+
+  @Field(() => [String])
+  tags!: string[]
+
+  @Field(() => GraphQLJSON)
+  tagGroups!: Record<string, string[]>
+
+  @Field(() => GraphQLJSON)
+  sort!: { field: 'title.sort' | 'releaseDate'; order: SortDirection }
+}
+
+@ObjectType()
+export class GetPublishedMaterialObject {
   @Field(() => String)
   @IsString()
   lang: ElasticsearchIndexLocale = 'is'

--- a/libs/cms/src/lib/models/enhancedAssetSearchResult.model.ts
+++ b/libs/cms/src/lib/models/enhancedAssetSearchResult.model.ts
@@ -1,6 +1,4 @@
 import { Field, ObjectType } from '@nestjs/graphql'
-import { GetPublishedMaterialObject } from '../dto/getPublishedMaterial.input'
-
 import { EnhancedAsset } from './enhancedAsset.model'
 
 @ObjectType()
@@ -11,6 +9,6 @@ export class EnhancedAssetSearchResult {
   @Field()
   total!: number
 
-  @Field(() => GetPublishedMaterialObject)
-  input!: GetPublishedMaterialObject
+  @Field()
+  hash!: number
 }

--- a/libs/cms/src/lib/models/enhancedAssetSearchResult.model.ts
+++ b/libs/cms/src/lib/models/enhancedAssetSearchResult.model.ts
@@ -1,4 +1,6 @@
 import { Field, ObjectType } from '@nestjs/graphql'
+import { GetPublishedMaterialObject } from '../dto/getPublishedMaterial.input'
+
 import { EnhancedAsset } from './enhancedAsset.model'
 
 @ObjectType()
@@ -8,4 +10,7 @@ export class EnhancedAssetSearchResult {
 
   @Field()
   total!: number
+
+  @Field(() => GetPublishedMaterialObject)
+  input!: GetPublishedMaterialObject
 }


### PR DESCRIPTION
# Organization published material, request-response matching

## What

* Matched what was searched with what got returned by comparing the hashed input with what the response gave us

## Why

* If the communication between the front- and backend suddenly lags then the UI on the page might be out of sync with what got returned so this change is to circumvent that 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
