### PR TITLE
feat(web): Digital Iceland Service Card acts as a link

### DIFF
--- a/apps/web/components/Organization/Slice/LifeEventPageListSlice/LifeEventPageListSlice.tsx
+++ b/apps/web/components/Organization/Slice/LifeEventPageListSlice/LifeEventPageListSlice.tsx
@@ -1,4 +1,4 @@
-import { Box, ProfileCard } from '@island.is/island-ui/core'
+import { Box, Link, ProfileCard } from '@island.is/island-ui/core'
 import { IconTitleCard } from '@island.is/web/components'
 import type { LifeEventPageListSlice as LifeEventPageListSliceSchema } from '@island.is/web/graphql/schema'
 import { linkResolver, LinkType, useNamespace } from '@island.is/web/hooks'
@@ -26,23 +26,27 @@ export const LifeEventPageListSlice: React.FC<LifeEventPageListSliceProps> = ({
     return (
       <Box className={styles.profileCardContainer} marginLeft={[0, 0, 0, 0, 6]}>
         {slice.lifeEventPageList?.map((page) => {
+          const href = linkResolver(
+            'digitalicelandservicesdetailpage',
+            [page.slug],
+            activeLocale,
+          ).href
           return (
-            <ProfileCard
-              key={page.id}
-              variant="title-above"
-              size="small"
-              title={page.shortTitle || page.title}
-              description={page.shortIntro || page.intro}
-              link={{
-                text: page.seeMoreText || n('profileCardSeeMore', 'Sjá nánar'),
-                url: linkResolver(
-                  'digitalicelandservicesdetailpage',
-                  [page.slug],
-                  activeLocale,
-                ).href,
-              }}
-              image={page.thumbnail?.url}
-            />
+            <Link key={page.id} href={href}>
+              <ProfileCard
+                heightFull={true}
+                variant="title-above"
+                size="small"
+                title={page.shortTitle || page.title}
+                description={page.shortIntro || page.intro}
+                link={{
+                  text:
+                    page.seeMoreText || n('profileCardSeeMore', 'Sjá nánar'),
+                  url: href,
+                }}
+                image={page.thumbnail?.url}
+              />
+            </Link>
           )
         })}
       </Box>


### PR DESCRIPTION
# Digital Iceland Service Card acts as a link

## What

* Clicking on a card will be the same as clicking on the cards link

## Why

* This was a requested feature

## Screenshots / Gifs

https://user-images.githubusercontent.com/43557895/197505788-e286d5bd-182c-44b5-a862-37be94d63203.mov




## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
