### PR TITLE
chore(service-portal): Remove vehicle detail title. Update some default strings

### DIFF
--- a/libs/service-portal/core/src/lib/messages.ts
+++ b/libs/service-portal/core/src/lib/messages.ts
@@ -238,7 +238,7 @@ export const m = defineMessages({
   },
   greetingIntro: {
     defaultMessage:
-      'Síðan er í þróun með þarfir notanda að leiðarljósi. Ef þú finnur ekki þá þjónustu sem var á eldri Mínum síðum getur þú fundið þær upplýsingar á eldri útgáfu.',
+      'Á Mínum síðum Ísland.is er markmiðið að auka þægindi og gegnsæi upplýsinga fyrir einstaklinga og fyrirtæki. Hér má finna sundurliðun skulda hjá ríkissjóði, upplýsingar úr fasteignaskrá, upplýsingar úr ökutækjaskrá og fleira sem nálgast má í valmyndinni hér til hliðar.',
     id: 'service.portal:greeting-intro',
   },
   olderVersion: {

--- a/libs/service-portal/information/src/lib/messages.ts
+++ b/libs/service-portal/information/src/lib/messages.ts
@@ -95,7 +95,7 @@ export const spmm = {
     subtitle: {
       id: 'sp.company:company-subtitle',
       defaultMessage:
-        'Hér fyrir neðan eru þín gögn sem hafa verið sótt frá Ríkisskattstjóra.',
+        'Hér má nálgast upplýsingar úr fyrirtækjaskrá hjá Skattinum.',
     },
     name: {
       id: 'sp.company:name',

--- a/libs/service-portal/vehicles/src/lib/messages.ts
+++ b/libs/service-portal/vehicles/src/lib/messages.ts
@@ -15,7 +15,7 @@ export const messages = defineMessages({
   },
   intro: {
     id: 'sp.vehicles:vehicles-intro',
-    defaultMessage: `Hér færðu upplýsingar úr ökutækjaskrá um ökutæki sem þú ert skráð/ur eigandi að.`,
+    defaultMessage: `Hér má nálgast upplýsingar um þín ökutæki úr ökutækjaskrá Samgöngustofu.`,
   },
   clearFilter: {
     id: 'sp.vehicles:clear-filters',
@@ -24,11 +24,6 @@ export const messages = defineMessages({
   notFound: {
     id: 'sp.vehicles:not-found',
     defaultMessage: 'Ökutæki fannst ekki',
-  },
-  introDetail: {
-    id: 'sp.vehicles:data-info-detail',
-    defaultMessage:
-      'Hér færðu upplýsingar úr ökutækjaskrá um ökutæki sem þú er skráð/ur eigandi að. ',
   },
   infoNote: {
     id: 'sp.vehicles:detail-info-note',

--- a/libs/service-portal/vehicles/src/screens/VehicleDetail/VehicleDetail.tsx
+++ b/libs/service-portal/vehicles/src/screens/VehicleDetail/VehicleDetail.tsx
@@ -79,7 +79,6 @@ const VehicleDetail: ServicePortalModuleComponent = ({ userInfo }) => {
                   mainInfo?.model + ' ' + mainInfo?.subModel + ' ' + year
                 )}
               </Text>
-              <Text>{formatMessage(messages.introDetail)}</Text>
             </Stack>
           </GridColumn>
         </GridRow>


### PR DESCRIPTION
## What

* Remove vehicle detail subtitle
* Update few default strings

## Why

* No subtitle should be displayed on the vehicle detail page.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
