### PR TITLE
feat(web): Remove paddingTop from first slice on Organization page if there is no description 

### DIFF
--- a/apps/web/components/Organization/Slice/SliceMachine.tsx
+++ b/apps/web/components/Organization/Slice/SliceMachine.tsx
@@ -85,6 +85,7 @@ interface SliceMachineProps {
   renderedOnOrganizationSubpage?: boolean
   marginBottom?: ResponsiveSpace
   params?: Record<string, any>
+  paddingTop?: ResponsiveSpace
 }
 
 const fullWidthSlices = [
@@ -161,12 +162,13 @@ export const SliceMachine = ({
   renderedOnOrganizationSubpage = false,
   marginBottom = 0,
   params,
+  paddingTop = 6,
 }: SliceMachineProps) => {
   return !fullWidth ? (
     <GridContainer>
       <GridRow marginBottom={marginBottom}>
         <GridColumn
-          paddingTop={6}
+          paddingTop={paddingTop}
           span={
             fullWidthSlices.includes(slice.__typename)
               ? '9/9'

--- a/apps/web/screens/Organization/Home/Home.tsx
+++ b/apps/web/screens/Organization/Home/Home.tsx
@@ -81,6 +81,7 @@ const Home: Screen<HomeProps> = ({ organizationPage, namespace }) => {
                   : undefined,
             }}
             renderedOnOrganizationSubpage={false}
+            paddingTop={!organizationPage.description && index === 0 ? 0 : 6}
           />
         )
       })}


### PR DESCRIPTION
# Remove paddingTop from first slice on Organization page if there is no description

## What

* We were asked to move the content up a bit (no need to have padding top for the top slice)

## Screenshots / Gifs

### Before
![image](https://user-images.githubusercontent.com/43557895/198299137-26e6ca63-97ad-4518-949e-c0a08025d654.png)


### After
![image](https://user-images.githubusercontent.com/43557895/198298984-f1d0dc75-d2b4-408b-9416-01223fa7b43e.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
