### PR TITLE
feat(service-portal): Print finance details

### DIFF
--- a/libs/service-portal/core/src/components/ExpandableTable/Row.tsx
+++ b/libs/service-portal/core/src/components/ExpandableTable/Row.tsx
@@ -81,7 +81,6 @@ const ExpandableLine: FC<Props> = ({
             alignItems: 'flexEnd',
             background: color,
             borderColor: borderColor,
-            printHidden: true,
             position: 'relative',
           }}
           style={tableStyles}

--- a/libs/service-portal/finance/src/screens/FinanceStatus/FinanceStatus.tsx
+++ b/libs/service-portal/finance/src/screens/FinanceStatus/FinanceStatus.tsx
@@ -34,6 +34,7 @@ import {
   FinanceStatusDataType,
   FinanceStatusOrganizationType,
 } from './FinanceStatusData.types'
+import * as styles from './Table.css'
 
 const GetFinanceStatusQuery = gql`
   query GetFinanceStatusQuery {
@@ -222,7 +223,7 @@ const FinanceStatus: ServicePortalModuleComponent = ({ userInfo }) => {
             </Box>
           )}
           {financeStatusData?.organizations?.length > 0 || financeStatusZero ? (
-            <Box marginTop={2}>
+            <Box className={styles.printStyle} marginTop={2}>
               <T.Table>
                 <ExpandHeader
                   data={[

--- a/libs/service-portal/finance/src/screens/FinanceStatus/Table.css.ts
+++ b/libs/service-portal/finance/src/screens/FinanceStatus/Table.css.ts
@@ -1,5 +1,4 @@
 import { style, globalStyle } from '@vanilla-extract/css'
-import { spacing, theme } from '@island.is/island-ui/theme'
 
 export const printStyle = style({})
 

--- a/libs/service-portal/finance/src/screens/FinanceStatus/Table.css.ts
+++ b/libs/service-portal/finance/src/screens/FinanceStatus/Table.css.ts
@@ -1,0 +1,31 @@
+import { style, globalStyle } from '@vanilla-extract/css'
+import { spacing, theme } from '@island.is/island-ui/theme'
+
+export const printStyle = style({})
+
+globalStyle(
+  `${printStyle} td div, ${printStyle} td div p, ${printStyle} p, ${printStyle} span`,
+  {
+    '@media': {
+      print: {
+        fontSize: 10,
+      },
+    },
+  },
+)
+
+globalStyle(`${printStyle} td, ${printStyle} th`, {
+  '@media': {
+    print: {
+      padding: '6px !important',
+    },
+  },
+})
+
+globalStyle(`${printStyle} span[type=button]`, {
+  '@media': {
+    print: {
+      display: 'none',
+    },
+  },
+})


### PR DESCRIPTION
## What

Add print styles for detail table on finance status screen.

## Why

Details will be cut off with current styling when printing.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
