### PR TITLE
feat(web): Add header and footer for Ríkislögmaður's organization page

### DIFF
--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -54,6 +54,8 @@ import { FiskistofaHeader } from './Themes/FiskistofaTheme/FiskistofaHeader'
 import FiskistofaFooter from './Themes/FiskistofaTheme/FiskistofaFooter'
 import { LandskjorstjornFooter } from './Themes/LandkjorstjornTheme/LandkjorstjornFooter'
 import { LatestNewsCardConnectedComponent } from '../LatestNewsCardConnectedComponent'
+import { RikislogmadurHeader } from './Themes/RikislogmadurTheme/RikislogmadurHeader'
+import { RikislogmadurFooter } from './Themes/RikislogmadurTheme/RikislogmadurFooter'
 import * as styles from './OrganizationWrapper.css'
 
 interface NavigationData {
@@ -109,6 +111,9 @@ export const footerEnabled = [
   'landskjorstjorn',
 
   'hsn',
+
+  'rikislogmadur',
+  'office-of-the-attorney-general-civil-affairs',
 ]
 
 export const getThemeConfig = (
@@ -121,7 +126,7 @@ export const getThemeConfig = (
     footerVersion = 'organization'
   }
 
-  if (theme === 'sjukratryggingar')
+  if (theme === 'sjukratryggingar' || theme === 'rikislogmadur')
     return {
       themeConfig: {
         headerButtonColorScheme: 'blueberry',
@@ -162,6 +167,8 @@ const OrganizationHeader: React.FC<HeaderProps> = ({ organizationPage }) => {
       return <LandlaeknirHeader organizationPage={organizationPage} />
     case 'fiskistofa':
       return <FiskistofaHeader organizationPage={organizationPage} />
+    case 'rikislogmadur':
+      return <RikislogmadurHeader organizationPage={organizationPage} />
     default:
       return <DefaultHeader organizationPage={organizationPage} />
   }
@@ -283,6 +290,15 @@ export const OrganizationFooter: React.FC<FooterProps> = ({
         <LandskjorstjornFooter footerItems={organization.footerItems} />
       )
       break
+    case 'rikislogmadur':
+    case 'office-of-the-attorney-general-civil-affairs':
+      OrganizationFooterComponent = (
+        <RikislogmadurFooter
+          title={organization.title}
+          footerItems={organization.footerItems}
+          logo={organization.logo?.url}
+        />
+      )
   }
 
   return OrganizationFooterComponent

--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -299,6 +299,7 @@ export const OrganizationFooter: React.FC<FooterProps> = ({
           logo={organization.logo?.url}
         />
       )
+      break
   }
 
   return OrganizationFooterComponent

--- a/apps/web/components/Organization/Wrapper/Themes/RikislogmadurTheme/RikislogmadurFooter.css.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/RikislogmadurTheme/RikislogmadurFooter.css.ts
@@ -1,0 +1,25 @@
+import { globalStyle, style } from '@vanilla-extract/css'
+import { theme } from '@island.is/island-ui/theme'
+
+export const footerBg = style({
+  background:
+    'linear-gradient(178.67deg, rgba(0, 61, 133, 0.2) 1.87%, rgba(0, 61, 133, 0.3) 99.6%)',
+})
+
+export const logoStyle = style({
+  width: 80,
+})
+
+export const footerItemFirst = style({
+  '@media': {
+    [`screen and (max-width: ${theme.breakpoints.lg}px)`]: {
+      maxWidth: 'none',
+      flexBasis: '100%',
+    },
+  },
+})
+
+globalStyle(`${footerBg} a, ${footerBg} a:hover`, {
+  color: 'white',
+  boxShadow: 'inset 0 -1px 0 0 white',
+})

--- a/apps/web/components/Organization/Wrapper/Themes/RikislogmadurTheme/RikislogmadurFooter.css.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/RikislogmadurTheme/RikislogmadurFooter.css.ts
@@ -1,4 +1,4 @@
-import { globalStyle, style } from '@vanilla-extract/css'
+import { style } from '@vanilla-extract/css'
 import { theme } from '@island.is/island-ui/theme'
 
 export const footerBg = style({
@@ -17,9 +17,4 @@ export const footerItemFirst = style({
       flexBasis: '100%',
     },
   },
-})
-
-globalStyle(`${footerBg} a, ${footerBg} a:hover`, {
-  color: 'white',
-  boxShadow: 'inset 0 -1px 0 0 white',
 })

--- a/apps/web/components/Organization/Wrapper/Themes/RikislogmadurTheme/RikislogmadurFooter.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/RikislogmadurTheme/RikislogmadurFooter.tsx
@@ -1,0 +1,87 @@
+import { FooterItem } from '@island.is/web/graphql/schema'
+import {
+  Box,
+  GridColumn,
+  GridContainer,
+  GridRow,
+  Link,
+  Text,
+} from '@island.is/island-ui/core'
+import { richText, SliceType } from '@island.is/island-ui/contentful'
+import { BLOCKS } from '@contentful/rich-text-types'
+import * as styles from './RikislogmadurFooter.css'
+
+interface FooterProps {
+  title: string
+  logo?: string
+  footerItems: Array<FooterItem>
+}
+
+export const RikislogmadurFooter = ({
+  title,
+  logo,
+  footerItems,
+}: FooterProps) => {
+  return (
+    <footer aria-labelledby="organizationFooterTitle">
+      <Box className={styles.footerBg} paddingTop={5}>
+        <GridContainer>
+          <Box paddingTop={[2, 2, 0]} paddingBottom={[0, 0, 4]}>
+            <Box
+              display="flex"
+              flexDirection="row"
+              alignItems="center"
+              paddingBottom={5}
+              marginBottom={5}
+              borderColor="blueberry600"
+              borderBottomWidth="standard"
+            >
+              {!!logo && (
+                <Box marginRight={4}>
+                  <img src={logo} alt="" className={styles.logoStyle} />
+                </Box>
+              )}
+              <div id="organizationFooterTitle">
+                <Text variant="h2" color="blueberry600">
+                  {title}
+                </Text>
+              </div>
+            </Box>
+            <GridRow>
+              {footerItems.map((item, index) => (
+                <GridColumn key={index} span={['12/12', '12/12', '4/12']}>
+                  <Box marginBottom={5}>
+                    <Box marginBottom={2}>
+                      {item.link ? (
+                        <Link
+                          href={item.link.url}
+                          underline="small"
+                          underlineVisibility="always"
+                        >
+                          {item.title}
+                        </Link>
+                      ) : (
+                        <Text color="blueberry600" fontWeight="semiBold">
+                          {item.title}
+                        </Text>
+                      )}
+                    </Box>
+                    {richText(item.content as SliceType[], {
+                      renderNode: {
+                        [BLOCKS.PARAGRAPH]: (_node, children) => (
+                          <Text color="blueberry600" paddingBottom={2}>
+                            {children}
+                          </Text>
+                        ),
+                      },
+                    })}
+                  </Box>
+                </GridColumn>
+              ))}
+            </GridRow>
+          </Box>
+        </GridContainer>
+      </Box>
+    </footer>
+  )
+}

--- a/apps/web/components/Organization/Wrapper/Themes/RikislogmadurTheme/RikislogmadurHeader.css.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/RikislogmadurTheme/RikislogmadurHeader.css.ts
@@ -1,0 +1,72 @@
+import { style } from '@vanilla-extract/css'
+import { themeUtils } from '@island.is/island-ui/theme'
+
+export const headerBg = style({
+  height: 385,
+  marginTop: -130,
+  paddingTop: 130,
+  backgroundBlendMode: 'saturation',
+  background: `
+        linear-gradient(178.67deg, rgba(0, 61, 133, 0.2) 1.87%, rgba(0, 61, 133, 0.3) 99.6%),
+        url('https://images.ctfassets.net/8k0h54kbe6bj/c2BVu7RrN6C7tH3gvdkI0/578a34b27b455c6030c6d1cef2113fea/rikislogmadur-haus.png')`,
+  backgroundRepeat: 'no-repeat !important',
+  backgroundPositionX: '0%',
+  backgroundSize: '100% 100% 100%',
+})
+
+export const iconCircle = style({
+  height: 136,
+  width: 136,
+  background: '#fff',
+  borderRadius: '50%',
+  margin: '0 auto',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  boxShadow: '0px 4px 30px rgba(0, 97, 255, 0.08)',
+  ...themeUtils.responsiveStyle({
+    xs: {
+      marginTop: 32,
+    },
+    md: {
+      marginTop: 104,
+      position: 'relative',
+    },
+  }),
+})
+
+export const headerBorder = style({
+  ...themeUtils.responsiveStyle({
+    xs: {
+      marginTop: 32,
+    },
+    md: {
+      borderBottom: '4px solid #ffbe43',
+    },
+  }),
+})
+
+export const headerWrapper = style({
+  marginTop: -20,
+})
+
+export const headerLogo = style({
+  width: 70,
+  maxHeight: 70,
+})
+
+export const navigation = style({
+  ...themeUtils.responsiveStyle({
+    md: {
+      background: 'none',
+      paddingTop: 0,
+    },
+    xs: {
+      marginLeft: -24,
+      marginRight: -24,
+      paddingLeft: 24,
+      paddingRight: 24,
+      paddingTop: 32,
+    },
+  }),
+})

--- a/apps/web/components/Organization/Wrapper/Themes/RikislogmadurTheme/RikislogmadurHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/RikislogmadurTheme/RikislogmadurHeader.tsx
@@ -1,0 +1,66 @@
+import { Box, Hidden, Link, Text } from '@island.is/island-ui/core'
+import { OrganizationPage } from '@island.is/web/graphql/schema'
+import { useLinkResolver } from '@island.is/web/hooks'
+import SidebarLayout from '@island.is/web/screens/Layouts/SidebarLayout'
+
+import * as styles from './RikislogmadurHeader.css'
+
+interface HeaderProps {
+  organizationPage: OrganizationPage
+}
+
+export const RikislogmadurHeader = ({ organizationPage }: HeaderProps) => {
+  const { linkResolver } = useLinkResolver()
+  return (
+    <Box className={styles.headerBg}>
+      <Box className={styles.headerWrapper}>
+        <SidebarLayout
+          sidebarContent={
+            !!organizationPage.organization.logo && (
+              <Link
+                href={
+                  linkResolver('organizationpage', [organizationPage.slug]).href
+                }
+                className={styles.iconCircle}
+              >
+                <img
+                  src={organizationPage.organization.logo.url}
+                  className={styles.headerLogo}
+                  alt=""
+                />
+              </Link>
+            )
+          }
+        >
+          {!!organizationPage.organization.logo && (
+            <Hidden above="sm">
+              <Link
+                href={
+                  linkResolver('organizationpage', [organizationPage.slug]).href
+                }
+                className={styles.iconCircle}
+              >
+                <img
+                  src={organizationPage.organization.logo.url}
+                  className={styles.headerLogo}
+                  alt=""
+                />
+              </Link>
+            </Hidden>
+          )}
+          <Box marginTop={[2, 2, 6]} textAlign={['center', 'center', 'right']}>
+            <Link
+              href={
+                linkResolver('organizationpage', [organizationPage.slug]).href
+              }
+            >
+              <Text variant="h1" as="h1" color="blueberry600">
+                {organizationPage.title}
+              </Text>
+            </Link>
+          </Box>
+        </SidebarLayout>
+      </Box>
+    </Box>
+  )
+}


### PR DESCRIPTION
# Add header and footer for Ríkislögmaður's organization page

## What

* Added a header and footer component for the Ríkislögmaður organization page
* (I noticed that all organization headers and footers aren't dynamically imported which I believe is increasing the bundle size for no reason, I'll have to address that in another PR (if you were wondering))

## Screenshots / Gifs

<img width="1115" alt="image" src="https://user-images.githubusercontent.com/43557895/192575557-430ae0c7-ee91-4036-b27b-07b9016d5053.png">

![image](https://user-images.githubusercontent.com/43557895/192577571-bea0fdb3-0865-4665-8024-a40a11cd045b.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
