### PR TITLE
fix(j-s): Fix text in notifications in indictments

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/formatters.spec.ts
+++ b/apps/judicial-system/backend/src/app/formatters/formatters.spec.ts
@@ -605,6 +605,26 @@ describe('formatProsecutorReceivedByCourtSmsNotification', () => {
       'Héraðsdómur Reykjavíkur hefur móttekið kröfu um rannsóknarheimild sem þú sendir og úthlutað málsnúmerinu R-898/2021. Sjá nánar á rettarvorslugatt.island.is.',
     )
   })
+
+  test('should format received by court notification for an indictment of type MURDER', () => {
+    // Arranged
+    const type = CaseType.MURDER
+    const court = 'Héraðsdómur Reykjavíkur'
+    const courtCaseNumber = 'R-898/2021'
+
+    // Act
+    const res = formatProsecutorReceivedByCourtSmsNotification(
+      formatMessage,
+      type,
+      court,
+      courtCaseNumber,
+    )
+
+    // Assert
+    expect(res).toBe(
+      'Héraðsdómur Reykjavíkur hefur móttekið kröfu um ákæru sem þú sendir og úthlutað málsnúmerinu R-898/2021. Sjá nánar á rettarvorslugatt.island.is.',
+    )
+  })
 })
 
 describe('formatProsecutorCourtDateEmailNotification', () => {

--- a/apps/judicial-system/backend/src/app/formatters/formatters.spec.ts
+++ b/apps/judicial-system/backend/src/app/formatters/formatters.spec.ts
@@ -842,6 +842,34 @@ describe('formatProsecutorCourtDateEmailNotification', () => {
     )
   })
 
+  test('should format court date notification for indictments', () => {
+    // Arrange
+    const type = CaseType.MURDER
+    const courtCaseNumber = 'S-898/2021'
+    const court = 'Héraðsdómur Reykjavíkur'
+    const courtDate = new Date('2021-12-24T10:00')
+    const courtRoom = '999'
+    const judgeName = 'Dóra Dómari'
+    const registrarName = 'Dalli Dómritari'
+
+    // Act
+    const res = fn(
+      type,
+      courtCaseNumber,
+      court,
+      courtDate,
+      courtRoom,
+      judgeName,
+      registrarName,
+    )
+
+    // Assert
+    expect(res.subject).toBe('Þingfesting í máli: S-898/2021')
+    expect(res.body).toBe(
+      'Héraðsdómur Reykjavíkur boðar til þingfestingar í máli S-898/2021.<br /><br />Þingfesting mun fara fram 24. desember 2021, kl. 10:00.<br /><br />Dómsalur: 999.<br /><br />Dómari: Dóra Dómari.<br /><br />Dómritari: Dalli Dómritari.',
+    )
+  })
+
   test('should format court date notification when defender will not attend', () => {
     // Arrange
     const type = CaseType.OTHER

--- a/apps/judicial-system/backend/src/app/formatters/formatters.ts
+++ b/apps/judicial-system/backend/src/app/formatters/formatters.ts
@@ -226,17 +226,20 @@ export function formatProsecutorCourtDateEmailNotification(
   sessionArrangements?: SessionArrangements,
 ): { subject: string; body: string } {
   const cf = notifications.prosecutorCourtDateEmail
-  const scheduledCaseText = formatMessage(cf.scheduledCase, {
-    court,
-    investigationPrefix:
-      type === CaseType.OTHER
-        ? 'onlyPrefix'
-        : isInvestigationCase(type)
-        ? 'withPrefix'
-        : 'noPrefix',
-    courtTypeName: caseTypes[type],
-  })
+  const scheduledCaseText = isIndictmentCase(type)
+    ? formatMessage(cf.sheduledIndictmentCase, { court, courtCaseNumber })
+    : formatMessage(cf.scheduledCase, {
+        court,
+        investigationPrefix:
+          type === CaseType.OTHER
+            ? 'onlyPrefix'
+            : isInvestigationCase(type)
+            ? 'withPrefix'
+            : 'noPrefix',
+        courtTypeName: caseTypes[type],
+      })
   const courtDateText = formatMessage(cf.courtDate, {
+    isIndictment: isIndictmentCase(type),
     courtDate: courtDate
       ? formatDate(courtDate, 'PPPp')?.replace(' kl.', ', kl.')
       : 'NONE',
@@ -255,17 +258,26 @@ export function formatProsecutorCourtDateEmailNotification(
     sessionArrangements,
   })
 
-  const body = formatMessage(cf.body, {
-    scheduledCaseText,
-    courtDateText,
-    courtRoomText,
-    judgeText,
-    registrarText: registrarText || 'NONE',
-    defenderText,
-    sessionArrangements,
-  })
+  const body = isIndictmentCase(type)
+    ? formatMessage(cf.bodyIndictments, {
+        scheduledCaseText,
+        courtDateText,
+        courtRoomText,
+        judgeText,
+        registrarText: registrarText || 'NONE',
+      })
+    : formatMessage(cf.body, {
+        scheduledCaseText,
+        courtDateText,
+        courtRoomText,
+        judgeText,
+        registrarText: registrarText || 'NONE',
+        defenderText,
+        sessionArrangements,
+      })
 
   const subject = formatMessage(cf.subject, {
+    isIndictment: isIndictmentCase(type),
     courtCaseNumber: courtCaseNumber || '',
   })
 

--- a/apps/judicial-system/backend/src/app/formatters/formatters.ts
+++ b/apps/judicial-system/backend/src/app/formatters/formatters.ts
@@ -201,6 +201,8 @@ export function formatProsecutorReceivedByCourtSmsNotification(
     investigationPrefix = 'onlyPrefix'
   } else if (isInvestigationCase(type)) {
     investigationPrefix = 'withPrefix'
+  } else if (isIndictmentCase(type)) {
+    investigationPrefix = 'withIndictmentPrefix'
   }
 
   return formatMessage(notifications.prosecutorReceivedByCourt, {

--- a/apps/judicial-system/backend/src/app/messages/notifications.ts
+++ b/apps/judicial-system/backend/src/app/messages/notifications.ts
@@ -154,7 +154,7 @@ export const notifications = {
   prosecutorReceivedByCourt: {
     id: 'judicial.system.backend:notifications.prosecutor_received_by_court',
     defaultMessage:
-      '{court} hefur móttekið kröfu um {investigationPrefix, select, onlyPrefix {rannsóknarheimild} withPrefix {rannsóknarheimild ({courtTypeName})} other {{courtTypeName}}} sem þú sendir og úthlutað málsnúmerinu {courtCaseNumber}. Sjá nánar á rettarvorslugatt.island.is.',
+      '{court} hefur móttekið kröfu um {investigationPrefix, select, onlyPrefix {rannsóknarheimild} withPrefix {rannsóknarheimild ({courtTypeName})} withIndictmentPrefix {ákæru} other {{courtTypeName}}} sem þú sendir og úthlutað málsnúmerinu {courtCaseNumber}. Sjá nánar á rettarvorslugatt.island.is.',
     description: 'Notaður sem texti í sms-i þegar sækjandi fær kröfuskjal',
   },
   prosecutorCourtDateEmail: defineMessages({

--- a/apps/judicial-system/backend/src/app/messages/notifications.ts
+++ b/apps/judicial-system/backend/src/app/messages/notifications.ts
@@ -166,18 +166,27 @@ export const notifications = {
       description:
         'Notaður sem texti í pósti sem tilgreinir að dómstól hefur staðfest fyrirtökutíma',
     },
+    sheduledIndictmentCase: {
+      id:
+        'judicial.system.backend:notifications.prosecutor_court_date_email.scheduled_indictment_case',
+      defaultMessage:
+        '{court} boðar til þingfestingar í máli {courtCaseNumber}.',
+      description:
+        'Notaður sem texti í pósti sem tilgreinir að dómstól boði til þingfestingar',
+    },
     courtDate: {
       id:
         'judicial.system.backend:notifications.prosecutor_court_date_email.court_date',
       defaultMessage:
-        'Fyrirtaka mun fara fram {courtDate, select, NONE {á ótilgreindum tíma} other {{courtDate}}}.',
+        '{isIndictment, select, true {Þingfesting} other {Fyrirtaka}} mun fara fram {courtDate, select, NONE {á ótilgreindum tíma} other {{courtDate}}}.',
       description:
         'Notaður sem texti í pósti sem tilgreinir hvenær fyrirtaka fer fram',
     },
     subject: {
       id:
         'judicial.system.backend:notifications.prosecutor_court_date_email.subject',
-      defaultMessage: 'Fyrirtaka í máli: {courtCaseNumber}',
+      defaultMessage:
+        '{isIndictment, select, true {Þingfesting} other {Fyrirtaka}} í máli: {courtCaseNumber}',
       description:
         'Notaður sem titil á  pósti til sækjanda þegar fyrirtökutími er staðfestur',
     },
@@ -188,6 +197,14 @@ export const notifications = {
         '{scheduledCaseText}<br /><br />{courtDateText}<br /><br />{courtRoomText}<br /><br />{judgeText}{registrarText, select, NONE {} other {<br /><br />{registrarText}}}{sessionArrangements, select, PROSECUTOR_PRESENT {} other {<br /><br />{defenderText}.}}',
       description:
         'Notaður fyrir beinagrind á pósti til sækjanda þegar fyrirtökutími er staðfestur',
+    },
+    bodyIndictments: {
+      id:
+        'judicial.system.backend:notifications.prosecutor_court_date_email.body_indictments',
+      defaultMessage:
+        '{scheduledCaseText}<br /><br />{courtDateText}<br /><br />{courtRoomText}<br /><br />{judgeText}{registrarText, select, NONE {} other {<br /><br />{registrarText}}}',
+      description:
+        'Notaður fyrir beinagrind á pósti til sækjanda þegar fyrirtökutími er staðfestur í ákærum',
     },
   }),
   signedRuling: defineMessages({


### PR DESCRIPTION
# Fix text in notifications in indictments

[Asana](https://app.asana.com/0/1199153462262248/1202861834321035/f)

## What

An SMS that gets sent to prosecutors when a court has received their case currently says 

```
Héraðsdómur Reykjavíkur hefur móttekið kröfu um **fjárdráttur** sem þú sendir..
```

With this PR it changes this to 

```
Héraðsdómur Reykjavíkur hefur móttekið kröfu um **ákæru** sem þú sendir..
```

We're also changing the text in an email that is sent to prosecutors when they are invited to the court hearings. It currently says 

```
Subject: 
Fyrirtaka í máli S-4444/2022

Body: 
Héraðsdómur Reykjavíkur hefur staðfest fyrirtökutíma fyrir kröfu um gæsluvarðhald.
Fyrirtaka fer fram 14. september 2022, kl. 12:00.
Dómsalur: 201.
Dómari: Amy Madison Gray.
```

With this PR it changes to

```
Subject: 
Þingfesting í máli S-4444/2022

Body: 
Héraðsdómur Reykjavíkur boðar til þingfestingar í máli S-4444/2022.
Þingfesting fer fram 14. september 2022, kl. 12:00.
Dómsalur: 201.
Dómari: Amy Madison Gray.
```

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
