### PR TITLE
feat(web): Email signup image for default variant

### DIFF
--- a/apps/web/components/MailingListSignup/MailingListSignup.css.ts
+++ b/apps/web/components/MailingListSignup/MailingListSignup.css.ts
@@ -1,0 +1,13 @@
+import { themeUtils } from '@island.is/island-ui/theme'
+import { style } from '@vanilla-extract/css'
+
+export const image = style({
+  marginRight: '48px',
+  minHeight: '100%',
+  display: 'none',
+  ...themeUtils.responsiveStyle({
+    xl: {
+      display: 'block',
+    },
+  }),
+})

--- a/apps/web/components/MailingListSignup/MailingListSignup.tsx
+++ b/apps/web/components/MailingListSignup/MailingListSignup.tsx
@@ -3,12 +3,15 @@ import { useFormik } from 'formik'
 import { Box, NewsletterSignup } from '@island.is/island-ui/core'
 import { isValidEmail } from '@island.is/web/utils/isValidEmail'
 import {
+  Image,
   MailchimpSubscribeMutation,
   MailchimpSubscribeMutationVariables,
 } from '@island.is/web/graphql/schema'
 import { useNamespace } from '@island.is/web/hooks'
 import { useMutation } from '@apollo/client/react'
 import { MAILING_LIST_SIGNUP_MUTATION } from '@island.is/web/screens/queries'
+
+import * as styles from './MailingListSignup.css'
 
 type FormState = {
   type: 'default' | 'error' | 'success'
@@ -28,6 +31,7 @@ interface MailingListSignupProps {
   placeholder?: string
   buttonText: string
   signupID: string
+  image?: Image
 }
 
 export const MailingListSignup: React.FC<MailingListSignupProps> = ({
@@ -39,6 +43,7 @@ export const MailingListSignup: React.FC<MailingListSignupProps> = ({
   placeholder,
   buttonText,
   signupID,
+  image,
 }) => {
   const n = useNamespace(namespace)
   const [status, setStatus] = useState<FormState>({
@@ -109,7 +114,14 @@ export const MailingListSignup: React.FC<MailingListSignupProps> = ({
   }, [status.type, formik.values.email])
 
   return (
-    <Box background="blue100" paddingX={[2, 2, 8]} paddingY={[2, 2, 6]}>
+    <Box
+      display="flex"
+      flexDirection="row"
+      background="blue100"
+      paddingX={[2, 2, 8]}
+      paddingY={[2, 2, 6]}
+    >
+      {image?.url && <img className={styles.image} src={image.url} alt="" />}
       <NewsletterSignup
         id={id}
         name="email"

--- a/apps/web/components/Organization/Slice/MailingListSignupSlice/MailingListSignupSlice.tsx
+++ b/apps/web/components/Organization/Slice/MailingListSignupSlice/MailingListSignupSlice.tsx
@@ -55,6 +55,7 @@ export const MailingListSignupSlice: React.FC<SliceProps> = ({
             inputLabel={slice.inputLabel}
             buttonText={slice.buttonText}
             signupID={slice.id}
+            image={slice.image}
           />
         </Box>
       )}

--- a/apps/web/screens/queries/fragments.ts
+++ b/apps/web/screens/queries/fragments.ts
@@ -56,6 +56,9 @@ export const slices = gql`
     categories
     buttonText
     signupUrl
+    image {
+      ...ImageFields
+    }
   }
 
   fragment StoryFields on StorySlice {

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -1586,6 +1586,9 @@ export interface IMailingListSignupFields {
 
   /** Signup URL */
   signupUrl: string
+
+  /** Image */
+  image?: Asset | undefined
 }
 
 export interface IMailingListSignup extends Entry<IMailingListSignupFields> {

--- a/libs/cms/src/lib/models/mailingListSignupSlice.model.ts
+++ b/libs/cms/src/lib/models/mailingListSignupSlice.model.ts
@@ -1,6 +1,7 @@
 import { Field, ID, ObjectType } from '@nestjs/graphql'
 import { IMailingListSignup } from '../generated/contentfulTypes'
 import { SystemMetadata } from '@island.is/shared/types'
+import { Image, mapImage } from './image.model'
 
 @ObjectType()
 export class MailingListSignupSlice {
@@ -45,6 +46,9 @@ export class MailingListSignupSlice {
 
   @Field()
   signupUrl!: string
+
+  @Field(() => Image, { nullable: true })
+  image?: Image
 }
 
 export const mapMailingListSignup = ({
@@ -66,4 +70,5 @@ export const mapMailingListSignup = ({
   categories: JSON.stringify(fields.categories) ?? '',
   buttonText: fields.buttonText ?? '',
   signupUrl: fields.signupUrl ?? '',
+  image: fields.image ? mapImage(fields.image) : undefined,
 })


### PR DESCRIPTION
# Email signup image for default variant

## What

* Add Email signup image for default variant

## Why

* This is a design decision made for the new look of the Stafrænt Ísland organization page

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/43557895/190677514-d3ade977-1918-4adb-9a36-44a3c433e2c8.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
