### PR TITLE
fix(skuldleysisvottord): Increase timeout for FinanceClient

### DIFF
--- a/apps/api/infra/api.ts
+++ b/apps/api/infra/api.ts
@@ -108,6 +108,7 @@ export const serviceSetup = (services: {
       XROAD_PROPERTIES_TIMEOUT: '20000',
       SYSLUMENN_TIMEOUT: '30000',
       XROAD_DRIVING_LICENSE_BOOK_TIMEOUT: '20000',
+      XROAD_FINANCES_TIMEOUT: '20000',
       IDENTITY_SERVER_ISSUER_URL: {
         dev: 'https://identity-server.dev01.devland.is',
         staging: 'https://identity-server.staging01.devland.is',

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -281,6 +281,7 @@ api:
     XROAD_DRIVING_LICENSE_PATH: 'r1/IS-DEV/GOV/10005/Logreglan-Protected/RafraentOkuskirteini-v1'
     XROAD_DRIVING_LICENSE_V2_PATH: 'r1/IS-DEV/GOV/10005/Logreglan-Protected/RafraentOkuskirteini-v2'
     XROAD_FINANCES_PATH: 'IS-DEV/GOV/10021/FJS-Public/financeIsland'
+    XROAD_FINANCES_TIMEOUT: '20000'
     XROAD_FINANCIAL_AID_BACKEND_PATH: 'IS-DEV/MUN/10023/samband-sveitarfelaga/financial-aid-backend'
     XROAD_HEALTH_INSURANCE_ID: 'IS-DEV/GOV/10007/SJUKRA-Protected'
     XROAD_HEALTH_INSURANCE_WSDLURL: 'https://test-huld.sjukra.is/islandrg?wsdl'

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -273,6 +273,7 @@ api:
     XROAD_DRIVING_LICENSE_PATH: 'r1/IS/GOV/5309672079/Logreglan-Protected/Okuskirteini-v1'
     XROAD_DRIVING_LICENSE_V2_PATH: 'r1/IS/GOV/5309672079/Logreglan-Protected/Okuskirteini-v2'
     XROAD_FINANCES_PATH: 'IS/GOV/5402697509/FJS-Public/financeIsland'
+    XROAD_FINANCES_TIMEOUT: '20000'
     XROAD_FINANCIAL_AID_BACKEND_PATH: 'IS/MUN/5502694739/samband-sveitarfelaga/financial-aid-backend'
     XROAD_HEALTH_INSURANCE_ID: 'IS/GOV/4804080550/SJUKRA-Protected'
     XROAD_HEALTH_INSURANCE_WSDLURL: 'https://huld.sjukra.is/islandrg?wsdl'

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -281,6 +281,7 @@ api:
     XROAD_DRIVING_LICENSE_PATH: 'r1/IS/GOV/5309672079/Logreglan-Protected/RafraentOkuskirteini-v1'
     XROAD_DRIVING_LICENSE_V2_PATH: 'r1/IS/GOV/5309672079/Logreglan-Protected/RafraentOkuskirteini-v2'
     XROAD_FINANCES_PATH: 'IS-DEV/GOV/10021/FJS-Public/financeIsland'
+    XROAD_FINANCES_TIMEOUT: '20000'
     XROAD_FINANCIAL_AID_BACKEND_PATH: 'IS-TEST/MUN/5502694739/samband-sveitarfelaga/financial-aid-backend'
     XROAD_HEALTH_INSURANCE_ID: 'IS-TEST/GOV/4804080550/SJUKRA-Protected'
     XROAD_HEALTH_INSURANCE_WSDLURL: 'https://test-huld.sjukra.is/islandrg?wsdl'

--- a/libs/clients/finance/src/lib/FinanceClientConfig.ts
+++ b/libs/clients/finance/src/lib/FinanceClientConfig.ts
@@ -4,6 +4,7 @@ import { defineConfig } from '@island.is/nest/config'
 const schema = z.object({
   xRoadServicePath: z.string(),
   tokenExchangeScope: z.array(z.string()),
+  fetchTimeout: z.number().int(),
 })
 
 export const FinanceClientConfig = defineConfig({
@@ -19,5 +20,6 @@ export const FinanceClientConfig = defineConfig({
       // TODO: Remove when fjs has migrated to the scope above.
       'api_resource.scope',
     ],
+    fetchTimeout: env.optionalJSON('XROAD_FINANCES_TIMEOUT') ?? 20000,
   }),
 })

--- a/libs/clients/finance/src/lib/FinanceClientService.ts
+++ b/libs/clients/finance/src/lib/FinanceClientService.ts
@@ -46,6 +46,7 @@ export class FinanceClientService {
             scope: this.config.tokenExchangeScope,
           }
         : undefined,
+      timeout: this.config.fetchTimeout,
     })
   }
 


### PR DESCRIPTION
## What

Increase timeout for FinanceClient from 10s to 20s, since it takes about 10s for FJS to create a Skuldleysisvottorð and stamp it. 

## Why

When testing on prod, we sometimes get a Network timeout error, but the user then still gets the vottorð in pósthólf sometime later

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
