### PR TITLE
fix(j-s): Prosecutor Navigation

### DIFF
--- a/apps/judicial-system/web/src/utils/hooks/useSections/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useSections/index.ts
@@ -210,7 +210,8 @@ const useSections = () => {
                   (activeSubSection && activeSubSection > 4) ||
                   (isDefendantStepValidForSidebarIC(workingCase) &&
                     isHearingArrangementsStepValidIC(workingCase) &&
-                    isPoliceDemandsStepValidIC(workingCase))
+                    isPoliceDemandsStepValidIC(workingCase) &&
+                    isPoliceReportStepValidIC(workingCase))
                     ? `${constants.IC_CASE_FILES_ROUTE}/${id}`
                     : undefined,
               },
@@ -222,7 +223,8 @@ const useSections = () => {
                 href:
                   isDefendantStepValidForSidebarIC(workingCase) &&
                   isHearingArrangementsStepValidIC(workingCase) &&
-                  isPoliceDemandsStepValidIC(workingCase)
+                  isPoliceDemandsStepValidIC(workingCase) &&
+                  isPoliceReportStepValidIC(workingCase)
                     ? `${constants.IC_POLICE_CONFIRMATION_ROUTE}/${id}`
                     : undefined,
               },


### PR DESCRIPTION
# Prosecutor Navigation

Attach a link to issue if relevant

## What

- Prevents prosecutors from navigating to the case files page (and beyond) until the case facts and legal arguments have been filled in.

## Why

Bug.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
