### PR TITLE
feat(web): Organization page english footers

### DIFF
--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -167,6 +167,7 @@ export const OrganizationFooter: React.FC<FooterProps> = ({
 
   switch (organization.slug) {
     case 'syslumenn':
+    case 'district-commissioner':
       return (
         <SyslumennFooter
           title={organization.title}
@@ -175,6 +176,7 @@ export const OrganizationFooter: React.FC<FooterProps> = ({
         />
       )
     case 'sjukratryggingar':
+    case 'icelandic-health-insurance':
       return (
         <SjukratryggingarFooter
           title={organization.title}
@@ -183,6 +185,7 @@ export const OrganizationFooter: React.FC<FooterProps> = ({
         />
       )
     case 'utlendingastofnun':
+    case 'directorate-of-immigration':
       return (
         <UtlendingastofnunFooter
           title={organization.title}


### PR DESCRIPTION
# Organization page english footers

## What

* Previously the english page version of Organization pages did not show the corresponding footers

## Why

* We want the footer to be shown on multiple locales

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
