### PR TITLE
fix(j-s): Use court end time instead of ruling date where relevant

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/custodyNoticePdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/custodyNoticePdf.ts
@@ -115,7 +115,7 @@ function constructCustodyNoticePdf(
   addNormalText(
     doc,
     `Úrskurður kveðinn upp ${
-      formatDate(theCase.rulingDate, 'PPPp')?.replace(' kl.', ', kl.') ?? '?'
+      formatDate(theCase.courtEndTime, 'PPPp')?.replace(' kl.', ', kl.') ?? '?'
     }`,
   )
   addNormalText(

--- a/apps/judicial-system/backend/src/app/formatters/rulingPdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/rulingPdf.ts
@@ -56,7 +56,7 @@ function constructRulingPdf(
   setLineGap(doc, 2)
   addMediumHeading(
     doc,
-    `${title} ${formatDate(theCase.rulingDate ?? nowFactory(), 'PPP')}`,
+    `${title} ${formatDate(theCase.courtEndTime ?? nowFactory(), 'PPP')}`,
   )
   setLineGap(doc, 30)
   addMediumHeading(

--- a/apps/judicial-system/web/messages/Core/signedVerdictOverview.ts
+++ b/apps/judicial-system/web/messages/Core/signedVerdictOverview.ts
@@ -7,20 +7,6 @@ export const signedVerdictOverview = {
     defaultMessage: 'Úrskurðað {courtEndTime}',
     description: 'Notaður sem label fyrir hvenær úrskurðurinn var.',
   }),
-  accusedAppealed: defineMessage({
-    id: 'judicial.system.core:signed_verdict_overview.accused_appealed',
-    defaultMessage:
-      '{genderedAccused} hefur kært úrskurðinn í þinghaldi sem lauk {courtEndTime}',
-    description:
-      'Notaður sem upplýsingatexti sem útskýrir að kærði kærði úrskurðinn í þinghaldi á yfirlitsskjá afgreiddra mála.',
-  }),
-  prosecutorAppealed: defineMessage({
-    id: 'judicial.system.core:signed_verdict_overview.prosecutor_appealed',
-    defaultMessage:
-      'Sækjandi hefur kært úrskurðinn í þinghaldi sem lauk {courtEndTime}',
-    description:
-      'Notaður sem upplýsingatexti sem útskýrir að sækjandi kærði úrskurðinn í þinghaldi á yfirlitsskjá afgreiddra mála.',
-  }),
   dismissedTitle: defineMessage({
     id: 'judicial.system.core:signed_verdict_overview.dismissed_title',
     defaultMessage: 'Kröfu vísað frá',
@@ -428,6 +414,35 @@ export const signedVerdictOverview = {
           'judicial.system.core:signed_verdict_overview.case_dates.isolation_valid_to',
         defaultMessage: 'Einangrun til {date}',
         description: 'Texti sem tilgreinir hversu lengi einangrun er í gildi',
+      },
+    }),
+    appeal: defineMessages({
+      title: {
+        id: 'judicial.system.core:signed_verdict_overview.appeal.title',
+        defaultMessage: 'Ákvörðun um kæru',
+        description:
+          'Notaður sem titill í Ákvörðun um kæru hluta á yfirlitsskjá afgreiddra mála.',
+      },
+      deadline: {
+        id: 'judicial.system.core:signed_verdict_overview.appeal.deadline',
+        defaultMessage:
+          'Kærufrestur {isAppealDeadlineExpired, select, true {rann} false {rennur}} út {appealDeadline}',
+      },
+      accusedAppealed: {
+        id:
+          'judicial.system.core:signed_verdict_overview.appeal.accused_appealed',
+        defaultMessage:
+          '{genderedAccused} hefur kært úrskurðinn í þinghaldi sem lauk {courtEndTime}',
+        description:
+          'Notaður sem upplýsingatexti sem útskýrir að kærði kærði úrskurðinn í þinghaldi á yfirlitsskjá afgreiddra mála.',
+      },
+      prosecutorAppealed: {
+        id:
+          'judicial.system.core:signed_verdict_overview.appeal.prosecutor_appealed',
+        defaultMessage:
+          'Sækjandi hefur kært úrskurðinn í þinghaldi sem lauk {courtEndTime}',
+        description:
+          'Notaður sem upplýsingatexti sem útskýrir að sækjandi kærði úrskurðinn í þinghaldi á yfirlitsskjá afgreiddra mála.',
       },
     }),
   },

--- a/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/Components/AppealSection/AppealSection.spec.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/Components/AppealSection/AppealSection.spec.tsx
@@ -5,8 +5,10 @@ import { MockedProvider } from '@apollo/client/testing'
 
 import {
   CaseAppealDecision,
+  CaseOrigin,
   CaseState,
   CaseType,
+  Defendant,
 } from '@island.is/judicial-system/types'
 
 import AppealSection from './AppealSection'
@@ -19,7 +21,8 @@ describe('Appeal section component', () => {
     type: CaseType.CUSTODY,
     state: CaseState.ACCEPTED,
     policeCaseNumber: '000',
-    defendants: [{ nationalId: '000000-0000' }],
+    defendants: [{ nationalId: '000000-0000' }] as Defendant[],
+    origin: CaseOrigin.UNKNOWN,
   }
 
   test('should say when a case is no longer appealable if either the prosecutors or judges appeal decision is to postpone', async () => {
@@ -30,7 +33,7 @@ describe('Appeal section component', () => {
             workingCase={{
               ...baseWorkingCase,
               isAppealDeadlineExpired: true,
-              rulingDate: '2020-09-16T19:50:00.000Z',
+              courtEndTime: '2020-09-16T19:50:00.000Z',
               accusedAppealDecision: CaseAppealDecision.POSTPONE,
             }}
             setAccusedAppealDate={() => null}
@@ -60,7 +63,7 @@ describe('Appeal section component', () => {
             workingCase={{
               ...baseWorkingCase,
               isAppealDeadlineExpired: false,
-              rulingDate: `${dd}T19:50:00.000Z`,
+              courtEndTime: `${dd}T19:50:00.000Z`,
               prosecutorAppealDecision: CaseAppealDecision.POSTPONE,
             }}
             setAccusedAppealDate={() => null}
@@ -94,7 +97,7 @@ describe('Appeal section component', () => {
             workingCase={{
               ...baseWorkingCase,
               isAppealDeadlineExpired: false,
-              rulingDate: `${dd}T19:50:00.000Z`,
+              courtEndTime: `${dd}T19:50:00.000Z`,
             }}
             setAccusedAppealDate={() => null}
             setProsecutorAppealDate={() => null}

--- a/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/Components/AppealSection/AppealSection.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/Components/AppealSection/AppealSection.tsx
@@ -14,7 +14,10 @@ import {
 import { BlueBox } from '@island.is/judicial-system-web/src/components'
 import InfoBox from '@island.is/judicial-system-web/src/components/InfoBox/InfoBox'
 import { capitalize, formatDate } from '@island.is/judicial-system/formatters'
-import { signedVerdictOverview } from '@island.is/judicial-system-web/messages/Core/signedVerdictOverview'
+import {
+  core,
+  signedVerdictOverview,
+} from '@island.is/judicial-system-web/messages'
 import { UserContext } from '@island.is/judicial-system-web/src/components/UserProvider/UserProvider'
 import type { Case } from '@island.is/judicial-system/types'
 
@@ -23,7 +26,6 @@ import ProsecutorAppealInfo from '../Prosecutor/ProsecutorAppealInfo'
 import AccusedAppealDatePicker from '../Accused/AccusedAppealDatePicker'
 import ProsecutorAppealDatePicker from '../Prosecutor/ProsecutorAppealDatePicker'
 import * as styles from './AppealSection.css'
-import { core } from '@island.is/judicial-system-web/messages'
 
 interface Props {
   workingCase: Case
@@ -55,18 +57,19 @@ const AppealSection: React.FC<Props> = (props) => {
     <>
       <Box marginBottom={1}>
         <Text variant="h3" as="h3">
-          Ákvörðun um kæru
+          {formatMessage(signedVerdictOverview.sections.appeal.title)}
         </Text>
       </Box>
       {(workingCase.accusedAppealDecision === CaseAppealDecision.POSTPONE ||
         workingCase.prosecutorAppealDecision === CaseAppealDecision.POSTPONE) &&
-        workingCase.rulingDate &&
+        workingCase.courtEndTime &&
         !isHighCourt && (
           <Box marginBottom={3}>
             <Text>
-              {`Kærufrestur ${
-                workingCase.isAppealDeadlineExpired ? 'rann' : 'rennur'
-              } út ${getAppealEndDate(workingCase.rulingDate)}`}
+              {formatMessage(signedVerdictOverview.sections.appeal.deadline, {
+                isAppealDeadlineExpired: workingCase.isAppealDeadlineExpired,
+                appealDeadline: getAppealEndDate(workingCase.courtEndTime),
+              })}
             </Text>
           </Box>
         )}
@@ -74,30 +77,33 @@ const AppealSection: React.FC<Props> = (props) => {
         <div className={styles.appealContainer}>
           <BlueBox>
             <InfoBox
-              text={formatMessage(signedVerdictOverview.accusedAppealed, {
-                genderedAccused: capitalize(
-                  isRestrictionCase(workingCase.type)
-                    ? formatMessage(core.accused, {
-                        suffix:
-                          workingCase.defendants &&
-                          workingCase.defendants.length > 0 &&
-                          workingCase.defendants[0].gender === Gender.MALE
-                            ? 'i'
-                            : 'a',
-                      })
-                    : formatMessage(core.defendant, {
-                        suffix:
-                          workingCase.defendants &&
-                          workingCase.defendants?.length > 1
-                            ? 'ar'
-                            : 'i',
-                      }),
-                ),
-                courtEndTime: `${formatDate(
-                  workingCase.rulingDate,
-                  'PP',
-                )} kl. ${formatDate(workingCase.rulingDate, 'p')}`,
-              })}
+              text={formatMessage(
+                signedVerdictOverview.sections.appeal.accusedAppealed,
+                {
+                  genderedAccused: capitalize(
+                    isRestrictionCase(workingCase.type)
+                      ? formatMessage(core.accused, {
+                          suffix:
+                            workingCase.defendants &&
+                            workingCase.defendants.length > 0 &&
+                            workingCase.defendants[0].gender === Gender.MALE
+                              ? 'i'
+                              : 'a',
+                        })
+                      : formatMessage(core.defendant, {
+                          suffix:
+                            workingCase.defendants &&
+                            workingCase.defendants?.length > 1
+                              ? 'ar'
+                              : 'i',
+                        }),
+                  ),
+                  courtEndTime: `${formatDate(
+                    workingCase.rulingDate,
+                    'PP',
+                  )} kl. ${formatDate(workingCase.rulingDate, 'p')}`,
+                },
+              )}
               fluid
               light
             />
@@ -108,12 +114,15 @@ const AppealSection: React.FC<Props> = (props) => {
         <div className={styles.appealContainer}>
           <BlueBox>
             <InfoBox
-              text={formatMessage(signedVerdictOverview.prosecutorAppealed, {
-                courtEndTime: `${formatDate(
-                  workingCase.courtEndTime,
-                  'PP',
-                )} kl. ${formatDate(workingCase.courtEndTime, 'p')}`,
-              })}
+              text={formatMessage(
+                signedVerdictOverview.sections.appeal.prosecutorAppealed,
+                {
+                  courtEndTime: `${formatDate(
+                    workingCase.courtEndTime,
+                    'PP',
+                  )} kl. ${formatDate(workingCase.courtEndTime, 'p')}`,
+                },
+              )}
               fluid
               light
             />


### PR DESCRIPTION
# Use court end time instead of ruling date where relevant

[Asana](https://app.asana.com/0/1199153462262248/1202246183652724/f)

## What

Use court end time instead of ruling date where relevant

## Why

It doesn't matter when a judge signs a verdict, what matters is when the court proceedings finish.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
