### PR TITLE
fix(parental-leave): right code fix

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/parental-leave.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/parental-leave.service.ts
@@ -153,13 +153,9 @@ export class ParentalLeaveService extends BaseTemplateApiService {
     )
     const person = await this.nationalRegistryApi.getIndividual(auth.nationalId)
 
-    if (!person) {
-      return null
-    }
-
     return (
-      spouse && {
-        spouse: {
+      person && {
+        spouse: spouse && {
           nationalId: spouse.spouseNationalId,
           name: spouse.spouseName,
         },


### PR DESCRIPTION
## What

We where sending in the wrong right code if the applicants where not in registered cohabitation. 

## Why

If no spouse found we didn't not fill in fullname and gendercode of the person. Therefor we were sending in FO rights code instead of F.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
