### PR TITLE
fix(financial-statement-inao): rename message duplicate

### DIFF
--- a/libs/application/templates/financial-statements-inao/src/lib/messages.ts
+++ b/libs/application/templates/financial-statements-inao/src/lib/messages.ts
@@ -139,7 +139,7 @@ export const m = defineMessages({
     description: 'statement',
   },
   electionDeclare: {
-    id: 'fsn.application:electionStatementLaw',
+    id: 'fsn.application:electionStatementDeclare',
     defaultMessage:
       'Ég lýsi því hér með yfir að viðlögðum drengskap að hvorki heildartekjur né heildarkostnaður vegna framboðs míns í kjörinu voru hærri en kr.',
     description: 'statement',
@@ -578,7 +578,7 @@ export const m = defineMessages({
     description: 'Participated in election',
   },
   overview: {
-    id: 'fsn.application:overview.general.sectionTitle',
+    id: 'fsn.application:overview.general.overview',
     defaultMessage: 'Yfirferð',
     description: 'Overview section title',
   },
@@ -593,12 +593,12 @@ export const m = defineMessages({
     description: 'Overview correct',
   },
   overviewTitle: {
-    id: 'fsn.application:overview.general.name',
+    id: 'fsn.application:overview.general.title',
     defaultMessage: 'Yfitlit uppgjörs',
     description: 'Overview title',
   },
   overviewReview: {
-    id: 'fsn.application:overview.general.name',
+    id: 'fsn.application:overview.general.review',
     defaultMessage: 'Yfitlit uppgjörs',
     description: 'Overview review',
   },


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## Why

a few duplicate id-s for messages

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
