### PR TITLE
feat(web): Pushed the Chat bubble up in the mobile view

### DIFF
--- a/apps/web/components/ChatPanel/BoostChatPanel/BoostChatPanel.tsx
+++ b/apps/web/components/ChatPanel/BoostChatPanel/BoostChatPanel.tsx
@@ -73,7 +73,6 @@ export const BoostChatPanel: React.FC<BoostChatPanelProps> = ({
     <ChatBubble
       text={'Hæ, get ég aðstoðað?'}
       onClick={() => window.boost.chatPanel.show()}
-      pushUp={pushUp}
       isVisible={showButton}
     />
   )

--- a/apps/web/components/ChatPanel/ChatBubble/ChatBubble.tsx
+++ b/apps/web/components/ChatPanel/ChatBubble/ChatBubble.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import cn from 'classnames'
 import { FocusableBox, Text } from '@island.is/island-ui/core'
 import * as styles from './ChatBubble.css'
+import { useWindowSize } from '@island.is/web/hooks/useViewport'
+import { theme } from '@island.is/island-ui/theme'
 
 interface ChatBubbleProps {
   text: string
@@ -12,16 +14,19 @@ interface ChatBubbleProps {
 
 export const ChatBubble = ({
   text,
-  pushUp = false,
   isVisible = true,
   onClick,
 }: ChatBubbleProps) => {
+  const { width } = useWindowSize()
+
+  const isMobile = width < theme.breakpoints.md
+
   return (
     <div className={cn(styles.root, { [styles.hidden]: !isVisible })}>
       <FocusableBox
         component="button"
         tabIndex={0}
-        className={cn(styles.message, pushUp && styles.messagePushUp)}
+        className={cn(styles.message, isMobile && styles.messagePushUp)}
         onClick={onClick}
       >
         <Text variant="h5" color="white">


### PR DESCRIPTION
# Pushed the Chat bubble up in the mobile view

## What

* Relocated the chat bubble in the mobile view

## Why

* So the chat bubble doesn't cover the application button in the mobile view

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/43557895/170664707-a18ae8dc-2ab1-439c-96e2-86df04fca621.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
