### PR TITLE
feat(service-portal): add mortage certificate to assets

### DIFF
--- a/libs/service-portal/assets/src/screens/AssetsOverview/AssetsOverview.tsx
+++ b/libs/service-portal/assets/src/screens/AssetsOverview/AssetsOverview.tsx
@@ -3,15 +3,19 @@ import { defineMessage } from 'react-intl'
 import { useNamespaces, useLocale } from '@island.is/localization'
 import { gql, useQuery } from '@apollo/client'
 import { Query } from '@island.is/api/schema'
-import { Box, AlertBanner } from '@island.is/island-ui/core'
+import {
+  Box,
+  Text,
+  Button,
+  GridColumn,
+  GridRow,
+} from '@island.is/island-ui/core'
 import {
   ServicePortalModuleComponent,
-  IntroHeader,
   m,
   EmptyState,
 } from '@island.is/service-portal/core'
 import AssetListCards from '../../components/AssetListCards'
-import AssetDisclaimer from '../../components/AssetDisclaimer'
 import { AssetCardLoader } from '../../components/AssetCardLoader'
 import { DEFAULT_PAGING_ITEMS } from '../../utils/const'
 
@@ -85,19 +89,50 @@ export const AssetsOverview: ServicePortalModuleComponent = () => {
 
   return (
     <>
-      <Box marginBottom={[3, 4, 5]}>
-        <IntroHeader
-          title={defineMessage({
-            id: 'sp.assets:title',
-            defaultMessage: 'Fasteignir',
-          })}
-          intro={defineMessage({
-            id: 'sp.assets:intro',
-            defaultMessage:
-              'Hér birtast upplýsingar úr fasteignaskrá Þjóðskrár um fasteignir þínar, lönd og lóðir sem þú ert þinglýstur eigandi að.',
-          })}
-        />
-      </Box>
+      <Text variant="h3" as="h1">
+        {formatMessage({
+          id: 'sp.assets:title',
+          defaultMessage: 'Fasteignir',
+        })}
+      </Text>
+      <GridRow marginBottom={7}>
+        <GridColumn span={['12/12', '12/12', '12/12', '6/12']}>
+          <Text variant="default" paddingTop={2}>
+            {formatMessage({
+              id: 'sp.assets:intro',
+              defaultMessage:
+                'Hér birtast upplýsingar úr fasteignaskrá Þjóðskrár um fasteignir þínar, lönd og lóðir sem þú ert þinglýstur eigandi að.',
+            })}
+          </Text>
+        </GridColumn>
+        <GridColumn span={['12/12', '12/12', '12/12', '6/12']}>
+          <Box
+            display="flex"
+            justifyContent="flexEnd"
+            alignItems="flexEnd"
+            marginTop={2}
+            printHidden
+            height="full"
+          >
+            <a
+              href="/umsoknir/vedbokarvottord/"
+              target="_blank"
+              rel="noreferrer"
+            >
+              <Button
+                colorScheme="default"
+                icon="document"
+                iconType="filled"
+                size="default"
+                type="button"
+                variant="utility"
+              >
+                {formatMessage(m.mortageCertificate)}
+              </Button>
+            </a>
+          </Box>
+        </GridColumn>
+      </GridRow>
       {loading && <AssetCardLoader />}
       {data && (
         <AssetListCards paginateCallback={paginate} assets={assetData} />

--- a/libs/service-portal/core/src/lib/messages.ts
+++ b/libs/service-portal/core/src/lib/messages.ts
@@ -669,4 +669,8 @@ export const m = defineMessages({
     id: 'service.portal:your-licenses',
     defaultMessage: 'Þín skírteini',
   },
+  mortageCertificate: {
+    id: 'service.portal:mortage-certificate',
+    defaultMessage: 'Veðbókarvottorð',
+  },
 })

--- a/libs/service-portal/finance/src/screens/FinanceStatus/FinanceStatus.tsx
+++ b/libs/service-portal/finance/src/screens/FinanceStatus/FinanceStatus.tsx
@@ -137,8 +137,7 @@ const FinanceStatus: ServicePortalModuleComponent = ({ userInfo }) => {
                       <Button
                         colorScheme="default"
                         icon="receipt"
-                        iconType="outline"
-                        preTextIconType="outline"
+                        iconType="filled"
                         size="default"
                         type="button"
                         variant="utility"


### PR DESCRIPTION
# Service Portal - Mortage certificate 

## What

Add mortage certificate "veðbókarvottorð" application link to assets overview.

## Screenshots / Gifs

<img width="1415" alt="Screenshot 2022-06-09 at 22 55 44" src="https://user-images.githubusercontent.com/19873770/172958635-7cca7377-dd80-42d1-86f4-e22a8238dc97.png">


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
