### PR TITLE
feat(service-portal): Add delete functionality on applications

### DIFF
--- a/apps/service-portal/src/auth.ts
+++ b/apps/service-portal/src/auth.ts
@@ -38,6 +38,7 @@ if (userMocked) {
       'profile',
       'api_resource.scope',
       ApplicationScope.read,
+      ApplicationScope.write,
       UserProfileScope.read,
       UserProfileScope.write,
       AuthScope.actorDelegations,

--- a/libs/service-portal/graphql/src/lib/fragments/application.ts
+++ b/libs/service-portal/graphql/src/lib/fragments/application.ts
@@ -15,6 +15,7 @@ export const ApplicationFragment = gql`
         label
         variant
       }
+      deleteButton
     }
     typeId
     name


### PR DESCRIPTION
## What

Add delete button to applications component in Service portal


## Why

So users can delete their drafted applications in the service portal.

## Screenshots / Gifs

![image](
https://user-images.githubusercontent.com/2643113/165759979-a267dd6f-dbe4-4bc9-b2b8-dad5508a44c0.png)
## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
