### PR TITLE
fix(services-auth-admin-api): Undo multi issuer on auth admin api

### DIFF
--- a/apps/services/auth/admin-api/infra/auth-admin-api.ts
+++ b/apps/services/auth/admin-api/infra/auth-admin-api.ts
@@ -1,4 +1,4 @@
-import { json, service, ServiceBuilder } from '../../../../../infra/src/dsl/dsl'
+import { service, ServiceBuilder } from '../../../../../infra/src/dsl/dsl'
 
 export const serviceSetup = (): ServiceBuilder<'services-auth-admin-api'> => {
   return service('services-auth-admin-api')
@@ -14,18 +14,6 @@ export const serviceSetup = (): ServiceBuilder<'services-auth-admin-api'> => {
         dev: 'https://identity-server.dev01.devland.is',
         staging: 'https://identity-server.staging01.devland.is',
         prod: 'https://innskra.island.is',
-      },
-      IDENTITY_SERVER_ISSUER_URL_LIST: {
-        dev: json([
-          'https://identity-server.dev01.devland.is',
-          'https://identity-server.staging01.devland.is',
-          'https://innskra.island.is',
-        ]),
-        staging: json([
-          'https://identity-server.staging01.devland.is',
-          'https://innskra.island.is',
-        ]),
-        prod: json(['https://innskra.island.is']),
       },
     })
     .ingress({

--- a/apps/services/auth/admin-api/src/environments/environment.ts
+++ b/apps/services/auth/admin-api/src/environments/environment.ts
@@ -21,7 +21,8 @@ const prodConfig = {
   },
   auth: {
     audience,
-    issuer: JSON.parse(process.env.IDENTITY_SERVER_ISSUER_URL_LIST || '[]'),
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    issuer: process.env.IDENTITY_SERVER_ISSUER_URL!,
   },
   port: 3333,
 }

--- a/libs/api/domains/auth-admin/src/lib/tenant/tenants.service.ts
+++ b/libs/api/domains/auth-admin/src/lib/tenant/tenants.service.ts
@@ -7,6 +7,7 @@ import {
   AdminProdApi,
   AdminStagingApi,
 } from '@island.is/clients/auth/admin-api'
+import { FetchError } from '@island.is/clients/middlewares'
 import type { Logger } from '@island.is/logging'
 import { LOGGER_PROVIDER } from '@island.is/logging'
 import { Environment } from '@island.is/shared/types'
@@ -44,11 +45,30 @@ export class TenantsService {
     return this.adminProdApi?.withMiddleware(new AuthMiddleware(auth))
   }
 
+  private handleError(error: Error) {
+    if (error instanceof FetchError && error.status === 401) {
+      // If 401 is returned we log it as info as it is intentional
+      this.logger.info('Unauthorized request to admin api', error)
+    } else {
+      // Otherwise we log it as error
+      this.logger.error('Error while fetching tenants', error)
+    }
+
+    // We swallow the errors
+    return undefined
+  }
+
   async getTenants(user: User): Promise<TenantsPayload> {
     const tenants = await Promise.all([
-      this.adminDevApiWithAuth(user)?.meTenantsControllerFindAll(),
-      this.adminStagingApiWithAuth(user)?.meTenantsControllerFindAll(),
-      this.adminProdApiWithAuth(user)?.meTenantsControllerFindAll(),
+      this.adminDevApiWithAuth(user)
+        ?.meTenantsControllerFindAll()
+        .catch(this.handleError.bind(this)),
+      this.adminStagingApiWithAuth(user)
+        ?.meTenantsControllerFindAll()
+        .catch(this.handleError.bind(this)),
+      this.adminProdApiWithAuth(user)
+        ?.meTenantsControllerFindAll()
+        .catch(this.handleError.bind(this)),
     ])
 
     const tenantMap = new Map<string, TenantEnvironment[]>()


### PR DESCRIPTION
## What

Undo multi issuer for auth-admin-api as it needs refactor of JwtStrategy.
Add catch all swallow error handler in auth-admin gql domain for tenants.service.

## Why

To unblock auth-admin-api for release until we refactor JwtStrategy.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
