### PR TITLE
fix(service-portal): Fixes domain name update to keep in sync

### DIFF
--- a/libs/service-portal/access-control/delegations/src/screens/GrantAccess/GrantAccess.tsx
+++ b/libs/service-portal/access-control/delegations/src/screens/GrantAccess/GrantAccess.tsx
@@ -34,7 +34,7 @@ import {
   useCreateAuthDelegationMutation,
   useIdentityLazyQuery,
 } from '@island.is/service-portal/graphql'
-import { useDomains } from '../../hooks/useDomains'
+import { DomainOption, useDomains } from '../../hooks/useDomains'
 import { ALL_DOMAINS } from '../../constants/domain'
 
 const GrantAccess: ServicePortalModuleComponent = ({ userInfo }) => {
@@ -44,7 +44,12 @@ const GrantAccess: ServicePortalModuleComponent = ({ userInfo }) => {
   const inputRef = React.useRef<HTMLInputElement>(null)
   const history = useHistory()
   const { md } = useBreakpoint()
-  const { options, selectedOption, loading: domainLoading } = useDomains(false)
+  const {
+    options,
+    selectedOption,
+    loading: domainLoading,
+    updateDomain,
+  } = useDomains(false)
 
   const [
     createAuthDelegation,
@@ -266,6 +271,13 @@ const GrantAccess: ServicePortalModuleComponent = ({ userInfo }) => {
                     })}
                     error={errors.domainName?.message}
                     options={options}
+                    onSelect={(option) => {
+                      const opt = option as DomainOption
+
+                      if (opt) {
+                        updateDomain(opt)
+                      }
+                    }}
                     rules={{
                       required: {
                         value: true,


### PR DESCRIPTION
# Fixes domain name update to keep in sync

## What

Domain name was not updating in session storage when creating new delegation.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
