### PR TITLE
feat(web): Fetch nested fields in one column text

### DIFF
--- a/apps/web/screens/queries/fragments.ts
+++ b/apps/web/screens/queries/fragments.ts
@@ -687,7 +687,7 @@ export const nestedOneColumnTextFields = gql`
   }
 `
 
-export const nestedFields = `
+const nestedContainerFields = `
   ... on AccordionSlice {
     ...AccordionSliceFields
     accordionItems {
@@ -723,4 +723,15 @@ export const nestedFields = `
       }
     }
   }
+`
+
+export const nestedFields = `
+  ... on OneColumnText {
+    ...OneColumnTextFields
+    content {
+      ...AllSlices
+      ${nestedContainerFields}
+    }
+  }
+  ${nestedContainerFields}
 `

--- a/libs/cms/src/lib/search/importers/organizationSubpage.service.ts
+++ b/libs/cms/src/lib/search/importers/organizationSubpage.service.ts
@@ -1,10 +1,11 @@
+import { Entry } from 'contentful'
+import { Injectable } from '@nestjs/common'
+import isCircular from 'is-circular'
 import { MappedData } from '@island.is/content-search-indexer/types'
 import { logger } from '@island.is/logging'
-import { Injectable } from '@nestjs/common'
-import { Entry } from 'contentful'
-import { IOrganizationSubpage } from '../../generated/contentfulTypes'
-import { CmsSyncProvider, processSyncDataInput } from '../cmsSync.service'
 import { mapOrganizationSubpage } from '../../models/organizationSubpage.model'
+import { CmsSyncProvider, processSyncDataInput } from '../cmsSync.service'
+import { IOrganizationSubpage } from '../../generated/contentfulTypes'
 import { extractStringsFromObject } from './utils'
 
 @Injectable()
@@ -25,6 +26,17 @@ export class OrganizationSubpageSyncService
       .map<MappedData | boolean>((entry) => {
         try {
           const mapped = mapOrganizationSubpage(entry)
+
+          if (isCircular(mapped)) {
+            logger.warn(
+              'Failed to import organization subpage due to circularity',
+              {
+                id: entry?.sys?.id,
+              },
+            )
+            return false
+          }
+
           const content = extractStringsFromObject(mapped.description ?? [])
           return {
             _id: mapped.id,


### PR DESCRIPTION
# Fetch nested fields in one column text

## What

* Placing a faqlist or accordion inside a onecolumn text didn't work since we didn't query for them
* This change tweaks the query to support nested fields inside onecolumn text
* While I was at it I noticed a max call stack error if an accordion referenced a onecolumn text that referenced that accordion (causing a circularity which the extractStrings function would recurse infinitely on)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
