### PR TITLE
feat(service-portal): add error handling to pkpass

### DIFF
--- a/libs/service-portal/licenses/src/lib/messages.ts
+++ b/libs/service-portal/licenses/src/lib/messages.ts
@@ -282,4 +282,8 @@ export const m = defineMessages({
     id: 'sp.license:see-licenses',
     defaultMessage: 'Skoða skírteini',
   },
+  licenseFetchError: {
+    id: 'sp.license:license-fetch-error',
+    defaultMessage: 'Í augnablikinu er ekki hægt að senda skilríki í síma',
+  },
 })


### PR DESCRIPTION
# Service portal - License pkpass error handling

## What

* Add error handling if QR code or Pkpass link returns an error
* Safari users in mobile always had to press two times

## Why

* User's were having trouble if service was returning error

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
