### PR TITLE
feat(web): Added support for fetching english related articles

### DIFF
--- a/libs/cms/src/lib/cms.resolver.ts
+++ b/libs/cms/src/lib/cms.resolver.ts
@@ -85,6 +85,7 @@ import { GetSupportCategoriesInput } from './dto/getSupportCategories.input'
 import { GetSupportCategoriesInOrganizationInput } from './dto/getSupportCategoriesInOrganization.input'
 import { GetPublishedMaterialInput } from './dto/getPublishedMaterial.input'
 import { EnhancedAssetSearchResult } from './models/enhancedAssetSearchResult.model'
+import { Locale } from '@island.is/shared/types'
 
 const { cacheTime } = environment
 
@@ -347,13 +348,15 @@ export class CmsResolver {
 
   @Directive(cacheControlDirective())
   @Query(() => Article, { nullable: true })
-  getSingleArticle(
-    @Args('input') { lang, slug }: GetSingleArticleInput,
-  ): Promise<Article | null> {
-    return this.cmsElasticsearchService.getSingleDocumentTypeBySlug<Article>(
+  async getSingleArticle(@Args('input') { lang, slug }: GetSingleArticleInput) {
+    const article: Article | null = await this.cmsElasticsearchService.getSingleDocumentTypeBySlug<Article>(
       getElasticsearchIndex(lang),
       { type: 'webArticle', slug },
     )
+    return {
+      ...article,
+      lang,
+    }
   }
 
   @Directive(cacheControlDirective())
@@ -497,7 +500,10 @@ export class ArticleResolver {
 
   @Directive(cacheControlDirective())
   @ResolveField(() => [Article])
-  async relatedArticles(@Parent() article: Article) {
-    return this.cmsContentfulService.getRelatedArticles(article.slug, 'is')
+  async relatedArticles(@Parent() article: Article & { lang?: Locale }) {
+    return this.cmsContentfulService.getRelatedArticles(
+      article.slug,
+      article?.lang ?? 'is',
+    )
   }
 }


### PR DESCRIPTION
# Added support for fetching english related articles

## What

* Added a way to fetch related articles for different locales

## Why

* Before this change you couldn't see related articles on english locale

## Screenshots / Gifs

### Before
![image](https://user-images.githubusercontent.com/43557895/173373699-1acb1a6e-a3a4-42f3-a9bb-e22f9cd0cfae.png)

### After
![image](https://user-images.githubusercontent.com/43557895/173373822-07ecd678-6c1e-4f89-a18a-7c96d193c6d7.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
