### PR TITLE
fix(service-portal): hide vehicle lookup

### DIFF
--- a/libs/service-portal/core/src/lib/navigation/masterNavigation.ts
+++ b/libs/service-portal/core/src/lib/navigation/masterNavigation.ts
@@ -232,10 +232,10 @@ export const servicePortalMasterNavigation: ServicePortalNavigationItem[] = [
             name: m.myVehicles,
             path: ServicePortalPath.AssetsMyVehicles,
           },
-          {
-            name: m.vehiclesLookup,
-            path: ServicePortalPath.AssetsVehiclesLookup,
-          },
+          // {
+          //   name: m.vehiclesLookup,
+          //   path: ServicePortalPath.AssetsVehiclesLookup,
+          // },
           {
             name: m.vehiclesHistory,
             path: ServicePortalPath.AssetsVehiclesHistory,

--- a/libs/service-portal/vehicles/src/index.ts
+++ b/libs/service-portal/vehicles/src/index.ts
@@ -30,11 +30,11 @@ export const vehiclesModule: ServicePortalModule = {
       render: () =>
         lazy(() => import('./screens/VehicleHistory/VehicleHistory')),
     },
-    {
-      name: m.vehiclesLookup,
-      path: ServicePortalPath.AssetsVehiclesLookup,
-      enabled: Boolean(!userInfo.profile.actor), // block if user is logged in as other
-      render: () => lazy(() => import('./screens/Lookup/Lookup')),
-    },
+    // {
+    //   name: m.vehiclesLookup,
+    //   path: ServicePortalPath.AssetsVehiclesLookup,
+    //   enabled: userInfo.scopes.includes(ApiScope.vehicles),
+    //   render: () => lazy(() => import('./screens/Lookup/Lookup')),
+    // },
   ],
 }

--- a/libs/service-portal/vehicles/src/lib/messages.ts
+++ b/libs/service-portal/vehicles/src/lib/messages.ts
@@ -474,4 +474,8 @@ export const messages = defineMessages({
     id: 'sp.vehicles:date-of-sold-to',
     defaultMessage: 'Söludagsetning til',
   },
+  recycleCar: {
+    id: 'sp.vehicles:recycle-car',
+    defaultMessage: 'Skilavottorð',
+  },
 })

--- a/libs/service-portal/vehicles/src/lib/messages.ts
+++ b/libs/service-portal/vehicles/src/lib/messages.ts
@@ -21,6 +21,10 @@ export const messages = defineMessages({
     id: 'sp.vehicles:vehicles-intro',
     defaultMessage: `Hér má nálgast upplýsingar um þín ökutæki úr ökutækjaskrá Samgöngustofu.`,
   },
+  historyIntro: {
+    id: 'sp.vehicles:vehicles-history-intro',
+    defaultMessage: `Hér má nálgast upplýsingar um þinn ökutækjaferil úr ökutækjaskrá Samgöngustofu.`,
+  },
   clearFilter: {
     id: 'sp.vehicles:clear-filters',
     defaultMessage: 'Hreinsa filter',
@@ -461,5 +465,13 @@ export const messages = defineMessages({
   noVehicleFound: {
     id: 'sp.vehicles:no-vehicle-found',
     defaultMessage: 'Ekkert ökutæki fannst',
+  },
+  dateOfPurchase: {
+    id: 'sp.vehicles:date-of-purchase-from',
+    defaultMessage: 'Kaupdagsetning frá',
+  },
+  dateOfSale: {
+    id: 'sp.vehicles:date-of-sold-to',
+    defaultMessage: 'Söludagsetning til',
   },
 })

--- a/libs/service-portal/vehicles/src/screens/Overview/Overview.tsx
+++ b/libs/service-portal/vehicles/src/screens/Overview/Overview.tsx
@@ -106,11 +106,30 @@ export const VehiclesOverview: ServicePortalModuleComponent = () => {
           <EmptyState />
         </Box>
       )}
+
+      {!loading && !error && vehicles.length > 0 && (
+        <Box marginBottom={3}>
+          <a
+            href="/app/skilavottord/my-cars"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Button
+              variant="utility"
+              size="small"
+              icon="reader"
+              iconType="outline"
+            >
+              {formatMessage(messages.recycleCar)}
+            </Button>
+          </a>
+        </Box>
+      )}
       <Stack space={2}>
         {!loading && !error && vehicles.length > 4 && (
           <GridRow>
             <GridColumn span={['12/12', '12/12', '5/12', '4/12', '3/12']}>
-              <Stack space={2}>
+              <Box marginBottom={1}>
                 <Input
                   icon="search"
                   backgroundColor="blue"
@@ -121,7 +140,7 @@ export const VehiclesOverview: ServicePortalModuleComponent = () => {
                   label={formatMessage(m.searchLabel)}
                   placeholder={formatMessage(m.searchPlaceholder)}
                 />
-              </Stack>
+              </Box>
             </GridColumn>
           </GridRow>
         )}

--- a/libs/service-portal/vehicles/src/screens/VehicleHistory/VehicleHistory.tsx
+++ b/libs/service-portal/vehicles/src/screens/VehicleHistory/VehicleHistory.tsx
@@ -107,15 +107,25 @@ export const VehiclesHistory: ServicePortalModuleComponent = () => {
                 {formatMessage(messages.historyTitle)}
               </Text>
               <Text as="p" variant="default">
-                {formatMessage(messages.intro)}
+                {formatMessage(messages.historyIntro)}
               </Text>
             </Stack>
           </GridColumn>
         </GridRow>
       </Box>
 
+      {error && (
+        <Box>
+          <EmptyState description={m.errorFetch} />
+        </Box>
+      )}
+      {!loading && !error && vehicles.length === 0 && (
+        <Box marginTop={8}>
+          <EmptyState />
+        </Box>
+      )}
       <Stack space={2}>
-        {!loading && !error && (
+        {!loading && !error && vehicles.length > 0 && (
           <GridRow marginTop={4}>
             <GridColumn span={['1/1', '8/12', '8/12', '3/12']}>
               <DatePicker
@@ -124,7 +134,7 @@ export const VehiclesHistory: ServicePortalModuleComponent = () => {
                 icon="calendar"
                 iconType="outline"
                 size="xs"
-                label={formatMessage(m.dateFrom)}
+                label={formatMessage(messages.dateOfPurchase)}
                 selected={fromDate}
                 locale="is"
                 placeholderText={formatMessage(m.chooseDate)}
@@ -141,7 +151,7 @@ export const VehiclesHistory: ServicePortalModuleComponent = () => {
                 icon="calendar"
                 iconType="outline"
                 size="xs"
-                label={formatMessage(m.dateTo)}
+                label={formatMessage(messages.dateOfSale)}
                 selected={toDate}
                 locale="is"
                 placeholderText={formatMessage(m.chooseDate)}
@@ -170,16 +180,17 @@ export const VehiclesHistory: ServicePortalModuleComponent = () => {
             </GridColumn>
           </GridRow>
         )}
-        {error && (
-          <Box>
-            <EmptyState description={m.errorFetch} />
-          </Box>
-        )}
-        {!loading && !error && filteredVehicles.length === 0 && (
-          <Box marginTop={8}>
-            <EmptyState />
-          </Box>
-        )}
+
+        {!loading &&
+          !error &&
+          vehicles.length > 0 &&
+          filteredVehicles.length === 0 && (
+            <Box display="flex" justifyContent="center" margin={[3, 3, 3, 6]}>
+              <Text variant="h3" as="h3">
+                {formatMessage(messages.noVehiclesFound)}
+              </Text>
+            </Box>
+          )}
 
         {loading && (
           <Box


### PR DESCRIPTION
# Service portal - Hide vehicle lookup

## What

Hide vehicle lookup as Samgöngutstofa is not ready with authentication service.

Bonus (the bigger the better right?):
* Text and spacing changes
* Display empty state if array from resolver is empty
* Display empty text if filtered vehicles is empty
* Add "Skilavottorð" button above search in vehicles overview

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
