### PR TITLE
chore(j-s): Move info panel about how to resend a case to the overview step

### DIFF
--- a/apps/judicial-system/web-e2e/src/integration/Prosecutor/RestrictionCases/overview.spec.ts
+++ b/apps/judicial-system/web-e2e/src/integration/Prosecutor/RestrictionCases/overview.spec.ts
@@ -1,6 +1,6 @@
 import faker from 'faker'
 
-import { Case, Defendant } from '@island.is/judicial-system/types'
+import { Case, CaseState, Defendant } from '@island.is/judicial-system/types'
 import { STEP_SIX_ROUTE } from '@island.is/judicial-system/consts'
 
 import {
@@ -11,11 +11,28 @@ import {
 } from '../../../utils'
 
 describe(`${STEP_SIX_ROUTE}/:id`, () => {
+  const caseData = makeCustodyCase()
   const defenderName = faker.name.findName()
   const defenderEmail = faker.internet.email()
   const defenderPhoneNumber = faker.phone.phoneNumber()
+
   beforeEach(() => {
-    const caseData = makeCustodyCase()
+    cy.stubAPIResponses()
+    cy.visit(`${STEP_SIX_ROUTE}/test_id_stadfesta`)
+  })
+
+  it('should have a info panel about how to resend a case if the case has been sent', () => {
+    const caseDataAddition: Case = {
+      ...caseData,
+      state: CaseState.RECEIVED,
+    }
+
+    intercept(caseDataAddition)
+
+    cy.getByTestid('rc-overview-info-panel').should('exist')
+  })
+
+  it('should have an overview of the current case', () => {
     const caseDataAddition: Case = {
       ...caseData,
       defendants: [
@@ -37,13 +54,8 @@ describe(`${STEP_SIX_ROUTE}/:id`, () => {
       defenderPhoneNumber,
     }
 
-    cy.stubAPIResponses()
-    cy.visit(`${STEP_SIX_ROUTE}/test_id_stadfesta`)
-
     intercept(caseDataAddition)
-  })
 
-  it('should have an overview of the current case', () => {
     cy.getByTestid('infoCard').contains(
       'Donald Duck, kt. 000000-0000, Batcave 1337',
     )
@@ -67,6 +79,8 @@ describe(`${STEP_SIX_ROUTE}/:id`, () => {
   })
 
   it('should have a button that links to a pdf of the case', () => {
+    intercept(caseData)
+
     cy.contains('button', 'Krafa - PDF')
   })
 

--- a/apps/judicial-system/web/messages/RestrictionCases/Prosecutor/accusedForm.ts
+++ b/apps/judicial-system/web/messages/RestrictionCases/Prosecutor/accusedForm.ts
@@ -7,21 +7,6 @@ export const accused = {
     description:
       'Notaður sem titill á sakbornings skrefi í gæsluvarðhalds- og farbannsmálum.',
   }),
-  receivedAlert: defineMessages({
-    title: {
-      id: 'judicial.system.restriction_cases:accused.received_alert.title',
-      defaultMessage: 'Athugið',
-      description:
-        'Notaður sem titill í upplýsingarboxi á sakbornings skrefi í gæsluvarðhalds- og farbannsmálum.',
-    },
-    message: {
-      id: 'judicial.system.restriction_cases:accused.received_alert.message',
-      defaultMessage:
-        'Hægt er að breyta efni kröfunnar og bæta við rannsóknargögnum eftir að hún hefur verið send dómstól en til að breytingar skili sér í dómskjalið sem verður til hliðsjónar í þinghaldinu þarf að smella á Endursenda kröfu á skjánum Yfirlit kröfu.',
-      description:
-        'Notaður sem skilaboð í upplýsingarboxi á sakbornings skrefi í gæsluvarðhalds- og farbannsmálum.',
-    },
-  }),
   sections: {
     accusedInfo: {
       heading: defineMessage({

--- a/apps/judicial-system/web/messages/RestrictionCases/Prosecutor/overview.ts
+++ b/apps/judicial-system/web/messages/RestrictionCases/Prosecutor/overview.ts
@@ -1,11 +1,20 @@
 import { defineMessage, defineMessages } from 'react-intl'
 
 export const rcOverview = {
-  // TODO: remove heading and use headingV2
-  heading: defineMessage({
-    id: 'judicial.system.restriction_cases:overview.heading',
-    defaultMessage: 'Yfirlit kröfu um {caseType}',
-    description: 'Notaður sem titill á yfirlits skrefi í rannsóknarheimildum.',
+  receivedAlert: defineMessages({
+    title: {
+      id: 'judicial.system.restriction_cases:overview.received_alert.title',
+      defaultMessage: 'Athugið',
+      description:
+        'Notaður sem titill í upplýsingarboxi á yfirlits skrefi í gæsluvarðhalds- og farbannsmálum.',
+    },
+    message: {
+      id: 'judicial.system.restriction_cases:overview.received_alert.message',
+      defaultMessage:
+        'Hægt er að breyta efni kröfunnar og bæta við rannsóknargögnum eftir að hún hefur verið send dómstól en til að breytingar skili sér í dómskjalið sem verður til hliðsjónar í þinghaldinu þarf að smella á Endursenda kröfu á skjánum Yfirlit kröfu.',
+      description:
+        'Notaður sem skilaboð í upplýsingarboxi á yfirlits skrefi í gæsluvarðhalds- og farbannsmálum.',
+    },
   }),
   headingV2: defineMessage({
     id: 'judicial.system.restriction_cases:overview.heading_v2',

--- a/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/Overview/Overview.css.ts
+++ b/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/Overview/Overview.css.ts
@@ -1,6 +1,9 @@
 import { theme } from '@island.is/island-ui/theme'
 import { style } from '@vanilla-extract/css'
 
+export const resendInfoPanelContainer = style({
+  marginBottom: theme.spacing[5],
+})
 export const prosecutorContainer = style({
   paddingBottom: theme.spacing[6],
   marginBottom: theme.spacing[5],

--- a/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/Overview/Overview.tsx
@@ -126,13 +126,16 @@ export const Overview: React.FC = () => {
       />
       <FormContentContainer>
         {workingCase.state === CaseState.RECEIVED && (
-          <Box marginBottom={5}>
+          <div
+            className={styles.resendInfoPanelContainer}
+            data-testid="rc-overview-info-panel"
+          >
             <AlertMessage
               title={formatMessage(rcOverview.receivedAlert.title)}
               message={formatMessage(rcOverview.receivedAlert.message)}
               type="info"
             />
-          </Box>
+          </div>
         )}
         <Box marginBottom={7}>
           <Text as="h1" variant="h1">

--- a/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/Overview/Overview.tsx
@@ -9,11 +9,11 @@ import {
   Accordion,
   AccordionItem,
   Input,
+  AlertMessage,
 } from '@island.is/island-ui/core'
 import {
   NotificationType,
   CaseState,
-  CaseType,
   CaseTransition,
   completedCaseStates,
 } from '@island.is/judicial-system/types'
@@ -40,8 +40,8 @@ import {
   laws,
   rcOverview,
   requestCourtDate,
+  restrictionsV2,
 } from '@island.is/judicial-system-web/messages'
-import { restrictionsV2 } from '@island.is/judicial-system-web/messages'
 import { FormContext } from '@island.is/judicial-system-web/src/components/FormProvider/FormProvider'
 import CommentsAccordionItem from '@island.is/judicial-system-web/src/components/AccordionItems/CommentsAccordionItem/CommentsAccordionItem'
 import { createCaseResentExplanation } from '@island.is/judicial-system-web/src/utils/stepHelper'
@@ -125,6 +125,15 @@ export const Overview: React.FC = () => {
         title={formatMessage(titles.prosecutor.restrictionCases.overview)}
       />
       <FormContentContainer>
+        {workingCase.state === CaseState.RECEIVED && (
+          <Box marginBottom={5}>
+            <AlertMessage
+              title={formatMessage(rcOverview.receivedAlert.title)}
+              message={formatMessage(rcOverview.receivedAlert.message)}
+              type="info"
+            />
+          </Box>
+        )}
         <Box marginBottom={7}>
           <Text as="h1" variant="h1">
             {formatMessage(rcOverview.headingV2, {

--- a/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/Overview/index.ts
+++ b/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/Overview/index.ts
@@ -1,1 +1,0 @@
-export { default as Overview } from './Overview'

--- a/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/StepOne/StepOneForm.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/StepOne/StepOneForm.tsx
@@ -1,35 +1,26 @@
 import React, { useState } from 'react'
 import { useIntl } from 'react-intl'
 
-import {
-  Text,
-  Input,
-  Box,
-  Tooltip,
-  AlertMessage,
-} from '@island.is/island-ui/core'
+import { Text, Input, Box, Tooltip } from '@island.is/island-ui/core'
 import {
   FormContentContainer,
   FormFooter,
 } from '@island.is/judicial-system-web/src/components'
-import {
-  CaseState,
-  CaseType,
-  UpdateDefendant,
-} from '@island.is/judicial-system/types'
+import { CaseType, UpdateDefendant } from '@island.is/judicial-system/types'
 import { isDefendantStepValidRC } from '@island.is/judicial-system-web/src/utils/validate'
 import DefenderInfo from '@island.is/judicial-system-web/src/components/DefenderInfo/DefenderInfo'
 import { accused as m } from '@island.is/judicial-system-web/messages'
 import useDefendants from '@island.is/judicial-system-web/src/utils/hooks/useDefendants'
-import type { Case } from '@island.is/judicial-system/types'
-import * as Constants from '@island.is/judicial-system/consts'
-import LokeCaseNumber from '../../SharedComponents/LokeCaseNumber/LokeCaseNumber'
-import DefendantInfo from '../../SharedComponents/DefendantInfo/DefendantInfo'
 import {
   validateAndSendToServer,
   validateAndSet,
 } from '@island.is/judicial-system-web/src/utils/formHelper'
 import { useCase } from '@island.is/judicial-system-web/src/utils/hooks'
+import type { Case } from '@island.is/judicial-system/types'
+import * as Constants from '@island.is/judicial-system/consts'
+
+import LokeCaseNumber from '../../SharedComponents/LokeCaseNumber/LokeCaseNumber'
+import DefendantInfo from '../../SharedComponents/DefendantInfo/DefendantInfo'
 
 interface Props {
   workingCase: Case
@@ -72,15 +63,6 @@ export const StepOneForm: React.FC<Props> = (props) => {
   return (
     <>
       <FormContentContainer>
-        {workingCase.state === CaseState.RECEIVED && (
-          <Box marginBottom={5}>
-            <AlertMessage
-              title={formatMessage(m.receivedAlert.title)}
-              message={formatMessage(m.receivedAlert.message)}
-              type="warning"
-            />
-          </Box>
-        )}
         <Box marginBottom={7}>
           <Text as="h1" variant="h1">
             {formatMessage(m.heading)}


### PR DESCRIPTION
# Move info panel about how to resend a case to the overview step

[Asana](https://app.asana.com/0/1199153462262248/1202086011710963/f)

## What

Move info panel about how to resend a case to the overview step

## Why

It used to be on the first step of the flow. Now, when you open a sent case you automatically go to the last step and therefore it makes sense to have this info panel there.

## Screenshots / Gifs

![screencapture-localhost-4200-krafa-stadfesta-fca01265-b519-48a6-94cf-b7a4a69a9ed4-2022-05-11-09_05_31](https://user-images.githubusercontent.com/3789875/167812944-7b0b22c9-8548-440b-9d33-902950422e2f.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
