### PR TITLE
fix(ads): Revert to old name functionality in ADS for now

### DIFF
--- a/apps/air-discount-scheme/backend/src/app/modules/nationalRegistry/nationalRegistry.service.ts
+++ b/apps/air-discount-scheme/backend/src/app/modules/nationalRegistry/nationalRegistry.service.ts
@@ -239,9 +239,9 @@ export class NationalRegistryService {
     const nameParts = response.fullName?.split(' ') ?? []
     return {
       nationalId: response.nationalId,
-      firstName: response.givenName ?? nameParts[0] ?? '',
-      middleName: response.middleName ?? nameParts.slice(1, -1).join(' ') ?? '',
-      lastName: response.familyName ?? nameParts.slice(-1).pop() ?? '',
+      firstName: nameParts[0] ?? '',
+      middleName: nameParts.slice(1, -1).join(' ') ?? '',
+      lastName: nameParts.slice(-1).pop() ?? '',
       gender: this.mapGender(response.genderCode),
       address: address?.streetAddress ?? '',
       postalcode: parseInt(address?.postalCode ?? '0'),


### PR DESCRIPTION
## Why

Need to reconsider how names are introduced but a fix(revert) is needed for now

Right now the cache will be invalid for any user who logs on

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
