### PR TITLE
fix(web): Fix category page when article belongs to multiple groups

### DIFF
--- a/apps/web/screens/Category/Category/Category.tsx
+++ b/apps/web/screens/Category/Category/Category.tsx
@@ -122,6 +122,14 @@ const Category: Screen<CategoryProps> = ({
         content.otherArticles.push(article)
         return content
       }
+      // Check if article belongs to multiple groups in this category
+      else if (
+        article?.otherCategories
+          .map((category) => category.title)
+          .includes(getCurrentCategory().title)
+      ) {
+        content.otherArticles.push(article)
+      }
 
       if (article?.group?.slug && !content.groups[article?.group?.slug]) {
         // group does not exist create the collection

--- a/apps/web/screens/queries/Category.tsx
+++ b/apps/web/screens/queries/Category.tsx
@@ -35,6 +35,9 @@ export const GET_ARTICLES_QUERY = gql`
         title
         importance
       }
+      otherCategories {
+        title
+      }
       otherSubgroups {
         title
         slug


### PR DESCRIPTION
# Fix category page when article belongs to multiple groups

## What

Articles can be shown in more than one group by adding to the `otherCategory` and `otherGroup` fields. Currently, this only works when an article's main category is different from the other category.

This PR fixes it so that articles can appear in the main group and also other groups on the same category page.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
