### PR TITLE
chore(web): Make sectionwithimage text optional as well as life event page image

### DIFF
--- a/apps/web/screens/LifeEvent/LifeEvent.tsx
+++ b/apps/web/screens/LifeEvent/LifeEvent.tsx
@@ -98,10 +98,10 @@ export const LifeEvent: Screen<LifeEventProps> = ({
       <HeadWithSocialSharing
         title={`${title} | Ísland.is`}
         description={intro}
-        imageUrl={image.url}
-        imageContentType={image.contentType}
-        imageWidth={image.width.toString()}
-        imageHeight={image.height.toString()}
+        imageUrl={image?.url}
+        imageContentType={image?.contentType}
+        imageWidth={image?.width?.toString()}
+        imageHeight={image?.height?.toString()}
       />
 
       <GridContainer id="main-content">
@@ -112,12 +112,14 @@ export const LifeEvent: Screen<LifeEventProps> = ({
             width="full"
             printHidden
           >
-            <BackgroundImage
-              ratio="12:4"
-              background="transparent"
-              boxProps={{ background: 'white' }}
-              image={image}
-            />
+            {image && (
+              <BackgroundImage
+                ratio="12:4"
+                background="transparent"
+                boxProps={{ background: 'white' }}
+                image={image}
+              />
+            )}
           </Box>
         </GridRow>
         <GridRow>

--- a/libs/cms/src/lib/models/sectionWithImage.model.ts
+++ b/libs/cms/src/lib/models/sectionWithImage.model.ts
@@ -15,8 +15,8 @@ export class SectionWithImage {
   @Field(() => Image, { nullable: true })
   image?: Image | null
 
-  @Field(() => Html)
-  html!: Html //fields.body is required in the contentful validation on the content model
+  @Field(() => Html, { nullable: true })
+  html?: Html | null
 }
 
 export const mapSectionWithImage = ({
@@ -27,5 +27,5 @@ export const mapSectionWithImage = ({
   id: sys.id,
   title: fields.title ?? '',
   image: fields.image?.fields?.file ? mapImage(fields.image) : null,
-  html: fields.body && mapHtml(fields.body, sys.id + ':html'),
+  html: fields.body ? mapHtml(fields.body, sys.id + ':html') : null,
 })


### PR DESCRIPTION
# Make sectionwithimage text optional as well as life event page image

## What

* The code isn't robust enough so when fields were missing from Contentful the user would see a 500 page on the web
* This change addresses that issue

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
