### PR TITLE
fix(web): Removed entry hyperlink fields that might cause circularity when mapping html

### DIFF
--- a/libs/cms/src/lib/models/html.model.ts
+++ b/libs/cms/src/lib/models/html.model.ts
@@ -55,23 +55,7 @@ export class Html {
 
 export const mapHtml = (html: Document | TopLevelBlock, id: string): Html => {
   const newHtml = sanitizeData(html)
-
-  // Remove all unnecessary fields from entry-hyperlinks
-  newHtml.content.forEach((node) => {
-    if (node.nodeType === 'entry-hyperlink') {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      if ('organizationPage' in ((node.data.target as any)?.fields ?? {})) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const slug = (node?.data?.target as any)?.fields?.organizationPage
-          ?.fields?.slug
-        removeEntryHyperlinkFields(node)
-        if (slug)
-          node.data.target.fields.organizationPage = { fields: { slug: slug } }
-      } else {
-        removeEntryHyperlinkFields(node)
-      }
-    }
-  })
+  removeEntryHyperlinkFields(newHtml)
 
   switch (newHtml.nodeType) {
     case BLOCKS.DOCUMENT:

--- a/libs/cms/src/lib/search/importers/utils.ts
+++ b/libs/cms/src/lib/search/importers/utils.ts
@@ -99,7 +99,14 @@ export const numberOfProcessEntries = (contentList: any[]) =>
 const pruneEntryHyperlink = (node: any) => {
   if (node?.data?.target?.fields) {
     for (const field of Object.keys(node.data.target.fields)) {
-      if (field !== 'slug' && field !== 'url') {
+      if (field === 'organizationPage') {
+        // Just in case there's an entry-hyperlink that needs an organization page in order to make the url
+        node.data.target.fields[field] = {
+          fields: {
+            slug: node.data.target.fields[field]?.fields?.slug,
+          },
+        }
+      } else if (field !== 'slug' && field !== 'url') {
         delete node.data.target.fields[field]
       }
     }

--- a/libs/island-ui/contentful/src/lib/RichTextRC/defaultRenderNode.tsx
+++ b/libs/island-ui/contentful/src/lib/RichTextRC/defaultRenderNode.tsx
@@ -179,15 +179,21 @@ export const defaultRenderNode: RenderNode = {
     const type = entry?.sys?.contentType?.sys?.id
     switch (type) {
       case 'article':
-        return entry.fields.slug ? (
-          <Hyperlink href={`/${entry.fields.slug}`}>{children}</Hyperlink>
+        return entry?.fields?.slug ? (
+          <Hyperlink
+            href={`/${
+              entry.sys?.locale === 'is-IS' ? '' : entry.sys?.locale + '/'
+            }${entry?.fields?.slug}`}
+          >
+            {children}
+          </Hyperlink>
         ) : null
       case 'subArticle':
-        return entry.fields.url ? (
+        return entry?.fields?.url ? (
           <Hyperlink href={entry.fields.url}>{children}</Hyperlink>
         ) : null
       case 'organizationPage': {
-        const prefix = getOrganizationPrefix(entry.sys?.locale)
+        const prefix = getOrganizationPrefix(entry?.sys?.locale)
         return entry.fields.slug ? (
           <Hyperlink href={`/${prefix}/${entry.fields.slug}`}>
             {children}
@@ -195,8 +201,8 @@ export const defaultRenderNode: RenderNode = {
         ) : null
       }
       case 'organizationSubpage': {
-        const prefix = getOrganizationPrefix(entry.sys?.locale)
-        return entry.fields.slug &&
+        const prefix = getOrganizationPrefix(entry?.sys?.locale)
+        return entry?.fields?.slug &&
           entry.fields.organizationPage?.fields?.slug ? (
           <Hyperlink
             href={`/${prefix}/${entry.fields.organizationPage.fields.slug}/${entry.fields.slug}`}
@@ -213,7 +219,7 @@ export const defaultRenderNode: RenderNode = {
 
 const getOrganizationPrefix = (locale: string) => {
   if (locale && !locale.includes('is')) {
-    return 'o'
+    return `${locale}/o`
   }
   return 's'
 }


### PR DESCRIPTION
# Removed entry hyperlink fields that might cause circularity when mapping html

## What

* We've seen that entry-hyperlinks can contain circular data (since we are referencing an entry which might reference an entry that references the original entry and so forth) which has been causing some issues when extracting strings from the object (since if the data is circular then that string extraction function will never end)
* This change removes all fields from entry-hyperlinks except for what's important (the actual values that make up the url)
* By doing this we no longer have to worry about making entry-hyperlinks in Contentful since we cut off everything that isn't necessary to make up the urls in the code
* While I was at it I also noticed some of the urls were wrong when the locale wasn't set to Icelandic so I fixed that as well

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
