### PR TITLE
feat(web): Add optional table of contents for organization subpages

### DIFF
--- a/apps/web/components/Organization/Slice/AccordionSlice/AccordionSlice.tsx
+++ b/apps/web/components/Organization/Slice/AccordionSlice/AccordionSlice.tsx
@@ -22,7 +22,7 @@ export const AccordionSlice: React.FC<SliceProps> = ({ slice }) => {
   const labelId = 'sliceTitle-' + slice.id
 
   return (
-    <section key={slice.id} aria-labelledby={labelId}>
+    <section key={slice.id} id={slice.id} aria-labelledby={labelId}>
       <Box
         borderTopWidth="standard"
         borderColor="standard"

--- a/apps/web/components/Organization/Slice/BulletList/BulletList.tsx
+++ b/apps/web/components/Organization/Slice/BulletList/BulletList.tsx
@@ -9,7 +9,11 @@ interface SliceProps {
 
 export const BulletListSlice: React.FC<SliceProps> = ({ slice }) => {
   return (
-    <section key={slice.id} aria-labelledby={'sliceTitle-' + slice.id}>
+    <section
+      key={slice.id}
+      id={slice.id}
+      aria-labelledby={'sliceTitle-' + slice.id}
+    >
       <Box paddingBottom={[8, 5, 10]}>
         <BulletList
           bullets={slice.bullets.map((bullet) => {

--- a/apps/web/components/Organization/Slice/Districts/DistrictsSlice.tsx
+++ b/apps/web/components/Organization/Slice/Districts/DistrictsSlice.tsx
@@ -17,7 +17,11 @@ interface SliceProps {
 export const DistrictsSlice: React.FC<SliceProps> = ({ slice }) => {
   return (
     !!slice.links.length && (
-      <section key={slice.id} aria-labelledby={'sliceTitle-' + slice.id}>
+      <section
+        key={slice.id}
+        id={slice.id}
+        aria-labelledby={'sliceTitle-' + slice.id}
+      >
         <Box
           borderTopWidth="standard"
           borderColor="standard"

--- a/apps/web/components/Organization/Slice/EventSlice/EventSlice.tsx
+++ b/apps/web/components/Organization/Slice/EventSlice/EventSlice.tsx
@@ -21,7 +21,11 @@ export const EventSlice: React.FC<SliceProps> = ({ slice }) => {
   const date = slice.date.split('-')
 
   return (
-    <section key={slice.id} aria-labelledby={'sliceTitle-' + slice.id}>
+    <section
+      key={slice.id}
+      id={slice.id}
+      aria-labelledby={'sliceTitle-' + slice.id}
+    >
       <Box
         className={styles.wrapper}
         style={{

--- a/apps/web/components/Organization/Slice/FeaturedArticles/FeaturedArticlesSlice.tsx
+++ b/apps/web/components/Organization/Slice/FeaturedArticles/FeaturedArticlesSlice.tsx
@@ -32,7 +32,7 @@ export const FeaturedArticlesSlice: React.FC<SliceProps> = ({
 
   return (
     !!slice.articles.length && (
-      <section key={slice.id} aria-labelledby={labelId}>
+      <section key={slice.id} id={slice.id} aria-labelledby={labelId}>
         <Box
           borderTopWidth="standard"
           borderColor="standard"

--- a/apps/web/components/Organization/Slice/Heading/HeadingSlice.tsx
+++ b/apps/web/components/Organization/Slice/Heading/HeadingSlice.tsx
@@ -9,7 +9,7 @@ interface SliceProps {
 
 export const HeadingSlice: React.FC<SliceProps> = ({ slice }) => {
   return (
-    <section key={slice.id}>
+    <section key={slice.id} id={slice.id}>
       <Box paddingTop={[8, 6, 6]} paddingBottom={[4, 5, 5]}>
         <Heading {...slice} />
       </Box>

--- a/apps/web/components/Organization/Slice/LogoList/LogoList.tsx
+++ b/apps/web/components/Organization/Slice/LogoList/LogoList.tsx
@@ -9,7 +9,11 @@ interface SliceProps {
 
 export const LogoListSlice: React.FC<SliceProps> = ({ slice }) => {
   return (
-    <section key={slice.id} aria-labelledby={'sliceTitle-' + slice.id}>
+    <section
+      key={slice.id}
+      id={slice.id}
+      aria-labelledby={'sliceTitle-' + slice.id}
+    >
       <GridContainer>
         <Box paddingTop={[8, 8, 12]} paddingBottom={4}>
           <LogoList

--- a/apps/web/components/Organization/Slice/MailingListSignupSlice/MailingListSignupSlice.tsx
+++ b/apps/web/components/Organization/Slice/MailingListSignupSlice/MailingListSignupSlice.tsx
@@ -19,7 +19,11 @@ export const MailingListSignupSlice: React.FC<SliceProps> = ({
   namespace,
 }) => {
   return (
-    <section key={slice.id} aria-labelledby={'sliceTitle-' + slice.id}>
+    <section
+      key={slice.id}
+      id={slice.id}
+      aria-labelledby={'sliceTitle-' + slice.id}
+    >
       {slice.variant === 'conference' ? (
         <GridContainer>
           <GridRow>

--- a/apps/web/components/Organization/Slice/MultipleStatistics/MultipleStatistics.tsx
+++ b/apps/web/components/Organization/Slice/MultipleStatistics/MultipleStatistics.tsx
@@ -16,7 +16,11 @@ interface SliceProps {
 
 export const MultipleStatistics: React.FC<SliceProps> = ({ slice }) => {
   return (
-    <section key={slice.id} aria-labelledby={'sliceTitle-' + slice.id}>
+    <section
+      key={slice.id}
+      id={slice.id}
+      aria-labelledby={'sliceTitle-' + slice.id}
+    >
       <Box
         borderTopWidth="standard"
         borderColor="standard"

--- a/apps/web/components/Organization/Slice/OneColumnText/OneColumnTextSlice.tsx
+++ b/apps/web/components/Organization/Slice/OneColumnText/OneColumnTextSlice.tsx
@@ -24,7 +24,11 @@ export const OneColumnTextSlice: React.FC<SliceProps> = ({ slice }) => {
     : {}
 
   return (
-    <section key={slice.id} aria-labelledby={'sliceTitle-' + slice.id}>
+    <section
+      key={slice.id}
+      id={slice.id}
+      aria-labelledby={'sliceTitle-' + slice.id}
+    >
       <GridContainer>
         <Box {...boxProps}>
           <Text

--- a/apps/web/components/Organization/Slice/OverviewLinks/OverviewLinks.tsx
+++ b/apps/web/components/Organization/Slice/OverviewLinks/OverviewLinks.tsx
@@ -21,7 +21,11 @@ export const OverviewLinksSlice: React.FC<SliceProps> = ({ slice }) => {
   const { linkResolver } = useLinkResolver()
 
   return (
-    <section key={slice.id} aria-labelledby={'sliceTitle-' + slice.id}>
+    <section
+      key={slice.id}
+      id={slice.id}
+      aria-labelledby={'sliceTitle-' + slice.id}
+    >
       <GridContainer>
         <Box borderTopWidth="standard" borderColor="standard" paddingTop={4}>
           <Stack space={6}>

--- a/apps/web/components/Organization/Slice/StorySlice/StorySlice.tsx
+++ b/apps/web/components/Organization/Slice/StorySlice/StorySlice.tsx
@@ -9,7 +9,11 @@ interface SliceProps {
 
 export const StorySlice: React.FC<SliceProps> = ({ slice }) => {
   return (
-    <section key={slice.id} aria-labelledby={'sliceTitle-' + slice.id}>
+    <section
+      key={slice.id}
+      id={slice.id}
+      aria-labelledby={'sliceTitle-' + slice.id}
+    >
       <Box paddingTop={[8, 8, 12]} paddingBottom={[12, 8, 10]}>
         <StoryList
           {...slice}

--- a/apps/web/components/Organization/Slice/TabSection/TabSection.tsx
+++ b/apps/web/components/Organization/Slice/TabSection/TabSection.tsx
@@ -13,7 +13,11 @@ interface SliceProps {
 
 export const TabSectionSlice: React.FC<SliceProps> = ({ slice }) => {
   return (
-    <section key={slice.id} aria-labelledby={'sliceTitle-' + slice.id}>
+    <section
+      key={slice.id}
+      id={slice.id}
+      aria-labelledby={'sliceTitle-' + slice.id}
+    >
       <Box paddingTop={2} paddingBottom={[0, 4, 4]}>
         <Tabs
           label={slice?.title}

--- a/apps/web/components/Organization/Slice/TimelineSlice/TimelineSlice.tsx
+++ b/apps/web/components/Organization/Slice/TimelineSlice/TimelineSlice.tsx
@@ -189,7 +189,11 @@ export const TimelineSlice: React.FC<SliceProps> = ({ slice }) => {
   const monthEvents = eventMap.get(months[month].year).get(months[month].month)
 
   return (
-    <section key={slice.id} aria-labelledby={'sliceTitle-' + slice.id}>
+    <section
+      key={slice.id}
+      id={slice.id}
+      aria-labelledby={'sliceTitle-' + slice.id}
+    >
       <GridContainer>
         <Box paddingLeft={1}>
           <GridContainer>

--- a/apps/web/components/Organization/Slice/TwoColumnText/TwoColumnTextSlice.tsx
+++ b/apps/web/components/Organization/Slice/TwoColumnText/TwoColumnTextSlice.tsx
@@ -23,7 +23,7 @@ export const TwoColumnTextSlice: React.FC<SliceProps> = ({ slice }) => {
     ? { borderTopWidth: 'standard', borderColor: 'standard', paddingTop: 4 }
     : {}
   return (
-    <section key={slice.id} aria-labelledby={labelId}>
+    <section key={slice.id} id={slice.id} aria-labelledby={labelId}>
       <GridContainer>
         <Box {...boxProps}>
           <GridRow>

--- a/apps/web/screens/Organization/SubPage.tsx
+++ b/apps/web/screens/Organization/SubPage.tsx
@@ -14,7 +14,6 @@ import {
 import { withMainLayout } from '@island.is/web/layouts/main'
 import {
   ContentLanguage,
-  OneColumnText,
   Query,
   QueryGetNamespaceArgs,
   QueryGetOrganizationPageArgs,

--- a/apps/web/screens/Organization/SubPage.tsx
+++ b/apps/web/screens/Organization/SubPage.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import React from 'react'
+import React, { FC, useMemo } from 'react'
 import {
   Box,
   GridColumn,
@@ -8,11 +8,13 @@ import {
   Link,
   NavigationItem,
   Stack,
+  TableOfContents,
   Text,
 } from '@island.is/island-ui/core'
 import { withMainLayout } from '@island.is/web/layouts/main'
 import {
   ContentLanguage,
+  OneColumnText,
   Query,
   QueryGetNamespaceArgs,
   QueryGetOrganizationPageArgs,
@@ -39,11 +41,40 @@ import useContentfulId from '@island.is/web/hooks/useContentfulId'
 import { richText, SliceType } from '@island.is/island-ui/contentful'
 import { ParsedUrlQuery } from 'querystring'
 import { useRouter } from 'next/router'
+import { scrollTo } from '@island.is/web/hooks/useScrollSpy'
 
 interface SubPageProps {
   organizationPage: Query['getOrganizationPage']
   subpage: Query['getOrganizationSubpage']
   namespace: Query['getNamespace']
+}
+
+const TOC: FC<{ slices: Slice[]; title: string }> = ({ slices, title }) => {
+  const navigation = useMemo(
+    () =>
+      slices
+        .map((slice) => ({
+          id: slice.id,
+          text: slice['title'] ?? slice['leftTitle'] ?? '',
+        }))
+        .filter((item) => !!item.text),
+    [slices],
+  )
+  if (navigation.length === 0) {
+    return null
+  }
+  return (
+    <Box marginY={2}>
+      <TableOfContents
+        tableOfContentsTitle={title}
+        headings={navigation.map(({ id, text }) => ({
+          headingTitle: text,
+          headingId: id,
+        }))}
+        onClick={(id) => scrollTo(id, { smooth: true })}
+      />
+    </Box>
+  )
 }
 
 const SubPage: Screen<SubPageProps> = ({
@@ -118,6 +149,12 @@ const SubPage: Screen<SubPageProps> = ({
                     </Box>
                   </GridColumn>
                 </GridRow>
+                {subpage.showTableOfContents && (
+                  <TOC
+                    slices={subpage.slices}
+                    title={n('navigationTitle', 'Efnisyfirlit')}
+                  />
+                )}
                 <GridRow>
                   <GridColumn
                     span={[

--- a/apps/web/screens/queries/Organization.tsx
+++ b/apps/web/screens/queries/Organization.tsx
@@ -189,6 +189,7 @@ export const GET_ORGANIZATION_SUBPAGE_QUERY = gql`
       slices {
         ...AllSlices
       }
+      showTableOfContents
       sliceCustomRenderer
       sliceExtraText
       featuredImage {

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -2099,6 +2099,9 @@ export interface IOrganizationSubpageFields {
       )[]
     | undefined
 
+  /** Show Table of Contents */
+  showTableOfContents?: boolean | undefined
+
   /** Slice Custom Renderer */
   sliceCustomRenderer?: 'SliceDropdown' | undefined
 

--- a/libs/cms/src/lib/models/organizationSubpage.model.ts
+++ b/libs/cms/src/lib/models/organizationSubpage.model.ts
@@ -36,6 +36,9 @@ export class OrganizationSubpage {
   @Field(() => [SliceUnion], { nullable: true })
   slices?: Array<typeof SliceUnion | null>
 
+  @Field(() => Boolean)
+  showTableOfContents?: boolean
+
   @Field({ nullable: true })
   sliceCustomRenderer?: string
 
@@ -63,6 +66,7 @@ export const mapOrganizationSubpage = ({
     : [],
   links: (fields.links ?? []).map(mapLink),
   slices: (fields.slices ?? []).map(safelyMapSliceUnion),
+  showTableOfContents: fields.showTableOfContents ?? false,
   sliceCustomRenderer: fields.sliceCustomRenderer ?? '',
   sliceExtraText: fields.sliceExtraText ?? '',
   organizationPage: fields.organizationPage


### PR DESCRIPTION
# Add optional table of contents for organization subpages

## What

This makes it possible to add TOC to organization subpages. All slices that have titles appear in the TOC.

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/3607456/180471550-f32f2725-547e-40f0-8578-f41c7d9fd048.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
