### PR TITLE
fix(web): Add missing graphql field to query and speed up local link for cta accordion on web

### DIFF
--- a/apps/web/components/Organization/Slice/AccordionSlice/AccordionSlice.tsx
+++ b/apps/web/components/Organization/Slice/AccordionSlice/AccordionSlice.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useRouter } from 'next/router'
 import {
   Accordion,
   AccordionCard,
@@ -37,6 +38,7 @@ interface SliceProps {
 }
 
 export const AccordionSlice: React.FC<SliceProps> = ({ slice }) => {
+  const router = useRouter()
   const labelId = 'sliceTitle-' + slice.id
 
   const borderProps: BoxProps = slice.hasBorderAbove
@@ -105,14 +107,17 @@ export const AccordionSlice: React.FC<SliceProps> = ({ slice }) => {
                 cta={{
                   label: item.link?.text ?? 'Default',
                   icon: 'arrowForward',
-                  onClick: () =>
-                    !!item.link?.url &&
-                    window.open(
+                  onClick: () => {
+                    if (!item.link?.url) return
+                    const openInNewWindow = shouldLinkOpenInNewWindow(
                       item.link.url,
-                      shouldLinkOpenInNewWindow(item.link.url)
-                        ? '_blank'
-                        : '_self',
-                    ),
+                    )
+                    if (openInNewWindow) {
+                      window.open(item.link.url, '_blank')
+                    } else {
+                      router.push(item.link.url)
+                    }
+                  },
                 }}
               />
             </Box>

--- a/apps/web/screens/queries/fragments.ts
+++ b/apps/web/screens/queries/fragments.ts
@@ -616,6 +616,7 @@ export const slices = gql`
   fragment FeaturedSupportQNAsFields on FeaturedSupportQNAs {
     __typename
     id
+    renderedTitle
     resolvedSupportQNAs {
       id
       title


### PR DESCRIPTION
# Add graphql field to query and speed up local link for cta accordion on web

## Why

* I forgot to query for the renderedTitle field for the featuredSupportQNAs type
* window.open() seemed to be slow at opening links on the dev web, so we're opting for router.push for local links

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
