### PR TITLE
fix(applications): Improved routing for applications to display error on unknown application

### DIFF
--- a/apps/application-system/form/src/routes/Applications.tsx
+++ b/apps/application-system/form/src/routes/Applications.tsx
@@ -117,8 +117,14 @@ export const Applications: FC = () => {
     }
   }, [type, data, delegationsChecked])
 
-  if (loading || !template) {
+  if (loading) {
     return <ApplicationLoading />
+  }
+
+  if (!template) {
+    return (
+      <ErrorShell title={formatMessage(coreMessages.notFoundApplicationType)} />
+    )
   }
 
   if (!type || applicationsError) {


### PR DESCRIPTION
# Error screen

https://app.clickup.com/t/2ymbcry

## What
Display error screen for unknown application

## Why
It is the expected behaviour


## Screenshots / Gifs
![image](https://user-images.githubusercontent.com/16030946/214297593-72423d3b-c43e-49f2-a67a-2b83e8cfd8bf.png)
## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
