### PR TITLE
feat(web): Added margin bottom prop to organization slices

### DIFF
--- a/apps/web/components/Organization/Slice/Districts/DistrictsSlice.tsx
+++ b/apps/web/components/Organization/Slice/Districts/DistrictsSlice.tsx
@@ -21,8 +21,8 @@ export const DistrictsSlice: React.FC<SliceProps> = ({ slice }) => {
         <Box
           borderTopWidth="standard"
           borderColor="standard"
-          paddingTop={[8, 6, 10]}
-          paddingBottom={[4, 5, 10]}
+          paddingTop={[8, 6]}
+          paddingBottom={[4, 5]}
         >
           <GridRow>
             <GridColumn span="12/12">

--- a/apps/web/components/Organization/Slice/OrganizationSlice.tsx
+++ b/apps/web/components/Organization/Slice/OrganizationSlice.tsx
@@ -2,7 +2,13 @@ import React from 'react'
 import { Slice } from '@island.is/web/graphql/schema'
 import { Namespace } from '@island.is/api/schema'
 import dynamic from 'next/dynamic'
-import { GridColumn, GridContainer, GridRow } from '@island.is/island-ui/core'
+import {
+  Box,
+  GridColumn,
+  GridContainer,
+  GridRow,
+  ResponsiveSpace,
+} from '@island.is/island-ui/core'
 import { RichText } from '@island.is/web/components'
 
 const DistrictsSlice = dynamic(() =>
@@ -75,6 +81,7 @@ interface OrganizationSliceProps {
   fullWidth?: boolean
   organizationPageSlug?: string
   renderedOnOrganizationSubpage?: boolean
+  marginBottom?: ResponsiveSpace
 }
 
 const fullWidthSlices = [
@@ -139,10 +146,11 @@ export const OrganizationSlice = ({
   fullWidth = false,
   organizationPageSlug = '',
   renderedOnOrganizationSubpage = false,
+  marginBottom = 0,
 }: OrganizationSliceProps) => {
   return !fullWidth ? (
     <GridContainer>
-      <GridRow>
+      <GridRow marginBottom={marginBottom}>
         <GridColumn
           paddingTop={6}
           span={
@@ -166,11 +174,13 @@ export const OrganizationSlice = ({
       </GridRow>
     </GridContainer>
   ) : (
-    renderSlice(
-      slice,
-      namespace,
-      organizationPageSlug,
-      renderedOnOrganizationSubpage,
-    )
+    <Box marginBottom={marginBottom}>
+      {renderSlice(
+        slice,
+        namespace,
+        organizationPageSlug,
+        renderedOnOrganizationSubpage,
+      )}
+    </Box>
   )
 }

--- a/apps/web/components/Organization/Slice/OrganizationSlice.tsx
+++ b/apps/web/components/Organization/Slice/OrganizationSlice.tsx
@@ -75,8 +75,6 @@ const MultipleStatistics = dynamic(() =>
   import('@island.is/web/components').then((mod) => mod.MultipleStatistics),
 )
 
-// Testing changed github settings, ignore this comment
-
 interface OrganizationSliceProps {
   slice: Slice
   namespace?: Namespace

--- a/apps/web/components/Organization/Slice/OrganizationSlice.tsx
+++ b/apps/web/components/Organization/Slice/OrganizationSlice.tsx
@@ -75,6 +75,8 @@ const MultipleStatistics = dynamic(() =>
   import('@island.is/web/components').then((mod) => mod.MultipleStatistics),
 )
 
+// Testing changed github settings, ignore this comment
+
 interface OrganizationSliceProps {
   slice: Slice
   namespace?: Namespace

--- a/apps/web/screens/Organization/Home.tsx
+++ b/apps/web/screens/Organization/Home.tsx
@@ -64,12 +64,13 @@ const Home: Screen<HomeProps> = ({ organizationPage, namespace }) => {
         title: n('navigationTitle', 'Efnisyfirlit'),
         items: navList,
       }}
-      mainContent={organizationPage.slices.map((slice) => (
+      mainContent={organizationPage.slices.map((slice, index) => (
         <OrganizationSlice
           key={slice.id}
           slice={slice}
           namespace={namespace}
           organizationPageSlug={organizationPage.slug}
+          marginBottom={index === organizationPage.slices.length - 1 ? 5 : 0}
         />
       ))}
       sidebarContent={

--- a/apps/web/screens/Organization/SubPage.tsx
+++ b/apps/web/screens/Organization/SubPage.tsx
@@ -172,13 +172,14 @@ const renderSlices = (
     case 'SliceDropdown':
       return <SliceDropdown slices={slices} sliceExtraText={extraText} />
     default:
-      return slices.map((slice) => (
+      return slices.map((slice, index) => (
         <OrganizationSlice
           key={slice.id}
           slice={slice}
           namespace={namespace}
           organizationPageSlug={organizationPageSlug}
           renderedOnOrganizationSubpage={true}
+          marginBottom={index === slices.length - 1 ? 5 : 0}
         />
       ))
   }


### PR DESCRIPTION
# Added margin bottom prop to organzation slices

## What

* Add more spacing below the last slice

## Screenshots / Gifs

### Before
![image](https://user-images.githubusercontent.com/43557895/180452117-0fe05582-3437-4378-8fce-d8a6a5a9a02e.png)

### After
![image](https://user-images.githubusercontent.com/43557895/180452160-93f316c2-705f-4dab-9dbf-24b82962bc92.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
