### PR TITLE
fix(j-s): fix validation for police case numbers input

### DIFF
--- a/apps/judicial-system/web-e2e/src/integration/Prosecutor/Indictments/defendant.spec.ts
+++ b/apps/judicial-system/web-e2e/src/integration/Prosecutor/Indictments/defendant.spec.ts
@@ -10,7 +10,7 @@ describe(CREATE_INDICTMENT_ROUTE, () => {
     // Police case number
     cy.get('#policeCaseNumbers').type('0').type('{enter}')
     cy.getByTestid('policeCaseNumbers-list').children().should('have.length', 0)
-    cy.get('#policeCaseNumbers').blur()
+    cy.get('#policeCaseNumbers').clear().blur()
     cy.getByTestid('inputErrorMessage').contains('Reitur má ekki vera tómur')
     cy.get('#policeCaseNumbers').type('007202201').type('{enter}')
     cy.getByTestid('policeCaseNumbers-list').children().should('have.length', 1)

--- a/apps/judicial-system/web-e2e/src/integration/Prosecutor/InvestigationCases/defendant.spec.ts
+++ b/apps/judicial-system/web-e2e/src/integration/Prosecutor/InvestigationCases/defendant.spec.ts
@@ -12,7 +12,7 @@ describe(CREATE_INVESTIGATION_CASE_ROUTE, () => {
     // Police case number
     cy.get('#policeCaseNumbers').type('0').type('{enter}')
     cy.getByTestid('policeCaseNumbers-list').children().should('have.length', 0)
-    cy.get('#policeCaseNumbers').blur()
+    cy.get('#policeCaseNumbers').clear().blur()
     cy.getByTestid('inputErrorMessage').contains('Reitur má ekki vera tómur')
     cy.get('#policeCaseNumbers').type('007202201').type('{enter}')
     cy.getByTestid('policeCaseNumbers-list').children().should('have.length', 1)

--- a/apps/judicial-system/web-e2e/src/integration/Prosecutor/RestrictionCases/defendant.spec.ts
+++ b/apps/judicial-system/web-e2e/src/integration/Prosecutor/RestrictionCases/defendant.spec.ts
@@ -9,7 +9,7 @@ describe(CREATE_RESTRICTION_CASE_ROUTE, () => {
   it('should require a valid data', () => {
     cy.get('#policeCaseNumbers').type('0').type('{enter}')
     cy.getByTestid('policeCaseNumbers-list').children().should('have.length', 0)
-    cy.get('#policeCaseNumbers').blur()
+    cy.get('#policeCaseNumbers').clear().blur()
     cy.getByTestid('inputErrorMessage').contains('Reitur má ekki vera tómur')
     cy.get('#policeCaseNumbers').type('007202201').type('{enter}')
     cy.getByTestid('policeCaseNumbers-list').children().should('have.length', 1)

--- a/apps/judicial-system/web/src/routes/Prosecutor/SharedComponents/PoliceCaseNumbers/PoliceCaseNumbers.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/SharedComponents/PoliceCaseNumbers/PoliceCaseNumbers.tsx
@@ -103,8 +103,8 @@ const PoliceCaseNumbers: React.FC<Props> = (props) => {
         isDisabled={(value) =>
           !validate([[value, ['empty', 'police-casenumber-format']]]).isValid
         }
-        onBlur={() => {
-          setHasError(clientPoliceNumbers.length === 0)
+        onBlur={(event) => {
+          setHasError(clientPoliceNumbers.length === 0 && !event.target.value)
         }}
         hasError={hasError}
         errorMessage={validate([[undefined, ['empty']]]).errorMessage}


### PR DESCRIPTION
[Asana ](https://app.asana.com/0/1199153462262248/1202891259672359/f)
## What

- Fix validation for police case numbers input

## Why

- Fix the flashing error message when entering in first police case number

## Screenshots / Gifs
![Small GIF (400x242)](https://user-images.githubusercontent.com/5700902/189156775-964c4c17-a8eb-47c0-8aa7-c7a408d6ddaf.gif)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
