### PR TITLE
fix(service-portal): Add padding to grid layout container

### DIFF
--- a/apps/service-portal/src/components/Layout/Layout.css.ts
+++ b/apps/service-portal/src/components/Layout/Layout.css.ts
@@ -29,6 +29,17 @@ export const layoutWrapperWide = style({
   }),
 })
 
+export const layoutContainer = style({
+  paddingLeft: theme.grid.gutter.mobile * 2,
+  paddingRight: theme.grid.gutter.mobile * 2,
+  ...themeUtils.responsiveStyle({
+    md: {
+      paddingLeft: theme.grid.gutter.desktop * 2,
+      paddingRight: theme.grid.gutter.desktop * 2,
+    },
+  }),
+})
+
 export const layoutGrid = style({
   transition: 'margin 150ms ease-in-out, flex-basis 150ms ease-in-out',
   willChange: 'margin, flex-basis',

--- a/apps/service-portal/src/components/Layout/Layout.tsx
+++ b/apps/service-portal/src/components/Layout/Layout.tsx
@@ -56,7 +56,7 @@ const Layout: FC = ({ children }) => {
         paddingBottom={7}
       >
         <Box as="main" component="main">
-          <GridContainer>
+          <GridContainer className={styles.layoutContainer}>
             <GridRow>
               <GridColumn span={'12/12'} className={styles.layoutGrid}>
                 <Hidden print>


### PR DESCRIPTION
## What

Add padding to gridcontainer in mobile

## Why

It was removed from the ui library. We need it for the service-portal.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
