### PR TITLE
fix(j-s): Limit Prosecutor Selection

### DIFF
--- a/apps/judicial-system/web/src/components/ProsecutorSelection/ProsecutorSelection.tsx
+++ b/apps/judicial-system/web/src/components/ProsecutorSelection/ProsecutorSelection.tsx
@@ -8,7 +8,10 @@ import {
   User,
   UserRole,
 } from '@island.is/judicial-system/types'
-import { FormContext } from '@island.is/judicial-system-web/src/components/FormProvider/FormProvider'
+import {
+  UserContext,
+  FormContext,
+} from '@island.is/judicial-system-web/src/components'
 import { strings } from './ProsecutorSelection.strings'
 import { ProsecutorSelectionUsersQuery } from './prosecutorSelectionUsersGql'
 import { OptionsType, ValueType } from 'react-select'
@@ -21,6 +24,7 @@ interface Props {
 const ProsecutorSelection: React.FC<Props> = (props) => {
   const { onChange } = props
   const { formatMessage } = useIntl()
+  const { user } = useContext(UserContext)
   const { workingCase } = useContext(FormContext)
 
   const selectedProsecutor = useMemo(() => {
@@ -42,15 +46,17 @@ const ProsecutorSelection: React.FC<Props> = (props) => {
       .filter(
         (aUser: User) =>
           aUser.role === UserRole.PROSECUTOR &&
-          (!workingCase.creatingProsecutor ||
-            aUser.institution?.id ===
-              workingCase.creatingProsecutor?.institution?.id),
+          ((!workingCase.creatingProsecutor &&
+            aUser.institution?.id === user?.institution?.id) ||
+            (workingCase.creatingProsecutor &&
+              aUser.institution?.id ===
+                workingCase.creatingProsecutor?.institution?.id)),
       )
       .map((prosecutor: User) => ({
         label: prosecutor.name,
         value: prosecutor.id,
       }))
-  }, [data?.users, workingCase.creatingProsecutor])
+  }, [data?.users, user?.institution?.id, workingCase.creatingProsecutor])
 
   return (
     <Select


### PR DESCRIPTION
# Limit Prosecutor Selection

[Takmarka val sækjanda við embætti notanda í nýju máli sem stonfað er úr LÖKE](https://app.asana.com/0/1199153462262248/1203447613452322/f)

## What

- Limits the prosecutors available for case assignment to the user's prosecutors office when no creating prosecutor has been set.

## Why

- If a prosecutor from another prosecutors office is selected, then the user looses access to the case.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
