### PR TITLE
feat(web): Service web, optional search indexing

### DIFF
--- a/apps/web/components/HeadWithSocialSharing/HeadWithSocialSharing.tsx
+++ b/apps/web/components/HeadWithSocialSharing/HeadWithSocialSharing.tsx
@@ -57,12 +57,12 @@ export const HeadWithSocialSharing: FC<HeadWithSocialSharingProps> = ({
         <>
           <meta
             property="og:image"
-            content={'https:' + imageUrl}
+            content={`${imageUrl.startsWith('//') ? 'https:' : ''}${imageUrl}`}
             key="ogImage"
           />
           <meta
             property="twitter:image"
-            content={'https:' + imageUrl}
+            content={`${imageUrl.startsWith('//') ? 'https:' : ''}${imageUrl}`}
             key="twitterImage"
           />
           <meta

--- a/apps/web/components/ServiceWeb/Wrapper/Wrapper.tsx
+++ b/apps/web/components/ServiceWeb/Wrapper/Wrapper.tsx
@@ -40,6 +40,7 @@ interface WrapperProps {
   searchTags?: Tag[]
   showLogoTitle?: boolean
   pageDescription?: string
+  indexableBySearchEngine?: boolean
 }
 
 export const Wrapper: FC<WrapperProps> = ({
@@ -55,6 +56,7 @@ export const Wrapper: FC<WrapperProps> = ({
   searchTags,
   showLogoTitle,
   pageDescription,
+  indexableBySearchEngine = false,
   children,
 }) => {
   const [options, setOptions] = useState<Options>({
@@ -75,24 +77,19 @@ export const Wrapper: FC<WrapperProps> = ({
 
   return (
     <>
-      {!organization.serviceWebFeaturedImage && (
-        <Head>
-          <title>{pageTitle}</title>
+      <HeadWithSocialSharing
+        title={pageTitle}
+        description={pageDescription}
+        imageUrl={organization.serviceWebFeaturedImage?.url}
+        imageContentType={organization.serviceWebFeaturedImage?.contentType}
+        imageWidth={organization.serviceWebFeaturedImage?.width?.toString()}
+        imageHeight={organization.serviceWebFeaturedImage?.height?.toString()}
+      >
+        {!indexableBySearchEngine && (
           <meta name="robots" content="noindex, nofollow" />
-        </Head>
-      )}
-      {organization.serviceWebFeaturedImage && (
-        <HeadWithSocialSharing
-          title={pageTitle}
-          description={pageDescription}
-          imageUrl={organization.serviceWebFeaturedImage?.url}
-          imageContentType={organization.serviceWebFeaturedImage?.contentType}
-          imageWidth={organization.serviceWebFeaturedImage?.width?.toString()}
-          imageHeight={organization.serviceWebFeaturedImage?.height?.toString()}
-        >
-          <meta name="robots" content="noindex, nofollow" />
-        </HeadWithSocialSharing>
-      )}
+        )}
+      </HeadWithSocialSharing>
+
       <ServiceWebContext.Provider value={{ textMode, institutionSlug }}>
         <ServiceWebHeader
           hideSearch={!smallBackground}

--- a/apps/web/screens/ServiceWeb/Home/Home.tsx
+++ b/apps/web/screens/ServiceWeb/Home/Home.tsx
@@ -110,6 +110,7 @@ const Home: Screen<HomeProps> = ({
       )}
       searchTags={searchTags}
       showLogoTitle={!institutionSlugBelongsToMannaudstorg}
+      indexableBySearchEngine={institutionSlugBelongsToMannaudstorg}
     >
       {hasContent && (
         <ServiceWebContext.Consumer>


### PR DESCRIPTION
# Service web, optional search indexing

## What

* Added a prop to the service web wrapper component that allows you to turn the search engine indexing on or off
* Also fixed an issue regarding image urls that already start with https by simply not prefixing the url with https if it does not start with '//'

## Why

* We want the mannaudstorg service web to be indexed by search engines

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
