### PR TITLE
fix(public-dept-payment-plan): ceil to month amount

### DIFF
--- a/libs/clients/payment-schedule/src/lib/payment-schedule.ts
+++ b/libs/clients/payment-schedule/src/lib/payment-schedule.ts
@@ -83,7 +83,8 @@ export class PaymentScheduleAPI extends RESTDataSource {
     const queryParams = new URLSearchParams()
     queryParams.append('totalAmount', totalAmount.toString())
 
-    if (monthAmount) queryParams.append('monthAmount', monthAmount.toString())
+    if (monthAmount)
+      queryParams.append('monthAmount', Math.ceil(monthAmount).toString())
     if (monthCount) queryParams.append('monthCount', monthCount.toString())
 
     const response = await this.get<PaymentDistributionResponse>(


### PR DESCRIPTION
# Adding ceil to monthAmount

[2ehaqkj](https://app.clickup.com/t/2ehaqkj)

## What

Adding ceil to monthAmount in client. 

## Why

For some reason users were able to get a number with decimal number. This is not suppose to happen (my guess, it is happening in the max number for some reason). But I added a Math.ceil to the number in client, so that if this happen, we don't send the decimal numbers!).

Error from FJS:
2022-06-01 00:30:45 GMT
TBRIslandis.api.v1._paymentSchedule.services:getPaymentDistribution
Invalid input "488594.99999999994" for param "monthAmount"

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
