### PR TITLE
fix(j-s): remove force autofill

### DIFF
--- a/apps/judicial-system/web/src/routes/Court/InvestigationCase/CourtRecord/CourtRecord.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationCase/CourtRecord/CourtRecord.tsx
@@ -116,7 +116,7 @@ const CourtRecord = () => {
 
       autofill(
         [
-          { key: 'courtStartDate', value: workingCase.courtDate, force: true },
+          { key: 'courtStartDate', value: workingCase.courtDate },
           {
             key: 'courtLocation',
             value: workingCase.court
@@ -126,7 +126,6 @@ const CourtRecord = () => {
                     : workingCase.court.name
                 }`
               : undefined,
-            force: true,
           },
           {
             key: 'courtAttendees',
@@ -134,7 +133,6 @@ const CourtRecord = () => {
               autofillAttendees.length > 0
                 ? autofillAttendees.join('')
                 : undefined,
-            force: true,
           },
           {
             key: 'sessionBookings',


### PR DESCRIPTION
[Asana - Rannsóknarheimild/Þingbók - Mættir eru syncast ekki í bakenda](https://app.asana.com/0/1199153462262248/1202360581950488/f)
## What

- Remove force autofill for fields `courtStartDate, courtAttendees, courtLocation`

## Why

- So that fields are not overwritten if users change them and hits refresh or navigates to the next page

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
