### PR TITLE
feat(web): Allow Process entry asset reference instead of url

### DIFF
--- a/apps/web/screens/Adgerdir/Article.tsx
+++ b/apps/web/screens/Adgerdir/Article.tsx
@@ -133,7 +133,7 @@ const AdgerdirArticle: Screen<AdgerdirArticleProps> = ({
           <Text variant="h1" as="h1">
             {article.title}
           </Text>
-          {!!processEntry && (
+          {processEntry?.processLink && (
             <Box marginTop={3} display={['none', 'none', 'block']} printHidden>
               <ProcessEntry {...processEntry} />
             </Box>
@@ -145,7 +145,7 @@ const AdgerdirArticle: Screen<AdgerdirArticleProps> = ({
           activeLocale,
         )}
         <Box>
-          {!!processEntry &&
+          {processEntry?.processLink &&
             mounted &&
             createPortal(
               <Box

--- a/apps/web/screens/Article/Article.tsx
+++ b/apps/web/screens/Article/Article.tsx
@@ -531,7 +531,7 @@ const ArticleScreen: Screen<ArticleProps> = ({
               isMenuDialog
             />
           </Box>
-          {!!processEntry && (
+          {processEntry?.processLink && (
             <Box
               marginTop={3}
               display={['none', 'none', 'block']}
@@ -592,7 +592,7 @@ const ArticleScreen: Screen<ArticleProps> = ({
             marginTop={7}
             printHidden
           >
-            {!!processEntry && <ProcessEntry {...processEntry} />}
+            {processEntry?.processLink && <ProcessEntry {...processEntry} />}
           </Box>
           {article.organization.length > 0 && (
             <Box
@@ -636,7 +636,7 @@ const ArticleScreen: Screen<ArticleProps> = ({
             )}
           </Box>
         </Box>
-        {!!processEntry &&
+        {processEntry?.processLink &&
           mounted &&
           isVisible &&
           createPortal(

--- a/apps/web/screens/queries/Adgerdir.tsx
+++ b/apps/web/screens/queries/Adgerdir.tsx
@@ -29,7 +29,6 @@ export const GET_ADGERDIR_PAGE_QUERY = gql`
       longDescription
       processEntry {
         id
-        type
         processTitle
         processLink
         openLinkInModal

--- a/apps/web/screens/queries/Article.ts
+++ b/apps/web/screens/queries/Article.ts
@@ -45,7 +45,6 @@ export const GET_ARTICLE_QUERY = gql`
       }
       processEntry {
         id
-        type
         processTitle
         processLink
         openLinkInModal

--- a/apps/web/screens/queries/fragments.ts
+++ b/apps/web/screens/queries/fragments.ts
@@ -193,7 +193,6 @@ export const slices = gql`
   fragment ProcessEntryFields on ProcessEntry {
     __typename
     id
-    type
     processTitle
     processLink
     openLinkInModal

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -119,9 +119,6 @@ export interface IArticleFields {
   /** Process Entry */
   processEntry?: IProcessEntry | undefined
 
-  /** Contains application form? (Deprecated) */
-  containsApplicationForm?: boolean | undefined
-
   /** Category (Main) */
   category: IArticleCategory
 
@@ -1520,7 +1517,7 @@ export interface IMailingListSignupFields {
   title: string
 
   /** Variant */
-  variant: 'default' | 'conference'
+  variant: 'default' | 'conference' | 'categories'
 
   /** Description */
   description?: string | undefined
@@ -1542,6 +1539,12 @@ export interface IMailingListSignupFields {
 
   /** Disclaimer Label */
   disclaimerLabel?: string | undefined
+
+  /** Category Label */
+  categoryLabel?: string | undefined
+
+  /** Categories */
+  categories?: Record<string, any> | undefined
 
   /** Submit button text */
   buttonText: string
@@ -2065,6 +2068,9 @@ export interface IOrganizationPageFields {
     | 'sjukratryggingar'
     | 'syslumenn'
     | 'digital_iceland'
+    | 'hsn'
+    | 'fiskistofa'
+    | 'landlaeknir'
 
   /** Slices */
   slices?:
@@ -2089,7 +2095,13 @@ export interface IOrganizationPageFields {
 
   /** Bottom slices */
   bottomSlices?:
-    | (ILatestNewsSlice | ILogoListSlice | IOneColumnText | ITwoColumnText)[]
+    | (
+        | ILatestNewsSlice
+        | ILogoListSlice
+        | IOneColumnText
+        | ITimeline
+        | ITwoColumnText
+      )[]
     | undefined
 
   /** News tag */
@@ -2174,6 +2186,7 @@ export interface IOrganizationSubpageFields {
         | IDistricts
         | IMailingListSignup
         | IEventSlice
+        | IFeaturedArticles
         | ILatestNewsSlice
         | IMultipleStatistics
         | IOneColumnText
@@ -2318,6 +2331,9 @@ export interface IProcessEntryFields {
 
   /** Process link */
   processLink: string
+
+  /** Process asset */
+  processAsset?: Asset | undefined
 
   /** Open link in modal */
   openLinkInModal?: boolean | undefined

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -1517,7 +1517,7 @@ export interface IMailingListSignupFields {
   title: string
 
   /** Variant */
-  variant: 'default' | 'conference' | 'categories'
+  variant: 'default' | 'conference'
 
   /** Description */
   description?: string | undefined
@@ -1539,12 +1539,6 @@ export interface IMailingListSignupFields {
 
   /** Disclaimer Label */
   disclaimerLabel?: string | undefined
-
-  /** Category Label */
-  categoryLabel?: string | undefined
-
-  /** Categories */
-  categories?: Record<string, any> | undefined
 
   /** Submit button text */
   buttonText: string
@@ -2068,9 +2062,6 @@ export interface IOrganizationPageFields {
     | 'sjukratryggingar'
     | 'syslumenn'
     | 'digital_iceland'
-    | 'hsn'
-    | 'fiskistofa'
-    | 'landlaeknir'
 
   /** Slices */
   slices?:
@@ -2095,13 +2086,7 @@ export interface IOrganizationPageFields {
 
   /** Bottom slices */
   bottomSlices?:
-    | (
-        | ILatestNewsSlice
-        | ILogoListSlice
-        | IOneColumnText
-        | ITimeline
-        | ITwoColumnText
-      )[]
+    | (ILatestNewsSlice | ILogoListSlice | IOneColumnText | ITwoColumnText)[]
     | undefined
 
   /** News tag */
@@ -2186,7 +2171,6 @@ export interface IOrganizationSubpageFields {
         | IDistricts
         | IMailingListSignup
         | IEventSlice
-        | IFeaturedArticles
         | ILatestNewsSlice
         | IMultipleStatistics
         | IOneColumnText

--- a/libs/cms/src/lib/models/processEntry.model.ts
+++ b/libs/cms/src/lib/models/processEntry.model.ts
@@ -8,13 +8,10 @@ export class ProcessEntry {
   id!: string
 
   @Field()
-  type!: string
-
-  @Field()
   processTitle!: string
 
   @Field()
-  processLink!: string
+  processLink?: string
 
   @Field({ nullable: true })
   openLinkInModal?: boolean
@@ -26,12 +23,25 @@ export class ProcessEntry {
 export const mapProcessEntry = ({
   fields,
   sys,
-}: IProcessEntry): SystemMetadata<ProcessEntry> => ({
-  typename: 'ProcessEntry',
-  id: sys.id,
-  type: fields.type ?? '',
-  processTitle: fields.processTitle ?? '',
-  processLink: fields.processLink ?? '',
-  openLinkInModal: Boolean(fields.openLinkInModal),
-  buttonText: fields.buttonText ?? '',
-})
+}: IProcessEntry): SystemMetadata<ProcessEntry> => {
+  let processLink = ''
+
+  if (fields.processLink?.length > 0) {
+    processLink = fields.processLink
+  } else if (fields.processAsset?.fields?.file?.url) {
+    let prefix = ''
+    if (fields.processAsset.fields.file.url.startsWith('//')) {
+      prefix = 'https:'
+    }
+    processLink = prefix + fields.processAsset.fields.file.url
+  }
+
+  return {
+    typename: 'ProcessEntry',
+    id: sys.id,
+    processTitle: fields.processTitle ?? '',
+    processLink,
+    openLinkInModal: Boolean(fields.openLinkInModal),
+    buttonText: fields.buttonText ?? '',
+  }
+}

--- a/libs/island-ui/contentful/src/lib/ProcessEntry/ProcessEntry.tsx
+++ b/libs/island-ui/contentful/src/lib/ProcessEntry/ProcessEntry.tsx
@@ -34,11 +34,6 @@ export const ProcessEntryLinkButton: FC<
   newTab = true,
   ...buttonProps
 }) => {
-  // Make sure that links without a protocol get prefixed with https:
-  const url = processLink.startsWith('//')
-    ? `https:${processLink}`
-    : processLink
-
   const button = (
     <Button icon="open" iconType="outline" nowrap {...buttonProps}>
       {buttonText}
@@ -50,10 +45,10 @@ export const ProcessEntryLinkButton: FC<
       title={processTitle}
       baseId="process-entry-modal-iframe"
       disclosure={button}
-      src={url}
+      src={processLink}
     />
   ) : (
-    <Link href={url} newTab={newTab} skipTab>
+    <Link href={processLink} newTab={newTab} skipTab>
       {button}
     </Link>
   )

--- a/libs/island-ui/contentful/src/lib/ProcessEntry/ProcessEntry.tsx
+++ b/libs/island-ui/contentful/src/lib/ProcessEntry/ProcessEntry.tsx
@@ -12,22 +12,6 @@ import IframeModal from '../IframeModal/IframeModal'
 
 import * as styles from './ProcessEntry.css'
 
-export const Titles: {
-  [Digital: string]: { is: string; en: string }
-} = {
-  Digital: { is: 'Stafræn umsókn', en: 'Digital application' },
-  'Digital w/login': {
-    is: 'Aðgangsstýrð stafræn umsókn',
-    en: 'Digital application with access control',
-  },
-  'Not digital': { is: 'Handvirk umsókn', en: 'Manual application' },
-  'Not digital w/login': {
-    is: 'Handvirk umsókn með innskráningu',
-    en: 'Manual application with access control',
-  },
-  'No type': { is: '', en: '' },
-}
-
 export interface ProcessEntryProps {
   processTitle: string
   processLink: string

--- a/libs/island-ui/contentful/src/lib/ProcessEntry/ProcessEntry.tsx
+++ b/libs/island-ui/contentful/src/lib/ProcessEntry/ProcessEntry.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import { FC } from 'react'
 import {
   Text,
   Button,
@@ -34,6 +34,11 @@ export const ProcessEntryLinkButton: FC<
   newTab = true,
   ...buttonProps
 }) => {
+  // Make sure that links without a protocol get prefixed with https:
+  const url = processLink.startsWith('//')
+    ? `https:${processLink}`
+    : processLink
+
   const button = (
     <Button icon="open" iconType="outline" nowrap {...buttonProps}>
       {buttonText}
@@ -45,10 +50,10 @@ export const ProcessEntryLinkButton: FC<
       title={processTitle}
       baseId="process-entry-modal-iframe"
       disclosure={button}
-      src={processLink}
+      src={url}
     />
   ) : (
-    <Link href={processLink} newTab={newTab} skipTab>
+    <Link href={url} newTab={newTab} skipTab>
       {button}
     </Link>
   )


### PR DESCRIPTION
# Allow Process entry asset reference instead of url

## What

* Now users can select an asset in Contentful instead of having to use a url
* Removed the type field from Process Entry since it's no longer used
* Only render a process entry if there is a process link provided, since the field is no longer required in Contentful and we don't want to show a process entry if there is no link

(Now there's a new field in Contentful for an asset)
![image](https://user-images.githubusercontent.com/43557895/182330114-d287a639-40ee-4c5d-8912-120fa424556a.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
