### PR TITLE
feat(parental-leave): remove country code from prefilled tel number

### DIFF
--- a/libs/application/data-providers/src/providers/UserProfileProvider.ts
+++ b/libs/application/data-providers/src/providers/UserProfileProvider.ts
@@ -49,7 +49,7 @@ export class UserProfileProvider extends BasicDataProvider {
     if (isRunningOnEnvironment('local')) {
       return Promise.resolve({
         email: 'mockEmail@island.is',
-        mobilePhoneNumber: '+3549999999',
+        mobilePhoneNumber: '9999999',
       })
     }
 

--- a/libs/application/data-providers/src/providers/UserProfileProvider.ts
+++ b/libs/application/data-providers/src/providers/UserProfileProvider.ts
@@ -49,7 +49,7 @@ export class UserProfileProvider extends BasicDataProvider {
     if (isRunningOnEnvironment('local')) {
       return Promise.resolve({
         email: 'mockEmail@island.is',
-        mobilePhoneNumber: '9999999',
+        mobilePhoneNumber: '+3549999999',
       })
     }
 

--- a/libs/application/templates/parental-leave/src/forms/ParentalLeaveForm.ts
+++ b/libs/application/templates/parental-leave/src/forms/ParentalLeaveForm.ts
@@ -29,6 +29,7 @@ import {
   getApplicationAnswers,
   allowOtherParent,
   getLastValidPeriodEndDate,
+  removeCountryCode,
 } from '../lib/parentalLeaveUtils'
 import {
   GetPensionFunds,
@@ -96,9 +97,7 @@ export const ParentalLeaveForm: Form = buildForm({
                   width: 'half',
                   title: parentalLeaveFormMessages.applicant.phoneNumber,
                   defaultValue: (application: Application) =>
-                    (application.externalData.userProfile?.data as {
-                      mobilePhoneNumber?: string
-                    })?.mobilePhoneNumber?.slice(4),
+                    removeCountryCode(application),
                   id: 'applicant.phoneNumber',
                   variant: 'tel',
                   format: '###-####',

--- a/libs/application/templates/parental-leave/src/forms/ParentalLeaveForm.ts
+++ b/libs/application/templates/parental-leave/src/forms/ParentalLeaveForm.ts
@@ -98,7 +98,7 @@ export const ParentalLeaveForm: Form = buildForm({
                   defaultValue: (application: Application) =>
                     (application.externalData.userProfile?.data as {
                       mobilePhoneNumber?: string
-                    })?.mobilePhoneNumber,
+                    })?.mobilePhoneNumber?.slice(4),
                   id: 'applicant.phoneNumber',
                   variant: 'tel',
                   format: '###-####',

--- a/libs/application/templates/parental-leave/src/lib/parentalLeaveUtils.spec.ts
+++ b/libs/application/templates/parental-leave/src/lib/parentalLeaveUtils.spec.ts
@@ -21,6 +21,7 @@ import {
   calculatePeriodLengthInMonths,
   applicantIsMale,
   getOtherParentName,
+  removeCountryCode,
 } from './parentalLeaveUtils'
 import { PersonInformation } from '../types'
 
@@ -496,5 +497,31 @@ describe('applicantIsMale', () => {
     set(application.externalData, 'person.data.genderCode', '1')
 
     expect(applicantIsMale(application)).toBe(true)
+  })
+})
+
+describe('removeCountryCode', () => {
+  it('should return the last 7 digits of the phone number', () => {
+    const application = buildApplication()
+    set(
+      application.externalData,
+      'userProfile.data.mobilePhoneNumber',
+      '+3541234567',
+    )
+    expect(removeCountryCode(application)).toEqual('1234567')
+  })
+  it('should return the last 7 digits of the phone number', () => {
+    const application = buildApplication()
+    set(
+      application.externalData,
+      'userProfile.data.mobilePhoneNumber',
+      '003541234567',
+    )
+    expect(removeCountryCode(application)).toEqual('1234567')
+  })
+  it("should return null if phone number wouldn't exist", () => {
+    const application = buildApplication()
+    set(application.externalData, 'userProfile', null)
+    expect(removeCountryCode(application)).toEqual(undefined)
   })
 })

--- a/libs/application/templates/parental-leave/src/lib/parentalLeaveUtils.ts
+++ b/libs/application/templates/parental-leave/src/lib/parentalLeaveUtils.ts
@@ -781,3 +781,21 @@ export const calculatePeriodLengthInMonths = (
 
   return round(diffMonths + roundedDays, 1)
 }
+
+export const removeCountryCode = (application: Application) => {
+  return (application.externalData.userProfile?.data as {
+    mobilePhoneNumber?: string
+  })?.mobilePhoneNumber?.startsWith('+354')
+    ? (application.externalData.userProfile?.data as {
+        mobilePhoneNumber?: string
+      })?.mobilePhoneNumber?.slice(4)
+    : (application.externalData.userProfile?.data as {
+        mobilePhoneNumber?: string
+      })?.mobilePhoneNumber?.startsWith('00354')
+    ? (application.externalData.userProfile?.data as {
+        mobilePhoneNumber?: string
+      })?.mobilePhoneNumber?.slice(5)
+    : (application.externalData.userProfile?.data as {
+        mobilePhoneNumber?: string
+      })?.mobilePhoneNumber
+}


### PR DESCRIPTION
## What

remove country code (+354) from function that prefills user tel number in application

## Why

Otherwise 1234567 will be shown as 3541234

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
