### PR TITLE
fix(delegation-api): Stop actor from being able to find delegations to self with otherUser filter.

### DIFF
--- a/libs/auth-api-lib/src/lib/delegations/delegations-outgoing.service.ts
+++ b/libs/auth-api-lib/src/lib/delegations/delegations-outgoing.service.ts
@@ -101,6 +101,12 @@ export class DelegationsOutgoingService {
       )
     }
 
+    if (otherUser === user.actor?.nationalId) {
+      throw new BadRequestException(
+        'Cannot fetch delegations for yourself as actor.',
+      )
+    }
+
     const delegation = await this.findOneInternal(
       user,
       DelegationDirection.OUTGOING,


### PR DESCRIPTION
## What

Stop actor from being able to find delegation to self with the `otherUser` filter.

## Why

To stop the user from going into the delegation detail view to modify delegation for self.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
