### PR TITLE
fix(j-s): Fix a broken back link on ruling page

### DIFF
--- a/apps/judicial-system/web/src/routes/Court/InvestigationCase/Ruling/Ruling.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationCase/Ruling/Ruling.tsx
@@ -51,7 +51,6 @@ import {
   SIGNED_VERDICT_OVERVIEW,
   IC_MODIFY_RULING_ROUTE,
   IC_COURT_RECORD_ROUTE,
-  IC_HEARING_ARRANGEMENTS_ROUTE,
   IC_COURT_HEARING_ARRANGEMENTS_ROUTE,
 } from '@island.is/judicial-system/consts'
 import SigningModal, {

--- a/apps/judicial-system/web/src/routes/Court/InvestigationCase/Ruling/Ruling.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationCase/Ruling/Ruling.tsx
@@ -52,6 +52,7 @@ import {
   IC_MODIFY_RULING_ROUTE,
   IC_COURT_RECORD_ROUTE,
   IC_HEARING_ARRANGEMENTS_ROUTE,
+  IC_COURT_HEARING_ARRANGEMENTS_ROUTE,
 } from '@island.is/judicial-system/consts'
 import SigningModal, {
   useRequestRulingSignature,
@@ -481,7 +482,7 @@ const Ruling = () => {
           previousUrl={
             isModifyingRuling
               ? `${SIGNED_VERDICT_OVERVIEW}/${workingCase.id}`
-              : `${IC_HEARING_ARRANGEMENTS_ROUTE}/${workingCase.id}`
+              : `${IC_COURT_HEARING_ARRANGEMENTS_ROUTE}/${workingCase.id}`
           }
           nextButtonText={
             isModifyingRuling


### PR DESCRIPTION
# Fix a broken back link on ruling page

[Asana](https://app.asana.com/0/1199153462262248/1202413161940505/f)

## What

When you click the Back button in the footer of the Ruling page in investigation cases, you are routed to the prosecutor flow, i.e. to "/krafa/rannsoknarheimild/fyrirtaka" (should be "/domur/rannsoknarheimild/fyrirtaka")

## Why

It's a bug

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
