### PR TITLE
fix(service-portal): Show parents if there is a parent response

### DIFF
--- a/libs/service-portal/family/src/components/ChildView/ChildView.tsx
+++ b/libs/service-portal/family/src/components/ChildView/ChildView.tsx
@@ -183,26 +183,30 @@ const ChildView: FC<Props> = ({
           </>
         )}
         <Box marginY={3} />
-        <Parents
-          title={formatMessage({
-            id: 'sp.family:custody-and-parents',
-            defaultMessage: 'Forsjá & foreldrar',
-          })}
-          label={formatMessage({
-            id: 'sp.family:parents',
-            defaultMessage: 'Foreldrar',
-          })}
-          parent1={person?.nameParent1}
-          parent2={person?.nameParent2}
-          loading={loading}
-        />
-        <Parents
-          label={formatMessage(m.natreg)}
-          parent1={person?.parent1 ? formatNationalId(person.parent1) : ''}
-          parent2={person?.parent2 ? formatNationalId(person.parent2) : ''}
-          loading={loading}
-        />
-        <Divider />
+        {(person?.parent1 || person?.parent2 || loading) && (
+          <>
+            <Parents
+              title={formatMessage({
+                id: 'sp.family:custody-and-parents',
+                defaultMessage: 'Forsjá & foreldrar',
+              })}
+              label={formatMessage({
+                id: 'sp.family:parents',
+                defaultMessage: 'Foreldrar',
+              })}
+              parent1={person?.nameParent1}
+              parent2={person?.nameParent2}
+              loading={loading}
+            />
+            <Parents
+              label={formatMessage(m.natreg)}
+              parent1={person?.parent1 ? formatNationalId(person.parent1) : ''}
+              parent2={person?.parent2 ? formatNationalId(person.parent2) : ''}
+              loading={loading}
+            />
+            <Divider />
+          </>
+        )}
         {!person?.fate && !error && hasDetails ? (
           <>
             <Parents


### PR DESCRIPTION
## What

Show parents if there is a parent response

## Why

Parents response can be in some extremely rare cases.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
