### PR TITLE
fix(air-discount-scheme): Return legacy gender value for external contacts

### DIFF
--- a/apps/air-discount-scheme/backend/src/app/modules/discount/discount.controller.ts
+++ b/apps/air-discount-scheme/backend/src/app/modules/discount/discount.controller.ts
@@ -63,6 +63,11 @@ export class PublicDiscountController {
 
     // Constructor masks nationalId
     const airlineUser = new AirlineUser(discount.user, discount.user.fund)
+
+    // TODO: remove once addressed externally
+    if (airlineUser.gender === 'x') {
+      airlineUser.gender = 'hvk'
+    }
     return airlineUser
   }
 }

--- a/libs/air-discount-scheme/types/src/lib/user.ts
+++ b/libs/air-discount-scheme/types/src/lib/user.ts
@@ -1,4 +1,4 @@
-export type RegistryGender = 'kk' | 'kvk' | 'x'
+export type RegistryGender = 'kk' | 'kvk' | 'x' | 'hvk'
 
 export type UncategorizedGender = 'manneskja'
 


### PR DESCRIPTION
From our air discount codes, airline companies are using the user info value for their frontends. The legacy value for genderqueer shall be presented externally until all parties are ready to switch.

Since a database migration has already taken place for user data I'd recommend overwriting the response upon retrieval but leave everything else as is.


## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
