### PR TITLE
fix(web): SupportQNA circularity check

### DIFF
--- a/libs/cms/src/lib/search/importers/supportQNA.service.ts
+++ b/libs/cms/src/lib/search/importers/supportQNA.service.ts
@@ -2,9 +2,7 @@ import { MappedData } from '@island.is/content-search-indexer/types'
 import { logger } from '@island.is/logging'
 import { Injectable } from '@nestjs/common'
 import { Entry } from 'contentful'
-import { writeFileSync } from 'fs'
 import isCircular from 'is-circular'
-import { inspect } from 'util'
 import { ISupportQna } from '../../generated/contentfulTypes'
 import { mapSupportQNA, SupportQNA } from '../../models/supportQNA.model'
 import { CmsSyncProvider, processSyncDataInput } from '../cmsSync.service'
@@ -32,14 +30,6 @@ export class SupportQNASyncService implements CmsSyncProvider<ISupportQna> {
     return entries.reduce(
       (processedEntries: ISupportQna[], entry: Entry<any>) => {
         if (this.validateArticle(entry)) {
-          writeFileSync(
-            `${entry.sys.id}.js`,
-            inspect(
-              { ...entry, fields: { ...entry.fields, relatedLinks: [] } },
-              true,
-              100,
-            ),
-          )
           // We know that relatedLinks can contain circular references and that is dealt with during the mapping so we ignore it during the circularity check here
           if (
             !isCircular({

--- a/libs/cms/src/lib/search/importers/supportQNA.service.ts
+++ b/libs/cms/src/lib/search/importers/supportQNA.service.ts
@@ -2,7 +2,9 @@ import { MappedData } from '@island.is/content-search-indexer/types'
 import { logger } from '@island.is/logging'
 import { Injectable } from '@nestjs/common'
 import { Entry } from 'contentful'
+import { writeFileSync } from 'fs'
 import isCircular from 'is-circular'
+import { inspect } from 'util'
 import { ISupportQna } from '../../generated/contentfulTypes'
 import { mapSupportQNA, SupportQNA } from '../../models/supportQNA.model'
 import { CmsSyncProvider, processSyncDataInput } from '../cmsSync.service'
@@ -30,8 +32,21 @@ export class SupportQNASyncService implements CmsSyncProvider<ISupportQna> {
     return entries.reduce(
       (processedEntries: ISupportQna[], entry: Entry<any>) => {
         if (this.validateArticle(entry)) {
+          writeFileSync(
+            `${entry.sys.id}.js`,
+            inspect(
+              { ...entry, fields: { ...entry.fields, relatedLinks: [] } },
+              true,
+              100,
+            ),
+          )
           // We know that relatedLinks can contain circular references and that is dealt with during the mapping so we ignore it during the circularity check here
-          if (!isCircular({ ...entry, relatedLinks: [] })) {
+          if (
+            !isCircular({
+              ...entry,
+              fields: { ...entry.fields, relatedLinks: [] },
+            })
+          ) {
             processedEntries.push(entry)
           } else {
             logger.warn('Circular reference found in question', {


### PR DESCRIPTION
# SupportQNA circularity check

## What

* We recently wanted to ignore relatedLinks field in the circularity check for the SupportQNA content type but I forgot to add the "fields" field before so the last fix didn't work.
* See last PR https://github.com/island-is/island.is/pull/8693

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
