### PR TITLE
feat(web): Organization pages, external script support

### DIFF
--- a/apps/web/screens/Organization/Home.tsx
+++ b/apps/web/screens/Organization/Home.tsx
@@ -53,16 +53,16 @@ const Home: Screen<HomeProps> = ({ organizationPage, namespace }) => {
   )
 
   useEffect(() => {
-    if (!organizationPage.organization?.statusMonitoringScriptUrl) return
+    if (!organizationPage.organization?.externalScriptUrl) return
     const element = document.createElement('script')
     element.type = 'text/javascript'
-    element.src = organizationPage.organization.statusMonitoringScriptUrl
+    element.src = organizationPage.organization.externalScriptUrl
     document.body.appendChild(element)
 
     return () => {
       document.body.removeChild(element)
     }
-  }, [organizationPage.organization?.statusMonitoringScriptUrl])
+  }, [organizationPage.organization?.externalScriptUrl])
 
   return (
     <OrganizationWrapper

--- a/apps/web/screens/Organization/Home.tsx
+++ b/apps/web/screens/Organization/Home.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import React from 'react'
+import { useEffect } from 'react'
 import { NavigationItem } from '@island.is/island-ui/core'
 import { withMainLayout } from '@island.is/web/layouts/main'
 import {
@@ -51,6 +51,18 @@ const Home: Screen<HomeProps> = ({ organizationPage, namespace }) => {
       })),
     }),
   )
+
+  useEffect(() => {
+    if (!organizationPage.organization?.statusMonitoringScriptUrl) return
+    const element = document.createElement('script')
+    element.type = 'text/javascript'
+    element.src = organizationPage.organization.statusMonitoringScriptUrl
+    document.body.appendChild(element)
+
+    return () => {
+      document.body.removeChild(element)
+    }
+  }, [organizationPage.organization?.statusMonitoringScriptUrl])
 
   return (
     <OrganizationWrapper

--- a/apps/web/screens/queries/Organization.tsx
+++ b/apps/web/screens/queries/Organization.tsx
@@ -125,6 +125,7 @@ export const GET_ORGANIZATION_PAGE_QUERY = gql`
             url
           }
         }
+        statusMonitoringScriptUrl
       }
       slices {
         ...AllSlices

--- a/apps/web/screens/queries/Organization.tsx
+++ b/apps/web/screens/queries/Organization.tsx
@@ -36,7 +36,7 @@ export const GET_ORGANIZATION_QUERY = gql`
         title
         url
       }
-      statusMonitoringScriptUrl
+      externalScriptUrl
       publishedMaterialSearchFilterGenericTags {
         id
         title
@@ -125,7 +125,7 @@ export const GET_ORGANIZATION_PAGE_QUERY = gql`
             url
           }
         }
-        statusMonitoringScriptUrl
+        externalScriptUrl
       }
       slices {
         ...AllSlices

--- a/apps/web/screens/queries/Organization.tsx
+++ b/apps/web/screens/queries/Organization.tsx
@@ -36,6 +36,7 @@ export const GET_ORGANIZATION_QUERY = gql`
         title
         url
       }
+      statusMonitoringScriptUrl
       publishedMaterialSearchFilterGenericTags {
         id
         title

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -1940,8 +1940,8 @@ export interface IOrganizationFields {
   /** Shows up on the organizations page */
   showsUpOnTheOrganizationsPage?: boolean | undefined
 
-  /** Status Monitoring Script URL */
-  statusMonitoringScriptUrl?: string | undefined
+  /** External script url */
+  externalScriptUrl?: string | undefined
 }
 
 export interface IOrganization extends Entry<IOrganizationFields> {

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -1939,6 +1939,9 @@ export interface IOrganizationFields {
 
   /** Shows up on the organizations page */
   showsUpOnTheOrganizationsPage?: boolean | undefined
+
+  /** Status Monitoring Script URL */
+  statusMonitoringScriptUrl?: string | undefined
 }
 
 export interface IOrganization extends Entry<IOrganizationFields> {

--- a/libs/cms/src/lib/models/organization.model.ts
+++ b/libs/cms/src/lib/models/organization.model.ts
@@ -61,6 +61,9 @@ export class Organization {
 
   @Field(() => Boolean, { nullable: true })
   showsUpOnTheOrganizationsPage?: boolean
+
+  @Field()
+  statusMonitoringScriptUrl?: string
 }
 
 export const mapOrganization = ({
@@ -90,5 +93,6 @@ export const mapOrganization = ({
       ? fields.publishedMaterialSearchFilterGenericTags.map(mapGenericTag)
       : [],
     showsUpOnTheOrganizationsPage: fields.showsUpOnTheOrganizationsPage ?? true,
+    statusMonitoringScriptUrl: fields.statusMonitoringScriptUrl ?? '',
   }
 }

--- a/libs/cms/src/lib/models/organization.model.ts
+++ b/libs/cms/src/lib/models/organization.model.ts
@@ -63,7 +63,7 @@ export class Organization {
   showsUpOnTheOrganizationsPage?: boolean
 
   @Field()
-  statusMonitoringScriptUrl?: string
+  externalScriptUrl?: string
 }
 
 export const mapOrganization = ({
@@ -93,6 +93,6 @@ export const mapOrganization = ({
       ? fields.publishedMaterialSearchFilterGenericTags.map(mapGenericTag)
       : [],
     showsUpOnTheOrganizationsPage: fields.showsUpOnTheOrganizationsPage ?? true,
-    statusMonitoringScriptUrl: fields.statusMonitoringScriptUrl ?? '',
+    externalScriptUrl: fields.externalScriptUrl ?? '',
   }
 }


### PR DESCRIPTION
# Organization pages, external script support

## What

* Added a way for organization pages to load an external script

## Why

* This was a requested feature

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
