### PR TITLE
fix(search-indexer): Revert "fix(search-indexer): Increase performance of search-indexer (#9892)"

### DIFF
--- a/apps/services/search-indexer/infra/search-indexer-service.ts
+++ b/apps/services/search-indexer/infra/search-indexer-service.ts
@@ -37,7 +37,6 @@ export const serviceSetup = (): ServiceBuilder<'search-indexer-service'> =>
     .secrets({
       CONTENTFUL_ACCESS_TOKEN: '/k8s/search-indexer/CONTENTFUL_ACCESS_TOKEN',
       API_CMS_SYNC_TOKEN: '/k8s/search-indexer/API_CMS_SYNC_TOKEN',
-      API_CMS_DELETION_TOKEN: '/k8s/search-indexer/API_CMS_DELETION_TOKEN',
     })
     .env(envs)
     .initContainer({

--- a/apps/web/components/PageLoader/PageLoader.tsx
+++ b/apps/web/components/PageLoader/PageLoader.tsx
@@ -12,7 +12,7 @@ export const PageLoader = () => {
       ref.current.continuousStart()
     }
     const done = () => {
-      ref.current?.complete()
+      ref.current.complete()
     }
     router.events.on('routeChangeStart', start)
     router.events.on('routeChangeComplete', done)

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -1785,7 +1785,6 @@ search-indexer-service:
       cpu: '100m'
       memory: '512Mi'
   secrets:
-    API_CMS_DELETION_TOKEN: '/k8s/search-indexer/API_CMS_DELETION_TOKEN'
     API_CMS_SYNC_TOKEN: '/k8s/search-indexer/API_CMS_SYNC_TOKEN'
     CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
     CONTENTFUL_ACCESS_TOKEN: '/k8s/search-indexer/CONTENTFUL_ACCESS_TOKEN'

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -1470,7 +1470,6 @@ search-indexer-service:
       cpu: '100m'
       memory: '512Mi'
   secrets:
-    API_CMS_DELETION_TOKEN: '/k8s/search-indexer/API_CMS_DELETION_TOKEN'
     API_CMS_SYNC_TOKEN: '/k8s/search-indexer/API_CMS_SYNC_TOKEN'
     CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
     CONTENTFUL_ACCESS_TOKEN: '/k8s/search-indexer/CONTENTFUL_ACCESS_TOKEN'

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -1478,7 +1478,6 @@ search-indexer-service:
       cpu: '100m'
       memory: '512Mi'
   secrets:
-    API_CMS_DELETION_TOKEN: '/k8s/search-indexer/API_CMS_DELETION_TOKEN'
     API_CMS_SYNC_TOKEN: '/k8s/search-indexer/API_CMS_SYNC_TOKEN'
     CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
     CONTENTFUL_ACCESS_TOKEN: '/k8s/search-indexer/CONTENTFUL_ACCESS_TOKEN'

--- a/libs/cms/src/lib/environments/environment.ts
+++ b/libs/cms/src/lib/environments/environment.ts
@@ -67,9 +67,6 @@ export default {
     'tabContent',
     'footerItem',
     'featuredSupportQNAs',
-    'uiConfiguration',
-    'organizationTag',
-    'logoListSlice',
   ],
   contentful: {
     space: process.env.CONTENTFUL_SPACE || '8k0h54kbe6bj',

--- a/libs/cms/src/lib/search/cmsSync.service.ts
+++ b/libs/cms/src/lib/search/cmsSync.service.ts
@@ -174,7 +174,7 @@ export class CmsSyncService implements ContentSearchImporter<PostSyncOptions> {
     // gets all data that needs importing
     const {
       items,
-      deletedEntryIds,
+      deletedItems,
       token,
       elasticIndex,
     } = await this.contentfulService.getSyncEntries(cmsSyncOptions)
@@ -190,7 +190,7 @@ export class CmsSyncService implements ContentSearchImporter<PostSyncOptions> {
 
     return {
       add: flatten(importableData),
-      remove: deletedEntryIds,
+      remove: deletedItems,
       postSyncOptions: {
         folderHash,
         elasticIndex,
@@ -207,25 +207,5 @@ export class CmsSyncService implements ContentSearchImporter<PostSyncOptions> {
       await this.updateLastFolderHash({ elasticIndex, folderHash })
     }
     return true
-  }
-
-  async handleDocumentDeletion(
-    elasticIndex: string,
-    document: Pick<Entry<unknown>, 'sys'>,
-  ) {
-    // If we're gonna delete an 'article' from ElasticSearch then we need to also delete all subArticles that are have a parent field that points to this article
-    if (document.sys.contentType.sys.id === 'article') {
-      const subArticles = await this.contentfulService.getContentfulData(100, {
-        content_type: 'subArticle',
-        'fields.parent.sys.id': document.sys.id,
-      })
-
-      return this.elasticService.deleteByIds(
-        elasticIndex,
-        [document.sys.id].concat(subArticles.map((s) => s.sys.id)),
-      )
-    }
-
-    return this.elasticService.deleteByIds(elasticIndex, [document.sys.id])
   }
 }

--- a/libs/cms/src/lib/search/contentful.service.ts
+++ b/libs/cms/src/lib/search/contentful.service.ts
@@ -1,5 +1,4 @@
 import {
-  ClientLogLevel,
   ContentfulClientApi,
   createClient,
   CreateClientParams,
@@ -20,22 +19,10 @@ import {
 } from '@island.is/content-search-index-manager'
 import { Locale } from 'locale'
 
-// Taken from here: https://github.com/contentful/contentful-sdk-core/blob/054328ba2d0df364a5f1ce6d164c5018efb63572/lib/create-http-client.js#L34-L42
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const defaultContentfulClientLogging = (level: ClientLogLevel, data: any) => {
-  if (level === 'error' && data) {
-    const title = [data.name, data.message].filter((a) => a).join(' - ')
-    logger.error(`[error] ${title}`)
-    logger.error(data)
-    return
-  }
-  logger.info(`[${level}] ${data}`)
-}
-
 interface SyncerResult {
-  token: string
   items: Entry<unknown>[]
-  deletedEntryIds: string[]
+  deletedItems: string[]
+  token: string
   elasticIndex: string
 }
 
@@ -65,19 +52,6 @@ export class ContentfulService {
       environment: environment.contentful.environment,
       host: environment.contentful.host,
       removeUnresolved: true,
-      logHandler(level, data) {
-        const logContainsRateLimitWarning =
-          level === 'warning' &&
-          typeof data === 'string' &&
-          data.includes('Rate limit')
-
-        if (logContainsRateLimitWarning) {
-          logger.debug(`Search indexer sync caused rate limit - ${data}`)
-          return
-        }
-
-        defaultContentfulClientLogging(level, data)
-      },
     }
     logger.debug('Syncer created', params)
     this.contentfulClient = createClient(params)
@@ -99,7 +73,7 @@ export class ContentfulService {
     }, [])
   }
 
-  async getContentfulData(
+  private async getContentfulData(
     chunkSize: number,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     query?: any,
@@ -211,7 +185,7 @@ export class ContentfulService {
     })
   }
 
-  private async getPopulatedContentulEntries(
+  private async getAllEntriesFromContentful(
     entries: Entry<unknown>[],
     locale: ElasticsearchIndexLocale,
     chunkSize: number,
@@ -253,7 +227,7 @@ export class ContentfulService {
       deletedEntries,
     } = await this.getSyncData(typeOfSync)
 
-    const nestedEntryIds = entries
+    const nestedEntries = entries
       .filter((entry) =>
         environment.nestedContentTypes.includes(entry.sys.contentType.sys.id),
       )
@@ -262,27 +236,24 @@ export class ContentfulService {
     logger.info('Sync found entries', {
       entries: entries.length,
       deletedEntries: deletedEntries.length,
-      nestedEntries: nestedEntryIds.length,
+      nestedEntries: nestedEntries.length,
     })
 
     // get all sync entries from Contentful endpoints for this locale, we could parse the sync response into locales but we are opting for this for simplicity
-    const indexableEntries = await this.getPopulatedContentulEntries(
-      entries.filter((entry) =>
-        // Only populate the indexable entries
-        environment.indexableTypes.includes(entry.sys.contentType.sys.id),
-      ),
+    const items = await this.getAllEntriesFromContentful(
+      entries,
       locale,
       chunkSize,
     )
 
     // extract ids from deletedEntries
-    const deletedEntryIds = deletedEntries.map((entry) => entry.sys.id)
+    const deletedItems = deletedEntries.map((entry) => entry.sys.id)
 
     return {
-      indexableEntries,
-      nestedEntryIds,
-      deletedEntryIds,
+      items,
+      nestedEntries,
       newNextSyncToken,
+      deletedItems,
     }
   }
 
@@ -307,79 +278,46 @@ export class ContentfulService {
       chunkSize,
     )
 
-    const {
-      indexableEntries,
-      newNextSyncToken,
-      deletedEntryIds,
-    } = populatedSyncEntriesResult
-    let { nestedEntryIds } = populatedSyncEntriesResult
-
-    const isDeltaUpdate = syncType !== 'full'
+    const { items, newNextSyncToken, deletedItems } = populatedSyncEntriesResult
+    let { nestedEntries } = populatedSyncEntriesResult
 
     // In case of delta updates, we need to resolve embedded entries to their root model
-    if (isDeltaUpdate) {
+    if (syncType !== 'full' && nestedEntries) {
       logger.info('Finding root entries from nestedEntries')
 
-      const visitedEntryIds = new Set<string>()
-
       for (let i = 0; i < this.defaultIncludeDepth; i += 1) {
-        if (nestedEntryIds.length <= 0) break
-
-        const nextLevelOfNestedEntryIds = new Set<string>()
-
-        const promises: Promise<Entry<unknown>[]>[] = []
-        for (const entryId of nestedEntryIds) {
-          if (visitedEntryIds.has(entryId)) {
-            continue
-          }
-          visitedEntryIds.add(entryId)
-
-          promises.push(
-            this.getContentfulData(chunkSize, {
-              include: this.defaultIncludeDepth,
-              links_to_entry: entryId,
-              locale: this.contentfulLocaleMap[locale],
-            }),
+        const linkedEntries = []
+        for (const entryId of nestedEntries) {
+          // We fetch the entries that are linking to our nested entries
+          linkedEntries.push(
+            ...(
+              await this.getContentfulData(chunkSize, {
+                include: this.defaultIncludeDepth,
+                links_to_entry: entryId,
+                locale: this.contentfulLocaleMap[locale],
+              })
+            ).filter(
+              (entry) => !items.some((item) => item.sys.id === entry.sys.id),
+            ),
           )
         }
-
-        const responses = await Promise.all(promises)
-
-        let counter = 0
-        for (const linkedEntries of responses) {
-          for (const linkedEntry of linkedEntries) {
-            counter += 1
-            if (
-              environment.indexableTypes.includes(
-                linkedEntry.sys.contentType.sys.id,
-              )
-            ) {
-              const entryAlreadyListed =
-                indexableEntries.findIndex(
-                  (entry) => entry.sys.id === linkedEntry.sys.id,
-                ) >= 0
-              if (!entryAlreadyListed) indexableEntries.push(linkedEntry)
-            }
-            if (
-              environment.nestedContentTypes.includes(
-                linkedEntry.sys.contentType.sys.id,
-              )
-            ) {
-              nextLevelOfNestedEntryIds.add(linkedEntry.sys.id)
-            }
-          }
-        }
-
-        // Next round of the loop will only find linked entries to nested entries
-        nestedEntryIds = Array.from(nextLevelOfNestedEntryIds)
-        logger.info(`Found ${counter} nested entries at depth ${i + 1}`)
+        items.push(
+          ...linkedEntries.filter((entry) =>
+            environment.indexableTypes.includes(entry.sys.contentType.sys.id),
+          ),
+        )
+        // Next round of the loop will only find linked entries to these entries
+        nestedEntries = linkedEntries.map((entry) => entry.sys.id)
+        logger.info(
+          `Found ${linkedEntries.length} nested entries at depth ${i + 1}`,
+        )
       }
     }
 
     return {
       token: newNextSyncToken,
-      items: indexableEntries,
-      deletedEntryIds,
+      items,
+      deletedItems,
       elasticIndex,
     }
   }

--- a/libs/cms/src/lib/search/importers/utils.ts
+++ b/libs/cms/src/lib/search/importers/utils.ts
@@ -8,7 +8,7 @@ export const createTerms = (termStrings: string[]): string[] => {
       .split(/\s+/)
     return words
   })
-  return flatten(singleWords).filter((word) => word.length > 1) // filter out 1 letter words and empty string
+  return flatten(singleWords).filter((word) => word.length > 1) // fitler out 1 letter words and empty string
 }
 
 export const extractStringsFromObject = (

--- a/libs/content-search-indexer/src/environments/environment.ts
+++ b/libs/content-search-indexer/src/environments/environment.ts
@@ -1,6 +1,5 @@
 export const environment = {
   syncToken: process.env.API_CMS_SYNC_TOKEN ?? '',
-  deletionToken: process.env.API_CMS_DELETION_TOKEN ?? '',
-  lockTime: 30 * 60, // 30 minutes
+  lockTime: 300,
   locales: ['is', 'en'],
 }

--- a/libs/content-search-indexer/src/lib/indexing.controller.ts
+++ b/libs/content-search-indexer/src/lib/indexing.controller.ts
@@ -1,11 +1,8 @@
 import {
-  Body,
   Controller,
   Get,
-  Headers,
   HttpException,
   HttpStatus,
-  Post,
   Query,
 } from '@nestjs/common'
 import { IndexingService } from './indexing.service'
@@ -13,7 +10,6 @@ import { logger } from '@island.is/logging'
 import { environment } from '../environments/environment'
 import { SyncInput } from './dto/syncInput.input'
 import { ElasticsearchIndexLocale } from '@island.is/content-search-index-manager'
-import { Entry } from 'contentful'
 
 @Controller('')
 export class IndexingController {
@@ -35,7 +31,7 @@ export class IndexingController {
   async sync(@Query() { locale = 'is', token = '' }: SyncInput) {
     if (environment.syncToken !== token) {
       logger.warn('Failed to validate sync access token', {
-        receivedToken: token,
+        recivedToken: token,
       })
       throw new HttpException('Forbidden', HttpStatus.FORBIDDEN)
     }
@@ -72,7 +68,7 @@ export class IndexingController {
   async resync(@Query() { locale = 'is', token = '' }: SyncInput) {
     if (environment.syncToken !== token) {
       logger.warn('Failed to validate sync access token', {
-        receivedToken: token,
+        recivedToken: token,
       })
       throw new HttpException('Forbidden', HttpStatus.FORBIDDEN)
     }
@@ -88,7 +84,7 @@ export class IndexingController {
   async status(@Query() { locale = 'is', token = '' }: SyncInput) {
     if (environment.syncToken !== token) {
       logger.warn('Failed to validate sync access token', {
-        receivedToken: token,
+        recivedToken: token,
       })
       throw new HttpException('Forbidden', HttpStatus.FORBIDDEN)
     }
@@ -102,7 +98,7 @@ export class IndexingController {
   ) {
     if (environment.syncToken !== token) {
       logger.warn('Failed to validate sync access token', {
-        receivedToken: token,
+        recivedToken: token,
       })
       throw new HttpException('Forbidden', HttpStatus.FORBIDDEN)
     }
@@ -111,38 +107,6 @@ export class IndexingController {
       return this.indexingService.getDocumentById(locale, id)
     } catch (error) {
       return { error: true }
-    }
-  }
-
-  @Post('delete-document')
-  async deleteDocument(
-    @Query()
-    { locale = 'is' as ElasticsearchIndexLocale, token = '' },
-    @Body()
-    document: Pick<Entry<unknown>, 'sys'>,
-    @Headers('deletionToken') deletionToken,
-  ) {
-    if (environment.syncToken !== token) {
-      logger.warn('Failed to validate sync access token', {
-        receivedToken: token,
-      })
-      throw new HttpException('Forbidden', HttpStatus.FORBIDDEN)
-    }
-
-    if (
-      // Since this is a delete operation we require also require a deletion token
-      environment.deletionToken !== deletionToken
-    ) {
-      logger.warn('Failed to validate sync deletion token', {
-        receivedToken: deletionToken,
-      })
-      throw new HttpException('Forbidden', HttpStatus.FORBIDDEN)
-    }
-
-    await this.indexingService.deleteDocument(locale, document)
-
-    return {
-      acknowledge: true,
     }
   }
 }

--- a/libs/content-search-indexer/src/lib/indexing.service.ts
+++ b/libs/content-search-indexer/src/lib/indexing.service.ts
@@ -12,7 +12,6 @@ import {
   getElasticsearchIndex,
 } from '@island.is/content-search-index-manager'
 import { environment } from '../environments/environment'
-import { Entry } from 'contentful'
 
 type SyncStatus = {
   running?: boolean
@@ -84,7 +83,7 @@ export class IndexingService {
 
     // wait for all importers to finish
     await Promise.all(importPromises).catch((error) => {
-      logger.debug('Importer failure error', error)
+      logger.debug('Importer faliure error', error)
       logger.error('Importer failed', {
         message: error.message,
         index: elasticIndex,
@@ -162,13 +161,5 @@ export class IndexingService {
     } catch {
       return { error: true }
     }
-  }
-
-  async deleteDocument(
-    locale: ElasticsearchIndexLocale,
-    document: Pick<Entry<unknown>, 'sys'>,
-  ) {
-    const elasticIndex = getElasticsearchIndex(locale)
-    return this.cmsSyncService.handleDocumentDeletion(elasticIndex, document)
   }
 }

--- a/libs/content-search-toolkit/src/services/elastic.service.ts
+++ b/libs/content-search-toolkit/src/services/elastic.service.ts
@@ -327,7 +327,7 @@ export class ElasticService {
       body: {
         query: {
           bool: {
-            should: ids.map((id) => ({ match: { _id: id } })),
+            must: ids.map((id) => ({ match: { _id: id } })),
           },
         },
       },


### PR DESCRIPTION
This reverts commit 79456e434f3e438c4f421375d28b714b14540439.

# Revert "fix(search-indexer): Increase performance of search-indexer (#9892)"

## What

* The search-indexer on dev is running out of heap memory while re-syncing on dev.

## Why

* So we don't ship something which might be causing memory errors to production, we decided to revert this change for now
