### PR TITLE
feat(service-portal): Hotfix - drivers license error spam

### DIFF
--- a/libs/api/domains/license-service/src/lib/client/driving-license-client/drivingLicenseService.api.ts
+++ b/libs/api/domains/license-service/src/lib/client/driving-license-client/drivingLicenseService.api.ts
@@ -87,9 +87,12 @@ export class GenericDrivingLicenseApi
       })
 
       if (!res.ok) {
-        throw new Error(
-          `Expected 200 status for Drivers license query, got ${res.status}`,
-        )
+        if (res.status !== 400 && res.status !== 404) {
+          throw new Error(
+            `Expected 200 status for Drivers license query, got ${res.status}`,
+          )
+        }
+        return null
       }
     } catch (e) {
       this.logger.error('Unable to query for drivers licence', {


### PR DESCRIPTION
# Hotfix - drivers license error spam

Took a change from this PR
* https://github.com/island-is/island.is/pull/8606
## Why
The drivers license service seems to return 400 when a user has an expired/invalid license. This isn't an error and thus shouldn't be thrown!

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
