### PR TITLE
fix(infra): Remove enable-global-auth for auth-admin-web staging

### DIFF
--- a/apps/auth-admin-web/infra/auth-admin-web.ts
+++ b/apps/auth-admin-web/infra/auth-admin-web.ts
@@ -40,7 +40,6 @@ export const serviceSetup = (): ServiceBuilder<'auth-admin-web'> => {
             'nginx.ingress.kubernetes.io/proxy-buffer-size': '8k',
           },
           staging: {
-            'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
             'nginx.ingress.kubernetes.io/proxy-buffering': 'on',
             'nginx.ingress.kubernetes.io/proxy-buffer-size': '8k',
           },

--- a/charts/identity-server/values.staging.yaml
+++ b/charts/identity-server/values.staging.yaml
@@ -32,7 +32,6 @@ auth-admin-web:
     primary-alb:
       annotations:
         kubernetes.io/ingress.class: 'nginx-external-alb'
-        nginx.ingress.kubernetes.io/enable-global-auth: 'false'
         nginx.ingress.kubernetes.io/proxy-buffer-size: '8k'
         nginx.ingress.kubernetes.io/proxy-buffering: 'on'
       hosts:


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Remove enable-global-auth for staging

## Why

This was causing CSP violations, and wasn't set in the original Helm setup.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
