### PR TITLE
fix(transport-authority-transfer-of-vehicle-ownership): Use correct errorNo for vehicle locks

### DIFF
--- a/libs/clients/transport-authority/vehicle-owner-change/src/lib/vehicleOwnerChangeClient.service.ts
+++ b/libs/clients/transport-authority/vehicle-owner-change/src/lib/vehicleOwnerChangeClient.service.ts
@@ -60,10 +60,21 @@ export class VehicleOwnerChangeClient {
 
     return {
       hasError: errorList.length > 0,
-      errorMessages: errorList.map((item) => ({
-        errorNo: (item.warnSever || '_') + item.warningSerialNumber,
-        defaultMessage: item.errorMess,
-      })),
+      errorMessages: errorList.map((item) => {
+        let errorNo = item.warningSerialNumber?.toString()
+
+        // Note: For vehicle locks, we need to do some special parsing since
+        // the error number (warningSerialNumber) is always -1 for locks,
+        // but the number is included in the errorMess field (value before the first space)
+        if (item.warnSever === warnSeverityLock) {
+          errorNo = item.errorMess?.split(' ')[0]
+        }
+
+        return {
+          errorNo: (item.warnSever || '_') + errorNo,
+          defaultMessage: item.errorMess,
+        }
+      }),
     }
   }
 
@@ -130,10 +141,21 @@ export class VehicleOwnerChangeClient {
 
     return {
       hasError: errorList.length > 0,
-      errorMessages: errorList.map((item) => ({
-        errorNo: (item.warnSever || '_') + item.warningSerialNumber,
-        defaultMessage: item.errorMess,
-      })),
+      errorMessages: errorList.map((item) => {
+        let errorNo = item.warningSerialNumber?.toString()
+
+        // Note: For vehicle locks, we need to do some special parsing since
+        // the error number (warningSerialNumber) is always -1 for locks,
+        // but the number is included in the errorMess field (value before the first space)
+        if (item.warnSever === warnSeverityLock) {
+          errorNo = item.errorMess?.split(' ')[0]
+        }
+
+        return {
+          errorNo: (item.warnSever || '_') + errorNo,
+          defaultMessage: item.errorMess,
+        }
+      }),
     }
   }
 


### PR DESCRIPTION
## What

Fetch the correct errorNo for vehicle locks when validating vehicle for ownerchange

## Why

To be able to translate the error message (using text from contentful)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
