### PR TITLE
test(j-s): remove it.only mark for e2e test

### DIFF
--- a/apps/judicial-system/web-e2e/src/integration/Court/InvestigationCases/overview.spec.ts
+++ b/apps/judicial-system/web-e2e/src/integration/Court/InvestigationCases/overview.spec.ts
@@ -103,7 +103,7 @@ describe(`${IC_OVERVIEW_ROUTE}/:id`, () => {
     cy.getByTestid('inputErrorMessage').should('not.exist')
   })
 
-  it.only('should upload files to court', () => {
+  it('should upload files to court', () => {
     cy.get('button[aria-controls="caseFilesAccordionItem"]').click()
     cy.getByTestid('upload-to-court-button').click()
 


### PR DESCRIPTION

## What

- Remove it.only mark on tests

## Why

- So it is not only test run in this test module


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
