### PR TITLE
chore(service-portal): Hide insurance temporarily

### DIFF
--- a/libs/service-portal/vehicles/src/components/DetailTable/FeeInfoItem.tsx
+++ b/libs/service-portal/vehicles/src/components/DetailTable/FeeInfoItem.tsx
@@ -4,7 +4,7 @@ import Column from './Column'
 import Row from './Row'
 import { Box } from '@island.is/island-ui/core'
 import { VehiclesInspectionInfo } from '@island.is/api/schema'
-import { useLocale } from '@island.is/localization'
+// import { useLocale } from '@island.is/localization'
 import { messages } from '../../lib/messages'
 import { amountFormat } from '@island.is/service-portal/core'
 import isNumber from 'lodash/isNumber'
@@ -14,7 +14,7 @@ interface PropTypes {
 }
 
 const FeeInfoItem = ({ data }: PropTypes) => {
-  const { formatMessage } = useLocale()
+  // const { formatMessage } = useLocale()
 
   return (
     <Box marginBottom={4}>
@@ -27,7 +27,7 @@ const FeeInfoItem = ({ data }: PropTypes) => {
           }
         />
 
-        <Column
+        {/* <Column
           label={messages.insured}
           value={
             data.insuranceStatus === true
@@ -36,9 +36,7 @@ const FeeInfoItem = ({ data }: PropTypes) => {
               ? formatMessage(messages.no)
               : ''
           }
-        />
-      </Row>
-      <Row>
+        /> */}
         <Column
           label={messages.negligence}
           value={
@@ -47,6 +45,8 @@ const FeeInfoItem = ({ data }: PropTypes) => {
               : ''
           }
         />
+      </Row>
+      <Row>
         <Column
           label={messages.vehicleFee}
           value={

--- a/libs/service-portal/vehicles/src/screens/VehicleDetail/VehicleDetail.tsx
+++ b/libs/service-portal/vehicles/src/screens/VehicleDetail/VehicleDetail.tsx
@@ -129,7 +129,7 @@ const VehicleDetail: ServicePortalModuleComponent = () => {
         />
         <Divider />
 
-        <UserInfoLine
+        {/* <UserInfoLine
           label={formatMessage(messages.insured)}
           content={
             inspectionInfo?.insuranceStatus === true
@@ -141,7 +141,7 @@ const VehicleDetail: ServicePortalModuleComponent = () => {
           warning={inspectionInfo?.insuranceStatus === false}
           loading={loading}
         />
-        <Divider />
+        <Divider /> */}
 
         <UserInfoLine
           label={formatMessage(messages.unpaidVehicleFee)}


### PR DESCRIPTION
## What

Hide insurance temporarily. Will add back in very soon.

## Why

The vehicle service cannot show correct information for car insurance as things stand now.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
