### PR TITLE
feat(web): Embed slice

### DIFF
--- a/apps/web/screens/queries/fragments.ts
+++ b/apps/web/screens/queries/fragments.ts
@@ -465,6 +465,12 @@ export const slices = gql`
     }
   }
 
+  fragment EmbedSliceFields on EmbedSlice {
+    title
+    url
+    height
+  }
+
   fragment BaseSlices on Slice {
     ...TimelineFields
     ...MailingListSignupFields
@@ -494,6 +500,7 @@ export const slices = gql`
     ...AccordionSliceFields
     ...OverviewLinksField
     ...EventSliceFields
+    ...EmbedSliceFields
   }
 
   fragment AllSlices on Slice {

--- a/apps/web/screens/queries/fragments.ts
+++ b/apps/web/screens/queries/fragments.ts
@@ -468,7 +468,7 @@ export const slices = gql`
   fragment EmbedSliceFields on EmbedSlice {
     title
     url
-    height
+    frameHeight
   }
 
   fragment BaseSlices on Slice {

--- a/libs/cms/src/lib/environments/environment.ts
+++ b/libs/cms/src/lib/environments/environment.ts
@@ -57,6 +57,7 @@ export default {
     'namespace',
     'timeline',
     'timelineEvent',
+    'embedSlice',
   ],
   contentful: {
     space: process.env.CONTENTFUL_SPACE || '8k0h54kbe6bj',

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -506,6 +506,36 @@ export interface IEmbeddedVideo extends Entry<IEmbeddedVideoFields> {
   }
 }
 
+export interface IEmbedSliceFields {
+  /** Title */
+  title?: string | undefined
+
+  /** URL */
+  url: string
+
+  /** Frame Height */
+  frameHeight?: number | undefined
+}
+
+/** A slice that you can use to create an iframe */
+
+export interface IEmbedSlice extends Entry<IEmbedSliceFields> {
+  sys: {
+    id: string
+    type: string
+    createdAt: string
+    updatedAt: string
+    locale: string
+    contentType: {
+      sys: {
+        id: 'embedSlice'
+        linkType: 'ContentType'
+        type: 'Link'
+      }
+    }
+  }
+}
+
 export interface IEnhancedAssetFields {
   /** Title */
   title?: string | undefined
@@ -2018,11 +2048,11 @@ export interface IOrganizationPageFields {
   /** External Links */
   externalLinks?: ILink[] | undefined
 
-  /** Alert Banner */
-  alertBanner?: IAlertBanner | undefined
-
   /** Default Header Image */
   defaultHeaderImage?: Asset | undefined
+
+  /** Alert Banner */
+  alertBanner?: IAlertBanner | undefined
 }
 
 export interface IOrganizationPage extends Entry<IOrganizationPageFields> {
@@ -3524,6 +3554,7 @@ export type CONTENT_TYPE =
   | 'contactUs'
   | 'districts'
   | 'embeddedVideo'
+  | 'embedSlice'
   | 'enhancedAsset'
   | 'errorPage'
   | 'eventSlice'

--- a/libs/cms/src/lib/models/embedSlice.model.ts
+++ b/libs/cms/src/lib/models/embedSlice.model.ts
@@ -1,0 +1,34 @@
+import { Field, ID, Int, ObjectType } from '@nestjs/graphql'
+// import { IEmbedSlice } from '../generated/contentfulTypes'
+import { SystemMetadata } from '@island.is/shared/types'
+
+@ObjectType()
+export class EmbedSlice {
+  @Field(() => ID)
+  id!: string
+
+  @Field()
+  title!: string
+
+  @Field()
+  url!: string
+
+  @Field(() => Int)
+  height!: number
+}
+
+export const mapEmbedSlice = ({
+  fields,
+  sys,
+}: {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  fields: Record<string, any>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  sys: Record<string, any>
+}): SystemMetadata<EmbedSlice> => ({
+  typename: 'EmbedSlice',
+  id: sys.id,
+  title: fields.title ?? '',
+  url: fields.url ?? '',
+  height: fields.height ?? 300,
+})

--- a/libs/cms/src/lib/models/embedSlice.model.ts
+++ b/libs/cms/src/lib/models/embedSlice.model.ts
@@ -1,5 +1,5 @@
 import { Field, ID, Int, ObjectType } from '@nestjs/graphql'
-// import { IEmbedSlice } from '../generated/contentfulTypes'
+import { IEmbedSlice } from '../generated/contentfulTypes'
 import { SystemMetadata } from '@island.is/shared/types'
 
 @ObjectType()
@@ -13,22 +13,17 @@ export class EmbedSlice {
   @Field()
   url!: string
 
-  @Field(() => Int)
-  height!: number
+  @Field(() => Int, { nullable: true })
+  frameHeight?: number
 }
 
 export const mapEmbedSlice = ({
   fields,
   sys,
-}: {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fields: Record<string, any>
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  sys: Record<string, any>
-}): SystemMetadata<EmbedSlice> => ({
+}: IEmbedSlice): SystemMetadata<EmbedSlice> => ({
   typename: 'EmbedSlice',
   id: sys.id,
   title: fields.title ?? '',
   url: fields.url ?? '',
-  height: fields.height ?? 300,
+  frameHeight: fields.frameHeight,
 })

--- a/libs/cms/src/lib/unions/slice.union.ts
+++ b/libs/cms/src/lib/unions/slice.union.ts
@@ -29,6 +29,7 @@ import {
   IAccordionSlice,
   IOverviewLinks,
   IEventSlice,
+  IEmbedSlice,
 } from '../generated/contentfulTypes'
 import { Image, mapImage } from '../models/image.model'
 import { Asset, mapAsset } from '../models/asset.model'
@@ -83,6 +84,7 @@ import {
   MultipleStatistics,
 } from '../models/multipleStatistics.model'
 import { EventSlice, mapEventSlice } from '../models/eventSlice.model'
+import { EmbedSlice, mapEmbedSlice } from '../models/embedSlice.model'
 
 type SliceTypes =
   | ITimeline
@@ -111,6 +113,7 @@ type SliceTypes =
   | IAccordionSlice
   | IOverviewLinks
   | IEventSlice
+  | IEmbedSlice
 
 export const SliceUnion = createUnionType({
   name: 'Slice',
@@ -144,6 +147,7 @@ export const SliceUnion = createUnionType({
     AccordionSlice,
     OverviewLinks,
     EventSlice,
+    EmbedSlice,
   ],
   resolveType: (document) => document.typename, // typename is appended to request on indexing
 })
@@ -203,6 +207,8 @@ export const mapSliceUnion = (slice: SliceTypes): typeof SliceUnion => {
       return mapOverviewLinks(slice as IOverviewLinks)
     case 'eventSlice':
       return mapEventSlice(slice as IEventSlice)
+    case 'embedSlice':
+      return mapEmbedSlice(slice as IEmbedSlice)
     default:
       throw new ApolloError(`Can not convert to slice: ${contentType}`)
   }

--- a/libs/island-ui/contentful/src/lib/Embed/Embed.css.ts
+++ b/libs/island-ui/contentful/src/lib/Embed/Embed.css.ts
@@ -1,3 +1,9 @@
 import { style } from '@vanilla-extract/css'
 
-export const container = style({ border: 'none' })
+export const container = style({
+  border: 'none',
+})
+
+export const fullHeight = style({
+  height: '100vh',
+})

--- a/libs/island-ui/contentful/src/lib/Embed/Embed.css.ts
+++ b/libs/island-ui/contentful/src/lib/Embed/Embed.css.ts
@@ -1,0 +1,3 @@
+import { style } from '@vanilla-extract/css'
+
+export const container = style({ border: 'none' })

--- a/libs/island-ui/contentful/src/lib/Embed/Embed.tsx
+++ b/libs/island-ui/contentful/src/lib/Embed/Embed.tsx
@@ -4,17 +4,17 @@ import * as styles from './Embed.css'
 export interface EmbedProps {
   title: string
   url: string
-  height: number
+  frameHeight: number
 }
 
-export const Embed = ({ title, url, height }: EmbedProps) => {
+export const Embed = ({ title, url, frameHeight }: EmbedProps) => {
   return (
     <iframe
-      className={styles.container}
+      className={`${styles.container} ${frameHeight ? '' : styles.fullHeight}`}
       src={url}
-      width="100%"
-      height={height}
       title={title}
+      width="100%"
+      height={frameHeight}
     />
   )
 }

--- a/libs/island-ui/contentful/src/lib/Embed/Embed.tsx
+++ b/libs/island-ui/contentful/src/lib/Embed/Embed.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import * as styles from './Embed.css'
+
+export interface EmbedProps {
+  title: string
+  url: string
+  height: number
+}
+
+export const Embed = ({ title, url, height }: EmbedProps) => {
+  return (
+    <iframe
+      className={styles.container}
+      src={url}
+      width="100%"
+      height={height}
+      title={title}
+    />
+  )
+}
+
+export default Embed

--- a/libs/island-ui/contentful/src/lib/RichTextRC/RichText.tsx
+++ b/libs/island-ui/contentful/src/lib/RichTextRC/RichText.tsx
@@ -21,6 +21,7 @@ import { defaultRenderNode } from './defaultRenderNode'
 import { defaultRenderMark } from './defaultRenderMark'
 import { defaultRenderComponent } from './defaultRenderComponents'
 import { Box } from '@island.is/island-ui/core'
+import { EmbedProps } from '../Embed/Embed'
 
 type HtmlSlice = { __typename: 'Html'; id: string; document: Document }
 type FaqListSlice = { __typename: 'FaqList'; id: string } & FaqListProps
@@ -63,6 +64,11 @@ type SectionWithImageSlice = {
   id: string
 } & SectionWithImageProps
 
+type EmbedSlice = {
+  __typename: 'EmbedSlice'
+  id: string
+} & EmbedProps
+
 export type SliceType =
   | HtmlSlice
   | FaqListSlice
@@ -77,6 +83,7 @@ export type SliceType =
   | LocationSlice
   | TellUsAStorySlice
   | SectionWithImageSlice
+  | EmbedSlice
   | {
       // TODO: these are used on the about page - we need to move their rendering
       // to here to make them re-usable by other page types

--- a/libs/island-ui/contentful/src/lib/RichTextRC/defaultRenderComponents.tsx
+++ b/libs/island-ui/contentful/src/lib/RichTextRC/defaultRenderComponents.tsx
@@ -15,6 +15,7 @@ import { SectionWithImage } from '../SectionWithImage/SectionWithImage'
 import { TeamList } from '../TeamList/TeamList'
 import { ContactUs } from '../ContactUs/ContactUs'
 import { Location } from '../Location/Location'
+import { Embed } from '../Embed/Embed'
 
 const renderConnectedComponent = (slice) => {
   const data = slice.json
@@ -76,4 +77,6 @@ export const defaultRenderComponent = {
       state="edit"
     />
   ),
+
+  EmbedSlice: (slice) => <Embed {...slice} />,
 }


### PR DESCRIPTION
# Embed slice

## What

* This slice can be used inside rich text in Contentful to, for example, embed a Power BI graph.

## Why

* This allows us to embed PowerBI graphs on a page
* This also allows us to embed extremely specific content for an organization like custom email list sign up forms and so forth

## Screenshots / Gifs

Here's an example
![image](https://user-images.githubusercontent.com/43557895/169400790-e75d49ab-e603-4601-a494-64548cbb8693.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
