### PR TITLE
feat(web): Ship search component for directorate of fisheries organization pages

### DIFF
--- a/apps/web/components/Organization/Slice/SliceMachine.tsx
+++ b/apps/web/components/Organization/Slice/SliceMachine.tsx
@@ -8,6 +8,7 @@ import {
   ResponsiveSpace,
 } from '@island.is/island-ui/core'
 import { RichText, EmailSignup } from '@island.is/web/components'
+import { webRenderConnectedComponent } from '@island.is/web/utils/richText'
 
 const DistrictsSlice = dynamic(() =>
   import('@island.is/web/components').then((mod) => mod.DistrictsSlice),
@@ -138,6 +139,8 @@ const renderSlice = (slice, namespace, slug, params) => {
       )
     case 'EmailSignup':
       return <EmailSignup slice={slice} marginLeft={[0, 0, 0, 6]} />
+    case 'ConnectedComponent':
+      return webRenderConnectedComponent(slice)
     default:
       return <RichText body={[slice]} />
   }

--- a/apps/web/components/connected/fiskistofa/ShipSearchBoxedInput/ShipSearchBoxedInput.tsx
+++ b/apps/web/components/connected/fiskistofa/ShipSearchBoxedInput/ShipSearchBoxedInput.tsx
@@ -1,8 +1,44 @@
 import { useState } from 'react'
 import { useRouter } from 'next/router'
-import { AsyncSearchInput, Box, Text } from '@island.is/island-ui/core'
+import {
+  Box,
+  BoxProps,
+  Button,
+  GridColumn,
+  GridRow,
+  Input,
+  ResponsiveSpace,
+  Stack,
+  Text,
+} from '@island.is/island-ui/core'
 import { useNamespace } from '@island.is/web/hooks'
 import { shouldLinkOpenInNewWindow } from '@island.is/shared/utils'
+import { useWindowSize } from '@island.is/web/hooks/useViewport'
+import { theme } from '@island.is/island-ui/theme'
+import { SpanType } from '@island.is/island-ui/core/types'
+
+const INPUT_COLUMN_SPAN: SpanType = [
+  '12/12',
+  '12/12',
+  '12/12',
+  '12/12',
+  '10/12',
+]
+const SEARCH_BUTTON_COLUMN_SPAN: SpanType = [
+  '12/12',
+  '12/12',
+  '12/12',
+  '12/12',
+  '2/12',
+]
+const SEARCH_BUTTON_JUSTIFY_CONTENT: BoxProps['justifyContent'] = [
+  'flexEnd',
+  'flexEnd',
+  'flexEnd',
+  'flexEnd',
+  'flexStart',
+]
+const SEARCH_BUTTON_MARGIN_TOP: ResponsiveSpace = [3, 3, 3, 3, 0]
 
 interface ShipSearchBoxedInputProps {
   namespace: {
@@ -16,10 +52,10 @@ interface ShipSearchBoxedInputProps {
 }
 
 const ShipSearchBoxedInput = ({ namespace }: ShipSearchBoxedInputProps) => {
+  const { width } = useWindowSize()
   const n = useNamespace(namespace)
   const [searchValue, setSearchValue] = useState('')
   const router = useRouter()
-  const [hasFocus, setHasFocus] = useState(false)
 
   const search = () => {
     const searchValueIsNumber =
@@ -54,37 +90,60 @@ const ShipSearchBoxedInput = ({ namespace }: ShipSearchBoxedInputProps) => {
     }
   }
 
-  const label = n('label', 'Skoða skip')
-  const placeholder = n('placeholder', 'Skipaskrárnúmer eða nafn')
+  const label = n('label', 'Skipaskrárnúmer eða nafn skips')
+  const placeholder = n('placeholder', '')
+  const title = n('title', 'Skipaleit')
+  const description = n(
+    'description',
+    'Upplýsingar um skip, veiðiheimildir, landanir og fleira',
+  )
+  const searchButtonText = n('searcButtonText', 'Leita')
 
   return (
     <Box background="blue100" padding="containerGutter" borderRadius="large">
-      {label && (
-        <Box margin={1}>
-          <Text variant="eyebrow">{label}</Text>
-        </Box>
-      )}
-      <AsyncSearchInput
-        rootProps={{}}
-        buttonProps={{ onClick: search }}
-        hasFocus={hasFocus}
-        inputProps={{
-          onFocus: () => setHasFocus(true),
-          onBlur: () => setHasFocus(false),
-          placeholder,
-          inputSize: 'medium',
-          name: 'fiskistofa-skipaleit-sidebar',
-          value: searchValue,
-          onChange: (ev) => {
-            setSearchValue(ev.target.value)
-          },
-          onKeyDown: (ev) => {
-            if (ev.key === 'Enter') {
-              search()
-            }
-          },
-        }}
-      />
+      <Stack space={2}>
+        {title && <Text variant="h2">{title}</Text>}
+        {description && (
+          <Box marginBottom={2}>
+            <Text>{description}</Text>
+          </Box>
+        )}
+
+        <GridRow>
+          <GridColumn span={INPUT_COLUMN_SPAN}>
+            <Box>
+              <Input
+                value={searchValue}
+                onChange={(ev) => {
+                  setSearchValue(ev.target.value)
+                }}
+                size="md"
+                placeholder={placeholder}
+                name="fiskistofa-skipaleit"
+                label={label}
+                onKeyDown={(ev) => {
+                  if (ev.key === 'Enter') {
+                    search()
+                  }
+                }}
+              />
+            </Box>
+          </GridColumn>
+          <GridColumn span={SEARCH_BUTTON_COLUMN_SPAN}>
+            <Box
+              display="flex"
+              justifyContent={SEARCH_BUTTON_JUSTIFY_CONTENT}
+              height="full"
+              alignItems="center"
+              marginTop={SEARCH_BUTTON_MARGIN_TOP}
+            >
+              <Button fluid={width > theme.breakpoints.xl} onClick={search}>
+                {searchButtonText}
+              </Button>
+            </Box>
+          </GridColumn>
+        </GridRow>
+      </Stack>
     </Box>
   )
 }

--- a/apps/web/components/connected/fiskistofa/ShipSearchBoxedInput/ShipSearchBoxedInput.tsx
+++ b/apps/web/components/connected/fiskistofa/ShipSearchBoxedInput/ShipSearchBoxedInput.tsx
@@ -1,0 +1,92 @@
+import { useState } from 'react'
+import { useRouter } from 'next/router'
+import { AsyncSearchInput, Box, Text } from '@island.is/island-ui/core'
+import { useNamespace } from '@island.is/web/hooks'
+import { shouldLinkOpenInNewWindow } from '@island.is/shared/utils'
+
+interface ShipSearchBoxedInputProps {
+  namespace: {
+    shipDetailsHref?: string
+    shipSearchHref?: string
+    placeholder?: string
+    label?: string
+    title?: string
+    description?: string
+  }
+}
+
+const ShipSearchBoxedInput = ({ namespace }: ShipSearchBoxedInputProps) => {
+  const n = useNamespace(namespace)
+  const [searchValue, setSearchValue] = useState('')
+  const router = useRouter()
+  const [hasFocus, setHasFocus] = useState(false)
+
+  const search = () => {
+    const searchValueIsNumber =
+      !isNaN(Number(searchValue)) && searchValue.length > 0
+    if (searchValueIsNumber) {
+      const pathname = n('shipDetailsHref', '/v/gagnasidur-fiskistofu')
+      const query = {
+        ...router.query,
+        [n('shipDetailsNumberQueryParam', 'nr')]: searchValue,
+        selectedTab: router.query?.selectedTab ?? 'skip',
+      }
+
+      const params = new URLSearchParams()
+
+      for (const [name, value] of Object.entries(query)) {
+        params.append(name, value as string)
+      }
+
+      const url = `${pathname}?${params}`
+
+      window.open(
+        url,
+        shouldLinkOpenInNewWindow(pathname) ? '_blank' : '_self',
+        'noopener,noreferrer',
+      )
+    } else {
+      const query = { ...router.query, name: searchValue }
+      router.push({
+        pathname: n('shipSearchHref', '/s/fiskistofa/skipaleit'),
+        query,
+      })
+    }
+  }
+
+  const label = n('label', 'Skoða skip')
+  const placeholder = n('placeholder', 'Skipaskrárnúmer eða nafn')
+
+  return (
+    <Box background="blue100" padding="containerGutter" borderRadius="large">
+      {label && (
+        <Box margin={1}>
+          <Text variant="eyebrow">{label}</Text>
+        </Box>
+      )}
+      <AsyncSearchInput
+        rootProps={{}}
+        buttonProps={{ onClick: search }}
+        hasFocus={hasFocus}
+        inputProps={{
+          onFocus: () => setHasFocus(true),
+          onBlur: () => setHasFocus(false),
+          placeholder,
+          inputSize: 'medium',
+          name: 'fiskistofa-skipaleit-sidebar',
+          value: searchValue,
+          onChange: (ev) => {
+            setSearchValue(ev.target.value)
+          },
+          onKeyDown: (ev) => {
+            if (ev.key === 'Enter') {
+              search()
+            }
+          },
+        }}
+      />
+    </Box>
+  )
+}
+
+export default ShipSearchBoxedInput

--- a/apps/web/components/connected/fiskistofa/index.ts
+++ b/apps/web/components/connected/fiskistofa/index.ts
@@ -26,3 +26,10 @@ export const SidebarShipSearchInput = dynamic(
     ssr: false,
   },
 )
+
+export const ShipSearchBoxedInput = dynamic(
+  () => import('./ShipSearchBoxedInput/ShipSearchBoxedInput'),
+  {
+    ssr: false,
+  },
+)

--- a/apps/web/utils/richText.tsx
+++ b/apps/web/utils/richText.tsx
@@ -19,6 +19,7 @@ import {
   PowerBiSlice,
   SelectedShip,
   ShipSearch,
+  ShipSearchBoxedInput,
   SidebarShipSearchInput,
   StraddlingStockCalculator,
   TwoColumnTextSlice,
@@ -31,7 +32,7 @@ import {
 import { Locale } from '@island.is/shared/types'
 import { MonthlyStatistics } from '../components/connected/electronicRegistrationStatistics'
 
-const webRenderConnectedComponent = (slice) => {
+export const webRenderConnectedComponent = (slice) => {
   const data = slice.json ?? {}
 
   switch (slice.componentType) {
@@ -47,6 +48,8 @@ const webRenderConnectedComponent = (slice) => {
       return <SelectedShip />
     case 'ElectronicRegistrations/MonthlyStatistics':
       return <MonthlyStatistics slice={slice} />
+    case 'Fiskistofa/ShipSearchBoxedInput':
+      return <ShipSearchBoxedInput namespace={data} />
     default:
       break
   }

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -2216,7 +2216,6 @@ export interface IOrganizationPageFields {
         | ILifeEventPageListSlice
         | IBigBulletList
         | IDistricts
-        | IMailingListSignup
         | IEmailSignup
         | IEventSlice
         | IFeaturedArticles
@@ -2225,6 +2224,7 @@ export interface IOrganizationPageFields {
         | IMultipleStatistics
         | IOneColumnText
         | IOverviewLinks
+        | ISliceConnectedComponent
         | IStorySection
         | ITabSection
         | ITimeline
@@ -2324,7 +2324,6 @@ export interface IOrganizationSubpageFields {
         | IBigBulletList
         | IContactUs
         | IDistricts
-        | IMailingListSignup
         | IEmailSignup
         | IEventSlice
         | IFeaturedArticles
@@ -2582,7 +2581,7 @@ export interface IProjectPageFields {
         | IAccordionSlice
         | IBigBulletList
         | IContactUs
-        | IMailingListSignup
+        | IEmailSignup
         | IEventSlice
         | IFaqList
         | IFeaturedArticles
@@ -2676,7 +2675,7 @@ export interface IProjectSubpageFields {
         | IBigBulletList
         | IContactUs
         | IDistricts
-        | IMailingListSignup
+        | IEmailSignup
         | IEventSlice
         | IFaqList
         | IFeaturedArticles
@@ -2854,6 +2853,7 @@ export interface ISliceConnectedComponentFields {
     | 'Fiskistofa/CatchQuotaCalculator'
     | 'Fiskistofa/StraddlingStockCalculator'
     | 'Fiskistofa/SelectedShip'
+    | 'Fiskistofa/ShipSearchBoxedInput'
     | undefined
 
   /** Localized JSON */


### PR DESCRIPTION
# Ship search component for directorate of fisheries organization pages

## What

* Add connected component for the Directorate of fisheries organization page

## Why

* This was a requested by the Directorate of fisheries
* The search input used to be in the sidebar but that wasn't an obvious enough spot for the users so this was deemed a better solution

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/43557895/213313343-14bed338-5867-4495-b7bc-2c86e0f16457.png)
## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
