### PR TITLE
feat(api-sessions): Use data loader to load client name and logo

### DIFF
--- a/apps/services/sessions/sequelize.config.js
+++ b/apps/services/sessions/sequelize.config.js
@@ -1,12 +1,12 @@
 /* eslint-env node */
 module.exports = {
   development: {
-    username: 'dev_db',
-    password: 'dev_db',
-    database: 'dev_db',
+    username: 'dev_db' ?? process.env.DB_USER_SESSIONS,
+    password: 'dev_db' ?? process.env.DB_PASS_SESSIONS,
+    database: 'dev_db' ?? process.env.DB_NAME_SESSIONS,
     host: 'localhost',
     dialect: 'postgres',
-    port: 5434,
+    port: 5434 ?? process.env.DB_PORT_SESSIONS,
   },
   production: {
     username: process.env.DB_USER,

--- a/apps/services/sessions/sequelize.config.js
+++ b/apps/services/sessions/sequelize.config.js
@@ -1,12 +1,12 @@
 /* eslint-env node */
 module.exports = {
   development: {
-    username: 'dev_db' ?? process.env.DB_USER_SESSIONS,
-    password: 'dev_db' ?? process.env.DB_PASS_SESSIONS,
-    database: 'dev_db' ?? process.env.DB_NAME_SESSIONS,
+    username: process.env.DB_USER_SESSIONS ?? 'dev_db',
+    password: process.env.DB_PASS_SESSIONS ?? 'dev_db',
+    database: process.env.DB_NAME_SESSIONS ?? 'dev_db',
     host: 'localhost',
     dialect: 'postgres',
-    port: 5434 ?? process.env.DB_PORT_SESSIONS,
+    port: process.env.DB_PORT_SESSIONS ?? 5434,
   },
   production: {
     username: process.env.DB_USER,

--- a/libs/api/domains/auth/src/lib/auth.module.ts
+++ b/libs/api/domains/auth/src/lib/auth.module.ts
@@ -21,6 +21,7 @@ import { ActorDelegationsService } from './services/actorDelegations.service'
 import { DomainService } from './services/domain.service'
 import { MeDelegationsService } from './services/meDelegations.service'
 import { ApiScopeService } from './services/apiScope.service'
+import { ClientsService } from './services/clients.service'
 
 @Module({
   providers: [
@@ -38,6 +39,7 @@ import { ApiScopeService } from './services/apiScope.service'
     ClientLoader,
     DomainLoader,
     CmsModule,
+    ClientsService,
   ],
   imports: [
     AuthPublicApiClientModule,

--- a/libs/api/domains/auth/src/lib/loaders/client.loader.ts
+++ b/libs/api/domains/auth/src/lib/loaders/client.loader.ts
@@ -1,29 +1,62 @@
-import { Injectable } from '@nestjs/common'
+import {
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common'
 import DataLoader from 'dataloader'
 
+import { GraphQLContext, User } from '@island.is/auth-nest-tools'
 import { NestDataLoader } from '@island.is/nest/dataloader'
 
 import { ClientInput } from '../dto/client.input'
 import { Client } from '../models/client.model'
+import { ClientsService } from '../services/clients.service'
+import { DomainService } from '../services/domain.service'
 
 export type ClientDataLoader = DataLoader<ClientInput, Client>
 
 @Injectable()
 export class ClientLoader implements NestDataLoader<ClientInput, Client> {
+  constructor(
+    private readonly clientService: ClientsService,
+    private readonly domainsService: DomainService,
+  ) {}
+
   keyFn(input: ClientInput): string {
     return `${input.lang}##${input.clientId}`
   }
 
-  async loadClients(inputs: readonly ClientInput[]): Promise<Array<Client>> {
-    // Todo: Add call to client endpoint in delegation api when ready.
+  async loadClients(
+    user: User | undefined,
+    inputs: readonly ClientInput[],
+  ): Promise<Array<Client | Error>> {
+    if (!user) {
+      throw new UnauthorizedException()
+    }
 
-    return inputs.map((input) => ({
-      id: input.clientId,
+    // Only support one language at a time.
+    const lang = inputs[0].lang
+    const authClients = await this.clientService.getClients(user, {
+      lang,
+      clientIds: inputs.map((input) => input.clientId),
+    })
+    const domains = await this.domainsService.getDomains(user, { lang })
+
+    const clients: Client[] = authClients.map((client) => ({
+      clientId: client.clientId,
+      clientName: client.clientName,
+      domain: domains.find((domain) => domain.name === client.domainName),
     }))
+
+    return inputs.map(
+      (input) =>
+        clients.find((client) => client.clientId === input.clientId) ??
+        new NotFoundException(`Could not find client: ${input.clientId}`),
+    )
   }
 
-  generateDataLoader(): ClientDataLoader {
-    return new DataLoader(this.loadClients.bind(this), {
+  generateDataLoader(ctx: GraphQLContext): ClientDataLoader {
+    return new DataLoader(this.loadClients.bind(this, ctx.req.user), {
       cacheKeyFn: this.keyFn,
     })
   }

--- a/libs/api/domains/auth/src/lib/models/client.model.ts
+++ b/libs/api/domains/auth/src/lib/models/client.model.ts
@@ -1,10 +1,14 @@
 import { Field, ID, ObjectType } from '@nestjs/graphql'
+import { Domain } from './domain.model'
 
 @ObjectType('AuthClient')
 export class Client {
   @Field(() => ID)
-  id!: string
+  clientId!: string
 
-  @Field(() => String, { nullable: true })
-  name?: string
+  @Field(() => String)
+  clientName!: string
+
+  @Field(() => Domain, { nullable: true })
+  domain?: Domain
 }

--- a/libs/api/domains/auth/src/lib/services/clients.service.ts
+++ b/libs/api/domains/auth/src/lib/services/clients.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common'
+
+import { Auth, AuthMiddleware, User } from '@island.is/auth-nest-tools'
+import { ClientDto, ClientsApi } from '@island.is/clients/auth/delegation-api'
+
+import { ClientsInput } from './types'
+
+@Injectable()
+export class ClientsService {
+  constructor(private clientsApi: ClientsApi) {}
+
+  private clientsApiWithAuth(auth: Auth) {
+    return this.clientsApi.withMiddleware(new AuthMiddleware(auth))
+  }
+
+  getClients(user: User, input: ClientsInput): Promise<ClientDto[]> {
+    return this.clientsApiWithAuth(user).clientsControllerFindAll({
+      lang: input.lang,
+      clientIds: input.clientIds,
+    })
+  }
+}

--- a/libs/api/domains/auth/src/lib/services/types.ts
+++ b/libs/api/domains/auth/src/lib/services/types.ts
@@ -79,3 +79,8 @@ export enum DelegationType {
   PersonalRepresentative = 'PersonalRepresentative',
   Custom = 'Custom',
 }
+
+export interface ClientsInput {
+  lang: string
+  clientIds: string[]
+}

--- a/libs/clients/auth/delegation-api/src/lib/apis.ts
+++ b/libs/clients/auth/delegation-api/src/lib/apis.ts
@@ -1,8 +1,15 @@
-import { Configuration, DomainsApi, MeDelegationsApi } from '../../gen/fetch'
+import {
+  ClientsApi,
+  Configuration,
+  DomainsApi,
+  MeDelegationsApi,
+} from '../../gen/fetch'
 import { ApiConfiguration } from './api-configuration'
 
-export const exportedApis = [MeDelegationsApi, DomainsApi].map((Api) => ({
-  provide: Api,
-  useFactory: (configuration: Configuration) => new Api(configuration),
-  inject: [ApiConfiguration.provide],
-}))
+export const exportedApis = [MeDelegationsApi, DomainsApi, ClientsApi].map(
+  (Api) => ({
+    provide: Api,
+    useFactory: (configuration: Configuration) => new Api(configuration),
+    inject: [ApiConfiguration.provide],
+  }),
+)


### PR DESCRIPTION
## What

Finish implementation of `ClientLoader` to load client to resolve `clientName` and resolve domain to get logo for display.

## Why

To use client name and logo in session history UI.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
