### PR TITLE
feat(service-portal): hide access settings when scope doesnt allow

### DIFF
--- a/libs/service-portal/settings/access-control/src/index.ts
+++ b/libs/service-portal/settings/access-control/src/index.ts
@@ -20,6 +20,7 @@ export const accessControlModule: ServicePortalModule = {
       {
         name: m.accessControl,
         path: ServicePortalPath.SettingsAccessControl,
+        navHide: !userInfo.scopes.includes(AuthScope.writeDelegations),
         enabled: personDelegation
           ? false
           : userInfo.scopes.includes(AuthScope.writeDelegations),


### PR DESCRIPTION
# Service portal - Hide access settings 

## What

Hide access settings from sidebar if user doesnt have scope

## Why

Having lock icon visible indicates that the user can ask for access to the access settings 

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
