### PR TITLE
fix(j-s): support admission case in extend custody modal

### DIFF
--- a/apps/judicial-system/web/messages/Core/signedVerdictOverview.ts
+++ b/apps/judicial-system/web/messages/Core/signedVerdictOverview.ts
@@ -146,6 +146,7 @@ export const signedVerdictOverview = {
           'Notaður sem texti fyrir "loka hnappi" í "undirritun þingbókar" skrefi á yfirlitsskjá afgreiddra mála.',
       },
     }),
+    // TODO: remove strings that are not used
     modifyDatesModal: defineMessages({
       title: {
         id:
@@ -154,6 +155,14 @@ export const signedVerdictOverview = {
         description:
           'Notaður sem titill í "Breyting á lengd gæsluvarðhalds" glugga á yfirlitsskjá afgreiddra mála.',
       },
+      titleV2: {
+        id:
+          'judicial.system.core:signed_verdict_overview.modify_dates_modal.title_v2',
+        defaultMessage:
+          'Breyting á lengd {caseType, select, ADMISSION_TO_FACILITY {vistunar} other {gæsluvarðhalds}}',
+        description:
+          'Notaður sem titill í "Breyting á lengd gæsluvarðhalds/vistunar" glugga á yfirlitsskjá afgreiddra mála.',
+      },
       successTitle: {
         id:
           'judicial.system.core:signed_verdict_overview.modify_dates_modal.success_title',
@@ -161,19 +170,27 @@ export const signedVerdictOverview = {
         description:
           'Notaður sem titill í "Lengd gæsluvarðhalds breytt" glugga á yfirlitsskjá afgreiddra mála þegar breyting á lengd gæsluvarðhalds hefur verið geymd.',
       },
+      successTitleV2: {
+        id:
+          'judicial.system.core:signed_verdict_overview.modify_dates_modal.success_title_v2',
+        defaultMessage:
+          'Lengd {caseType, select, ADMISSION_TO_FACILITY {vistunar} other {gæsluvarðhalds}} breytt',
+        description:
+          'Notaður sem titill í "Lengd gæsluvarðhalds/vistunar breytt" glugga á yfirlitsskjá afgreiddra mála þegar breyting á lengd gæsluvarðhalds/vistunar hefur verið geymd.',
+      },
       reasonForChangeTitle: {
         id:
           'judicial.system.core:signed_verdict_overview.modify_dates_modal.reason_for_change_title',
         defaultMessage: 'Ástæða breytingar',
         description:
-          'Notaður sem titill fyrir "Ástæða breytingar" hlutann í "Breyting á lengd gæsluvarðhalds" glugga.',
+          'Notaður sem titill fyrir "Ástæða breytingar" hlutann í "Breyting á lengd gæsluvarðhalds/vistunar" glugga.',
       },
       reasonForChangeLabel: {
         id:
           'judicial.system.core:signed_verdict_overview.modify_dates_modal.reason_for_change_label',
         defaultMessage: 'Ástæða breytingar',
         description:
-          'Notaður sem titill í "Ástæða breytingar" textaboxi í "Breyting á lengd gæsluvarðhalds" glugga.',
+          'Notaður sem titill í "Ástæða breytingar" textaboxi í "Breyting á lengd gæsluvarðhalds/vistunar" glugga.',
       },
       reasonForChangePlaceholder: {
         id:
@@ -183,6 +200,14 @@ export const signedVerdictOverview = {
         description:
           'Notaður sem skýritexti í "Ástæða breytingar" textaboxi í "Breyting á lengd gæsluvarðhalds" glugga.',
       },
+      reasonForChangePlaceholderV2: {
+        id:
+          'judicial.system.core:signed_verdict_overview.modify_dates_modal.reason_for_change_placeholder_v2',
+        defaultMessage:
+          'Bóka þarf ástæðu fyrir breytingu á skráðri lengd {caseType, select, ADMISSION_TO_FACILITY {vistunar} other {gæsluvarðhalds}}.',
+        description:
+          'Notaður sem skýritexti í "Ástæða breytingar" textaboxi í "Breyting á lengd gæsluvarðhalds/vistunar" glugga.',
+      },
       text: {
         id:
           'judicial.system.core:signed_verdict_overview.modify_dates_modal.text',
@@ -190,6 +215,14 @@ export const signedVerdictOverview = {
           'Hafi gæsluvarðhaldi eða einangrun verið aflétt, kæra til Landsréttar leitt til breytingar eða leiðrétta þarf ranga skráningu, er hægt að uppfæra lengd gæsluvarðhalds. Sýnilegt verður hver gerði leiðréttinguna, hvenær og af hvaða ástæðu.',
         description:
           'Notaður sem texti í "Breyting á lengd gæsluvarðhalds" glugga á yfirlitsskjá afgreiddra mála.',
+      },
+      textV2: {
+        id:
+          'judicial.system.core:signed_verdict_overview.modify_dates_modal.text_v2',
+        defaultMessage:
+          'Hafi {caseType, select, ADMISSION_TO_FACILITY {vistun} other {gæsluvarðhaldi}} eða einangrun verið aflétt, kæra til Landsréttar leitt til breytingar eða leiðrétta þarf ranga skráningu, er hægt að uppfæra lengd {caseType, select, ADMISSION_TO_FACILITY {vistunar} other {gæsluvarðhalds}}. Sýnilegt verður hver gerði leiðréttinguna, hvenær og af hvaða ástæðu.',
+        description:
+          'Notaður sem texti í "Breyting á lengd gæsluvarðhalds/vistunar" glugga á yfirlitsskjá afgreiddra mála.',
       },
       validToDateAndIsolationToDateAreTheSame: {
         id:
@@ -212,7 +245,7 @@ export const signedVerdictOverview = {
           'judicial.system.core:signed_verdict_overview.modify_dates_modal.isolation_date_changed',
         defaultMessage: 'Einangrun til {date}.',
         description:
-          'Notaður sem texti "Lengd gæsluvarðhalds breytt" glugga á yfirlitsskjá afgreiddra mála.',
+          'Notaður sem texti "Lengd gæsluvarðhalds breytt/vistunar" glugga á yfirlitsskjá afgreiddra mála.',
       },
       successText: {
         id:
@@ -220,28 +253,28 @@ export const signedVerdictOverview = {
         defaultMessage:
           '{modification}\nTilkynning verður send á ábyrgðaraðila málsins hjá {courtOrProsecutor}. Ef gæsluvarðhaldsfangelsi hefur ekki verið upplýst og þörf er á því, þarf að gera það eftir hefðbundinni boðleið.',
         description:
-          'Notaður sem texti í "Lengd gæsluvarðhalds breytt" glugga á yfirlitsskjá afgreiddra mála.',
+          'Notaður sem texti í "Lengd gæsluvarðhalds/vistunar breytt" glugga á yfirlitsskjá afgreiddra mála.',
       },
       primaryButtonText: {
         id:
           'judicial.system.core:signed_verdict_overview.modify_dates_modal.primary_button_text',
         defaultMessage: 'Staðfesta',
         description:
-          'Notaður sem texti í staðfesta takka í "Breyta lengd gæsluvarðhalds" glugga á yfirlitsskjá afgreiddra mála.',
+          'Notaður sem texti í staðfesta takka í "Breyta lengd gæsluvarðhalds/vistunar" glugga á yfirlitsskjá afgreiddra mála.',
       },
       secondaryButtonText: {
         id:
           'judicial.system.core:signed_verdict_overview.modify_dates_modal.secondary_button_text',
         defaultMessage: 'Hætta við',
         description:
-          'Notaður sem texti í hætta við takka í "Breyta lengd gæsluvarðhalds" glugga á yfirlitsskjá afgreiddra mála.',
+          'Notaður sem texti í hætta við takka í "Breyta lengd gæsluvarðhalds/vistunar" glugga á yfirlitsskjá afgreiddra mála.',
       },
       secondaryButtonTextSuccess: {
         id:
           'judicial.system.core:signed_verdict_overview.modify_dates_modal.secondary_button_text_success',
         defaultMessage: 'Loka glugga',
         description:
-          'Notaður sem texti í loka takka í "Lengd gæsluvarðhalds breytt" glugga á yfirlitsskjá afgreiddra mála.',
+          'Notaður sem texti í loka takka í "Lengd gæsluvarðhalds/vistunar breytt" glugga á yfirlitsskjá afgreiddra mála.',
       },
       modifiedValidToDateLabel: {
         id:
@@ -254,7 +287,7 @@ export const signedVerdictOverview = {
         id:
           'judicial.system.core:signed_verdict_overview.modify_dates_modal.modified_valid_to_date_label_v2',
         defaultMessage:
-          '{caseTye, select, ADMISSION_TO_FACILITY {Vistun á viðeigandi stofnun} other {Gæsluvarðhald}} til',
+          '{caseType, select, ADMISSION_TO_FACILITY {Vistun á viðeigandi stofnun} other {Gæsluvarðhald}} til',
         description:
           'Notaður sem texti í  "Breyting á lengd gæsluvarðhalds/vistunar" glugga á yfirlitsskjá afgreiddra mála.',
       },

--- a/apps/judicial-system/web/messages/RestrictionCases/Prosecutor/accusedForm.ts
+++ b/apps/judicial-system/web/messages/RestrictionCases/Prosecutor/accusedForm.ts
@@ -108,7 +108,7 @@ export const accused = {
           id:
             'judicial.system.restriction_cases:accused.defender_info.send_request.tooltip_v2',
           defaultMessage:
-            'Ef hakað er hér þá fær verjandi {caseType, select, ADMISSION_TO_FACILITY) {kröfuna um vistun á viðeigandi stofnun} TRAVEL_BAN {farbannskröfuna} other {gæsluvarðhaldskröfuna}} senda þegar fyrirtökutíma hefur verið úthlutað',
+            'Ef hakað er hér þá fær verjandi {caseType, select, ADMISSION_TO_FACILITY {kröfuna um vistun á viðeigandi stofnun} TRAVEL_BAN {farbannskröfuna} other {gæsluvarðhaldskröfuna}} senda þegar fyrirtökutíma hefur verið úthlutað',
           description:
             'Notaður sem upplýsingatexti í upplýsingasvæði við "senda kröfu sjálfvirkt..." gátreit á sakbornings skrefi í gæsluvarðhalds- og farbannsmálum.',
         },

--- a/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/SignedVerdictOverview.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/SignedVerdictOverview.tsx
@@ -657,8 +657,12 @@ export const SignedVerdictOverview: React.FC = () => {
               transition={{ duration: 0.5 }}
             >
               <Modal
-                title={formatMessage(m.sections.modifyDatesModal.title)}
-                text={formatMessage(m.sections.modifyDatesModal.text)}
+                title={formatMessage(m.sections.modifyDatesModal.titleV2, {
+                  caseType: workingCase.type,
+                })}
+                text={formatMessage(m.sections.modifyDatesModal.textV2, {
+                  caseType: workingCase.type,
+                })}
                 primaryButtonText={formatMessage(
                   m.sections.modifyDatesModal.primaryButtonText,
                 )}
@@ -701,7 +705,8 @@ export const SignedVerdictOverview: React.FC = () => {
                       m.sections.modifyDatesModal.reasonForChangeLabel,
                     )}
                     placeholder={formatMessage(
-                      m.sections.modifyDatesModal.reasonForChangePlaceholder,
+                      m.sections.modifyDatesModal.reasonForChangePlaceholderV2,
+                      { caseType: workingCase.type },
                     )}
                     onChange={(event) => {
                       handleCaseModifiedExplanationChange(event.target.value)
@@ -788,7 +793,10 @@ export const SignedVerdictOverview: React.FC = () => {
               transition={{ duration: 0.5 }}
             >
               <Modal
-                title={formatMessage(m.sections.modifyDatesModal.successTitle)}
+                title={formatMessage(
+                  m.sections.modifyDatesModal.successTitleV2,
+                  { caseType: workingCase.type },
+                )}
                 text={getModificationSuccessText()}
                 secondaryButtonText={formatMessage(
                   m.sections.modifyDatesModal.secondaryButtonTextSuccess,


### PR DESCRIPTION
[Asana](https://app.asana.com/0/0/1202188672896410/f)
## What

- Support Admission cases in modal when extending custody/admission


## Screenshots / Gifs
![Screenshot 2022-04-29 at 10 31 47](https://user-images.githubusercontent.com/5700902/165928719-f717132f-9ec7-4346-81b9-6e339561ca9c.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
