### PR TITLE
chore: Add util-deprecate to esbuild.json files

### DIFF
--- a/apps/air-discount-scheme/api/esbuild.json
+++ b/apps/air-discount-scheme/api/esbuild.json
@@ -20,6 +20,7 @@
     "graphql",
     "pg",
     "winston",
+    "util-deprecate",
     "source-map-resolve",
     "atob",
     "logform",

--- a/apps/air-discount-scheme/backend/esbuild.json
+++ b/apps/air-discount-scheme/backend/esbuild.json
@@ -22,6 +22,7 @@
     "graphql",
     "pg",
     "winston",
+    "util-deprecate",
     "source-map-resolve",
     "atob",
     "logform",

--- a/apps/api/esbuild.json
+++ b/apps/api/esbuild.json
@@ -21,6 +21,7 @@
     "graphql",
     "pg",
     "winston",
+    "util-deprecate",
     "source-map-resolve",
     "atob",
     "logform",

--- a/apps/application-system/api/esbuild.json
+++ b/apps/application-system/api/esbuild.json
@@ -22,6 +22,7 @@
     "graphql",
     "pg",
     "winston",
+    "util-deprecate",
     "source-map-resolve",
     "atob",
     "logform",

--- a/apps/download-service/esbuild.json
+++ b/apps/download-service/esbuild.json
@@ -20,6 +20,7 @@
     "graphql",
     "pg",
     "winston",
+    "util-deprecate",
     "source-map-resolve",
     "atob",
     "logform",

--- a/apps/external-contracts-tests/esbuild.json
+++ b/apps/external-contracts-tests/esbuild.json
@@ -21,6 +21,7 @@
     "http-errors",
     "graphql",
     "winston",
+    "util-deprecate",
     "pg",
     "source-map-resolve",
     "atob",

--- a/apps/financial-aid/api/esbuild.json
+++ b/apps/financial-aid/api/esbuild.json
@@ -20,6 +20,7 @@
     "graphql",
     "pg",
     "winston",
+    "util-deprecate",
     "source-map-resolve",
     "atob",
     "logform",

--- a/apps/financial-aid/backend/esbuild.json
+++ b/apps/financial-aid/backend/esbuild.json
@@ -24,6 +24,7 @@
     "graphql",
     "pg",
     "winston",
+    "util-deprecate",
     "source-map-resolve",
     "atob",
     "logform",

--- a/apps/icelandic-names-registry/backend/esbuild.json
+++ b/apps/icelandic-names-registry/backend/esbuild.json
@@ -20,6 +20,7 @@
     "graphql",
     "pg",
     "winston",
+    "util-deprecate",
     "source-map-resolve",
     "atob",
     "logform",

--- a/apps/judicial-system/api/esbuild.json
+++ b/apps/judicial-system/api/esbuild.json
@@ -16,6 +16,7 @@
     "@nestjs/typeorm",
     "dd-trace",
     "express",
+    "util-deprecate",
     "http-errors",
     "graphql",
     "pg",

--- a/apps/judicial-system/backend/esbuild.json
+++ b/apps/judicial-system/backend/esbuild.json
@@ -24,6 +24,7 @@
     "graphql",
     "pg",
     "winston",
+    "util-deprecate",
     "source-map-resolve",
     "atob",
     "logform",

--- a/apps/judicial-system/message-handler/esbuild.json
+++ b/apps/judicial-system/message-handler/esbuild.json
@@ -20,6 +20,7 @@
     "graphql",
     "pg",
     "winston",
+    "util-deprecate",
     "source-map-resolve",
     "atob",
     "logform",

--- a/apps/judicial-system/scheduler/esbuild.json
+++ b/apps/judicial-system/scheduler/esbuild.json
@@ -20,6 +20,7 @@
     "graphql",
     "pg",
     "winston",
+    "util-deprecate",
     "source-map-resolve",
     "atob",
     "logform",

--- a/apps/judicial-system/xrd-api/esbuild.json
+++ b/apps/judicial-system/xrd-api/esbuild.json
@@ -20,6 +20,7 @@
     "graphql",
     "pg",
     "winston",
+    "util-deprecate",
     "source-map-resolve",
     "atob",
     "logform",

--- a/apps/reference-backend/esbuild.json
+++ b/apps/reference-backend/esbuild.json
@@ -20,6 +20,7 @@
     "graphql",
     "pg",
     "winston",
+    "util-deprecate",
     "source-map-resolve",
     "atob",
     "logform",

--- a/apps/services/auth/admin-api/esbuild.json
+++ b/apps/services/auth/admin-api/esbuild.json
@@ -20,6 +20,7 @@
     "graphql",
     "pg",
     "winston",
+    "util-deprecate",
     "source-map-resolve",
     "atob",
     "logform",

--- a/apps/services/auth/delegation-api/esbuild.json
+++ b/apps/services/auth/delegation-api/esbuild.json
@@ -22,6 +22,7 @@
     "graphql",
     "pg",
     "winston",
+    "util-deprecate",
     "source-map-resolve",
     "atob",
     "logform",

--- a/apps/services/auth/ids-api/esbuild.json
+++ b/apps/services/auth/ids-api/esbuild.json
@@ -20,6 +20,7 @@
     "graphql",
     "pg",
     "winston",
+    "util-deprecate",
     "source-map-resolve",
     "atob",
     "logform",

--- a/apps/services/auth/personal-representative-public/esbuild.json
+++ b/apps/services/auth/personal-representative-public/esbuild.json
@@ -22,6 +22,7 @@
     "graphql",
     "pg",
     "winston",
+    "util-deprecate",
     "source-map-resolve",
     "atob",
     "logform",

--- a/apps/services/auth/personal-representative/esbuild.json
+++ b/apps/services/auth/personal-representative/esbuild.json
@@ -22,6 +22,7 @@
     "graphql",
     "pg",
     "winston",
+    "util-deprecate",
     "source-map-resolve",
     "atob",
     "logform",

--- a/apps/services/auth/public-api/esbuild.json
+++ b/apps/services/auth/public-api/esbuild.json
@@ -22,6 +22,7 @@
     "graphql",
     "pg",
     "winston",
+    "util-deprecate",
     "source-map-resolve",
     "atob",
     "logform",

--- a/apps/services/contentful-entry-tagger/esbuild.json
+++ b/apps/services/contentful-entry-tagger/esbuild.json
@@ -20,6 +20,7 @@
     "graphql",
     "pg",
     "winston",
+    "util-deprecate",
     "source-map-resolve",
     "atob",
     "logform",

--- a/apps/services/documents/esbuild.json
+++ b/apps/services/documents/esbuild.json
@@ -20,6 +20,7 @@
     "graphql",
     "pg",
     "winston",
+    "util-deprecate",
     "source-map-resolve",
     "atob",
     "logform",

--- a/apps/services/endorsements/api/esbuild.json
+++ b/apps/services/endorsements/api/esbuild.json
@@ -21,6 +21,7 @@
     "graphql",
     "pg",
     "winston",
+    "util-deprecate",
     "source-map-resolve",
     "atob",
     "logform",

--- a/apps/services/license-api/esbuild.json
+++ b/apps/services/license-api/esbuild.json
@@ -20,6 +20,7 @@
     "graphql",
     "pg",
     "winston",
+    "util-deprecate",
     "@protobufjs/aspromise",
     "@protobufjs/base64",
     "@protobufjs/codegen",

--- a/apps/services/search-indexer/esbuild.json
+++ b/apps/services/search-indexer/esbuild.json
@@ -20,6 +20,7 @@
     "graphql",
     "pg",
     "winston",
+    "util-deprecate",
     "source-map-resolve",
     "atob",
     "logform",

--- a/apps/services/sessions/esbuild.json
+++ b/apps/services/sessions/esbuild.json
@@ -22,6 +22,7 @@
     "graphql",
     "pg",
     "winston",
+    "util-deprecate",
     "source-map-resolve",
     "atob",
     "logform",

--- a/apps/services/user-notification/esbuild.json
+++ b/apps/services/user-notification/esbuild.json
@@ -20,6 +20,7 @@
     "graphql",
     "pg",
     "winston",
+    "util-deprecate",
     "source-map-resolve",
     "atob",
     "logform",

--- a/apps/services/user-profile/esbuild.json
+++ b/apps/services/user-profile/esbuild.json
@@ -20,6 +20,7 @@
     "graphql",
     "pg",
     "winston",
+    "util-deprecate",
     "source-map-resolve",
     "atob",
     "logform",

--- a/apps/services/xroad-collector/esbuild.json
+++ b/apps/services/xroad-collector/esbuild.json
@@ -20,6 +20,7 @@
     "graphql",
     "pg",
     "winston",
+    "util-deprecate",
     "source-map-resolve",
     "atob",
     "logform",

--- a/apps/skilavottord/ws/esbuild.json
+++ b/apps/skilavottord/ws/esbuild.json
@@ -20,6 +20,7 @@
     "graphql",
     "pg",
     "winston",
+    "util-deprecate",
     "source-map-resolve",
     "atob",
     "logform",


### PR DESCRIPTION
## What

Fix esbuild node_modules handling.

## Why

Because it's flaky and broke after a recent dependency change.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
