### PR TITLE
fix(island-ui): Add scroll y auto to popover in filter

### DIFF
--- a/libs/island-ui/core/src/lib/Filter/Filter.css.ts
+++ b/libs/island-ui/core/src/lib/Filter/Filter.css.ts
@@ -13,5 +13,5 @@ export const popoverContainer = style({
   zIndex: 100,
   maxWidth: 360,
   width: '100%',
-  overflowY: 'scroll',
+  overflowY: 'auto',
 })


### PR DESCRIPTION
## What

Add scroll y auto to popover in filter

## Why

The popover in the filter component is always visible even when there's nothing to scroll.

## Screenshots / Gifs

Current:
![Screenshot 2022-07-04 at 11 05 13](https://user-images.githubusercontent.com/24840451/177142976-ccb29895-94e3-4086-b2fa-c3c5f48ae9bc.png)

Becomes:
![Screenshot 2022-07-04 at 11 05 26](https://user-images.githubusercontent.com/24840451/177142992-6aadce5d-8cb5-4a14-b7ce-e212c5382699.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
