### PR TITLE
chore(web): Add hsn slug to footerEnabled list

### DIFF
--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -107,6 +107,7 @@ export const footerEnabled = [
   'directorate-of-fisheries',
 
   'landskjorstjorn',
+  'hsn',
 ]
 
 export const getThemeConfig = (

--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -107,6 +107,7 @@ export const footerEnabled = [
   'directorate-of-fisheries',
 
   'landskjorstjorn',
+
   'hsn',
 ]
 


### PR DESCRIPTION
# Add hsn slug to footerEnabled list

## What

* The hsn slug was missing from the list and that means that the larger island.is footer is below the hsn footer, we want to change that.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
