### PR TITLE
fix(web): Hotfix - Add fail-safe to slug field in search results (#9354)

### DIFF
--- a/apps/web/screens/Search/Search.tsx
+++ b/apps/web/screens/Search/Search.tsx
@@ -311,7 +311,7 @@ const Search: Screen<CategoryProps> = ({
       return linkResolver('digitalicelandservicesdetailpage', [item.slug])
     }
 
-    return linkResolver(item.__typename, item?.url ?? item.slug.split('/'))
+    return linkResolver(item.__typename, item.url ?? item.slug?.split('/'))
   }
 
   const getItemImages = (item: SearchType) => {


### PR DESCRIPTION
#  Hotfix - Add fail-safe to slug field in search results (#9354)
