### PR TITLE
fix(j-s): Remove dash from National IDs

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/police/police.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/police.service.ts
@@ -252,7 +252,7 @@ export class PoliceService {
         caseNumber: policeCaseNumber,
         ssn:
           defendantNationalIds && defendantNationalIds[0]
-            ? defendantNationalIds[0]
+            ? defendantNationalIds[0].replace('-', '')
             : '',
         type: caseType,
         courtVerdict: caseState,


### PR DESCRIPTION
# Remove dash from national IDs when calling police service

[Taka bandstrik af kennitölu áður en hún er send í LÖKE.](https://app.asana.com/0/1199153462262248/1203984021474236/f)

## What

Remove dash from national IDs before sending update request to police service

## Why

To avoid getting an error that comes when a national ID is sent with an update request


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
