### PR TITLE
feat(delegation-api): Add domains and scope direction support for filtering

### DIFF
--- a/apps/services/auth/delegation-api/src/app/domains/domains.controller.ts
+++ b/apps/services/auth/delegation-api/src/app/domains/domains.controller.ts
@@ -3,6 +3,7 @@ import { ApiSecurity, ApiTags } from '@nestjs/swagger'
 
 import {
   ApiScopeTreeDTO,
+  DelegationDirection,
   DelegationResourcesService,
   DomainDTO,
 } from '@island.is/auth-api-lib'
@@ -39,6 +40,15 @@ const lang: DocumentationQueryOptions = {
   type: 'string',
 }
 
+const direction: DocumentationQueryOptions = {
+  description:
+    'The direction of the delegations to apply on domain filtering. Default returns all domains.',
+  required: false,
+  schema: {
+    enum: [DelegationDirection.OUTGOING],
+  },
+}
+
 @UseGuards(IdsUserGuard, ScopesGuard, FeatureFlagGuard)
 @FeatureFlag(Features.outgoingDelegationsV2)
 @Scopes(AuthScope.delegations)
@@ -58,6 +68,7 @@ export class DomainsController {
     request: {
       query: {
         lang,
+        direction,
       },
     },
     response: { status: 200, type: [DomainDTO] },
@@ -68,8 +79,9 @@ export class DomainsController {
   findAll(
     @CurrentUser() user: User,
     @Query('lang') language?: string,
+    @Query('direction') direction?: DelegationDirection,
   ): Promise<DomainDTO[]> {
-    return this.resourceService.findAllDomains(user, language)
+    return this.resourceService.findAllDomains(user, language, direction)
   }
 
   @Get(':domainName')
@@ -109,6 +121,7 @@ export class DomainsController {
       },
       query: {
         lang,
+        direction,
       },
     },
     response: { status: 200, type: [ApiScopeTreeDTO] },
@@ -120,8 +133,14 @@ export class DomainsController {
     @CurrentUser() user: User,
     @Param('domainName') domainName: string,
     @Query('lang') language?: string,
+    @Query('direction') direction?: DelegationDirection,
   ): Promise<ApiScopeTreeDTO[]> {
-    return this.resourceService.findScopeTree(user, domainName, language)
+    return this.resourceService.findScopeTree(
+      user,
+      domainName,
+      language,
+      direction,
+    )
   }
 
   @Get(':domainName/scopes')
@@ -133,6 +152,7 @@ export class DomainsController {
       },
       query: {
         lang,
+        direction,
       },
     },
     response: { status: 200, type: [ApiScopeTreeDTO] },
@@ -141,7 +161,13 @@ export class DomainsController {
     @CurrentUser() user: User,
     @Param('domainName') domainName: string,
     @Query('lang') language?: string,
+    @Query('direction') direction?: DelegationDirection,
   ): Promise<ApiScopeTreeDTO[]> {
-    return this.resourceService.findScopes(user, domainName, language)
+    return this.resourceService.findScopes(
+      user,
+      domainName,
+      language,
+      direction,
+    )
   }
 }

--- a/apps/services/auth/delegation-api/src/app/domains/test/domains.controller.spec.ts
+++ b/apps/services/auth/delegation-api/src/app/domains/test/domains.controller.spec.ts
@@ -69,7 +69,9 @@ describe('DomainsController', () => {
           }))
 
           // Act
-          const res = await server.get('/v1/domains')
+          const res = await server.get(
+            `/v1/domains?direction=${testCase.direction}`,
+          )
 
           // Assert
           expect(res.status).toEqual(200)
@@ -108,7 +110,9 @@ describe('DomainsController', () => {
               const expected = domain.scopes
 
               // Act
-              const res = await server.get(`/v1/domains/${domainName}/scopes`)
+              const res = await server.get(
+                `/v1/domains/${domainName}/scopes?direction=${testCase.direction}`,
+              )
 
               // Assert
               expect(res.status).toEqual(200)
@@ -129,7 +133,7 @@ describe('DomainsController', () => {
 
               // Act
               const res = await server.get(
-                `/v1/domains/${domainName}/scope-tree`,
+                `/v1/domains/${domainName}/scope-tree?direction=${testCase.direction}`,
               )
 
               // Assert
@@ -142,22 +146,11 @@ describe('DomainsController', () => {
 
         if (invalidDomains.length) {
           it.each(invalidDomains)(
-            'GET /domains/%s returns no content response',
-            async (domainName) => {
-              // Act
-              const res = await server.get(`/v1/domains/${domainName}`)
-
-              // Assert
-              expect(res.status).toEqual(204)
-            },
-          )
-
-          it.each(invalidDomains)(
             'GET /domains/%s/scope-tree returns no results',
             async (domainName) => {
               // Act
               const res = await server.get(
-                `/v1/domains/${domainName}/scope-tree`,
+                `/v1/domains/${domainName}/scope-tree?direction=${testCase.direction}`,
               )
 
               // Assert
@@ -170,7 +163,9 @@ describe('DomainsController', () => {
             'GET /domains/%s/scopes returns no results',
             async (domainName) => {
               // Act
-              const res = await server.get(`/v1/domains/${domainName}/scopes`)
+              const res = await server.get(
+                `/v1/domains/${domainName}/scopes?direction=${testCase.direction}`,
+              )
 
               // Assert
               expect(res.status).toEqual(200)
@@ -314,6 +309,24 @@ describe('DomainsController', () => {
       // Assert
       expect(res.status).toEqual(200)
       expect(res.body).toMatchObject(expected)
+    })
+
+    it('GET /domains/:domainName returns no content response for invalid domain', async () => {
+      // Arrange
+      const app = await setupWithAuth({
+        user: createCurrentUser({ scope: [AuthScope.delegations] }),
+      })
+      const factory = new FixtureFactory(app)
+      await factory.createDomain({ name: 'd1' })
+      const invalidDomainName = 'invalid-d1'
+
+      // Act
+      const res = await request(app.getHttpServer()).get(
+        `/v1/domains/${invalidDomainName}`,
+      )
+
+      // Assert
+      expect(res.status).toEqual(204)
     })
   })
 

--- a/apps/services/auth/delegation-api/src/app/domains/test/domains.controller.spec.ts
+++ b/apps/services/auth/delegation-api/src/app/domains/test/domains.controller.spec.ts
@@ -12,7 +12,10 @@ import {
 import { TestEndpointOptions } from '../../../../test/types'
 import { FixtureFactory } from '../../../../test/fixtures/fixture-factory'
 import { accessTestCases } from '../../../../test/access-test-cases'
-import { createCurrentUser } from '@island.is/testing/fixtures'
+import {
+  createCurrentUser,
+  createNationalId,
+} from '@island.is/testing/fixtures'
 import { AuthScope } from '@island.is/auth/scopes'
 import shuffle from 'lodash/shuffle'
 
@@ -22,10 +25,11 @@ describe('DomainsController', () => {
       'with test case: %s',
       (caseName) => {
         const testCase = accessTestCases[caseName]
-        const validDomains = testCase.expected.map((domain) => domain.name)
+        const expectedDomains = testCase.expectedDomains ?? testCase.expected
+        const validDomains = expectedDomains.map((domain) => domain.name)
         const invalidDomains = differenceWith(
           testCase.domains,
-          testCase.expected,
+          expectedDomains,
           (a, b) => a.name === b.name,
         ).map((domain) => domain.name)
         let app: TestApp
@@ -64,7 +68,7 @@ describe('DomainsController', () => {
 
         it('GET /domains returns expected domains', async () => {
           // Arrange
-          const expected = testCase.expected.map(({ name }) => ({
+          const expected = expectedDomains.map(({ name }) => ({
             name,
           }))
 
@@ -75,7 +79,7 @@ describe('DomainsController', () => {
 
           // Assert
           expect(res.status).toEqual(200)
-          expect(res.body).toHaveLength(testCase.expected.length)
+          expect(res.body).toHaveLength(expected.length)
           expect(res.body).toMatchObject(expected)
         })
 
@@ -84,7 +88,7 @@ describe('DomainsController', () => {
             'GET /domains/%s returns expected domains',
             async (domainName) => {
               // Arrange
-              const domain = testCase.expected.find(
+              const domain = expectedDomains.find(
                 (domain) => domain.name === domainName,
               )
               assert(domain)
@@ -103,7 +107,7 @@ describe('DomainsController', () => {
             'GET /domains/%s/scopes returns expected scopes',
             async (domainName) => {
               // Arrange
-              const domain = testCase.expected.find(
+              const domain = expectedDomains.find(
                 (domain) => domain.name === domainName,
               )
               assert(domain)
@@ -125,7 +129,7 @@ describe('DomainsController', () => {
             'GET /domains/%s/scope-tree returns expected scopes',
             async (domainName) => {
               // Arrange
-              const domain = testCase.expected.find(
+              const domain = expectedDomains.find(
                 (domain) => domain.name === domainName,
               )
               assert(domain)
@@ -309,6 +313,48 @@ describe('DomainsController', () => {
       // Assert
       expect(res.status).toEqual(200)
       expect(res.body).toMatchObject(expected)
+    })
+
+    it('GET /domains returns list of all domains when no direction', async () => {
+      // Arrange
+      const domains = [
+        {
+          name: 'd1',
+          apiScopes: [{ name: 's1', allowExplicitDelegationGrant: true }],
+        },
+        {
+          name: 'd2',
+          apiScopes: [{ name: 's2', allowExplicitDelegationGrant: true }],
+        },
+        {
+          name: 'd3',
+          apiScopes: [{ name: 's3', allowExplicitDelegationGrant: true }],
+        },
+      ]
+      const expectedDomains = domains.map((domain) => ({ name: domain.name }))
+      const currentUser = createCurrentUser({ scope: [AuthScope.delegations] })
+      const app = await setupWithAuth({
+        user: currentUser,
+        customScopeRules: [
+          { scopeName: 's2', onlyForDelegationType: ['ProcurationHolder'] },
+        ],
+      })
+      const factory = new FixtureFactory(app)
+      await Promise.all(domains.map((domain) => factory.createDomain(domain)))
+      await factory.createCustomDelegation({
+        domainName: 'd3',
+        fromNationalId: createNationalId('person'),
+        toNationalId: currentUser.nationalId,
+        scopes: [{ scopeName: 's3' }],
+      })
+
+      // Act
+      const res = await request(app.getHttpServer()).get(`/v1/domains`)
+
+      // Assert
+      expect(res.status).toEqual(200)
+      expect(res.body).toHaveLength(3)
+      expect(res.body).toMatchObject(expectedDomains)
     })
 
     it('GET /domains/:domainName returns no content response for invalid domain', async () => {

--- a/apps/services/auth/delegation-api/test/access-test-cases.ts
+++ b/apps/services/auth/delegation-api/test/access-test-cases.ts
@@ -5,7 +5,7 @@ import {
 import { AuthScope } from '@island.is/auth/scopes'
 import { User } from '@island.is/auth-nest-tools'
 import { ConfigType } from '@island.is/nest/config'
-import { DelegationConfig } from '@island.is/auth-api-lib'
+import { DelegationConfig, DelegationDirection } from '@island.is/auth-api-lib'
 import { CreateCustomDelegation, CreateDomain } from './fixtures/types'
 
 export interface DomainAssertion {
@@ -20,12 +20,19 @@ export interface TestCase {
   accessTo?: string[]
   domains: CreateDomain[]
   expected: DomainAssertion[]
+  direction?: DelegationDirection
 }
+
+const personUser = createCurrentUser({
+  nationalIdType: 'person',
+  scope: [AuthScope.delegations],
+})
 
 export const accessTestCases: Record<string, TestCase> = {
   // Normal user should be able to grant delegations for scopes allowing explicit delegation grants.
   happyCase: {
-    user: createCurrentUser({ scope: [AuthScope.delegations] }),
+    direction: DelegationDirection.OUTGOING,
+    user: personUser,
     domains: [
       {
         name: 'd1',
@@ -50,7 +57,8 @@ export const accessTestCases: Record<string, TestCase> = {
   },
   // Should not see scopes unless they allow explicit delegation grants.
   noExplicitDelegationGrant: {
-    user: createCurrentUser({ scope: [AuthScope.delegations] }),
+    direction: DelegationDirection.OUTGOING,
+    user: personUser,
     domains: [
       {
         name: 'd1',
@@ -66,6 +74,7 @@ export const accessTestCases: Record<string, TestCase> = {
   },
   // Procuring holder should only see scopes they have access to.
   procuringHolderScopes: {
+    direction: DelegationDirection.OUTGOING,
     user: createCurrentUser({
       nationalIdType: 'company',
       delegationType: 'ProcurationHolder',
@@ -106,6 +115,7 @@ export const accessTestCases: Record<string, TestCase> = {
   },
   // Can grant forward custom delegations which you have.
   customDelegationScopes: {
+    direction: DelegationDirection.OUTGOING,
     user: createCurrentUser({
       nationalIdType: 'company',
       delegationType: 'Custom',
@@ -179,10 +189,16 @@ export const accessTestCases: Record<string, TestCase> = {
         ],
       },
     ],
-    expected: [],
+    expected: [
+      {
+        name: 'd1',
+        scopes: [{ name: 's1' }],
+      },
+    ],
   },
   // Company actor should not see access controlled scopes except as procuration holder or custom delegation.
   accessControlledCompanyScopes: {
+    direction: DelegationDirection.OUTGOING,
     user: createCurrentUser({
       nationalIdType: 'company',
       scope: [AuthScope.delegations],
@@ -227,6 +243,7 @@ export const accessTestCases: Record<string, TestCase> = {
   },
   // Should see scopes configured for specific types of delegation.
   customScopeRulesIncluded: {
+    direction: DelegationDirection.OUTGOING,
     user: createCurrentUser({
       nationalIdType: 'company',
       scope: [AuthScope.delegations],
@@ -269,9 +286,8 @@ export const accessTestCases: Record<string, TestCase> = {
   },
   // Should not see scopes configured for other types of delegation.
   customScopeRulesExcluded: {
-    user: createCurrentUser({
-      scope: [AuthScope.delegations],
-    }),
+    direction: DelegationDirection.OUTGOING,
+    user: personUser,
     customScopeRules: [
       { scopeName: 's1', onlyForDelegationType: ['ProcurationHolder'] },
       { scopeName: 's2', onlyForDelegationType: ['Custom'] },
@@ -301,5 +317,81 @@ export const accessTestCases: Record<string, TestCase> = {
       },
     ],
     expected: [],
+  },
+  // Should get list of all domains if not filtered by direction.
+  allDomains: {
+    user: personUser,
+    customScopeRules: [
+      { scopeName: 's2', onlyForDelegationType: ['ProcurationHolder'] },
+    ],
+    delegations: [
+      {
+        domainName: 'd3',
+        fromNationalId: createNationalId('person'),
+        toNationalId: personUser.nationalId,
+        scopes: [{ scopeName: 's3' }],
+      },
+    ],
+    domains: [
+      {
+        name: 'd1',
+        apiScopes: [{ name: 's1', allowExplicitDelegationGrant: true }],
+      },
+      {
+        name: 'd2',
+        apiScopes: [{ name: 's2', allowExplicitDelegationGrant: true }],
+      },
+      {
+        name: 'd3',
+        apiScopes: [{ name: 's3', allowExplicitDelegationGrant: true }],
+      },
+    ],
+    expected: [
+      {
+        name: 'd1',
+        scopes: [{ name: 's1' }],
+      },
+      {
+        name: 'd2',
+        scopes: [{ name: 's2' }],
+      },
+      {
+        name: 'd3',
+        scopes: [{ name: 's3' }],
+      },
+    ],
+  },
+  // Should get list of domains the user has access to grant outgoing delegations.
+  onlyOutgoingDomains: {
+    direction: DelegationDirection.OUTGOING,
+    user: personUser,
+    delegations: [
+      // Incoming delegation on a company scope, domain should not be listed in outgoing domains.
+      {
+        domainName: 'd2',
+        fromNationalId: createNationalId('company'),
+        toNationalId: personUser.nationalId,
+        scopes: [{ scopeName: 's2' }],
+      },
+    ],
+    customScopeRules: [
+      { scopeName: 's2', onlyForDelegationType: ['ProcurationHolder'] },
+    ],
+    domains: [
+      {
+        name: 'd1',
+        apiScopes: [{ name: 's1', allowExplicitDelegationGrant: true }],
+      },
+      {
+        name: 'd2',
+        apiScopes: [{ name: 's2', allowExplicitDelegationGrant: true }],
+      },
+    ],
+    expected: [
+      {
+        name: 'd1',
+        scopes: [{ name: 's1' }],
+      },
+    ],
   },
 }

--- a/apps/services/auth/delegation-api/test/access-test-cases.ts
+++ b/apps/services/auth/delegation-api/test/access-test-cases.ts
@@ -20,6 +20,7 @@ export interface TestCase {
   accessTo?: string[]
   domains: CreateDomain[]
   expected: DomainAssertion[]
+  expectedDomains?: DomainAssertion[]
   direction?: DelegationDirection
 }
 
@@ -189,7 +190,8 @@ export const accessTestCases: Record<string, TestCase> = {
         ],
       },
     ],
-    expected: [
+    expected: [],
+    expectedDomains: [
       {
         name: 'd1',
         scopes: [{ name: 's1' }],
@@ -317,49 +319,6 @@ export const accessTestCases: Record<string, TestCase> = {
       },
     ],
     expected: [],
-  },
-  // Should get list of all domains if not filtered by direction.
-  allDomains: {
-    user: personUser,
-    customScopeRules: [
-      { scopeName: 's2', onlyForDelegationType: ['ProcurationHolder'] },
-    ],
-    delegations: [
-      {
-        domainName: 'd3',
-        fromNationalId: createNationalId('person'),
-        toNationalId: personUser.nationalId,
-        scopes: [{ scopeName: 's3' }],
-      },
-    ],
-    domains: [
-      {
-        name: 'd1',
-        apiScopes: [{ name: 's1', allowExplicitDelegationGrant: true }],
-      },
-      {
-        name: 'd2',
-        apiScopes: [{ name: 's2', allowExplicitDelegationGrant: true }],
-      },
-      {
-        name: 'd3',
-        apiScopes: [{ name: 's3', allowExplicitDelegationGrant: true }],
-      },
-    ],
-    expected: [
-      {
-        name: 'd1',
-        scopes: [{ name: 's1' }],
-      },
-      {
-        name: 'd2',
-        scopes: [{ name: 's2' }],
-      },
-      {
-        name: 'd3',
-        scopes: [{ name: 's3' }],
-      },
-    ],
   },
   // Should get list of domains the user has access to grant outgoing delegations.
   onlyOutgoingDomains: {

--- a/libs/api/domains/auth/src/lib/dto/apiScopes.input.ts
+++ b/libs/api/domains/auth/src/lib/dto/apiScopes.input.ts
@@ -1,5 +1,9 @@
 import { Field, InputType } from '@nestjs/graphql'
 
+import { DomainsControllerFindScopeTreeDirectionEnum } from '@island.is/clients/auth/delegation-api'
+
+import { DomainDirection } from './domainDirection'
+
 @InputType('AuthApiScopesInput')
 export class ApiScopesInput {
   @Field(() => String)
@@ -7,4 +11,7 @@ export class ApiScopesInput {
 
   @Field(() => String, { nullable: true })
   domain?: string
+
+  @Field(() => DomainDirection, { nullable: true })
+  direction?: DomainsControllerFindScopeTreeDirectionEnum
 }

--- a/libs/api/domains/auth/src/lib/dto/domainDirection.ts
+++ b/libs/api/domains/auth/src/lib/dto/domainDirection.ts
@@ -1,0 +1,9 @@
+import { registerEnumType } from '@nestjs/graphql'
+
+import { DomainsControllerFindAllDirectionEnum } from '@island.is/clients/auth/delegation-api'
+
+export const DomainDirection = DomainsControllerFindAllDirectionEnum
+
+registerEnumType(DomainsControllerFindAllDirectionEnum, {
+  name: 'AuthDomainDirection',
+})

--- a/libs/api/domains/auth/src/lib/dto/domains.input.ts
+++ b/libs/api/domains/auth/src/lib/dto/domains.input.ts
@@ -1,7 +1,14 @@
 import { Field, InputType } from '@nestjs/graphql'
 
+import { DomainsControllerFindAllDirectionEnum } from '@island.is/clients/auth/delegation-api'
+
+import { DomainDirection } from './domainDirection'
+
 @InputType('AuthDomainsInput')
 export class DomainsInput {
   @Field(() => String)
   lang = 'is'
+
+  @Field(() => DomainDirection, { nullable: true })
+  direction?: DomainsControllerFindAllDirectionEnum
 }

--- a/libs/api/domains/auth/src/lib/services-v1/meDelegations.service.ts
+++ b/libs/api/domains/auth/src/lib/services-v1/meDelegations.service.ts
@@ -46,8 +46,8 @@ export class MeDelegationsServiceV1 implements MeDelegationsServiceInterface {
     this.checkDomain(input.domain)
 
     return this.delegationsApiWithAuth(user).meDelegationsControllerFindAll({
-      direction: MeDelegationsControllerFindAllDirectionEnum.Outgoing,
-      validity: MeDelegationsControllerFindAllValidityEnum.IncludeFuture,
+      direction: MeDelegationsControllerFindAllDirectionEnum.outgoing,
+      validity: MeDelegationsControllerFindAllValidityEnum.includeFuture,
     })
   }
 
@@ -73,7 +73,7 @@ export class MeDelegationsServiceV1 implements MeDelegationsServiceInterface {
     const delegations = await this.delegationsApiWithAuth(
       user,
     ).meDelegationsControllerFindAll({
-      direction: MeDelegationsControllerFindAllDirectionEnum.Outgoing,
+      direction: MeDelegationsControllerFindAllDirectionEnum.outgoing,
       otherUser: toNationalId,
     })
 

--- a/libs/api/domains/auth/src/lib/services-v2/apiScope.service.ts
+++ b/libs/api/domains/auth/src/lib/services-v2/apiScope.service.ts
@@ -1,7 +1,10 @@
 import { BadRequestException, Injectable } from '@nestjs/common'
 
 import { Auth, AuthMiddleware, User } from '@island.is/auth-nest-tools'
-import { DomainsApi } from '@island.is/clients/auth/delegation-api'
+import {
+  DomainsApi,
+  DomainsControllerFindScopesDirectionEnum,
+} from '@island.is/clients/auth/delegation-api'
 import { ApiScope } from '../models/apiScope.model'
 import { ScopeTreeNode } from '../models/scopeTreeNode.model'
 import { ApiScopeServiceInterface } from '../services/types'
@@ -21,6 +24,8 @@ export class ApiScopeServiceV2 implements ApiScopeServiceInterface {
     return this.domainsApiWithAuth(user).domainsControllerFindScopes({
       domainName: input.domain,
       lang: input.lang,
+      // If we fix our openApi generation to support enumName to alias the enum type we can fix this.
+      direction: (input.direction as unknown) as DomainsControllerFindScopesDirectionEnum,
     })
   }
 
@@ -33,6 +38,7 @@ export class ApiScopeServiceV2 implements ApiScopeServiceInterface {
     return this.domainsApiWithAuth(user).domainsControllerFindScopeTree({
       domainName: input.domain,
       lang: input.lang,
+      direction: input.direction,
     })
   }
 

--- a/libs/api/domains/auth/src/lib/services-v2/meDelegations.service.ts
+++ b/libs/api/domains/auth/src/lib/services-v2/meDelegations.service.ts
@@ -36,8 +36,8 @@ export class MeDelegationsServiceV2 implements MeDelegationsServiceInterface {
       user,
     ).meDelegationsControllerFindAll({
       domain: input.domain ?? undefined,
-      direction: MeDelegationsControllerFindAllDirectionEnum.Outgoing,
-      validity: MeDelegationsControllerFindAllValidityEnum.IncludeFuture,
+      direction: MeDelegationsControllerFindAllDirectionEnum.outgoing,
+      validity: MeDelegationsControllerFindAllValidityEnum.includeFuture,
     })
     return delegations.map(this.includeDomainNameInScopes)
   }
@@ -63,7 +63,7 @@ export class MeDelegationsServiceV2 implements MeDelegationsServiceInterface {
     const delegations = await this.delegationsApiWithAuth(
       user,
     ).meDelegationsControllerFindAll({
-      direction: MeDelegationsControllerFindAllDirectionEnum.Outgoing,
+      direction: MeDelegationsControllerFindAllDirectionEnum.outgoing,
       xQueryOtherUser: toNationalId,
       domain: domain ?? undefined,
     })

--- a/libs/api/domains/auth/src/lib/services/actorDelegations.service.ts
+++ b/libs/api/domains/auth/src/lib/services/actorDelegations.service.ts
@@ -21,7 +21,7 @@ export class ActorDelegationsService {
     delegationTypes?: DelegationType[],
   ): Promise<MergedDelegationDTO[]> {
     return this.delegationsApiWithAuth(user).actorDelegationsControllerFindAll({
-      direction: ActorDelegationsControllerFindAllDirectionEnum.Incoming,
+      direction: ActorDelegationsControllerFindAllDirectionEnum.incoming,
       delegationTypes,
     })
   }

--- a/libs/api/domains/auth/src/lib/services/domain.service.ts
+++ b/libs/api/domains/auth/src/lib/services/domain.service.ts
@@ -3,8 +3,8 @@ import { Injectable } from '@nestjs/common'
 import { Auth, AuthMiddleware, User } from '@island.is/auth-nest-tools'
 import { DomainsApi } from '@island.is/clients/auth/delegation-api'
 
-import { Domain } from '../models/domain.model'
 import { DomainsInput } from '../dto/domains.input'
+import { Domain } from '../models/domain.model'
 
 @Injectable()
 export class DomainService {
@@ -17,6 +17,7 @@ export class DomainService {
   getDomains(user: User, input: DomainsInput): Promise<Domain[]> {
     return this.domainsApiWithAuth(user).domainsControllerFindAll({
       lang: input.lang,
+      direction: input.direction,
     })
   }
 }

--- a/libs/api/domains/auth/src/lib/services/types.ts
+++ b/libs/api/domains/auth/src/lib/services/types.ts
@@ -7,7 +7,6 @@ import {
   PatchDelegationInput,
   UpdateDelegationInput,
 } from '../dto'
-import { DelegationByOtherUserInput } from '../dto/delegationByOtherUser.input'
 import { ApiScope } from '../models'
 import { ScopeTreeNode } from '../models/scopeTreeNode.model'
 import { ApiScopesInput } from '../dto/apiScopes.input'
@@ -80,10 +79,10 @@ export interface MergedDelegationDTO {
 }
 
 export enum DelegationProvider {
-  Thjodskra = 'thjodskra',
-  Fyrirtaekjaskra = 'fyrirtaekjaskra',
-  Talsmannagrunnur = 'talsmannagrunnur',
-  Delegationdb = 'delegationdb',
+  thjodskra = 'thjodskra',
+  fyrirtaekjaskra = 'fyrirtaekjaskra',
+  talsmannagrunnur = 'talsmannagrunnur',
+  delegationdb = 'delegationdb',
 }
 
 export enum DelegationType {

--- a/libs/auth-api-lib/src/lib/delegations/delegations-outgoing.service.ts
+++ b/libs/auth-api-lib/src/lib/delegations/delegations-outgoing.service.ts
@@ -74,7 +74,10 @@ export class DelegationsOutgoingService {
               model: ApiScope,
               required: true,
               include: [
-                ...this.delegationResourceService.apiScopeInclude(user),
+                ...this.delegationResourceService.apiScopeInclude(
+                  user,
+                  DelegationDirection.OUTGOING,
+                ),
               ],
             },
           ],
@@ -336,6 +339,7 @@ export class DelegationsOutgoingService {
     const userScopes = await this.delegationResourceService.findScopeNames(
       user,
       delegation.domainName,
+      direction,
     )
     if (!userScopes.length) {
       return null

--- a/libs/auth-api-lib/src/lib/delegations/delegations-outgoing.service.ts
+++ b/libs/auth-api-lib/src/lib/delegations/delegations-outgoing.service.ts
@@ -196,9 +196,13 @@ export class DelegationsOutgoingService {
       createDelegation.scopes,
     )
 
-    const newDelegation = await this.findOneInternal(user, {
-      id: delegation.id,
-    })
+    const newDelegation = await this.findOneInternal(
+      user,
+      DelegationDirection.OUTGOING,
+      {
+        id: delegation.id,
+      },
+    )
 
     if (!newDelegation) {
       throw new InternalServerErrorException(

--- a/libs/auth-api-lib/src/lib/resources/delegation-resources.service.ts
+++ b/libs/auth-api-lib/src/lib/resources/delegation-resources.service.ts
@@ -1,25 +1,26 @@
-import { isCompany } from 'kennitala'
 import { ForbiddenException, Inject, Injectable } from '@nestjs/common'
 import { InjectModel } from '@nestjs/sequelize'
-import type { Attributes, WhereOptions } from 'sequelize'
+import { isCompany } from 'kennitala'
 import { and, Op, or } from 'sequelize'
+import type { Attributes, WhereOptions } from 'sequelize'
+import { Includeable } from 'sequelize/types/model'
 
 import { User } from '@island.is/auth-nest-tools'
 import type { ConfigType } from '@island.is/nest/config'
 import { NoContentException } from '@island.is/nest/problem'
 
+import { DelegationConfig } from '../delegations/DelegationConfig'
+import { DelegationScope } from '../delegations/models/delegation-scope.model'
+import { Delegation } from '../delegations/models/delegation.model'
+import { DelegationDirection } from '../delegations/types/delegationDirection'
 import { ApiScopeListDTO } from './dto/api-scope-list.dto'
 import { ApiScopeTreeDTO } from './dto/api-scope-tree.dto'
 import { ApiScopeGroup } from './models/api-scope-group.model'
+import { ApiScopeUserAccess } from './models/api-scope-user-access.model'
 import { ApiScope } from './models/api-scope.model'
 import { Domain } from './models/domain.model'
 import { ResourceTranslationService } from './resource-translation.service'
-import { ApiScopeUserAccess } from './models/api-scope-user-access.model'
-import { DelegationScope } from '../delegations/models/delegation-scope.model'
-import { Delegation } from '../delegations/models/delegation.model'
-import { DelegationConfig } from '../delegations/DelegationConfig'
 import { col } from './utils/col'
-import { Includeable } from 'sequelize/types/model'
 
 type DelegationConfigType = ConfigType<typeof DelegationConfig>
 type ScopeRule = DelegationConfigType['customScopeRules'] extends Array<
@@ -40,9 +41,13 @@ export class DelegationResourcesService {
     private delegationConfig: ConfigType<typeof DelegationConfig>,
   ) {}
 
-  async findAllDomains(user: User, language?: string): Promise<Domain[]> {
+  async findAllDomains(
+    user: User,
+    language?: string,
+    direction?: DelegationDirection,
+  ): Promise<Domain[]> {
     const domains = await this.domainModel.findAll({
-      where: and(...this.apiScopeFilter(user, 'scopes')),
+      where: and(...this.apiScopeFilter({ user, prefix: 'scopes', direction })),
       include: [
         {
           model: ApiScope,
@@ -71,7 +76,7 @@ export class DelegationResourcesService {
         {
           name: domainName,
         },
-        ...this.apiScopeFilter(user, 'scopes'),
+        ...this.apiScopeFilter({ user, prefix: 'scopes' }),
       ),
       include: [
         {
@@ -100,8 +105,14 @@ export class DelegationResourcesService {
     user: User,
     domainName: string,
     language?: string,
+    direction?: DelegationDirection,
   ): Promise<ApiScopeTreeDTO[]> {
-    const scopes = await this.findScopesInternal(user, domainName, language)
+    const scopes = await this.findScopesInternal({
+      user,
+      domainName,
+      direction,
+      language,
+    })
     return scopes.map((node) => new ApiScopeListDTO(node))
   }
 
@@ -109,8 +120,14 @@ export class DelegationResourcesService {
     user: User,
     domainName: string,
     language?: string,
+    direction?: DelegationDirection,
   ): Promise<ApiScopeTreeDTO[]> {
-    const scopes = await this.findScopesInternal(user, domainName, language)
+    const scopes = await this.findScopesInternal({
+      user,
+      domainName,
+      direction,
+      language,
+    })
 
     const groupChildren = new Map<string, ApiScopeTreeDTO[]>()
     const scopeTree: Array<ApiScope | ApiScopeGroup> = []
@@ -137,19 +154,27 @@ export class DelegationResourcesService {
       }))
   }
 
-  async findScopeNames(user: User, domainName: string) {
-    const scopes = await this.findScopesInternal(user, domainName, undefined, [
-      'name',
-    ])
+  async findScopeNames(
+    user: User,
+    domainName: string,
+    direction?: DelegationDirection,
+  ) {
+    const scopes = await this.findScopesInternal({
+      user,
+      domainName,
+      direction,
+      attributes: ['name'],
+    })
     return scopes.map((scope) => scope.name)
   }
 
   async validateScopeAccess(
     user: User,
     domainName: string,
+    direction: DelegationDirection,
     scopesToCheck: Array<string>,
   ): Promise<boolean> {
-    const userScopes = await this.findScopeNames(user, domainName)
+    const userScopes = await this.findScopeNames(user, domainName, direction)
     if (userScopes.length === 0) {
       return false
     }
@@ -157,16 +182,31 @@ export class DelegationResourcesService {
     return scopesToCheck.every((scopeName) => userScopes.includes(scopeName))
   }
 
-  apiScopeFilter(user: User, prefix?: string) {
-    return [
+  apiScopeFilter({
+    user,
+    prefix,
+    direction,
+  }: {
+    user: User
+    prefix?: string
+    direction?: DelegationDirection
+  }) {
+    const apiScopeFilter: Array<WhereOptions<ApiScope>> = [
       {
         [col(prefix, 'allowExplicitDelegationGrant')]: true,
         [col(prefix, 'enabled')]: true,
       },
-      ...this.skipScopeFilter(user, prefix),
-      ...this.accessControlFilter(user, prefix),
-      ...this.delegationTypeFilter(user, prefix),
     ]
+
+    if (direction === DelegationDirection.OUTGOING) {
+      apiScopeFilter.push(
+        ...this.skipScopeFilter(user, prefix),
+        ...this.accessControlFilter(user, prefix),
+        ...this.delegationTypeFilter(user, prefix),
+      )
+    }
+
+    return apiScopeFilter
   }
 
   apiScopeInclude(user: User) {
@@ -176,19 +216,26 @@ export class DelegationResourcesService {
     ]
   }
 
-  private async findScopesInternal(
-    user: User,
-    domainName: string,
-    language?: string,
-    attributes?: Array<keyof Attributes<ApiScope>>,
-  ): Promise<ApiScope[]> {
+  private async findScopesInternal({
+    user,
+    domainName,
+    language,
+    direction,
+    attributes,
+  }: {
+    user: User
+    domainName: string
+    language?: string
+    direction?: DelegationDirection
+    attributes?: Array<keyof Attributes<ApiScope>>
+  }): Promise<ApiScope[]> {
     const scopes = await this.apiScopeModel.findAll({
       attributes: attributes as string[],
       where: and(
         {
           domainName,
         },
-        ...this.apiScopeFilter(user),
+        ...this.apiScopeFilter({ user, direction }),
       ),
       include: [ApiScopeGroup, ...this.apiScopeInclude(user)],
       order: [

--- a/libs/auth-api-lib/src/lib/resources/delegation-resources.service.ts
+++ b/libs/auth-api-lib/src/lib/resources/delegation-resources.service.ts
@@ -54,7 +54,7 @@ export class DelegationResourcesService {
           attributes: [],
           required: true,
           duplicating: false,
-          include: [...this.apiScopeInclude(user)],
+          include: [...this.apiScopeInclude(user, direction)],
         },
       ],
     })
@@ -209,11 +209,15 @@ export class DelegationResourcesService {
     return apiScopeFilter
   }
 
-  apiScopeInclude(user: User) {
-    return [
-      this.accessControlInclude(user),
-      ...this.delegationTypeInclude(user),
-    ]
+  apiScopeInclude(user: User, direction?: DelegationDirection) {
+    if (direction === DelegationDirection.OUTGOING) {
+      return [
+        this.accessControlInclude(user),
+        ...this.delegationTypeInclude(user),
+      ]
+    } else {
+      return []
+    }
   }
 
   private async findScopesInternal({
@@ -237,7 +241,7 @@ export class DelegationResourcesService {
         },
         ...this.apiScopeFilter({ user, direction }),
       ),
-      include: [ApiScopeGroup, ...this.apiScopeInclude(user)],
+      include: [ApiScopeGroup, ...this.apiScopeInclude(user, direction)],
       order: [
         ['group_id', 'ASC NULLS FIRST'],
         ['order', 'ASC'],

--- a/libs/clients/auth/delegation-api/project.json
+++ b/libs/clients/auth/delegation-api/project.json
@@ -21,7 +21,7 @@
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "outputPath": "libs/clients/auth/delegation-api/gen",
-        "command": "yarn openapi-generator -o libs/clients/auth/delegation-api/gen/fetch -i apps/services/auth/delegation-api/src/openapi.yaml"
+        "command": "yarn openapi-generator -o libs/clients/auth/delegation-api/gen/fetch -i apps/services/auth/delegation-api/src/openapi.yaml --additional-properties=enumPropertyNaming=original"
       }
     }
   },

--- a/libs/clients/auth/public-api/project.json
+++ b/libs/clients/auth/public-api/project.json
@@ -23,7 +23,7 @@
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "outputPath": "libs/clients/auth/public-api/gen",
-        "command": "yarn openapi-generator -o libs/clients/auth/public-api/gen/fetch -i apps/services/auth/public-api/src/openapi.yaml"
+        "command": "yarn openapi-generator -o libs/clients/auth/public-api/gen/fetch -i apps/services/auth/public-api/src/openapi.yaml --additional-properties=enumPropertyNaming=original"
       }
     }
   },

--- a/libs/service-portal/access-control/delegations/src/components/access/AccessForm.tsx
+++ b/libs/service-portal/access-control/delegations/src/components/access/AccessForm.tsx
@@ -22,6 +22,7 @@ import { servicePortalSaveAccessControl } from '@island.is/plausible'
 import {
   useUpdateAuthDelegationMutation,
   useAuthScopeTreeQuery,
+  AuthDomainDirection,
 } from '@island.is/service-portal/graphql'
 import { AccessFormScope } from './access.types'
 import { extendApiScope, formatScopeTreeToScope } from './access.utils'
@@ -70,6 +71,7 @@ export const AccessForm = ({ delegation, validityPeriod }: AccessFormProps) => {
       input: {
         domain: delegation.domain.name,
         lang,
+        direction: AuthDomainDirection.Outgoing,
       },
     },
   })

--- a/libs/service-portal/access-control/delegations/src/hooks/useDomains.ts
+++ b/libs/service-portal/access-control/delegations/src/hooks/useDomains.ts
@@ -1,6 +1,9 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useLocale } from '@island.is/localization'
-import { useAuthDomainsQuery } from '@island.is/service-portal/graphql'
+import {
+  AuthDomainDirection,
+  useAuthDomainsQuery,
+} from '@island.is/service-portal/graphql'
 import { ALL_DOMAINS, ISLAND_DOMAIN } from '../constants/domain'
 import { useQueryParam } from '@island.is/service-portal/core'
 import { useLocation, useHistory } from 'react-router-dom'
@@ -45,6 +48,7 @@ export const useDomains = (includeDefaultOption = true) => {
     variables: {
       input: {
         lang,
+        direction: AuthDomainDirection.Outgoing,
       },
     },
   })


### PR DESCRIPTION
# ...

[Extend scopes API to support incoming delegations UI](https://www.notion.so/Extend-scopes-API-to-support-incoming-delegations-UI-c8ab6d2436df4543ad26d03e948706e4)
[Extend domains API to support incoming delegations UI](https://www.notion.so/Extend-domains-API-to-support-incoming-delegations-UI-f0e87875e03f4234a5abc54a80e5869b)

## What

Adding `direction` query parameter to `/domains`, `/ domains/:domainId/scope-tree` and `/domains/:domainId/scopes` endpoints.

## Why

To change default case to return all domains and all scopes in domain when not filtered by direction. Then support `direction=outgoing` to filter the list to filtered scopes for only allowed for outgoing delegations.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
