### PR TITLE
feat(transport authority applications): Add internalProcuring to VehiclesDetail

### DIFF
--- a/libs/api/domains/vehicles/src/lib/api-domains-vehicles.resolver.ts
+++ b/libs/api/domains/vehicles/src/lib/api-domains-vehicles.resolver.ts
@@ -56,7 +56,7 @@ export class VehiclesResolver {
     return await this.vehiclesService.getVehiclesForUser(user, true, true)
   }
 
-  @Scopes(ApiScope.vehicles, ApiScope.internal)
+  @Scopes(ApiScope.vehicles, ApiScope.internal, ApiScope.internalProcuring)
   @Query(() => VehiclesDetail, { name: 'vehiclesDetail', nullable: true })
   @Audit()
   async getVehicleDetail(


### PR DESCRIPTION
## What

Add the scope internalProcuring to the VehiclesDetail endpoint

## Why

So it is possible to get information about the vehicle when using delegation

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
