### PR TITLE
chore(docker-compose): Remove obsolete somaxconn sysctl

### DIFF
--- a/apps/application-system/api/docker-compose.yml
+++ b/apps/application-system/api/docker-compose.yml
@@ -19,8 +19,6 @@ services:
     networks:
       - local
     privileged: true
-    sysctls:
-      net.core.somaxconn: '511'
     environment:
       - IP=0.0.0.0
     ports:

--- a/apps/github-actions-cache/docker-compose.yml
+++ b/apps/github-actions-cache/docker-compose.yml
@@ -5,8 +5,6 @@ services:
     container_name: gha_cache_redis_cluster
     image: grokzen/redis-cluster:5.0.6
     privileged: true
-    sysctls:
-      net.core.somaxconn: '511'
     environment:
       - IP=0.0.0.0
     ports:


### PR DESCRIPTION
## What
Remove a little used and unnecessary setting in `docker-compose.yml`, i.e. `net.core.somaxconn=511`.

## Why
Running `docker-compose up` on my machine (linux using podman-compose) causes an error, and this seems to be unnecessary for local development.

## Testing
Not sure how to test that this doesn't break for someone else.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~My changes generate no new warnings~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
