### PR TITLE
fix(service-portal):  Apollo caching delegations

### DIFF
--- a/libs/service-portal/settings/access-control/src/screens/AccessControl/AccessControl.tsx
+++ b/libs/service-portal/settings/access-control/src/screens/AccessControl/AccessControl.tsx
@@ -30,6 +30,7 @@ const AccessControl: ServicePortalModuleComponent = ({ userInfo, client }) => {
   useNamespaces('sp.settings-access-control')
   const { data, loading } = useQuery<Query>(AuthDelegationsQuery, {
     variables: { input: { domain: ISLAND_DOMAIN } },
+    fetchPolicy: 'cache-and-network',
   })
   const { switchUser } = useAuth()
   const { formatMessage } = useLocale()


### PR DESCRIPTION
# Hot fix for Apollo caching delegations query

## What

Apollo seams to be caching authDelegtions query in delegation access control screen and because of that No data screen is displayed when you add delegation for the first time

## Why

Needs fixing on dev and prod

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
