### PR TITLE
chore(j-s): Show defenders on closed indictment info card

### DIFF
--- a/apps/judicial-system/web/src/components/InfoCard/InfoCard.spec.tsx
+++ b/apps/judicial-system/web/src/components/InfoCard/InfoCard.spec.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
+import { MockedProvider } from '@apollo/client/testing'
+
+import { LocaleProvider } from '@island.is/localization'
+import { SessionArrangements } from '@island.is/judicial-system/types'
 
 import InfoCard from './InfoCard'
-import { LocaleProvider } from '@island.is/localization'
-import { MockedProvider } from '@apollo/client/testing'
-import { SessionArrangements } from '@island.is/judicial-system/types'
 
 describe('InfoCard', () => {
   test('should display the assigned defender name if that info is provided even though the defender email is not', async () => {
@@ -14,10 +15,12 @@ describe('InfoCard', () => {
         <LocaleProvider locale="is" messages={{}}>
           <InfoCard
             data={[]}
-            defender={{
-              name: 'Joe',
-              sessionArrangement: SessionArrangements.ALL_PRESENT,
-            }}
+            defenders={[
+              {
+                name: 'Joe',
+                sessionArrangement: SessionArrangements.ALL_PRESENT,
+              },
+            ]}
           />
         </LocaleProvider>
       </MockedProvider>,
@@ -34,11 +37,13 @@ describe('InfoCard', () => {
         <LocaleProvider locale="is" messages={{}}>
           <InfoCard
             data={[]}
-            defender={{
-              name: 'Joe',
-              phoneNumber: '555-5555',
-              sessionArrangement: SessionArrangements.ALL_PRESENT,
-            }}
+            defenders={[
+              {
+                name: 'Joe',
+                phoneNumber: '555-5555',
+                sessionArrangement: SessionArrangements.ALL_PRESENT,
+              },
+            ]}
           />
         </LocaleProvider>
       </MockedProvider>,
@@ -55,12 +60,14 @@ describe('InfoCard', () => {
         <LocaleProvider locale="is" messages={{}}>
           <InfoCard
             data={[]}
-            defender={{
-              name: 'Joe',
-              email: 'joe@joe.is',
-              phoneNumber: '455-5544',
-              sessionArrangement: SessionArrangements.ALL_PRESENT,
-            }}
+            defenders={[
+              {
+                name: 'Joe',
+                email: 'joe@joe.is',
+                phoneNumber: '455-5544',
+                sessionArrangement: SessionArrangements.ALL_PRESENT,
+              },
+            ]}
           />
         </LocaleProvider>
       </MockedProvider>,
@@ -70,6 +77,38 @@ describe('InfoCard', () => {
     expect(await screen.findByText('Joe, joe@joe.is, s. 455-5544')).toBeTruthy()
   })
 
+  test('should display multiple defenders', async () => {
+    // Arrange
+    render(
+      <MockedProvider>
+        <LocaleProvider locale="is" messages={{}}>
+          <InfoCard
+            data={[]}
+            defenders={[
+              {
+                name: 'Joe',
+                email: 'joe@joe.is',
+                phoneNumber: '455-5544',
+                sessionArrangement: SessionArrangements.ALL_PRESENT,
+              },
+              {
+                name: 'Melissa',
+                email: 'mel@issa.is',
+                phoneNumber: '411-1114',
+              },
+            ]}
+          />
+        </LocaleProvider>
+      </MockedProvider>,
+    )
+
+    // Act and Assert
+    expect(await screen.findByText('Joe, joe@joe.is, s. 455-5544')).toBeTruthy()
+    expect(
+      await screen.findByText('Melissa, mel@issa.is, s. 411-1114'),
+    ).toBeTruthy()
+  })
+
   test('should display a message saying that a defender has not been set if the defender info is missing', async () => {
     // Arrange
     render(
@@ -77,13 +116,15 @@ describe('InfoCard', () => {
         <LocaleProvider locale="is" messages={{}}>
           <InfoCard
             data={[]}
-            defender={{
-              name: '',
-              defenderNationalId: '',
-              email: '',
-              phoneNumber: '',
-              sessionArrangement: SessionArrangements.ALL_PRESENT,
-            }}
+            defenders={[
+              {
+                name: '',
+                defenderNationalId: '',
+                email: '',
+                phoneNumber: '',
+                sessionArrangement: SessionArrangements.ALL_PRESENT,
+              },
+            ]}
           />
         </LocaleProvider>
       </MockedProvider>,

--- a/apps/judicial-system/web/src/components/InfoCard/InfoCard.tsx
+++ b/apps/judicial-system/web/src/components/InfoCard/InfoCard.tsx
@@ -9,20 +9,58 @@ import { formatDOB } from '@island.is/judicial-system/formatters'
 
 import * as styles from './InfoCard.css'
 
+interface Defender {
+  name: string
+  defenderNationalId?: string
+  sessionArrangement: SessionArrangements | undefined
+  email?: string
+  phoneNumber?: string
+}
+
+interface UniqueDefendersProps {
+  defenders: Defender[]
+}
+
 interface Props {
   data: Array<{ title: string; value?: React.ReactNode }>
   defendants?: { title: string; items: Defendant[] }
-  defender?: {
-    name: string
-    defenderNationalId?: string
-    sessionArrangement: SessionArrangements | undefined
-    email?: string
-    phoneNumber?: string
-  }
+  defenders?: Defender[]
+}
+
+const UniqueDefenders: React.FC<UniqueDefendersProps> = (props) => {
+  const { defenders } = props
+  const uniqueDefenders = defenders?.filter(
+    (defender, index, self) =>
+      index === self.findIndex((d) => d.email === defender.email),
+  )
+
+  return (
+    <>
+      <Text variant="h4">
+        {defenders[0].sessionArrangement ===
+        SessionArrangements.ALL_PRESENT_SPOKESPERSON
+          ? 'Talsmaður'
+          : `Verj${uniqueDefenders.length > 1 ? 'endur' : 'andi'}`}
+      </Text>
+      {uniqueDefenders.map((defender) =>
+        defender?.name ? (
+          <Box display="flex">
+            <Text>
+              {`${defender.name}${defender.email ? `, ${defender.email}` : ''}${
+                defender.phoneNumber ? `, s. ${defender.phoneNumber}` : ''
+              }`}
+            </Text>
+          </Box>
+        ) : (
+          <Text>Hefur ekki verið skráður</Text>
+        ),
+      )}
+    </>
+  )
 }
 
 const InfoCard: React.FC<Props> = (props) => {
-  const { data, defendants, defender } = props
+  const { data, defendants, defenders } = props
 
   return (
     <Box
@@ -38,7 +76,7 @@ const InfoCard: React.FC<Props> = (props) => {
         {defendants && (
           <>
             <Text variant="h4">{defendants.title}</Text>
-            <Box marginBottom={defender ? [2, 2, 3, 3] : 0}>
+            <Box marginBottom={defenders ? [2, 2, 3, 3] : 0}>
               {defendants.items.map((defendant) => (
                 <Text key={defendant.id}>
                   <span className={styles.infoCardDefendant}>
@@ -66,29 +104,7 @@ const InfoCard: React.FC<Props> = (props) => {
             </Box>
           </>
         )}
-        {defender && (
-          <>
-            <Text variant="h4">
-              {defender.sessionArrangement ===
-              SessionArrangements.ALL_PRESENT_SPOKESPERSON
-                ? 'Talsmaður'
-                : 'Verjandi'}
-            </Text>
-            {defender?.name ? (
-              <Box display="flex">
-                <Text>
-                  {`${defender.name}${
-                    defender.email ? `, ${defender.email}` : ''
-                  }${
-                    defender.phoneNumber ? `, s. ${defender.phoneNumber}` : ''
-                  }`}
-                </Text>
-              </Box>
-            ) : (
-              <Text>Hefur ekki verið skráður</Text>
-            )}
-          </>
-        )}
+        {defenders && <UniqueDefenders defenders={defenders} />}
       </Box>
       <Box className={styles.infoCardDataContainer}>
         {data.map((dataItem, index) => {

--- a/apps/judicial-system/web/src/components/InfoCard/InfoCard.tsx
+++ b/apps/judicial-system/web/src/components/InfoCard/InfoCard.tsx
@@ -12,7 +12,7 @@ import * as styles from './InfoCard.css'
 interface Defender {
   name: string
   defenderNationalId?: string
-  sessionArrangement: SessionArrangements | undefined
+  sessionArrangement?: SessionArrangements
   email?: string
   phoneNumber?: string
 }

--- a/apps/judicial-system/web/src/components/InfoCard/InfoCardClosedIndictment.tsx
+++ b/apps/judicial-system/web/src/components/InfoCard/InfoCardClosedIndictment.tsx
@@ -17,6 +17,16 @@ import { FormContext } from '../FormProvider/FormProvider'
 const InfoCardClosedIndictment: React.FC = () => {
   const { workingCase } = useContext(FormContext)
   const { formatMessage } = useIntl()
+  const defenders = workingCase.defendants?.map((defendant) => {
+    return {
+      name: defendant.defenderName || '',
+      defenderNationalId: defendant.defenderNationalId,
+      sessionArrangement: undefined,
+      email: defendant.defenderEmail,
+      phoneNumber: defendant.defenderPhoneNumber,
+    }
+  })
+
   return (
     <InfoCard
       data={[
@@ -76,6 +86,7 @@ const InfoCardClosedIndictment: React.FC = () => {
             }
           : undefined
       }
+      defenders={defenders}
     />
   )
 }

--- a/apps/judicial-system/web/src/routes/Court/InvestigationCase/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationCase/Overview/Overview.tsx
@@ -193,13 +193,15 @@ const Overview = () => {
                   }
                 : undefined
             }
-            defender={{
-              name: workingCase.defenderName ?? '',
-              defenderNationalId: workingCase.defenderNationalId,
-              sessionArrangement: workingCase.sessionArrangements,
-              email: workingCase.defenderEmail,
-              phoneNumber: workingCase.defenderPhoneNumber,
-            }}
+            defenders={[
+              {
+                name: workingCase.defenderName ?? '',
+                defenderNationalId: workingCase.defenderNationalId,
+                sessionArrangement: workingCase.sessionArrangements,
+                email: workingCase.defenderEmail,
+                phoneNumber: workingCase.defenderPhoneNumber,
+              },
+            ]}
           />
         </Box>
         <>

--- a/apps/judicial-system/web/src/routes/Court/RestrictionCase/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Court/RestrictionCase/Overview/Overview.tsx
@@ -215,12 +215,14 @@ export const JudgeOverview: React.FC = () => {
                   }
                 : undefined
             }
-            defender={{
-              name: workingCase.defenderName ?? '',
-              email: workingCase.defenderEmail,
-              sessionArrangement: workingCase.sessionArrangements,
-              phoneNumber: workingCase.defenderPhoneNumber,
-            }}
+            defenders={[
+              {
+                name: workingCase.defenderName ?? '',
+                email: workingCase.defenderEmail,
+                sessionArrangement: workingCase.sessionArrangements,
+                phoneNumber: workingCase.defenderPhoneNumber,
+              },
+            ]}
           />
         </Box>
         <Box marginBottom={5}>

--- a/apps/judicial-system/web/src/routes/Defender/CaseOverview.tsx
+++ b/apps/judicial-system/web/src/routes/Defender/CaseOverview.tsx
@@ -213,13 +213,15 @@ export const CaseOverview: React.FC = () => {
                   }
                 : undefined
             }
-            defender={{
-              name: workingCase.defenderName ?? '',
-              defenderNationalId: workingCase.defenderNationalId,
-              sessionArrangement: workingCase.sessionArrangements,
-              email: workingCase.defenderEmail,
-              phoneNumber: workingCase.defenderPhoneNumber,
-            }}
+            defenders={[
+              {
+                name: workingCase.defenderName ?? '',
+                defenderNationalId: workingCase.defenderNationalId,
+                sessionArrangement: workingCase.sessionArrangements,
+                email: workingCase.defenderEmail,
+                phoneNumber: workingCase.defenderPhoneNumber,
+              },
+            ]}
           />
         </Box>
         {completedCaseStates.includes(workingCase.state) && (

--- a/apps/judicial-system/web/src/routes/Prosecutor/InvestigationCase/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/InvestigationCase/Overview/Overview.tsx
@@ -241,13 +241,15 @@ export const Overview: React.FC = () => {
                   }
                 : undefined
             }
-            defender={{
-              name: workingCase.defenderName ?? '',
-              defenderNationalId: workingCase.defenderNationalId,
-              sessionArrangement: workingCase.sessionArrangements,
-              email: workingCase.defenderEmail,
-              phoneNumber: workingCase.defenderPhoneNumber,
-            }}
+            defenders={[
+              {
+                name: workingCase.defenderName ?? '',
+                defenderNationalId: workingCase.defenderNationalId,
+                sessionArrangement: workingCase.sessionArrangements,
+                email: workingCase.defenderEmail,
+                phoneNumber: workingCase.defenderPhoneNumber,
+              },
+            ]}
           />
         </Box>
         {workingCase.description && (

--- a/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/Overview/Overview.tsx
@@ -268,13 +268,15 @@ export const Overview: React.FC = () => {
                   }
                 : undefined
             }
-            defender={{
-              name: workingCase.defenderName ?? '',
-              defenderNationalId: workingCase.defenderNationalId,
-              sessionArrangement: workingCase.sessionArrangements,
-              email: workingCase.defenderEmail,
-              phoneNumber: workingCase.defenderPhoneNumber,
-            }}
+            defenders={[
+              {
+                name: workingCase.defenderName ?? '',
+                defenderNationalId: workingCase.defenderNationalId,
+                sessionArrangement: workingCase.sessionArrangements,
+                email: workingCase.defenderEmail,
+                phoneNumber: workingCase.defenderPhoneNumber,
+              },
+            ]}
           />
         </Box>
         <Box component="section" marginBottom={5} data-testid="demands">

--- a/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/SignedVerdictOverview.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/SignedVerdictOverview.tsx
@@ -639,13 +639,15 @@ export const SignedVerdictOverview: React.FC = () => {
                   }
                 : undefined
             }
-            defender={{
-              name: workingCase.defenderName ?? '',
-              defenderNationalId: workingCase.defenderNationalId,
-              sessionArrangement: workingCase.sessionArrangements,
-              email: workingCase.defenderEmail,
-              phoneNumber: workingCase.defenderPhoneNumber,
-            }}
+            defenders={[
+              {
+                name: workingCase.defenderName ?? '',
+                defenderNationalId: workingCase.defenderNationalId,
+                sessionArrangement: workingCase.sessionArrangements,
+                email: workingCase.defenderEmail,
+                phoneNumber: workingCase.defenderPhoneNumber,
+              },
+            ]}
           />
         </Box>
         {(workingCase.accusedAppealDecision === CaseAppealDecision.POSTPONE ||


### PR DESCRIPTION
# Show defenders on closed indictment info card

[Asana](https://app.asana.com/0/1199153462262248/1203335296623515/f)

## What

Show defenders on closed indictment info card. If there are two defendants with defenders that have the same email address, we only show that defender once (because then they have the same defender.)

## Why

For clarity

## Screenshots / Gifs

### When two defendants have defenders with the same email address

<img width="776" alt="Screenshot 2022-12-29 at 09 02 20" src="https://user-images.githubusercontent.com/3789875/209929234-51311191-94f7-4ac1-abb1-d85cb5045177.png">


### When two defendants have defenders with different email addresses
<img width="800" alt="Screenshot 2022-12-29 at 09 03 29" src="https://user-images.githubusercontent.com/3789875/209929236-50302bd4-13c7-4cc5-933d-85aa6fb2e1ce.png">

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
