### PR TITLE
fix(j-s): remove template strings from contentful strings

### DIFF
--- a/apps/judicial-system/backend/src/app/messages/notifications.ts
+++ b/apps/judicial-system/backend/src/app/messages/notifications.ts
@@ -1,14 +1,10 @@
 import { defineMessages } from '@formatjs/intl'
-import {
-  CaseType,
-  Gender,
-  SessionArrangements,
-} from '@island.is/judicial-system/types'
 
 export const notifications = {
   defender: {
     id: 'judicial.system.backend:notifications.defender',
-    defaultMessage: `{sessionArrangements, select, ${SessionArrangements.ALL_PRESENT_SPOKESPERSON} {Talsmaður} other {Verjandi}} sakbornings{defenderName, select, NONE { hefur ekki verið skráður} other {: {defenderName}}}`,
+    defaultMessage:
+      '{sessionArrangements, select, ALL_PRESENT_SPOKESPERSON {Talsmaður} other {Verjandi}} sakbornings{defenderName, select, NONE { hefur ekki verið skráður} other {: {defenderName}}}',
     description:
       'Texti í pósti sem tilgreinir hver talsmaður/verjandi er í máli.',
   },
@@ -61,11 +57,8 @@ export const notifications = {
     prosecutorHtmlV2: {
       id:
         'judicial.system.backend:notifications.ready_for_court.prosecutor_html_v2',
-      defaultMessage: `Þú hefur sent kröfu um {caseType, select,
-        ${CaseType.CUSTODY} {gæsluvarðhald}
-        ${CaseType.TRAVEL_BAN} {farbann}
-        ${CaseType.ADMISSION_TO_FACILITY} {vistun á viðeigandi stofnun}
-        other {rannsóknarheimild}} á {courtName} vegna LÖKE máls {policeCaseNumber}. Skjalið er aðgengilegt undir {linkStart}málinu í Réttarvörslugátt{linkEnd}.`,
+      defaultMessage:
+        'Þú hefur sent kröfu um {caseType, select, CUSTODY {gæsluvarðhald} TRAVEL_BAN {farbann} ADMISSION_TO_FACILITY {vistun á viðeigandi stofnun} other {rannsóknarheimild}} á {courtName} vegna LÖKE máls {policeCaseNumber}. Skjalið er aðgengilegt undir {linkStart}málinu í Réttarvörslugátt{linkEnd}.',
       description:
         'Notaður sem texti í pósti til ákæranda varðandi kröfu sem hefur verið send á héraðsdómara',
     },
@@ -74,7 +67,8 @@ export const notifications = {
     caseTypeRevoked: {
       id:
         'judicial.system.backend:notifications.court_revoked.case_type_revoked',
-      defaultMessage: `{caseType, select, ${CaseType.TRAVEL_BAN} {Farbannskrafa} ${CaseType.ADMISSION_TO_FACILITY} {Krafa um vistun á viðeigandi stofnun} other {Gæsluvarðhaldskrafa}} afturkölluð.`,
+      defaultMessage:
+        '{caseType, select, TRAVEL_BAN {Farbannskrafa} ADMISSION_TO_FACILITY {Krafa um vistun á viðeigandi stofnun} other {Gæsluvarðhaldskrafa}} afturkölluð.',
       description:
         'Notaður sem texti í sms-i til dómstóla þegar krafa er afturkölluð',
     },
@@ -116,7 +110,8 @@ export const notifications = {
     },
     newCaseText: {
       id: 'judicial.system.backend:notifications.court_heads_up.new_case_text',
-      defaultMessage: `Ný {caseType, select, ${CaseType.TRAVEL_BAN} {farbannskrafa} ${CaseType.ADMISSION_TO_FACILITY} {krafa um vistun á viðeigandi stofnun} ${CaseType.CUSTODY} {gæsluvarðhaldskrafa} ${CaseType.OTHER} {krafa um rannsóknarheimild} other {krafa um rannsóknarheimild ({courtTypeName})}} í vinnslu.`,
+      defaultMessage:
+        'Ný {caseType, select, TRAVEL_BAN {farbannskrafa} ADMISSION_TO_FACILITY {krafa um vistun á viðeigandi stofnun} CUSTODY {gæsluvarðhaldskrafa} OTHER {krafa um rannsóknarheimild} other {krafa um rannsóknarheimild ({courtTypeName})}} í vinnslu.',
       description:
         'Notaður sem texti í sms-i til þess að tilgreina að mál sé komið í vinnslu',
     },
@@ -125,7 +120,8 @@ export const notifications = {
     submittedCase: {
       id:
         'judicial.system.backend:notifications.court_ready_for_court.case_ready_for_court',
-      defaultMessage: `{caseType, select, ${CaseType.TRAVEL_BAN} {Farbannskrafa} ${CaseType.ADMISSION_TO_FACILITY} {Krafa um vistun á viðeigandi stofnun} ${CaseType.CUSTODY} {Gæsluvarðhaldskrafa} ${CaseType.OTHER} {Krafa um rannsóknarheimild} other {Krafa um rannsóknarheimild ({courtTypeName})}} tilbúin til afgreiðslu.`,
+      defaultMessage:
+        '{caseType, select, TRAVEL_BAN {Farbannskrafa} ADMISSION_TO_FACILITY {Krafa um vistun á viðeigandi stofnun} CUSTODY {Gæsluvarðhaldskrafa} OTHER {Krafa um rannsóknarheimild} other {Krafa um rannsóknarheimild ({courtTypeName})}} tilbúin til afgreiðslu.',
       description:
         'Notaður sem texti í sms-i sem tilgreinir að krafa sé tilbúin til afgreiðslu',
     },
@@ -155,7 +151,8 @@ export const notifications = {
     scheduledCase: {
       id:
         'judicial.system.backend:notifications.prosecutor_court_date_email.scheduled_case',
-      defaultMessage: `{court} hefur staðfest fyrirtökutíma fyrir kröfu um {investigationPrefix, select, onlyPrefix {rannsóknarheimild} withPrefix {rannsóknarheimild ({courtTypeName})} other {{courtTypeName}}}.`,
+      defaultMessage:
+        '{court} hefur staðfest fyrirtökutíma fyrir kröfu um {investigationPrefix, select, onlyPrefix {rannsóknarheimild} withPrefix {rannsóknarheimild ({courtTypeName})} other {{courtTypeName}}}.',
       description:
         'Notaður sem texti í pósti sem tilgreinir að dómstól hefur staðfest fyrirtökutíma',
     },
@@ -170,7 +167,8 @@ export const notifications = {
     body: {
       id:
         'judicial.system.backend:notifications.prosecutor_court_date_email.body',
-      defaultMessage: `{scheduledCaseText}<br /><br />{courtDateText}<br /><br />{courtRoomText}<br /><br />{judgeText}{registrarText, select, NONE {} other {<br /><br />{registrarText}}}{sessionArrangements, select, ${SessionArrangements.PROSECUTOR_PRESENT} {} other {<br /><br />{defenderText}.}}`,
+      defaultMessage:
+        '{scheduledCaseText}<br /><br />{courtDateText}<br /><br />{courtRoomText}<br /><br />{judgeText}{registrarText, select, NONE {} other {<br /><br />{registrarText}}}{sessionArrangements, select, PROSECUTOR_PRESENT {} other {<br /><br />{defenderText}.}}',
       description:
         'Notaður fyrir beinagrind á pósti til sækjanda þegar fyrirtökutími er staðfestur',
     },
@@ -248,7 +246,8 @@ export const notifications = {
     requestText: {
       id:
         'judicial.system.backend:notifications.prison_court_date_email.request_text',
-      defaultMessage: `Nafn sakbornings: {accusedName, select, NONE {Ekki skráð} other {{accusedName}}}.<br /><br />Kyn sakbornings: {gender, select, ${Gender.MALE} {Karl} ${Gender.FEMALE} {Kona} other {Kynsegin/Annað}}.<br /><br />Krafist er {caseType, select, ${CaseType.ADMISSION_TO_FACILITY} {vistunar} other {gæsluvarðhalds}} til {requestedValidToDateText}.`,
+      defaultMessage:
+        'Nafn sakbornings: {accusedName, select, NONE {Ekki skráð} other {{accusedName}}}.<br /><br />Kyn sakbornings: {gender, select, MALE {Karl} FEMALE {Kona} other {Kynsegin/Annað}}.<br /><br />Krafist er {caseType, select, ADMISSION_TO_FACILITY {vistunar} other {gæsluvarðhalds}} til {requestedValidToDateText}.',
       description:
         'Texti í pósti til fangeslis sem tilgreinir hver sakborningur er',
     },
@@ -270,26 +269,30 @@ export const notifications = {
     },
     body: {
       id: 'judicial.system.backend:notifications.prison_court_date_email.body',
-      defaultMessage: `{prosecutorOffice, select, NONE {Ótilgreindur sækjandi} other {{prosecutorOffice}}} hefur sent kröfu um {isExtension, select, yes {áframhaldandi } other {}}{caseType, select, ${CaseType.ADMISSION_TO_FACILITY} {vistunar á viðeignadi stofnun} other {gæsluvarðhald}} til {courtText} og verður málið tekið fyrir {courtDateText}.<br /><br />{requestText}<br /><br />{isolationText}<br /><br />{defenderText}.`,
+      defaultMessage:
+        '{prosecutorOffice, select, NONE {Ótilgreindur sækjandi} other {{prosecutorOffice}}} hefur sent kröfu um {isExtension, select, yes {áframhaldandi } other {}}{caseType, select, ADMISSION_TO_FACILITY {vistunar á viðeignadi stofnun} other {gæsluvarðhald}} til {courtText} og verður málið tekið fyrir {courtDateText}.<br /><br />{requestText}<br /><br />{isolationText}<br /><br />{defenderText}.',
       description: 'Notaður sem beinagrind á í pósti til fangelsis',
     },
     subject: {
       id:
         'judicial.system.backend:notifications.prison_court_date_email.subject',
-      defaultMessage: `Krafa um {caseType, select, ${CaseType.ADMISSION_TO_FACILITY} {vistun} other {gæsluvarðhald}} í vinnslu`,
+      defaultMessage:
+        'Krafa um {caseType, select, ADMISSION_TO_FACILITY {vistun} other {gæsluvarðhald}} í vinnslu',
       description: 'Fyrirsögn í pósti til fangeslis þegar krafa fer í vinnslu',
     },
   }),
   prisonRulingEmail: defineMessages({
     subject: {
       id: 'judicial.system.backend:notifications.prison_ruling_email.subject',
-      defaultMessage: `Úrskurður um {caseType, select, ${CaseType.ADMISSION_TO_FACILITY} {vistun á viðeigandi stofnun} other {gæsluvarðhald}}`,
+      defaultMessage:
+        'Úrskurður um {caseType, select, ADMISSION_TO_FACILITY {vistun á viðeigandi stofnun} other {gæsluvarðhald}}',
       description:
         'Fyrirsögn í pósti til fangeslis þegar vistunarseðill og þingbók eru send',
     },
     body: {
       id: 'judicial.system.backend:notifications.prison_ruling_email',
-      defaultMessage: `Meðfylgjandi er vistunarseðill aðila sem var úrskurðaður í {caseType, select, ${CaseType.ADMISSION_TO_FACILITY} {vistun á viðeigandi stofnun} other {gæsluvarðhald}} í héraðsdómi {courtEndTime, select, NONE {á ótilgreindum tíma} other {{courtEndTime}}}, auk þingbókar þar sem úrskurðarorðin koma fram.`,
+      defaultMessage:
+        'Meðfylgjandi er vistunarseðill aðila sem var úrskurðaður í {caseType, select, ADMISSION_TO_FACILITY {vistun á viðeigandi stofnun} other {gæsluvarðhald}} í héraðsdómi {courtEndTime, select, NONE {á ótilgreindum tíma} other {{courtEndTime}}}, auk þingbókar þar sem úrskurðarorðin koma fram.',
       description:
         'Texti í pósti til fangelis þegar vistunarseðill og þingbók eru send',
     },
@@ -297,13 +300,15 @@ export const notifications = {
   prisonRevokedEmail: defineMessages({
     subject: {
       id: 'judicial.system.backend:notifications.prison_revoked_email.subject',
-      defaultMessage: `{caseType, select, ${CaseType.ADMISSION_TO_FACILITY} {Krafa um vistun á viðeignadi stofnun} other {Gæsluvarðhaldskrafa}} afturkölluð`,
+      defaultMessage:
+        '{caseType, select, ADMISSION_TO_FACILITY {Krafa um vistun á viðeignadi stofnun} other {Gæsluvarðhaldskrafa}} afturkölluð',
       description: 'Fyrirsögn í pósti til fangeslis þegar krafa er afturkölluð',
     },
     revokedCase: {
       id:
         'judicial.system.backend:notifications.prison_revoked_email.revoked_case',
-      defaultMessage: `{prosecutorOffice, select, NONE {Ótilgreindur sækjandi} other {{prosecutorOffice}}} hefur afturkallað kröfu um {isExtension, select, yes {áframhaldandi } other {}}{caseType, select, ${CaseType.ADMISSION_TO_FACILITY} {vistun} other {gæsluvarðhald}} sem send var til {courtText} og taka átti fyrir {courtDateText}.`,
+      defaultMessage:
+        '{prosecutorOffice, select, NONE {Ótilgreindur sækjandi} other {{prosecutorOffice}}} hefur afturkallað kröfu um {isExtension, select, yes {áframhaldandi } other {}}{caseType, select, ADMISSION_TO_FACILITY {vistun} other {gæsluvarðhald}} sem send var til {courtText} og taka átti fyrir {courtDateText}.',
       description:
         'Texti í pósti til fangelsis þegar sækjandi afturkallar kröfu',
     },
@@ -341,7 +346,8 @@ export const notifications = {
     sessionArrangements: {
       id:
         'judicial.system.backend:notifications.defender_court_date_email.session_arrangements',
-      defaultMessage: `{court} hefur boðað þig í fyrirtöku sem {sessionArrangements, select, ${SessionArrangements.ALL_PRESENT_SPOKESPERSON} {talsmann} other {verjanda}} sakbornings.`,
+      defaultMessage:
+        '{court} hefur boðað þig í fyrirtöku sem {sessionArrangements, select, ALL_PRESENT_SPOKESPERSON {talsmann} other {verjanda}} sakbornings.',
       description:
         'Texti í pósti til verjanda/talsmanns þegar dómstóll boðar í fyrirtöku',
     },
@@ -425,7 +431,8 @@ export const notifications = {
     subject: {
       id:
         'judicial.system.backend:notifications.defender_revoked_email.subject',
-      defaultMessage: `Krafa um {caseType, select, ${CaseType.CUSTODY} {gæsluvarðhald} ${CaseType.TRAVEL_BAN} {farbann} ${CaseType.ADMISSION_TO_FACILITY} {vistun} other {rannsóknarheimild}} afturkölluð`,
+      defaultMessage:
+        'Krafa um {caseType, select, CUSTODY {gæsluvarðhald} TRAVEL_BAN {farbann} ADMISSION_TO_FACILITY {vistun} other {rannsóknarheimild}} afturkölluð',
       description:
         'Fyrirsögn í pósti til verjanda/talsmanns /egar krafa er afturkölluð',
     },
@@ -433,19 +440,22 @@ export const notifications = {
   modified: defineMessages({
     subject: {
       id: 'judicial.system.backend:notifications.modified.subject',
-      defaultMessage: `{caseType, select, ${CaseType.ADMISSION_TO_FACILITY} {Vistunarmál} other {Gæsluvarðhaldsmál}} {courtCaseNumber}`,
+      defaultMessage:
+        '{caseType, select, ADMISSION_TO_FACILITY {Vistunarmál} other {Gæsluvarðhaldsmál}} {courtCaseNumber}',
       description:
         'Notaður sem titill á tölvupósti vegna breytingar á lengd gæslu/einangrunar/vistunar þar sem {courtCaseNumber} er málsnúmer dómstóls.',
     },
     html: {
       id: 'judicial.system.backend:notifications.modified.html',
-      defaultMessage: `{actorInstitution}, {actorName} {actorTitle}, hefur uppfært lengd {caseType, select, ${CaseType.ADMISSION_TO_FACILITY} {vistunar} other {gæslu}} í máli {courtCaseNumber}. Sjá {linkStart}yfirlitssíðu málsins í Réttarvörslugátt{linkEnd}.<br /><br />Lok {caseType, select, ${CaseType.ADMISSION_TO_FACILITY} {vistunar} other {gæslu}}: {validToDate}.`,
+      defaultMessage:
+        '{actorInstitution}, {actorName} {actorTitle}, hefur uppfært lengd {caseType, select, ADMISSION_TO_FACILITY {vistunar} other {gæslu}} í máli {courtCaseNumber}. Sjá {linkStart}yfirlitssíðu málsins í Réttarvörslugátt{linkEnd}.<br /><br />Lok {caseType, select, ADMISSION_TO_FACILITY {vistunar} other {gæslu}}: {validToDate}.',
       description:
         'Notaður sem texti í tölvupósti vegna breytingar á lengd gæslu/vistunar þar sem ekki var úrskurðað í einangrun.',
     },
     isolationHtml: {
       id: 'judicial.system.backend:notifications.modified.isolation_html',
-      defaultMessage: `{actorInstitution}, {actorName} {actorTitle}, hefur uppfært lengd {caseType, select, ${CaseType.ADMISSION_TO_FACILITY} {vistunar} other {gæslu}}/einangrunar í máli {courtCaseNumber}. Sjá {linkStart}yfirlitssíðu málsins í Réttarvörslugátt{linkEnd}.<br /><br />Lok {caseType, select, ${CaseType.ADMISSION_TO_FACILITY} {vistunar} other {gæslu}}: {validToDate}.<br /><br />Lok einangrunar: {isolationToDate}.`,
+      defaultMessage:
+        '{actorInstitution}, {actorName} {actorTitle}, hefur uppfært lengd {caseType, select, ADMISSION_TO_FACILITY {vistunar} other {gæslu}}/einangrunar í máli {courtCaseNumber}. Sjá {linkStart}yfirlitssíðu málsins í Réttarvörslugátt{linkEnd}.<br /><br />Lok {caseType, select, ADMISSION_TO_FACILITY {vistunar} other {gæslu}}: {validToDate}.<br /><br />Lok einangrunar: {isolationToDate}.',
       description:
         'Notaður sem texti í tölvupósti vegna breytingar á lengd gæslu/einangrunar/vistunar þar sem úrskurðað var í einangrun.',
     },

--- a/apps/judicial-system/backend/src/app/messages/pdfCustodyNotice.ts
+++ b/apps/judicial-system/backend/src/app/messages/pdfCustodyNotice.ts
@@ -1,5 +1,4 @@
 import { defineMessage } from '@formatjs/intl'
-import { CaseType } from '@island.is/judicial-system/types'
 
 export const custodyNotice = {
   isolationDisclaimer: defineMessage({
@@ -8,18 +7,16 @@ export const custodyNotice = {
       '{genderedAccused} skal sæta einangrun til {isolationPeriod}.',
     description: 'Notaður sem texti til að segja til um einangrun',
   }),
-  rulingTitle: {
+  rulingTitle: defineMessage({
     id: 'judicial.system.backend:pdf.custody_notice.ruling_title',
-    defaultMessage: `Úrskuður um {caseType, select,
-      ${CaseType.ADMISSION_TO_FACILITY} {vistun á viðeigandi stofnun} 
-      other {gæsluvarðhald}}`,
+    defaultMessage:
+      'Úrskuður um {caseType, select, ADMISSION_TO_FACILITY {vistun á viðeigandi stofnun} other {gæsluvarðhald}}',
     description:
       'Titill á vistunarselði sem tilgreinir í hverning máli úrskurðurinn er',
-  },
-  arrangement: {
+  }),
+  arrangement: defineMessage({
     id: 'judicial.system.backend:pdf.custody_notice.arrangement',
-    defaultMessage: `Tilhögun {caseType, select,
-      ${CaseType.ADMISSION_TO_FACILITY} {vistunar á viðeigandi stofnun}
-      other {gæsluvarðhalds}}`,
-  },
+    defaultMessage:
+      'Tilhögun {caseType, select, ADMISSION_TO_FACILITY {vistunar á viðeigandi stofnun} other {gæsluvarðhalds}}',
+  }),
 }

--- a/apps/judicial-system/web/messages/Core/index.ts
+++ b/apps/judicial-system/web/messages/Core/index.ts
@@ -1,4 +1,3 @@
-import { CaseType } from '@island.is/judicial-system/types'
 import { defineMessages } from 'react-intl'
 
 export const core = defineMessages({
@@ -154,7 +153,8 @@ export const core = defineMessages({
   },
   pastRestrictionCase: {
     id: 'judicial.system.core:past_restriction_case',
-    defaultMessage: `{caseType, select, ${CaseType.ADMISSION_TO_FACILITY} {Fyrri vistun} ${CaseType.TRAVEL_BAN} {Fyrra farbann} other {Fyrri gæsla}}`,
+    defaultMessage:
+      '{caseType, select, ADMISSION_TO_FACILITY {Fyrri vistun} TRAVEL_BAN {Fyrra farbann} other {Fyrri gæsla}}',
     description: 'Notað fyrir fyrri mál í öllum flæðum.',
   },
   // TODO: remove pastCustody and pastTravelBan, use pastRestrictionCase instead

--- a/apps/judicial-system/web/messages/Core/restrictions.ts
+++ b/apps/judicial-system/web/messages/Core/restrictions.ts
@@ -1,8 +1,5 @@
-import { defineMessages } from 'react-intl'
-import {
-  CaseCustodyRestrictions,
-  CaseType,
-} from '@island.is/judicial-system/types'
+import { defineMessage, defineMessages } from 'react-intl'
+import { CaseCustodyRestrictions } from '@island.is/judicial-system/types'
 
 // TODO: remove restrictions and use restrictionsV2
 export const restrictions = defineMessages({
@@ -51,7 +48,8 @@ export const restrictions = defineMessages({
   },
   fallback: {
     id: 'judicial.system.core:restrictions.fallback',
-    defaultMessage: `Ekki er farið fram á takmarkanir á {caseType, select, ${CaseType.ADMISSION_TO_FACILITY} {vistun} ${CaseType.TRAVEL_BAN} {farbanni} other {gæslu}}.`,
+    defaultMessage:
+      'Ekki er farið fram á takmarkanir á {caseType, select, ADMISSION_TO_FACILITY {vistun} TRAVEL_BAN {farbanni} other {gæslu}}.',
     description:
       'Notaður til þessa að tilgreina að ekki er farið fram á takmarkanir',
   },
@@ -153,16 +151,18 @@ export const restrictionsV2 = {
       },
     },
   ),
-  title: {
-    id: 'judicial.system.core:restrictionsV2.title',
-    defaultMessage: `Takmarkanir og tilhögun {caseType, select, ${CaseType.ADMISSION_TO_FACILITY} {vistunar} ${CaseType.TRAVEL_BAN} {farbanns} other {gæslu}}`,
+  title: defineMessage({
+    id: 'judicial.system.core:restrictionsV2_title',
+    defaultMessage:
+      'Takmarkanir og tilhögun {caseType, select, ADMISSION_TO_FACILITY {vistunar} TRAVEL_BAN {farbanns} other {gæslu}}',
     description:
       'Notaður sem titil þegar útlistað er hvaða takmarkanir eru á gæslu/vistun/farbanni',
-  },
-  fallback: {
-    id: 'judicial.system.core:restrictionsV2.fallback',
-    defaultMessage: `Ekki er farið fram á takmarkanir á {caseType, select, ${CaseType.ADMISSION_TO_FACILITY} {vistun} ${CaseType.TRAVEL_BAN} {farbanni} other {gæslu}}.`,
+  }),
+  fallback: defineMessage({
+    id: 'judicial.system.core:restrictionsV2_fallback',
+    defaultMessage:
+      'Ekki er farið fram á takmarkanir á {caseType, select, ADMISSION_TO_FACILITY {vistun} TRAVEL_BAN {farbanni} other {gæslu}}.',
     description:
       'Notaður til þessa að tilgreina að ekki er farið fram á takmarkanir',
-  },
+  }),
 }

--- a/apps/judicial-system/web/messages/Core/sections.ts
+++ b/apps/judicial-system/web/messages/Core/sections.ts
@@ -1,11 +1,11 @@
-import { CaseType } from '@island.is/judicial-system/types'
 import { defineMessages, defineMessage } from 'react-intl'
 
 export const sections = {
   // TODO: remove custodyAndTravelBanProsecutorSection, it's renamed to restrictionCaseProsecutorSection
   title: defineMessage({
     id: 'judicial.system.core:sections.title',
-    defaultMessage: `{caseType, select, ${CaseType.CUSTODY} {Gæsluvarðhald} ${CaseType.TRAVEL_BAN} {Farbann} ${CaseType.ADMISSION_TO_FACILITY} {Vistun á viðeignadi stofnun} other {Rannsóknarheimild}}`,
+    defaultMessage:
+      '{caseType, select, CUSTODY {Gæsluvarðhald} TRAVEL_BAN {Farbann} ADMISSION_TO_FACILITY {Vistun á viðeignadi stofnun} other {Rannsóknarheimild}}',
     description: 'Notaður sem titill á hliðarstiku í öllum ferlum',
   }),
   custodyAndTravelBanProsecutorSection: defineMessages({
@@ -63,7 +63,8 @@ export const sections = {
     caseTitle: {
       id:
         'judicial.system.core:sections.restriction_case_prosecutor_section.case_title',
-      defaultMessage: `Krafa um {caseType, select, ${CaseType.ADMISSION_TO_FACILITY} {vistun} ${CaseType.TRAVEL_BAN} {farbann} other {gæsluvarðhald}}`,
+      defaultMessage:
+        'Krafa um {caseType, select, ADMISSION_TO_FACILITY {vistun} TRAVEL_BAN {farbann} other {gæsluvarðhald}}',
       description:
         'Notaður sem titill í hliðarstiku í gæslu-, farbanns- og vistunarmálum hjá sækjendum',
     },
@@ -328,13 +329,15 @@ export const sections = {
     },
     restrictionActive: {
       id: 'judicial.system.core:sections.case_results.restriction_active',
-      defaultMessage: `{caseType, select, ${CaseType.ADMISSION_TO_FACILITY} {Vistun virk} ${CaseType.TRAVEL_BAN} {Farbann virkt} other {Gæsluvarðhald virkt}}`,
+      defaultMessage:
+        '{caseType, select, ADMISSION_TO_FACILITY {Vistun virk} TRAVEL_BAN {Farbann virkt} other {Gæsluvarðhald virkt}}',
       description:
         'Notaður sem texti í skrefum á hliðarstiku þegar gæslu/farbann/vistun er virk',
     },
     restrictionOver: {
       id: 'judicial.system.core:sections.case_results.restriction_over',
-      defaultMessage: `{caseType, select, ${CaseType.ADMISSION_TO_FACILITY} {Vistun á stofnun} ${CaseType.TRAVEL_BAN} {Farbanni} other {Gæsluvarðhaldi}} lokið`,
+      defaultMessage:
+        '{caseType, select, ADMISSION_TO_FACILITY {Vistun á stofnun} TRAVEL_BAN {Farbanni} other {Gæsluvarðhaldi}} lokið',
       description:
         'Notaður sem texti í skrefum á hliðarstiku þegar gæslu/farbann/vistun er lokið',
     },

--- a/apps/judicial-system/web/messages/Core/signedVerdictOverview.ts
+++ b/apps/judicial-system/web/messages/Core/signedVerdictOverview.ts
@@ -1,4 +1,3 @@
-import { CaseType } from '@island.is/judicial-system/types'
 import { defineMessage, defineMessages } from 'react-intl'
 
 // Strings on signed verdict overview screen
@@ -31,19 +30,15 @@ export const signedVerdictOverview = {
   validToDateInThePast: defineMessage({
     id:
       'judicial.system.core:signed_verdict_overview.valid_to_date_in_the_past',
-    defaultMessage: `{caseType, select,
-        ${CaseType.ADMISSION_TO_FACILITY} {Vistun á viðeigandi stofnun}
-        ${CaseType.TRAVEL_BAN} {Farbanni}
-        other {Gæsluvarðhaldi}} lokið`,
+    defaultMessage:
+      '{caseType, select, ADMISSION_TO_FACILITY {Vistun á viðeigandi stofnun} TRAVEL_BAN {Farbanni} other {Gæsluvarðhaldi}} lokið',
     description:
       'Notaður sem titil á yfirlitsskjá afreiddra mála þegar dagsetning gæslu/vistunar/farbanni er liðin.',
   }),
   restrictionActive: defineMessage({
     id: 'judicial.system.core:signed_verdict_overview.restriction_active',
-    defaultMessage: `{caseType, select,
-        ${CaseType.ADMISSION_TO_FACILITY} {Vistun á viðeigandi stofnun virk}
-        ${CaseType.TRAVEL_BAN} {Farbann virkt}
-        other {Gæsluvarðhald virkt}}`,
+    defaultMessage:
+      '{caseType, select, ADMISSION_TO_FACILITY {Vistun á viðeigandi stofnun virk} TRAVEL_BAN {Farbann virkt} other {Gæsluvarðhald virkt}}',
     description:
       'Notaður sem titil á yfirlitsskjá afreiddra mála þegar dagsetning gæslu/vistunar/farbanni er liðin.',
   }),
@@ -199,25 +194,23 @@ export const signedVerdictOverview = {
       validToDateAndIsolationToDateAreTheSame: {
         id:
           'judicial.system.core:signed_verdict_overview.modify_dates_modal.valid_to_date_and_isolation_to_date_are_the_same',
-        defaultMessage: `{caseType, select,
-          ${CaseType.ADMISSION_TO_FACILITY} {Vistun á viðeigandi stofnun}
-          other {Gælsuvarðhald}} og einangrun til {date}`,
+        defaultMessage:
+          '{caseType, select, ADMISSION_TO_FACILITY {Vistun á viðeigandi stofnun} other {Gælsuvarðhald}} og einangrun til {date}',
         description:
           'Notaður sem texti í "Lengd gæsluvarðhalds breytt" glugga á yfirlitsskjá afgreiddra mála.',
       },
       validToDateChanged: {
         id:
           'judicial.system.core:signed_verdict_overview.modify_dates_modal.valid_to_date_changed',
-        defaultMessage: `{caseType, select,
-          ${CaseType.ADMISSION_TO_FACILITY} {Vistun á viðeigandi stofnun}
-          other {Gælsuvarðhald}} til {date}.`,
+        defaultMessage:
+          '{caseType, select, ADMISSION_TO_FACILITY {Vistun á viðeigandi stofnun} other {Gælsuvarðhald}} til {date}.',
         description:
           'Notaður sem texti "Lengd gæsluvarðhalds breytt" glugga á yfirlitsskjá afgreiddra mála.',
       },
       isolationDateChanged: {
         id:
           'judicial.system.core:signed_verdict_overview.modify_dates_modal.isolation_date_changed',
-        defaultMessage: `Einangrun til {date}.`,
+        defaultMessage: 'Einangrun til {date}.',
         description:
           'Notaður sem texti "Lengd gæsluvarðhalds breytt" glugga á yfirlitsskjá afgreiddra mála.',
       },
@@ -260,9 +253,8 @@ export const signedVerdictOverview = {
       modifiedValidToDateLabelV2: {
         id:
           'judicial.system.core:signed_verdict_overview.modify_dates_modal.modified_valid_to_date_label_v2',
-        defaultMessage: `{caseTye, select,
-        ${CaseType.ADMISSION_TO_FACILITY} {Vistun á viðeigandi stofnun}
-        other {Gæsluvarðhald}} til`,
+        defaultMessage:
+          '{caseTye, select, ADMISSION_TO_FACILITY {Vistun á viðeigandi stofnun} other {Gæsluvarðhald}} til',
         description:
           'Notaður sem texti í  "Breyting á lengd gæsluvarðhalds/vistunar" glugga á yfirlitsskjá afgreiddra mála.',
       },
@@ -285,9 +277,8 @@ export const signedVerdictOverview = {
       titleV2: {
         id:
           'judicial.system.core:signed_verdict_overview.modify_dates_info.title_V2',
-        defaultMessage: `Lengd {caseType, select,
-          ${CaseType.ADMISSION_TO_FACILITY} {vistunar}
-          other {gæslu}} uppfærð`,
+        defaultMessage:
+          'Lengd {caseType, select, ADMISSION_TO_FACILITY {vistunar} other {gæslu}} uppfærð',
         description:
           'Notaður sem titill í upplýsingaboxi um uppfærða lengd gæslu á yfirlitsskjá afgreiddra mála.',
       },
@@ -370,28 +361,15 @@ export const signedVerdictOverview = {
       buttonLabel: {
         id:
           'judicial.system.core:signed_verdict_overview.case_extension.button_label',
-        defaultMessage: `Framlengja {caseType, select,
-        ${CaseType.ADMISSION_TO_FACILITY} {vistun}
-        ${CaseType.TRAVEL_BAN} {farbann}
-        ${CaseType.CUSTODY} {gæslu}
-        other {heimild}}`,
+        defaultMessage:
+          'Framlengja {caseType, select, ADMISSION_TO_FACILITY {vistun} TRAVEL_BAN {farbann} CUSTODY {gæslu} other {heimild}}',
         description: 'Notaður sem label á framlengja mál takka',
       },
       extensionInfo: {
         id:
           'judicial.system.core:signed_verdict_overview.case_extension.button',
-        defaultMessage: `{hasChildCase, select,
-        yes {Framlengingarkrafa hefur þegar verið útbúin}
-        other {Ekki hægt að framlengja {caseType, select,
-        ${CaseType.ADMISSION_TO_FACILITY} {vistun á viðeigandi stofnun}
-        ${CaseType.TRAVEL_BAN} {farbann}
-        ${CaseType.CUSTODY} {gæsluvarðhald}
-        other {kröfu}} {rejectReason, select,
-          rejected {sem var hafnað}
-          dismissed {sem var vísað frá}
-          isValidToDateInThePast {sem er lokið}
-          acceptingAlternativeTravelBan {þegar dómari hefur úrskurðað um annað en dómkröfur sögðu til um}
-          other {}}}}.`,
+        defaultMessage:
+          '{hasChildCase, select, yes {Framlengingarkrafa hefur þegar verið útbúin} other {Ekki hægt að framlengja {caseType, select, ADMISSION_TO_FACILITY {vistun á viðeigandi stofnun} TRAVEL_BAN {farbann} CUSTODY {gæsluvarðhald} other {kröfu}} {rejectReason, select, rejected {sem var hafnað} dismissed {sem var vísað frá} isValidToDateInThePast {sem er lokið} acceptingAlternativeTravelBan {þegar dómari hefur úrskurðað um annað en dómkröfur sögðu til um} other {}}}}.',
         description:
           'Notaður sem upplýsingatexti á info búbblu hjá framlengja mál takka',
       },
@@ -400,26 +378,22 @@ export const signedVerdictOverview = {
       restrictionExpired: {
         id:
           'judicial.system.core:signed_verdict_overview.case_dates.restriction_expired',
-        defaultMessage: `{caseType, select,
-      ${CaseType.ADMISSION_TO_FACILITY} {Vistun}
-      ${CaseType.TRAVEL_BAN} {Farbann}
-      other {Gæsla}} rann út {date}`,
+        defaultMessage:
+          '{caseType, select, ADMISSION_TO_FACILITY {Vistun} TRAVEL_BAN {Farbann} other {Gæsla}} rann út {date}',
         description: 'Texti sem tilgreinir hvenær gæsla/vistun/farbann rann út',
       },
       restrictionValidTo: {
         id:
           'judicial.system.core:signed_verdict_overview.case_dates.restriction_valid_to',
-        defaultMessage: `{caseType, select,
-      ${CaseType.ADMISSION_TO_FACILITY} {Vistun}
-      ${CaseType.TRAVEL_BAN} {Farbann}
-      other {Gæsla}} til {date}`,
+        defaultMessage:
+          '{caseType, select, ADMISSION_TO_FACILITY {Vistun} TRAVEL_BAN {Farbann} other {Gæsla}} til {date}',
         description:
           'Texti sem tilgreinir hversu lengi gæsla/vistun/farbann er í gildi',
       },
       isolationValidTo: {
         id:
           'judicial.system.core:signed_verdict_overview.case_dates.isolation_valid_to',
-        defaultMessage: `Einangrun til {date}`,
+        defaultMessage: 'Einangrun til {date}',
         description: 'Texti sem tilgreinir hversu lengi einangrun er í gildi',
       },
     }),

--- a/apps/judicial-system/web/messages/RestrictionCases/Court/courtRecordForm.ts
+++ b/apps/judicial-system/web/messages/RestrictionCases/Court/courtRecordForm.ts
@@ -1,4 +1,3 @@
-import { CaseType } from '@island.is/judicial-system/types'
 import { defineMessages } from 'react-intl'
 
 export const rcCourtRecord = {
@@ -107,15 +106,8 @@ export const rcCourtRecord = {
       autofillPresentationsV2: {
         id:
           'judicial.system.restriction_cases:court_record.session_bookings.autofill_presentations_v2#markdown',
-        defaultMessage: `Sækjandi ítrekar kröfu um {caseType, select,
-        ${CaseType.ADMISSION_TO_FACILITY} {vistun á viðeigandi stofnun}
-        other {gæsluvarðhald}}, reifar og rökstyður kröfuna og leggur málið í úrskurð með venjulegum fyrirvara.\n\nVerjandi {accused} ítrekar mótmæli hans, krefst þess að kröfunni verði hafnað, til vara að {accused} verði gert að sæta farbanni í stað {caseType, select,
-        ${CaseType.ADMISSION_TO_FACILITY} {vistunar}
-        other {gæsluvarðhalds}}, en til þrautavara að {caseType, select,
-        ${CaseType.ADMISSION_TO_FACILITY} {vistun}
-        other {gæsluvarðhaldi}} verði markaður skemmri tími en krafist er og að {accused} verði ekki gert að sæta einangrun á meðan á {caseType, select,
-        ${CaseType.ADMISSION_TO_FACILITY} {vistun}
-        other {gæsluvarðhaldi}} stendur. Verjandinn reifar og rökstyður mótmælin og leggur málið í úrskurð með venjulegum fyrirvara.`,
+        defaultMessage:
+          'Sækjandi ítrekar kröfu um {caseType, select, ADMISSION_TO_FACILITY {vistun á viðeigandi stofnun} other {gæsluvarðhald}}, reifar og rökstyður kröfuna og leggur málið í úrskurð með venjulegum fyrirvara.\n\nVerjandi {accused} ítrekar mótmæli hans, krefst þess að kröfunni verði hafnað, til vara að {accused} verði gert að sæta farbanni í stað {caseType, select, ADMISSION_TO_FACILITY {vistunar} other {gæsluvarðhalds}}, en til þrautavara að {caseType, select, ADMISSION_TO_FACILITY {vistun} other {gæsluvarðhaldi}} verði markaður skemmri tími en krafist er og að {accused} verði ekki gert að sæta einangrun á meðan á {caseType, select, ADMISSION_TO_FACILITY {vistun} other {gæsluvarðhaldi}} stendur. Verjandinn reifar og rökstyður mótmælin og leggur málið í úrskurð með venjulegum fyrirvara.',
         description:
           'Sjálfgefinn texti í "Afstaða varnaraðila, málflutningur og aðrar bókanir" textaboxi á þingbókar skrefi í gæsluvarðhaldsmálum.',
       },
@@ -288,10 +280,8 @@ export const rcCourtRecord = {
       disclaimerV2: {
         id:
           'judicial.system.restriction_cases:court_record.custody_restrictions.disclaimer_v2',
-        defaultMessage: `Dómari bendir sakborningi/umboðsaðila á að honum sé heimilt að bera atriði er lúta að framkvæmd {caseType, select,
-        ${CaseType.ADMISSION_TO_FACILITY} {vistunarinnar á viðeigandi stofnun}
-        ${CaseType.TRAVEL_BAN} {farbannsins}
-        other {gæsluvarðhaldsins}} undir dómara.`,
+        defaultMessage:
+          'Dómari bendir sakborningi/umboðsaðila á að honum sé heimilt að bera atriði er lúta að framkvæmd {caseType, select, ADMISSION_TO_FACILITY {vistunarinnar á viðeigandi stofnun} TRAVEL_BAN {farbannsins} other {gæsluvarðhaldsins}} undir dómara.',
         description:
           'Notaður sem upplýsingatexti í upplýsingasvæði við "greinargerð um lagarök" titlinn á úrskurðar skrefi í gæsluvarðhalds- og farbannsmálum.',
       },

--- a/apps/judicial-system/web/messages/RestrictionCases/Court/overview.ts
+++ b/apps/judicial-system/web/messages/RestrictionCases/Court/overview.ts
@@ -1,11 +1,11 @@
-import { CaseType } from '@island.is/judicial-system/types'
 import { defineMessages } from 'react-intl'
 
 export const rcCourtOverview = {
   sections: {
     title: {
       id: 'rcCourtOverview.sections.title',
-      defaultMessage: `Yfirlit {caseType, select, ${CaseType.ADMISSION_TO_FACILITY} {kröfu um vistun á viðeigandi stofnun} ${CaseType.TRAVEL_BAN} {farbannskröfu} other {gæsluvarðhaldskröfu}}`,
+      defaultMessage:
+        'Yfirlit {caseType, select, ADMISSION_TO_FACILITY {kröfu um vistun á viðeigandi stofnun} TRAVEL_BAN {farbannskröfu} other {gæsluvarðhaldskröfu}}',
       description:
         'Notaður sem titill á yfirlitssíðu í gæsluvarðhalds-, vistunar- og farbannsmálum.',
     },

--- a/apps/judicial-system/web/messages/RestrictionCases/Court/ruling.ts
+++ b/apps/judicial-system/web/messages/RestrictionCases/Court/ruling.ts
@@ -1,4 +1,3 @@
-import { CaseType } from '@island.is/judicial-system/types'
 import { defineMessage, defineMessages } from 'react-intl'
 
 export const rcRuling = {
@@ -134,7 +133,8 @@ export const rcRuling = {
       },
       caseType: {
         id: 'judicial.system.restriction_cases:ruling.decision.case_type',
-        defaultMessage: `{caseType, select, ${CaseType.ADMISSION_TO_FACILITY} {vistun} ${CaseType.TRAVEL_BAN} {farbann} other {gæsluvarðhald}}`,
+        defaultMessage:
+          '{caseType, select, ADMISSION_TO_FACILITY {vistun} TRAVEL_BAN {farbann} other {gæsluvarðhald}}',
         description:
           'Notaður sem texti við radio takka með vali um að samþykkja/hafna/vísa frá kröfu á úrskurðar skrefi í gæsluvarðhalds-, vistunar- og farbannsmálum.',
       },
@@ -180,7 +180,7 @@ export const rcRuling = {
       acceptingAlternativeTravelBanLabelV2: {
         id:
           'judicial.system.restriction_cases:ruling.decision.accepting_alternative_travel_ban_label_v2',
-        defaultMessage: `Kröfu um {caseType} hafnað en úrskurðað í farbann`,
+        defaultMessage: 'Kröfu um {caseType} hafnað en úrskurðað í farbann',
         description:
           'Notaður sem texti við radio takka með vali um að hafna gæsluvarðhaldi en úrskurða í farbann á úrskurðar skrefi í gæsluvarðhalds- og vistunarfálum.',
       },
@@ -239,7 +239,8 @@ export const rcRuling = {
       dismissingAutofillV2: {
         id:
           'judicial.system.restriction_cases:ruling.conclusion.dismissing_autofill_v2',
-        defaultMessage: `Kröfu um að {genderedAccused}, {accusedName}, sæti{isExtended, select, yes { áframhaldandi} other {}} {caseType, select, ${CaseType.ADMISSION_TO_FACILITY} {vistun á viðeigandi stofnun} ${CaseType.TRAVEL_BAN} {farbanni} other {gæsluvarðhaldi}} er vísað frá.`,
+        defaultMessage:
+          'Kröfu um að {genderedAccused}, {accusedName}, sæti{isExtended, select, yes { áframhaldandi} other {}} {caseType, select, ADMISSION_TO_FACILITY {vistun á viðeigandi stofnun} TRAVEL_BAN {farbanni} other {gæsluvarðhaldi}} er vísað frá.',
         description:
           'Notaður sem sjálfgefinn texti í "Úrskurðarorð" textaboxi þegar kröfu er vísað frá á úrskurðar skrefi í gæsluvarðhalds-, vistunar- og farbannsmálum.',
       },
@@ -254,7 +255,8 @@ export const rcRuling = {
       rejectingAutofillV2: {
         id:
           'judicial.system.restriction_cases:ruling.conclusion.rejecting_autofill_v2',
-        defaultMessage: `Kröfu um að {genderedAccused}, {accusedName}{accusedNationalId}sæti{isExtended, select, yes { áframhaldandi} other {}} {caseType, select, ${CaseType.ADMISSION_TO_FACILITY} {vistun á viðeigandi stofnun} ${CaseType.TRAVEL_BAN} {farbanni} other {gæsluvarðhaldi}} er hafnað.`,
+        defaultMessage:
+          'Kröfu um að {genderedAccused}, {accusedName}{accusedNationalId}sæti{isExtended, select, yes { áframhaldandi} other {}} {caseType, select, ADMISSION_TO_FACILITY {vistun á viðeigandi stofnun} TRAVEL_BAN {farbanni} other {gæsluvarðhaldi}} er hafnað.',
         description:
           'Notaður sem sjálfgefinn texti í "Úrskurðarorð" textaboxi þegar kröfu er hafnað á úrskurðar skrefi í gæsluvarðhalds- og farbannsmálum.',
       },
@@ -269,16 +271,8 @@ export const rcRuling = {
       acceptingAutofillV2: {
         id:
           'judicial.system.restriction_cases:ruling.conclusion.accepting_autofill_v2',
-        defaultMessage: `{genderedAccused}, {accusedName}{accusedNationalId}skal sæta {isExtended, select, yes {áframhaldandi } other {}}{caseType, select,
-          ${CaseType.TRAVEL_BAN} {farbanni}
-          ${CaseType.ADMISSION_TO_FACILITY} {vistun á viðeigandi stofnun}
-          other {gæsluvarðhaldi}}, þó ekki lengur en til {validToDate}.{hasIsolation, select,
-            yes { {genderedAccused} skal sæta einangrun {isolationEndsBeforeValidToDate, select,
-              yes {ekki lengur en til {isolationToDate}} 
-              other {á meðan á {caseType, select, 
-                ${CaseType.ADMISSION_TO_FACILITY} {vistunni} 
-                other {gæsluvarðhaldinu}} stendur}}.}
-            other {}}`,
+        defaultMessage:
+          '{genderedAccused}, {accusedName}{accusedNationalId}skal sæta {isExtended, select, yes {áframhaldandi } other {}}{caseType, select, TRAVEL_BAN {farbanni} ADMISSION_TO_FACILITY {vistun á viðeigandi stofnun} other {gæsluvarðhaldi}}, þó ekki lengur en til {validToDate}.{hasIsolation, select, yes { {genderedAccused} skal sæta einangrun {isolationEndsBeforeValidToDate, select, yes {ekki lengur en til {isolationToDate}} other {á meðan á {caseType, select, ADMISSION_TO_FACILITY {vistunni} other {gæsluvarðhaldinu}} stendur}}.} other {}}',
         description:
           'Notaður sem sjálfgefinn texti í "Úrskurðarorð" textaboxi þegar krafa er samþykkt á úrskurðar skrefi í gæsluvarðhalds- og farbannsmálum.',
       },

--- a/apps/judicial-system/web/messages/RestrictionCases/Prosecutor/accusedForm.ts
+++ b/apps/judicial-system/web/messages/RestrictionCases/Prosecutor/accusedForm.ts
@@ -1,4 +1,3 @@
-import { CaseType } from '@island.is/judicial-system/types'
 import { defineMessage, defineMessages } from 'react-intl'
 
 export const accused = {
@@ -108,10 +107,8 @@ export const accused = {
         tooltipV2: {
           id:
             'judicial.system.restriction_cases:accused.defender_info.send_request.tooltip_v2',
-          defaultMessage: `Ef hakað er hér þá fær verjandi {caseType, select,
-          ${CaseType.ADMISSION_TO_FACILITY}) {kröfuna um vistun á viðeigandi stofnun}
-          ${CaseType.TRAVEL_BAN} {farbannskröfuna}
-          other {gæsluvarðhaldskröfuna}} senda þegar fyrirtökutíma hefur verið úthlutað`,
+          defaultMessage:
+            'Ef hakað er hér þá fær verjandi {caseType, select, ADMISSION_TO_FACILITY) {kröfuna um vistun á viðeigandi stofnun} TRAVEL_BAN {farbannskröfuna} other {gæsluvarðhaldskröfuna}} senda þegar fyrirtökutíma hefur verið úthlutað',
           description:
             'Notaður sem upplýsingatexti í upplýsingasvæði við "senda kröfu sjálfvirkt..." gátreit á sakbornings skrefi í gæsluvarðhalds- og farbannsmálum.',
         },

--- a/apps/judicial-system/web/messages/RestrictionCases/Prosecutor/demandsForm.ts
+++ b/apps/judicial-system/web/messages/RestrictionCases/Prosecutor/demandsForm.ts
@@ -1,4 +1,3 @@
-import { CaseType } from '@island.is/judicial-system/types'
 import { defineMessage, defineMessages } from 'react-intl'
 
 export const rcDemands = {
@@ -40,20 +39,16 @@ export const rcDemands = {
       pastRestriction: defineMessage({
         id:
           'judicial.system.restriction_cases:police_demands.demands.past_restriction',
-        defaultMessage: `{caseType, select,
-          ${CaseType.ADMISSION_TO_FACILITY} {Fyrri vistun}
-          ${CaseType.TRAVEL_BAN} {Fyrra farbann}
-          other {Fyrri gæsla}} var/er til `,
+        defaultMessage:
+          '{caseType, select, ADMISSION_TO_FACILITY {Fyrri vistun} TRAVEL_BAN {Fyrra farbann} other {Fyrri gæsla}} var/er til ',
         description:
           'Notaður sem texti yfir fyrri gæslu/vistun/farbann ef um framlengt mál er að ræða í skrefi lagagrundvöllur og dómkörfur.',
       }),
       restrictionValidDateLabel: defineMessage({
         id:
           'judicial.system.restriction_cases:police_demands.demands.restriction_label',
-        defaultMessage: `{caseType, select,
-          ${CaseType.ADMISSION_TO_FACILITY} {Vistun á viðeignandi stofnun}
-          ${CaseType.TRAVEL_BAN} {Farbann}
-          other {Gæsluvarðhald}} til`,
+        defaultMessage:
+          '{caseType, select, ADMISSION_TO_FACILITY {Vistun á viðeignandi stofnun} TRAVEL_BAN {Farbann} other {Gæsluvarðhald}} til',
         description:
           'Notaður sem texti þegar valið er lengd á gæslu/vistun/farbanni í "dómkröfu" á lagagrundvöllur og dómkröfur skrefi.',
       }),
@@ -118,10 +113,8 @@ export const rcDemands = {
       headingV2: {
         id:
           'judicial.system.restriction_cases:police_demands.custody_restrictions.heading_v2',
-        defaultMessage: `Takmarkanir og tilhögun {caseType, select,
-        ${CaseType.ADMISSION_TO_FACILITY} {vistunar}
-        ${CaseType.TRAVEL_BAN} {farbanns}
-        other {gæslu}}`,
+        defaultMessage:
+          'Takmarkanir og tilhögun {caseType, select, ADMISSION_TO_FACILITY {vistunar} TRAVEL_BAN {farbanns} other {gæslu}}',
         description:
           'Notaður sem titill fyrir "takmarkanir og tilhögun gæslu/farbanns/vistunar" hlutann á lagagrundvöllur og dómkröfur skrefi í gæsluvarðhalds-, vistunar- og farbannsmálum.',
       },
@@ -135,10 +128,8 @@ export const rcDemands = {
       subHeadingV2: {
         id:
           'judicial.system.restriction_cases:police_demands.custody_restrictions.sub_heading_v2',
-        defaultMessage: `Ef ekkert er valið er {caseType, select,
-        ${CaseType.ADMISSION_TO_FACILITY} {vistun}
-        ${CaseType.TRAVEL_BAN} {farbann}
-        other {gæsla}} án takmarkana`,
+        defaultMessage:
+          'Ef ekkert er valið er {caseType, select, ADMISSION_TO_FACILITY {vistun} TRAVEL_BAN {farbann} other {gæsla}} án takmarkana',
         description:
           'Notaður sem undirtitill fyrir "takmarkanir og tilhögun gæslu" hlutann á lagagrundvöllur og dómkröfur skrefi í gæsluvarðhalds- og farbannsmálum.',
       },

--- a/apps/judicial-system/web/messages/RestrictionCases/Prosecutor/overview.ts
+++ b/apps/judicial-system/web/messages/RestrictionCases/Prosecutor/overview.ts
@@ -1,4 +1,3 @@
-import { CaseType } from '@island.is/judicial-system/types'
 import { defineMessage, defineMessages } from 'react-intl'
 
 export const rcOverview = {
@@ -10,10 +9,8 @@ export const rcOverview = {
   }),
   headingV2: defineMessage({
     id: 'judicial.system.restriction_cases:overview.heading_v2',
-    defaultMessage: `Yfirlit kröfu um {caseType, select,
-      ${CaseType.ADMISSION_TO_FACILITY} {{isExtended, select, yes {framlengingu á } other {}}vistun á viðeigandi stofnun}
-      ${CaseType.TRAVEL_BAN} {{isExtended, select, yes {farbanni} other {farbann}}}
-      other {{isExtended, select, yes {framlengingu á gæsluvarðhaldi} other {gæsluvarðhald}}}}`,
+    defaultMessage:
+      'Yfirlit kröfu um {caseType, select, ADMISSION_TO_FACILITY {{isExtended, select, yes {framlengingu á } other {}}vistun á viðeigandi stofnun} TRAVEL_BAN {{isExtended, select, yes {farbanni} other {farbann}}} other {{isExtended, select, yes {framlengingu á gæsluvarðhaldi} other {gæsluvarðhald}}}}',
     description: 'Notaður sem titill á yfirlits skrefi í rannsóknarheimildum.',
   }),
   sections: {
@@ -26,10 +23,8 @@ export const rcOverview = {
       },
       headingV2: {
         id: 'judicial.system.restriction_cases:overview.modal.heading_v2',
-        defaultMessage: `Krafa um {caseType, select,
-          ${CaseType.ADMISSION_TO_FACILITY} {vistun á viðeigandi stofnun}
-          ${CaseType.TRAVEL_BAN} {farbann}
-          other {gæsluvarhald}} hefur verið send til dómstóls`,
+        defaultMessage:
+          'Krafa um {caseType, select, ADMISSION_TO_FACILITY {vistun á viðeigandi stofnun} TRAVEL_BAN {farbann} other {gæsluvarhald}} hefur verið send til dómstóls',
         description:
           'Notaður sem titill á modal sem birtist þegar krafa hefur verið send til dómstóls',
       },

--- a/apps/judicial-system/web/messages/RestrictionCases/Prosecutor/reportForm.ts
+++ b/apps/judicial-system/web/messages/RestrictionCases/Prosecutor/reportForm.ts
@@ -1,4 +1,3 @@
-import { CaseType } from '@island.is/judicial-system/types'
 import { defineMessage, defineMessages } from 'react-intl'
 
 // Strings for report form 'Greinargerð'
@@ -47,14 +46,8 @@ export const rcReportForm = {
       },
       autofillV2: {
         id: 'judicial.system.restriction_cases:report_form.demands.autofill_v2',
-        defaultMessage: `Þess er krafist að {accusedName}{accusedNationalId}sæti{isExtended, select,
-          yes { áframhaldandi}
-          other {}} {caseType, select,
-            ${CaseType.ADMISSION_TO_FACILITY} {vistun á viðeigandi stofnun}
-            ${CaseType.TRAVEL_BAN} {farbanni}
-            other {gæsluvarðhaldi}} með úrskurði {court}, til {requestedValidToDate}{hasIsolationRequest, select,
-              yes {, og verði gert að sæta einangrun á meðan á varðhaldi stendur}
-              other {}}.`,
+        defaultMessage:
+          'Þess er krafist að {accusedName}{accusedNationalId}sæti{isExtended, select, yes { áframhaldandi} other {}} {caseType, select, ADMISSION_TO_FACILITY {vistun á viðeigandi stofnun} TRAVEL_BAN {farbanni} other {gæsluvarðhaldi}} með úrskurði {court}, til {requestedValidToDate}{hasIsolationRequest, select, yes {, og verði gert að sæta einangrun á meðan á varðhaldi stendur} other {}}.',
         description:
           'Notaður sem sjálfgefinn texti í textaboxi fyrir "dómkröfur" á greinargerðar skrefi í gæsluvarðhalds-, vistunar- og farbannsmálum.',
       },

--- a/apps/judicial-system/web/messages/RestrictionCases/Prosecutor/requestedHearingArrangementsForm.ts
+++ b/apps/judicial-system/web/messages/RestrictionCases/Prosecutor/requestedHearingArrangementsForm.ts
@@ -1,5 +1,4 @@
 import { defineMessage, defineMessages } from 'react-intl'
-import { CaseType } from '@island.is/judicial-system/types'
 
 export const rcRequestedHearingArrangements = {
   heading: defineMessage({
@@ -80,10 +79,8 @@ export const rcRequestedHearingArrangements = {
     textV2: {
       id:
         'judicial.system.restriction_cases:requested_hearing_arrangements.modal.text_v2',
-      defaultMessage: `Með því að senda tilkynningu á dómara og dómritara á vakt um að krafa um {caseType, select,
-          ${CaseType.ADMISSION_TO_FACILITY} {vistun í viðeigandi stofun}
-          ${CaseType.TRAVEL_BAN} {farbann}
-          other {gæsluvarhald}} sé í vinnslu flýtir það fyrir málsmeðferð og allir aðilar eru upplýstir.`,
+      defaultMessage:
+        'Með því að senda tilkynningu á dómara og dómritara á vakt um að krafa um {caseType, select, ADMISSION_TO_FACILITY {vistun í viðeigandi stofun} TRAVEL_BAN {farbann} other {gæsluvarhald}} sé í vinnslu flýtir það fyrir málsmeðferð og allir aðilar eru upplýstir.',
       description:
         'Notaður sem texti í "viltu senda tilkynningu" tilkynningaglugganum á óskir um fyrirtöku skrefi í gæsluvarðhalds-, vistunar- og farbannsmálum.',
     },


### PR DESCRIPTION
[Asana](https://app.asana.com/0/0/1202188672896414/f)
## What

- Remove template string being used for contentful strings

## Why

- They are not supported and result in empty translations when uploading to contentful

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
