### PR TITLE
fix(service-portal): remove prepended https

### DIFF
--- a/libs/service-portal/documents/src/utils/getOrganizationLogoUrl.ts
+++ b/libs/service-portal/documents/src/utils/getOrganizationLogoUrl.ts
@@ -22,8 +22,8 @@ const getOrganizationLogoUrl = (
     const c = match?.logo?.url
     const url =
       c ??
-      '//images.ctfassets.net/8k0h54kbe6bj/6XhCz5Ss17OVLxpXNVDxAO/d3d6716bdb9ecdc5041e6baf68b92ba6/coat_of_arms.svg'
-    const uri = `https:${url}?w=60&h=60&fit=pad&bg=white&fm=png`
+      'https://images.ctfassets.net/8k0h54kbe6bj/6XhCz5Ss17OVLxpXNVDxAO/d3d6716bdb9ecdc5041e6baf68b92ba6/coat_of_arms.svg'
+    const uri = `${url}?w=60&h=60&fit=pad&bg=white&fm=png`
     return uri
   }
   return ''


### PR DESCRIPTION
# Remove https in front of organisations logo

## What

Remove prepending https 

## Why

Because it was done in another file (see https://github.com/island-is/island.is/pull/7100) 

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
