### PR TITLE
feat(web): Frontpage login button appearing in mobile view

### DIFF
--- a/apps/web/components/Header/Header.tsx
+++ b/apps/web/components/Header/Header.tsx
@@ -89,6 +89,7 @@ export const Header: FC<HeaderProps> = ({
                         />
                       </Box>
                     )}
+
                     <Hidden below="lg">
                       <Box marginLeft={marginLeft}>
                         <Link {...linkResolver('login')} skipTab>
@@ -103,6 +104,20 @@ export const Header: FC<HeaderProps> = ({
                         </Link>
                       </Box>
                     </Hidden>
+
+                    <Hidden above="md">
+                      <Box marginLeft={marginLeft}>
+                        <Link {...linkResolver('login')} skipTab>
+                          <Button
+                            colorScheme={buttonColorScheme}
+                            variant="utility"
+                            icon="person"
+                            as="span"
+                          />
+                        </Link>
+                      </Box>
+                    </Hidden>
+
                     <Box
                       marginLeft={marginLeft}
                       display={['none', 'none', 'none', 'block']}


### PR DESCRIPTION
# Frontpage login button appearing in mobile view

## What

* Added the login button to the mobile view on the frontpage

## Why

* Previously the login button would dissapear when the screen width was below "large"

## Screenshots / Gifs


https://user-images.githubusercontent.com/43557895/169146406-fd14fa5d-023e-4b42-a593-9a4b6966fd2f.mp4



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
