### PR TITLE
feat(j-s): add more margin under police case number tags

### DIFF
--- a/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.tsx
+++ b/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.tsx
@@ -85,7 +85,9 @@ export const ProsecutorCaseInfo: React.FC<Props & { hideCourt?: boolean }> = ({
 
   return (
     <Box component="section" marginBottom={5}>
-      <PoliceCaseNumbersTags policeCaseNumbers={policeCaseNumbers} />
+      <Box marginBottom={2}>
+        <PoliceCaseNumbersTags policeCaseNumbers={policeCaseNumbers} />
+      </Box>
       {!hideCourt && court?.name && (
         <Entry label={formatMessage(core.court)} value={court?.name} />
       )}


### PR DESCRIPTION
[Asana - LÖKE nr tögg, bæta við bili fyrir neðan](https://app.asana.com/0/1199153462262248/1202972048201126/f)

## What
- Add margin bottom under police case number tags
## Why
- Looks better

## Screenshots / Gifs

| Before | After |
| - | - |
| ![Screenshot 2022-10-14 at 15 15 38](https://user-images.githubusercontent.com/5700902/195882245-06670b19-a2c7-4f82-9286-823fd26d5678.png) | ![Screenshot 2022-10-14 at 15 15 28](https://user-images.githubusercontent.com/5700902/195882465-edc63a50-3d24-484b-aabd-01f6037b3013.png) |

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
