### PR TITLE
fix(j-s): PDF Max Length

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/pdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/pdf.ts
@@ -222,7 +222,7 @@ export const PdfDocument = async (title?: string): Promise<PdfDocument> => {
       const { y } = position ?? {}
       const font = bold ? boldFont : normalFont
 
-      if (maxWidth) {
+      if (maxWidth && font.widthOfTextAtSize(text, fontSize) > maxWidth) {
         while (
           text.length > 0 &&
           font.widthOfTextAtSize(`${text}...`, fontSize) > maxWidth


### PR DESCRIPTION
# PDF Max Length

[Laga overflow í efnisyfirliti málaskrár pdf](https://app.asana.com/0/1199153462262248/1203265017403973/f)

## What

Only adds "..." to text that is cut off.

## Why

Bug

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/795382/200812369-9742b248-ed7a-4dc5-95ff-278d31282c7a.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
