### PR TITLE
feat(ads): Polling every minute instead of every ten seconds

### DIFF
--- a/apps/air-discount-scheme/web/screens/Subsidy/components/Benefits/Benefits.tsx
+++ b/apps/air-discount-scheme/web/screens/Subsidy/components/Benefits/Benefits.tsx
@@ -18,7 +18,7 @@ import {
 } from '@island.is/island-ui/core'
 import { NoBenefits, CodeCard } from '../'
 
-const TEN_SECONDS = 10000 // milli-seconds
+const ONE_MINUTE = 1000 * 60 // milli-seconds
 
 interface PropTypes {
   misc: string
@@ -52,7 +52,7 @@ const DiscountsQuery = gql`
 function Benefits({ misc }: PropTypes) {
   const { data, loading, called } = useQuery(DiscountsQuery, {
     ssr: false,
-    pollInterval: TEN_SECONDS,
+    pollInterval: ONE_MINUTE,
   })
   const { user: authUser } = useContext(UserContext)
   const { discounts = [] } = data || {}


### PR DESCRIPTION
# What
Users poll the graphql api every 10 seconds once on Air Discount Scheme.

# Why the change
Reduce request load by sixfold.

# Impact on users
Some users may figure out that they either have to wait or manually refresh themselves in the case where they are trying to use multiple discount codes in quick succession.

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
