### PR TITLE
feat(web): Organization footer UI improvements

### DIFF
--- a/apps/web/components/Organization/OrganizationIslandFooter/OrganizationIslandFooter.css.ts
+++ b/apps/web/components/Organization/OrganizationIslandFooter/OrganizationIslandFooter.css.ts
@@ -30,18 +30,25 @@ export const languageToggleContainer = style({
 export const leftContent = style({
   display: 'flex',
   flexFlow: 'row nowrap',
-  alignItems: 'center',
   gap: '20px',
+  ...themeUtils.responsiveStyle({
+    xs: {
+      alignItems: 'flex-start',
+    },
+    sm: {
+      alignItems: 'center',
+    },
+  }),
 })
 
 export const rightContent = style({
   display: 'flex',
-  flexFlow: 'row nowrap',
+  flexFlow: 'row wrap',
   alignItems: 'center',
   gap: '20px',
   ...themeUtils.responsiveStyle({
     xs: {
-      paddingTop: '12px',
+      paddingTop: '20px',
       alignSelf: 'flex-end',
     },
     lg: {

--- a/apps/web/components/Organization/OrganizationIslandFooter/OrganizationIslandFooter.tsx
+++ b/apps/web/components/Organization/OrganizationIslandFooter/OrganizationIslandFooter.tsx
@@ -7,6 +7,7 @@ import {
   Box,
   Text,
   Link,
+  Hidden,
 } from '@island.is/island-ui/core'
 import { useNamespaceStrict } from '@island.is/web/hooks'
 import { useI18n } from '@island.is/web/i18n'
@@ -34,7 +35,9 @@ export const OrganizationIslandFooter = () => {
       <Box background="blue100" width="full" padding={5}>
         <GridContainer className={styles.contentContainer}>
           <Box className={styles.leftContent}>
-            <Logo iconOnly={true} />
+            <Hidden below="sm">
+              <Logo iconOnly={true} />
+            </Hidden>
             <Text color="blue600">
               <Link href={n('digitalIcelandLink', '/s/stafraent-island')}>
                 {n('digitalIceland', 'Stafrænt Ísland')}

--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -136,7 +136,7 @@ export const getThemeConfig = (
 ): { themeConfig: Partial<LayoutProps> } => {
   let footerVersion: LayoutProps['footerVersion'] = 'default'
 
-  if (footerEnabled.includes(slug)) {
+  if (footerEnabled.includes(slug) || theme === 'landing_page') {
     footerVersion = 'organization'
   }
 

--- a/apps/web/screens/Organization/Home/LandingPage/LandingPage.tsx
+++ b/apps/web/screens/Organization/Home/LandingPage/LandingPage.tsx
@@ -30,6 +30,8 @@ import useContentfulId from '@island.is/web/hooks/useContentfulId'
 import useLocalLinkTypeResolver from '@island.is/web/hooks/useLocalLinkTypeResolver'
 import { LandingPageFooter } from './index'
 
+const ARTICLES_PAGE_SIZE = 10
+
 const parseOrganizationLinkHref = (organization: Query['getOrganization']) => {
   let link = organization.link
   if (link.includes('://')) {
@@ -74,7 +76,7 @@ const LandingPage = ({ organization, namespace }: LandingPageProps) => {
           lang: activeLocale,
           organization: organization.slug,
           sort: SortField.Popular,
-          size: 10,
+          size: ARTICLES_PAGE_SIZE,
         },
       },
     },
@@ -165,18 +167,28 @@ const LandingPage = ({ organization, namespace }: LandingPageProps) => {
                     resolvedArticles: articleResponse.data
                       .getArticles as Article[],
                     sortBy: SortField.Popular,
-                    title: n('', 'Efni stofnunar sem komið er á Ísland.is'),
+                    title: n(
+                      'agencyServicesTitle',
+                      'Efni stofnunar sem komið er á Ísland.is',
+                    ),
                     automaticallyFetchArticles: true,
                     hasBorderAbove: true,
                     image: null,
-                    link: {
-                      date: new Date().toISOString(),
-                      id: `featured-articles-${organization.slug}-link`,
-                      text: n('landingPageSeeMoreArticles', 'Sjá allt efni'),
-                      url: `${linkResolver('search').href}?q=*&organization=${
-                        organization.slug
-                      }`,
-                    },
+                    link:
+                      articleResponse.data.getArticles.length >
+                      ARTICLES_PAGE_SIZE
+                        ? {
+                            date: new Date().toISOString(),
+                            id: `featured-articles-${organization.slug}-link`,
+                            text: n(
+                              'landingPageSeeMoreArticles',
+                              'Sjá allt efni',
+                            ),
+                            url: `${
+                              linkResolver('search').href
+                            }?q=*&organization=${organization.slug}`,
+                          }
+                        : null,
                   }}
                   namespace={namespace}
                 />


### PR DESCRIPTION
# Organization footer UI improvements

## What

* When on small screens the links went outside of the viewport, so this change wraps the links
* Show the smalller version of the Ísland.is footer when on an organization landing page
* There was a missing key in a translation namespace so I added a key

## Screenshots / Gifs

https://user-images.githubusercontent.com/43557895/205031067-d475fb60-2262-4c56-a428-d646221d64a6.mov

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
