### PR TITLE
fix(web): Add word break to Hyperlink component

### DIFF
--- a/libs/island-ui/contentful/src/lib/Hyperlink/Hyperlink.css.ts
+++ b/libs/island-ui/contentful/src/lib/Hyperlink/Hyperlink.css.ts
@@ -1,0 +1,5 @@
+import { style } from '@vanilla-extract/css'
+
+export const link = style({
+  wordWrap: 'break-word',
+})

--- a/libs/island-ui/contentful/src/lib/Hyperlink/Hyperlink.tsx
+++ b/libs/island-ui/contentful/src/lib/Hyperlink/Hyperlink.tsx
@@ -1,6 +1,8 @@
 import React, { FC } from 'react'
 import { TextProps, Link } from '@island.is/island-ui/core'
 
+import * as styles from './Hyperlink.css'
+
 interface HyperlinkProps {
   href?: string
   slug?: string
@@ -14,6 +16,7 @@ export const Hyperlink: FC<HyperlinkProps> = ({ href, children }) => (
     color="blue400"
     underline="small"
     underlineVisibility="always"
+    className={styles.link}
   >
     {children}
   </Link>


### PR DESCRIPTION
# Add word break to Hyperlink component

## What

* 

## Why

Specify why you need to achieve this

## Screenshots / Gifs

### Before
![image](https://user-images.githubusercontent.com/43557895/198722529-fab76a02-2fd4-4f9e-bb2f-61476e9f50d5.png)

### After
![image](https://user-images.githubusercontent.com/43557895/198723060-de05c43e-f469-410a-9011-f64e27d11e3b.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
