### PR TITLE
fix(fa): Use another build executor

### DIFF
--- a/apps/financial-aid/api/project.json
+++ b/apps/financial-aid/api/project.json
@@ -6,7 +6,7 @@
   "generators": {},
   "targets": {
     "build": {
-      "executor": "./tools/executors/node:build",
+      "executor": "@anatine/esbuildnx:build",
       "options": {
         "outputPath": "dist/apps/financial-aid/api",
         "main": "apps/financial-aid/api/src/main.ts",


### PR DESCRIPTION
# ... 👆

## What

The financial-aid apps (Veita and Ósk) are not working on DEV and it looks like they are having trouble with the financial-aid-api. A change was made to the build method of financial-aid-api by the core team that effected the build: https://github.com/island-is/island.is/pull/8192/files#diff-6dcba6421dee2c251e7211c916a97e452585a09dabca450615b2bd69fd728779.
The local build was fixed with this PR: https://github.com/island-is/island.is/pull/8317, but the DEV is still broken.
This change to revert is not certain to fix the problem on DEV but is safe to do after talking to the core team.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
