### PR TITLE
fix(web): Email Signup config

### DIFF
--- a/apps/web/components/Organization/Slice/EmailSignup/EmailSignup.tsx
+++ b/apps/web/components/Organization/Slice/EmailSignup/EmailSignup.tsx
@@ -108,6 +108,7 @@ const EmailSignup = ({ slice, marginLeft }: EmailSignupProps) => {
     for (const [fieldName, value] of Object.entries(values)) {
       const field = formFields.find((f) => f.name === fieldName)
       inputFields.push({
+        id: field.id,
         name: fieldName,
         type: field.type,
         value,

--- a/apps/web/screens/queries/fragments.ts
+++ b/apps/web/screens/queries/fragments.ts
@@ -618,6 +618,7 @@ export const slices = gql`
     title
     description
     formFields {
+      id
       title
       name
       placeholder

--- a/libs/api/domains/mailchimp/src/lib/dto/emailSignup.input.ts
+++ b/libs/api/domains/mailchimp/src/lib/dto/emailSignup.input.ts
@@ -3,6 +3,8 @@ import { Field, InputType } from '@nestjs/graphql'
 @InputType()
 class EmailSignupInputField {
   @Field()
+  id!: string
+  @Field()
   name!: string
   @Field()
   value!: string

--- a/libs/api/domains/mailchimp/src/lib/emailSignup.resolver.spec.ts
+++ b/libs/api/domains/mailchimp/src/lib/emailSignup.resolver.spec.ts
@@ -31,11 +31,13 @@ describe('emailSignupResolver', () => {
           name: 'EMAIL',
           type: 'email',
           value: 'test@example.com',
+          id: '1',
         },
         {
           name: 'NAME',
           type: 'input',
           value: 'Tester',
+          id: '2',
         },
       ],
     }
@@ -48,7 +50,6 @@ describe('emailSignupResolver', () => {
         )
 
       jest.spyOn(axios, 'get').mockImplementation((url) => {
-        console.log('URL', url)
         if (
           url ===
           'https://example.com/signup?EMAIL=test@example.com&NAME=Tester'

--- a/libs/api/domains/mailchimp/src/lib/emailSignup.resolver.ts
+++ b/libs/api/domains/mailchimp/src/lib/emailSignup.resolver.ts
@@ -31,9 +31,18 @@ export class EmailSignupResolver {
           // The checkboxes type can have many selected options
           if (field.type === FormFieldType.CHECKBOXES) {
             const fieldValues = JSON.parse(field.value)
+
+            // The field from the email signup model in the CMS (that's where we can access specific config)
+            const emailSignupModelField = emailSignupModel.formFields?.find(
+              (f) => f.id === field.id,
+            )
             const checkboxOptions = Object.entries(fieldValues)
               .filter(([_, value]) => value === 'true')
-              .map(([name, _]) => `${name}=1`)
+              .map(
+                ([name, _]) =>
+                  // The field name maps to a specific mailchimp related value in the email config
+                  `${emailSignupModelField?.emailConfig?.[name] ?? name}=1`,
+              )
               .join('&')
 
             // Make sure we don't add an extra &
@@ -46,6 +55,7 @@ export class EmailSignupResolver {
         })
         .join('&'),
     )
+
     return axios
       .get(populatedUrl)
       .then((response) => {


### PR DESCRIPTION
# Email Signup config

## What

* I forgot to use the email config field when mapping checkboxes to query parameter strings when sending the signup request to mailchimp, resulting in the checkbox fields not working :) 

## Why

* This change addresses that issue and will correctly map the checkbox values to mailchimp values

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
