### PR TITLE
fix(web): Add fail safe to link group's primarylink field since it's been causing 500 errors

### DIFF
--- a/apps/web/screens/Organization/Home/Home.tsx
+++ b/apps/web/screens/Organization/Home/Home.tsx
@@ -69,9 +69,9 @@ const OrganizationHomePage: Screen<HomeProps> = ({
   const { linkResolver } = useLinkResolver()
 
   const navList: NavigationItem[] =
-    organizationPage?.menuLinks?.map(({ primaryLink, childrenLinks }) => ({
-      title: primaryLink.text,
-      href: primaryLink.url,
+    organizationPage.menuLinks.map(({ primaryLink, childrenLinks }) => ({
+      title: primaryLink?.text,
+      href: primaryLink?.url,
       active: false,
       items: childrenLinks.map(({ text, url }) => ({
         title: text,

--- a/apps/web/screens/Organization/OrganizationNewsArticle.tsx
+++ b/apps/web/screens/Organization/OrganizationNewsArticle.tsx
@@ -61,11 +61,11 @@ const OrganizationNewsArticle: Screen<OrganizationNewsArticleProps> = ({
   )
 
   const currentNavItem = organizationPage.menuLinks.find(
-    ({ primaryLink }) => primaryLink.url === overviewPath,
+    ({ primaryLink }) => primaryLink?.url === overviewPath,
   )
 
   const newsOverviewTitle: string = currentNavItem
-    ? currentNavItem.primaryLink.text
+    ? currentNavItem.primaryLink?.text
     : n('newsTitle', 'Fréttir og tilkynningar')
 
   const isNewsletter = newsItem?.genericTags?.some(
@@ -116,11 +116,11 @@ const OrganizationNewsArticle: Screen<OrganizationNewsArticleProps> = ({
 
   const navList: NavigationItem[] = organizationPage.menuLinks.map(
     ({ primaryLink, childrenLinks }) => ({
-      title: primaryLink.text,
-      href: primaryLink.url,
+      title: primaryLink?.text,
+      href: primaryLink?.url,
       active:
         newsHavePrimaryNewsTagOfOrganization &&
-        primaryLink.url === overviewPath,
+        primaryLink?.url === overviewPath,
       items: childrenLinks.map(({ text, url }) => ({
         title: text,
         href: url,

--- a/apps/web/screens/Organization/OrganizationNewsList.tsx
+++ b/apps/web/screens/Organization/OrganizationNewsList.tsx
@@ -91,7 +91,7 @@ const OrganizationNewsList: Screen<OrganizationNewsListProps> = ({
 
   const currentNavItem =
     organizationPage.menuLinks.find(
-      ({ primaryLink }) => primaryLink.url === baseRouterPath,
+      ({ primaryLink }) => primaryLink?.url === baseRouterPath,
     )?.primaryLink ??
     organizationPage.secondaryMenu?.childrenLinks.find(
       ({ url }) => url === baseRouterPath,
@@ -131,10 +131,10 @@ const OrganizationNewsList: Screen<OrganizationNewsListProps> = ({
 
   const navList: NavigationItem[] = organizationPage.menuLinks.map(
     ({ primaryLink, childrenLinks }) => ({
-      title: primaryLink.text,
-      href: primaryLink.url,
+      title: primaryLink?.text,
+      href: primaryLink?.url,
       active:
-        primaryLink.url === baseRouterPath ||
+        primaryLink?.url === baseRouterPath ||
         childrenLinks.some((link) => link.url === baseRouterPath),
       items: childrenLinks.map(({ text, url }) => ({
         title: text,

--- a/apps/web/screens/Organization/PublishedMaterial/PublishedMaterial.tsx
+++ b/apps/web/screens/Organization/PublishedMaterial/PublishedMaterial.tsx
@@ -114,10 +114,10 @@ const PublishedMaterial: Screen<PublishedMaterialProps> = ({
 
   const navList: NavigationItem[] = organizationPage.menuLinks.map(
     ({ primaryLink, childrenLinks }) => ({
-      title: primaryLink.text,
-      href: primaryLink.url,
+      title: primaryLink?.text,
+      href: primaryLink?.url,
       active:
-        primaryLink.url === router.asPath ||
+        primaryLink?.url === router.asPath ||
         childrenLinks.some((link) => link.url === router.asPath),
       items: childrenLinks.map(({ text, url }) => ({
         title: text,

--- a/apps/web/screens/Organization/Services.tsx
+++ b/apps/web/screens/Organization/Services.tsx
@@ -70,11 +70,11 @@ const ServicesPage: Screen<ServicesPageProps> = ({
 
   const navList: NavigationItem[] = organizationPage.menuLinks.map(
     ({ primaryLink, childrenLinks }) => ({
-      title: primaryLink.text,
-      href: primaryLink.url,
+      title: primaryLink?.text,
+      href: primaryLink?.url,
       active:
-        primaryLink.url.includes(`${organizationPage.slug}/thjonusta`) ||
-        primaryLink.url.includes(`${organizationPage.slug}/services`),
+        primaryLink?.url?.includes(`${organizationPage.slug}/thjonusta`) ||
+        primaryLink?.url?.includes(`${organizationPage.slug}/services`),
       items: childrenLinks.map(({ text, url }) => ({
         title: text,
         href: url,

--- a/apps/web/screens/Organization/StafraentIsland/ApiCatalogue.tsx
+++ b/apps/web/screens/Organization/StafraentIsland/ApiCatalogue.tsx
@@ -208,10 +208,10 @@ const ApiCatalogue: Screen<HomestayProps> = ({
 
   const navList: NavigationItem[] = organizationPage.menuLinks.map(
     ({ primaryLink, childrenLinks }) => ({
-      title: primaryLink.text,
-      href: primaryLink.url,
+      title: primaryLink?.text,
+      href: primaryLink?.url,
       active:
-        primaryLink.url === Router.asPath ||
+        primaryLink?.url === Router.asPath ||
         childrenLinks.some((link) => link.url === Router.asPath),
       items: childrenLinks.map(({ text, url }) => ({
         title: text,

--- a/apps/web/screens/Organization/StafraentIsland/ApiDetails.tsx
+++ b/apps/web/screens/Organization/StafraentIsland/ApiDetails.tsx
@@ -87,10 +87,10 @@ const ServiceDetails: Screen<ServiceDetailsProps> = ({
 
   const navList: NavigationItem[] = organizationPage.menuLinks.map(
     ({ primaryLink, childrenLinks }) => ({
-      title: primaryLink.text,
-      href: primaryLink.url,
+      title: primaryLink?.text,
+      href: primaryLink?.url,
       active:
-        primaryLink.url === cataloguePath ||
+        primaryLink?.url === cataloguePath ||
         childrenLinks.some((link) => link.url === cataloguePath),
       items: childrenLinks.map(({ text, url }) => ({
         title: text,

--- a/apps/web/screens/Organization/SubPage.tsx
+++ b/apps/web/screens/Organization/SubPage.tsx
@@ -98,10 +98,10 @@ const SubPage: Screen<SubPageProps> = ({
 
   const navList: NavigationItem[] = organizationPage.menuLinks.map(
     ({ primaryLink, childrenLinks }) => ({
-      title: primaryLink.text,
-      href: primaryLink.url,
+      title: primaryLink?.text,
+      href: primaryLink?.url,
       active:
-        primaryLink.url === pathWithoutHash ||
+        primaryLink?.url === pathWithoutHash ||
         childrenLinks.some((link) => link.url === pathWithoutHash),
       items: childrenLinks.map(({ text, url }) => ({
         title: text,

--- a/apps/web/screens/Organization/Syslumenn/Auctions.tsx
+++ b/apps/web/screens/Organization/Syslumenn/Auctions.tsx
@@ -409,10 +409,10 @@ const Auctions: Screen<AuctionsProps> = ({
 
   const navList: NavigationItem[] = organizationPage.menuLinks.map(
     ({ primaryLink, childrenLinks }) => ({
-      title: primaryLink.text,
-      href: primaryLink.url,
+      title: primaryLink?.text,
+      href: primaryLink?.url,
       active:
-        primaryLink.url === pageUrl ||
+        primaryLink?.url === pageUrl ||
         childrenLinks.some((link) => link.url === pageUrl),
       items: childrenLinks.map(({ text, url }) => ({
         title: text,

--- a/apps/web/screens/Organization/Syslumenn/Homestay.tsx
+++ b/apps/web/screens/Organization/Syslumenn/Homestay.tsx
@@ -59,10 +59,10 @@ const Homestay: Screen<HomestayProps> = ({
 
   const navList: NavigationItem[] = organizationPage.menuLinks.map(
     ({ primaryLink, childrenLinks }) => ({
-      title: primaryLink.text,
-      href: primaryLink.url,
+      title: primaryLink?.text,
+      href: primaryLink?.url,
       active:
-        primaryLink.url === pageUrl ||
+        primaryLink?.url === pageUrl ||
         childrenLinks.some((link) => link.url === pageUrl),
       items: childrenLinks.map(({ text, url }) => ({
         title: text,

--- a/apps/web/screens/Organization/Syslumenn/OperatingLicenses.tsx
+++ b/apps/web/screens/Organization/Syslumenn/OperatingLicenses.tsx
@@ -246,9 +246,9 @@ const OperatingLicenses: Screen<OperatingLicensesProps> = ({
 
   const navList: NavigationItem[] = organizationPage.menuLinks.map(
     ({ primaryLink, childrenLinks }) => ({
-      title: primaryLink.text,
-      href: primaryLink.url,
-      active: pageUrl === primaryLink.url,
+      title: primaryLink?.text,
+      href: primaryLink?.url,
+      active: pageUrl === primaryLink?.url,
       items: childrenLinks.map(({ text, url }) => ({
         title: text,
         href: url,

--- a/apps/web/screens/Project/ProjectNewsArticle.tsx
+++ b/apps/web/screens/Project/ProjectNewsArticle.tsx
@@ -55,11 +55,11 @@ const ProjectNewsArticle: Screen<ProjectNewsArticleleProps> = ({
   )
 
   const currentNavItem = projectPage.sidebarLinks.find(
-    ({ primaryLink }) => primaryLink.url === overviewPath,
+    ({ primaryLink }) => primaryLink?.url === overviewPath,
   )
 
   const newsOverviewTitle: string = currentNavItem
-    ? currentNavItem.primaryLink.text
+    ? currentNavItem.primaryLink?.text
     : n('newsTitle', 'Fréttir og tilkynningar')
 
   const breadCrumbs: BreadCrumbItem[] = [

--- a/apps/web/screens/Project/ProjectNewsList.tsx
+++ b/apps/web/screens/Project/ProjectNewsList.tsx
@@ -87,7 +87,7 @@ const ProjectNewsList: Screen<ProjectNewsListProps> = ({
   const baseRouterPath = router.asPath.split('?')[0].split('#')[0]
 
   const currentNavItem = projectPage.sidebarLinks.find(
-    ({ primaryLink }) => primaryLink.url === baseRouterPath,
+    ({ primaryLink }) => primaryLink?.url === baseRouterPath,
   )?.primaryLink
 
   const newsTitle =

--- a/apps/web/screens/Project/utils.tsx
+++ b/apps/web/screens/Project/utils.tsx
@@ -60,8 +60,8 @@ export const convertLinkGroupsToNavigationItems = (
 ): NavigationItem[] =>
   linkGroups.map(({ primaryLink, childrenLinks }) => {
     return {
-      title: primaryLink.text,
-      href: primaryLink.url,
+      title: primaryLink?.text,
+      href: primaryLink?.url,
       active: false,
       items: convertLinksToNavigationItem(childrenLinks),
     }


### PR DESCRIPTION
# Add fail safe to link group's primarylink field since it's been causing 500 errors

## What

* We noticed that if a user doesn't provide a primary link to a link group the web displays a 500 error, this change addresses that issue

## Why

* A contentful user should not be able to cause 500 errors on the web,

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
