### PR TITLE
feat(web): Read organization footer image urls from cms

### DIFF
--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -273,7 +273,6 @@ export const OrganizationFooter: React.FC<FooterProps> = ({
     () => JSON.parse(organization?.namespace?.fields ?? '{}'),
     [],
   )
-  const n = useNamespace(namespace)
 
   let OrganizationFooterComponent = null
 
@@ -285,18 +284,17 @@ export const OrganizationFooter: React.FC<FooterProps> = ({
           title={organization.title}
           logo={organization.logo?.url}
           footerItems={organization.footerItems}
-          questionsAndAnswersText={n(
-            'questionsAndAnswers',
-            'Spurningar og svör',
-          )}
-          canWeHelpText={n('canWeHelp', 'Getum við aðstoðað?')}
+          namespace={namespace}
         />
       )
       break
     case 'sjukratryggingar':
     case 'icelandic-health-insurance':
       OrganizationFooterComponent = (
-        <SjukratryggingarFooter footerItems={organization.footerItems} />
+        <SjukratryggingarFooter
+          footerItems={organization.footerItems}
+          namespace={namespace}
+        />
       )
       break
     case 'utlendingastofnun':
@@ -321,13 +319,17 @@ export const OrganizationFooter: React.FC<FooterProps> = ({
     case 'landlaeknir':
     case 'directorate-of-health':
       OrganizationFooterComponent = (
-        <LandlaeknirFooter footerItems={organization.footerItems} />
+        <LandlaeknirFooter
+          footerItems={organization.footerItems}
+          namespace={namespace}
+        />
       )
       break
     case 'hsn':
       OrganizationFooterComponent = (
         <HeilbrigdisstofnunNordurlandsFooter
           footerItems={organization.footerItems}
+          namespace={namespace}
         />
       )
       break
@@ -335,18 +337,25 @@ export const OrganizationFooter: React.FC<FooterProps> = ({
       OrganizationFooterComponent = (
         <HeilbrigdisstofnunSudurlandsFooter
           footerItems={organization.footerItems}
+          namespace={namespace}
         />
       )
       break
     case 'fiskistofa':
     case 'directorate-of-fisheries':
       OrganizationFooterComponent = (
-        <FiskistofaFooter footerItems={organization.footerItems} />
+        <FiskistofaFooter
+          footerItems={organization.footerItems}
+          namespace={namespace}
+        />
       )
       break
     case 'landskjorstjorn':
       OrganizationFooterComponent = (
-        <LandskjorstjornFooter footerItems={organization.footerItems} />
+        <LandskjorstjornFooter
+          footerItems={organization.footerItems}
+          namespace={namespace}
+        />
       )
       break
     case 'rikislogmadur':
@@ -365,6 +374,7 @@ export const OrganizationFooter: React.FC<FooterProps> = ({
         <FjarsyslaRikisinsFooter
           footerItems={organization.footerItems}
           logo={organization.logo?.url}
+          namespace={namespace}
         />
       )
   }

--- a/apps/web/components/Organization/Wrapper/Themes/FiskistofaTheme/FiskistofaFooter.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/FiskistofaTheme/FiskistofaFooter.tsx
@@ -14,14 +14,20 @@ import { useWindowSize } from '@island.is/web/hooks/useViewport'
 import { theme } from '@island.is/island-ui/theme'
 import { SliceType } from '@island.is/island-ui/contentful'
 import { webRichText } from '@island.is/web/utils/richText'
+import { useNamespace } from '@island.is/web/hooks'
 
 import * as styles from './FiskistofaFooter.css'
 
 interface FiskistofaFooterProps {
   footerItems: FooterItem[]
+  namespace: Record<string, string>
 }
 
-export const FiskistofaFooter = ({ footerItems }: FiskistofaFooterProps) => {
+export const FiskistofaFooter = ({
+  footerItems,
+  namespace,
+}: FiskistofaFooterProps) => {
+  const n = useNamespace(namespace)
   const { width } = useWindowSize()
 
   const isMobile = width < theme.breakpoints.md
@@ -34,7 +40,10 @@ export const FiskistofaFooter = ({ footerItems }: FiskistofaFooterProps) => {
             <GridRow>
               <Box marginLeft={2}>
                 <img
-                  src="https://images.ctfassets.net/8k0h54kbe6bj/2JSIJ4WbQ4Up84KQlMnIBb/34c1a74806884e456e3ab809a54d41f6/fiskistofa-footer-logo.png"
+                  src={n(
+                    'fiskistofaFooterLogo',
+                    'https://images.ctfassets.net/8k0h54kbe6bj/2JSIJ4WbQ4Up84KQlMnIBb/34c1a74806884e456e3ab809a54d41f6/fiskistofa-footer-logo.png',
+                  )}
                   alt="fiskistofa-logo"
                 />
               </Box>
@@ -77,19 +86,28 @@ export const FiskistofaFooter = ({ footerItems }: FiskistofaFooterProps) => {
                   })}
                   <Box className={styles.iconContainer}>
                     <img
-                      src="https://images.ctfassets.net/8k0h54kbe6bj/2w9jCgdlKvT1gG5Vyk2arB/e3043e0ae9331ebad4e6e6bca684b87a/grSkref1080x680_BW.png"
+                      src={n(
+                        'fiskistofaGraenSkrefLogo',
+                        'https://images.ctfassets.net/8k0h54kbe6bj/2w9jCgdlKvT1gG5Vyk2arB/e3043e0ae9331ebad4e6e6bca684b87a/grSkref1080x680_BW.png',
+                      )}
                       alt="graen-skref"
                       width={isMobile ? 62 : 109}
                       height={isMobile ? 39 : 69}
                     />
                     <img
-                      src="https://images.ctfassets.net/8k0h54kbe6bj/7076IkepUKnI8eKHbo69Ys/40d84cf75b177a8bef7beb1f6d45f6cd/fiskistofa-jafnlaunavottun.png"
+                      src={n(
+                        'fiskistofaJafnlaunavottunLogo',
+                        'https://images.ctfassets.net/8k0h54kbe6bj/7076IkepUKnI8eKHbo69Ys/40d84cf75b177a8bef7beb1f6d45f6cd/fiskistofa-jafnlaunavottun.png',
+                      )}
                       alt="fiskistofa-jafnlaunavottun"
                       width={isMobile ? 45 : 80}
                       height={isMobile ? 45 : 80}
                     />
                     <img
-                      src="https://images.ctfassets.net/8k0h54kbe6bj/71f5kkbe52Y21n62JfdxlQ/bd5c7f87d582ab1cd74b6e6ca61d6890/fiskistofa-bsi.png"
+                      src={n(
+                        'fiskistofaBsiLogo',
+                        'https://images.ctfassets.net/8k0h54kbe6bj/71f5kkbe52Y21n62JfdxlQ/bd5c7f87d582ab1cd74b6e6ca61d6890/fiskistofa-bsi.png',
+                      )}
                       alt="fiskistofa-bsi"
                       className={cn({
                         [styles.bsiLogo]: !isMobile,

--- a/apps/web/components/Organization/Wrapper/Themes/FjarsyslaRikisinsTheme/FjarsyslaRikisinsFooter.css.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/FjarsyslaRikisinsTheme/FjarsyslaRikisinsFooter.css.ts
@@ -15,3 +15,7 @@ export const firstRow = style({
   alignItems: 'center',
   gap: '20px',
 })
+
+export const heading = style({
+  color: '#2222c6',
+})

--- a/apps/web/components/Organization/Wrapper/Themes/FjarsyslaRikisinsTheme/FjarsyslaRikisinsFooter.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/FjarsyslaRikisinsTheme/FjarsyslaRikisinsFooter.tsx
@@ -9,27 +9,33 @@ import {
   Hidden,
 } from '@island.is/island-ui/core'
 import { FooterItem } from '@island.is/web/graphql/schema'
+import { useNamespace } from '@island.is/web/hooks'
 
 import * as styles from './FjarsyslaRikisinsFooter.css'
 
 interface FjarsyslaRikisinsFooterProps {
   footerItems: FooterItem[]
   logo?: string
+  namespace: Record<string, string>
 }
 
 const FjarsyslaRikisinsFooter = ({
   footerItems,
   logo,
+  namespace,
 }: FjarsyslaRikisinsFooterProps) => {
+  const n = useNamespace(namespace)
+
   return (
     <footer className={styles.container} aria-labelledby="fjarsyslan-footer">
       <GridContainer>
         <Box className={styles.firstRow}>
           {!!logo && <img width={80} height={80} src={logo} alt="" />}
-          <img
-            src="https://images.ctfassets.net/8k0h54kbe6bj/2SjyMU3OtnoSqJg4fan1Tc/3d94afd4232f59f056e9f803e07d1433/Fja__rsy__slan.svg"
-            alt="Fjársýslan"
-          />
+          <Text variant="h2" as="div">
+            <span className={styles.heading}>
+              {n('fjarsyslanTitle', 'Fjársýslan')}
+            </span>
+          </Text>
         </Box>
 
         <Box marginY={2} borderTopWidth="standard" borderColor="blue600" />

--- a/apps/web/components/Organization/Wrapper/Themes/FjarsyslaRikisinsTheme/FjarsyslaRikisinsHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/FjarsyslaRikisinsTheme/FjarsyslaRikisinsHeader.tsx
@@ -61,11 +61,9 @@ const FjarsyslaRikisinsHeader = ({ organizationPage }: HeaderProps) => {
                 </Text>
               </Hidden>
               <Hidden below="md">
-                <img
-                  width="253px"
-                  src="https://images.ctfassets.net/8k0h54kbe6bj/TqkgXfX1Zv8DGPDpNFA6U/e4fd87176da12c972df40512ee323d84/fjs-header-texti.svg"
-                  alt="Fjársýsla ríkisins"
-                />
+                <Text fontWeight="semiBold" variant="h1" as="h1" color="white">
+                  {organizationPage.title}
+                </Text>
               </Hidden>
             </Link>
           </Box>

--- a/apps/web/components/Organization/Wrapper/Themes/HeilbrigdisstofnunNordurlandsTheme/HeilbrigdisstofnunNordurlandsFooter.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/HeilbrigdisstofnunNordurlandsTheme/HeilbrigdisstofnunNordurlandsFooter.tsx
@@ -1,3 +1,4 @@
+import { BLOCKS } from '@contentful/rich-text-types'
 import {
   Box,
   GridColumn,
@@ -11,64 +12,67 @@ import {
 import { webRichText } from '@island.is/web/utils/richText'
 import { FooterItem } from '@island.is/web/graphql/schema'
 import { SliceType } from '@island.is/island-ui/contentful'
-import { BLOCKS } from '@contentful/rich-text-types'
 import { SpanType } from '@island.is/island-ui/core/types'
+import { useNamespace } from '@island.is/web/hooks'
 import * as styles from './HeilbrigdisstofnunNordurlandsFooter.css'
+
+const renderColumn = (
+  column: FooterItem[],
+  span: SpanType = ['4/8', '2/8', '1/8'],
+  offset = false,
+) => {
+  if (column.length <= 0) return null
+  return (
+    <GridColumn span={span}>
+      {column.map((item, index) => (
+        <Box
+          key={`${item.id}-${index}`}
+          className={styles.locationBox}
+          marginLeft={offset ? [0, 0, 0, 10] : 0}
+        >
+          {item.link?.url ? (
+            <Link href={item.link.url} color="white">
+              <Text fontWeight="semiBold" color="white" marginBottom={1}>
+                <Hyphen>{item.title}</Hyphen>
+              </Text>
+            </Link>
+          ) : (
+            <Text fontWeight="semiBold" color="white" marginBottom={1}>
+              <Hyphen>{item.title}</Hyphen>
+            </Text>
+          )}
+
+          {webRichText(item.content as SliceType[], {
+            renderNode: {
+              [BLOCKS.PARAGRAPH]: (_node, children) => (
+                <Text
+                  color="white"
+                  variant="eyebrow"
+                  fontWeight="regular"
+                  lineHeight="xl"
+                  marginBottom={2}
+                >
+                  {children}
+                </Text>
+              ),
+            },
+          })}
+        </Box>
+      ))}
+    </GridColumn>
+  )
+}
 
 interface HeilbrigdisstofnunNordurlandsFooterProps {
   footerItems: FooterItem[]
+  namespace: Record<string, string>
 }
 
 export const HeilbrigdisstofnunNordurlandsFooter = ({
   footerItems,
+  namespace,
 }: HeilbrigdisstofnunNordurlandsFooterProps) => {
-  const renderColumn = (
-    column: FooterItem[],
-    span: SpanType = ['4/8', '2/8', '1/8'],
-    offset = false,
-  ) => {
-    if (column.length <= 0) return null
-    return (
-      <GridColumn span={span}>
-        {column.map((item, index) => (
-          <Box
-            key={`${item.id}-${index}`}
-            className={styles.locationBox}
-            marginLeft={offset ? [0, 0, 0, 10] : 0}
-          >
-            {item.link?.url ? (
-              <Link href={item.link.url} color="white">
-                <Text fontWeight="semiBold" color="white" marginBottom={1}>
-                  <Hyphen>{item.title}</Hyphen>
-                </Text>
-              </Link>
-            ) : (
-              <Text fontWeight="semiBold" color="white" marginBottom={1}>
-                <Hyphen>{item.title}</Hyphen>
-              </Text>
-            )}
-
-            {webRichText(item.content as SliceType[], {
-              renderNode: {
-                [BLOCKS.PARAGRAPH]: (_node, children) => (
-                  <Text
-                    color="white"
-                    variant="eyebrow"
-                    fontWeight="regular"
-                    lineHeight="xl"
-                    marginBottom={2}
-                  >
-                    {children}
-                  </Text>
-                ),
-              },
-            })}
-          </Box>
-        ))}
-      </GridColumn>
-    )
-  }
-
+  const n = useNamespace(namespace)
   return (
     <footer aria-labelledby="heilbrigdisstofnun-nordurlands-footer">
       <Box className={styles.container}>
@@ -76,7 +80,10 @@ export const HeilbrigdisstofnunNordurlandsFooter = ({
           <GridColumn className={styles.mainColumn}>
             <GridRow>
               <img
-                src="https://images.ctfassets.net/8k0h54kbe6bj/rXPqjnjJYePJHhHvO0UDT/b5aaf2e6dc54abb4b1dc2bd8065217b7/HSN_landscape_hvittGratt.png?h=250"
+                src={n(
+                  'hsnFooterLogo',
+                  'https://images.ctfassets.net/8k0h54kbe6bj/rXPqjnjJYePJHhHvO0UDT/b5aaf2e6dc54abb4b1dc2bd8065217b7/HSN_landscape_hvittGratt.png?h=250',
+                )}
                 alt="heilbrigdisstofnun-nordurlands-logo"
                 width={590}
               />
@@ -95,12 +102,18 @@ export const HeilbrigdisstofnunNordurlandsFooter = ({
               <Box marginRight={[4, 4, 12]}>
                 <Inline alignY="center" align="center" space={5}>
                   <img
-                    src="https://images.ctfassets.net/8k0h54kbe6bj/1igNLuoV9IQAwP1A4bfyXd/0d96a9a057e48b28616832552838c7a5/hsn-jafnlaunavottun.svg"
+                    src={n(
+                      'hsnJafnlaunavottunLogo',
+                      'https://images.ctfassets.net/8k0h54kbe6bj/1igNLuoV9IQAwP1A4bfyXd/0d96a9a057e48b28616832552838c7a5/hsn-jafnlaunavottun.svg',
+                    )}
                     alt="jafnlaunavottun"
                     width={50}
                   />
                   <img
-                    src="https://images.ctfassets.net/8k0h54kbe6bj/2QMl8Mw50Vj0AjlI6jzENH/cc4792e02ff1b152ede7e892da333669/greenSteps.png"
+                    src={n(
+                      'hsnGraenSkrefLogo',
+                      'https://images.ctfassets.net/8k0h54kbe6bj/2QMl8Mw50Vj0AjlI6jzENH/cc4792e02ff1b152ede7e892da333669/greenSteps.png',
+                    )}
                     alt="graen-skref"
                     width={90}
                   />

--- a/apps/web/components/Organization/Wrapper/Themes/HeilbrigdisstofnunSudurlandsTheme/HeilbrigdisstofnunSudurlandsFooter.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/HeilbrigdisstofnunSudurlandsTheme/HeilbrigdisstofnunSudurlandsFooter.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import { BLOCKS } from '@contentful/rich-text-types'
 import {
   Box,
   GridColumn,
@@ -12,8 +13,8 @@ import {
 import { webRichText } from '@island.is/web/utils/richText'
 import { FooterItem } from '@island.is/web/graphql/schema'
 import { SliceType } from '@island.is/island-ui/contentful'
-import { BLOCKS } from '@contentful/rich-text-types'
 import { SpanType } from '@island.is/island-ui/core/types'
+import { useNamespace } from '@island.is/web/hooks'
 import * as styles from './HeilbrigdisstofnunSudurlandsFooter.css'
 
 const ROWS_PER_COLUMN = 3
@@ -101,11 +102,14 @@ const convertFooterItemsToFooterColumns = (footerItems: FooterItem[]) => {
 
 interface HeilbrigdisstofnunSudurlandsFooterProps {
   footerItems: FooterItem[]
+  namespace: Record<string, string>
 }
 
 export const HeilbrigdisstofnunSudurlandsFooter = ({
   footerItems,
+  namespace,
 }: HeilbrigdisstofnunSudurlandsFooterProps) => {
+  const n = useNamespace(namespace)
   const footerColumns = useMemo(
     () => convertFooterItemsToFooterColumns(footerItems),
     [footerItems],
@@ -118,7 +122,10 @@ export const HeilbrigdisstofnunSudurlandsFooter = ({
           <GridColumn className={styles.mainColumn}>
             <GridRow>
               <img
-                src="https://images.ctfassets.net/8k0h54kbe6bj/4OcAjYnwPUP4dwFA6duFaB/f188b1c188b535ec464f37cae87733a3/HSU-footer.png?h=250"
+                src={n(
+                  'hsuFooterLogo',
+                  'https://images.ctfassets.net/8k0h54kbe6bj/4OcAjYnwPUP4dwFA6duFaB/f188b1c188b535ec464f37cae87733a3/HSU-footer.png?h=250',
+                )}
                 alt="heilbrigdisstofnun-sudurlands-logo"
                 width={590}
               />
@@ -134,17 +141,26 @@ export const HeilbrigdisstofnunSudurlandsFooter = ({
               <Box marginRight={[4, 4, 12]}>
                 <Inline alignY="center" align="center" space={5}>
                   <img
-                    src="https://images.ctfassets.net/8k0h54kbe6bj/1igNLuoV9IQAwP1A4bfyXd/0d96a9a057e48b28616832552838c7a5/hsn-jafnlaunavottun.svg"
+                    src={n(
+                      'hsuJafnlaunavottunLogo',
+                      'https://images.ctfassets.net/8k0h54kbe6bj/1igNLuoV9IQAwP1A4bfyXd/0d96a9a057e48b28616832552838c7a5/hsn-jafnlaunavottun.svg',
+                    )}
                     alt="jafnlaunavottun"
                     width={60}
                   />
                   <img
-                    src="https://images.ctfassets.net/8k0h54kbe6bj/2QMl8Mw50Vj0AjlI6jzENH/cc4792e02ff1b152ede7e892da333669/greenSteps.png"
+                    src={n(
+                      'hsuGraenSkrefLogo',
+                      'https://images.ctfassets.net/8k0h54kbe6bj/2QMl8Mw50Vj0AjlI6jzENH/cc4792e02ff1b152ede7e892da333669/greenSteps.png',
+                    )}
                     alt="graen-skref"
                     width={100}
                   />
                   <img
-                    src="https://images.ctfassets.net/8k0h54kbe6bj/4wF7MeLqjkMkw11wLJf2Ko/25a5592603ca0e29aaa58c13ecbf55fe/Heilsueflandi_vinnusta__ur_logo_1.svg"
+                    src={n(
+                      'hsuHeilsueflandiVinnustadurLogo',
+                      'https://images.ctfassets.net/8k0h54kbe6bj/4wF7MeLqjkMkw11wLJf2Ko/25a5592603ca0e29aaa58c13ecbf55fe/Heilsueflandi_vinnusta__ur_logo_1.svg',
+                    )}
                     width={90}
                     alt="heilsueflandi-vinnustadur"
                   />

--- a/apps/web/components/Organization/Wrapper/Themes/LandkjorstjornTheme/LandkjorstjornFooter.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/LandkjorstjornTheme/LandkjorstjornFooter.tsx
@@ -11,17 +11,21 @@ import {
   Text,
 } from '@island.is/island-ui/core'
 import { FooterItem } from '@island.is/web/graphql/schema'
+import { useNamespace } from '@island.is/web/hooks'
 import { webRichText } from '@island.is/web/utils/richText'
 
 import * as styles from './LandskjorstjornFooter.css'
 
 interface LandskjorstjornFooterProps {
   footerItems: FooterItem[]
+  namespace: Record<string, string>
 }
 
 export const LandskjorstjornFooter = ({
   footerItems,
+  namespace,
 }: LandskjorstjornFooterProps) => {
+  const n = useNamespace(namespace)
   return (
     <footer
       className={styles.container}
@@ -34,7 +38,10 @@ export const LandskjorstjornFooter = ({
               <img
                 width={80}
                 height={78}
-                src="https://images.ctfassets.net/8k0h54kbe6bj/60DIqBGQ8ejcpEak0bSrak/9481d5d92bcf9b2ea5f2efe3fee952f7/Landskjorstjorn-logo-hvitt.svg"
+                src={n(
+                  'landskjorstjornFooterLogo',
+                  'https://images.ctfassets.net/8k0h54kbe6bj/60DIqBGQ8ejcpEak0bSrak/9481d5d92bcf9b2ea5f2efe3fee952f7/Landskjorstjorn-logo-hvitt.svg',
+                )}
                 alt=""
               />
             </Box>

--- a/apps/web/components/Organization/Wrapper/Themes/LandlaeknirTheme/LandlaeknirFooter.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/LandlaeknirTheme/LandlaeknirFooter.tsx
@@ -1,3 +1,4 @@
+import { BLOCKS } from '@contentful/rich-text-types'
 import {
   Box,
   GridColumn,
@@ -11,8 +12,8 @@ import {
 } from '@island.is/island-ui/core'
 import { FooterItem, Slice } from '@island.is/web/graphql/schema'
 import { SliceType } from '@island.is/island-ui/contentful'
-import { BLOCKS } from '@contentful/rich-text-types'
 import { webRichText } from '@island.is/web/utils/richText'
+import { useNamespace } from '@island.is/web/hooks'
 import * as styles from './LandlaeknirFooter.css'
 
 const renderParagraphs = (
@@ -35,9 +36,14 @@ const renderParagraphs = (
 
 interface LandLaeknirFooterProps {
   footerItems: Array<FooterItem>
+  namespace: Record<string, string>
 }
 
-export const LandLaeknirFooter = ({ footerItems }: LandLaeknirFooterProps) => {
+export const LandLaeknirFooter = ({
+  footerItems,
+  namespace,
+}: LandLaeknirFooterProps) => {
+  const n = useNamespace(namespace)
   return (
     <footer aria-labelledby="organizationFooterTitle">
       <Box className={styles.container}>
@@ -46,7 +52,11 @@ export const LandLaeknirFooter = ({ footerItems }: LandLaeknirFooterProps) => {
             <GridRow>
               <Box marginLeft={2}>
                 <img
-                  src="https://images.ctfassets.net/8k0h54kbe6bj/3aKn7lTVtvZVVHJVPSs6Gh/bf8844713aa03d44916e98ae612ea5da/landlaeknir-heilbrigdisraduneytid.png"
+                  width="100%"
+                  src={n(
+                    'landlaeknirFooterImage',
+                    'https://images.ctfassets.net/8k0h54kbe6bj/3aKn7lTVtvZVVHJVPSs6Gh/bf8844713aa03d44916e98ae612ea5da/landlaeknir-heilbrigdisraduneytid.png',
+                  )}
                   alt="landlaeknirLogo"
                 />
               </Box>
@@ -145,7 +155,10 @@ export const LandLaeknirFooter = ({ footerItems }: LandLaeknirFooterProps) => {
                       {renderParagraphs(footerItems[5].content, 0)}
                     </Box>
                     <img
-                      src="https://images.ctfassets.net/8k0h54kbe6bj/1hx4HeCK1OFzPIjtKkMmrL/fa769439b9221a92bfb124b598494ba4/Facebook-Logo-Dark.svg"
+                      src={n(
+                        'landlaeknirFacebookLogo',
+                        'https://images.ctfassets.net/8k0h54kbe6bj/1hx4HeCK1OFzPIjtKkMmrL/fa769439b9221a92bfb124b598494ba4/Facebook-Logo-Dark.svg',
+                      )}
                       alt="facebookLogo"
                     />
                   </Box>
@@ -167,7 +180,10 @@ export const LandLaeknirFooter = ({ footerItems }: LandLaeknirFooterProps) => {
                     alignItems="center"
                   >
                     <img
-                      src="https://images.ctfassets.net/8k0h54kbe6bj/3vtLh2dJ55PA1Y1aOXIkM9/6c60a95ed3db8136a49e9734adbc8c7c/Jafnlaunavottun.svg"
+                      src={n(
+                        'landlaeknirJafnlaunavottunLogo',
+                        'https://images.ctfassets.net/8k0h54kbe6bj/3vtLh2dJ55PA1Y1aOXIkM9/6c60a95ed3db8136a49e9734adbc8c7c/Jafnlaunavottun.svg',
+                      )}
                       alt="jafnlaunavottunLogo"
                     />
                     <Box marginLeft={2}>
@@ -178,12 +194,18 @@ export const LandLaeknirFooter = ({ footerItems }: LandLaeknirFooterProps) => {
 
                   <img
                     width={114}
-                    src="https://images.ctfassets.net/8k0h54kbe6bj/2w9jCgdlKvT1gG5Vyk2arB/e3043e0ae9331ebad4e6e6bca684b87a/grSkref1080x680_BW.png"
+                    src={n(
+                      'landlaeknirGraenskrefLogo',
+                      'https://images.ctfassets.net/8k0h54kbe6bj/2w9jCgdlKvT1gG5Vyk2arB/e3043e0ae9331ebad4e6e6bca684b87a/grSkref1080x680_BW.png',
+                    )}
                     alt=""
                   />
                   <img
                     width={114}
-                    src="https://images.ctfassets.net/8k0h54kbe6bj/4wF7MeLqjkMkw11wLJf2Ko/25a5592603ca0e29aaa58c13ecbf55fe/Heilsueflandi_vinnusta__ur_logo_1.svg"
+                    src={n(
+                      'landlaeknirHeilsueflandiVinnustadurLogo',
+                      'https://images.ctfassets.net/8k0h54kbe6bj/4wF7MeLqjkMkw11wLJf2Ko/25a5592603ca0e29aaa58c13ecbf55fe/Heilsueflandi_vinnusta__ur_logo_1.svg',
+                    )}
                     alt=""
                   />
                 </GridRow>

--- a/apps/web/components/Organization/Wrapper/Themes/SjukratryggingarTheme/SjukratryggingarFooter.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/SjukratryggingarTheme/SjukratryggingarFooter.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { BLOCKS } from '@contentful/rich-text-types'
 import { FooterItem } from '@island.is/web/graphql/schema'
 import {
   Box,
@@ -8,17 +9,20 @@ import {
   Text,
 } from '@island.is/island-ui/core'
 import { SliceType } from '@island.is/island-ui/contentful'
-import { BLOCKS } from '@contentful/rich-text-types'
 import { webRichText } from '@island.is/web/utils/richText'
+import { useNamespace } from '@island.is/web/hooks'
 import * as styles from './SjukratryggingarFooter.css'
 
 interface FooterProps {
   footerItems: Array<FooterItem>
+  namespace: Record<string, string>
 }
 
 export const SjukratryggingarFooter: React.FC<FooterProps> = ({
   footerItems,
+  namespace,
 }) => {
+  const n = useNamespace(namespace)
   return (
     <footer aria-labelledby="organizationFooterTitle">
       <Box className={styles.footerBg} color="white" paddingTop={5}>
@@ -35,7 +39,10 @@ export const SjukratryggingarFooter: React.FC<FooterProps> = ({
             >
               <Box marginRight={4}>
                 <img
-                  src="/assets/sjukratryggingar_logo.png"
+                  src={n(
+                    'sjukratryggingarFooterLogo',
+                    '/assets/sjukratryggingar_logo.png',
+                  )}
                   alt=""
                   className={styles.logoStyle}
                 />
@@ -72,7 +79,10 @@ export const SjukratryggingarFooter: React.FC<FooterProps> = ({
                   className={styles.footerSecondRow}
                 >
                   <img
-                    src="/assets/sjukratryggingar_heilbrigdisraduneytid.png"
+                    src={n(
+                      'sjukratryggingarFooterBottomLogo',
+                      '/assets/sjukratryggingar_heilbrigdisraduneytid.png',
+                    )}
                     alt="heilbrygdisraduneytid"
                   />
                 </GridColumn>

--- a/apps/web/components/Organization/Wrapper/Themes/SyslumennTheme/SyslumennFooter.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/SyslumennTheme/SyslumennFooter.tsx
@@ -12,7 +12,7 @@ import {
   LinkProps,
   Text,
 } from '@island.is/island-ui/core'
-import { LinkType, useLinkResolver } from '@island.is/web/hooks'
+import { LinkType, useLinkResolver, useNamespace } from '@island.is/web/hooks'
 import { SliceType } from '@island.is/island-ui/contentful'
 import { GlobalContext } from '@island.is/web/context'
 import { BLOCKS } from '@contentful/rich-text-types'
@@ -26,15 +26,19 @@ interface FooterProps {
   footerItems: Array<FooterItem>
   questionsAndAnswersText?: string
   canWeHelpText?: string
+  namespace: Record<string, string>
 }
 
 export const SyslumennFooter: React.FC<FooterProps> = ({
   title,
   logo,
   footerItems,
-  questionsAndAnswersText = 'Spurningar og svör',
-  canWeHelpText = 'Getum við aðstoðað?',
+  namespace,
 }) => {
+  const n = useNamespace(namespace)
+  const questionsAndAnswersText = n('questionsAndAnswers', 'Spurningar og svör')
+  const canWeHelpText = n('canWeHelp', 'Getum við aðstoðað?')
+
   const { isServiceWeb } = useContext(GlobalContext)
   const { linkResolver } = useLinkResolver()
 


### PR DESCRIPTION
# Read organization footer image urls from cms

## What

* Instead of having hardcoded values inside the code we'd like to have the option to change images without it requiring a code change

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
