### PR TITLE
chore(web): Content search article boost comment

### DIFF
--- a/libs/content-search-toolkit/src/queries/search.ts
+++ b/libs/content-search-toolkit/src/queries/search.ts
@@ -6,6 +6,8 @@ import { processAggregationQuery } from './processAggregation'
 
 const getBoostForType = (type: string, defaultBoost: string | number = 1) => {
   if (type === 'webArticle') {
+    // The number 55 was chosen since it was the threshold between the highest scoring news and the highest scoring article in search results
+    // The test that determined this boost was to type in "Umsókn um fæðingarorlof" and compare the news and article scores
     return 55
   }
   return defaultBoost


### PR DESCRIPTION
# Content search article boost comment

## What

* Added a comment that explains why the number 55 was chosen as a boost to articles

## Why

* It's weird seeing a random number in a codebase with no explanation

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
