### PR TITLE
fix(applications): Accident notification required fields are now actually required

### DIFF
--- a/libs/application/templates/accident-notification/src/forms/AccidentNotificationForm/aboutTheAccidentSection.ts
+++ b/libs/application/templates/accident-notification/src/forms/AccidentNotificationForm/aboutTheAccidentSection.ts
@@ -84,6 +84,7 @@ export const aboutTheAccidentSection = buildSection({
               ],
               width: 'half',
               largeButtons: true,
+              required: true,
             }),
             buildCustomField({
               component: 'FieldAlertMessage',
@@ -108,6 +109,7 @@ export const aboutTheAccidentSection = buildSection({
               ],
               width: 'half',
               largeButtons: true,
+              required: true,
             }),
             buildCustomField({
               component: 'FieldAlertMessage',
@@ -528,6 +530,7 @@ export const aboutTheAccidentSection = buildSection({
               title: '',
               backgroundColor: 'blue',
               width: 'half',
+              required: true,
               options: [
                 { value: YES, label: application.general.yesOptionLabel },
                 { value: NO, label: application.general.noOptionLabel },
@@ -618,6 +621,7 @@ export const aboutTheAccidentSection = buildSection({
               id: 'injuryCertificate.answer',
               title: '',
               description: attachments.general.description,
+              required: true,
               options: (application) =>
                 isRepresentativeOfCompanyOrInstitute(application.answers)
                   ? [
@@ -690,6 +694,7 @@ export const aboutTheAccidentSection = buildSection({
               title: '',
               backgroundColor: 'blue',
               width: 'half',
+              required: true,
               options: [
                 { value: YES, label: application.general.yesOptionLabel },
                 { value: NO, label: application.general.noOptionLabel },
@@ -709,6 +714,7 @@ export const aboutTheAccidentSection = buildSection({
               id: 'fatalAccidentUploadDeathCertificateNow',
               title: '',
               backgroundColor: 'blue',
+              required: true,
               options: [
                 {
                   value: YES,
@@ -767,6 +773,7 @@ export const aboutTheAccidentSection = buildSection({
               id: 'additionalAttachments.answer',
               title: '',
               description: attachments.general.additionalAttachmentDescription,
+              required: true,
               options: () => [
                 {
                   value: AttachmentsEnum.ADDITIONALNOW,


### PR DESCRIPTION
# Accident notification

https://app.clickup.com/t/326kt3k

## What
Make fields required

## Why
They were supposed to be required but weren't

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
