### PR TITLE
feat(island-ui): add image to action card + refactor

### DIFF
--- a/libs/application/ui-components/src/components/ApplicationList/ApplicationList.tsx
+++ b/libs/application/ui-components/src/components/ApplicationList/ApplicationList.tsx
@@ -148,7 +148,7 @@ const ApplicationList = ({
 
             return (
               <ActionCard
-                logo={getLogo(application.typeId)}
+                image={{ type: 'logo', url: getLogo(application.typeId) }}
                 key={`${application.id}-${index}`}
                 date={format(new Date(application.modified), formattedDate)}
                 tag={{

--- a/libs/application/ui-shell/src/components/DelegationsScreen.tsx
+++ b/libs/application/ui-shell/src/components/DelegationsScreen.tsx
@@ -204,7 +204,7 @@ export const DelegationsScreen = ({
               {screenData.authDelegations?.map((delegation: Delegation) => (
                 <ActionCard
                   key={delegation.from.nationalId}
-                  avatar
+                  image={{ type: 'avatar' }}
                   heading={delegation.from.name}
                   text={
                     formatMessage(

--- a/libs/island-ui/core/src/lib/ActionCard/ActionCard.stories.tsx
+++ b/libs/island-ui/core/src/lib/ActionCard/ActionCard.stories.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 
 import { ActionCard } from './ActionCard'
-
 export default {
   title: 'Cards/ActionCard',
   component: ActionCard,
@@ -138,9 +137,47 @@ export const ApplicationCardCompletedVariant = () => (
   />
 )
 
-export const Avatar = () => (
+export const ApplicationCardWithLogo = () => (
   <ActionCard
-    avatar
+    image={{ type: 'logo', url: 'https://via.placeholder.com/100' }}
+    date="16/03/2021"
+    heading="Parental Leave"
+    tag={{
+      label: 'Completed',
+      variant: 'blue',
+      outlined: false,
+    }}
+    text="Your application is in progress. Waiting for VMST approval."
+    cta={{
+      label: 'Open application',
+      variant: 'ghost',
+      size: 'small',
+      icon: undefined,
+    }}
+    progressMeter={{
+      active: true,
+      progress: 1,
+      variant: 'blue',
+    }}
+  />
+)
+
+export const WithAvatar = () => (
+  <ActionCard
+    image={{ type: 'avatar' }}
+    heading="Jón Jónsson"
+    text="Kennitala: 010100-0100"
+    cta={{
+      label: 'Skoða upplýsingar',
+      variant: 'text',
+      size: 'small',
+    }}
+  />
+)
+
+export const WithImage = () => (
+  <ActionCard
+    image={{ type: 'image', url: 'https://via.placeholder.com/100' }}
     heading="Jón Jónsson"
     text="Kennitala: 010100-0100"
     cta={{

--- a/libs/island-ui/core/src/lib/ActionCard/ActionCard.tsx
+++ b/libs/island-ui/core/src/lib/ActionCard/ActionCard.tsx
@@ -21,7 +21,6 @@ type ActionCardProps = {
   headingVariant?: 'h3' | 'h4'
   text?: string
   eyebrow?: string
-  logo?: string
   backgroundColor?: 'white' | 'blue' | 'red'
   tag?: {
     label: string
@@ -54,7 +53,10 @@ type ActionCardProps = {
     label?: string
     message?: string
   }
-  avatar?: boolean
+  image?: {
+    type: 'avatar' | 'image' | 'logo'
+    url?: string
+  }
   deleteButton?: {
     visible?: boolean
     onClick?: () => void
@@ -114,8 +116,7 @@ export const ActionCard: React.FC<ActionCardProps> = ({
   unavailable: _unavailable,
   progressMeter: _progressMeter,
   deleteButton: _delete,
-  avatar,
-  logo,
+  image,
 }) => {
   const cta = { ...defaultCta, ..._cta }
   const progressMeter = { ...defaultProgressMeter, ..._progressMeter }
@@ -129,27 +130,55 @@ export const ActionCard: React.FC<ActionCardProps> = ({
       ? 'red100'
       : 'blue100'
 
-  const renderAvatar = () => {
-    if (!avatar) {
+  const renderImage = () => {
+    if (!image) {
       return null
     }
 
-    return heading ? (
-      <Box
-        display="flex"
-        justifyContent="center"
-        alignItems="center"
-        flexShrink={0}
-        marginRight={[2, 3]}
-        borderRadius="circle"
-        background="blue100"
-        className={styles.avatar}
-      >
-        <Text variant="h3" as="p" color="blue400">
-          {getTitleAbbreviation(heading)}
-        </Text>
-      </Box>
-    ) : null
+    if (image.type === 'avatar' && heading) {
+      return (
+        <Box
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          flexShrink={0}
+          marginRight={[2, 3]}
+          borderRadius="circle"
+          background="blue100"
+          className={styles.avatar}
+        >
+          <Text variant="h3" as="p" color="blue400">
+            {getTitleAbbreviation(heading)}
+          </Text>
+        </Box>
+      )
+    }
+    if (!image.url || image.url.length === 0) return null
+    if (image.type === 'image') {
+      return (
+        <Box
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          flexShrink={0}
+          marginRight={[2, 3]}
+          borderRadius="circle"
+        >
+          <img className={styles.avatar} src={image.url} alt="action-card" />
+        </Box>
+      )
+    }
+    if (image.type === 'logo') {
+      return (
+        <Box
+          padding={2}
+          marginRight={2}
+          className={styles.logo}
+          style={{ backgroundImage: `url(${image.url})` }}
+        ></Box>
+      )
+    }
+    return null
   }
 
   const renderDisabled = () => {
@@ -242,13 +271,6 @@ export const ActionCard: React.FC<ActionCardProps> = ({
         title={deleteButton.dialogTitle}
         description={deleteButton.dialogDescription}
         ariaLabel="delete"
-        img={
-          <img
-            src={`assets/images/settings.svg`}
-            style={{ float: 'right' }}
-            width="80%"
-          />
-        }
         disclosureElement={
           <Tag outlined={tag.outlined} variant={tag.variant}>
             <Box display="flex" flexDirection="row" alignItems="center">
@@ -342,18 +364,6 @@ export const ActionCard: React.FC<ActionCardProps> = ({
     )
   }
 
-  const renderLogo = () => {
-    if (!logo || logo.length === 0) return null
-    return (
-      <Box
-        padding={2}
-        marginRight={2}
-        className={styles.logo}
-        style={{ backgroundImage: `url(${logo})` }}
-      ></Box>
-    )
-  }
-
   return (
     <Box
       display="flex"
@@ -379,7 +389,8 @@ export const ActionCard: React.FC<ActionCardProps> = ({
         display="flex"
         flexDirection={['column', 'row']}
       >
-        {renderAvatar()}
+        {/* Checking image type so the image is placed correctly */}
+        {image?.type !== 'logo' && renderImage()}
         <Box flexDirection="row" width="full">
           {heading && (
             <Box
@@ -389,7 +400,8 @@ export const ActionCard: React.FC<ActionCardProps> = ({
               alignItems={['flexStart', 'flexStart', 'flexEnd']}
             >
               <Box display="flex" flexDirection="row" alignItems="center">
-                {renderLogo()}
+                {/* Checking image type so the logo is placed correctly */}
+                {image?.type === 'logo' && renderImage()}
                 <Text
                   variant={headingVariant}
                   color={

--- a/libs/service-portal/education-degree/src/screens/EducationDegree/components/DegreeCards/DegreeCards.tsx
+++ b/libs/service-portal/education-degree/src/screens/EducationDegree/components/DegreeCards/DegreeCards.tsx
@@ -42,7 +42,7 @@ const DegreeCards = () => {
             }}
             heading={`Leyfisbréf - ${degree.programme}`}
             text={`Dags: ${degree.date}`}
-            avatar
+            image={{ type: 'avatar' }}
           />
         </Box>
       ))}

--- a/libs/service-portal/information/src/components/FamilyMemberCard/FamilyMemberCard.tsx
+++ b/libs/service-portal/information/src/components/FamilyMemberCard/FamilyMemberCard.tsx
@@ -87,7 +87,7 @@ export const FamilyMemberCard: FC<Props> = ({
     })
   return (
     <ActionCard
-      avatar
+      image={{ type: 'avatar' }}
       heading={title}
       headingVariant="h4"
       text={


### PR DESCRIPTION
# Action card refactor

## What

Refactor images on action card. 

Image has 3 types
1. Avatar, displays heading initials 
2. Logo, displays a small image leftside of Heading and above Text 
3. Image, displays a larger image leftside of both Heading and Text

## Why

Instead of having these types as three seperate props, we merge them together in one. We never want to display more then one of these types in the same card.

## Screenshots / Gifs
Screenshot from Storybook 📖 

![Screenshot 2022-08-24 at 10 19 42](https://user-images.githubusercontent.com/19873770/186394379-84111c8d-b545-440a-9f18-5bea8a2ef132.png)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
