### PR TITLE
chore(web): Hotfix - Increase number of articles fetched on category page (#8362)

### DIFF
--- a/apps/web/screens/Category/Category/Category.tsx
+++ b/apps/web/screens/Category/Category/Category.tsx
@@ -579,7 +579,7 @@ Category.getInitialProps = async ({ apolloClient, locale, query }) => {
         input: {
           lang: locale as ContentLanguage,
           category: slug,
-          size: 150,
+          size: 1000,
         },
       },
     }),


### PR DESCRIPTION
# Hotfix - Increase number of articles fetched on category page (#8362)

## What

* Currently articles aren't appearing on the category pages due to a limit of how many are fetched
* This fixes that issue

## Why

* There are 176 articles on a particular category page and only 150 of them are appearing

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
