### PR TITLE
fix(j-s): fix date and time format in notifications

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/formatters.spec.ts
+++ b/apps/judicial-system/backend/src/app/formatters/formatters.spec.ts
@@ -909,7 +909,7 @@ describe('formatPrisonCourtDateEmailNotification', () => {
 
   let formatMessage: FormatMessage
   beforeAll(() => {
-    formatMessage = createTestIntl('is-IS', messages).formatMessage
+    formatMessage = createTestIntl('is', messages).formatMessage
   })
 
   test('should format court date notification', () => {
@@ -1287,6 +1287,24 @@ describe('formatPrisonRulingEmailNotification', () => {
     // Assert
     expect(res).toBe(
       'Meðfylgjandi er vistunarseðill aðila sem var úrskurðaður í gæsluvarðhald í héraðsdómi 20. desember 2020, auk þingbókar þar sem úrskurðarorðin koma fram.',
+    )
+  })
+
+  test('should format prison ruling notification when date is missing', () => {
+    // Arrange
+    const courtEndTime = undefined
+    const caseType = CaseType.ADMISSION_TO_FACILITY
+
+    // Act
+    const res = formatPrisonRulingEmailNotification(
+      formatMessage,
+      caseType,
+      courtEndTime,
+    )
+
+    // Assert
+    expect(res).toBe(
+      'Meðfylgjandi er vistunarseðill aðila sem var úrskurðaður í vistun á viðeigandi stofnun í héraðsdómi á ótilgreindum tíma, auk þingbókar þar sem úrskurðarorðin koma fram.',
     )
   })
 

--- a/apps/judicial-system/backend/src/app/formatters/formatters.ts
+++ b/apps/judicial-system/backend/src/app/formatters/formatters.ts
@@ -199,7 +199,11 @@ export function formatProsecutorCourtDateEmailNotification(
         : 'noPrefix',
     courtTypeName: caseTypes[type],
   })
-  const courtDateText = formatMessage(cf.courtDate, { courtDate })
+  const courtDateText = formatMessage(cf.courtDate, {
+    courtDate: courtDate
+      ? formatDate(courtDate, 'PPPp')?.replace(' kl.', ', kl.')
+      : 'NONE',
+  })
   const courtRoomText = formatMessage(notifications.courtRoom, {
     courtRoom: courtRoom || 'NONE',
   })
@@ -247,21 +251,22 @@ export function formatPrisonCourtDateEmailNotification(
   const courtDateText = formatMessage(
     notifications.prisonCourtDateEmail.courtDateText,
     {
-      date: formatDate(courtDate, 'PPPP')?.replace('dagur,', 'daginn'),
-      time: courtDate,
-      dateMissing: courtDate ? 'defined' : 'missing',
+      courtDate: courtDate
+        ? formatDate(courtDate, 'PPPPp')
+            ?.replace('dagur,', 'daginn')
+            ?.replace(' kl.', ', kl.')
+        : 'NONE',
     },
   )
 
   const requestedValidToDateText = formatMessage(
     notifications.prisonCourtDateEmail.requestedValidToDateText,
     {
-      date: formatDate(requestedValidToDate, 'PPPP')?.replace(
-        'dagur,',
-        'dagsins',
-      ),
-      time: requestedValidToDate,
-      dateMissing: requestedValidToDate ? 'defined' : 'missing',
+      requestedValidToDate: requestedValidToDate
+        ? formatDate(requestedValidToDate, 'PPPPp')
+            ?.replace('dagur,', 'dagsins')
+            ?.replace(' kl.', ', kl.')
+        : 'NONE',
     },
   )
 
@@ -316,8 +321,11 @@ export function formatDefenderCourtDateEmailNotification(
     sessionArrangements,
   })
   const courtDateText = formatMessage(cf.courtDate, {
-    date: formatDate(courtDate, 'PPPP')?.replace('dagur,', 'daginn'),
-    time: courtDate,
+    courtDate: courtDate
+      ? formatDate(courtDate, 'PPPPp')
+          ?.replace('dagur,', 'daginn')
+          ?.replace(' kl.', ', kl.')
+      : 'NONE',
   })
   const courtCaseNumberText = formatMessage(cf.courtCaseNumber, {
     courtCaseNumber,
@@ -356,7 +364,7 @@ export function formatPrisonRulingEmailNotification(
   courtEndTime?: Date,
 ): string {
   return formatMessage(notifications.prisonRulingEmail.body, {
-    courtEndTime,
+    courtEndTime: courtEndTime ? formatDate(courtEndTime, 'PPP') : 'NONE',
     caseType: type,
   })
 }
@@ -407,9 +415,13 @@ export function formatPrisonRevokedEmailNotification(
 ): string {
   const cf = notifications.prisonRevokedEmail
   const courtText = formatMessage(cf.court, { court })?.replace('dómur', 'dóms')
+
   const courtDateText = formatMessage(cf.courtDate, {
-    courtDate: courtDate || 'NONE',
-    date: formatDate(courtDate, 'PPPP')?.replace('dagur,', 'daginn'),
+    courtDate: courtDate
+      ? formatDate(courtDate, 'PPPPp')
+          ?.replace('dagur,', 'daginn')
+          ?.replace(' kl.', ', kl.')
+      : 'NONE',
   })
   const accusedNameText = formatMessage(notifications.accused, {
     accusedName: accusedName || 'NONE',
@@ -446,8 +458,11 @@ export function formatDefenderRevokedEmailNotification(
   }).replace('dómur', 'dómi')
 
   const courtDateText = formatMessage(cf.courtDate, {
-    date: formatDate(courtDate, 'PPPP')?.replace('dagur,', 'daginn'),
-    courtDate: courtDate || 'NONE',
+    courtDate: courtDate
+      ? formatDate(courtDate, 'PPPPp')
+          ?.replace('dagur,', 'daginn')
+          ?.replace(' kl.', ', kl.')
+      : 'NONE',
   })
   const revokedText = formatMessage(cf.revoked, {
     courtText,

--- a/apps/judicial-system/backend/src/app/messages/notifications.ts
+++ b/apps/judicial-system/backend/src/app/messages/notifications.ts
@@ -163,7 +163,7 @@ export const notifications = {
       id:
         'judicial.system.backend:notifications.prosecutor_court_date_email.court_date',
       defaultMessage:
-        'Fyrirtaka mun fara fram {courtDate, date, long}, kl. {courtDate, time, short}.',
+        'Fyrirtaka mun fara fram {courtDate, select, NONE {á ótilgreindum tíma} other {{courtDate}}}.',
       description:
         'Notaður sem texti í pósti sem tilgreinir hvenær fyrirtaka fer fram',
     },
@@ -241,7 +241,7 @@ export const notifications = {
       id:
         'judicial.system.backend:notifications.prison_court_date_email.court_date_text',
       defaultMessage:
-        '{dateMissing, select, missing {á ótilgreindum tíma} other {{date}, kl. {time, time, short}}}',
+        '{courtDate, select, NONE {á ótilgreindum tíma} other {{courtDate}}}',
       description:
         'Texti í pósti til fangelsis sem tilgreinir hvernær mál verður tekið fyrir.',
     },
@@ -264,7 +264,7 @@ export const notifications = {
       id:
         'judicial.system.backend:notifications.prison_court_date_email.requested_valid_to_date_text',
       defaultMessage:
-        '{dateMissing, select, missing {ótilgreinds tíma} other {{date}, kl. {time, time, short}}}',
+        '{requestedValidToDate, select, NONE {ótilgreinds tíma} other {{requestedValidToDate}}}',
       description:
         'Texti í pósti til fangeslis sem tilgreinir hversu lengi gæsluvarðhandls er krafist',
     },
@@ -289,7 +289,7 @@ export const notifications = {
     },
     body: {
       id: 'judicial.system.backend:notifications.prison_ruling_email',
-      defaultMessage: `Meðfylgjandi er vistunarseðill aðila sem var úrskurðaður í {caseType, select, ${CaseType.ADMISSION_TO_FACILITY} {vistun á viðeigandi stofnun} other {gæsluvarðhald}} í héraðsdómi {courtEndTime, date, long}, auk þingbókar þar sem úrskurðarorðin koma fram.`,
+      defaultMessage: `Meðfylgjandi er vistunarseðill aðila sem var úrskurðaður í {caseType, select, ${CaseType.ADMISSION_TO_FACILITY} {vistun á viðeigandi stofnun} other {gæsluvarðhald}} í héraðsdómi {courtEndTime, select, NONE {á ótilgreindum tíma} other {{courtEndTime}}}, auk þingbókar þar sem úrskurðarorðin koma fram.`,
       description:
         'Texti í pósti til fangelis þegar vistunarseðill og þingbók eru send',
     },
@@ -318,7 +318,7 @@ export const notifications = {
       id:
         'judicial.system.backend:notifications.prison_revoked_email.court_date_text',
       defaultMessage:
-        '{courtDate, select, NONE {á ótilgreindum tíma} other {{date}, kl. {courtDate, time, short}}}',
+        '{courtDate, select, NONE {á ótilgreindum tíma} other {{courtDate}}}',
       description:
         'Texti í pósti til fangelsis sem tilgreinir hvernær fyrirtaka átti að fara fram í afturkallaðri kröfu',
     },
@@ -349,7 +349,7 @@ export const notifications = {
       id:
         'judicial.system.backend:notifications.defender_court_date_email.court_date',
       defaultMessage:
-        'Fyrirtaka mun fara fram {date}, kl. {time, time, short}.',
+        'Fyrirtaka mun fara fram {courtDate, select, NONE {á ótilgreindum tíma} other {{courtDate}}}.',
       description:
         'Texti í pósti til verjanda/talsmanns sem tilgreinir hvernær fyrirtaka mun fara fram',
     },
@@ -388,7 +388,7 @@ export const notifications = {
       id:
         'judicial.system.backend:notifications.defender_revoked_email.court_date',
       defaultMessage:
-        '{courtDate, select, NONE {á ótilgreindum tíma} other {{date}, kl. {courtDate, time, short}}}',
+        '{courtDate, select, NONE {á ótilgreindum tíma} other {{courtDate}}}',
       description:
         'Texti í pósti til verjanda/talsmanns sem tilgreinir hvernær fyrirtaka var skráð',
     },


### PR DESCRIPTION
[Asana](https://app.asana.com/0/1199153462262248/1202148289367437/f)

## What

- Fix wrong format of date and time 

## Why

- It was defaulting to english for some unknown reason

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
