### PR TITLE
fix(j-s): Don't send courtDateLinkEmail if sendRequestToDefender is not set

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/formatters.spec.ts
+++ b/apps/judicial-system/backend/src/app/formatters/formatters.spec.ts
@@ -1143,37 +1143,6 @@ describe('formatDefenderCourtDateEmailNotification', () => {
     )
   })
 
-  test('should format defender court date notification with RVG link', () => {
-    // Arrange
-    const court = 'Héraðsdómur Norðurlands'
-    const courtCaseNumber = 'R-77/2021'
-    const courtDate = new Date('2020-12-19T10:19')
-    const courtRoom = '101'
-    const judgeName = 'Judy'
-    const registrarName = 'Robin'
-    const prosecutor = makeProsecutor()
-    const sessionArrangements = SessionArrangements.ALL_PRESENT
-
-    // Act
-    const res = formatDefenderCourtDateEmailNotification(
-      formatMessage,
-      court,
-      courtCaseNumber,
-      courtDate,
-      courtRoom,
-      judgeName,
-      registrarName,
-      prosecutor.name,
-      prosecutor.institution?.name,
-      sessionArrangements,
-    )
-
-    // Assert
-    expect(res).toBe(
-      'Héraðsdómur Norðurlands hefur boðað þig í fyrirtöku sem verjanda sakbornings.<br /><br />Fyrirtaka mun fara fram laugardaginn 19. desember 2020, kl. 10:19.<br /><br />Málsnúmer: R-77/2021.<br /><br />Dómsalur: 101.<br /><br />Dómari: Judy.<br /><br />Dómritari: Robin.<br /><br />Sækjandi: Áki Ákærandi (Lögreglan á Höfuðborgarsvæðinu).',
-    )
-  })
-
   test('should format defender court date notification with referral to court', () => {
     // Arrange
     const court = 'Héraðsdómur Norðurlands'
@@ -1309,13 +1278,11 @@ describe('formatDefenderCourtDateLinkEmailNotification', () => {
     // Arrange
     const court = 'Héraðsdómur Norðurlands'
     const courtCaseNumber = 'R-77/2021'
-    const sendRequestToDefender = true
     const overviewUrl = 'https://example.com/overview'
 
     // Act
     const res = formatDefenderCourtDateLinkEmailNotification(
       formatMessage,
-      sendRequestToDefender,
       overviewUrl,
       court,
       courtCaseNumber,

--- a/apps/judicial-system/backend/src/app/formatters/formatters.ts
+++ b/apps/judicial-system/backend/src/app/formatters/formatters.ts
@@ -387,7 +387,6 @@ export function formatDefenderCourtDateEmailNotification(
 
 export function formatDefenderCourtDateLinkEmailNotification(
   formatMessage: FormatMessage,
-  sendRequestToDefender?: boolean,
   overviewUrl?: string,
   court?: string,
   courtCaseNumber?: string,
@@ -397,14 +396,12 @@ export function formatDefenderCourtDateLinkEmailNotification(
     courtCaseNumber,
   })
 
-  const link = sendRequestToDefender
-    ? formatMessage(cf.link, {
-        defenderHasAccessToRvg: Boolean(overviewUrl),
-        courtName: court?.replace('dómur', 'dómi'),
-        linkStart: `<a href="${overviewUrl}">`,
-        linkEnd: '</a>',
-      })
-    : ''
+  const link = formatMessage(cf.link, {
+    defenderHasAccessToRvg: Boolean(overviewUrl),
+    courtName: court?.replace('dómur', 'dómi'),
+    linkStart: `<a href="${overviewUrl}">`,
+    linkEnd: '</a>',
+  })
 
   return `${body}${link}`
 }

--- a/apps/judicial-system/backend/src/app/modules/notification/notification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/notification.service.ts
@@ -621,7 +621,7 @@ export class NotificationService {
   private sendCourtDateEmailNotificationToDefender(
     theCase: Case,
     user: User,
-  ): [Promise<Recipient>, Promise<Recipient>] {
+  ): Promise<Recipient>[] {
     const subject = `Fyrirtaka í máli ${theCase.courtCaseNumber}`
     const linkSubject = `Gögn í máli ${theCase.courtCaseNumber}`
     const html = formatDefenderCourtDateEmailNotification(
@@ -638,54 +638,60 @@ export class NotificationService {
     )
     const linkHtml = formatDefenderCourtDateLinkEmailNotification(
       this.formatMessage,
-      theCase.sendRequestToDefender,
       theCase.defenderNationalId &&
         `${environment.deepLinks.defenderCaseOverviewUrl}${theCase.id}`,
       theCase.court?.name,
+      theCase.courtCaseNumber,
     )
     const calendarInvite = this.createICalAttachment(theCase)
     const attachments: Attachment[] = calendarInvite ? [calendarInvite] : []
 
-    const courtDateEmail = this.sendEmail(
-      subject,
-      html,
-      theCase.defenderName,
-      theCase.defenderEmail,
-      attachments,
-    ).then((recipient) => {
-      if (recipient.success) {
-        // No need to wait
-        this.uploadEmailToCourt(
-          theCase,
-          user,
-          subject,
-          html,
-          theCase.defenderEmail,
-        )
-      }
-      return recipient
-    })
+    const promises = [
+      this.sendEmail(
+        subject,
+        html,
+        theCase.defenderName,
+        theCase.defenderEmail,
+        attachments,
+      ).then((recipient) => {
+        if (recipient.success) {
+          // No need to wait
+          this.uploadEmailToCourt(
+            theCase,
+            user,
+            subject,
+            html,
+            theCase.defenderEmail,
+          )
+        }
+        return recipient
+      }),
+    ]
 
-    const linkEmail = this.sendEmail(
-      linkSubject,
-      linkHtml,
-      theCase.defenderName,
-      theCase.defenderEmail,
-    ).then((recipient) => {
-      if (recipient.success) {
-        // No need to wait
-        this.uploadEmailToCourt(
-          theCase,
-          user,
+    if (theCase.sendRequestToDefender) {
+      promises.push(
+        this.sendEmail(
           linkSubject,
           linkHtml,
+          theCase.defenderName,
           theCase.defenderEmail,
-        )
-      }
-      return recipient
-    })
+        ).then((recipient) => {
+          if (recipient.success) {
+            // No need to wait
+            this.uploadEmailToCourt(
+              theCase,
+              user,
+              linkSubject,
+              linkHtml,
+              theCase.defenderEmail,
+            )
+          }
+          return recipient
+        }),
+      )
+    }
 
-    return [courtDateEmail, linkEmail]
+    return promises
   }
 
   private async sendCourtDateNotifications(
@@ -710,12 +716,9 @@ export class NotificationService {
           SessionArrangements.ALL_PRESENT_SPOKESPERSON) &&
       theCase.defenderEmail
     ) {
-      const [
-        courtDateEmail,
-        linkEmail,
-      ] = this.sendCourtDateEmailNotificationToDefender(theCase, user)
-      promises.push(courtDateEmail)
-      promises.push(linkEmail)
+      promises.push(
+        ...this.sendCourtDateEmailNotificationToDefender(theCase, user),
+      )
     }
 
     if (


### PR DESCRIPTION
# Don't send courtDateLinkEmail if sendRequestToDefender is not set

[Asana](https://app.asana.com/0/1199153462262248/1202438223074125/f)

## What

Don't send courtDateLinkEmail if sendRequestToDefender is not set

## Why

It's a bug

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
