### PR TITLE
refactor(portals-admin): Update static module switcher when outside active module

### DIFF
--- a/apps/portals/admin/src/components/ModuleSwitcher/ModuleSwitcher.tsx
+++ b/apps/portals/admin/src/components/ModuleSwitcher/ModuleSwitcher.tsx
@@ -4,9 +4,16 @@ import { Hidden } from '@island.is/island-ui/core'
 
 import { ModuleSwitcherDesktop } from './ModuleSwitcherDesktop'
 import { ModuleSwitcherMobile } from './ModuleSwitcherMobile'
+import {
+  SingleNavigationItemStatus,
+  useSingleNavigationItem,
+} from '@island.is/portals/core'
+import { BOTTOM_NAVIGATION, TOP_NAVIGATION } from '../../lib/masterNavigation'
 
 export const ModuleSwitcher = () => {
-  return (
+  const { status } = useSingleNavigationItem(TOP_NAVIGATION, BOTTOM_NAVIGATION)
+
+  return status === SingleNavigationItemStatus.NO_ITEM ? null : (
     <>
       <Hidden below="lg">
         <ModuleSwitcherDesktop />

--- a/apps/portals/admin/src/components/ModuleSwitcher/ModuleSwitcher.tsx
+++ b/apps/portals/admin/src/components/ModuleSwitcher/ModuleSwitcher.tsx
@@ -1,14 +1,12 @@
-import React from 'react'
-
 import { Hidden } from '@island.is/island-ui/core'
-
-import { ModuleSwitcherDesktop } from './ModuleSwitcherDesktop'
-import { ModuleSwitcherMobile } from './ModuleSwitcherMobile'
 import {
   SingleNavigationItemStatus,
   useSingleNavigationItem,
 } from '@island.is/portals/core'
+
 import { BOTTOM_NAVIGATION, TOP_NAVIGATION } from '../../lib/masterNavigation'
+import { ModuleSwitcherDesktop } from './ModuleSwitcherDesktop'
+import { ModuleSwitcherMobile } from './ModuleSwitcherMobile'
 
 export const ModuleSwitcher = () => {
   const { status } = useSingleNavigationItem(TOP_NAVIGATION, BOTTOM_NAVIGATION)

--- a/apps/portals/admin/src/components/ModuleSwitcher/ModuleSwitcherDesktop.css.ts
+++ b/apps/portals/admin/src/components/ModuleSwitcher/ModuleSwitcherDesktop.css.ts
@@ -1,15 +1,29 @@
-import { style } from '@vanilla-extract/css'
+import { style, styleVariants } from '@vanilla-extract/css'
 
 import { theme } from '@island.is/island-ui/theme'
 
-export const container = style({
+const baseContainer = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'spaceBetween',
   width: '290px',
   height: theme.headerHeight.large,
   marginLeft: theme.spacing[5],
-  boxShadow: `inset 1px 0 0 0 ${theme.color.blue200}, inset -1px 0 0 0 ${theme.color.blue200}`,
+})
+
+export const container = styleVariants({
+  normal: [
+    baseContainer,
+    {
+      boxShadow: `inset 1px 0 0 0 ${theme.color.blue200}, inset -1px 0 0 0 ${theme.color.blue200}`,
+    },
+  ],
+  skipRightBorder: [
+    baseContainer,
+    {
+      boxShadow: `inset 1px 0 0 0 ${theme.color.blue200}`,
+    },
+  ],
 })
 
 export const menuButton = style({

--- a/apps/portals/admin/src/components/ModuleSwitcher/ModuleSwitcherDesktop.tsx
+++ b/apps/portals/admin/src/components/ModuleSwitcher/ModuleSwitcherDesktop.tsx
@@ -21,7 +21,7 @@ export const ModuleSwitcherDesktop = () => {
     unstable_offset: [0, -60],
   })
   const { formatMessage } = useLocale()
-  const isNotActiveModule = !useActiveModule()
+  const activeModule = useActiveModule()
   const { status } = useSingleNavigationItem(TOP_NAVIGATION, BOTTOM_NAVIGATION)
   const isStaticSwitcher = status !== SingleNavigationItemStatus.MULTIPLE_ITEMS
 
@@ -29,7 +29,7 @@ export const ModuleSwitcherDesktop = () => {
     <div
       className={
         styles.container[
-          isStaticSwitcher && isNotActiveModule ? 'skipRightBorder' : 'normal'
+          isStaticSwitcher && !activeModule ? 'skipRightBorder' : 'normal'
         ]
       }
     >

--- a/apps/portals/admin/src/components/ModuleSwitcher/ModuleSwitcherDesktop.tsx
+++ b/apps/portals/admin/src/components/ModuleSwitcher/ModuleSwitcherDesktop.tsx
@@ -5,6 +5,7 @@ import { useLocale } from '@island.is/localization'
 import { m } from '@island.is/portals/admin/core'
 import {
   SingleNavigationItemStatus,
+  useActiveModule,
   useSingleNavigationItem,
 } from '@island.is/portals/core'
 
@@ -20,11 +21,18 @@ export const ModuleSwitcherDesktop = () => {
     unstable_offset: [0, -60],
   })
   const { formatMessage } = useLocale()
+  const isNotActiveModule = !useActiveModule()
   const { status } = useSingleNavigationItem(TOP_NAVIGATION, BOTTOM_NAVIGATION)
   const isStaticSwitcher = status !== SingleNavigationItemStatus.MULTIPLE_ITEMS
 
   return (
-    <div className={styles.container}>
+    <div
+      className={
+        styles.container[
+          isStaticSwitcher && isNotActiveModule ? 'skipRightBorder' : 'normal'
+        ]
+      }
+    >
       {isStaticSwitcher ? (
         <ModuleSwitcherHeader isStaticSwitcher />
       ) : (

--- a/apps/portals/admin/src/components/ModuleSwitcher/ModuleSwitcherDesktop.tsx
+++ b/apps/portals/admin/src/components/ModuleSwitcher/ModuleSwitcherDesktop.tsx
@@ -3,7 +3,10 @@ import { Menu, MenuButton, useMenuState } from 'reakit/Menu'
 import { Box, Button, Text } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
 import { m } from '@island.is/portals/admin/core'
-import { useSingleNavigationItem } from '@island.is/portals/core'
+import {
+  SingleNavigationItemStatus,
+  useSingleNavigationItem,
+} from '@island.is/portals/core'
 
 import { BOTTOM_NAVIGATION, TOP_NAVIGATION } from '../../lib/masterNavigation'
 import { ModuleSwitcherHeader } from './ModuleSwitcherHeader'
@@ -17,15 +20,13 @@ export const ModuleSwitcherDesktop = () => {
     unstable_offset: [0, -60],
   })
   const { formatMessage } = useLocale()
-  const hasSingleModuleAccess = !!useSingleNavigationItem(
-    TOP_NAVIGATION,
-    BOTTOM_NAVIGATION,
-  )
+  const { status } = useSingleNavigationItem(TOP_NAVIGATION, BOTTOM_NAVIGATION)
+  const isStaticSwitcher = status !== SingleNavigationItemStatus.MULTIPLE_ITEMS
 
   return (
     <div className={styles.container}>
-      {hasSingleModuleAccess ? (
-        <ModuleSwitcherHeader />
+      {isStaticSwitcher ? (
+        <ModuleSwitcherHeader isStaticSwitcher />
       ) : (
         <>
           <MenuButton

--- a/apps/portals/admin/src/components/ModuleSwitcher/ModuleSwitcherHeader.tsx
+++ b/apps/portals/admin/src/components/ModuleSwitcher/ModuleSwitcherHeader.tsx
@@ -28,11 +28,13 @@ export const ModuleSwitcherHeader = ({
     >
       <div>
         <Text variant="eyebrow">{formatMessage(m.shortTitle)}</Text>
-        <Text>
-          {formatMessage(
-            activeModule ? activeModule.name : rootNavigationItem.name,
-          )}
-        </Text>
+        {(!isStaticSwitcher || activeModule) && (
+          <Text>
+            {formatMessage(
+              activeModule ? activeModule.name : rootNavigationItem.name,
+            )}
+          </Text>
+        )}
       </div>
       {!isStaticSwitcher && (
         <Box

--- a/apps/portals/admin/src/components/ModuleSwitcher/ModuleSwitcherHeader.tsx
+++ b/apps/portals/admin/src/components/ModuleSwitcher/ModuleSwitcherHeader.tsx
@@ -1,35 +1,30 @@
 import { Box, Button, Text } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
 import { m } from '@island.is/portals/admin/core'
-import {
-  useActiveModule,
-  useSingleNavigationItem,
-} from '@island.is/portals/core'
+import { useActiveModule } from '@island.is/portals/core'
 
-import {
-  BOTTOM_NAVIGATION,
-  rootNavigationItem,
-  TOP_NAVIGATION,
-} from '../../lib/masterNavigation'
+import { rootNavigationItem } from '../../lib/masterNavigation'
 
 interface ModuleSwitcherHeaderProps {
   mobile?: boolean
+
+  // If true, the header will be static and not clickable
+  isStaticSwitcher?: boolean
 }
 
-export const ModuleSwitcherHeader = ({ mobile }: ModuleSwitcherHeaderProps) => {
+export const ModuleSwitcherHeader = ({
+  mobile,
+  isStaticSwitcher,
+}: ModuleSwitcherHeaderProps) => {
   const activeModule = useActiveModule()
   const { formatMessage } = useLocale()
-  const hasSingleNavItem = !!useSingleNavigationItem(
-    TOP_NAVIGATION,
-    BOTTOM_NAVIGATION,
-  )
 
   return (
     <Box
       display="flex"
       justifyContent="spaceBetween"
       paddingX={mobile ? undefined : 3}
-      cursor={hasSingleNavItem ? undefined : 'pointer'}
+      cursor={isStaticSwitcher ? undefined : 'pointer'}
     >
       <div>
         <Text variant="eyebrow">{formatMessage(m.shortTitle)}</Text>
@@ -39,7 +34,7 @@ export const ModuleSwitcherHeader = ({ mobile }: ModuleSwitcherHeaderProps) => {
           )}
         </Text>
       </div>
-      {!hasSingleNavItem && (
+      {isStaticSwitcher && (
         <Box
           display="flex"
           alignItems="center"

--- a/apps/portals/admin/src/components/ModuleSwitcher/ModuleSwitcherHeader.tsx
+++ b/apps/portals/admin/src/components/ModuleSwitcher/ModuleSwitcherHeader.tsx
@@ -34,7 +34,7 @@ export const ModuleSwitcherHeader = ({
           )}
         </Text>
       </div>
-      {isStaticSwitcher && (
+      {!isStaticSwitcher && (
         <Box
           display="flex"
           alignItems="center"

--- a/apps/portals/admin/src/components/ModuleSwitcher/ModuleSwitcherMobile.tsx
+++ b/apps/portals/admin/src/components/ModuleSwitcher/ModuleSwitcherMobile.tsx
@@ -3,7 +3,10 @@ import { Dialog, DialogDisclosure, useDialogState } from 'reakit/Dialog'
 import { Box, Button, Logo, Text } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
 import { m } from '@island.is/portals/admin/core'
-import { useSingleNavigationItem } from '@island.is/portals/core'
+import {
+  SingleNavigationItemStatus,
+  useSingleNavigationItem,
+} from '@island.is/portals/core'
 
 import { BOTTOM_NAVIGATION, TOP_NAVIGATION } from '../../lib/masterNavigation'
 import { ModuleSwitcherHeader } from './ModuleSwitcherHeader'
@@ -14,15 +17,13 @@ import * as styles from './ModuleSwitcherMobile.css'
 export const ModuleSwitcherMobile = () => {
   const dialog = useDialogState()
   const { formatMessage } = useLocale()
-  const hasSingleNavItem = !!useSingleNavigationItem(
-    TOP_NAVIGATION,
-    BOTTOM_NAVIGATION,
-  )
+  const { status } = useSingleNavigationItem(TOP_NAVIGATION, BOTTOM_NAVIGATION)
+  const isStaticSwitcher = status !== SingleNavigationItemStatus.MULTIPLE_ITEMS
 
   return (
     <Box display="flex" marginLeft={2}>
-      {hasSingleNavItem ? (
-        <ModuleSwitcherHeader mobile />
+      {isStaticSwitcher ? (
+        <ModuleSwitcherHeader mobile isStaticSwitcher />
       ) : (
         <>
           <DialogDisclosure

--- a/apps/portals/admin/src/screens/Dashboard/Dashboard.tsx
+++ b/apps/portals/admin/src/screens/Dashboard/Dashboard.tsx
@@ -28,7 +28,7 @@ export const Dashboard = () => {
   const { md } = useBreakpoint()
   const topNavigation = useNavigation(TOP_NAVIGATION)
   const bottomNavigation = useNavigation(BOTTOM_NAVIGATION)
-  const navigationItem = useSingleNavigationItem(
+  const { navigationItem } = useSingleNavigationItem(
     TOP_NAVIGATION,
     BOTTOM_NAVIGATION,
   )

--- a/libs/portals/core/src/hooks/useSingleNavigationItem.spec.tsx
+++ b/libs/portals/core/src/hooks/useSingleNavigationItem.spec.tsx
@@ -5,7 +5,6 @@ import { IntlProvider } from 'react-intl'
 import { BrowserRouter as Router } from 'react-router-dom'
 
 import { MockedAuthenticator } from '@island.is/auth/react'
-
 import { defaultLanguage } from '@island.is/shared/constants'
 
 import { testCases } from '../../test/useSingleNavigationItem-test-cases'

--- a/libs/portals/core/src/hooks/useSingleNavigationItem.ts
+++ b/libs/portals/core/src/hooks/useSingleNavigationItem.ts
@@ -3,6 +3,18 @@ import concat from 'lodash/concat'
 import { useNavigation } from './useNavigation'
 import { PortalNavigationItem } from '../types/portalCore'
 
+export enum SingleNavigationItemStatus {
+  NO_ITEM = 'no_item',
+  SINGLE_ITEM = 'single_item',
+  MULTIPLE_ITEMS = 'multiple_items',
+}
+
+export interface UseSingleNavigationItemResult {
+  navigationItem?: PortalNavigationItem
+
+  status: SingleNavigationItemStatus
+}
+
 /**
  * Accepts one or more arrays of PortalNavigationItem and checks
  * if the filtered navigation results in a single child item.
@@ -24,7 +36,7 @@ import { PortalNavigationItem } from '../types/portalCore'
  */
 export const useSingleNavigationItem = (
   ...navigationTrees: PortalNavigationItem[]
-): PortalNavigationItem | null => {
+): UseSingleNavigationItemResult => {
   const combinedNavigation: PortalNavigationItem = {
     name: 'Combined navigation',
     // Combine all navigation trees into single item with combined children
@@ -34,7 +46,18 @@ export const useSingleNavigationItem = (
   // Filter out all items that are not accessible or enabled
   const filteredNavigation = useNavigation(combinedNavigation)
 
-  return filteredNavigation?.children?.length === 1
-    ? filteredNavigation.children[0]
-    : null
+  const navigationItem =
+    filteredNavigation?.children?.length === 1
+      ? filteredNavigation.children[0]
+      : undefined
+
+  return {
+    navigationItem,
+    status:
+      filteredNavigation?.children && filteredNavigation.children.length > 0
+        ? filteredNavigation.children.length === 1
+          ? SingleNavigationItemStatus.SINGLE_ITEM
+          : SingleNavigationItemStatus.MULTIPLE_ITEMS
+        : SingleNavigationItemStatus.NO_ITEM,
+  }
 }

--- a/libs/portals/core/test/useSingleNavigationItem-test-cases.ts
+++ b/libs/portals/core/test/useSingleNavigationItem-test-cases.ts
@@ -1,3 +1,7 @@
+import {
+  SingleNavigationItemStatus,
+  UseSingleNavigationItemResult,
+} from '../src/hooks/useSingleNavigationItem'
 import { PortalModule, PortalNavigationItem } from '../src/types/portalCore'
 
 type TestPortalModule = Pick<PortalModule, 'name' | 'enabled' | 'routes'>
@@ -5,11 +9,11 @@ type TestPortalModule = Pick<PortalModule, 'name' | 'enabled' | 'routes'>
 interface TestCase {
   modules: TestPortalModule[]
   navigationTrees: PortalNavigationItem[]
-  expected: PortalNavigationItem | null
+  expected: UseSingleNavigationItemResult
 }
 
 export const testCases: Record<string, TestCase> = {
-  'should return null when no navigation trees': {
+  'should return NO_ITEM and undefined item when no navigation trees': {
     modules: [
       {
         name: 'Test module',
@@ -24,9 +28,11 @@ export const testCases: Record<string, TestCase> = {
       },
     ],
     navigationTrees: [],
-    expected: null,
+    expected: {
+      status: SingleNavigationItemStatus.NO_ITEM,
+    },
   },
-  'should return single navigation item for single navigation tree with single valid child': {
+  'should return SINGLE_ITEM and an item for single navigation tree with single valid child': {
     modules: [
       {
         name: 'Test module',
@@ -53,11 +59,14 @@ export const testCases: Record<string, TestCase> = {
       },
     ],
     expected: {
-      name: 'Test child',
-      path: '/test',
+      navigationItem: {
+        name: 'Test child',
+        path: '/test',
+      },
+      status: SingleNavigationItemStatus.SINGLE_ITEM,
     },
   },
-  'should return single navigation item for multiple navigation trees with combined single valid child': {
+  'should return SINGLE_ITEM and an item for multiple navigation trees with combined single valid child': {
     modules: [
       {
         name: 'Accessible module',
@@ -104,11 +113,95 @@ export const testCases: Record<string, TestCase> = {
       },
     ],
     expected: {
-      name: 'Test accessible child',
-      path: '/valid',
+      navigationItem: {
+        name: 'Test accessible child',
+        path: '/valid',
+      },
+      status: SingleNavigationItemStatus.SINGLE_ITEM,
     },
   },
-  'should return null for single navigation tree with multiple valid children': {
+  'should return NO_ITEM and undefined item for single navigation tree with no valid child': {
+    modules: [
+      {
+        name: 'Test module',
+        enabled: () => false,
+        routes: () => [
+          {
+            name: 'Test route',
+            path: '/test',
+            enabled: false,
+          },
+        ],
+      },
+    ],
+    navigationTrees: [
+      {
+        name: 'Test tree',
+        path: '/',
+        children: [
+          {
+            name: 'Test child',
+            path: '/test',
+          },
+        ],
+      },
+    ],
+    expected: {
+      status: SingleNavigationItemStatus.NO_ITEM,
+    },
+  },
+  'should return NO_ITEM and undefined item for multiple navigation trees with no combined valid child': {
+    modules: [
+      {
+        name: 'Top module',
+        enabled: () => false,
+        routes: () => [
+          {
+            name: 'Top route',
+            path: '/top',
+            enabled: false,
+          },
+        ],
+      },
+      {
+        name: 'Bottom module',
+        enabled: () => false,
+        routes: () => [
+          {
+            name: 'Bottom route',
+            path: '/bottom',
+            enabled: false,
+          },
+        ],
+      },
+    ],
+    navigationTrees: [
+      {
+        name: 'Test top tree',
+        path: '/',
+        children: [
+          {
+            name: 'Test top child',
+            path: '/top',
+          },
+        ],
+      },
+      {
+        name: 'Test bottom tree',
+        path: '/',
+        children: [
+          {
+            name: 'Test bottom child',
+            path: '/bottom',
+          },
+        ],
+      },
+    ],
+    expected: {
+      status: SingleNavigationItemStatus.NO_ITEM,
+    },
+  },
+  'should return MULTIPLE_ITEMS and undefined item for single navigation tree with multiple valid children': {
     modules: [
       {
         name: 'Test module',
@@ -143,9 +236,11 @@ export const testCases: Record<string, TestCase> = {
         ],
       },
     ],
-    expected: null,
+    expected: {
+      status: SingleNavigationItemStatus.MULTIPLE_ITEMS,
+    },
   },
-  'should return null for multiple navigation tree with combined multiple valid children': {
+  'should return MULTIPLE_ITEMS and undefined item for multiple navigation tree with combined multiple valid children': {
     modules: [
       {
         name: 'Top module',
@@ -192,6 +287,8 @@ export const testCases: Record<string, TestCase> = {
         ],
       },
     ],
-    expected: null,
+    expected: {
+      status: SingleNavigationItemStatus.MULTIPLE_ITEMS,
+    },
   },
 }


### PR DESCRIPTION
## What

Few updates to the module switcher:
- Removing right border and displaying only "Stjórnborð" when navigating to access denied modules when static.
- Remove completely if user doesn't have any access to any module.

## Why

To fix awkward module switcher for those cases.

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/54210288/212029307-30771f14-a897-4ffc-8bd2-3d229b310620.png)

![image](https://user-images.githubusercontent.com/54210288/212029528-d97d54bf-f0d8-46d9-89d5-0959957088b8.png)

![image](https://user-images.githubusercontent.com/54210288/212029613-9c917668-21b7-4c63-9830-0af5428cfe77.png)

![image](https://user-images.githubusercontent.com/54210288/212030069-2cef9039-300a-4c40-a3c1-739bcde50228.png)

![image](https://user-images.githubusercontent.com/54210288/212030012-0916cc0c-5f23-401d-be38-3184d613ddba.png)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
