### PR TITLE
fix(search-indexer): Fix filtering of logged objects

### DIFF
--- a/libs/content-search-toolkit/src/services/elastic.service.ts
+++ b/libs/content-search-toolkit/src/services/elastic.service.ts
@@ -115,7 +115,7 @@ export class ElasticService {
     if (Object.keys(o).length == 0) return false
     for (const key in o) {
       const value = o[key]
-      // Only these huge documents should reach this limit
+      // Only HUMONGOUS documents should reach this limit
       if (typeof value == 'string' && value.length > 10000) {
         delete o[key]
         deleted = true

--- a/libs/content-search-toolkit/src/services/elastic.service.ts
+++ b/libs/content-search-toolkit/src/services/elastic.service.ts
@@ -107,6 +107,7 @@ export class ElasticService {
 
   /**
    * @param {T} err Error object
+   * @return {boolean} True iff a document was removed
    * Filter the HUMONGOUS documents in an error object
    */
   private filterDoc<T>(o: T): boolean {

--- a/libs/content-search-toolkit/src/services/elastic.service.ts
+++ b/libs/content-search-toolkit/src/services/elastic.service.ts
@@ -107,20 +107,15 @@ export class ElasticService {
 
   /**
    * @param {T} err Error object
-   * @return {boolean} True iff a document was removed
    * Filter the HUMONGOUS documents in an error object
    */
-  private filterDoc<T>(o: T, parent?: string): boolean {
+  private filterDoc<T>(o: T): boolean {
     let deleted = false
     if (Object.keys(o).length == 0) return false
     for (const key in o) {
       const value = o[key]
-      // A document is typically nested in request.params.body
-      if (
-        key == 'doc' ||
-        (key == 'body' && parent == 'params') ||
-        (key == 'body' && typeof value == 'string' && value.match(/^\{?"?doc/))
-      ) {
+      // Only these huge documents should reach this limit
+      if (typeof value == 'string' && value.length > 10000) {
         delete o[key]
         deleted = true
       }


### PR DESCRIPTION
Big objects are being logged, resulting in end-of-json. This should improve the filtering of objects being logged.

In my testing, full articles are getting logged, resulting in >44000 character long strings

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
