### PR TITLE
fix(fa): Fix thjodskra spouse error

### DIFF
--- a/libs/api/domains/national-registry-x-road/src/lib/nationalRegistryXRoad.service.ts
+++ b/libs/api/domains/national-registry-x-road/src/lib/nationalRegistryXRoad.service.ts
@@ -150,6 +150,7 @@ export class NationalRegistryXRoadService {
     const spouse = await this.nationalRegistryApiWithAuth(user)
       .einstaklingarGetHjuskapur({ id: nationalId })
       .catch(this.handle400)
+      .catch(this.handle404)
 
     return (
       spouse && {


### PR DESCRIPTION
# ... 👆

## What

There is a mismatch between the error codes that Þjóðskrá is returning from their dev and staging/prod environments. When retrieving a spouse from Þjóðskrá and the spouse does not exist, Þjóðskrá will return 400 on dev but 404 on staging/prod. 
This hotfix makes sure we handle both cases.

A conversation with Þjóðskrá about their error codes is ongoing.

This change was also made as a hotfix for release 17.0.0: https://github.com/island-is/island.is/pull/8126

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
