### PR TITLE
fix(auth-react): Remove access_token revocation token type

### DIFF
--- a/libs/auth/react/src/lib/AuthSettings.spec.ts
+++ b/libs/auth/react/src/lib/AuthSettings.spec.ts
@@ -23,7 +23,6 @@ describe('mergeAuthSettings', () => {
         "redirectPathSilent": "/auth/callback-silent",
         "response_type": "code",
         "revokeTokenTypes": Array [
-          "access_token",
           "refresh_token",
         ],
         "revokeTokensOnSignout": true,

--- a/libs/auth/react/src/lib/AuthSettings.ts
+++ b/libs/auth/react/src/lib/AuthSettings.ts
@@ -62,7 +62,7 @@ export const mergeAuthSettings = (settings: AuthSettings): AuthSettings => {
     silent_redirect_uri: `${baseUrl}${redirectPathSilent}`,
     post_logout_redirect_uri: baseUrl,
     response_type: 'code',
-    revokeTokenTypes: ['access_token', 'refresh_token'],
+    revokeTokenTypes: ['refresh_token'],
     revokeTokensOnSignout: true,
     loadUserInfo: true,
     monitorSession: onIdsDomain,


### PR DESCRIPTION
## What

As we do not use reference access tokens, we should not be calling revocation on the access tokens, only refresh tokens.

## Why

This results in 404 errors in auth-api when trying to look for access_token as reference token on revocation.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
