### PR TITLE
fix(tax-calculator): Fix broken tests due to new year

### DIFF
--- a/libs/financial-aid/shared/src/lib/taxCalculator.ts
+++ b/libs/financial-aid/shared/src/lib/taxCalculator.ts
@@ -1,4 +1,16 @@
-export const taxInfoNumbers = {
+import format from 'date-fns/format'
+import { Amount, Calculations } from './interfaces'
+
+export interface TaxInfo {
+  personalTaxAllowance: number
+  taxPercentage: number
+}
+interface TaxInfoYear {
+  [id: string]: TaxInfo
+}
+
+const currentYear = format(new Date(), 'yyyy')
+export const taxInfoNumbers: TaxInfoYear = {
   '2021': {
     taxPercentage: 31.45,
     personalTaxAllowance: 50792,
@@ -9,18 +21,12 @@ export const taxInfoNumbers = {
   },
 }
 
-interface TaxInfoYear {
-  [id: string]: TaxInfo
+// Set current year tax to latest available if tax info is missing
+// for the current year
+if (!taxInfoNumbers[currentYear]) {
+  const keys = Object.keys(taxInfoNumbers).sort()
+  taxInfoNumbers[currentYear] = taxInfoNumbers[keys[keys.length - 1]]
 }
-
-export interface TaxInfo {
-  personalTaxAllowance: number
-  taxPercentage: number
-}
-import format from 'date-fns/format'
-import { Amount, Calculations } from './interfaces'
-
-const currentYear = format(new Date(), 'yyyy')
 
 export const calculateAidFinalAmount = (
   amount: number,


### PR DESCRIPTION
The tax calculator tests use the actual current year, which recently changed, and tax info wasn't present.

Duplicate of https://github.com/island-is/island.is/pull/9479

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
