### PR TITLE
feat(web): Reload page on online chat link click

### DIFF
--- a/apps/web/components/ServiceWeb/Footer/Footer.tsx
+++ b/apps/web/components/ServiceWeb/Footer/Footer.tsx
@@ -15,6 +15,7 @@ import {
 } from '@island.is/island-ui/core'
 import Illustration from './Illustration'
 import { Locale } from '@island.is/shared/types'
+import { shouldLinkOpenInNewWindow } from '@island.is/shared/utils'
 import { useNamespace } from '@island.is/web/hooks'
 
 import * as styles from './Footer.css'
@@ -91,6 +92,14 @@ export const Footer: FC<Props> = ({
                                 color="blue600"
                                 underline="normal"
                                 underlineVisibility="always"
+                                onClick={() =>
+                                  window.open(
+                                    href,
+                                    shouldLinkOpenInNewWindow(href)
+                                      ? '_target'
+                                      : '_self',
+                                  )
+                                }
                               >
                                 {children}
                               </Link>


### PR DESCRIPTION
# Reload page on online chat link click

## What

* When a user presses the online chat link then the chat window is supposed to open up and connect you to an agent, but since the link prefetches data and doesn't fully reload the page then the watson chat bot doesn't recognize the link change. So we use the window.open() function instead to make sure that the watson chat bot loads correctly and recognized the query param in the route that triggers the agent chat to commence.

## Why

* This was a requested feature by Digital Iceland

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
