### PR TITLE
fix(driving-license-application): Name mapping and formatting

### DIFF
--- a/libs/api/domains/driving-license/src/lib/util/hasResidenceHistory.ts
+++ b/libs/api/domains/driving-license/src/lib/util/hasResidenceHistory.ts
@@ -71,7 +71,7 @@ export const hasLocalResidence = (
       ({ dateOfChange: a }, { dateOfChange: b }) =>
         compareDesc(new Date(a), new Date(b)),
     )
-    return sorted[0].country === 'IS'
+    return sorted[0]?.country === 'IS' || false
   }
   return false
 }

--- a/libs/application/templates/driving-license/src/forms/draft/subSectionSummary.ts
+++ b/libs/application/templates/driving-license/src/forms/draft/subSectionSummary.ts
@@ -17,6 +17,7 @@ import { YES } from '../../lib/constants'
 import { B_TEMP } from '../../shared/constants'
 import {
   hasNoDrivingLicenseInOtherCountry,
+  isApplicationForCondition,
   needsHealthCertificateCondition,
 } from '../../lib/utils'
 
@@ -46,7 +47,10 @@ export const subSectionSummary = buildSubSection({
         }),
         buildKeyValueField({
           label: m.overviewSubType,
-          value: ({ answers: { subType } }) => subType as string[],
+          value: ({ answers: { applicationFor } }) =>
+            applicationFor === B_TEMP
+              ? m.applicationForTempLicenseTitle
+              : m.applicationForFullLicenseTitle,
         }),
         buildDividerField({}),
         buildKeyValueField({
@@ -54,18 +58,6 @@ export const subSectionSummary = buildSubSection({
           width: 'half',
           value: ({ externalData: { nationalRegistry } }) =>
             (nationalRegistry.data as NationalRegistryUser).fullName,
-        }),
-        buildKeyValueField({
-          label: m.overviewPhoneNumber,
-          width: 'half',
-          value: ({ answers: { phone } }) => phone as string,
-        }),
-        buildKeyValueField({
-          label: m.overviewStreetAddress,
-          width: 'half',
-          value: ({ externalData: { nationalRegistry } }) =>
-            (nationalRegistry.data as NationalRegistryUser).address
-              ?.streetAddress,
         }),
         buildKeyValueField({
           label: m.overviewNationalId,
@@ -76,15 +68,29 @@ export const subSectionSummary = buildSubSection({
             ),
         }),
         buildKeyValueField({
-          label: m.overviewPostalCode,
+          label: m.overviewPhoneNumber,
           width: 'half',
-          value: ({ externalData: { nationalRegistry } }) =>
-            (nationalRegistry.data as NationalRegistryUser).address?.postalCode,
+          condition: (answers) => !!answers?.phone,
+          value: ({ answers: { phone } }) => phone as string,
         }),
         buildKeyValueField({
           label: m.overviewEmail,
           width: 'half',
+          condition: (answers) => !!answers?.email,
           value: ({ answers: { email } }) => email as string,
+        }),
+        buildKeyValueField({
+          label: m.overviewStreetAddress,
+          width: 'half',
+          value: ({ externalData: { nationalRegistry } }) =>
+            (nationalRegistry.data as NationalRegistryUser).address
+              ?.streetAddress,
+        }),
+        buildKeyValueField({
+          label: m.overviewPostalCode,
+          width: 'half',
+          value: ({ externalData: { nationalRegistry } }) =>
+            (nationalRegistry.data as NationalRegistryUser).address?.postalCode,
         }),
         buildKeyValueField({
           label: m.overviewCity,
@@ -92,25 +98,24 @@ export const subSectionSummary = buildSubSection({
           value: ({ externalData: { nationalRegistry } }) =>
             (nationalRegistry.data as NationalRegistryUser).address?.city,
         }),
-        buildDividerField({}),
+        buildDividerField({
+          condition: isApplicationForCondition(B_TEMP),
+        }),
         buildKeyValueField({
           label: m.overviewTeacher,
           width: 'half',
+          condition: isApplicationForCondition(B_TEMP),
           value: ({
             externalData: {
-              studentAssessment,
               teachers: { data },
             },
             answers,
           }) => {
-            if (answers.applicationFor === B_TEMP) {
-              const teacher = (data as Teacher[]).find(
-                ({ nationalId }) =>
-                  getValueViaPath(answers, 'drivingInstructor') === nationalId,
-              )
-              return teacher?.name
-            }
-            return (studentAssessment.data as StudentAssessment).teacherName
+            const teacher = (data as Teacher[]).find(
+              ({ nationalId }) =>
+                getValueViaPath(answers, 'drivingInstructor') === nationalId,
+            )
+            return teacher?.name
           },
         }),
         buildDividerField({

--- a/libs/application/templates/driving-license/src/lib/dataSchema.ts
+++ b/libs/application/templates/driving-license/src/lib/dataSchema.ts
@@ -10,7 +10,6 @@ const isValidPhoneNumber = (phoneNumber: string) => {
 
 export const dataSchema = z.object({
   type: z.array(z.enum(['car', 'trailer', 'motorcycle'])).nonempty(),
-  subType: z.array(z.string()).nonempty(),
   approveExternalData: z.boolean().refine((v) => v),
   juristiction: z.string(),
   healthDeclaration: z.object({

--- a/libs/application/templates/operating-license/src/lib/utils.ts
+++ b/libs/application/templates/operating-license/src/lib/utils.ts
@@ -67,7 +67,7 @@ export const get24HFormatTime = (value: string) => {
   }
   const { hours, minutes } = getHoursMinutes(value)
 
-  return `${hours}:${minutes}`
+  return `${hours}:${minutes > 10 ? minutes : '0' + minutes}`
 }
 
 const vskNrRegex = /([0-9]){6}/


### PR DESCRIPTION
Fixing formatting for Operating License time. 
If user get driving assessment after the application is created the driving teachers name will not show up in summary. Put a condition on this field for now so it only shows for b-temp applications. There are some changes coming the driving license application, will reassess this functionality then. This is just to fix the bug for now. 
Also some minor cleanup.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
