### PR TITLE
fix(web): Various fixes for the web project (#9201)

### DIFF
--- a/apps/web/components/ServiceWeb/Forms/StandardForm/StandardForm.tsx
+++ b/apps/web/components/ServiceWeb/Forms/StandardForm/StandardForm.tsx
@@ -38,7 +38,6 @@ import {
   SearchableTags,
   SupportQna,
 } from '@island.is/web/graphql/schema'
-import { ModifySearchTerms } from '../../SearchInput/SearchInput'
 import orderBy from 'lodash/orderBy'
 import { useNamespace } from '@island.is/web/hooks'
 import slugify from '@sindresorhus/slugify'
@@ -111,6 +110,10 @@ type CategoryId =
    * Fullnustugerðir
    */
   | '7LkzuYSzqwM7k8fJyeRbm6'
+
+const mannaudstorgTag = [
+  { key: 'mannaudstorg', type: SearchableTags.Organization },
+]
 
 const labels: Record<string, string> = {
   syslumadur: 'Sýslumannsembætti',
@@ -269,14 +272,9 @@ export const StandardForm = ({
                 queryString,
                 size: 10,
                 types: [SearchableContentTypes['WebQna']],
-                tags: institutionSlugBelongsToMannaudstorg
-                  ? [
-                      {
-                        key: 'mannaudstorg',
-                        type: SearchableTags.Organization,
-                      },
-                    ]
-                  : [],
+                [institutionSlugBelongsToMannaudstorg
+                  ? 'tags'
+                  : 'excludedTags']: mannaudstorgTag,
               },
             },
           })
@@ -617,13 +615,13 @@ export const StandardForm = ({
                       >
                         <Text key={index} variant="small" color="blue600">
                           <a
-                            href={`${
-                              linkResolver('supportcategory', [
+                            href={
+                              linkResolver('supportqna', [
                                 organizationSlug,
                                 categorySlug,
                                 slug,
                               ]).href
-                            }?q=${slug}`}
+                            }
                           >
                             {title}
                           </a>

--- a/apps/web/screens/Organization/Services.tsx
+++ b/apps/web/screens/Organization/Services.tsx
@@ -116,7 +116,7 @@ const ServicesPage: Screen<ServicesPageProps> = ({
   groups = groups.filter((x) =>
     services
       .filter((x) => parameters.categories.includes(x.category?.slug))
-      .map((x) => x.group.slug)
+      .map((x) => x.group?.slug)
       .includes(x.value),
   )
 


### PR DESCRIPTION
* Make services code a bit more robust if there is a missing group

* Fix supportqna link for suggestions

* Exclude mannaudstorg from suggestions (unless we are on their web)

* Make services page more robust by not directly accessing the article group slug (we saw an issue regarding this and this change fixes that issue)


# Various fixes for the web project (#9201)
