### PR TITLE
feat(test): Make proxy script cancellable

### DIFF
--- a/scripts/run-test-proxies.sh
+++ b/scripts/run-test-proxies.sh
@@ -2,4 +2,8 @@
 
 set -euo pipefail
 
-./scripts/run-es-proxy.sh "$@" & ./scripts/run-soffia-proxy.sh "$@" & ./scripts/run-xroad-proxy.sh "$@" &
+./scripts/run-es-proxy.sh "$@" &
+./scripts/run-soffia-proxy.sh "$@" &
+./scripts/run-xroad-proxy.sh "$@" &
+
+wait


### PR DESCRIPTION

## What
Make it possible to cancel running proxies using `./scripts/run-test-proxies.sh` and `Ctrl+C`.

## Why
Otherwise, killing proxies requires searching for processes running with the used ports and killing them by process IDs.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
