### PR TITLE
fix(j-s): Case File State

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/file/file.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/file/file.service.ts
@@ -402,4 +402,11 @@ export class FileService {
         return false
       })
   }
+
+  async resetCaseFileStates(caseId: string, transaction: Transaction) {
+    await this.fileModel.update(
+      { state: CaseFileState.STORED_IN_RVG },
+      { where: { caseId, state: CaseFileState.STORED_IN_COURT }, transaction },
+    )
+  }
 }


### PR DESCRIPTION
# Case File State

[Breyta stöðu case files úr STORED_IN_COURT í STORED_IN_RVG ef málsnúmer dómstóls breytist](https://app.asana.com/0/1199153462262248/1203447613452318/f)

## What

- Resets case file states to STORED_IN_RVG when court case number is changed or removed.

## Why

- Otherwise, case files will. not be uploaded to court when a new court case number is assigned.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
