### PR TITLE
fix(j-s): Message Handler Service Account

### DIFF
--- a/apps/judicial-system/message-handler/infra/judicial-system-message-handler.ts
+++ b/apps/judicial-system/message-handler/infra/judicial-system-message-handler.ts
@@ -5,6 +5,7 @@ export const serviceSetup = (services: {
 }): ServiceBuilder<'judicial-system-message-handler'> =>
   service('judicial-system-message-handler')
     .namespace('judicial-system')
+    .serviceAccount('judicial-system-message-handler')
     .image('judicial-system-message-handler')
     .env({
       SQS_QUEUE_NAME: 'sqs-judicial-system',

--- a/charts/judicial-system/values.dev.yaml
+++ b/charts/judicial-system/values.dev.yaml
@@ -258,6 +258,8 @@ judicial-system-message-handler:
   image:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/judicial-system-message-handler'
   namespace: 'judicial-system'
+  podSecurityContext:
+    fsGroup: 65534
   replicaCount:
     default: 2
     max: 3
@@ -275,6 +277,11 @@ judicial-system-message-handler:
   securityContext:
     allowPrivilegeEscalation: false
     privileged: false
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: 'arn:aws:iam::013313053092:role/judicial-system-message-handler'
+    create: true
+    name: 'judicial-system-message-handler'
 judicial-system-scheduler:
   args:
     - 'main.js'


### PR DESCRIPTION
# Message Handler Service Account

[Vista gögn sjálfkrafa í Auði eftir afgreiðslu ef þau hafa ekki verið vistuð](https://app.asana.com/0/1199153462262248/1201777996978577/f)

## What

- Adds a service account to the message handler.

## Why

The service account was missing from the helm charts.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
