### PR TITLE
fix(web): Change padding on web form depending on screen size

### DIFF
--- a/apps/web/components/Form/Form.tsx
+++ b/apps/web/components/Form/Form.tsx
@@ -534,7 +534,12 @@ export const Form = ({ form, namespace }: FormProps) => {
   const failure = result?.genericForm?.sent === false || !!error || submitError
 
   return (
-    <Box background="blue100" paddingY={8} paddingX={12} borderRadius="large">
+    <Box
+      background="blue100"
+      paddingY={[3, 3, 5]}
+      paddingX={[3, 3, 3, 3, 12]}
+      borderRadius="large"
+    >
       {success && (
         <>
           <Text variant="h3" marginBottom={2} color="blue600">


### PR DESCRIPTION
# Change padding on web form depending on screen size

## What

* I noticed that the padding was way too much on mobile screen sizes so I decreased it for better usability

## Screenshots / Gifs

### Before
![image](https://user-images.githubusercontent.com/43557895/219663614-1c3f2e21-f6ea-4812-988c-e5197b3dcfec.png)

### After
![image](https://user-images.githubusercontent.com/43557895/219663667-7b4c4680-117f-4b51-b568-f332606bb493.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
