### PR TITLE
feat(web): Change what footer gets rendered depending on theme on Project pages

### DIFF
--- a/apps/web/screens/Project/utils.tsx
+++ b/apps/web/screens/Project/utils.tsx
@@ -7,21 +7,36 @@ import { Navigation, NavigationItem } from '@island.is/island-ui/core'
 import { LayoutProps } from '@island.is/web/layouts/main'
 import Link from 'next/link'
 
-const lightThemes = ['traveling-to-iceland', 'election', 'ukraine', 'default']
+const footerEnabled = ['opinbernyskopun']
+
+const lightThemes = [
+  'traveling-to-iceland',
+  'election',
+  'ukraine',
+  'default',
+  'opinbernyskopun',
+]
 
 export const getThemeConfig = (
   theme: string,
 ): { themeConfig: Partial<LayoutProps> } => {
+  let footerVersion: LayoutProps['footerVersion'] = 'default'
+
+  if (footerEnabled.includes(theme)) {
+    footerVersion = 'organization'
+  }
+
   const isLightTheme = lightThemes.includes(theme)
   if (!isLightTheme) {
     return {
       themeConfig: {
         headerButtonColorScheme: 'negative',
         headerColorScheme: 'white',
+        footerVersion,
       },
     }
   }
-  return { themeConfig: {} }
+  return { themeConfig: { footerVersion } }
 }
 
 export const convertLinksToNavigationItem = (links: LinkSchema[]) =>


### PR DESCRIPTION
# Change what footer gets rendered depending on theme on Project pages

## What

* We want to render the smaller version of the island.is footer if there already is a project page footer present

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
