### PR TITLE
fix(web): Fiskistofa ship search - duplicated query param

### DIFF
--- a/apps/web/components/connected/fiskistofa/ShipSearch/ShipSearch.tsx
+++ b/apps/web/components/connected/fiskistofa/ShipSearch/ShipSearch.tsx
@@ -50,10 +50,11 @@ const ShipSearch = ({ namespace }: ShipSearchProps) => {
       '/v/gagnasidur-fiskistofu?selectedTab=skip',
     ) as string
 
-    const queryParams = new URLSearchParams(href.split('?')[1])
-    queryParams.append(n('shipDetailsNumberQueryParam', 'nr'), String(id))
+    const [pathname, params] = href.split('?')
 
-    return `${href}?${queryParams.toString()}`
+    const queryParams = new URLSearchParams(params)
+    queryParams.append(n('shipDetailsNumberQueryParam', 'nr'), String(id))
+    return `${pathname}?${queryParams.toString()}`
   }
 
   const [loadShips, { data, error, loading, called }] = useLazyQuery<


### PR DESCRIPTION
# Fiskistofa ship search - duplicated query param

## What

* The url creation logic appended the query params twice since the entire url was used as the pathname instead of it just being the pathname

Example: 
`https://gamli.fiskistofa.is/veidar/aflastada/einstokskip?timabil=2223`
would become 
`https://gamli.fiskistofa.is/veidar/aflastada/einstokskip?timabil=2223?timabil=2223`

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
