### PR TITLE
fix(enhanced-fetch): HOTFIX Handle 304 responses when revalidating (#7834)

### DIFF
--- a/libs/clients/middlewares/src/lib/withCache/withCache.ts
+++ b/libs/clients/middlewares/src/lib/withCache/withCache.ts
@@ -188,12 +188,15 @@ export function withCache({
     try {
       revalidationResponse = await fetch(revalidationRequest)
     } catch (fetchError) {
-      if (cacheResponse.policy._useStaleIfError()) {
+      if (fetchError instanceof FetchError && fetchError.status === 304) {
+        revalidationResponse = fetchError.response
+      } else if (cacheResponse.policy._useStaleIfError()) {
         cacheResponse.cacheStatus.hit = true
         debugLog('Revalidate error, return stale', cacheResponse)
         return cacheResponse
+      } else {
+        throw fetchError
       }
-      throw fetchError
     }
 
     const {


### PR DESCRIPTION
* fix(enhanced-fetch): Handle 304 responses when revalidating

* Format
