### PR TITLE
WIP: Implement getUserProfile

### DIFF
--- a/apps/application-system/api/src/environments/environment.ts
+++ b/apps/application-system/api/src/environments/environment.ts
@@ -114,6 +114,11 @@ const devConfig = {
       password: process.env.SOFFIA_PASS ?? '',
       host: 'soffiaprufa.skra.is',
     },
+    islykill: {
+      cert: process.env.ISLYKILL_CERT,
+      passphrase: process.env.ISLYKILL_SERVICE_PASSPHRASE,
+      basePath: process.env.ISLYKILL_SERVICE_BASEPATH,
+    },
   },
 
   application: {
@@ -230,6 +235,11 @@ const prodConfig = {
       user: process.env.SOFFIA_USER,
       password: process.env.SOFFIA_PASS,
       host: process.env.SOFFIA_HOST_URL,
+    },
+    islykill: {
+      cert: process.env.ISLYKILL_CERT,
+      passphrase: process.env.ISLYKILL_SERVICE_PASSPHRASE,
+      basePath: process.env.ISLYKILL_SERVICE_BASEPATH,
     },
   },
   application: {

--- a/libs/application/template-api-modules/src/lib/modules/shared/data-providers/user-profile/user-profile.module.ts
+++ b/libs/application/template-api-modules/src/lib/modules/shared/data-providers/user-profile/user-profile.module.ts
@@ -11,14 +11,23 @@ import { BaseTemplateAPIModuleConfig } from '../../../../types'
 import { UserProfileService } from './user-profile.service'
 
 import { Configuration, UserProfileApi } from '@island.is/clients/user-profile'
+import { IslyklarApi, IslykillApiModule } from '@island.is/clients/islykill'
 
 export class UserProfileModule {
   static register(config: BaseTemplateAPIModuleConfig): DynamicModule {
     return {
       module: UserProfileModule,
-      imports: [SharedTemplateAPIModule.register(config)],
+      imports: [
+        SharedTemplateAPIModule.register(config),
+        IslykillApiModule.register({
+          cert: config.islykill.cert,
+          passphrase: config.islykill.passphrase,
+          basePath: config.islykill.basePath,
+        }),
+      ],
       providers: [
         UserProfileService,
+        IslyklarApi,
         {
           provide: UserProfileApi,
           useFactory: () =>

--- a/libs/application/template-api-modules/src/lib/modules/shared/data-providers/user-profile/user-profile.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/shared/data-providers/user-profile/user-profile.service.ts
@@ -1,45 +1,149 @@
 import { Auth, AuthMiddleware } from '@island.is/auth-nest-tools'
 import { UserProfileApi } from '@island.is/clients/user-profile'
-import { ProblemError } from '@island.is/nest/problem'
-import { ProblemType } from '@island.is/shared/problem'
-import { isRunningOnEnvironment } from '@island.is/shared/utils'
+import { IslyklarApi } from '@island.is/clients/islykill'
+import { logger } from '@island.is/logging'
 import { Injectable } from '@nestjs/common'
 import { SharedTemplateApiService } from '../..'
 import { TemplateApiModuleActionProps } from '../../../../types'
+import { isRunningOnEnvironment } from '@island.is/shared/utils'
+import differenceInMonths from 'date-fns/differenceInMonths'
+
+export const MAX_OUT_OF_DATE_MONTHS = 6
+
+const handleError = (error: any) => {
+  logger.error(JSON.stringify(error))
+  throw new Error(`Failed to resolve request (${error.status})`)
+}
+
+enum DataStatus {
+  NOT_DEFINED = 'NOT_DEFINED',
+  NOT_VERIFIED = 'NOT_VERIFIED',
+  VERIFIED = 'VERIFIED',
+  EMPTY = 'EMPTY',
+}
+
 @Injectable()
 export class UserProfileService {
   constructor(
     private readonly sharedTemplateAPIService: SharedTemplateApiService,
     private readonly userProfileApi: UserProfileApi,
-  ) {}
+    private readonly islyklarApi: IslyklarApi,
+  ) { }
 
-  userProfileApiWithAuth(auth: Auth) {
+  userProfileApiWithAuth(auth: Auth): UserProfileApi {
     return this.userProfileApi.withMiddleware(new AuthMiddleware(auth))
   }
 
-  async getUserProfile({ auth }: TemplateApiModuleActionProps) {
-    try {
-      //TODO finish this
-      const profile = await this.userProfileApiWithAuth(
-        auth,
-      ).userProfileControllerFindOneByNationalId({
-        nationalId: auth.nationalId,
-      })
-
-      return {
-        email: profile.email,
-        emailVerified: profile.emailVerified,
-        mobilePhoneNumber: profile.mobilePhoneNumber,
-        mobilePhoneNumberVerified: profile.mobilePhoneNumberVerified,
-      }
-    } catch (e) {
-      if (isRunningOnEnvironment('local')) {
-        return {
-          email: 'mockEmail@island.is',
-          mobilePhoneNumber: '9999999',
-        }
-      }
-      throw e
+  async getIslykillProfile(auth: Auth) {
+    if (auth.nationalId === undefined) {
+      return null
     }
+
+    this.islyklarApi.islyklarGet({ ssn: auth.nationalId })
+      .then(islyklarData => {
+        return {
+          nationalId: auth.nationalId,
+          emailVerified: false,
+          mobilePhoneNumberVerified: false,
+          documentNotifications: false,
+          emailStatus: DataStatus.NOT_VERIFIED,
+          mobileStatus: DataStatus.NOT_VERIFIED,
+
+          // Islyklar data:
+          mobilePhoneNumber: islyklarData?.mobile,
+          email: islyklarData?.email,
+          canNudge: islyklarData?.canNudge,
+          bankInfo: islyklarData?.bankInfo,
+        }
+      }).catch(error => {
+        if (isRunningOnEnvironment('local')) {
+          return null
+        }
+
+        logger.error(JSON.stringify(error))
+        return null
+      })
+  }
+
+  async getUserProfileStatus(auth: Auth) {
+    /**
+     * this.getUserProfile can be a bit slower with the addition of islyklar data call.
+     * getUserProfileStatus can be used for a check if the userprofile exists, or if the userdata is old
+     * Old userdata can mean a user will be prompted to verify their info in the UI.
+     */
+    if (auth.nationalId === undefined) {
+      return null
+    }
+
+    this.userProfileApiWithAuth(auth)
+      .userProfileControllerFindOneByNationalId({ nationalId: auth.nationalId })
+      .then(profile => {
+        /**
+         * If user has empty email or tel data
+         * Then the user will be prompted every 6 months (MAX_OUT_OF_DATE_MONTHS)
+         * to verify if they want to keep their info empty
+         */
+        const emptyMail = profile?.emailStatus === 'EMPTY'
+        const emptyMobile = profile?.mobileStatus === 'EMPTY'
+        const modifiedProfileDate = profile?.modified
+        const dateNow = new Date()
+        const dateModified = new Date(modifiedProfileDate)
+        const diffInMonths = differenceInMonths(dateNow, dateModified)
+        const diffOutOfDate = diffInMonths >= MAX_OUT_OF_DATE_MONTHS
+        const outOfDateEmailMobile = (emptyMail || emptyMobile) && diffOutOfDate
+
+        return {
+          hasData: !!modifiedProfileDate,
+          hasModifiedDateLate: outOfDateEmailMobile,
+        }
+
+      }).catch(error => {
+        if (isRunningOnEnvironment('local')) {
+          return {
+            email: 'mockEmail@island.is',
+            mobilePhoneNumber: '9999999',
+          }
+        }
+
+        if (error.status === 404) {
+          return {
+            hasData: false,
+            hasModifiedDateLate: true,
+          }
+        }
+        handleError(error)
+      })
+  }
+
+  async getUserProfile({ auth }: TemplateApiModuleActionProps) {
+    Promise.all([
+      this.userProfileApiWithAuth(auth)
+        .userProfileControllerFindOneByNationalId({ nationalId: auth.nationalId }),
+      this.islyklarApi.islyklarGet({ ssn: auth.nationalId })
+    ]).then(results => {
+      const profile = results[0]
+      const islyklarData = results[1]
+      return {
+        ...profile,
+        // Temporary solution while we still run the old user profile service.
+        mobilePhoneNumber: islyklarData?.mobile,
+        email: islyklarData?.email,
+        canNudge: islyklarData?.canNudge,
+        bankInfo: islyklarData?.bankInfo,
+      }
+    }).catch((error) => {
+      if (isRunningOnEnvironment('local')) {
+        return null
+      }
+
+      if (error.status === 404) {
+        /**
+         * Even if userProfileApiWithAuth does not exist.
+         * Islykill data might exist for the user, so we need to get that, with default values in the userprofile data.
+         */
+        return this.getIslykillProfile(auth)
+      }
+      handleError(error)
+    })
   }
 }

--- a/libs/application/template-api-modules/src/lib/types/index.ts
+++ b/libs/application/template-api-modules/src/lib/types/index.ts
@@ -7,6 +7,8 @@ import { Config as CriminalRecordConfig } from '@island.is/api/domains/criminal-
 import { PaymentServiceOptions } from '@island.is/clients/payment'
 import { Message } from '@island.is/email-service'
 import { User } from '@island.is/auth-nest-tools'
+import { IslykillApiModuleConfig } from '@island.is/clients/islykill'
+
 import { PaymentScheduleServiceOptions } from '@island.is/clients/payment-schedule'
 import { HealthInsuranceV2Options } from '@island.is/clients/health-insurance-v2'
 import { DataProtectionComplaintClientConfig } from '@island.is/clients/data-protection-complaint'
@@ -54,6 +56,7 @@ export interface BaseTemplateAPIModuleConfig {
     password: string
     host: string
   }
+  islykill: IslykillApiModuleConfig
 }
 
 export interface TemplateApiModuleActionProps {


### PR DESCRIPTION
We weren't told what to return from this function, so it seems to make sense to just return the object we got from the client call.

That client has more functions. We had talked about only implementing the read ones, that is, the ones that use HTTP GET. Those are:

- userProfileControllerFindOneByNationalId
- userTokenControllerFindOneByNationalId
- userTokenControllerGetDeviceTokens

This commit implements the first one. We didn't (yet) do the second two because the module this gets used in is UserProfileModule.  As far as I can tell, that module is configured in SharedDataProviders, where it appears as an instance of ApplicationTemplateAPIAction. That interface has a single field called apiModuleAction, and our original module is only configured with getUserProfile as that action. So... we're done?