### PR TITLE
fix(web): Straddling Stock calculator - Allow users to still calculate values even though server returns 404

### DIFF
--- a/apps/web/components/connected/fiskistofa/SidebarShipSearchInput/SidebarShipSearchInput.tsx
+++ b/apps/web/components/connected/fiskistofa/SidebarShipSearchInput/SidebarShipSearchInput.tsx
@@ -24,7 +24,11 @@ const SidebarShipSearchInput = ({ namespace }: SidebarShipSearchInputProps) => {
     if (searchValueIsNumber) {
       const basePath = router.asPath.split('?')[0].split('#')[0]
       const pathname = n('shipDetailsHref', '/v/gagnasidur-fiskistofu')
-      const query = { nr: searchValue, selectedTab: 'skip' }
+      const query = {
+        ...router.query,
+        nr: searchValue,
+        selectedTab: router.query?.selectedTab ?? 'skip',
+      }
       router
         .push({
           pathname,
@@ -36,9 +40,7 @@ const SidebarShipSearchInput = ({ namespace }: SidebarShipSearchInputProps) => {
           }
         })
     } else {
-      const query = {
-        name: searchValue,
-      }
+      const query = { ...router.query, name: searchValue }
       router.push({
         pathname: n('shipSearchHref', '/s/fiskistofa/skipaleit'),
         query,

--- a/libs/cms/src/lib/environments/environment.ts
+++ b/libs/cms/src/lib/environments/environment.ts
@@ -65,6 +65,7 @@ export default {
     'emailSignup',
     'tabSection',
     'tabContent',
+    'footerItem',
   ],
   contentful: {
     space: process.env.CONTENTFUL_SPACE || '8k0h54kbe6bj',


### PR DESCRIPTION
# Straddling Stock calculator - Allow users to still calculate values even though server returns 404

## What

* As of right now if there isn't pre-existing information for a ship you won't be able to add categories and calculate values in the StraddlingStockCalculator
* I also added footerItem as a nested contentful type since I noticed it wasn't listed

## Why

* This feature was requested by the directorate of fisheries

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
