### PR TITLE
revert(service-portal): image going under cards

### DIFF
--- a/apps/service-portal/src/components/Greeting/Greeting.tsx
+++ b/apps/service-portal/src/components/Greeting/Greeting.tsx
@@ -46,7 +46,7 @@ const Greeting: FC<{}> = () => {
               ? formatMessage(m.eveningGreeting)
               : formatMessage(m.dayGreeting)}
           </Text>
-          <Text variant="h3" as="h1" marginBottom={1}>
+          <Text variant="h2" as="h1" marginBottom={1}>
             {userInfo?.profile.name}
           </Text>
           <Text marginBottom={2}>{formatMessage(m.greetingIntro)}</Text>

--- a/apps/service-portal/src/components/Greeting/Greeting.tsx
+++ b/apps/service-portal/src/components/Greeting/Greeting.tsx
@@ -32,6 +32,7 @@ const Greeting: FC<{}> = () => {
           ? styles.greetingContainerRelative
           : styles.greetingContainer
       }
+      marginTop={4}
     >
       <GridColumn span={['12/12', '7/12']}>
         <Box marginTop={[2, 3, 4]} data-testid="greeting">
@@ -45,7 +46,7 @@ const Greeting: FC<{}> = () => {
               ? formatMessage(m.eveningGreeting)
               : formatMessage(m.dayGreeting)}
           </Text>
-          <Text variant="h1" as="h1" marginBottom={1}>
+          <Text variant="h3" as="h1" marginBottom={1}>
             {userInfo?.profile.name}
           </Text>
           <Text marginBottom={2}>{formatMessage(m.greetingIntro)}</Text>
@@ -73,7 +74,7 @@ const Greeting: FC<{}> = () => {
             height="full"
             display="flex"
             justifyContent="center"
-            alignItems="center"
+            alignItems="flexStart"
           >
             <img
               src={`./assets/images/${

--- a/apps/service-portal/src/screens/Dashboard/Dashboard.css.ts
+++ b/apps/service-portal/src/screens/Dashboard/Dashboard.css.ts
@@ -9,7 +9,7 @@ export const imageAbsolute = style({
   display: 'none',
   ...themeUtils.responsiveStyle({
     md: {
-      top: -252,
+      top: -288,
       display: 'block',
       position: 'absolute',
       right: -55,

--- a/apps/service-portal/src/screens/Dashboard/Dashboard.tsx
+++ b/apps/service-portal/src/screens/Dashboard/Dashboard.tsx
@@ -116,6 +116,7 @@ export const Dashboard: FC<{}> = () => {
   const isLegalGuardian = delegationTypes.includes(
     AuthDelegationType.LegalGuardian,
   )
+
   useEffect(() => {
     PlausiblePageviewDetail(ServicePortalPath.MinarSidurRoot)
   }, [location])


### PR DESCRIPTION
# Service portal - Dashboard

## What

Revert image on dashboard going under the cards
Make name heading smaller to match design

## Why

Comments from PO

## Screenshots / Gifs

Before:

![Screenshot 2022-09-12 at 11 24 04](https://user-images.githubusercontent.com/19873770/189641694-2fe9982b-e798-4196-bd49-1c81fa563276.png)

After:

![Screenshot 2022-09-12 at 11 23 49](https://user-images.githubusercontent.com/19873770/189641700-929ff953-a31d-4697-9c49-abb61553a04f.png)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
