### PR TITLE
fix(web): Open featured articles in same window and change youtube embed regex

### DIFF
--- a/apps/web/components/Organization/Slice/AccordionSlice/AccordionSlice.tsx
+++ b/apps/web/components/Organization/Slice/AccordionSlice/AccordionSlice.tsx
@@ -8,6 +8,7 @@ import {
   BoxProps,
   Text,
 } from '@island.is/island-ui/core'
+import { shouldLinkOpenInNewWindow } from '@island.is/shared/utils'
 import {
   AccordionSlice as AccordionSliceSchema,
   Html,
@@ -108,7 +109,9 @@ export const AccordionSlice: React.FC<SliceProps> = ({ slice }) => {
                     !!item.link?.url &&
                     window.open(
                       item.link.url,
-                      item.link.url.includes('://') ? '_blank' : '_self',
+                      shouldLinkOpenInNewWindow(item.link.url)
+                        ? '_blank'
+                        : '_self',
                     ),
                 }}
               />

--- a/apps/web/components/Organization/Slice/FeaturedArticles/FeaturedArticlesSlice.tsx
+++ b/apps/web/components/Organization/Slice/FeaturedArticles/FeaturedArticlesSlice.tsx
@@ -12,8 +12,6 @@ import {
 } from '@island.is/island-ui/core'
 import { LinkType, useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
 import { useNamespace } from '@island.is/web/hooks'
-import { useWindowSize } from 'react-use'
-import { theme } from '@island.is/island-ui/theme'
 
 interface SliceProps {
   slice: FeaturedArticles
@@ -26,8 +24,6 @@ export const FeaturedArticlesSlice: React.FC<SliceProps> = ({
 }) => {
   const n = useNamespace(namespace)
   const { linkResolver } = useLinkResolver()
-  const { width } = useWindowSize()
-  const isMobile = width < theme.breakpoints.md
   const labelId = 'sliceTitle-' + slice.id
 
   const sortedArticles =
@@ -72,12 +68,7 @@ export const FeaturedArticlesSlice: React.FC<SliceProps> = ({
               }) => {
                 const url = linkResolver('Article' as LinkType, [slug])
                 return (
-                  <FocusableBox
-                    key={slug}
-                    borderRadius="large"
-                    href={url.href}
-                    target={isMobile ? '' : '_blank'}
-                  >
+                  <FocusableBox key={slug} borderRadius="large" href={url.href}>
                     <TopicCard
                       tag={
                         (!!processEntry || processEntryButtonText) &&

--- a/libs/island-ui/contentful/src/lib/EmbeddedVideo/EmbeddedVideo.tsx
+++ b/libs/island-ui/contentful/src/lib/EmbeddedVideo/EmbeddedVideo.tsx
@@ -69,7 +69,13 @@ const EmbeddedVideo: FC<EmbeddedVideoProps> = ({ title, url, locale }) => {
       const regExp = /^.*((youtu.be|youtube.com\/)|(v\/)|(\/u\/\w\/)|(embed\/)|(watch\?))\??v?=?([^#&?]*).*/
       const match = item.href.match(regExp)
 
-      const youtubeId = match && match[7].length === 11 ? match[7] : false
+      let youtubeId: string | undefined = undefined
+
+      if (match) {
+        let id = match[7]
+        if (id.startsWith('/')) id = id.slice(1)
+        if (id.length === 11) youtubeId = id
+      }
 
       if (youtubeId) {
         setEmbedUrl(`https://www.youtube.com/embed/${youtubeId}`)


### PR DESCRIPTION
# Open featured articles in same window and change youtube embed regex

## What

* It was weird that featured articles would open in a new window
* The youtube regex match doesn't support video urls of the format: https://youtu.be/hX9Bnmn8fv8

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
