### PR TITLE
fix(web): Trim leading and trailing whitespace from link url

### DIFF
--- a/libs/cms/src/lib/models/link.model.ts
+++ b/libs/cms/src/lib/models/link.model.ts
@@ -26,7 +26,7 @@ export const mapLink = ({ sys, fields }: ILink): Link => {
   return {
     id: sys.id,
     text: fields?.text ?? '',
-    url: fields?.url ?? '',
+    url: fields?.url?.trim() ?? '',
     intro: fields?.intro ?? '',
     labels: fields?.labels ?? [],
     date: fields?.date ?? '',


### PR DESCRIPTION
# Trim leading and trailing whitespace from link url

## What

* Removed leading and trailing whitespace from link url

## Why

* We ran into an issue where a link url had a trailing whitespace in the CMS which resulted in a sidebar menu not highlighting it since the code was checking for an exact match

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
