### PR TITLE
feat(web): Add close button to watson chat panel

### DIFF
--- a/apps/web/components/ChatPanel/WatsonChatPanel/WatsonChatPanel.tsx
+++ b/apps/web/components/ChatPanel/WatsonChatPanel/WatsonChatPanel.tsx
@@ -57,6 +57,14 @@ export const WatsonChatPanel = (props: WatsonChatPanelProps) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const windowObject: any = window
     windowObject.watsonAssistantChatOptions = {
+      showCloseAndRestartButton: true,
+      pageLinkConfig: {
+        linkIDs: {
+          t10: {
+            text: n('t10', 'Tala við manneskju'),
+          },
+        },
+      },
       ...props,
       onLoad: (instance) => {
         watsonInstance.current = instance


### PR DESCRIPTION
# Add close button to watson chat panel

## What

* Now there's a close button in the watson chat panel (previously there was only a minimize button)

## Why

* This was requested by Digital Iceland

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/43557895/210244263-7669eac4-8cdd-4838-95fc-af8fef3285d3.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
