### PR TITLE
feat(web): Fiskistofa ship search query param names can be changed in cms (#9335)

### DIFF
--- a/apps/web/components/connected/fiskistofa/ShipSearch/ShipSearch.tsx
+++ b/apps/web/components/connected/fiskistofa/ShipSearch/ShipSearch.tsx
@@ -16,6 +16,7 @@ import {
 } from '@island.is/api/schema'
 import { GET_SHIPS_QUERY } from './queries'
 import { useNamespace } from '@island.is/web/hooks'
+import { shouldLinkOpenInNewWindow } from '@island.is/shared/utils'
 
 interface ShipSearchProps {
   namespace: {
@@ -49,10 +50,10 @@ const ShipSearch = ({ namespace }: ShipSearchProps) => {
       '/v/gagnasidur-fiskistofu?selectedTab=skip',
     ) as string
 
-    return `${href}${href?.includes('?') ? '&' : '?'}${n(
-      'shipDetailsNumberQueryParam',
-      'nr',
-    )}=${id}`
+    const queryParams = new URLSearchParams(href.split('?')[1])
+    queryParams.append(n('shipDetailsNumberQueryParam', 'nr'), String(id))
+
+    return `${href}?${queryParams.toString()}`
   }
 
   const [loadShips, { data, error, loading, called }] = useLazyQuery<
@@ -84,7 +85,12 @@ const ShipSearch = ({ namespace }: ShipSearchProps) => {
       setInputError('')
     }
     if (nameInputIsNumber) {
-      router.push(getShipDetailsHref(Number(nameInput)))
+      const href = getShipDetailsHref(Number(nameInput))
+      window.open(
+        href,
+        shouldLinkOpenInNewWindow(href) ? '_blank' : '_self',
+        'noopener,noreferrer',
+      )
     } else {
       setNameInputDuringLastSearch(nameInput)
       loadShips({
@@ -167,13 +173,20 @@ const ShipSearch = ({ namespace }: ShipSearchProps) => {
             <T.Body>
               {ships.map((ship) => {
                 const href = getShipDetailsHref(ship.id)
+                const target = shouldLinkOpenInNewWindow(href)
+                  ? '_blank'
+                  : '_self'
                 return (
                   <T.Row key={ship.id}>
                     <T.Data>
-                      <a href={href}>{ship.id}</a>
+                      <a href={href} rel="noreferrer" target={target}>
+                        {ship.id}
+                      </a>
                     </T.Data>
                     <T.Data>
-                      <a href={href}>{ship.name}</a>
+                      <a href={href} rel="noreferrer" target={target}>
+                        {ship.name}
+                      </a>
                     </T.Data>
                     <T.Data>{ship.typeOfVessel}</T.Data>
                     <T.Data>{ship.operator}</T.Data>

--- a/apps/web/components/connected/fiskistofa/ShipSearch/ShipSearch.tsx
+++ b/apps/web/components/connected/fiskistofa/ShipSearch/ShipSearch.tsx
@@ -44,10 +44,15 @@ const ShipSearch = ({ namespace }: ShipSearchProps) => {
   const router = useRouter()
 
   const getShipDetailsHref = (id: number) => {
-    return `${n(
+    const href = n(
       'shipDetailsHref',
       '/v/gagnasidur-fiskistofu?selectedTab=skip',
-    )}&nr=${id}`
+    ) as string
+
+    return `${href}${href?.includes('?') ? '&' : '?'}${n(
+      'shipDetailsNumberQueryParam',
+      'nr',
+    )}=${id}`
   }
 
   const [loadShips, { data, error, loading, called }] = useLazyQuery<

--- a/apps/web/components/connected/fiskistofa/SidebarShipSearchInput/SidebarShipSearchInput.tsx
+++ b/apps/web/components/connected/fiskistofa/SidebarShipSearchInput/SidebarShipSearchInput.tsx
@@ -23,10 +23,10 @@ const SidebarShipSearchInput = ({ namespace }: SidebarShipSearchInputProps) => {
     const searchValueIsNumber =
       !isNaN(Number(searchValue)) && searchValue.length > 0
     if (searchValueIsNumber) {
-      const pathname = n('b', '/v/gagnasidur-fiskistofu')
+      const pathname = n('shipDetailsHref', '/v/gagnasidur-fiskistofu')
       const query = {
         ...router.query,
-        [n('a', 'nr')]: searchValue,
+        [n('shipDetailsNumberQueryParam', 'nr')]: searchValue,
         selectedTab: router.query?.selectedTab ?? 'skip',
       }
 

--- a/apps/web/components/connected/fiskistofa/SidebarShipSearchInput/SidebarShipSearchInput.tsx
+++ b/apps/web/components/connected/fiskistofa/SidebarShipSearchInput/SidebarShipSearchInput.tsx
@@ -26,7 +26,7 @@ const SidebarShipSearchInput = ({ namespace }: SidebarShipSearchInputProps) => {
       const pathname = n('shipDetailsHref', '/v/gagnasidur-fiskistofu')
       const query = {
         ...router.query,
-        nr: searchValue,
+        [n('shipDetailsNumberQueryParam', 'nr')]: searchValue,
         selectedTab: router.query?.selectedTab ?? 'skip',
       }
       router

--- a/apps/web/components/connected/fiskistofa/SidebarShipSearchInput/SidebarShipSearchInput.tsx
+++ b/apps/web/components/connected/fiskistofa/SidebarShipSearchInput/SidebarShipSearchInput.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useRouter } from 'next/router'
 import { AsyncSearchInput, Box, Text } from '@island.is/island-ui/core'
 import { useNamespace } from '@island.is/web/hooks'
+import { shouldLinkOpenInNewWindow } from '@island.is/shared/utils'
 
 interface SidebarShipSearchInputProps {
   namespace: {
@@ -22,23 +23,26 @@ const SidebarShipSearchInput = ({ namespace }: SidebarShipSearchInputProps) => {
     const searchValueIsNumber =
       !isNaN(Number(searchValue)) && searchValue.length > 0
     if (searchValueIsNumber) {
-      const basePath = router.asPath.split('?')[0].split('#')[0]
-      const pathname = n('shipDetailsHref', '/v/gagnasidur-fiskistofu')
+      const pathname = n('b', '/v/gagnasidur-fiskistofu')
       const query = {
         ...router.query,
-        [n('shipDetailsNumberQueryParam', 'nr')]: searchValue,
+        [n('a', 'nr')]: searchValue,
         selectedTab: router.query?.selectedTab ?? 'skip',
       }
-      router
-        .push({
-          pathname,
-          query,
-        })
-        .then(() => {
-          if (pathname === basePath) {
-            router.reload()
-          }
-        })
+
+      const params = new URLSearchParams()
+
+      for (const [name, value] of Object.entries(query)) {
+        params.append(name, value as string)
+      }
+
+      const url = `${pathname}?${params}`
+
+      window.open(
+        url,
+        shouldLinkOpenInNewWindow(pathname) ? '_blank' : '_self',
+        'noopener,noreferrer',
+      )
     } else {
       const query = { ...router.query, name: searchValue }
       router.push({


### PR DESCRIPTION
# Fiskistofa ship search query param names can be changed in cms (#9335)
This PR contains cherry picked commits from the PR #9335 which got merged to main, we'd like to hotfix this change in since fiskistofa.is needs this functionality since they're redirecting fiskistofa.is to island.is/s/fiskistofa