### PR TITLE
chore(j-s): Refactor useDep hook

### DIFF
--- a/apps/judicial-system/web/src/routes/Court/InvestigationCase/CourtRecord/CourtRecord.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationCase/CourtRecord/CourtRecord.tsx
@@ -104,11 +104,13 @@ const CourtRecord = () => {
     setSessionBookingsMessage,
   ] = useState<string>('')
 
-  useDeb(workingCase, 'courtAttendees')
-  useDeb(workingCase, 'sessionBookings')
-  useDeb(workingCase, 'accusedAppealAnnouncement')
-  useDeb(workingCase, 'prosecutorAppealAnnouncement')
-  useDeb(workingCase, 'endOfSessionBookings')
+  useDeb(workingCase, [
+    'courtAttendees',
+    'sessionBookings',
+    'accusedAppealAnnouncement',
+    'prosecutorAppealAnnouncement',
+    'endOfSessionBookings',
+  ])
 
   useEffect(() => {
     if (isCaseUpToDate && !initialAutoFillDone) {

--- a/apps/judicial-system/web/src/routes/Court/InvestigationCase/Ruling/Ruling.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationCase/Ruling/Ruling.tsx
@@ -84,10 +84,12 @@ const Ruling = () => {
     constants.INVESTIGATION_CASE_MODIFY_RULING_ROUTE,
   )
 
-  useDeb(workingCase, 'prosecutorDemands')
-  useDeb(workingCase, 'courtCaseFacts')
-  useDeb(workingCase, 'courtLegalArguments')
-  useDeb(workingCase, 'conclusion')
+  useDeb(workingCase, [
+    'prosecutorDemands',
+    'courtCaseFacts',
+    'courtLegalArguments',
+    'conclusion',
+  ])
 
   useEffect(() => {
     if (isCaseUpToDate && !initialAutoFillDone) {

--- a/apps/judicial-system/web/src/routes/Court/RestrictionCase/CourtRecord/CourtRecord.tsx
+++ b/apps/judicial-system/web/src/routes/Court/RestrictionCase/CourtRecord/CourtRecord.tsx
@@ -74,11 +74,13 @@ export const CourtRecord: React.FC = () => {
   const { updateCase, setAndSendCaseToServer } = useCase()
   const { formatMessage } = useIntl()
 
-  useDeb(workingCase, 'courtAttendees')
-  useDeb(workingCase, 'sessionBookings')
-  useDeb(workingCase, 'accusedAppealAnnouncement')
-  useDeb(workingCase, 'prosecutorAppealAnnouncement')
-  useDeb(workingCase, 'endOfSessionBookings')
+  useDeb(workingCase, [
+    'courtAttendees',
+    'sessionBookings',
+    'accusedAppealAnnouncement',
+    'prosecutorAppealAnnouncement',
+    'endOfSessionBookings',
+  ])
 
   useEffect(() => {
     if (isCaseUpToDate && !initialAutoFillDone) {

--- a/apps/judicial-system/web/src/routes/Court/RestrictionCase/Ruling/Ruling.tsx
+++ b/apps/judicial-system/web/src/routes/Court/RestrictionCase/Ruling/Ruling.tsx
@@ -162,10 +162,12 @@ export const Ruling: React.FC = () => {
   const { updateCase, setAndSendCaseToServer } = useCase()
   const { formatMessage } = useIntl()
 
-  useDeb(workingCase, 'prosecutorDemands')
-  useDeb(workingCase, 'courtCaseFacts')
-  useDeb(workingCase, 'courtLegalArguments')
-  useDeb(workingCase, 'conclusion')
+  useDeb(workingCase, [
+    'prosecutorDemands',
+    'courtCaseFacts',
+    'courtLegalArguments',
+    'conclusion',
+  ])
 
   const {
     requestRulingSignature,

--- a/apps/judicial-system/web/src/routes/Prosecutor/InvestigationCase/PoliceDemands/PoliceDemands.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/InvestigationCase/PoliceDemands/PoliceDemands.tsx
@@ -59,9 +59,7 @@ const PoliceDemands: React.FC = () => {
   const [legalBasisEM, setLegalBasisEM] = useState<string>('')
   const [initialAutoFillDone, setInitialAutoFillDone] = useState(false)
 
-  useDeb(workingCase, 'demands')
-  useDeb(workingCase, 'lawsBroken')
-  useDeb(workingCase, 'legalBasis')
+  useDeb(workingCase, ['demands', 'lawsBroken', 'legalBasis'])
 
   useEffect(() => {
     const courtClaimPrefill: Partial<

--- a/apps/judicial-system/web/src/routes/Prosecutor/InvestigationCase/PoliceReport/PoliceReport.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/InvestigationCase/PoliceReport/PoliceReport.tsx
@@ -38,9 +38,11 @@ const PoliceReport = () => {
   const [legalArgumentsEM, setLegalArgumentsEM] = useState<string>('')
   const { updateCase, setAndSendCaseToServer } = useCase()
 
-  useDeb(workingCase, 'caseFacts')
-  useDeb(workingCase, 'legalArguments')
-  useDeb(workingCase, 'prosecutorOnlySessionRequest')
+  useDeb(workingCase, [
+    'caseFacts',
+    'legalArguments',
+    'prosecutorOnlySessionRequest',
+  ])
 
   useEffect(() => {
     if (

--- a/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/StepFour/StepFour.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/StepFour/StepFour.tsx
@@ -45,9 +45,7 @@ export const StepFour: React.FC = () => {
 
   const { updateCase } = useCase()
 
-  useDeb(workingCase, 'demands')
-  useDeb(workingCase, 'caseFacts')
-  useDeb(workingCase, 'legalArguments')
+  useDeb(workingCase, ['demands', 'caseFacts', 'legalArguments'])
 
   const stepIsValid = isPoliceReportStepValidRC(workingCase)
   const handleNavigationTo = (destination: string) =>

--- a/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/StepThree/StepThree.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/StepThree/StepThree.tsx
@@ -105,9 +105,11 @@ export const StepThree: React.FC = () => {
     '',
   )
   const { updateCase, setAndSendCaseToServer } = useCase()
-  useDeb(workingCase, 'lawsBroken')
-  useDeb(workingCase, 'legalBasis')
-  useDeb(workingCase, 'requestedOtherRestrictions')
+  useDeb(workingCase, [
+    'lawsBroken',
+    'legalBasis',
+    'requestedOtherRestrictions',
+  ])
 
   useEffect(() => {
     if (

--- a/apps/judicial-system/web/src/utils/hooks/useDeb/index.tsx
+++ b/apps/judicial-system/web/src/utils/hooks/useDeb/index.tsx
@@ -4,15 +4,21 @@ import { Case } from '@island.is/judicial-system/types'
 
 import useCase from '../useCase'
 
-const useDeb = (workingCase: Case, key: keyof Case) => {
+const useDeb = (workingCase: Case, keys: Array<keyof Case> | keyof Case) => {
   const { updateCase } = useCase()
+  const newKeys = Array.isArray(keys) ? keys : [keys]
 
   useDebounce(
     () => {
-      updateCase(workingCase.id, { [key]: workingCase[key] })
+      updateCase(workingCase.id, {
+        ...newKeys.reduce(
+          (acc, key) => ({ ...acc, [key]: workingCase[key] }),
+          {},
+        ),
+      })
     },
     2000,
-    [workingCase[key]],
+    [...newKeys.map((key) => workingCase[key])],
   )
 }
 


### PR DESCRIPTION
# Refactor useDep hook

[Asana](https://app.asana.com/0/1199153462262248/1203621685545197/f)

## What

Refactor useDep hook to accept list of workingCase keys

## Why

By not accepting a list of keys, if there were multiple values that needed debouncing you'd have to call the hook multiple times i.e.

_old_
`useDep(workingCase, 'valueA')`
`useDep(workingCase, 'valueB')`

_new_
`useDep(workingCase, ['valueA',  'valueB'])`

You can also use a keyof workingCase for single values i.e.
`useDep(workingCase, 'valueB')`

## Screenshots / Gifs


https://user-images.githubusercontent.com/3789875/210052712-04089236-d2a4-48a9-976d-b7a49c4ed8e4.mov



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
