### PR TITLE
fix(financial-statements-inao): Added genitiveName to graphql object

### DIFF
--- a/libs/api/domains/financial-statements-inao/src/lib/models/election.model.ts
+++ b/libs/api/domains/financial-statements-inao/src/lib/models/election.model.ts
@@ -10,4 +10,7 @@ export class Election {
 
   @Field(() => Date)
   electionDate!: Date
+
+  @Field({ nullable: true })
+  genitiveName?: string
 }


### PR DESCRIPTION
# Added genitiveName to graphql object

## What

Added genitiveName to graphql object

## Why

Must be accessable through graphql layer

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
