### PR TITLE
fix(search-indexer):  Hotfix - use correcly sized request bulk chunk size in ElasticSearch

### DIFF
--- a/libs/content-search-toolkit/src/services/utils/index.ts
+++ b/libs/content-search-toolkit/src/services/utils/index.ts
@@ -31,3 +31,28 @@ export function filterDoc<T>(
   }
   return deleted
 }
+
+export function getValidBulkRequestChunk(
+  requests: Record<string, unknown>[],
+  maxSize = 20,
+) {
+  let count = 0
+  for (let i = requests.length - 1; i >= 0; i -= 1) {
+    let increment = 0
+
+    const requestTakesUpASingleLine = 'delete' in requests[i]
+
+    if (requestTakesUpASingleLine) {
+      increment = 1
+    } else {
+      increment = 2
+      i -= 1 // Skip the next request since that's the operation for this request
+    }
+
+    const wouldGoOverMaxSize = count + increment > maxSize
+    if (wouldGoOverMaxSize) break
+
+    count += increment
+  }
+  return requests.splice(-count, count)
+}


### PR DESCRIPTION
* Use correct number of operations instead of relying on an even number since delete is single line

* Change logic for request chunk function

# Hotfix - use correcly sized request bulk chunk size in ElasticSearch

This PR contains a cherry picked commit from main https://github.com/island-is/island.is/pull/9755