### PR TITLE
fix(ads): Add nginx-ingress-external to air discount scheme web.

### DIFF
--- a/apps/air-discount-scheme/web/infra/web.ts
+++ b/apps/air-discount-scheme/web/infra/web.ts
@@ -65,4 +65,5 @@ export const serviceSetup = (services: {
     })
     .readiness('/readiness')
     .liveness('/liveness')
+    .grantNamespaces('nginx-ingress-external')
 }

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -16,7 +16,7 @@ air-discount-scheme-api:
     NO_UPDATE_NOTIFIER: 'true'
     SERVERSIDE_FEATURES_ON: ''
   grantNamespaces:
-    - 'islandis'
+    - 'nginx-ingress-external'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:
@@ -195,7 +195,7 @@ air-discount-scheme-web:
     NODE_OPTIONS: '--max-old-space-size=208'
     SERVERSIDE_FEATURES_ON: ''
   grantNamespaces:
-    - 'islandis'
+    - 'nginx-ingress-external'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -16,7 +16,7 @@ air-discount-scheme-api:
     NO_UPDATE_NOTIFIER: 'true'
     SERVERSIDE_FEATURES_ON: 'driving-license-use-v1-endpoint-for-v2-comms'
   grantNamespaces:
-    - 'islandis'
+    - 'nginx-ingress-external'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:
@@ -189,7 +189,7 @@ air-discount-scheme-web:
     NODE_OPTIONS: '--max-old-space-size=208'
     SERVERSIDE_FEATURES_ON: 'driving-license-use-v1-endpoint-for-v2-comms'
   grantNamespaces:
-    - 'islandis'
+    - 'nginx-ingress-external'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -16,7 +16,7 @@ air-discount-scheme-api:
     NO_UPDATE_NOTIFIER: 'true'
     SERVERSIDE_FEATURES_ON: ''
   grantNamespaces:
-    - 'islandis'
+    - 'nginx-ingress-external'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:
@@ -195,7 +195,7 @@ air-discount-scheme-web:
     NODE_OPTIONS: '--max-old-space-size=208'
     SERVERSIDE_FEATURES_ON: ''
   grantNamespaces:
-    - 'islandis'
+    - 'nginx-ingress-external'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:


### PR DESCRIPTION
# 👆

## What

Add ingress external namespace to enable internet traffic.

## Why

#9672 added islandis namespace to the backend which is applied to the whole air-discount-scheme namespace so `nginx-ingress-external` needs to be added explicitly to the web app.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
