### PR TITLE
fix(fa): Add english translation to months

### DIFF
--- a/apps/financial-aid/web-osk/src/components/DataGathering/AboutDataGathering.tsx
+++ b/apps/financial-aid/web-osk/src/components/DataGathering/AboutDataGathering.tsx
@@ -13,8 +13,8 @@ const AboutDataGathering = () => {
       <Text marginBottom={[4, 4, 5]}>
         Við þurfum að fá þig til að renna yfir nokkur atriði varðandi þína
         persónuhagi og fjármál til að reikna út fjárhagsaðstoð til útgreiðslu í
-        byrjun {getNextPeriod.month}. Í lok umsóknar getur þú sent hana inn eða
-        eytt henni og öllum tengdum gögnum.
+        byrjun {getNextPeriod().month}. Í lok umsóknar getur þú sent hana inn
+        eða eytt henni og öllum tengdum gögnum.
       </Text>
     </>
   )

--- a/apps/financial-aid/web-osk/src/components/Estimation/Estimation.tsx
+++ b/apps/financial-aid/web-osk/src/components/Estimation/Estimation.tsx
@@ -72,7 +72,7 @@ const Estimation = ({
         </Box>
 
         <Text variant="small">
-          (til útgreiðslu í byrjun {getNextPeriod.month})
+          (til útgreiðslu í byrjun {getNextPeriod().month})
         </Text>
       </Box>
 

--- a/apps/financial-aid/web-osk/src/components/Status/InProgress.tsx
+++ b/apps/financial-aid/web-osk/src/components/Status/InProgress.tsx
@@ -31,7 +31,9 @@ const InProgress = ({ application, isApplicant = true }: Props) => {
   const header = () => {
     return application.state === ApplicationState.NEW
       ? 'Umsókn móttekin'
-      : `Umsókn í vinnslu til útgreiðslu í ${getNextPeriod.month} ${getNextPeriod.year}`
+      : `Umsókn í vinnslu til útgreiðslu í ${getNextPeriod().month} ${
+          getNextPeriod().year
+        }`
   }
 
   return (

--- a/apps/financial-aid/web-osk/src/routes/application/Confirmation/confirmation.tsx
+++ b/apps/financial-aid/web-osk/src/routes/application/Confirmation/confirmation.tsx
@@ -30,7 +30,9 @@ const Confirmation = () => {
 
   const nextSteps = [
     'Vinnsluaðili sveitarfélagsins vinnur úr umsókninni. Umsóknin verður afgreidd eins fljótt og auðið er.',
-    `Ef umsóknin er samþykkt getur þú reiknað með útgreiðslu í byrjun ${getNextPeriod.month}.`,
+    `Ef umsóknin er samþykkt getur þú reiknað með útgreiðslu í byrjun ${
+      getNextPeriod().month
+    }.`,
     'Ef þörf er á frekari upplýsingum eða gögnum til að vinna úr umsókninni mun vinnsluaðili sveitarfélagsins hafa samband.',
   ]
 

--- a/libs/application/templates/financial-aid/src/fields/AboutForm/AboutForm.tsx
+++ b/libs/application/templates/financial-aid/src/fields/AboutForm/AboutForm.tsx
@@ -1,21 +1,24 @@
 import React from 'react'
-import { Text, Box } from '@island.is/island-ui/core'
-import { aboutForm } from '../../lib/messages'
 import { useIntl } from 'react-intl'
 
+import { Text, Box } from '@island.is/island-ui/core'
+import { useLocale } from '@island.is/localization'
 import { currentMonth } from '@island.is/financial-aid/shared/lib'
+
 import { DescriptionText, PrivacyPolicyAccordion } from '..'
 import { FAFieldBaseProps } from '../../lib/types'
 import withLogo from '../Logo/Logo'
+import { aboutForm } from '../../lib/messages'
 
 const AboutForm = ({ application }: FAFieldBaseProps) => {
   const { formatMessage } = useIntl()
+  const { lang } = useLocale()
 
   return (
     <>
       <Text variant="h3" fontWeight="light" marginBottom={3}>
         {formatMessage(aboutForm.general.description, {
-          currentMonth: currentMonth(),
+          currentMonth: currentMonth(lang),
         })}
       </Text>
       <Box marginBottom={5}>

--- a/libs/application/templates/financial-aid/src/fields/AboutSpouseForm/AboutSpouseForm.tsx
+++ b/libs/application/templates/financial-aid/src/fields/AboutSpouseForm/AboutSpouseForm.tsx
@@ -1,16 +1,18 @@
 import React from 'react'
 import {
   currentMonth,
-  months,
-  nextMonth,
+  getNextPeriod,
 } from '@island.is/financial-aid/shared/lib'
 import { Box } from '@island.is/island-ui/core'
+import { useLocale } from '@island.is/localization'
+
 import { aboutSpouseForm } from '../../lib/messages'
 import { DescriptionText, PrivacyPolicyAccordion } from '..'
 import { FAFieldBaseProps } from '../../lib/types'
 import withLogo from '../Logo/Logo'
 
 const AboutSpouseForm = ({ application }: FAFieldBaseProps) => {
+  const { lang } = useLocale()
   const { nationalRegistry } = application.externalData
 
   return (
@@ -20,8 +22,8 @@ const AboutSpouseForm = ({ application }: FAFieldBaseProps) => {
         text={aboutSpouseForm.general.description}
         format={{
           spouseName: nationalRegistry?.data?.applicant?.fullName,
-          currentMonth: currentMonth(),
-          nextMonth: months[nextMonth()],
+          currentMonth: currentMonth(lang),
+          nextMonth: getNextPeriod(lang).month,
         }}
       />
       <Box marginTop={5}>

--- a/libs/application/templates/financial-aid/src/fields/Confirmation/Confirmation.tsx
+++ b/libs/application/templates/financial-aid/src/fields/Confirmation/Confirmation.tsx
@@ -3,6 +3,7 @@ import { MessageDescriptor, useIntl } from 'react-intl'
 
 import { getNextPeriod } from '@island.is/financial-aid/shared/lib'
 import { AlertMessage, Box, Text } from '@island.is/island-ui/core'
+import { useLocale } from '@island.is/localization'
 
 import { confirmation, copyUrl } from '../../lib/messages'
 import { DescriptionText, ConfirmationSectionImage, CopyUrl } from '..'
@@ -23,6 +24,7 @@ const Confirmation = ({
   municipalityHomepage,
 }: Props) => {
   const { formatMessage } = useIntl()
+  const { lang } = useLocale()
 
   return (
     <>
@@ -71,7 +73,7 @@ const Confirmation = ({
         <Box marginTop={2}>
           <DescriptionText
             text={confirmation.nextSteps.content}
-            format={{ nextMonth: getNextPeriod.month }}
+            format={{ nextMonth: getNextPeriod(lang).month }}
           />
         </Box>
       </Box>

--- a/libs/application/templates/financial-aid/src/fields/Status/Header/Header.tsx
+++ b/libs/application/templates/financial-aid/src/fields/Status/Header/Header.tsx
@@ -6,6 +6,8 @@ import {
   ApplicationState,
   getNextPeriod,
 } from '@island.is/financial-aid/shared/lib'
+import { useLocale } from '@island.is/localization'
+
 import { getStateMessageAndColor } from '../../../lib/formatters'
 
 interface Props {
@@ -14,6 +16,7 @@ interface Props {
 
 const Header = ({ state }: Props) => {
   const { formatMessage } = useIntl()
+  const { lang } = useLocale()
 
   if (!state) {
     return null
@@ -27,8 +30,8 @@ const Header = ({ state }: Props) => {
       marginBottom={[4, 4, 5]}
     >
       {formatMessage(getStateMessageAndColor[state][0], {
-        month: getNextPeriod.month,
-        year: getNextPeriod.year,
+        month: getNextPeriod(lang).month,
+        year: getNextPeriod(lang).year,
       })}
     </Text>
   )

--- a/libs/application/templates/financial-aid/src/fields/Status/SpouseApproved/SpouseApproved.tsx
+++ b/libs/application/templates/financial-aid/src/fields/Status/SpouseApproved/SpouseApproved.tsx
@@ -3,16 +3,18 @@ import { useIntl } from 'react-intl'
 
 import { Text } from '@island.is/island-ui/core'
 import { getNextPeriod } from '@island.is/financial-aid/shared/lib'
+import { useLocale } from '@island.is/localization'
 
 import { spouseApproved } from '../../../lib/messages'
 
 const SpouseApproved = () => {
   const { formatMessage } = useIntl()
+  const { lang } = useLocale()
 
   return (
     <Text variant="h3" fontWeight="light" marginBottom={[4, 4, 5]}>
       {formatMessage(spouseApproved.message, {
-        month: getNextPeriod.month,
+        month: getNextPeriod(lang).month,
       })}
     </Text>
   )

--- a/libs/application/templates/financial-aid/src/fields/Summary/SummaryForm.tsx
+++ b/libs/application/templates/financial-aid/src/fields/Summary/SummaryForm.tsx
@@ -8,6 +8,7 @@ import {
   aidCalculator,
   FamilyStatus,
 } from '@island.is/financial-aid/shared/lib'
+import { useLocale } from '@island.is/localization'
 
 import * as m from '../../lib/messages'
 import {
@@ -38,6 +39,8 @@ const SummaryForm = ({
   setBeforeSubmitCallback,
 }: FAFieldBaseProps) => {
   const { formatMessage } = useIntl()
+  const { lang } = useLocale()
+
   const { id, answers, externalData } = application
   const summaryCommentType = SummaryCommentType.FORMCOMMENT
 
@@ -80,7 +83,7 @@ const SummaryForm = ({
 
         <Text variant="small">
           {formatMessage(m.summaryForm.general.descriptionSubtitle, {
-            nextMonth: getNextPeriod.month,
+            nextMonth: getNextPeriod(lang).month,
           })}
         </Text>
       </Box>

--- a/libs/application/templates/financial-aid/src/fields/TaxBreakdown/TaxBreakdown.tsx
+++ b/libs/application/templates/financial-aid/src/fields/TaxBreakdown/TaxBreakdown.tsx
@@ -12,6 +12,7 @@ import { directTaxPaymentModal } from '../../lib/messages'
 
 import * as styles from './TaxBreakdown.css'
 import { useIntl } from 'react-intl'
+import { useLocale } from '@island.is/localization'
 
 interface Dictionary<T> {
   [index: string]: T
@@ -31,6 +32,7 @@ interface Props {
 
 const TaxBreakdown = ({ items, dateDataWasFetched }: Props) => {
   const { formatMessage } = useIntl()
+  const { lang } = useLocale()
 
   const date = dateDataWasFetched ? new Date(dateDataWasFetched) : new Date()
 
@@ -91,6 +93,7 @@ const TaxBreakdown = ({ items, dateDataWasFetched }: Props) => {
                   key={`${month}-taxHeadline`}
                   headline={`${getMonth(
                     monthNumber < 0 ? 12 + monthNumber : monthNumber,
+                    lang,
                   )} ${monthItems[0].year}`}
                 />
                 {monthItems.map((item, index) =>

--- a/libs/financial-aid/shared/src/lib/const.ts
+++ b/libs/financial-aid/shared/src/lib/const.ts
@@ -1,3 +1,5 @@
+import { Locale } from '@island.is/shared/types'
+
 const formRoutes = '/umsokn/'
 
 export const Routes = {
@@ -56,18 +58,40 @@ export const months = [
   'desember',
 ]
 
-export const getMonth = (month: number) => {
-  return months[month]
+export const monthsEnglish = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+]
+
+export const getMonth = (month: number, lang: Locale = 'is') => {
+  if (lang === 'is') {
+    return months[month]
+  }
+  return monthsEnglish[month]
 }
 
 export const nextMonth = (month?: number) => {
   return (month ?? new Date().getMonth() + 1) % 12
 }
 
-export const getNextPeriod = {
-  month: getMonth(nextMonth()),
-  year:
-    nextMonth() === 0 ? new Date().getFullYear() + 1 : new Date().getFullYear(),
+export const getNextPeriod = (lang: Locale = 'is') => {
+  return {
+    month: getMonth(nextMonth(), lang),
+    year:
+      nextMonth() === 0
+        ? new Date().getFullYear() + 1
+        : new Date().getFullYear(),
+  }
 }
 
 export const apiBasePath = 'api/financial-aid'

--- a/libs/financial-aid/shared/src/lib/utils.ts
+++ b/libs/financial-aid/shared/src/lib/utils.ts
@@ -1,8 +1,9 @@
-import { months } from './const'
+import { months, monthsEnglish } from './const'
 
 import React from 'react'
 import { DirectTaxPayment, NationalRegistryData } from './interfaces'
 import { StaffRole, UserType } from './enums'
+import { Locale } from '@island.is/shared/types'
 
 export const getFileType = (fileName: string) => {
   return fileName?.substring(fileName.lastIndexOf('.') + 1)
@@ -28,8 +29,11 @@ export const firstDateOfMonth = () => {
   return new Date(date.getFullYear(), date.getMonth(), 1)
 }
 
-export const currentMonth = () => {
-  return months[new Date().getMonth()].toLowerCase()
+export const currentMonth = (lang: Locale = 'is') => {
+  if (lang === 'is') {
+    return months[new Date().getMonth()].toLowerCase()
+  }
+  return monthsEnglish[new Date().getMonth()]
 }
 
 export const insertAt = (str: string, sub: string, pos: number) =>


### PR DESCRIPTION
# ... 👆

https://app.asana.com/0/1202167941440767/1202488702554254

## What

Check on which localization the user is using and display correct months with correct language.

## Why

So the months fit in when the project will be translated in Contentful.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
