### PR TITLE
chore(web): Make fields IntroLinkImage fields optional to prevent graphql errors on english pages

### DIFF
--- a/apps/web/components/Organization/Slice/OverviewLinks/OverviewLinks.tsx
+++ b/apps/web/components/Organization/Slice/OverviewLinks/OverviewLinks.tsx
@@ -66,8 +66,8 @@ export const OverviewLinksSlice: React.FC<SliceProps> = ({ slice }) => {
                         paddingRight={leftImage ? [10, 0, 0, 0, 6] : [10, 0]}
                       >
                         <Image
-                          url={image.url + '?w=774&fm=webp&q=80'}
-                          thumbnail={image.url + '?w=50&fm=webp&q=80'}
+                          url={image?.url + '?w=774&fm=webp&q=80'}
+                          thumbnail={image?.url + '?w=50&fm=webp&q=80'}
                           {...image}
                         />
                       </Box>
@@ -97,17 +97,19 @@ export const OverviewLinksSlice: React.FC<SliceProps> = ({ slice }) => {
                               )}{' '}
                             </Box>
                           )}
-                          <Link
-                            {...linkResolver(link.type as LinkType, [
-                              link.slug,
-                            ])}
-                            skipTab
-                            newTab={openLinkInNewTab ?? true}
-                          >
-                            <Button icon="arrowForward" variant="text">
-                              {linkTitle}
-                            </Button>
-                          </Link>
+                          {link?.slug && link?.type && (
+                            <Link
+                              {...linkResolver(link.type as LinkType, [
+                                link.slug,
+                              ])}
+                              skipTab
+                              newTab={openLinkInNewTab ?? true}
+                            >
+                              <Button icon="arrowForward" variant="text">
+                                {linkTitle}
+                              </Button>
+                            </Link>
+                          )}
                         </Box>
                       </Box>
                     </GridColumn>

--- a/libs/cms/src/lib/models/introLinkImage.model.ts
+++ b/libs/cms/src/lib/models/introLinkImage.model.ts
@@ -9,20 +9,20 @@ export class IntroLinkImage {
   @Field()
   title?: string
 
-  @Field(() => Html)
+  @Field(() => Html, { nullable: true })
   intro?: Html
 
   @Field(() => Image, { nullable: true })
-  image!: Image
+  image?: Image | null
 
   @Field(() => Boolean)
   leftImage?: boolean
 
   @Field()
-  linkTitle!: string
+  linkTitle?: string
 
-  @Field(() => ReferenceLink)
-  link!: ReferenceLink | null
+  @Field(() => ReferenceLink, { nullable: true })
+  link?: ReferenceLink | null
 
   @Field(() => Boolean)
   openLinkInNewTab?: boolean
@@ -34,7 +34,7 @@ export const mapIntroLinkImage = ({
 }: IIntroLinkImage): IntroLinkImage => ({
   title: fields.title ?? '',
   intro: (fields.intro && mapHtml(fields.intro, sys.id + ':intro')) ?? null,
-  image: mapImage(fields.image),
+  image: fields.image ? mapImage(fields.image) : null,
   leftImage: fields.leftImage ?? false,
   linkTitle: fields.linkTitle ?? '',
   link: fields.link ? mapReferenceLink(fields.link) : null,


### PR DESCRIPTION
# Make fields IntroLinkImage fields optional to prevent graphql errors on english pages

## What

* Contentful allows you to publish content even though required fields are missing (on other locales than the default one)
* This allows Contentful users to cause 500 errors on english pages because the code expects fields to be there when they are not
* This change addresses that issue for the IntroLinkImage content type (but there are probably more content types which are like this)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
