### PR TITLE
feat(financial-statements-inao): Extra try-catch around post for personal election in submitApplication

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/financial-statements-inao/financial-statements-inao.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/financial-statements-inao/financial-statements-inao.service.ts
@@ -179,29 +179,37 @@ export class FinancialStatementsInaoTemplateService {
         file: fileName,
       }
 
-      const result: DataResponse = await this.financialStatementsClientService
-        .postFinancialStatementForPersonalElection(input)
-        .then((data) => {
-          if (data === true) {
-            return { success: true }
-          } else {
-            return { success: false }
-          }
-        })
-        .catch((e) => {
-          this.logger.error(
-            'Failed to post financial statement for personal election',
-            e,
-          )
-          return {
-            success: false,
-            errorMessage: e.message,
-          }
-        })
-      if (!result.success) {
-        throw new Error(`Application submission failed`)
+      try {
+        const result: DataResponse = await this.financialStatementsClientService
+          .postFinancialStatementForPersonalElection(input)
+          .then((data) => {
+            if (data === true) {
+              return { success: true }
+            } else {
+              return { success: false }
+            }
+          })
+          .catch((e) => {
+            this.logger.error(
+              'Failed to post financial statement for personal election',
+              e,
+            )
+            return {
+              success: false,
+              errorMessage: e.message,
+            }
+          })
+        if (!result.success) {
+          throw new Error(`Application submission failed`)
+        }
+        return { success: result.success }
+      } catch (e) {
+        this.logger.error(
+          'Failed to run postFinancialStatementForPersonalElection',
+          e,
+        )
+        return { success: false }
       }
-      return { success: result.success }
     } else if (currentUserType === FSIUSERTYPE.PARTY) {
       const values: PoliticalPartyFinancialStatementValues = mapValuesToPartytype(
         answers,


### PR DESCRIPTION
# Extra try-catch around post for personal election in submitApplication

## What

Added extra try-catch around post for personal election in submitApplication

## Why

Trying to find out why the postFinancialStatementForPersonalElection is not found

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
