### PR TITLE
fix(auth-api): Fixing auth api service to check for invalid uuid delegation lookup

### DIFF
--- a/apps/services/auth-public-api/src/app/modules/delegations/meDelegations.controller.spec.ts
+++ b/apps/services/auth-public-api/src/app/modules/delegations/meDelegations.controller.spec.ts
@@ -741,6 +741,39 @@ describe('MeDelegationsController', () => {
 
         // Assert
         expect(res.status).toEqual(404)
+        expect(res.body).toMatchInlineSnapshot(`
+          Object {
+            "status": 404,
+            "title": "Not Found",
+            "type": "https://httpstatuses.com/404",
+          }
+        `)
+      })
+
+      it('should return 400 Bad Request if delegationId is not valid uuid', async () => {
+        // Arrange
+        await delegationModel.bulkCreate(Object.values(mockDelegations), {
+          include: [
+            {
+              model: DelegationScope,
+              as: 'delegationScopes',
+            },
+          ],
+        })
+
+        // Act
+        const res = await server.get(`${path}/delegationId`)
+
+        // Assert
+        expect(res.status).toEqual(400)
+        expect(res.body).toMatchInlineSnapshot(`
+          Object {
+            "detail": "delegationId must be a valid uuid",
+            "status": 400,
+            "title": "Bad Request",
+            "type": "https://httpstatuses.com/400",
+          }
+        `)
       })
     })
 

--- a/apps/services/auth-public-api/src/app/modules/delegations/meDelegations.controller.ts
+++ b/apps/services/auth-public-api/src/app/modules/delegations/meDelegations.controller.ts
@@ -109,6 +109,7 @@ export class MeDelegationsController {
       params: {
         delegationId: {
           type: 'string',
+          format: 'uuid',
           description: 'Delegation ID.',
         },
       },

--- a/libs/auth-api-lib/src/lib/services/delegations.service.ts
+++ b/libs/auth-api-lib/src/lib/services/delegations.service.ts
@@ -10,7 +10,7 @@ import { InjectModel } from '@nestjs/sequelize'
 import startOfDay from 'date-fns/startOfDay'
 import uniqBy from 'lodash/uniqBy'
 import { Op, WhereOptions } from 'sequelize'
-import { uuid } from 'uuidv4'
+import { isUuid, uuid } from 'uuidv4'
 
 import { AuthMiddleware } from '@island.is/auth-nest-tools'
 import {
@@ -201,6 +201,10 @@ export class DelegationsService {
    * @returns
    */
   async findById(user: User, id: string): Promise<DelegationDTO | null> {
+    if (!isUuid(id)) {
+      throw new BadRequestException('delegationId must be a valid uuid')
+    }
+
     this.logger.debug(`Finding a delegation with id ${id}`)
     const delegation = await this.delegationModel.findOne({
       where: {


### PR DESCRIPTION
## What

Add check for `delegationId` if it is a valid UUID, otherwise throw a `BadRequest` response.

## Why

To let the server respond with 400 BadRequest to indicate request error, instead of 500 internal server error from the database.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
