### PR TITLE
fix(parental-leave): Add validation on startDate on OtherParent's approval and employer's approval

### DIFF
--- a/apps/application-system/api/src/app/modules/application/e2e/application.spec.ts
+++ b/apps/application-system/api/src/app/modules/application/e2e/application.spec.ts
@@ -798,6 +798,11 @@ describe('Application system API', () => {
       .expect(201)
     const answers = {
       employer: { isSelfEmployed: 'no' },
+      periods: [
+        {
+          startDate: '3000-01-01',
+        },
+      ],
     }
 
     await server

--- a/libs/application/templates/parental-leave/src/fields/Review/Review.tsx
+++ b/libs/application/templates/parental-leave/src/fields/Review/Review.tsx
@@ -45,11 +45,12 @@ import {
   getApplicationExternalData,
   getOtherParentId,
   getOtherParentName,
+  formatPeriods,
 } from '../../lib/parentalLeaveUtils'
 // TODO: Bring back payment calculation info, once we have an api
 // import PaymentsTable from '../PaymentSchedule/PaymentsTable'
 // import { getEstimatedPayments } from '../PaymentSchedule/estimatedPaymentsQuery'
-import { parentalLeaveFormMessages } from '../../lib/messages'
+import { errorMessages, parentalLeaveFormMessages } from '../../lib/messages'
 import {
   YES,
   NO,
@@ -69,6 +70,9 @@ import { useStatefulAnswers } from '../../hooks/useStatefulAnswers'
 import { getSelectOptionLabel } from '../../lib/parentalLeaveClientUtils'
 
 import * as styles from './Review.css'
+import { currentDateStartTime } from '../../lib/parentalLeaveTemplateUtils'
+
+type ValidOtherParentAnswer = typeof NO | typeof MANUAL | undefined
 
 interface ReviewScreenProps {
   application: Application
@@ -207,6 +211,8 @@ export const Review: FC<ReviewScreenProps> = ({
       },
     })
   }
+
+  const periods = formatPeriods(application, formatMessage)
 
   return (
     <>
@@ -909,6 +915,11 @@ export const Review: FC<ReviewScreenProps> = ({
         isLast={true}
       >
         <SummaryTimeline application={application} />
+        {new Date(periods[0].startDate).getTime() < currentDateStartTime() && (
+          <p style={{ color: '#B30038', fontSize: '14px', fontWeight: '500' }}>
+            {formatMessage(errorMessages.startDateInThePast)}
+          </p>
+        )}
       </ReviewGroup>
 
       {/**

--- a/libs/application/templates/parental-leave/src/forms/EmployerApproval.ts
+++ b/libs/application/templates/parental-leave/src/forms/EmployerApproval.ts
@@ -13,7 +13,9 @@ import {
 } from '@island.is/application/core'
 
 import Logo from '../assets/Logo'
-import { employerFormMessages } from '../lib/messages'
+import { employerFormMessages, otherParentApprovalFormMessages, parentalLeaveFormMessages } from '../lib/messages'
+import { currentDateStartTime } from '../lib/parentalLeaveTemplateUtils'
+import { getApplicationAnswers } from '../lib/parentalLeaveUtils'
 
 export const EmployerApproval: Form = buildForm({
   id: 'EmployerApprovalForParentalLeave',
@@ -65,6 +67,17 @@ export const EmployerApproval: Form = buildForm({
                   title: '',
                   component: 'EmployerApprovalExtraInformation',
                 }),
+                buildDescriptionField({
+                  id: 'final',
+                  title: otherParentApprovalFormMessages.warning,
+                  titleVariant: 'h4',
+                  description:
+                    otherParentApprovalFormMessages.startDateInThePast,
+                  condition: (answers) =>
+                    new Date(
+                      getApplicationAnswers(answers).periods[0].startDate,
+                    ).getTime() < currentDateStartTime(),
+                }),
                 buildSubmitField({
                   id: 'submit',
                   title: coreMessages.buttonSubmit,
@@ -84,6 +97,30 @@ export const EmployerApproval: Form = buildForm({
                 }),
               ],
             }),
+          ],
+        }),
+        buildSubSection({
+          title: '',
+          condition: (answers) =>
+            new Date(
+              getApplicationAnswers(answers).periods[0].startDate,
+            ).getTime() < currentDateStartTime(),
+          children: [
+            buildSubmitField({
+              id: 'reject',
+              placement: 'footer',
+              title: parentalLeaveFormMessages.finalScreen.startDateInThePast,
+              actions: [],
+            }),
+          ],
+        }),
+        buildSubSection({
+          title: '',
+          condition: (answers) =>
+            new Date(
+              getApplicationAnswers(answers).periods[0].startDate,
+            ).getTime() >= currentDateStartTime(),
+          children: [
             buildDescriptionField({
               id: 'final.approve',
               title: coreMessages.thanks,

--- a/libs/application/templates/parental-leave/src/forms/EmployerApproval.ts
+++ b/libs/application/templates/parental-leave/src/forms/EmployerApproval.ts
@@ -13,7 +13,11 @@ import {
 } from '@island.is/application/core'
 
 import Logo from '../assets/Logo'
-import { employerFormMessages, otherParentApprovalFormMessages, parentalLeaveFormMessages } from '../lib/messages'
+import {
+  employerFormMessages,
+  otherParentApprovalFormMessages,
+  parentalLeaveFormMessages,
+} from '../lib/messages'
 import { currentDateStartTime } from '../lib/parentalLeaveTemplateUtils'
 import { getApplicationAnswers } from '../lib/parentalLeaveUtils'
 

--- a/libs/application/templates/parental-leave/src/forms/OtherParentApproval.ts
+++ b/libs/application/templates/parental-leave/src/forms/OtherParentApproval.ts
@@ -14,7 +14,10 @@ import {
 
 import Logo from '../assets/Logo'
 import { YES } from '../constants'
-import { otherParentApprovalFormMessages, parentalLeaveFormMessages } from '../lib/messages'
+import {
+  otherParentApprovalFormMessages,
+  parentalLeaveFormMessages,
+} from '../lib/messages'
 import { currentDateStartTime } from '../lib/parentalLeaveTemplateUtils'
 import { getApplicationAnswers } from '../lib/parentalLeaveUtils'
 import { YesOrNo } from '../types'

--- a/libs/application/templates/parental-leave/src/forms/OtherParentApproval.ts
+++ b/libs/application/templates/parental-leave/src/forms/OtherParentApproval.ts
@@ -14,7 +14,8 @@ import {
 
 import Logo from '../assets/Logo'
 import { YES } from '../constants'
-import { otherParentApprovalFormMessages } from '../lib/messages'
+import { otherParentApprovalFormMessages, parentalLeaveFormMessages } from '../lib/messages'
+import { currentDateStartTime } from '../lib/parentalLeaveTemplateUtils'
 import { getApplicationAnswers } from '../lib/parentalLeaveUtils'
 import { YesOrNo } from '../types'
 
@@ -106,6 +107,16 @@ export const OtherParentApproval: Form = buildForm({
                 return `${spouseUsage}%`
               },
             }),
+            buildDescriptionField({
+              id: 'final',
+              title: otherParentApprovalFormMessages.warning,
+              titleVariant: 'h4',
+              description: otherParentApprovalFormMessages.startDateInThePast,
+              condition: (answers) =>
+                new Date(
+                  getApplicationAnswers(answers).periods[0].startDate,
+                ).getTime() < currentDateStartTime(),
+            }),
             buildSubmitField({
               id: 'submit',
               title: coreMessages.buttonSubmit,
@@ -125,6 +136,30 @@ export const OtherParentApproval: Form = buildForm({
             }),
           ],
         }),
+      ],
+    }),
+    buildSection({
+      title: '',
+      condition: (answers) =>
+        new Date(
+          getApplicationAnswers(answers).periods[0].startDate,
+        ).getTime() < currentDateStartTime(),
+      children: [
+        buildSubmitField({
+          id: 'reject',
+          placement: 'footer',
+          title: parentalLeaveFormMessages.finalScreen.startDateInThePast,
+          actions: [],
+        }),
+      ],
+    }),
+    buildSection({
+      title: '',
+      condition: (answers) =>
+        new Date(
+          getApplicationAnswers(answers).periods[0].startDate,
+        ).getTime() >= currentDateStartTime(),
+      children: [
         buildDescriptionField({
           id: 'final',
           title: coreMessages.thanks,

--- a/libs/application/templates/parental-leave/src/forms/ParentalLeaveForm.ts
+++ b/libs/application/templates/parental-leave/src/forms/ParentalLeaveForm.ts
@@ -56,6 +56,7 @@ import {
   GetPrivatePensionFundsQuery,
   GetUnionsQuery,
 } from '../types/schema'
+import { currentDateStartTime } from '../lib/parentalLeaveTemplateUtils'
 
 export const ParentalLeaveForm: Form = buildForm({
   id: 'ParentalLeaveDraft',
@@ -832,6 +833,32 @@ export const ParentalLeaveForm: Form = buildForm({
             }),
           ],
         }),
+      ],
+    }),
+    buildSection({
+      title: '',
+      condition: (answers) =>
+        getApplicationAnswers(answers).periods.length > 0 &&
+        new Date(
+          getApplicationAnswers(answers).periods[0].startDate,
+        ).getTime() < currentDateStartTime(),
+      children: [
+        buildSubmitField({
+          id: 'reject',
+          placement: 'footer',
+          title: parentalLeaveFormMessages.finalScreen.startDateInThePast,
+          actions: [],
+        }),
+      ],
+    }),
+    buildSection({
+      title: '',
+      condition: (answers) =>
+        getApplicationAnswers(answers).periods.length > 0 &&
+        new Date(
+          getApplicationAnswers(answers).periods[0].startDate,
+        ).getTime() >= currentDateStartTime(),
+      children: [
         buildCustomField({
           id: 'thankYou',
           title: parentalLeaveFormMessages.finalScreen.title,

--- a/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.spec.ts
+++ b/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.spec.ts
@@ -73,6 +73,11 @@ describe('Parental Leave Application Template', () => {
               otherParentId,
             },
             selectedChild: '0',
+            periods: [
+              {
+                startDate: '3000-01-01',
+              },
+            ],
           },
         }),
         ParentalLeaveTemplate,
@@ -99,6 +104,11 @@ describe('Parental Leave Application Template', () => {
             employer: {
               isSelfEmployed: 'no',
             },
+            periods: [
+              {
+                startDate: '3000-01-01',
+              },
+            ],
           },
         }),
         ParentalLeaveTemplate,
@@ -128,6 +138,11 @@ describe('Parental Leave Application Template', () => {
               isSelfEmployed: 'no',
             },
             selectedChild: '0',
+            periods: [
+              {
+                startDate: '3000-01-01',
+              },
+            ],
           },
         }),
         ParentalLeaveTemplate,
@@ -170,6 +185,11 @@ describe('Parental Leave Application Template', () => {
               isSelfEmployed: 'yes',
             },
             selectedChild: '0',
+            periods: [
+              {
+                startDate: '3000-01-01',
+              },
+            ],
           },
         }),
         ParentalLeaveTemplate,
@@ -223,6 +243,11 @@ describe('Parental Leave Application Template', () => {
                   email: 'selfemployed@test.test',
                   isSelfEmployed: YES,
                 },
+                periods: [
+                  {
+                    startDate: '3000-01-01',
+                  },
+                ],
               },
             }),
             ParentalLeaveTemplate,
@@ -250,6 +275,11 @@ describe('Parental Leave Application Template', () => {
               employer: {
                 isSelfEmployed: 'no',
               },
+              periods: [
+                {
+                  startDate: '3000-01-01',
+                },
+              ],
             },
           }),
           ParentalLeaveTemplate,
@@ -275,6 +305,11 @@ describe('Parental Leave Application Template', () => {
               employer: {
                 isSelfEmployed: 'no',
               },
+              periods: [
+                {
+                  startDate: '3000-01-01',
+                },
+              ],
             },
           }),
           ParentalLeaveTemplate,
@@ -298,6 +333,11 @@ describe('Parental Leave Application Template', () => {
               employer: {
                 isSelfEmployed: 'no',
               },
+              periods: [
+                {
+                  startDate: '3000-01-01',
+                },
+              ],
             },
           }),
           ParentalLeaveTemplate,
@@ -328,6 +368,11 @@ describe('Parental Leave Application Template', () => {
               employer: {
                 isSelfEmployed: 'no',
               },
+              periods: [
+                {
+                  startDate: '3000-01-01',
+                },
+              ],
             },
           }),
           ParentalLeaveTemplate,
@@ -365,6 +410,11 @@ describe('Parental Leave Application Template', () => {
               employer: {
                 isSelfEmployed: 'no',
               },
+              periods: [
+                {
+                  startDate: '3000-01-01',
+                },
+              ],
             },
           }),
           ParentalLeaveTemplate,
@@ -403,6 +453,11 @@ describe('Parental Leave Application Template', () => {
               employer: {
                 isSelfEmployed: 'no',
               },
+              periods: [
+                {
+                  startDate: '3000-01-01',
+                },
+              ],
             },
           }),
           ParentalLeaveTemplate,
@@ -495,6 +550,11 @@ describe('Parental Leave Application Template', () => {
             employer: {
               isSelfEmployed: 'no',
             },
+            periods: [
+              {
+                startDate: '3000-01-01',
+              },
+            ],
           },
           state: ApplicationStates.EDIT_OR_ADD_PERIODS,
         }),

--- a/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.ts
+++ b/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.ts
@@ -33,6 +33,7 @@ import { parentalLeaveFormMessages, statesMessages } from './messages'
 import {
   hasEmployer,
   needsOtherParentApproval,
+  startDateInTheFuture,
 } from './parentalLeaveTemplateUtils'
 import {
   getApplicationAnswers,
@@ -151,13 +152,14 @@ const ParentalLeaveTemplate: ApplicationTemplate<
             { target: States.EMPLOYER_WAITING_TO_ASSIGN, cond: hasEmployer },
             {
               target: States.VINNUMALASTOFNUN_APPROVAL,
+              cond: startDateInTheFuture,
             },
           ],
         },
       },
       [States.OTHER_PARENT_APPROVAL]: {
         entry: 'assignToOtherParent',
-        exit: ['clearAssignees', 'removePeriodsOrAllowanceOnSpouseRejection'],
+        exit: ['clearAssignees'],
         meta: {
           name: States.OTHER_PARENT_APPROVAL,
           actionCard: {
@@ -189,6 +191,7 @@ const ParentalLeaveTemplate: ApplicationTemplate<
                   'requestRights',
                   'usePersonalAllowanceFromSpouse',
                   'personalAllowanceFromSpouse',
+                  'periods',
                 ],
               },
             },
@@ -212,6 +215,7 @@ const ParentalLeaveTemplate: ApplicationTemplate<
             },
             {
               target: States.VINNUMALASTOFNUN_APPROVAL,
+              cond: startDateInTheFuture,
             },
           ],
           [DefaultEvents.EDIT]: { target: States.DRAFT },
@@ -219,6 +223,7 @@ const ParentalLeaveTemplate: ApplicationTemplate<
         },
       },
       [States.OTHER_PARENT_ACTION]: {
+        entry: 'removePeriodsOrAllowanceOnSpouseRejection',
         meta: {
           name: States.OTHER_PARENT_ACTION,
           actionCard: {
@@ -333,6 +338,7 @@ const ParentalLeaveTemplate: ApplicationTemplate<
           [DefaultEvents.APPROVE]: [
             {
               target: States.VINNUMALASTOFNUN_APPROVAL,
+              cond: startDateInTheFuture,
             },
           ],
           [DefaultEvents.REJECT]: { target: States.EMPLOYER_ACTION },

--- a/libs/application/templates/parental-leave/src/lib/messages.ts
+++ b/libs/application/templates/parental-leave/src/lib/messages.ts
@@ -1470,6 +1470,13 @@ export const parentalLeaveFormMessages: MessageDir = {
       description:
         'Finally, the application goes to the Parental Leave Fund, where its final processing takes place.',
     },
+    startDateInThePast: {
+      id: 'pl.application:finalscreen.start.date.in.the.past',
+      defaultMessage:
+        'icel-trans: "Parental leave starting date is in the past, please correct this date"',
+      description:
+        'Parental leave starting date is in the past, please correct this date',
+    },
   }),
 }
 
@@ -1595,6 +1602,18 @@ export const otherParentApprovalFormMessages = defineMessages({
     id: 'pl.application:otherParent.final.title',
     defaultMessage: 'Takk fyrir',
     description: 'Thank you',
+  },
+  warning: {
+    id: 'pl.application:otherParent.warning',
+    defaultMessage: 'icel-trans: "Warning!"',
+    description: 'Warning!',
+  },
+  startDateInThePast: {
+    id: 'pl.application:otherParent.start.date.in.the.past',
+    defaultMessage:
+      'icel-trans: "Application will not be processsed! Parental leave starting date has already passed!"',
+    description:
+      'Application will not be processsed! Parental leave starting date has already passed!',
   },
 })
 
@@ -1839,6 +1858,12 @@ export const errorMessages = defineMessages({
       'Villa kom upp við útreikning á tímabilum, veldu annað tímabil eða hafðu samband við okkur til að fá stuðning.',
     description:
       'An error happened while calculating your periods, choose another period or contact us for support.',
+  },
+  startDateInThePast: {
+    id: 'pl.application:errors.start.date.in.the.past',
+    defaultMessage:
+      'icel-trans: "Start date is in the past. The form will not be sent!"',
+    description: 'Start date is in the past. The form will not be sent!',
   },
 })
 

--- a/libs/application/templates/parental-leave/src/lib/parentalLeaveTemplateUtils.ts
+++ b/libs/application/templates/parental-leave/src/lib/parentalLeaveTemplateUtils.ts
@@ -8,14 +8,19 @@ export function hasEmployer(context: ApplicationContext) {
     employer: { isSelfEmployed: typeof YES | typeof NO }
   }
 
-  return currentApplicationAnswers.employer.isSelfEmployed === NO && startDateInTheFuture(context)
+  return (
+    currentApplicationAnswers.employer.isSelfEmployed === NO &&
+    startDateInTheFuture(context)
+  )
 }
 
 export function needsOtherParentApproval(context: ApplicationContext) {
-  return requiresOtherParentApproval(
-    context.application.answers,
-    context.application.externalData,
-  ) && startDateInTheFuture(context)
+  return (
+    requiresOtherParentApproval(
+      context.application.answers,
+      context.application.externalData,
+    ) && startDateInTheFuture(context)
+  )
 }
 
 export function startDateInTheFuture(context: ApplicationContext) {

--- a/libs/application/templates/parental-leave/src/lib/parentalLeaveTemplateUtils.ts
+++ b/libs/application/templates/parental-leave/src/lib/parentalLeaveTemplateUtils.ts
@@ -8,12 +8,28 @@ export function hasEmployer(context: ApplicationContext) {
     employer: { isSelfEmployed: typeof YES | typeof NO }
   }
 
-  return currentApplicationAnswers.employer.isSelfEmployed === NO
+  return currentApplicationAnswers.employer.isSelfEmployed === NO && startDateInTheFuture(context)
 }
 
 export function needsOtherParentApproval(context: ApplicationContext) {
   return requiresOtherParentApproval(
     context.application.answers,
     context.application.externalData,
+  ) && startDateInTheFuture(context)
+}
+
+export function startDateInTheFuture(context: ApplicationContext) {
+  const currentApplicationAnswers = context.application.answers as {
+    periods: [{ startDate: string }]
+  }
+  return (
+    currentApplicationAnswers.periods &&
+    new Date(currentApplicationAnswers.periods[0].startDate).getTime() >=
+      currentDateStartTime()
   )
+}
+
+export function currentDateStartTime() {
+  const date = new Date().toDateString()
+  return new Date(date).getTime()
 }


### PR DESCRIPTION
## What

applicant/spouse/employer shouldn't be able to confirm application if parental leave start date already has passed (submit button hidden)

## Why

https://dit-iceland.atlassian.net/jira/software/projects/UUFV/boards/71?selectedIssue=UUFV-80

## Screenshots / Gifs

#### applicant:
<img width="894" alt="image" src="https://user-images.githubusercontent.com/52431776/172802102-97ca3667-3247-4b03-98bd-4004eb61017c.png">

#### spouse:
<img width="899" alt="image" src="https://user-images.githubusercontent.com/52431776/172802727-b1b08342-6982-4907-8801-ec09f97136d8.png">

#### employer:
<img width="895" alt="image" src="https://user-images.githubusercontent.com/52431776/172803287-165a0439-c7df-4008-97b7-5d39cb521ef3.png">

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
