### PR TITLE
fix(j-s): fix court date being confirmed automatically

### DIFF
--- a/apps/judicial-system/web-e2e/src/integration/Court/InvestigationCases/hearingArrangements.spec.ts
+++ b/apps/judicial-system/web-e2e/src/integration/Court/InvestigationCases/hearingArrangements.spec.ts
@@ -61,21 +61,36 @@ describe(`${IC_COURT_HEARING_ARRANGEMENTS_ROUTE}/:id`, () => {
     cy.get('[name="defenderPhoneNumber"]').should('not.exist')
   })
 
-  it('should allow users to choose if they send COURT_DATE notification', () => {
+  it.only('should autofill form correctly and allow court to confirm court date and send notification', () => {
     const caseData = makeInvestigationCase()
     const caseDataAddition: Case = {
       ...caseData,
       court: makeCourt(),
       requestedCourtDate: '2020-09-16T19:50:08.033Z',
       state: CaseState.RECEIVED,
+      defenderName: 'Test Testesen',
     }
 
     intercept(caseDataAddition)
 
-    cy.get('[name="session-arrangements-all-present"]').click()
-    cy.getByTestid('courtroom').type('1337')
+    cy.wait('@UpdateCaseMutation')
+      .its('response.body.data.updateCase')
+      .should('have.keys', 'sessionArrangements', 'id', '__typename')
+
+    cy.get('[name="session-arrangements-all-present"]').should('be.checked')
+    cy.getByTestid('courtDate-time').should('have.value', '19:50')
+
+    cy.getByTestid('continueButton').should('not.be.disabled')
     cy.getByTestid('continueButton').click()
+    cy.wait('@UpdateCaseMutation')
+      .its('response.body.data.updateCase')
+      .should('have.any.key', 'courtDate')
+
     cy.getByTestid('modal').should('be.visible')
+    cy.getByTestid('modalSecondaryButton').click()
+    cy.wait('@SendNotificationMutation')
+      .its('request.body.variables.input.type')
+      .should('equal', 'COURT_DATE')
   })
 
   it('should navigate to the next step when all input data is valid and the continue button is clicked', () => {
@@ -93,10 +108,6 @@ describe(`${IC_COURT_HEARING_ARRANGEMENTS_ROUTE}/:id`, () => {
 
     cy.getByTestid('continueButton').should('not.be.disabled')
     cy.getByTestid('continueButton').click()
-    cy.wait('@UpdateCaseMutation')
-      .its('response.body.data.updateCase')
-      .should('have.any.key', 'courtDate')
-
     cy.getByTestid('modalSecondaryButton').click()
     cy.url().should('include', IC_RULING_ROUTE)
   })

--- a/apps/judicial-system/web-e2e/src/utils/index.ts
+++ b/apps/judicial-system/web-e2e/src/utils/index.ts
@@ -49,6 +49,16 @@ export const intercept = (res: Case) => {
           updateCase: { ...body.variables?.input, __typename: 'Case' },
         },
       })
+    } else if (hasOperationName(req, 'SendNotificationMutation')) {
+      req.alias = 'SendNotificationMutation'
+      req.reply({
+        data: {
+          sendNotification: {
+            notificationSent: true,
+            __typename: 'SendNotificationResponse',
+          },
+        },
+      })
     }
   })
 }

--- a/apps/judicial-system/web/src/routes/Court/InvestigationCase/HearingArrangements/HearingArrangements.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationCase/HearingArrangements/HearingArrangements.tsx
@@ -32,7 +32,6 @@ const HearingArrangements = () => {
     if (isCaseUpToDate && !initialAutoFillDone) {
       autofill(
         [
-          { key: 'courtDate', value: workingCase.requestedCourtDate },
           {
             key: 'sessionArrangements',
             value: workingCase.defenderName

--- a/apps/judicial-system/web/src/routes/Court/InvestigationCase/HearingArrangements/HearingArrangementsForm.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationCase/HearingArrangements/HearingArrangementsForm.tsx
@@ -54,7 +54,7 @@ const HearingArrangementsForm: React.FC<Props> = (props) => {
   const router = useRouter()
 
   const [courtDate, setCourtDate] = useState<Case['courtDate']>(
-    workingCase.courtDate,
+    workingCase.courtDate || workingCase.requestedCourtDate,
   )
 
   const handleNextButtonClick = useCallback(() => {


### PR DESCRIPTION

[Asana](https://app.asana.com/0/1199153462262248/1202086011710880/f)
## What

Specify what you're trying to achieve
remove autofill of courtDate with requestedCourtDate
test if court date is autofilled and confirmed correctly

## Why

Court date should only be confirmed when user presses the continue button

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
