### PR TITLE
Fix/private pension fund validation changes

### DIFF
--- a/libs/application/templates/parental-leave/src/fields/Review/Review.tsx
+++ b/libs/application/templates/parental-leave/src/fields/Review/Review.tsx
@@ -168,7 +168,7 @@ export const Review: FC<ReviewScreenProps> = ({
   const validatePrivatePensionFundPercentage = () => {
     if (usePrivatePensionFund !== YES) return undefined
 
-    if (privatePensionFundPercentage === '') {
+    if (privatePensionFundPercentage === '0') {
       return formatMessage(coreErrorMessages.defaultError)
     }
 
@@ -521,7 +521,7 @@ export const Review: FC<ReviewScreenProps> = ({
                     const privatePensionFund =
                       s === NO ? NO_PRIVATE_PENSION_FUND : ''
                     const privatePensionFundPercentage =
-                      s === NO ? '' : prev.privatePensionFundPercentage
+                      s === NO ? '0' : prev.privatePensionFundPercentage
                     setValue('payments.privatePensionFund', privatePensionFund)
                     setValue(
                       'payments.privatePensionFundPercentage',

--- a/libs/application/templates/parental-leave/src/fields/UsePrivatePensionFund/index.tsx
+++ b/libs/application/templates/parental-leave/src/fields/UsePrivatePensionFund/index.tsx
@@ -52,10 +52,11 @@ export const UsePrivatePensionFund: FC<FieldBaseProps> = ({
           onSelect: (s: string) => {
             if (s === NO) {
               setValue('payments.privatePensionFund', NO_PRIVATE_PENSION_FUND)
-              setValue('payments.privatePensionFundPercentage', '')
+              setValue('payments.privatePensionFundPercentage', '0')
             }
             if (s === YES) {
               setValue('payments.privatePensionFund', '')
+              setValue('payments.privatePensionFundPercentage', '')
             }
           },
         }}

--- a/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.ts
+++ b/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.ts
@@ -106,7 +106,7 @@ const ParentalLeaveTemplate: ApplicationTemplate<
           'setOtherParentIdIfSelectedSpouse',
           'clearPersonalAllowanceIfUsePersonalAllowanceIsNo',
           'clearSpouseAllowanceIfUseSpouseAllowanceIsNo',
-          'clearPrivatePensionIfUsePrivatePensionIsNo',
+          'setPrivatePensionValuesIfUsePrivatePensionFundIsNO',
         ],
         meta: {
           name: States.DRAFT,
@@ -724,23 +724,27 @@ const ParentalLeaveTemplate: ApplicationTemplate<
 
         return context
       }),
-
-      clearPrivatePensionIfUsePrivatePensionIsNo: assign((context) => {
+      setPrivatePensionValuesIfUsePrivatePensionFundIsNO: assign((context) => {
         const { application } = context
 
         const answers = getApplicationAnswers(application.answers)
 
         if (
           answers.usePrivatePensionFund === NO &&
-          (answers.privatePensionFund !== NO_PRIVATE_PENSION_FUND ||
-            answers.privatePensionFundPercentage !== '')
+          answers.privatePensionFund !== NO_PRIVATE_PENSION_FUND
         ) {
           set(
             application.answers,
             'payments.privatePensionFund',
             NO_PRIVATE_PENSION_FUND,
           )
-          set(application.answers, 'payments.privatePensionFundPercentage', '')
+        }
+
+        if (
+          answers.usePrivatePensionFund === NO &&
+          answers.privatePensionFundPercentage !== '0'
+        ) {
+          set(application.answers, 'payments.privatePensionFundPercentage', '0')
         }
 
         return context

--- a/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.ts
+++ b/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.ts
@@ -24,6 +24,7 @@ import {
   NO,
   MANUAL,
   SPOUSE,
+  NO_PRIVATE_PENSION_FUND,
 } from '../constants'
 import { dataSchema } from './dataSchema'
 import { answerValidators } from './answerValidators'
@@ -105,6 +106,7 @@ const ParentalLeaveTemplate: ApplicationTemplate<
           'setOtherParentIdIfSelectedSpouse',
           'clearPersonalAllowanceIfUsePersonalAllowanceIsNo',
           'clearSpouseAllowanceIfUseSpouseAllowanceIsNo',
+          'clearPrivatePensionIfUsePrivatePensionIsNo',
         ],
         meta: {
           name: States.DRAFT,
@@ -718,6 +720,27 @@ const ParentalLeaveTemplate: ApplicationTemplate<
           (answers.spouseUsage || answers.spouseUseAsMuchAsPossible)
         ) {
           set(application.answers, 'personalAllowanceFromSpouse', null)
+        }
+
+        return context
+      }),
+
+      clearPrivatePensionIfUsePrivatePensionIsNo: assign((context) => {
+        const { application } = context
+
+        const answers = getApplicationAnswers(application.answers)
+
+        if (
+          answers.usePrivatePensionFund === NO &&
+          (answers.privatePensionFund !== NO_PRIVATE_PENSION_FUND ||
+            answers.privatePensionFundPercentage !== '')
+        ) {
+          set(
+            application.answers,
+            'payments.privatePensionFund',
+            NO_PRIVATE_PENSION_FUND,
+          )
+          set(application.answers, 'payments.privatePensionFundPercentage', '')
         }
 
         return context

--- a/libs/application/templates/parental-leave/src/lib/answerValidators.spec.ts
+++ b/libs/application/templates/parental-leave/src/lib/answerValidators.spec.ts
@@ -94,81 +94,83 @@ describe('answerValidators', () => {
     })
   })
 
-  it('should create error when privatePensionFund is empty', () => {
-    const newAnswers = {
-      bank: '123456789012',
-      pensionFund: 'id-frjalsi',
-      privatePensionFund: '',
-      privatePensionFundPercentage: '',
-    }
+  describe('privatePensionFund', () => {
+    it('should create error when privatePensionFund is empty', () => {
+      const newAnswers = {
+        bank: '123456789012',
+        pensionFund: 'id-frjalsi',
+        privatePensionFund: '',
+        privatePensionFundPercentage: '',
+      }
 
-    expect(answerValidators['payments'](newAnswers, application)).toStrictEqual(
-      {
+      expect(
+        answerValidators['payments'](newAnswers, application),
+      ).toStrictEqual({
         message: coreErrorMessages.defaultError,
         path: 'payments.privatePensionFund',
         values: undefined,
-      },
-    )
-  })
+      })
+    })
 
-  it('should create error when privatePensionFundPercentage is empty', () => {
-    const newAnswers = {
-      bank: '123456789012',
-      pensionFund: 'id-frjalsi',
-      privatePensionFund: 'id-frjalsi',
-      privatePensionFundPercentage: '',
-    }
+    it('should create error when privatePensionFundPercentage is empty', () => {
+      const newAnswers = {
+        bank: '123456789012',
+        pensionFund: 'id-frjalsi',
+        privatePensionFund: 'id-frjalsi',
+        privatePensionFundPercentage: '',
+      }
 
-    expect(answerValidators['payments'](newAnswers, application)).toStrictEqual(
-      {
+      expect(
+        answerValidators['payments'](newAnswers, application),
+      ).toStrictEqual({
         message: coreErrorMessages.defaultError,
         path: 'payments.privatePensionFundPercentage',
         values: undefined,
-      },
-    )
-  })
+      })
+    })
 
-  it('should only accept 2 or 4 as values for privatePensionFundPercentage', () => {
-    const newAnswers = {
-      bank: '123456789012',
-      pensionFund: 'id-frjalsi',
-      privatePensionFund: 'id-frjalsi',
-      privatePensionFundPercentage: 'test input',
-    }
+    it('should only accept 2 or 4 as values for privatePensionFundPercentage', () => {
+      const newAnswers = {
+        bank: '123456789012',
+        pensionFund: 'id-frjalsi',
+        privatePensionFund: 'id-frjalsi',
+        privatePensionFundPercentage: 'test input',
+      }
 
-    expect(answerValidators['payments'](newAnswers, application)).toStrictEqual(
-      {
+      expect(
+        answerValidators['payments'](newAnswers, application),
+      ).toStrictEqual({
         message: coreErrorMessages.defaultError,
         path: 'payments.privatePensionFundPercentage',
         values: undefined,
-      },
-    )
-  })
+      })
+    })
 
-  it('should accept 2 as a value for privatePensionFundPercentage', () => {
-    const newAnswers = {
-      bank: '123456789012',
-      pensionFund: 'id-frjalsi',
-      privatePensionFund: 'id-frjalsi',
-      privatePensionFundPercentage: '2',
-    }
+    it('should accept 2 as a value for privatePensionFundPercentage', () => {
+      const newAnswers = {
+        bank: '123456789012',
+        pensionFund: 'id-frjalsi',
+        privatePensionFund: 'id-frjalsi',
+        privatePensionFundPercentage: '2',
+      }
 
-    expect(answerValidators['payments'](newAnswers, application)).toStrictEqual(
-      undefined,
-    )
-  })
+      expect(
+        answerValidators['payments'](newAnswers, application),
+      ).toStrictEqual(undefined)
+    })
 
-  it('should accept 4 as a value for privatePensionFundPercentage', () => {
-    const newAnswers = {
-      bank: '123456789012',
-      pensionFund: 'id-frjalsi',
-      privatePensionFund: 'id-frjalsi',
-      privatePensionFundPercentage: '4',
-    }
+    it('should accept 4 as a value for privatePensionFundPercentage', () => {
+      const newAnswers = {
+        bank: '123456789012',
+        pensionFund: 'id-frjalsi',
+        privatePensionFund: 'id-frjalsi',
+        privatePensionFundPercentage: '4',
+      }
 
-    expect(answerValidators['payments'](newAnswers, application)).toStrictEqual(
-      undefined,
-    )
+      expect(
+        answerValidators['payments'](newAnswers, application),
+      ).toStrictEqual(undefined)
+    })
   })
 })
 

--- a/libs/application/templates/parental-leave/src/lib/answerValidators.ts
+++ b/libs/application/templates/parental-leave/src/lib/answerValidators.ts
@@ -90,15 +90,27 @@ export const answerValidators: Record<string, AnswerValidator> = {
     // if privatePensionFund is NO_PRIVATE_PENSION_FUND and privatePensionFundPercentage is an empty string, allow the user to continue.
     // this will only happen when the usePrivatePensionFund field is set to NO
     if (
-      (payments.privatePensionFund === NO_PRIVATE_PENSION_FUND &&
-        payments.privatePensionFundPercentage === '') ||
-      (privatePensionFund === NO_PRIVATE_PENSION_FUND &&
-        privatePensionFundPercentage === '')
+      payments.privatePensionFund === NO_PRIVATE_PENSION_FUND &&
+      payments.privatePensionFundPercentage === '0'
     )
       return undefined
 
-    if (payments.privatePensionFund === '' || privatePensionFund === '') {
+    if (
+      payments.privatePensionFund === '' ||
+      payments.privatePensionFund === NO_PRIVATE_PENSION_FUND
+    ) {
       return buildError(coreErrorMessages.defaultError, 'privatePensionFund')
+    }
+
+    if (
+      privatePensionFund === NO_PRIVATE_PENSION_FUND &&
+      privatePensionFundPercentage === '0' &&
+      payments.privatePensionFundPercentage === ''
+    ) {
+      return buildError(
+        coreErrorMessages.defaultError,
+        'privatePensionFundPercentage',
+      )
     }
 
     if (!payments.privatePensionFund) {
@@ -107,16 +119,16 @@ export const answerValidators: Record<string, AnswerValidator> = {
 
     // validate that the privatePensionFundPercentage is either 2 or 4 percent
     if (
-      typeof privatePensionFundPercentage === 'string' ||
-      typeof payments.privatePensionFundPercentage === 'string'
+      payments.privatePensionFundPercentage === '2' ||
+      payments.privatePensionFundPercentage === '4'
     ) {
-      if (
-        payments.privatePensionFundPercentage === '2' ||
-        payments.privatePensionFundPercentage === '4'
-      ) {
-        return undefined
-      }
+      return undefined
+    }
 
+    if (
+      payments.privatePensionFundPercentage !== '2' &&
+      payments.privatePensionFundPercentage !== '4'
+    ) {
       return buildError(
         coreErrorMessages.defaultError,
         'privatePensionFundPercentage',

--- a/libs/application/templates/parental-leave/src/lib/dataSchema.ts
+++ b/libs/application/templates/parental-leave/src/lib/dataSchema.ts
@@ -46,7 +46,7 @@ export const dataSchema = z.object({
     ),
     pensionFund: z.string(),
     privatePensionFund: z.string().optional(),
-    privatePensionFundPercentage: z.enum(['2', '4', '']).optional(),
+    privatePensionFundPercentage: z.enum(['0', '2', '4', '']).optional(),
     union: z.string().optional(),
   }),
   shareInformationWithOtherParent: z.enum([YES, NO]),


### PR DESCRIPTION
## What

Changing validation for privatePensionFund and privatePensionFundPercentage, to follow requirements from the client.
- The percentage of private pension savings is a number
- The code of a private pension fund exists and is a private pension fund and not a mutual fund
- If the applicant claims not to pay into a private pension fund, the percentage of private pension funds must be zero

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
