### PR TITLE
fix(auth-react): Disabling automatic access token refresh

### DIFF
--- a/libs/auth/react/src/lib/AuthSettings.spec.ts
+++ b/libs/auth/react/src/lib/AuthSettings.spec.ts
@@ -12,6 +12,7 @@ describe('mergeAuthSettings', () => {
     expect(settings).toMatchInlineSnapshot(`
       Object {
         "authority": "https://innskra.island.is",
+        "automaticSilentRenew": false,
         "baseUrl": "http://localhost",
         "checkSessionPath": "/connect/sessioninfo",
         "client_id": "test-client",

--- a/libs/auth/react/src/lib/AuthSettings.ts
+++ b/libs/auth/react/src/lib/AuthSettings.ts
@@ -58,6 +58,7 @@ export const mergeAuthSettings = (settings: AuthSettings): AuthSettings => {
     baseUrl,
     redirectPath,
     redirectPathSilent,
+    automaticSilentRenew: false,
     checkSessionPath: '/connect/sessioninfo',
     silent_redirect_uri: `${baseUrl}${redirectPathSilent}`,
     post_logout_redirect_uri: baseUrl,


### PR DESCRIPTION
## What

The `oidc-client-ts` automatically updates the access token before it expires. This causes the IDS user session to slide, creating infinite user session.

## Why

To fix the regression the `oidc-client-ts` library introduced.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
