### PR TITLE
feat(j-s): Display auto generated indictment pdf

### DIFF
--- a/apps/judicial-system/web/src/components/IndictmentCaseFilesList/IndictmentCaseFilesList.tsx
+++ b/apps/judicial-system/web/src/components/IndictmentCaseFilesList/IndictmentCaseFilesList.tsx
@@ -6,12 +6,14 @@ import {
   CaseFile,
   CaseFileCategory,
   completedCaseStates,
+  Feature,
   isExtendedCourtRole,
 } from '@island.is/judicial-system/types'
 import { TempCase as Case } from '@island.is/judicial-system-web/src/types'
 import { Box, Text } from '@island.is/island-ui/core'
 import { core, errors } from '@island.is/judicial-system-web/messages'
 import { UserRole } from '@island.is/judicial-system-web/src/graphql/schema'
+import { isTrafficViolationCase } from '@island.is/judicial-system-web/src/utils/stepHelper'
 
 import PdfButton from '../PdfButton/PdfButton'
 import { caseFiles } from '../../routes/Prosecutor/Indictments/CaseFiles/CaseFiles.strings'
@@ -22,6 +24,7 @@ import SectionHeading from '../SectionHeading/SectionHeading'
 import * as styles from './IndictmentCaseFilesList.css'
 import { courtRecord } from '../../routes/Court/Indictments/CourtRecord/CourtRecord.strings'
 import Modal from '../Modal/Modal'
+import { FeatureContext } from '../FeatureProvider/FeatureProvider'
 
 interface Props {
   workingCase: Case
@@ -58,6 +61,12 @@ const RenderFiles: React.FC<Props & RenderFilesProps> = (props) => {
 const IndictmentCaseFilesList: React.FC<Props> = (props) => {
   const { workingCase } = props
   const { formatMessage } = useIntl()
+  const { features } = useContext(FeatureContext)
+
+  const isTrafficViolationCaseCheck =
+    features.includes(Feature.INDICTMENT_ROUTE) &&
+    isTrafficViolationCase(workingCase.indictmentSubtypes)
+
   const { onOpen, fileNotFound, dismissFileNotFound } = useFileList({
     caseId: workingCase.id,
   })
@@ -116,6 +125,25 @@ const IndictmentCaseFilesList: React.FC<Props> = (props) => {
               onOpenFile={onOpen}
               workingCase={workingCase}
             />
+          </Box>
+        )}
+        {isTrafficViolationCaseCheck && (
+          <Box marginBottom={5}>
+            <Text variant="h4" as="h4" marginBottom={1}>
+              {formatMessage(caseFiles.indictmentSection)}
+            </Text>
+            <Box
+              marginBottom={2}
+              key={`indictment-${workingCase.id}`}
+              className={styles.caseFileContainer}
+            >
+              <PdfButton
+                caseId={workingCase.id}
+                title={formatMessage(caseFiles.trafficViolationIndictmentTitle)}
+                pdfType="indictment"
+                renderAs="row"
+              />
+            </Box>
           </Box>
         )}
         {criminalRecords && criminalRecords.length > 0 && (

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/CaseFiles/CaseFiles.strings.ts
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/CaseFiles/CaseFiles.strings.ts
@@ -47,4 +47,10 @@ export const caseFiles = defineMessages({
     defaultMessage: 'Önnur gögn',
     description: 'Titill á önnur gögn hluta á dómskjalaskjá í ákærum.',
   },
+  trafficViolationIndictmentTitle: {
+    id:
+      'judicial.system.core:indictments.case_files.traffic_violation_indictment_title',
+    defaultMessage: 'Ákæra.pdf',
+    description: 'Titill á ákæru pdf fyrir umferðalagabrot.',
+  },
 })


### PR DESCRIPTION
#  Display auto generated indictment pdf

[Umferðarlagabrot - Birta ákæru á yfirliti sækjanda og dómaramegin](https://app.asana.com/0/1199153462262248/1203966413719356/f)

## What

Display link to auto generated indictment for traffic violation cases

## Why

Because it is not uploaded by the user in these cases so in order for them to be displayed on the overview screen we must instead link to the auto generated file

## Screenshots / Gifs
 
<img width="749" alt="image" src="https://user-images.githubusercontent.com/4820859/220595514-3496d0a6-5a6b-4739-a853-c428e6a0ec7d.png">

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
