### PR TITLE
fix(admin-poral): UserMenu updates

### DIFF
--- a/apps/portals/admin/src/components/Header/Header.tsx
+++ b/apps/portals/admin/src/components/Header/Header.tsx
@@ -56,7 +56,7 @@ export const Header = () => {
                 flexWrap="nowrap"
                 marginLeft={1}
               >
-                <UserMenu fullscreen />
+                <UserMenu showLanguageSwitcher={false} iconOnlyMobile />
               </Box>
             </Hidden>
           </Box>

--- a/libs/shared/components/src/auth/UserMenu/UserButton.tsx
+++ b/libs/shared/components/src/auth/UserMenu/UserButton.tsx
@@ -15,13 +15,20 @@ import { checkDelegation } from '@island.is/shared/utils'
 interface UserButtonProps {
   user: User
   small: boolean
-  onClick: () => void
+  onClick(): void
+  iconOnlyMobile?: boolean
 }
 
-export const UserButton = ({ onClick, user, small }: UserButtonProps) => {
+export const UserButton = ({
+  onClick,
+  user,
+  small,
+  iconOnlyMobile = false,
+}: UserButtonProps) => {
   const isDelegation = checkDelegation(user)
   const { profile } = user
   const { formatMessage } = useLocale()
+
   return (
     <>
       <Hidden above="sm">
@@ -29,7 +36,7 @@ export const UserButton = ({ onClick, user, small }: UserButtonProps) => {
           <Box className={styles.smallAvatar}>
             <UserAvatar
               isDelegation={isDelegation}
-              username={profile.name}
+              username={iconOnlyMobile ? undefined : profile.name}
               onClick={onClick}
               aria-label={formatMessage(userMessages.userButtonAria)}
               dataTestid="user-menu"
@@ -40,18 +47,18 @@ export const UserButton = ({ onClick, user, small }: UserButtonProps) => {
             variant="utility"
             colorScheme={isDelegation ? 'primary' : 'default'}
             onClick={onClick}
-            icon="person"
+            icon={isDelegation ? 'people' : 'person'}
             iconType="outline"
             aria-label={formatMessage(userMessages.userButtonAria)}
             data-testid="user-menu"
           >
-            <div className={styles.resetButtonPadding}>
-              {
+            {!iconOnlyMobile && (
+              <div className={styles.resetButtonPadding}>
                 <Inline space={1} alignY="center">
                   {profile.name.split(' ')[0]}
                 </Inline>
-              }
-            </div>
+              </div>
+            )}
           </Button>
         )}
       </Hidden>

--- a/libs/shared/components/src/auth/UserMenu/UserDropdown.tsx
+++ b/libs/shared/components/src/auth/UserMenu/UserDropdown.tsx
@@ -29,6 +29,7 @@ interface UserDropdownProps {
   onLogout?: () => void
   onSwitchUser: (nationalId: string) => void
   fullscreen: boolean
+
   showDropdownLanguage: boolean
 }
 

--- a/libs/shared/components/src/auth/UserMenu/UserMenu.spec.tsx
+++ b/libs/shared/components/src/auth/UserMenu/UserMenu.spec.tsx
@@ -231,4 +231,26 @@ describe('UserMenu', () => {
     // Assert
     expect(switchUser).toHaveBeenCalled()
   })
+
+  it('hides language switcher', async () => {
+    // Arrange
+    renderAuthenticated(<UserMenu showLanguageSwitcher={false} />, { user: {} })
+
+    // Assert
+    const languageSelector = await screen.queryByTestId(
+      'language-switcher-button',
+    )
+    expect(languageSelector).toBeNull()
+  })
+
+  it('user button shows icon only in mobile and not name', async () => {
+    // Act
+    renderAuthenticated(<UserMenu iconOnlyMobile />, {
+      user: { profile: { name: 'John' } },
+    })
+
+    // Assert
+    const button = await screen.getAllByRole('button')[0]
+    expect(button).not.toHaveTextContent('John')
+  })
 })

--- a/libs/shared/components/src/auth/UserMenu/UserMenu.tsx
+++ b/libs/shared/components/src/auth/UserMenu/UserMenu.tsx
@@ -5,19 +5,25 @@ import { UserButton } from './UserButton'
 import { UserDropdown } from './UserDropdown'
 import { UserLanguageSwitcher } from './UserLanguageSwitcher'
 
+type UserMenuProps = {
+  fullscreen?: boolean
+  small?: boolean
+  showDropdownLanguage?: boolean
+  setUserMenuOpen?(state: boolean): void
+  userMenuOpen?: boolean
+  iconOnlyMobile?: boolean
+  showLanguageSwitcher?: boolean
+}
+
 export const UserMenu = ({
-  fullscreen = false,
+  fullscreen = true,
   showDropdownLanguage = false,
   userMenuOpen,
   small = false,
   setUserMenuOpen,
-}: {
-  fullscreen?: boolean
-  small?: boolean
-  showDropdownLanguage?: boolean
-  setUserMenuOpen?: (state: boolean) => void
-  userMenuOpen?: boolean
-}) => {
+  showLanguageSwitcher = true,
+  iconOnlyMobile = false,
+}: UserMenuProps) => {
   const [dropdownState, setDropdownState] = useState<'closed' | 'open'>(
     'closed',
   )
@@ -42,10 +48,17 @@ export const UserMenu = ({
 
   return (
     <Box display="flex" position="relative" height="full">
-      <Hidden below="md">
-        <UserLanguageSwitcher user={user} />
-      </Hidden>
-      <UserButton user={user} onClick={handleClick} small={small} />
+      {showLanguageSwitcher && (
+        <Hidden below="md">
+          <UserLanguageSwitcher user={user} />
+        </Hidden>
+      )}
+      <UserButton
+        user={user}
+        onClick={handleClick}
+        small={small}
+        iconOnlyMobile={iconOnlyMobile}
+      />
       <UserDropdown
         user={user}
         dropdownState={dropdownState}


### PR DESCRIPTION
# UserMenu updates

## What
Added support for some variations of the user menu.
- iconOnlyMobile prop to hide name in button.
- display people icon if user is logged in delegation.
- showLanguageSwitcher prop to show and hide language picker. Defaults to true

## Why

As per design.


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
