### PR TITLE
fix(general-fishing-license): Add file size limit and disable multiple to file upload fields 

### DIFF
--- a/libs/application/templates/general-fishing-license/src/forms/GeneralFishingLicenseForm/fishingLicenseFurtherInfoSection.ts
+++ b/libs/application/templates/general-fishing-license/src/forms/GeneralFishingLicenseForm/fishingLicenseFurtherInfoSection.ts
@@ -16,6 +16,7 @@ import {
   licenseHasFileUploadField,
   licenseHasRailNetAndRoeNetField,
   FILE_UPLOAD_ACCEPT,
+  FILE_SIZE_LIMIT,
 } from '../../utils/licenses'
 
 // Condition that determines whether given license has file upload field
@@ -118,6 +119,9 @@ export const fishingLicenseFurtherInfoSection = buildSection({
           id: ATTACHMENTS_FIELD_ID,
           title: fishingLicenseFurtherInformation.labels.attachments,
           maxSize: FILE_SIZE_LIMIT,
+          maxSizeErrorText:
+            fishingLicenseFurtherInformation.errorMessages
+              .attachmentMaxSizeError,
           uploadHeader: fishingLicenseFurtherInformation.attachmentInfo.title,
           uploadDescription:
             fishingLicenseFurtherInformation.attachmentInfo.subtitle,

--- a/libs/application/templates/general-fishing-license/src/forms/GeneralFishingLicenseForm/fishingLicenseFurtherInfoSection.ts
+++ b/libs/application/templates/general-fishing-license/src/forms/GeneralFishingLicenseForm/fishingLicenseFurtherInfoSection.ts
@@ -117,6 +117,7 @@ export const fishingLicenseFurtherInfoSection = buildSection({
         buildFileUploadField({
           id: ATTACHMENTS_FIELD_ID,
           title: fishingLicenseFurtherInformation.labels.attachments,
+          maxSize: FILE_SIZE_LIMIT,
           uploadHeader: fishingLicenseFurtherInformation.attachmentInfo.title,
           uploadDescription:
             fishingLicenseFurtherInformation.attachmentInfo.subtitle,

--- a/libs/application/templates/general-fishing-license/src/forms/GeneralFishingLicenseForm/fishingLicenseFurtherInfoSection.ts
+++ b/libs/application/templates/general-fishing-license/src/forms/GeneralFishingLicenseForm/fishingLicenseFurtherInfoSection.ts
@@ -128,6 +128,7 @@ export const fishingLicenseFurtherInfoSection = buildSection({
           uploadButtonLabel:
             fishingLicenseFurtherInformation.attachmentInfo.buttonLabel,
           uploadAccept: FILE_UPLOAD_ACCEPT,
+          uploadMultiple: false,
           condition: hasFileUpload,
         }),
         // Roe net and rail net information fields - only for selected license(s)

--- a/libs/application/templates/general-fishing-license/src/lib/dataSchema.ts
+++ b/libs/application/templates/general-fishing-license/src/lib/dataSchema.ts
@@ -75,7 +75,10 @@ export const GeneralFishingLicenseSchema = z.object({
     attachments: z
       .array(FileSchema)
       .optional()
-      .refine((x) => x === undefined || x.length > 0),
+      .refine((x) => x === undefined || (x.length > 0 && x.length < 2), {
+        params:
+          fishingLicenseFurtherInformation.errorMessages.attachmentLimitError,
+      }),
     railAndRoeNet: z
       .object({
         railnet: z.string().optional(),

--- a/libs/application/templates/general-fishing-license/src/lib/dataSchema.ts
+++ b/libs/application/templates/general-fishing-license/src/lib/dataSchema.ts
@@ -75,7 +75,7 @@ export const GeneralFishingLicenseSchema = z.object({
     attachments: z
       .array(FileSchema)
       .optional()
-      .refine((x) => x === undefined || (x.length > 0 && x.length < 2), {
+      .refine((x) => x === undefined || x.length === 1), {
         params:
           fishingLicenseFurtherInformation.errorMessages.attachmentLimitError,
       }),

--- a/libs/application/templates/general-fishing-license/src/lib/dataSchema.ts
+++ b/libs/application/templates/general-fishing-license/src/lib/dataSchema.ts
@@ -75,7 +75,7 @@ export const GeneralFishingLicenseSchema = z.object({
     attachments: z
       .array(FileSchema)
       .optional()
-      .refine((x) => x === undefined || x.length === 1), {
+      .refine((x) => x === undefined || x.length === 1, {
         params:
           fishingLicenseFurtherInformation.errorMessages.attachmentLimitError,
       }),

--- a/libs/application/templates/general-fishing-license/src/lib/messages/fishingLicenseFurtherInformation.ts
+++ b/libs/application/templates/general-fishing-license/src/lib/messages/fishingLicenseFurtherInformation.ts
@@ -133,5 +133,11 @@ export const fishingLicenseFurtherInformation = {
       defaultMessage: 'Vinsamlegast fylltu út alla reiti',
       description: 'Please fill out all required fields',
     },
+    attachmentMaxSizeError: {
+      id:
+        'gfl.application:fishingLicenseFurtherInformation.errorMessages.attachmentMaxSizeError',
+      defaultMessage: 'Hámark 5 MB á skrá',
+      description: 'Max 5 MB per file',
+    },
   }),
 }

--- a/libs/application/templates/general-fishing-license/src/lib/messages/fishingLicenseFurtherInformation.ts
+++ b/libs/application/templates/general-fishing-license/src/lib/messages/fishingLicenseFurtherInformation.ts
@@ -139,5 +139,11 @@ export const fishingLicenseFurtherInformation = {
       defaultMessage: 'Hámark 5 MB á skrá',
       description: 'Max 5 MB per file',
     },
+    attachmentLimitError: {
+      id:
+        'gfl.application:fishingLicenseFurtherInformation.errorMessages.attachmentLimitError',
+      defaultMessage: 'Hlaða á upp aðeins einni skrá',
+      description: 'Max one file',
+    },
   }),
 }

--- a/libs/application/templates/general-fishing-license/src/utils/licenses.ts
+++ b/libs/application/templates/general-fishing-license/src/utils/licenses.ts
@@ -2,6 +2,8 @@ import { FishingLicenseEnum } from '../types'
 
 export const FILE_UPLOAD_ACCEPT = '.pdf, .jpg, .jpeg, .png'
 
+export const FILE_SIZE_LIMIT = 5000000 // 5MB
+
 // Determines whether fishing license has a file upload field
 export const licenseHasFileUploadField = (
   license: FishingLicenseEnum | string,


### PR DESCRIPTION
# Add file size limit and disable multiple to file upload fields 

[Task
](https://app.clickup.com/t/861md43c1)

## What

Add file size limit of 5MB to file upload fields for general fishing license
Disable multiple to file upload fields 

## Why

Request from Fiskistofa

## Screenshots / Gifs

![Dragou skjöl hingad til ad hlada upp](https://user-images.githubusercontent.com/16048954/220323644-2180c36f-b351-44ee-90a3-6fc205c484f7.png)
![image](https://user-images.githubusercontent.com/16048954/220332693-28817eaf-b84f-47a3-b93f-d890b16aa6b1.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
