### PR TITLE
revert(dependency): downgrade ioredis from v5 to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "identicon.js": "2.3.3",
     "intl": "1.2.5",
     "intl-locales-supported": "1.8.12",
-    "ioredis": "5.2.3",
+    "ioredis": "4.28.5",
     "is-circular": "1.0.2",
     "is-url": "1.2.4",
     "isomorphic-fetch": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4513,11 +4513,6 @@
   resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.5.tgz#b32366c89b43c6f8cefbdefac778b9c828e3ba8c"
   integrity sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==
 
-"@ioredis/commands@^1.1.1":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@ioredis/commands/-/commands-1.2.0.tgz#6d61b3097470af1fdbbe622795b8921d42018e11"
-  integrity sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==
-
 "@island.is/login@1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@island.is/login/-/login-1.2.1.tgz#b9f720d07134d185a363b7c5485166374fc002f1"
@@ -14465,11 +14460,6 @@ denque@^1.1.0:
   resolved "https://registry.yarnpkg.com/denque/-/denque-1.5.0.tgz#773de0686ff2d8ec2ff92914316a47b73b1c73de"
   integrity sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ==
 
-denque@^2.0.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/denque/-/denque-2.1.0.tgz#e93e1a6569fb5e66f16a3c2a2964617d349d6ab1"
-  integrity sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==
-
 depd@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
@@ -18770,22 +18760,7 @@ io-ts@^2.2.13:
   resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-2.2.16.tgz#597dffa03db1913fc318c9c6df6931cb4ed808b2"
   integrity sha512-y5TTSa6VP6le0hhmIyN0dqEXkrZeJLeC5KApJq6VLci3UEKF80lZ+KuoUs02RhBxNWlrqSNxzfI7otLX1Euv8Q==
 
-ioredis@5.2.3:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-5.2.3.tgz#d5b37eb13e643241660d6cee4eeb41a026cda8c0"
-  integrity sha512-gQNcMF23/NpvjCaa1b5YycUyQJ9rBNH2xP94LWinNpodMWVUPP5Ai/xXANn/SM7gfIvI62B5CCvZxhg5pOgyMw==
-  dependencies:
-    "@ioredis/commands" "^1.1.1"
-    cluster-key-slot "^1.1.0"
-    debug "^4.3.4"
-    denque "^2.0.1"
-    lodash.defaults "^4.2.0"
-    lodash.isarguments "^3.1.0"
-    redis-errors "^1.2.0"
-    redis-parser "^3.0.0"
-    standard-as-callback "^2.1.0"
-
-ioredis@^4.0.0, ioredis@^4.14.1:
+ioredis@4.28.5, ioredis@^4.0.0, ioredis@^4.14.1:
   version "4.28.5"
   resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-4.28.5.tgz#5c149e6a8d76a7f8fa8a504ffc85b7d5b6797f9f"
   integrity sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==


### PR DESCRIPTION
## What
After bumping ioredis from v4 to v5, `application-system-api` pods are crashing because of missing `lodash.flatten`, although its installed as peer dep in several packages.

### Pod error
```bash
│ _modules/bull/node_modules/ioredis/built/redis/index.js","/webapp/node_modules/bull/node_modules/ioredis/built/index.js","/webapp/node_modules/bull/lib/queue.js","/webapp/node_modules/bull/index.js","/webapp/ │
│ main.js"]},"exception":true,"level":"error","message":"unhandledRejection: Cannot find module 'lodash.flatten'\nRequire stack:\n- /webapp/node_modules/bull/node_modules/ioredis/built/utils/lodash.js\n- /webap │
```

### yarn why
```bash
> yarn why lodash.flatten

=> Found "lodash.flatten@4.4.0"
info Reasons this module exists
   - "apollo-server-cache-redis#ioredis" depends on it
   - Hoisted from "apollo-server-cache-redis#ioredis#lodash.flatten"
   - Hoisted from "bull#ioredis#lodash.flatten"
   - Hoisted from "cache-manager-ioredis#ioredis#lodash.flatten"
   - Hoisted from "testcontainers#archiver#archiver-utils#lodash.flatten"
info Disk size without dependencies: "24KB"
info Disk size with unique dependencies: "24KB"
info Disk size with transitive dependencies: "24KB"
info Number of shared dependencies: 0
```
Bumping `ioredis` was a bit careless of me since we are now running different versions because of implicit dep to v4 still.

```bash
> yarn why ioredis

=> Found "ioredis@5.2.3"
info Has been hoisted to "ioredis"
info This module exists because it's specified in "dependencies".
info Disk size without dependencies: "948KB"
info Disk size with unique dependencies: "1.32MB"
info Disk size with transitive dependencies: "1.34MB"
info Number of shared dependencies: 10
=> Found "apollo-server-cache-redis#ioredis@4.28.5"
info This module exists because "apollo-server-cache-redis" depends on it.
info Disk size without dependencies: "428KB"
info Disk size with unique dependencies: "872KB"
info Disk size with transitive dependencies: "888KB"
info Number of shared dependencies: 12
=> Found "bull#ioredis@4.28.5"
info This module exists because "bull" depends on it.
info Disk size without dependencies: "428KB"
info Disk size with unique dependencies: "872KB"
info Disk size with transitive dependencies: "888KB"
info Number of shared dependencies: 12
=> Found "cache-manager-ioredis#ioredis@4.28.5"
info This module exists because "cache-manager-ioredis" depends on it.
info Disk size without dependencies: "428KB"
info Disk size with unique dependencies: "872KB"
info Disk size with transitive dependencies: "888KB"
info Number of shared dependencies: 12
```
Lets revert this for now.


## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
