### PR TITLE
feat(web): Electronic registration statistics - Keep registration type selection between years if possible

### DIFF
--- a/apps/web/components/connected/electronicRegistrationStatistics/MonthlyStatistics/MonthlyStatistics.tsx
+++ b/apps/web/components/connected/electronicRegistrationStatistics/MonthlyStatistics/MonthlyStatistics.tsx
@@ -46,10 +46,6 @@ export const MonthlyStatistics = ({ slice }: MonthlyStatisticsProps) => {
     value: String(currentYear),
   })
 
-  useEffect(() => {
-    setSelectedRegistrationTypeOption({ label: 'Allt', value: 'Allt' })
-  }, [selectedYear])
-
   const { data: serverData, loading } = useQuery<QueryType>(
     GET_BROKEN_DOWN_ELECTRONIC_REGISTRATION_STATISTICS_QUERY,
     {
@@ -71,13 +67,27 @@ export const MonthlyStatistics = ({ slice }: MonthlyStatisticsProps) => {
 
   useEffect(() => {
     if (!data) return
-    setRegistrationTypes(
-      extractRegistrationTypesFromData(data).map((type) => ({
-        label: type,
-        value: type,
-      })),
-    )
-  }, [data])
+
+    const types = extractRegistrationTypesFromData(data)
+    const typeOptions = types.map((type) => ({
+      label: type,
+      value: type,
+    }))
+
+    // Default back to viewing all registration types if the currently selected one isn't available for the selected year
+    if (!types.includes(selectedRegistrationTypeOption.value)) {
+      setSelectedRegistrationTypeOption(defaultSelection)
+    } else {
+      // Make sure to keep the reference intact since we're renewing the list
+      setSelectedRegistrationTypeOption(
+        typeOptions.find(
+          (type) => type.value === selectedRegistrationTypeOption.value,
+        ),
+      )
+    }
+
+    setRegistrationTypes(typeOptions)
+  }, [data, selectedRegistrationTypeOption.value])
 
   const yearOptions = useMemo(() => {
     const options = []


### PR DESCRIPTION
# Electronic registration statistics - Keep registration type selection between years if possible

## What

* The registration type dropdown would default to "Allt" if the user changed what year was selected
* This change keeps the same registration type selected if the type exists for the newly selected year

## Screenshots / Gifs

### Before

https://user-images.githubusercontent.com/43557895/205661328-c6dcce34-a128-4923-8cd5-f1c845a12daf.mov



### After (with test data)
https://user-images.githubusercontent.com/43557895/205661103-fa04e14a-c4bf-481e-a725-637b7a8414e9.mov


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
