### PR TITLE
fix(e2e): Fix brittle homepage test

### DIFF
--- a/apps/web/components/SearchSection/SearchSection.tsx
+++ b/apps/web/components/SearchSection/SearchSection.tsx
@@ -142,12 +142,12 @@ export const SearchSection = ({
                 justifyContent="center"
                 alignItems="center"
                 aria-hidden="true"
+                dataTestId="home-banner"
               >
                 {videos?.length ? (
                   <Video
                     name="desktop"
                     title={imageAlternativeText}
-                    dataTestId="home-banner"
                     sources={videos.map(({ url, contentType }) => {
                       return {
                         src: url,

--- a/libs/island-ui/core/src/lib/Box/Box.tsx
+++ b/libs/island-ui/core/src/lib/Box/Box.tsx
@@ -2,8 +2,9 @@ import { createElement, forwardRef } from 'react'
 
 import { BoxProps } from './types'
 import { useBoxStyles } from './useBoxStyles'
+import { TestSupport } from '@island.is/island-ui/utils'
 
-export const Box = forwardRef<HTMLElement, BoxProps>(
+export const Box = forwardRef<HTMLElement, BoxProps & TestSupport>(
   (
     {
       component = 'div',

--- a/libs/island-ui/core/src/lib/Box/Box.tsx
+++ b/libs/island-ui/core/src/lib/Box/Box.tsx
@@ -63,6 +63,7 @@ export const Box = forwardRef<HTMLElement, BoxProps>(
       opacity,
       printHidden,
       className,
+      dataTestId,
       ...restProps
     },
     ref,
@@ -129,6 +130,7 @@ export const Box = forwardRef<HTMLElement, BoxProps>(
 
     return createElement(component, {
       className: boxStyles,
+      'data-testid': dataTestId,
       ...restProps,
       ref,
     })

--- a/libs/island-ui/core/src/lib/Box/types.ts
+++ b/libs/island-ui/core/src/lib/Box/types.ts
@@ -5,5 +5,4 @@ export interface BoxProps
   extends Omit<UseBoxStylesProps, 'component'>,
     Omit<AllHTMLAttributes<HTMLElement>, 'width' | 'height' | 'className'> {
   component?: ElementType
-  dataTestId?: string
 }

--- a/libs/island-ui/core/src/lib/Box/types.ts
+++ b/libs/island-ui/core/src/lib/Box/types.ts
@@ -5,4 +5,5 @@ export interface BoxProps
   extends Omit<UseBoxStylesProps, 'component'>,
     Omit<AllHTMLAttributes<HTMLElement>, 'width' | 'height' | 'className'> {
   component?: ElementType
+  dataTestId?: string
 }


### PR DESCRIPTION
- Add `data-testid` to the shared `Box` component
- Move `data-testid` on homepage image to container instead of graphic


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
