### PR TITLE
feat(web): Add ð to alphabetical sorting

### DIFF
--- a/libs/shared/connected/src/utils/sortAlpha.ts
+++ b/libs/shared/connected/src/utils/sortAlpha.ts
@@ -11,7 +11,7 @@ type Item = {
 }
 
 const order =
-  '0123456789aAáÁbBcCdDeEéÉfFgGhHiIíÍjJkKlLmMnNoOóÓpPqQrRsStTuUúÚvVwWxXyYýÝzZþÞæÆöÖ'
+  '0123456789aAáÁbBcCdDðÐeEéÉfFgGhHiIíÍjJkKlLmMnNoOóÓpPqQrRsStTuUúÚvVwWxXyYýÝzZþÞæÆöÖ'
 
 const charOrder = (a: string) => {
   const ix = order.indexOf(a)


### PR DESCRIPTION
# Add ð to alphabetical sorting

## What

* ð was missing from the alphabet, so I added it

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
