### PR TITLE
chore(j-s): default to block access too new states

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/case/filters/case.filters.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/filters/case.filters.spec.ts
@@ -743,7 +743,7 @@ describe('getCasesQueryFilter', () => {
       expect(res).toStrictEqual({
         [Op.and]: [
           { isArchived: false },
-          { [Op.not]: { state: [CaseState.DELETED, CaseState.NEW] } },
+          { [Op.not]: { state: [CaseState.NEW, CaseState.DELETED] } },
           {
             [Op.or]: [
               { court_id: { [Op.is]: null } },
@@ -771,11 +771,11 @@ describe('getCasesQueryFilter', () => {
           {
             [Op.not]: {
               state: [
-                CaseState.DELETED,
                 CaseState.NEW,
                 CaseState.DRAFT,
                 CaseState.SUBMITTED,
                 CaseState.RECEIVED,
+                CaseState.DELETED,
               ],
             },
           },

--- a/apps/judicial-system/backend/src/app/modules/case/filters/case.filters.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/filters/case.filters.ts
@@ -18,31 +18,49 @@ import { Case } from '../models/case.model'
 
 const hideArchived = { isArchived: false }
 
+function getAllowedStates(
+  role: UserRole,
+  institutionType?: InstitutionType,
+): CaseState[] {
+  if (role === UserRole.PROSECUTOR) {
+    return [
+      CaseState.NEW,
+      CaseState.DRAFT,
+      CaseState.SUBMITTED,
+      CaseState.RECEIVED,
+      CaseState.ACCEPTED,
+      CaseState.REJECTED,
+      CaseState.DISMISSED,
+    ]
+  }
+
+  if (institutionType === InstitutionType.COURT) {
+    return [
+      CaseState.DRAFT,
+      CaseState.SUBMITTED,
+      CaseState.RECEIVED,
+      CaseState.ACCEPTED,
+      CaseState.REJECTED,
+      CaseState.DISMISSED,
+    ]
+  }
+
+  if (institutionType === InstitutionType.HIGH_COURT) {
+    return [CaseState.ACCEPTED, CaseState.REJECTED, CaseState.DISMISSED]
+  }
+
+  return [CaseState.ACCEPTED]
+}
+
 function getBlockedStates(
   role: UserRole,
   institutionType?: InstitutionType,
 ): CaseState[] {
-  const blockedStates = [CaseState.DELETED]
+  const allowedStates = getAllowedStates(role, institutionType)
 
-  if (role === UserRole.PROSECUTOR) {
-    return blockedStates
-  }
-
-  blockedStates.push(CaseState.NEW)
-
-  if (institutionType === InstitutionType.COURT) {
-    return blockedStates
-  }
-
-  blockedStates.push(CaseState.DRAFT, CaseState.SUBMITTED, CaseState.RECEIVED)
-
-  if (institutionType === InstitutionType.HIGH_COURT) {
-    return blockedStates
-  }
-
-  blockedStates.push(CaseState.REJECTED, CaseState.DISMISSED)
-
-  return blockedStates
+  return Object.values(CaseState).filter(
+    (state) => !allowedStates.includes(state as CaseState),
+  )
 }
 
 function prosecutorsOfficeMustMatchUserInstitution(role: UserRole): boolean {


### PR DESCRIPTION
[Asana - Snúa við blocking logic í controller guards](https://app.asana.com/0/1199153462262248/1202974314193379/f)
## What

- Default to block access to cases with a given role or institution in a given state 

## Why

- More secure if we add new institution types, user roles and case states


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
