### PR TITLE
fix(license-api): Pick out properties for verify

### DIFF
--- a/apps/services/license-api/src/app/modules/license/clients/firearmLicense/firearmLicenseApiClient.service.ts
+++ b/apps/services/license-api/src/app/modules/license/clients/firearmLicense/firearmLicenseApiClient.service.ts
@@ -127,7 +127,7 @@ export class FirearmLicenseApiClientService implements GenericLicenseClient {
       }
     }
 
-    const verifyRes = await this.smartApi.verifyPkPass(parsedInput)
+    const verifyRes = await this.smartApi.verifyPkPass({ code, date })
 
     if (!verifyRes.ok) {
       return verifyRes


### PR DESCRIPTION
## What

Pick out individual properties for the verification function.

## Why

Too many props makes the service go sour.


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
