### PR TITLE
fix: show correct final date when viewing original version

### DIFF
--- a/apps/web/components/Regulations/RegulationStatus.tsx
+++ b/apps/web/components/Regulations/RegulationStatus.tsx
@@ -61,7 +61,12 @@ export const RegulationStatus = (props: RegulationStatusProps) => {
 
   const getNextHistoryDate = () => {
     const idx = (history || []).findIndex((item) => item.date === timelineDate)
-    const nextItem = idx > -1 && history[idx + 1]
+    const nextItem =
+      idx > -1
+        ? history[idx + 1]
+        : idx === -1 && history.length
+        ? history[0]
+        : false
     return nextItem ? nextItem.date : undefined
   }
 


### PR DESCRIPTION
## What

When viewing original version of a regulation and the regulation had history, the date range was showing wrong final date

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
