### PR TITLE
fix(parental-leave): answer validation for privatePensionFund and privatePensionFundPercentage

### DIFF
--- a/libs/application/templates/parental-leave/src/fields/Review/Review.tsx
+++ b/libs/application/templates/parental-leave/src/fields/Review/Review.tsx
@@ -10,6 +10,9 @@ import {
   buildFieldOptions,
   RecordObject,
   Field,
+  buildValidationError,
+  coreErrorMessages,
+  StaticText,
 } from '@island.is/application/core'
 import {
   Box,
@@ -154,7 +157,39 @@ export const Review: FC<ReviewScreenProps> = ({
     application.externalData,
   )
 
+  const buildError = (message: StaticText, path: string) =>
+    buildValidationError(path)(message)
+
+  const validatePrivatePensionFund = () => {
+    if (usePrivatePensionFund !== YES) return undefined
+
+    if (privatePensionFund === '') {
+      return formatMessage(coreErrorMessages.defaultError)
+    }
+
+    return undefined
+  }
+
+  const validatePrivatePensionFundPercentage = () => {
+    if (usePrivatePensionFund !== YES) return undefined
+
+    if (privatePensionFundPercentage === '') {
+      return formatMessage(coreErrorMessages.defaultError)
+    }
+
+    return undefined
+  }
+
   const hasError = (id: string) => get(errors, id) as string
+
+  const checkPaymentErrors = (ids: string[]) => {
+
+    if (typeof(validatePrivatePensionFund()) === 'string') return false
+    else if (typeof(validatePrivatePensionFundPercentage()) === 'string') return false
+
+    return groupHasNoErrors(ids)
+  }
+
   const groupHasNoErrors = (ids: string[]) =>
     ids.every((id) => !has(errors, id))
 
@@ -356,13 +391,14 @@ export const Review: FC<ReviewScreenProps> = ({
       <ReviewGroup
         saveAction={saveApplication}
         isEditable={editable}
-        canCloseEdit={groupHasNoErrors([
+        canCloseEdit={checkPaymentErrors([
           'payments.bank',
           'payments.pensionFund',
           'useUnion',
           'payments.union',
           'usePrivatePensionFund',
           'payments.privatePensionFund',
+          'payments.privatePensionFundPercentage'
         ])}
         editChildren={
           <Stack space={3}>
@@ -490,7 +526,7 @@ export const Review: FC<ReviewScreenProps> = ({
                     const privatePensionFund =
                       s === NO
                         ? NO_PRIVATE_PENSION_FUND
-                        : prev.privatePensionFund
+                        : ''
                     const privatePensionFundPercentage =
                       s === NO ? '' : prev.privatePensionFundPercentage
                     setValue('payments.privatePensionFund', privatePensionFund)
@@ -526,7 +562,7 @@ export const Review: FC<ReviewScreenProps> = ({
                           privatePensionFund: s.value as string,
                         }))
                       }
-                      error={hasError('payments.privatePensionFund')}
+                      error={validatePrivatePensionFund()}
                     />
                   </GridColumn>
 
@@ -552,7 +588,7 @@ export const Review: FC<ReviewScreenProps> = ({
                           privatePensionFundPercentage: s.value as string,
                         }))
                       }
-                      error={hasError('payments.privatePensionFundPercentage')}
+                      error={validatePrivatePensionFundPercentage()}
                     />
                   </GridColumn>
                 </GridRow>

--- a/libs/application/templates/parental-leave/src/fields/Review/Review.tsx
+++ b/libs/application/templates/parental-leave/src/fields/Review/Review.tsx
@@ -10,9 +10,7 @@ import {
   buildFieldOptions,
   RecordObject,
   Field,
-  buildValidationError,
   coreErrorMessages,
-  StaticText,
 } from '@island.is/application/core'
 import {
   Box,
@@ -156,9 +154,6 @@ export const Review: FC<ReviewScreenProps> = ({
     application.answers,
     application.externalData,
   )
-
-  const buildError = (message: StaticText, path: string) =>
-    buildValidationError(path)(message)
 
   const validatePrivatePensionFund = () => {
     if (usePrivatePensionFund !== YES) return undefined

--- a/libs/application/templates/parental-leave/src/fields/Review/Review.tsx
+++ b/libs/application/templates/parental-leave/src/fields/Review/Review.tsx
@@ -183,9 +183,9 @@ export const Review: FC<ReviewScreenProps> = ({
   const hasError = (id: string) => get(errors, id) as string
 
   const checkPaymentErrors = (ids: string[]) => {
-
-    if (typeof(validatePrivatePensionFund()) === 'string') return false
-    else if (typeof(validatePrivatePensionFundPercentage()) === 'string') return false
+    if (typeof validatePrivatePensionFund() === 'string') return false
+    else if (typeof validatePrivatePensionFundPercentage() === 'string')
+      return false
 
     return groupHasNoErrors(ids)
   }
@@ -398,7 +398,7 @@ export const Review: FC<ReviewScreenProps> = ({
           'payments.union',
           'usePrivatePensionFund',
           'payments.privatePensionFund',
-          'payments.privatePensionFundPercentage'
+          'payments.privatePensionFundPercentage',
         ])}
         editChildren={
           <Stack space={3}>
@@ -524,9 +524,7 @@ export const Review: FC<ReviewScreenProps> = ({
                 onSelect={(s: string) => {
                   setStateful((prev) => {
                     const privatePensionFund =
-                      s === NO
-                        ? NO_PRIVATE_PENSION_FUND
-                        : ''
+                      s === NO ? NO_PRIVATE_PENSION_FUND : ''
                     const privatePensionFundPercentage =
                       s === NO ? '' : prev.privatePensionFundPercentage
                     setValue('payments.privatePensionFund', privatePensionFund)

--- a/libs/application/templates/parental-leave/src/fields/UsePrivatePensionFund/index.tsx
+++ b/libs/application/templates/parental-leave/src/fields/UsePrivatePensionFund/index.tsx
@@ -54,6 +54,9 @@ export const UsePrivatePensionFund: FC<FieldBaseProps> = ({
               setValue('payments.privatePensionFund', NO_PRIVATE_PENSION_FUND)
               setValue('payments.privatePensionFundPercentage', '')
             }
+            if (s === YES) {
+              setValue('payments.privatePensionFund', '')
+            }
           },
         }}
       />

--- a/libs/application/templates/parental-leave/src/lib/answerValidators.spec.ts
+++ b/libs/application/templates/parental-leave/src/lib/answerValidators.spec.ts
@@ -2,12 +2,13 @@ import {
   Application,
   ApplicationStatus,
   ApplicationTypes,
+  coreErrorMessages,
 } from '@island.is/application/core'
 import addDays from 'date-fns/addDays'
 import format from 'date-fns/format'
 
 import { minimumPeriodStartBeforeExpectedDateOfBirth } from '../config'
-import { ParentalRelations } from '../constants'
+import { NO_PRIVATE_PENSION_FUND, ParentalRelations } from '../constants'
 import { answerValidators, VALIDATE_LATEST_PERIOD } from './answerValidators'
 import { errorMessages } from './messages'
 import { NO, StartDateOptions } from '../constants'
@@ -90,6 +91,34 @@ describe('answerValidators', () => {
       message: errorMessages.periodsPeriodRange,
       path: 'periods[0].startDate',
       values: { usageMaxMonths: 23.5 },
+    })
+  })
+
+  it('should create error when privatePensionFund is empty', () => {
+    const newAnswers = {
+      bank: '123456789012',
+      pensionFund: 'id-frjalsi',
+      privatePensionFund: '',
+      privatePensionFundProcentage: ''
+    }
+
+    expect(answerValidators['payments'](newAnswers, application)).toEqual({
+      message: coreErrorMessages.defaultError,
+      path: "payments.privatePensionFund",
+    })
+  })
+
+  it('should create error when privatePensionFundPercentage is empty', () => {
+    const newAnswers = {
+      bank: '123456789012',
+      pensionFund: 'id-frjalsi',
+      privatePensionFund: 'id-frjalsi',
+      privatePensionFundProcentage: ''
+    }
+
+    expect(answerValidators['payments'](newAnswers, application)).toEqual({
+      message: coreErrorMessages.defaultError,
+      path: "payments.privatePensionFundPercentage",
     })
   })
 })

--- a/libs/application/templates/parental-leave/src/lib/answerValidators.spec.ts
+++ b/libs/application/templates/parental-leave/src/lib/answerValidators.spec.ts
@@ -99,12 +99,12 @@ describe('answerValidators', () => {
       bank: '123456789012',
       pensionFund: 'id-frjalsi',
       privatePensionFund: '',
-      privatePensionFundProcentage: ''
+      privatePensionFundProcentage: '',
     }
 
     expect(answerValidators['payments'](newAnswers, application)).toEqual({
       message: coreErrorMessages.defaultError,
-      path: "payments.privatePensionFund",
+      path: 'payments.privatePensionFund',
     })
   })
 
@@ -113,12 +113,12 @@ describe('answerValidators', () => {
       bank: '123456789012',
       pensionFund: 'id-frjalsi',
       privatePensionFund: 'id-frjalsi',
-      privatePensionFundProcentage: ''
+      privatePensionFundProcentage: '',
     }
 
     expect(answerValidators['payments'](newAnswers, application)).toEqual({
       message: coreErrorMessages.defaultError,
-      path: "payments.privatePensionFundPercentage",
+      path: 'payments.privatePensionFundPercentage',
     })
   })
 })

--- a/libs/application/templates/parental-leave/src/lib/answerValidators.spec.ts
+++ b/libs/application/templates/parental-leave/src/lib/answerValidators.spec.ts
@@ -8,7 +8,7 @@ import addDays from 'date-fns/addDays'
 import format from 'date-fns/format'
 
 import { minimumPeriodStartBeforeExpectedDateOfBirth } from '../config'
-import { NO_PRIVATE_PENSION_FUND, ParentalRelations } from '../constants'
+import { ParentalRelations } from '../constants'
 import { answerValidators, VALIDATE_LATEST_PERIOD } from './answerValidators'
 import { errorMessages } from './messages'
 import { NO, StartDateOptions } from '../constants'

--- a/libs/application/templates/parental-leave/src/lib/answerValidators.spec.ts
+++ b/libs/application/templates/parental-leave/src/lib/answerValidators.spec.ts
@@ -99,13 +99,16 @@ describe('answerValidators', () => {
       bank: '123456789012',
       pensionFund: 'id-frjalsi',
       privatePensionFund: '',
-      privatePensionFundProcentage: '',
+      privatePensionFundPercentage: '',
     }
 
-    expect(answerValidators['payments'](newAnswers, application)).toEqual({
-      message: coreErrorMessages.defaultError,
-      path: 'payments.privatePensionFund',
-    })
+    expect(answerValidators['payments'](newAnswers, application)).toStrictEqual(
+      {
+        message: coreErrorMessages.defaultError,
+        path: 'payments.privatePensionFund',
+        values: undefined,
+      },
+    )
   })
 
   it('should create error when privatePensionFundPercentage is empty', () => {
@@ -113,13 +116,59 @@ describe('answerValidators', () => {
       bank: '123456789012',
       pensionFund: 'id-frjalsi',
       privatePensionFund: 'id-frjalsi',
-      privatePensionFundProcentage: '',
+      privatePensionFundPercentage: '',
     }
 
-    expect(answerValidators['payments'](newAnswers, application)).toEqual({
-      message: coreErrorMessages.defaultError,
-      path: 'payments.privatePensionFundPercentage',
-    })
+    expect(answerValidators['payments'](newAnswers, application)).toStrictEqual(
+      {
+        message: coreErrorMessages.defaultError,
+        path: 'payments.privatePensionFundPercentage',
+        values: undefined,
+      },
+    )
+  })
+
+  it('should only accept 2 or 4 as values for privatePensionFundPercentage', () => {
+    const newAnswers = {
+      bank: '123456789012',
+      pensionFund: 'id-frjalsi',
+      privatePensionFund: 'id-frjalsi',
+      privatePensionFundPercentage: 'test input',
+    }
+
+    expect(answerValidators['payments'](newAnswers, application)).toStrictEqual(
+      {
+        message: coreErrorMessages.defaultError,
+        path: 'payments.privatePensionFundPercentage',
+        values: undefined,
+      },
+    )
+  })
+
+  it('should accept 2 as a value for privatePensionFundPercentage', () => {
+    const newAnswers = {
+      bank: '123456789012',
+      pensionFund: 'id-frjalsi',
+      privatePensionFund: 'id-frjalsi',
+      privatePensionFundPercentage: '2',
+    }
+
+    expect(answerValidators['payments'](newAnswers, application)).toStrictEqual(
+      undefined,
+    )
+  })
+
+  it('should accept 4 as a value for privatePensionFundPercentage', () => {
+    const newAnswers = {
+      bank: '123456789012',
+      pensionFund: 'id-frjalsi',
+      privatePensionFund: 'id-frjalsi',
+      privatePensionFundPercentage: '4',
+    }
+
+    expect(answerValidators['payments'](newAnswers, application)).toStrictEqual(
+      undefined,
+    )
   })
 })
 

--- a/libs/application/templates/parental-leave/src/lib/answerValidators.ts
+++ b/libs/application/templates/parental-leave/src/lib/answerValidators.ts
@@ -106,8 +106,8 @@ export const answerValidators: Record<string, AnswerValidator> = {
 
     // validate that the privatePensionFundPercentage is either 2 or 4 percent
     if (
-      typeof (privatePensionFundPercentage) === 'string' ||
-      typeof (payments.privatePensionFundPercentage) === 'string'
+      typeof privatePensionFundPercentage === 'string' ||
+      typeof payments.privatePensionFundPercentage === 'string'
     ) {
       if (
         payments.privatePensionFundPercentage === '2' ||

--- a/libs/application/templates/parental-leave/src/lib/answerValidators.ts
+++ b/libs/application/templates/parental-leave/src/lib/answerValidators.ts
@@ -26,6 +26,7 @@ import { filterValidPeriods } from '../lib/parentalLeaveUtils'
 import { validatePeriod } from './answerValidator-utils'
 
 const EMPLOYER = 'employer'
+const PAYMENTS = 'payments'
 // When attempting to continue from the periods repeater main screen
 // this validator will get called to validate all of the periods
 export const VALIDATE_PERIODS = 'validatedPeriods'
@@ -33,8 +34,6 @@ export const VALIDATE_PERIODS = 'validatedPeriods'
 // the repeater sends all the periods saved in 'periods'
 // to this validator, which will validate the latest one
 export const VALIDATE_LATEST_PERIOD = 'periods'
-
-const PAYMENTS = 'payments'
 
 export const answerValidators: Record<string, AnswerValidator> = {
   [EMPLOYER]: (newAnswer: unknown, application: Application) => {

--- a/libs/application/templates/parental-leave/src/lib/answerValidators.ts
+++ b/libs/application/templates/parental-leave/src/lib/answerValidators.ts
@@ -88,17 +88,15 @@ export const answerValidators: Record<string, AnswerValidator> = {
     const buildError = (message: StaticText, path: string) =>
       buildValidationError(`${PAYMENTS}.${path}`)(message)
 
-    // if privatePensionFund is NO_PRIVATE_PENSION_FUND and privatePensionFundPercentage is an empty string, allow the user to continue. 
+    // if privatePensionFund is NO_PRIVATE_PENSION_FUND and privatePensionFundPercentage is an empty string, allow the user to continue.
     // this will only happen when the usePrivatePensionFund field is set to NO
     if (
       payments.privatePensionFund === NO_PRIVATE_PENSION_FUND &&
       payments.privatePensionFundPercentage === ''
-    ) return undefined
+    )
+      return undefined
 
-    if (
-      payments.privatePensionFund === '' ||
-      privatePensionFund === ''
-    ) {
+    if (payments.privatePensionFund === '' || privatePensionFund === '') {
       return buildError(coreErrorMessages.defaultError, 'privatePensionFund')
     }
 
@@ -111,12 +109,19 @@ export const answerValidators: Record<string, AnswerValidator> = {
       if (
         payments.privatePensionFundPercentage === '2' ||
         payments.privatePensionFundPercentage === '4'
-      ) return undefined
-      return buildError(coreErrorMessages.defaultError, 'privatePensionFundPercentage')
+      )
+        return undefined
+      return buildError(
+        coreErrorMessages.defaultError,
+        'privatePensionFundPercentage',
+      )
     }
 
     if (!payments.privatePensionFundPercentage) {
-      return buildError(coreErrorMessages.defaultError, 'privatePensionFundPercentage')
+      return buildError(
+        coreErrorMessages.defaultError,
+        'privatePensionFundPercentage',
+      )
     }
 
     return undefined

--- a/libs/application/templates/parental-leave/src/lib/answerValidators.ts
+++ b/libs/application/templates/parental-leave/src/lib/answerValidators.ts
@@ -105,12 +105,17 @@ export const answerValidators: Record<string, AnswerValidator> = {
     }
 
     // validate that the privatePensionFundPercentage is either 2 or 4 percent
-    if (privatePensionFundPercentage === '') {
+    if (
+      typeof (privatePensionFundPercentage) === 'string' ||
+      typeof (payments.privatePensionFundPercentage) === 'string'
+    ) {
       if (
         payments.privatePensionFundPercentage === '2' ||
         payments.privatePensionFundPercentage === '4'
-      )
+      ) {
         return undefined
+      }
+
       return buildError(
         coreErrorMessages.defaultError,
         'privatePensionFundPercentage',

--- a/libs/application/templates/parental-leave/src/types.ts
+++ b/libs/application/templates/parental-leave/src/types.ts
@@ -44,3 +44,11 @@ export interface Payment {
     paid: boolean
   }
 }
+
+export interface Payments {
+  bank: string,
+  pensionFund: string,
+  privatePensionFund: string,
+  privatePensionFundPercentage: string,
+  union: string,
+}

--- a/libs/application/templates/parental-leave/src/types.ts
+++ b/libs/application/templates/parental-leave/src/types.ts
@@ -46,9 +46,9 @@ export interface Payment {
 }
 
 export interface Payments {
-  bank: string,
-  pensionFund: string,
-  privatePensionFund: string,
-  privatePensionFundPercentage: string,
-  union: string,
+  bank: string
+  pensionFund: string
+  privatePensionFund: string
+  privatePensionFundPercentage: string
+  union: string
 }


### PR DESCRIPTION
## What

Adding answer validation for privatePensionFund and privatePensionFundPercentage, both on the Payment Information page and on the Review page (see images)

## Why

Doing this to avoid issues with users not filling in these fields.

## Screenshots / Gifs

<img width="780" alt="Screenshot 2022-04-27 at 16 01 14" src="https://user-images.githubusercontent.com/54942355/165536577-1548d1e8-10fa-485f-b54f-28adb338a689.png">
<img width="780" alt="Screenshot 2022-04-27 at 16 01 30" src="https://user-images.githubusercontent.com/54942355/165536562-df0dfdaa-9948-48e5-aaf1-7bd85770f970.png">

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
