### PR TITLE
fix(fa): Add nullish check for missing municipalities

### DIFF
--- a/apps/financial-aid/backend/src/app/modules/municipality/municipality.service.ts
+++ b/apps/financial-aid/backend/src/app/modules/municipality/municipality.service.ts
@@ -217,8 +217,8 @@ export class MunicipalityService {
     return { numberOfAffectedRows, updatedMunicipality }
   }
 
-  decryptNavPassword(municipality: MunicipalityModel) {
-    if (municipality.navPassword) {
+  decryptNavPassword(municipality?: MunicipalityModel) {
+    if (municipality?.navPassword) {
       municipality.navPassword = CryptoJS.AES.decrypt(
         municipality.navPassword,
         environment.navEncryptionKey,


### PR DESCRIPTION
# ... ☝️

https://app.asana.com/0/1202167941440767/1202721143583930

## What

When decrypting the navPassword field of a municipality, we need to add a check wether the municipality is empty. This happens when a user starts the application but his municipality is currently not registered in our system.

## Why

So users without registered municipality can continue the application.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
