### PR TITLE
fix(announcement-of-death): Fixed duplication issue for filerecipients regarding applicant

### DIFF
--- a/libs/application/templates/announcement-of-death/src/fields/FilesRecipientCard/FilesRecipientCard.tsx
+++ b/libs/application/templates/announcement-of-death/src/fields/FilesRecipientCard/FilesRecipientCard.tsx
@@ -39,18 +39,23 @@ export const FilesRecipientCard: FC<
 
   options = options.filter((member) => isPerson(member.value))
 
-  // Add the option for selecting noone
-  options.push({
-    label: formatMessage(m.selectOptionNobody),
-    value: '',
-  })
-
-  if (field.id !== 'financesDataCollectionPermission') {
+  if (
+    field.id !== 'financesDataCollectionPermission' &&
+    !application.answers?.estateMembers?.members.find(
+      (member) => member.nationalId === application.applicant,
+    )
+  ) {
     options.push({
       label: application.answers.applicantName,
       value: application.applicant,
     })
   }
+
+  // Add the option for selecting noone
+  options.push({
+    label: formatMessage(m.selectOptionNobody),
+    value: '',
+  })
 
   return (
     <Box


### PR DESCRIPTION
If applicant is a part of Estates then they were added twice to FileRecipients.

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
