### PR TITLE
refactor(nest-problem): Update httpstatuses reference to .org instead of .com (#8002)

### DIFF
--- a/apps/application-system/api/src/app/modules/application/e2e/application.spec.ts
+++ b/apps/application-system/api/src/app/modules/application/e2e/application.spec.ts
@@ -343,7 +343,7 @@ describe('Application system API', () => {
         ],
         "status": 400,
         "title": "Bad Request",
-        "type": "https://httpstatuses.com/400",
+        "type": "https://httpstatuses.org/400",
       }
     `)
   })

--- a/apps/judicial-system/web/src/routes/Prosecutor/InvestigationCase/CaseFiles/CaseFiles.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/InvestigationCase/CaseFiles/CaseFiles.tsx
@@ -306,7 +306,7 @@ export const CaseFiles: React.FC = () => {
                     </Box>
                   ) : policeCaseFiles?.hasError ? (
                     policeCaseFiles?.errorCode ===
-                    'https://httpstatuses.com/404' ? (
+                    'https://httpstatuses.org/404' ? (
                       <PoliceCaseFilesMessageBox
                         icon="warning"
                         iconColor="yellow400"

--- a/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/StepFive/StepFive.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/StepFive/StepFive.tsx
@@ -306,7 +306,7 @@ export const StepFive: React.FC = () => {
                     </Box>
                   ) : policeCaseFiles?.hasError ? (
                     policeCaseFiles?.errorCode ===
-                    'https://httpstatuses.com/404' ? (
+                    'https://httpstatuses.org/404' ? (
                       <PoliceCaseFilesMessageBox
                         icon="warning"
                         iconColor="yellow400"

--- a/apps/judicial-system/web/src/utils/hooks/useCourtUpload/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useCourtUpload/index.ts
@@ -131,7 +131,7 @@ export const useCourtUpload = (
                 ?.detail,
           }
 
-          if (errorCode === 'https://httpstatuses.com/404') {
+          if (errorCode === 'https://httpstatuses.org/404') {
             if (detail?.startsWith('Case Not Found')) {
               setFileUploadStatus(workingCase, file, 'case-not-found')
             } else {
@@ -142,7 +142,7 @@ export const useCourtUpload = (
               )
             }
           } else if (
-            errorCode === 'https://httpstatuses.com/415' // Unsupported Media Type
+            errorCode === 'https://httpstatuses.org/415' // Unsupported Media Type
           ) {
             setFileUploadStatus(workingCase, file, 'unsupported')
           } else {

--- a/apps/judicial-system/web/src/utils/hooks/useFileList/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useFileList/index.ts
@@ -30,8 +30,8 @@ const useFileList = ({ caseId }: Parameters) => {
 
       // If the file no longer exists or access in no longer permitted
       if (
-        code === 'https://httpstatuses.com/404' ||
-        code === 'https://httpstatuses.com/403'
+        code === 'https://httpstatuses.org/404' ||
+        code === 'https://httpstatuses.org/403'
       ) {
         setFileNotFound(true)
         setWorkingCase((theCase) => ({

--- a/apps/services/auth-public-api/src/app/modules/delegations/actorDelegations.controller.spec.ts
+++ b/apps/services/auth-public-api/src/app/modules/delegations/actorDelegations.controller.spec.ts
@@ -293,7 +293,7 @@ describe('ActorDelegationsController', () => {
         expect(res.status).toEqual(400)
         expect(res.body).toMatchObject({
           status: 400,
-          type: 'https://httpstatuses.com/400',
+          type: 'https://httpstatuses.org/400',
           title: 'Bad Request',
           detail:
             "'direction' can only be set to incoming for the /actor alias",
@@ -725,7 +725,7 @@ describe('ActorDelegationsController', () => {
         expect(res.status).toEqual(401)
         expect(res.body).toMatchObject({
           status: 401,
-          type: 'https://httpstatuses.com/401',
+          type: 'https://httpstatuses.org/401',
           title: 'Unauthorized',
         })
 
@@ -751,7 +751,7 @@ describe('ActorDelegationsController', () => {
         expect(res.status).toEqual(403)
         expect(res.body).toMatchObject({
           status: 403,
-          type: 'https://httpstatuses.com/403',
+          type: 'https://httpstatuses.org/403',
           title: 'Forbidden',
           detail: 'Forbidden resource',
         })

--- a/apps/services/auth-public-api/src/app/modules/delegations/meDelegations.controller.spec.ts
+++ b/apps/services/auth-public-api/src/app/modules/delegations/meDelegations.controller.spec.ts
@@ -515,7 +515,7 @@ describe('MeDelegationsController', () => {
         expect(res.status).toEqual(500)
         expect(res.body).toMatchObject({
           status: 500,
-          type: 'https://httpstatuses.com/500',
+          type: 'https://httpstatuses.org/500',
           title: 'Internal Server Error',
           detail:
             'Invalid state of delegation. User has two or more delegations with an other user.',
@@ -530,7 +530,7 @@ describe('MeDelegationsController', () => {
         expect(res.status).toEqual(400)
         expect(res.body).toMatchObject({
           status: 400,
-          type: 'https://httpstatuses.com/400',
+          type: 'https://httpstatuses.org/400',
           title: 'Bad Request',
           detail: 'direction=outgoing is currently the only supported value',
         })
@@ -544,7 +544,7 @@ describe('MeDelegationsController', () => {
         expect(res.status).toEqual(400)
         expect(res.body).toMatchObject({
           status: 400,
-          type: 'https://httpstatuses.com/400',
+          type: 'https://httpstatuses.org/400',
           title: 'Bad Request',
           detail: 'direction=outgoing is currently the only supported value',
         })
@@ -745,7 +745,7 @@ describe('MeDelegationsController', () => {
           Object {
             "status": 404,
             "title": "Not Found",
-            "type": "https://httpstatuses.com/404",
+            "type": "https://httpstatuses.org/404",
           }
         `)
       })
@@ -771,7 +771,7 @@ describe('MeDelegationsController', () => {
             "detail": "delegationId must be a valid uuid",
             "status": 400,
             "title": "Bad Request",
-            "type": "https://httpstatuses.com/400",
+            "type": "https://httpstatuses.org/400",
           }
         `)
       })
@@ -838,7 +838,7 @@ describe('MeDelegationsController', () => {
         expect(res.status).toEqual(400)
         expect(res.body).toMatchObject({
           status: 400,
-          type: 'https://httpstatuses.com/400',
+          type: 'https://httpstatuses.org/400',
           title: 'Bad Request',
           detail: 'User does not have access to the requested scopes.',
         })
@@ -869,7 +869,7 @@ describe('MeDelegationsController', () => {
         expect(res.status).toEqual(400)
         expect(res.body).toMatchObject({
           status: 400,
-          type: 'https://httpstatuses.com/400',
+          type: 'https://httpstatuses.org/400',
           title: 'Bad Request',
           detail: 'User does not have access to the requested scopes.',
         })
@@ -895,7 +895,7 @@ describe('MeDelegationsController', () => {
         expect(res.status).toEqual(400)
         expect(res.body).toMatchObject({
           status: 400,
-          type: 'https://httpstatuses.com/400',
+          type: 'https://httpstatuses.org/400',
           title: 'Bad Request',
           detail:
             'When scope validTo property is provided it must be in the future',
@@ -921,7 +921,7 @@ describe('MeDelegationsController', () => {
         expect(res.status).toEqual(400)
         expect(res.body).toMatchObject({
           status: 400,
-          type: 'https://httpstatuses.com/400',
+          type: 'https://httpstatuses.org/400',
           title: 'Bad Request',
           detail: ['0.validTo must be a Date instance'],
         })
@@ -947,7 +947,7 @@ describe('MeDelegationsController', () => {
         expect(res.status).toEqual(400)
         expect(res.body).toMatchObject({
           status: 400,
-          type: 'https://httpstatuses.com/400',
+          type: 'https://httpstatuses.org/400',
           title: 'Bad Request',
           detail: ['0.type must be a valid enum value'],
         })
@@ -1107,7 +1107,7 @@ describe('MeDelegationsController', () => {
         expect(res.status).toEqual(400)
         expect(res.body).toMatchObject({
           status: 400,
-          type: 'https://httpstatuses.com/400',
+          type: 'https://httpstatuses.org/400',
           title: 'Bad Request',
           detail: 'User does not have access to the requested scopes.',
         })
@@ -1140,7 +1140,7 @@ describe('MeDelegationsController', () => {
         expect(res.status).toEqual(400)
         expect(res.body).toMatchObject({
           status: 400,
-          type: 'https://httpstatuses.com/400',
+          type: 'https://httpstatuses.org/400',
           title: 'Bad Request',
           detail: 'User does not have access to the requested scopes.',
         })
@@ -1173,7 +1173,7 @@ describe('MeDelegationsController', () => {
         expect(res.status).toEqual(400)
         expect(res.body).toMatchObject({
           status: 400,
-          type: 'https://httpstatuses.com/400',
+          type: 'https://httpstatuses.org/400',
           title: 'Bad Request',
           detail:
             'If scope validTo property is provided it must be in the future',
@@ -1207,7 +1207,7 @@ describe('MeDelegationsController', () => {
         expect(res.status).toEqual(400)
         expect(res.body).toMatchObject({
           status: 400,
-          type: 'https://httpstatuses.com/400',
+          type: 'https://httpstatuses.org/400',
           title: 'Bad Request',
           detail: ['0.type must be a valid enum value'],
         })
@@ -1233,7 +1233,7 @@ describe('MeDelegationsController', () => {
         expect(res.status).toEqual(404)
         expect(res.body).toMatchObject({
           status: 404,
-          type: 'https://httpstatuses.com/404',
+          type: 'https://httpstatuses.org/404',
           title: 'Not Found',
         })
       })
@@ -1309,7 +1309,7 @@ describe('MeDelegationsController', () => {
         expect(res.status).toEqual(404)
         expect(res.body).toMatchObject({
           status: 404,
-          type: 'https://httpstatuses.com/404',
+          type: 'https://httpstatuses.org/404',
           title: 'Not Found',
         })
       })
@@ -1443,7 +1443,7 @@ describe('MeDelegationsController', () => {
         expect(res.status).toEqual(401)
         expect(res.body).toMatchObject({
           status: 401,
-          type: 'https://httpstatuses.com/401',
+          type: 'https://httpstatuses.org/401',
           title: 'Unauthorized',
         })
 
@@ -1473,7 +1473,7 @@ describe('MeDelegationsController', () => {
         expect(res.status).toEqual(403)
         expect(res.body).toMatchObject({
           status: 403,
-          type: 'https://httpstatuses.com/403',
+          type: 'https://httpstatuses.org/403',
           title: 'Forbidden',
           detail: 'Forbidden resource',
         })

--- a/apps/services/auth-public-api/src/app/modules/resources/scopes.controller.spec.ts
+++ b/apps/services/auth-public-api/src/app/modules/resources/scopes.controller.spec.ts
@@ -308,7 +308,7 @@ describe('ScopesController', () => {
         expect(res.status).toEqual(401)
         expect(res.body).toMatchObject({
           status: 401,
-          type: 'https://httpstatuses.com/401',
+          type: 'https://httpstatuses.org/401',
           title: 'Unauthorized',
         })
 
@@ -334,7 +334,7 @@ describe('ScopesController', () => {
         expect(res.status).toEqual(403)
         expect(res.body).toMatchObject({
           status: 403,
-          type: 'https://httpstatuses.com/403',
+          type: 'https://httpstatuses.org/403',
           title: 'Forbidden',
           detail: 'Forbidden resource',
         })

--- a/handbook/reference/problems/README.md
+++ b/handbook/reference/problems/README.md
@@ -4,11 +4,11 @@ This reference lists the custom [problem types](../../technical-overview/api-des
 
 ## Standard http problems
 
-- [400 Bad Request](https://httpstatuses.com/400)
-- [401 Unauthorized](https://httpstatuses.com/401)
-- [403 Forbidden](https://httpstatuses.com/403)
-- [404 Not Found](https://httpstatuses.com/404)
-- [500 Internal Server Error](https://httpstatuses.com/500)
+- [400 Bad Request](https://httpstatuses.org/400)
+- [401 Unauthorized](https://httpstatuses.org/401)
+- [403 Forbidden](https://httpstatuses.org/403)
+- [404 Not Found](https://httpstatuses.org/404)
+- [500 Internal Server Error](https://httpstatuses.org/500)
 
 ## Custom problems
 

--- a/libs/nest/problem/src/lib/ProblemError.ts
+++ b/libs/nest/problem/src/lib/ProblemError.ts
@@ -31,7 +31,7 @@ export class ProblemError extends Error {
 
     return new ProblemError({
       status: status,
-      type: `https://httpstatuses.com/${status}`,
+      type: `https://httpstatuses.org/${status}`,
       title,
       detail,
     } as HttpProblem)

--- a/libs/nest/problem/src/lib/apolloError.filter.spec.ts
+++ b/libs/nest/problem/src/lib/apolloError.filter.spec.ts
@@ -26,7 +26,7 @@ describe('ApolloErrorFilter', () => {
         "detail": "User does not access.",
         "status": 403,
         "title": "Forbidden",
-        "type": "https://httpstatuses.com/403",
+        "type": "https://httpstatuses.org/403",
       }
     `)
   })

--- a/libs/nest/problem/src/lib/apolloError.filter.ts
+++ b/libs/nest/problem/src/lib/apolloError.filter.ts
@@ -16,7 +16,7 @@ export class ApolloErrorFilter extends BaseProblemFilter {
     const info = errorInfo[error.extensions.code] ?? errorInfo.BAD_USER_INPUT
     return {
       ...info,
-      type: `https://httpstatuses.com/${info.status}`,
+      type: `https://httpstatuses.org/${info.status}`,
       detail: error.message,
     } as HttpProblem
   }

--- a/libs/nest/problem/src/lib/httpException.filter.spec.ts
+++ b/libs/nest/problem/src/lib/httpException.filter.spec.ts
@@ -27,7 +27,7 @@ describe('HttpExceptionFilter', () => {
       Object {
         "status": 403,
         "title": "Forbidden",
-        "type": "https://httpstatuses.com/403",
+        "type": "https://httpstatuses.org/403",
       }
     `)
   })
@@ -50,7 +50,7 @@ describe('HttpExceptionFilter', () => {
         "detail": "Custom error",
         "status": 403,
         "title": "Forbidden",
-        "type": "https://httpstatuses.com/403",
+        "type": "https://httpstatuses.org/403",
       }
     `)
   })

--- a/libs/nest/problem/src/lib/httpException.filter.ts
+++ b/libs/nest/problem/src/lib/httpException.filter.ts
@@ -12,13 +12,13 @@ export class HttpExceptionFilter extends BaseProblemFilter {
     if (typeof response === 'string') {
       return {
         status,
-        type: `https://httpstatuses.com/${status}`,
+        type: `https://httpstatuses.org/${status}`,
         title: response,
       } as HttpProblem
     }
     return {
       status,
-      type: `https://httpstatuses.com/${status}`,
+      type: `https://httpstatuses.org/${status}`,
       title: response.error || response.message,
       detail: response.error ? response.message : undefined,
     } as HttpProblem

--- a/libs/shared/problem/src/ProblemType.ts
+++ b/libs/shared/problem/src/ProblemType.ts
@@ -1,9 +1,9 @@
 export enum ProblemType {
-  HTTP_BAD_REQUEST = 'https://httpstatuses.com/400',
-  HTTP_UNAUTHORIZED = 'https://httpstatuses.com/401',
-  HTTP_FORBIDDEN = 'https://httpstatuses.com/403',
-  HTTP_NOT_FOUND = 'https://httpstatuses.com/404',
-  HTTP_INTERNAL_SERVER_ERROR = 'https://httpstatuses.com/500',
+  HTTP_BAD_REQUEST = 'https://httpstatuses.org/400',
+  HTTP_UNAUTHORIZED = 'https://httpstatuses.org/401',
+  HTTP_FORBIDDEN = 'https://httpstatuses.org/403',
+  HTTP_NOT_FOUND = 'https://httpstatuses.org/404',
+  HTTP_INTERNAL_SERVER_ERROR = 'https://httpstatuses.org/500',
   VALIDATION_FAILED = 'https://docs.devland.is/reference/problems/validation-failed',
   BAD_SUBJECT = 'https://docs.devland.is/reference/problems/bad-subject',
 }


### PR DESCRIPTION
## What

Hotfix httpstatuses url from #8002 

## Why

To stop reference .com which redirects to another domain.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
