### PR TITLE
feat(application-system): Default markdown styles

### DIFF
--- a/libs/application/core/src/types/Form.ts
+++ b/libs/application/core/src/types/Form.ts
@@ -107,7 +107,6 @@ export interface MultiField extends FormItem {
   children: Field[]
   isPartOfRepeater?: boolean
   readonly description?: FormText
-  descriptionMarkdownOptions?: MarkdownToJSX.Options
   space?: BoxProps['paddingTop']
 }
 

--- a/libs/application/core/src/types/Form.ts
+++ b/libs/application/core/src/types/Form.ts
@@ -2,7 +2,6 @@ import { Dispatch, SetStateAction } from 'react'
 import { GraphQLError } from 'graphql'
 import { ZodObject } from 'zod'
 import { MessageDescriptor } from 'react-intl'
-import { MarkdownToJSX } from 'markdown-to-jsx'
 
 import type { BoxProps } from '@island.is/island-ui/core/types'
 import { Field, RecordObject } from '@island.is/application/core'

--- a/libs/application/templates/announcement-of-death/src/forms/done.ts
+++ b/libs/application/templates/announcement-of-death/src/forms/done.ts
@@ -6,7 +6,6 @@ import {
   buildMultiField,
 } from '@island.is/application/core'
 import { m } from '../lib/messages'
-import { markdownOptions } from '../lib/markdownOptions'
 
 export const done: Form = buildForm({
   id: 'done',
@@ -17,7 +16,6 @@ export const done: Form = buildForm({
       id: 'done',
       title: m.announcementComplete,
       description: m.nextStepsText,
-      descriptionMarkdownOptions: markdownOptions,
       space: 1,
       children: [
         buildCustomField({

--- a/libs/application/templates/announcement-of-death/src/forms/draft/subSectionInheritance.ts
+++ b/libs/application/templates/announcement-of-death/src/forms/draft/subSectionInheritance.ts
@@ -4,7 +4,6 @@ import {
   buildSubSection,
   buildCustomField,
 } from '@island.is/application/core'
-import { markdownOptions } from '../../lib/markdownOptions'
 import { m } from '../../lib/messages'
 
 export const subSectionInheritance = buildSubSection({
@@ -15,7 +14,6 @@ export const subSectionInheritance = buildSubSection({
       id: 'inheritanceTitle',
       title: m.inheritanceTitle,
       description: m.inheritanceDescription,
-      descriptionMarkdownOptions: markdownOptions,
       space: 1,
       children: [
         buildDescriptionField({

--- a/libs/application/ui-components/src/components/Markdown/Markdown.css.ts
+++ b/libs/application/ui-components/src/components/Markdown/Markdown.css.ts
@@ -1,0 +1,10 @@
+import { theme } from '@island.is/island-ui/theme'
+import { style, globalStyle } from '@vanilla-extract/css'
+
+export const container = style({})
+
+//TODO: Currently overriding the default p in markdown is removing link styles, we need to override global styles until we have a solution for overriding p with the Text component
+globalStyle(`${container} p`, {
+  fontWeight: theme.typography.light,
+  ['-webkit-font-smoothing' as string]: 'antialiased',
+})

--- a/libs/application/ui-components/src/components/Markdown/Markdown.tsx
+++ b/libs/application/ui-components/src/components/Markdown/Markdown.tsx
@@ -1,0 +1,11 @@
+import { compiler } from 'markdown-to-jsx'
+import { markdownOptions } from './markdownOptions'
+
+interface Props {
+  children: string
+}
+
+export const Markdown = ({ children }: Props) =>
+  compiler(children, markdownOptions)
+
+export default Markdown

--- a/libs/application/ui-components/src/components/Markdown/markdownOptions.tsx
+++ b/libs/application/ui-components/src/components/Markdown/markdownOptions.tsx
@@ -7,6 +7,7 @@ import {
 } from '@island.is/island-ui/core'
 import { MarkdownToJSX } from 'markdown-to-jsx'
 import React from 'react'
+import * as styles from './Markdown.css'
 
 const markdownOverrides: MarkdownToJSX.Overrides = {
   ul: BulletList,
@@ -25,15 +26,17 @@ const markdownOverrides: MarkdownToJSX.Overrides = {
       variant: 'h3',
     },
   },
-  p: {
-    component: Text,
-    props: {
-      fontWeight: 'light',
-    },
-  },
 }
 
 export const markdownOptions: MarkdownToJSX.Options = {
   overrides: markdownOverrides,
-  wrapper: ({ children }) => <Stack space={1}>{children}</Stack>,
+  wrapper: ({ children }) => (
+    //TODO: Currently overriding the default p in markdown is removing link styles, we need to override global styles until we have a solution for overriding p with the Text component
+    <div className={styles.container}>
+      <Stack space={1}>{children}</Stack>
+    </div>
+  ),
+  forceBlock: true,
+  forceWrapper: true,
+  disableParsingRawHTML: true,
 }

--- a/libs/application/ui-components/src/index.ts
+++ b/libs/application/ui-components/src/index.ts
@@ -13,3 +13,4 @@ export { InputImageUpload } from './components/InputImageUpload/InputImageUpload
 export { PaymentPending } from './components/PaymentPending/PaymentPending'
 export { CompanySearchController } from './components/CompanySearchController/CompanySearchController'
 export * from './types'
+export { Markdown } from './components/Markdown/Markdown'

--- a/libs/application/ui-shell/src/components/FormMultiField.tsx
+++ b/libs/application/ui-shell/src/components/FormMultiField.tsx
@@ -38,12 +38,7 @@ const FormMultiField: FC<{
   setBeforeSubmitCallback,
   setFieldLoadingState,
 }) => {
-  const {
-    description,
-    descriptionMarkdownOptions,
-    children,
-    space = 0,
-  } = multiField
+  const { description, children, space = 0 } = multiField
   const { formatMessage } = useLocale()
   return (
     <GridRow>
@@ -58,7 +53,6 @@ const FormMultiField: FC<{
         <GridColumn>
           <FieldDescription
             description={formatText(description, application, formatMessage)}
-            markdownOptions={descriptionMarkdownOptions}
           />
         </GridColumn>
       )}

--- a/libs/shared/form-fields/src/lib/FieldDescription/FieldDescription.tsx
+++ b/libs/shared/form-fields/src/lib/FieldDescription/FieldDescription.tsx
@@ -1,20 +1,15 @@
 import React, { FC } from 'react'
-import { Text } from '@island.is/island-ui/core'
-import Markdown, { MarkdownToJSX } from 'markdown-to-jsx'
-
+import { Box } from '@island.is/island-ui/core'
+import { Markdown } from '@island.is/application/ui-components'
 interface Props {
   description: string
-  markdownOptions?: MarkdownToJSX.Options
 }
 
-export const FieldDescription: FC<Props> = ({
-  description,
-  markdownOptions,
-}) => {
+export const FieldDescription: FC<Props> = ({ description }) => {
   return (
-    <Text marginTop={1} marginBottom={1} as="div">
-      <Markdown options={markdownOptions}>{description}</Markdown>
-    </Text>
+    <Box marginTop={1} marginBottom={1}>
+      <Markdown>{description}</Markdown>
+    </Box>
   )
 }
 

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "libphonenumber-js": "1.7.53",
     "lodash": "4.17.21",
     "lottie-web": "5.7.13",
-    "markdown-to-jsx": "7.1.1",
+    "markdown-to-jsx": "7.1.7",
     "memoizee": "0.4.15",
     "mobx": "6.3.7",
     "msw": "0.21.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22106,10 +22106,10 @@ markdown-escapes@^1.0.0:
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.4.tgz#c95415ef451499d7602b91095f3c8e8975f78535"
   integrity sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==
 
-markdown-to-jsx@7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.1.1.tgz#269145a585650258691a9a1ec9fb4b273ed2d32a"
-  integrity sha512-PJgNmvdKM7f7dFDgr4N2ZQv5OuJ2dwwBZvKel61BO7JLh2QQLDs880uQO+OjsEKNmhCZ0ZOIKkCXFEuY9G0yEA==
+markdown-to-jsx@7.1.7:
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.1.7.tgz#a5f22102fb12241c8cea1ca6a4050bb76b23a25d"
+  integrity sha512-VI3TyyHlGkO8uFle0IOibzpO1c1iJDcXcS/zBrQrXQQvJ2tpdwVzVZ7XdKsyRz1NdRmre4dqQkMZzUHaKIG/1w==
 
 markdown-to-jsx@^6.11.4:
   version "6.11.4"


### PR DESCRIPTION
## What

Adding styled markdown to the application system UI components.
Currently only supporting h1, bullet lists, and anchors

## Why

This will make rich text areas easier to work with

## Screenshots / Gifs

<img width="810" alt="image" src="https://user-images.githubusercontent.com/5655741/174486440-e831f1ce-5af2-4012-9142-3eaf543cbf0a.png">

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
