### PR TITLE
feat(web): Add ImageFields to GraphQL query for slices

### DIFF
--- a/apps/web/screens/queries/fragments.ts
+++ b/apps/web/screens/queries/fragments.ts
@@ -422,6 +422,7 @@ export const slices = gql`
     content {
       ...HtmlFields
       ...AssetFields
+      ...ImageFields
     }
     dividerOnTop
     showTitle
@@ -438,6 +439,7 @@ export const slices = gql`
       content {
         ...HtmlFields
         ...AssetFields
+        ...ImageFields
       }
       link {
         url


### PR DESCRIPTION
# Add ImageFields to GraphQL query for slices

## What

* Images were not appearing on the web when they were inside a slice, this change adds that feature

## Why

* Content on the web already presumed that this would work, we want to add this feature because it isn't uncommon to want to add an image inside a rich text field

## Screenshots / Gifs

### Before:
![image](https://user-images.githubusercontent.com/43557895/195385096-cd0deb53-b6d2-40e1-b67c-c9ae919e5bfa.png)

### After:
![image](https://user-images.githubusercontent.com/43557895/195385263-bc2ae411-e5fb-47e8-ac7e-64a0b838aa49.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
