### PR TITLE
feat(web): Hotfix - life event tag removed for digital iceland service in search results

### DIFF
--- a/apps/web/screens/Search/Search.tsx
+++ b/apps/web/screens/Search/Search.tsx
@@ -197,9 +197,12 @@ const Search: Screen<CategoryProps> = ({
     const labels = []
 
     switch (item.__typename) {
-      case 'LifeEventPage':
-        labels.push(n('lifeEvent'))
+      case 'LifeEventPage': {
+        if (item.pageType !== 'Digital Iceland Service') {
+          labels.push(n('lifeEvent'))
+        }
         break
+      }
       case 'News':
         labels.push(n('newsTitle'))
         break
@@ -292,6 +295,16 @@ const Search: Screen<CategoryProps> = ({
     return false
   }
 
+  const getItemLink = (item: SearchType) => {
+    if (
+      item.__typename === 'LifeEventPage' &&
+      item.pageType === 'Digital Iceland Service'
+    ) {
+      return linkResolver('digitalicelandservicesdetailpage', [item.slug])
+    }
+    return linkResolver(item.__typename, item?.url ?? item.slug.split('/'))
+  }
+
   const searchResultsItems = (searchResults.items as Array<SearchType>).map(
     (item) => ({
       typename: item.__typename,
@@ -299,7 +312,7 @@ const Search: Screen<CategoryProps> = ({
       parentTitle: item.parent?.title,
       description:
         item.intro ?? item.description ?? item.parent?.intro ?? item.subtitle,
-      link: linkResolver(item.__typename, item?.url ?? item.slug.split('/')),
+      link: getItemLink(item),
       categorySlug: item.category?.slug ?? item.parent?.category?.slug,
       category: item.category ?? item.parent?.category,
       hasProcessEntry: checkForProcessEntries(item),
@@ -676,6 +689,7 @@ Search.getInitialProps = async ({ apolloClient, locale, query }) => {
   const allTypes = [
     'webArticle' as SearchableContentTypes,
     'webLifeEventPage' as SearchableContentTypes,
+    'webDigitalIcelandService' as SearchableContentTypes,
     'webAdgerdirPage' as SearchableContentTypes,
     'webSubArticle' as SearchableContentTypes,
     'webLink' as SearchableContentTypes,

--- a/apps/web/screens/queries/Search.tsx
+++ b/apps/web/screens/queries/Search.tsx
@@ -233,6 +233,7 @@ export const GET_SEARCH_RESULTS_QUERY_DETAILED = gql`
             width
             height
           }
+          pageType
         }
 
         ... on News {

--- a/libs/api/domains/content-search/src/lib/enums/searchableContentTypes.ts
+++ b/libs/api/domains/content-search/src/lib/enums/searchableContentTypes.ts
@@ -4,6 +4,7 @@ export enum SearchableContentTypes {
   webArticle = 'webArticle',
   webSubArticle = 'webSubArticle',
   webLifeEventPage = 'webLifeEventPage',
+  webDigitalIcelandService = 'webDigitalIcelandService',
   webNews = 'webNews',
   webAdgerdirPage = 'webAdgerdirPage',
   webOrganizationSubpage = 'webOrganizationSubpage',

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -1304,6 +1304,9 @@ export interface ILifeEventPageFields {
 
   /** see more text */
   seeMoreText?: string | undefined
+
+  /** Page Type */
+  pageType?: 'Life Event' | 'Digital Iceland Service' | undefined
 }
 
 export interface ILifeEventPage extends Entry<ILifeEventPageFields> {

--- a/libs/cms/src/lib/models/lifeEventPage.model.ts
+++ b/libs/cms/src/lib/models/lifeEventPage.model.ts
@@ -41,6 +41,9 @@ export class LifeEventPage {
 
   @Field({ nullable: true })
   seeMoreText?: string
+
+  @Field({ nullable: true })
+  pageType?: 'Life Event' | 'Digital Iceland Service'
 }
 
 export const mapLifeEventPage = ({
@@ -61,4 +64,5 @@ export const mapLifeEventPage = ({
   category: fields.category ? mapArticleCategory(fields.category) : null,
   shortIntro: fields.shortIntro ?? '',
   seeMoreText: fields.seeMoreText ?? '',
+  pageType: fields.pageType ?? 'Life Event',
 })

--- a/libs/cms/src/lib/search/importers/lifeEventsPage.service.ts
+++ b/libs/cms/src/lib/search/importers/lifeEventsPage.service.ts
@@ -35,7 +35,11 @@ export class LifeEventsPageSyncService
             title: mapped.title,
             content,
             contentWordCount: content.split(/\s+/).length,
-            type: 'webLifeEventPage',
+            type:
+              // We are reusing the life event page look for Digital Iceland Services so we want to distinguish them in the search by having two different types here
+              entry.fields?.pageType === 'Digital Iceland Service'
+                ? 'webDigitalIcelandService'
+                : 'webLifeEventPage',
             termPool: createTerms([mapped.title]),
             response: JSON.stringify({ ...mapped, typename: 'LifeEventPage' }),
             tags: [],


### PR DESCRIPTION
# Hotfix - life event tag removed for digital iceland service in search results
original PR can be seen here: https://github.com/island-is/island.is/pull/8524