### PR TITLE
fix(web): Project subpage double breadcrumbs

### DIFF
--- a/apps/web/screens/Project/Project.tsx
+++ b/apps/web/screens/Project/Project.tsx
@@ -23,7 +23,6 @@ import {
 import {
   Box,
   BreadCrumbItem,
-  Breadcrumbs,
   TableOfContents,
   Text,
 } from '@island.is/island-ui/core'
@@ -129,9 +128,6 @@ const ProjectPage: Screen<PageProps> = ({
       >
         {!!subpage && (
           <Box marginBottom={1}>
-            <Box marginBottom={3}>
-              <Breadcrumbs items={breadCrumbs} />
-            </Box>
             <Text as="h1" variant="h1">
               {subpage.title}
             </Text>


### PR DESCRIPTION
# Project subpage double breadcrumbs

## What

* I recently moved the breadcrumbs to the wrapper but forget to remove them from subpage's, resulting in double breadcrumbs
* This change fixes that issue

## Screenshots / Gifs

### Before
![Screenshot 2022-09-12 at 09 03 11 2](https://user-images.githubusercontent.com/43557895/189615084-b0af125d-0378-44c4-be9c-e4ee4926ce3d.png)

### After
![Screenshot 2022-09-12 at 09 04 54 2](https://user-images.githubusercontent.com/43557895/189615288-b61b7b21-6ade-41ab-9792-7b8f2e6f18d6.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
