### PR TITLE
fix(web): Add a way to hide mobile banner

### DIFF
--- a/apps/web/components/MobileAppBanner/MobileAppBanner.tsx
+++ b/apps/web/components/MobileAppBanner/MobileAppBanner.tsx
@@ -17,7 +17,9 @@ export const MobileAppBanner = ({ namespace }: MobileAppBannerProps) => {
   const appleLink = n('mobileAppLinkApple')
   const androidLink = n('mobileAppLinkAndroid')
 
-  const [hidden, setHidden] = useState<boolean>(!!Cookies.get(COOKIE_NAME))
+  const [hidden, setHidden] = useState<boolean>(
+    !!Cookies.get(COOKIE_NAME) || !appleLink || !androidLink,
+  )
   const [isApple, setIsApple] = useState<boolean>(false)
 
   const getMobilePlatform = (): string => {


### PR DESCRIPTION
# Add a way to hide mobile banner

## What

Hide the mobile app banner if links are not specified in UI configuration.

## Why

The mobile app banner may need to be disabled sometimes.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
