### PR TITLE
fix(e2e): Hide onboarding in service portal tests

### DIFF
--- a/apps/system-e2e/src/tests/islandis/service-portal/smoke/access-control.spec.ts
+++ b/apps/system-e2e/src/tests/islandis/service-portal/smoke/access-control.spec.ts
@@ -28,7 +28,9 @@ test.describe('Service portal, in access control', () => {
 
     await test.step('Remove delegations', async () => {
       // Arrange
-      await page.goto('/minarsidur/adgangsstyring/umbod?locale=is')
+      await page.goto(
+        '/minarsidur/adgangsstyring/umbod?locale=is&hide_onboarding_modal=true',
+      )
       await expect(
         page.locator(
           '[data-testid="access-card"], [data-testid="delegations-empty-state"]',
@@ -58,7 +60,9 @@ test.describe('Service portal, in access control', () => {
     await test.step('Create delegation', async () => {
       // Arrange
       const page = await context.newPage()
-      await page.goto('/minarsidur/adgangsstyring/umbod?locale=is')
+      await page.goto(
+        '/minarsidur/adgangsstyring/umbod?locale=is&hide_onboarding_modal=true',
+      )
 
       // Act
       await page.locator('role=button[name="Nýtt umboð"]').click()
@@ -95,7 +99,7 @@ test.describe('Service portal, in access control', () => {
       })
       const page = await context2.newPage()
       const { findByRole } = helpers(page)
-      await page.goto('/minarsidur?locale=is')
+      await page.goto('/minarsidur?locale=is&hide_onboarding_modal=true')
 
       // Act
       await page.locator('data-testid=user-menu >> visible=true').click()

--- a/apps/system-e2e/src/tests/islandis/service-portal/smoke/company-delegation.spec.ts
+++ b/apps/system-e2e/src/tests/islandis/service-portal/smoke/company-delegation.spec.ts
@@ -27,7 +27,7 @@ test.describe('Service portal', () => {
     // Arrange
     const page = await context.newPage()
     const { findByRole } = helpers(page)
-    await page.goto('/minarsidur?locale=is')
+    await page.goto('/minarsidur?locale=is&hide_onboarding_modal=true')
 
     // Act
     await page.locator('data-testid=user-menu >> visible=true').click()


### PR DESCRIPTION
## What

Hide onboarding modal in service portal e2e tests.

## Why

Because it breaks most tests.

Would be nice to abstract this in service-portal tests somehow so it is hidden automatically in all tests.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
