### PR TITLE
fix(web): News Cards should display image if width of container is more than 600 px

### DIFF
--- a/apps/web/components/NewsCard/NewsCard.tsx
+++ b/apps/web/components/NewsCard/NewsCard.tsx
@@ -44,7 +44,6 @@ export const NewsCard: React.FC<NewsCardProps> = ({
   if (mini) {
     return (
       <FocusableBox
-        ref={ref}
         href={href}
         paddingX={[0, 2, 5]}
         paddingY={[2, 2, 3]}
@@ -69,68 +68,70 @@ export const NewsCard: React.FC<NewsCardProps> = ({
   }
 
   return (
-    <FocusableBox
-      ref={ref}
-      href={href}
-      paddingX={[2, 2, 5, 5]}
-      paddingY={[3, 3, 5, 5]}
-      display="flex"
-      height="full"
-      background="white"
-      borderRadius="large"
-      borderColor="blue200"
-      borderWidth="standard"
-    >
-      <Box
+    <Box ref={ref}>
+      <FocusableBox
+        href={href}
+        paddingX={[2, 2, 5, 5]}
+        paddingY={[3, 3, 5, 5]}
         display="flex"
-        flexDirection="row"
+        height="full"
         background="white"
-        justifyContent="spaceBetween"
+        borderRadius="large"
+        borderColor="blue200"
+        borderWidth="standard"
       >
         <Box
           display="flex"
-          flexDirection="column"
-          flexGrow={1}
+          flexDirection="row"
+          background="white"
           width="full"
           justifyContent="spaceBetween"
         >
-          <Stack space={2}>
-            <Text variant="eyebrow">{formattedDate}</Text>
-            <Text variant="h2" as={titleAs}>
-              {title}
-            </Text>
-            <Text>{introduction}</Text>
-          </Stack>
-          <Box marginTop={2}>
-            <Button
-              icon="arrowForward"
-              iconType="filled"
-              variant="text"
-              as="span"
-              unfocusable
-            >
-              {readMoreText}
-            </Button>
+          <Box
+            display="flex"
+            flexDirection="column"
+            flexGrow={1}
+            width="full"
+            justifyContent="spaceBetween"
+          >
+            <Stack space={2}>
+              <Text variant="eyebrow">{formattedDate}</Text>
+              <Text variant="h2" as={titleAs}>
+                {title}
+              </Text>
+              <Text>{introduction}</Text>
+            </Stack>
+            <Box marginTop={2}>
+              <Button
+                icon="arrowForward"
+                iconType="filled"
+                variant="text"
+                as="span"
+                unfocusable
+              >
+                {readMoreText}
+              </Button>
+            </Box>
           </Box>
+          {!!showImage && (
+            <Box flexGrow={0} width="full" className={styles.image}>
+              <BackgroundImage
+                width={600}
+                quality={60}
+                positionX="left"
+                backgroundSize="cover"
+                ratio="1:1"
+                thumbnailColor="blue100"
+                image={{
+                  url: image.url,
+                  title: image.title,
+                }}
+              />
+            </Box>
+          )}
         </Box>
-        {!!showImage && (
-          <Box flexGrow={0} width="full" className={styles.image}>
-            <BackgroundImage
-              width={600}
-              quality={60}
-              positionX="left"
-              backgroundSize="cover"
-              ratio="1:1"
-              thumbnailColor="blue100"
-              image={{
-                url: image.url,
-                title: image.title,
-              }}
-            />
-          </Box>
-        )}
-      </Box>
-    </FocusableBox>
+      </FocusableBox>
+    </Box>
   )
 }
 


### PR DESCRIPTION
# News Cards should display image if width of container is more than 600 px

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
