### PR TITLE
fix(parental-leave): personal allowance (#10521)

### DIFF
--- a/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.spec.ts
+++ b/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.spec.ts
@@ -341,6 +341,7 @@ describe('Parental Leave Application Template', () => {
         )
 
         const answer = {
+          usePersonalAllowance: YES,
           useAsMuchAsPossible: YES,
           usage: '100',
         }
@@ -371,6 +372,7 @@ describe('Parental Leave Application Template', () => {
         )
 
         const answer = {
+          usePersonalAllowance: YES,
           useAsMuchAsPossible: YES,
           usage: '100',
         }

--- a/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.ts
+++ b/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.ts
@@ -1369,6 +1369,7 @@ const ParentalLeaveTemplate: ApplicationTemplate<
           set(application.answers, 'personalAllowance', {
             useAsMuchAsPossible: YES,
             usage: '100',
+            usePersonalAllowance: YES,
           })
         }
 
@@ -1386,6 +1387,7 @@ const ParentalLeaveTemplate: ApplicationTemplate<
           set(application.answers, 'personalAllowanceFromSpouse', {
             useAsMuchAsPossible: YES,
             usage: '100',
+            usePersonalAllowance: YES,
           })
         }
 


### PR DESCRIPTION
## What

If selected NO and then YES in personal allowance questions - 'usePersonalAllowance' parameter from 'personalAllowance' was removed after the application has been sent.

**for example before the fix:**

before the application has been sent in:
 "personalAllowance": {"usage": "1", "useAsMuchAsPossible": "yes", "usePersonalAllowance": "yes"}

after the application has been sent in:
 "personalAllowance": {"usage": "100", "useAsMuchAsPossible": "yes"}


**for example after the fix:**

before the application has been sent in:
 "personalAllowance": {"usage": "1", "useAsMuchAsPossible": "yes", "usePersonalAllowance": "yes"}

after the application has been sent in:
  "personalAllowance": {"usage": "100", "useAsMuchAsPossible": "yes", "usePersonalAllowance": "yes"}

## Why

these function that fixes the personal allowance answers after application has been sent where missing 'usePersonalAllowance' :
setPersonalUsageToHundredIfUseAsMuchAsPossibleIsYes
setSpouseUsageToHundredIfUseAsMuchAsPossibleIsYes

## Screenshots / Gifs

<img width="891" alt="Screenshot 2023-03-15 at 14 12 29" src="https://user-images.githubusercontent.com/102811817/225440019-c7736d39-889d-47c5-8614-87e5a78a5edd.png">

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
