### PR TITLE
chore(web): Render nested embedded asset fields

### DIFF
--- a/apps/web/utils/richText.tsx
+++ b/apps/web/utils/richText.tsx
@@ -21,6 +21,7 @@ import {
   ShipSearch,
   SidebarShipSearchInput,
   StraddlingStockCalculator,
+  TwoColumnTextSlice,
 } from '@island.is/web/components'
 import {
   PowerBiSlice as PowerBiSliceSchema,
@@ -60,6 +61,7 @@ const defaultRenderComponent = {
   ConnectedComponent: (slice) => webRenderConnectedComponent(slice),
   GraphCard: (chart) => <ChartsCard chart={chart} />,
   OneColumnText: (slice) => <OneColumnTextSlice slice={slice} />,
+  TwoColumnText: (slice) => <TwoColumnTextSlice slice={slice} />,
   EmailSignup: (slice) => <EmailSignup slice={slice} />,
   FaqList: (slice: FaqListProps) => slice?.questions && <FaqList {...slice} />,
 }

--- a/libs/island-ui/contentful/src/lib/RichTextRC/defaultRenderNode.tsx
+++ b/libs/island-ui/contentful/src/lib/RichTextRC/defaultRenderNode.tsx
@@ -160,6 +160,15 @@ export const defaultRenderNodeObject: RenderNode = {
     <T.HeadData>{children}</T.HeadData>
   ),
   [BLOCKS.TABLE_CELL]: (_node, children) => <T.Data>{children}</T.Data>,
+  [BLOCKS.EMBEDDED_ASSET]: (node) => {
+    const url = node?.data?.target?.fields?.file?.url
+    const title = node?.data?.target?.fields
+    return (
+      <Box marginTop={url ? 5 : 0}>
+        <img src={url} alt={title} />
+      </Box>
+    )
+  },
   [INLINES.HYPERLINK]: (node, children) => (
     <Hyperlink href={node.data.uri}>{children}</Hyperlink>
   ),


### PR DESCRIPTION
# Render nested asset fields

## What

* If an asset gets embedded inside some kind of nested structure (like inside of an unordered list item) it simply won't appear, this change addresses that issue
* I also added the TwoColumnText option to the richText function in the web project so if someone embeds a TwoColumnText inside of a rich text field it'll appear on the web

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
