### PR TITLE
fix(web): Gradient text not showing up in Safari

### DIFF
--- a/apps/web/components/Organization/Wrapper/Themes/DigitalIcelandTheme/DigitalIcelandHeader.css.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/DigitalIcelandTheme/DigitalIcelandHeader.css.ts
@@ -30,11 +30,15 @@ export const title = style({
   width: 200,
   marginTop: 80,
   marginLeft: 16,
-  background:
-    'linear-gradient(122.37deg, #0161FD -20.11%, #3F46D2 19.5%, #812EA4 60.71%, #C21578 101.91%, #FD0050 138.36%)',
-  backgroundClip: 'text',
-  ['-webkit-background-clip' as any]: 'text',
-  ['-webkit-text-fill-color' as any]: 'transparent',
+  '@supports': {
+    '(-webkit-text-fill-color: transparent)': {
+      background:
+        'linear-gradient(122.37deg, #0161FD -20.11%, #3F46D2 19.5%, #812EA4 60.71%, #C21578 101.91%, #FD0050 138.36%)',
+      backgroundClip: 'text',
+      ['-webkit-background-clip' as any]: 'text',
+      ['-webkit-text-fill-color' as any]: 'transparent',
+    },
+  },
 })
 
 export const iconCircle = style({

--- a/apps/web/components/Organization/Wrapper/Themes/DigitalIcelandTheme/DigitalIcelandHeader.css.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/DigitalIcelandTheme/DigitalIcelandHeader.css.ts
@@ -30,15 +30,12 @@ export const title = style({
   width: 200,
   marginTop: 80,
   marginLeft: 16,
-  '@supports': {
-    '(-webkit-text-fill-color: transparent)': {
-      background:
-        'linear-gradient(122.37deg, #0161FD -20.11%, #3F46D2 19.5%, #812EA4 60.71%, #C21578 101.91%, #FD0050 138.36%)',
-      backgroundClip: 'text',
-      ['-webkit-background-clip' as any]: 'text',
-      ['-webkit-text-fill-color' as any]: 'transparent',
-    },
-  },
+  background:
+    'linear-gradient(122.37deg, #0161FD -20.11%, #3F46D2 19.5%, #812EA4 60.71%, #C21578 101.91%, #FD0050 138.36%)',
+  backgroundClip: 'text',
+  ['-webkit-background-clip' as any]: 'text',
+  ['-webkit-text-fill-color' as any]: 'transparent',
+  textShadow: '0px 0px #00000000',
 })
 
 export const iconCircle = style({


### PR DESCRIPTION
# Gradient text not showing up in Safari

## What

* The title on the Stafrænt Ísland organization page was not rendered in some versions of Safari

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/43557895/181013808-c8770e7d-fd55-406d-9217-552e32fabfb7.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
