### PR TITLE
chore(island.is): Change email sent to island.is

### DIFF
--- a/libs/api/domains/communications/src/lib/emailTemplates/contactUs.ts
+++ b/libs/api/domains/communications/src/lib/emailTemplates/contactUs.ts
@@ -6,7 +6,7 @@ import { environment } from '../environments/environment'
 export const getTemplate = (input: ContactUsInput): SendMailOptions => ({
   from: {
     name: 'Island.is communications',
-    address: environment.emailOptions.sendFrom!,
+    address: input.email,
   },
   replyTo: {
     name: input.name,

--- a/libs/api/domains/communications/src/lib/emailTemplates/tellUsAStory.ts
+++ b/libs/api/domains/communications/src/lib/emailTemplates/tellUsAStory.ts
@@ -6,7 +6,7 @@ import { environment } from '../environments/environment'
 export const getTemplate = (input: TellUsAStoryInput): SendMailOptions => ({
   from: {
     name: 'Island.is communications',
-    address: environment.emailOptions.sendFrom!,
+    address: input.email,
   },
   replyTo: {
     name: input.name,


### PR DESCRIPTION
# Change email sent to island.is

Attach a link to issue if relevant

## What

Change email sent to island.is so that the sender is the input email.

## Why

On the tell us a story and contact us we are using island.is as the email sent from when sending an email to island.is.
Email sent to island.is from island.is are sent to a hidden mail folder and are sometimes missed by island.is

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
