### PR TITLE
fix(j-s): Other Case Files

### DIFF
--- a/apps/judicial-system/web/src/utils/formHelper.ts
+++ b/apps/judicial-system/web/src/utils/formHelper.ts
@@ -350,4 +350,5 @@ export const mapCaseFileToUploadFile = (file: CaseFile): TUploadFile => ({
   percent: 100,
   size: file.size,
   category: file.category,
+  policeCaseNumber: file.policeCaseNumber,
 })


### PR DESCRIPTION
# Other Case Files

[Retry virkar ekki eftir að ekki tekst að hlaða upp skrá](https://app.asana.com/0/1199153462262248/1203374349779618/f)

## What

- Ignores case files that are attached to a police case when displaying "Önnur gögn" on the screen "Dómskjöl".

## Why

- Verified bug.

## Screenshots / Gifs

### Before
![image](https://user-images.githubusercontent.com/795382/211616912-0556ae8f-1790-4437-9e99-b6a1ffa27704.png)

### After
![image](https://user-images.githubusercontent.com/795382/211617009-2baa7e15-e65e-4075-815c-cbb851eadfed.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
