### PR TITLE
fix(marriage-conditions): remove duplicate data provider text

### DIFF
--- a/libs/application/templates/marriage-conditions/src/forms/sharedSections/dataCollection.ts
+++ b/libs/application/templates/marriage-conditions/src/forms/sharedSections/dataCollection.ts
@@ -20,11 +20,6 @@ export const dataCollection = [
     subTitle: m.dataCollectionUserProfileSubtitle,
   }),
   buildDataProviderItem({
-    provider: undefined,
-    title: m.dataCollectionUserProfileTitle,
-    subTitle: m.dataCollectionUserProfileSubtitle,
-  }),
-  buildDataProviderItem({
     provider: MaritalStatusApi,
     title: m.dataCollectionMaritalStatusTitle,
     subTitle: m.dataCollectionMaritalStatusDescription,


### PR DESCRIPTION
Duplicate userprofile text removed

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
