### PR TITLE
chore(web): Add landskjorstjorn slug to footerEnabled list

### DIFF
--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -105,6 +105,8 @@ export const footerEnabled = [
 
   'fiskistofa',
   'directorate-of-fisheries',
+
+  'landskjorstjorn',
 ]
 
 export const getThemeConfig = (


### PR DESCRIPTION
# Add landskjorstjorn slug to footerEnabled list

## What

* We want to show the smaller version of the island.is footer below the landskjorstjorn footer so that's what this change implies

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
