### PR TITLE
feat(web): Remove digital iceland service images in search results

### DIFF
--- a/apps/web/screens/Search/Search.tsx
+++ b/apps/web/screens/Search/Search.tsx
@@ -118,6 +118,11 @@ const connectedTypes: Partial<
 const stringToArray = (value: string | string[]) =>
   Array.isArray(value) ? value : value?.length ? [value] : []
 
+enum AnchorPageType {
+  LIFE_EVENT = 'Life Event',
+  DIGITAL_ICELAND_SERVICE = 'Digital Iceland Service',
+}
+
 const Search: Screen<CategoryProps> = ({
   q,
   page,
@@ -198,7 +203,7 @@ const Search: Screen<CategoryProps> = ({
 
     switch (item.__typename) {
       case 'LifeEventPage': {
-        if (item.pageType !== 'Digital Iceland Service') {
+        if (item.pageType !== AnchorPageType.DIGITAL_ICELAND_SERVICE) {
           labels.push(n('lifeEvent'))
         }
         break
@@ -298,11 +303,27 @@ const Search: Screen<CategoryProps> = ({
   const getItemLink = (item: SearchType) => {
     if (
       item.__typename === 'LifeEventPage' &&
-      item.pageType === 'Digital Iceland Service'
+      item.pageType === AnchorPageType.DIGITAL_ICELAND_SERVICE
     ) {
       return linkResolver('digitalicelandservicesdetailpage', [item.slug])
     }
     return linkResolver(item.__typename, item?.url ?? item.slug.split('/'))
+  }
+
+  const getItemImages = (item: SearchType) => {
+    if (
+      item.__typename === 'LifeEventPage' &&
+      item.pageType === AnchorPageType.DIGITAL_ICELAND_SERVICE
+    ) {
+      return {
+        image: undefined,
+        thumbnail: undefined,
+      }
+    }
+    return {
+      ...(item.image && { image: item.image as Image }),
+      ...(item.thumbnail && { thumbnail: item.thumbnail as Image }),
+    }
   }
 
   const searchResultsItems = (searchResults.items as Array<SearchType>).map(
@@ -317,8 +338,7 @@ const Search: Screen<CategoryProps> = ({
       category: item.category ?? item.parent?.category,
       hasProcessEntry: checkForProcessEntries(item),
       group: item.group,
-      ...(item.image && { image: item.image as Image }),
-      ...(item.thumbnail && { thumbnail: item.thumbnail as Image }),
+      ...getItemImages(item),
       labels: getLabels(item),
     }),
   )


### PR DESCRIPTION
# Remove digital iceland service images in search results

## What

* Added an enum instead of "hardcoding" the pageType string check
* Removed images for Digital Iceland Service Anchor page type in search results

## Why

* This was requested by Digital Iceland

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
