### PR TITLE
feat(web): Allow faqlists inside stepper subtitles

### DIFF
--- a/apps/web/components/Stepper/utils.ts
+++ b/apps/web/components/Stepper/utils.ts
@@ -371,6 +371,7 @@ const stepContainsQuestion = (step: Step) => {
   return (
     step.subtitle &&
     step.subtitle.length > 0 &&
+    step.stepType !== STEP_TYPES.ANSWER &&
     step.subtitle[0].__typename === 'Html' &&
     step.subtitle[0].document.content.length > 0 &&
     step.subtitle[0].document.content[0].content &&

--- a/apps/web/screens/queries/Article.ts
+++ b/apps/web/screens/queries/Article.ts
@@ -38,7 +38,7 @@ export const GET_ARTICLE_QUERY = gql`
           slug
           stepType
           subtitle {
-            ...HtmlFields
+            ...AllSlices
           }
           config
         }


### PR DESCRIPTION
# Allow faqlists inside stepper subtitles

## What

* Previously if users would place an accordion or an faq list inside a step subtitle field it wouldn't be displayed
* While I was at it I improved the stepContainsQuestion function by making it check whether the step was indeed a question to begin with

## Why

* We want to allow such embeds inside the rich text fields of steps
* 
## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
