### PR TITLE
fix(p-sign-application): Email and phone from user profile and answers

### DIFF
--- a/libs/application/templates/p-sign/src/forms/applicationSections/sectionInformation.ts
+++ b/libs/application/templates/p-sign/src/forms/applicationSections/sectionInformation.ts
@@ -8,6 +8,7 @@ import { Application } from '@island.is/application/types'
 import type { User } from '@island.is/api/domains/national-registry'
 import { format as formatNationalId } from 'kennitala'
 import { m } from '../../lib/messages'
+import { UserProfile } from '@island.is/api/schema'
 
 export const sectionInformation = buildSection({
   id: 'information',
@@ -73,6 +74,11 @@ export const sectionInformation = buildSection({
           variant: 'email',
           width: 'half',
           backgroundColor: 'blue',
+          defaultValue: (application: Application) => {
+            const data = application.externalData.userProfile
+              .data as UserProfile
+            return data.email
+          },
         }),
         buildTextField({
           id: 'phone',
@@ -80,6 +86,11 @@ export const sectionInformation = buildSection({
           variant: 'tel',
           width: 'half',
           backgroundColor: 'blue',
+          defaultValue: (application: Application) => {
+            const data = application.externalData.userProfile
+              .data as UserProfile
+            return data.mobilePhoneNumber
+          },
         }),
         buildDateField({
           id: 'validityPeriod',

--- a/libs/application/templates/p-sign/src/forms/applicationSections/sectionInformationActor.ts
+++ b/libs/application/templates/p-sign/src/forms/applicationSections/sectionInformationActor.ts
@@ -77,7 +77,6 @@ export const sectionInformationActor = buildSection({
           defaultValue: (application: Application) => {
             const data = application.externalData.userProfile
               .data as UserProfile
-              console.log(data)
             return data.email
           },
         }),

--- a/libs/application/templates/p-sign/src/forms/applicationSections/sectionInformationActor.ts
+++ b/libs/application/templates/p-sign/src/forms/applicationSections/sectionInformationActor.ts
@@ -77,6 +77,7 @@ export const sectionInformationActor = buildSection({
           defaultValue: (application: Application) => {
             const data = application.externalData.userProfile
               .data as UserProfile
+              console.log(data)
             return data.email
           },
         }),

--- a/libs/application/templates/p-sign/src/forms/applicationSections/sectionOverview.ts
+++ b/libs/application/templates/p-sign/src/forms/applicationSections/sectionOverview.ts
@@ -61,14 +61,12 @@ export const sectionOverview = buildSection({
         buildKeyValueField({
           label: m.applicantsEmail,
           width: 'half',
-          value: ({ externalData: { userProfile } }) =>
-            (userProfile.data as UserProfile).email as string,
+          value: ({ answers: { email } }) => email as string,
         }),
         buildKeyValueField({
           label: m.applicantsPhoneNumber,
           width: 'half',
-          value: ({ externalData: { userProfile } }) =>
-            (userProfile.data as UserProfile).mobilePhoneNumber as string,
+          value: ({ answers: { phone } }) => phone as string,
         }),
         buildDividerField({}),
         buildKeyValueField({


### PR DESCRIPTION
Showing email and phone from userprofile for applicant in info section and from answers in overview.
