### PR TITLE
chore(web): Change codeowners due to hotfixes before next release

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,7 @@
 # that are developed by others teams, we first list down the team working on the core and
 # further below the other team working on other part of the project.
 /apps/application-system/                                                                           @island-is/sendiradid-applications
-/apps/web*/                                                                                         @island-is/juni
+/apps/web*/                                                                                         @island-is/juni @island-is/stefna
 /libs/application/                                                                                  @island-is/sendiradid-applications
 /libs/contentful-extensions/                                                                        @island-is/juni
 /libs/service-portal/                                                                               @island-is/hugsmidjan
@@ -27,7 +27,7 @@
 /apps/services/endorsements/                                                                        @island-is/juni
 /apps/icelandic-names-registry*/                                                                    @island-is/juni
 /apps/web/screens/PetitionView/                                                                     @island-is/juni
-/libs/cms/                                                                                          @island-is/juni
+/libs/cms/                                                                                          @island-is/juni @island-is/stefna
 /libs/api/domains/endorsement-system                                                                @island-is/juni
 /libs/api/domains/icelandic-names-registry/                                                         @island-is/juni
 /libs/clients/payment/                                                                              @island-is/juni


### PR DESCRIPTION
# Change codeowners due to hotfixes before next release

## What

* Stefna recently became a codeowner of web and libs/cms and since we are expecting to hotfix a few things before the next release we'd like to also change the codeowners on the release branch
