### PR TITLE
feat(web): Add a way to embed stepper in article body

### DIFF
--- a/apps/web/components/Stepper/Stepper/Stepper.tsx
+++ b/apps/web/components/Stepper/Stepper/Stepper.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { useRouter } from 'next/router'
-import { ValueType } from 'react-select'
 import { ParsedUrlQuery } from 'querystring'
 
 import {
@@ -60,12 +59,6 @@ interface StepperProps {
   webReaderClassName?: string
 }
 
-interface StepOptionSelectItem {
-  label: string
-  value: string
-  transition: string
-}
-
 interface QuestionAndAnswer {
   question: string
   answer: string
@@ -98,7 +91,7 @@ const getInitialStateAndAnswersByQueryParams = (
     if (stepType === STEP_TYPES.ANSWER) break
 
     const options = getStepOptions(step, activeLocale, optionsFromNamespace)
-    const selectedOption = options.find((o) => o.slug === answer)
+    const selectedOption = options.find((o) => o.value === answer)
     if (!selectedOption) break
 
     initialState = stepperMachine.transition(
@@ -111,7 +104,7 @@ const getInitialStateAndAnswersByQueryParams = (
       questionsAndAnswers.push({
         question: stepQuestion,
         answer: selectedOption.label,
-        slug: selectedOption.slug,
+        slug: selectedOption.value,
       })
     }
   }
@@ -210,7 +203,7 @@ const Stepper = ({
 
   const isOnFirstStep = stepperMachine.initialState.value === currentState.value
   const [selectedOption, setSelectedOption] = useState<StepOption | null>(null)
-  const stepOptions = useMemo<StepOption[]>(
+  const stepOptions = useMemo(
     () => getStepOptions(currentStep, activeLocale, optionsFromNamespace),
     [activeLocale, currentStep, optionsFromNamespace],
   )
@@ -232,7 +225,7 @@ const Stepper = ({
 
     // Select the option that was previously selected if we want to change an answer
     if (previousAnswer && selectedOption === null) {
-      const option = stepOptions.find((o) => o.slug === previousAnswer) ?? null
+      const option = stepOptions.find((o) => o.value === previousAnswer) ?? null
       setSelectedOption(option)
       previousAnswerIsValid = option !== null
     }
@@ -335,7 +328,7 @@ const Stepper = ({
                 pathname: pathnameWithoutQueryParams,
                 query: {
                   ...router.query,
-                  answers: `${previousAnswers}${selectedOption.slug}`,
+                  answers: `${previousAnswers}${selectedOption.value}`,
                 },
               })
               .then(() => {
@@ -399,7 +392,7 @@ const Stepper = ({
                 hasClickedContinueWithoutSelecting && selectedOption === null
               }
               label={option.label}
-              checked={option.slug === selectedOption?.slug}
+              checked={option.value === selectedOption?.value}
               onChange={() => setSelectedOption(option)}
             />
           </Box>
@@ -415,24 +408,11 @@ const Stepper = ({
                 size="sm"
                 name="step-option-select"
                 noOptionsMessage={n('noOptions', 'Enginn valmöguleiki')}
-                value={{
-                  label: selectedOption?.label ?? '',
-                  value: selectedOption?.slug ?? '',
+                value={selectedOption}
+                onChange={(option) => {
+                  setSelectedOption(option as StepOption)
                 }}
-                onChange={(option: ValueType<StepOptionSelectItem>) => {
-                  const stepOptionSelectItem = option as StepOptionSelectItem
-                  const newSelectedOption = {
-                    label: stepOptionSelectItem.label,
-                    slug: stepOptionSelectItem.value,
-                    transition: stepOptionSelectItem.transition,
-                  }
-                  setSelectedOption(newSelectedOption)
-                }}
-                options={stepOptions.map((option) => ({
-                  label: option.label,
-                  value: option.slug,
-                  transition: option.transition,
-                }))}
+                options={stepOptions}
               />
             </GridColumn>
           </GridRow>
@@ -472,7 +452,10 @@ const Stepper = ({
               {n('yourAnswers', 'Svörin þín')}
             </Text>
             <Box marginBottom={3} textAlign="right">
-              <Link shallow={true} href={router.asPath.split('?')[0]}>
+              <Link
+                shallow={true}
+                href={`${router.asPath.split('?')[0]}?stepper=true`}
+              >
                 <Button variant="text" icon="reload" size="small" nowrap={true}>
                   {n('startAgain', 'Byrja aftur')}
                 </Button>

--- a/apps/web/components/Stepper/utils.ts
+++ b/apps/web/components/Stepper/utils.ts
@@ -70,7 +70,7 @@ interface StepConfig {
 interface StepOption {
   label: string
   transition: string
-  slug: string
+  value: string
 }
 
 interface StateMeta {
@@ -332,7 +332,7 @@ const getStepOptions = (
       return {
         label: label,
         transition: stepTransition,
-        slug: o[optionSlugField],
+        value: o[optionSlugField],
       }
     })
 
@@ -354,7 +354,7 @@ const getStepOptions = (
     return {
       label: label,
       transition: o.transition,
-      slug: o.optionSlug,
+      value: o.optionSlug,
     }
   })
 }

--- a/apps/web/screens/Article/Article.tsx
+++ b/apps/web/screens/Article/Article.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useMemo, useRef, useState } from 'react'
+import { FC, useEffect, useMemo, useRef, useState } from 'react'
 import { useRouter } from 'next/router'
 import NextLink from 'next/link'
 import { BLOCKS } from '@contentful/rich-text-types'
@@ -414,6 +414,7 @@ const ArticleScreen: Screen<ArticleProps> = ({
           ],
     [article.category, article.group, inStepperView],
   )
+  console.log(article.body)
 
   return (
     <>
@@ -541,7 +542,8 @@ const ArticleScreen: Screen<ArticleProps> = ({
               <ProcessEntry {...processEntry} />
             </Box>
           )}
-          {article.stepper?.title && !inStepperView && (
+          {/* TODO: remove */}
+          {/* {article.stepper?.title && !inStepperView && (
             <Box marginTop={3} printHidden className="rs_read">
               <ProcessEntry
                 buttonText={n(
@@ -553,7 +555,7 @@ const ArticleScreen: Screen<ArticleProps> = ({
                 newTab={false}
               />
             </Box>
-          )}
+          )} */}
           {(subArticle
             ? subArticle.showTableOfContents
             : article.showTableOfContents) && (
@@ -579,7 +581,25 @@ const ArticleScreen: Screen<ArticleProps> = ({
             <Box className="rs_read">
               {richText(
                 (subArticle ?? article).body as SliceType[],
-                undefined,
+                {
+                  renderComponent: {
+                    Stepper: () => (
+                      <Box marginY={3} printHidden className="rs_read">
+                        <ProcessEntry
+                          buttonText={n(
+                            article.processEntryButtonText || 'application',
+                            '',
+                          )}
+                          processLink={asPath
+                            .split('?')[0]
+                            .concat('?stepper=true')}
+                          processTitle={article.stepper.title}
+                          newTab={false}
+                        />
+                      </Box>
+                    ),
+                  },
+                },
                 activeLocale,
               )}
               <AppendedArticleComponents article={article} />

--- a/apps/web/screens/Article/Article.tsx
+++ b/apps/web/screens/Article/Article.tsx
@@ -541,20 +541,6 @@ const ArticleScreen: Screen<ArticleProps> = ({
               <ProcessEntry {...processEntry} />
             </Box>
           )}
-          {/* TODO: remove */}
-          {/* {article.stepper?.title && !inStepperView && (
-            <Box marginTop={3} printHidden className="rs_read">
-              <ProcessEntry
-                buttonText={n(
-                  article.processEntryButtonText || 'application',
-                  '',
-                )}
-                processLink={asPath.split('?')[0].concat('?stepper=true')}
-                processTitle={article.stepper.title}
-                newTab={false}
-              />
-            </Box>
-          )} */}
           {(subArticle
             ? subArticle.showTableOfContents
             : article.showTableOfContents) && (

--- a/apps/web/screens/Article/Article.tsx
+++ b/apps/web/screens/Article/Article.tsx
@@ -414,7 +414,6 @@ const ArticleScreen: Screen<ArticleProps> = ({
           ],
     [article.category, article.group, inStepperView],
   )
-  console.log(article.body)
 
   return (
     <>

--- a/apps/web/screens/queries/fragments.ts
+++ b/apps/web/screens/queries/fragments.ts
@@ -490,6 +490,23 @@ export const slices = gql`
     successText
   }
 
+  fragment StepperFields on Stepper {
+    __typename
+    id
+    title
+    steps {
+      id
+      title
+      slug
+      stepType
+      subtitle {
+        ...HtmlFields
+      }
+      config
+    }
+    config
+  }
+
   fragment BaseSlices on Slice {
     ...TimelineFields
     ...MailingListSignupFields
@@ -520,6 +537,7 @@ export const slices = gql`
     ...OverviewLinksField
     ...EventSliceFields
     ...FormFields
+    ...StepperFields
   }
 
   fragment AllSlices on Slice {

--- a/libs/cms/src/lib/environments/environment.ts
+++ b/libs/cms/src/lib/environments/environment.ts
@@ -59,7 +59,6 @@ export default {
     'timelineEvent',
     'form',
     'formField',
-    'stepperSlice',
   ],
   contentful: {
     space: process.env.CONTENTFUL_SPACE || '8k0h54kbe6bj',

--- a/libs/cms/src/lib/models/stepper.model.ts
+++ b/libs/cms/src/lib/models/stepper.model.ts
@@ -23,7 +23,7 @@ export const mapStepper = ({
   sys,
   fields,
 }: IStepper): SystemMetadata<Stepper> => ({
-  typename: 'AccordionSlice',
+  typename: 'Stepper',
   id: sys.id,
   title: fields.title ?? '',
   steps: (fields.steps ?? []).map(mapStep),

--- a/libs/cms/src/lib/models/subArticle.model.ts
+++ b/libs/cms/src/lib/models/subArticle.model.ts
@@ -3,7 +3,6 @@ import { Field, ID, ObjectType } from '@nestjs/graphql'
 import { ISubArticle } from '../generated/contentfulTypes'
 import { mapDocument, SliceUnion } from '../unions/slice.union'
 import { ArticleReference, mapArticleReference } from './articleReference'
-import { mapStepper, Stepper } from './stepper.model'
 
 @ObjectType()
 export class SubArticle {

--- a/libs/cms/src/lib/unions/slice.union.ts
+++ b/libs/cms/src/lib/unions/slice.union.ts
@@ -30,6 +30,7 @@ import {
   IOverviewLinks,
   IEventSlice,
   IForm,
+  IStepper,
 } from '../generated/contentfulTypes'
 import { Image, mapImage } from '../models/image.model'
 import { Asset, mapAsset } from '../models/asset.model'
@@ -85,6 +86,7 @@ import {
 } from '../models/multipleStatistics.model'
 import { EventSlice, mapEventSlice } from '../models/eventSlice.model'
 import { Form, mapForm } from '../models/form.model'
+import { mapStepper, Stepper } from '../models/stepper.model'
 
 type SliceTypes =
   | ITimeline
@@ -114,6 +116,7 @@ type SliceTypes =
   | IOverviewLinks
   | IEventSlice
   | IForm
+  | IStepper
 
 export const SliceUnion = createUnionType({
   name: 'Slice',
@@ -148,6 +151,7 @@ export const SliceUnion = createUnionType({
     OverviewLinks,
     EventSlice,
     Form,
+    Stepper,
   ],
   resolveType: (document) => document.typename, // typename is appended to request on indexing
 })
@@ -209,6 +213,8 @@ export const mapSliceUnion = (slice: SliceTypes): typeof SliceUnion => {
       return mapEventSlice(slice as IEventSlice)
     case 'form':
       return mapForm(slice as IForm)
+    case 'stepper':
+      return mapStepper(slice as IStepper)
     default:
       throw new ApolloError(`Can not convert to slice: ${contentType}`)
   }


### PR DESCRIPTION
# Add a way to embed stepper in article body

## What

* Instead of having the stepper process entry always at the top you can now place it where you want (in between text for example)
* Made the step option value for the select component actually reference the same memory address as exists in the list of options, meaning that when you now open the select box you'll actually see the selected value highlighted instead of just the top one in the list
* 

## Why

* Before this change a stepper process entry would only be at the top of the page, we want to be able to choose where it appears

## Screenshots / Gifs

### Before
![image](https://user-images.githubusercontent.com/43557895/182024121-da09892a-5efe-41a1-9e81-f983ba0d6557.png)

(Highlight was off due to the way the Select component compares values)
![image](https://user-images.githubusercontent.com/43557895/182024266-2241e9da-5a2a-48fe-9086-b1039c41db9b.png)


### After (now we can actually choose where the process entry is displayed)
![image](https://user-images.githubusercontent.com/43557895/182024142-2d382087-b3f3-4344-a9c6-39e9877a57eb.png)

(Highlight is correct now)
![image](https://user-images.githubusercontent.com/43557895/182024286-cd177f19-a931-4f92-9df2-e6492056bd8d.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
