### PR TITLE
feat(regulations): show all impacts in history list

### DIFF
--- a/apps/web/components/Regulations/DiffModeToggle.tsx
+++ b/apps/web/components/Regulations/DiffModeToggle.tsx
@@ -24,10 +24,11 @@ export const DiffModeToggle = (props: DiffModeToggleProps) => {
     publishedDate,
     lastAmendDate,
     showingDiff,
-    history,
+    history: regulationHistory,
   } = regulation
 
-  const firstEvent = regulation.history[0]
+  const history = regulationHistory.filter((h) => h.status === 'published')
+  const firstEvent = history[0]
 
   if (!firstEvent || firstEvent.effect !== 'amend') {
     return null

--- a/apps/web/components/Regulations/HistoryStepper.tsx
+++ b/apps/web/components/Regulations/HistoryStepper.tsx
@@ -9,7 +9,12 @@ import { toISODate, RegulationMaybeDiff } from '@island.is/regulations'
 
 const useStepperState = (regulation: RegulationMaybeDiff) =>
   useMemo(() => {
-    const { timelineDate, history, lastAmendDate } = regulation
+    const {
+      timelineDate,
+      history: regulationHistory,
+      lastAmendDate,
+    } = regulation
+    const history = regulationHistory.filter((h) => h.status === 'published')
 
     const changes = history.filter(({ effect }) => effect !== 'repeal')
 

--- a/apps/web/components/Regulations/RegulationChangelog.tsx
+++ b/apps/web/components/Regulations/RegulationChangelog.tsx
@@ -121,7 +121,9 @@ export const useRegulationEffectPrepper = (
                   diff: true,
                 })
               : item.effect === 'amend' && item.status === 'pending'
-              ? linkToRegulation(item.name)
+              ? // Link to current version (no diff) because the impact (text-changes)
+                // has not been inserted yet.
+                linkToRegulation(item.name)
               : undefined
 
           const active = isItemActive(item.date)

--- a/apps/web/components/Regulations/RegulationChangelog.tsx
+++ b/apps/web/components/Regulations/RegulationChangelog.tsx
@@ -2,7 +2,7 @@ import * as s from './RegulationsSidebarBox.css'
 
 import React, { useEffect, useMemo, useState } from 'react'
 import cn from 'classnames'
-import { Text } from '@island.is/island-ui/core'
+import { Icon, Text } from '@island.is/island-ui/core'
 import { useNamespaceStrict as useNamespace } from '@island.is/web/hooks'
 import {
   ISODate,
@@ -115,11 +115,13 @@ export const useRegulationEffectPrepper = (
             { name },
           )
           const href =
-            item.effect === 'amend'
+            item.effect === 'amend' && item.status === 'published'
               ? linkToRegulation(regulation.name, {
                   d: item.date,
                   diff: true,
                 })
+              : item.effect === 'amend' && item.status === 'pending'
+              ? linkToRegulation(item.name)
               : undefined
 
           const active = isItemActive(item.date)
@@ -127,7 +129,10 @@ export const useRegulationEffectPrepper = (
 
           const Content = (
             <>
-              <strong>{formatDate(item.date)}</strong>
+              <strong>{formatDate(item.date)}</strong>{' '}
+              {item.status === 'pending' && (
+                <Icon icon="warning" type="outline" size="small" />
+              )}
               <br />
               <span className={className} title={label + ' ' + item.title}>
                 {label}

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@formatjs/intl-numberformat": "7.1.5",
     "@hookform/error-message": "0.0.5",
     "@island.is/login": "1.2.1",
-    "@island.is/regulations-tools": "0.7.5",
+    "@island.is/regulations-tools": "0.7.8",
     "@nestjs/bull": "0.1.2",
     "@nestjs/common": "7.4.4",
     "@nestjs/config": "0.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5701,10 +5701,10 @@
     xml2js "^0.4.23"
     xmldom "^0.3.0"
 
-"@island.is/regulations-tools@0.7.5":
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@island.is/regulations-tools/-/regulations-tools-0.7.5.tgz#52f224bddc3148c7235d35ca0c4d831b5155d6dd"
-  integrity sha512-1n056thoZ40IizeRAtIMDL+7UlqlskEUEEt3DVpeeyH0iIf55p53sgiBF3WGh0pG8UXjUuyBp6mLq5IlCL/Vhw==
+"@island.is/regulations-tools@0.7.8":
+  version "0.7.8"
+  resolved "https://registry.yarnpkg.com/@island.is/regulations-tools/-/regulations-tools-0.7.8.tgz#e89e5bf0cc4781a86b419b39100991852ba4c402"
+  integrity sha512-lDG6/K6A7Cv53FSG4sRS4eeWLBP9jBSVBEqd0chlSqOjqEvQJJpaHsLXTHZQQ2C63TjhiuAHY8Og6WliStZbSg==
   dependencies:
     "@hugsmidjan/qj" "^4.7.0"
     "@hugsmidjan/react" "^0.4.4"


### PR DESCRIPTION
## What

Incomplete impacts were missing from regulation timeline

## Why

Timeline needs to show all impacts to display the real status of a regulation

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
