### PR TITLE
fix(j-s): disable continue btn if court-case-number is invalid

### DIFF
--- a/apps/judicial-system/web-e2e/src/integration/Court/InvestigationCases/receptionAndAssignment.spec.ts
+++ b/apps/judicial-system/web-e2e/src/integration/Court/InvestigationCases/receptionAndAssignment.spec.ts
@@ -23,14 +23,20 @@ describe(`${IC_RECEPTION_AND_ASSIGNMENT_ROUTE}/:id`, () => {
     intercept(caseDataAddition)
   })
 
-  it('should require a valid case id', () => {
+  it('should enable continue button when required fields are valid', () => {
+    // case number validation
     cy.getByTestid('courtCaseNumber').click().blur()
     cy.getByTestid('inputErrorMessage').contains('Reitur má ekki vera tómur')
     cy.getByTestid('courtCaseNumber').type('R-X/2021')
     cy.getByTestid('inputErrorMessage').should('be.visible')
 
+    // continue button enabled when form becomes valid
     cy.getByTestid('courtCaseNumber').clear().type('R-1/2021')
     cy.getByTestid('inputErrorMessage').should('not.exist')
+    cy.getByTestid('continueButton').should('be.disabled')
+    cy.getByTestid('select-judge').click()
+    cy.get('#react-select-judge-option-0').click()
+    cy.getByTestid('continueButton').should('be.enabled')
   })
 
   it('should navigate to the next step when all input data is valid and the continue button is clicked', () => {

--- a/apps/judicial-system/web-e2e/src/integration/Court/RestrictionCases/receptionAndAssignment.spec.ts
+++ b/apps/judicial-system/web-e2e/src/integration/Court/RestrictionCases/receptionAndAssignment.spec.ts
@@ -23,14 +23,20 @@ describe(`${RECEPTION_AND_ASSIGNMENT_ROUTE}/:id`, () => {
     intercept(caseDataAddition)
   })
 
-  it('should require a valid case id', () => {
+  it('should require a valid form', () => {
+    // case number validation
     cy.getByTestid('courtCaseNumber').click().blur()
     cy.getByTestid('inputErrorMessage').contains('Reitur má ekki vera tómur')
     cy.getByTestid('courtCaseNumber').type('R-X/2021')
     cy.getByTestid('inputErrorMessage').should('be.visible')
 
+    // continue button enabled when form becomes valid
     cy.getByTestid('courtCaseNumber').clear().type('R-1/2021')
     cy.getByTestid('inputErrorMessage').should('not.exist')
+    cy.getByTestid('continueButton').should('be.disabled')
+    cy.getByTestid('select-judge').click()
+    cy.get('#react-select-judge-option-0').click()
+    cy.getByTestid('continueButton').should('be.enabled')
   })
 
   it('should navigate to the next step when all input data is valid and the continue button is clicked', () => {

--- a/apps/judicial-system/web/src/utils/validate.ts
+++ b/apps/judicial-system/web/src/utils/validate.ts
@@ -201,6 +201,7 @@ export const isPoliceReportStepValidIC = (workingCase: Case) => {
 export const isReceptionAndAssignmentStepValidRC = (workingCase: Case) => {
   return (
     validate(workingCase.courtCaseNumber || '', 'empty').isValid &&
+    validate(workingCase.courtCaseNumber || '', 'court-case-number').isValid &&
     workingCase.judge
   )
 }
@@ -208,6 +209,7 @@ export const isReceptionAndAssignmentStepValidRC = (workingCase: Case) => {
 export const isReceptionAndAssignmentStepValidIC = (workingCase: Case) => {
   return (
     validate(workingCase.courtCaseNumber || '', 'empty').isValid &&
+    validate(workingCase.courtCaseNumber || '', 'court-case-number').isValid &&
     workingCase.judge
   )
 }


### PR DESCRIPTION
[Asana](https://app.asana.com/0/1199153462262248/1202216317858343/f)
## What

- Disable the continue button when the court case number is invalid

## Screenshots / Gifs
![Screenshot 2022-05-03 at 10 43 08](https://user-images.githubusercontent.com/5700902/166440200-7c8913ab-90a6-4163-826e-04b89871c8c9.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
