### PR TITLE
feat(web): Hotfix - add hsn slug to footer enabled list (#8475)

### DIFF
--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -107,6 +107,8 @@ export const footerEnabled = [
   'directorate-of-fisheries',
 
   'landskjorstjorn',
+
+  'hsn',
 ]
 
 export const getThemeConfig = (


### PR DESCRIPTION
# Hotfix - add hsn slug to footer enabled list

## What

* Hotfix PR, here's the PR that got merged to main: https://github.com/island-is/island.is/pull/8475)

## Why

* We want to have the correct footers on the hsn organization page

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
