### PR TITLE
fix(web): Filter out alert banners that should not be shown

### DIFF
--- a/apps/web/layouts/main.tsx
+++ b/apps/web/layouts/main.tsx
@@ -178,26 +178,30 @@ const Layout: NextComponentType<
   const [alertBanners, setAlertBanners] = useState([])
 
   useEffect(() => {
-    setAlertBanners([
-      {
-        bannerId: `alert-${stringHash(
-          JSON.stringify(alertBannerContent ?? {}),
-        )}`,
-        ...alertBannerContent,
-      },
-      {
-        bannerId: `organization-alert-${stringHash(
-          JSON.stringify(organizationAlertBannerContent ?? {}),
-        )}`,
-        ...organizationAlertBannerContent,
-      },
-      {
-        bannerId: `article-alert-${stringHash(
-          JSON.stringify(articleAlertBannerContent ?? {}),
-        )}`,
-        ...articleAlertBannerContent,
-      },
-    ])
+    setAlertBanners(
+      [
+        {
+          bannerId: `alert-${stringHash(
+            JSON.stringify(alertBannerContent ?? {}),
+          )}`,
+          ...alertBannerContent,
+        },
+        {
+          bannerId: `organization-alert-${stringHash(
+            JSON.stringify(organizationAlertBannerContent ?? {}),
+          )}`,
+          ...organizationAlertBannerContent,
+        },
+        {
+          bannerId: `article-alert-${stringHash(
+            JSON.stringify(articleAlertBannerContent ?? {}),
+          )}`,
+          ...articleAlertBannerContent,
+        },
+      ].filter(
+        (banner) => !Cookies.get(banner.bannerId) && banner?.showAlertBanner,
+      ),
+    )
   }, [
     alertBannerContent,
     articleAlertBannerContent,


### PR DESCRIPTION
# Filter out alert banners that should not be shown

* In a recent PR I accidentally removed the filter function call for the alert banners resulting in unwanted banners appearing on dev
