### PR TITLE
fix(search-indexer): Hotfix - Add circularity fail-safe to error filtering (#9337)

### DIFF
--- a/libs/content-search-toolkit/README.md
+++ b/libs/content-search-toolkit/README.md
@@ -2,3 +2,11 @@
 
 Contains useful functions to help with querying data from content search elasticsearch.
 This library should only contain generic code
+
+## Unit testing util functions
+
+Run the following command to unit test the util functions:
+
+```
+yarn nx test content-search-toolkit
+```

--- a/libs/content-search-toolkit/src/services/utils/index.ts
+++ b/libs/content-search-toolkit/src/services/utils/index.ts
@@ -1,0 +1,33 @@
+/**
+ * @param {T} err Error object
+ * @return {boolean} True iff a document was removed
+ *
+ * Filter the HUMONGOUS documents in an error object
+ */
+export function filterDoc<T>(
+  node: T,
+  visited = new Set(),
+  letterLimit = 10000,
+): boolean {
+  if (visited.has(node) || !node) return false
+
+  visited.add(node)
+
+  let deleted = false
+  if (Object.keys(node).length == 0) return false
+  for (const key in node) {
+    const value = node[key]
+    // Only HUMONGOUS documents should reach this limit
+    if (typeof value === 'string' && value.length > letterLimit) {
+      delete node[key]
+      deleted = true
+      continue
+    } else if (
+      typeof value === 'object' &&
+      filterDoc(value, visited, letterLimit)
+    ) {
+      deleted = true
+    }
+  }
+  return deleted
+}

--- a/libs/content-search-toolkit/src/services/utils/utils.spec.ts
+++ b/libs/content-search-toolkit/src/services/utils/utils.spec.ts
@@ -1,0 +1,26 @@
+import { filterDoc } from './index'
+
+describe('filterDoc', () => {
+  it('should not recurse infinitely if the node is circular', () => {
+    const test: Record<string, unknown> = {
+      a: 'some-value',
+    }
+    test.b = test
+    const result = filterDoc(test)
+
+    // No field should be pruned
+    expect(result).toBe(false)
+  })
+  it('should prune fields that are longer than the letter limit', () => {
+    const test: Record<string, unknown> = {
+      a: 'some-value',
+      b: {
+        c: 'some-really-long-value-that-should-get-pruned',
+      },
+    }
+
+    const result = filterDoc(test, new Set(), 20)
+    expect(result).toBe(true)
+    expect(test.b).toStrictEqual({})
+  })
+})


### PR DESCRIPTION
# Hotfix - Add circularity fail-safe to error filtering (#9337)

Production web content isn't being updated due to circular error objects being processed by a function that can't handle circular data. This change (containing a cherry-pick commit from main) addresses that issue

* Add first draft of a circular fail safe implementation

* Call correct function and type function in a generic manner

* Move function to utils.ts

* Renamed param

* Add unit test and refactor code

* Combine tests into one single test

* Add seperate circularity check

* Update README

Co-authored-by: kodiakhq[bot] <49736102+kodiakhq[bot]@users.noreply.github.com>
