### PR TITLE
fix(web): Organization page UI tweaks

### DIFF
--- a/apps/web/components/Organization/Wrapper/Themes/SjukratryggingarTheme/SjukratryggingarHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/SjukratryggingarTheme/SjukratryggingarHeader.tsx
@@ -7,9 +7,9 @@ import {
   Link,
   Text,
 } from '@island.is/island-ui/core'
-import * as styles from './SjukratryggingarHeader.css'
 import SidebarLayout from '@island.is/web/screens/Layouts/SidebarLayout'
 import { useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
+import * as styles from './SjukratryggingarHeader.css'
 
 interface HeaderProps {
   organizationPage: OrganizationPage
@@ -76,7 +76,7 @@ export const SjukratryggingarHeader: React.FC<HeaderProps> = ({
                   <div className={styles.titleImage}></div>
                 </Hidden>
                 <Hidden above="sm">
-                  <Text variant="h1" color="white">
+                  <Text variant="h1" color="blueberry600">
                     {organizationPage.title}
                   </Text>
                 </Hidden>

--- a/apps/web/screens/Organization/SubPage.tsx
+++ b/apps/web/screens/Organization/SubPage.tsx
@@ -246,7 +246,7 @@ SubPage.getInitialProps = async ({ apolloClient, locale, query, pathname }) => {
     subpage: getOrganizationSubpage,
     namespace,
     showSearchInHeader: false,
-    ...getThemeConfig(getOrganizationPage.theme),
+    ...getThemeConfig(getOrganizationPage.theme, getOrganizationPage.slug),
   }
 }
 

--- a/libs/island-ui/core/src/lib/AsyncSearch/shared/Input/Input.tsx
+++ b/libs/island-ui/core/src/lib/AsyncSearch/shared/Input/Input.tsx
@@ -27,7 +27,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
           [styles.colored]: colored,
           [styles.hasLabel]: hasLabel,
           [styles.white]: white,
-          [styles.blueberry]: blueberry,
+          [styles.blueberry]: !white && blueberry,
         })}
         ref={ref}
       />

--- a/libs/island-ui/core/src/lib/Breadcrumbs/Breadcrumbs.tsx
+++ b/libs/island-ui/core/src/lib/Breadcrumbs/Breadcrumbs.tsx
@@ -45,7 +45,7 @@ export const Breadcrumbs: FC<BreadcrumbsProps> = ({
       {visibleItems.map((item, index) => {
         const isLink: boolean = !!item.href || !!item.slug
         const renderCrumb = item.isTag ? (
-          <Tag disabled={!isLink} variant={tagVariant}>
+          <Tag textLeft={true} disabled={!isLink} variant={tagVariant}>
             {item.title}
           </Tag>
         ) : (


### PR DESCRIPTION
# Organization page UI tweaks

## What

* Changed Sjúkratryggingar mobile header text to be dark
* Left aligned breadcrumb items
* Changed the fixed nav scroll header input box to by adding a higher priority to the white color scheme

## Screenshots / Gifs

### Before
![image](https://user-images.githubusercontent.com/43557895/167612368-428deda3-170b-4583-aad4-61ec3c79b7ee.png)



### After
![image](https://user-images.githubusercontent.com/43557895/167612253-5e0f6035-dc19-441e-af4f-cd16b52b26ac.png)


### Before
![image](https://user-images.githubusercontent.com/43557895/167612467-dea1d30c-b924-4cf4-9542-29bd78e66a48.png)

### After
![image](https://user-images.githubusercontent.com/43557895/167612526-22830a1e-f388-4dfe-9b85-80bff3389361.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
