### PR TITLE
fix(contentful-role-permissions): Load all content types, not just the first 100 in Contentful dev tool

### DIFF
--- a/apps/tools/contentful-role-permissions/constants/index.ts
+++ b/apps/tools/contentful-role-permissions/constants/index.ts
@@ -26,7 +26,7 @@ export const DEFAULT_EDITABLE_ENTRY_TYPE_IDS = [
   'sidebarCard',
   'sliceConnectedComponent',
   'twoColumnText',
-  'mailingListSignup',
+  'emailSignup',
   'bigBulletList',
   'districts',
   'iconBullet',

--- a/apps/tools/contentful-role-permissions/utils/index.ts
+++ b/apps/tools/contentful-role-permissions/utils/index.ts
@@ -4,6 +4,7 @@ import {
   environmentId,
 } from '../constants'
 import {
+  CollectionProp,
   ContentTypeProps,
   createClient as createManagementClient,
   PlainClientAPI,
@@ -38,14 +39,28 @@ export const getAllRoles = async () => {
 
 export const getAllContentTypesInAscendingOrder = async () => {
   const client = getContentfulManagementApiClient()
-  const contentfulTypesResponse = await client.contentType.getMany({
-    limit: 1000,
-  })
-  const contentTypes = contentfulTypesResponse.items
+  let contentfulTypesResponse: CollectionProp<ContentTypeProps> | null = null
+
+  const contentTypes: ContentTypeProps[] = []
+
+  while (
+    contentfulTypesResponse === null ||
+    contentTypes.length < contentfulTypesResponse.total
+  ) {
+    contentfulTypesResponse = await client.contentType.getMany({
+      limit: 1000,
+      query: {
+        skip: contentTypes.length,
+      },
+    })
+    for (const type of contentfulTypesResponse.items) contentTypes.push(type)
+  }
+
   contentTypes.sort((a, b) =>
     a.name.toLowerCase().localeCompare(b.name.toLowerCase()),
   )
-  return contentfulTypesResponse.items
+
+  return contentTypes
 }
 
 export const getAllTags = async () => {

--- a/apps/tools/contentful-role-permissions/utils/index.ts
+++ b/apps/tools/contentful-role-permissions/utils/index.ts
@@ -48,7 +48,7 @@ export const getAllContentTypesInAscendingOrder = async () => {
     contentTypes.length < contentfulTypesResponse.total
   ) {
     contentfulTypesResponse = await client.contentType.getMany({
-      limit: 1000,
+      limit: 100,
       query: {
         skip: contentTypes.length,
       },


### PR DESCRIPTION
# Load all content types, not just the first 100 in Contentful dev tool

## What

* The dropdown was missing a few content types since we've surpassed a 100 in Contentful (and the api only returns a 100 at a time)
* Also since the mailingListSignupSlice content type will be deleted soon I added it's replacement as a default option

## Why

* We need to see all content types in the dropdown to be able to set correct permissions for users

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
