### PR TITLE
fix(admin-portal): Add access denied if user has no access

### DIFF
--- a/apps/portals/admin/src/components/Layout/Layout.tsx
+++ b/apps/portals/admin/src/components/Layout/Layout.tsx
@@ -12,10 +12,12 @@ import { useNamespaces } from '@island.is/localization'
 import Header from '../Header/Header'
 import * as styles from './Layout.css'
 import {
+  AccessDenied,
   useModuleProps,
   PortalModule,
   usePortalMeta,
   useActiveModule,
+  useModules,
 } from '@island.is/portals/core'
 
 const boxProps = {
@@ -82,9 +84,20 @@ export const Layout: FC = ({ children }) => {
   useNamespaces(['admin.portal', 'global'])
   const { portalType } = usePortalMeta()
   const activeModule = useActiveModule()
+  const modules = useModules()
   const moduleProps = useModuleProps()
   const { layout = 'default', moduleLayoutWrapper: ModuleLayoutWrapper } =
     activeModule || {}
+
+  if (modules.length === 0) {
+    return (
+      <LayoutOuterContainer>
+        <LayoutModuleContainer layout={layout}>
+          <AccessDenied />
+        </LayoutModuleContainer>
+      </LayoutOuterContainer>
+    )
+  }
 
   const moduleLayout = !activeModule ? 'none' : layout
 

--- a/libs/portals/admin/air-discount-scheme/src/module.ts
+++ b/libs/portals/admin/air-discount-scheme/src/module.ts
@@ -13,17 +13,17 @@ export const airDiscountSchemeAdminModule: PortalModule = {
   name: m.airDiscountScheme,
   widgets: () => [],
   layout: 'full',
-  routes: ({ userInfo }) => [
+  enabled: ({ userInfo }) =>
+    userInfo.scopes.includes(AdminPortalScope.airDiscountScheme),
+  routes: () => [
     {
       name: m.overview,
       path: AirDiscountSchemePaths.Root,
-      enabled: userInfo.scopes.includes(AdminPortalScope.airDiscountScheme),
       render: () => OverviewScreen,
     },
     {
       name: m.createDiscount,
       path: AirDiscountSchemePaths.CreateDiscount,
-      enabled: userInfo.scopes.includes(AdminPortalScope.airDiscountScheme),
       render: () => CreateDiscount,
     },
   ],

--- a/libs/portals/core/src/index.ts
+++ b/libs/portals/core/src/index.ts
@@ -20,6 +20,7 @@ export * from './hooks/useSingleNavigationItem'
 export * from './utils/plausible'
 
 // screens
+export * from './screens/AccessDenied'
 export * from './screens/NotFound'
 
 // components

--- a/libs/portals/core/src/screens/AccessDenied.tsx
+++ b/libs/portals/core/src/screens/AccessDenied.tsx
@@ -1,11 +1,11 @@
 import { useLocale } from '@island.is/localization'
 import { useAuth } from '@island.is/auth/react'
 import { checkDelegation } from '@island.is/shared/utils'
+
 import { m } from '../lib/messages'
-import { PortalModuleComponent } from '../types/portalCore'
 import { ErrorScreen } from './ErrorScreen/ErrorScreen'
 
-export const AccessDenied: PortalModuleComponent = () => {
+export const AccessDenied = () => {
   const { formatMessage } = useLocale()
   const { userInfo: user } = useAuth()
   const isDelegation = user && checkDelegation(user)

--- a/libs/portals/core/src/screens/Modules.tsx
+++ b/libs/portals/core/src/screens/Modules.tsx
@@ -106,7 +106,7 @@ export const Modules = () => {
       {modules.length > 0 ? (
         <RouteLoader routes={routes} userInfo={userInfo} client={client} />
       ) : (
-        <AccessDenied userInfo={userInfo} client={client} />
+        <AccessDenied />
       )}
     </Box>
   )


### PR DESCRIPTION
## What

If user managed to be routed to the Admin dashboard, we make sure to render a access denied screen.

Set enabled property of ADS module to be disabled if user doesn't have the scope.

## Why

To handle if user is routed to the admin dashboard with valid login but no access to any admin module.

Note: The module switcher will be updated in a separate PR to handle access denied and single module access better.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
