### PR TITLE
fix(service-portal): Revert reverse child modal enabling

### DIFF
--- a/libs/service-portal/information/src/components/ChildView/ChildView.tsx
+++ b/libs/service-portal/information/src/components/ChildView/ChildView.tsx
@@ -122,7 +122,7 @@ const ChildView: FC<Props> = ({
               flexDirection={['column', 'row']}
             >
               <Inline space={2}>
-                {!loading && !isChild && !modalFlagEnabled && (
+                {!loading && !isChild && modalFlagEnabled && (
                   <>
                     <ChildRegistrationModal
                       data={{


### PR DESCRIPTION
Somehow this went past me in the code-review in a [recent code change of this file](https://github.com/island-is/island.is/commit/c04ddb880b6cb1b2adfdf1d9c19ba9f83e4b7e78). This was accidentally reversed. Reverting the reverse to set it back to normal 🤝 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
