### PR TITLE
fix(j-s): only check failed courtRecord upload when not modifying ruling

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/case/case.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/case.service.ts
@@ -471,6 +471,7 @@ export class CaseService {
     let rulingUploadedToS3 = false
     let rulingUploadedToCourt = false
     let courtRecordUploadedToCourt = false
+    const isModifyingRuling = Boolean(theCase.rulingDate)
 
     const uploadPromises = [
       this.uploadSignedRulingPdfToS3(theCase, signedRulingPdf).then((res) => {
@@ -486,8 +487,6 @@ export class CaseService {
           },
         ),
       )
-
-      const isModifyingRuling = Boolean(theCase.rulingDate)
 
       if (!isModifyingRuling) {
         uploadPromises.push(
@@ -527,7 +526,10 @@ export class CaseService {
       this.sendEmailToProsecutor(theCase, rulingUploadedToS3, rulingAttachment),
     ]
 
-    if (!rulingUploadedToCourt || !courtRecordUploadedToCourt) {
+    if (
+      !rulingUploadedToCourt ||
+      (!isModifyingRuling && !courtRecordUploadedToCourt)
+    ) {
       emailPromises.push(
         this.sendEmailToCourt(theCase, rulingUploadedToS3, rulingAttachment),
       )


### PR DESCRIPTION
[Asana - Passa að villutölvupóstur fari ekki út við successfull leiðréttingu](https://app.asana.com/0/0/1202362015988803/f)
## What

- Don't check if court record fails to upload when modifying ruling

## Why

- Court record is not uploaded when modifying ruling


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
