### PR TITLE
feat(web): Add option for whether overview links should open in a new tab

### DIFF
--- a/apps/web/components/Organization/Slice/OverviewLinks/OverviewLinks.tsx
+++ b/apps/web/components/Organization/Slice/OverviewLinks/OverviewLinks.tsx
@@ -26,7 +26,18 @@ export const OverviewLinksSlice: React.FC<SliceProps> = ({ slice }) => {
         <Box borderTopWidth="standard" borderColor="standard" paddingTop={4}>
           <Stack space={6}>
             {slice.overviewLinks.map(
-              ({ title, linkTitle, link, image, leftImage, intro }, index) => {
+              (
+                {
+                  title,
+                  linkTitle,
+                  link,
+                  image,
+                  leftImage,
+                  intro,
+                  openLinkInNewTab,
+                },
+                index,
+              ) => {
                 return (
                   <GridRow
                     key={index}
@@ -76,7 +87,7 @@ export const OverviewLinksSlice: React.FC<SliceProps> = ({ slice }) => {
                               link.slug,
                             ])}
                             skipTab
-                            newTab={true}
+                            newTab={openLinkInNewTab ?? true}
                           >
                             <Button icon="arrowForward" variant="text">
                               {linkTitle}

--- a/apps/web/screens/queries/fragments.ts
+++ b/apps/web/screens/queries/fragments.ts
@@ -448,6 +448,7 @@ export const slices = gql`
         width
         height
       }
+      openLinkInNewTab
     }
     link {
       text

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -1127,6 +1127,9 @@ export interface IIntroLinkImageFields {
     | INews
     | IVidspyrnaFrontpage
     | IVidspyrnaPage
+
+  /** Open Link in New Tab */
+  openLinkInNewTab: boolean
 }
 
 export interface IIntroLinkImage extends Entry<IIntroLinkImageFields> {

--- a/libs/cms/src/lib/models/introLinkImage.model.ts
+++ b/libs/cms/src/lib/models/introLinkImage.model.ts
@@ -23,6 +23,9 @@ export class IntroLinkImage {
 
   @Field(() => ReferenceLink)
   link!: ReferenceLink | null
+
+  @Field(() => Boolean)
+  openLinkInNewTab?: boolean
 }
 
 export const mapIntroLinkImage = ({
@@ -35,4 +38,5 @@ export const mapIntroLinkImage = ({
   leftImage: fields.leftImage ?? false,
   linkTitle: fields.linkTitle ?? '',
   link: fields.link ? mapReferenceLink(fields.link) : null,
+  openLinkInNewTab: fields.openLinkInNewTab ?? true,
 })


### PR DESCRIPTION
# Add option for whether overview links should open in a new tab

## What

Currently, all links on overview slices open in a new tab (for example on https://island.is/s/stafraent-island/thjonustur). This PR adds a boolean in Contentful to change this.

The default is still to open in a new tab.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
