### PR TITLE
fix(auth): Fix issue where delegations are assumed deceased

### DIFF
--- a/libs/auth-api-lib/src/lib/delegations/delegations.service.ts
+++ b/libs/auth-api-lib/src/lib/delegations/delegations.service.ts
@@ -464,14 +464,13 @@ export class DelegationsService {
       }
     }
 
-    const delegationsPromises = delegations
-      // Filter out companies, since we do not need to make a national registry call for them.
-      .filter(({ fromNationalId }) => !kennitala.isCompany(fromNationalId))
-      .map(({ fromNationalId }) =>
-        this.nationalRegistryClient
-          .getIndividual(fromNationalId)
-          .catch(this.handlerGetIndividualError),
-      )
+    const delegationsPromises = delegations.map(({ fromNationalId }) =>
+      kennitala.isCompany(fromNationalId)
+        ? null
+        : this.nationalRegistryClient
+            .getIndividual(fromNationalId)
+            .catch(this.handlerGetIndividualError),
+    )
 
     try {
       // Check if delegations is linked to a person, i.e. not deceased


### PR DESCRIPTION
## What

Fix bug.

## Why

The logic incorrectly handled company and person delegations.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
