### PR TITLE
fix(web): Filter out slices that failed mapping

### DIFF
--- a/libs/cms/src/lib/models/organizationPage.model.ts
+++ b/libs/cms/src/lib/models/organizationPage.model.ts
@@ -82,8 +82,10 @@ export const mapOrganizationPage = ({
   description: fields.description ?? '',
   theme: fields.theme ?? 'default',
   themeProperties: mapOrganizationTheme(fields.themeProperties ?? {}),
-  slices: (fields.slices ?? []).map(safelyMapSliceUnion),
-  bottomSlices: (fields.bottomSlices ?? []).map(safelyMapSliceUnion),
+  slices: (fields.slices ?? []).map(safelyMapSliceUnion).filter(Boolean),
+  bottomSlices: (fields.bottomSlices ?? [])
+    .map(safelyMapSliceUnion)
+    .filter(Boolean),
   newsTag: fields.newsTag ? mapGenericTag(fields.newsTag) : null,
   menuLinks: (fields.menuLinks ?? []).map(mapLinkGroup),
   secondaryMenu: fields.secondaryMenu

--- a/libs/cms/src/lib/models/organizationSubpage.model.ts
+++ b/libs/cms/src/lib/models/organizationSubpage.model.ts
@@ -65,7 +65,7 @@ export const mapOrganizationSubpage = ({
     ? mapDocument(fields.description, sys.id + ':content')
     : [],
   links: (fields.links ?? []).map(mapLink),
-  slices: (fields.slices ?? []).map(safelyMapSliceUnion),
+  slices: (fields.slices ?? []).map(safelyMapSliceUnion).filter(Boolean),
   showTableOfContents: fields.showTableOfContents ?? false,
   sliceCustomRenderer: fields.sliceCustomRenderer ?? '',
   sliceExtraText: fields.sliceExtraText ?? '',

--- a/libs/cms/src/lib/models/projectPage.model.ts
+++ b/libs/cms/src/lib/models/projectPage.model.ts
@@ -79,7 +79,7 @@ export const mapProjectPage = ({ sys, fields }: IProjectPage): ProjectPage => ({
     ? mapDocument(fields.content, sys.id + ':content')
     : [],
   stepper: fields.stepper ? mapStepper(fields.stepper) : null,
-  slices: (fields.slices ?? []).map(safelyMapSliceUnion),
+  slices: (fields.slices ?? []).map(safelyMapSliceUnion).filter(Boolean),
   newsTag: fields.newsTag ? mapGenericTag(fields.newsTag) : null,
   projectSubpages: (fields.projectSubpages ?? [])
     .filter((p) => p.fields?.title)

--- a/libs/cms/src/lib/models/projectSubpage.model.ts
+++ b/libs/cms/src/lib/models/projectSubpage.model.ts
@@ -39,5 +39,5 @@ export const mapProjectSubpage = ({
     ? mapDocument(fields.content, sys.id + ':content')
     : [],
   renderSlicesAsTabs: fields.renderSlicesAsTabs ?? false,
-  slices: (fields.slices ?? []).map(safelyMapSliceUnion),
+  slices: (fields.slices ?? []).map(safelyMapSliceUnion).filter(Boolean),
 })


### PR DESCRIPTION
# Filter out slices that failed mapping

## What

* We recently had an incident where a slice list in contentful had one item in draft and that caused an entire organization page to down due to a 500 error (The error was that slices can't contain a null value).
* This fix addresses the issue since now we filter out the slices that aren't successfully mapped

## Why

* We don't want something in Contentful to cause a 500 error on the web

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
