### PR TITLE
Improve documentation on creating secrets on AWS

### DIFF
--- a/handbook/repository/aws-secrets.md
+++ b/handbook/repository/aws-secrets.md
@@ -231,15 +231,20 @@ AWS_PROFILE=islandis-dev yarn create-secret
 AWS_PROFILE=islandis-staging yarn create-secret
 AWS_PROFILE=islandis-prod yarn create-secret
 ```
+
 {% endhint %}
 
 ### Finalizing creating secrets
-In order to use the secrets in your app you need to add it to its `infra` configuration. 
+
+In order to use the secrets in your app you need to add it to its `infra` configuration.
+
 1. Add the new secret to `your-app/infra/your-app.ts`
 2. Generate helm charts for your app with
-  ```
-  yarn charts islandis
-  ```
+
+```
+yarn charts islandis
+```
+
 3. Follow the documentation on [Config Module](/libs/nest/config)
 
 ## Making dev secrets available locally

--- a/handbook/repository/aws-secrets.md
+++ b/handbook/repository/aws-secrets.md
@@ -231,8 +231,16 @@ AWS_PROFILE=islandis-dev yarn create-secret
 AWS_PROFILE=islandis-staging yarn create-secret
 AWS_PROFILE=islandis-prod yarn create-secret
 ```
-
 {% endhint %}
+
+### Finalizing creating secrets
+In order to use the secrets in your app you need to add it to its `infra` configuration. 
+1. Add the new secret to `your-app/infra/your-app.ts`
+2. Generate helm charts for your app with
+  ```
+  yarn charts islandis
+  ```
+3. Follow the documentation on [Config Module](/libs/nest/config)
 
 ## Making dev secrets available locally
 

--- a/handbook/repository/aws-secrets.md
+++ b/handbook/repository/aws-secrets.md
@@ -185,6 +185,10 @@ AWS_PROFILE=<profile-name> create-secret
 yarn create-secret
 ```
 
+{% hint style="warning" %}
+Only alphanumeric characters, `/` and `-` are allowed. The length of the _secret name_ should be from 6-128 characters long.
+{% endhint %}
+
 You will be asked for a _secret name_ that will be added to the `/k8s/` secrets namespace, a _secret value_ and the _secret type_ (`SecureString` or `String`).
 
 ### Example
@@ -228,10 +232,6 @@ AWS_PROFILE=islandis-staging yarn create-secret
 AWS_PROFILE=islandis-prod yarn create-secret
 ```
 
-{% endhint %}
-
-{% hint style="warning" %}
-Only alphanumeric characters, `/` and `-` are allowed. The length of the _secret name_ should be from 6-128 characters long.
 {% endhint %}
 
 ## Making dev secrets available locally


### PR DESCRIPTION
## What
Improve documentation for developers adding new secrets with `yarn create-secret`

## Why
Current documentation is missing important steps on what to do _after_ adding a new secret.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
