### PR TITLE
fix(j-s): fix hiddenFeatures split

### DIFF
--- a/apps/judicial-system/api/src/app/modules/feature/feature.controller.ts
+++ b/apps/judicial-system/api/src/app/modules/feature/feature.controller.ts
@@ -4,7 +4,7 @@ import type { Feature } from '@island.is/judicial-system/types'
 
 import { environment } from '../../../environments'
 
-const hiddenFeatures = environment.features?.hidden?.split(',')
+const hiddenFeatures = environment.features?.hidden?.trim().split(/[, ]+/)
 
 // This controller is not guearded as it should also be available to users not logged in
 @Controller('api/feature')

--- a/apps/judicial-system/api/src/app/modules/feature/feature.controller.ts
+++ b/apps/judicial-system/api/src/app/modules/feature/feature.controller.ts
@@ -1,10 +1,11 @@
 import { Controller, Get, Param } from '@nestjs/common'
 
 import type { Feature } from '@island.is/judicial-system/types'
+import { splitStringByComma } from '@island.is/judicial-system/formatters'
 
 import { environment } from '../../../environments'
 
-const hiddenFeatures = environment.features?.hidden?.trim().split(/[, ]+/)
+const hiddenFeatures = splitStringByComma(environment.features?.hidden)
 
 // This controller is not guearded as it should also be available to users not logged in
 @Controller('api/feature')

--- a/libs/judicial-system/formatters/src/lib/formatters.spec.ts
+++ b/libs/judicial-system/formatters/src/lib/formatters.spec.ts
@@ -11,6 +11,7 @@ import {
   formatDOB,
   formatPhoneNumber,
   displayFirstPlusRemaining,
+  splitStringByComma,
 } from './formatters'
 
 describe('formatDate', () => {
@@ -267,4 +268,29 @@ describe('displayFirstPlusRemaining', () => {
       'apple +2',
     )
   })
+})
+
+describe('splitStringByComma', () => {
+  test('should handle "apple" as input', () => {
+    expect(splitStringByComma('apple')).toEqual(['apple'])
+  })
+
+  test.each(['apple, pear', 'apple pear', 'apple,pear'])(
+    'should handle "%s" as input',
+    (input) => {
+      const result = splitStringByComma(input)
+
+      expect(result).toHaveLength(2)
+      expect(result).toEqual(['apple', 'pear'])
+    },
+  )
+  test.each(['apple, pear, orange', 'apple pear orange'])(
+    'should handle %s as input',
+    (input) => {
+      const result = splitStringByComma(input)
+
+      expect(result).toHaveLength(3)
+      expect(result).toEqual(['apple', 'pear', 'orange'])
+    },
+  )
 })

--- a/libs/judicial-system/formatters/src/lib/formatters.ts
+++ b/libs/judicial-system/formatters/src/lib/formatters.ts
@@ -9,7 +9,6 @@ import {
   CaseType,
   isRestrictionCase,
   isIndictmentCase,
-  SessionArrangements,
 } from '@island.is/judicial-system/types'
 
 const getAsDate = (date: Date | string | undefined | null): Date => {
@@ -284,4 +283,8 @@ export const formatDefenderRoute = (
   return `${baseUrl}/verjandi${
     isIndictmentCase(caseType) ? '/akaera' : ''
   }/${id}`
+}
+
+export const splitStringByComma = (str?: string): string[] => {
+  return str?.trim().split(/[, ]+/) || []
 }


### PR DESCRIPTION

## What

- More graceful handling for string split

## Why

- Handles strings like:
  - `feature1, otherFeature`
  - `feature1,otherFeature`
  - `feature1 otherFeature`
  - `feature1 otherFeature `

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
