### PR TITLE
chore(web): Add stefna as codeowner of libs/cms

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,7 +27,7 @@
 /apps/services/endorsements/                                                                        @island-is/juni
 /apps/icelandic-names-registry*/                                                                    @island-is/juni
 /apps/web/screens/PetitionView/                                                                     @island-is/juni
-/libs/cms/                                                                                          @island-is/juni
+/libs/cms/                                                                                          @island-is/juni @island-is/stefna
 /libs/api/domains/endorsement-system                                                                @island-is/juni
 /libs/api/domains/icelandic-names-registry/                                                         @island-is/juni
 /libs/clients/payment/                                                                              @island-is/juni


### PR DESCRIPTION
# Add stefna as codeowner of libs/cms

## Why

* Stefna is very frequently working on content models and contentful related things so it's about time we are codeowners :)
