### PR TITLE
fix(service-portal): Update sms code test for mismatching numbers

### DIFF
--- a/apps/services/user-profile/src/app/user-profile/e2e/userProfile.spec.ts
+++ b/apps/services/user-profile/src/app/user-profile/e2e/userProfile.spec.ts
@@ -720,14 +720,22 @@ describe('User profile API', () => {
         },
       })
 
-      // Assert
+      // Act
       const response = await request(app.getHttpServer())
         .post(`/confirmSms/${mockProfile.nationalId}`)
         .send({
           code: verification.smsCode,
-          mobilePhoneNumber: mockProfile.mobilePhoneNumber,
+          mobilePhoneNumber: '1234567',
         })
         .expect(200)
+
+      // Assert
+      expect(response.body).toMatchInlineSnapshot(`
+          Object {
+            "confirmed": false,
+            "message": "Sms verification does not exist for this user",
+          }
+        `)
     })
   })
 


### PR DESCRIPTION
## What

Update the test for non-matching mobile numbers

## Why

The test was wrong. It was not checking for the mismatching emails. Only if the response was good, which is done in a different test.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
