### PR TITLE
feat(web): Add form to articles, show organization logo for landing pages

### DIFF
--- a/apps/web/screens/Article/Article.tsx
+++ b/apps/web/screens/Article/Article.tsx
@@ -31,6 +31,7 @@ import {
   footerEnabled,
   Stepper,
   stepperUtils,
+  Form,
 } from '@island.is/web/components'
 import { withMainLayout } from '@island.is/web/layouts/main'
 import { GET_ARTICLE_QUERY, GET_NAMESPACE_QUERY } from '../queries'
@@ -585,6 +586,7 @@ const ArticleScreen: Screen<ArticleProps> = ({
                         />
                       </Box>
                     ),
+                    Form: (form) => <Form form={form} namespace={namespace} />,
                   },
                 },
                 activeLocale,

--- a/apps/web/screens/Organization/Home/Home.tsx
+++ b/apps/web/screens/Organization/Home/Home.tsx
@@ -6,6 +6,7 @@ import {
   Box,
   Breadcrumbs,
   GridContainer,
+  Inline,
   NavigationItem,
   Text,
 } from '@island.is/island-ui/core'
@@ -135,9 +136,19 @@ const OrganizationHomePage: Screen<HomeProps> = ({
                 />
               </Box>
               <Box marginBottom={5}>
-                <Text variant="h1" color="blueberry600">
-                  {organizationPage.title}
-                </Text>
+                <Inline space={1} alignY="center">
+                  {organization.logo?.url && (
+                    <img
+                      width={70}
+                      height={70}
+                      src={organization.logo.url}
+                      alt="organization-logo"
+                    />
+                  )}
+                  <Text variant="h1" color="blueberry600">
+                    {organization.title}
+                  </Text>
+                </Inline>
               </Box>
 
               <Box marginBottom={8}>

--- a/apps/web/screens/Organization/Home/LandingPage/LandingPageFooter.tsx
+++ b/apps/web/screens/Organization/Home/LandingPage/LandingPageFooter.tsx
@@ -22,7 +22,7 @@ const LandingPageFooter: React.FC<LandingPageFooterProps> = ({
         <Box className={styles.container}>
           {footerItems.map((item, index) =>
             index === 0 ? (
-              <Box className={styles.item}>
+              <Box key={`${item.id}-${index}`} className={styles.item}>
                 <Text fontWeight="semiBold">{item.title}</Text>
               </Box>
             ) : (


### PR DESCRIPTION
# Add form to articles, show organization logo for landing pages

## What

* Now forms can be embedded inside the rich text field of articles
* The organization logo was missing from organization pages that had the landing page theme

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
