### PR TITLE
fix(fa): Add size and type restriction to upload files

### DIFF
--- a/libs/application/templates/financial-aid/src/fields/Files/Files.tsx
+++ b/libs/application/templates/financial-aid/src/fields/Files/Files.tsx
@@ -7,6 +7,7 @@ import { FileUploadContainer } from '..'
 import { UploadFileType } from '../../lib/types'
 import { useFormContext } from 'react-hook-form'
 import { useFileUpload } from '../../lib/hooks/useFileUpload'
+import { FILE_SIZE_LIMIT, UPLOAD_ACCEPT } from '../../lib/constants'
 
 interface Props {
   uploadFiles: UploadFile[]
@@ -25,6 +26,7 @@ const Files = ({ uploadFiles, fileKey, folderId, hasError = false }: Props) => {
     onChange,
     onRemove,
     onRetry,
+    onUploadRejection,
   } = useFileUpload(uploadFiles, folderId)
 
   const fileToObject = (file: UploadFile) => {
@@ -58,6 +60,9 @@ const Files = ({ uploadFiles, fileKey, folderId, hasError = false }: Props) => {
         onChange={onChange}
         onRemove={onRemove}
         onRetry={onRetry}
+        onUploadRejection={onUploadRejection}
+        maxSize={FILE_SIZE_LIMIT}
+        accept={UPLOAD_ACCEPT}
       />
     </FileUploadContainer>
   )

--- a/libs/application/templates/financial-aid/src/lib/constants.ts
+++ b/libs/application/templates/financial-aid/src/lib/constants.ts
@@ -47,3 +47,6 @@ export enum Routes {
 export enum ApiActions {
   CREATEAPPLICATION = 'createApplication',
 }
+
+export const UPLOAD_ACCEPT = ['.pdf', '.doc', '.docx', '.rtf', '.jpg', '.jpeg', '.png', '.heic']
+export const FILE_SIZE_LIMIT = 10000000 // 10MB

--- a/libs/application/templates/financial-aid/src/lib/constants.ts
+++ b/libs/application/templates/financial-aid/src/lib/constants.ts
@@ -48,5 +48,14 @@ export enum ApiActions {
   CREATEAPPLICATION = 'createApplication',
 }
 
-export const UPLOAD_ACCEPT = ['.pdf', '.doc', '.docx', '.rtf', '.jpg', '.jpeg', '.png', '.heic']
+export const UPLOAD_ACCEPT = [
+  '.pdf',
+  '.doc',
+  '.docx',
+  '.rtf',
+  '.jpg',
+  '.jpeg',
+  '.png',
+  '.heic',
+]
 export const FILE_SIZE_LIMIT = 10000000 // 10MB

--- a/libs/application/templates/financial-aid/src/lib/hooks/useFileUpload.ts
+++ b/libs/application/templates/financial-aid/src/lib/hooks/useFileUpload.ts
@@ -284,11 +284,11 @@ export const useFileUpload = (formFiles: UploadFile[], folderId: string) => {
   }
 
   const onUploadRejection = (files: FileRejection[]) => {
-      files.forEach((file: FileRejection) => {
-        if (file.file.size > FILE_SIZE_LIMIT) {
-          return setUploadErrorMessage(formatMessage(filesText.sizeErrorMessage))
-        }
-      })
+    files.forEach((file: FileRejection) => {
+      if (file.file.size > FILE_SIZE_LIMIT) {
+        return setUploadErrorMessage(formatMessage(filesText.sizeErrorMessage))
+      }
+    })
   }
 
   const openFileById = (fileId: String) => {

--- a/libs/application/templates/financial-aid/src/lib/hooks/useFileUpload.ts
+++ b/libs/application/templates/financial-aid/src/lib/hooks/useFileUpload.ts
@@ -1,13 +1,18 @@
 import { useEffect, useRef, useState } from 'react'
+import { FileRejection } from 'react-dropzone'
+import { useIntl } from 'react-intl'
 import { useLazyQuery, useMutation } from '@apollo/client'
+import { gql } from '@apollo/client'
+
 import { UploadFile } from '@island.is/island-ui/core'
 import {
   CreateFilesResponse,
   FileType,
   SignedUrl,
 } from '@island.is/financial-aid/shared/lib'
-import { gql } from '@apollo/client'
 import { encodeFilenames } from '../utils'
+import { FILE_SIZE_LIMIT } from '../constants'
+import { filesText } from '../messages'
 
 export const CreateSignedUrlMutation = gql`
   mutation CreateMunicipalitiesFinancialAidSignedUrlQuery(
@@ -48,6 +53,7 @@ export const SignedUrlQuery = gql`
 `
 
 export const useFileUpload = (formFiles: UploadFile[], folderId: string) => {
+  const { formatMessage } = useIntl()
   const [files, _setFiles] = useState<UploadFile[]>([])
   const filesRef = useRef<UploadFile[]>(files)
   const [uploadErrorMessage, setUploadErrorMessage] = useState<string>()
@@ -277,6 +283,14 @@ export const useFileUpload = (formFiles: UploadFile[], folderId: string) => {
     onChange([file as File], true)
   }
 
+  const onUploadRejection = (files: FileRejection[]) => {
+      files.forEach((file: FileRejection) => {
+        if (file.file.size > FILE_SIZE_LIMIT) {
+          return setUploadErrorMessage(formatMessage(filesText.sizeErrorMessage))
+        }
+      })
+  }
+
   const openFileById = (fileId: String) => {
     return openFile({ variables: { input: { id: fileId } } })
   }
@@ -287,6 +301,7 @@ export const useFileUpload = (formFiles: UploadFile[], folderId: string) => {
     onChange,
     onRemove,
     onRetry,
+    onUploadRejection,
     uploadFiles,
     uploadStateFiles,
     openFileById,

--- a/libs/application/templates/financial-aid/src/lib/messages/application.ts
+++ b/libs/application/templates/financial-aid/src/lib/messages/application.ts
@@ -92,6 +92,11 @@ export const filesText = defineMessages({
     defaultMessage: 'Þú þarft að hlaða upp gögnum',
     description: 'Error message when user has to upload files',
   },
+  sizeErrorMessage: {
+    id: 'fa.application:section.filesText.sizeErrorMessage',
+    defaultMessage: 'Hámark 10 MB á skrá',
+    description: 'Error message when user uploads files exceeding the allowed size',
+  },
 })
 
 export const familystatus = defineMessages({

--- a/libs/application/templates/financial-aid/src/lib/messages/application.ts
+++ b/libs/application/templates/financial-aid/src/lib/messages/application.ts
@@ -95,7 +95,8 @@ export const filesText = defineMessages({
   sizeErrorMessage: {
     id: 'fa.application:section.filesText.sizeErrorMessage',
     defaultMessage: 'Hámark 10 MB á skrá',
-    description: 'Error message when user uploads files exceeding the allowed size',
+    description:
+      'Error message when user uploads files exceeding the allowed size',
   },
 })
 


### PR DESCRIPTION
# ... 👆

https://app.asana.com/0/1202167941440767/1202882546493116

## What

- Add constants to restrict the size and types of attachments
- Handle when too big files are uploaded and add error message for that

## Why

So users can not send problematic file types or really big files to the database.
This problem was spotted after a security review.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
