### PR TITLE
feat(fa): Allow employee to add a comment when approving an application

### DIFF
--- a/apps/financial-aid/backend/src/app/modules/application/application.service.ts
+++ b/apps/financial-aid/backend/src/app/modules/application/application.service.ts
@@ -192,7 +192,10 @@ export class ApplicationService {
             eventType: {
               [Op.in]: isEmployee
                 ? Object.values(ApplicationEventType)
-                : [ApplicationEventType.DATANEEDED],
+                : [
+                    ApplicationEventType.DATANEEDED,
+                    ApplicationEventType.APPROVED,
+                  ],
             },
           },
           order: [['created', 'DESC']],

--- a/apps/financial-aid/web-veita/src/components/ModalTypes/AcceptModal.tsx
+++ b/apps/financial-aid/web-veita/src/components/ModalTypes/AcceptModal.tsx
@@ -22,7 +22,7 @@ import * as modalStyles from './ModalTypes.css'
 
 interface Props {
   onCancel: (event: React.MouseEvent<HTMLButtonElement>) => void
-  onSaveApplication: (amount: Amount) => void
+  onSaveApplication: (amount: Amount, comment: string) => void
   isModalVisable: boolean
   homeCircumstances: HomeCircumstances
   familyStatus: FamilyStatus
@@ -38,6 +38,7 @@ interface calculationsState {
   hasError: boolean
   hasSubmitError: boolean
   deductionFactor: Array<{ description: string; amount: number }>
+  comment: string
 }
 
 const AcceptModal = ({
@@ -84,6 +85,7 @@ const AcceptModal = ({
     deductionFactor: [],
     hasError: false,
     hasSubmitError: false,
+    comment: '',
   })
 
   const sumValues = state.deductionFactor.reduce(
@@ -115,16 +117,19 @@ const AcceptModal = ({
       return
     }
 
-    onSaveApplication({
-      applicationId: router.query.id as string,
-      aidAmount: state.amount,
-      income: state.income,
-      personalTaxCredit: state.personalTaxCreditPercentage ?? 0,
-      spousePersonalTaxCredit: state.secondPersonalTaxCredit,
-      tax: taxAmount,
-      finalAmount: finalAmount,
-      deductionFactors: state.deductionFactor,
-    })
+    onSaveApplication(
+      {
+        applicationId: router.query.id as string,
+        aidAmount: state.amount,
+        income: state.income,
+        personalTaxCredit: state.personalTaxCreditPercentage ?? 0,
+        spousePersonalTaxCredit: state.secondPersonalTaxCredit,
+        tax: taxAmount,
+        finalAmount: finalAmount,
+        deductionFactors: state.deductionFactor,
+      },
+      state.comment,
+    )
   }
 
   return (
@@ -319,13 +324,30 @@ const AcceptModal = ({
         </Button>
       </Box>
 
-      <Box marginBottom={[3, 3, 5]}>
+      <Box marginBottom={3}>
         <Input
           label="Skattur "
           id="tax"
           name="tax"
           value={taxAmount.toLocaleString('de-DE')}
           readOnly={true}
+        />
+      </Box>
+
+      <Box marginBottom={[3, 3, 5]}>
+        <Input
+          label="Skýring"
+          placeholder="Sláðu inn skýringu ef þarf"
+          id="comment"
+          name="comment"
+          value={state.comment}
+          onChange={(e) => {
+            setState({
+              ...state,
+              comment: e.target.value,
+            })
+          }}
+          backgroundColor="blue"
         />
       </Box>
 

--- a/apps/financial-aid/web-veita/src/components/StateModal/StateModal.tsx
+++ b/apps/financial-aid/web-veita/src/components/StateModal/StateModal.tsx
@@ -173,7 +173,7 @@ const StateModal = ({
           <AcceptModal
             isModalVisable={selected === ApplicationState.APPROVED}
             onCancel={onClickCancel}
-            onSaveApplication={(amount: Amount) => {
+            onSaveApplication={(amount: Amount, comment: string) => {
               if (!selected) {
                 return
               }
@@ -183,7 +183,7 @@ const StateModal = ({
                 undefined,
                 `Samþykkt upphæð: kr. ${amount?.finalAmount.toLocaleString(
                   'de-DE',
-                )}.-`,
+                )}.-${comment ? '\n' + comment : comment}`,
                 amount,
               )
             }}

--- a/apps/financial-aid/web-veita/src/components/Timeline/ChatElement.tsx
+++ b/apps/financial-aid/web-veita/src/components/Timeline/ChatElement.tsx
@@ -15,7 +15,7 @@ const ChatElement = ({ comment }: Props) => {
   return (
     <Box paddingLeft={3} marginBottom={2} className={styles.timelineMessages}>
       <Icon icon="chatbubble" type="outline" />{' '}
-      <Text marginBottom={2}>„{comment}“</Text>
+      <Text marginBottom={2} whiteSpace="breakSpaces">„{comment}“</Text>
     </Box>
   )
 }

--- a/apps/financial-aid/web-veita/src/components/Timeline/ChatElement.tsx
+++ b/apps/financial-aid/web-veita/src/components/Timeline/ChatElement.tsx
@@ -15,7 +15,9 @@ const ChatElement = ({ comment }: Props) => {
   return (
     <Box paddingLeft={3} marginBottom={2} className={styles.timelineMessages}>
       <Icon icon="chatbubble" type="outline" />{' '}
-      <Text marginBottom={2} whiteSpace="breakSpaces">„{comment}“</Text>
+      <Text marginBottom={2} whiteSpace="breakSpaces">
+        „{comment}“
+      </Text>
     </Box>
   )
 }

--- a/libs/application/templates/financial-aid/src/fields/Status/ApplicantStatus.tsx
+++ b/libs/application/templates/financial-aid/src/fields/Status/ApplicantStatus.tsx
@@ -7,6 +7,7 @@ import { FAFieldBaseProps } from '../../lib/types'
 import { hasSpouse, waitingForSpouse } from '../../lib/utils'
 import {
   AidAmount,
+  ApprovedAlert,
   Header,
   MissingFilesCard,
   MoreActions,
@@ -35,6 +36,10 @@ const ApplicantStatus = ({ application, goToScreen }: FAFieldBaseProps) => {
 
       {isWaitingForSpouse && (
         <SpouseAlert showCopyUrl={!application.answers.spouseEmailSuccess} />
+      )}
+
+      {state === ApplicationState.APPROVED && (
+        <ApprovedAlert events={currentApplication?.applicationEvents} />
       )}
 
       {state === ApplicationState.REJECTED && (

--- a/libs/application/templates/financial-aid/src/fields/Status/ApprovedAlert/ApprovedAlert.tsx
+++ b/libs/application/templates/financial-aid/src/fields/Status/ApprovedAlert/ApprovedAlert.tsx
@@ -1,0 +1,45 @@
+import React, { useMemo } from 'react'
+import { useIntl } from 'react-intl'
+
+import {
+  ApplicationEvent,
+  ApplicationEventType,
+} from '@island.is/financial-aid/shared/lib'
+import { AlertMessage, Box, Text } from '@island.is/island-ui/core'
+
+import { approvedAlert } from '../../../lib/messages'
+
+interface Props {
+  events?: ApplicationEvent[]
+}
+
+const ApprovedAlert = ({ events }: Props) => {
+  const { formatMessage } = useIntl()
+
+  const approvedComment = useMemo(() => {
+    if (events) {
+      return events.find((el) => el.eventType === ApplicationEventType.APPROVED)
+        ?.comment
+    }
+  }, [events])
+
+  if (!approvedComment) {
+    return null
+  }
+
+  return (
+    <Box marginBottom={[4, 4, 5]}>
+      <AlertMessage
+        type="info"
+        title={formatMessage(approvedAlert.title)}
+        message={
+          <Text variant="small" whiteSpace="breakSpaces">
+            „{approvedComment}“
+          </Text>
+        }
+      />
+    </Box>
+  )
+}
+
+export default ApprovedAlert

--- a/libs/application/templates/financial-aid/src/fields/Status/index.ts
+++ b/libs/application/templates/financial-aid/src/fields/Status/index.ts
@@ -7,3 +7,4 @@ export { default as RejectionMessage } from './RejectionMessage/RejectionMessage
 export { default as SpouseAlert } from './SpouseAlert/SpouseAlert'
 export { default as SpouseApproved } from './SpouseApproved/SpouseApproved'
 export { default as Timeline } from './Timeline/Timeline'
+export { default as ApprovedAlert } from './ApprovedAlert/ApprovedAlert'

--- a/libs/application/templates/financial-aid/src/lib/messages/status.ts
+++ b/libs/application/templates/financial-aid/src/lib/messages/status.ts
@@ -218,7 +218,7 @@ export const spouseApproved = defineMessages({
 
 export const approvedAlert = defineMessages({
   title: {
-    id: 'fa.application:section.acceptedAlert.title',
+    id: 'fa.application:section.approvedAlert.title',
     defaultMessage: 'Skýring frá vinnsluaðila',
     description: 'Title of accepted alert box',
   },

--- a/libs/application/templates/financial-aid/src/lib/messages/status.ts
+++ b/libs/application/templates/financial-aid/src/lib/messages/status.ts
@@ -215,3 +215,11 @@ export const spouseApproved = defineMessages({
     description: 'Message for spouse when application is apporoved',
   },
 })
+
+export const approvedAlert = defineMessages({
+  title: {
+    id: 'fa.application:section.acceptedAlert.title',
+    defaultMessage: 'Skýring frá vinnsluaðila',
+    description: 'Title of accepted alert box',
+  },
+})


### PR DESCRIPTION
# ... 👆

https://app.asana.com/0/1202244723867117/1202244723867128

## What

- Add new input field for comment in AcceptModal
- Display comment in Veita history
- Display alert on status page for applicant when application is approved

## Why

Specify why you need to achieve this

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/43727721/172424923-57107454-d5ad-4c8b-b64b-93cc04662c81.png)

![image](https://user-images.githubusercontent.com/43727721/172425012-bfed60ea-fe04-4583-a846-2a8231fca9ec.png)

<img width="851" alt="image" src="https://user-images.githubusercontent.com/43727721/172425129-ccbb27da-8720-44f1-8e7e-09bccc296910.png">


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
