### PR TITLE
refactor(service-portal): Refactor ContentBreadcrumbs

### DIFF
--- a/apps/service-portal/src/components/ContentBreadcrumbs/ContentBreadcrumbs.tsx
+++ b/apps/service-portal/src/components/ContentBreadcrumbs/ContentBreadcrumbs.tsx
@@ -1,48 +1,83 @@
-import React, { FC } from 'react'
-import { Link, useLocation, matchPath } from 'react-router-dom'
+import { FC } from 'react'
+import { MessageDescriptor } from 'react-intl'
+import { Link, match, matchPath, useLocation } from 'react-router-dom'
+
 import {
-  BreadcrumbsDeprecated as Breadcrumbs,
   Box,
-  Tag,
+  BreadcrumbsDeprecated as Breadcrumbs,
 } from '@island.is/island-ui/core'
-import { ServicePortalNavigationItem } from '@island.is/service-portal/core'
-import useNavigation from '../../hooks/useNavigation/useNavigation'
 import { useLocale } from '@island.is/localization'
+import { ServicePortalNavigationItem } from '@island.is/service-portal/core'
 
-const reduce = (
-  f: (
-    acc: ServicePortalNavigationItem[],
-    n: ServicePortalNavigationItem,
-  ) => ServicePortalNavigationItem[],
-  tree: ServicePortalNavigationItem,
-  acc: ServicePortalNavigationItem[],
-): ServicePortalNavigationItem[] => {
-  const { children } = tree
-  const newAcc = f(acc, tree)
+import useNavigation from '../../hooks/useNavigation/useNavigation'
 
-  if (!children) return newAcc
-  return children.reduce((iAcc, n) => reduce(f, n, iAcc), newAcc)
+interface ContentBreadcrumb {
+  name: string | MessageDescriptor
+  path?: string
 }
 
-const ContentBreadcrumbs: FC<{}> = () => {
+/**
+ * navItem.name can be set as a key of path parameter.
+ * This parses the activePath to check if to use route
+ * param instead of navItem name.
+ */
+const parseNavItemName = (
+  navItem: ServicePortalNavigationItem,
+  activePath: match<Record<string, string>> | null,
+) => {
+  if (activePath && activePath.params && typeof navItem.name === 'string') {
+    return activePath.params[navItem.name] || navItem.name
+  }
+
+  return navItem.name
+}
+
+/**
+ * Will explore all paths of the navigation tree
+ * and select the deepest path with an exact path
+ * match as the Breadcrumbs to render.
+ */
+const ContentBreadcrumbs: FC = () => {
   const navigation = useNavigation()
   const location = useLocation()
   const { formatMessage } = useLocale()
-  const items: ServicePortalNavigationItem[] = reduce(
-    (acc, n) => {
-      const isPathActive = matchPath(location.pathname, n.path || '')
-      if (isPathActive) {
-        return [...acc, n]
-      } else {
-        return acc
+  let items: ContentBreadcrumb[] = []
+
+  const findBreadcrumbsPath = (
+    navItem: ServicePortalNavigationItem,
+    currentBreadcrumbs: ContentBreadcrumb[],
+  ) => {
+    if (navItem) {
+      // Check if the current navItem is the active browser path
+      const activePath = matchPath(location.pathname, {
+        path: navItem.path,
+        exact: true,
+      })
+
+      // Push the nav item to the current array as we are currently located here in our search
+      currentBreadcrumbs.push({
+        name: parseNavItemName(navItem, activePath),
+        path: activePath ? location.pathname : navItem.path,
+      })
+
+      // Only update if we have found a deeper path
+      if (activePath && currentBreadcrumbs.length > items.length) {
+        items = [...currentBreadcrumbs]
       }
-    },
-    {
-      name: 'root',
-      children: navigation,
-    },
-    [] as ServicePortalNavigationItem[],
-  )
+
+      // Explore all of the childrens
+      if (navItem.children && navItem.children.length) {
+        for (const children of navItem.children) {
+          findBreadcrumbsPath(children, currentBreadcrumbs)
+        }
+      }
+
+      // Pop the nav item back of the array before we move on to the next item at the same level
+      currentBreadcrumbs.pop()
+    }
+  }
+
+  findBreadcrumbsPath(navigation[0], [])
 
   if (items.length < 2) return null
 
@@ -51,15 +86,9 @@ const ContentBreadcrumbs: FC<{}> = () => {
       <Breadcrumbs color="blue400" separatorColor="blue400">
         {items.map((item, index) =>
           item.path !== undefined ? (
-            index === items.length - 1 ? (
-              <Tag key={index} variant="blue" disabled outlined>
-                {formatMessage(item.name)}
-              </Tag>
-            ) : (
-              <Link key={index} to={item.path}>
-                {formatMessage(item.name)}
-              </Link>
-            )
+            <Link key={index} to={item.path}>
+              {formatMessage(item.name)}
+            </Link>
           ) : null,
         )}
       </Breadcrumbs>

--- a/libs/service-portal/core/src/lib/messages.ts
+++ b/libs/service-portal/core/src/lib/messages.ts
@@ -352,6 +352,14 @@ export const m = defineMessages({
     id: 'service.portal:family-number',
     defaultMessage: 'Fjölskyldunúmer',
   },
+  familySpouse: {
+    id: 'service.portal:family-spouse',
+    defaultMessage: 'Maki',
+  },
+  familyChild: {
+    id: 'service.portal:family-child',
+    defaultMessage: 'Barn',
+  },
   endorsements: {
     id: 'service.portal:endorsements',
     defaultMessage: 'Meðmæli',

--- a/libs/service-portal/core/src/lib/navigation/masterNavigation.ts
+++ b/libs/service-portal/core/src/lib/navigation/masterNavigation.ts
@@ -56,6 +56,18 @@ export const servicePortalMasterNavigation: ServicePortalNavigationItem[] = [
             name: m.family,
             navHide: true,
             path: ServicePortalPath.FamilyRoot,
+            children: [
+              {
+                name: m.familySpouse,
+                navHide: true,
+                path: ServicePortalPath.Spouse,
+              },
+              {
+                name: m.familyChild,
+                navHide: true,
+                path: ServicePortalPath.Child,
+              },
+            ],
           },
           {
             // Petitions

--- a/libs/service-portal/core/src/lib/navigation/masterNavigation.ts
+++ b/libs/service-portal/core/src/lib/navigation/masterNavigation.ts
@@ -4,18 +4,13 @@ import { ServicePortalPath } from './paths'
 
 export const servicePortalMasterNavigation: ServicePortalNavigationItem[] = [
   {
-    name: m.info,
+    name: m.overview,
+    systemRoute: true,
+    path: ServicePortalPath.MinarSidurRoot,
+    icon: {
+      icon: 'home',
+    },
     children: [
-      // Yfirlit
-      {
-        name: m.overview,
-        systemRoute: true,
-        path: ServicePortalPath.MinarSidurRoot,
-        icon: {
-          icon: 'home',
-        },
-      },
-
       // Rafraen skjol
       {
         name: m.documents,
@@ -231,6 +226,14 @@ export const servicePortalMasterNavigation: ServicePortalNavigationItem[] = [
           {
             name: m.myVehicles,
             path: ServicePortalPath.AssetsMyVehicles,
+            children: [
+              {
+                // Path param reference
+                name: 'id',
+                navHide: true,
+                path: ServicePortalPath.AssetsVehiclesDetail,
+              },
+            ],
           },
           // {
           //   name: m.vehiclesLookup,
@@ -251,14 +254,16 @@ export const servicePortalMasterNavigation: ServicePortalNavigationItem[] = [
           {
             name: m.accessControl,
             path: ServicePortalPath.SettingsAccessControl,
-          },
-          {
-            name: m.accessControlGrant,
-            path: ServicePortalPath.SettingsAccessControlGrant,
-          },
-          {
-            name: m.accessControlAccess,
-            path: ServicePortalPath.SettingsAccessControlAccess,
+            children: [
+              {
+                name: m.accessControlGrant,
+                path: ServicePortalPath.SettingsAccessControlGrant,
+              },
+              {
+                name: m.accessControlAccess,
+                path: ServicePortalPath.SettingsAccessControlAccess,
+              },
+            ],
           },
           {
             name: m.mySettings,


### PR DESCRIPTION
## What

Refactoring `ContentBreadcrumbs` in Service Portal.

## Why

To resolve some issues that the current implementation has:
* Fixes breadcrumb duplication if found multiple times in the navigation definition.
* Resolves route params.
* Allows for having a breadcrumb name defined as the route param value (see screenshot).
* Adds Spouse and Child breadcrumb in when viewing in Family.
* Removes the last item to be rendered as a tag.

## Screenshots / Gifs

Old duplicated breadcrumbs:
<img width="1193" alt="image" src="https://user-images.githubusercontent.com/54210288/177958597-2d7df7d3-a3fb-4b05-a794-027b2f18ca68.png">

New not duplicated breadcrumbs:
<img width="1187" alt="image" src="https://user-images.githubusercontent.com/54210288/177958486-ef3a5064-4b67-4f2c-a5e2-9dbcfcc284a0.png">

No breadcrumb for route param:
<img width="1189" alt="image" src="https://user-images.githubusercontent.com/54210288/177959124-adaefd39-6958-41da-977c-217358dea5ab.png">

Route param breadcrumb title:
<img width="1186" alt="image" src="https://user-images.githubusercontent.com/54210288/177959036-40cafa92-5267-4b7f-a430-4cbb40180b64.png">

Spouse and Child breadcrumb:
<img width="1191" alt="image" src="https://user-images.githubusercontent.com/54210288/177958031-1c7d9b94-784f-4e25-9662-201738f9cf47.png">

<img width="1186" alt="image" src="https://user-images.githubusercontent.com/54210288/177958378-82c87372-70ae-4487-90b9-e4b714b9903a.png">



## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
