### PR TITLE
fix(financial-statement-inao):  validation error caretaker screen

### DIFF
--- a/libs/application/templates/financial-statements-inao/src/fields/CemetryCaretaker/index.tsx
+++ b/libs/application/templates/financial-statements-inao/src/fields/CemetryCaretaker/index.tsx
@@ -173,7 +173,7 @@ export const CemetryCaretaker: FC<FieldBaseProps<FinancialStatementsInao>> = ({
   const values = getValues()
 
   const { fields, append, remove } = useFieldArray({
-    name: `${id}.caretakers`,
+    name: `${id}`,
   })
 
   const handleAddCaretaker = useCallback(() => {

--- a/libs/application/templates/financial-statements-inao/src/forms/application/cemetry/sectionCemetryCaretaker.ts
+++ b/libs/application/templates/financial-statements-inao/src/forms/application/cemetry/sectionCemetryCaretaker.ts
@@ -13,7 +13,7 @@ import {
 import { FSIUSERTYPE } from '../../../types'
 
 export const sectionCemetryCaretaker = buildSection({
-  id: 'cemetryCaretaker',
+  id: 'cemetryCaretakerSection',
   title: m.cemeteryCaretakers,
   condition: (answers, externalData) => {
     const userType = getCurrentUserType(answers, externalData)

--- a/libs/application/templates/financial-statements-inao/src/lib/constants.ts
+++ b/libs/application/templates/financial-statements-inao/src/lib/constants.ts
@@ -115,7 +115,6 @@ export const CAPITALNUMBERS = {
 }
 
 export const CEMETRYCARETAKER = {
-  caretaking: 'cemetryCaretaker.caretaking',
   nationalId: 'cemetryCaretaker.nationalId',
   name: 'cemetryCaretaker.name',
   role: 'cemetryCaretaker.role',


### PR DESCRIPTION

## What

- removed extra object on cemetryCaretaker object
- caretaking property is unused
- changed cemeterycaretaker  section id in case of conflict with cemeterycaretaker custom field

## Why

The `.caretakers` created an extra object on cemetryCaretaker object and hence failed validation.


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
