### PR TITLE
fix(api): Add duplexer3 to esbuild.json

### DIFF
--- a/apps/api/esbuild.json
+++ b/apps/api/esbuild.json
@@ -44,7 +44,8 @@
     "@protobufjs/utf8",
     "safer-buffer",
     "ts-morph",
-    "ioredis"
+    "ioredis",
+    "duplexer3"
   ],
   "keepNames": true
 }


### PR DESCRIPTION
# Add duplexer3 to esbuild.json

## What

* It seems that api project is crashlooping due to this package missing

