### PR TITLE
fix(j-s): Wrap updateDefendantState in useCallback

### DIFF
--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/Defendant.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/Defendant.tsx
@@ -81,7 +81,7 @@ const Defendant: React.FC = () => {
   )
 
   const handleUpdateDefendant = useCallback(
-    async (defendantId: string, updatedDefendant: UpdateDefendant) => {
+    (defendantId: string, updatedDefendant: UpdateDefendant) => {
       updateDefendantState(defendantId, updatedDefendant, setWorkingCase)
 
       if (workingCase.id) {

--- a/apps/judicial-system/web/src/routes/Prosecutor/components/DefendantInfo/DefendantInfo.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/components/DefendantInfo/DefendantInfo.tsx
@@ -257,7 +257,7 @@ const DefendantInfo: React.FC<Props> = (props) => {
           autoComplete="off"
           label={formatMessage(core.fullName)}
           placeholder={formatMessage(core.fullName)}
-          value={defendant?.name ?? ''}
+          value={defendant.name ?? ''}
           errorMessage={accusedNameErrorMessage}
           hasError={accusedNameErrorMessage !== ''}
           onChange={(evt) => {

--- a/apps/judicial-system/web/src/routes/Prosecutor/components/DefendantInfo/DefendantInfo.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/components/DefendantInfo/DefendantInfo.tsx
@@ -38,10 +38,7 @@ interface Props {
   defendant: Defendant
   workingCase: Case
   setWorkingCase: React.Dispatch<React.SetStateAction<Case>>
-  onChange: (
-    defendantId: string,
-    updatedDefendant: UpdateDefendant,
-  ) => Promise<void>
+  onChange: (defendantId: string, updatedDefendant: UpdateDefendant) => void
   updateDefendantState: (
     defendantId: string,
     update: UpdateDefendant,
@@ -260,7 +257,7 @@ const DefendantInfo: React.FC<Props> = (props) => {
           autoComplete="off"
           label={formatMessage(core.fullName)}
           placeholder={formatMessage(core.fullName)}
-          value={defendant.name ?? ''}
+          value={defendant?.name ?? ''}
           errorMessage={accusedNameErrorMessage}
           hasError={accusedNameErrorMessage !== ''}
           onChange={(evt) => {

--- a/apps/judicial-system/web/src/utils/hooks/useDefendants/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useDefendants/index.ts
@@ -119,29 +119,32 @@ const useDefendants = () => {
     [formatMessage, updateDefendantMutation],
   )
 
-  const updateDefendantState = (
-    defendantId: string,
-    update: UpdateDefendant,
-    setWorkingCase: React.Dispatch<React.SetStateAction<Case>>,
-  ) => {
-    setWorkingCase((theCase: Case) => {
-      if (!theCase.defendants) {
-        return theCase
-      }
-      const indexOfDefendantToUpdate = theCase.defendants.findIndex(
-        (defendant) => defendant.id === defendantId,
-      )
+  const updateDefendantState = useCallback(
+    (
+      defendantId: string,
+      update: UpdateDefendant,
+      setWorkingCase: React.Dispatch<React.SetStateAction<Case>>,
+    ) => {
+      setWorkingCase((theCase: Case) => {
+        if (!theCase.defendants) {
+          return theCase
+        }
+        const indexOfDefendantToUpdate = theCase.defendants.findIndex(
+          (defendant) => defendant.id === defendantId,
+        )
 
-      const newDefendants = [...theCase.defendants]
+        const newDefendants = [...theCase.defendants]
 
-      newDefendants[indexOfDefendantToUpdate] = {
-        ...newDefendants[indexOfDefendantToUpdate],
-        ...update,
-      }
+        newDefendants[indexOfDefendantToUpdate] = {
+          ...newDefendants[indexOfDefendantToUpdate],
+          ...update,
+        }
 
-      return { ...theCase, defendants: newDefendants }
-    })
-  }
+        return { ...theCase, defendants: newDefendants }
+      })
+    },
+    [],
+  )
 
   const setAndSendDefendantToServer = useCallback(
     (
@@ -153,7 +156,7 @@ const useDefendants = () => {
       updateDefendantState(defendantId, update, setWorkingCase)
       updateDefendant(caseId, defendantId, update)
     },
-    [updateDefendant],
+    [updateDefendant, updateDefendantState],
   )
 
   return {


### PR DESCRIPTION
# Wrap updateDefendantState in useCallback

[Asana](https://app.asana.com/0/1199153462262248/1203337457990688/f)

## What

Fix a bug where users are unable to change defendant after entering a ssn while creating an indictment

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
