### PR TITLE
fix(j-s): Defender Tooltip

### DIFF
--- a/apps/judicial-system/web/src/components/DefenderInfo/DefenderInfo.tsx
+++ b/apps/judicial-system/web/src/components/DefenderInfo/DefenderInfo.tsx
@@ -116,7 +116,7 @@ const DefenderInfo: React.FC<Props> = (props) => {
                       },
                     )
                   : formatMessage(
-                      defenderInfo.restrictionCases.sections.sendRequest
+                      defenderInfo.investigationCases.sections.sendRequest
                         .tooltip,
                     )
               }


### PR DESCRIPTION
# Defender Tooltip

[Texti i info bubblu er rangur á skjánum varnaraðili - verjandi varnaraðila.](https://app.asana.com/0/1199153462262248/1203865140441049/f)

## What

- Fixes a tooltip in the defender section for investigation cases.

## Why

- Verified bug.

## Screenshots / Gifs

### Before
<img width="393" alt="image" src="https://user-images.githubusercontent.com/795382/217194754-633d2450-ae68-459a-aa91-da76efba9b58.png">

### After
<img width="402" alt="image" src="https://user-images.githubusercontent.com/795382/217194604-90cf243f-cbfb-4761-aa97-13bb84b870ff.png">

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
