### PR TITLE
fix(service-portal): Preselect finance filter for transactions

### DIFF
--- a/libs/service-portal/finance/src/screens/FinanceTransactions/FinanceTransactions.tsx
+++ b/libs/service-portal/finance/src/screens/FinanceTransactions/FinanceTransactions.tsx
@@ -55,8 +55,8 @@ const FinanceTransactions: ServicePortalModuleComponent = () => {
   const [openCal, setOpenCal] = useState<{ top: boolean; lower: boolean }>(
     defaultCalState,
   )
-  const [fromDate, setFromDate] = useState<Date | null>()
-  const [toDate, setToDate] = useState<Date | null>()
+  const [fromDate, setFromDate] = useState<Date>()
+  const [toDate, setToDate] = useState<Date>()
   const [q, setQ] = useState<string>('')
   const [chargeTypesEmpty, setChargeTypesEmpty] = useState(false)
   const [dropdownSelect, setDropdownSelect] = useState<string[] | undefined>()
@@ -101,14 +101,20 @@ const FinanceTransactions: ServicePortalModuleComponent = () => {
     setToDate(new Date())
   }, [])
 
+  function getAllChargeTypes() {
+    const allChargeTypeValues = chargeTypeData?.chargeType?.map((ct) => ct.id)
+    return allChargeTypeValues ?? []
+  }
+
   function setAllChargeTypes() {
-    setDropdownSelect([])
+    const allChargeTypes = getAllChargeTypes()
+    setDropdownSelect(allChargeTypes)
   }
 
   function clearAllFilters() {
-    setDropdownSelect([])
-    setFromDate(null)
-    setToDate(null)
+    setAllChargeTypes()
+    setFromDate(backInTheDay)
+    setToDate(new Date())
     setQ('')
   }
 


### PR DESCRIPTION
## What

preselect finance filter for transactions

## Why

Screen can become empty to start with unless pre-selected.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
