### PR TITLE
fix(service-portal): Only show marital status to adults

### DIFF
--- a/libs/service-portal/core/src/lib/messages.ts
+++ b/libs/service-portal/core/src/lib/messages.ts
@@ -391,7 +391,7 @@ export const m = defineMessages({
   },
   familyNumber: {
     id: 'service.portal:family-number',
-    defaultMessage: 'Fjölskyldunúmer',
+    defaultMessage: 'Lögheimilistengsl',
   },
   familySpouse: {
     id: 'service.portal:family-spouse',

--- a/libs/service-portal/information/src/lib/messages.ts
+++ b/libs/service-portal/information/src/lib/messages.ts
@@ -87,7 +87,7 @@ export const spmm = defineMessages({
   },
   userFamilyMembersOnNumber: {
     id: 'sp.family:user-famly-on-nr',
-    defaultMessage: 'Einstaklingar á fjölskyldunúmerinu mínu',
+    defaultMessage: 'Einstaklingar með sömu lögheimilistengsl',
   },
   childRegisterSuccess: {
     id: 'sp.family:child-registration-generic-success',

--- a/libs/service-portal/information/src/screens/UserInfo/UserInfo.tsx
+++ b/libs/service-portal/information/src/screens/UserInfo/UserInfo.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { defineMessage } from 'react-intl'
 import { checkDelegation } from '@island.is/shared/utils'
+import { info } from 'kennitala'
 
 import { useQuery } from '@apollo/client'
 import { Query } from '@island.is/api/schema'
@@ -48,6 +49,7 @@ const SubjectInfo = () => {
     },
   )
   const { nationalRegistryFamily } = famData || {}
+  const isUserAdult = info(userInfo.profile.nationalId).age >= 18
   return (
     <>
       <IntroHeader title={userInfo.profile.name} intro={spmm.userInfoDesc} />
@@ -111,25 +113,29 @@ const SubjectInfo = () => {
           tooltip={formatMessage({
             id: 'sp.family:family-number-tooltip',
             defaultMessage:
-              'Fjölskyldunúmer er samtenging á milli einstaklinga á lögheimili, en veitir ekki upplýsingar um hverjir eru foreldrar barns eða forsjáraðilar.',
+              'Lögheimilistengsl er samtenging á milli einstaklinga á lögheimili, en veitir ekki upplýsingar um hverjir eru foreldrar barns eða forsjáraðilar.',
           })}
         />
-        <Divider />
-        <UserInfoLine
-          label={m.maritalStatus}
-          content={
-            error
-              ? formatMessage(dataNotFoundMessage)
-              : nationalRegistryUser?.maritalStatus
-              ? formatMessage(
-                  natRegMaritalStatusMessageDescriptorRecord[
-                    nationalRegistryUser?.maritalStatus
-                  ],
-                )
-              : ''
-          }
-          loading={loading}
-        />
+        {isUserAdult ? (
+          <>
+            <Divider />
+            <UserInfoLine
+              label={m.maritalStatus}
+              content={
+                error
+                  ? formatMessage(dataNotFoundMessage)
+                  : nationalRegistryUser?.maritalStatus
+                  ? formatMessage(
+                      natRegMaritalStatusMessageDescriptorRecord[
+                        nationalRegistryUser?.maritalStatus
+                      ],
+                    )
+                  : ''
+              }
+              loading={loading}
+            />
+          </>
+        ) : null}
 
         <Divider />
         <UserInfoLine


### PR DESCRIPTION
## What

Only show marital status to adults

## Why

This is a requirement from the data providers.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
