### PR TITLE
feat(web): Add AccordionSlice to rich text embed on articles, organization and project pages

### DIFF
--- a/apps/web/screens/Article/Article.tsx
+++ b/apps/web/screens/Article/Article.tsx
@@ -34,6 +34,7 @@ import {
   stepperUtils,
   ChartsCard,
   OneColumnTextSlice,
+  AccordionSlice,
 } from '@island.is/web/components'
 import { withMainLayout } from '@island.is/web/layouts/main'
 import { GET_ARTICLE_QUERY, GET_NAMESPACE_QUERY } from '../queries'
@@ -591,6 +592,7 @@ const ArticleScreen: Screen<ArticleProps> = ({
                     OneColumnText: (slice) => (
                       <OneColumnTextSlice slice={slice} />
                     ),
+                    AccordionSlice: (slice) => <AccordionSlice slice={slice} />,
                   },
                 },
                 activeLocale,

--- a/apps/web/screens/Organization/SubPage.tsx
+++ b/apps/web/screens/Organization/SubPage.tsx
@@ -37,6 +37,7 @@ import {
   Form,
   OneColumnTextSlice,
   PowerBiSlice,
+  AccordionSlice,
 } from '@island.is/web/components'
 import { CustomNextError } from '@island.is/web/units/errors'
 import useContentfulId from '@island.is/web/hooks/useContentfulId'
@@ -182,6 +183,9 @@ const SubPage: Screen<SubPageProps> = ({
                         ),
                         PowerBiSlice: (slice: PowerBiSliceSchema) => (
                           <PowerBiSlice slice={slice} />
+                        ),
+                        AccordionSlice: (slice) => (
+                          <AccordionSlice slice={slice} />
                         ),
                       },
                     })}

--- a/apps/web/screens/Project/Project.tsx
+++ b/apps/web/screens/Project/Project.tsx
@@ -20,6 +20,7 @@ import {
   stepperUtils,
   Form,
   PowerBiSlice,
+  AccordionSlice,
 } from '@island.is/web/components'
 import {
   Box,
@@ -139,6 +140,7 @@ const ProjectPage: Screen<PageProps> = ({
                 renderComponent: {
                   Form: (slice) => <Form form={slice} namespace={namespace} />,
                   PowerBiSlice: (slice) => <PowerBiSlice slice={slice} />,
+                  AccordionSlice: (slice) => <AccordionSlice slice={slice} />,
                 },
               })}
           </Box>
@@ -176,6 +178,7 @@ const ProjectPage: Screen<PageProps> = ({
             renderComponent: {
               Form: (slice) => <Form form={slice} namespace={namespace} />,
               PowerBiSlice: (slice) => <PowerBiSlice slice={slice} />,
+              AccordionSlice: (slice) => <AccordionSlice slice={slice} />,
             },
           })}
         {!subpage && projectPage.stepper && (


### PR DESCRIPTION
# Add AccordionSlice to rich text embed on articles, organization and project pages

* Now you can embed an accordion slice inside of richtext for the following content types
   * Article
   * Baby Article
   * Project Page
   * Project subpage
   * Organization subpage

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
