### PR TITLE
Fix/parental leave uufv 35

### DIFF
--- a/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.spec.ts
+++ b/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.spec.ts
@@ -8,7 +8,7 @@ import {
   ApplicationStatus,
 } from '@island.is/application/core'
 import ParentalLeaveTemplate from './ParentalLeaveTemplate'
-import { SPOUSE, States as ApplicationStates, YES } from '../constants'
+import { NO, SPOUSE, States as ApplicationStates, YES } from '../constants'
 
 function buildApplication(data: {
   answers?: FormValue
@@ -217,6 +217,56 @@ describe('Parental Leave Application Template', () => {
           expect(newState).toBe('vinnumalastofnunApproval')
           expect(newApplication.answers.otherParentId).toEqual(otherParentId)
         })
+      })
+    })
+
+    describe('allowance', () => {
+      it('should remove spouse allowance useAll and usage on submit, if usePersonalAllowanceFromSpouse is equal to NO', () => {
+        const helper = new ApplicationTemplateHelper(
+          buildApplication({
+            answers: {
+              usePersonalAllowanceFromSpouse: NO,
+              personalAllowanceFromSpouse: {
+                usage: '33%',
+                useAsMuchAsPossible: NO
+              },
+              employer: {
+                isSelfEmployed: 'no',
+              },
+            },
+          }),
+          ParentalLeaveTemplate,
+        )
+        const [hasChanged, _, newApplication] = helper.changeState({
+          type: DefaultEvents.SUBMIT,
+        })
+        console.log(newApplication.answers)
+        expect(hasChanged).toBe(true)
+        expect(newApplication.answers.personalAllowanceFromSpouse).toEqual(null)
+      })
+
+      it('should remove allowance useAll and usage on submit, if usePersonalAllowance is equal to NO', () => {
+        const helper = new ApplicationTemplateHelper(
+          buildApplication({
+            answers: {
+              usePersonalAllowance: NO,
+              personalAllowance: {
+                usage: '33%',
+                useAsMuchAsPossible: NO
+              },
+              employer: {
+                isSelfEmployed: 'no',
+              },
+            },
+          }),
+          ParentalLeaveTemplate,
+        )
+        const [hasChanged, _, newApplication] = helper.changeState({
+          type: DefaultEvents.SUBMIT,
+        })
+        console.log(newApplication.answers)
+        expect(hasChanged).toBe(true)
+        expect(newApplication.answers.personalAllowance).toEqual(null)
       })
     })
   })

--- a/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.spec.ts
+++ b/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.spec.ts
@@ -228,7 +228,7 @@ describe('Parental Leave Application Template', () => {
               usePersonalAllowanceFromSpouse: NO,
               personalAllowanceFromSpouse: {
                 usage: '33%',
-                useAsMuchAsPossible: NO
+                useAsMuchAsPossible: NO,
               },
               employer: {
                 isSelfEmployed: 'no',
@@ -251,7 +251,7 @@ describe('Parental Leave Application Template', () => {
               usePersonalAllowance: NO,
               personalAllowance: {
                 usage: '33%',
-                useAsMuchAsPossible: NO
+                useAsMuchAsPossible: NO,
               },
               employer: {
                 isSelfEmployed: 'no',

--- a/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.spec.ts
+++ b/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.spec.ts
@@ -240,7 +240,6 @@ describe('Parental Leave Application Template', () => {
         const [hasChanged, _, newApplication] = helper.changeState({
           type: DefaultEvents.SUBMIT,
         })
-        console.log(newApplication.answers)
         expect(hasChanged).toBe(true)
         expect(newApplication.answers.personalAllowanceFromSpouse).toEqual(null)
       })
@@ -264,7 +263,6 @@ describe('Parental Leave Application Template', () => {
         const [hasChanged, _, newApplication] = helper.changeState({
           type: DefaultEvents.SUBMIT,
         })
-        console.log(newApplication.answers)
         expect(hasChanged).toBe(true)
         expect(newApplication.answers.personalAllowance).toEqual(null)
       })

--- a/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.ts
+++ b/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.ts
@@ -103,7 +103,7 @@ const ParentalLeaveTemplate: ApplicationTemplate<
         exit: [
           'setOtherParentIdIfSelectedSpouse',
           'clearPersonalAllowanceIfUsePersonalAllowanceIsNo',
-          'clearSpouseAllowanceIfUseSpouseAllowanceIsNo'
+          'clearSpouseAllowanceIfUseSpouseAllowanceIsNo',
         ],
         meta: {
           name: States.DRAFT,
@@ -692,13 +692,11 @@ const ParentalLeaveTemplate: ApplicationTemplate<
 
         const answers = getApplicationAnswers(application.answers)
 
-        if (answers.usePersonalAllowance === NO
-          && (answers.personalUsage || answers.personalUseAsMuchAsPossible)) {
-          set(
-            application.answers,
-            'personalAllowance',
-            null,
-          )
+        if (
+          answers.usePersonalAllowance === NO &&
+          (answers.personalUsage || answers.personalUseAsMuchAsPossible)
+        ) {
+          set(application.answers, 'personalAllowance', null)
         }
 
         return context
@@ -708,13 +706,11 @@ const ParentalLeaveTemplate: ApplicationTemplate<
 
         const answers = getApplicationAnswers(application.answers)
 
-        if (answers.usePersonalAllowanceFromSpouse === NO
-          && (answers.spouseUsage || answers.spouseUseAsMuchAsPossible)) {
-          set(
-            application.answers,
-            'personalAllowanceFromSpouse',
-            null,
-          )
+        if (
+          answers.usePersonalAllowanceFromSpouse === NO &&
+          (answers.spouseUsage || answers.spouseUseAsMuchAsPossible)
+        ) {
+          set(application.answers, 'personalAllowanceFromSpouse', null)
         }
 
         return context

--- a/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.ts
+++ b/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.ts
@@ -100,7 +100,11 @@ const ParentalLeaveTemplate: ApplicationTemplate<
       },
       [States.DRAFT]: {
         entry: 'clearAssignees',
-        exit: 'setOtherParentIdIfSelectedSpouse',
+        exit: [
+          'setOtherParentIdIfSelectedSpouse',
+          'clearPersonalAllowanceIfUsePersonalAllowanceIsNo',
+          'clearSpouseAllowanceIfUseSpouseAllowanceIsNo'
+        ],
         meta: {
           name: States.DRAFT,
           actionCard: {
@@ -678,6 +682,38 @@ const ParentalLeaveTemplate: ApplicationTemplate<
             application.answers,
             'otherParentId',
             getOtherParentId(application),
+          )
+        }
+
+        return context
+      }),
+      clearPersonalAllowanceIfUsePersonalAllowanceIsNo: assign((context) => {
+        const { application } = context
+
+        const answers = getApplicationAnswers(application.answers)
+
+        if (answers.usePersonalAllowance === NO
+          && (answers.personalUsage || answers.personalUseAsMuchAsPossible)) {
+          set(
+            application.answers,
+            'personalAllowance',
+            null,
+          )
+        }
+
+        return context
+      }),
+      clearSpouseAllowanceIfUseSpouseAllowanceIsNo: assign((context) => {
+        const { application } = context
+
+        const answers = getApplicationAnswers(application.answers)
+
+        if (answers.usePersonalAllowanceFromSpouse === NO
+          && (answers.spouseUsage || answers.spouseUseAsMuchAsPossible)) {
+          set(
+            application.answers,
+            'personalAllowanceFromSpouse',
+            null,
           )
         }
 


### PR DESCRIPTION
## What

Fixing an issue in the parental leave application, where the personalAllowance and personalAllowanceFromSpouse data would still be present in the data that is submitted even if the user had removed the option where they said that they wanted to use the personalAllowance or personalAllowanceFromSpouse.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
