### PR TITLE
chore(j-s): Change tooltip for prosecutor section in indictments

### DIFF
--- a/apps/judicial-system/web/src/routes/Prosecutor/components/ProsecutorSection/ProsecutorSection.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/components/ProsecutorSection/ProsecutorSection.tsx
@@ -6,6 +6,7 @@ import {
   FormContext,
   ProsecutorSelection,
 } from '@island.is/judicial-system-web/src/components'
+import { isIndictmentCase } from '@island.is/judicial-system/types'
 
 import ProsecutorSectionHeading from './ProsecutorSectionHeading'
 
@@ -30,7 +31,9 @@ const ProsecutorSection: React.FC = () => {
 
   return (
     <Box component="section" marginBottom={5}>
-      <ProsecutorSectionHeading />
+      <ProsecutorSectionHeading
+        isIndictment={isIndictmentCase(workingCase.type)}
+      />
       <ProsecutorSelection onChange={handleProsecutorChange} />
     </Box>
   )

--- a/apps/judicial-system/web/src/routes/Prosecutor/components/ProsecutorSection/ProsecutorSectionHeading.strings.ts
+++ b/apps/judicial-system/web/src/routes/Prosecutor/components/ProsecutorSection/ProsecutorSectionHeading.strings.ts
@@ -14,4 +14,11 @@ export const strings = defineMessages({
     description:
       'Notaður sem skýritexti fyrir "ákærandi" hlutann á óskir um fyrirtöku skrefi í öllum málstegundum.',
   },
+  indictmentTooltip: {
+    id: 'judicial.system.core:prosecutor_section_heading.indictment_tooltip',
+    defaultMessage:
+      'Ákærandi sem valinn er hér er skráður fyrir málinu og fær upplýsingaskeyti vegna málsmeðferðarinnar.',
+    description:
+      'Notaður sem skýritexti fyrir "ákærandi" hlutann á óskir um fyrirtöku skrefi í ákærum.',
+  },
 })

--- a/apps/judicial-system/web/src/routes/Prosecutor/components/ProsecutorSection/ProsecutorSectionHeading.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/components/ProsecutorSection/ProsecutorSectionHeading.tsx
@@ -3,9 +3,15 @@ import { useIntl } from 'react-intl'
 
 import { Box, Tooltip } from '@island.is/island-ui/core'
 import { SectionHeading } from '@island.is/judicial-system-web/src/components'
+
 import { strings } from './ProsecutorSectionHeading.strings'
 
-const ProsecutorSectionHeading: React.FC = () => {
+interface Props {
+  isIndictment?: boolean
+}
+
+const ProsecutorSectionHeading: React.FC<Props> = (props) => {
+  const { isIndictment = false } = props
   const { formatMessage } = useIntl()
 
   return (
@@ -13,7 +19,11 @@ const ProsecutorSectionHeading: React.FC = () => {
       title={`${formatMessage(strings.title)} `}
       tooltip={
         <Box component="span" data-testid="prosecutor-tooltip">
-          <Tooltip text={formatMessage(strings.tooltip)} />
+          <Tooltip
+            text={formatMessage(
+              isIndictment ? strings.indictmentTooltip : strings.tooltip,
+            )}
+          />
         </Box>
       }
     />


### PR DESCRIPTION
# Change tooltip for prosecutor section in indictments

[Asana](https://app.asana.com/0/1199153462262248/1203176015076412/f)

## What

Change tooltip for prosecutor section in indictments

## Why

The old text only applies to R-cases

## Screenshots / Gifs

### R-cases

<img width="389" alt="Screen Shot 2022-11-29 at 13 47 06" src="https://user-images.githubusercontent.com/3789875/204546285-6a11f10b-4ef4-4238-bbcd-9e0ba0982409.png">

### S-cases

<img width="405" alt="Screen Shot 2022-11-29 at 13 43 38" src="https://user-images.githubusercontent.com/3789875/204546290-da11f361-5250-4cc9-b8e0-0a17cc208979.png">

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
