### PR TITLE
fix(web): Power Bi Slice - Query params changing back to old values

### DIFF
--- a/apps/web/components/Organization/Slice/PowerBiSlice/PowerBiSlice.tsx
+++ b/apps/web/components/Organization/Slice/PowerBiSlice/PowerBiSlice.tsx
@@ -147,6 +147,8 @@ export const PowerBiSlice = ({ slice }: PowerBiSliceProps) => {
           if (nr) query['nr'] = nr
         }
 
+        router.query = query
+
         // Store via query params the state of the report
         router.push(
           {

--- a/apps/web/components/connected/fiskistofa/SidebarShipSearchInput/SidebarShipSearchInput.tsx
+++ b/apps/web/components/connected/fiskistofa/SidebarShipSearchInput/SidebarShipSearchInput.tsx
@@ -22,17 +22,21 @@ const SidebarShipSearchInput = ({ namespace }: SidebarShipSearchInputProps) => {
     const searchValueIsNumber =
       !isNaN(Number(searchValue)) && searchValue.length > 0
     if (searchValueIsNumber) {
+      const query = { nr: searchValue, selectedTab: 'skip' }
       router.push({
         pathname: n('shipDetailsHref', '/v/gagnasidur-fiskistofu'),
-        query: { nr: Number(searchValue), selectedTab: 'skip' },
+        query,
       })
+      router.query = query
     } else {
+      const query = {
+        name: searchValue,
+      }
       router.push({
         pathname: n('shipSearchHref', '/s/fiskistofa/skipaleit'),
-        query: {
-          name: searchValue,
-        },
+        query,
       })
+      router.query = query
     }
   }
 

--- a/libs/api/domains/powerbi/README.md
+++ b/libs/api/domains/powerbi/README.md
@@ -2,7 +2,8 @@
 
 # API Domains Powerbi
 
-This library was generated with [Nx](https://nx.dev).
+This domain corresponds to Power Bi functionality for the web.
+The web can embed Power Bi reports and some reports require an embed token, which this api domain can provide if given a workspace id, report id and an owner (which is a unique string that's used to map to the correct secret values).
 
 ## Running unit tests
 


### PR DESCRIPTION
# Power Bi Slice - Query params changing back to old values

## What

* When changing values in a powerbi dropdown the query params were out of date due to me presuming that the router.query object would update on shallow router.push, but it turns out it doesn't change
* This change fixes that issue
* (I also updated the README for the powerbi api domain)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
