### PR TITLE
fix(web): Search route for service web

### DIFF
--- a/apps/web/components/ServiceWeb/SearchInput/SearchInput.tsx
+++ b/apps/web/components/ServiceWeb/SearchInput/SearchInput.tsx
@@ -216,10 +216,21 @@ export const SearchInput = ({
           return onSelect(activeItem)
         }
 
+        const defaultInstitutionSlug =
+          activeLocale === 'en' ? 'digital-iceland' : 'stafraent-island'
+
+        let slug = institutionSlug
+
+        if (
+          institutionSlug === 'leit' ||
+          institutionSlug === 'search' ||
+          !institutionSlug
+        ) {
+          slug = defaultInstitutionSlug
+        }
+
         Router.push({
-          pathname: linkResolver('serviceweborganizationsearch', [
-            institutionSlug,
-          ]).href,
+          pathname: linkResolver('serviceweborganizationsearch', [slug]).href,
           query: { q: value },
         })
       }}

--- a/apps/web/screens/ServiceWeb/Search/ServiceSearch.tsx
+++ b/apps/web/screens/ServiceWeb/Search/ServiceSearch.tsx
@@ -339,8 +339,10 @@ const ServiceSearch: Screen<ServiceSearchProps> = ({
 const single = <T,>(x: T | T[]): T => (Array.isArray(x) ? x[0] : x)
 
 ServiceSearch.getInitialProps = async ({ apolloClient, locale, query }) => {
+  const defaultSlug = locale === 'is' ? 'stafraent-island' : 'digital-iceland'
+
   const q = single(query.q) || ''
-  const slug = query.slug ? (query.slug as string) : 'stafraent-island'
+  const slug = query.slug ? (query.slug as string) : defaultSlug
   const page = Number(single(query.page)) || 1
 
   const types = ['webQNA' as SearchableContentTypes]

--- a/libs/cms/src/lib/models/supportCategory.model.ts
+++ b/libs/cms/src/lib/models/supportCategory.model.ts
@@ -8,8 +8,8 @@ export class SupportCategory {
   @Field(() => ID)
   id!: string
 
-  @Field()
-  title!: string
+  @Field({ nullable: true })
+  title?: string
 
   @Field({ nullable: true })
   description?: string


### PR DESCRIPTION
# Fix search route for service web

## What

* There was a bug regarding service web search when the url was /adstod/leit
* This change addresses that issue

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
