### PR TITLE
fix(fa): Fix email link on status page

### DIFF
--- a/libs/application/templates/financial-aid/src/fields/Status/MoreActions/MoreActions.tsx
+++ b/libs/application/templates/financial-aid/src/fields/Status/MoreActions/MoreActions.tsx
@@ -37,7 +37,7 @@ const MoreActions = ({ municipalityRulesPage, municipalityEmail }: Props) => {
             textProps={{ variant: 'small' }}
             text={moreActions.emailLink}
             format={{
-              email: municipalityEmail,
+              email: `mailto:${municipalityEmail}`,
             }}
           />
         )}


### PR DESCRIPTION
# ... 👆

https://app.asana.com/0/1202167941440767/1202356772658370

## What

Prefix the email link with "mailto:"

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
