### PR TITLE
fix(auth-public-api): Add filter for custom scope rules in checkIfScopeAllowed.

### DIFF
--- a/libs/auth-api-lib/src/lib/config/DelegationConfig.ts
+++ b/libs/auth-api-lib/src/lib/config/DelegationConfig.ts
@@ -4,39 +4,41 @@ import { ApiScope, AuthScope } from '@island.is/auth/scopes'
 import { defineConfig } from '@island.is/nest/config'
 import { DelegationType } from '../entities/dto/delegation.dto'
 
+const customScopeRuleSchema = z.array(
+  z.object({
+    // The name of the scope which should have special logic.
+    scopeName: z.string(),
+    // This property adds extra conditions to custom delegation grants. It is an array of
+    // delegation types which can grant the scope to other users.
+    //
+    // * Self: Normal "person" users can grant this scope to other users on their behalf.
+    // * ProcurationHolder: "Company owners" can grant this scope to other users on behalf of their company.
+    // * LegalGuardian: "Parents" can grant this scope to other users on behalf of their child.
+    // * Custom: Custom delegatee can grant this scope to other users on behalf of the original delegator.
+    //
+    // In all cases, the active user still needs to have this scope and the
+    // `delegation:write` scope in their access token.
+    onlyForDelegationType: z.array(
+      z
+        .string()
+        .refine((val) =>
+          ['Self', ...Object.values(DelegationType)].includes(val),
+        ),
+    ),
+  }),
+)
+
 const schema = z.object({
   // Configures special rules affecting when specific scopes can be granted to other
   // users in custom delegations.
-  customScopeRules: z.array(
-    z.object({
-      // The name of the scope which should have special logic.
-      scopeName: z.string(),
-      // This property adds extra conditions to custom delegation grants. It is an array of
-      // delegation types which can grant the scope to other users.
-      //
-      // * Self: Normal "person" users can grant this scope to other users on their behalf.
-      // * ProcurationHolder: "Company owners" can grant this scope to other users on behalf of their company.
-      // * LegalGuardian: "Parents" can grant this scope to other users on behalf of their child.
-      // * Custom: Custom delegatee can grant this scope to other users on behalf of the original delegator.
-      //
-      // In all cases, the active user still needs to have this scope and the
-      // `delegation:write` scope in their access token.
-      onlyForDelegationType: z.array(
-        z
-          .string()
-          .refine((val) =>
-            ['Self', ...Object.values(DelegationType)].includes(val),
-          ),
-      ),
-    }),
-  ),
+  customScopeRules: customScopeRuleSchema,
 })
 
 export const DelegationConfig = defineConfig({
   name: 'DelegationConfig',
   schema,
   load: (env) => ({
-    customScopeRules: env.optionalJSON('DELEGATION_CUSTOM_SCOPE_RULES') ?? [
+    customScopeRules: (env.optionalJSON('DELEGATION_CUSTOM_SCOPE_RULES') ?? [
       {
         scopeName: AuthScope.writeDelegations,
         onlyForDelegationType: ['ProcurationHolder'],
@@ -49,6 +51,6 @@ export const DelegationConfig = defineConfig({
         scopeName: ApiScope.company,
         onlyForDelegationType: ['ProcurationHolder'],
       },
-    ],
+    ]) as z.infer<typeof customScopeRuleSchema>,
   }),
 })

--- a/libs/auth-api-lib/src/lib/services/delegations.service.ts
+++ b/libs/auth-api-lib/src/lib/services/delegations.service.ts
@@ -1,4 +1,3 @@
-import type { AuthConfig, User } from '@island.is/auth-nest-tools'
 import {
   BadRequestException,
   Inject,
@@ -6,13 +5,15 @@ import {
   InternalServerErrorException,
   NotFoundException,
 } from '@nestjs/common'
+import { ConfigType } from '@nestjs/config'
 import { InjectModel } from '@nestjs/sequelize'
 import startOfDay from 'date-fns/startOfDay'
 import uniqBy from 'lodash/uniqBy'
 import { Op, WhereOptions } from 'sequelize'
 import { isUuid, uuid } from 'uuidv4'
 
-import { AuthMiddleware } from '@island.is/auth-nest-tools'
+import { AuthDelegationType, AuthMiddleware } from '@island.is/auth-nest-tools'
+import type { AuthConfig, User } from '@island.is/auth-nest-tools'
 import {
   createEnhancedFetch,
   EnhancedFetchAPI,
@@ -23,6 +24,7 @@ import { LOGGER_PROVIDER } from '@island.is/logging'
 import type { Logger } from '@island.is/logging'
 import { FeatureFlagService, Features } from '@island.is/nest/feature-flags'
 
+import { DelegationConfig } from '../config/DelegationConfig'
 import { UpdateDelegationScopeDTO } from '../entities/dto/delegation-scope.dto'
 import {
   CreateDelegationDTO,
@@ -32,8 +34,8 @@ import {
   UpdateDelegationDTO,
 } from '../entities/dto/delegation.dto'
 import { ApiScope } from '../entities/models/api-scope.model'
-import { Client } from '../entities/models/client.model'
 import { ClientAllowedScope } from '../entities/models/client-allowed-scope.model'
+import { Client } from '../entities/models/client.model'
 import { DelegationScope } from '../entities/models/delegation-scope.model'
 import { Delegation } from '../entities/models/delegation.model'
 import { PersonalRepresentativeService } from '../personal-representative'
@@ -67,6 +69,8 @@ export class DelegationsService {
     private authConfig: AuthConfig,
     @Inject(LOGGER_PROVIDER)
     private logger: Logger,
+    @Inject(DelegationConfig.KEY)
+    private delegationConfig: ConfigType<typeof DelegationConfig>,
     private rskProcuringClient: RskProcuringClient,
     private personApi: EinstaklingarApi,
     private delegationScopeService: DelegationScopeService,
@@ -237,7 +241,7 @@ export class DelegationsService {
 
     if (delegation) {
       delegation.delegationScopes = delegation.delegationScopes?.filter((s) =>
-        this.checkIfScopeAllowed(s, user.scope),
+        this.checkIfScopeAllowed(s, user),
       )
     }
 
@@ -301,14 +305,12 @@ export class DelegationsService {
     return delegations
       .filter((d) =>
         // The user must have access to at least one scope in the delegation
-        d.delegationScopes?.some((s) =>
-          this.checkIfScopeAllowed(s, user.scope),
-        ),
+        d.delegationScopes?.some((s) => this.checkIfScopeAllowed(s, user)),
       )
       .map((d) => {
         // Filter out scopes the user does not have access to
         d.delegationScopes = d.delegationScopes?.filter((s) =>
-          this.checkIfScopeAllowed(s, user.scope),
+          this.checkIfScopeAllowed(s, user),
         )
         return d.toDTO()
       })
@@ -401,7 +403,7 @@ export class DelegationsService {
 
     if (delegation) {
       delegation.delegationScopes = delegation.delegationScopes?.filter((s) =>
-        this.checkIfScopeAllowed(s, user.scope),
+        this.checkIfScopeAllowed(s, user),
       )
     }
 
@@ -594,13 +596,14 @@ export class DelegationsService {
 
     return delegations
       .filter((d) =>
+        // The requesting client must have access to at least one scope for the delegation to be relevant.
         d.delegationScopes?.some((s) =>
-          this.checkIfScopeAllowed(s, allowedScopes),
+          this.checkIfScopeAllowed(s, user, allowedScopes),
         ),
       )
       .map((d) => {
         d.delegationScopes = d.delegationScopes?.filter((s) =>
-          this.checkIfScopeAllowed(s, user.scope),
+          this.checkIfScopeAllowed(s, user),
         )
         return d.toDTO()
       })
@@ -647,13 +650,34 @@ export class DelegationsService {
 
   private checkIfScopeAllowed(
     scope: DelegationScope,
-    allowedScopes: string[],
+    user: User,
+    allowedScopes?: string[],
   ): boolean {
+    allowedScopes = (allowedScopes ?? user.scope).filter((scope) =>
+      this.filterCustomScopeRule(scope, user),
+    )
+
+    const hasScope = Boolean(
+      scope.scopeName && allowedScopes.includes(scope.scopeName),
+    )
+    const hasIdentityResource = Boolean(
+      scope.identityResourceName &&
+        allowedScopes.includes(scope.identityResourceName),
+    )
+
+    return hasScope || hasIdentityResource
+  }
+
+  private filterCustomScopeRule(scope: string, user: User): boolean {
+    const customRule = this.delegationConfig.customScopeRules.find(
+      (rule) => rule.scopeName === scope,
+    )
+
     return (
-      (scope.scopeName && allowedScopes.includes(scope.scopeName)) ||
-      (scope.identityResourceName &&
-        allowedScopes.includes(scope.identityResourceName)) ||
-      false
+      !customRule ||
+      customRule.onlyForDelegationType.some((type) =>
+        user.delegationType?.includes(type as AuthDelegationType),
+      )
     )
   }
 


### PR DESCRIPTION
## What

Adding filter in scope check to compare against custom scope rules.

## Why

When scope was once allowed for delegation, but is then later changed by using the custom scope rules, i.e. to allow only for companies (ProcurationHolder), the Access Control UI was still displaying the scope tag due to the public api still returning the scope as part of the delegation. This PR filters these scopes out of the scope list.

## Screenshots / Gifs

Before:
![image](https://user-images.githubusercontent.com/54210288/178971721-b273444e-98b4-47fb-b302-65015160fba0.png)

After:
![image](https://user-images.githubusercontent.com/54210288/178971753-e12859cc-5f64-4b68-8574-2efc28ce8eea.png)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
