### PR TITLE
fix(web): Hotfix - Electronic registration statistics UI not showing correct values via filter

### DIFF
--- a/apps/web/components/connected/electronicRegistrationStatistics/MonthlyStatistics/MonthlyStatistics.css.ts
+++ b/apps/web/components/connected/electronicRegistrationStatistics/MonthlyStatistics/MonthlyStatistics.css.ts
@@ -1,7 +1,13 @@
+import { themeUtils } from '@island.is/island-ui/theme'
 import { style } from '@vanilla-extract/css'
 
 export const barChartContainer = style({
   overflowX: 'scroll',
   overflowY: 'hidden',
   minHeight: 368,
+  ...themeUtils.responsiveStyle({
+    xl: {
+      overflowX: 'hidden',
+    },
+  }),
 })

--- a/apps/web/components/connected/electronicRegistrationStatistics/MonthlyStatistics/MonthlyStatistics.tsx
+++ b/apps/web/components/connected/electronicRegistrationStatistics/MonthlyStatistics/MonthlyStatistics.tsx
@@ -25,6 +25,8 @@ type QueryType = {
   getBrokenDownElectronicRegistrationStatistics: BrokenDownRegistrationStatisticResponse
 }
 
+const defaultSelection = { label: 'Allt', value: 'Allt' }
+
 interface MonthlyStatisticsProps {
   slice?: ConnectedComponent
 }
@@ -33,7 +35,7 @@ export const MonthlyStatistics = ({ slice }: MonthlyStatisticsProps) => {
   const [
     selectedRegistrationTypeOption,
     setSelectedRegistrationTypeOption,
-  ] = useState({ label: 'Allt', value: 'Allt' })
+  ] = useState(defaultSelection)
 
   const n = useNamespace(slice?.json ?? {})
 
@@ -80,7 +82,7 @@ export const MonthlyStatistics = ({ slice }: MonthlyStatisticsProps) => {
   const yearOptions = useMemo(() => {
     const options = []
 
-    for (let year = 2019; year <= currentYear; year += 1) {
+    for (let year = 2020; year <= currentYear; year += 1) {
       options.push({
         label: String(year),
         value: String(year),
@@ -92,6 +94,7 @@ export const MonthlyStatistics = ({ slice }: MonthlyStatisticsProps) => {
 
   const paper = n('paper', 'Pappír')
   const electronic = n('electronic', 'Rafrænt')
+  const manual = n('manual', 'Handvirk vinnsla')
 
   return (
     <Box>
@@ -144,17 +147,29 @@ export const MonthlyStatistics = ({ slice }: MonthlyStatisticsProps) => {
                 item.periodIntervalName,
               ) as string).slice(0, 3),
               [paper]:
-                item.registrationTypes?.find(
-                  (t) =>
-                    t.registrationType === selectedRegistrationTypeOption.value,
-                )?.totalPaperRegistrationsOfType ??
-                item.totalPaperRegistrationsForCurrentPeriodInterval,
+                selectedRegistrationTypeOption.value === defaultSelection.value
+                  ? item.totalPaperRegistrationsForCurrentPeriodInterval
+                  : item.registrationTypes?.find(
+                      (t) =>
+                        t.registrationType ===
+                        selectedRegistrationTypeOption.value,
+                    )?.totalPaperRegistrationsOfType ?? 0,
               [electronic]:
-                item.registrationTypes?.find(
-                  (t) =>
-                    t.registrationType === selectedRegistrationTypeOption.value,
-                )?.totalElectronicRegistrationsOfType ??
-                item.totalElectronicRegistrationsForCurrentPeriodInterval,
+                selectedRegistrationTypeOption.value === defaultSelection.value
+                  ? item.totalElectronicRegistrationsForCurrentPeriodInterval
+                  : item.registrationTypes?.find(
+                      (t) =>
+                        t.registrationType ===
+                        selectedRegistrationTypeOption.value,
+                    )?.totalElectronicRegistrationsOfType ?? 0,
+              [manual]:
+                selectedRegistrationTypeOption.value === defaultSelection.value
+                  ? item.totalManualRegistrationsForCurrentPeriodInterval
+                  : item.registrationTypes?.find(
+                      (t) =>
+                        t.registrationType ===
+                        selectedRegistrationTypeOption.value,
+                    )?.totalManualRegistrationsOfType ?? 0,
             }))}
           >
             <Bar
@@ -169,6 +184,12 @@ export const MonthlyStatistics = ({ slice }: MonthlyStatisticsProps) => {
               radius={[20, 20, 0, 0]}
               dataKey={electronic}
               fill="#ef8838"
+            />
+            <Bar
+              barSize={16}
+              radius={[20, 20, 0, 0]}
+              dataKey={manual}
+              fill="green"
             />
             <XAxis dataKey="name" height={60} />
             <YAxis />


### PR DESCRIPTION
# Electronic registration statistics UI not showing correct values via filter

This PR contains a cherry picked commit that got merged to main (https://github.com/island-is/island.is/pull/9234)
We want to hotfix this change to prod since the statistics UI on prod is displaying incorrect data
