### PR TITLE
chore: bump cypress version from v10.2.0 to v10.6.0, improved local-e2e

### DIFF
--- a/package.json
+++ b/package.json
@@ -386,7 +386,7 @@
     "cross-spawn": "7.0.3",
     "csstype": "2.6.13",
     "csv-parse": "4.16.0",
-    "cypress": "10.2.0",
+    "cypress": "10.6.0",
     "cypress-file-upload": "5.0.8",
     "dotenv": "14.3.2",
     "esbuild": "0.12.1",

--- a/scripts/ci/Dockerfile
+++ b/scripts/ci/Dockerfile
@@ -164,7 +164,7 @@ RUN echo "whoami: $(whoami)" \
   # uid=0(root) gid=0(root) groups=0(root)
   # which means the current user is root
   && id \
-  && npm install -g "cypress@10.2.0" "@testing-library/cypress" \
+  && npm install -g "cypress@10.6.0" "@testing-library/cypress" \
   && cypress verify \
   # Cypress cache and installed version
   # should be in the root user's home folder

--- a/scripts/local-e2e.sh
+++ b/scripts/local-e2e.sh
@@ -144,12 +144,12 @@ usage() {
   echo
   echo "menu          opens up Cypress interactive spec dashboard " 2>&1
   echo "build         [-a app-name: default system-e2e]" 2>&1
-  echo "run           -i integration -t smoke|acceptance -c <source|dist|container> [-e <local|dev|staging|prod>, default: local] [-b browser, default: chrome] [-d, default: headless]" 2>&1
+  echo "run           -i integration -t smoke|acceptance -c <source|dist|container> [-e <local|dev|staging|prod>, default: local] [-b browser, default: chrome] [-l, default: headless] [-d, extremely verbose cypress debugging]" 2>&1
   echo
   echo "examples " 2>&1
-  echo "         $(basename "$0") run -i air-discount-scheme -t acceptance -c source -d" 2>&1
+  echo "         $(basename "$0") run -i air-discount-scheme -t acceptance -c source -l" 2>&1
   echo "         $(basename "$0") run -i skilavottord -t acceptance -c container -b electron" 2>&1
-  echo "         $(basename "$0") run -i web -t smoke -c dist -b firefox -d" 2>&1
+  echo "         $(basename "$0") run -i web -t smoke -c dist -b firefox -l" 2>&1
   exit 1
 }
 
@@ -184,7 +184,7 @@ if [ ! 0 == $# ]; then
       ;;
     run)
       shift
-      while getopts ":i:c:t:b:e:d" opt; do
+      while getopts ":i:c:t:b:e:ld" opt; do
         case "${opt}" in
           i)
             INTEGRATION=${OPTARG}
@@ -200,6 +200,9 @@ if [ ! 0 == $# ]; then
             BROWSER=${OPTARG}
             ;;
           d)
+            export DEBUG="cypress:*"
+            ;;
+          l)
             HEAD="--headed"
             ;;
           e)

--- a/yarn.lock
+++ b/yarn.lock
@@ -7616,20 +7616,6 @@
     pretty-format "^27.0.2"
 
 "@testing-library/dom@^8.1.0":
-  version "8.17.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.17.1.tgz#2d7af4ff6dad8d837630fecd08835aee08320ad7"
-  integrity sha512-KnH2MnJUzmFNPW6RIKfd+zf2Wue8mEKX0M3cpX6aKl5ZXrJM1/c/Pc8c2xDNYQCnJO48Sm5ITbMXgqTr3h4jxQ==
-  dependencies:
-    "@babel/code-frame" "^7.10.4"
-    "@babel/runtime" "^7.12.5"
-    "@types/aria-query" "^4.2.0"
-    aria-query "^5.0.0"
-    chalk "^4.1.0"
-    dom-accessibility-api "^0.5.9"
-    lz-string "^1.4.4"
-    pretty-format "^27.0.2"
-
-"@testing-library/dom@^8.1.0":
   version "8.16.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.16.0.tgz#d6fc50250aed17b1035ca1bd64655e342db3936a"
   integrity sha512-uxF4zmnLHHDlmW4l+0WDjcgLVwCvH+OVLpD8Dfp+Bjfz85prwxWGbwXgJdLtkgjD0qfOzkJF9SmA6YZPsMYX4w==
@@ -14012,10 +13998,10 @@ cypress-promise@1.1.0:
   resolved "https://registry.yarnpkg.com/cypress-promise/-/cypress-promise-1.1.0.tgz#f2d66965945fe198431aaf692d5157cea9d47b25"
   integrity sha512-DhIf5PJ/a0iY+Yii6n7Rbwq+9TJxU4pupXYzf9mZd8nPG0AzQrj9i+pqINv4xbI2EV1p+PKW3maCkR7oPG4GrA==
 
-cypress@10.2.0:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-10.2.0.tgz#ca078abfceb13be2a33cbba6e0e80ded770f542a"
-  integrity sha512-+i9lY5ENlfi2mJwsggzR+XASOIgMd7S/Gd3/13NCpv596n3YSplMAueBTIxNLcxDpTcIksp+9pM3UaDrJDpFqA==
+cypress@10.6.0:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-10.6.0.tgz#13f46867febf2c3715874ed5dce9c2e946b175fe"
+  integrity sha512-6sOpHjostp8gcLO34p6r/Ci342lBs8S5z9/eb3ZCQ22w2cIhMWGUoGKkosabPBfKcvRS9BE4UxybBtlIs8gTQA==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"


### PR DESCRIPTION
## What
Bump cypress v10.2.0 to v10.6.0

Highlights concerning our scenario:
- Updated cross-origin cookie handling to align with browser behavior. This fixed various issues with cookies when testing across multiple origins.
- Corrected the Typescript types to include baseUrl as a valid test config override option
- Fixed an issue where the Proxy-Authorization header included capitalization that would fail with certain proxies. 
- Fixed issues with document.cookie when testing multiple origins
- Upgraded electron from 18.3.0 to 19.0.8
- Upgraded bundled Chromium version from 100.0.4896.75 to 102.0.5005.148
- Fixes issue where cookies were not handled within cy.origin for requests other than the AUT page request
- Fixed an issue that could lead to infinite recursion and thus a crash when running tests that make use of cy.intercept()
- Added new testIsolation configuration option to allow users to revert to legacy mode when experimentalSessionAndOrigin is set to true. Read more about [test isolation](https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests#Test-Isolation) in Cypress to learn more.
- Fixed an issue in cy.session() where the unique session id logic was not persisting registered session ids, which incorrectly allowed session ids to override previously used session ids with different setups.


Full changelog: https://docs.cypress.io/guides/references/changelog


## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
