### PR TITLE
fix(service-portal): default drivers license when querying all licenses without input.

### DIFF
--- a/libs/api/domains/license-service/src/lib/client/adr-license-client/adrLicenseService.api.ts
+++ b/libs/api/domains/license-service/src/lib/client/adr-license-client/adrLicenseService.api.ts
@@ -32,6 +32,7 @@ export class GenericAdrLicenseApi implements GenericLicenseClient<AdrDto> {
     } catch (e) {
       this.logger.error('ADR license fetch failed', {
         exception: e,
+        message: (e as Error)?.message,
         category: LOG_CATEGORY,
       })
       return null

--- a/libs/api/domains/license-service/src/lib/client/machine-license-client/machineLicenseService.api.ts
+++ b/libs/api/domains/license-service/src/lib/client/machine-license-client/machineLicenseService.api.ts
@@ -36,6 +36,7 @@ export class GenericMachineLicenseApi
     } catch (e) {
       this.logger.error('Machine license fetch failed', {
         exception: e,
+        message: (e as Error)?.message,
         category: LOG_CATEGORY,
       })
       return null

--- a/libs/api/domains/license-service/src/lib/graphql/main.resolver.ts
+++ b/libs/api/domains/license-service/src/lib/graphql/main.resolver.ts
@@ -93,7 +93,7 @@ export class MainResolver {
       user,
       locale,
       {
-        includedTypes: input?.includedTypes,
+        includedTypes: input?.includedTypes ?? ['DriversLicense'],
         excludedTypes: input?.excludedTypes,
         force: input?.force,
         onlyList: input?.onlyList,


### PR DESCRIPTION
hotfix: #7939 