### PR TITLE
chore(web): Increase number of articles fetched on category page

### DIFF
--- a/apps/web/screens/Category/Category/Category.tsx
+++ b/apps/web/screens/Category/Category/Category.tsx
@@ -579,7 +579,7 @@ Category.getInitialProps = async ({ apolloClient, locale, query }) => {
         input: {
           lang: locale as ContentLanguage,
           category: slug,
-          size: 150,
+          size: 1000,
         },
       },
     }),


### PR DESCRIPTION
# Increase number of articles fetched on category page

## What

* We've reached the currently set limit of articles fetched for some categories (meaning that new articles will not appear on the category page)
* I set the limit to be a 1000 (which is the same number used for the island.is/s page)

## Why

* We want to be able to see new articles on category pages even though there are more than 150 articles

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
