### PR TITLE
fix(web): Pruned entry hyperlinks from related articles and subarticles

### DIFF
--- a/libs/cms/src/lib/search/importers/article.service.ts
+++ b/libs/cms/src/lib/search/importers/article.service.ts
@@ -92,12 +92,26 @@ export class ArticleSyncService implements CmsSyncProvider<IArticle> {
               : undefined) as IArticleFields['subArticles'],
           },
         }
+
         // An entry hyperlink does not need the extra content present in
         // the entry hyperlink associated fields
         // We remove them from the reference itself on nodeType `entry-hyperlink`
         if (processedEntry.fields?.content) {
           removeEntryHyperlinkFields(processedEntry.fields.content)
         }
+        // Remove all unnecessary entry hyperlink fields for the subArticles
+        if (processedEntry.fields?.subArticles?.length) {
+          for (const subArticle of processedEntry.fields.subArticles) {
+            removeEntryHyperlinkFields(subArticle.fields.content)
+          }
+        }
+        // Also remove all unnecessary entry hyperlink fields for the relatedArticles
+        if (processedEntry.fields?.relatedArticles?.length) {
+          for (const relatedArticle of processedEntry.fields.relatedArticles) {
+            removeEntryHyperlinkFields(relatedArticle.fields.content)
+          }
+        }
+
         if (!isCircular(processedEntry)) {
           processedEntries.push(processedEntry)
         } else {
@@ -191,7 +205,10 @@ export class ArticleSyncService implements CmsSyncProvider<IArticle> {
             dateUpdated: new Date().getTime().toString(),
           }
         } catch (error) {
-          logger.warn('Failed to import article', { error: error.message })
+          logger.warn('Failed to import article', {
+            error: error.message,
+            id: entry.sys.id,
+          })
           return false
         }
       })


### PR DESCRIPTION
# Pruned entry hyperlinks from related articles and subarticles

## What

* Pruned entry hyperlinks from related articles and subarticles when saving data in elasticsearch
* Added the entry id to the exception log since this issue was hard to debug without knowing the id's

## Why

* This was causing an issue where articles were not showing up on the web due to circularity caused by entry hyperlinks in subarticles or related articles

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
