### PR TITLE
fix(parental-leave): fix assign other parent sms not containing link

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/parental-leave.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/parental-leave.service.ts
@@ -94,8 +94,14 @@ export class ParentalLeaveService {
     )
 
     if (otherParentPhoneNumber) {
+      const clientLocationOrigin = getConfigValue(
+        this.configService,
+        'clientLocationOrigin',
+      ) as string
+      const link = `${clientLocationOrigin}/${ApplicationConfigurations.ParentalLeave.slug}/${application.id}`
+
       await this.sharedTemplateAPIService.sendSms(
-        generateAssignOtherParentApplicationSms,
+        () => generateAssignOtherParentApplicationSms(application, link),
         application,
       )
     }

--- a/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/smsGenerators/assignOtherParentSms.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/smsGenerators/assignOtherParentSms.ts
@@ -2,11 +2,17 @@ import {
   getApplicationAnswers,
   getApplicationExternalData,
 } from '@island.is/application/templates/parental-leave'
-import { SmsTemplateGenerator } from '../../../../types'
-import { linkOtherParentSMS } from '../emailGenerators'
+import { SmsMessage } from '../../../../types'
+import { Application } from '@island.is/application/types'
 
-export const generateAssignOtherParentApplicationSms: SmsTemplateGenerator = (
+export type AssingOtherParentGenerator = (
+  application: Application,
+  link: string,
+) => SmsMessage
+
+export const generateAssignOtherParentApplicationSms: AssingOtherParentGenerator = (
   application,
+  link,
 ) => {
   const { otherParentPhoneNumber } = getApplicationAnswers(application.answers)
   const { applicantName } = getApplicationExternalData(application.externalData)
@@ -16,6 +22,6 @@ export const generateAssignOtherParentApplicationSms: SmsTemplateGenerator = (
     phoneNumber: otherParentPhoneNumber,
     message: `Umsækjandi ${applicantName} kt: ${applicantId} hefur skráð þig sem maka í umsókn sinni um fæðingarorlof og er að óska eftir réttindum frá þér.
       Ef þú áttir von á þessari beiðni máttu smella á linkinn hér fyrir neðan. Kveðja, Fæðingarorlofssjóður
-      ${linkOtherParentSMS}`,
+      ${link}`,
   }
 }


### PR DESCRIPTION
## What

fixing issue where the sms to otherparent would not have the link in it.

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
