### PR TITLE
feat(j-s): hide copy link button if no defender is assigned

### DIFF
--- a/apps/judicial-system/web-e2e/src/integration/Prosecutor/InvestigationCases/overview.spec.ts
+++ b/apps/judicial-system/web-e2e/src/integration/Prosecutor/InvestigationCases/overview.spec.ts
@@ -21,6 +21,7 @@ describe(`${INVESTIGATION_CASE_POLICE_CONFIRMATION_ROUTE}/:id`, () => {
   beforeEach(() => {
     const caseDataAddition: Case = {
       ...caseData,
+      defenderNationalId: '0000000000',
       defenderName,
       defenderEmail,
       defenderPhoneNumber,

--- a/apps/judicial-system/web-e2e/src/integration/Prosecutor/RestrictionCases/overview.spec.ts
+++ b/apps/judicial-system/web-e2e/src/integration/Prosecutor/RestrictionCases/overview.spec.ts
@@ -38,6 +38,7 @@ describe(`${RESTRICTION_CASE_OVERVIEW_ROUTE}/:id`, () => {
     court: makeCourt(),
     creatingProsecutor: makeProsecutor(),
     prosecutor: makeProsecutor(),
+    defenderNationalId: '0000000000',
     defenderName,
     defenderEmail,
     defenderPhoneNumber,

--- a/apps/judicial-system/web/src/routes/Prosecutor/InvestigationCase/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/InvestigationCase/Overview/Overview.tsx
@@ -344,11 +344,13 @@ export const Overview: React.FC = () => {
             title={formatMessage(core.pdfButtonRequest)}
             pdfType="request"
           />
-          <Box marginTop={3}>
-            <CopyLinkForDefenderButton caseId={workingCase.id}>
-              {formatMessage(m.sections.copyLinkForDefenderButton)}
-            </CopyLinkForDefenderButton>
-          </Box>
+          {workingCase.defenderNationalId && (
+            <Box marginTop={3}>
+              <CopyLinkForDefenderButton caseId={workingCase.id}>
+                {formatMessage(m.sections.copyLinkForDefenderButton)}
+              </CopyLinkForDefenderButton>
+            </Box>
+          )}
         </Box>
       </FormContentContainer>
       <FormContentContainer isFooter>

--- a/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/Overview/Overview.tsx
@@ -388,11 +388,13 @@ export const Overview: React.FC = () => {
             title={formatMessage(core.pdfButtonRequest)}
             pdfType="request"
           />
-          <Box marginTop={3}>
-            <CopyLinkForDefenderButton caseId={workingCase.id}>
-              {formatMessage(m.sections.copyLinkForDefenderButton)}
-            </CopyLinkForDefenderButton>
-          </Box>
+          {workingCase.defenderNationalId && (
+            <Box marginTop={3}>
+              <CopyLinkForDefenderButton caseId={workingCase.id}>
+                {formatMessage(m.sections.copyLinkForDefenderButton)}
+              </CopyLinkForDefenderButton>
+            </Box>
+          )}
         </Box>
       </FormContentContainer>
       <FormContentContainer isFooter>


### PR DESCRIPTION
[Asana - Það er hægt að afrita hlekk fyrir verjanda, þó ekki sé hægt að skrá verjanda á málið, t.d. i húsleit](https://app.asana.com/0/1199153462262248/1202963759598703/f)
## What

- Hide button if there is no defender assigned to the case

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
