### PR TITLE
fix(web): Fix FeaturedArticles display condition for resolved articles

### DIFF
--- a/apps/web/components/Organization/Slice/FeaturedArticles/FeaturedArticlesSlice.tsx
+++ b/apps/web/components/Organization/Slice/FeaturedArticles/FeaturedArticlesSlice.tsx
@@ -44,7 +44,7 @@ export const FeaturedArticlesSlice: React.FC<SliceProps> = ({
       : slice.resolvedArticles
 
   return (
-    !!slice.articles.length && (
+    (!!slice.articles.length || !!slice.resolvedArticles.length) && (
       <section key={slice.id} id={slice.id} aria-labelledby={labelId}>
         <Box
           borderTopWidth="standard"


### PR DESCRIPTION
# Fix FeaturedArticles display condition for resolved articles

## What

The slice should be displayed if there are articles OR resolved articles.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
