### PR TITLE
feat(web): Hotfix - Add Webreader to more pages and tweak url hash for categories and life event pages (#9252)

### DIFF
--- a/apps/web/components/NewsList/NewsList.tsx
+++ b/apps/web/components/NewsList/NewsList.tsx
@@ -9,8 +9,13 @@ import {
   Box,
   Link,
 } from '@island.is/island-ui/core'
-import { LinkType, useLinkResolver, useNamespace } from '@island.is/web/hooks'
-import { NewsCard } from '@island.is/web/components'
+import {
+  LinkType,
+  useFeatureFlag,
+  useLinkResolver,
+  useNamespace,
+} from '@island.is/web/hooks'
+import { NewsCard, Webreader } from '@island.is/web/components'
 import { useRouter } from 'next/router'
 import { GetNewsQuery } from '@island.is/web/graphql/schema'
 import { makeHref } from './utils'
@@ -48,6 +53,10 @@ export const NewsList = ({
   newsPerPage = 10,
   monthOptions,
 }: NewsListProps) => {
+  const { value: isWebReaderEnabledForNews } = useFeatureFlag(
+    'isWebReaderEnabledForNews',
+    false,
+  )
   const router = useRouter()
   const n = useNamespace(namespace)
 
@@ -59,9 +68,21 @@ export const NewsList = ({
 
   return (
     <Stack space={[3, 3, 4]}>
-      <Text variant="h1" as="h1" marginBottom={2}>
+      <Text
+        variant="h1"
+        as="h1"
+        marginBottom={isWebReaderEnabledForNews ? 0 : 2}
+      >
         {title}
       </Text>
+      {isWebReaderEnabledForNews && (
+        <Webreader
+          marginTop={0}
+          marginBottom={0}
+          readId={null}
+          readClass="rs_read"
+        />
+      )}
       {selectedYear && (
         <Hidden below="lg">
           <Text variant="h2" as="h2">
@@ -113,20 +134,25 @@ export const NewsList = ({
           {n('newsListEmptyMonth', 'Engar fréttir fundust í þessum mánuði.')}
         </Text>
       )}
-      {newsList.map((newsItem, index) => (
-        <NewsCard
-          key={index}
-          title={newsItem.title}
-          introduction={newsItem.intro}
-          image={newsItem.image}
-          titleAs="h2"
-          href={
-            linkResolver(newsItemLinkType, [parentPageSlug, newsItem.slug]).href
-          }
-          date={newsItem.date}
-          readMoreText={n('readMore', 'Lesa nánar')}
-        />
-      ))}
+      <Box className="rs_read">
+        <Stack space={[3, 3, 4]}>
+          {newsList.map((newsItem, index) => (
+            <NewsCard
+              key={index}
+              title={newsItem.title}
+              introduction={newsItem.intro}
+              image={newsItem.image}
+              titleAs="h2"
+              href={
+                linkResolver(newsItemLinkType, [parentPageSlug, newsItem.slug])
+                  .href
+              }
+              date={newsItem.date}
+              readMoreText={n('readMore', 'Lesa nánar')}
+            />
+          ))}
+        </Stack>
+      </Box>
       {newsList.length > 0 && (
         <Box paddingTop={[4, 4, 8]}>
           <Pagination

--- a/apps/web/components/Organization/NewsArticle/NewsArticle.tsx
+++ b/apps/web/components/Organization/NewsArticle/NewsArticle.tsx
@@ -1,16 +1,21 @@
 import React from 'react'
 import { Box, Text } from '@island.is/island-ui/core'
 import { useDateUtils } from '@island.is/web/i18n/useDateUtils'
-
-import { GetSingleNewsItemQuery } from '../../../graphql/schema'
 import { Slice as SliceType, Image } from '@island.is/island-ui/contentful'
 import { webRichText } from '@island.is/web/utils/richText'
+import { useFeatureFlag } from '@island.is/web/hooks'
+import { Webreader } from '@island.is/web/components'
+import { GetSingleNewsItemQuery } from '../../../graphql/schema'
 
 interface NewsArticleProps {
   newsItem: GetSingleNewsItemQuery['getSingleNews']
 }
 
 export const NewsArticle: React.FC<NewsArticleProps> = ({ newsItem }) => {
+  const { value: isWebReaderEnabledForNews } = useFeatureFlag(
+    'isWebReaderEnabledForNews',
+    false,
+  )
   const { format } = useDateUtils()
 
   const formattedDate = newsItem.date
@@ -19,15 +24,24 @@ export const NewsArticle: React.FC<NewsArticleProps> = ({ newsItem }) => {
 
   return (
     <Box paddingBottom={[0, 0, 4]}>
-      <Text variant="h1" as="h1" paddingBottom={2}>
-        {newsItem.title}
-      </Text>
-      <Text variant="h4" as="p" paddingBottom={2} color="blue400">
-        {formattedDate}
-      </Text>
-      <Text variant="intro" as="p" paddingBottom={2}>
-        {newsItem.intro}
-      </Text>
+      <Box className="rs_read">
+        <Text variant="h1" as="h1" paddingBottom={2}>
+          {newsItem.title}
+        </Text>
+      </Box>
+      {isWebReaderEnabledForNews && (
+        <Webreader marginTop={0} readId={null} readClass="rs_read" />
+      )}
+      <Box className="rs_read">
+        <Text variant="h4" as="p" paddingBottom={2} color="blue400">
+          {formattedDate}
+        </Text>
+      </Box>
+      <Box className="rs_read">
+        <Text variant="intro" as="p" paddingBottom={2}>
+          {newsItem.intro}
+        </Text>
+      </Box>
       {Boolean(newsItem.image) && (
         <Box paddingY={2}>
           <Image
@@ -37,7 +51,7 @@ export const NewsArticle: React.FC<NewsArticleProps> = ({ newsItem }) => {
           />
         </Box>
       )}
-      <Box paddingBottom={4} width="full">
+      <Box className="rs_read" paddingBottom={4} width="full">
         {webRichText(newsItem.content as SliceType[])}
       </Box>
     </Box>

--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -30,9 +30,10 @@ import {
   LiveChatIncChatPanel,
   Sticky,
   SidebarShipSearchInput,
+  Webreader,
 } from '@island.is/web/components'
 import SidebarLayout from '@island.is/web/screens/Layouts/SidebarLayout'
-import { useNamespace } from '@island.is/web/hooks'
+import { useFeatureFlag, useNamespace } from '@island.is/web/hooks'
 import { useI18n } from '@island.is/web/i18n'
 import { WatsonChatPanel } from '@island.is/web/components'
 
@@ -87,6 +88,7 @@ interface WrapperProps {
   minimal?: boolean
   showSecondaryMenu?: boolean
   showExternalLinks?: boolean
+  showReadSpeaker?: boolean
 }
 
 interface HeaderProps {
@@ -203,7 +205,7 @@ interface ExternalLinksProps {
 export const OrganizationExternalLinks: React.FC<ExternalLinksProps> = ({
   organizationPage,
 }) => {
-  if (organizationPage.externalLinks) {
+  if (organizationPage.externalLinks?.length) {
     return (
       <Box
         display={['none', 'none', 'flex', 'flex']}
@@ -471,10 +473,16 @@ export const OrganizationWrapper: React.FC<WrapperProps> = ({
   minimal = false,
   showSecondaryMenu = true,
   showExternalLinks = false,
+  showReadSpeaker = true,
 }) => {
   const router = useRouter()
   const { width } = useWindowSize()
   const [isMobile, setIsMobile] = useState<boolean | undefined>()
+
+  const { value: isWebReaderEnabledForOrganizationPages } = useFeatureFlag(
+    'isWebReaderEnabledForOrganizationPages',
+    false,
+  )
 
   useEffect(() => setIsMobile(width < theme.breakpoints.md), [width])
 
@@ -613,45 +621,60 @@ export const OrganizationWrapper: React.FC<WrapperProps> = ({
               )}
             </Box>
           )}
-          {(!!breadcrumbItems || !!pageDescription) && (
-            <GridContainer>
-              <GridRow>
-                <GridColumn
-                  span={fullWidthContent ? ['9/9', '9/9', '7/9'] : '9/9'}
-                  offset={fullWidthContent ? ['0', '0', '1/9'] : '0'}
-                >
-                  {showExternalLinks && (
-                    <OrganizationExternalLinks
-                      organizationPage={organizationPage}
-                    />
-                  )}
-                  {breadcrumbItems && (
-                    <Breadcrumbs
-                      items={breadcrumbItems ?? []}
-                      renderLink={(link, item) => {
-                        return item?.href ? (
-                          <NextLink href={item?.href}>{link}</NextLink>
-                        ) : (
-                          link
-                        )
-                      }}
-                    />
-                  )}
-                  {pageDescription && (
-                    <Box paddingTop={[2, 2, breadcrumbItems ? 5 : 0]}>
-                      <Text variant="default">{pageDescription}</Text>
-                    </Box>
-                  )}
-                </GridColumn>
-              </GridRow>
-            </GridContainer>
-          )}
+
+          <GridContainer>
+            <GridRow>
+              <GridColumn
+                span={fullWidthContent ? ['9/9', '9/9', '7/9'] : '9/9'}
+                offset={fullWidthContent ? ['0', '0', '1/9'] : '0'}
+              >
+                {showExternalLinks && (
+                  <OrganizationExternalLinks
+                    organizationPage={organizationPage}
+                  />
+                )}
+                {breadcrumbItems && (
+                  <Breadcrumbs
+                    items={breadcrumbItems ?? []}
+                    renderLink={(link, item) => {
+                      return item?.href ? (
+                        <NextLink href={item?.href}>{link}</NextLink>
+                      ) : (
+                        link
+                      )
+                    }}
+                  />
+                )}
+
+                {showReadSpeaker && isWebReaderEnabledForOrganizationPages && (
+                  <Webreader
+                    marginTop={breadcrumbItems?.length ? 3 : 0}
+                    marginBottom={breadcrumbItems?.length ? 0 : 3}
+                    readId={null}
+                    readClass="rs_read"
+                  />
+                )}
+
+                {pageDescription && (
+                  <Box
+                    className="rs_read"
+                    paddingTop={[2, 2, breadcrumbItems ? 5 : 0]}
+                  >
+                    <Text variant="default">{pageDescription}</Text>
+                  </Box>
+                )}
+              </GridColumn>
+            </GridRow>
+          </GridContainer>
+
           {isMobile && sidebarContent}
-          <Box paddingTop={fullWidthContent ? 0 : 4}>
+
+          <Box className="rs_read" paddingTop={fullWidthContent ? 0 : 4}>
             {mainContent ?? children}
           </Box>
         </SidebarLayout>
       )}
+
       {minimal && (
         <GridContainer>
           <GridRow>
@@ -659,18 +682,21 @@ export const OrganizationWrapper: React.FC<WrapperProps> = ({
               paddingTop={6}
               span={['12/12', '12/12', '10/12']}
               offset={['0', '0', '1/12']}
+              className="rs_read"
             >
               {mainContent}
             </GridColumn>
           </GridRow>
         </GridContainer>
       )}
-      {!!mainContent && children}
+      {!!mainContent && <Box className="rs_read">{children}</Box>}
       {!minimal && (
-        <OrganizationFooter
-          organizations={[organizationPage.organization]}
-          force={true}
-        />
+        <Box className="rs_read">
+          <OrganizationFooter
+            organizations={[organizationPage.organization]}
+            force={true}
+          />
+        </Box>
       )}
       <OrganizationChatPanel
         organizationIds={[organizationPage?.organization?.id]}

--- a/apps/web/screens/Category/Category/Category.tsx
+++ b/apps/web/screens/Category/Category/Category.tsx
@@ -241,10 +241,8 @@ const Category: Screen<CategoryProps> = ({
   const handleAccordionClick = (groupSlug: string) => {
     const updatedArr = updateHashArray(hashArray, groupSlug)
     setHashArray(updatedArr)
-    Router.replace({
-      pathname: linkResolver(category.__typename as LinkType, [slug]).href,
-      hash: getHashString(updatedArr),
-    })
+    // eslint-disable-next-line no-restricted-globals
+    history?.replaceState({}, '', `#${getHashString(updatedArr)}`)
   }
 
   const sortArticles = (articles: Articles) => {

--- a/apps/web/screens/LifeEvent/LifeEvent.tsx
+++ b/apps/web/screens/LifeEvent/LifeEvent.tsx
@@ -31,13 +31,14 @@ import {
   QueryGetNamespaceArgs,
 } from '@island.is/web/graphql/schema'
 import { createNavigation } from '@island.is/web/utils/navigation'
-import { useNamespace } from '@island.is/web/hooks'
+import { useFeatureFlag, useNamespace } from '@island.is/web/hooks'
 import useContentfulId from '@island.is/web/hooks/useContentfulId'
 import { useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
 import { useRouter } from 'next/router'
 import { Locale } from 'locale'
 import { useLocalLinkTypeResolver } from '@island.is/web/hooks/useLocalLinkTypeResolver'
 import { webRichText } from '@island.is/web/utils/richText'
+import { Webreader } from '@island.is/web/components'
 
 interface LifeEventProps {
   lifeEvent: GetLifeEventQuery['getLifeEventPage']
@@ -50,6 +51,11 @@ export const LifeEvent: Screen<LifeEventProps> = ({
   namespace,
   locale,
 }) => {
+  const { value: isWebReaderEnabledForLifeEventPages } = useFeatureFlag(
+    'isWebReaderEnabledForLifeEventPages',
+    false,
+  )
+
   useContentfulId(id)
   useLocalLinkTypeResolver()
 
@@ -143,11 +149,18 @@ export const LifeEvent: Screen<LifeEventProps> = ({
                   />
                 </Box>
                 <Text variant="h1" as="h1">
-                  <span id={slugify(title)}>{title}</span>
+                  <span className="rs_read" id={slugify(title)}>
+                    {title}
+                  </span>
                 </Text>
+                {isWebReaderEnabledForLifeEventPages && (
+                  <Webreader readId={null} readClass="rs_read" />
+                )}
                 {intro && (
                   <Text variant="intro" as="p" paddingTop={2}>
-                    <span id={slugify(intro)}>{intro}</span>
+                    <span className="rs_read" id={slugify(intro)}>
+                      {intro}
+                    </span>
                   </Text>
                 )}
                 <Box
@@ -162,7 +175,7 @@ export const LifeEvent: Screen<LifeEventProps> = ({
                     position="right"
                   />
                 </Box>
-                <Box paddingTop={[3, 3, 4]}>
+                <Box className="rs_read" paddingTop={[3, 3, 4]}>
                   {webRichText(content as SliceType[])}
                 </Box>
               </GridColumn>

--- a/apps/web/screens/News.tsx
+++ b/apps/web/screens/News.tsx
@@ -44,9 +44,9 @@ import {
 import {
   NewsCard,
   HeadWithSocialSharing,
-  TableSlice,
+  Webreader,
 } from '@island.is/web/components'
-import { useNamespace } from '@island.is/web/hooks'
+import { useFeatureFlag, useNamespace } from '@island.is/web/hooks'
 import { LinkType, useLinkResolver } from '../hooks/useLinkResolver'
 import { FRONTPAGE_NEWS_TAG_ID } from '@island.is/web/constants'
 import { CustomNextError } from '../units/errors'
@@ -81,6 +81,10 @@ const NewsListNew: Screen<NewsListProps> = ({
   selectedTagSlug,
   namespace,
 }) => {
+  const { value: isWebReaderEnabledForNews } = useFeatureFlag(
+    'isWebReaderEnabledForNews',
+    false,
+  )
   const Router = useRouter()
   const { linkResolver } = useLinkResolver()
   const { format, getMonthByIndex } = useDateUtils()
@@ -216,6 +220,9 @@ const NewsListNew: Screen<NewsListProps> = ({
       <Text variant="h1" as="h1" paddingTop={[3, 3, 3, 5]} paddingBottom={2}>
         {newsItem.title}
       </Text>
+      {isWebReaderEnabledForNews && (
+        <Webreader marginTop={0} readId={null} readClass="rs_read" />
+      )}
       <Text variant="intro" as="p" paddingBottom={2}>
         {newsItem.intro}
       </Text>
@@ -329,9 +336,16 @@ const NewsListNew: Screen<NewsListProps> = ({
             {n('newsListEmptyMonth', 'Engar fréttir fundust í þessum mánuði.')}
           </Text>
         )}
-        {newsItemContent && <Box width="full">{newsItemContent}</Box>}
+        {!newsItemContent && isWebReaderEnabledForNews && (
+          <Webreader readId={null} readClass="rs_read" />
+        )}
+        {newsItemContent && (
+          <Box className="rs_read" width="full">
+            {newsItemContent}
+          </Box>
+        )}
         {!!newsList.length && (
-          <Box marginTop={spacing}>
+          <Box className="rs_read" marginTop={spacing}>
             {newsList.map(({ title, intro, image, slug, date }, index) => {
               const mini = index > 2
 

--- a/apps/web/screens/Organization/OrganizationNewsArticle.tsx
+++ b/apps/web/screens/Organization/OrganizationNewsArticle.tsx
@@ -134,6 +134,7 @@ const OrganizationNewsArticle: Screen<OrganizationNewsArticleProps> = ({
         pageTitle={organizationPage.title}
         organizationPage={organizationPage}
         breadcrumbItems={breadCrumbs}
+        showReadSpeaker={false}
         navigationData={{
           title: n('navigationTitle', 'Efnisyfirlit'),
           items: navList,

--- a/apps/web/screens/Organization/OrganizationNewsList.tsx
+++ b/apps/web/screens/Organization/OrganizationNewsList.tsx
@@ -148,6 +148,7 @@ const OrganizationNewsList: Screen<OrganizationNewsListProps> = ({
     <OrganizationWrapper
       pageTitle={newsTitle}
       organizationPage={organizationPage}
+      showReadSpeaker={false}
       breadcrumbItems={breadCrumbs}
       navigationData={{
         title: n('navigationTitle', 'Efnisyfirlit'),

--- a/apps/web/screens/Organization/PublishedMaterial/PublishedMaterial.tsx
+++ b/apps/web/screens/Organization/PublishedMaterial/PublishedMaterial.tsx
@@ -8,7 +8,6 @@ import {
   GridColumn,
   GridContainer,
   GridRow,
-  Icon,
   Inline,
   LoadingDots,
   NavigationItem,
@@ -17,7 +16,11 @@ import {
   Text,
 } from '@island.is/island-ui/core'
 import { theme } from '@island.is/island-ui/theme'
-import { getThemeConfig, OrganizationWrapper } from '@island.is/web/components'
+import {
+  getThemeConfig,
+  OrganizationWrapper,
+  Webreader,
+} from '@island.is/web/components'
 import {
   ContentLanguage,
   GenericTag,
@@ -27,7 +30,11 @@ import {
   QueryGetOrganizationPageArgs,
   QueryGetPublishedMaterialArgs,
 } from '@island.is/web/graphql/schema'
-import { linkResolver, useNamespace } from '@island.is/web/hooks'
+import {
+  linkResolver,
+  useFeatureFlag,
+  useNamespace,
+} from '@island.is/web/hooks'
 import useContentfulId from '@island.is/web/hooks/useContentfulId'
 import useLocalLinkTypeResolver from '@island.is/web/hooks/useLocalLinkTypeResolver'
 import { useWindowSize } from '@island.is/web/hooks/useViewport'
@@ -69,6 +76,10 @@ const PublishedMaterial: Screen<PublishedMaterialProps> = ({
   genericTagFilters,
   namespace,
 }) => {
+  const { value: isWebReaderEnabledForOrganizationPages } = useFeatureFlag(
+    'isWebReaderEnabledForOrganizationPages',
+    false,
+  )
   const router = useRouter()
   const { width } = useWindowSize()
   const [searchValue, setSearchValue] = useState('')
@@ -249,6 +260,7 @@ const PublishedMaterial: Screen<PublishedMaterialProps> = ({
     <OrganizationWrapper
       pageTitle={pageTitle}
       organizationPage={organizationPage}
+      showReadSpeaker={false}
       breadcrumbItems={[
         {
           title: 'Ísland.is',
@@ -268,9 +280,17 @@ const PublishedMaterial: Screen<PublishedMaterialProps> = ({
         <GridColumn span="12/12">
           <GridRow>
             <GridColumn span={['12/12', '12/12', '6/12', '6/12', '8/12']}>
-              <Text variant="h1" as="h1" marginBottom={4} marginTop={1}>
+              <Text
+                variant="h1"
+                as="h1"
+                marginBottom={isWebReaderEnabledForOrganizationPages ? 0 : 4}
+                marginTop={1}
+              >
                 {pageTitle}
               </Text>
+              {isWebReaderEnabledForOrganizationPages && (
+                <Webreader readId={null} readClass="rs_read" />
+              )}
             </GridColumn>
           </GridRow>
           <GridRow>

--- a/apps/web/screens/Organization/Services.tsx
+++ b/apps/web/screens/Organization/Services.tsx
@@ -31,9 +31,13 @@ import {
   GET_ORGANIZATION_SERVICES_QUERY,
 } from '../queries'
 import { Screen } from '../../types'
-import { useNamespace } from '@island.is/web/hooks'
+import { useFeatureFlag, useNamespace } from '@island.is/web/hooks'
 import { LinkType, useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
-import { getThemeConfig, OrganizationWrapper } from '@island.is/web/components'
+import {
+  getThemeConfig,
+  OrganizationWrapper,
+  Webreader,
+} from '@island.is/web/components'
 import { CustomNextError } from '@island.is/web/units/errors'
 import { useWindowSize } from 'react-use'
 import { theme } from '@island.is/island-ui/theme'
@@ -62,6 +66,10 @@ const ServicesPage: Screen<ServicesPageProps> = ({
   sort,
   namespace,
 }) => {
+  const { value: isWebReaderEnabledForOrganizationPages } = useFeatureFlag(
+    'isWebReaderEnabledForOrganizationPages',
+    false,
+  )
   const n = useNamespace(namespace)
   const { linkResolver } = useLinkResolver()
 
@@ -130,6 +138,7 @@ const ServicesPage: Screen<ServicesPageProps> = ({
       pageFeaturedImage={organizationPage.featuredImage}
       fullWidthContent={false}
       stickySidebar={false}
+      showReadSpeaker={false}
       breadcrumbItems={[
         {
           title: 'Ísland.is',
@@ -148,9 +157,17 @@ const ServicesPage: Screen<ServicesPageProps> = ({
       <GridContainer>
         <GridRow>
           <GridColumn span={['12/12', '12/12', '6/12', '6/12', '8/12']}>
-            <Text variant="h1" as="h1" marginBottom={4} marginTop={1}>
+            <Text
+              variant="h1"
+              as="h1"
+              marginBottom={isWebReaderEnabledForOrganizationPages ? 0 : 4}
+              marginTop={1}
+            >
               {n('allServices', 'Öll þjónusta')}
             </Text>
+            {isWebReaderEnabledForOrganizationPages && (
+              <Webreader marginBottom={4} readId={null} readClass="rs_read" />
+            )}
           </GridColumn>
         </GridRow>
         <GridRow marginBottom={4}>

--- a/apps/web/screens/Organization/StafraentIsland/ApiCatalogue.tsx
+++ b/apps/web/screens/Organization/StafraentIsland/ApiCatalogue.tsx
@@ -31,10 +31,11 @@ import {
   ApiCatalogueFilter,
   OrganizationWrapper,
   ServiceList,
+  Webreader,
 } from '@island.is/web/components'
 import { CustomNextError } from '@island.is/web/units/errors'
 import { SliceType } from '@island.is/island-ui/contentful'
-import { useNamespace } from '@island.is/web/hooks'
+import { useFeatureFlag, useNamespace } from '@island.is/web/hooks'
 import {
   GetApiCatalogueInput,
   QueryGetApiCatalogueArgs,
@@ -70,6 +71,10 @@ const ApiCatalogue: Screen<HomestayProps> = ({
   filterContent,
   navigationLinks,
 }) => {
+  const { value: isWebReaderEnabledForOrganizationPages } = useFeatureFlag(
+    'isWebReaderEnabledForOrganizationPages',
+    false,
+  )
   const { width } = useWindowSize()
   const [isMobile, setIsMobile] = useState(false)
   const Router = useRouter()
@@ -227,6 +232,7 @@ const ApiCatalogue: Screen<HomestayProps> = ({
         pageTitle={subpage.title}
         organizationPage={organizationPage}
         pageFeaturedImage={subpage.featuredImage}
+        showReadSpeaker={false}
         breadcrumbItems={[
           {
             title: 'Ísland.is',
@@ -244,10 +250,13 @@ const ApiCatalogue: Screen<HomestayProps> = ({
         }}
         showSecondaryMenu={false}
       >
-        <Box paddingBottom={4}>
+        <Box paddingBottom={isWebReaderEnabledForOrganizationPages ? 0 : 4}>
           <Text variant="h1" as="h2">
             {subpage.title}
           </Text>
+          {isWebReaderEnabledForOrganizationPages && (
+            <Webreader readId={null} readClass="rs_read" />
+          )}
         </Box>
         {webRichText(subpage.description as SliceType[], {
           renderNode: {

--- a/apps/web/screens/Organization/StafraentIsland/ApiDetails.tsx
+++ b/apps/web/screens/Organization/StafraentIsland/ApiDetails.tsx
@@ -105,6 +105,7 @@ const ServiceDetails: Screen<ServiceDetailsProps> = ({
       <OrganizationWrapper
         pageTitle={service.title ?? ''}
         organizationPage={organizationPage}
+        showReadSpeaker={false}
         breadcrumbItems={[
           {
             title: 'Ísland.is',

--- a/apps/web/screens/Organization/SubPage.tsx
+++ b/apps/web/screens/Organization/SubPage.tsx
@@ -26,7 +26,7 @@ import {
   GET_ORGANIZATION_SUBPAGE_QUERY,
 } from '../queries'
 import { Screen } from '../../types'
-import { useNamespace } from '@island.is/web/hooks'
+import { useFeatureFlag, useNamespace } from '@island.is/web/hooks'
 import { LinkType, useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
 import {
   getThemeConfig,
@@ -34,6 +34,7 @@ import {
   OrganizationWrapper,
   SliceDropdown,
   Form,
+  Webreader,
 } from '@island.is/web/components'
 import { CustomNextError } from '@island.is/web/units/errors'
 import useContentfulId from '@island.is/web/hooks/useContentfulId'
@@ -86,6 +87,10 @@ const SubPage: Screen<SubPageProps> = ({
   namespace,
   locale,
 }) => {
+  const { value: isWebReaderEnabledForOrganizationPages } = useFeatureFlag(
+    'isWebReaderEnabledForOrganizationPages',
+    false,
+  )
   const router = useRouter()
   const { activeLocale } = useI18n()
 
@@ -114,6 +119,7 @@ const SubPage: Screen<SubPageProps> = ({
   return (
     <OrganizationWrapper
       showExternalLinks={true}
+      showReadSpeaker={false}
       pageTitle={subpage.title}
       organizationPage={organizationPage}
       fullWidthContent={true}
@@ -152,11 +158,18 @@ const SubPage: Screen<SubPageProps> = ({
                       subpage.links.length ? '7/12' : '12/12',
                     ]}
                   >
-                    <Box marginBottom={2}>
+                    <Box className="rs_read" marginBottom={2}>
                       <Text variant="h1" as="h1">
                         {subpage.title}
                       </Text>
                     </Box>
+                    {isWebReaderEnabledForOrganizationPages && (
+                      <Webreader
+                        marginTop={0}
+                        readId={null}
+                        readClass="rs_read"
+                      />
+                    )}
                   </GridColumn>
                 </GridRow>
                 {subpage.showTableOfContents && (
@@ -165,7 +178,7 @@ const SubPage: Screen<SubPageProps> = ({
                     title={n('navigationTitle', 'Efnisyfirlit')}
                   />
                 )}
-                <GridRow>
+                <GridRow className="rs_read">
                   <GridColumn
                     span={[
                       '12/12',

--- a/apps/web/screens/Organization/Syslumenn/Auctions.tsx
+++ b/apps/web/screens/Organization/Syslumenn/Auctions.tsx
@@ -33,9 +33,9 @@ import {
   GET_SYSLUMENN_AUCTIONS_QUERY,
 } from '../../queries'
 import { Screen } from '../../../types'
-import { useNamespace } from '@island.is/web/hooks'
+import { useFeatureFlag, useNamespace } from '@island.is/web/hooks'
 import { useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
-import { OrganizationWrapper } from '@island.is/web/components'
+import { OrganizationWrapper, Webreader } from '@island.is/web/components'
 import { useQuery } from '@apollo/client'
 import { useDateUtils } from '@island.is/web/i18n/useDateUtils'
 import { useRouter } from 'next/router'
@@ -397,6 +397,10 @@ const Auctions: Screen<AuctionsProps> = ({
   namespace,
   subpage,
 }) => {
+  const { value: isWebReaderEnabledForOrganizationPages } = useFeatureFlag(
+    'isWebReaderEnabledForOrganizationPages',
+    false,
+  )
   const n = useNamespace(namespace)
   const { linkResolver } = useLinkResolver()
   const { format } = useDateUtils()
@@ -638,6 +642,7 @@ const Auctions: Screen<AuctionsProps> = ({
     <OrganizationWrapper
       pageTitle={subpage?.title ?? n('auctions', 'Uppboð')}
       organizationPage={organizationPage}
+      showReadSpeaker={false}
       breadcrumbItems={[
         {
           title: 'Ísland.is',
@@ -657,6 +662,9 @@ const Auctions: Screen<AuctionsProps> = ({
         <Text variant="h1" as="h2">
           {subpage?.title ?? n('auctions', 'Uppboð')}
         </Text>
+        {isWebReaderEnabledForOrganizationPages && (
+          <Webreader readId={null} readClass="rs_read" />
+        )}
       </Box>
       <GridContainer>
         <GridRow>

--- a/apps/web/screens/Organization/Syslumenn/Homestay.tsx
+++ b/apps/web/screens/Organization/Syslumenn/Homestay.tsx
@@ -26,9 +26,9 @@ import {
   GET_ORGANIZATION_SUBPAGE_QUERY,
 } from '../../queries'
 import { Screen } from '../../../types'
-import { useNamespace } from '@island.is/web/hooks'
+import { useFeatureFlag, useNamespace } from '@island.is/web/hooks'
 import { useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
-import { OrganizationWrapper } from '@island.is/web/components'
+import { OrganizationWrapper, Webreader } from '@island.is/web/components'
 import { CustomNextError } from '@island.is/web/units/errors'
 import { SliceType } from '@island.is/island-ui/contentful'
 import useContentfulId from '@island.is/web/hooks/useContentfulId'
@@ -48,6 +48,10 @@ const Homestay: Screen<HomestayProps> = ({
   homestays,
   namespace,
 }) => {
+  const { value: isWebReaderEnabledForOrganizationPages } = useFeatureFlag(
+    'isWebReaderEnabledForOrganizationPages',
+    false,
+  )
   useContentfulId(organizationPage.id, subpage.id)
 
   const n = useNamespace(namespace)
@@ -94,6 +98,7 @@ const Homestay: Screen<HomestayProps> = ({
     <OrganizationWrapper
       pageTitle={subpage.title}
       organizationPage={organizationPage}
+      showReadSpeaker={false}
       pageFeaturedImage={subpage.featuredImage}
       breadcrumbItems={[
         {
@@ -110,10 +115,13 @@ const Homestay: Screen<HomestayProps> = ({
         items: navList,
       }}
     >
-      <Box paddingBottom={4}>
+      <Box paddingBottom={isWebReaderEnabledForOrganizationPages ? 0 : 4}>
         <Text variant="h1" as="h2">
           {subpage.title}
         </Text>
+        {isWebReaderEnabledForOrganizationPages && (
+          <Webreader readId={null} readClass="rs_read" />
+        )}
       </Box>
       {webRichText(subpage.description as SliceType[])}
       <Box

--- a/apps/web/screens/Organization/Syslumenn/OperatingLicenses.tsx
+++ b/apps/web/screens/Organization/Syslumenn/OperatingLicenses.tsx
@@ -28,11 +28,12 @@ import {
   GET_OPERATING_LICENSES_QUERY,
 } from '../../queries'
 import { Screen } from '../../../types'
-import { useNamespace } from '@island.is/web/hooks'
+import { useFeatureFlag, useNamespace } from '@island.is/web/hooks'
 import { useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
 import {
   OrganizationWrapper,
   OperatingLicensesCsvExport,
+  Webreader,
 } from '@island.is/web/components'
 import { CustomNextError } from '@island.is/web/units/errors'
 import { useRouter } from 'next/router'
@@ -234,6 +235,10 @@ const OperatingLicenses: Screen<OperatingLicensesProps> = ({
   subpage,
   namespace,
 }) => {
+  const { value: isWebReaderEnabledForOrganizationPages } = useFeatureFlag(
+    'isWebReaderEnabledForOrganizationPages',
+    false,
+  )
   const n = useNamespace(namespace)
   const { linkResolver } = useLinkResolver()
   const Router = useRouter()
@@ -325,6 +330,7 @@ const OperatingLicenses: Screen<OperatingLicensesProps> = ({
       pageTitle={subpage.title}
       organizationPage={organizationPage}
       pageFeaturedImage={subpage.featuredImage}
+      showReadSpeaker={false}
       breadcrumbItems={[
         {
           title: 'Ísland.is',
@@ -340,10 +346,13 @@ const OperatingLicenses: Screen<OperatingLicensesProps> = ({
         items: navList,
       }}
     >
-      <Box paddingBottom={2}>
+      <Box paddingBottom={isWebReaderEnabledForOrganizationPages ? 0 : 2}>
         <Text variant="h1" as="h2">
           {subpage.title}
         </Text>
+        {isWebReaderEnabledForOrganizationPages && (
+          <Webreader readId={null} readClass="rs_read" />
+        )}
       </Box>
       {webRichText(subpage.description as SliceType[])}
       <Box marginBottom={3}>

--- a/apps/web/screens/Project/Project.tsx
+++ b/apps/web/screens/Project/Project.tsx
@@ -9,7 +9,11 @@ import {
 } from '@island.is/web/graphql/schema'
 import { GET_NAMESPACE_QUERY } from '../queries'
 import { Screen } from '../../types'
-import { linkResolver, useNamespace } from '@island.is/web/hooks'
+import {
+  linkResolver,
+  useFeatureFlag,
+  useNamespace,
+} from '@island.is/web/hooks'
 import { CustomNextError } from '@island.is/web/units/errors'
 import useContentfulId from '@island.is/web/hooks/useContentfulId'
 import { GET_PROJECT_PAGE_QUERY } from '@island.is/web/screens/queries/Project'
@@ -20,6 +24,7 @@ import {
   stepperUtils,
   Form,
   TabSectionSlice,
+  Webreader,
 } from '@island.is/web/components'
 import {
   Box,
@@ -52,6 +57,10 @@ const ProjectPage: Screen<PageProps> = ({
   stepOptionsFromNamespace,
   locale,
 }) => {
+  const { value: isWebReaderEnabledForProjectPages } = useFeatureFlag(
+    'isWebReaderEnabledForProjectPages',
+    false,
+  )
   const n = useNamespace(namespace)
   const router = useRouter()
 
@@ -130,11 +139,17 @@ const ProjectPage: Screen<PageProps> = ({
         sidebarNavigationTitle={navigationTitle}
         withSidebar={projectPage.sidebar}
       >
+        {!subpage && isWebReaderEnabledForProjectPages && (
+          <Webreader marginTop={0} readId={null} readClass="rs_read" />
+        )}
         {!!subpage && (
           <Box marginBottom={1}>
             <Text as="h1" variant="h1">
               {subpage.title}
             </Text>
+            {isWebReaderEnabledForProjectPages && (
+              <Webreader readId={null} readClass="rs_read" />
+            )}
             {subpage.content &&
               webRichText(subpage.content as SliceType[], {
                 renderComponent: {


### PR DESCRIPTION
# Hotfix - Add Webreader to more pages and tweak url hash for categories and life event pages (#9252)

This PR contains a cherry picked commit that got merged to main (https://github.com/island-is/island.is/pull/9252)

* Add Webreader to more pages and tweak url hash for categories and life event pages

* Move readspeaker below title of organization pages

* Add webreader to news

* Use different feature flag for webreader news feature

* Add webreader to project pages

* Add comment


