### PR TITLE
fix(instructor-registration): format completed hours

### DIFF
--- a/libs/application/templates/driving-instructor-registrations/src/fields/StudentsOverview/index.tsx
+++ b/libs/application/templates/driving-instructor-registrations/src/fields/StudentsOverview/index.tsx
@@ -136,7 +136,9 @@ const StudentsOverview: FC<FieldBaseProps> = ({ application }) => {
                           {formatKennitala(student.nationalId)}
                         </T.Data>
                         <T.Data box={{ textAlign: 'center' }}>
-                          {student.totalLessonCount ?? 0}
+                          {student.totalLessonCount % 2 === 0
+                            ? student.totalLessonCount
+                            : student.totalLessonCount.toFixed(2) ?? 0}
                         </T.Data>
                         <T.Data
                           box={{ textAlign: 'center' }}

--- a/libs/application/templates/driving-instructor-registrations/src/fields/ViewStudent/index.tsx
+++ b/libs/application/templates/driving-instructor-registrations/src/fields/ViewStudent/index.tsx
@@ -281,9 +281,9 @@ const ViewStudent = ({
                 {formatMessage(m.viewStudentCompleteHours)}
               </Text>
               <Text variant="default">
-                {student.totalLessonCount % 2 === 0
-                  ? student.totalLessonCount
-                  : student.totalLessonCount.toFixed(2) ?? 0}
+                {student.book?.totalLessonCount % 2 === 0
+                  ? student.book?.totalLessonCount
+                  : student.book?.totalLessonCount.toFixed(2) ?? 0}
               </Text>
             </GridColumn>
             {/* Practice driving */}

--- a/libs/application/templates/driving-instructor-registrations/src/fields/ViewStudent/index.tsx
+++ b/libs/application/templates/driving-instructor-registrations/src/fields/ViewStudent/index.tsx
@@ -281,7 +281,9 @@ const ViewStudent = ({
                 {formatMessage(m.viewStudentCompleteHours)}
               </Text>
               <Text variant="default">
-                {student.book?.totalLessonCount ?? 0}
+                {student.totalLessonCount % 2 === 0
+                  ? student.totalLessonCount
+                  : student.totalLessonCount.toFixed(2) ?? 0}
               </Text>
             </GridColumn>
             {/* Practice driving */}


### PR DESCRIPTION
Driving License book api now returns completed hours with 2 decimal points. It was blowing up the number field and had to be rounded down so adding that in.

## Screenshots / Gifs
<img width="992" alt="Screenshot 2023-02-21 at 16 00 20" src="https://user-images.githubusercontent.com/42963845/220396176-c2a6ec90-ec5e-47d6-9c0a-56e84c89dc19.png">

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
