### PR TITLE
feat(regulations-admin): Update create regulation selection button

### DIFF
--- a/libs/portals/admin/regulations-admin/src/components/EditBasics.tsx
+++ b/libs/portals/admin/regulations-admin/src/components/EditBasics.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import * as s from './EditBasics.css'
 import {
   Box,
@@ -30,48 +30,18 @@ export const EditBasics = () => {
     draft.type.value &&
     t(draft.type.value === 'amending' ? msg.type_amending : msg.type_base)
 
+  useEffect(() => {
+    if (draft.type.value === 'base') {
+      updateState('title', 'Reglugerð um ')
+    }
+    if (draft.type.value === 'amending') {
+      updateState('title', 'Reglugerð um breytingu á reglugerð um ')
+    }
+  }, [draft.type.value])
+
   return (
     <>
       <Box marginBottom={3}>
-        {!draft.title.value && (
-          <Box className={s.shortcuts} marginBottom={[2, 2, 3]}>
-            Flýtileiðir:
-            <Box className={s.shortcutsButton}>
-              <Button
-                onClick={() => updateState('title', 'Reglugerð um ')}
-                variant="text"
-                size="small"
-              >
-                {t(msg.type_base)}
-              </Button>
-            </Box>
-            <Box className={s.shortcutsButton}>
-              <Button
-                onClick={() =>
-                  updateState('title', 'Reglugerð um breytingu á reglugerð um ')
-                }
-                variant="text"
-                size="small"
-              >
-                {t(msg.type_amending)}
-              </Button>
-            </Box>
-            <Box className={s.shortcutsButton}>
-              <Button
-                onClick={() =>
-                  updateState(
-                    'title',
-                    'Reglugerð um brottfellingu reglugerðar um ',
-                  )
-                }
-                variant="text"
-                size="small"
-              >
-                {t(msg.type_repealing)}
-              </Button>
-            </Box>
-          </Box>
-        )}
         <MagicTextarea
           label={t(msg.title)}
           name="title"

--- a/libs/portals/admin/regulations-admin/src/lib/messages.ts
+++ b/libs/portals/admin/regulations-admin/src/lib/messages.ts
@@ -530,7 +530,7 @@ export const homeMessages = defineMessages({
   },
   createRegulation: {
     id: 'ap.regulations-admin:create-regulation-cta',
-    defaultMessage: 'Skrá nýja reglugerð',
+    defaultMessage: 'Skrá reglugerð',
   },
   taskList_draftTitleMissing: {
     id: 'ap.regulations-admin:tasklist-draft-title-missing',

--- a/libs/portals/admin/regulations-admin/src/screens/Edit.tsx
+++ b/libs/portals/admin/regulations-admin/src/screens/Edit.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useEffect } from 'react'
-import { useParams } from 'react-router-dom'
+import { useHistory, useParams } from 'react-router-dom'
 
 import { useLocale, useNamespaces } from '@island.is/localization'
 import { DraftImpactId, RegulationDraftId } from '@island.is/regulations/admin'
@@ -35,6 +35,7 @@ import {
 import { SaveDeleteButtons } from '../components/SaveDeleteButtons'
 import { DraftingNotes } from '../components/DraftingNotes'
 import { ButtonBar } from '../components/ButtonBar'
+import { RegulationType } from '@island.is/regulations'
 
 // ---------------------------------------------------------------------------
 
@@ -102,16 +103,23 @@ const stepData: Record<
 
 const EditScreen = () => {
   const t = useLocale().formatMessage
-  const state = useDraftingState()
-  const step = stepData[state.step.name]
+  const { error: errorSate, step: stepState, actions } = useDraftingState()
+  const history = useHistory<{ type: RegulationType }>()
+  const { updateState } = actions
+  const step = stepData[stepState.name]
 
   useEffect(() => {
-    if (state.error) {
-      const { message, error } = state.error
+    if (errorSate) {
+      const { message, error } = errorSate
       console.error(error || message)
       toast.error(t(message))
     }
-  }, [state.error, t])
+  }, [errorSate, t])
+
+  useEffect(() => {
+    const regType = history.location?.state?.type
+    updateState('type', regType)
+  }, [history.location?.state?.type])
 
   return (
     <>
@@ -126,7 +134,7 @@ const EditScreen = () => {
         </GridColumn>
       </GridRow>
 
-      {state.step.name !== 'publish' && <SaveDeleteButtons wrap />}
+      {stepState.name !== 'publish' && <SaveDeleteButtons wrap />}
       <step.Component />
       <DraftingNotes />
       <ButtonBar />

--- a/libs/portals/admin/regulations-admin/src/screens/Home.css.ts
+++ b/libs/portals/admin/regulations-admin/src/screens/Home.css.ts
@@ -2,7 +2,5 @@ import { spacing } from '@island.is/island-ui/theme'
 import { style } from '@vanilla-extract/css'
 
 export const newButtonBox = style({
-  float: 'right',
-  marginLeft: spacing[2],
-  marginBottom: spacing[3],
+  zIndex: 2,
 })

--- a/libs/portals/admin/regulations-admin/src/screens/Home.tsx
+++ b/libs/portals/admin/regulations-admin/src/screens/Home.tsx
@@ -8,10 +8,11 @@ import {
   Text,
   GridColumn,
   GridRow,
+  DropdownMenu,
 } from '@island.is/island-ui/core'
 import { useNamespaces } from '@island.is/localization'
 
-import { homeMessages as msg } from '../lib/messages'
+import { editorMsgs, homeMessages as msg } from '../lib/messages'
 import { useLocale } from '@island.is/localization'
 import { useCreateRegulationDraft } from '../utils/dataHooks'
 import { RegulationsTabs } from '../components/RegulationsTabs'
@@ -46,18 +47,23 @@ const Home = () => {
             display="flex"
             justifyContent={['flexStart', 'flexStart', 'flexEnd']}
             alignItems="center"
+            position="relative"
+            className={s.newButtonBox}
           >
-            <Button
-              colorScheme="default"
-              iconType="filled"
-              preTextIconType="filled"
-              size="small"
-              variant="primary"
-              disabled={creating}
-              onClick={() => createNewDraft()}
-            >
-              {t(msg.createRegulation)}
-            </Button>
+            <DropdownMenu
+              icon="ellipsisHorizontal"
+              items={[
+                {
+                  onClick: () => createNewDraft({ regulationType: 'base' }),
+                  title: t(editorMsgs.type_base),
+                },
+                {
+                  onClick: () => createNewDraft({ regulationType: 'amending' }),
+                  title: t(editorMsgs.type_amending),
+                },
+              ]}
+              title={t(msg.createRegulation)}
+            />
           </Box>
         </GridColumn>
       </GridRow>

--- a/libs/portals/admin/regulations-admin/src/state/useDraftingState.ts
+++ b/libs/portals/admin/regulations-admin/src/state/useDraftingState.ts
@@ -43,7 +43,7 @@ const isDraftEmpty = (draft: RegDraftForm): boolean => {
     draft.title.value ||
     draft.text.value ||
     draft.appendixes.some(({ text, title }) => title.value || text.value) ||
-    draft.impacts.length
+    draft.impacts['length']
 
   return !someContent
 }

--- a/libs/portals/admin/regulations-admin/src/utils/dataHooks.ts
+++ b/libs/portals/admin/regulations-admin/src/utils/dataHooks.ts
@@ -17,6 +17,7 @@ import {
   RegName,
   Regulation,
   RegulationOptionList,
+  RegulationType,
 } from '@island.is/regulations'
 import { ShippedSummary } from '@island.is/regulations/admin'
 import { getEditUrl } from './routing'
@@ -160,7 +161,7 @@ export const useS3Upload = () => {
       })
       return
     }
-    uploadToS3(file, presignedPost.fields.key, presignedPost)
+    uploadToS3(file, presignedPost.fields['key'], presignedPost)
   }
 
   const onRetry = (file: File, regId: string) => {
@@ -404,6 +405,10 @@ const CREATE_DRAFT_REGULATION_MUTATION = gql`
   }
 `
 
+type useRegulationProps = {
+  regulationType?: RegulationType
+}
+
 export const useCreateRegulationDraft = () => {
   type CreateStatus =
     | { creating: boolean; error?: never }
@@ -416,7 +421,7 @@ export const useCreateRegulationDraft = () => {
   return {
     ...status,
 
-    createNewDraft: () => {
+    createNewDraft: ({ regulationType }: useRegulationProps) => {
       if (status.creating) {
         return
       }
@@ -431,7 +436,12 @@ export const useCreateRegulationDraft = () => {
           }
 
           setStatus({ creating: false })
-          history.push(getEditUrl(newDraft.id))
+          history.push({
+            pathname: getEditUrl(newDraft.id),
+            state: {
+              type: regulationType,
+            },
+          })
         })
         .catch((e) => {
           const error = e instanceof Error ? e : new Error(String(e))


### PR DESCRIPTION
## What

* Add dropdown for creating new regulations

## Why

There can be more than one type of regulation created. Selection in the first step.

## Screenshots / Gifs

![Screenshot 2023-01-16 at 16 21 47](https://user-images.githubusercontent.com/24840451/212725040-1434992b-0467-46b5-8133-4a401b5981d0.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
