### PR TITLE
fix(estate): Einkaskipti - skip displaying disabled members/assets

### DIFF
--- a/libs/application/templates/estate/src/forms/DivisionOfEstateByHeirs/overviewSection.ts
+++ b/libs/application/templates/estate/src/forms/DivisionOfEstateByHeirs/overviewSection.ts
@@ -62,7 +62,9 @@ export const overview = buildSection({
           {
             cards: ({ answers }: Application) =>
               (
-                ((answers.estate as unknown) as EstateInfo).estateMembers ?? []
+                ((answers.estate as unknown) as EstateInfo).estateMembers.filter(
+                  (member) => (member as any).enabled,
+                ) ?? []
               ).map((member) => ({
                 title: member.name,
                 description: [
@@ -96,14 +98,16 @@ export const overview = buildSection({
           },
           {
             cards: ({ answers }: Application) =>
-              (((answers.estate as unknown) as EstateInfo).assets ?? []).map(
-                (asset) => ({
-                  title: asset.description,
-                  description: [
-                    `${m.propertyNumber.defaultMessage}: ${asset.assetNumber}`,
-                  ],
-                }),
-              ),
+              (
+                ((answers.estate as unknown) as EstateInfo).assets.filter(
+                  (asset) => (asset as any).enabled,
+                ) ?? []
+              ).map((asset) => ({
+                title: asset.description,
+                description: [
+                  `${m.propertyNumber.defaultMessage}: ${asset.assetNumber}`,
+                ],
+              })),
           },
         ),
         buildDividerField({}),
@@ -152,16 +156,16 @@ export const overview = buildSection({
           },
           {
             cards: ({ answers }: Application) =>
-              (((answers.estate as unknown) as EstateInfo)?.vehicles ?? []).map(
-                (vehicle) => ({
-                  title: vehicle.description,
-                  description: [
-                    m.propertyNumber.defaultMessage +
-                      ': ' +
-                      vehicle.assetNumber,
-                  ],
-                }),
-              ),
+              (
+                ((answers.estate as unknown) as EstateInfo)?.vehicles.filter(
+                  (vehicle) => (vehicle as any).enabled,
+                ) ?? []
+              ).map((vehicle) => ({
+                title: vehicle.description,
+                description: [
+                  m.propertyNumber.defaultMessage + ': ' + vehicle.assetNumber,
+                ],
+              })),
           },
         ),
         buildDividerField({}),


### PR DESCRIPTION
## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
