### PR TITLE
fix(j-s): Fix title CF string on court overview page

### DIFF
--- a/apps/judicial-system/web/messages/RestrictionCases/Court/overview.ts
+++ b/apps/judicial-system/web/messages/RestrictionCases/Court/overview.ts
@@ -3,9 +3,9 @@ import { defineMessages } from 'react-intl'
 export const rcCourtOverview = {
   sections: {
     title: {
-      id: 'rcCourtOverview.sections.title',
+      id: 'judicial.system.restriction_cases:court_overview.sections.title',
       defaultMessage:
-        'Yfirlit {caseType, select, ADMISSION_TO_FACILITY {kröfu um vistun á viðeigandi stofnun} TRAVEL_BAN {farbannskröfu} other {gæsluvarðhaldskröfu}}',
+        'Yfirlit kröfu um {caseType, select, ADMISSION_TO_FACILITY {vistun á viðeigandi stofnun} TRAVEL_BAN {farbann} other {gæsluvarðhald}}',
       description:
         'Notaður sem titill á yfirlitssíðu í gæsluvarðhalds-, vistunar- og farbannsmálum.',
     },


### PR DESCRIPTION
# Fix title CF string on court overview page

[Asana](https://app.asana.com/0/1199153462262248/1202228548332921/f)

## What

Fix title CF string on court overview page. 

## Why

The id was incorrectly set up and the default message was a tiny bit off.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
