### PR TITLE
feat(ap): New delegation scope for admin portal

### DIFF
--- a/apps/services/auth/delegation-api/src/app/delegations/me-delegations.controller.ts
+++ b/apps/services/auth/delegation-api/src/app/delegations/me-delegations.controller.ts
@@ -30,7 +30,7 @@ import {
   ScopesGuard,
   User,
 } from '@island.is/auth-nest-tools'
-import { AuthScope } from '@island.is/auth/scopes'
+import { delegationScopes } from '@island.is/auth/scopes'
 import { Audit, AuditService } from '@island.is/nest/audit'
 import {
   FeatureFlag,
@@ -53,8 +53,8 @@ const delegationId: DocumentationParamOptions = {
 
 @UseGuards(IdsUserGuard, ScopesGuard, FeatureFlagGuard)
 @FeatureFlag(Features.outgoingDelegationsV2)
-@Scopes(AuthScope.delegations)
-@ApiSecurity('ias', [AuthScope.delegations])
+@Scopes(...delegationScopes)
+@ApiSecurity('ias', delegationScopes)
 @ApiTags('me/delegations')
 @Controller({
   path: 'me/delegations',

--- a/apps/services/auth/delegation-api/src/app/domains/domains.controller.ts
+++ b/apps/services/auth/delegation-api/src/app/domains/domains.controller.ts
@@ -14,7 +14,7 @@ import {
   ScopesGuard,
   User,
 } from '@island.is/auth-nest-tools'
-import { AuthScope } from '@island.is/auth/scopes'
+import { delegationScopes } from '@island.is/auth/scopes'
 import { Audit } from '@island.is/nest/audit'
 import {
   FeatureFlag,
@@ -51,7 +51,7 @@ const direction: DocumentationQueryOptions = {
 
 @UseGuards(IdsUserGuard, ScopesGuard, FeatureFlagGuard)
 @FeatureFlag(Features.outgoingDelegationsV2)
-@Scopes(AuthScope.delegations)
+@Scopes(...delegationScopes)
 @ApiSecurity('ias')
 @ApiTags('domains')
 @Controller({

--- a/libs/auth-api-lib/seeders/data/scope-delegation-admin.ts
+++ b/libs/auth-api-lib/seeders/data/scope-delegation-admin.ts
@@ -1,0 +1,17 @@
+import { compose, createScope } from './helpers'
+
+export const up = compose(
+  createScope({
+    name: '@admin.island.is/delegations',
+    displayName: 'Aðgangsstýring',
+    description:
+      'Gefur leyfi til að veita öðrum aðgang að þeim upplýsingum og aðgerðum sem aðilinn hefur.',
+    accessControlled: true,
+    addToClients: ['@admin.island.is/web'],
+    addToResource: '@admin.island.is',
+    delegation: {
+      custom: true,
+      procuringHolders: true,
+    },
+  }),
+)

--- a/libs/auth/scopes/src/lib/admin-portal.scope.ts
+++ b/libs/auth/scopes/src/lib/admin-portal.scope.ts
@@ -1,3 +1,4 @@
 export enum AdminPortalScope {
   airDiscountScheme = '@admin.island.is/ads',
+  delegations = '@admin.island.is/delegations',
 }

--- a/libs/auth/scopes/src/lib/auth.scope.ts
+++ b/libs/auth/scopes/src/lib/auth.scope.ts
@@ -1,6 +1,13 @@
+import { AdminPortalScope } from './admin-portal.scope'
+
 export enum AuthScope {
   actorDelegations = '@island.is/auth/actor-delegations',
   delegations = '@island.is/auth/delegations:write',
   adminPersonalRepresentative = '@island.is/auth/personal-representative-admin',
   publicPersonalRepresentative = '@island.is/auth/personal-representative-public',
 }
+
+export const delegationScopes = [
+  AuthScope.delegations,
+  AdminPortalScope.delegations,
+]

--- a/libs/portals/shared-modules/delegations/src/module.ts
+++ b/libs/portals/shared-modules/delegations/src/module.ts
@@ -1,4 +1,4 @@
-import { AuthScope } from '@island.is/auth/scopes'
+import { delegationScopes } from '@island.is/auth/scopes'
 import { lazy } from 'react'
 import { Features } from '@island.is/feature-flags'
 
@@ -11,7 +11,9 @@ export const delegationsModule: PortalModule = {
   featureFlag: Features.outgoingDelegationsV2,
   widgets: () => [],
   routes({ userInfo }) {
-    const hasAccess = userInfo.scopes.includes(AuthScope.delegations)
+    const hasAccess = delegationScopes.some((scope) =>
+      userInfo.scopes.includes(scope),
+    )
     const accessControlCommonFields = {
       name: m.accessControlDelegations,
       path: DelegationPaths.Delegations,


### PR DESCRIPTION
## What

Add new scope for admin portal delegations.

## Why

So users can give access to delegations both in My Pages or in the Admin Portal.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
