### PR TITLE
feat(user-profile): Add english translations to confirmation code email

### DIFF
--- a/apps/services/user-profile/src/app/user-profile/verification.service.ts
+++ b/apps/services/user-profile/src/app/user-profile/verification.service.ts
@@ -281,11 +281,22 @@ export class VerificationService {
             },
             {
               component: 'Heading',
-              context: { copy: 'Staðfesting á netfangi', small: true },
+              context: {
+                copy: 'Staðfesting á netfangi',
+                small: true,
+              },
+            },
+            {
+              component: 'Heading',
+              context: {
+                copy: '',
+                small: true,
+                eyebrow: 'Email confirmation',
+              },
             },
             {
               component: 'Copy',
-              context: { copy: 'Öryggiskóðinn þinn', small: true },
+              context: { copy: 'Öryggiskóði / Security code', small: true },
             },
             {
               component: 'Heading',
@@ -295,14 +306,15 @@ export class VerificationService {
               component: 'Copy',
               context: {
                 copy:
-                  'Þetta er öryggiskóðinn þinn til staðfestingar á netfangi. Hann eyðist sjálfkrafa eftir 5 mínútur, eftir þann tíma þarftu að láta senda nýjan í sama ferli og þú varst að fara gegnum.',
+                  'Þetta er öryggiskóði til staðfestingar á netfangi, hann eyðist sjálfkrafa eftir 5 mínútur. Vinsamlegst hunsaðu póstinn ef þú varst ekki að skrá netfangið þitt á Mínum síðum.',
               },
             },
             {
               component: 'Copy',
               context: {
+                small: true,
                 copy:
-                  'Vinsamlegst hunsaðu þennan póst ef þú varst ekki að skrá netfangið þitt á Mínum síðum.',
+                  'This is your security code to verify your email address, it will be deleted automatically after 5 minutes. Please ignore this email if you did not enter your email address on My pages.',
               },
             },
           ],


### PR DESCRIPTION
## What

Add english text to confirmation code email along with the Icelandic text.

## Why

Support both languages. `EN` + `IS`

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
