### PR TITLE
feat(web): Organizations page - CMS can change what organizations are shown

### DIFF
--- a/apps/web/screens/Organizations/Organizations.tsx
+++ b/apps/web/screens/Organizations/Organizations.tsx
@@ -300,7 +300,12 @@ OrganizationPage.getInitialProps = async ({ apolloClient, locale }) => {
   }
 
   return {
-    organizations: getOrganizations,
+    organizations: {
+      __typename: getOrganizations.__typename,
+      items: getOrganizations.items.filter(
+        (o) => o.showsUpOnTheOrganizationsPage,
+      ),
+    },
     tags: getOrganizationTags,
     namespace,
   }

--- a/apps/web/screens/queries/Organization.tsx
+++ b/apps/web/screens/queries/Organization.tsx
@@ -9,6 +9,7 @@ export const GET_ORGANIZATIONS_QUERY = gql`
         slug
         title
         description
+        showsUpOnTheOrganizationsPage
         logo {
           title
           url

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -2023,6 +2023,9 @@ export interface IOrganizationPageFields {
 
   /** Default Header Image */
   defaultHeaderImage?: Asset | undefined
+
+  /** Alert Banner */
+  alertBanner?: IAlertBanner | undefined
 }
 
 export interface IOrganizationPage extends Entry<IOrganizationPageFields> {

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -1918,6 +1918,9 @@ export interface IOrganizationFields {
 
   /** Published Material Search Filter Generic Tags */
   publishedMaterialSearchFilterGenericTags?: IGenericTag[] | undefined
+
+  /** Shows up on the organizations page */
+  showsUpOnTheOrganizationsPage?: boolean | undefined
 }
 
 export interface IOrganization extends Entry<IOrganizationFields> {
@@ -2017,9 +2020,6 @@ export interface IOrganizationPageFields {
 
   /** External Links */
   externalLinks?: ILink[] | undefined
-
-  /** Alert Banner */
-  alertBanner?: IAlertBanner | undefined
 
   /** Default Header Image */
   defaultHeaderImage?: Asset | undefined

--- a/libs/cms/src/lib/models/organization.model.ts
+++ b/libs/cms/src/lib/models/organization.model.ts
@@ -55,6 +55,9 @@ export class Organization {
 
   @Field(() => [GenericTag])
   publishedMaterialSearchFilterGenericTags!: GenericTag[]
+
+  @Field(() => Boolean, { nullable: true })
+  showsUpOnTheOrganizationsPage?: boolean
 }
 
 export const mapOrganization = ({
@@ -82,5 +85,6 @@ export const mapOrganization = ({
     publishedMaterialSearchFilterGenericTags: fields.publishedMaterialSearchFilterGenericTags
       ? fields.publishedMaterialSearchFilterGenericTags.map(mapGenericTag)
       : [],
+    showsUpOnTheOrganizationsPage: fields.showsUpOnTheOrganizationsPage ?? true,
   }
 }


### PR DESCRIPTION
# Organizations page - CMS can change what organizations are shown

## What

* Added a new field to the Organization model that allows you to set whether or not that organization gets shown on the organizations page

## Why

* We want to be able to change in the CMS what organizations are shown on the organizations page https://island.is/s

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
