### PR TITLE
fix(j-s): fix files being displayed in progress state

### DIFF
--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/PoliceCaseFiles/PoliceCaseFilesRoute.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/PoliceCaseFiles/PoliceCaseFilesRoute.tsx
@@ -85,14 +85,14 @@ const UploadFilesToPoliceCase: React.FC<{
   }, [setAllUploaded, displayFiles])
 
   const setSingleFile = useCallback(
-    (displayFile) => {
+    (displayFile: UploadFile, newId?: string) => {
       setDisplayFiles((previous) => {
         const index = previous.findIndex((f) => f.id === displayFile.id)
         if (index === -1) {
           return previous
         }
         const next = [...previous]
-        next[index] = displayFile
+        next[index] = { ...displayFile, id: newId ?? displayFile.id }
         return next
       })
     },

--- a/apps/judicial-system/web/src/utils/hooks/useS3UploadV2/useS3UploadV2.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useS3UploadV2/useS3UploadV2.ts
@@ -82,7 +82,10 @@ export const useS3UploadV2 = (
   >(DeleteFileMutationDocument)
 
   const upload = useCallback(
-    (files: Array<[File, string]>, updateFile: (file: UploadFile) => void) => {
+    (
+      files: Array<[File, string]>,
+      updateFile: (file: UploadFile, newId?: string) => void,
+    ) => {
       files.forEach(async ([file, id]) => {
         try {
           const data = await createPresignedMutation({
@@ -124,13 +127,16 @@ export const useS3UploadV2 = (
             throw Error('failed to add file to case')
           }
 
-          updateFile({
-            name: file.name,
-            percent: 100,
-            status: 'done',
-            // We need to set the id so we are able to delete the file later
-            id: data2.data.createFile.id,
-          })
+          updateFile(
+            {
+              id: id,
+              name: file.name,
+              percent: 100,
+              status: 'done',
+              // We need to set the id so we are able to delete the file later
+            },
+            data2.data.createFile.id,
+          )
         } catch (e) {
           updateFile({
             id: id,


### PR DESCRIPTION
[Asana - Málsgögn - upload-skjár fyrir gagnapakka](https://app.asana.com/0/1199153462262248/1203046355378025/f)
## What

- Fix files being displayed stuck in progress state after upload

## Why

- Send both the previous id and new id to the `setSingleFile` to be able to find the file

## Screenshots / Gifs
| Before | After |
| - | - |
| ![Screenshot 2022-10-17 at 15 48 40](https://user-images.githubusercontent.com/5700902/196223689-103d858c-cd82-4ded-9527-54a1fe78eccd.png) | ![Screenshot 2022-10-17 at 15 48 22](https://user-images.githubusercontent.com/5700902/196223694-dae6ee8e-a2e3-4171-ba71-e6b648b5dd12.png) |


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
