### PR TITLE
fix(service-portal): Use current username in avatar

### DIFF
--- a/libs/shared/components/src/auth/UserMenu/UserDropdown.tsx
+++ b/libs/shared/components/src/auth/UserMenu/UserDropdown.tsx
@@ -109,7 +109,7 @@ export const UserDropdown = ({
                 <Icon icon="business" type="filled" color="blue400" />
               </Box>
             ) : (
-              <UserAvatar username={isDelegation ? actorName : userName} />
+              <UserAvatar username={userName} />
             )}
             <Box marginLeft={1} marginRight={4}>
               <Text variant="h4" as="h4">


### PR DESCRIPTION
## What

Use the initals of the current actor as the initials in the avatar.

## Screenshots / Gifs

Is now:
<img width="431" alt="Screenshot 2022-06-28 at 22 03 30" src="https://user-images.githubusercontent.com/24840451/176308279-398e1997-0d1c-4458-a121-61255e54f66f.png">

Becomes:
<img width="412" alt="Screenshot 2022-06-28 at 22 03 00" src="https://user-images.githubusercontent.com/24840451/176308358-630210b5-1d0e-4817-a6ad-8bbc1b16958d.png">


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
