### PR TITLE
fix(j-s): fix demands for restriction cases

### DIFF
--- a/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/StepThree/StepThreeForm.spec.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/StepThree/StepThreeForm.spec.tsx
@@ -1,0 +1,108 @@
+import {
+  CaseType,
+  Defendant,
+  CaseCustodyRestrictions,
+  CaseDecision,
+} from '@island.is/judicial-system/types'
+import { createIntl } from 'react-intl'
+
+import { DemandsAutofillProps, getDemandsAutofill } from './StepThreeForm'
+
+const intl = createIntl({ locale: 'is', onError: () => jest.fn() })
+describe('getDemandsAutofill', () => {
+  const baseDefendant = {
+    name: 'Blær',
+    noNationalId: false,
+    nationalId: '0000000000',
+  } as Defendant
+  const courtName = 'Héraðsdómur'
+  const f = (props: DemandsAutofillProps): string => {
+    return getDemandsAutofill(intl.formatMessage, props)
+  }
+
+  it('should format custody case', () => {
+    const props = {
+      caseType: CaseType.CUSTODY,
+      defentant: baseDefendant,
+      type: CaseType.CUSTODY,
+      courtName,
+      requestedValidToDate: '2020-01-01',
+    } as DemandsAutofillProps
+
+    const result = f(props)
+
+    expect(result).toEqual(
+      'Þess er krafist að Blær, kt. 000000-0000, sæti gæsluvarðhaldi með úrskurði Héraðsdóms, til miðvikudagsins 1. janúar 2020, kl. 00:00.',
+    )
+  })
+
+  it('should format extended custody case', () => {
+    const props = {
+      caseType: CaseType.CUSTODY,
+      defentant: baseDefendant,
+      type: CaseType.CUSTODY,
+      courtName,
+      requestedValidToDate: '2020-01-01',
+      parentCaseDecision: CaseDecision.ACCEPTING,
+    } as DemandsAutofillProps
+
+    const result = f(props)
+
+    expect(result).toEqual(
+      'Þess er krafist að Blær, kt. 000000-0000, sæti áframhaldandi gæsluvarðhaldi með úrskurði Héraðsdóms, til miðvikudagsins 1. janúar 2020, kl. 00:00.',
+    )
+  })
+
+  it('should format custody case with isolation', () => {
+    const props = {
+      caseType: CaseType.CUSTODY,
+      defentant: baseDefendant,
+      type: CaseType.CUSTODY,
+      courtName,
+      requestedValidToDate: '2020-01-01',
+      requestedCustodyRestrictions: [CaseCustodyRestrictions.ISOLATION],
+    } as DemandsAutofillProps
+
+    const result = f(props)
+
+    expect(result).toEqual(
+      'Þess er krafist að Blær, kt. 000000-0000, sæti gæsluvarðhaldi með úrskurði Héraðsdóms, til miðvikudagsins 1. janúar 2020, kl. 00:00, og verði gert að sæta einangrun á meðan á varðhaldi stendur.',
+    )
+  })
+
+  it('should format travel ban case', () => {
+    const props = {
+      caseType: CaseType.TRAVEL_BAN,
+      defentant: {
+        ...baseDefendant,
+        noNationalId: true,
+        nationalId: '1991-01-01',
+      },
+      type: CaseType.CUSTODY,
+      courtName,
+      requestedValidToDate: '2020-01-01',
+    } as DemandsAutofillProps
+
+    const result = f(props)
+
+    expect(result).toEqual(
+      'Þess er krafist að Blær sæti farbanni með úrskurði Héraðsdóms, til miðvikudagsins 1. janúar 2020, kl. 00:00.',
+    )
+  })
+
+  it('should format admission to facility case', () => {
+    const props = {
+      caseType: CaseType.ADMISSION_TO_FACILITY,
+      defentant: baseDefendant,
+      type: CaseType.CUSTODY,
+      courtName,
+      requestedValidToDate: '2020-01-01',
+    } as DemandsAutofillProps
+
+    const result = f(props)
+
+    expect(result).toEqual(
+      'Þess er krafist að Blær, kt. 000000-0000, sæti vistun á viðeigandi stofnun með úrskurði Héraðsdóms, til miðvikudagsins 1. janúar 2020, kl. 00:00.',
+    )
+  })
+})

--- a/apps/judicial-system/web/src/utils/formHelper.spec.ts
+++ b/apps/judicial-system/web/src/utils/formHelper.spec.ts
@@ -1,0 +1,43 @@
+import { toggleInArray } from './formHelper'
+
+describe('toggleInArray', () => {
+  it.each`
+    values
+    ${undefined}
+    ${null}
+    ${[]}
+  `("should return values=['test'] when values=$values", ({ values }) => {
+    const item = 'test'
+
+    const res = toggleInArray(values, item)
+
+    expect(res).toEqual([item])
+  })
+
+  it.each`
+    values
+    ${['removeMe']}
+    ${['keepMe', 'removeMe']}
+    ${['removeMe', 'keepMe']}
+    ${['keepMe', 'removeMe', 'keepMe2']}
+  `('should remove item if already in values array', ({ values }) => {
+    const item = 'removeMe'
+
+    const res = toggleInArray(values, item)
+
+    expect(res.includes(item)).toEqual(false)
+  })
+
+  it.each`
+    values
+    ${['keepMe']}
+    ${['keepMe', 'keepMe2']}
+    ${['keepMe', 'keepMe2']}
+  `('should add item without removing other items', ({ values }) => {
+    const item = 'addMe'
+
+    const res = toggleInArray(values, item)
+
+    expect(res.includes(item)).toEqual(true)
+  })
+})

--- a/apps/judicial-system/web/src/utils/formHelper.ts
+++ b/apps/judicial-system/web/src/utils/formHelper.ts
@@ -215,7 +215,7 @@ export const setAndSendToServer = (
  * otherwise it is appended
  */
 export function toggleInArray<T>(values: T[] | undefined, entry: T) {
-  if (!values) return undefined
+  if (!values) return [entry]
 
   return values.includes(entry)
     ? values.filter((x) => x !== entry)


### PR DESCRIPTION
- fix(j-s): fix toggleInArray not handling empty state
- fix(j-s): pass in changing demands prop to demands autofill

Asana[https://app.asana.com/0/1199153462262248/1202188672896423/f]
## What

- Fix the isolation radio button
- Make sure changed demands are passed into demands autofill function

## Why

- Isolation radio button was not able to be toggled
- Changing type to admission to the facility had no changes to the text of the demands on next page

## Screenshots / Gifs
<img width="808" alt="Screenshot 2022-05-17 at 10 28 53" src="https://user-images.githubusercontent.com/5700902/168791149-6acf7c57-2633-472f-b94d-6698c5d6ca30.png">

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
