### PR TITLE
feat(web): Change graphql queries to support nested slices and add optional border above accordion slice

### DIFF
--- a/apps/web/components/Organization/Slice/AccordionSlice/AccordionSlice.tsx
+++ b/apps/web/components/Organization/Slice/AccordionSlice/AccordionSlice.tsx
@@ -30,8 +30,8 @@ export const AccordionSlice: React.FC<SliceProps> = ({ slice }) => {
         paddingBottom: [4, 4, 6],
       }
     : {
-        paddingTop: 3,
-        paddingBottom: 3,
+        paddingTop: 2,
+        paddingBottom: 2,
       }
 
   return (

--- a/apps/web/components/Organization/Slice/AccordionSlice/AccordionSlice.tsx
+++ b/apps/web/components/Organization/Slice/AccordionSlice/AccordionSlice.tsx
@@ -5,6 +5,7 @@ import {
   AccordionItem,
   ActionCard,
   Box,
+  BoxProps,
   Text,
 } from '@island.is/island-ui/core'
 import {
@@ -21,14 +22,21 @@ interface SliceProps {
 export const AccordionSlice: React.FC<SliceProps> = ({ slice }) => {
   const labelId = 'sliceTitle-' + slice.id
 
+  const borderProps: BoxProps = slice.hasBorderAbove
+    ? {
+        borderTopWidth: 'standard',
+        borderColor: 'standard',
+        paddingTop: [4, 4, 6],
+        paddingBottom: [4, 4, 6],
+      }
+    : {
+        paddingTop: 3,
+        paddingBottom: 3,
+      }
+
   return (
     <section key={slice.id} id={slice.id} aria-labelledby={labelId}>
-      <Box
-        borderTopWidth="standard"
-        borderColor="standard"
-        paddingTop={[4, 4, 6]}
-        paddingBottom={[4, 4, 6]}
-      >
+      <Box {...borderProps}>
         <Text variant="h2" as="h2" marginBottom={2} id={labelId}>
           {slice.title}
         </Text>

--- a/apps/web/components/Organization/Slice/Districts/DistrictsSlice.tsx
+++ b/apps/web/components/Organization/Slice/Districts/DistrictsSlice.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Districts } from '@island.is/web/graphql/schema'
 import {
   Box,
+  BoxProps,
   Button,
   GridColumn,
   GridRow,
@@ -15,6 +16,18 @@ interface SliceProps {
 }
 
 export const DistrictsSlice: React.FC<SliceProps> = ({ slice }) => {
+  const boxProps: BoxProps = slice.hasBorderAbove
+    ? {
+        borderTopWidth: 'standard',
+        borderColor: 'standard',
+        paddingTop: [8, 6],
+        paddingBottom: [4, 5],
+      }
+    : {
+        paddingTop: 2,
+        paddingBottom: 2,
+      }
+
   return (
     !!slice.links.length && (
       <section
@@ -22,12 +35,7 @@ export const DistrictsSlice: React.FC<SliceProps> = ({ slice }) => {
         id={slice.id}
         aria-labelledby={'sliceTitle-' + slice.id}
       >
-        <Box
-          borderTopWidth="standard"
-          borderColor="standard"
-          paddingTop={[8, 6]}
-          paddingBottom={[4, 5]}
-        >
+        <Box {...boxProps}>
           <GridRow>
             <GridColumn span="12/12">
               <Text variant="h3" as="h2" id={'sliceTitle-' + slice.id}>

--- a/apps/web/components/Organization/Slice/FeaturedArticles/FeaturedArticlesSlice.tsx
+++ b/apps/web/components/Organization/Slice/FeaturedArticles/FeaturedArticlesSlice.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { FeaturedArticles } from '@island.is/web/graphql/schema'
 import {
   Box,
+  BoxProps,
   Button,
   FocusableBox,
   Link,
@@ -42,15 +43,19 @@ export const FeaturedArticlesSlice: React.FC<SliceProps> = ({
           )
       : slice.resolvedArticles
 
+  const borderProps: BoxProps = slice.hasBorderAbove
+    ? {
+        borderTopWidth: 'standard',
+        borderColor: 'standard',
+        paddingTop: [8, 6, 8],
+        paddingBottom: [8, 6, 6],
+      }
+    : {}
+
   return (
     (!!slice.articles.length || !!slice.resolvedArticles.length) && (
       <section key={slice.id} id={slice.id} aria-labelledby={labelId}>
-        <Box
-          borderTopWidth="standard"
-          borderColor="standard"
-          paddingTop={[8, 6, 8]}
-          paddingBottom={[8, 6, 6]}
-        >
+        <Box {...borderProps}>
           <Text as="h2" variant="h3" paddingBottom={6} id={labelId}>
             {slice.title}
           </Text>

--- a/apps/web/components/Organization/Slice/MultipleStatistics/MultipleStatistics.tsx
+++ b/apps/web/components/Organization/Slice/MultipleStatistics/MultipleStatistics.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import {
   Box,
+  BoxProps,
   Button,
   GridColumn,
   GridContainer,
@@ -15,18 +16,25 @@ interface SliceProps {
 }
 
 export const MultipleStatistics: React.FC<SliceProps> = ({ slice }) => {
+  const boxProps: BoxProps = slice.hasBorderAbove
+    ? {
+        borderTopWidth: 'standard',
+        borderColor: 'standard',
+        paddingTop: [4, 4, 6],
+        paddingBottom: [4, 4, 6],
+      }
+    : {
+        paddingTop: 2,
+        paddingBottom: 2,
+      }
+
   return (
     <section
       key={slice.id}
       id={slice.id}
       aria-labelledby={'sliceTitle-' + slice.id}
     >
-      <Box
-        borderTopWidth="standard"
-        borderColor="standard"
-        paddingTop={[4, 4, 6]}
-        paddingBottom={[4, 4, 6]}
-      >
+      <Box {...boxProps}>
         {!!slice.title && (
           <Text variant="h2" as="h2" marginBottom={4}>
             {slice.title}

--- a/apps/web/components/Organization/Slice/OverviewLinks/OverviewLinks.tsx
+++ b/apps/web/components/Organization/Slice/OverviewLinks/OverviewLinks.tsx
@@ -8,6 +8,7 @@ import {
   Stack,
   Text,
   Link,
+  BoxProps,
 } from '@island.is/island-ui/core'
 import { OverviewLinks } from '@island.is/web/graphql/schema'
 import { Image, richText, SliceType } from '@island.is/island-ui/contentful'
@@ -20,6 +21,16 @@ interface SliceProps {
 export const OverviewLinksSlice: React.FC<SliceProps> = ({ slice }) => {
   const { linkResolver } = useLinkResolver()
 
+  const boxProps: BoxProps = slice.hasBorderAbove
+    ? {
+        borderTopWidth: 'standard',
+        borderColor: 'standard',
+        paddingTop: 4,
+      }
+    : {
+        paddingTop: 2,
+      }
+
   return (
     <section
       key={slice.id}
@@ -27,7 +38,7 @@ export const OverviewLinksSlice: React.FC<SliceProps> = ({ slice }) => {
       aria-labelledby={'sliceTitle-' + slice.id}
     >
       <GridContainer>
-        <Box borderTopWidth="standard" borderColor="standard" paddingTop={4}>
+        <Box {...boxProps}>
           <Stack space={6}>
             {slice.overviewLinks.map(
               (

--- a/apps/web/screens/queries/Article.ts
+++ b/apps/web/screens/queries/Article.ts
@@ -1,5 +1,5 @@
 import gql from 'graphql-tag'
-import { slices } from './fragments'
+import { nestedAccordionAndFaqListFields, slices } from './fragments'
 
 export const GET_ARTICLE_QUERY = gql`
   query GetSingleArticle($input: GetSingleArticleInput!) {
@@ -27,6 +27,7 @@ export const GET_ARTICLE_QUERY = gql`
       }
       body {
         ...AllSlices
+        ${nestedAccordionAndFaqListFields}
       }
       stepper {
         id
@@ -120,6 +121,7 @@ export const GET_ARTICLE_QUERY = gql`
         slug
         body {
           ...AllSlices
+          ${nestedAccordionAndFaqListFields}
         }
         showTableOfContents
       }

--- a/apps/web/screens/queries/Organization.tsx
+++ b/apps/web/screens/queries/Organization.tsx
@@ -1,5 +1,5 @@
 import gql from 'graphql-tag'
-import { slices } from './fragments'
+import { slices, nestedAccordionAndFaqListFields } from './fragments'
 
 export const GET_ORGANIZATIONS_QUERY = gql`
   query GetOrganizations($input: GetOrganizationsInput!) {
@@ -170,6 +170,7 @@ export const GET_ORGANIZATION_SUBPAGE_QUERY = gql`
       slug
       description {
         ...AllSlices
+        ${nestedAccordionAndFaqListFields}
       }
       links {
         text
@@ -177,6 +178,7 @@ export const GET_ORGANIZATION_SUBPAGE_QUERY = gql`
       }
       slices {
         ...AllSlices
+        ${nestedAccordionAndFaqListFields}
       }
       showTableOfContents
       sliceCustomRenderer

--- a/apps/web/screens/queries/Project.tsx
+++ b/apps/web/screens/queries/Project.tsx
@@ -1,5 +1,9 @@
 import gql from 'graphql-tag'
-import { nestedOneColumnTextFields, slices } from './fragments'
+import {
+  nestedAccordionAndFaqListFields,
+  nestedOneColumnTextFields,
+  slices,
+} from './fragments'
 
 export const GET_PROJECT_PAGE_QUERY = gql`
   query GetProjectPage($input: GetProjectPageInput!) {
@@ -52,9 +56,11 @@ export const GET_PROJECT_PAGE_QUERY = gql`
       }
       slices {
         ...AllSlices
+        ${nestedAccordionAndFaqListFields}
       }
       bottomSlices {
         ...AllSlices
+        ${nestedAccordionAndFaqListFields}
       }
       newsTag {
         id
@@ -71,6 +77,7 @@ export const GET_PROJECT_PAGE_QUERY = gql`
         slices {
           ...AllSlices
           ...NestedOneColumnTextFields
+          ${nestedAccordionAndFaqListFields}
         }
       }
       featuredImage {

--- a/apps/web/screens/queries/fragments.ts
+++ b/apps/web/screens/queries/fragments.ts
@@ -433,6 +433,7 @@ export const slices = gql`
     id
     title
     type
+    hasBorderAbove
     accordionItems {
       id
       title
@@ -638,6 +639,30 @@ export const nestedOneColumnTextFields = gql`
     ...OneColumnTextFields
     content {
       ...AllSlices
+    }
+  }
+`
+
+export const nestedAccordionAndFaqListFields = `
+  ... on AccordionSlice {
+    ...AccordionSliceFields
+    accordionItems {
+      ... on OneColumnText {
+        ...OneColumnTextFields
+        content {
+          ...AllSlices
+        }
+      }
+    }
+  }
+  ... on FaqList {
+    ...FaqListFields
+    questions {
+      id
+      question
+      answer {
+        ...AllSlices
+      }
     }
   }
 `

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -12,6 +12,9 @@ export interface IAccordionSliceFields {
 
   /** Accordion Items */
   accordionItems?: IOneColumnText[] | undefined
+
+  /** Has Border Above */
+  hasBorderAbove?: boolean | undefined
 }
 
 /** A slice with accordions */
@@ -2370,33 +2373,6 @@ export interface IPageHeader extends Entry<IPageHeaderFields> {
   }
 }
 
-export interface IPowerBiSliceFields {
-  /** Title */
-  title?: string | undefined
-
-  /** Config */
-  config: Record<string, any>
-}
-
-/** A Slice that embeds a Power BI report */
-
-export interface IPowerBiSlice extends Entry<IPowerBiSliceFields> {
-  sys: {
-    id: string
-    type: string
-    createdAt: string
-    updatedAt: string
-    locale: string
-    contentType: {
-      sys: {
-        id: 'powerBiSlice'
-        linkType: 'ContentType'
-        type: 'Link'
-      }
-    }
-  }
-}
-
 export interface IProcessEntryFields {
   /** Type */
   type:
@@ -3831,7 +3807,6 @@ export type CONTENT_TYPE =
   | 'organizationTag'
   | 'overviewLinks'
   | 'pageHeader'
-  | 'powerBiSlice'
   | 'processEntry'
   | 'projectPage'
   | 'projectSubpage'

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -469,6 +469,9 @@ export interface IDistrictsFields {
 
   /** Links */
   links?: ILink[] | undefined
+
+  /** Has Border Above */
+  hasBorderAbove?: boolean | undefined
 }
 
 export interface IDistricts extends Entry<IDistrictsFields> {
@@ -711,6 +714,9 @@ export interface IFeaturedArticlesFields {
 
   /** Article Count */
   articleCount?: number | undefined
+
+  /** Has Border Above */
+  hasBorderAbove?: boolean | undefined
 }
 
 export interface IFeaturedArticles extends Entry<IFeaturedArticlesFields> {
@@ -1739,6 +1745,9 @@ export interface IMultipleStatisticsFields {
 
   /** Link */
   link?: ILink | undefined
+
+  /** Has Border Above */
+  hasBorderAbove?: boolean | undefined
 }
 
 export interface IMultipleStatistics extends Entry<IMultipleStatisticsFields> {
@@ -2320,6 +2329,9 @@ export interface IOverviewLinksFields {
 
   /** Link */
   link?: ILink | undefined
+
+  /** Has Border Above */
+  hasBorderAbove?: boolean | undefined
 }
 
 export interface IOverviewLinks extends Entry<IOverviewLinksFields> {

--- a/libs/cms/src/lib/models/accordionSlice.model.ts
+++ b/libs/cms/src/lib/models/accordionSlice.model.ts
@@ -17,6 +17,9 @@ export class AccordionSlice {
 
   @Field(() => [OneColumnText], { nullable: true })
   accordionItems?: Array<OneColumnText>
+
+  @Field(() => Boolean, { nullable: true })
+  hasBorderAbove?: boolean
 }
 
 export const mapAccordionSlice = ({
@@ -28,4 +31,5 @@ export const mapAccordionSlice = ({
   title: fields.title ?? '',
   type: fields.type ?? '',
   accordionItems: (fields.accordionItems ?? []).map(mapOneColumnText),
+  hasBorderAbove: fields.hasBorderAbove ?? true,
 })

--- a/libs/cms/src/lib/models/districts.model.ts
+++ b/libs/cms/src/lib/models/districts.model.ts
@@ -21,6 +21,9 @@ export class Districts {
 
   @Field(() => [Link])
   links?: Array<Link>
+
+  @Field(() => Boolean, { nullable: true })
+  hasBorderAbove?: boolean
 }
 
 export const mapDistricts = ({
@@ -33,4 +36,5 @@ export const mapDistricts = ({
   description: fields.description ?? '',
   image: fields.image ? mapImage(fields.image) : null,
   links: (fields.links ?? []).map(mapLink),
+  hasBorderAbove: fields.hasBorderAbove ?? true,
 })

--- a/libs/cms/src/lib/models/featuredArticles.model.ts
+++ b/libs/cms/src/lib/models/featuredArticles.model.ts
@@ -36,6 +36,9 @@ export class FeaturedArticles {
 
   @Field(() => Link, { nullable: true })
   link?: Link | null
+
+  @Field(() => Boolean, { nullable: true })
+  hasBorderAbove?: boolean
 }
 
 export const mapFeaturedArticles = ({
@@ -68,4 +71,5 @@ export const mapFeaturedArticles = ({
     }),
   },
   link: fields.link ? mapLink(fields.link) : null,
+  hasBorderAbove: fields.hasBorderAbove ?? true,
 })

--- a/libs/cms/src/lib/models/multipleStatistics.model.ts
+++ b/libs/cms/src/lib/models/multipleStatistics.model.ts
@@ -17,6 +17,9 @@ export class MultipleStatistics {
 
   @Field(() => Link, { nullable: true })
   link!: Link | null
+
+  @Field(() => Boolean, { nullable: true })
+  hasBorderAbove?: boolean
 }
 
 export const mapMultipleStatistics = ({
@@ -28,4 +31,5 @@ export const mapMultipleStatistics = ({
   title: fields.title ?? '',
   statistics: (fields.statistics ?? []).map(mapStatistics),
   link: fields.link ? mapLink(fields.link) : null,
+  hasBorderAbove: fields.hasBorderAbove ?? true,
 })

--- a/libs/cms/src/lib/models/overviewLinks.model.ts
+++ b/libs/cms/src/lib/models/overviewLinks.model.ts
@@ -14,6 +14,9 @@ export class OverviewLinks {
 
   @Field(() => Link, { nullable: true })
   link!: Link | null
+
+  @Field(() => Boolean, { nullable: true })
+  hasBorderAbove?: boolean
 }
 
 export const mapOverviewLinks = ({
@@ -24,4 +27,5 @@ export const mapOverviewLinks = ({
   id: sys.id,
   overviewLinks: (fields.overviewLinks ?? []).map(mapIntroLinkImage),
   link: fields.link ? mapLink(fields.link) : null,
+  hasBorderAbove: fields.hasBorderAbove ?? true,
 })


### PR DESCRIPTION
# Change graphql queries to support nested slices and add optional border above slices

## What

* If someone adds a faqlist inside a onecolumn text it won't appear on the web due to a graphql query, this change tweaks graphql richtext queries to support nested slices
* Add a way to optionally render a border above each slice
* Removed powerbislice related fields from contentful types since it was causing an error due to the slicetype not being in the code (that's because the powerbi slice is still in the works so it's safe to remove the type)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
