### PR TITLE
fix(search-indexer): Invalid ElasticSearch bulk request chunk size

### DIFF
--- a/libs/content-search-toolkit/src/services/utils/index.ts
+++ b/libs/content-search-toolkit/src/services/utils/index.ts
@@ -31,3 +31,16 @@ export function filterDoc<T>(
   }
   return deleted
 }
+
+export function getValidBulkRequestChunk(
+  requests: Record<string, unknown>[],
+  maxSize = 20,
+) {
+  let count = 0
+  for (let i = requests.length - 1; i >= 0; i -= 1) {
+    const increment = 'delete' in requests[i] ? 1 : 2
+    if (count + increment > maxSize) break
+    count += increment
+  }
+  return requests.splice(-count, count)
+}

--- a/libs/content-search-toolkit/src/services/utils/index.ts
+++ b/libs/content-search-toolkit/src/services/utils/index.ts
@@ -38,8 +38,20 @@ export function getValidBulkRequestChunk(
 ) {
   let count = 0
   for (let i = requests.length - 1; i >= 0; i -= 1) {
-    const increment = 'delete' in requests[i] ? 1 : 2
-    if (count + increment > maxSize) break
+    let increment = 0
+
+    const requestTakesUpASingleLine = 'delete' in requests[i]
+
+    if (requestTakesUpASingleLine) {
+      increment = 1
+    } else {
+      increment = 2
+      i -= 1 // Skip the next request since that's the operation for this request
+    }
+
+    const wouldGoOverMaxSize = count + increment > maxSize
+    if (wouldGoOverMaxSize) break
+
     count += increment
   }
   return requests.splice(-count, count)


### PR DESCRIPTION
# Bulk request chunk size

## What

* I noticed that ElasticSearch has been throwing an IllegalArgumentException and I believe it might be due to the request chunk size being invalid 

Here below we can see the bulkBody of the error and the first element in the list is a document (it should be an operation like update, delete or something of the sort https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html#bulk-api-request-body)

Since the delete operation is only a single line and all other operations (as far as I can tell) are 2 lines then the code that was there previously was incorrect since it relied on an even numbered chunk size.

![image](https://user-images.githubusercontent.com/43557895/215082942-fab1c1b6-c2c6-42d9-8239-0af23826f12c.png)

So I added a variant chunk size depending on the data we have at hand.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
