### PR TITLE
fix(parental-leave): get applicant name not all external data

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/emailGenerators/assignEmployerEmail.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/emailGenerators/assignEmployerEmail.ts
@@ -38,7 +38,7 @@ export const generateAssignEmployerApplicationEmail: AssignEmployerEmail = (
 
   const employerEmail =
     employers.length > 0 ? employers[0].email : employerEmailOld ?? ''
-  const applicantName = getApplicationExternalData(application.externalData)
+  const { applicantName } = getApplicationExternalData(application.externalData)
   const subject = 'Yfirferð á umsókn um fæðingarorlof'
 
   return {


### PR DESCRIPTION
## What

Get applicant name to send in the email to employer not all external dat

## Why

Was returning [object Object] instead og applicant name

## Screenshots / Gifs

![Screenshot 2023-02-16 at 13 18 38](https://user-images.githubusercontent.com/102811817/219375499-7b405af3-6a37-486b-8bff-ab43289f8c0a.png)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
