### PR TITLE
fix(j-s): Use maxWidth instead of width for case file names

### DIFF
--- a/apps/judicial-system/web/src/components/AccordionItems/IndictmentsCaseFilesAccordionItem/IndictmentsCaseFilesAccordionItem.tsx
+++ b/apps/judicial-system/web/src/components/AccordionItems/IndictmentsCaseFilesAccordionItem/IndictmentsCaseFilesAccordionItem.tsx
@@ -349,7 +349,7 @@ const CaseFile: React.FC<CaseFileProps> = (props) => {
                       <span
                         style={{
                           display: 'block',
-                          width: `${width - 180}px`,
+                          maxWidth: `${width - 180}px`,
                           overflow: 'hidden',
                           textOverflow: 'ellipsis',
                           whiteSpace: 'nowrap',


### PR DESCRIPTION
# Use maxWidth instead of width for case file names

[Asana](https://app.asana.com/0/1199153462262248/1203284582867790/f)

## What

Use maxWidth instead of width for case file names

## Why

Otherwise, the file names are centered instead of left aligned, which is weird

## Screenshots / Gifs

### Before 

<img width="793" alt="Screenshot 2022-11-09 at 11 11 47" src="https://user-images.githubusercontent.com/3789875/200815458-23724878-9b11-4b81-8ef4-46cf2e886486.png">

### After 

<img width="795" alt="Screenshot 2022-11-09 at 11 11 56" src="https://user-images.githubusercontent.com/3789875/200815415-8261d886-a78f-4ba4-806f-0125b7963057.png">

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
