### PR TITLE
fix(web): Wrong english project news link

### DIFF
--- a/apps/web/hooks/useLinkResolver/useLinkResolver.ts
+++ b/apps/web/hooks/useLinkResolver/useLinkResolver.ts
@@ -115,7 +115,7 @@ export const routesTemplate = {
   },
   projectnews: {
     is: '/v/[slug]/frett/[subSlug]',
-    en: '/en/o/[slug]/news/[subSlug]',
+    en: '/en/p/[slug]/news/[subSlug]',
   },
   projectnewsoverview: {
     is: '/v/[slug]/frett',


### PR DESCRIPTION
# Wrong english project news link

## What

* There's an accidental 'o' in the english projectnews link that should be a 'p'

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
