### PR TITLE
fix(parental leave): remove personalAllowance(FromSpouse) if the user does not want to use it

### DIFF
--- a/libs/application/templates/parental-leave/src/fields/SpouseUseAsMuchAsPossible/index.tsx
+++ b/libs/application/templates/parental-leave/src/fields/SpouseUseAsMuchAsPossible/index.tsx
@@ -54,7 +54,7 @@ export const SpouseUseAsMuchAsPossible: FC<FieldBaseProps> = ({
               setValue('personalAllowanceFromSpouse.usage', '100')
             }
             if (s === NO) {
-              setValue('personalAllowanceFromSpouse.usage', '')
+              setValue('personalAllowanceFromSpouse.usage', '0')
             }
           },
         }}

--- a/libs/application/templates/parental-leave/src/fields/personalUseAsMuchAsPossible/index.tsx
+++ b/libs/application/templates/parental-leave/src/fields/personalUseAsMuchAsPossible/index.tsx
@@ -54,7 +54,7 @@ export const PersonalUseAsMuchAsPossible: FC<FieldBaseProps> = ({
               setValue('personalAllowance.usage', '100')
             }
             if (s === NO) {
-              setValue('personalAllowance.usage', '')
+              setValue('personalAllowance.usage', '0')
             }
           },
         }}

--- a/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.spec.ts
+++ b/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.spec.ts
@@ -228,7 +228,7 @@ describe('Parental Leave Application Template', () => {
     })
 
     describe('allowance', () => {
-      it('should remove spouse allowance useAll and usage on submit, if usePersonalAllowanceFromSpouse is equal to NO', () => {
+      it('should remove personalAllowanceFromSpouse on submit, if usePersonalAllowanceFromSpouse is equal to NO and personalAllowanceFromSpouse exists', () => {
         const helper = new ApplicationTemplateHelper(
           buildApplication({
             answers: {
@@ -248,10 +248,12 @@ describe('Parental Leave Application Template', () => {
           type: DefaultEvents.SUBMIT,
         })
         expect(hasChanged).toBe(true)
-        expect(newApplication.answers.personalAllowanceFromSpouse).toEqual(null)
+        expect(newApplication.answers.personalAllowanceFromSpouse).toEqual(
+          undefined,
+        )
       })
 
-      it('should remove allowance useAll and usage on submit, if usePersonalAllowance is equal to NO', () => {
+      it('should remove personalAllowance on submit, if usePersonalAllowance is equal to NO  and personalAllowance exists', () => {
         const helper = new ApplicationTemplateHelper(
           buildApplication({
             answers: {
@@ -271,7 +273,7 @@ describe('Parental Leave Application Template', () => {
           type: DefaultEvents.SUBMIT,
         })
         expect(hasChanged).toBe(true)
-        expect(newApplication.answers.personalAllowance).toEqual(null)
+        expect(newApplication.answers.personalAllowance).toEqual(undefined)
       })
 
       it('should set usage to 100 if useAsMuchAsPossible in personalAllowance is set to YES', () => {

--- a/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.spec.ts
+++ b/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.spec.ts
@@ -248,9 +248,9 @@ describe('Parental Leave Application Template', () => {
           type: DefaultEvents.SUBMIT,
         })
         expect(hasChanged).toBe(true)
-        expect(newApplication.answers.personalAllowanceFromSpouse).toEqual(
-          undefined,
-        )
+        expect(
+          newApplication.answers.personalAllowanceFromSpouse,
+        ).toBeUndefined()
       })
 
       it('should remove personalAllowance on submit, if usePersonalAllowance is equal to NO  and personalAllowance exists', () => {
@@ -273,7 +273,7 @@ describe('Parental Leave Application Template', () => {
           type: DefaultEvents.SUBMIT,
         })
         expect(hasChanged).toBe(true)
-        expect(newApplication.answers.personalAllowance).toEqual(undefined)
+        expect(newApplication.answers.personalAllowance).toBeUndefined()
       })
 
       it('should set usage to 100 if useAsMuchAsPossible in personalAllowance is set to YES', () => {

--- a/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.ts
+++ b/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.ts
@@ -105,10 +105,10 @@ const ParentalLeaveTemplate: ApplicationTemplate<
         entry: 'clearAssignees',
         exit: [
           'setOtherParentIdIfSelectedSpouse',
-          'clearPersonalAllowanceIfUsePersonalAllowanceIsNo',
-          'clearSpouseAllowanceIfUseSpouseAllowanceIsNo',
           'setPrivatePensionValuesIfUsePrivatePensionFundIsNO',
           'setUnionValuesIfUseUnionIsNO',
+          'clearPersonalAllowanceIfUsePersonalAllowanceIsNo',
+          'clearSpouseAllowanceIfUseSpouseAllowanceIsNo',
           'setPersonalUsageToHundredIfUseAsMuchAsPossibleIsYes',
           'setSpouseUsageToHundredIfUseAsMuchAsPossibleIsYes',
         ],
@@ -705,11 +705,10 @@ const ParentalLeaveTemplate: ApplicationTemplate<
 
         const answers = getApplicationAnswers(application.answers)
 
-        if (
-          answers.usePersonalAllowance === NO &&
-          (answers.personalUsage || answers.personalUseAsMuchAsPossible)
-        ) {
-          set(application.answers, 'personalAllowance', null)
+        if (answers.usePersonalAllowance === NO) {
+          if (application.answers.personalAllowance) {
+            unset(application.answers, 'personalAllowance')
+          }
         }
 
         return context
@@ -719,11 +718,10 @@ const ParentalLeaveTemplate: ApplicationTemplate<
 
         const answers = getApplicationAnswers(application.answers)
 
-        if (
-          answers.usePersonalAllowanceFromSpouse === NO &&
-          (answers.spouseUsage || answers.spouseUseAsMuchAsPossible)
-        ) {
-          set(application.answers, 'personalAllowanceFromSpouse', null)
+        if (answers.usePersonalAllowanceFromSpouse === NO) {
+          if (application.answers.personalAllowanceFromSpouse) {
+            unset(application.answers, 'personalAllowanceFromSpouse')
+          }
         }
 
         return context


### PR DESCRIPTION
## What

Remove personalAllowance if usePersonalAllowance is set to NO and personalAllowance exists
Remove personalAllowanceFromSpouse if usePersonalAllowanceFromSpouse is set to NO and personalAllowanceFromSpouse exists

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
