### PR TITLE
fix(web): Fix error that was appearing on the layout load of the error page (404 and 500)

### DIFF
--- a/apps/web/layouts/main.tsx
+++ b/apps/web/layouts/main.tsx
@@ -152,7 +152,7 @@ const Layout: NextComponentType<
   const { activeLocale, t } = useI18n()
   const { linkResolver } = useLinkResolver()
   const n = useNamespace(namespace)
-  const { route, pathname, query, asPath } = useRouter()
+  const { asPath } = useRouter()
   const fullUrl = `${respOrigin}${asPath}`
 
   const menuTabs = [
@@ -199,12 +199,12 @@ const Layout: NextComponentType<
         },
       ]
         .concat(
-          customAlertBanners.map((banner) => ({
+          customAlertBanners?.map((banner) => ({
             bannerId: `custom-alert-${stringHash(
               JSON.stringify(banner ?? {}),
             )}`,
             ...banner,
-          })),
+          })) ?? [],
         )
         .filter(
           (banner) => !Cookies.get(banner.bannerId) && banner?.showAlertBanner,

--- a/apps/web/pages/_error.tsx
+++ b/apps/web/pages/_error.tsx
@@ -118,12 +118,11 @@ class ErrorPage extends React.Component<ErrorPageProps> {
         locale,
         statusCode,
       })
-      // eslint-disable-next-line no-empty
-    } catch {}
-
-    console.error(
-      new Error(`_error.tsx getInitialProps missing data at path: ${asPath}`),
-    )
+    } catch {
+      console.error(
+        new Error(`_error.tsx getInitialProps missing data at path: ${asPath}`),
+      )
+    }
 
     return {
       statusCode,


### PR DESCRIPTION
# Fix error that was appearing on the layout load of the error page (404 and 500)

## What

* An error was occurring on the error page which meant the layout wasn't loading)
* Also I moved the console.error to the catch block instead of having it run each time the error page gets loaded (even though everything got loaded succesfully it would still log an error)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
