### PR TITLE
fix(service-portal): Hotfix - hide air-discount when logged in as a company in serviceportal

### DIFF
--- a/libs/service-portal/air-discount/src/module.ts
+++ b/libs/service-portal/air-discount/src/module.ts
@@ -14,6 +14,7 @@ const rootName = defineMessage({
 export const airDiscountModule: PortalModule = {
   name: rootName,
   featureFlag: Features.servicePortalAirDiscountModule,
+  enabled: ({ isCompany }) => !isCompany,
   routes: ({ userInfo }) => [
     {
       name: rootName,


### PR DESCRIPTION
* Hide air discount when logged in as a company

Hotfix: https://github.com/island-is/island.is/pull/10065