### PR TITLE
fix(service-portal): Block vehicle lookup when personal delegation is active

### DIFF
--- a/libs/service-portal/vehicles/src/index.ts
+++ b/libs/service-portal/vehicles/src/index.ts
@@ -6,50 +6,57 @@ import {
   ServicePortalPath,
   m,
 } from '@island.is/service-portal/core'
+import { isPersonDelegation } from '@island.is/shared/utils'
 
 export const vehiclesModule: ServicePortalModule = {
   name: 'Ökutæki',
   widgets: () => [],
-  routes: ({ userInfo }) => [
-    {
-      name: m.yourVehicles,
-      path: ServicePortalPath.AssetsVehicles,
-      enabled: userInfo.scopes.includes(ApiScope.vehicles),
-      render: () => lazy(() => import('./screens/Overview/Overview')),
-    },
-    {
-      name: m.yourVehicles,
-      path: ServicePortalPath.AssetsMyVehicles,
-      enabled: userInfo.scopes.includes(ApiScope.vehicles),
-      render: () => lazy(() => import('./screens/Overview/Overview')),
-    },
-    {
-      name: m.vehicles,
-      path: ServicePortalPath.AssetsVehiclesDetail,
-      enabled: userInfo.scopes.includes(ApiScope.vehicles),
-      render: () => lazy(() => import('./screens/VehicleDetail/VehicleDetail')),
-    },
-    {
-      name: m.vehiclesHistory,
-      path: ServicePortalPath.AssetsVehiclesHistory,
-      enabled: userInfo.scopes.includes(ApiScope.vehicles),
-      render: () =>
-        lazy(() => import('./screens/VehicleHistory/VehicleHistory')),
-    },
-    {
-      name: m.vehiclesDrivingLessons,
-      path: ServicePortalPath.AssetsVehiclesDrivingLessons,
-      enabled: userInfo.scopes.includes(ApiScope.vehicles),
-      dynamic: true,
-      render: () =>
-        lazy(() => import('./screens/DrivingLessonsBook/DrivingLessonsBook')),
-    },
-    {
-      name: m.vehiclesLookup,
-      path: ServicePortalPath.AssetsVehiclesLookup,
-      enabled: userInfo.scopes.includes(ApiScope.vehicles),
-      key: 'VehicleLookup',
-      render: () => lazy(() => import('./screens/Lookup/Lookup')),
-    },
-  ],
+  routes: ({ userInfo }) => {
+    const isPersonDelegationActor = isPersonDelegation(userInfo)
+    return [
+      {
+        name: m.yourVehicles,
+        path: ServicePortalPath.AssetsVehicles,
+        enabled: userInfo.scopes.includes(ApiScope.vehicles),
+        render: () => lazy(() => import('./screens/Overview/Overview')),
+      },
+      {
+        name: m.yourVehicles,
+        path: ServicePortalPath.AssetsMyVehicles,
+        enabled: userInfo.scopes.includes(ApiScope.vehicles),
+        render: () => lazy(() => import('./screens/Overview/Overview')),
+      },
+      {
+        name: m.vehicles,
+        path: ServicePortalPath.AssetsVehiclesDetail,
+        enabled: userInfo.scopes.includes(ApiScope.vehicles),
+        render: () =>
+          lazy(() => import('./screens/VehicleDetail/VehicleDetail')),
+      },
+      {
+        name: m.vehiclesHistory,
+        path: ServicePortalPath.AssetsVehiclesHistory,
+        enabled: userInfo.scopes.includes(ApiScope.vehicles),
+        render: () =>
+          lazy(() => import('./screens/VehicleHistory/VehicleHistory')),
+      },
+      {
+        name: m.vehiclesDrivingLessons,
+        path: ServicePortalPath.AssetsVehiclesDrivingLessons,
+        enabled: userInfo.scopes.includes(ApiScope.vehicles),
+        dynamic: true,
+        render: () =>
+          lazy(() => import('./screens/DrivingLessonsBook/DrivingLessonsBook')),
+      },
+      {
+        name: m.vehiclesLookup,
+        path: ServicePortalPath.AssetsVehiclesLookup,
+        enabled:
+          !isPersonDelegationActor &&
+          userInfo.scopes.includes(ApiScope.vehicles),
+        key: 'VehicleLookup',
+        render: () => lazy(() => import('./screens/Lookup/Lookup')),
+      },
+    ]
+  },
 }

--- a/libs/shared/utils/src/index.ts
+++ b/libs/shared/utils/src/index.ts
@@ -7,7 +7,11 @@ export { sleep } from './lib/sleep'
 export { isRunningOnEnvironment } from './lib/environment'
 export { shouldLinkOpenInNewWindow } from './lib/shouldLinkOpenInNewWindow'
 export { getOrganizationLogoUrl } from './lib/getOrganizationLogoUrl'
-export { checkDelegation } from './lib/isDelegation'
+export {
+  checkDelegation,
+  isCompanyDelegation,
+  isPersonDelegation,
+} from './lib/isDelegation'
 export { isDefined } from './lib/isDefined'
 export { storageFactory } from './lib/storageFactory'
 export { sortAlpha } from './lib/sortAlpha'

--- a/libs/shared/utils/src/lib/isDelegation.spec.ts
+++ b/libs/shared/utils/src/lib/isDelegation.spec.ts
@@ -1,0 +1,106 @@
+import {
+  checkDelegation,
+  isCompanyDelegation,
+  isPersonDelegation,
+} from './isDelegation'
+import { User } from '@island.is/shared/types'
+
+export interface MockUser extends Partial<Omit<User, 'profile'>> {
+  profile?: Partial<User['profile']>
+}
+
+export const createMockUser = (user?: MockUser) =>
+  ({
+    profile: {
+      name: 'Mock',
+      locale: 'is',
+      nationalId: '0000000000',
+      ...user?.profile,
+    },
+    expired: false,
+    expires_in: 9999,
+    scopes: [],
+    ...user,
+  } as User)
+
+describe('Delegation utilities', () => {
+  describe('checkDelegation', () => {
+    it('should return false when not in delegation', () => {
+      const user = createMockUser()
+      const isDelegation = checkDelegation(user)
+      expect(isDelegation).toBe(false)
+    })
+
+    it('should return true when in delegation', () => {
+      const user = createMockUser({
+        profile: {
+          actor: {
+            nationalId: '1111111111',
+            name: 'Mock name',
+          },
+        },
+      })
+      const isDelegation = checkDelegation(user)
+      expect(isDelegation).toBe(true)
+    })
+  })
+  describe('isCompanyDelegation', () => {
+    it('should return true when in company delegation', () => {
+      const user = createMockUser({
+        profile: {
+          subjectType: 'legalEntity',
+          actor: {
+            nationalId: '1111111111',
+            name: 'Mock Company',
+          },
+        },
+      })
+      const isCompany = isCompanyDelegation(user)
+      expect(isCompany).toBe(true)
+    })
+
+    it('should return false when not in company delegation', () => {
+      const user = createMockUser({
+        profile: {
+          subjectType: 'person',
+          actor: {
+            nationalId: '1111111111',
+            name: 'Mock Person',
+          },
+        },
+      })
+      const isCompany = isCompanyDelegation(user)
+      expect(isCompany).toBe(false)
+    })
+  })
+
+  describe('isPersonDelegation', () => {
+    it('should return true when in person delegation', () => {
+      const user = createMockUser({
+        profile: {
+          subjectType: 'person',
+          actor: {
+            nationalId: '1111111111',
+            name: 'Mock Person',
+          },
+        },
+      })
+      const isPerson = isPersonDelegation(user)
+      expect(isPerson).toBe(true)
+    })
+
+    it('should return false when not in person delegation', () => {
+      const user = createMockUser({
+        profile: {
+          subjectType: 'legalEntity',
+          actor: {
+            nationalId: '1111111111',
+            name: 'Mock Company',
+          },
+        },
+      })
+      const isPerson = isPersonDelegation(user)
+      expect(isPerson).toBe(false)
+    })
+  })
+})

--- a/libs/shared/utils/src/lib/isDelegation.ts
+++ b/libs/shared/utils/src/lib/isDelegation.ts
@@ -24,8 +24,8 @@ export const isCompanyDelegation = (user: User) => {
  * @returns boolean
  */
 export const isPersonDelegation = (user: User) => {
-  const isCompany = isCompanyDelegation(user)
+  const isPerson = user?.profile?.subjectType === 'person'
   const isDelegation = checkDelegation(user)
-  const personDelegation = isDelegation && !isCompany
+  const personDelegation = isDelegation && isPerson
   return personDelegation
 }

--- a/libs/shared/utils/src/lib/isDelegation.ts
+++ b/libs/shared/utils/src/lib/isDelegation.ts
@@ -1,5 +1,31 @@
 import { User } from '@island.is/shared/types'
 
+/**
+ * Is the currently logged in user acting in a delegation
+ * @param user IDS User
+ * @returns boolean
+ */
 export const checkDelegation = (user: User) => {
   return Boolean(user?.profile.actor)
+}
+
+/**
+ * Is the currently logged in user acting as a company
+ * @param user IDS User
+ * @returns boolean
+ */
+export const isCompanyDelegation = (user: User) => {
+  return user?.profile?.subjectType === 'legalEntity'
+}
+
+/**
+ * Is the currently logged in user acting in a delegation of another user, not a company.
+ * @param user IDS User
+ * @returns boolean
+ */
+export const isPersonDelegation = (user: User) => {
+  const isCompany = isCompanyDelegation(user)
+  const isDelegation = checkDelegation(user)
+  const personDelegation = isDelegation && !isCompany
+  return personDelegation
 }


### PR DESCRIPTION
## What

* Block vehicle lookup when personal delegation is active. 
* Add delegation helpers

## Why

Vehicle is kind of a special case where you only get 5 lookups per day. It should only be available for the individual themselves. But should be available to companies. So we can't really block all delegations. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
