### PR TITLE
fix(parental-leave): edit other parent on review page

### DIFF
--- a/libs/application/templates/parental-leave/src/fields/Review/Review.tsx
+++ b/libs/application/templates/parental-leave/src/fields/Review/Review.tsx
@@ -327,7 +327,7 @@ export const Review: FC<ReviewScreenProps> = ({
 
       <ReviewGroup
         isEditable={editable && isPrimaryParent}
-        editAction={() => goToScreen?.('otherParent')}
+        editAction={() => goToScreen?.('otherParentObj')}
       >
         {otherParent === NO && (
           <RadioValue


### PR DESCRIPTION
## What

Edit button doesn't respond when clicked on in review page

## Why

Didn't work after other parent structure changed 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
