### PR TITLE
fix(web): Add fail-safe for published material page when an enhanced asset is missing a file

### DIFF
--- a/apps/web/screens/Organization/PublishedMaterial/PublishedMaterial.tsx
+++ b/apps/web/screens/Organization/PublishedMaterial/PublishedMaterial.tsx
@@ -27,6 +27,7 @@ import {
   GetNamespaceQuery,
   Query,
   QueryGetNamespaceArgs,
+  QueryGetOrganizationArgs,
   QueryGetOrganizationPageArgs,
   QueryGetPublishedMaterialArgs,
 } from '@island.is/web/graphql/schema'
@@ -45,7 +46,11 @@ import { useRouter } from 'next/router'
 import { useEffect, useMemo, useState } from 'react'
 import { useDebounce } from 'react-use'
 import { Screen } from '../../../types'
-import { GET_NAMESPACE_QUERY, GET_ORGANIZATION_PAGE_QUERY } from '../../queries'
+import {
+  GET_NAMESPACE_QUERY,
+  GET_ORGANIZATION_PAGE_QUERY,
+  GET_ORGANIZATION_QUERY,
+} from '../../queries'
 import { GET_PUBLISHED_MATERIAL_QUERY } from '../../queries/PublishedMaterial'
 import FilterTag from './components/FilterTag/FilterTag'
 import { PublishedMaterialItem } from './components/PublishedMaterialItem'
@@ -452,10 +457,22 @@ PublishedMaterial.getInitialProps = async ({ apolloClient, locale, query }) => {
     throw new CustomNextError(404, 'Organization page not found')
   }
 
+  const {
+    data: { getOrganization },
+  } = await apolloClient.query<Query, QueryGetOrganizationArgs>({
+    query: GET_ORGANIZATION_QUERY,
+    variables: {
+      input: {
+        slug: getOrganizationPage.organization?.slug ?? (query.slug as string),
+        lang: locale as ContentLanguage,
+      },
+    },
+  })
+
   return {
     organizationPage: getOrganizationPage,
     genericTagFilters:
-      getOrganizationPage?.organization
+      (getOrganization ?? getOrganizationPage?.organization)
         ?.publishedMaterialSearchFilterGenericTags ?? [],
     namespace,
     ...getThemeConfig(getOrganizationPage.theme, getOrganizationPage.slug),

--- a/apps/web/screens/Organization/PublishedMaterial/components/PublishedMaterialItem/PublishedMaterialItem.tsx
+++ b/apps/web/screens/Organization/PublishedMaterial/components/PublishedMaterialItem/PublishedMaterialItem.tsx
@@ -18,16 +18,16 @@ export const PublishedMaterialItem = ({ item }: PublishedMaterialItemProps) => {
   const { format } = useDateUtils()
   const fileEnding = getFileEnding(item.file?.url ?? '')
   const date =
-    item?.releaseDate && format(new Date(item.releaseDate), 'do MMMM yyyy')
+    item.releaseDate && format(new Date(item.releaseDate), 'do MMMM yyyy')
 
   return (
     <FocusableBox
       width="full"
       padding={[2, 2, 3]}
       href={
-        item.file.url.startsWith('//')
+        item.file?.url?.startsWith('//')
           ? `https:${item.file.url}`
-          : item.file.url
+          : item.file?.url
       }
       border="standard"
       borderRadius="large"


### PR DESCRIPTION
# Add fail-safe for published material page when an enhanced asset is missing a file

## What

* We noticed a 500 error if an enhanced asset was missing a file on dev, this change prevents that from happening
* I also added a query to fetch the organization on the published material screen since we need to use fields it has

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
