### PR TITLE
fix(web): Correctly sort organizations by title

### DIFF
--- a/apps/web/screens/Organizations/Organizations.tsx
+++ b/apps/web/screens/Organizations/Organizations.tsx
@@ -34,6 +34,7 @@ import { useNamespace } from '@island.is/web/hooks'
 import { Screen } from '@island.is/web/types'
 import { CustomNextError } from '../../units/errors'
 import { useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
+import sortAlpha from '@island.is/web/utils/sortAlpha'
 import {
   FilterMenu,
   CategoriesProps,
@@ -96,9 +97,9 @@ const OrganizationPage: Screen<OrganizationProps> = ({
   const organizationsItems = useMemo(() => {
     const items = [...organizations.items]
     if (selectedTitleSortOption.value === 'asc') {
-      items.sort((a, b) => a.title.localeCompare(b.title))
+      items.sort(sortAlpha('title'))
     } else {
-      items.sort((a, b) => b.title.localeCompare(a.title))
+      items.sort((a, b) => sortAlpha('title')(b, a))
     }
     return items
   }, [organizations, selectedTitleSortOption])

--- a/apps/web/utils/sortAlpha.ts
+++ b/apps/web/utils/sortAlpha.ts
@@ -3,7 +3,7 @@ type Item = {
 }
 
 const order =
-  '0123456789aAáÁbBcCdDeEéÉfFgGhHiIíÍjJkKlLmMnNoOóÓpPqQrRsStTuUúÚvVwWxXyYýÝzZþÞæÆöÖ'
+  '0123456789aAáÁbBcCdDðÐeEéÉfFgGhHiIíÍjJkKlLmMnNoOóÓpPqQrRsStTuUúÚvVwWxXyYýÝzZþÞæÆöÖ'
 
 const charOrder = (a: string) => {
   const ix = order.indexOf(a)


### PR DESCRIPTION
# Correctly sort organizations by title

## What

* On the /s page we were sorting with the localeCompare function but that doesn't correctly sort the items in an alphabetical order
* So instead I used the sortAlpha utility function which handles alphabetical sorting

## Screenshots / Gifs

### Before
![Screenshot 2022-10-24 at 10 43 51](https://user-images.githubusercontent.com/43557895/197508655-46ce101f-3c68-447a-b7c5-647064422b7b.png)

### After
![image](https://user-images.githubusercontent.com/43557895/197508726-30f198d1-df5f-4ad6-80b2-13beaf73d07b.png)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
