### PR TITLE
fix(island-ui): add mobile GridContainer padding again that was recently removed

### DIFF
--- a/libs/island-ui/core/src/lib/Grid/GridContainer/GridContainer.css.ts
+++ b/libs/island-ui/core/src/lib/Grid/GridContainer/GridContainer.css.ts
@@ -6,6 +6,8 @@ export const root = style({
   boxSizing: 'border-box',
   margin: '0 auto',
   maxWidth: theme.breakpoints.xl,
+  paddingLeft: theme.grid.gutter.mobile * 2,
+  paddingRight: theme.grid.gutter.mobile * 2,
   width: '100%',
   selectors: {
     // Opt out of horizontal padding on nested grids

--- a/yarn.lock
+++ b/yarn.lock
@@ -2499,6 +2499,11 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.7.tgz#6099720c8839ca865a2637e6c85852ead0bdb595"
   integrity sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==
 
+"@babel/parser@^7.13.0", "@babel/parser@^7.13.10", "@babel/parser@^7.14.5", "@babel/parser@^7.14.6", "@babel/parser@^7.14.7", "@babel/parser@^7.15.4", "@babel/parser@^7.16.0", "@babel/parser@^7.16.5":
+  version "7.18.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.3.tgz#39e99c7b0c4c56cef4d1eed8de9f506411c2ebc2"
+  integrity sha512-rL50YcEuHbbauAFAysNsJA4/f89fGTOBRNs9P81sniKnKAr4xULe5AecolcsKbi88xu0ByWYDj/S1AJ3FSFuSQ==
+
 "@babel/parser@^7.15.8":
   version "7.15.8"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.15.8.tgz#7bacdcbe71bdc3ff936d510c15dcea7cf0b99016"


### PR DESCRIPTION
## What

Add padding to `GridContainer` that was removed with [this change](https://github.com/island-is/island.is/commit/06b1d8beeb3afd2dbd064f686a232af936cda6bd#diff-80b1aa19cefce2ff45e548154501bd10fe9be4998facfa7edc7cd9981809380fL9) in this PR: https://github.com/island-is/island.is/pull/7383

## Why

I was asked to look into why the padding had disappeared on island.is when looking at the site in mobile (below 767px).

## Screenshots / Gifs

### Currently
<img width="357" alt="image" src="https://user-images.githubusercontent.com/8450096/170715171-4cecd811-0a02-471d-b8c9-dea0faef2756.png">

### After this change
<img width="357" alt="image" src="https://user-images.githubusercontent.com/8450096/170715339-6ed766db-0afc-45b5-b4b9-cd85fb0cb101.png">

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
