### PR TITLE
fix(applications): Url parameter for delegation

### DIFF
--- a/libs/application/ui-shell/src/components/DelegationsScreen.tsx
+++ b/libs/application/ui-shell/src/components/DelegationsScreen.tsx
@@ -20,7 +20,7 @@ import { getApplicationTemplateByTypeId } from '@island.is/application/template-
 import { LoadingShell } from './LoadingShell'
 import { format as formatKennitala } from 'kennitala'
 import { useLocale } from '@island.is/localization'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useLocation } from 'react-router-dom'
 import { ScreenType, DelegationsScreenDataType, Delegation } from '../types'
 import { FeatureFlagClient, Features } from '@island.is/feature-flags'
 import { useFeatureFlagClient } from '@island.is/react/feature-flags'
@@ -44,6 +44,7 @@ export const DelegationsScreen = ({
   const { switchUser, userInfo: user } = useAuth()
   const navigate = useNavigate()
   const featureFlagClient: FeatureFlagClient = useFeatureFlagClient()
+  const location = useLocation()
 
   // Check for user delegations if application supports delegations
   const { data: delegations, error } = useQuery(ACTOR_DELEGATIONS, {
@@ -170,10 +171,10 @@ export const DelegationsScreen = ({
   ])
 
   const handleClick = (nationalId?: string) => {
-    if (screenData.screenType !== ScreenType.ONGOING) {
-      navigate('?delegationChecked=true')
-    }
-    if (nationalId) {
+    if (screenData.screenType !== ScreenType.ONGOING && nationalId) {
+      location.search = '?delegationChecked=true'
+      switchUser(nationalId, location)
+    } else if (nationalId) {
       switchUser(nationalId)
     } else {
       checkDelegation(true)

--- a/libs/auth/react/src/lib/Authenticator/AuthContext.tsx
+++ b/libs/auth/react/src/lib/Authenticator/AuthContext.tsx
@@ -1,11 +1,11 @@
 import { createContext, useContext } from 'react'
-
+import { Location } from 'react-router-dom'
 import { AuthReducerState, initialState } from './Authenticator.state'
 
 export interface AuthContextType extends AuthReducerState {
   signIn: () => void
   signInSilent: () => void
-  switchUser: (nationalId?: string) => void
+  switchUser: (nationalId?: string, location?: Location) => void
   signOut: () => void
 }
 
@@ -17,7 +17,7 @@ export const defaultAuthContext = {
   signInSilent() {
     // Intentionally empty
   },
-  switchUser(nationalId?: string) {
+  switchUser(nationalId?: string, location?: Location) {
     // Intentionally empty
   },
   signOut() {

--- a/libs/auth/react/src/lib/Authenticator/AuthContext.tsx
+++ b/libs/auth/react/src/lib/Authenticator/AuthContext.tsx
@@ -5,7 +5,7 @@ import { AuthReducerState, initialState } from './Authenticator.state'
 export interface AuthContextType extends AuthReducerState {
   signIn: () => void
   signInSilent: () => void
-  switchUser: (nationalId?: string, location?: Location) => void
+  switchUser: (nationalId?: string, newLocation?: Location) => void
   signOut: () => void
 }
 
@@ -17,7 +17,7 @@ export const defaultAuthContext = {
   signInSilent() {
     // Intentionally empty
   },
-  switchUser(nationalId?: string, location?: Location) {
+  switchUser(nationalId?: string, newLocation?: Location) {
     // Intentionally empty
   },
   signOut() {

--- a/libs/auth/react/src/lib/Authenticator/Authenticator.tsx
+++ b/libs/auth/react/src/lib/Authenticator/Authenticator.tsx
@@ -71,7 +71,10 @@ export const Authenticator: FC<Props> = ({ children, autoLogin = true }) => {
   )
 
   const switchUser = useCallback(
-    async function switchUser(nationalId?: string, location?: Location) {
+    async function switchUser(nationalId?: string, newLocation?: Location) {
+      if (newLocation) {
+        locationRef.current = newLocation
+      }
       const args =
         nationalId !== undefined
           ? {
@@ -94,10 +97,7 @@ export const Authenticator: FC<Props> = ({ children, autoLogin = true }) => {
       return userManager.signinRedirect({
         state:
           authSettings.switchUserRedirectUrl ??
-          getReturnUrl(
-            location != null ? location : locationRef.current,
-            authSettings,
-          ),
+          getReturnUrl(locationRef.current, authSettings),
         ...args,
       })
       // Nothing more happens here since browser will redirect to IDS.

--- a/libs/auth/react/src/lib/Authenticator/Authenticator.tsx
+++ b/libs/auth/react/src/lib/Authenticator/Authenticator.tsx
@@ -71,7 +71,7 @@ export const Authenticator: FC<Props> = ({ children, autoLogin = true }) => {
   )
 
   const switchUser = useCallback(
-    async function switchUser(nationalId?: string) {
+    async function switchUser(nationalId?: string, location?: Location) {
       const args =
         nationalId !== undefined
           ? {
@@ -94,7 +94,10 @@ export const Authenticator: FC<Props> = ({ children, autoLogin = true }) => {
       return userManager.signinRedirect({
         state:
           authSettings.switchUserRedirectUrl ??
-          getReturnUrl(locationRef.current, authSettings),
+          getReturnUrl(
+            location != null ? location : locationRef.current,
+            authSettings,
+          ),
         ...args,
       })
       // Nothing more happens here since browser will redirect to IDS.


### PR DESCRIPTION
# Url parameter fix

## What
Adding correct url parameter to delegation checked application

## Why
In the new react router package when calling
useNavigation
and instantly
useLocation

the useNavigation is not fast enough to update itself so the uselocation gets the old value.

Fixed by sending the value itself into the function from parent.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
