### PR TITLE
chore(company-regisry): Add audit decorators to rsk resolver

### DIFF
--- a/libs/api/domains/company-registry/src/lib/api-domains-company-registry.resolver.ts
+++ b/libs/api/domains/company-registry/src/lib/api-domains-company-registry.resolver.ts
@@ -27,6 +27,7 @@ export class CompanyRegistryResolver {
     name: 'companyRegistryCompany',
     nullable: true,
   })
+  @Audit()
   async companyInformation(
     @Args('input', { type: () => RskCompanyInfoInput })
     input: RskCompanyInfoInput,
@@ -45,6 +46,7 @@ export class CompanyRegistryResolver {
   @Query(() => RskCompanySearchItems, {
     name: 'companyRegistryCompanies',
   })
+  @Audit()
   async companyInformationSearch(
     @Args('input', { type: () => RskCompanyInfoSearchInput })
     input: RskCompanyInfoSearchInput,
@@ -58,6 +60,7 @@ export class CompanyRegistryResolver {
   }
 
   @ResolveField(() => RskCompanyInfo)
+  @Audit()
   async companyInfo(
     @Parent() rskCompanyItem: RskCompany,
   ): Promise<RskCompanyInfo | undefined> {


### PR DESCRIPTION
## What

Add audit decorators to rsk resolver

## Why

Not seeing the audit records for rsk lookup with current setup.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
