### PR TITLE
feat(web): OneColumnText Slice link url

### DIFF
--- a/apps/web/components/Organization/Slice/OneColumnText/OneColumnTextSlice.tsx
+++ b/apps/web/components/Organization/Slice/OneColumnText/OneColumnTextSlice.tsx
@@ -37,8 +37,8 @@ export const OneColumnTextSlice: React.FC<SliceProps> = ({
             {slice.title}
           </Text>
           {richText(slice.content as SliceType[])}
-          {slice.link && (
-            <Link href="#">
+          {slice.link && slice.link.url && (
+            <Link href={slice.link.url}>
               <Button
                 icon="arrowForward"
                 iconType="filled"


### PR DESCRIPTION
# OneColumnText Slice link url

## What

* Replaced '#' with the actual link url

## Why

* We want to be able to use the link, the # link is a leftover

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
