### PR TITLE
feat(auth): Create ApiScopeUserClaim models in scope migrations. (#9638) HOTFIX

### DIFF
--- a/libs/auth-api-lib/seeders/data/helpers/createScope.ts
+++ b/libs/auth-api-lib/seeders/data/helpers/createScope.ts
@@ -41,6 +41,11 @@ interface ScopeOptions {
    * Adds this scope as `allowedScopes` for the specified clients.
    */
   addToClients?: Array<string>
+
+  /**
+   * Configures which claims the scope requires. Defaults to `nationalId`.
+   */
+  claims?: Array<string>
 }
 
 const getScopeFields = (options: ScopeOptions): DbScope => ({
@@ -74,6 +79,18 @@ export const createScope = (options: ScopeOptions) => async (
     'api_scope',
     [scope],
     () => `creating scope ${scope.name}`,
+  )
+
+  const claims = options.claims ?? ['nationalId']
+  await safeBulkInsert(
+    queryInterface,
+    'api_scope_user_claim',
+    claims.map((claim) => ({
+      api_scope_name: scope.name,
+      claim_name: claim,
+    })),
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    ({ claim_name }) => `linking scope ${scope.name} to claim ${claim_name}`,
   )
 
   await safeBulkInsert(


### PR DESCRIPTION
Would be nice to include #9638 in the release so the IDS scope seeding migrations are more complete. Otherwise they require more manual work before the admin portal starts working.