### PR TITLE
fix(delegation-api): Add admin audience

### DIFF
--- a/apps/services/auth/delegation-api/src/environments/environment.ts
+++ b/apps/services/auth/delegation-api/src/environments/environment.ts
@@ -1,10 +1,12 @@
+const audience = ['island.is', '@admin.island.is']
+
 const devConfig = {
   audit: {
     defaultNamespace: '@island.is/auth/delegation-api',
   },
   auth: {
     issuer: 'https://identity-server.dev01.devland.is',
-    audience: '@island.is',
+    audience,
   },
   port: 5333,
 }
@@ -16,7 +18,7 @@ const prodConfig = {
     serviceName: 'services-auth-public-api',
   },
   auth: {
-    audience: '@island.is',
+    audience,
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     issuer: process.env.IDENTITY_SERVER_ISSUER_URL!,
   },


### PR DESCRIPTION
# Add admin audience

## What

As the delegation system is used both in service portal and admin portal, the api needs to support both `island.is` and `@admin.island.is` audience.

## Why

To authorize api requests from the admin porta.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
