### PR TITLE
chore(auth-public-api): Adding company only scopes for custom delegations

### DIFF
--- a/libs/auth-api-lib/src/lib/config/DelegationConfig.ts
+++ b/libs/auth-api-lib/src/lib/config/DelegationConfig.ts
@@ -1,6 +1,6 @@
 import * as z from 'zod'
 
-import { AuthScope } from '@island.is/auth/scopes'
+import { ApiScope, AuthScope } from '@island.is/auth/scopes'
 import { defineConfig } from '@island.is/nest/config'
 import { DelegationType } from '../entities/dto/delegation.dto'
 
@@ -39,6 +39,14 @@ export const DelegationConfig = defineConfig({
     customScopeRules: env.optionalJSON('DELEGATION_CUSTOM_SCOPE_RULES') ?? [
       {
         scopeName: AuthScope.writeDelegations,
+        onlyForDelegationType: ['ProcurationHolder'],
+      },
+      {
+        scopeName: ApiScope.financeSalary,
+        onlyForDelegationType: ['ProcurationHolder'],
+      },
+      {
+        scopeName: ApiScope.company,
         onlyForDelegationType: ['ProcurationHolder'],
       },
     ],


### PR DESCRIPTION
## What

Updating the default config list for scopes that should only be returned in the scope list for companies to grant access using custom delegations.

## Why

To hide these scopes when individuals are giving custom delegations.

## Screenshots / Gifs


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
