### PR TITLE
feat(auth): Support delegations one level deep

### DIFF
--- a/apps/service-portal/src/screens/Modules/Modules.tsx
+++ b/apps/service-portal/src/screens/Modules/Modules.tsx
@@ -54,8 +54,9 @@ const RouteLoader: FC<{
     {routes.map((route) =>
       route.enabled === false ? (
         <Route
-          key={Array.isArray(route.path) ? route.path[0] : route.path}
           path={route.path}
+          exact
+          key={Array.isArray(route.path) ? route.path[0] : route.path}
           component={AccessDenied}
         />
       ) : (

--- a/apps/services/auth/public-api/src/app/modules/delegations/meDelegations.controller.spec.ts
+++ b/apps/services/auth/public-api/src/app/modules/delegations/meDelegations.controller.spec.ts
@@ -34,8 +34,12 @@ import {
 } from '../../../../test/utils'
 
 const client = createClient({ clientId: '@island.is/webapp' })
+const actorNationalId = createNationalId('person')
 const user = createCurrentUser({
-  nationalId: '1122334455',
+  nationalId: createNationalId(),
+  actor: {
+    nationalId: actorNationalId,
+  },
   scope: [
     AuthScope.delegations,
     Scopes[0].name,
@@ -131,6 +135,14 @@ const mockDelegations = {
     fromNationalId: user.nationalId,
     toNationalId: createNationalId('person'),
     scopes: [Scopes[5].name],
+    today,
+  }),
+  // Valid outgoing delegation to actor
+  validOutgoingToActor: createDelegation({
+    fromNationalId: user.nationalId,
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    toNationalId: actorNationalId,
+    scopes: [Scopes[0].name],
     today,
   }),
 }
@@ -348,6 +360,21 @@ describe('MeDelegationsController', () => {
         const res = await server.get(
           `${path}?direction=outgoing&otherUser=${mockDelegations.outgoingOnlyOtherDomain.toNationalId}`,
         )
+
+        // Assert
+        expect(res.status).toEqual(200)
+        expect(res.body).toHaveLength(0)
+        expectMatchingObject(res.body, [])
+      })
+
+      it('should not return delegation to the actor', async () => {
+        // Arrange
+        await createDelegationModels(delegationModel, [
+          mockDelegations.validOutgoingToActor,
+        ])
+
+        // Act
+        const res = await server.get(`${path}?direction=outgoing`)
 
         // Assert
         expect(res.status).toEqual(200)
@@ -629,6 +656,30 @@ describe('MeDelegationsController', () => {
         })
       })
 
+      it('should return 400 Bad Request when creating delegation to actor', async () => {
+        // Arrange
+        const model = {
+          toNationalId: actorNationalId,
+          scopes: [
+            {
+              name: Scopes[0].name,
+              validTo: addDays(today, 1),
+            },
+          ],
+        }
+        // Act
+        const res = await server.post(path).send(model)
+
+        // Assert
+        expect(res.status).toEqual(400)
+        expect(res.body).toMatchObject({
+          status: 400,
+          type: 'https://httpstatuses.org/400',
+          title: 'Bad Request',
+          detail: 'Can not create delegation to self.',
+        })
+      })
+
       it('should return 400 Bad Request when user does not have access to all the requested scopes', async () => {
         // Arrange
         const model = {
@@ -862,6 +913,38 @@ describe('MeDelegationsController', () => {
           type: 'https://httpstatuses.org/400',
           title: 'Bad Request',
           detail: 'User does not have access to the requested scopes.',
+        })
+      })
+
+      it('should return 400 Bad Request when updating delegation to actor', async () => {
+        // Arrange
+        const { id } = await delegationModel.create(
+          createDelegation({
+            fromNationalId: user.nationalId,
+            toNationalId: actorNationalId,
+            scopes: [],
+            today,
+          }),
+        )
+        const model = {
+          scopes: [
+            {
+              name: Scopes[0].name,
+              validTo: addDays(today, 2),
+            },
+          ],
+        }
+
+        // Act
+        const res = await server.put(`${path}/${id}`).send(model)
+
+        // Assert
+        expect(res.status).toEqual(400)
+        expect(res.body).toMatchObject({
+          status: 400,
+          type: 'https://httpstatuses.org/400',
+          title: 'Bad Request',
+          detail: 'Can not update delegation to self.',
         })
       })
 

--- a/libs/auth-api-lib/src/lib/delegations/delegations.service.ts
+++ b/libs/auth-api-lib/src/lib/delegations/delegations.service.ts
@@ -92,7 +92,10 @@ export class DelegationsService {
     user: User,
     createDelegation: CreateDelegationDTO,
   ): Promise<DelegationDTO | null> {
-    if (createDelegation.toNationalId === user.nationalId) {
+    if (
+      createDelegation.toNationalId === user.nationalId ||
+      this.isDelegationToActor(user, createDelegation)
+    ) {
       throw new BadRequestException(`Can not create delegation to self.`)
     }
 
@@ -150,6 +153,13 @@ export class DelegationsService {
     input: UpdateDelegationDTO,
     delegationId: string,
   ): Promise<DelegationDTO | null> {
+    const delegation = await this.delegationModel.findByPk(delegationId)
+    if (!delegation) {
+      throw new NotFoundException()
+    }
+    if (this.isDelegationToActor(user, delegation)) {
+      throw new BadRequestException('Can not update delegation to self.')
+    }
     if (!(await this.validateScopesAccess(user, input.scopes))) {
       throw new BadRequestException(
         'User does not have access to the requested scopes.',
@@ -296,9 +306,11 @@ export class DelegationsService {
     }
 
     return delegations
-      .filter((d) =>
-        // The user must have access to at least one scope in the delegation
-        d.delegationScopes?.some((s) => this.checkIfScopeAllowed(s, user)),
+      .filter(
+        (d) =>
+          // The user must have access to at least one scope in the delegation
+          d.delegationScopes?.some((s) => this.checkIfScopeAllowed(s, user)) &&
+          !this.isDelegationToActor(user, d),
       )
       .map((d) => {
         // Filter out scopes the user does not have access to
@@ -307,6 +319,13 @@ export class DelegationsService {
         )
         return d.toDTO()
       })
+  }
+
+  private isDelegationToActor(
+    user: User,
+    delegation: { toNationalId: string },
+  ): boolean {
+    return user.actor?.nationalId === delegation.toNationalId
   }
 
   /***** Incoming Delegations *****/

--- a/libs/testing/fixtures/src/lib/currentUser.ts
+++ b/libs/testing/fixtures/src/lib/currentUser.ts
@@ -11,6 +11,9 @@ interface UserOptions {
   authorization?: string
   client?: string
   nationalIdType?: NationalIdType
+  actor?: {
+    nationalId: string
+  }
 }
 
 export const createCurrentUser = (user: UserOptions = {}): User => {
@@ -19,5 +22,9 @@ export const createCurrentUser = (user: UserOptions = {}): User => {
     scope: user.scope ?? [],
     authorization: user.authorization ?? faker.random.word(),
     client: user.client ?? faker.random.word(),
+    actor: user.actor && {
+      nationalId: user.actor.nationalId,
+      scope: [],
+    },
   }
 }


### PR DESCRIPTION
## What

- Remove extra checks in service-portal.
- Filter out actor delegation.
- Block POST/PUT on delegation to actor.

## Why

Requested functionality.

For now we hide and disable any edits to the actor delegation since it has some unexpected edge cases with the delegation scope and the user's active access token.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] ~I have made corresponding changes to the documentation~
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
