### PR TITLE
chore(codeowners): remove vice versa as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,8 +21,8 @@
 /.github/                                                                                           @island-is/core
 /handbook/                                                                                          @island-is/core
 /libs/api/domains/identity/                                                                         @island-is/core
-/libs/testing/                                                                                      @island-is/core @island-is/vice-versa
-/libs/nest/swagger/                                                                                 @island-is/core @island-is/vice-versa
+/libs/testing/                                                                                      @island-is/core
+/libs/nest/swagger/                                                                                 @island-is/core
 
 /apps/services/endorsements/                                                                        @island-is/juni
 /apps/icelandic-names-registry*/                                                                    @island-is/juni


### PR DESCRIPTION
# Remove Vice Versa as codeowners

![michael-goodbye](https://user-images.githubusercontent.com/5694851/193257383-d2dc3600-d5e9-4425-83ef-7f9fc9039bca.gif)
