### PR TITLE
chore(qa): Do not fail homepage tests due to a long list of pages to visit

### DIFF
--- a/apps/system-e2e/src/tests/web/smoke/homepage.spec.ts
+++ b/apps/system-e2e/src/tests/web/smoke/homepage.spec.ts
@@ -34,6 +34,7 @@ test.describe('Front page', () => {
     { lang: 'en', home: '/en' },
   ]) {
     test(`should have life event @lang:${lang}`, async () => {
+      test.slow()
       const page = await context.newPage()
       await page.goto(home)
       const lifeEventsCards = page.locator('[data-testid="lifeevent-card"]')
@@ -51,6 +52,7 @@ test.describe('Front page', () => {
       }
     })
     test(`should navigate to featured link @lang:${lang}`, async () => {
+      test.slow()
       const page = await context.newPage()
       await page.goto(home)
       const featuredLinks = page.locator('[data-testid="featured-link"]')
@@ -70,6 +72,7 @@ test.describe('Front page', () => {
     })
 
     test(`should have link on life events pages to navigate back to the main page @lang:${lang}`, async () => {
+      test.slow()
       const page = await context.newPage()
       await page.goto(home)
       const lifeEventsCards = page.locator('[data-testid="lifeevent-card"]')


### PR DESCRIPTION
# Homepage tests sometimes fail

Since we are visiting a lot of web pages in homepage tests, those can take a while to finish. In some cases, they need just a tad over the 90 seconds limit. So marking those as slow should actually prevent them from failing and shorten the runtime all around.

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
