### PR TITLE
fix(financial-statement-inao):  values only undefined when novaluestatement is false

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/financial-statements-inao/financial-statements-inao.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/financial-statements-inao/financial-statements-inao.service.ts
@@ -31,6 +31,7 @@ export interface AttachmentData {
 
 export const getCurrentUserType = (answers: any, externalData: any) => {
   const fakeUserType: any = getValueViaPath(answers, 'fakeData.options')
+
   const currentUserType: any = getValueViaPath(
     externalData,
     'getUserType.data.value',
@@ -116,8 +117,8 @@ export class FinancialStatementsInaoTemplateService {
       const values:
         | PersonalElectionFinancialStatementValues
         | undefined = noValueStatement
-        ? mapValuesToIndividualtype(answers)
-        : undefined
+        ? undefined
+        : mapValuesToIndividualtype(answers)
 
       const electionId = getValueViaPath(
         answers,


### PR DESCRIPTION
## What

values is undefinef when novaluestatement is false should be the opposite

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
