### PR TITLE
fix(service-portal): Add company title as translation string

### DIFF
--- a/libs/service-portal/core/src/lib/messages.ts
+++ b/libs/service-portal/core/src/lib/messages.ts
@@ -673,4 +673,8 @@ export const m = defineMessages({
     id: 'service.portal:mortage-certificate',
     defaultMessage: 'Veðbókarvottorð',
   },
+  companyTitle: {
+    id: 'service.portal:company-title',
+    defaultMessage: 'Um fyrirtæki',
+  },
 })

--- a/libs/service-portal/core/src/lib/navigation/masterNavigation.ts
+++ b/libs/service-portal/core/src/lib/navigation/masterNavigation.ts
@@ -37,7 +37,7 @@ export const servicePortalMasterNavigation: ServicePortalNavigationItem[] = [
 
       // Company
       {
-        name: 'Um fyriræki',
+        name: m.companyTitle,
         path: ServicePortalPath.Company,
         icon: {
           icon: 'business',


### PR DESCRIPTION
## What

Add company title as translation string

## Why

Cant update in cms as things stand now.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
