### PR TITLE
chore(web): Strict types for the web project

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "jsx": "preserve",
     "allowJs": true,
-    "strict": false,
+    "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
# Strict types for the web project

## What

* It's better practice to have stricter types to make sure we maximize the amount of assistance that TypeScript provides us with

## Why

* This started out in the PR https://github.com/island-is/island.is/pull/10412 where we noticed that the web could go through the build process even though there were existing type errors.
* We deemed it appropriate to go a bit further and also have the types set to `strict`

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
