### PR TITLE
fix(parental leave): Don't show employer text for beneficiaries in final screen

### DIFF
--- a/libs/application/templates/parental-leave/src/fields/PeriodsSectionImage/ConclusionImageScreen.tsx
+++ b/libs/application/templates/parental-leave/src/fields/PeriodsSectionImage/ConclusionImageScreen.tsx
@@ -17,19 +17,23 @@ import * as styles from './ConclusionImageScreen.css'
 
 const ConclusionSectionImage: FC<FieldBaseProps> = ({ application }) => {
   const { formatMessage } = useLocale()
-  const { isSelfEmployed, applicationType, isRecivingUnemploymentBenefits } = useApplicationAnswers(application)
+  const {
+    isSelfEmployed,
+    applicationType,
+    isRecivingUnemploymentBenefits,
+  } = useApplicationAnswers(application)
   const history = useHistory()
   const steps = [formatMessage(parentalLeaveFormMessages.finalScreen.step3)]
 
-   // Added this check for applications that is in the db already
-   const oldApplication = applicationType === undefined 
-   const isBeneficiaries = !oldApplication
-     ? applicationType === PARENTAL_LEAVE
-       ? isRecivingUnemploymentBenefits === YES
-       : false
-     : false
- 
-   if (isSelfEmployed === NO && !isBeneficiaries) {
+  // Added this check for applications that is in the db already
+  const oldApplication = applicationType === undefined
+  const isBeneficiaries = !oldApplication
+    ? applicationType === PARENTAL_LEAVE
+      ? isRecivingUnemploymentBenefits === YES
+      : false
+    : false
+
+  if (isSelfEmployed === NO && !isBeneficiaries) {
     steps.unshift(
       formatMessage(parentalLeaveFormMessages.reviewScreen.employerDesc),
     )

--- a/libs/application/templates/parental-leave/src/fields/PeriodsSectionImage/ConclusionImageScreen.tsx
+++ b/libs/application/templates/parental-leave/src/fields/PeriodsSectionImage/ConclusionImageScreen.tsx
@@ -11,17 +11,25 @@ import {
   otherParentApprovalDescription,
   requiresOtherParentApproval,
 } from '../../lib/parentalLeaveUtils'
-import { NO } from '../../constants'
+import { NO, PARENTAL_LEAVE, YES } from '../../constants'
 
 import * as styles from './ConclusionImageScreen.css'
 
 const ConclusionSectionImage: FC<FieldBaseProps> = ({ application }) => {
   const { formatMessage } = useLocale()
-  const { isSelfEmployed } = useApplicationAnswers(application)
+  const { isSelfEmployed, applicationType, isRecivingUnemploymentBenefits } = useApplicationAnswers(application)
   const history = useHistory()
   const steps = [formatMessage(parentalLeaveFormMessages.finalScreen.step3)]
 
-  if (isSelfEmployed === NO) {
+   // Added this check for applications that is in the db already
+   const oldApplication = applicationType === undefined 
+   const isBeneficiaries = !oldApplication
+     ? applicationType === PARENTAL_LEAVE
+       ? isRecivingUnemploymentBenefits === YES
+       : false
+     : false
+ 
+   if (isSelfEmployed === NO && !isBeneficiaries) {
     steps.unshift(
       formatMessage(parentalLeaveFormMessages.reviewScreen.employerDesc),
     )


### PR DESCRIPTION
## What

If applicant is receiving benefits then we don't want to show the text about employers on the final screen.

## Screenshots / Gifs
<img width="888" alt="Screenshot 2022-10-24 at 10 54 11" src="https://user-images.githubusercontent.com/102811817/197510415-4e2332d7-cf15-43f1-b04c-c354c307a9c6.png">

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
