### PR TITLE
fix(web): Fix styles for Fiskistofa footer

### DIFF
--- a/apps/web/components/Organization/Wrapper/Themes/FiskistofaTheme/FiskistofaFooter.css.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/FiskistofaTheme/FiskistofaFooter.css.ts
@@ -14,12 +14,13 @@ export const iconContainer = style({
   display: 'flex',
   flexFlow: 'row wrap',
   gap: '8px',
-  marginTop: '4px',
+  marginTop: '12px',
 })
 
 export const linkContainer = style({
-  alignSelf: 'center',
-  marginTop: '16px',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '16px',
   ...themeUtils.responsiveStyle({
     md: {
       marginLeft: 0,
@@ -30,6 +31,10 @@ export const linkContainer = style({
   }),
 })
 
+export const linkRow = style({
+  marginLeft: '72px',
+})
+
 export const bsiLogo = style({
-  height: '75px',
+  height: '60px',
 })

--- a/apps/web/components/Organization/Wrapper/Themes/FiskistofaTheme/FiskistofaFooter.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/FiskistofaTheme/FiskistofaFooter.tsx
@@ -31,22 +31,39 @@ export const FiskistofaFooter = ({ footerItems }: FiskistofaFooterProps) => {
                 />
               </Box>
             </GridRow>
-            <GridRow marginTop={2}>
-              {footerItems.slice(0, 3).map((item) => (
-                <GridColumn>
+            <GridRow marginTop={2} className={styles.linkRow}>
+              {footerItems.slice(0, 3).map((item, idx) => (
+                <GridColumn span={['10/10', '10/10', '5/10', '2/10']}>
                   <Text fontWeight="semiBold" marginBottom={2}>
                     <Hyphen>{item.title}</Hyphen>
                   </Text>
-                  {richText(item.content as SliceType[])}
+                  {richText(item.content as SliceType[], {
+                    renderNode: {
+                      [BLOCKS.PARAGRAPH]: (_node, children) => (
+                        <Text
+                          variant={'medium'}
+                          marginBottom={1}
+                          lineHeight={'lg'}
+                        >
+                          {children}
+                        </Text>
+                      ),
+                    },
+                  })}
                 </GridColumn>
               ))}
 
               {footerItems[3] && (
-                <GridColumn className={styles.linkContainer}>
+                <GridColumn
+                  className={styles.linkContainer}
+                  paddingTop={[2, 2, 0]}
+                >
                   {richText(footerItems[3].content as SliceType[], {
                     renderNode: {
                       [BLOCKS.PARAGRAPH]: (_node, children) => (
-                        <Text>{children}</Text>
+                        <Text variant={'eyebrow'} fontWeight={'medium'}>
+                          {children}
+                        </Text>
                       ),
                     },
                   })}
@@ -54,8 +71,8 @@ export const FiskistofaFooter = ({ footerItems }: FiskistofaFooterProps) => {
                     <img
                       src="https://images.ctfassets.net/8k0h54kbe6bj/7076IkepUKnI8eKHbo69Ys/40d84cf75b177a8bef7beb1f6d45f6cd/fiskistofa-jafnlaunavottun.png"
                       alt="fiskistofa-jafnlaunavottun"
-                      width={100}
-                      height={100}
+                      width={80}
+                      height={80}
                     />
                     <img
                       src="https://images.ctfassets.net/8k0h54kbe6bj/71f5kkbe52Y21n62JfdxlQ/bd5c7f87d582ab1cd74b6e6ca61d6890/fiskistofa-bsi.png"


### PR DESCRIPTION
# Fix styles for Fiskistofa footer

## What

There were small style inconsistencies in the Fiskistofa footer.

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/3607456/174585339-01834aa8-6e66-4ce3-b686-98323fa21015.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
