### PR TITLE
feat(system-e2e): Disable noisy failing tests

### DIFF
--- a/apps/system-e2e/src/tests/admin-portal/smoke/admin-portal.spec.ts
+++ b/apps/system-e2e/src/tests/admin-portal/smoke/admin-portal.spec.ts
@@ -19,7 +19,7 @@ test.describe('Admin portal', () => {
   test.afterAll(async () => {
     await context.close()
   })
-  test('should see welcome title', async () => {
+  test.skip('should see welcome title', async () => {
     const page = await context.newPage()
     const { findByRole } = helpers(page)
     await page.goto('/stjornbord')


### PR DESCRIPTION
Currently an admin portal test is failing with near 100% failure rate. This PR disables the failing tests until it's fixed.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
