### PR TITLE
feat(web): Organization subpage - nested one column text fields

### DIFF
--- a/apps/web/components/Organization/Slice/AccordionSlice/AccordionSlice.tsx
+++ b/apps/web/components/Organization/Slice/AccordionSlice/AccordionSlice.tsx
@@ -41,7 +41,13 @@ export const AccordionSlice: React.FC<SliceProps> = ({ slice }) => {
                 startExpanded={slice.accordionItems.length === 1}
               >
                 <Box className={styles.accordionBox}>
-                  {richText(item.content as SliceType[])}
+                  {richText(item.content as SliceType[], {
+                    renderComponent: {
+                      AccordionSlice: (slice) => (
+                        <AccordionSlice slice={slice} />
+                      ),
+                    },
+                  })}
                 </Box>
               </AccordionCard>
             </Box>
@@ -56,7 +62,15 @@ export const AccordionSlice: React.FC<SliceProps> = ({ slice }) => {
                   label={item.title}
                   startExpanded={slice.accordionItems.length === 1}
                 >
-                  <Text>{richText(item.content as SliceType[])}</Text>
+                  <Text>
+                    {richText(item.content as SliceType[], {
+                      renderComponent: {
+                        AccordionSlice: (slice) => (
+                          <AccordionSlice slice={slice} />
+                        ),
+                      },
+                    })}
+                  </Text>
                 </AccordionItem>
               ))}
             </Accordion>

--- a/apps/web/screens/Organization/SubPage.tsx
+++ b/apps/web/screens/Organization/SubPage.tsx
@@ -35,6 +35,7 @@ import {
   SliceDropdown,
   Form,
   OneColumnTextSlice,
+  AccordionSlice,
 } from '@island.is/web/components'
 import { CustomNextError } from '@island.is/web/units/errors'
 import useContentfulId from '@island.is/web/hooks/useContentfulId'
@@ -177,6 +178,9 @@ const SubPage: Screen<SubPageProps> = ({
                         ),
                         OneColumnText: (slice) => (
                           <OneColumnTextSlice slice={slice} />
+                        ),
+                        AccordionSlice: (slice) => (
+                          <AccordionSlice slice={slice} />
                         ),
                       },
                     })}

--- a/apps/web/screens/Project/Project.tsx
+++ b/apps/web/screens/Project/Project.tsx
@@ -19,6 +19,7 @@ import {
   Stepper,
   stepperUtils,
   Form,
+  AccordionSlice,
 } from '@island.is/web/components'
 import {
   Box,
@@ -136,6 +137,7 @@ const ProjectPage: Screen<PageProps> = ({
               richText(subpage.content as SliceType[], {
                 renderComponent: {
                   Form: (slice) => <Form form={slice} namespace={namespace} />,
+                  AccordionSlice: (slice) => <AccordionSlice slice={slice} />,
                 },
               })}
           </Box>

--- a/apps/web/screens/queries/Organization.tsx
+++ b/apps/web/screens/queries/Organization.tsx
@@ -1,5 +1,5 @@
 import gql from 'graphql-tag'
-import { slices } from './fragments'
+import { nestedOneColumnTextFields, slices } from './fragments'
 
 export const GET_ORGANIZATIONS_QUERY = gql`
   query GetOrganizations($input: GetOrganizationsInput!) {
@@ -170,6 +170,7 @@ export const GET_ORGANIZATION_SUBPAGE_QUERY = gql`
       slug
       description {
         ...AllSlices
+        ...NestedOneColumnTextFields
       }
       links {
         text
@@ -177,6 +178,7 @@ export const GET_ORGANIZATION_SUBPAGE_QUERY = gql`
       }
       slices {
         ...AllSlices
+        ...NestedOneColumnTextFields
       }
       showTableOfContents
       sliceCustomRenderer
@@ -190,6 +192,7 @@ export const GET_ORGANIZATION_SUBPAGE_QUERY = gql`
     }
   }
   ${slices}
+  ${nestedOneColumnTextFields}
 `
 
 export const GET_ORGANIZATION_SERVICES_QUERY = gql`


### PR DESCRIPTION
# Organization subpage - nested one column text fields

## What

* Add support for embedding slices inside of one column text on organization subpages

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
