### PR TITLE
feat(j-s): Semi optional ruling

### DIFF
--- a/apps/judicial-system/backend/infra/judicial-system-backend.ts
+++ b/apps/judicial-system/backend/infra/judicial-system-backend.ts
@@ -1,5 +1,5 @@
 import { Base, JudicialSystem } from '../../../../infra/src/dsl/xroad'
-import { ref, service, ServiceBuilder } from '../../../../infra/src/dsl/dsl'
+import { service, ServiceBuilder } from '../../../../infra/src/dsl/dsl'
 
 const postgresInfo = {
   passwordSecret: '/k8s/judicial-system/DB_PASSWORD',

--- a/apps/judicial-system/web-e2e/src/integration/Court/InvestigationCases/courtRecord.spec.ts
+++ b/apps/judicial-system/web-e2e/src/integration/Court/InvestigationCases/courtRecord.spec.ts
@@ -143,48 +143,6 @@ describe(`${IC_COURT_RECORD_ROUTE}/:id`, () => {
     cy.getByTestid('sessionBookings').should('not.match', ':empty')
   })
 
-  it('should require a valid court location', () => {
-    const caseData = makeInvestigationCase()
-
-    const caseDataAddition: Case = {
-      ...caseData,
-      prosecutor: makeProsecutor(),
-      courtDate: '2021-12-16T10:50:04.033Z',
-    }
-
-    cy.stubAPIResponses()
-    cy.visit(`${IC_COURT_RECORD_ROUTE}/test_id_stadfest`)
-
-    intercept(caseDataAddition)
-
-    cy.wait('@gqlCaseQuery')
-    cy.getByTestid('courtLocation').clear().blur()
-    cy.getByTestid('inputErrorMessage').contains('Reitur má ekki vera tómur')
-    cy.getByTestid('courtLocation').type(faker.lorem.word())
-    cy.getByTestid('inputErrorMessage').should('not.exist')
-  })
-
-  it('should require valid session bookings', () => {
-    const caseData = makeInvestigationCase()
-
-    const caseDataAddition: Case = {
-      ...caseData,
-      prosecutor: makeProsecutor(),
-      courtDate: '2021-12-16T10:50:04.033Z',
-    }
-
-    cy.stubAPIResponses()
-    cy.visit(`${IC_COURT_RECORD_ROUTE}/test_id_stadfest`)
-
-    intercept(caseDataAddition)
-
-    cy.wait('@gqlCaseQuery')
-    cy.getByTestid('sessionBookings').clear().blur()
-    cy.getByTestid('inputErrorMessage').contains('Reitur má ekki vera tómur')
-    cy.getByTestid('sessionBookings').type(faker.lorem.words(5))
-    cy.getByTestid('inputErrorMessage').should('not.exist')
-  })
-
   it('should not allow users to continue if conclusion is not set', () => {
     const caseData = makeInvestigationCase()
 
@@ -193,6 +151,7 @@ describe(`${IC_COURT_RECORD_ROUTE}/:id`, () => {
       prosecutor: makeProsecutor(),
       courtDate: '2021-12-16T10:50:04.033Z',
       decision: CaseDecision.ACCEPTING,
+      conclusion: undefined,
     }
 
     cy.stubAPIResponses()
@@ -200,7 +159,10 @@ describe(`${IC_COURT_RECORD_ROUTE}/:id`, () => {
 
     intercept(caseDataAddition)
 
-    cy.getByTestid('continueButton').should('not.exist')
+    cy.getByTestid('formFooter')
+      .children()
+      .getByTestid('infobox')
+      .should('exist')
   })
 
   it('should not allow users to continue if decision is not set', () => {
@@ -211,6 +173,7 @@ describe(`${IC_COURT_RECORD_ROUTE}/:id`, () => {
       prosecutor: makeProsecutor(),
       courtDate: '2021-12-16T10:50:04.033Z',
       conclusion: faker.lorem.words(5),
+      decision: undefined,
     }
 
     cy.stubAPIResponses()
@@ -218,7 +181,30 @@ describe(`${IC_COURT_RECORD_ROUTE}/:id`, () => {
 
     intercept(caseDataAddition)
 
-    cy.getByTestid('continueButton').should('not.exist')
+    cy.getByTestid('formFooter')
+      .children()
+      .getByTestid('infobox')
+      .should('exist')
+  })
+
+  it('should not allow users to continue if ruling is not set', () => {
+    const caseData = makeInvestigationCase()
+    const caseDataAddition: Case = {
+      ...caseData,
+      prosecutor: makeProsecutor(),
+      courtDate: '2021-12-16T10:50:04.033Z',
+      conclusion: faker.lorem.words(5),
+      decision: CaseDecision.ACCEPTING,
+      ruling: undefined,
+    }
+
+    cy.visit(`${IC_COURT_RECORD_ROUTE}/test_id_stadfest`)
+    intercept(caseDataAddition)
+
+    cy.getByTestid('formFooter')
+      .children()
+      .getByTestid('infobox')
+      .should('exist')
   })
 
   it('should navigate to the next step when all input data is valid and the continue button is clicked', () => {
@@ -230,6 +216,7 @@ describe(`${IC_COURT_RECORD_ROUTE}/:id`, () => {
       courtDate: '2021-12-16T10:50:04.033Z',
       decision: CaseDecision.ACCEPTING,
       conclusion: faker.lorem.words(5),
+      ruling: faker.lorem.words(5),
     }
 
     cy.stubAPIResponses()

--- a/apps/judicial-system/web-e2e/src/integration/Court/InvestigationCases/ruling.spec.ts
+++ b/apps/judicial-system/web-e2e/src/integration/Court/InvestigationCases/ruling.spec.ts
@@ -1,6 +1,10 @@
 import faker from 'faker'
 
-import { IC_RULING_ROUTE } from '@island.is/judicial-system/consts'
+import {
+  IC_COURT_RECORD_ROUTE,
+  IC_RULING_ROUTE,
+} from '@island.is/judicial-system/consts'
+import { Case } from '@island.is/judicial-system/types'
 
 import { makeInvestigationCase, intercept } from '../../../utils'
 
@@ -27,5 +31,60 @@ describe(`${IC_RULING_ROUTE}/:id`, () => {
     cy.get('#case-decision-rejecting').click()
 
     cy.get('[name="conclusion"]').should('match', ':empty')
+  })
+
+  it('should navigate to the next step when all input data is valid and the continue button is clicked', () => {
+    const caseData = makeInvestigationCase()
+    const caseDataAddition: Case = {
+      ...caseData,
+      caseFacts: 'lorem ipsum',
+      legalArguments: 'lorem ipsum',
+      demands:
+        'Þess er krafist að Donald Duck, kt. 000000-0000, sæti gæsluvarðhaldi með úrskurði Héraðsdóms Reykjavíkur, til miðvikudagsins 16. september 2020, kl. 19:50, og verði gert að sæta einangrun á meðan á varðhaldi stendur.',
+    }
+    cy.visit(`${IC_RULING_ROUTE}/test_id_stadfest`)
+
+    intercept(caseDataAddition)
+    cy.wait('@gqlCaseQuery')
+
+    // Introduction validation
+    cy.getByTestid('introduction').invoke('val').should('not.be.empty')
+    cy.getByTestid('introduction').clear()
+    cy.clickOutside()
+    cy.getByTestid('inputErrorMessage').contains('Reitur má ekki vera tómur')
+    cy.getByTestid('introduction').type('lorem')
+    cy.getByTestid('inputErrorMessage').should('not.exist')
+
+    // Prosecutor demands validation
+    cy.getByTestid('prosecutorDemands').invoke('val').should('not.be.empty')
+    cy.getByTestid('prosecutorDemands').clear()
+    cy.clickOutside()
+    cy.getByTestid('inputErrorMessage').contains('Reitur má ekki vera tómur')
+    cy.getByTestid('prosecutorDemands').type('lorem')
+    cy.getByTestid('inputErrorMessage').should('not.exist')
+
+    // Court case facts validation
+    cy.getByTestid('courtCaseFacts').invoke('val').should('not.be.empty')
+    cy.getByTestid('courtCaseFacts').clear()
+    cy.clickOutside()
+    cy.getByTestid('inputErrorMessage').contains('Reitur má ekki vera tómur')
+    cy.getByTestid('courtCaseFacts').type('lorem')
+    cy.getByTestid('inputErrorMessage').should('not.exist')
+
+    // Legal arguments validation
+    cy.getByTestid('courtLegalArguments').invoke('val').should('not.be.empty')
+    cy.getByTestid('courtLegalArguments').clear()
+    cy.clickOutside()
+    cy.getByTestid('inputErrorMessage').contains('Reitur má ekki vera tómur')
+    cy.getByTestid('courtLegalArguments').type('lorem')
+    cy.getByTestid('inputErrorMessage').should('not.exist')
+
+    // Ruling should be autofilled but not required
+    cy.getByTestid('ruling').invoke('val').should('not.be.empty')
+    cy.getByTestid('ruling').clear()
+
+    cy.get('#case-decision-accepting').check()
+    cy.getByTestid('continueButton').should('not.be.disabled').click()
+    cy.url().should('include', IC_COURT_RECORD_ROUTE)
   })
 })

--- a/apps/judicial-system/web-e2e/src/integration/Court/RestrictionCases/courtRecord.spec.ts
+++ b/apps/judicial-system/web-e2e/src/integration/Court/RestrictionCases/courtRecord.spec.ts
@@ -107,6 +107,7 @@ describe(`${COURT_RECORD_ROUTE}/:id`, () => {
       decision: CaseDecision.ACCEPTING,
       courtDate: '2020-09-16T19:50:08.033Z',
       conclusion: faker.lorem.words(5),
+      ruling: faker.lorem.words(5),
     }
 
     cy.visit(`${COURT_RECORD_ROUTE}/test_id_stadfest`)
@@ -130,6 +131,7 @@ describe(`${COURT_RECORD_ROUTE}/:id`, () => {
       prosecutor: makeProsecutor(),
       courtDate: '2021-12-16T10:50:04.033Z',
       decision: CaseDecision.ACCEPTING,
+      conclusion: undefined,
     }
 
     cy.stubAPIResponses()
@@ -137,7 +139,10 @@ describe(`${COURT_RECORD_ROUTE}/:id`, () => {
 
     intercept(caseDataAddition)
 
-    cy.getByTestid('continueButton').should('not.exist')
+    cy.getByTestid('formFooter')
+      .children()
+      .getByTestid('infobox')
+      .should('exist')
   })
 
   it('should not allow users to continue if decision is not set', () => {
@@ -148,6 +153,7 @@ describe(`${COURT_RECORD_ROUTE}/:id`, () => {
       prosecutor: makeProsecutor(),
       courtDate: '2021-12-16T10:50:04.033Z',
       conclusion: faker.lorem.words(5),
+      decision: undefined,
     }
 
     cy.stubAPIResponses()
@@ -155,7 +161,30 @@ describe(`${COURT_RECORD_ROUTE}/:id`, () => {
 
     intercept(caseDataAddition)
 
-    cy.getByTestid('continueButton').should('not.exist')
+    cy.getByTestid('formFooter')
+      .children()
+      .getByTestid('infobox')
+      .should('exist')
+  })
+
+  it('should not allow users to continue if ruling is not set', () => {
+    const caseData = makeRestrictionCase()
+    const caseDataAddition: Case = {
+      ...caseData,
+      prosecutor: makeProsecutor(),
+      courtDate: '2021-12-16T10:50:04.033Z',
+      conclusion: faker.lorem.words(5),
+      decision: CaseDecision.ACCEPTING,
+      ruling: undefined,
+    }
+
+    cy.visit(`${COURT_RECORD_ROUTE}/test_id_stadfest`)
+    intercept(caseDataAddition)
+
+    cy.getByTestid('formFooter')
+      .children()
+      .getByTestid('infobox')
+      .should('exist')
   })
 
   it('should navigate to the next step when all input data is valid and the continue button is clicked', () => {
@@ -167,6 +196,7 @@ describe(`${COURT_RECORD_ROUTE}/:id`, () => {
       decision: CaseDecision.ACCEPTING,
       courtDate: '2020-09-16T19:50:08.033Z',
       conclusion: faker.lorem.words(5),
+      ruling: faker.lorem.words(5),
     }
 
     cy.visit(`${COURT_RECORD_ROUTE}/test_id_stadfest`)

--- a/apps/judicial-system/web-e2e/src/integration/Court/RestrictionCases/ruling.spec.ts
+++ b/apps/judicial-system/web-e2e/src/integration/Court/RestrictionCases/ruling.spec.ts
@@ -29,48 +29,6 @@ describe(`${RULING_ROUTE}/:id`, () => {
     )
   })
 
-  it('should require a valid introduction', () => {
-    const caseData = makeRestrictionCase()
-    const caseDataAddition: Case = {
-      ...caseData,
-      courtDate: '2020-12-22T11:23:00.000Z',
-    }
-
-    cy.visit(`${RULING_ROUTE}/test_id_stadfest`)
-
-    intercept(caseDataAddition)
-
-    cy.wait('@gqlCaseQuery')
-    cy.getByTestid('introduction').invoke('val').should('not.be.empty')
-    cy.getByTestid('introduction').clear()
-    cy.clickOutside()
-    cy.getByTestid('inputErrorMessage').contains('Reitur má ekki vera tómur')
-    cy.getByTestid('introduction').type('lorem')
-    cy.getByTestid('inputErrorMessage').should('not.exist')
-  })
-
-  it('should require a valid ruling', () => {
-    const caseData = makeRestrictionCase()
-    const caseDataAddition: Case = {
-      ...caseData,
-      caseFacts: 'lorem ipsum',
-      legalArguments: 'lorem ipsum',
-      demands:
-        'Þess er krafist að Donald Duck, kt. 000000-0000, sæti gæsluvarðhaldi með úrskurði Héraðsdóms Reykjavíkur, til miðvikudagsins 16. september 2020, kl. 19:50, og verði gert að sæta einangrun á meðan á varðhaldi stendur.',
-    }
-    cy.visit(`${RULING_ROUTE}/test_id_stadfest`)
-
-    intercept(caseDataAddition)
-
-    cy.wait('@gqlCaseQuery')
-    cy.getByTestid('ruling').invoke('val').should('not.be.empty')
-    cy.getByTestid('ruling').clear()
-    cy.clickOutside()
-    cy.getByTestid('inputErrorMessage').contains('Reitur má ekki vera tómur')
-    cy.getByTestid('ruling').type('lorem')
-    cy.getByTestid('inputErrorMessage').should('not.exist')
-  })
-
   it('should show appropriate valid to dates based on decision', () => {
     const caseData = makeRestrictionCase()
     const caseDataAddition: Case = {
@@ -121,10 +79,46 @@ describe(`${RULING_ROUTE}/:id`, () => {
     cy.visit(`${RULING_ROUTE}/test_id_stadfest`)
 
     intercept(caseDataAddition)
+    cy.wait('@gqlCaseQuery')
 
-    cy.getByTestid('ruling').type('lorem')
+    // Introduction validation
+    cy.getByTestid('introduction').invoke('val').should('not.be.empty')
+    cy.getByTestid('introduction').clear()
+    cy.clickOutside()
+    cy.getByTestid('inputErrorMessage').contains('Reitur má ekki vera tómur')
+    cy.getByTestid('introduction').type('lorem')
+    cy.getByTestid('inputErrorMessage').should('not.exist')
+
+    // Prosecutor demands validation
+    cy.getByTestid('prosecutorDemands').invoke('val').should('not.be.empty')
+    cy.getByTestid('prosecutorDemands').clear()
+    cy.clickOutside()
+    cy.getByTestid('inputErrorMessage').contains('Reitur má ekki vera tómur')
+    cy.getByTestid('prosecutorDemands').type('lorem')
+    cy.getByTestid('inputErrorMessage').should('not.exist')
+
+    // Court case facts validation
+    cy.getByTestid('courtCaseFacts').invoke('val').should('not.be.empty')
+    cy.getByTestid('courtCaseFacts').clear()
+    cy.clickOutside()
+    cy.getByTestid('inputErrorMessage').contains('Reitur má ekki vera tómur')
+    cy.getByTestid('courtCaseFacts').type('lorem')
+    cy.getByTestid('inputErrorMessage').should('not.exist')
+
+    // Legal arguments validation
+    cy.getByTestid('courtLegalArguments').invoke('val').should('not.be.empty')
+    cy.getByTestid('courtLegalArguments').clear()
+    cy.clickOutside()
+    cy.getByTestid('inputErrorMessage').contains('Reitur má ekki vera tómur')
+    cy.getByTestid('courtLegalArguments').type('lorem')
+    cy.getByTestid('inputErrorMessage').should('not.exist')
+
+    // Ruling should be autofilled but not required
+    cy.getByTestid('ruling').invoke('val').should('not.be.empty')
+    cy.getByTestid('ruling').clear()
+
     cy.get('#case-decision-accepting').check()
-    cy.getByTestid('continueButton').click()
+    cy.getByTestid('continueButton').should('not.be.disabled').click()
     cy.url().should('include', COURT_RECORD_ROUTE)
   })
 })

--- a/apps/judicial-system/web/src/components/ConclusionDraft/ConclusionDraft.tsx
+++ b/apps/judicial-system/web/src/components/ConclusionDraft/ConclusionDraft.tsx
@@ -107,7 +107,6 @@ const ConclusionDraft: React.FC<Props> = (props) => {
       <RulingInput
         workingCase={workingCase}
         setWorkingCase={setWorkingCase}
-        isRequired
         rows={12}
       />
     </>

--- a/apps/judicial-system/web/src/components/FormFooter/FormFooter.tsx
+++ b/apps/judicial-system/web/src/components/FormFooter/FormFooter.tsx
@@ -37,7 +37,12 @@ const FormFooter: React.FC<Props> = (props: Props) => {
   const isMobile = width <= theme.breakpoints.md
 
   return (
-    <Box display="flex" justifyContent="spaceBetween" alignItems="center">
+    <Box
+      display="flex"
+      justifyContent="spaceBetween"
+      alignItems="center"
+      data-testid="formFooter"
+    >
       <Box className={styles.footerItem}>
         <Button
           variant="ghost"

--- a/apps/judicial-system/web/src/components/RulingInput/RulingInput.tsx
+++ b/apps/judicial-system/web/src/components/RulingInput/RulingInput.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react'
-import { Input } from '@island.is/island-ui/core'
+import React from 'react'
 import { useIntl } from 'react-intl'
 
+import { Input } from '@island.is/island-ui/core'
 import { Case } from '@island.is/judicial-system/types'
 import { ruling as m } from '@island.is/judicial-system-web/messages'
 
@@ -15,15 +15,13 @@ import useDeb from '../../utils/hooks/useDeb'
 interface Props {
   workingCase: Case
   setWorkingCase: React.Dispatch<React.SetStateAction<Case>>
-  isRequired: boolean
   rows?: number
 }
 
 const RulingInput: React.FC<Props> = (props) => {
-  const { workingCase, setWorkingCase, isRequired, rows } = props
+  const { workingCase, setWorkingCase, rows } = props
   const { updateCase } = useCase()
   const { formatMessage } = useIntl()
-  const [rulingErrorMessage, setRulingErrorMessage] = useState('')
 
   useDeb(workingCase, 'ruling')
 
@@ -34,28 +32,22 @@ const RulingInput: React.FC<Props> = (props) => {
       label={formatMessage(m.label)}
       placeholder={formatMessage(m.placeholder)}
       value={workingCase.ruling || ''}
-      errorMessage={rulingErrorMessage}
-      hasError={rulingErrorMessage !== ''}
-      required={isRequired}
       onChange={(event) =>
         removeTabsValidateAndSet(
           'ruling',
           event.target.value,
-          ['empty'],
+          [],
           workingCase,
           setWorkingCase,
-          rulingErrorMessage,
-          setRulingErrorMessage,
         )
       }
       onBlur={(event) =>
         validateAndSendToServer(
           'ruling',
           event.target.value,
-          ['empty'],
+          [],
           workingCase,
           updateCase,
-          setRulingErrorMessage,
         )
       }
       textarea

--- a/apps/judicial-system/web/src/routes/Court/InvestigationCase/CourtRecord/CourtRecordForm.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationCase/CourtRecord/CourtRecordForm.tsx
@@ -715,9 +715,15 @@ const CourtRecordForm: React.FC<Props> = (props) => {
           nextIsLoading={isLoading}
           nextUrl={`${Constants.IC_CONFIRMATION_ROUTE}/${workingCase.id}`}
           nextIsDisabled={!isCourtRecordStepValidIC(workingCase)}
-          hideNextButton={!workingCase.decision || !workingCase.conclusion}
+          hideNextButton={
+            !workingCase.decision ||
+            !workingCase.conclusion ||
+            !workingCase.ruling
+          }
           infoBoxText={
-            !workingCase.decision || !workingCase.conclusion
+            !workingCase.decision ||
+            !workingCase.conclusion ||
+            !workingCase.ruling
               ? formatMessage(m.nextButtonInfo)
               : ''
           }

--- a/apps/judicial-system/web/src/routes/Court/InvestigationCase/Ruling/Ruling.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationCase/Ruling/Ruling.tsx
@@ -380,7 +380,6 @@ const Ruling = () => {
           <RulingInput
             workingCase={workingCase}
             setWorkingCase={setWorkingCase}
-            isRequired
           />
         </Box>
         <Box component="section" marginBottom={5}>

--- a/apps/judicial-system/web/src/routes/Court/RestrictionCase/CourtRecord/CourtRecord.tsx
+++ b/apps/judicial-system/web/src/routes/Court/RestrictionCase/CourtRecord/CourtRecord.tsx
@@ -985,9 +985,15 @@ export const CourtRecord: React.FC = () => {
           previousUrl={`${Constants.RULING_ROUTE}/${workingCase.id}`}
           nextUrl={`${Constants.CONFIRMATION_ROUTE}/${id}`}
           nextIsDisabled={!isCourtRecordStepValidRC(workingCase)}
-          hideNextButton={!workingCase.decision || !workingCase.conclusion}
+          hideNextButton={
+            !workingCase.decision ||
+            !workingCase.conclusion ||
+            !workingCase.ruling
+          }
           infoBoxText={
-            !workingCase.decision || !workingCase.conclusion
+            !workingCase.decision ||
+            !workingCase.conclusion ||
+            !workingCase.ruling
               ? formatMessage(m.nextButtonInfo)
               : ''
           }

--- a/apps/judicial-system/web/src/routes/Court/RestrictionCase/Ruling/Ruling.tsx
+++ b/apps/judicial-system/web/src/routes/Court/RestrictionCase/Ruling/Ruling.tsx
@@ -510,7 +510,6 @@ export const Ruling: React.FC = () => {
           <RulingInput
             workingCase={workingCase}
             setWorkingCase={setWorkingCase}
-            isRequired
           />
         </Box>
         <Box component="section" marginBottom={5}>

--- a/apps/judicial-system/web/src/utils/validate.ts
+++ b/apps/judicial-system/web/src/utils/validate.ts
@@ -253,8 +253,7 @@ export const isRulingValidIC = (workingCase: Case) => {
   return (
     validate(workingCase.prosecutorDemands || '', 'empty').isValid &&
     validate(workingCase.courtCaseFacts || '', 'empty').isValid &&
-    validate(workingCase.courtLegalArguments || '', 'empty').isValid &&
-    validate(workingCase.ruling || '', 'empty').isValid
+    validate(workingCase.courtLegalArguments || '', 'empty').isValid
   )
 }
 
@@ -285,7 +284,8 @@ export const isCourtRecordStepValidIC = (workingCase: Case) => {
     validate(workingCase.courtEndTime || '', 'empty').isValid &&
     validate(workingCase.courtEndTime || '', 'date-format').isValid &&
     validate(workingCase.decision || '', 'empty').isValid &&
-    validate(workingCase.conclusion || '', 'empty').isValid
+    validate(workingCase.conclusion || '', 'empty').isValid &&
+    validate(workingCase.ruling || '', 'empty').isValid
   )
 }
 

--- a/apps/judicial-system/web/src/utils/validate.ts
+++ b/apps/judicial-system/web/src/utils/validate.ts
@@ -245,8 +245,7 @@ export const isRulingValidRC = (workingCase: Case) => {
   return (
     validate(workingCase.prosecutorDemands || '', 'empty').isValid &&
     validate(workingCase.courtCaseFacts || '', 'empty').isValid &&
-    validate(workingCase.courtLegalArguments || '', 'empty').isValid &&
-    validate(workingCase.ruling || '', 'empty').isValid
+    validate(workingCase.courtLegalArguments || '', 'empty').isValid
   )
 }
 

--- a/apps/judicial-system/web/src/utils/validate.ts
+++ b/apps/judicial-system/web/src/utils/validate.ts
@@ -269,7 +269,8 @@ export const isCourtRecordStepValidRC = (workingCase: Case) => {
     validate(workingCase.courtEndTime || '', 'empty').isValid &&
     validate(workingCase.courtEndTime || '', 'date-format').isValid &&
     validate(workingCase.decision || '', 'empty').isValid &&
-    validate(workingCase.conclusion || '', 'empty').isValid
+    validate(workingCase.conclusion || '', 'empty').isValid &&
+    validate(workingCase.ruling || '', 'empty').isValid
   )
 }
 


### PR DESCRIPTION
# Semi optional ruling

[Asana](https://app.asana.com/0/1199153462262248/1202252374368501/f)

## What

Make the ruling field optional on the ruling page but don't allow the users to go past the courtRecord screen if they have not filled in the ruling.

## Why

It's common for court users to work on the ruling and court record screens simultaneously so they need to be able to move back and fourth on these screens without having filled everything out. 

## Screenshots / Gifs

https://user-images.githubusercontent.com/3789875/170267494-79787d59-0141-4849-8e6d-3cb9c4568303.mov

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
