### PR TITLE
fix(service-portal): button doubling on smaller screens

### DIFF
--- a/libs/service-portal/finance/src/screens/FinanceStatus/FinanceStatus.tsx
+++ b/libs/service-portal/finance/src/screens/FinanceStatus/FinanceStatus.tsx
@@ -131,7 +131,7 @@ const FinanceStatus: ServicePortalModuleComponent = ({ userInfo }) => {
       />
       <Stack space={2}>
         <GridRow>
-          <GridColumn span={['12/12', '12/12', '12/12', '6/12']}>
+          <GridColumn span={['12/12', '12/12', '12/12', '8/12']}>
             {financeStatusData.organizations?.length > 0 ||
             financeStatusZero ? (
               <Box display="flex" justifyContent="flexStart" printHidden>


### PR DESCRIPTION
# Service portal - Button container width

## What

Fixing button with long title doubling. Button container made wider.

<img width="308" alt="Screenshot 2022-10-25 at 12 39 51" src="https://user-images.githubusercontent.com/19873770/197791288-72e0c676-3f79-474c-b76c-149b9afcf5a6.png">
. 
## Why


## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
