### PR TITLE
fix(regulations): issue with status order

### DIFF
--- a/apps/web/components/Regulations/RegulationStatus.tsx
+++ b/apps/web/components/Regulations/RegulationStatus.tsx
@@ -40,7 +40,7 @@ export const RegulationStatus = (props: RegulationStatusProps) => {
 
   const today = toISODate(new Date())
 
-  const hasPending = !timelineDate && history[0]?.status === 'pending'
+  const hasPending = history[0]?.status === 'pending'
 
   const color: BallColor = repealed
     ? 'red'
@@ -127,13 +127,6 @@ export const RegulationStatus = (props: RegulationStatusProps) => {
                   </small>
                 ))}
             </>
-          ) : !lastAmendDate ? (
-            <>
-              {txt(
-                type === 'base' ? 'statusCurrentBase' : 'statusCurrentAmending',
-              ) + ' '}
-              {onDateText}
-            </>
           ) : hasPending ? (
             <>
               {txt('statusCurrentBase') + ' '}
@@ -143,6 +136,13 @@ export const RegulationStatus = (props: RegulationStatusProps) => {
                   'Reglugerð án breytinga, sjá breytingasögu.',
                 )}
               </small>
+            </>
+          ) : !lastAmendDate ? (
+            <>
+              {txt(
+                type === 'base' ? 'statusCurrentBase' : 'statusCurrentAmending',
+              ) + ' '}
+              {onDateText}
             </>
           ) : (
             <>


### PR DESCRIPTION
## What

Edge case where regulation status would not display correct status text

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
