### PR TITLE
feat(web): Hotfix - Remove paddingTop from first slice on Organization page if there is no description  (#8818)

### DIFF
--- a/apps/web/components/Organization/Slice/SliceMachine.tsx
+++ b/apps/web/components/Organization/Slice/SliceMachine.tsx
@@ -85,6 +85,7 @@ interface SliceMachineProps {
   renderedOnOrganizationSubpage?: boolean
   marginBottom?: ResponsiveSpace
   params?: Record<string, any>
+  paddingTop?: ResponsiveSpace
 }
 
 const fullWidthSlices = [
@@ -161,12 +162,13 @@ export const SliceMachine = ({
   renderedOnOrganizationSubpage = false,
   marginBottom = 0,
   params,
+  paddingTop = 6,
 }: SliceMachineProps) => {
   return !fullWidth ? (
     <GridContainer>
       <GridRow marginBottom={marginBottom}>
         <GridColumn
-          paddingTop={6}
+          paddingTop={paddingTop}
           span={
             fullWidthSlices.includes(slice.__typename)
               ? '9/9'

--- a/apps/web/screens/Organization/Home/Home.tsx
+++ b/apps/web/screens/Organization/Home/Home.tsx
@@ -81,6 +81,7 @@ const Home: Screen<HomeProps> = ({ organizationPage, namespace }) => {
                   : undefined,
             }}
             renderedOnOrganizationSubpage={false}
+            paddingTop={!organizationPage.description && index === 0 ? 0 : 6}
           />
         )
       })}


### PR DESCRIPTION
Co-authored-by: kodiakhq[bot] <49736102+kodiakhq[bot]@users.noreply.github.com>

# Hotfix - Remove paddingTop from first slice on Organization page if there is no description  (#8818)

This is a cherry-pick commit that we'd like to hotfix in since the layout change was requested by Digital Iceland
