### PR TITLE
fix(fa): Add check if municipality is active

### DIFF
--- a/libs/application/templates/financial-aid/src/lib/utils.ts
+++ b/libs/application/templates/financial-aid/src/lib/utils.ts
@@ -59,7 +59,7 @@ export function isMuncipalityNotRegistered(context: ApplicationContext) {
     externalData,
     `nationalRegistry.data.municipality.`,
   ) as Municipality | null
-  return municipality == null
+  return municipality == null || !municipality.active
 }
 
 export const encodeFilenames = (filename: string) =>


### PR DESCRIPTION
# ... 👆

## What

To determine wether a municipality is registered we need to both check if it exists and if it is active. The latter check was added.

## Why

So non-active municipalities are also considered as unregistered.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
