### PR TITLE
feat(auth): Filter delegations based on user access

### DIFF
--- a/apps/services/auth/delegation-api/src/app/delegations/test/meDelegations.access.spec.ts
+++ b/apps/services/auth/delegation-api/src/app/delegations/test/meDelegations.access.spec.ts
@@ -1,0 +1,390 @@
+import assert from 'assert'
+import addYears from 'date-fns/addYears'
+import startOfDay from 'date-fns/startOfDay'
+import faker from 'faker'
+import differenceWith from 'lodash/differenceWith'
+import { Op } from 'sequelize'
+import request from 'supertest'
+
+import {
+  CreateDelegationDTO,
+  Delegation,
+  DelegationScope,
+  Domain,
+  NamesService,
+  PatchDelegationDTO,
+} from '@island.is/auth-api-lib'
+import { isDefined } from '@island.is/shared/utils'
+import { createNationalId } from '@island.is/testing/fixtures'
+import { TestApp } from '@island.is/testing/nest'
+
+import { FixtureFactory } from '../../../../test/fixtures/fixture-factory'
+import { setupWithAuth } from '../../../../test/setup'
+import { accessTestCases } from '../../../../test/access-test-cases'
+import { partitionDomainsByScopeAccess } from './utils'
+import { getModelToken } from '@nestjs/sequelize'
+
+describe.each(Object.keys(accessTestCases))(
+  'MeDelegationsController Access with test case: %s',
+  (caseName) => {
+    const testCase = accessTestCases[caseName]
+    const invalidDomains = differenceWith(
+      testCase.domains,
+      testCase.expected,
+      (a, b) => a.name === b.name,
+    ).map((domain) => domain.name)
+    const [accessible, inaccessible] = partitionDomainsByScopeAccess(testCase)
+    let app: TestApp
+    let server: request.SuperTest<request.Test>
+    let factory: FixtureFactory
+    let domains: Domain[]
+    let delegations: Delegation[]
+
+    beforeAll(async () => {
+      // Arrange
+      app = await setupWithAuth({
+        user: testCase.user,
+        customScopeRules: testCase.customScopeRules,
+      })
+      server = request(app.getHttpServer())
+      const namesService = app.get(NamesService)
+      jest
+        .spyOn(namesService, 'getPersonName')
+        .mockResolvedValue(faker.name.findName())
+      jest
+        .spyOn(namesService, 'getUserName')
+        .mockResolvedValue(faker.name.findName())
+
+      factory = new FixtureFactory(app)
+      domains = await Promise.all(
+        testCase.domains.map((domain) => factory.createDomain(domain)),
+      )
+      await Promise.all(
+        (testCase.accessTo ?? []).map((scope) =>
+          factory.createApiScopeUserAccess({
+            nationalId: testCase.user.nationalId,
+            scope,
+          }),
+        ),
+      )
+      await Promise.all(
+        (testCase.delegations ?? []).map((delegation) =>
+          factory.createCustomDelegation({
+            fromNationalId: testCase.user.nationalId,
+            toNationalId: testCase.user.actor?.nationalId,
+            ...delegation,
+          }),
+        ),
+      )
+    })
+
+    beforeEach(async () => {
+      if (delegations) {
+        await Delegation.destroy({
+          where: {
+            id: { [Op.in]: delegations.map((delegation) => delegation.id) },
+          },
+        })
+      }
+
+      // Create custom delegations for testing.
+      delegations = await Promise.all(
+        domains
+          .map((domain) => {
+            const customDelegationScopes = domain.scopes
+              ?.filter((scope) => scope.allowExplicitDelegationGrant)
+              .map(({ name }) => ({ scopeName: name }))
+
+            if (customDelegationScopes && customDelegationScopes.length > 0) {
+              return factory.createCustomDelegation({
+                fromNationalId: testCase.user.nationalId,
+                domainName: domain.name,
+                scopes: customDelegationScopes,
+              })
+            }
+          })
+          .filter(isDefined),
+      )
+    })
+
+    it('GET /v1/me/delegations filters delegations and scopes by access', async () => {
+      // Act
+      const res = await server.get('/v1/me/delegations')
+
+      // Assert
+      expect(res.status).toEqual(200)
+      expect(res.body).toMatchObject(
+        delegations
+          .map((delegation) => {
+            const expectedScopes = testCase.expected
+              .find((domain) => domain.name === delegation.domainName)
+              ?.scopes.map(({ name }) => ({ scopeName: name }))
+            if (expectedScopes?.length) {
+              return {
+                id: delegation.id,
+                domainName: delegation.domainName,
+                scopes: expectedScopes,
+              }
+            }
+          })
+          .filter(isDefined),
+      )
+    })
+
+    if (accessible.length > 0) {
+      it.each(accessible)(
+        'GET /v1/me/delegation/:id filters scopes by access in domain $name',
+        async (domain) => {
+          // Arrange
+          const delegation = delegations.find(
+            (delegation) => delegation.domainName === domain.name,
+          )
+          assert(delegation)
+
+          // Act
+          const res = await server.get(`/v1/me/delegations/${delegation.id}`)
+
+          // Assert
+          expect(res.status).toEqual(200)
+          expect(res.body).toMatchObject({
+            scopes: domain.scopes.map((scope) => ({ scopeName: scope.name })),
+          })
+        },
+      )
+    }
+
+    if (invalidDomains.length > 0) {
+      it.each(invalidDomains)(
+        'GET /v1/me/delegation/:id fails without access to domain %s',
+        async (domainName) => {
+          // Arrange
+          const delegation = delegations.find(
+            (delegation) => delegation.domainName === domainName,
+          )
+          if (!delegation) {
+            return
+          }
+
+          // Act
+          const res = await server.get(`/v1/me/delegations/${delegation.id}`)
+
+          // Assert
+          expect(res.status).toEqual(204)
+        },
+      )
+    }
+
+    if (accessible.length > 0) {
+      it.each(accessible)(
+        'POST /v1/me/delegations works for scopes you have access to in $name',
+        async (domain) => {
+          // Arrange
+          const delegationScopeDtos = domain.scopes.map(({ name }) => ({
+            name: name,
+            validTo: startOfDay(addYears(new Date(), 1)),
+          }))
+          const delegationDto: CreateDelegationDTO = {
+            toNationalId: createNationalId('person'),
+            domainName: domain.name,
+            scopes: delegationScopeDtos,
+          }
+
+          // Act
+          const res = await server
+            .post('/v1/me/delegations')
+            .send(delegationDto)
+
+          // Assert
+          expect(res.status).toEqual(201)
+          expect(res.body).toMatchObject({
+            scopes: delegationScopeDtos.map((scope) => ({
+              scopeName: scope.name,
+              validTo: scope.validTo.toISOString(),
+            })),
+          })
+        },
+      )
+
+      it.each(accessible)(
+        'PATCH /v1/me/delegations/:id can update scopes you have access to in $name',
+        async (domain) => {
+          // Arrange
+          const delegation = delegations.find(
+            (delegation) => delegation.domainName === domain.name,
+          )
+          assert(delegation)
+          const delegationScopeDtos = domain.scopes.map(({ name }) => ({
+            name: name,
+            validTo: startOfDay(addYears(new Date(), 1)),
+          }))
+          const delegationDto: PatchDelegationDTO = {
+            updateScopes: delegationScopeDtos,
+          }
+
+          // Act
+          const res = await server
+            .patch(`/v1/me/delegations/${delegation.id}`)
+            .send(delegationDto)
+
+          // Assert
+          expect(res.status).toEqual(200)
+          expect(res.body).toMatchObject({
+            scopes: delegationScopeDtos.map((scope) => ({
+              scopeName: scope.name,
+              validTo: scope.validTo.toISOString(),
+            })),
+          })
+        },
+      )
+
+      it.each(accessible)(
+        'PATCH /v1/me/delegations/:id can delete scopes you have access to in $name',
+        async (domain) => {
+          // Arrange
+          const delegation = delegations.find(
+            (delegation) => delegation.domainName === domain.name,
+          )
+          assert(delegation)
+          const delegationDto: PatchDelegationDTO = {
+            deleteScopes: domain.scopes.map(({ name }) => name),
+          }
+
+          // Act
+          const res = await server
+            .patch(`/v1/me/delegations/${delegation.id}`)
+            .send(delegationDto)
+
+          // Assert
+          expect(res.status).toEqual(200)
+          expect(res.body).toMatchObject({
+            scopes: [],
+          })
+        },
+      )
+
+      it.each(accessible)(
+        'DELETE /v1/me/delegations/:id works and removes scopes you have access to in $name',
+        async (domain) => {
+          // Arrange
+          const delegationScopeModel = await app.get<typeof DelegationScope>(
+            getModelToken(DelegationScope),
+          )
+          const delegation = delegations.find(
+            (delegation) => delegation.domainName === domain.name,
+          )
+          assert(delegation)
+
+          // Act
+          const res = await server.delete(`/v1/me/delegations/${delegation.id}`)
+
+          // Assert
+          expect(res.status).toEqual(204)
+          const after = await delegationScopeModel.findAll({
+            where: {
+              delegationId: delegation.id,
+              scopeName: domain.scopes.map(({ name }) => name),
+            },
+          })
+          expect(after).toHaveLength(0)
+        },
+      )
+    }
+
+    if (inaccessible.length > 0) {
+      it.each(inaccessible)(
+        "POST /v1/me/delegations fails for scopes you don't have access to in $name",
+        async (domain) => {
+          // Arrange
+          const delegationScopeDtos = domain.scopes.map(({ name }) => ({
+            name: name,
+            validTo: startOfDay(addYears(new Date(), 1)),
+          }))
+          const delegationDto: CreateDelegationDTO = {
+            toNationalId: createNationalId('person'),
+            domainName: domain.name,
+            scopes: delegationScopeDtos,
+          }
+
+          // Act
+          const res = await server
+            .post('/v1/me/delegations')
+            .send(delegationDto)
+
+          // Assert
+          expect(res.status).toEqual(400)
+          expect(res.body).toEqual({
+            detail: 'User does not have access to the requested scopes.',
+            status: 400,
+            title: 'Bad Request',
+            type: 'https://httpstatuses.org/400',
+          })
+        },
+      )
+    }
+
+    if (
+      inaccessible.length > 0 &&
+      testCase !== accessTestCases.noExplicitDelegationGrant
+    ) {
+      it.each(inaccessible)(
+        "PATCH /v1/me/delegations/:id fails updating scopes you don't have access to in $name",
+        async (domain) => {
+          // Arrange
+          const delegation = delegations.find(
+            (delegation) => delegation.domainName === domain.name,
+          )
+          assert(delegation)
+          const delegationScopeDtos = domain.scopes.map(({ name }) => ({
+            name: name,
+            validTo: startOfDay(addYears(new Date(), 1)),
+          }))
+          const delegationDto: PatchDelegationDTO = {
+            updateScopes: delegationScopeDtos,
+          }
+
+          // Act
+          const res = await server
+            .patch(`/v1/me/delegations/${delegation.id}`)
+            .send(delegationDto)
+
+          // Assert
+          expect(res.status).toEqual(400)
+          expect(res.body).toEqual({
+            detail: 'User does not have access to the requested scopes.',
+            status: 400,
+            title: 'Bad Request',
+            type: 'https://httpstatuses.org/400',
+          })
+        },
+      )
+
+      it.each(inaccessible)(
+        "PATCH /v1/me/delegations/:id fails deleting scopes you don't have access to in $name",
+        async (domain) => {
+          // Arrange
+          const delegation = delegations.find(
+            (delegation) => delegation.domainName === domain.name,
+          )
+          assert(delegation)
+          const delegationDto: PatchDelegationDTO = {
+            deleteScopes: domain.scopes.map(({ name }) => name),
+          }
+
+          // Act
+          const res = await server
+            .patch(`/v1/me/delegations/${delegation.id}`)
+            .send(delegationDto)
+
+          // Assert
+          expect(res.status).toEqual(400)
+          expect(res.body).toEqual({
+            detail: 'User does not have access to the requested scopes.',
+            status: 400,
+            title: 'Bad Request',
+            type: 'https://httpstatuses.org/400',
+          })
+        },
+      )
+    }
+  },
+)

--- a/apps/services/auth/delegation-api/src/app/delegations/test/meDelegations.auth.spec.ts
+++ b/apps/services/auth/delegation-api/src/app/delegations/test/meDelegations.auth.spec.ts
@@ -1,0 +1,94 @@
+import request from 'supertest'
+
+import { User } from '@island.is/auth-nest-tools'
+import { createCurrentUser } from '@island.is/testing/fixtures'
+import { getRequestMethod, TestApp } from '@island.is/testing/nest'
+
+import { FixtureFactory } from '../../../../test/fixtures/fixture-factory'
+import { TestEndpointOptions } from '../../../../test/types'
+import {
+  setupWithoutAuth,
+  setupWithoutPermission,
+} from '../../../../test/setup'
+
+describe('withoutAuth and permissions', () => {
+  async function formatUrl(app: TestApp, endpoint: string, user?: User) {
+    if (!endpoint.includes(':delegation')) {
+      return endpoint
+    }
+    const factory = new FixtureFactory(app)
+    const domain = await factory.createDomain({
+      apiScopes: [{ name: 's1' }],
+    })
+    const delegation = await factory.createCustomDelegation({
+      fromNationalId: user?.nationalId,
+      domainName: domain.name,
+      scopes: [{ scopeName: 's1' }],
+    })
+    return endpoint.replace(':delegation', encodeURIComponent(delegation.id))
+  }
+
+  it.each`
+    method      | endpoint
+    ${'GET'}    | ${'/v1/me/delegations'}
+    ${'POST'}   | ${'/v1/me/delegations'}
+    ${'GET'}    | ${'/v1/me/delegations/:delegation'}
+    ${'PATCH'}  | ${'/v1/me/delegations/:delegation'}
+    ${'DELETE'} | ${'/v1/me/delegations/:delegation'}
+  `(
+    '$method $endpoint should return 401 when user is not authenticated',
+    async ({ method, endpoint }: TestEndpointOptions) => {
+      // Arrange
+      const app = await setupWithoutAuth()
+      const server = request(app.getHttpServer())
+      const url = await formatUrl(app, endpoint)
+
+      // Act
+      const res = await getRequestMethod(server, method)(url)
+
+      // Assert
+      expect(res.status).toEqual(401)
+      expect(res.body).toMatchObject({
+        status: 401,
+        type: 'https://httpstatuses.org/401',
+        title: 'Unauthorized',
+      })
+
+      // CleanUp
+      app.cleanUp()
+    },
+  )
+
+  it.each`
+    method      | endpoint
+    ${'GET'}    | ${'/v1/me/delegations'}
+    ${'POST'}   | ${'/v1/me/delegations'}
+    ${'GET'}    | ${'/v1/me/delegations/:delegation'}
+    ${'PATCH'}  | ${'/v1/me/delegations/:delegation'}
+    ${'DELETE'} | ${'/v1/me/delegations/:delegation'}
+  `(
+    '$method $endpoint should return 403 Forbidden when user does not have the correct scope',
+    async ({ method, endpoint }: TestEndpointOptions) => {
+      // Arrange
+      const user = createCurrentUser()
+      const app = await setupWithoutPermission({ user })
+      const server = request(app.getHttpServer())
+      const url = await formatUrl(app, endpoint, user)
+
+      // Act
+      const res = await getRequestMethod(server, method)(url)
+
+      // Assert
+      expect(res.status).toEqual(403)
+      expect(res.body).toMatchObject({
+        status: 403,
+        type: 'https://httpstatuses.org/403',
+        title: 'Forbidden',
+        detail: 'Forbidden resource',
+      })
+
+      // CleanUp
+      app.cleanUp()
+    },
+  )
+})

--- a/apps/services/auth/delegation-api/src/app/delegations/test/meDelegations.filters.spec.ts
+++ b/apps/services/auth/delegation-api/src/app/delegations/test/meDelegations.filters.spec.ts
@@ -7,11 +7,11 @@ import {
   DelegationValidity,
   PatchDelegationDTO,
 } from '@island.is/auth-api-lib'
-import { expectMatchingDelegations } from '@island.is/services/auth/testing'
 import {
-  createCurrentUser,
-  createNationalId,
-} from '@island.is/testing/fixtures'
+  expectMatchingDelegations,
+  findExpectedDelegationModels,
+} from '@island.is/services/auth/testing'
+import { createNationalId } from '@island.is/testing/fixtures'
 import { TestApp } from '@island.is/testing/nest'
 
 import { FixtureFactory } from '../../../../test/fixtures/fixture-factory'
@@ -25,7 +25,6 @@ import {
   testScopes,
   testUser,
 } from './test-data'
-import { findExpectedDelegationModels } from '../../../../../public-api/test/utils'
 
 describe('MeDelegationsController filters', () => {
   let app: TestApp

--- a/apps/services/auth/delegation-api/src/app/delegations/test/meDelegations.filters.spec.ts
+++ b/apps/services/auth/delegation-api/src/app/delegations/test/meDelegations.filters.spec.ts
@@ -1,0 +1,532 @@
+import addDays from 'date-fns/addDays'
+import request from 'supertest'
+
+import {
+  CreateDelegationDTO,
+  Delegation,
+  DelegationValidity,
+  PatchDelegationDTO,
+} from '@island.is/auth-api-lib'
+import { expectMatchingDelegations } from '@island.is/services/auth/testing'
+import {
+  createCurrentUser,
+  createNationalId,
+} from '@island.is/testing/fixtures'
+import { TestApp } from '@island.is/testing/nest'
+
+import { FixtureFactory } from '../../../../test/fixtures/fixture-factory'
+import { setupWithAuth } from '../../../../test/setup'
+import {
+  testCompanyActorNationalId,
+  testCompanyDelegations,
+  testCompanyUser,
+  testDelegations,
+  testDomains,
+  testScopes,
+  testUser,
+} from './test-data'
+import { findExpectedDelegationModels } from '../../../../../public-api/test/utils'
+
+describe('MeDelegationsController filters', () => {
+  let app: TestApp
+  let server: request.SuperTest<request.Test>
+  let factory: FixtureFactory
+  let delegations: Record<keyof typeof testDelegations, Delegation>
+
+  beforeAll(async () => {
+    app = await setupWithAuth({
+      user: testUser,
+    })
+    server = request(app.getHttpServer())
+    factory = new FixtureFactory(app)
+
+    await Object.values(testDomains).map((domain) =>
+      factory.createDomain(domain),
+    )
+
+    delegations = Object.fromEntries(
+      await Promise.all(
+        Object.entries(testDelegations).map(([key, delegation]) =>
+          factory
+            .createCustomDelegation(delegation)
+            .then((delegation) => [key, delegation]),
+        ),
+      ),
+    )
+  })
+
+  it('GET /v1/me/delegations returns all outgoing delegations across domains with all scopes', async () => {
+    // Arrange
+    const expectedModels = await findExpectedDelegationModels(
+      factory.get(Delegation),
+      [
+        delegations.validOutgoing.id,
+        delegations.futureValidOutgoing.id,
+        delegations.expiredOutgoing.id,
+        delegations.variedValidity.id,
+        delegations.withOneNotAllowedOutgoing.id,
+        delegations.validOutgoingInOtherDomain.id,
+      ],
+      [
+        testScopes.mainValid,
+        testScopes.mainFuture,
+        testScopes.mainExpired,
+        testScopes.otherValid,
+      ],
+    )
+
+    // Act
+    const res = await server.get(`/v1/me/delegations`)
+
+    // Assert
+    expect(res.status).toEqual(200)
+    expectMatchingDelegations(res.body, expectedModels)
+  })
+
+  it('GET /v1/me/delegations?validity=now returns valid outgoing delegations across domains with filtered scopes', async () => {
+    // Arrange
+    const expectedModels = await findExpectedDelegationModels(
+      factory.get(Delegation),
+      [
+        delegations.validOutgoing.id,
+        delegations.variedValidity.id,
+        delegations.withOneNotAllowedOutgoing.id,
+        delegations.validOutgoingInOtherDomain.id,
+      ],
+      [testScopes.mainValid, testScopes.otherValid],
+    )
+
+    // Act
+    const res = await server.get(
+      `/v1/me/delegations?validity=${DelegationValidity.NOW}`,
+    )
+
+    // Assert
+    expect(res.status).toEqual(200)
+    expectMatchingDelegations(res.body, expectedModels)
+  })
+
+  it('GET /v1/me/delegations?validity=includeFuture returns future valid outgoing delegations across domains with filtered scopes', async () => {
+    // Arrange
+    const expectedModels = await findExpectedDelegationModels(
+      factory.get(Delegation),
+      [
+        delegations.validOutgoing.id,
+        delegations.futureValidOutgoing.id,
+        delegations.variedValidity.id,
+        delegations.withOneNotAllowedOutgoing.id,
+        delegations.validOutgoingInOtherDomain.id,
+      ],
+      [testScopes.mainValid, testScopes.mainFuture, testScopes.otherValid],
+    )
+
+    // Act
+    const res = await server.get(
+      `/v1/me/delegations?validity=${DelegationValidity.INCLUDE_FUTURE}`,
+    )
+
+    // Assert
+    expect(res.status).toEqual(200)
+    expectMatchingDelegations(res.body, expectedModels)
+  })
+
+  it('GET /v1/me/delegations?validity=past returns expired delegations across domains', async () => {
+    // Arrange
+    const expectedModels = await findExpectedDelegationModels(
+      factory.get(Delegation),
+      [delegations.expiredOutgoing.id, delegations.variedValidity.id],
+      [testScopes.mainExpired],
+    )
+
+    // Act
+    const res = await server.get(
+      `/v1/me/delegations?validity=${DelegationValidity.PAST}`,
+    )
+
+    // Assert
+    expect(res.status).toEqual(200)
+    expectMatchingDelegations(res.body, expectedModels)
+  })
+
+  it('GET /v1/me/delegations?domain=domainName returns delegation for a specific domain', async () => {
+    // Arrange
+    const expectedModels = await findExpectedDelegationModels(
+      factory.get(Delegation),
+      [delegations.validOutgoingInOtherDomain.id],
+      [testScopes.otherValid],
+    )
+
+    // Act
+    const res = await server.get(
+      `/v1/me/delegations?domain=${delegations.validOutgoingInOtherDomain.domainName}`,
+    )
+
+    // Assert
+    expect(res.status).toEqual(200)
+    expectMatchingDelegations(res.body, expectedModels)
+  })
+
+  it('GET /v1/me/delegations?domain=domainName with X-Query-OtherUser returns delegation for a specific individual', async () => {
+    // Arrange
+    const expectedModels = await findExpectedDelegationModels(
+      factory.get(Delegation),
+      [delegations.validOutgoing.id],
+      [testScopes.mainValid],
+    )
+
+    // Act
+    const res = await server
+      .get(`/v1/me/delegations?domain=${delegations.validOutgoing.domainName}`)
+      .set('X-Query-OtherUser', delegations.validOutgoing.toNationalId)
+
+    // Assert
+    expect(res.status).toEqual(200)
+    expectMatchingDelegations(res.body, expectedModels)
+  })
+
+  it('GET /v1/me/delegations?domain=domainName with X-Query-OtherUser returns empty array if no delegation exists for a specific individual', async () => {
+    // Act
+    const res = await server
+      .get(`/v1/me/delegations?domain=${delegations.validOutgoing.domainName}`)
+      .set('X-Query-OtherUser', createNationalId('person'))
+
+    // Assert
+    expect(res.status).toEqual(200)
+    expect(res.body).toEqual([])
+  })
+
+  it('GET /v1/me/delegations with X-Query-OtherUser fails without domainName', async () => {
+    // Act
+    const res = await server
+      .get(`/v1/me/delegations`)
+      .set('X-Query-OtherUser', delegations.validOutgoing.toNationalId)
+
+    // Assert
+    expect(res.status).toEqual(400)
+    expect(res.body).toMatchInlineSnapshot(`
+      Object {
+        "detail": "Domain name is required when fetching delegation by other user.",
+        "status": 400,
+        "title": "Bad Request",
+        "type": "https://httpstatuses.org/400",
+      }
+    `)
+  })
+
+  it('GET /v1/me/delegations should return 400 Bad Request when direction has invalid value', async () => {
+    // Act
+    const res = await server.get(`/v1/me/delegations?direction=asdf`)
+
+    // Assert
+    expect(res.status).toEqual(400)
+    expect(res.body).toMatchInlineSnapshot(`
+      Object {
+        "detail": "direction=outgoing is currently the only supported value",
+        "status": 400,
+        "title": "Bad Request",
+        "type": "https://httpstatuses.org/400",
+      }
+    `)
+  })
+
+  it('GET /v1/me/delegations/:id should not filter expired scopes', async () => {
+    // Arrange
+    const expectedModel = await findExpectedDelegationModels(
+      factory.get(Delegation),
+      delegations.variedValidity.id,
+    )
+
+    // Act
+    const res = await server.get(
+      `/v1/me/delegations/${delegations.variedValidity.id}`,
+    )
+
+    // Assert
+    expect(res.status).toEqual(200)
+    expectMatchingDelegations(res.body, expectedModel)
+  })
+
+  it('GET /v1/me/delegations/:id should return 204 if delegation belongs to another user', async () => {
+    // Act
+    const res = await server.get(
+      `/v1/me/delegations/${delegations.otherUsers.id}`,
+    )
+
+    // Assert
+    expect(res.status).toEqual(204)
+  })
+
+  it('POST /v1/me/delegations should return 400 when scopes have a validTo in the past', async () => {
+    // Arrange
+    const dto: CreateDelegationDTO = {
+      domainName: testDomains.main.name,
+      toNationalId: createNationalId('person'),
+      scopes: [
+        { name: testScopes.mainValid, validTo: addDays(new Date(), -3) },
+      ],
+    }
+    // Act
+    const res = await server.post(`/v1/me/delegations`).send(dto)
+
+    // Assert
+    expect(res.status).toEqual(400)
+    expect(res.body).toMatchInlineSnapshot(`
+      Object {
+        "detail": "When scope validTo property is provided it must be in the future",
+        "status": 400,
+        "title": "Bad Request",
+        "type": "https://httpstatuses.org/400",
+      }
+    `)
+  })
+
+  it("POST /v1/me/delegations should return 400 when scopes don't have validTo set", async () => {
+    // Arrange
+    const dto: CreateDelegationDTO = {
+      domainName: testDomains.main.name,
+      toNationalId: createNationalId('person'),
+      scopes: [{ name: testScopes.mainValid } as never],
+    }
+    // Act
+    const res = await server.post(`/v1/me/delegations`).send(dto)
+
+    // Assert
+    expect(res.status).toEqual(400)
+    expect(res.body).toMatchInlineSnapshot(`
+      Object {
+        "detail": Array [
+          "scopes.0.validTo must be a Date instance",
+        ],
+        "status": 400,
+        "title": "Bad Request",
+        "type": "https://httpstatuses.org/400",
+      }
+    `)
+  })
+
+  it('PATCH /v1/me/delegations/:id should return 400 when scopes have a validTo in the past', async () => {
+    // Arrange
+    const dto: PatchDelegationDTO = {
+      updateScopes: [
+        { name: testScopes.mainValid, validTo: addDays(new Date(), -3) },
+      ],
+    }
+
+    // Act
+    const res = await server
+      .patch(`/v1/me/delegations/${delegations.validOutgoing.id}`)
+      .send(dto)
+
+    // Assert
+    expect(res.status).toEqual(400)
+    expect(res.body).toMatchInlineSnapshot(`
+      Object {
+        "detail": "If scope validTo property is provided it must be in the future",
+        "status": 400,
+        "title": "Bad Request",
+        "type": "https://httpstatuses.org/400",
+      }
+    `)
+  })
+
+  it("PATCH /v1/me/delegations/:id should return 400 when scopes don't have validTo set", async () => {
+    // Arrange
+    const dto: PatchDelegationDTO = {
+      updateScopes: [{ name: testScopes.mainValid } as never],
+    }
+
+    // Act
+    const res = await server
+      .patch(`/v1/me/delegations/${delegations.validOutgoing.id}`)
+      .send(dto)
+
+    // Assert
+    expect(res.status).toEqual(400)
+    expect(res.body).toMatchInlineSnapshot(`
+      Object {
+        "detail": Array [
+          "updateScopes.0.validTo must be a Date instance",
+        ],
+        "status": 400,
+        "title": "Bad Request",
+        "type": "https://httpstatuses.org/400",
+      }
+    `)
+  })
+
+  it('PATCH /v1/me/delegations/:id should return 204 if delegation belongs to another user', async () => {
+    // Arrange
+    const dto: PatchDelegationDTO = {
+      updateScopes: [
+        { name: testScopes.mainValid, validTo: addDays(new Date(), 30) },
+      ],
+    }
+
+    // Act
+    const res = await server
+      .patch(`/v1/me/delegations/${delegations.otherUsers.id}`)
+      .send(dto)
+
+    // Assert
+    expect(res.status).toEqual(204)
+  })
+
+  it('PATCH /v1/me/delegations/:id should return 204 for incoming delegations', async () => {
+    // Arrange
+    const dto: PatchDelegationDTO = {
+      updateScopes: [
+        { name: testScopes.mainValid, validTo: addDays(new Date(), 30) },
+      ],
+    }
+
+    // Act
+    const res = await server
+      .patch(`/v1/me/delegations/${delegations.incomingValid.id}`)
+      .send(dto)
+
+    // Assert
+    expect(res.status).toEqual(204)
+  })
+
+  it('DELETE /v1/me/delegations/:id should return 204 if delegation belongs to another user', async () => {
+    // Act
+    const res = await server.delete(
+      `/v1/me/delegations/${delegations.otherUsers.id}`,
+    )
+
+    // Assert
+    expect(res.status).toEqual(204)
+  })
+})
+
+describe('MeDelegationController company filters', () => {
+  let app: TestApp
+  let server: request.SuperTest<request.Test>
+  let factory: FixtureFactory
+  let delegations: Record<keyof typeof testCompanyDelegations, Delegation>
+
+  beforeAll(async () => {
+    app = await setupWithAuth({
+      user: testCompanyUser,
+    })
+    server = request(app.getHttpServer())
+    factory = new FixtureFactory(app)
+
+    await Object.values(testDomains).map((domain) =>
+      factory.createDomain(domain),
+    )
+
+    delegations = Object.fromEntries(
+      await Promise.all(
+        Object.entries(testCompanyDelegations).map(([key, delegation]) =>
+          factory
+            .createCustomDelegation(delegation)
+            .then((delegation) => [key, delegation]),
+        ),
+      ),
+    )
+  })
+
+  it('GET /v1/me/delegations should not return delegations to the actor', async () => {
+    // Arrange
+    const expectedModels = await findExpectedDelegationModels(
+      factory.get(Delegation),
+      [delegations.validOutgoing.id],
+    )
+
+    // Act
+    const res = await server.get(`/v1/me/delegations`)
+
+    // Assert
+    expect(res.status).toEqual(200)
+    expectMatchingDelegations(res.body, expectedModels)
+  })
+
+  it('GET /v1/me/delegations?domain=domainName with X-Query-OtherUser returns empty delegation array if user has access to domain but no delegation scopes', async () => {
+    // Arrange
+    const expectedModels = await findExpectedDelegationModels(
+      factory.get(Delegation),
+      [delegations.otherScope.id],
+      [],
+    )
+
+    // Act
+    const res = await server
+      .get(`/v1/me/delegations?domain=${delegations.otherScope.domainName}`)
+      .set('X-Query-OtherUser', delegations.otherScope.toNationalId)
+
+    // Assert
+    expect(res.status).toEqual(200)
+    expectMatchingDelegations(res.body, expectedModels)
+  })
+
+  it('GET /v1/me/delegations?domain=domainName with X-Query-OtherUser returns empty array if user has no access in domain', async () => {
+    // Act
+    const res = await server
+      .get(`/v1/me/delegations?domain=${delegations.otherDomain.domainName}`)
+      .set('X-Query-OtherUser', delegations.otherDomain.toNationalId)
+
+    // Assert
+    expect(res.status).toEqual(200)
+    expect(res.body).toEqual([])
+  })
+
+  it('POST /v1/me/delegations should return 400 when creating delegation to actor', async () => {
+    // Arrange
+    const dto: CreateDelegationDTO = {
+      domainName: testDomains.main.name,
+      toNationalId: testCompanyActorNationalId,
+      scopes: [
+        { name: testScopes.mainValid, validTo: addDays(new Date(), 30) },
+      ],
+    }
+    // Act
+    const res = await server.post(`/v1/me/delegations`).send(dto)
+
+    // Assert
+    expect(res.status).toEqual(400)
+    expect(res.body).toMatchInlineSnapshot(`
+      Object {
+        "detail": "Cannot create delegation to self or actor.",
+        "status": 400,
+        "title": "Bad Request",
+        "type": "https://httpstatuses.org/400",
+      }
+    `)
+  })
+
+  it('GET /v1/me/delegations/:id should return empty delegation if user has access to domain but no delegation scopes', async () => {
+    // Arrange
+    const expectedModel = await findExpectedDelegationModels(
+      factory.get(Delegation),
+      delegations.otherScope.id,
+      [],
+    )
+
+    // Act
+    const res = await server.get(
+      `/v1/me/delegations/${delegations.otherScope.id}`,
+    )
+
+    // Assert
+    expect(res.status).toEqual(200)
+    expectMatchingDelegations(res.body, expectedModel)
+  })
+
+  it('PATCH /v1/me/delegations/:id should return 204 when updating delegation to actor', async () => {
+    // Arrange
+    const dto: PatchDelegationDTO = {
+      updateScopes: [
+        { name: testScopes.mainValid, validTo: addDays(new Date(), 30) },
+      ],
+    }
+
+    // Act
+    const res = await server
+      .patch(`/v1/me/delegations/${delegations.actorDelegation.id}`)
+      .send(dto)
+
+    // Assert
+    expect(res.status).toEqual(204)
+  })
+})

--- a/apps/services/auth/delegation-api/src/app/delegations/test/test-data.ts
+++ b/apps/services/auth/delegation-api/src/app/delegations/test/test-data.ts
@@ -1,0 +1,161 @@
+import {
+  createCurrentUser,
+  createNationalId,
+} from '@island.is/testing/fixtures'
+import { AuthScope } from '@island.is/auth/scopes'
+import {
+  CreateCustomDelegation,
+  CreateDomain,
+} from '../../../../test/fixtures/types'
+import addDays from 'date-fns/addDays'
+
+// TODO: Refactor to use satisfied operator in TypeScript 4.9
+const createDomain = (domain: CreateDomain): CreateDomain => domain
+const createDelegation = (
+  delegation: CreateCustomDelegation,
+): CreateCustomDelegation => delegation
+
+export const testUser = createCurrentUser({
+  scope: [AuthScope.delegations],
+})
+
+export const testCompanyActorNationalId = createNationalId('person')
+export const testCompanyUser = createCurrentUser({
+  nationalIdType: 'company',
+  delegationType: 'Custom',
+  scope: [AuthScope.delegations],
+  actor: {
+    nationalId: testCompanyActorNationalId,
+  },
+})
+
+export const testScopes = {
+  mainValid: 'main.VALID',
+  mainFuture: 'main.FUTURE',
+  mainExpired: 'main.EXPIRED',
+  mainNotAllowed: 'main.NOT_ALLOWED',
+  otherValid: 'other.VALID',
+}
+
+export const testDomains = {
+  main: createDomain({
+    name: 'main',
+    apiScopes: [
+      { name: testScopes.mainValid, allowExplicitDelegationGrant: true },
+      { name: testScopes.mainFuture, allowExplicitDelegationGrant: true },
+      { name: testScopes.mainExpired, allowExplicitDelegationGrant: true },
+      { name: testScopes.mainNotAllowed, allowExplicitDelegationGrant: false },
+    ],
+  }),
+  other: createDomain({
+    name: 'other',
+    apiScopes: [
+      { name: testScopes.otherValid, allowExplicitDelegationGrant: true },
+    ],
+  }),
+}
+
+export const testDelegations = {
+  // Valid outgoing delegation
+  validOutgoing: createDelegation({
+    domainName: 'main',
+    fromNationalId: testUser.nationalId,
+    scopes: [{ scopeName: testScopes.mainValid }],
+  }),
+  // Valid but becomes active in the future outgoing delegation
+  futureValidOutgoing: createDelegation({
+    domainName: 'main',
+    fromNationalId: testUser.nationalId,
+    scopes: [
+      { scopeName: testScopes.mainFuture, validFrom: addDays(new Date(), 2) },
+    ],
+  }),
+  // Expired outgoing delegation
+  expiredOutgoing: createDelegation({
+    domainName: 'main',
+    fromNationalId: testUser.nationalId,
+    scopes: [
+      {
+        scopeName: testScopes.mainExpired,
+        validFrom: addDays(new Date(), -30),
+        validTo: addDays(new Date(), -5),
+      },
+    ],
+  }),
+  // With multiple scopes where one is active, one is expired and one is in future
+  variedValidity: createDelegation({
+    domainName: 'main',
+    fromNationalId: testUser.nationalId,
+    scopes: [
+      { scopeName: testScopes.mainValid },
+      { scopeName: testScopes.mainFuture, validFrom: addDays(new Date(), 2) },
+      {
+        scopeName: testScopes.mainExpired,
+        validFrom: addDays(new Date(), -30),
+        validTo: addDays(new Date(), -5),
+      },
+    ],
+  }),
+  // With scope that changes to be not allowed for delegation
+  notAllowedOutgoing: createDelegation({
+    domainName: 'main',
+    fromNationalId: testUser.nationalId,
+    scopes: [{ scopeName: testScopes.mainNotAllowed }],
+  }),
+  // With multiple scopes where one changes to be not allowed for delegation
+  withOneNotAllowedOutgoing: createDelegation({
+    domainName: 'main',
+    fromNationalId: testUser.nationalId,
+    scopes: [
+      { scopeName: testScopes.mainValid },
+      { scopeName: testScopes.mainNotAllowed },
+    ],
+  }),
+  // Should not be able to edit incoming delegations.
+  incomingValid: createDelegation({
+    domainName: 'main',
+    toNationalId: testUser.nationalId,
+    scopes: [{ scopeName: testScopes.mainValid }],
+  }),
+  // Other users
+  otherUsers: createDelegation({
+    domainName: 'main',
+    fromNationalId: createNationalId('person'),
+    toNationalId: createNationalId('person'),
+    scopes: [{ scopeName: testScopes.mainValid }],
+  }),
+  // Valid outgoing delegation in another domain
+  validOutgoingInOtherDomain: createDelegation({
+    domainName: 'other',
+    fromNationalId: testUser.nationalId,
+    scopes: [{ scopeName: testScopes.otherValid }],
+  }),
+}
+
+export const testCompanyDelegations = {
+  // Set up actor access.
+  actorDelegation: createDelegation({
+    domainName: 'main',
+    fromNationalId: testCompanyUser.nationalId,
+    toNationalId: testCompanyActorNationalId,
+    scopes: [{ scopeName: testScopes.mainValid }],
+  }),
+  // Another delegation which the actor can see.
+  validOutgoing: createDelegation({
+    domainName: 'main',
+    fromNationalId: testCompanyUser.nationalId,
+    scopes: [{ scopeName: testScopes.mainValid }],
+  }),
+  // Actor has access to a scope in this domain so they can look up this delegation but can't see the scope.
+  otherScope: createDelegation({
+    domainName: 'main',
+    fromNationalId: testCompanyUser.nationalId,
+    scopes: [{ scopeName: testScopes.mainFuture }],
+  }),
+  // Actor has no access to this domain so they can't look up this delegation.
+  otherDomain: createDelegation({
+    domainName: 'other',
+    fromNationalId: testCompanyUser.nationalId,
+    scopes: [{ scopeName: testScopes.otherValid }],
+  }),
+}

--- a/apps/services/auth/delegation-api/src/app/delegations/test/utils.ts
+++ b/apps/services/auth/delegation-api/src/app/delegations/test/utils.ts
@@ -6,17 +6,19 @@ export const partitionDomainsByScopeAccess = (testCase: TestCase) => {
   const inaccessible: DomainAssertion[] = []
 
   testCase.domains.forEach((domain) => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const name = domain.name!
     const scopes = (domain.apiScopes ?? []).map((scope) => ({
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       name: scope.name!,
     }))
     const expectedDomain = testCase.expected.find(
-      (expected) => expected.name === domain.name,
+      (expected) => expected.name === name,
     )
 
     if (expectedDomain) {
       const [accessibleScopes, inaccessibleScopes] = partition(
-        scopes ?? [],
+        scopes,
         (scope) =>
           expectedDomain.scopes.find(
             (expected) => expected.name === scope.name,

--- a/apps/services/auth/delegation-api/src/app/delegations/test/utils.ts
+++ b/apps/services/auth/delegation-api/src/app/delegations/test/utils.ts
@@ -1,0 +1,35 @@
+import partition from 'lodash/partition'
+import { DomainAssertion, TestCase } from '../../../../test/access-test-cases'
+
+export const partitionDomainsByScopeAccess = (testCase: TestCase) => {
+  const accessible: DomainAssertion[] = []
+  const inaccessible: DomainAssertion[] = []
+
+  testCase.domains.forEach((domain) => {
+    const name = domain.name!
+    const scopes = (domain.apiScopes ?? []).map((scope) => ({
+      name: scope.name!,
+    }))
+    const expectedDomain = testCase.expected.find(
+      (expected) => expected.name === domain.name,
+    )
+
+    if (expectedDomain) {
+      const [accessibleScopes, inaccessibleScopes] = partition(
+        scopes ?? [],
+        (scope) =>
+          expectedDomain.scopes.find(
+            (expected) => expected.name === scope.name,
+          ),
+      )
+
+      accessible.push({ name, scopes: accessibleScopes })
+      if (inaccessibleScopes.length > 0) {
+        inaccessible.push({ name, scopes: inaccessibleScopes })
+      }
+    } else {
+      inaccessible.push({ name, scopes })
+    }
+  })
+  return [accessible, inaccessible]
+}

--- a/apps/services/auth/delegation-api/test/access-test-cases.ts
+++ b/apps/services/auth/delegation-api/test/access-test-cases.ts
@@ -6,17 +6,14 @@ import { AuthScope } from '@island.is/auth/scopes'
 import { User } from '@island.is/auth-nest-tools'
 import { ConfigType } from '@island.is/nest/config'
 import { DelegationConfig } from '@island.is/auth-api-lib'
-import {
-  CreateCustomDelegation,
-  CreateDomain,
-} from '../../../../test/fixtures/types'
+import { CreateCustomDelegation, CreateDomain } from './fixtures/types'
 
-type DomainAssertion = {
+export interface DomainAssertion {
   name: string
   scopes: Array<{ name: string }>
 }
 
-type TestCase = {
+export interface TestCase {
   user: User
   customScopeRules?: ConfigType<typeof DelegationConfig>['customScopeRules']
   delegations?: CreateCustomDelegation[]
@@ -25,7 +22,7 @@ type TestCase = {
   expected: DomainAssertion[]
 }
 
-export const testCases: Record<string, TestCase> = {
+export const accessTestCases: Record<string, TestCase> = {
   // Normal user should be able to grant delegations for scopes allowing explicit delegation grants.
   happyCase: {
     user: createCurrentUser({ scope: [AuthScope.delegations] }),

--- a/apps/services/auth/delegation-api/test/fixtures/fixture-factory.ts
+++ b/apps/services/auth/delegation-api/test/fixtures/fixture-factory.ts
@@ -22,6 +22,7 @@ import {
   CreateCustomDelegation,
   CreateDomain,
 } from './types'
+import startOfDay from 'date-fns/startOfDay'
 
 export class FixtureFactory {
   constructor(private app: TestApp) {}
@@ -41,7 +42,7 @@ export class FixtureFactory {
       description: description ?? faker.lorem.sentence(),
       nationalId: nationalId ?? createNationalId('company'),
     })
-    await Promise.all(
+    domain.scopes = await Promise.all(
       apiScopes.map((apiScope) =>
         this.createApiScope({ domainName: domain.name, ...apiScope }),
       ),
@@ -136,13 +137,13 @@ export class FixtureFactory {
       toName: faker.name.findName(),
     })
 
-    await Promise.all(
+    delegation.delegationScopes = await Promise.all(
       scopes.map(({ scopeName, validFrom, validTo }) =>
         this.get(DelegationScope).create({
           id: faker.datatype.uuid(),
           delegationId: delegation.id,
           scopeName,
-          validFrom,
+          validFrom: validFrom ?? startOfDay(new Date()),
           validTo: validTo ?? addYears(new Date(), 1),
         }),
       ),

--- a/apps/services/auth/delegation-api/test/fixtures/types.ts
+++ b/apps/services/auth/delegation-api/test/fixtures/types.ts
@@ -6,7 +6,6 @@ import {
   DelegationDTO,
   DelegationScopeDTO,
   DomainDTO,
-  Translation,
 } from '@island.is/auth-api-lib'
 
 export type CreateDomain = Partial<DomainDTO> & { apiScopes?: CreateApiScope[] }

--- a/apps/services/auth/delegation-api/test/setup.ts
+++ b/apps/services/auth/delegation-api/test/setup.ts
@@ -21,6 +21,7 @@ import { ConfigType } from '@island.is/nest/config'
 interface SetupOptions {
   user?: User
   customScopeRules?: ConfigType<typeof DelegationConfig>['customScopeRules']
+  override?: (builder: TestingModuleBuilder) => TestingModuleBuilder
 }
 
 const delegationConfig: ConfigType<typeof DelegationConfig> = {
@@ -33,13 +34,14 @@ const delegationConfig: ConfigType<typeof DelegationConfig> = {
 export const setupWithAuth = ({
   user = createCurrentUser(),
   customScopeRules,
+  override = (builder) => builder,
 }: SetupOptions = {}): Promise<TestApp> => {
   // Setup app with authentication and database
   return testServer({
     appModule: AppModule,
     enableVersioning: true,
     override: (builder: TestingModuleBuilder) =>
-      builder
+      override(builder)
         .overrideProvider(FeatureFlagService)
         .useValue(FeatureFlagServiceMock)
         .overrideProvider(DelegationConfig.KEY)
@@ -62,8 +64,9 @@ export const setupWithoutAuth = (): Promise<TestApp> => {
   })
 }
 
-export const setupWithoutPermission = (): Promise<TestApp> => {
-  const user = createCurrentUser()
+export const setupWithoutPermission = ({
+  user = createCurrentUser(),
+}: { user?: User } = {}): Promise<TestApp> => {
   return testServer({
     appModule: AppModule,
     enableVersioning: true,

--- a/apps/services/auth/public-api/src/app/modules/delegations/actorDelegations.controller.spec.ts
+++ b/apps/services/auth/public-api/src/app/modules/delegations/actorDelegations.controller.spec.ts
@@ -27,7 +27,13 @@ import {
 } from '@island.is/testing/fixtures'
 import { TestApp, getRequestMethod } from '@island.is/testing/nest'
 import { NationalRegistryClientPerson } from '@island.is/shared/types'
-import { createDelegation } from '@island.is/services/auth/testing'
+import {
+  createDelegation,
+  expectMatchingDelegations,
+  getFakeName,
+  createDelegationModels,
+  findExpectedDelegationModels,
+} from '@island.is/services/auth/testing'
 
 import { createClient } from '../../../../test/fixtures'
 import {
@@ -37,12 +43,6 @@ import {
   setupWithoutPermission,
 } from '../../../../test/setup'
 import { TestEndpointOptions } from '../../../../test/types'
-import {
-  expectMatchingObject,
-  getFakeName,
-  createDelegationModels,
-  findExpectedDelegationModels,
-} from '../../../../test/utils'
 
 const swapNames = (
   delegation: DelegationDTO,
@@ -240,7 +240,7 @@ describe('ActorDelegationsController', () => {
         // Assert
         expect(res.status).toEqual(200)
         expect(res.body).toHaveLength(3)
-        expectMatchingObject(
+        expectMatchingDelegations(
           res.body,
           updateDelegationFromNameToPersonName(
             expectedModels,
@@ -266,7 +266,7 @@ describe('ActorDelegationsController', () => {
         // Assert
         expect(res.status).toEqual(200)
         expect(res.body).toHaveLength(1)
-        expectMatchingObject(
+        expectMatchingDelegations(
           res.body[0],
           updateDelegationFromNameToPersonName(
             expectedModel,
@@ -294,7 +294,7 @@ describe('ActorDelegationsController', () => {
         // Assert
         expect(res.status).toEqual(200)
         expect(res.body).toHaveLength(1)
-        expectMatchingObject(
+        expectMatchingDelegations(
           res.body[0],
           updateDelegationFromNameToPersonName(
             expectedModel,
@@ -336,7 +336,7 @@ describe('ActorDelegationsController', () => {
         // Assert
         expect(res.status).toEqual(200)
         expect(res.body).toHaveLength(1)
-        expectMatchingObject(
+        expectMatchingDelegations(
           res.body[0],
           updateDelegationFromNameToPersonName(
             expectedModel,
@@ -389,7 +389,7 @@ describe('ActorDelegationsController', () => {
         // Assert
         expect(res.status).toEqual(200)
         expect(res.body).toHaveLength(2)
-        expectMatchingObject(
+        expectMatchingDelegations(
           res.body,
           updateDelegationFromNameToPersonName(
             expectedModels,
@@ -421,7 +421,7 @@ describe('ActorDelegationsController', () => {
 
         // Assert
         expect(res.status).toEqual(200)
-        expectMatchingObject(
+        expectMatchingDelegations(
           res.body,
           updateDelegationFromNameToPersonName(
             expectedModels,
@@ -447,7 +447,7 @@ describe('ActorDelegationsController', () => {
         // Assert
         expect(res.status).toEqual(200)
         expect(res.body).toHaveLength(1)
-        expectMatchingObject(
+        expectMatchingDelegations(
           res.body[0],
           updateDelegationFromNameToPersonName(
             expectedModel,
@@ -514,7 +514,7 @@ describe('ActorDelegationsController', () => {
         // Assert
         expect(res.status).toEqual(200)
         expect(res.body).toHaveLength(0)
-        expectMatchingObject(
+        expectMatchingDelegations(
           res.body,
           updateDelegationFromNameToPersonName(
             expectedModels,
@@ -540,7 +540,7 @@ describe('ActorDelegationsController', () => {
         // Assert
         expect(res.status).toEqual(200)
         expect(res.body).toHaveLength(0)
-        expectMatchingObject(
+        expectMatchingDelegations(
           res.body,
           updateDelegationFromNameToPersonName(
             expectedModels,
@@ -566,7 +566,7 @@ describe('ActorDelegationsController', () => {
         // Assert
         expect(res.status).toEqual(200)
         expect(res.body).toHaveLength(1)
-        expectMatchingObject(
+        expectMatchingDelegations(
           res.body,
           updateDelegationFromNameToPersonName(
             expectedModels,
@@ -910,7 +910,7 @@ describe('ActorDelegationsController', () => {
         // Assert
         expect(res.status).toEqual(200)
         expect(res.body).toHaveLength(1)
-        expectMatchingObject(
+        expectMatchingDelegations(
           res.body[0],
           updateDelegationFromNameToPersonName(
             expectedModel,

--- a/apps/services/auth/public-api/src/app/modules/delegations/meDelegations.controller.spec.ts
+++ b/apps/services/auth/public-api/src/app/modules/delegations/meDelegations.controller.spec.ts
@@ -17,7 +17,12 @@ import {
   createNationalRegistryUser,
 } from '@island.is/testing/fixtures'
 import { TestApp, getRequestMethod } from '@island.is/testing/nest'
-import { createDelegation } from '@island.is/services/auth/testing'
+import {
+  createDelegation,
+  createDelegationModels,
+  expectMatchingDelegations,
+  findExpectedDelegationModels,
+} from '@island.is/services/auth/testing'
 
 import { createClient } from '../../../../test/fixtures'
 import {
@@ -27,11 +32,6 @@ import {
   setupWithoutPermission,
 } from '../../../../test/setup'
 import { TestEndpointOptions } from '../../../../test/types'
-import {
-  createDelegationModels,
-  expectMatchingObject,
-  findExpectedDelegationModels,
-} from '../../../../test/utils'
 
 const client = createClient({ clientId: '@island.is/webapp' })
 const actorNationalId = createNationalId('person')
@@ -222,7 +222,7 @@ describe('MeDelegationsController', () => {
         // Assert
         expect(res.status).toEqual(200)
         expect(res.body).toHaveLength(5)
-        expectMatchingObject(res.body, expectedModels)
+        expectMatchingDelegations(res.body, expectedModels)
       })
 
       it('should return only delegations with scopes the user has access to', async () => {
@@ -242,7 +242,7 @@ describe('MeDelegationsController', () => {
         // Assert
         expect(res.status).toEqual(200)
         expect(res.body).toHaveLength(1)
-        expectMatchingObject(res.body, [expectedModel])
+        expectMatchingDelegations(res.body, [expectedModel])
       })
 
       it('should return no delegation when the client does not have access to any scope', async () => {
@@ -283,7 +283,7 @@ describe('MeDelegationsController', () => {
         // Assert
         expect(res.status).toEqual(200)
         expect(res.body).toHaveLength(3)
-        expectMatchingObject(res.body, expectedModels)
+        expectMatchingDelegations(res.body, expectedModels)
       })
 
       it('should return all valid delegations with direction=outgoing&validity=includeFuture', async () => {
@@ -311,7 +311,7 @@ describe('MeDelegationsController', () => {
         // Assert
         expect(res.status).toEqual(200)
         expect(res.body).toHaveLength(4)
-        expectMatchingObject(res.body, expectedModels)
+        expectMatchingDelegations(res.body, expectedModels)
       })
 
       it('should return all expired delegations with direction=outgoing&validity=past', async () => {
@@ -333,7 +333,7 @@ describe('MeDelegationsController', () => {
         // Assert
         expect(res.status).toEqual(200)
         expect(res.body).toHaveLength(1)
-        expectMatchingObject(res.body, expectedModels)
+        expectMatchingDelegations(res.body, expectedModels)
       })
 
       it('should return an array with single delegation when filtered to specific otherUser', async () => {
@@ -355,7 +355,7 @@ describe('MeDelegationsController', () => {
         // Assert
         expect(res.status).toEqual(200)
         expect(res.body).toHaveLength(1)
-        expectMatchingObject(res.body, expectedModels)
+        expectMatchingDelegations(res.body, expectedModels)
       })
 
       it('should return no delegation for otherUser when user has access to none of the scopes', async () => {
@@ -372,7 +372,7 @@ describe('MeDelegationsController', () => {
         // Assert
         expect(res.status).toEqual(200)
         expect(res.body).toHaveLength(0)
-        expectMatchingObject(res.body, [])
+        expectMatchingDelegations(res.body, [])
       })
 
       it('should not return delegation to the actor', async () => {
@@ -387,7 +387,7 @@ describe('MeDelegationsController', () => {
         // Assert
         expect(res.status).toEqual(200)
         expect(res.body).toHaveLength(0)
-        expectMatchingObject(res.body, [])
+        expectMatchingDelegations(res.body, [])
       })
 
       it('should return an empty array when filtered to specific otherUser and no delegation exists', async () => {
@@ -476,7 +476,7 @@ describe('MeDelegationsController', () => {
         // Assert
         expect(res.status).toEqual(200)
         expect((res.body as DelegationDTO).scopes).toHaveLength(1)
-        expectMatchingObject(res.body, expectedModel)
+        expectMatchingDelegations(res.body, expectedModel)
       })
 
       it('should return a delegation with no scopes if no scope is allowed for delegation', async () => {
@@ -498,7 +498,7 @@ describe('MeDelegationsController', () => {
         // Assert
         expect(res.status).toEqual(200)
         expect((res.body as DelegationDTO).scopes).toHaveLength(0)
-        expectMatchingObject(res.body, expectedModel)
+        expectMatchingDelegations(res.body, expectedModel)
       })
 
       it('should return a delegation with filtered scopes list by user access', async () => {
@@ -517,7 +517,7 @@ describe('MeDelegationsController', () => {
 
         // Assert
         expect(res.status).toEqual(200)
-        expectMatchingObject(res.body, expectedModel)
+        expectMatchingDelegations(res.body, expectedModel)
       })
 
       it('should return a delegation with empty scopes list when user does not have access to any scopes', async () => {
@@ -536,7 +536,7 @@ describe('MeDelegationsController', () => {
 
         // Assert
         expect(res.status).toEqual(200)
-        expectMatchingObject(res.body, expectedModel)
+        expectMatchingDelegations(res.body, expectedModel)
       })
 
       it('should filter expired scopes for delegation that exists for auth user', async () => {
@@ -558,7 +558,7 @@ describe('MeDelegationsController', () => {
 
         // Assert
         expect(res.status).toEqual(200)
-        expectMatchingObject(res.body, expectedModel)
+        expectMatchingDelegations(res.body, expectedModel)
       })
 
       it('should return 404 not found if delegation does not exist or not connected to the user', async () => {
@@ -663,7 +663,7 @@ describe('MeDelegationsController', () => {
             (res.body as DelegationDTO).id!,
           )
           expect(res.status).toEqual(201)
-          expectMatchingObject(res.body, expectedModel)
+          expectMatchingDelegations(res.body, expectedModel)
         },
       )
 

--- a/apps/services/auth/public-api/test/utils.ts
+++ b/apps/services/auth/public-api/test/utils.ts
@@ -8,37 +8,6 @@ import {
 } from '@island.is/auth-api-lib'
 import { CreateDelegation } from '@island.is/services/auth/testing'
 
-/**
- * Helper to match complete object when the received object has gone over the "wire"
- * and was JSON stringified.
- * @param received The SUT object recevied
- * @param expected The expected object to be matched against the received object
- */
-export const expectMatchingObject = (
-  received: DelegationDTO | DelegationDTO[],
-  expected: DelegationDTO | DelegationDTO[],
-) => {
-  if (Array.isArray(received)) {
-    sortDelegations(received)
-  }
-  if (Array.isArray(expected)) {
-    sortDelegations(expected)
-  }
-
-  expect(received).toMatchObject(JSON.parse(JSON.stringify(expected)))
-}
-
-/**
- * Sorts the delegation by id parameter to use for consistent expecting
- * @param delegations
- */
-const sortDelegations = (delegations: DelegationDTO[]) => {
-  delegations.sort((a, b) => {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    return a.id === b.id ? 0 : a.id! < b.id! ? -1 : 1
-  })
-}
-
 export type NameIdTuple = [name: string, id: string]
 
 export const getFakeName = () =>

--- a/libs/auth-api-lib/src/lib/delegations/delegations-outgoing.service.ts
+++ b/libs/auth-api-lib/src/lib/delegations/delegations-outgoing.service.ts
@@ -68,7 +68,7 @@ export class DelegationsOutgoingService {
           model: DelegationScope,
           include: [
             {
-              attributes: [],
+              attributes: ['displayName'],
               model: ApiScope,
               required: true,
               include: [
@@ -298,6 +298,12 @@ export class DelegationsOutgoingService {
         {
           model: DelegationScope,
           required: false,
+          include: [
+            {
+              attributes: ['displayName'],
+              model: ApiScope,
+            },
+          ],
         },
       ],
     })
@@ -312,8 +318,9 @@ export class DelegationsOutgoingService {
       delegation.domainName,
     )
     if (!userScopes.length) {
-      throw new BadRequestException('User does not have access to this domain.')
+      return null
     }
+
     delegation.delegationScopes = delegation.delegationScopes?.filter((scope) =>
       userScopes.includes(scope.scopeName),
     )

--- a/libs/auth-api-lib/src/lib/delegations/delegations-outgoing.service.ts
+++ b/libs/auth-api-lib/src/lib/delegations/delegations-outgoing.service.ts
@@ -4,7 +4,7 @@ import {
   InternalServerErrorException,
 } from '@nestjs/common'
 import { InjectModel } from '@nestjs/sequelize'
-import { Op } from 'sequelize'
+import { and, Op, WhereOptions } from 'sequelize'
 import { isUuid, uuid } from 'uuidv4'
 
 import { User } from '@island.is/auth-nest-tools'
@@ -20,9 +20,13 @@ import {
 import { DelegationScope } from './models/delegation-scope.model'
 import { Delegation } from './models/delegation.model'
 import { DelegationValidity } from './types/delegationValidity'
-import { validateScopesPeriod } from './utils/scopes'
+import {
+  getScopeValidityWhereClause,
+  validateScopesPeriod,
+} from './utils/scopes'
 import { NamesService } from './names.service'
 import { getDelegationNoActorWhereClause } from './utils/delegations'
+import { DelegationResourcesService } from '../resources/delegation-resources.service'
 
 /**
  * Service class for outgoing delegations.
@@ -34,6 +38,7 @@ export class DelegationsOutgoingService {
     @InjectModel(Delegation)
     private delegationModel: typeof Delegation,
     private delegationScopeService: DelegationScopeService,
+    private delegationResourceService: DelegationResourcesService,
     private namesService: NamesService,
   ) {}
 
@@ -43,38 +48,60 @@ export class DelegationsOutgoingService {
     domainName?: string,
     otherUser?: string,
   ): Promise<DelegationDTO[]> {
+    if (otherUser) {
+      return this.findByOtherUser(user, otherUser, domainName)
+    }
     const delegations = await this.delegationModel.findAll({
-      where: {
-        [Op.and]: [
-          {
-            fromNationalId: user.nationalId,
-          },
-          otherUser ? { toNationalId: otherUser } : {},
-          domainName ? { domainName } : {},
-          getDelegationNoActorWhereClause(user),
-        ],
-      },
+      where: and(
+        {
+          fromNationalId: user.nationalId,
+        },
+        domainName ? { domainName } : {},
+        getDelegationNoActorWhereClause(user),
+        ...this.delegationResourceService.apiScopeFilter(
+          user,
+          'delegationScopes->apiScope',
+        ),
+      ),
       include: [
         {
           model: DelegationScope,
           include: [
             {
+              attributes: [],
               model: ApiScope,
-              as: 'apiScope',
-              where: {
-                enabled: true,
-                allowExplicitDelegationGrant: true,
-              },
+              required: true,
+              include: [
+                ...this.delegationResourceService.apiScopeInclude(user),
+              ],
             },
           ],
           required: validity !== DelegationValidity.ALL,
+          where: getScopeValidityWhereClause(validity),
         },
       ],
     })
 
-    // TODO: Validate user scope access to the delegation scopes.
-
     return delegations.map((d) => d.toDTO())
+  }
+
+  async findByOtherUser(
+    user: User,
+    otherUser: string,
+    domainName?: string,
+  ): Promise<DelegationDTO[]> {
+    if (!domainName) {
+      throw new BadRequestException(
+        'Domain name is required when fetching delegation by other user.',
+      )
+    }
+
+    const delegation = await this.findOneInternal(user, {
+      fromNationalId: user.nationalId,
+      toNationalId: otherUser,
+      domainName,
+    })
+    return delegation ? [delegation] : []
   }
 
   async findById(user: User, delegationId: string): Promise<DelegationDTO> {
@@ -82,40 +109,14 @@ export class DelegationsOutgoingService {
       throw new BadRequestException('delegationId must be a valid uuid')
     }
 
-    const delegation = await this.delegationModel.findOne({
-      where: {
-        id: delegationId,
-        [Op.or]: [
-          { fromNationalId: user.nationalId },
-          { toNationalId: user.nationalId },
-        ],
-      },
-      include: [
-        {
-          model: DelegationScope,
-          as: 'delegationScopes',
-          required: false,
-          include: [
-            {
-              model: ApiScope,
-              as: 'apiScope',
-              where: {
-                enabled: true,
-                allowExplicitDelegationGrant: true,
-              },
-            },
-          ],
-        },
-      ],
+    const delegation = await this.findOneInternal(user, {
+      fromNationalId: user.nationalId,
+      id: delegationId,
     })
-
     if (!delegation) {
       throw new NoContentException()
     }
-
-    // TODO: Validate user scope access to the delegation scopes.
-
-    return delegation.toDTO()
+    return delegation
   }
 
   async create(
@@ -134,6 +135,18 @@ export class DelegationsOutgoingService {
     if (!createDelegation.domainName) {
       throw new BadRequestException(
         'Domain name is required to create delegation.',
+      )
+    }
+
+    if (
+      !(await this.delegationResourceService.validateScopeAccess(
+        user,
+        createDelegation.domainName,
+        (createDelegation.scopes ?? []).map((scope) => scope.name),
+      ))
+    ) {
+      throw new BadRequestException(
+        'User does not have access to the requested scopes.',
       )
     }
 
@@ -166,8 +179,6 @@ export class DelegationsOutgoingService {
         toName,
       })
     }
-
-    // TODO: User authorization on the scopes
 
     await this.delegationScopeService.createOrUpdate(
       delegation.id,
@@ -205,6 +216,21 @@ export class DelegationsOutgoingService {
       throw new NoContentException()
     }
 
+    if (
+      !(await this.delegationResourceService.validateScopeAccess(
+        user,
+        currentDelegation.domainName,
+        [
+          ...(patchedDelegation.updateScopes ?? []).map((scope) => scope.name),
+          ...(patchedDelegation.deleteScopes ?? []),
+        ],
+      ))
+    ) {
+      throw new BadRequestException(
+        'User does not have access to the requested scopes.',
+      )
+    }
+
     if (!validateScopesPeriod(patchedDelegation.updateScopes)) {
       throw new BadRequestException(
         'If scope validTo property is provided it must be in the future',
@@ -240,18 +266,59 @@ export class DelegationsOutgoingService {
       return
     }
 
-    // TODO: Scope authorization and delete only scopes the user has access to.
-    await this.delegationScopeService.delete(delegationId)
+    const userScopes = await this.delegationResourceService.findScopes(
+      user,
+      delegation.domainName,
+    )
+    await this.delegationScopeService.delete(
+      delegationId,
+      userScopes.map((scope) => scope.name),
+    )
 
     // If no scopes are left delete the delegation.
-    const scopes = await this.delegationScopeService.findAll(delegationId)
-    if (scopes.length === 0) {
+    const remainingScopes = await this.delegationScopeService.findAll(
+      delegationId,
+    )
+    if (remainingScopes.length === 0) {
       await this.delegationModel.destroy({
         where: {
           id: delegationId,
         },
       })
     }
+  }
+
+  private async findOneInternal(
+    user: User,
+    where: WhereOptions<Delegation>,
+  ): Promise<DelegationDTO | null> {
+    const delegation = await this.delegationModel.findOne({
+      where,
+      include: [
+        {
+          model: DelegationScope,
+          required: false,
+        },
+      ],
+    })
+
+    if (!delegation) {
+      return null
+    }
+
+    // Verify and filter scopes.
+    const userScopes = await this.delegationResourceService.findScopeNames(
+      user,
+      delegation.domainName,
+    )
+    if (!userScopes.length) {
+      throw new BadRequestException('User does not have access to this domain.')
+    }
+    delegation.delegationScopes = delegation.delegationScopes?.filter((scope) =>
+      userScopes.includes(scope.scopeName),
+    )
+
+    return delegation.toDTO()
   }
 
   private isConnectedToDelegation(user: User, delegation: Delegation): boolean {

--- a/libs/auth-api-lib/src/lib/delegations/models/delegation.model.ts
+++ b/libs/auth-api-lib/src/lib/delegations/models/delegation.model.ts
@@ -2,6 +2,7 @@ import type {
   CreationOptional,
   InferAttributes,
   InferCreationAttributes,
+  NonAttribute,
 } from 'sequelize'
 import {
   Column,
@@ -99,7 +100,7 @@ export class Delegation extends Model<
   readonly modified?: Date
 
   @HasMany(() => DelegationScope)
-  delegationScopes?: DelegationScope[]
+  delegationScopes?: NonAttribute<DelegationScope[]>
 
   toDTO(): DelegationDTO {
     return {

--- a/libs/services/auth/testing/src/index.ts
+++ b/libs/services/auth/testing/src/index.ts
@@ -1,1 +1,2 @@
 export * from './fixtures'
+export * from './utils/delegations'

--- a/libs/services/auth/testing/src/utils/delegations.ts
+++ b/libs/services/auth/testing/src/utils/delegations.ts
@@ -1,4 +1,12 @@
-import { DelegationDTO } from '@island.is/auth-api-lib'
+import faker from 'faker'
+
+import {
+  ApiScope,
+  Delegation,
+  DelegationDTO,
+  DelegationScope,
+} from '@island.is/auth-api-lib'
+import { CreateDelegation } from '../fixtures/delegation.fixture'
 
 const compareById = (a: { id?: string | null }, b: { id?: string | null }) => {
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -32,4 +40,74 @@ export const expectMatchingDelegations = (
   }
 
   expect(received).toMatchObject(JSON.parse(JSON.stringify(expected)))
+}
+
+export type NameIdTuple = [name: string, id: string]
+
+export const getFakeName = () =>
+  faker.fake('{{name.firstName}} {{name.lastName}}')
+
+export async function createDelegationModels(
+  model: typeof Delegation,
+  creationModels: CreateDelegation[],
+) {
+  await model.bulkCreate(creationModels, {
+    include: [
+      {
+        model: DelegationScope,
+        as: 'delegationScopes',
+      },
+    ],
+  })
+}
+
+export async function findExpectedDelegationModels(
+  model: typeof Delegation,
+  modelIds: string,
+  allowedScopes?: string[],
+): Promise<DelegationDTO>
+export async function findExpectedDelegationModels(
+  model: typeof Delegation,
+  modelIds: string[],
+  allowedScopes?: string[],
+): Promise<DelegationDTO[]>
+export async function findExpectedDelegationModels(
+  model: typeof Delegation,
+  modelIds: string | string[],
+  allowedScopes?: string[],
+): Promise<DelegationDTO | DelegationDTO[]> {
+  const expectedModels = await model.findAll({
+    where: {
+      id: modelIds,
+    },
+    include: [
+      {
+        model: DelegationScope,
+        as: 'delegationScopes',
+        include: [
+          {
+            model: ApiScope,
+            as: 'apiScope',
+            where: {
+              allowExplicitDelegationGrant: true,
+            },
+          },
+        ],
+      },
+    ],
+  })
+
+  if (allowedScopes) {
+    for (const expectedModel of expectedModels) {
+      expectedModel.delegationScopes = expectedModel.delegationScopes?.filter(
+        (s) => allowedScopes.includes(s.scopeName),
+      )
+    }
+  }
+
+  if (Array.isArray(modelIds)) {
+    return expectedModels.map((delegation) => delegation.toDTO())
+  } else {
+    return expectedModels[0].toDTO()
+  }
 }

--- a/libs/services/auth/testing/src/utils/delegations.ts
+++ b/libs/services/auth/testing/src/utils/delegations.ts
@@ -1,0 +1,35 @@
+import { DelegationDTO } from '@island.is/auth-api-lib'
+
+const compareById = (a: { id?: string | null }, b: { id?: string | null }) => {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  return a.id === b.id ? 0 : a.id! < b.id! ? -1 : 1
+}
+
+/**
+ * Sorts the delegation by id parameter to use for consistent expecting
+ * @param delegations
+ */
+const sortDelegations = (delegations: DelegationDTO[]) => {
+  delegations.forEach((delegation) => delegation.scopes?.sort(compareById))
+  delegations.sort(compareById)
+}
+
+/**
+ * Helper to match complete object when the received object has gone over the "wire"
+ * and was JSON stringified.
+ * @param received The SUT object recevied
+ * @param expected The expected object to be matched against the received object
+ */
+export const expectMatchingDelegations = (
+  received: DelegationDTO | DelegationDTO[],
+  expected: DelegationDTO | DelegationDTO[],
+) => {
+  if (Array.isArray(received)) {
+    sortDelegations(received)
+  }
+  if (Array.isArray(expected)) {
+    sortDelegations(expected)
+  }
+
+  expect(received).toMatchObject(JSON.parse(JSON.stringify(expected)))
+}

--- a/libs/services/auth/testing/tsconfig.json
+++ b/libs/services/auth/testing/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "commonjs"
+    "module": "commonjs",
+    "types": ["jest", "node"]
   },
   "files": [],
   "include": [],

--- a/libs/services/auth/testing/tsconfig.spec.json
+++ b/libs/services/auth/testing/tsconfig.spec.json
@@ -2,8 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../../dist/out-tsc",
-    "module": "commonjs",
-    "types": ["jest", "node"]
+    "module": "commonjs"
   },
   "include": ["**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
 }


### PR DESCRIPTION
## What

Filter delegation endpoints so they match which scopes the user can manage delegations for.

Includes an API test suite for this.

## Why

This is needed for DelegationsV2

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
