### PR TITLE
feat(j-s): Prepares Norðurland eystra for Go Live

### DIFF
--- a/apps/judicial-system/backend/migrations/20220419164419-update-institution.js
+++ b/apps/judicial-system/backend/migrations/20220419164419-update-institution.js
@@ -1,0 +1,52 @@
+'use strict'
+
+module.exports = {
+  up: (queryInterface) => {
+    return queryInterface.sequelize.transaction((t) =>
+      Promise.all([
+        queryInterface.bulkUpdate(
+          'institution',
+          { active: true },
+          {
+            id: ['c98547fd-cc63-408c-815a-9c5d33ee5ba0'],
+          },
+          { transaction: t },
+        ),
+        queryInterface.bulkInsert(
+          'institution',
+          [
+            {
+              id: 'a4b204f3-b072-41b6-853c-42ec4b263bd6',
+              name: 'Lögreglustjórinn á Norðurlandi eystra',
+              type: 'PROSECUTORS_OFFICE',
+              active: true,
+            },
+          ],
+          { transaction: t },
+        ),
+      ]),
+    )
+  },
+
+  down: (queryInterface) => {
+    return queryInterface.sequelize.transaction((t) =>
+      Promise.all([
+        queryInterface.bulkUpdate(
+          'institution',
+          { active: false },
+          {
+            id: ['c98547fd-cc63-408c-815a-9c5d33ee5ba0'],
+          },
+          { transaction: t },
+        ),
+        queryInterface.bulkDelete(
+          'institution',
+          {
+            id: ['a4b204f3-b072-41b6-853c-42ec4b263bd6'],
+          },
+          { transaction: t },
+        ),
+      ]),
+    )
+  },
+}

--- a/apps/judicial-system/backend/test/e2e.spec.ts
+++ b/apps/judicial-system/backend/test/e2e.spec.ts
@@ -509,7 +509,7 @@ describe('Institution', () => {
       .send()
       .expect(200)
       .then((response) => {
-        expect(response.body.length).toBe(14)
+        expect(response.body.length).toBe(16)
       })
   })
 })


### PR DESCRIPTION
# Prepares Norðurland eystra for Go Live

https://app.asana.com/0/1199153462262248/1202148289367382/f

## What

- Activates Héraðsdómur Norðurlands eystra.
- Creates Lögreglustjórinn á Norðurlandi eystra.

## Why

Necessary preparation for go live.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
