### PR TITLE
fix: remove 0, fix dates in timeline

### DIFF
--- a/apps/consultation-portal/components/CaseTimeline/CaseTimeline.tsx
+++ b/apps/consultation-portal/components/CaseTimeline/CaseTimeline.tsx
@@ -25,7 +25,7 @@ export const CaseTimeline = ({ status, updatedDate }: CaseTimelineProps) => {
       subSections={
         item === status && [
           <Text variant="medium" key="sub1">
-            {`frá ${format(new Date(updatedDate), 'dd.MM.yyyy')}`}
+            {updatedDate}
           </Text>,
         ]
       }

--- a/apps/consultation-portal/components/ReviewCard/ReviewCard.tsx
+++ b/apps/consultation-portal/components/ReviewCard/ReviewCard.tsx
@@ -21,7 +21,7 @@ export const ReviewCard = ({ advice }) => {
           <Text variant="eyebrow" color="purple400">
             {format(new Date(advice.created), 'dd.MM.yyyy')}
           </Text>
-          {advice.content.length > 50 && (
+          {advice.content && advice.content.length > 50 && (
             <FocusableBox onClick={() => setOpen(!open)}>
               <Icon
                 icon={open ? 'close' : 'open'}

--- a/apps/consultation-portal/screens/Case/Case.tsx
+++ b/apps/consultation-portal/screens/Case/Case.tsx
@@ -20,6 +20,7 @@ import Layout from '../../components/Layout/Layout'
 import { Advice } from '../../types/viewModels'
 import { SimpleCardSkeleton } from '../../components/Card'
 import StackedTitleAndDescription from '../../components/StackedTitleAndDescription/StackedTitleAndDescription'
+import { getTimeLineDate } from '../../utils/helpers/dateFormatter'
 
 const CaseScreen = ({ chosenCase, advices, isLoggedIn }) => {
   // Remove following lines after connecting to API
@@ -64,7 +65,7 @@ const CaseScreen = ({ chosenCase, advices, isLoggedIn }) => {
               <Divider />
               <CaseTimeline
                 status={chosenCase.statusName}
-                updatedDate={chosenCase.changed}
+                updatedDate={getTimeLineDate(chosenCase)}
               />
               <Divider />
               <Box paddingLeft={1}>

--- a/apps/consultation-portal/types/interfaces.ts
+++ b/apps/consultation-portal/types/interfaces.ts
@@ -13,6 +13,7 @@ export interface Case {
   processBegins?: string
   processEnds?: string
   created?: string
+  summaryDate?: string
 }
 
 export interface UserAdvice {

--- a/apps/consultation-portal/utils/helpers/dateFormatter.ts
+++ b/apps/consultation-portal/utils/helpers/dateFormatter.ts
@@ -1,10 +1,18 @@
+import { Case } from '@island.is/consultation-portal/types/interfaces'
 import format from 'date-fns/format'
 
+export function removeZeroInDate(date: string) {
+  let updatedDate = date.replace('.0', '.')
+  if (date.indexOf('0') == 0) {
+    updatedDate = updatedDate.substring(1)
+  }
+  return updatedDate
+}
 export function getShortDate(date: string | Date, noYear?: boolean) {
   if (noYear) {
-    return format(new Date(date), 'dd.MM')
+    return removeZeroInDate(format(new Date(date), 'dd.MM'))
   }
-  return format(new Date(date), 'dd.MM.yyyy')
+  return removeZeroInDate(format(new Date(date), 'dd.MM.yyyy'))
 }
 
 export function getDateBeginDateEnd(begin: string | Date, end: string | Date) {
@@ -13,8 +21,18 @@ export function getDateBeginDateEnd(begin: string | Date, end: string | Date) {
   const sameYear = beginDate.getFullYear() == endDate.getFullYear()
   const sameMonth = beginDate.getMonth() == endDate.getMonth()
   const formatstring = `dd.${!sameMonth ? 'MM.' : ''}${!sameYear ? 'yyyy' : ''}`
-  return `${format(new Date(begin), formatstring)} - ${format(
-    new Date(end),
-    'dd.MM.yyyy',
-  )} `
+  return `${removeZeroInDate(
+    format(new Date(begin), formatstring),
+  )} - ${removeZeroInDate(format(new Date(end), 'dd.MM.yyyy'))} `
+}
+
+export function getTimeLineDate(Case: Case) {
+  switch (Case.statusName) {
+    case 'Til umsagnar':
+      return getDateBeginDateEnd(Case.processBegins, Case.processEnds)
+    case 'Niðurstöður í vinnslu':
+      return `frá ${getShortDate(Case.processEnds)}`
+    case 'Niðurstöður birtar':
+      return getShortDate(Case.summaryDate)
+  }
 }

--- a/apps/consultation-portal/utils/helpers/dateFormatter.ts
+++ b/apps/consultation-portal/utils/helpers/dateFormatter.ts
@@ -1,4 +1,4 @@
-import { Case } from '@island.is/consultation-portal/types/interfaces'
+import { Case } from '../../types/interfaces'
 import format from 'date-fns/format'
 
 export function removeZeroInDate(date: string) {


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Remove front 0 in day and month
fix timeline dates so it shows a period in 1 state, shows "from ... " in 2 state and "date" in last state 

## Why

Specify why you need to achieve this

## Screenshots / Gifs
![Screenshot 2023-03-20 at 11 10 36](https://user-images.githubusercontent.com/64030465/226322955-6969e7c6-dc37-438e-add7-6024c175cedc.png)
![Screenshot 2023-03-20 at 11 09 44](https://user-images.githubusercontent.com/64030465/226322978-f0f61906-9d7a-43f5-a25e-de0b1196189d.png)
![Screenshot 2023-03-20 at 11 09 37](https://user-images.githubusercontent.com/64030465/226323012-04e9fd45-e3d8-4407-91e5-c20d68a472bb.png)




## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
