### PR TITLE
feat(web): Web footer links to support page

### DIFF
--- a/apps/web/layouts/main.tsx
+++ b/apps/web/layouts/main.tsx
@@ -396,6 +396,13 @@ const Layout: NextComponentType<
                     title: activeLocale === 'en' ? 'Íslenska' : 'English',
                     href: activeLocale === 'en' ? '/' : '/en',
                   }}
+                  privacyPolicyLink={{
+                    title: n('privacyPolicyTitle', 'Persónuverndarstefna'),
+                    href: n(
+                      'privacyPolicyHref',
+                      '/personuverndarstefna-stafraent-islands',
+                    ),
+                  }}
                   showMiddleLinks
                 />
               </>

--- a/apps/web/layouts/main.tsx
+++ b/apps/web/layouts/main.tsx
@@ -45,7 +45,7 @@ import { MenuTabsContext } from '../context/MenuTabsContext/MenuTabsContext'
 import { useI18n } from '../i18n'
 import { GET_ALERT_BANNER_QUERY } from '../screens/queries/AlertBanner'
 import { environment } from '../environments'
-import { useNamespace } from '../hooks'
+import { useFeatureFlag, useNamespace } from '../hooks'
 import {
   formatMegaMenuCategoryLinks,
   formatMegaMenuLinks,
@@ -66,8 +66,6 @@ const { publicRuntimeConfig = {} } = getConfig() ?? {}
 
 const IS_MOCK =
   process.env.NODE_ENV !== 'production' && process.env.API_MOCKS === 'true'
-
-const SHOULD_LINK_TO_SERVICE_WEB = false
 
 const absoluteUrl = (req, setLocalhost) => {
   let protocol = 'https:'
@@ -169,6 +167,11 @@ const Layout: NextComponentType<
   const { route, pathname, query, asPath } = useRouter()
   const fullUrl = `${respOrigin}${asPath}`
 
+  const { value: isWebFooterLinkingToSupportPage } = useFeatureFlag(
+    'iswebfooterlinkingtosupportpage',
+    false,
+  )
+
   Sentry.configureScope((scope) => {
     scope.setExtra('lang', activeLocale)
 
@@ -239,11 +242,7 @@ const Layout: NextComponentType<
   const isServiceWeb = pathIsRoute(asPath, 'serviceweb')
 
   return (
-    <GlobalContextProvider
-      namespace={namespace}
-      shouldLinkToServiceWeb={SHOULD_LINK_TO_SERVICE_WEB}
-      isServiceWeb={isServiceWeb}
-    >
+    <GlobalContextProvider namespace={namespace} isServiceWeb={isServiceWeb}>
       <Page component="div">
         <Head>
           {preloadedFonts.map((href, index) => {
@@ -384,7 +383,7 @@ const Layout: NextComponentType<
                   topLinks={footerUpperInfo}
                   {...(activeLocale === 'is'
                     ? {
-                        linkToHelpWeb: SHOULD_LINK_TO_SERVICE_WEB
+                        linkToHelpWeb: isWebFooterLinkingToSupportPage
                           ? linkResolver('serviceweb').href
                           : '',
                       }

--- a/libs/island-ui/core/src/lib/Footer/Footer.tsx
+++ b/libs/island-ui/core/src/lib/Footer/Footer.tsx
@@ -14,9 +14,9 @@ import { Link } from '../Link/Link'
 import { Button } from '../Button/Button'
 import Hyphen from '../Hyphen/Hyphen'
 import { LinkContext } from '../context/LinkContext/LinkContext'
+import { Stack } from '../Stack/Stack'
 
 import * as styles from './Footer.css'
-import { Stack } from '../Stack/Stack'
 
 export interface FooterLinkProps {
   title: string
@@ -35,6 +35,7 @@ interface FooterProps {
   middleLinksTitle?: string
   bottomLinksTitle?: string
   languageSwitchLink?: FooterLinkProps
+  privacyPolicyLink?: FooterLinkProps
   hideLanguageSwitch?: boolean
   showMiddleLinks?: boolean
   /**
@@ -54,6 +55,7 @@ export const Footer = ({
   bottomLinksTitle = 'Aðrir opinberir vefir',
   showMiddleLinks = false,
   languageSwitchLink = defaultLanguageSwitchLink,
+  privacyPolicyLink = defaultPrivacyPolicyLink,
   hideLanguageSwitch = false,
   linkToHelpWeb,
   linkToHelpWebText = 'Getum við aðstoðað?',
@@ -139,6 +141,19 @@ export const Footer = ({
                 </Box>
                 <div>
                   <Stack space={1}>
+                    <Inline space={1} alignY="center">
+                      <Icon
+                        type="info"
+                        height="15"
+                        width="15"
+                        color="blue400"
+                      />
+                      <Text variant="h5" color="blue600" fontWeight="light">
+                        <Link href={privacyPolicyLink.href}>
+                          {privacyPolicyLink.title}
+                        </Link>
+                      </Text>
+                    </Inline>
                     {!hideLanguageSwitch && (
                       <Inline space={1} alignY="center">
                         <Icon
@@ -157,6 +172,7 @@ export const Footer = ({
                         </Text>
                       </Inline>
                     )}
+
                     <Inline space={1} alignY="center">
                       <Icon
                         height="15"
@@ -167,22 +183,6 @@ export const Footer = ({
                       <Text variant="h5" color="blue600" fontWeight="light">
                         <Link href="https://www.facebook.com/islandid">
                           Facebook
-                        </Link>
-                      </Text>
-                    </Inline>
-                    <Inline space={1} alignY="center">
-                      <Icon
-                        type="info"
-                        height="15"
-                        width="15"
-                        color="blue400"
-                      />
-                      <Text variant="h5" color="blue600" fontWeight="light">
-                        <Link
-                          href={languageSwitchLink.href}
-                          onClick={languageSwitchOnClick}
-                        >
-                          Persónuverndarstefna
                         </Link>
                       </Text>
                     </Inline>
@@ -298,6 +298,11 @@ const defaultTopLinksContact = [
 const defaultLanguageSwitchLink = {
   title: 'English',
   href: 'https://island.is/en',
+}
+
+const defaultPrivacyPolicyLink = {
+  title: 'Persónuverndarstefna',
+  href: '/personuverndarstefna-stafraent-islands',
 }
 
 const defaultBottomLinks = [

--- a/libs/island-ui/core/src/lib/Footer/Footer.tsx
+++ b/libs/island-ui/core/src/lib/Footer/Footer.tsx
@@ -16,6 +16,7 @@ import Hyphen from '../Hyphen/Hyphen'
 import { LinkContext } from '../context/LinkContext/LinkContext'
 
 import * as styles from './Footer.css'
+import { Stack } from '../Stack/Stack'
 
 export interface FooterLinkProps {
   title: string
@@ -34,7 +35,7 @@ interface FooterProps {
   middleLinksTitle?: string
   bottomLinksTitle?: string
   languageSwitchLink?: FooterLinkProps
-  hideLanguageSwith?: boolean
+  hideLanguageSwitch?: boolean
   showMiddleLinks?: boolean
   /**
    * The link to the help web. If used it will be shown instead of the contact information links.
@@ -53,7 +54,7 @@ export const Footer = ({
   bottomLinksTitle = 'Aðrir opinberir vefir',
   showMiddleLinks = false,
   languageSwitchLink = defaultLanguageSwitchLink,
-  hideLanguageSwith = false,
+  hideLanguageSwitch = false,
   linkToHelpWeb,
   linkToHelpWebText = 'Getum við aðstoðað?',
   languageSwitchOnClick,
@@ -137,8 +138,8 @@ export const Footer = ({
                   )}
                 </Box>
                 <div>
-                  <Inline space={3}>
-                    {!hideLanguageSwith && (
+                  <Stack space={1}>
+                    {!hideLanguageSwitch && (
                       <Inline space={1} alignY="center">
                         <Icon
                           height="15"
@@ -169,7 +170,23 @@ export const Footer = ({
                         </Link>
                       </Text>
                     </Inline>
-                  </Inline>
+                    <Inline space={1} alignY="center">
+                      <Icon
+                        type="info"
+                        height="15"
+                        width="15"
+                        color="blue400"
+                      />
+                      <Text variant="h5" color="blue600" fontWeight="light">
+                        <Link
+                          href={languageSwitchLink.href}
+                          onClick={languageSwitchOnClick}
+                        >
+                          Persónuverndarstefna
+                        </Link>
+                      </Text>
+                    </Inline>
+                  </Stack>
                 </div>
               </Box>
             </GridColumn>


### PR DESCRIPTION
# Web footer links to support page

## What

* Web footer links to support page now
* Changed the layout for the bottom left links
* Put the support page link behind a feature flag

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/43557895/168085954-b30cd26d-7e4b-47fc-8e21-56572ff872ad.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
