### PR TITLE
feat(island-ui): Support for openOnHover in DropdownMenu

### DIFF
--- a/apps/web/components/Header/LoginButton.tsx
+++ b/apps/web/components/Header/LoginButton.tsx
@@ -80,6 +80,7 @@ export function LoginButton(props: {
             </Button>
           }
           items={items}
+          openOnHover
         />
       </Hidden>
     </>

--- a/libs/island-ui/core/src/lib/DropdownMenu/DropdownMenu.tsx
+++ b/libs/island-ui/core/src/lib/DropdownMenu/DropdownMenu.tsx
@@ -1,17 +1,18 @@
-import React, { ReactElement, MouseEvent } from 'react'
-import {
-  useMenuState,
-  Menu,
-  MenuItem,
-  MenuButton,
-  MenuStateReturn,
-} from 'reakit/Menu'
 import cn from 'classnames'
+import React, { MouseEvent, ReactElement } from 'react'
+import {
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuStateReturn,
+  useMenuState,
+} from 'reakit/Menu'
 import { useBoxStyles } from '../Box/useBoxStyles'
 import { Button, ButtonProps } from '../Button/Button'
 import { getTextStyles } from '../Text/Text'
 
 import * as styles from './DropdownMenu.css'
+import { useMenuHoverProps } from './useMenuHoverProps'
 
 export interface DropdownMenuProps {
   /**
@@ -39,6 +40,7 @@ export interface DropdownMenuProps {
   icon?: ButtonProps['icon']
   disclosure?: ReactElement
   menuClassName?: string
+  openOnHover?: boolean
 }
 
 export const DropdownMenu = ({
@@ -48,8 +50,10 @@ export const DropdownMenu = ({
   icon,
   disclosure,
   menuClassName,
+  openOnHover = false,
 }: DropdownMenuProps) => {
   const menu = useMenuState({ placement: 'bottom', gutter: 8 })
+  const hoverProps = useMenuHoverProps(menu, openOnHover)
   const menuBoxStyle = useBoxStyles({
     component: 'div',
     background: 'white',
@@ -73,11 +77,17 @@ export const DropdownMenu = ({
   return (
     <>
       {disclosure ? (
-        <MenuButton {...menu} {...disclosure.props}>
+        <MenuButton {...menu} {...disclosure.props} {...hoverProps}>
           {(disclosureProps) => React.cloneElement(disclosure, disclosureProps)}
         </MenuButton>
       ) : (
-        <MenuButton as={Button} variant="utility" icon={icon} {...menu}>
+        <MenuButton
+          as={Button}
+          variant="utility"
+          icon={icon}
+          {...menu}
+          {...hoverProps}
+        >
           {title}
         </MenuButton>
       )}
@@ -85,6 +95,7 @@ export const DropdownMenu = ({
         {...menu}
         aria-label={menuLabel}
         className={cn(styles.menu, menuBoxStyle, menuClassName)}
+        {...hoverProps}
       >
         {items.map((item, index) => {
           let anchorProps = {}

--- a/libs/island-ui/core/src/lib/DropdownMenu/useMenuHoverProps.tsx
+++ b/libs/island-ui/core/src/lib/DropdownMenu/useMenuHoverProps.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { MenuStateReturn } from 'reakit/Menu'
+
+interface HoverPropsRefState {
+  hoverCount: number
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  hideTimeout?: any
+}
+
+const MENU_LEAVE_DELAY = 500
+export const useMenuHoverProps = (
+  menu: MenuStateReturn,
+  openOnHover: boolean,
+) => {
+  const hoverRef = React.useRef<HoverPropsRefState>({
+    hoverCount: 0,
+    hideTimeout: undefined,
+  })
+  const hoverState = hoverRef.current
+
+  return openOnHover
+    ? {
+        onMouseEnter: () => {
+          hoverState.hoverCount++
+          if (hoverState.hoverCount === 1) {
+            clearTimeout(hoverState.hideTimeout)
+            menu.show()
+          }
+        },
+        onMouseLeave: () => {
+          hoverState.hoverCount--
+          if (hoverState.hoverCount === 0) {
+            hoverState.hideTimeout = setTimeout(() => {
+              menu.hide()
+            }, MENU_LEAVE_DELAY)
+          }
+        },
+      }
+    : undefined
+}


### PR DESCRIPTION
## What

Extend DropdownMenu to support `openOnHover`.

Went setTimeout route because of 8px gutter between button and menu.

## Why

Needed for login button on island.is.

## Screenshots / Gifs

https://drops.aranja.com/L1uDYvNJ

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
