### PR TITLE
fix(service-portal): dereg dates missing in vehicle fix

### DIFF
--- a/libs/api/domains/vehicles/src/models/usersVehicles.model.ts
+++ b/libs/api/domains/vehicles/src/models/usersVehicles.model.ts
@@ -83,7 +83,7 @@ export class VehiclesVehicle {
   nextInspection?: NextInspection
 
   @Field({ nullable: true })
-  deregistrationDate?: string
+  deregistrationDate?: Date
 
   @Field({ nullable: true, defaultValue: null })
   operatorNumber?: number


### PR DESCRIPTION
# Service Portal - Vehicle History fix

## What

Missing fix for deregistration date in previous fix 😭 


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
