### PR TITLE
feat(web): Add landing page theme to Organization pages

### DIFF
--- a/apps/web/components/NewsItems/Item.tsx
+++ b/apps/web/components/NewsItems/Item.tsx
@@ -25,6 +25,7 @@ type ItemProps = {
   href: string
   image?: Partial<Image>
   tags?: Tag[]
+  colorVariant?: 'default' | 'blue'
 }
 
 export const Item = ({
@@ -33,6 +34,7 @@ export const Item = ({
   text,
   href,
   image,
+  colorVariant = 'default',
   tags = [],
 }: ItemProps) => {
   const hasTags = Array.isArray(tags) && tags.length > 0
@@ -58,13 +60,24 @@ export const Item = ({
         <div className={styles.content}>
           <Box flexGrow={1} height="full">
             <Stack space={2}>
-              <Text as="span" variant="eyebrow">
+              <Text
+                color={colorVariant === 'blue' ? 'blue400' : undefined}
+                as="span"
+                variant="eyebrow"
+              >
                 {formattedDate}
               </Text>
-              <Text as="h3" variant="h2" title={heading}>
+              <Text
+                color={colorVariant === 'blue' ? 'blue600' : undefined}
+                as="h3"
+                variant="h2"
+                title={heading}
+              >
                 {heading}
               </Text>
-              <Text>{text}</Text>
+              <Text color={colorVariant === 'blue' ? 'blue600' : undefined}>
+                {text}
+              </Text>
             </Stack>
           </Box>
           {hasTags && (

--- a/apps/web/components/NewsItems/NewsItems.tsx
+++ b/apps/web/components/NewsItems/NewsItems.tsx
@@ -27,6 +27,8 @@ interface NewsItemsProps {
   // This boolean value can be used to forcefully add horizontal padding to the title section
   // This is useful if the NewsItems component is nested inside a GridContainer but we still want title section padding
   forceTitleSectionHorizontalPadding?: boolean
+
+  colorVariant?: 'default' | 'blue'
 }
 
 export const NewsItems = ({
@@ -38,6 +40,7 @@ export const NewsItems = ({
   overview = 'newsoverview',
   parameters = [],
   seeMoreHref,
+  colorVariant,
   forceTitleSectionHorizontalPadding = false,
 }: NewsItemsProps) => {
   const { linkResolver } = useLinkResolver()
@@ -61,7 +64,13 @@ export const NewsItems = ({
           })}
         >
           <Box display="flex" flexDirection="row" justifyContent="spaceBetween">
-            <Text variant="h3" as="h2" id={headingTitle} dataTestId="home-news">
+            <Text
+              color={colorVariant === 'blue' ? 'blue600' : undefined}
+              variant="h3"
+              as="h2"
+              id={headingTitle}
+              dataTestId="home-news"
+            >
               {heading}
             </Text>
             <Box display={['none', 'none', 'none', 'block']}>
@@ -100,6 +109,7 @@ export const NewsItems = ({
                 date={date}
                 heading={title}
                 text={intro}
+                colorVariant={colorVariant}
                 href={
                   linkResolver(linkType ?? (tn as LinkType), [
                     ...parameters,

--- a/apps/web/components/Organization/Slice/LatestNewsSlice/LatestNewsSlice.tsx
+++ b/apps/web/components/Organization/Slice/LatestNewsSlice/LatestNewsSlice.tsx
@@ -1,28 +1,30 @@
 import React from 'react'
 import { LatestNewsSlice as LatestNewsSliceSchema } from '@island.is/web/graphql/schema'
 import { NewsItems } from '@island.is/web/components'
-import { Box } from '@island.is/island-ui/core'
+import { Box, BoxProps } from '@island.is/island-ui/core'
 import { LinkType } from '@island.is/web/hooks'
 
 interface SliceProps {
   slice: LatestNewsSliceSchema
   slug: string
-  renderedOnOrganizationSubpage: boolean
   linkType?: LinkType
   overview?: LinkType
+  latestNewsSliceBackground?: BoxProps['background']
+  forceTitleSectionHorizontalPadding?: boolean
 }
 
 export const LatestNewsSlice: React.FC<SliceProps> = ({
   slice,
   slug,
-  renderedOnOrganizationSubpage,
   linkType = 'organizationnews',
   overview = 'organizationnewsoverview',
+  latestNewsSliceBackground = 'purple100',
+  forceTitleSectionHorizontalPadding = false,
 }) => {
   return (
     <Box
       component="section"
-      background={renderedOnOrganizationSubpage ? undefined : 'purple100'}
+      background={latestNewsSliceBackground}
       paddingTop={[5, 5, 8]}
       paddingBottom={[2, 2, 5]}
       aria-labelledby="news-items-title"
@@ -36,7 +38,7 @@ export const LatestNewsSlice: React.FC<SliceProps> = ({
         overview={overview}
         parameters={[slug]}
         seeMoreHref={slice.readMoreLink?.url}
-        forceTitleSectionHorizontalPadding={renderedOnOrganizationSubpage}
+        forceTitleSectionHorizontalPadding={forceTitleSectionHorizontalPadding}
       />
     </Box>
   )

--- a/apps/web/components/Organization/Slice/LatestNewsSlice/LatestNewsSlice.tsx
+++ b/apps/web/components/Organization/Slice/LatestNewsSlice/LatestNewsSlice.tsx
@@ -10,6 +10,7 @@ interface SliceProps {
   linkType?: LinkType
   overview?: LinkType
   latestNewsSliceBackground?: BoxProps['background']
+  latestNewsSliceColorVariant?: 'default' | 'blue'
   forceTitleSectionHorizontalPadding?: boolean
 }
 
@@ -19,6 +20,7 @@ export const LatestNewsSlice: React.FC<SliceProps> = ({
   linkType = 'organizationnews',
   overview = 'organizationnewsoverview',
   latestNewsSliceBackground = 'purple100',
+  latestNewsSliceColorVariant = 'default',
   forceTitleSectionHorizontalPadding = false,
 }) => {
   return (
@@ -39,6 +41,7 @@ export const LatestNewsSlice: React.FC<SliceProps> = ({
         parameters={[slug]}
         seeMoreHref={slice.readMoreLink?.url}
         forceTitleSectionHorizontalPadding={forceTitleSectionHorizontalPadding}
+        colorVariant={latestNewsSliceColorVariant}
       />
     </Box>
   )

--- a/apps/web/components/Organization/Slice/OneColumnText/OneColumnTextSlice.tsx
+++ b/apps/web/components/Organization/Slice/OneColumnText/OneColumnTextSlice.tsx
@@ -20,6 +20,7 @@ export const OneColumnTextSlice: React.FC<SliceProps> = ({ slice }) => {
         borderTopWidth: 'standard',
         borderColor: 'standard',
         paddingTop: 4,
+        paddingBottom: 4,
       }
     : {}
 

--- a/apps/web/components/Organization/Slice/SliceMachine.tsx
+++ b/apps/web/components/Organization/Slice/SliceMachine.tsx
@@ -82,7 +82,6 @@ interface SliceMachineProps {
   namespace?: Record<string, string>
   fullWidth?: boolean
   slug?: string
-  renderedOnOrganizationSubpage?: boolean
   marginBottom?: ResponsiveSpace
   params?: Record<string, any>
   paddingTop?: ResponsiveSpace
@@ -94,13 +93,7 @@ const fullWidthSlices = [
   'MailingListSignupSlice',
 ]
 
-const renderSlice = (
-  slice,
-  namespace,
-  slug,
-  renderedOnOrganizationSubpage = false,
-  params,
-) => {
+const renderSlice = (slice, namespace, slug, params) => {
   switch (slice.__typename) {
     case 'HeadingSlice':
       return <HeadingSlice slice={slice} />
@@ -131,14 +124,7 @@ const renderSlice = (
     case 'EventSlice':
       return <EventSlice slice={slice} />
     case 'LatestNewsSlice':
-      return (
-        <LatestNewsSlice
-          slice={slice}
-          slug={slug}
-          renderedOnOrganizationSubpage={renderedOnOrganizationSubpage}
-          {...params}
-        />
-      )
+      return <LatestNewsSlice slice={slice} slug={slug} {...params} />
     case 'MailingListSignupSlice':
       return <MailingListSignupSlice slice={slice} namespace={namespace} />
     case 'LifeEventPageListSlice':
@@ -159,7 +145,6 @@ export const SliceMachine = ({
   namespace,
   fullWidth = false,
   slug = '',
-  renderedOnOrganizationSubpage = false,
   marginBottom = 0,
   params,
   paddingTop = 6,
@@ -178,25 +163,13 @@ export const SliceMachine = ({
             fullWidthSlices.includes(slice.__typename) ? '0' : ['0', '0', '1/9']
           }
         >
-          {renderSlice(
-            slice,
-            namespace,
-            slug,
-            renderedOnOrganizationSubpage,
-            params,
-          )}
+          {renderSlice(slice, namespace, slug, params)}
         </GridColumn>
       </GridRow>
     </GridContainer>
   ) : (
     <Box marginBottom={marginBottom}>
-      {renderSlice(
-        slice,
-        namespace,
-        slug,
-        renderedOnOrganizationSubpage,
-        params,
-      )}
+      {renderSlice(slice, namespace, slug, params)}
     </Box>
   )
 }

--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -91,6 +91,7 @@ export const lightThemes = [
   'default',
   'landlaeknir',
   'fiskistofa',
+  'landing_page',
 ]
 export const footerEnabled = [
   'syslumenn',
@@ -173,6 +174,8 @@ const OrganizationHeader: React.FC<HeaderProps> = ({ organizationPage }) => {
       return <RikislogmadurHeader organizationPage={organizationPage} />
     case 'landskjorstjorn':
       return <LandskjorstjornHeader organizationPage={organizationPage} />
+    case 'landing_page':
+      return null
     default:
       return <DefaultHeader organizationPage={organizationPage} />
   }
@@ -601,7 +604,6 @@ export const OrganizationWrapper: React.FC<WrapperProps> = ({
           </Box>
         </SidebarLayout>
       )}
-      {!!mainContent && children}
       {minimal && (
         <GridContainer>
           <GridRow>
@@ -610,11 +612,12 @@ export const OrganizationWrapper: React.FC<WrapperProps> = ({
               span={['12/12', '12/12', '10/12']}
               offset={['0', '0', '1/12']}
             >
-              {children}
+              {mainContent}
             </GridColumn>
           </GridRow>
         </GridContainer>
       )}
+      {!!mainContent && children}
       {!minimal && (
         <OrganizationFooter
           organizations={[organizationPage.organization]}

--- a/apps/web/screens/Organization/Home/Home.tsx
+++ b/apps/web/screens/Organization/Home/Home.tsx
@@ -1,5 +1,24 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import { NavigationItem } from '@island.is/island-ui/core'
+import { useMemo } from 'react'
+import NextLink from 'next/link'
+
+import {
+  Box,
+  Breadcrumbs,
+  GridContainer,
+  NavigationItem,
+  Text,
+} from '@island.is/island-ui/core'
+import { LinkType, useLinkResolver, useNamespace } from '@island.is/web/hooks'
+import {
+  getThemeConfig,
+  SliceMachine,
+  OrganizationWrapper,
+  SearchBox,
+  IconTitleCard,
+} from '@island.is/web/components'
+import { CustomNextError } from '@island.is/web/units/errors'
+import useContentfulId from '@island.is/web/hooks/useContentfulId'
 import { withMainLayout } from '@island.is/web/layouts/main'
 import {
   ContentLanguage,
@@ -7,18 +26,11 @@ import {
   QueryGetNamespaceArgs,
   QueryGetOrganizationPageArgs,
 } from '@island.is/web/graphql/schema'
-import { GET_NAMESPACE_QUERY, GET_ORGANIZATION_PAGE_QUERY } from '../../queries'
+
 import { Screen } from '../../../types'
-import { LinkType, useNamespace } from '@island.is/web/hooks'
-import {
-  getThemeConfig,
-  SliceMachine,
-  OrganizationWrapper,
-  SearchBox,
-} from '@island.is/web/components'
-import { CustomNextError } from '@island.is/web/units/errors'
-import useContentfulId from '@island.is/web/hooks/useContentfulId'
+import { GET_NAMESPACE_QUERY, GET_ORGANIZATION_PAGE_QUERY } from '../../queries'
 import { getCustomAlertBanners } from './utils'
+import { LandingPageFooter } from './LandingPageFooter'
 
 interface HomeProps {
   organizationPage: Query['getOrganizationPage']
@@ -40,6 +52,13 @@ const Home: Screen<HomeProps> = ({ organizationPage, namespace }) => {
   const n = useNamespace(namespace)
   useContentfulId(organizationPage.id)
 
+  const organizationNamespace = useMemo(() => {
+    return JSON.parse(organizationPage?.organization?.namespace?.fields ?? '{}')
+  }, [organizationPage?.organization?.namespace?.fields])
+  const o = useNamespace(organizationNamespace)
+
+  const { linkResolver } = useLinkResolver()
+
   const navList: NavigationItem[] = organizationPage.menuLinks.map(
     ({ primaryLink, childrenLinks }) => ({
       title: primaryLink.text,
@@ -60,31 +79,85 @@ const Home: Screen<HomeProps> = ({ organizationPage, namespace }) => {
       organizationPage={organizationPage}
       pageFeaturedImage={organizationPage.featuredImage}
       fullWidthContent={true}
+      minimal={organizationPage.theme === 'landing_page'}
       navigationData={{
         title: n('navigationTitle', 'Efnisyfirlit'),
         items: navList,
       }}
-      mainContent={organizationPage.slices.map((slice, index) => {
-        const digitalIcelandDetailPageLinkType: LinkType =
-          'digitalicelandservicesdetailpage'
-        return (
-          <SliceMachine
-            key={slice.id}
-            slice={slice}
-            namespace={namespace}
-            slug={organizationPage.slug}
-            marginBottom={index === organizationPage.slices.length - 1 ? 5 : 0}
-            params={{
-              anchorPageLinkType:
-                organizationPage.theme === 'digital_iceland'
-                  ? digitalIcelandDetailPageLinkType
-                  : undefined,
-            }}
-            renderedOnOrganizationSubpage={false}
-            paddingTop={!organizationPage.description && index === 0 ? 0 : 6}
-          />
-        )
-      })}
+      mainContent={
+        <Box>
+          {organizationPage.theme === 'landing_page' && (
+            <GridContainer>
+              <Box marginBottom={3}>
+                <Breadcrumbs
+                  items={[
+                    {
+                      title: 'Ísland.is',
+                      href: linkResolver('homepage').href,
+                    },
+                    {
+                      title: n(
+                        'landingPageOrganizationsBreadcrumbTitle',
+                        'Opinberir aðilar',
+                      ),
+                      href: '/s',
+                    },
+                  ]}
+                  renderLink={(link, item) => {
+                    return item?.href ? (
+                      <NextLink href={item?.href}>{link}</NextLink>
+                    ) : (
+                      link
+                    )
+                  }}
+                />
+              </Box>
+              <Box marginBottom={5}>
+                <Text variant="h1" color="blueberry600">
+                  {organizationPage.title}
+                </Text>
+              </Box>
+
+              <Box marginBottom={8}>
+                <IconTitleCard
+                  heading={o('landingPageTitleCardHeading', '')}
+                  href={o('landingPageTitleCardHref', '')}
+                  imgSrc={o(
+                    'landingPageTitleCardImageSrc',
+                    'https://images.ctfassets.net/8k0h54kbe6bj/dMv61A2SII5Y6AACjOzFo/63d1627ccf2113ae137c401725b1b35b/T__lva_og_kaffibolli.svg',
+                  )}
+                  alt={o('landingPageTitleCardImageAlt', '')}
+                />
+              </Box>
+            </GridContainer>
+          )}
+          {organizationPage.slices.map((slice, index) => {
+            const digitalIcelandDetailPageLinkType: LinkType =
+              'digitalicelandservicesdetailpage'
+            return (
+              <SliceMachine
+                key={slice.id}
+                slice={slice}
+                namespace={namespace}
+                slug={organizationPage.slug}
+                fullWidth={organizationPage.theme === 'landing_page'}
+                marginBottom={
+                  index === organizationPage.slices.length - 1 ? 5 : 0
+                }
+                params={{
+                  anchorPageLinkType:
+                    organizationPage.theme === 'digital_iceland'
+                      ? digitalIcelandDetailPageLinkType
+                      : undefined,
+                }}
+                paddingTop={
+                  !organizationPage.description && index === 0 ? 0 : 6
+                }
+              />
+            )
+          })}
+        </Box>
+      }
       sidebarContent={
         WITH_SEARCH.includes(organizationPage.slug) && (
           <SearchBox
@@ -110,8 +183,21 @@ const Home: Screen<HomeProps> = ({ organizationPage, namespace }) => {
           namespace={namespace}
           slug={organizationPage.slug}
           fullWidth={true}
+          params={{
+            latestNewsSliceBackground:
+              organizationPage.theme === 'landing_page' ? 'white' : 'purple100',
+            latestNewsSliceColorVariant:
+              organizationPage.theme === 'landing_page'
+                ? 'blueberry600'
+                : 'default',
+          }}
         />
       ))}
+      {organizationPage.theme === 'landing_page' && (
+        <LandingPageFooter
+          footerItems={organizationPage.organization?.footerItems}
+        />
+      )}
     </OrganizationWrapper>
   )
 }

--- a/apps/web/screens/Organization/Home/Home.tsx
+++ b/apps/web/screens/Organization/Home/Home.tsx
@@ -113,9 +113,7 @@ const Home: Screen<HomeProps> = ({ organizationPage, namespace }) => {
                 />
               </Box>
               <Box marginBottom={5}>
-                <Text variant="h1" color="blueberry600">
-                  {organizationPage.title}
-                </Text>
+                <Text variant="h1">{organizationPage.title}</Text>
               </Box>
 
               <Box marginBottom={8}>

--- a/apps/web/screens/Organization/Home/Home.tsx
+++ b/apps/web/screens/Organization/Home/Home.tsx
@@ -113,7 +113,9 @@ const Home: Screen<HomeProps> = ({ organizationPage, namespace }) => {
                 />
               </Box>
               <Box marginBottom={5}>
-                <Text variant="h1">{organizationPage.title}</Text>
+                <Text variant="h1" color="blueberry600">
+                  {organizationPage.title}
+                </Text>
               </Box>
 
               <Box marginBottom={8}>
@@ -185,9 +187,7 @@ const Home: Screen<HomeProps> = ({ organizationPage, namespace }) => {
             latestNewsSliceBackground:
               organizationPage.theme === 'landing_page' ? 'white' : 'purple100',
             latestNewsSliceColorVariant:
-              organizationPage.theme === 'landing_page'
-                ? 'blueberry600'
-                : 'default',
+              organizationPage.theme === 'landing_page' ? 'blue' : 'default',
           }}
         />
       ))}

--- a/apps/web/screens/Organization/Home/LandingPageFooter/LandingPageFooter.css.ts
+++ b/apps/web/screens/Organization/Home/LandingPageFooter/LandingPageFooter.css.ts
@@ -1,0 +1,33 @@
+import { style } from '@vanilla-extract/css'
+import { themeUtils } from '@island.is/island-ui/theme'
+
+export const container = style({
+  display: 'flex',
+  flexFlow: 'column nowrap',
+  ...themeUtils.responsiveStyle({
+    xs: {
+      gap: '12px',
+    },
+    lg: {
+      flexFlow: 'row nowrap',
+    },
+  }),
+})
+
+export const item = style({
+  marginRight: '12px',
+  display: 'flex',
+  flexWrap: 'nowrap',
+  alignItems: 'center',
+})
+
+export const dotBefore = style({
+  ...themeUtils.responsiveStyle({
+    lg: {
+      '::before': {
+        content: '•',
+        marginRight: '12px',
+      },
+    },
+  }),
+})

--- a/apps/web/screens/Organization/Home/LandingPageFooter/LandingPageFooter.tsx
+++ b/apps/web/screens/Organization/Home/LandingPageFooter/LandingPageFooter.tsx
@@ -1,0 +1,56 @@
+import cn from 'classnames'
+import { INLINES } from '@contentful/rich-text-types'
+import { Box, GridContainer, Link, Text } from '@island.is/island-ui/core'
+import { FooterItem } from '@island.is/web/graphql/schema'
+import { richText, SliceType } from '@island.is/island-ui/contentful'
+
+import * as styles from './LandingPageFooter.css'
+
+interface LandingPageFooterProps {
+  footerItems?: FooterItem[]
+}
+
+const LandingPageFooter: React.FC<LandingPageFooterProps> = ({
+  footerItems,
+}) => {
+  if (!footerItems?.length) return null
+
+  return (
+    <Box background="blue200" paddingY={2}>
+      <GridContainer>
+        <Box className={styles.container}>
+          {footerItems.map((item, index) =>
+            index === 0 ? (
+              <Box className={styles.item}>
+                <Text fontWeight="semiBold">{item.title}</Text>
+              </Box>
+            ) : (
+              <Box
+                className={cn({ [styles.dotBefore]: index > 0 }, styles.item)}
+                key={`${item.id}-${index}`}
+              >
+                {item.content?.length &&
+                  richText(item.content as SliceType[], {
+                    renderNode: {
+                      [INLINES.HYPERLINK]: (node, children) => (
+                        <Link
+                          underlineVisibility="always"
+                          underline="small"
+                          href={node.data.uri}
+                          className={styles.item}
+                        >
+                          {children}
+                        </Link>
+                      ),
+                    },
+                  })}
+              </Box>
+            ),
+          )}
+        </Box>
+      </GridContainer>
+    </Box>
+  )
+}
+
+export default LandingPageFooter

--- a/apps/web/screens/Organization/Home/LandingPageFooter/index.ts
+++ b/apps/web/screens/Organization/Home/LandingPageFooter/index.ts
@@ -1,0 +1,4 @@
+import dynamic from 'next/dynamic'
+export const LandingPageFooter = dynamic(() => import('./LandingPageFooter'), {
+  ssr: false,
+})

--- a/apps/web/screens/Organization/SubPage.tsx
+++ b/apps/web/screens/Organization/SubPage.tsx
@@ -246,7 +246,6 @@ const renderSlices = (
               slice={slice}
               namespace={namespace}
               slug={slug}
-              renderedOnOrganizationSubpage={true}
               marginBottom={index === slices.length - 1 ? 5 : 0}
               params={{
                 renderLifeEventPagesAsProfileCards: true,
@@ -254,6 +253,8 @@ const renderSlices = (
                   organizationPage.theme === 'digital_iceland'
                     ? digitalIcelandDetailPageLinkType
                     : undefined,
+                latestNewsSliceBackground: 'white',
+                forceTitleSectionHorizontalPadding: 'true',
               }}
               fullWidth={true}
             />
@@ -266,9 +267,12 @@ const renderSlices = (
             slice={slice}
             namespace={namespace}
             slug={slug}
-            renderedOnOrganizationSubpage={true}
             marginBottom={index === slices.length - 1 ? 5 : 0}
-            params={{ renderLifeEventPagesAsProfileCards: true }}
+            params={{
+              renderLifeEventPagesAsProfileCards: true,
+              latestNewsSliceBackground: 'white',
+              forceTitleSectionHorizontalPadding: 'true',
+            }}
           />
         )
       })

--- a/apps/web/screens/queries/Organization.tsx
+++ b/apps/web/screens/queries/Organization.tsx
@@ -111,6 +111,9 @@ export const GET_ORGANIZATION_PAGE_QUERY = gql`
         logo {
           url
         }
+        namespace {
+          fields
+        }
         footerItems {
           title
           content {

--- a/apps/web/screens/queries/fragments.ts
+++ b/apps/web/screens/queries/fragments.ts
@@ -348,6 +348,7 @@ export const slices = gql`
     }
     automaticallyFetchArticles
     sortBy
+    hasBorderAbove
     articles {
       id
       slug

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -2140,6 +2140,7 @@ export interface IOrganizationPageFields {
     | 'landlaeknir'
     | 'rikislogmadur'
     | 'landskjorstjorn'
+    | 'landing_page'
 
   /** Slices */
   slices?:

--- a/libs/cms/src/lib/models/organizationPage.model.ts
+++ b/libs/cms/src/lib/models/organizationPage.model.ts
@@ -6,7 +6,6 @@ import { LinkGroup, mapLinkGroup } from './linkGroup.model'
 import { Link, mapLink } from './link.model'
 import { Image, mapImage } from './image.model'
 import { safelyMapSliceUnion, SliceUnion } from '../unions/slice.union'
-import { FooterItem, mapFooterItem } from './footerItem.model'
 import {
   mapOrganizationTheme,
   OrganizationTheme,
@@ -55,9 +54,6 @@ export class OrganizationPage {
   @Field(() => Image, { nullable: true })
   featuredImage!: Image | null
 
-  @Field(() => [FooterItem])
-  footerItems!: Array<FooterItem>
-
   @Field(() => [SliceUnion], { nullable: true })
   sidebarCards?: Array<typeof SliceUnion | null>
 
@@ -94,7 +90,6 @@ export const mapOrganizationPage = ({
     ? mapOrganization(fields.organization)
     : null,
   featuredImage: fields.featuredImage ? mapImage(fields.featuredImage) : null,
-  footerItems: (fields.footerItems ?? []).map(mapFooterItem),
   sidebarCards: (fields.sidebarCards ?? [])
     .map(safelyMapSliceUnion)
     .filter(Boolean),


### PR DESCRIPTION
# Add landing page theme to Organization pages

## What

* I added a new theme to organization pages called "landing_page"

## Why

* This was a requested feature
* So we can make cards on island.is/s link to a landing page for an organization on the island.is web

## Screenshots / Gifs

https://user-images.githubusercontent.com/43557895/199037034-de72b2cb-9ef5-473d-8d3f-3e996547dc35.mov



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
