### PR TITLE
fix(application-system): Reintroduce userprofile locale logic

### DIFF
--- a/apps/application-system/form/src/app/App.tsx
+++ b/apps/application-system/form/src/app/App.tsx
@@ -14,6 +14,7 @@ import { AssignApplication } from '../routes/AssignApplication'
 import { Layout } from '../components/Layout/Layout'
 import { environment } from '../environments'
 import { FeatureFlagProvider } from '@island.is/react/feature-flags'
+import { UserProfileLocale } from '@island.is/shared/components'
 
 export const App = () => (
   <ApolloProvider client={initializeClient(environment.baseApiUrl)}>
@@ -22,6 +23,7 @@ export const App = () => (
         <Authenticator>
           <FeatureFlagProvider sdkKey={environment.featureFlagSdkKey}>
             <HeaderInfoProvider>
+              <UserProfileLocale />
               <Layout>
                 <Switch>
                   <Route

--- a/apps/application-system/form/src/routes/Applications.tsx
+++ b/apps/application-system/form/src/routes/Applications.tsx
@@ -1,9 +1,7 @@
 import React, { FC, useEffect } from 'react'
-import { useLazyQuery, useMutation } from '@apollo/client'
+import { useMutation } from '@apollo/client'
 import { useParams, useHistory } from 'react-router-dom'
 import isEmpty from 'lodash/isEmpty'
-import { isLocale } from 'class-validator'
-
 import {
   CREATE_APPLICATION,
   APPLICATION_APPLICATIONS,
@@ -16,26 +14,21 @@ import {
   GridContainer,
 } from '@island.is/island-ui/core'
 import { coreMessages, getTypeFromSlug } from '@island.is/application/core'
-import { Locale } from '@island.is/shared/types'
 import { ApplicationList } from '@island.is/application/ui-components'
 import { ErrorShell } from '@island.is/application/ui-shell'
-import { useAuth } from '@island.is/auth/react'
 import {
   useApplicationNamespaces,
   useLocale,
   useLocalizedQuery,
 } from '@island.is/localization'
-import { USER_PROFILE } from '@island.is/service-portal/graphql'
-import { Query } from '@island.is/api/schema'
 
 import { ApplicationLoading } from '../components/ApplicationsLoading/ApplicationLoading'
 
 export const Applications: FC = () => {
   const { slug } = useParams<{ slug: string }>()
   const history = useHistory()
-  const { formatMessage, changeLanguage, lang } = useLocale()
+  const { formatMessage } = useLocale()
   const type = getTypeFromSlug(slug)
-  const { userInfo } = useAuth()
 
   useApplicationNamespaces(type)
 
@@ -70,33 +63,12 @@ export const Applications: FC = () => {
     })
   }
 
-  // TODO: Change when IDS has locale
-  // const [
-  //   getUserProfile,
-  //   { data: userProfData, loading: userProfileLoading },
-  // ] = useLazyQuery<Query>(USER_PROFILE)
-  // const userProfile = userProfData?.getUserProfile || null
-
-  // useEffect(() => {
-  //   if (userInfo?.profile.nationalId) getUserProfile()
-  // }, [userInfo, getUserProfile])
-
-  // useEffect(() => {
-  //   if (
-  //     userProfile?.locale &&
-  //     isLocale(userProfile.locale) &&
-  //     userProfile.locale !== lang
-  //   )
-  //     changeLanguage(userProfile.locale as Locale)
-  // }, [userProfile, changeLanguage, lang])
-
   useEffect(() => {
     if (type && data && isEmpty(data.applicationApplications)) {
       createApplication()
     }
   }, [type, data])
 
-  // if (loading || userProfileLoading) {
   if (loading) {
     return <ApplicationLoading />
   }

--- a/apps/service-portal/src/app/App.tsx
+++ b/apps/service-portal/src/app/App.tsx
@@ -16,7 +16,7 @@ import Layout from '../components/Layout/Layout'
 import Modules from '../screens/Modules/Modules'
 import * as styles from './App.css'
 import { GlobalModules } from '../components/GlobalModules/GlobalModules'
-import { UserProfileLocale } from '../components/UserProfileLocale/UserProfileLocale'
+import { UserProfileLocale } from '@island.is/shared/components'
 import ApplicationErrorBoundary from './../components/ApplicationErrorBoundary/ApplicationErrorBoundary'
 
 export const App = () => {

--- a/libs/application/ui-shell/src/lib/ApplicationForm.tsx
+++ b/libs/application/ui-shell/src/lib/ApplicationForm.tsx
@@ -1,7 +1,6 @@
 import React, { FC, useEffect, useState } from 'react'
-import { useLazyQuery, useQuery } from '@apollo/client'
+import { useQuery } from '@apollo/client'
 import * as Sentry from '@sentry/react'
-import { isLocale } from 'class-validator'
 
 import { APPLICATION_APPLICATION } from '@island.is/application/graphql'
 import {
@@ -11,7 +10,6 @@ import {
   Schema,
   coreMessages,
 } from '@island.is/application/core'
-import { Locale } from '@island.is/shared/types'
 import {
   getApplicationTemplateByTypeId,
   getApplicationUIFields,
@@ -24,9 +22,6 @@ import { FieldProvider, useFields } from '../context/FieldContext'
 import { LoadingShell } from '../components/LoadingShell'
 import { FormShell } from './FormShell'
 import { ErrorShell } from '../components/ErrorShell'
-import { Query } from '@island.is/api/schema'
-import { USER_PROFILE } from '@island.is/service-portal/graphql'
-import { useAuth } from '@island.is/auth/react'
 
 const ApplicationLoader: FC<{
   applicationId: string
@@ -78,11 +73,11 @@ const ShellWrapper: FC<{
   const [dataSchema, setDataSchema] = useState<Schema>()
   const [form, setForm] = useState<Form>()
   const [, fieldsDispatch] = useFields()
-  const { formatMessage, changeLanguage, lang } = useLocale()
+  const { formatMessage } = useLocale()
   const featureFlagClient = useFeatureFlagClient()
-  const { userInfo } = useAuth()
 
   useApplicationNamespaces(application.typeId)
+
   useEffect(() => {
     async function populateForm() {
       if (dataSchema === undefined && form === undefined) {
@@ -133,27 +128,6 @@ const ShellWrapper: FC<{
     featureFlagClient,
   ])
 
-  // TODO: Change when IDS has locale. TODO2:
-  // const [
-  //   getUserProfile,
-  //   { data: userProfData, loading: userProfileLoading },
-  // ] = useLazyQuery<Query>(USER_PROFILE)
-  // const userProfile = userProfData?.getUserProfile || null
-
-  // useEffect(() => {
-  //   if (userInfo?.profile.nationalId) getUserProfile()
-  // }, [userInfo, getUserProfile])
-
-  // useEffect(() => {
-  //   if (
-  //     userProfile?.locale &&
-  //     isLocale(userProfile.locale) &&
-  //     userProfile.locale !== lang
-  //   )
-  //     changeLanguage(userProfile.locale as Locale)
-  // }, [userProfile, changeLanguage, lang])
-
-  // if (!form || !dataSchema || userProfileLoading) {
   if (!form || !dataSchema) {
     return <LoadingShell />
   }

--- a/libs/service-portal/graphql/src/lib/client.ts
+++ b/libs/service-portal/graphql/src/lib/client.ts
@@ -34,5 +34,11 @@ const errorLink = onError(({ graphQLErrors, networkError }) => {
 
 export const client = new ApolloClient({
   link: ApolloLink.from([retryLink, errorLink, authLink, httpLink]),
-  cache: new InMemoryCache(),
+  cache: new InMemoryCache({
+    typePolicies: {
+      UserProfile: {
+        keyFields: ['nationalId'],
+      },
+    },
+  }),
 })

--- a/libs/shared/components/src/auth/UserMenu/UserProfileLocale.tsx
+++ b/libs/shared/components/src/auth/UserMenu/UserProfileLocale.tsx
@@ -1,9 +1,7 @@
-import { useLazyQuery } from '@apollo/client'
-import { Query } from '@island.is/api/schema'
 import { useLocale, useNamespaces, isLocale } from '@island.is/localization'
-import { USER_PROFILE } from '@island.is/service-portal/graphql'
 import { useEffect } from 'react'
 import { useAuth } from '@island.is/auth/react'
+import { useGetUserProfileLocaleLazyQuery } from '../../../gen/graphql'
 
 /**
  * If the user has set a preferred language in his user
@@ -17,12 +15,13 @@ export const UserProfileLocale = () => {
   const { changeLanguage } = useNamespaces()
   const { lang } = useLocale()
   const { userInfo } = useAuth()
-  const [getUserProfile, { data }] = useLazyQuery<Query>(USER_PROFILE)
+  const [getUserProfile, { data }] = useGetUserProfileLocaleLazyQuery()
+
   const userProfile = data?.getUserProfile || null
 
   useEffect(() => {
     if (userInfo?.profile.nationalId) getUserProfile()
-  }, [userInfo])
+  }, [userInfo, getUserProfile])
 
   useEffect(() => {
     if (

--- a/libs/shared/components/src/auth/UserMenu/userProfile.graphql.ts
+++ b/libs/shared/components/src/auth/UserMenu/userProfile.graphql.ts
@@ -17,3 +17,12 @@ export const UPDATE_USER_PROFILE = gql`
     }
   }
 `
+
+export const GET_USER_PROFILE_LOCALE = gql`
+  query GetUserProfileLocale {
+    getUserProfile {
+      nationalId
+      locale
+    }
+  }
+`

--- a/libs/shared/components/src/index.ts
+++ b/libs/shared/components/src/index.ts
@@ -1,2 +1,3 @@
 export * from './auth/UserMenu/UserMenu'
 export * from './auth/UserMenu/UserLanguageSwitcher'
+export * from './auth/UserMenu/UserProfileLocale'


### PR DESCRIPTION
# Use UserProfileLocale from service-portal in application

Attach a link to issue if relevant

## What

Use UserProfileLocale from service-portal in application and place that component into the shared react components.

## Why

Persisting locale through refreshes and between browsers.
Shared component used to avoid duplication of code.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
