### PR TITLE
fix(portals): Replace service.portal namespace in core module

### DIFF
--- a/libs/portals/core/project.json
+++ b/libs/portals/core/project.json
@@ -5,19 +5,35 @@
   "targets": {
     "lint": {
       "executor": "@nrwl/linter:eslint",
-      "outputs": ["{options.outputFile}"],
+      "outputs": [
+        "{options.outputFile}"
+      ],
       "options": {
-        "lintFilePatterns": ["libs/portals/core/**/*.{ts,tsx,js,jsx}"]
+        "lintFilePatterns": [
+          "libs/portals/core/**/*.{ts,tsx,js,jsx}"
+        ]
       }
     },
     "test": {
       "executor": "@nrwl/jest:jest",
-      "outputs": ["coverage/libs/portals/core"],
+      "outputs": [
+        "coverage/libs/portals/core"
+      ],
       "options": {
         "jestConfig": "libs/portals/core/jest.config.js",
         "passWithNoTests": true
       }
+    },
+    "extract-strings": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "command": "yarn ts-node -P libs/localization/tsconfig.lib.json libs/localization/scripts/extract 'libs/portals/core/src/{screens,components,lib}/**/*.{js,ts,tsx}'"
+      }
     }
   },
-  "tags": ["lib:portals-admin", "lib:portals-mypages", "scope:react-spa"]
+  "tags": [
+    "lib:portals-admin",
+    "lib:portals-mypages",
+    "scope:react-spa"
+  ]
 }

--- a/libs/portals/core/src/components/ApplicationErrorBoundary/ApplicationErrorBoundary.tsx
+++ b/libs/portals/core/src/components/ApplicationErrorBoundary/ApplicationErrorBoundary.tsx
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react'
 import { useLocale } from '@island.is/localization'
 import * as styles from './ApplicationErrorBoundry.css'
 import { Box, Text, Tag, Button } from '@island.is/island-ui/core'
+import { m } from '../../lib/messages'
 
 interface PropTypes {
   children: React.ReactNode
@@ -57,17 +58,10 @@ const Error = () => {
           <Tag variant="red">{500}</Tag>
         </Box>
         <Text variant="h1" as="h1" marginBottom={3}>
-          {formatMessage({
-            id: 'sp:error-page-heading',
-            defaultMessage: 'Eitthvað fór úrskeiðis',
-          })}
+          {formatMessage(m.errorPageHeading)}
         </Text>
         <Text variant="default" as="p">
-          {formatMessage({
-            id: 'sp:error-page-text',
-            defaultMessage:
-              'Því miður hefur eitthvað farið úrskeiðis og ekki næst samband við vefþjón.',
-          })}
+          {formatMessage(m.errorPageText)}
         </Text>
         <Box marginTop={2}>
           <a href="https://island.is" target="_blank" rel="noreferrer">

--- a/libs/portals/core/src/components/LoadingScreen/LoadingScreen.tsx
+++ b/libs/portals/core/src/components/LoadingScreen/LoadingScreen.tsx
@@ -1,5 +1,6 @@
 import { Box, LoadingDots } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
+import { m } from '../../lib/messages'
 import * as styles from './LoadingScreen.css'
 
 interface LoadingScreenProps {
@@ -16,13 +17,7 @@ export const LoadingScreen = ({ ariaLabel }: LoadingScreenProps) => {
       alignItems="center"
       className={styles.fullScreen}
       role="progressbar"
-      aria-valuetext={
-        ariaLabel ??
-        formatMessage({
-          id: 'portals:loading-screen',
-          defaultMessage: 'Er að hlaða nauðsynlegum gögnum',
-        })
-      }
+      aria-valuetext={ariaLabel ?? formatMessage(m.loadingScreen)}
     >
       <LoadingDots large />
     </Box>

--- a/libs/portals/core/src/lib/messages.ts
+++ b/libs/portals/core/src/lib/messages.ts
@@ -2,41 +2,54 @@ import { defineMessages } from 'react-intl'
 
 export const m = defineMessages({
   overview: {
-    id: 'service.portal:overview',
+    id: 'portals:overview',
     defaultMessage: 'Yfirlit',
   },
   couldNotFetch: {
-    id: 'service.portal:could-not-fetch',
+    id: 'portals:could-not-fetch',
     defaultMessage: 'Tókst ekki að sækja',
   },
   somethingWrong: {
-    id: 'service.portal:something-went-wrong',
+    id: 'portals:something-went-wrong',
     defaultMessage: 'Eitthvað fór úrskeiðis',
   },
   accessDenied: {
-    id: 'service.portal:accessDenied',
+    id: 'portals:accessDenied',
     defaultMessage: 'Ekki með aðgang',
   },
   accessNeeded: {
-    id: 'service.portal:access-needed',
+    id: 'portals:access-needed',
     defaultMessage: 'Umboð vantar',
   },
   accessNeededText: {
-    id: 'service.portal:access-needed-text',
+    id: 'portals:access-needed-text',
     defaultMessage: 'Umboð vantar',
   },
   accessDeniedText: {
-    id: 'service.portal:accessDeniedText',
+    id: 'portals:accessDeniedText',
     defaultMessage:
       'Því miður vantar þig umboð til þess að hafa aðgang að þessu svæði. Vinsamlegast hafðu samband við viðeigandi aðila sem sér um þessi mál.',
   },
   notFound: {
-    id: 'service.portal:not-found',
+    id: 'portals:not-found',
     defaultMessage: 'Síða finnst ekki',
   },
   notFoundMessage: {
-    id: 'service.portal:not-found-message',
+    id: 'portals:not-found-message',
     defaultMessage:
       'Ekkert fannst á slóðinni {path}. Mögulega hefur síðan verið fjarlægð eða færð til',
+  },
+  errorPageHeading: {
+    id: 'portals:error-page-heading',
+    defaultMessage: 'Eitthvað fór úrskeiðis',
+  },
+  errorPageText: {
+    id: 'portals:error-page-text',
+    defaultMessage:
+      'Því miður hefur eitthvað farið úrskeiðis og ekki næst samband við vefþjón.',
+  },
+  loadingScreen: {
+    id: 'portals:loading-screen',
+    defaultMessage: 'Er að hlaða nauðsynlegum gögnum',
   },
 })


### PR DESCRIPTION
# Replace service.portal namespace in translations in core module

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
