### PR TITLE
fix(ads): More test data on local development

### DIFF
--- a/apps/air-discount-scheme/backend/seeders/20211108100835-development.js
+++ b/apps/air-discount-scheme/backend/seeders/20211108100835-development.js
@@ -1,9 +1,9 @@
 'use strict'
 const faker = require('faker')
 
-// Good to have one test user accumulate more than the statistically
+// Good to have test users accumulate more than the statistically
 // likely singular flight leg.
-const specific_test_user = faker.phone.phoneNumber('##########')
+const specific_test_users = ['0101302399', '2222222229']
 
 const pairings = [
   [
@@ -43,9 +43,9 @@ const getRandomFlightLeg = (flightId, flightDate, pairing) => {
 }
 
 const getRandomFlight = (nationalId) => {
-  // Random time, max 30 days in the past
+  // Random time, max 1 day into the future
   const randomDate = new Date(
-    Date.now() - Math.ceil(Math.random() * 2592000000),
+    Date.now() + Math.ceil(Math.random() * 1000 * 60 * 60 * 24),
   ).toISOString()
   return {
     id: faker.datatype.uuid(),
@@ -68,7 +68,11 @@ module.exports = {
     const flight_legs = []
     for (let i = 0; i < 100; i++) {
       const nationalId =
-        i < 2 ? specific_test_user : faker.phone.phoneNumber('##########')
+        i < 2
+          ? specific_test_users[0]
+          : i < 4
+          ? specific_test_users[1]
+          : faker.phone.phoneNumber('##########')
       const pairingLeg = Math.round(Math.random() * (pairings[0].length - 1))
       const flight = getRandomFlight(nationalId)
       flights.push(flight)


### PR DESCRIPTION
Make testing easier.
Gervimaður Færeyjar has a child '2222222229' so we ensure that they both are inserted upon generating noisy random data.

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
