### PR TITLE
chore(island-is): Added a facebook logo

### DIFF
--- a/libs/island-ui/core/src/lib/IconRC/iconMap.ts
+++ b/libs/island-ui/core/src/lib/IconRC/iconMap.ts
@@ -32,6 +32,7 @@ export type Icon =
   | 'ellipsisVertical'
   | 'eye'
   | 'eyeOff'
+  | 'facebook'
   | 'fileTrayFull'
   | 'filter'
   | 'heart'
@@ -98,6 +99,7 @@ export default {
     ellipsisVertical: 'EllipsisVertical',
     eye: 'Eye',
     eyeOff: 'EyeOff',
+    facebook: 'Facebook',
     fileTrayFull: 'FileTrayFull',
     filter: 'Filter',
     heart: 'Heart',
@@ -163,6 +165,7 @@ export default {
     ellipsisVertical: 'EllipsisVerticalOutline',
     eye: 'EyeOutline',
     eyeOff: 'EyeOffOutline',
+    facebook: 'Facebook',
     fileTrayFull: 'FileTrayFullOutline',
     filter: 'FilterOutline',
     heart: 'HeartOutline',

--- a/libs/island-ui/core/src/lib/IconRC/icons/Facebook.tsx
+++ b/libs/island-ui/core/src/lib/IconRC/icons/Facebook.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { SvgProps as SVGRProps } from '../Icon'
+
+const Facebook = ({
+  title,
+  titleId,
+  ...props
+}: React.SVGProps<SVGSVGElement> & SVGRProps) => {
+  return (
+    <svg
+      className="facebook_svg__ionicon"
+      viewBox="0 0 512 512"
+      aria-label={titleId}
+      {...props}
+    >
+      {title ? <title>{title}</title> : null}
+      <path
+        d="M480 257.35c0-123.7-100.3-224-224-224s-224 100.3-224 224c0 111.8 81.9 204.47 189 221.29V322.12h-56.89v-64.77H221V208c0-56.13 33.45-87.16 84.61-87.16 24.51 0 50.15 4.38 50.15 4.38v55.13H327.5c-27.81 0-36.51 17.26-36.51 35v42h62.12l-9.92 64.77H291v156.54c107.1-16.81 189-109.48 189-221.31z"
+        fillRule="evenodd"
+      />
+    </svg>
+  )
+}
+
+export default Facebook


### PR DESCRIPTION
# Added a facebook logo

## What

Added a facebook icon in the icon component

## Why

The deprecated Icon component has this icon but not the new one.

## Screenshots / Gifs

<img width="125" alt="Screen Shot 2023-02-01 at 14 17 49" src="https://user-images.githubusercontent.com/3789875/216069716-f230cc69-de19-40cf-aefc-4db2ea015690.png">

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
