### PR TITLE
fix(j-s): Reset chapter and orderWithinChapter if ordered not in a chapter

### DIFF
--- a/apps/judicial-system/web/src/components/AccordionItems/IndictmentsCaseFilesAccordionItem/IndictmentsCaseFilesAccordionItem.tsx
+++ b/apps/judicial-system/web/src/components/AccordionItems/IndictmentsCaseFilesAccordionItem/IndictmentsCaseFilesAccordionItem.tsx
@@ -416,11 +416,6 @@ const IndictmentsCaseFilesAccordionItem: React.FC<Props> = (props) => {
     )
     const filesBelowInChapter = getFilesBelowInChapter(fileId, reorderableItems)
 
-    // Do not update the order of files if the file is not in a chapter
-    if (chapter === null || orderWithinChapter === null) {
-      return
-    }
-
     const { errors } = await updateFilesMutation({
       variables: {
         input: {
@@ -435,7 +430,10 @@ const IndictmentsCaseFilesAccordionItem: React.FC<Props> = (props) => {
               return {
                 id: file.id,
                 chapter,
-                orderWithinChapter: orderWithinChapter + index + 1,
+                orderWithinChapter:
+                  orderWithinChapter === null
+                    ? null
+                    : orderWithinChapter + index + 1,
               }
             }),
           ],


### PR DESCRIPTION
# Reset chapter and orderWithinChapter if ordered not in a chapter

[Asana](https://app.asana.com/0/1199153462262248/1203046355378049/f)

## What

Reset chapter and orderWithinChapter if ordered not in a chapter

## Why

Bug

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
