### PR TITLE
fix(parental-leave): start date missing constant return (#9746)

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/parental-leave.service.spec.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/parental-leave.service.spec.ts
@@ -324,7 +324,7 @@ describe('ParentalLeaveService', () => {
 
       expect(res).toEqual([
         {
-          from: '2021-05-17',
+          from: 'date_of_birth',
           to: '2021-11-16',
           ratio: '100',
           approved: false,

--- a/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/parental-leave.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/parental-leave.service.ts
@@ -124,6 +124,19 @@ export class ParentalLeaveService extends BaseTemplateApiService {
     return phoneNumberStartStr.some((substr) => phoneNumber.startsWith(substr))
   }
 
+  getFromDate(
+    isFirstPeriod: boolean,
+    isActualDateOfBirth: boolean,
+    useLength: string,
+    period: AnswerPeriod,
+  ) {
+    return isFirstPeriod && isActualDateOfBirth && useLength === YES
+      ? apiConstants.actualDateOfBirthMonths
+      : isFirstPeriod && isActualDateOfBirth
+      ? apiConstants.actualDateOfBirth
+      : period.startDate
+  }
+
   async getChildren({ application, auth }: TemplateApiModuleActionProps) {
     return this.childrenService.provideChildren(application, auth.nationalId)
   }
@@ -599,7 +612,7 @@ export class ParentalLeaveService extends BaseTemplateApiService {
 
       const startDate = new Date(period.startDate)
       const endDate = new Date(period.endDate)
-      const useLength = period.useLength
+      const useLength = period.useLength || ''
 
       let periodLength = 0
 
@@ -670,12 +683,12 @@ export class ParentalLeaveService extends BaseTemplateApiService {
       ) {
         // We know its a normal period and it will not exceed personal rights
         periods.push({
-          from:
-            isFirstPeriod && isActualDateOfBirth && useLength === YES
-              ? apiConstants.actualDateOfBirthMonths
-              : isFirstPeriod && isActualDateOfBirth
-              ? apiConstants.actualDateOfBirth
-              : period.startDate,
+          from: this.getFromDate(
+            isFirstPeriod,
+            isActualDateOfBirth,
+            useLength,
+            period,
+          ),
           to: period.endDate,
           ratio: getRatio(
             period.ratio,
@@ -716,12 +729,12 @@ export class ParentalLeaveService extends BaseTemplateApiService {
               // Personal rights
               const daysLeftOfPersonalRights =
                 maximumPersonalDaysToSpend - numberOfDaysAlreadySpent
-              const fromDate =
-                isFirstPeriod && isActualDateOfBirth && useLength === YES
-                  ? apiConstants.actualDateOfBirthMonths
-                  : isFirstPeriod && isActualDateOfBirth
-                  ? apiConstants.actualDateOfBirth
-                  : period.startDate
+              const fromDate = this.getFromDate(
+                isFirstPeriod,
+                isActualDateOfBirth,
+                useLength,
+                period,
+              )
 
               const personalPeriod = await this.getCalculatedPeriod(
                 nationalRegistryId,
@@ -777,12 +790,12 @@ export class ParentalLeaveService extends BaseTemplateApiService {
               // Personal rights
               const daysLeftOfPersonalRights =
                 maximumPersonalDaysToSpend - numberOfDaysAlreadySpent
-              const fromDate =
-                isFirstPeriod && isActualDateOfBirth && useLength === YES
-                  ? apiConstants.actualDateOfBirthMonths
-                  : isFirstPeriod && isActualDateOfBirth
-                  ? apiConstants.actualDateOfBirth
-                  : period.startDate
+              const fromDate = this.getFromDate(
+                isFirstPeriod,
+                isActualDateOfBirth,
+                useLength,
+                period,
+              )
 
               const personalPeriod = await this.getCalculatedPeriod(
                 nationalRegistryId,
@@ -942,13 +955,20 @@ export class ParentalLeaveService extends BaseTemplateApiService {
 
           // 1. Period includes personal and transfer rights
           if (maximumMultipleBirthsDaysToSpend === 0) {
+            const fromDate = this.getFromDate(
+              isFirstPeriod,
+              isActualDateOfBirth,
+              useLength,
+              period,
+            )
+
             // Personal
             const daysLeftOfPersonalRights =
               maximumPersonalDaysToSpend - numberOfDaysAlreadySpent
             const personalPeriod = await this.getCalculatedPeriod(
               nationalRegistryId,
               startDate,
-              undefined,
+              fromDate,
               daysLeftOfPersonalRights,
               period,
               basicRightCodePeriod,
@@ -1019,12 +1039,12 @@ export class ParentalLeaveService extends BaseTemplateApiService {
             // Personal
             const daysLeftOfPersonalRights =
               maximumPersonalDaysToSpend - numberOfDaysAlreadySpent
-            const fromDate =
-              isFirstPeriod && isActualDateOfBirth && useLength === YES
-                ? apiConstants.actualDateOfBirthMonths
-                : isFirstPeriod && isActualDateOfBirth
-                ? apiConstants.actualDateOfBirth
-                : period.startDate
+            const fromDate = this.getFromDate(
+              isFirstPeriod,
+              isActualDateOfBirth,
+              useLength,
+              period,
+            )
             const personalPeriod = await this.getCalculatedPeriod(
               nationalRegistryId,
               startDate,
@@ -1095,12 +1115,12 @@ export class ParentalLeaveService extends BaseTemplateApiService {
           // Personal
           const daysLeftOfPersonalRights =
             maximumPersonalDaysToSpend - numberOfDaysAlreadySpent
-          const fromDate =
-            isFirstPeriod && isActualDateOfBirth && useLength === YES
-              ? apiConstants.actualDateOfBirthMonths
-              : isFirstPeriod && isActualDateOfBirth
-              ? apiConstants.actualDateOfBirth
-              : period.startDate
+          const fromDate = this.getFromDate(
+            isFirstPeriod,
+            isActualDateOfBirth,
+            useLength,
+            period,
+          )
           const personalPeriod = await this.getCalculatedPeriod(
             nationalRegistryId,
             startDate,


### PR DESCRIPTION
## What

Start date was missing returning constants if the applicant chose to start on actual birth date/expected birth date if the period was all personal and trasferred rights.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
