### PR TITLE
fix(parental-leave): privatepensionfund and percentage validation fix on failed submit

### DIFF
--- a/libs/application/templates/parental-leave/src/lib/answerValidators.ts
+++ b/libs/application/templates/parental-leave/src/lib/answerValidators.ts
@@ -90,8 +90,10 @@ export const answerValidators: Record<string, AnswerValidator> = {
     // if privatePensionFund is NO_PRIVATE_PENSION_FUND and privatePensionFundPercentage is an empty string, allow the user to continue.
     // this will only happen when the usePrivatePensionFund field is set to NO
     if (
-      payments.privatePensionFund === NO_PRIVATE_PENSION_FUND &&
-      payments.privatePensionFundPercentage === ''
+      (payments.privatePensionFund === NO_PRIVATE_PENSION_FUND &&
+        payments.privatePensionFundPercentage === '') ||
+      (privatePensionFund === NO_PRIVATE_PENSION_FUND &&
+        privatePensionFundPercentage === '')
     )
       return undefined
 


### PR DESCRIPTION
## What

Fixing issue where answer validation for privatepensionfund and privatePensionFundPercentage would fail on the review page if the submit failed.

## Why

Make sure that this issue does not occur if the submit fails. 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
