### PR TITLE
fix(web): Add locale to linkResolver for newslist

### DIFF
--- a/apps/web/components/NewsList/NewsList.tsx
+++ b/apps/web/components/NewsList/NewsList.tsx
@@ -9,7 +9,7 @@ import {
   Box,
   Link,
 } from '@island.is/island-ui/core'
-import { linkResolver, LinkType, useNamespace } from '@island.is/web/hooks'
+import { LinkType, useLinkResolver, useNamespace } from '@island.is/web/hooks'
 import { NewsCard } from '@island.is/web/components'
 import { useRouter } from 'next/router'
 import { GetNewsQuery } from '@island.is/web/graphql/schema'
@@ -50,6 +50,8 @@ export const NewsList = ({
 }: NewsListProps) => {
   const router = useRouter()
   const n = useNamespace(namespace)
+
+  const { linkResolver } = useLinkResolver()
 
   const allYearsString = n('allYears', 'Allar fréttir')
   const yearString = n('year', 'Ár')


### PR DESCRIPTION
# Add locale to linkResolver for newslist

## What

* The NewsList link is wrong on the english page due to a missing locale for the linkResolver
* This change fixes that issue

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
