### PR TITLE
fix(ads): Anticipate null names from NREG

### DIFF
--- a/apps/air-discount-scheme/backend/src/app/modules/nationalRegistry/nationalRegistry.service.ts
+++ b/apps/air-discount-scheme/backend/src/app/modules/nationalRegistry/nationalRegistry.service.ts
@@ -236,11 +236,12 @@ export class NationalRegistryService {
     response: IndividualDto,
   ): NationalRegistryUser {
     const address = response.legalDomicile ?? response.residence
+    const nameParts = response.fullName?.split(' ') ?? []
     return {
       nationalId: response.nationalId,
-      firstName: response.givenName ?? '',
-      middleName: response.middleName ?? '',
-      lastName: response.familyName ?? '',
+      firstName: response.givenName ?? nameParts[0] ?? '',
+      middleName: response.middleName ?? nameParts.slice(1, -1).join(' ') ?? '',
+      lastName: response.familyName ?? nameParts.slice(-1).pop() ?? '',
       gender: this.mapGender(response.genderCode),
       address: address?.streetAddress ?? '',
       postalcode: parseInt(address?.postalCode ?? '0'),


### PR DESCRIPTION
Re-introduces code that anticipates null names from the national registry.
Some users only have null values associated with their names except in their fullName field.
This, unfortunately, has to be taken into account.

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
