### PR TITLE
fix(service-portal): assets filter fix

### DIFF
--- a/libs/api/domains/assets/src/models/propertyDetail.model.spec.ts
+++ b/libs/api/domains/assets/src/models/propertyDetail.model.spec.ts
@@ -1,5 +1,5 @@
 import { MiddlewareContext } from '@nestjs/graphql'
-import { notPropertyOwner, PropertyDetail } from './propertyDetail.model'
+import { isPropertyOwner, PropertyDetail } from './propertyDetail.model'
 
 const MOCK_PROPERTY: PropertyDetail = {
   registeredOwners: {
@@ -22,7 +22,7 @@ describe('Asset Models', () => {
         ...MOCK_PROPERTY,
       }
       const context = { source: property } as MiddlewareContext
-      expect(notPropertyOwner(context)).toBeFalsy()
+      expect(isPropertyOwner(context)).toBeTruthy()
     })
 
     it('Non-owner should not be allowed to access data', async () => {
@@ -31,7 +31,7 @@ describe('Asset Models', () => {
         ...MOCK_PROPERTY,
       }
       const context = { source: property } as MiddlewareContext
-      expect(notPropertyOwner(context)).toBeTruthy()
+      expect(isPropertyOwner(context)).toBeFalsy()
     })
 
     it('User should not be allowed to access property with no owners', async () => {
@@ -40,7 +40,7 @@ describe('Asset Models', () => {
         ...MOCK_PROPERTY_SANS_OWNERS,
       }
       const context = { source: property } as MiddlewareContext
-      expect(notPropertyOwner(context)).toBeTruthy()
+      expect(isPropertyOwner(context)).toBeFalsy()
     })
   })
 })

--- a/libs/api/domains/assets/src/models/propertyDetail.model.ts
+++ b/libs/api/domains/assets/src/models/propertyDetail.model.ts
@@ -8,15 +8,15 @@ import { LandModel } from './Land.model'
 import { Extensions, Field, ObjectType } from '@nestjs/graphql'
 import { MiddlewareContext } from '@nestjs/graphql'
 
-export const notPropertyOwner = ({ source }: MiddlewareContext) => {
+export const isPropertyOwner = ({ source }: MiddlewareContext) => {
   const owners: PropertyOwner[] =
     (source as PropertyDetail).registeredOwners?.registeredOwners ?? []
   const isOwner = owners.some((owner) => owner.ssn == source.nationalId)
-  return !isOwner
+  return isOwner
 }
 @Extensions({
   filterFields: {
-    condition: notPropertyOwner,
+    condition: isPropertyOwner,
     fields: ['defaultAddress', 'land', 'propertyNumber'],
   },
 })


### PR DESCRIPTION
## What

Fix asset filterfields for property owner.

## Why

It's wrong. And has already been hotfixed on prod.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
