### PR TITLE
feat(web): Store anchor navigation state in url

### DIFF
--- a/apps/web/components/Organization/Slice/OneColumnText/OneColumnTextSlice.tsx
+++ b/apps/web/components/Organization/Slice/OneColumnText/OneColumnTextSlice.tsx
@@ -43,7 +43,7 @@ export const OneColumnTextSlice: React.FC<SliceProps> = ({ slice }) => {
               {slice.title}
             </Text>
           )}
-          {webRichText(slice.content as SliceType[])}
+          {slice.content && webRichText(slice.content as SliceType[])}
           {slice.link && slice.link.url && (
             <Link href={slice.link.url}>
               <Button


### PR DESCRIPTION
# Store anchor navigation state in url

## What

* Now the url changes depending on what is selected in the anchor navigation (when you click on an anchor navigation item)

## Why

* We got the request that people want to be able to create urls that directly link to a piece of content, so here's our solution

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
