### PR TITLE
fix(auth-admin-api): Use nestjs global prefix instead of ingress rewrite.

### DIFF
--- a/apps/services/auth/admin-api/infra/auth-admin-api.ts
+++ b/apps/services/auth/admin-api/infra/auth-admin-api.ts
@@ -23,26 +23,23 @@ export const serviceSetup = (): ServiceBuilder<'services-auth-admin-api'> => {
           staging: 'identity-server.staging01.devland.is',
           prod: 'innskra.island.is',
         },
-        paths: ['/backend(/|$)(.*)'],
+        paths: ['/backend'],
         public: true,
         extraAnnotations: {
           dev: {
             'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
-            'nginx.ingress.kubernetes.io/rewrite-target': '/$2',
           },
           staging: {
             'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
-            'nginx.ingress.kubernetes.io/rewrite-target': '/$2',
           },
           prod: {
             'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
-            'nginx.ingress.kubernetes.io/rewrite-target': '/$2',
           },
         },
       },
     })
-    .readiness('/liveness')
-    .liveness('/liveness')
+    .readiness('/backend/liveness')
+    .liveness('/backend/liveness')
     .resources({
       limits: {
         cpu: '400m',

--- a/apps/services/auth/admin-api/src/main.ts
+++ b/apps/services/auth/admin-api/src/main.ts
@@ -10,4 +10,5 @@ bootstrap({
   openApi,
   port: env.port,
   enableVersioning: true,
+  globalPrefix: 'backend',
 })

--- a/charts/identity-server/values.dev.yaml
+++ b/charts/identity-server/values.dev.yaml
@@ -214,11 +214,11 @@ services-auth-admin-api:
   healthCheck:
     liveness:
       initialDelaySeconds: 3
-      path: '/liveness'
+      path: '/backend/liveness'
       timeoutSeconds: 3
     readiness:
       initialDelaySeconds: 3
-      path: '/liveness'
+      path: '/backend/liveness'
       timeoutSeconds: 3
   hpa:
     scaling:
@@ -235,11 +235,10 @@ services-auth-admin-api:
       annotations:
         kubernetes.io/ingress.class: 'nginx-external-alb'
         nginx.ingress.kubernetes.io/enable-global-auth: 'false'
-        nginx.ingress.kubernetes.io/rewrite-target: '/$2'
       hosts:
         - host: 'identity-server.dev01.devland.is'
           paths:
-            - '/backend(/|$)(.*)'
+            - '/backend'
   namespace: 'identity-server-admin'
   pvcs: []
   replicaCount:

--- a/charts/identity-server/values.prod.yaml
+++ b/charts/identity-server/values.prod.yaml
@@ -211,11 +211,11 @@ services-auth-admin-api:
   healthCheck:
     liveness:
       initialDelaySeconds: 3
-      path: '/liveness'
+      path: '/backend/liveness'
       timeoutSeconds: 3
     readiness:
       initialDelaySeconds: 3
-      path: '/liveness'
+      path: '/backend/liveness'
       timeoutSeconds: 3
   hpa:
     scaling:
@@ -232,11 +232,10 @@ services-auth-admin-api:
       annotations:
         kubernetes.io/ingress.class: 'nginx-external-alb'
         nginx.ingress.kubernetes.io/enable-global-auth: 'false'
-        nginx.ingress.kubernetes.io/rewrite-target: '/$2'
       hosts:
         - host: 'innskra.island.is'
           paths:
-            - '/backend(/|$)(.*)'
+            - '/backend'
   namespace: 'identity-server-admin'
   pvcs: []
   replicaCount:

--- a/charts/identity-server/values.staging.yaml
+++ b/charts/identity-server/values.staging.yaml
@@ -214,11 +214,11 @@ services-auth-admin-api:
   healthCheck:
     liveness:
       initialDelaySeconds: 3
-      path: '/liveness'
+      path: '/backend/liveness'
       timeoutSeconds: 3
     readiness:
       initialDelaySeconds: 3
-      path: '/liveness'
+      path: '/backend/liveness'
       timeoutSeconds: 3
   hpa:
     scaling:
@@ -235,11 +235,10 @@ services-auth-admin-api:
       annotations:
         kubernetes.io/ingress.class: 'nginx-external-alb'
         nginx.ingress.kubernetes.io/enable-global-auth: 'false'
-        nginx.ingress.kubernetes.io/rewrite-target: '/$2'
       hosts:
         - host: 'identity-server.staging01.devland.is'
           paths:
-            - '/backend(/|$)(.*)'
+            - '/backend'
   namespace: 'identity-server-admin'
   pvcs: []
   replicaCount:


### PR DESCRIPTION
## What

Use NestJS global prefix instead of ingress rewrite to add the `/backend` prefix for auth-admin-api.

## Why

Ingress rewrite decodes url parameters without encoding them back causing issues in auth-admin-api, as our resource IDs contains url-unsafe characters.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
