### PR TITLE
fix(search-indexer): Revert "fix(search-indexer): Revert "fix(search-indexer): Increase performance of search-indexer (#9892)" (#10394)"

### DIFF
--- a/apps/services/search-indexer/infra/search-indexer-service.ts
+++ b/apps/services/search-indexer/infra/search-indexer-service.ts
@@ -95,6 +95,7 @@ export const serviceSetup = (): ServiceBuilder<'search-indexer-service'> =>
           prod: 'prod-es-custom-packages',
         },
         ELASTIC_DOMAIN: 'search',
+        NODE_OPTIONS: '--max-old-space-size=2048',
       }),
       secrets: {
         CONTENTFUL_ACCESS_TOKEN: '/k8s/search-indexer/CONTENTFUL_ACCESS_TOKEN',

--- a/apps/services/search-indexer/infra/search-indexer-service.ts
+++ b/apps/services/search-indexer/infra/search-indexer-service.ts
@@ -37,6 +37,7 @@ export const serviceSetup = (): ServiceBuilder<'search-indexer-service'> =>
     .secrets({
       CONTENTFUL_ACCESS_TOKEN: '/k8s/search-indexer/CONTENTFUL_ACCESS_TOKEN',
       API_CMS_SYNC_TOKEN: '/k8s/search-indexer/API_CMS_SYNC_TOKEN',
+      API_CMS_DELETION_TOKEN: '/k8s/search-indexer/API_CMS_DELETION_TOKEN',
     })
     .env(envs)
     .initContainer({

--- a/apps/web/components/PageLoader/PageLoader.tsx
+++ b/apps/web/components/PageLoader/PageLoader.tsx
@@ -12,7 +12,7 @@ export const PageLoader = () => {
       ref.current.continuousStart()
     }
     const done = () => {
-      ref.current.complete()
+      ref.current?.complete()
     }
     router.events.on('routeChangeStart', start)
     router.events.on('routeChangeComplete', done)

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -1785,6 +1785,7 @@ search-indexer-service:
       cpu: '100m'
       memory: '512Mi'
   secrets:
+    API_CMS_DELETION_TOKEN: '/k8s/search-indexer/API_CMS_DELETION_TOKEN'
     API_CMS_SYNC_TOKEN: '/k8s/search-indexer/API_CMS_SYNC_TOKEN'
     CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
     CONTENTFUL_ACCESS_TOKEN: '/k8s/search-indexer/CONTENTFUL_ACCESS_TOKEN'

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -1764,6 +1764,7 @@ search-indexer-service:
       ELASTIC_DOMAIN: 'search'
       ELASTIC_INDEX: 'island-is'
       ELASTIC_NODE: 'https://vpc-search-njkekqydiegezhr4vqpkfnw5la.eu-west-1.es.amazonaws.com'
+      NODE_OPTIONS: '--max-old-space-size=2048'
       S3_BUCKET: 'dev-es-custom-packages'
       SERVERSIDE_FEATURES_ON: ''
     secrets:

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -1449,6 +1449,7 @@ search-indexer-service:
       ELASTIC_DOMAIN: 'search'
       ELASTIC_INDEX: 'island-is'
       ELASTIC_NODE: 'https://vpc-search-mw4w5c2m2g5edjrtvwbpzhkw24.eu-west-1.es.amazonaws.com'
+      NODE_OPTIONS: '--max-old-space-size=2048'
       S3_BUCKET: 'prod-es-custom-packages'
       SERVERSIDE_FEATURES_ON: 'driving-license-use-v1-endpoint-for-v2-comms'
     secrets:

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -1470,6 +1470,7 @@ search-indexer-service:
       cpu: '100m'
       memory: '512Mi'
   secrets:
+    API_CMS_DELETION_TOKEN: '/k8s/search-indexer/API_CMS_DELETION_TOKEN'
     API_CMS_SYNC_TOKEN: '/k8s/search-indexer/API_CMS_SYNC_TOKEN'
     CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
     CONTENTFUL_ACCESS_TOKEN: '/k8s/search-indexer/CONTENTFUL_ACCESS_TOKEN'

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -1478,6 +1478,7 @@ search-indexer-service:
       cpu: '100m'
       memory: '512Mi'
   secrets:
+    API_CMS_DELETION_TOKEN: '/k8s/search-indexer/API_CMS_DELETION_TOKEN'
     API_CMS_SYNC_TOKEN: '/k8s/search-indexer/API_CMS_SYNC_TOKEN'
     CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
     CONTENTFUL_ACCESS_TOKEN: '/k8s/search-indexer/CONTENTFUL_ACCESS_TOKEN'

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -1457,6 +1457,7 @@ search-indexer-service:
       ELASTIC_DOMAIN: 'search'
       ELASTIC_INDEX: 'island-is'
       ELASTIC_NODE: 'https://vpc-search-q6hdtjcdlhkffyxvrnmzfwphuq.eu-west-1.es.amazonaws.com'
+      NODE_OPTIONS: '--max-old-space-size=2048'
       S3_BUCKET: 'staging-es-custom-packages'
       SERVERSIDE_FEATURES_ON: ''
     secrets:

--- a/libs/cms/src/lib/environments/environment.ts
+++ b/libs/cms/src/lib/environments/environment.ts
@@ -67,6 +67,9 @@ export default {
     'tabContent',
     'footerItem',
     'featuredSupportQNAs',
+    'uiConfiguration',
+    'organizationTag',
+    'logoListSlice',
   ],
   contentful: {
     space: process.env.CONTENTFUL_SPACE || '8k0h54kbe6bj',

--- a/libs/cms/src/lib/search/cmsSync.service.ts
+++ b/libs/cms/src/lib/search/cmsSync.service.ts
@@ -174,7 +174,7 @@ export class CmsSyncService implements ContentSearchImporter<PostSyncOptions> {
     // gets all data that needs importing
     const {
       items,
-      deletedItems,
+      deletedEntryIds,
       token,
       elasticIndex,
     } = await this.contentfulService.getSyncEntries(cmsSyncOptions)
@@ -190,7 +190,7 @@ export class CmsSyncService implements ContentSearchImporter<PostSyncOptions> {
 
     return {
       add: flatten(importableData),
-      remove: deletedItems,
+      remove: deletedEntryIds,
       postSyncOptions: {
         folderHash,
         elasticIndex,
@@ -207,5 +207,25 @@ export class CmsSyncService implements ContentSearchImporter<PostSyncOptions> {
       await this.updateLastFolderHash({ elasticIndex, folderHash })
     }
     return true
+  }
+
+  async handleDocumentDeletion(
+    elasticIndex: string,
+    document: Pick<Entry<unknown>, 'sys'>,
+  ) {
+    // If we're gonna delete an 'article' from ElasticSearch then we need to also delete all subArticles that are have a parent field that points to this article
+    if (document.sys.contentType.sys.id === 'article') {
+      const subArticles = await this.contentfulService.getContentfulData(100, {
+        content_type: 'subArticle',
+        'fields.parent.sys.id': document.sys.id,
+      })
+
+      return this.elasticService.deleteByIds(
+        elasticIndex,
+        [document.sys.id].concat(subArticles.map((s) => s.sys.id)),
+      )
+    }
+
+    return this.elasticService.deleteByIds(elasticIndex, [document.sys.id])
   }
 }

--- a/libs/cms/src/lib/search/contentful.service.ts
+++ b/libs/cms/src/lib/search/contentful.service.ts
@@ -1,4 +1,5 @@
 import {
+  ClientLogLevel,
   ContentfulClientApi,
   createClient,
   CreateClientParams,
@@ -19,10 +20,22 @@ import {
 } from '@island.is/content-search-index-manager'
 import { Locale } from 'locale'
 
+// Taken from here: https://github.com/contentful/contentful-sdk-core/blob/054328ba2d0df364a5f1ce6d164c5018efb63572/lib/create-http-client.js#L34-L42
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const defaultContentfulClientLogging = (level: ClientLogLevel, data: any) => {
+  if (level === 'error' && data) {
+    const title = [data.name, data.message].filter((a) => a).join(' - ')
+    logger.error(`[error] ${title}`)
+    logger.error(data)
+    return
+  }
+  logger.info(`[${level}] ${data}`)
+}
+
 interface SyncerResult {
-  items: Entry<unknown>[]
-  deletedItems: string[]
   token: string
+  items: Entry<unknown>[]
+  deletedEntryIds: string[]
   elasticIndex: string
 }
 
@@ -52,6 +65,19 @@ export class ContentfulService {
       environment: environment.contentful.environment,
       host: environment.contentful.host,
       removeUnresolved: true,
+      logHandler(level, data) {
+        const logContainsRateLimitWarning =
+          level === 'warning' &&
+          typeof data === 'string' &&
+          data.includes('Rate limit')
+
+        if (logContainsRateLimitWarning) {
+          logger.debug(`Search indexer sync caused rate limit - ${data}`)
+          return
+        }
+
+        defaultContentfulClientLogging(level, data)
+      },
     }
     logger.debug('Syncer created', params)
     this.contentfulClient = createClient(params)
@@ -73,7 +99,7 @@ export class ContentfulService {
     }, [])
   }
 
-  private async getContentfulData(
+  async getContentfulData(
     chunkSize: number,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     query?: any,
@@ -185,7 +211,7 @@ export class ContentfulService {
     })
   }
 
-  private async getAllEntriesFromContentful(
+  private async getPopulatedContentulEntries(
     entries: Entry<unknown>[],
     locale: ElasticsearchIndexLocale,
     chunkSize: number,
@@ -227,7 +253,7 @@ export class ContentfulService {
       deletedEntries,
     } = await this.getSyncData(typeOfSync)
 
-    const nestedEntries = entries
+    const nestedEntryIds = entries
       .filter((entry) =>
         environment.nestedContentTypes.includes(entry.sys.contentType.sys.id),
       )
@@ -236,24 +262,27 @@ export class ContentfulService {
     logger.info('Sync found entries', {
       entries: entries.length,
       deletedEntries: deletedEntries.length,
-      nestedEntries: nestedEntries.length,
+      nestedEntries: nestedEntryIds.length,
     })
 
     // get all sync entries from Contentful endpoints for this locale, we could parse the sync response into locales but we are opting for this for simplicity
-    const items = await this.getAllEntriesFromContentful(
-      entries,
+    const indexableEntries = await this.getPopulatedContentulEntries(
+      entries.filter((entry) =>
+        // Only populate the indexable entries
+        environment.indexableTypes.includes(entry.sys.contentType.sys.id),
+      ),
       locale,
       chunkSize,
     )
 
     // extract ids from deletedEntries
-    const deletedItems = deletedEntries.map((entry) => entry.sys.id)
+    const deletedEntryIds = deletedEntries.map((entry) => entry.sys.id)
 
     return {
-      items,
-      nestedEntries,
+      indexableEntries,
+      nestedEntryIds,
+      deletedEntryIds,
       newNextSyncToken,
-      deletedItems,
     }
   }
 
@@ -278,46 +307,79 @@ export class ContentfulService {
       chunkSize,
     )
 
-    const { items, newNextSyncToken, deletedItems } = populatedSyncEntriesResult
-    let { nestedEntries } = populatedSyncEntriesResult
+    const {
+      indexableEntries,
+      newNextSyncToken,
+      deletedEntryIds,
+    } = populatedSyncEntriesResult
+    let { nestedEntryIds } = populatedSyncEntriesResult
+
+    const isDeltaUpdate = syncType !== 'full'
 
     // In case of delta updates, we need to resolve embedded entries to their root model
-    if (syncType !== 'full' && nestedEntries) {
+    if (isDeltaUpdate) {
       logger.info('Finding root entries from nestedEntries')
 
+      const visitedEntryIds = new Set<string>()
+
       for (let i = 0; i < this.defaultIncludeDepth; i += 1) {
-        const linkedEntries = []
-        for (const entryId of nestedEntries) {
-          // We fetch the entries that are linking to our nested entries
-          linkedEntries.push(
-            ...(
-              await this.getContentfulData(chunkSize, {
-                include: this.defaultIncludeDepth,
-                links_to_entry: entryId,
-                locale: this.contentfulLocaleMap[locale],
-              })
-            ).filter(
-              (entry) => !items.some((item) => item.sys.id === entry.sys.id),
-            ),
+        if (nestedEntryIds.length <= 0) break
+
+        const nextLevelOfNestedEntryIds = new Set<string>()
+
+        const promises: Promise<Entry<unknown>[]>[] = []
+        for (const entryId of nestedEntryIds) {
+          if (visitedEntryIds.has(entryId)) {
+            continue
+          }
+          visitedEntryIds.add(entryId)
+
+          promises.push(
+            this.getContentfulData(chunkSize, {
+              include: this.defaultIncludeDepth,
+              links_to_entry: entryId,
+              locale: this.contentfulLocaleMap[locale],
+            }),
           )
         }
-        items.push(
-          ...linkedEntries.filter((entry) =>
-            environment.indexableTypes.includes(entry.sys.contentType.sys.id),
-          ),
-        )
-        // Next round of the loop will only find linked entries to these entries
-        nestedEntries = linkedEntries.map((entry) => entry.sys.id)
-        logger.info(
-          `Found ${linkedEntries.length} nested entries at depth ${i + 1}`,
-        )
+
+        const responses = await Promise.all(promises)
+
+        let counter = 0
+        for (const linkedEntries of responses) {
+          for (const linkedEntry of linkedEntries) {
+            counter += 1
+            if (
+              environment.indexableTypes.includes(
+                linkedEntry.sys.contentType.sys.id,
+              )
+            ) {
+              const entryAlreadyListed =
+                indexableEntries.findIndex(
+                  (entry) => entry.sys.id === linkedEntry.sys.id,
+                ) >= 0
+              if (!entryAlreadyListed) indexableEntries.push(linkedEntry)
+            }
+            if (
+              environment.nestedContentTypes.includes(
+                linkedEntry.sys.contentType.sys.id,
+              )
+            ) {
+              nextLevelOfNestedEntryIds.add(linkedEntry.sys.id)
+            }
+          }
+        }
+
+        // Next round of the loop will only find linked entries to nested entries
+        nestedEntryIds = Array.from(nextLevelOfNestedEntryIds)
+        logger.info(`Found ${counter} nested entries at depth ${i + 1}`)
       }
     }
 
     return {
       token: newNextSyncToken,
-      items,
-      deletedItems,
+      items: indexableEntries,
+      deletedEntryIds,
       elasticIndex,
     }
   }

--- a/libs/cms/src/lib/search/importers/utils.ts
+++ b/libs/cms/src/lib/search/importers/utils.ts
@@ -8,7 +8,7 @@ export const createTerms = (termStrings: string[]): string[] => {
       .split(/\s+/)
     return words
   })
-  return flatten(singleWords).filter((word) => word.length > 1) // fitler out 1 letter words and empty string
+  return flatten(singleWords).filter((word) => word.length > 1) // filter out 1 letter words and empty string
 }
 
 export const extractStringsFromObject = (

--- a/libs/content-search-indexer/src/environments/environment.ts
+++ b/libs/content-search-indexer/src/environments/environment.ts
@@ -1,5 +1,6 @@
 export const environment = {
   syncToken: process.env.API_CMS_SYNC_TOKEN ?? '',
-  lockTime: 300,
+  deletionToken: process.env.API_CMS_DELETION_TOKEN ?? '',
+  lockTime: 30 * 60, // 30 minutes
   locales: ['is', 'en'],
 }

--- a/libs/content-search-indexer/src/lib/indexing.service.ts
+++ b/libs/content-search-indexer/src/lib/indexing.service.ts
@@ -12,6 +12,7 @@ import {
   getElasticsearchIndex,
 } from '@island.is/content-search-index-manager'
 import { environment } from '../environments/environment'
+import { Entry } from 'contentful'
 
 type SyncStatus = {
   running?: boolean
@@ -83,7 +84,7 @@ export class IndexingService {
 
     // wait for all importers to finish
     await Promise.all(importPromises).catch((error) => {
-      logger.debug('Importer faliure error', error)
+      logger.debug('Importer failure error', error)
       logger.error('Importer failed', {
         message: error.message,
         index: elasticIndex,
@@ -161,5 +162,13 @@ export class IndexingService {
     } catch {
       return { error: true }
     }
+  }
+
+  async deleteDocument(
+    locale: ElasticsearchIndexLocale,
+    document: Pick<Entry<unknown>, 'sys'>,
+  ) {
+    const elasticIndex = getElasticsearchIndex(locale)
+    return this.cmsSyncService.handleDocumentDeletion(elasticIndex, document)
   }
 }

--- a/libs/content-search-toolkit/src/services/elastic.service.ts
+++ b/libs/content-search-toolkit/src/services/elastic.service.ts
@@ -327,7 +327,7 @@ export class ElasticService {
       body: {
         query: {
           bool: {
-            must: ids.map((id) => ({ match: { _id: id } })),
+            should: ids.map((id) => ({ match: { _id: id } })),
           },
         },
       },


### PR DESCRIPTION
This reverts commit 2a04937cddb9695d50d476975e794dd930c5f940.

# Revert "fix(search-indexer): Revert "fix(search-indexer): Increase performance of search-indexer (#9892)" (#10394)"

## What

* Turns out that the issue regarding the indexer running out of memory wasn't due to the code per say so we'd like to re-introduce the changes since they are beneficial for performance reasons as well as stability reasons
* The previous issue that caused us to go for the initial revert was due to Contentful data being too large to fit inside our heap memory allocations so we'll also include some node option changes in this PR