### PR TITLE
fix(service-portal): HOTFIX - vehicle history type error (#9488)

### DIFF
--- a/libs/api/domains/vehicles/src/lib/api-domains-vehicles.type.ts
+++ b/libs/api/domains/vehicles/src/lib/api-domains-vehicles.type.ts
@@ -78,10 +78,10 @@ export interface Vehicle {
   operatorStartDate?: Date | null
   /**
    *
-   * @type {String}
+   * @type {Date}
    * @memberof Vehicle
    */
-  operatorEndDate?: string | null
+  operatorEndDate?: Date | null
   /**
    *
    * @type {boolean}

--- a/libs/api/domains/vehicles/src/models/usersVehicles.model.ts
+++ b/libs/api/domains/vehicles/src/models/usersVehicles.model.ts
@@ -50,7 +50,7 @@ export class VehiclesVehicle {
   operatorStartDate?: Date
 
   @Field({ nullable: true })
-  operatorEndDate?: string
+  operatorEndDate?: Date
 
   @Field({ nullable: true })
   outOfUse?: boolean


### PR DESCRIPTION
# Service Portal - Vehicle history 

Fix date type error after auto generating client config in another PR 

See #9488 

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
