### PR TITLE
fix(core): Possible react-hook-form regressions

### DIFF
--- a/libs/application/templates/document-provider-onboarding/src/fields/TestPhase/TechnicalImplementation/index.tsx
+++ b/libs/application/templates/document-provider-onboarding/src/fields/TestPhase/TechnicalImplementation/index.tsx
@@ -22,7 +22,7 @@ const TestPhaseInfoScreen: FC<FieldBaseProps> = ({ application }) => {
   const {
     setValue,
     formState: { errors },
-    getValues,
+    watch,
   } = useFormContext()
 
   return (
@@ -76,10 +76,7 @@ const TestPhaseInfoScreen: FC<FieldBaseProps> = ({ application }) => {
                   formatMessage,
                 )}
                 large
-                hasError={
-                  errors.technicalAnswer &&
-                  getValues('technicalAnswer') === false
-                }
+                hasError={errors.technicalAnswer && value === false}
                 errorMessage={
                   errors && getErrorViaPath(errors, 'technicalAnswer')
                 }

--- a/libs/application/templates/financial-aid/src/fields/EmploymentForm/EmploymentForm.tsx
+++ b/libs/application/templates/financial-aid/src/fields/EmploymentForm/EmploymentForm.tsx
@@ -26,7 +26,7 @@ const EmploymentForm = ({ application, errors }: FAFieldBaseProps) => {
 
   const { answers } = application
 
-  const { setValue, getValues, clearErrors } = useFormContext()
+  const { setValue, watch, clearErrors } = useFormContext()
 
   return (
     <>
@@ -61,8 +61,7 @@ const EmploymentForm = ({ application, errors }: FAFieldBaseProps) => {
       <Box
         className={cn({
           [`${styles.inputContainer}`]: true,
-          [`${styles.inputAppear}`]:
-            getValues(typeInput.id) === Employment.OTHER,
+          [`${styles.inputAppear}`]: watch(typeInput.id) === Employment.OTHER,
         })}
       >
         <Controller

--- a/libs/application/templates/financial-aid/src/fields/HomeCircumstancesForm/HomeCircumstancesForm.tsx
+++ b/libs/application/templates/financial-aid/src/fields/HomeCircumstancesForm/HomeCircumstancesForm.tsx
@@ -26,7 +26,7 @@ const HomeCircumstancesForm = ({ application, errors }: FAFieldBaseProps) => {
 
   const { answers } = application
 
-  const { setValue, getValues, clearErrors } = useFormContext()
+  const { setValue, watch, clearErrors } = useFormContext()
 
   return (
     <>
@@ -81,7 +81,7 @@ const HomeCircumstancesForm = ({ application, errors }: FAFieldBaseProps) => {
         className={cn({
           [`${styles.inputContainer}`]: true,
           [`${styles.inputAppear}`]:
-            getValues(typeInput.id) === HomeCircumstances.OTHER,
+            watch(typeInput.id) === HomeCircumstances.OTHER,
         })}
       >
         <Controller

--- a/libs/application/templates/financial-aid/src/fields/MissingFiles/MissingFiles.tsx
+++ b/libs/application/templates/financial-aid/src/fields/MissingFiles/MissingFiles.tsx
@@ -36,11 +36,11 @@ const MissingFiles = ({
   const isSpouse = getValueViaPath(field as RecordObject<any>, 'props.isSpouse')
 
   const { formatMessage } = useIntl()
-  const { setValue, getValues } = useFormContext()
+  const { setValue, getValues, watch } = useFormContext()
 
   const fileType: UploadFileType = 'otherFiles'
   const commentType = 'fileUploadComment'
-  const files = getValues(fileType)
+  const files = watch(fileType)
 
   const { uploadFiles } = useFileUpload(files, application.id)
 

--- a/libs/application/templates/financial-aid/src/fields/MissingFiles/MissingFilesConfirmation/MissingFilesConfirmation.tsx
+++ b/libs/application/templates/financial-aid/src/fields/MissingFiles/MissingFilesConfirmation/MissingFilesConfirmation.tsx
@@ -10,7 +10,7 @@ import FileList from '../FileList/FileList'
 
 const MissingFilesConfirmation = ({ application }: FAFieldBaseProps) => {
   const { formatMessage } = useIntl()
-  const { getValues } = useFormContext()
+  const { watch } = useFormContext()
 
   const fileType: UploadFileType = 'otherFiles'
   const commentType = 'fileUploadComment'
@@ -23,12 +23,12 @@ const MissingFilesConfirmation = ({ application }: FAFieldBaseProps) => {
 
       <Box>
         <FileList
-          files={getValues(fileType)}
+          files={watch(fileType)}
           applicationSystemId={application.id}
         />
       </Box>
 
-      {getValues(commentType) && (
+      {watch(commentType) && (
         <Box
           background="purple100"
           paddingX={4}
@@ -38,7 +38,7 @@ const MissingFilesConfirmation = ({ application }: FAFieldBaseProps) => {
           <Text variant="eyebrow" marginBottom={1}>
             {formatMessage(missingFiles.confirmation.commentTitle)}
           </Text>
-          <Text>{getValues(commentType)}</Text>
+          <Text>{watch(commentType)}</Text>
         </Box>
       )}
 

--- a/libs/application/templates/financial-aid/src/fields/StudentForm/StudentForm.tsx
+++ b/libs/application/templates/financial-aid/src/fields/StudentForm/StudentForm.tsx
@@ -21,7 +21,7 @@ const StudentForm = ({ errors, application }: FAFieldBaseProps) => {
     id: 'student.custom',
     error: errors?.student?.custom,
   }
-  const { clearErrors, getValues } = useFormContext()
+  const { clearErrors, watch } = useFormContext()
 
   return (
     <>
@@ -47,8 +47,7 @@ const StudentForm = ({ errors, application }: FAFieldBaseProps) => {
       <Box
         className={cn({
           [`${styles.inputContainer}`]: true,
-          [`${styles.inputAppear}`]:
-            getValues(typeInput.id) === ApproveOptions.Yes,
+          [`${styles.inputAppear}`]: watch(typeInput.id) === ApproveOptions.Yes,
         })}
       >
         <InputController

--- a/libs/application/templates/financial-aid/src/fields/UnknownRelationshipForm/UnknownRelationshipForm.tsx
+++ b/libs/application/templates/financial-aid/src/fields/UnknownRelationshipForm/UnknownRelationshipForm.tsx
@@ -21,21 +21,21 @@ const errorIdForSpouse = 'relationshipStatus'
 
 const ValidationCheck = (errors: ErrorSchema, type: validationType) => {
   const { formatMessage } = useIntl()
-  const { getValues } = useFormContext()
+  const { watch } = useFormContext()
   switch (type) {
     case 'email':
       return errors.relationshipStatus !== undefined &&
-        !isValidEmail(getValues(`${errorIdForSpouse}.spouseEmail`))
+        !isValidEmail(watch(`${errorIdForSpouse}.spouseEmail`))
         ? formatMessage(error.validation.email)
         : undefined
     case 'nationalId':
       return errors.relationshipStatus !== undefined &&
-        !isValidNationalId(getValues(`${errorIdForSpouse}.spouseNationalId`))
+        !isValidNationalId(watch(`${errorIdForSpouse}.spouseNationalId`))
         ? formatMessage(error.validation.nationalId)
         : undefined
     case 'approveItems':
       return errors.relationshipStatus !== undefined &&
-        getValues(`${errorIdForSpouse}.spouseApproveTerms`)?.length !== 1
+        watch(`${errorIdForSpouse}.spouseApproveTerms`)?.length !== 1
         ? formatMessage(error.validation.approveSpouse)
         : undefined
   }
@@ -44,7 +44,7 @@ const ValidationCheck = (errors: ErrorSchema, type: validationType) => {
 const UnknownRelationshipForm = ({ errors, application }: FAFieldBaseProps) => {
   const { formatMessage } = useIntl()
   const { answers } = application
-  const { clearErrors, getValues } = useFormContext()
+  const { clearErrors, getValues, watch } = useFormContext()
 
   const typeInput = {
     id: 'relationshipStatus.unregisteredCohabitation',
@@ -99,8 +99,7 @@ const UnknownRelationshipForm = ({ errors, application }: FAFieldBaseProps) => {
       <Box
         className={cn({
           [`${styles.inputContainer}`]: true,
-          [`${styles.formAppear}`]:
-            getValues(typeInput.id) === ApproveOptions.Yes,
+          [`${styles.formAppear}`]: watch(typeInput.id) === ApproveOptions.Yes,
         })}
       >
         <Box marginBottom={[2, 2, 3]}>

--- a/libs/application/templates/financial-statements-inao/src/fields/CemetryCaretaker/index.tsx
+++ b/libs/application/templates/financial-statements-inao/src/fields/CemetryCaretaker/index.tsx
@@ -170,7 +170,6 @@ export const CemetryCaretaker: FC<FieldBaseProps<FinancialStatementsInao>> = ({
   const { id } = field
 
   const { getValues, setError } = useFormContext()
-  const values = getValues()
 
   const { fields, append, remove } = useFieldArray({
     name: `${id}.caretakers`,
@@ -194,7 +193,7 @@ export const CemetryCaretaker: FC<FieldBaseProps<FinancialStatementsInao>> = ({
     setBeforeSubmitCallback(async () => {
       const actors = application.applicantActors
       const currentActor: string = actors[actors.length - 1]
-      const allMembers = values.cemetryCaretaker
+      const allMembers = getValues().cemetryCaretaker
       const { careTakers, boardMembers } = getBoardmembersAndCaretakers(
         allMembers,
       )

--- a/libs/application/templates/financial-statements-inao/src/fields/CemetryOperation/cemetryExpenses.tsx
+++ b/libs/application/templates/financial-statements-inao/src/fields/CemetryOperation/cemetryExpenses.tsx
@@ -2,7 +2,7 @@ import React, { Fragment, useEffect } from 'react'
 import { useLocale } from '@island.is/localization'
 import { Box } from '@island.is/island-ui/core'
 import { InputController } from '@island.is/shared/form-fields'
-import { getErrorViaPath, getValueViaPath } from '@island.is/application/core'
+import { getErrorViaPath } from '@island.is/application/core'
 import { RecordObject } from '@island.is/application/types'
 import debounce from 'lodash/debounce'
 import { useFormContext } from 'react-hook-form'
@@ -25,11 +25,9 @@ export const CemetryExpenses = ({
   getSum,
 }: PropTypes): JSX.Element => {
   const { formatMessage } = useLocale()
-  const { clearErrors, setValue, getValues } = useFormContext()
-  const values = getValues()
+  const { clearErrors, setValue, watch } = useFormContext()
 
-  const donationsToCemeteryFund = getValueViaPath(
-    values,
+  const donationsToCemeteryFund = watch(
     CEMETRYOPERATIONIDS.donationsToCemeteryFund,
   )
 

--- a/libs/application/templates/financial-statements-inao/src/fields/ElectionsInfoFields/index.tsx
+++ b/libs/application/templates/financial-statements-inao/src/fields/ElectionsInfoFields/index.tsx
@@ -31,8 +31,8 @@ export const ElectionsInfoFields = ({
   const clientType = getCurrentUserType(answers, externalData)
 
   const [state, dispatch] = useReducer(electionReducer, electionInitialState)
-  const { getValues, setValue } = useFormContext()
-  const values = getValues()
+  const { watch, setValue } = useFormContext()
+  const selectElection = watch('election.selectElection')
   const { data, loading, error } = useQuery(getAvailableElections)
 
   const { formatMessage } = useLocale()
@@ -78,8 +78,7 @@ export const ElectionsInfoFields = ({
   )
 
   const getDefaultElection = useCallback(() => {
-    const selectedElectionId =
-      values?.election?.selectElection || defaultElections
+    const selectedElectionId = selectElection || defaultElections
 
     const currentElection = options?.find(
       (option) => option.value === selectedElectionId,
@@ -87,12 +86,7 @@ export const ElectionsInfoFields = ({
     getElectionInfo(currentElection?.value)
 
     return currentElection?.label || ''
-  }, [
-    defaultElections,
-    values?.election?.selectElection,
-    options,
-    getElectionInfo,
-  ])
+  }, [defaultElections, selectElection, options, getElectionInfo])
 
   return (
     <Fragment>

--- a/libs/application/templates/financial-statements-inao/src/fields/KeyNumbersCapital/index.tsx
+++ b/libs/application/templates/financial-statements-inao/src/fields/KeyNumbersCapital/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import {
   Box,
   GridColumn,
@@ -24,14 +24,14 @@ export const KeyNumbersCapital = () => {
     getValues,
   } = useFormContext()
 
-  const getTotalCapital = () => {
+  const getTotalCapital = useCallback(() => {
     const values = getValues()
 
     const income = getValueViaPath(values, CAPITALNUMBERS.capitalIncome) || '0'
     const expense = getValueViaPath(values, CAPITALNUMBERS.capitalCost) || '0'
     const total = Number(income) - Number(expense)
     setTotalCapital(total)
-  }
+  }, [getValues, setTotalCapital])
 
   useEffect(() => {
     getTotalCapital()

--- a/libs/application/templates/general-fishing-license/src/fields/AttachmentsTitleSection/index.tsx
+++ b/libs/application/templates/general-fishing-license/src/fields/AttachmentsTitleSection/index.tsx
@@ -7,8 +7,8 @@ import { useLocale } from '@island.is/localization'
 import { fishingLicenseFurtherInformation } from '../../lib/messages'
 
 export const AttachmentsTitleSection: FC<FieldBaseProps> = () => {
-  const { getValues } = useFormContext()
-  const description = getValues(ATTACHMENT_INFO_FIELD_ID)
+  const { watch } = useFormContext()
+  const description = watch(ATTACHMENT_INFO_FIELD_ID)
   const { formatMessage } = useLocale()
   return (
     <Box marginTop={4} marginBottom={2}>

--- a/libs/application/templates/institution-collaboration/src/fields/SecondaryContact/SecondaryContact.tsx
+++ b/libs/application/templates/institution-collaboration/src/fields/SecondaryContact/SecondaryContact.tsx
@@ -10,10 +10,10 @@ import { institutionApplicationMessages as m } from '../../lib/messages'
 import { useFormContext } from 'react-hook-form'
 import { useLocale } from '@island.is/localization'
 const SecondaryContact: FC<FieldBaseProps> = ({ field, application }) => {
-  const { setValue, getValues } = useFormContext()
+  const { setValue, watch } = useFormContext()
   const { formatMessage } = useLocale()
   const { id, title } = field
-  const isEnabled = getValues('hasSecondaryContact') === YES
+  const isEnabled = watch('hasSecondaryContact') === YES
 
   const enableSecondaryContact = () => {
     setValue('hasSecondaryContact', YES)

--- a/libs/portals/shared-modules/delegations/src/components/access/AccessItem/AccessItem.tsx
+++ b/libs/portals/shared-modules/delegations/src/components/access/AccessItem/AccessItem.tsx
@@ -116,8 +116,6 @@ export const AccessItem = ({
     })
   }
 
-  console.log('Rendering', apiScopes[0].name)
-
   return (
     <>
       {apiScopes.map((item, index) => {

--- a/libs/portals/shared-modules/delegations/src/components/access/AccessItem/AccessItem.tsx
+++ b/libs/portals/shared-modules/delegations/src/components/access/AccessItem/AccessItem.tsx
@@ -38,7 +38,7 @@ export const AccessItem = ({
   validityPeriod,
 }: PropTypes) => {
   const { lang, formatMessage } = useLocale()
-  const { setValue, getValues } = useFormContext()
+  const { setValue, getValues, watch } = useFormContext()
   const { md, lg } = useBreakpoint()
   const grantTranslation = formatMessage(m.permission)
 
@@ -116,6 +116,8 @@ export const AccessItem = ({
     })
   }
 
+  console.log('Rendering', apiScopes[0].name)
+
   return (
     <>
       {apiScopes.map((item, index) => {
@@ -136,8 +138,8 @@ export const AccessItem = ({
             : undefined
           : authDelegation.scopes.find((scope) => scope.name === item.name)
 
-        const checkboxValue = getValues(`${item.model}.name`)
-        const dateValue = getValues(`${item.model}.validTo`)
+        const checkboxValue = watch(`${item.model}.name`)
+        const dateValue = watch(`${item.model}.validTo`)
 
         // Either use the existing date value or newly modified date value
         const formattedDate =


### PR DESCRIPTION
## What

Reviewed all usage of react-hook-form#getValues, and switched to "watch" in rendering cases.

## Why

To fix possible regressions and hopefully not cause new regressions. The getValues function is mainly designed to get the latest state of the form in event handlers. Using getValues() during rendering and expecting its return to be up to date may not work in version 7.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
