### PR TITLE
feat(web): Add support for custom alert banners in layout

### DIFF
--- a/apps/web/layouts/main.tsx
+++ b/apps/web/layouts/main.tsx
@@ -103,6 +103,7 @@ export interface LayoutProps {
   alertBannerContent?: GetAlertBannerQuery['getAlertBanner']
   organizationAlertBannerContent?: GetAlertBannerQuery['getAlertBanner']
   articleAlertBannerContent?: GetAlertBannerQuery['getAlertBanner']
+  customAlertBanners?: GetAlertBannerQuery['getAlertBanner'][]
   footerVersion?: 'default' | 'organization'
   respOrigin
   megaMenuData
@@ -159,6 +160,7 @@ const Layout: NextComponentType<
   alertBannerContent,
   organizationAlertBannerContent,
   articleAlertBannerContent,
+  customAlertBanners,
   footerVersion = 'default',
   respOrigin,
   children,
@@ -234,14 +236,24 @@ const Layout: NextComponentType<
           )}`,
           ...articleAlertBannerContent,
         },
-      ].filter(
-        (banner) => !Cookies.get(banner.bannerId) && banner?.showAlertBanner,
-      ),
+      ]
+        .concat(
+          customAlertBanners.map((banner) => ({
+            bannerId: `custom-alert-${stringHash(
+              JSON.stringify(banner ?? {}),
+            )}`,
+            ...banner,
+          })),
+        )
+        .filter(
+          (banner) => !Cookies.get(banner.bannerId) && banner?.showAlertBanner,
+        ),
     )
   }, [
     alertBannerContent,
     articleAlertBannerContent,
     organizationAlertBannerContent,
+    customAlertBanners,
   ])
 
   const preloadedFonts = [
@@ -674,6 +686,11 @@ export const withMainLayout = <T,>(
         ? componentProps['article']['alertBanner']
         : undefined
 
+    const customAlertBanners =
+      'customAlertBanners' in componentProps
+        ? componentProps['customAlertBanners']
+        : []
+
     return {
       layoutProps: {
         ...layoutProps,
@@ -681,6 +698,7 @@ export const withMainLayout = <T,>(
         ...themeConfig,
         organizationAlertBannerContent,
         articleAlertBannerContent,
+        customAlertBanners,
       },
       componentProps,
     }

--- a/apps/web/screens/Organization/Home/Home.tsx
+++ b/apps/web/screens/Organization/Home/Home.tsx
@@ -132,11 +132,11 @@ Home.getInitialProps = async ({ apolloClient, locale, query }) => {
         },
       })
       .then((variables) =>
-        variables.data.getNamespace.fields
+        variables?.data?.getNamespace?.fields
           ? JSON.parse(variables.data.getNamespace.fields)
           : {},
       ),
-    getCustomAlertBanners(query),
+    getCustomAlertBanners(query, apolloClient, locale),
   ])
 
   if (!getOrganizationPage) {

--- a/apps/web/screens/Organization/Home/Home.tsx
+++ b/apps/web/screens/Organization/Home/Home.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import React from 'react'
 import { NavigationItem } from '@island.is/island-ui/core'
 import { withMainLayout } from '@island.is/web/layouts/main'
 import {
@@ -8,8 +7,8 @@ import {
   QueryGetNamespaceArgs,
   QueryGetOrganizationPageArgs,
 } from '@island.is/web/graphql/schema'
-import { GET_NAMESPACE_QUERY, GET_ORGANIZATION_PAGE_QUERY } from '../queries'
-import { Screen } from '../../types'
+import { GET_NAMESPACE_QUERY, GET_ORGANIZATION_PAGE_QUERY } from '../../queries'
+import { Screen } from '../../../types'
 import { useNamespace } from '@island.is/web/hooks'
 import {
   getThemeConfig,
@@ -19,6 +18,7 @@ import {
 } from '@island.is/web/components'
 import { CustomNextError } from '@island.is/web/units/errors'
 import useContentfulId from '@island.is/web/hooks/useContentfulId'
+import { getCustomAlertBanners } from './utils'
 
 interface HomeProps {
   organizationPage: Query['getOrganizationPage']
@@ -110,6 +110,7 @@ Home.getInitialProps = async ({ apolloClient, locale, query }) => {
       data: { getOrganizationPage },
     },
     namespace,
+    customAlertBanners,
   ] = await Promise.all([
     apolloClient.query<Query, QueryGetOrganizationPageArgs>({
       query: GET_ORGANIZATION_PAGE_QUERY,
@@ -135,6 +136,7 @@ Home.getInitialProps = async ({ apolloClient, locale, query }) => {
           ? JSON.parse(variables.data.getNamespace.fields)
           : {},
       ),
+    getCustomAlertBanners(query),
   ])
 
   if (!getOrganizationPage) {
@@ -145,6 +147,7 @@ Home.getInitialProps = async ({ apolloClient, locale, query }) => {
     organizationPage: getOrganizationPage,
     namespace,
     showSearchInHeader: false,
+    customAlertBanners,
     ...getThemeConfig(getOrganizationPage.theme, getOrganizationPage.slug),
   }
 }

--- a/apps/web/screens/Organization/Home/index.ts
+++ b/apps/web/screens/Organization/Home/index.ts
@@ -1,0 +1,3 @@
+import Home from './Home'
+
+export default Home

--- a/apps/web/screens/Organization/Home/utils.ts
+++ b/apps/web/screens/Organization/Home/utils.ts
@@ -1,0 +1,125 @@
+import { AlertBannerVariants } from '@island.is/island-ui/core'
+import { GetAlertBannerQuery } from '@island.is/web/graphql/schema'
+import { ParsedUrlQuery } from 'querystring'
+
+interface SjukratryggingarStatusPageDetails {
+  incidents: {
+    created_at: string // "2014-05-14T14:22:39.441-06:00",
+    id: string // "cp306tmzcl0y",
+    impact: string // "critical",
+    incident_updates: {
+      body: string
+      created_at: string
+      display_at: string
+      id: string
+      incident_id: string
+      status: string // "identified",
+      updated_at: string
+    }[]
+    monitoring_at: null | string
+    name: string
+    page_id: string
+    resolved_at: null | string
+    shortlink: string // "http://stspg.co:5000/Q0E",
+    status: string // "identified",
+    updated_at: string // "2014-05-14T14:35:21.711-06:00"
+  }[]
+  scheduled_maintenances: {
+    created_at: string
+    id: string // "w1zdr745wmfy",
+    impact: string // "none",
+    incident_updates: {
+      body: string
+      created_at: string // "2014-05-14T14:24:41.913-06:00",
+      display_at: string // "2014-05-14T14:24:41.913-06:00",
+      id: string // "qq0vx910b3qj",
+      incident_id: string // "w1zdr745wmfy",
+      status: string // "scheduled",
+      updated_at: string // "2014-05-14T14:24:41.913-06:00"
+    }[]
+    monitoring_at: null | string
+    name: string
+    page_id: string
+    resolved_at: null | string
+    scheduled_for: string
+    scheduled_until: string
+    shortlink: string // "http://stspg.co:5000/Q0F",
+    status: string // "scheduled",
+    updated_at: string // "2014-05-14T14:24:41.918-06:00"
+  }[]
+}
+
+const fetchSjukratryggingarStatusPageDetails = async (): Promise<SjukratryggingarStatusPageDetails> => {
+  try {
+    const response = await fetch('https://status.sjukra.is/api/v2/summary.json')
+    const data = await response.json()
+    return data
+  } catch (error) {
+    console.error(error)
+    return null
+  }
+}
+
+export const getCustomAlertBanners = async (query: ParsedUrlQuery) => {
+  // As of right now Sjúkratryggingar is the only organization with alert banners that are automatically read from a
+  if (
+    query?.slug !== 'sjukratryggingar' &&
+    query?.slug !== 'icelandic-health-insurance'
+  )
+    return []
+
+  const sjukratryggingarPageDetails = await fetchSjukratryggingarStatusPageDetails()
+  if (!sjukratryggingarPageDetails) return []
+  const customAlertBanners: GetAlertBannerQuery['getAlertBanner'][] = []
+
+  for (const incident of sjukratryggingarPageDetails?.incidents ?? []) {
+    const bannerVariant: AlertBannerVariants = 'warning'
+    customAlertBanners.push({
+      bannerVariant,
+      dismissedForDays: 1,
+      isDismissable: true,
+      showAlertBanner: true,
+      description: incident?.name,
+      // TODO: read link from cms
+      link: {
+        slug: 'https://status.sjukra.is',
+        type: '',
+      },
+      linkTitle: 'Frekari upplýsingar',
+    })
+  }
+
+  for (const maintenance of sjukratryggingarPageDetails?.scheduled_maintenances ??
+    []) {
+    const bannerVariant: AlertBannerVariants = 'info'
+    customAlertBanners.push({
+      bannerVariant,
+      dismissedForDays: 1,
+      isDismissable: true,
+      showAlertBanner: true,
+      description: maintenance?.name,
+      // TODO: read link from cms
+      link: {
+        slug: 'https://status.sjukra.is',
+        type: '',
+      },
+      linkTitle: 'Frekari upplýsingar',
+    })
+  }
+
+  customAlertBanners.push({
+    bannerVariant: 'info',
+    dismissedForDays: 1,
+    isDismissable: true,
+    showAlertBanner: true,
+    description: 'asdf',
+    // TODO: read link from cms
+    link: {
+      slug: 'https://status.sjukra.is',
+      type: '',
+    },
+    linkTitle: 'Frekari upplýsingar',
+  })
+
+  return customAlertBanners
+}

--- a/apps/web/screens/Organization/Home/utils.ts
+++ b/apps/web/screens/Organization/Home/utils.ts
@@ -61,7 +61,7 @@ const fetchSjukratryggingarStatusPageDetails = async (): Promise<Sjukratrygginga
 }
 
 export const getCustomAlertBanners = async (query: ParsedUrlQuery) => {
-  // As of right now Sjúkratryggingar is the only organization with alert banners that are automatically read from a
+  // As of right now Sjúkratryggingar is the only organization with alert banners that are automatically read from somewhere else than the CMS (Contentful)
   if (
     query?.slug !== 'sjukratryggingar' &&
     query?.slug !== 'icelandic-health-insurance'

--- a/apps/web/screens/Organization/Home/utils.ts
+++ b/apps/web/screens/Organization/Home/utils.ts
@@ -5,6 +5,7 @@ import {
   Query,
   QueryGetNamespaceArgs,
 } from '@island.is/web/graphql/schema'
+import { getFeatureFlag } from '@island.is/web/utils/featureFlag'
 import { ParsedUrlQuery } from 'querystring'
 import { GET_NAMESPACE_QUERY } from '../../queries'
 
@@ -66,11 +67,16 @@ const fetchSjukratryggingarStatusPageDetails = async (): Promise<Sjukratrygginga
   }
 }
 
+/** Gets all custom alert banners (banners that are read from somewhere else than the content management system) */
 export const getCustomAlertBanners = async (
   query: ParsedUrlQuery,
   apolloClient: ApolloClient<NormalizedCacheObject>,
   locale: string,
 ) => {
+  // Make sure that the feature flag is enabled
+  const flag = await getFeatureFlag('showSjukratryggingarStatusAlerts', false)
+  if (!flag) return []
+
   // As of right now Sjúkratryggingar is the only organization with alert banners that are automatically read from somewhere else than the CMS (Contentful)
   if (
     query?.slug !== 'sjukratryggingar' &&
@@ -98,9 +104,6 @@ export const getCustomAlertBanners = async (
   ])
   if (!sjukratryggingarPageDetails) return []
   const customAlertBanners: GetAlertBannerQuery['getAlertBanner'][] = []
-
-  // TODO: remove this console.log
-  console.log(sjukratryggingarPageDetails)
 
   for (const incident of sjukratryggingarPageDetails?.incidents ?? []) {
     const bannerVariant: AlertBannerVariants = 'warning'

--- a/apps/web/screens/Organization/Home/utils.ts
+++ b/apps/web/screens/Organization/Home/utils.ts
@@ -72,6 +72,9 @@ export const getCustomAlertBanners = async (query: ParsedUrlQuery) => {
   if (!sjukratryggingarPageDetails) return []
   const customAlertBanners: GetAlertBannerQuery['getAlertBanner'][] = []
 
+  // TODO: remove this console.log
+  console.log(sjukratryggingarPageDetails)
+
   for (const incident of sjukratryggingarPageDetails?.incidents ?? []) {
     const bannerVariant: AlertBannerVariants = 'warning'
     customAlertBanners.push({
@@ -101,7 +104,7 @@ export const getCustomAlertBanners = async (query: ParsedUrlQuery) => {
       // TODO: read link from cms
       link: {
         slug: 'https://status.sjukra.is',
-        type: '',
+        type: 'link',
       },
       linkTitle: 'Frekari upplýsingar',
     })
@@ -112,11 +115,11 @@ export const getCustomAlertBanners = async (query: ParsedUrlQuery) => {
     dismissedForDays: 1,
     isDismissable: true,
     showAlertBanner: true,
-    description: 'asdf',
-    // TODO: read link from cms
+    description: 'Prufa',
+    // TODO: read link from cms or use data
     link: {
       slug: 'https://status.sjukra.is',
-      type: '',
+      type: 'link',
     },
     linkTitle: 'Frekari upplýsingar',
   })


### PR DESCRIPTION
# feat(web): Add support for custom alert banners in layout

## What

* Sjúkratryggingar have a status page (https://status.sjukra.is) which indicates the status of their web services. Now their organization page will automatically show an alert banner if an incident or a scheduled maintenance is shown on the status page.
* To be able to do this I added a prop to the Layout component which can be used to add alert banners to the top of the page

## Why

* This was a requested feature

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/43557895/181011508-20fa9d7a-459f-49c2-9ca4-fcad40d1a241.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
