### PR TITLE
fix(parental leave): submit failure on page refresh

### DIFF
--- a/libs/application/templates/parental-leave/src/lib/answerValidators.ts
+++ b/libs/application/templates/parental-leave/src/lib/answerValidators.ts
@@ -142,6 +142,7 @@ export const answerValidators: Record<string, AnswerValidator> = {
       payments.privatePensionFundPercentage !== '2' &&
       payments.privatePensionFundPercentage !== '4'
     ) {
+      if (usePrivatePensionFund === NO) return undefined
       return buildError(
         coreErrorMessages.defaultError,
         'privatePensionFundPercentage',


### PR DESCRIPTION
## What

Fix issue when refreshing the page would cause the validation of privatePensionFundPercentage to fail

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
