### PR TITLE
fix(parental-leave): sms token same as email

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/emailGenerators/assignEmployerEmail.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/emailGenerators/assignEmployerEmail.ts
@@ -5,6 +5,8 @@ import { Message } from '@island.is/email-service'
 import { AssignmentEmailTemplateGenerator } from '../../../../types'
 import { pathToAsset } from '../parental-leave.utils'
 
+export let assignLinkEmployerSMS = ''
+
 // TODO handle translations
 export const generateAssignEmployerApplicationEmail: AssignmentEmailTemplateGenerator = (
   props,
@@ -14,6 +16,8 @@ export const generateAssignEmployerApplicationEmail: AssignmentEmailTemplateGene
     application,
     options: { email },
   } = props
+
+  assignLinkEmployerSMS = assignLink
 
   const employerEmail = get(application.answers, 'employer.email')
   const applicantName = get(application.externalData, 'person.data.fullName')

--- a/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/emailGenerators/assignOtherParentEmail.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/emailGenerators/assignOtherParentEmail.ts
@@ -6,6 +6,8 @@ import { Message } from '@island.is/email-service'
 import { EmailTemplateGenerator } from '../../../../types'
 import { pathToAsset } from '../parental-leave.utils'
 
+export let linkOtherParentSMS = ''
+
 // TODO handle translations
 export const generateAssignOtherParentApplicationEmail: EmailTemplateGenerator = (
   props,
@@ -24,6 +26,8 @@ export const generateAssignOtherParentApplicationEmail: EmailTemplateGenerator =
 
   const subject = 'Yfirferð á umsókn um fæðingarorlof'
   const link = `${clientLocationOrigin}/${ApplicationConfigurations.ParentalLeave.slug}/${application.id}`
+
+  linkOtherParentSMS = link
 
   return {
     from: {

--- a/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/parental-leave.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/parental-leave.service.ts
@@ -34,11 +34,11 @@ import {
   generateApplicationApprovedByEmployerEmail,
   generateApplicationApprovedByEmployerToEmployerEmail,
   assignLinkEmployerSMS,
+  linkOtherParentSMS,
 } from './emailGenerators'
 import {
   transformApplicationToParentalLeaveDTO,
   getRatio,
-  createAssignTokenWithoutNonce,
 } from './parental-leave.utils'
 import { apiConstants } from './constants'
 import { SmsService } from '@island.is/nova-sms'
@@ -97,24 +97,11 @@ export class ParentalLeaveService {
     )
 
     if (otherParentPhoneNumber) {
-      const token = createAssignTokenWithoutNonce(
-        application,
-        getConfigValue(this.configService, 'jwtSecret'),
-        SIX_MONTHS_IN_SECONDS_EXPIRES,
-      )
-
-      const clientLocationOrigin = getConfigValue(
-        this.configService,
-        'clientLocationOrigin',
-      ) as string
-
-      const assignLink = `${clientLocationOrigin}/tengjast-umsokn?token=${token}`
-
       await this.smsService.sendSms(
         otherParentPhoneNumber,
         `Umsækjandi ${applicantName} kt: ${applicantId} hefur skráð þig sem maka í umsókn sinni um fæðingarorlof og er að óska eftir réttindum frá þér.
         Ef þú áttir von á þessari beiðni máttu smella á linkinn hér fyrir neðan. Kveðja, Fæðingarorlofssjóður
-        ${assignLink}`,
+        ${linkOtherParentSMS}`,
       )
     }
   }

--- a/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/parental-leave.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/parental-leave.service.ts
@@ -33,6 +33,7 @@ import {
   generateOtherParentRejected,
   generateApplicationApprovedByEmployerEmail,
   generateApplicationApprovedByEmployerToEmployerEmail,
+  assignLinkEmployerSMS,
 } from './emailGenerators'
 import {
   transformApplicationToParentalLeaveDTO,
@@ -187,24 +188,11 @@ export class ParentalLeaveService {
 
     // send confirmation sms to employer
     if (employerPhoneNumber) {
-      const token = createAssignTokenWithoutNonce(
-        application,
-        getConfigValue(this.configService, 'jwtSecret'),
-        SIX_MONTHS_IN_SECONDS_EXPIRES,
-      )
-
-      const clientLocationOrigin = getConfigValue(
-        this.configService,
-        'clientLocationOrigin',
-      ) as string
-
-      const assignLink = `${clientLocationOrigin}/tengjast-umsokn?token=${token}`
-
       await this.smsService.sendSms(
         employerPhoneNumber,
         `Umsækjandi ${applicantName} kt: ${applicantId} hefur skráð þig sem atvinnuveitanda í umsókn sinni um fæðingarorlof.
         Ef þú áttir von á þessari beiðni máttu smella á linkinn hér fyrir neðan. Kveðja, Fæðingarorlofssjóður
-        ${assignLink}`,
+        ${assignLinkEmployerSMS}`,
       )
     }
   }


### PR DESCRIPTION
## What

Make sure the links in the sms and email being sent to spouse/employer is the same and no additional token is generated.

## Why

https://dit-iceland.atlassian.net/jira/software/projects/UUFV/boards/71?selectedIssue=UUFV-104

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
