### PR TITLE
fix(auth): Allow granting company and finance scopes 1-level deep

### DIFF
--- a/libs/auth-api-lib/src/lib/delegations/DelegationConfig.ts
+++ b/libs/auth-api-lib/src/lib/delegations/DelegationConfig.ts
@@ -46,11 +46,11 @@ export const DelegationConfig = defineConfig<z.infer<typeof schema>>({
       },
       {
         scopeName: ApiScope.financeSalary,
-        onlyForDelegationType: ['ProcurationHolder'],
+        onlyForDelegationType: ['ProcurationHolder', 'Custom'],
       },
       {
         scopeName: ApiScope.company,
-        onlyForDelegationType: ['ProcurationHolder'],
+        onlyForDelegationType: ['ProcurationHolder', 'Custom'],
       },
     ],
     userInfoUrl:


### PR DESCRIPTION
## What

See subject.

## Why

To make 1-level deep delegations work consistently.
