### PR TITLE
feat(web): Show title above Life event page list slice if it's present

### DIFF
--- a/apps/web/components/Organization/Slice/LifeEventPageListSlice/LifeEventPageListSlice.tsx
+++ b/apps/web/components/Organization/Slice/LifeEventPageListSlice/LifeEventPageListSlice.tsx
@@ -1,4 +1,4 @@
-import { Box, Link, ProfileCard } from '@island.is/island-ui/core'
+import { Box, Link, ProfileCard, Text } from '@island.is/island-ui/core'
 import { IconTitleCard } from '@island.is/web/components'
 import type { LifeEventPageListSlice as LifeEventPageListSliceSchema } from '@island.is/web/graphql/schema'
 import { linkResolver, LinkType, useNamespace } from '@island.is/web/hooks'
@@ -54,17 +54,24 @@ export const LifeEventPageListSlice: React.FC<LifeEventPageListSliceProps> = ({
   }
 
   return (
-    <Box className={styles.lifeEventCardContainer}>
-      {slice.lifeEventPageList?.map((page) => (
-        <IconTitleCard
-          heading={page.shortTitle || page.title}
-          imgSrc={page.tinyThumbnail?.url}
-          alt={page.tinyThumbnail?.title}
-          href={
-            linkResolver(anchorPageLinkType, [page.slug], activeLocale).href
-          }
-        />
-      ))}
+    <Box>
+      {slice.title && (
+        <Text variant="h2" marginBottom={3}>
+          {slice.title}
+        </Text>
+      )}
+      <Box className={styles.lifeEventCardContainer}>
+        {slice.lifeEventPageList?.map((page) => (
+          <IconTitleCard
+            heading={page.shortTitle || page.title}
+            imgSrc={page.tinyThumbnail?.url}
+            alt={page.tinyThumbnail?.title}
+            href={
+              linkResolver(anchorPageLinkType, [page.slug], activeLocale).href
+            }
+          />
+        ))}
+      </Box>
     </Box>
   )
 }


### PR DESCRIPTION
# Show title above Life event page list slice when the list is viewed in the icon card variant

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/43557895/198036645-1f7b0e2c-8351-4632-a0e8-6bc5416040d4.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
