### PR TITLE
feat(service-portal): improved logging for smart solutions

### DIFF
--- a/libs/clients/smartsolutions/src/lib/smartSolutions.types.ts
+++ b/libs/clients/smartsolutions/src/lib/smartSolutions.types.ts
@@ -52,7 +52,13 @@ export interface UpsertPkPassResponse {
   }
   message?: string
   status?: number
+  // If the payload is invalid, smart solutions returns a 200 ok with an errors field.
+  errors?: {
+    message: string
+    path: string
+  }[]
 }
+
 export interface PkPassVerifyError {
   /**
    * HTTP status code from the service.


### PR DESCRIPTION
## What

More robust logging for PkPass functionality

## Why

The service doesn't log errors in creation, only service errors.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
