### PR TITLE
fix(auth-react): Hotfix-Service Portal CheckIdpSession Update

### DIFF
--- a/libs/auth/react/src/lib/Authenticator/CheckIdpSession.tsx
+++ b/libs/auth/react/src/lib/Authenticator/CheckIdpSession.tsx
@@ -23,6 +23,9 @@ export interface SessionInfoResponse {
   // The time when the authenticated session expires.
   expiresUtc?: string
 
+  // Number of seconds until the session expires.
+  expiresIn?: number
+
   // Boolean flag to indicated if the Expires time is passed.
   isExpired?: boolean
 }
@@ -71,23 +74,12 @@ export const CheckIdpSession = () => {
         // SessionInfo was found, check if it is valid or expired
         if (sessionInfo.isExpired) {
           return signInRedirect()
-        } else if (sessionInfo.expiresUtc) {
-          // Calculate when the session should expire with padding when we should check again
-          const timeout =
-            new Date(sessionInfo.expiresUtc).getTime() -
-            new Date().getTime() +
-            1000
-
-          if (timeout <= 0) {
-            // The session is expired but for some reason the `isExpired` was not correctly set
-            return signInRedirect()
-          }
-
+        } else if (sessionInfo.expiresIn !== undefined) {
           if (!sessionTimeout.current) {
             const newSessionTimeout = setTimeout(() => {
               sessionTimeout.current = null
               setIframeChecksum((i) => i + 1)
-            }, timeout)
+            }, sessionInfo.expiresIn * 1000)
             sessionTimeout.current = newSessionTimeout
           }
         }


### PR DESCRIPTION
## What

Update `CheckIdpSession` to use `expiresIn` instead of `expiresUtc` to control when to check again for expired session.

## Why

Using `expiresUtc` causes problems when users change their clock without using time zones.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
