### PR TITLE
feat(web): Only relocate ChatBubble when an article that contains a process entry is viewed in mobile

### DIFF
--- a/apps/web/components/ChatPanel/ChatBubble/ChatBubble.tsx
+++ b/apps/web/components/ChatPanel/ChatBubble/ChatBubble.tsx
@@ -2,8 +2,6 @@ import React from 'react'
 import cn from 'classnames'
 import { FocusableBox, Text } from '@island.is/island-ui/core'
 import * as styles from './ChatBubble.css'
-import { useWindowSize } from '@island.is/web/hooks/useViewport'
-import { theme } from '@island.is/island-ui/theme'
 
 interface ChatBubbleProps {
   text: string
@@ -16,17 +14,14 @@ export const ChatBubble = ({
   text,
   isVisible = true,
   onClick,
+  pushUp = false,
 }: ChatBubbleProps) => {
-  const { width } = useWindowSize()
-
-  const isMobile = width < theme.breakpoints.md
-
   return (
     <div className={cn(styles.root, { [styles.hidden]: !isVisible })}>
       <FocusableBox
         component="button"
         tabIndex={0}
-        className={cn(styles.message, isMobile && styles.messagePushUp)}
+        className={cn(styles.message, pushUp && styles.messagePushUp)}
         onClick={onClick}
       >
         <Text variant="h5" color="white">

--- a/apps/web/components/ChatPanel/WatsonChatPanel/WatsonChatPanel.tsx
+++ b/apps/web/components/ChatPanel/WatsonChatPanel/WatsonChatPanel.tsx
@@ -23,6 +23,7 @@ export const WatsonChatPanel = (props: WatsonChatPanelProps) => {
     cssVariables,
     namespaceKey,
     onLoad,
+    pushUp = false,
   } = props
 
   const { data } = useQuery<Query, QueryGetNamespaceArgs>(GET_NAMESPACE_QUERY, {
@@ -90,6 +91,7 @@ export const WatsonChatPanel = (props: WatsonChatPanelProps) => {
       text={n('chatBubbleText', 'Hæ, get ég aðstoðað?')}
       isVisible={isButtonVisible}
       onClick={watsonInstance.current?.openWindow}
+      pushUp={pushUp}
     />
   )
 }

--- a/apps/web/components/ChatPanel/types.ts
+++ b/apps/web/components/ChatPanel/types.ts
@@ -28,6 +28,9 @@ export interface WatsonChatPanelProps {
 
   // Whether the default launcher is shown
   showLauncher?: boolean
+
+  // If don't use the default launcher that IBM Watson provides, should the chat bubble launcher be pushed up?
+  pushUp?: boolean
 }
 
 export type WatsonIntegration =

--- a/apps/web/screens/Article/components/ArticleChatPanel/ArticleChatPanel.tsx
+++ b/apps/web/screens/Article/components/ArticleChatPanel/ArticleChatPanel.tsx
@@ -28,12 +28,16 @@ export const ArticleChatPanel = ({
   }
   // Watson
   else if (article.id in watsonConfig) {
-    Component = <WatsonChatPanel {...watsonConfig[article.id]} />
+    Component = (
+      <WatsonChatPanel {...watsonConfig[article.id]} pushUp={pushUp} />
+    )
   } else if (article.organization?.some((o) => o.id in watsonConfig)) {
     const organizationId = article.organization.find(
       (o) => o.id in watsonConfig,
     ).id
-    Component = <WatsonChatPanel {...watsonConfig[organizationId]} />
+    Component = (
+      <WatsonChatPanel {...watsonConfig[organizationId]} pushUp={pushUp} />
+    )
   }
   // Boost
   else if (article.organization?.some((o) => o.id in boostChatPanelEndpoints)) {
@@ -44,7 +48,7 @@ export const ArticleChatPanel = ({
   }
   // If none of the above then use the default watson chat bot
   else {
-    Component = <WatsonChatPanel {...defaultWatsonConfig} />
+    Component = <WatsonChatPanel {...defaultWatsonConfig} pushUp={pushUp} />
   }
 
   return Component


### PR DESCRIPTION
# Only relocate ChatBubble when an article that contains a process entry is viewed in mobile

## What

* As of right now the ChatBubble is always moved up when island.is enters the mobile width, this change only relocates the chat bubble when a process entry banner appears on an article

## Screenshots / Gifs


https://user-images.githubusercontent.com/43557895/170684337-1f2bfe07-de76-4ced-a665-919c1c987f87.mp4



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
