### PR TITLE
fix(web): SupportQNA link

### DIFF
--- a/libs/cms/src/lib/models/supportQNA.model.ts
+++ b/libs/cms/src/lib/models/supportQNA.model.ts
@@ -85,7 +85,7 @@ const convertSupportQnAToLink = (supportQnA: ISupportQna, locale = 'is-IS') => {
       text: supportQnA.fields.question,
       url: `/${locale === 'is-IS' ? 'adstod' : `${locale}/help`}/${
         supportQnA.fields.organization?.fields?.slug ?? ''
-      }/${supportQnA.fields.category?.fields?.slug ?? ''}${
+      }/${supportQnA.fields.category?.fields?.slug ?? ''}/${
         supportQnA.fields?.slug ?? ''
       }`,
     },


### PR DESCRIPTION
# SupportQNA link

## What

* There was a missing slash so all related links of a supportqna lead to the wrong place
* This change adds that missing slash

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
