### PR TITLE
fix(e2e): Fix broken company e2e test

### DIFF
--- a/apps/system-e2e/src/tests/service-portal/smoke/company-delegation.spec.ts
+++ b/apps/system-e2e/src/tests/service-portal/smoke/company-delegation.spec.ts
@@ -39,7 +39,7 @@ test.describe('Service portal', () => {
       .textContent()
     expect(companyName).toBeTruthy()
     await firstCompany.click()
-    await page.waitForURL(homeUrl, {
+    await page.waitForURL(new RegExp(`${homeUrl}/?`), {
       waitUntil: 'domcontentloaded',
     })
 


### PR DESCRIPTION
Company signin was braken since Playwright expects an exact match when waiting for raw string URLs. Here we wrap it in regex to be more lenient.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
