### PR TITLE
fix(service-portal): Use correct attribute for svg image

### DIFF
--- a/libs/service-portal/core/src/components/EmptyState/EmptyImgSmall.tsx
+++ b/libs/service-portal/core/src/components/EmptyState/EmptyImgSmall.tsx
@@ -83,10 +83,10 @@ export function EmptyImageSmall(props: React.SVGProps<SVGSVGElement>) {
           y2="205.69"
           gradientUnits="userSpaceOnUse"
         >
-          <stop stop-color="#FF4C84" />
-          <stop offset="0.1681" stop-color="#DF599A" />
-          <stop offset="0.7433" stop-color="#7680E2" />
-          <stop offset="1" stop-color="#4C90FF" />
+          <stop stopColor="#FF4C84" />
+          <stop offset="0.1681" stopColor="#DF599A" />
+          <stop offset="0.7433" stopColor="#7680E2" />
+          <stop offset="1" stopColor="#4C90FF" />
         </linearGradient>
       </defs>
     </svg>


### PR DESCRIPTION
## What

Update stop-color attribute

## Why

Previous one was wrong and causing an error

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
