### PR TITLE
fix(auth-api): Set ApiScope include to be required in findAllValidCustomScopesTo

### DIFF
--- a/libs/auth-api-lib/src/lib/delegations/delegationScope.service.ts
+++ b/libs/auth-api-lib/src/lib/delegations/delegationScope.service.ts
@@ -102,7 +102,6 @@ export class DelegationScopeService {
           where: {
             allowExplicitDelegationGrant: true,
           },
-          required: false,
         },
       ],
     })


### PR DESCRIPTION
## What

After removing identity resources from delegation scopes we need to set ApiScopes to be required in `findAllValidCustomScopesTo`.

## Why

To prevent errors when scopes are no longer supports delegations or are expired.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
