### PR TITLE
feat(web): Hide the Watson chat bot launcher if the locale is not 'is'

### DIFF
--- a/apps/web/components/ChatPanel/WatsonChatPanel/WatsonChatPanel.tsx
+++ b/apps/web/components/ChatPanel/WatsonChatPanel/WatsonChatPanel.tsx
@@ -84,7 +84,7 @@ export const WatsonChatPanel = (props: WatsonChatPanelProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [namespace])
 
-  if (showLauncher) return null
+  if (showLauncher || activeLocale !== 'is') return null
 
   return (
     <ChatBubble

--- a/apps/web/components/ChatPanel/WatsonChatPanel/WatsonChatPanel.tsx
+++ b/apps/web/components/ChatPanel/WatsonChatPanel/WatsonChatPanel.tsx
@@ -84,7 +84,10 @@ export const WatsonChatPanel = (props: WatsonChatPanelProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [namespace])
 
-  if (showLauncher || activeLocale !== 'is') return null
+  // Hide the chat bubble for other than 'is' locales for now since the translations have not been set up yet
+  const shouldShowChatBubble = activeLocale === 'is'
+
+  if (showLauncher || !shouldShowChatBubble) return null
 
   return (
     <ChatBubble


### PR DESCRIPTION
# Hide the Watson chat bot launcher if the locale is not 'is'

## What

* Now the chat bubble for the watson chat bot won't appear when locale is not 'is'

## Why

* The chat bot is only in Icelandic right now so we want to not show it when the locale is set to english

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
