### PR TITLE
feat(search-indexer): Add env variable for chunk size of contentful fetch

### DIFF
--- a/apps/services/search-indexer/infra/search-indexer-service.ts
+++ b/apps/services/search-indexer/infra/search-indexer-service.ts
@@ -23,6 +23,11 @@ const envs = {
     staging: '40',
     prod: '40',
   },
+  LOG_LEVEL: {
+    dev: 'debug',
+    staging: 'debug',
+    prod: 'debug',
+  },
 }
 export const serviceSetup = (): ServiceBuilder<'search-indexer-service'> =>
   service('search-indexer-service')

--- a/apps/services/search-indexer/infra/search-indexer-service.ts
+++ b/apps/services/search-indexer/infra/search-indexer-service.ts
@@ -18,6 +18,11 @@ const envs = {
     staging: 'cdn.contentful.com',
     prod: 'cdn.contentful.com',
   },
+  CONTENTFUL_ENTRY_FETCH_CHUNK_SIZE: {
+    dev: '40',
+    staging: '40',
+    prod: '40',
+  },
 }
 export const serviceSetup = (): ServiceBuilder<'search-indexer-service'> =>
   service('search-indexer-service')

--- a/apps/services/search-indexer/infra/search-indexer-service.ts
+++ b/apps/services/search-indexer/infra/search-indexer-service.ts
@@ -43,11 +43,11 @@ export const serviceSetup = (): ServiceBuilder<'search-indexer-service'> =>
           resources: {
             requests: {
               cpu: '100m',
-              memory: '256Mi',
+              memory: '512Mi',
             },
             limits: {
               cpu: '400m',
-              memory: '1024Mi',
+              memory: '2048Mi',
             },
           },
         },
@@ -58,11 +58,11 @@ export const serviceSetup = (): ServiceBuilder<'search-indexer-service'> =>
           resources: {
             requests: {
               cpu: '100m',
-              memory: '256Mi',
+              memory: '512Mi',
             },
             limits: {
               cpu: '400m',
-              memory: '1024Mi',
+              memory: '2048Mi',
             },
           },
         },
@@ -73,11 +73,11 @@ export const serviceSetup = (): ServiceBuilder<'search-indexer-service'> =>
           resources: {
             requests: {
               cpu: '100m',
-              memory: '256Mi',
+              memory: '512Mi',
             },
             limits: {
               cpu: '400m',
-              memory: '1024Mi',
+              memory: '2048Mi',
             },
           },
         },
@@ -97,11 +97,11 @@ export const serviceSetup = (): ServiceBuilder<'search-indexer-service'> =>
     .resources({
       requests: {
         cpu: '100m',
-        memory: '256Mi',
+        memory: '512Mi',
       },
       limits: {
         cpu: '400m',
-        memory: '1024Mi',
+        memory: '2048Mi',
       },
     })
     .ingress({

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -1317,7 +1317,8 @@ search-indexer-service:
     CONTENTFUL_SPACE: '8k0h54kbe6bj'
     ELASTIC_INDEX: 'island-is'
     ELASTIC_NODE: 'https://vpc-search-njkekqydiegezhr4vqpkfnw5la.eu-west-1.es.amazonaws.com'
-    NODE_OPTIONS: '--max-old-space-size=976'
+    LOG_LEVEL: 'debug'
+    NODE_OPTIONS: '--max-old-space-size=2000'
     SERVERSIDE_FEATURES_ON: ''
   grantNamespaces: []
   grantNamespacesEnabled: false
@@ -1359,10 +1360,10 @@ search-indexer-service:
         resources:
           limits:
             cpu: '400m'
-            memory: '1024Mi'
+            memory: '2048Mi'
           requests:
             cpu: '100m'
-            memory: '256Mi'
+            memory: '512Mi'
       - args:
           - '/webapp/migrateElastic.js'
         command:
@@ -1371,10 +1372,10 @@ search-indexer-service:
         resources:
           limits:
             cpu: '400m'
-            memory: '1024Mi'
+            memory: '2048Mi'
           requests:
             cpu: '100m'
-            memory: '256Mi'
+            memory: '512Mi'
       - args:
           - '/webapp/migrateKibana.js'
         command:
@@ -1383,10 +1384,10 @@ search-indexer-service:
         resources:
           limits:
             cpu: '400m'
-            memory: '1024Mi'
+            memory: '2048Mi'
           requests:
             cpu: '100m'
-            memory: '256Mi'
+            memory: '512Mi'
     env:
       APPLICATION_URL: 'http://search-indexer-service'
       CONTENTFUL_ENTRY_FETCH_CHUNK_SIZE: '40'
@@ -1396,6 +1397,7 @@ search-indexer-service:
       ELASTIC_DOMAIN: 'search'
       ELASTIC_INDEX: 'island-is'
       ELASTIC_NODE: 'https://vpc-search-njkekqydiegezhr4vqpkfnw5la.eu-west-1.es.amazonaws.com'
+      LOG_LEVEL: 'debug'
       S3_BUCKET: 'dev-es-custom-packages'
       SERVERSIDE_FEATURES_ON: ''
     secrets:
@@ -1410,10 +1412,10 @@ search-indexer-service:
   resources:
     limits:
       cpu: '400m'
-      memory: '1024Mi'
+      memory: '2048Mi'
     requests:
       cpu: '100m'
-      memory: '256Mi'
+      memory: '512Mi'
   secrets:
     API_CMS_SYNC_TOKEN: '/k8s/search-indexer/API_CMS_SYNC_TOKEN'
     CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -1311,6 +1311,7 @@ search-indexer-service:
   enabled: true
   env:
     APPLICATION_URL: 'http://search-indexer-service'
+    CONTENTFUL_ENTRY_FETCH_CHUNK_SIZE: '40'
     CONTENTFUL_ENVIRONMENT: 'master'
     CONTENTFUL_HOST: 'preview.contentful.com'
     CONTENTFUL_SPACE: '8k0h54kbe6bj'
@@ -1388,6 +1389,7 @@ search-indexer-service:
             memory: '256Mi'
     env:
       APPLICATION_URL: 'http://search-indexer-service'
+      CONTENTFUL_ENTRY_FETCH_CHUNK_SIZE: '40'
       CONTENTFUL_ENVIRONMENT: 'master'
       CONTENTFUL_HOST: 'preview.contentful.com'
       CONTENTFUL_SPACE: '8k0h54kbe6bj'

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -1119,6 +1119,7 @@ search-indexer-service:
   enabled: true
   env:
     APPLICATION_URL: 'http://search-indexer-service'
+    CONTENTFUL_ENTRY_FETCH_CHUNK_SIZE: '40'
     CONTENTFUL_ENVIRONMENT: 'master'
     CONTENTFUL_HOST: 'cdn.contentful.com'
     CONTENTFUL_SPACE: '8k0h54kbe6bj'
@@ -1196,6 +1197,7 @@ search-indexer-service:
             memory: '256Mi'
     env:
       APPLICATION_URL: 'http://search-indexer-service'
+      CONTENTFUL_ENTRY_FETCH_CHUNK_SIZE: '40'
       CONTENTFUL_ENVIRONMENT: 'master'
       CONTENTFUL_HOST: 'cdn.contentful.com'
       CONTENTFUL_SPACE: '8k0h54kbe6bj'

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -1125,7 +1125,8 @@ search-indexer-service:
     CONTENTFUL_SPACE: '8k0h54kbe6bj'
     ELASTIC_INDEX: 'island-is'
     ELASTIC_NODE: 'https://vpc-search-mw4w5c2m2g5edjrtvwbpzhkw24.eu-west-1.es.amazonaws.com'
-    NODE_OPTIONS: '--max-old-space-size=976'
+    LOG_LEVEL: 'debug'
+    NODE_OPTIONS: '--max-old-space-size=2000'
     SERVERSIDE_FEATURES_ON: 'driving-license-use-v1-endpoint-for-v2-comms'
   grantNamespaces: []
   grantNamespacesEnabled: false
@@ -1167,10 +1168,10 @@ search-indexer-service:
         resources:
           limits:
             cpu: '400m'
-            memory: '1024Mi'
+            memory: '2048Mi'
           requests:
             cpu: '100m'
-            memory: '256Mi'
+            memory: '512Mi'
       - args:
           - '/webapp/migrateElastic.js'
         command:
@@ -1179,10 +1180,10 @@ search-indexer-service:
         resources:
           limits:
             cpu: '400m'
-            memory: '1024Mi'
+            memory: '2048Mi'
           requests:
             cpu: '100m'
-            memory: '256Mi'
+            memory: '512Mi'
       - args:
           - '/webapp/migrateKibana.js'
         command:
@@ -1191,10 +1192,10 @@ search-indexer-service:
         resources:
           limits:
             cpu: '400m'
-            memory: '1024Mi'
+            memory: '2048Mi'
           requests:
             cpu: '100m'
-            memory: '256Mi'
+            memory: '512Mi'
     env:
       APPLICATION_URL: 'http://search-indexer-service'
       CONTENTFUL_ENTRY_FETCH_CHUNK_SIZE: '40'
@@ -1204,6 +1205,7 @@ search-indexer-service:
       ELASTIC_DOMAIN: 'search'
       ELASTIC_INDEX: 'island-is'
       ELASTIC_NODE: 'https://vpc-search-mw4w5c2m2g5edjrtvwbpzhkw24.eu-west-1.es.amazonaws.com'
+      LOG_LEVEL: 'debug'
       S3_BUCKET: 'prod-es-custom-packages'
       SERVERSIDE_FEATURES_ON: 'driving-license-use-v1-endpoint-for-v2-comms'
     secrets:
@@ -1218,10 +1220,10 @@ search-indexer-service:
   resources:
     limits:
       cpu: '400m'
-      memory: '1024Mi'
+      memory: '2048Mi'
     requests:
       cpu: '100m'
-      memory: '256Mi'
+      memory: '512Mi'
   secrets:
     API_CMS_SYNC_TOKEN: '/k8s/search-indexer/API_CMS_SYNC_TOKEN'
     CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -1132,7 +1132,8 @@ search-indexer-service:
     CONTENTFUL_SPACE: '8k0h54kbe6bj'
     ELASTIC_INDEX: 'island-is'
     ELASTIC_NODE: 'https://vpc-search-q6hdtjcdlhkffyxvrnmzfwphuq.eu-west-1.es.amazonaws.com'
-    NODE_OPTIONS: '--max-old-space-size=976'
+    LOG_LEVEL: 'debug'
+    NODE_OPTIONS: '--max-old-space-size=2000'
     SERVERSIDE_FEATURES_ON: ''
   grantNamespaces: []
   grantNamespacesEnabled: false
@@ -1174,10 +1175,10 @@ search-indexer-service:
         resources:
           limits:
             cpu: '400m'
-            memory: '1024Mi'
+            memory: '2048Mi'
           requests:
             cpu: '100m'
-            memory: '256Mi'
+            memory: '512Mi'
       - args:
           - '/webapp/migrateElastic.js'
         command:
@@ -1186,10 +1187,10 @@ search-indexer-service:
         resources:
           limits:
             cpu: '400m'
-            memory: '1024Mi'
+            memory: '2048Mi'
           requests:
             cpu: '100m'
-            memory: '256Mi'
+            memory: '512Mi'
       - args:
           - '/webapp/migrateKibana.js'
         command:
@@ -1198,10 +1199,10 @@ search-indexer-service:
         resources:
           limits:
             cpu: '400m'
-            memory: '1024Mi'
+            memory: '2048Mi'
           requests:
             cpu: '100m'
-            memory: '256Mi'
+            memory: '512Mi'
     env:
       APPLICATION_URL: 'http://search-indexer-service'
       CONTENTFUL_ENTRY_FETCH_CHUNK_SIZE: '40'
@@ -1211,6 +1212,7 @@ search-indexer-service:
       ELASTIC_DOMAIN: 'search'
       ELASTIC_INDEX: 'island-is'
       ELASTIC_NODE: 'https://vpc-search-q6hdtjcdlhkffyxvrnmzfwphuq.eu-west-1.es.amazonaws.com'
+      LOG_LEVEL: 'debug'
       S3_BUCKET: 'staging-es-custom-packages'
       SERVERSIDE_FEATURES_ON: ''
     secrets:
@@ -1225,10 +1227,10 @@ search-indexer-service:
   resources:
     limits:
       cpu: '400m'
-      memory: '1024Mi'
+      memory: '2048Mi'
     requests:
       cpu: '100m'
-      memory: '256Mi'
+      memory: '512Mi'
   secrets:
     API_CMS_SYNC_TOKEN: '/k8s/search-indexer/API_CMS_SYNC_TOKEN'
     CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -1126,6 +1126,7 @@ search-indexer-service:
   enabled: true
   env:
     APPLICATION_URL: 'http://search-indexer-service'
+    CONTENTFUL_ENTRY_FETCH_CHUNK_SIZE: '40'
     CONTENTFUL_ENVIRONMENT: 'master'
     CONTENTFUL_HOST: 'cdn.contentful.com'
     CONTENTFUL_SPACE: '8k0h54kbe6bj'
@@ -1203,6 +1204,7 @@ search-indexer-service:
             memory: '256Mi'
     env:
       APPLICATION_URL: 'http://search-indexer-service'
+      CONTENTFUL_ENTRY_FETCH_CHUNK_SIZE: '40'
       CONTENTFUL_ENVIRONMENT: 'master'
       CONTENTFUL_HOST: 'cdn.contentful.com'
       CONTENTFUL_SPACE: '8k0h54kbe6bj'

--- a/libs/cms/src/lib/search/contentful.service.ts
+++ b/libs/cms/src/lib/search/contentful.service.ts
@@ -156,7 +156,9 @@ export class ContentfulService {
     locale: ElasticsearchIndexLocale,
   ): Promise<Entry<any>[]> {
     // contentful has a limit of 1000 entries per request but we get "414 Request URI Too Large" so we do a 500 per request
-    const chunkSize = 60
+    const chunkSize = Number(
+      process.env.CONTENTFUL_ENTRY_FETCH_CHUNK_SIZE ?? 40,
+    )
     const chunkedChanges = []
     let chunkToProcess = entries.splice(-chunkSize, chunkSize)
     do {


### PR DESCRIPTION
# Add env variable for chunk size of contentful fetch

## What

* The search-indexer is calling Contentful but getting back a "Response too big" response
* Changing the chunk size of the fetch locally helped with indexing so having an env variable to change in the deployed environment might not be such a bad idea

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
