### PR TITLE
feat(web): Render footer item links if they are present

### DIFF
--- a/apps/web/components/Organization/Wrapper/Themes/HeilbrigdisstofnunNordurlandsTheme/HeilbrigdisstofnunNordurlandsFooter.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/HeilbrigdisstofnunNordurlandsTheme/HeilbrigdisstofnunNordurlandsFooter.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import {
   Box,
   GridColumn,
@@ -7,12 +6,13 @@ import {
   Text,
   Hyphen,
   Inline,
+  Link,
 } from '@island.is/island-ui/core'
 import { FooterItem } from '@island.is/web/graphql/schema'
 import { richText, SliceType } from '@island.is/island-ui/contentful'
 import { BLOCKS } from '@contentful/rich-text-types'
-import * as styles from './HeilbrigdisstofnunNordurlandsFooter.css'
 import { SpanType } from '@island.is/island-ui/core/types'
+import * as styles from './HeilbrigdisstofnunNordurlandsFooter.css'
 
 interface HeilbrigdisstofnunNordurlandsFooterProps {
   footerItems: FooterItem[]
@@ -35,9 +35,18 @@ export const HeilbrigdisstofnunNordurlandsFooter = ({
             className={styles.locationBox}
             marginLeft={offset ? [0, 0, 0, 10] : 0}
           >
-            <Text fontWeight="semiBold" color="white" marginBottom={1}>
-              <Hyphen>{item.title}</Hyphen>
-            </Text>
+            {item.link?.url ? (
+              <Link href={item.link.url} color="white">
+                <Text fontWeight="semiBold" color="white" marginBottom={1}>
+                  <Hyphen>{item.title}</Hyphen>
+                </Text>
+              </Link>
+            ) : (
+              <Text fontWeight="semiBold" color="white" marginBottom={1}>
+                <Hyphen>{item.title}</Hyphen>
+              </Text>
+            )}
+
             {richText(item.content as SliceType[], {
               renderNode: {
                 [BLOCKS.PARAGRAPH]: (_node, children) => (

--- a/apps/web/components/Organization/Wrapper/Themes/LandkjorstjornTheme/LandkjorstjornFooter.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/LandkjorstjornTheme/LandkjorstjornFooter.tsx
@@ -7,6 +7,7 @@ import {
   GridRow,
   Hidden,
   Hyphen,
+  Link,
   Text,
 } from '@island.is/island-ui/core'
 import { FooterItem } from '@island.is/web/graphql/schema'
@@ -70,9 +71,19 @@ export const LandskjorstjornFooter = ({
           {footerItems.slice(1).map((item, index) => (
             <GridColumn key={index}>
               <Box marginLeft={index === 0 ? [2, 0] : 2} marginRight={8}>
-                <Text fontWeight="semiBold" color="white" marginBottom={2}>
-                  {item.title}
-                </Text>
+                <Box marginBottom={2}>
+                  {item.link?.url ? (
+                    <Link href={item.link.url} color="white">
+                      <Text fontWeight="semiBold" color="white">
+                        <Hyphen>{item.title}</Hyphen>
+                      </Text>
+                    </Link>
+                  ) : (
+                    <Text fontWeight="semiBold" color="white">
+                      <Hyphen>{item.title}</Hyphen>
+                    </Text>
+                  )}
+                </Box>
                 {richText(item.content as SliceType[], {
                   renderNode: {
                     [BLOCKS.PARAGRAPH]: (_node, children) => (

--- a/apps/web/components/Organization/Wrapper/Themes/LandlaeknirTheme/LandlaeknirFooter.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/LandlaeknirTheme/LandlaeknirFooter.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import {
   Box,
   GridColumn,
@@ -6,6 +5,7 @@ import {
   GridRow,
   Hidden,
   Hyphen,
+  Link,
   ResponsiveSpace,
   Text,
 } from '@island.is/island-ui/core'
@@ -61,9 +61,19 @@ export const LandLaeknirFooter = ({ footerItems }: LandLaeknirFooterProps) => {
                 <Box className={styles.borderTop} />
                 {footerItems?.[1] && (
                   <Box>
-                    <Text fontWeight="semiBold" marginBottom={2}>
-                      <Hyphen>{footerItems[1].title}</Hyphen>
-                    </Text>
+                    <Box marginBottom={2}>
+                      {footerItems[1].link?.url ? (
+                        <Link href={footerItems[1].link.url} color="white">
+                          <Text fontWeight="semiBold" marginBottom={2}>
+                            <Hyphen>{footerItems[1].title}</Hyphen>
+                          </Text>
+                        </Link>
+                      ) : (
+                        <Text fontWeight="semiBold" marginBottom={2}>
+                          <Hyphen>{footerItems[1].title}</Hyphen>
+                        </Text>
+                      )}
+                    </Box>
                     {renderParagraphs(footerItems[1].content)}
                   </Box>
                 )}
@@ -72,9 +82,19 @@ export const LandLaeknirFooter = ({ footerItems }: LandLaeknirFooterProps) => {
                 <Box className={styles.borderTop} />
                 {footerItems?.[2] && (
                   <Box>
-                    <Text fontWeight="semiBold" marginBottom={2}>
-                      <Hyphen>{footerItems[2].title}</Hyphen>
-                    </Text>
+                    <Box marginBottom={2}>
+                      {footerItems[2].link?.url ? (
+                        <Link href={footerItems[2].link.url} color="white">
+                          <Text fontWeight="semiBold" marginBottom={2}>
+                            <Hyphen>{footerItems[2].title}</Hyphen>
+                          </Text>
+                        </Link>
+                      ) : (
+                        <Text fontWeight="semiBold" marginBottom={2}>
+                          <Hyphen>{footerItems[2].title}</Hyphen>
+                        </Text>
+                      )}
+                    </Box>
                     {renderParagraphs(footerItems[2].content)}
                   </Box>
                 )}
@@ -83,9 +103,19 @@ export const LandLaeknirFooter = ({ footerItems }: LandLaeknirFooterProps) => {
                 <Box className={styles.borderTop} />
                 {footerItems.slice(3, 5).map((item, index) => (
                   <Box key={index}>
-                    <Text fontWeight="semiBold" marginBottom={2}>
-                      <Hyphen>{item.title}</Hyphen>
-                    </Text>
+                    <Box marginBottom={2}>
+                      {item.link?.url ? (
+                        <Link href={item.link.url} color="white">
+                          <Text fontWeight="semiBold" marginBottom={2}>
+                            <Hyphen>{item.title}</Hyphen>
+                          </Text>
+                        </Link>
+                      ) : (
+                        <Text fontWeight="semiBold" marginBottom={2}>
+                          <Hyphen>{item.title}</Hyphen>
+                        </Text>
+                      )}
+                    </Box>
                     {renderParagraphs(item.content)}
                   </Box>
                 ))}


### PR DESCRIPTION
# Render footer item links if they are present

## What

* If a footer item has a link it doesn't appear on the web

## Why

* We want footer item titles to render as links the CMS entry has a link attribute

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
