### PR TITLE
fix(service-portal): postholf disappearing in mobile menu

### DIFF
--- a/apps/service-portal/src/components/MobileMenu/MobileMenu.css.ts
+++ b/apps/service-portal/src/components/MobileMenu/MobileMenu.css.ts
@@ -1,8 +1,5 @@
 import { theme } from '@island.is/island-ui/theme'
-import {
-  SERVICE_PORTAL_HEADER_HEIGHT_SM,
-  zIndex,
-} from '@island.is/service-portal/constants'
+import { zIndex } from '@island.is/service-portal/constants'
 import { keyframes, style } from '@vanilla-extract/css'
 
 const wrapperAnimation = keyframes({
@@ -17,9 +14,7 @@ const wrapperAnimation = keyframes({
 })
 
 export const wrapper = style({
-  top: SERVICE_PORTAL_HEADER_HEIGHT_SM,
   zIndex: zIndex.mobileMenu,
-  maxHeight: `calc(100vh - ${SERVICE_PORTAL_HEADER_HEIGHT_SM}px)`,
   overflowY: 'auto',
   animation: `${wrapperAnimation} ease-in 200ms forwards`,
 })

--- a/apps/service-portal/src/components/MobileMenu/MobileMenu.tsx
+++ b/apps/service-portal/src/components/MobileMenu/MobileMenu.tsx
@@ -11,7 +11,7 @@ import { useAuth } from '@island.is/auth/react'
 import NavItem from '../Sidebar/NavItem/NavItem'
 import { sharedMessages } from '@island.is/shared/translations'
 import { useLocale } from '@island.is/localization'
-
+import { SERVICE_PORTAL_HEADER_HEIGHT_SM } from '@island.is/service-portal/constants'
 interface Props {
   position: number
 }
@@ -32,6 +32,8 @@ const MobileMenu = ({ position }: Props): ReactElement | null => {
 
   if (mobileMenuState === 'closed') return null
 
+  const topPosition = position + SERVICE_PORTAL_HEADER_HEIGHT_SM
+  // Inline style to dynamicly change position of header because of alert banners
   return (
     <Box
       position="fixed"
@@ -44,9 +46,8 @@ const MobileMenu = ({ position }: Props): ReactElement | null => {
       display="flex"
       flexDirection="column"
       justifyContent="spaceBetween"
-      style={{ top: position }}
+      style={{ top: topPosition, maxHeight: `calc(100vh - ${topPosition})` }}
     >
-      {/*  Inline style to dynamicly change position of header because of alert banners */}
       {navigation.map((rootItem, rootIndex) => (
         <Box key={rootIndex} paddingX={0} marginTop={3}>
           <Stack space={2}>


### PR DESCRIPTION
# Service portal - Mobile Menu

## What

Postholf is disappearing under mobile header in mobile menu

## Why

when adding position param for alert banners, it was overwriting position already defined in css file. 

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
