### PR TITLE
fix(national-registry): Transgender adults can be parents

### DIFF
--- a/libs/api/domains/national-registry/src/lib/nationalRegistry.service.ts
+++ b/libs/api/domains/national-registry/src/lib/nationalRegistry.service.ts
@@ -268,7 +268,7 @@ export class NationalRegistryService {
   }
 
   private isParent(person: ISLFjolskyldan): boolean {
-    return ['1', '2'].includes(person.Kyn)
+    return ['1', '2', '7'].includes(person.Kyn)
   }
 
   private isChild(person: ISLFjolskyldan): boolean {


### PR DESCRIPTION
From the Einstaklingar endpoint on gender code

```
{
    "kodi": "7",
    "lysing": "Kynsegin/annað fullorðinn"
}
```

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
