### PR TITLE
fix(application-system): Fix bug causing the company search info field to break

### DIFF
--- a/libs/application/ui-components/src/components/CompanySearchController/CompanySearchItem.tsx
+++ b/libs/application/ui-components/src/components/CompanySearchController/CompanySearchItem.tsx
@@ -7,10 +7,15 @@ interface CompanySearchItemProps extends ItemCmpProps {
   query: string
 }
 
+const escapeRegexp = (query: string) => {
+  return query.replace(/([.?*+^$[\]\\(){}|-])/g, '\\$1')
+}
+
 export const CompanySearchItem: FC<
   CompanySearchItemProps & { loading?: boolean }
 > = ({ active, nationalId, query, name }): ReactElement => {
-  const splitCompanyName = name.split(new RegExp(query, 'i'))
+  const cleanedQuery = escapeRegexp(query)
+  const splitCompanyName = name.split(new RegExp(cleanedQuery, 'i'))
   let cleanNationalId = nationalId.replace(/(\D)+/g, '')
   cleanNationalId =
     cleanNationalId.substring(0, 6) + '-' + cleanNationalId.substring(6, 10)


### PR DESCRIPTION
# Fix bug causing the company search info field to break

Attach a link to issue if relevant

## What

Fix bug causing the company search info field to break

## Why

When trying to search for * \ or any character used in reg exp you would break the company search info field. Fixed by escaping characters that would cause the crash.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
