### PR TITLE
fix(fa): Adding a spouse check when estimating aid

### DIFF
--- a/apps/financial-aid/web-osk/src/components/Estimation/Estimation.tsx
+++ b/apps/financial-aid/web-osk/src/components/Estimation/Estimation.tsx
@@ -30,7 +30,7 @@ const Estimation = ({
   )
   const getAidType = () => {
     switch (true) {
-      case nationalRegistryData?.spouse === null:
+      case !nationalRegistryData?.spouse:
         return true
       case nationalRegistryData?.spouse?.maritalStatus != undefined:
         return (


### PR DESCRIPTION
# ... 🆙 

https://app.asana.com/0/1202167941440767/1202189059355224

## What

- Added a check if spouse is from national registry 

## Why

- Needed so the applicant gets the right estimated financial aid 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
