### PR TITLE
feat(fetch): HOTFIX Default to log error response bodies

### DIFF
--- a/libs/clients/middlewares/src/lib/createEnhancedFetch.ts
+++ b/libs/clients/middlewares/src/lib/createEnhancedFetch.ts
@@ -49,8 +49,8 @@ export interface EnhancedFetchOptions {
   // Either way they will be logged and thrown.
   treat400ResponsesAsErrors?: boolean
 
-  // If true, will log error response body. Defaults to false.
-  // Should only be used if error objects do not have sensitive information or PII.
+  // If true (default), Enhanced Fetch will log error response bodies.
+  // Should be set to false if error objects may have sensitive information or PII.
   logErrorResponseBody?: boolean
 
   // Override logger.
@@ -115,7 +115,7 @@ export const createEnhancedFetch = (
     logger = defaultLogger,
     fetch = nodeFetch,
     timeout = DEFAULT_TIMEOUT,
-    logErrorResponseBody = false,
+    logErrorResponseBody = true,
     autoAuth,
     forwardAuthUserAgent = true,
     clientCertificate,

--- a/libs/clients/middlewares/src/lib/withErrorLog.ts
+++ b/libs/clients/middlewares/src/lib/withErrorLog.ts
@@ -27,12 +27,19 @@ export function withErrorLog({
         (error instanceof FetchError &&
           error.response.headers.get('cache-status')) ??
         undefined
+      const body =
+        error instanceof FetchError
+          ? typeof error.body === 'string'
+            ? trimBody(error.body)
+            : error.body
+          : undefined
 
       logger.log(logLevel, {
         ...error,
         stack: error.stack,
         url: request.url,
         message: `Fetch failure (${name}): ${error.message}`,
+        body,
         cacheStatus,
         // Do not log large response objects.
         response: undefined,
@@ -40,4 +47,13 @@ export function withErrorLog({
       throw error
     })
   }
+}
+
+const MAX_TEXT_BODY_LENGTH = 512
+
+const trimBody = (body: string) => {
+  if (body.length > MAX_TEXT_BODY_LENGTH) {
+    return `${body.slice(0, MAX_TEXT_BODY_LENGTH)}...`
+  }
+  return body
 }


### PR DESCRIPTION
This is to make devops life easier. Error responses should generally
not include user PII and we already filter out national ids and more
from our logs.

We can always toggle this off on case-by-case basis.