### PR TITLE
fix(j-s): Travel Ban Modification

### DIFF
--- a/apps/judicial-system/web/messages/Core/signedVerdictOverview.ts
+++ b/apps/judicial-system/web/messages/Core/signedVerdictOverview.ts
@@ -236,7 +236,7 @@ export const signedVerdictOverview = {
         id:
           'judicial.system.core:signed_verdict_overview.modify_dates_modal.travel_ban_success_text',
         defaultMessage:
-          'Farbann til {date}. Tilkynning verður send á ábyrgðaraðila málsins hjá héraðsdómstól.',
+          'Farbann til {date}. Tilkynning verður send á ábyrgðaraðila málsins hjá {courtOrProsecutor}.',
         description:
           'Notaður sem texti í "Lengd gæsluvarðhalds breytt" glugga á yfirlitsskjá afgreiddra mála.',
       },

--- a/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/Components/ModifyDatesModal/ModifyDatesModal.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/Components/ModifyDatesModal/ModifyDatesModal.tsx
@@ -96,6 +96,10 @@ const getModificationSuccessText = (
         'dagur,',
         'dagsins',
       )} kl. ${formatDate(modifiedValidToDate?.value, constants.TIME_FORMAT)}`,
+      courtOrProsecutor:
+        userRole === UserRole.PROSECUTOR
+          ? 'héraðsdómstól'
+          : 'saksóknaraembætti',
     })
   } else if (validToDateAndIsolationToDateAreTheSame) {
     modification = formatMessage(


### PR DESCRIPTION
# Travel Ban Modification

[Uppfæra lengd farbanns](https://app.asana.com/0/1199153462262248/1203426045107043/f)

## What

- Does not send a modified custody notice to prison for travel bans.
- Fixes notification in client when the modification is performed at court.

## Why

- Verified bugs.

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/795382/211375100-ccb90aa9-6aca-4945-a0f7-9a4b76dccbb1.png)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
