### PR TITLE
fix(service-portal): Await formsubmit for getting pdf

### DIFF
--- a/libs/service-portal/finance/src/components/DocumentScreen/DocumentScreen.tsx
+++ b/libs/service-portal/finance/src/components/DocumentScreen/DocumentScreen.tsx
@@ -329,8 +329,8 @@ const DocumentScreen: FC<Props> = ({
                         <Button
                           variant="text"
                           size="medium"
-                          onClick={() =>
-                            formSubmit(
+                          onClick={async () =>
+                            await formSubmit(
                               `${data?.getDocumentsList?.downloadServiceURL}${listItem.id}`,
                             )
                           }

--- a/libs/service-portal/finance/src/components/FinanceScheduleTable/FinanceScheduleTableRow.tsx
+++ b/libs/service-portal/finance/src/components/FinanceScheduleTable/FinanceScheduleTableRow.tsx
@@ -105,8 +105,8 @@ const FinanceScheduleTableRow: FC<Props> = ({ paymentSchedule }) => {
                 variant="text"
                 icon="document"
                 iconType="outline"
-                onClick={() =>
-                  formSubmit(`${paymentSchedule.downloadServiceURL}`)
+                onClick={async () =>
+                  await formSubmit(`${paymentSchedule.downloadServiceURL}`)
                 }
               >
                 PDF

--- a/libs/service-portal/finance/src/components/FinanceScheduleTable/FinanceScheduleTableRowCompressed.tsx
+++ b/libs/service-portal/finance/src/components/FinanceScheduleTable/FinanceScheduleTableRowCompressed.tsx
@@ -77,8 +77,8 @@ const FinanceScheduleTableRow: FC<Props> = ({ paymentSchedule }) => {
                 variant="text"
                 icon="document"
                 iconType="outline"
-                onClick={() =>
-                  formSubmit(`${paymentSchedule.downloadServiceURL}`)
+                onClick={async () =>
+                  await formSubmit(`${paymentSchedule.downloadServiceURL}`)
                 }
               >
                 PDF

--- a/libs/service-portal/finance/src/components/FinanceStatusDetailTable/FinanceStatusDetailTable.tsx
+++ b/libs/service-portal/finance/src/components/FinanceStatusDetailTable/FinanceStatusDetailTable.tsx
@@ -98,8 +98,8 @@ const FinanceStatusDetailTable: FC<Props> = ({
                   >
                     <Button
                       variant="text"
-                      onClick={() =>
-                        formSubmit(`${downloadURL}${row.documentID}`)
+                      onClick={async () =>
+                        await formSubmit(`${downloadURL}${row.documentID}`)
                       }
                     >
                       {item.value}

--- a/libs/service-portal/finance/src/screens/FinanceStatus/FinanceStatus.tsx
+++ b/libs/service-portal/finance/src/screens/FinanceStatus/FinanceStatus.tsx
@@ -192,8 +192,8 @@ const FinanceStatus: ServicePortalModuleComponent = ({ userInfo }) => {
                       title: formatMessage(endOfYearMessage, {
                         year: previousYear,
                       }),
-                      onClick: () =>
-                        formSubmit(
+                      onClick: async () =>
+                        await formSubmit(
                           `${financeStatusData.downloadServiceURL}${previousYear}`,
                           true,
                         ),
@@ -202,8 +202,8 @@ const FinanceStatus: ServicePortalModuleComponent = ({ userInfo }) => {
                       title: formatMessage(endOfYearMessage, {
                         year: twoYearsAgo,
                       }),
-                      onClick: () =>
-                        formSubmit(
+                      onClick: async () =>
+                        await formSubmit(
                           `${financeStatusData.downloadServiceURL}${twoYearsAgo}`,
                           true,
                         ),

--- a/libs/service-portal/vehicles/src/screens/Overview/Overview.tsx
+++ b/libs/service-portal/vehicles/src/screens/Overview/Overview.tsx
@@ -185,7 +185,7 @@ export const VehiclesOverview: ServicePortalModuleComponent = ({
           {modalFlagEnabled && !loading && ownershipPdf && (
             <Box marginRight={2}>
               <DropdownExport
-                onGetPDF={() => formSubmit(`${ownershipPdf}`)}
+                onGetPDF={async () => await formSubmit(`${ownershipPdf}`)}
                 onGetExcel={() =>
                   exportVehicleOwnedDocument(
                     filteredVehicles,

--- a/libs/service-portal/vehicles/src/screens/VehicleDetail/VehicleDetail.tsx
+++ b/libs/service-portal/vehicles/src/screens/VehicleDetail/VehicleDetail.tsx
@@ -262,7 +262,9 @@ const VehicleDetail: ServicePortalModuleComponent = () => {
                     size="default"
                     type="button"
                     variant="utility"
-                    onClick={() => formSubmit(`${downloadServiceURL}`)}
+                    onClick={async () =>
+                      await formSubmit(`${downloadServiceURL}`)
+                    }
                   >
                     {formatMessage(messages.vehicleHistoryReport)}
                   </Button>


### PR DESCRIPTION
## What

* Await formsubmit for getting pdf

## Why

* when the user waits for a while and the token needs to refresh, the onlick handler can finish before resolving the token

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
