### PR TITLE
fix(web): Add fail-safe to slug field in search results

### DIFF
--- a/apps/web/screens/Search/Search.tsx
+++ b/apps/web/screens/Search/Search.tsx
@@ -311,7 +311,7 @@ const Search: Screen<CategoryProps> = ({
       return linkResolver('digitalicelandservicesdetailpage', [item.slug])
     }
 
-    return linkResolver(item.__typename, item?.url ?? item.slug.split('/'))
+    return linkResolver(item.__typename, item.url ?? item.slug?.split('/'))
   }
 
   const getItemImages = (item: SearchType) => {


### PR DESCRIPTION
# Add fail-safe to slug field in search results

## What

* If a search result does not have a url or slug field it'll cause the web to show a 500 error
* This change addresses that issue

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
