### PR TITLE
fix(web): Change type import for NextPageContext

### DIFF
--- a/apps/web/types.tsx
+++ b/apps/web/types.tsx
@@ -1,7 +1,6 @@
 import { ApolloClient } from '@apollo/client/core'
 import { NormalizedCacheObject } from '@apollo/client/cache'
-import { NextComponentType } from 'next'
-import { NextPageContext } from 'next/dist/next-server/lib/utils'
+import { NextComponentType, NextPageContext } from 'next'
 
 export type GetInitialPropsContext<Context> = Context & {
   apolloClient: ApolloClient<NormalizedCacheObject>


### PR DESCRIPTION
# Change type import for NextPageContext

## What

* The import path for NextPageContext is outdated and was messing up with type hints
* Changing the import path fixed this issue

## Screenshots / Gifs

Here's a screenshot of code taken before this change:
![image](https://user-images.githubusercontent.com/43557895/180447083-88b5c79e-2a13-431d-af5e-fea04f93fa9a.png)

Here's a screenshot of code taken after this change (no more type errors since things are correctly typed now):
![image](https://user-images.githubusercontent.com/43557895/180447201-45653333-7d7c-4c95-b265-7f9b3f6ad561.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
