### PR TITLE
fix(ads): temporary heightened logging

### DIFF
--- a/apps/air-discount-scheme/backend/src/app/modules/nationalRegistry/nationalRegistry.service.ts
+++ b/apps/air-discount-scheme/backend/src/app/modules/nationalRegistry/nationalRegistry.service.ts
@@ -279,6 +279,7 @@ export class NationalRegistryService {
       .catch(this.handle404)
 
     if (response === undefined) {
+      this.logger.warn('Get Forsja: returns empty response')
       return []
     }
     return response
@@ -296,6 +297,7 @@ export class NationalRegistryService {
       .catch(this.handle404)
 
     if (response === undefined) {
+      this.logger.warn('Get Forsja Foreldri: returns empty response')
       return []
     }
 
@@ -327,6 +329,7 @@ export class NationalRegistryService {
       .catch(this.handle404)
 
     if (!response) {
+      this.logger.warn('Get Einstaklingur: returns empty response')
       return null
     }
 
@@ -335,9 +338,12 @@ export class NationalRegistryService {
   }
 
   private handle404(error: FetchError) {
+    // Temporary throw on all
+    /*
     if (error.status === 404) {
       return undefined
     }
+    */
     throw error
   }
 }

--- a/apps/air-discount-scheme/backend/src/app/modules/user/user.service.ts
+++ b/apps/air-discount-scheme/backend/src/app/modules/user/user.service.ts
@@ -92,7 +92,10 @@ export class UserService {
 
     if (this.flightService.isADSPostalCode(user.postalcode)) {
       meetsADSRequirements = true
-    } else if (info(user.nationalId).age < MAX_AGE_LIMIT) {
+    } else if (
+      !user.nationalId.startsWith('010130') ||
+      info(user.nationalId).age < MAX_AGE_LIMIT
+    ) {
       // NationalId is a minor and doesn't live in ADS postal codes.
       const cacheKey = this.getCacheKey(user.nationalId, 'custodians')
       const cacheValue = await this.cacheManager.get(cacheKey)

--- a/apps/air-discount-scheme/backend/src/app/modules/user/user.service.ts
+++ b/apps/air-discount-scheme/backend/src/app/modules/user/user.service.ts
@@ -92,10 +92,7 @@ export class UserService {
 
     if (this.flightService.isADSPostalCode(user.postalcode)) {
       meetsADSRequirements = true
-    } else if (
-      !user.nationalId.startsWith('010130') ||
-      info(user.nationalId).age < MAX_AGE_LIMIT
-    ) {
+    } else if (info(user.nationalId).age < MAX_AGE_LIMIT) {
       // NationalId is a minor and doesn't live in ADS postal codes.
       const cacheKey = this.getCacheKey(user.nationalId, 'custodians')
       const cacheValue = await this.cacheManager.get(cacheKey)


### PR DESCRIPTION
Need more explicit logs for when national registry is being contacted

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [X] I have rebased against release before asking for a review
