### PR TITLE
fix(j-s): Remove fixed width on add police case number button

### DIFF
--- a/apps/judicial-system/web/src/components/MultipleValueList/MultipleValueList.css.ts
+++ b/apps/judicial-system/web/src/components/MultipleValueList/MultipleValueList.css.ts
@@ -4,7 +4,7 @@ import { theme } from '@island.is/island-ui/theme'
 
 export const addCourtDocumentContainer = style({
   display: 'grid',
-  gridTemplateColumns: '1fr 240px',
+  gridTemplateColumns: '1fr auto',
   columnGap: theme.spacing[2],
   marginBottom: theme.spacing[3],
 })


### PR DESCRIPTION
# Remove fixed width on add police case number button

[Asana](https://app.asana.com/0/1199153462262248/1203004101582514/f)

## What

The "Add police case number button" had a fixed width. It now has a width: auto and resizes according to the text inside it.

## Why

Cosmetics

## Screenshots / Gifs

<img width="772" alt="Screenshot 2022-09-21 at 15 55 37" src="https://user-images.githubusercontent.com/3789875/191552751-684deac4-c30b-4a23-b201-23b25f88b757.png">

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
