### PR TITLE
fix(financial-statement-inao): operating year not persisting 

### DIFF
--- a/libs/application/templates/financial-statements-inao/src/forms/application/shared/about/clientInfoSection.ts
+++ b/libs/application/templates/financial-statements-inao/src/forms/application/shared/about/clientInfoSection.ts
@@ -31,8 +31,8 @@ export const clientInfoSection = buildSection({
       children: [
         buildDescriptionField({
           id: ABOUTIDS.operatingYear,
-          title: ''
-         }),
+          title: '',
+        }),
         buildCustomField({
           id: 'OperatingYear',
           childInputIds: [ABOUTIDS.operatingYear],

--- a/libs/application/templates/financial-statements-inao/src/forms/application/shared/about/clientInfoSection.ts
+++ b/libs/application/templates/financial-statements-inao/src/forms/application/shared/about/clientInfoSection.ts
@@ -78,6 +78,10 @@ export const clientInfoSection = buildSection({
             return nationalRegistry.name
           },
         }),
+        buildDescriptionField({
+          id: ABOUTIDS.powerOfAttorneyName,
+          title: '',
+        }),
         buildCustomField({
           id: 'powerOfAttorney',
           title: '',

--- a/libs/application/templates/financial-statements-inao/src/forms/application/shared/about/clientInfoSection.ts
+++ b/libs/application/templates/financial-statements-inao/src/forms/application/shared/about/clientInfoSection.ts
@@ -1,4 +1,5 @@
 import {
+  buildDescriptionField,
   buildCustomField,
   buildMultiField,
   buildSection,
@@ -28,9 +29,13 @@ export const clientInfoSection = buildSection({
           : m.reviewContact
       },
       children: [
+        buildDescriptionField({
+          id: ABOUTIDS.operatingYear,
+          title: ''
+         }),
         buildCustomField({
           id: 'OperatingYear',
-          childInputIds: Object.values(ABOUTIDS),
+          childInputIds: [ABOUTIDS.operatingYear],
           title: '',
           condition: (answers, externalData) => {
             const userType = getCurrentUserType(answers, externalData)

--- a/libs/application/templates/financial-statements-inao/src/forms/application/shared/keyNumbers/capitalNumbers.ts
+++ b/libs/application/templates/financial-statements-inao/src/forms/application/shared/keyNumbers/capitalNumbers.ts
@@ -7,7 +7,7 @@ import { CAPITALNUMBERS } from '../../../../lib/constants'
 import { m } from '../../../../lib/messages'
 
 export const capitalNumberSection = buildSubSection({
-  id: 'capitalNumbers',
+  id: 'keynumbers.capitalNumbers',
   title: m.capitalNumbers,
   children: [
     buildMultiField({


### PR DESCRIPTION
## What

operating year which is fetched dynamically had to be refetched each time entering the application

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review