### PR TITLE
fix(parental leave): not show employer email and phone number if receiving benefits

### DIFF
--- a/libs/application/templates/parental-leave/src/fields/Review/Review.tsx
+++ b/libs/application/templates/parental-leave/src/fields/Review/Review.tsx
@@ -920,27 +920,30 @@ export const Review: FC<ReviewScreenProps> = ({
                 )}
                 value={isSelfEmployed}
               />
-              {isSelfEmployed === NO && employerPhoneNumber && (
-                <Box paddingTop={2}>
-                  <DataValue
-                    label={formatMessage(
-                      parentalLeaveFormMessages.employer.phoneNumber,
-                    )}
-                    value={formatPhoneNumber(employerPhoneNumber)}
-                  />
-                </Box>
-              )}
+              {isSelfEmployed === NO &&
+                isRecivingUnemploymentBenefits === NO &&
+                employerPhoneNumber && (
+                  <Box paddingTop={2}>
+                    <DataValue
+                      label={formatMessage(
+                        parentalLeaveFormMessages.employer.phoneNumber,
+                      )}
+                      value={formatPhoneNumber(employerPhoneNumber)}
+                    />
+                  </Box>
+                )}
             </GridColumn>
 
             <GridColumn span={['12/12', '12/12', '12/12', '5/12']}>
-              {isSelfEmployed === NO && (
-                <DataValue
-                  label={formatMessage(
-                    parentalLeaveFormMessages.employer.email,
-                  )}
-                  value={employerEmail}
-                />
-              )}
+              {isSelfEmployed === NO &&
+                isRecivingUnemploymentBenefits === NO && (
+                  <DataValue
+                    label={formatMessage(
+                      parentalLeaveFormMessages.employer.email,
+                    )}
+                    value={employerEmail}
+                  />
+                )}
             </GridColumn>
           </GridRow>
           {isSelfEmployed === NO && ( // only show benefits in review if user had to answer that question


### PR DESCRIPTION
## What

Not show employer email and phone number if receiving benefits in review screen

## Screenshots / Gifs

before:
<img width="810" alt="Screenshot 2022-11-08 at 10 32 22" src="https://user-images.githubusercontent.com/102811817/200546080-2765713e-c617-410a-aa97-f4edabb95f2f.png">

after:
<img width="784" alt="Screenshot 2022-11-08 at 10 52 30" src="https://user-images.githubusercontent.com/102811817/200546111-b483d4bf-95e5-4e5a-bc6e-bc24c8b089ac.png">

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
