### PR TITLE
chore(web): Sort articles on categories screen alphabetically

### DIFF
--- a/apps/web/screens/Category/Category/Category.tsx
+++ b/apps/web/screens/Category/Category/Category.tsx
@@ -44,6 +44,7 @@ import {
 import { CustomNextError } from '@island.is/web/units/errors'
 import { LinkType, useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
 import { scrollTo } from '@island.is/web/hooks/useScrollSpy'
+import sortAlpha from '@island.is/web/utils/sortAlpha'
 
 type Articles = GetArticlesQuery['getArticles']
 type LifeEvents = GetLifeEventsInCategoryQuery['getLifeEventsInCategory']
@@ -248,16 +249,14 @@ const Category: Screen<CategoryProps> = ({
       a.importance > b.importance
         ? -1
         : a.importance === b.importance
-        ? a.title.localeCompare(b.title)
+        ? sortAlpha('title')(a, b)
         : 1,
     )
 
     // If it's sorted alphabetically we need to be able to communicate that.
     const isSortedAlphabetically =
       JSON.stringify(sortedArticles) ===
-      JSON.stringify(
-        [...articles].sort((a, b) => a.title.localeCompare(b.title)),
-      )
+      JSON.stringify([...articles].sort(sortAlpha('title')))
 
     return { sortedArticles, isSortedAlphabetically }
   }
@@ -280,10 +279,9 @@ const Category: Screen<CategoryProps> = ({
         return foundA.importance > foundB.importance
           ? -1
           : foundA.importance === foundB.importance
-          ? foundA.title.localeCompare(foundB.title)
+          ? sortAlpha('title')(foundA, foundB)
           : 1
       }
-
       // Fall back to alphabet
       return a.localeCompare(b)
     })
@@ -293,7 +291,7 @@ const Category: Screen<CategoryProps> = ({
   ).sort((a: ArticleGroup, b: ArticleGroup) =>
     a.importance > b.importance
       ? -1
-      : a.importance === b.importance && a.title.localeCompare(b.title, 'is'),
+      : a.importance === b.importance && sortAlpha('title')(a, b),
   )
 
   const ArticleGroupComponent = ({


### PR DESCRIPTION
# Sort articles on categories screen alphabetically

## What

* Articles weren't sorted correctly in an alphabetical order on the categories screen (/flokkur)
*This code change addresses that issue

## Screenshots / Gifs

### Before this change (notice that Ö isn't at the bottom)
![image](https://user-images.githubusercontent.com/43557895/198337636-4f13e1ba-eed0-4519-881c-339f0612f5cf.png)

### After this change
![image](https://user-images.githubusercontent.com/43557895/198337687-9c37efcf-0eb7-4942-8543-58f231fdbc55.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
