### PR TITLE
fix(sessions): Add env variable to docker-build step for geoip udpate

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -491,6 +491,7 @@ jobs:
       GIT_BRANCH: ${{ needs.pre-checks.outputs.GIT_BRANCH}}
       DOCKER_TAG: ${{ needs.prepare.outputs.DOCKER_TAG}}
       PUBLISH: true
+      GEOIP_LICENSE_KEY: ${{ secrets.GEOIP_LICENSE_KEY }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What

Map GH Actions secret to step env variable for geoip update script.

## Why

docker build is failing due to the env variable missing in the step.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
