### PR TITLE
fix(ads): Ensure callee parent is included in custodians

### DIFF
--- a/apps/air-discount-scheme/backend/src/app/modules/nationalRegistry/nationalRegistry.service.ts
+++ b/apps/air-discount-scheme/backend/src/app/modules/nationalRegistry/nationalRegistry.service.ts
@@ -298,6 +298,9 @@ export class NationalRegistryService {
     if (response === undefined) {
       return []
     }
+    // Add the callee parent to custodians
+    // Custody relation isn't circular/transitive
+    response.push(auth.nationalId)
 
     const custodians = []
     for (const custodian of response) {


### PR DESCRIPTION
Custody endpoint was operating on a faulty premise.
Custody endpoint returns other parent, if applicable, not the callee parent.

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
