### PR TITLE
fix(service-portal): Update html lang

### DIFF
--- a/apps/service-portal/src/index.html
+++ b/apps/service-portal/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="is">
   <head>
     <meta charset="utf-8" />
     <title>Mínar síður - Ísland.is</title>

--- a/libs/localization/src/lib/LocaleContext.tsx
+++ b/libs/localization/src/lib/LocaleContext.tsx
@@ -116,6 +116,7 @@ export const LocaleProvider = ({
       await polyfill(lang)
     }
     setActiveLocale(lang)
+    document.documentElement.setAttribute('lang', lang)
 
     if (loadedNamespaces.length > 0) {
       const { data } = await apolloClient.query<Query>({


### PR DESCRIPTION
## What

Update `lang` attribute to account for the current language.

## Why

Even though we do not need to account for SEO in the service portal..

We have some comments regarding the `<html lang="">` tag on the service-portal. It can be confusing for some assisted technologies like screen readers to go to a page in one language when the lang attr is showing a different language.

Details here: https://accessibility.psu.edu/foreignlanguages/langtaghtml/

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] ~I have made corresponding changes to the documentation~
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
