### PR TITLE
feat(web): Optionally render Accordion Slice title

### DIFF
--- a/apps/web/components/Organization/Slice/AccordionSlice/AccordionSlice.tsx
+++ b/apps/web/components/Organization/Slice/AccordionSlice/AccordionSlice.tsx
@@ -15,6 +15,21 @@ import {
 import { richText, SliceType } from '@island.is/island-ui/contentful'
 import * as styles from './AccordionSlice.css'
 
+const headingLevels = ['h2', 'h3', 'h4', 'h5'] as const
+type HeadingType = typeof headingLevels[number]
+
+export const extractHeadingLevels = (slice: AccordionSliceSchema) => {
+  let titleHeading: HeadingType = 'h2'
+  let childHeading: HeadingType = 'h3'
+
+  if (headingLevels.includes(slice.titleHeadingLevel as HeadingType)) {
+    titleHeading = slice.titleHeadingLevel as HeadingType
+    childHeading = `h${Number(titleHeading[1]) + 1}` as HeadingType
+  }
+
+  return { titleHeading, childHeading }
+}
+
 interface SliceProps {
   slice: AccordionSliceSchema
 }
@@ -34,18 +49,23 @@ export const AccordionSlice: React.FC<SliceProps> = ({ slice }) => {
         paddingBottom: 2,
       }
 
+  const { titleHeading, childHeading } = extractHeadingLevels(slice)
+
   return (
     <section key={slice.id} id={slice.id} aria-labelledby={labelId}>
       <Box {...borderProps}>
-        <Text variant="h2" as="h2" marginBottom={2} id={labelId}>
-          {slice.title}
-        </Text>
+        {slice.showTitle && (
+          <Text variant="h2" as={titleHeading} marginBottom={2} id={labelId}>
+            {slice.title}
+          </Text>
+        )}
         {slice.type === 'accordion' &&
           slice.accordionItems.map((item) => (
             <Box paddingY={1} key={item.id}>
               <AccordionCard
                 id={item.id}
                 label={item.title}
+                labelUse={childHeading}
                 startExpanded={slice.accordionItems.length === 1}
               >
                 <Box className={styles.accordionBox}>
@@ -68,6 +88,7 @@ export const AccordionSlice: React.FC<SliceProps> = ({ slice }) => {
                   key={item.id}
                   id={item.id}
                   label={item.title}
+                  labelUse={childHeading}
                   startExpanded={slice.accordionItems.length === 1}
                 >
                   <Text>

--- a/apps/web/screens/queries/fragments.ts
+++ b/apps/web/screens/queries/fragments.ts
@@ -435,6 +435,8 @@ export const slices = gql`
     title
     type
     hasBorderAbove
+    showTitle
+    titleHeadingLevel
     accordionItems {
       id
       title

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -15,6 +15,12 @@ export interface IAccordionSliceFields {
 
   /** Has Border Above */
   hasBorderAbove?: boolean | undefined
+
+  /** Title Heading Level */
+  titleHeadingLevel?: 'h2' | 'h3' | 'h4' | undefined
+
+  /** Show Title */
+  showTitle?: boolean | undefined
 }
 
 /** A slice with accordions */

--- a/libs/cms/src/lib/models/accordionSlice.model.ts
+++ b/libs/cms/src/lib/models/accordionSlice.model.ts
@@ -20,6 +20,12 @@ export class AccordionSlice {
 
   @Field(() => Boolean, { nullable: true })
   hasBorderAbove?: boolean
+
+  @Field(() => Boolean, { nullable: true })
+  showTitle?: boolean
+
+  @Field({ nullable: true })
+  titleHeadingLevel?: string
 }
 
 export const mapAccordionSlice = ({
@@ -32,4 +38,6 @@ export const mapAccordionSlice = ({
   type: fields.type ?? '',
   accordionItems: (fields.accordionItems ?? []).map(mapOneColumnText),
   hasBorderAbove: fields.hasBorderAbove ?? true,
+  showTitle: fields.showTitle ?? true,
+  titleHeadingLevel: fields.titleHeadingLevel ?? 'h2',
 })


### PR DESCRIPTION
# Optionally render Accordion Slice title

## What

* Add boolean field to Accordion Slice in Contentful called showTitle
* Add dropdown field to Accordion Slice in Contentful so we can choose what kind of heading element the title (and child titles) will be rendered as

## Why

* It's sometimes useful to be able to hide the accordion slice title
* We want to be able to change the semantics of the page so that it's more accessible

## Screenshots / Gifs

### Before (we couldn't change what heading level things got rendered as)
![image](https://user-images.githubusercontent.com/43557895/198615217-734dcbf6-8ac9-42d4-9de3-0d015ec13bd1.png)

### After (now we can alter the heading levels on titles to improve accessibility and semantics)
![image](https://user-images.githubusercontent.com/43557895/198615799-eba5d1e3-c3ea-4e5c-b498-91c8782b0caf.png)



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
