### PR TITLE
feat(service-portal): Assets service version 2

### DIFF
--- a/infra/src/dsl/xroad.ts
+++ b/infra/src/dsl/xroad.ts
@@ -185,6 +185,12 @@ export const Properties = new XroadConf({
       staging: 'IS-TEST/GOV/6503760649/SKRA-Protected/Fasteignir-v1',
       prod: 'IS/GOV/6503760649/SKRA-Protected/Fasteignir-v1',
     },
+    XROAD_PROPERTIES_SERVICE_V2_PATH: {
+      dev: 'IS-DEV/GOV/10033/HMS-Protected/Fasteignir-v1',
+      staging: 'IS-TEST/GOV/5812191480/HMS-Protected/Fasteignir-v1',
+      prod:
+        'IS/GOV/5812191480/Husnaeds-og-mannvirkjastofnun-Protected/Fasteignir-v1',
+    },
     // Deprecated:
     XROAD_PROPERTIES_API_PATH: '/SKRA-Protected/Fasteignir-v1',
   },

--- a/libs/api/domains/assets/src/lib/api-domains-assets.module.ts
+++ b/libs/api/domains/assets/src/lib/api-domains-assets.module.ts
@@ -1,13 +1,20 @@
 import { Module } from '@nestjs/common'
 import { AuthModule } from '@island.is/auth-nest-tools'
 import { AssetsClientModule } from '@island.is/clients/assets'
+import { AssetsV2ClientModule } from '@island.is/clients/assets-v2'
+import { FeatureFlagModule } from '@island.is/nest/feature-flags'
 
 import { AssetsXRoadResolver } from './api-domains-assets.resolver'
 import { AssetsXRoadService } from './api-domains-assets.service'
 
 @Module({
   providers: [AssetsXRoadResolver, AssetsXRoadService],
-  imports: [AssetsClientModule, AuthModule],
+  imports: [
+    AssetsClientModule,
+    AssetsV2ClientModule,
+    FeatureFlagModule,
+    AuthModule,
+  ],
   exports: [AssetsXRoadService],
 })
 export class AssetsModule {}

--- a/libs/clients/assets-v2/.babelrc
+++ b/libs/clients/assets-v2/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [["@nrwl/web/babel", { "useBuiltIns": "usage" }]]
+}

--- a/libs/clients/assets-v2/.eslintrc.json
+++ b/libs/clients/assets-v2/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/clients/assets-v2/README.md
+++ b/libs/clients/assets-v2/README.md
@@ -1,0 +1,17 @@
+# clients-assets-v2
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test clients-assets-v2` to execute the unit tests via [Jest](https://jestjs.io).
+
+## Running lint
+
+Run `nx lint clients-assets-v2` to execute the lint via [ESLint](https://eslint.org/).
+
+### Updating the open api definition (clientConfig.json)
+
+```sh
+yarn nx run clients-assets-v2:schemas/external-openapi-generator
+```

--- a/libs/clients/assets-v2/jest.config.js
+++ b/libs/clients/assets-v2/jest.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  displayName: 'clients-assets-v2',
+  preset: '../../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+    },
+  },
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../../coverage/libs/clients/assets-v2',
+}

--- a/libs/clients/assets-v2/project.json
+++ b/libs/clients/assets-v2/project.json
@@ -1,0 +1,28 @@
+{
+  "root": "libs/clients/assets-v2",
+  "sourceRoot": "libs/clients/assets-v2/src",
+  "projectType": "library",
+  "targets": {
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "options": {
+        "lintFilePatterns": ["libs/clients/assets-v2/**/*.{ts,tsx,js,jsx}"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["coverage/libs/clients/assets-v2"],
+      "options": {
+        "jestConfig": "libs/clients/assets-v2/jest.config.js",
+        "passWithNoTests": true
+      }
+    },
+    "schemas/external-openapi-generator": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "command": "yarn openapi-generator -o libs/clients/assets-v2/gen/fetch -i libs/clients/assets-v2/src/clientConfig.json"
+      }
+    }
+  },
+  "tags": []
+}

--- a/libs/clients/assets-v2/src/clientConfig.json
+++ b/libs/clients/assets-v2/src/clientConfig.json
@@ -1,0 +1,774 @@
+{
+  "x-generator": "NSwag v13.11.3.0 (NJsonSchema v10.4.4.0 (Newtonsoft.Json v13.0.0.0))",
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Fasteignir-Xroad",
+    "description": "Uppfletting í fasteignaskrá.",
+    "contact": {
+      "name": "Skra.is",
+      "url": "https://www.skra.is/",
+      "email": "skra@skra.is"
+    },
+    "version": "v1",
+    "x-category": ["personal", "official"],
+    "x-pricing": ["free", "paid"],
+    "x-links": {
+      "documentation": "https://www.skra.is/um-okkur/utgafur-og-skjol/taknmal-thjodskrar/",
+      "responsibleParty": "https://www.skra.is/um-okkur"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://api-staging.fasteignaskra.is/business/fasteignir-xroad"
+    }
+  ],
+  "paths": {
+    "/api/v1/fasteignir": {
+      "get": {
+        "tags": ["Fasteignir"],
+        "summary": "Sækir fasteignir skráðar á kennitölu.",
+        "operationId": "Fasteignir_GetFasteignir",
+        "parameters": [
+          {
+            "name": "kennitala",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 1
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 2
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "x-position": 3
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FasteignSimpleWrapper"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "auth": []
+          }
+        ]
+      }
+    },
+    "/api/v1/fasteignir/{fasteignanumer}": {
+      "get": {
+        "tags": ["Fasteignir"],
+        "summary": "Sækir fasteign eftir fasteignarnúmeri.",
+        "operationId": "Fasteignir_GetFasteign",
+        "parameters": [
+          {
+            "name": "fasteignanumer",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Fasteign"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "auth": []
+          }
+        ]
+      }
+    },
+    "/api/v1/fasteignir/{fasteignanumer}/thinglystir-eigendur": {
+      "get": {
+        "tags": ["Fasteignir"],
+        "summary": "Sækir eigendur fasteignar.",
+        "operationId": "Fasteignir_GetFasteignEigendur",
+        "parameters": [
+          {
+            "name": "fasteignanumer",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 1
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 2
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "x-position": 3
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThinglysturEigandiWrapper"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "auth": []
+          }
+        ]
+      }
+    },
+    "/api/v1/fasteignir/{fasteignanumer}/notkunareiningar": {
+      "get": {
+        "tags": ["Fasteignir"],
+        "summary": "Sækir notkunareiningar fasteignar.",
+        "operationId": "Fasteignir_GetFasteignNotkunareiningar",
+        "parameters": [
+          {
+            "name": "fasteignanumer",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 1
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 2
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "x-position": 3
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotkunareiningWrapper"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "auth": []
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "FasteignSimpleWrapper": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "fasteignir": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/FasteignSimple"
+            }
+          },
+          "paging": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Pagination"
+              }
+            ]
+          }
+        }
+      },
+      "FasteignSimple": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "fasteignanumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "sjalfgefidStadfang": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Stadfang"
+              }
+            ]
+          }
+        }
+      },
+      "Stadfang": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "stadfanganumer": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "landeignarnumer": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "postnumer": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "sveitarfelagBirting": {
+            "type": "string",
+            "nullable": true
+          },
+          "birting": {
+            "type": "string",
+            "nullable": true
+          },
+          "birtingStutt": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "Pagination": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "total": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "offset": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "hasPreviousPage": {
+            "type": "boolean"
+          },
+          "hasNextPage": {
+            "type": "boolean"
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["code", "message"],
+        "properties": {
+          "code": {
+            "type": "integer",
+            "description": "HTTP status code",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string",
+            "description": "Message describing the error"
+          },
+          "errors": {
+            "type": "array",
+            "description": "Detailed information of errors",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/ErrorDetails"
+            }
+          }
+        }
+      },
+      "ErrorDetails": {
+        "type": "object",
+        "description": "Detailed error message",
+        "additionalProperties": false,
+        "properties": {
+          "code": {
+            "type": "integer",
+            "description": "HTTP status code",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string",
+            "description": "Message describing the error",
+            "nullable": true
+          },
+          "help": {
+            "type": "string",
+            "description": "URL to a page explaining the error and possible solutions",
+            "nullable": true
+          },
+          "trackingId": {
+            "type": "string",
+            "description": "Identifier for mapping failures to service internal codes",
+            "nullable": true
+          },
+          "param": {
+            "type": "string",
+            "description": "Name of the parameter which was incorrect",
+            "nullable": true
+          }
+        }
+      },
+      "Fasteign": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/FasteignSimple"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "fasteignamat": {
+                "nullable": true,
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/Fasteignamat"
+                  }
+                ]
+              },
+              "landeign": {
+                "nullable": true,
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/Landeign"
+                  }
+                ]
+              },
+              "thinglystirEigendur": {
+                "nullable": true,
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/ThinglysturEigandiWrapper"
+                  }
+                ]
+              },
+              "notkunareiningar": {
+                "nullable": true,
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/NotkunareiningWrapper"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "Fasteignamat": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "gildandiFasteignamat": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "fyrirhugadFasteignamat": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "gildandiMannvirkjamat": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "fyrirhugadMannvirkjamat": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "gildandiLodarhlutamat": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "fyrirhugadLodarhlutamat": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "gildandiAr": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "fyrirhugadAr": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "Landeign": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "landeignarnumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "lodamat": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "notkunBirting": {
+            "type": "string",
+            "nullable": true
+          },
+          "flatarmal": {
+            "type": "string",
+            "nullable": true
+          },
+          "flatarmalEining": {
+            "type": "string",
+            "nullable": true
+          },
+          "thinglystirEigendur": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ThinglysturEigandiWrapper"
+              }
+            ]
+          }
+        }
+      },
+      "ThinglysturEigandiWrapper": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "thinglystirEigendur": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/ThinglysturEigandi"
+            }
+          },
+          "paging": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Pagination"
+              }
+            ]
+          }
+        }
+      },
+      "ThinglysturEigandi": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "nafn": {
+            "type": "string",
+            "nullable": true
+          },
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          },
+          "eignarhlutfall": {
+            "type": "number",
+            "format": "decimal"
+          },
+          "kaupdagur": {
+            "type": "string",
+            "format": "date"
+          },
+          "heimildBirting": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "NotkunareiningWrapper": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "notkunareiningar": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/Notkunareining"
+            }
+          },
+          "paging": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Pagination"
+              }
+            ]
+          }
+        }
+      },
+      "Notkunareining": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "birtStaerdMaelieining": {
+            "type": "string",
+            "nullable": true
+          },
+          "notkunareininganumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "fasteignanumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "stadfang": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Stadfang"
+              }
+            ]
+          },
+          "merking": {
+            "type": "string",
+            "nullable": true
+          },
+          "notkunBirting": {
+            "type": "string",
+            "nullable": true
+          },
+          "skyring": {
+            "type": "string",
+            "nullable": true
+          },
+          "byggingararBirting": {
+            "type": "string",
+            "nullable": true
+          },
+          "birtStaerd": {
+            "type": "number",
+            "format": "double"
+          },
+          "fasteignamat": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Fasteignamat"
+              }
+            ]
+          },
+          "brunabotamat": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "auth": {
+        "type": "apiKey",
+        "description": "Copy 'Bearer ' + valid JWT token into field",
+        "name": "Authorization",
+        "in": "header"
+      }
+    }
+  }
+}

--- a/libs/clients/assets-v2/src/index.ts
+++ b/libs/clients/assets-v2/src/index.ts
@@ -1,0 +1,3 @@
+export { AssetsV2ClientModule } from './lib/assetsV2.module'
+export { AssetsV2ClientConfig } from './lib/assetsV2.config'
+export * from '../gen/fetch'

--- a/libs/clients/assets-v2/src/lib/PropertiesV2ApiProvider.ts
+++ b/libs/clients/assets-v2/src/lib/PropertiesV2ApiProvider.ts
@@ -8,20 +8,17 @@ import {
   XRoadConfig,
 } from '@island.is/nest/config'
 
-import {
-  Configuration,
-  FasteignirApi as FasteignirApiV2,
-} from '../../gen/fetch'
+import { Configuration, FasteignirApi } from '../../gen/fetch'
 import { AssetsV2ClientConfig } from './assetsV2.config'
 
-export const PropertiesV2ApiProvider: Provider<FasteignirApiV2> = {
-  provide: FasteignirApiV2,
+export const PropertiesV2ApiProvider: Provider<FasteignirApi> = {
+  provide: FasteignirApi,
   scope: LazyDuringDevScope,
   useFactory: (
     xroadConfig: ConfigType<typeof XRoadConfig>,
     config: ConfigType<typeof AssetsV2ClientConfig>,
   ) =>
-    new FasteignirApiV2(
+    new FasteignirApi(
       new Configuration({
         fetchApi: createEnhancedFetch({
           name: 'clients-assets-v2',

--- a/libs/clients/assets-v2/src/lib/assetsV2.config.ts
+++ b/libs/clients/assets-v2/src/lib/assetsV2.config.ts
@@ -1,0 +1,53 @@
+import { NationalRegistryScope } from '@island.is/auth/scopes'
+import { defineConfig } from '@island.is/nest/config'
+import { z } from 'zod'
+
+const schema = z.object({
+  xRoadServicePath: z.string(),
+  fetch: z.object({
+    timeout: z.number().int(),
+    autoAuth: z
+      .object({
+        mode: z.enum(['token', 'tokenExchange', 'auto']),
+        issuer: z.string(),
+        clientId: z.string(),
+        clientSecret: z.string(),
+        scope: z.array(z.string()),
+      })
+      .optional(),
+  }),
+})
+
+export const AssetsV2ClientConfig = defineConfig<z.infer<typeof schema>>({
+  name: 'AssetsClient',
+  schema,
+  load(env) {
+    const clientSecret = env.optional('XROAD_PROPERTIES_CLIENT_SECRET')
+    return {
+      xRoadServicePath: env.required(
+        'XROAD_PROPERTIES_SERVICE_V2_PATH',
+        'IS-DEV/GOV/10033/HMS-Protected/Fasteignir-v1',
+      ),
+      fetch: {
+        timeout: env.optionalJSON('XROAD_PROPERTIES_TIMEOUT') ?? 15000,
+        autoAuth: clientSecret
+          ? {
+              mode: 'tokenExchange',
+              issuer: env.required(
+                'IDENTITY_SERVER_ISSUER_URL',
+                'https://identity-server.dev01.devland.is',
+              ),
+              clientId:
+                env.optional('XROAD_PROPERTIES_CLIENT_ID') ??
+                '@island.is/clients/national-registry',
+              clientSecret,
+              scope: env.optionalJSON('XROAD_PROPERTIES_SCOPE') ?? [
+                NationalRegistryScope.properties,
+                'api_resource.scope',
+              ],
+            }
+          : undefined,
+      },
+    }
+  },
+})

--- a/libs/clients/assets-v2/src/lib/assetsV2.module.ts
+++ b/libs/clients/assets-v2/src/lib/assetsV2.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common'
+import { PropertiesV2ApiProvider } from './PropertiesV2ApiProvider'
+
+@Module({
+  providers: [PropertiesV2ApiProvider],
+  exports: [PropertiesV2ApiProvider],
+})
+export class AssetsV2ClientModule {}

--- a/libs/clients/assets-v2/tsconfig.json
+++ b/libs/clients/assets-v2/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/clients/assets-v2/tsconfig.lib.json
+++ b/libs/clients/assets-v2/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["**/*.spec.ts", "**/*.test.ts"],
+  "include": ["**/*.ts"]
+}

--- a/libs/clients/assets-v2/tsconfig.spec.json
+++ b/libs/clients/assets-v2/tsconfig.spec.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.test.tsx",
+    "**/*.spec.tsx",
+    "**/*.test.js",
+    "**/*.spec.js",
+    "**/*.test.jsx",
+    "**/*.spec.jsx",
+    "**/*.d.ts"
+  ]
+}

--- a/libs/feature-flags/src/lib/features.ts
+++ b/libs/feature-flags/src/lib/features.ts
@@ -46,6 +46,7 @@ export enum Features {
   servicePortalPetitionsModule = 'isServicePortalPetitionsModuleEnabled',
   servicePortalDrivingLessonsBookModule = 'isServicePortalDrivingLessonsBookModuleEnabled',
   outgoingDelegationsV2 = 'outgoingdelegationsv2',
+  servicePortalAssetsApiV2Enabled = 'servicePortalAssetsApiV2Enabled',
 }
 
 export enum ServerSideFeature {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -340,6 +340,7 @@
         "libs/clients/adr-and-machine-license/src/index.ts"
       ],
       "@island.is/clients/assets": ["libs/clients/assets/src/index.ts"],
+      "@island.is/clients/assets-v2": ["libs/clients/assets-v2/src/index.ts"],
       "@island.is/clients/auth/delegation-api": [
         "libs/clients/auth/delegation-api/src/index.ts"
       ],

--- a/workspace.json
+++ b/workspace.json
@@ -114,6 +114,7 @@
     "cache": "libs/cache",
     "clients-adr-and-machine-license": "libs/clients/adr-and-machine-license",
     "clients-assets": "libs/clients/assets",
+    "clients-assets-v2": "libs/clients/assets-v2",
     "clients-auth-delegation-api": "libs/clients/auth/delegation-api",
     "clients-auth-public-api": "libs/clients/auth/public-api",
     "clients-charge-fjs-v2": "libs/clients/charge-fjs-v2",


### PR DESCRIPTION
## What

* Add assets service version 2
* Add feature flag to switch between v1 and v2

## Why

* Version 1 of the assets service will be discontinued on November 21st.
* We will add version 2 behind a feature-flag, where we can try v2 before the cut-over.
* Once we get the go-ahead from the service-providers we can turn the flag ON for everyone without having to hotfix.
* And we'll clean up the flag, and remove v1 once v2 has taken over.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] ~I have made corresponding changes to the documentation~
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~Formatting passes locally with my changes~
- [x] I have rebased against main before asking for a review
