### PR TITLE
feat(infra): Script to diff manifest between releases

### DIFF
--- a/infra/scripts/helm-diff.sh
+++ b/infra/scripts/helm-diff.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Requirements:
+# Install ydiff
+# - brew install ydiff
+# - pip install --upgrade ydiff
+# https://github.com/ymattw/ydiff
+
+if ! command -v ydiff &> /dev/null
+then
+    echo "Please install ydiff via pip or brew"
+    echo "https://github.com/ymattw/ydiff"
+    exit 1
+fi
+
+if [ -z "${1}" ]; then
+    echo "Specify the current release name"
+    exit 1
+fi
+if [ -z "${2}" ]; then
+    echo "Specify the new release name"
+    exit 1
+fi
+
+# Script to bake the helm chart as spinnaker does it
+
+# curl https://api.github.com/repos/island-is/island.is/contents/charts/islandis/values.prod.yaml | jq -r ".content" | base64 --decode
+
+curl -s -H "Accept: application/json" 'https://api.github.com/repos/island-is/island.is/contents/charts/islandis/values.prod.yaml?ref='release/${2}'' | jq -r ".content" | base64 --decode > new-release.json
+curl -s -H "Accept: application/json" 'https://api.github.com/repos/island-is/island.is/contents/charts/islandis/values.prod.yaml?ref='release/${1}'' | jq -r ".content" | base64 --decode > current-release.json
+
+
+diff -u ./current-release.json ./new-release.json | ydiff -w 0 -s
+
+rm -f ./new-release.json
+rm -f ./current-release.json

--- a/infra/scripts/helm-diff.sh
+++ b/infra/scripts/helm-diff.sh
@@ -22,15 +22,9 @@ if [ -z "${2}" ]; then
     exit 1
 fi
 
-# Script to bake the helm chart as spinnaker does it
-
 # curl https://api.github.com/repos/island-is/island.is/contents/charts/islandis/values.prod.yaml | jq -r ".content" | base64 --decode
-
-curl -s -H "Accept: application/json" 'https://api.github.com/repos/island-is/island.is/contents/charts/islandis/values.prod.yaml?ref='release/${2}'' | jq -r ".content" | base64 --decode > new-release.json
 curl -s -H "Accept: application/json" 'https://api.github.com/repos/island-is/island.is/contents/charts/islandis/values.prod.yaml?ref='release/${1}'' | jq -r ".content" | base64 --decode > current-release.json
-
-
+curl -s -H "Accept: application/json" 'https://api.github.com/repos/island-is/island.is/contents/charts/islandis/values.prod.yaml?ref='release/${2}'' | jq -r ".content" | base64 --decode > new-release.json
 diff -u ./current-release.json ./new-release.json | ydiff -w 0 -s
-
 rm -f ./new-release.json
 rm -f ./current-release.json


### PR DESCRIPTION
# ...

fixes: https://github.com/island-is/infrastructure/issues/1292

## What

This script will diff between two chosen releases by entering the version version. 
`./helm-diff.sh 16.1.0 16.2.0`

This will output in `less` a side by side diff comparison between kubernetes manifests of the two releases. 

Requires you to have the tool ydiff installed
https://github.com/ymattw/ydiff

## Why

To do smoke tests on missing environment variables before release. 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
