### PR TITLE
feat(service-portal): Documents - Block screen

### DIFF
--- a/libs/service-portal/documents/src/index.ts
+++ b/libs/service-portal/documents/src/index.ts
@@ -14,6 +14,18 @@ const rootName = defineMessage({
   defaultMessage: 'Pósthólf',
 })
 
+const enabled = (userInfo: User) => {
+  const hasScope = userInfo.scopes?.includes(DocumentsScope.main)
+
+  if (isLegalAndOver15(userInfo)) {
+    return false
+  }
+  if (hasScope) {
+    return true
+  } else {
+    return false
+  }
+}
 const isLegalAndOver15 = (userInfo: User) => {
   const isLegal = userInfo.profile.delegationType?.includes('LegalGuardian')
   const dateOfBirth = userInfo?.profile.dateOfBirth
@@ -31,9 +43,7 @@ export const documentsModule: ServicePortalModule = {
     {
       name: rootName,
       path: ServicePortalPath.ElectronicDocumentsRoot,
-      enabled:
-        !isLegalAndOver15(userInfo) ||
-        userInfo.scopes?.includes(DocumentsScope.main),
+      enabled: enabled(userInfo),
       render: isLegalAndOver15(userInfo)
         ? () =>
             lazy(() => import('./screens/AccessDeniedLegal/AccessDeniedLegal'))

--- a/libs/service-portal/documents/src/screens/AccessDeniedLegal/AccessDenied.css.ts
+++ b/libs/service-portal/documents/src/screens/AccessDeniedLegal/AccessDenied.css.ts
@@ -1,0 +1,16 @@
+import { themeUtils } from '@island.is/island-ui/theme'
+import { style } from '@vanilla-extract/css'
+
+export const img = style({
+  minHeight: '20vh',
+  ...themeUtils.responsiveStyle({
+    md: {
+      maxHeight: '300px',
+      minHeight: '250px',
+    },
+  }),
+})
+
+export const errorScreenTextContainer = style({
+  maxWidth: 660,
+})

--- a/libs/service-portal/documents/src/screens/AccessDeniedLegal/AccessDeniedLegal.tsx
+++ b/libs/service-portal/documents/src/screens/AccessDeniedLegal/AccessDeniedLegal.tsx
@@ -1,0 +1,92 @@
+import React from 'react'
+import { Box, Link, LinkContext, Tag, Text } from '@island.is/island-ui/core'
+import * as styles from './AccessDenied.css'
+import { useLocale, useNamespaces } from '@island.is/localization'
+import { ServicePortalModuleComponent } from '@island.is/service-portal/core'
+import { theme } from '@island.is/island-ui/theme'
+
+const AccessDeniedLegal: ServicePortalModuleComponent = () => {
+  useNamespaces('sp.documents')
+  const { formatMessage } = useLocale()
+  return (
+    <LinkContext.Provider
+      value={{
+        linkRenderer: (href, children) => (
+          <a
+            style={{
+              color: theme.color.blue400,
+              textDecoration: 'underline',
+              textUnderlineOffset: theme.spacing[1] / 2,
+            }}
+            href={href}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            {children}
+          </a>
+        ),
+      }}
+    >
+      <Box
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        flexDirection="column"
+      >
+        <Box
+          marginY={6}
+          textAlign="center"
+          justifyContent="center"
+          className={styles.errorScreenTextContainer}
+        >
+          <Box marginBottom={4}>
+            <Tag variant={'red'}>
+              {formatMessage({
+                id: 'sp.documents:error-tag-legal',
+                defaultMessage: 'Pósthólf',
+              })}
+            </Tag>
+          </Box>
+          <Text variant="h1" as="h1" marginBottom={3}>
+            {formatMessage({
+              id: 'sp.documents:error-title-legal-no-access',
+              defaultMessage: 'Aðgangur læstur',
+            })}
+          </Text>
+          <Text variant="default" as="p">
+            {formatMessage({
+              id: 'sp.documents:error-text-legal-no-access',
+              defaultMessage:
+                'Því miður hefur þú ekki aðgang að þessari síðu. ',
+            })}
+
+            <a
+              href="https://www.barnasattmali.is/is/um-barnasattmalann/heildartexti-barnasattmalans"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {formatMessage({
+                id: 'sp.documents:error-link-legal-no-access',
+                defaultMessage: 'Samkvæmt 16. grein Barnasáttmálans',
+              })}
+            </a>
+            {formatMessage({
+              id: 'sp.documents:error-text-legal-no-access-2',
+              defaultMessage:
+                ' þá eiga öll börn eiga rétt á einkalífi. Lögin eiga að vernda einkalíf barna, fjölskyldur og heimili. Börn eiga líka rétt á því að samskipti þeirra við aðra, orðspor þeirra og fjölskyldna þeirra sé verndað með lögum.',
+            })}
+          </Text>
+        </Box>
+        <Box display="flex" justifyContent="center">
+          <img
+            src="./assets/images/jobsGrid.svg"
+            alt=""
+            className={styles.img}
+          />
+        </Box>
+      </Box>
+    </LinkContext.Provider>
+  )
+}
+
+export default AccessDeniedLegal


### PR DESCRIPTION
# Service portal - Documents block screen

## What

New screen for when Documents are blocked because of actor is legal guardian and the child is 15+ years old.

## Why

Explanation of why only documents are blocked.


## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
