### PR TITLE
fix(phone-input): Hotfix: change feature flag functionality

### DIFF
--- a/libs/application/core/src/lib/fieldBuilders.ts
+++ b/libs/application/core/src/lib/fieldBuilders.ts
@@ -274,6 +274,7 @@ export function buildPhoneField(
     readOnly,
     rightAlign,
     allowedCountryCodes,
+    disableDropdown,
   } = data
   return {
     ...extractCommonFields(data),
@@ -283,6 +284,7 @@ export function buildPhoneField(
     required,
     readOnly,
     allowedCountryCodes,
+    disableDropdown,
     rightAlign,
     type: FieldTypes.PHONE,
     component: FieldComponents.PHONE,

--- a/libs/application/types/src/lib/Fields.ts
+++ b/libs/application/types/src/lib/Fields.ts
@@ -234,6 +234,7 @@ export interface PhoneField extends BaseField {
   placeholder?: FormText
   backgroundColor?: InputBackgroundColor
   allowedCountryCodes?: string[]
+  disableDropdown?: boolean
   required?: boolean
   onChange?: (...event: any[]) => void
 }

--- a/libs/application/ui-fields/src/lib/PhoneFormField/PhoneFormField.tsx
+++ b/libs/application/ui-fields/src/lib/PhoneFormField/PhoneFormField.tsx
@@ -9,6 +9,7 @@ import {
 } from '@island.is/shared/form-fields'
 import { useLocale } from '@island.is/localization'
 import { getDefaultValue } from '../../getDefaultValue'
+import { useFeatureFlag } from '@island.is/react/feature-flags'
 
 interface Props extends FieldBaseProps {
   field: PhoneField
@@ -32,10 +33,15 @@ export const PhoneFormField: FC<Props> = ({
     readOnly,
     dataTestId,
     allowedCountryCodes,
+    disableDropdown,
     onChange = () => undefined,
   } = field
   const { control, clearErrors } = useFormContext()
   const { formatMessage } = useLocale()
+  const { value: isPhoneInputV2Enabled } = useFeatureFlag(
+    'isPhoneInputV2Enabled',
+    false,
+  )
 
   return (
     <div>
@@ -65,6 +71,7 @@ export const PhoneFormField: FC<Props> = ({
           autoFocus={autoFocus}
           error={error}
           control={control}
+          disableDropdown={disableDropdown || !isPhoneInputV2Enabled}
           onChange={(e) => {
             if (error) {
               clearErrors(id)

--- a/libs/application/ui-fields/src/lib/PhoneFormField/PhoneFormField.tsx
+++ b/libs/application/ui-fields/src/lib/PhoneFormField/PhoneFormField.tsx
@@ -6,11 +6,9 @@ import { Box } from '@island.is/island-ui/core'
 import {
   PhoneInputController,
   FieldDescription,
-  InputController,
 } from '@island.is/shared/form-fields'
 import { useLocale } from '@island.is/localization'
 import { getDefaultValue } from '../../getDefaultValue'
-import { useFeatureFlag } from '@island.is/react/feature-flags'
 
 interface Props extends FieldBaseProps {
   field: PhoneField
@@ -38,10 +36,6 @@ export const PhoneFormField: FC<Props> = ({
   } = field
   const { control, clearErrors } = useFormContext()
   const { formatMessage } = useLocale()
-  const { value: isPhoneInputV2Enabled } = useFeatureFlag(
-    'isPhoneInputV2Enabled',
-    false,
-  )
 
   return (
     <div>
@@ -52,68 +46,35 @@ export const PhoneFormField: FC<Props> = ({
       )}
 
       <Box paddingTop={2}>
-        {isPhoneInputV2Enabled ? (
-          <PhoneInputController
-            disabled={disabled}
-            readOnly={readOnly}
-            id={id}
-            dataTestId={dataTestId}
-            allowedCountryCodes={allowedCountryCodes}
-            placeholder={formatText(
-              placeholder || '',
-              application,
-              formatMessage,
-            )}
-            label={
-              showFieldName
-                ? formatText(title, application, formatMessage)
-                : undefined
+        <PhoneInputController
+          disabled={disabled}
+          readOnly={readOnly}
+          id={id}
+          dataTestId={dataTestId}
+          allowedCountryCodes={allowedCountryCodes}
+          placeholder={formatText(
+            placeholder || '',
+            application,
+            formatMessage,
+          )}
+          label={
+            showFieldName
+              ? formatText(title, application, formatMessage)
+              : undefined
+          }
+          autoFocus={autoFocus}
+          error={error}
+          control={control}
+          onChange={(e) => {
+            if (error) {
+              clearErrors(id)
             }
-            autoFocus={autoFocus}
-            error={error}
-            control={control}
-            onChange={(e) => {
-              if (error) {
-                clearErrors(id)
-              }
-              onChange(e)
-            }}
-            defaultValue={getDefaultValue(field, application)}
-            backgroundColor={backgroundColor}
-            required={required}
-          />
-        ) : (
-          <InputController
-            disabled={disabled}
-            readOnly={readOnly}
-            id={`${id}NoV2`}
-            dataTestId={dataTestId}
-            type="tel"
-            format="###-####"
-            placeholder={formatText(
-              placeholder || '',
-              application,
-              formatMessage,
-            )}
-            label={
-              showFieldName
-                ? formatText(title, application, formatMessage)
-                : undefined
-            }
-            autoFocus={autoFocus}
-            error={error}
-            control={control}
-            onChange={(e) => {
-              if (error) {
-                clearErrors(id)
-              }
-              onChange(e)
-            }}
-            defaultValue={getDefaultValue(field, application)}
-            backgroundColor={backgroundColor}
-            required={required}
-          />
-        )}
+            onChange(e)
+          }}
+          defaultValue={getDefaultValue(field, application)}
+          backgroundColor={backgroundColor}
+          required={required}
+        />
       </Box>
     </div>
   )

--- a/libs/application/ui-forms/src/lib/applicantInformationMultiField/applicantInformationSchema.ts
+++ b/libs/application/ui-forms/src/lib/applicantInformationMultiField/applicantInformationSchema.ts
@@ -14,14 +14,7 @@ export const applicantInformationSchema = z.object({
   email: z.string().refine((x) => isValidEmail(x), {
     params: applicantInformation.error.email,
   }),
-  phoneNumber: z
-    .string()
-    .refine(isValidNumber, { params: applicantInformation.error.phoneNumber }),
-  // For feature flag testing
-  phoneNumberNoV2: z
-    .string()
-    .refine((x) => x.length === 7 || !x, {
-      params: applicantInformation.error.phoneNumber,
-    })
-    .optional(),
+  phoneNumber: z.string().refine((x) => !x || isValidNumber(x), {
+    params: applicantInformation.error.phoneNumber,
+  }),
 })

--- a/libs/island-ui/core/src/lib/PhoneInput/CountryCodeSelect/Components/index.tsx
+++ b/libs/island-ui/core/src/lib/PhoneInput/CountryCodeSelect/Components/index.tsx
@@ -49,12 +49,14 @@ export const IndicatorsContainer = (
   const { icon } = props.selectProps
   const size: CountryCodeSelectProps['size'] = props.selectProps.size || 'md'
   const hasLabel: boolean = props.selectProps.inputHasLabel
+  const disabled: boolean = props.selectProps.isDisabled ?? false
   return (
     <components.IndicatorsContainer
       className={cn(styles.indicatorsContainer, {
         [styles.dontRotateIconOnOpen]: icon !== 'chevronDown',
         [styles.indicatorsContainerExtraSmall]: size === 'xs',
         [styles.indicatorContainerWithLabel]: hasLabel,
+        [styles.indicatorsContainerDisabled]: disabled,
       })}
       {...props}
     />

--- a/libs/island-ui/core/src/lib/PhoneInput/CountryCodeSelect/CountryCodeSelect.css.ts
+++ b/libs/island-ui/core/src/lib/PhoneInput/CountryCodeSelect/CountryCodeSelect.css.ts
@@ -222,6 +222,18 @@ export const indicatorsContainer = style(
   'indicatorsContainer',
 )
 
+export const indicatorsContainerDisabled = style(
+  {
+    pointerEvents: 'none',
+    selectors: {
+      [`${wrapper} &`]: {
+        display: 'none',
+      },
+    },
+  },
+  'indicatorsContainer',
+)
+
 export const indicatorContainerWithLabel = style(
   {
     selectors: {

--- a/libs/island-ui/core/src/lib/PhoneInput/PhoneInput.tsx
+++ b/libs/island-ui/core/src/lib/PhoneInput/PhoneInput.tsx
@@ -86,6 +86,7 @@ type PhoneInputProps = Omit<
   allowedCountryCodes?: string[]
   format?: string
   onFormatValueChange?: (...event: any[]) => void
+  disableDropdown?: boolean
 }
 
 export const PhoneInput = forwardRef(
@@ -114,6 +115,7 @@ export const PhoneInput = forwardRef(
       autoExpand,
       loading,
       allowedCountryCodes,
+      disableDropdown,
       onFormatValueChange,
       onFocus,
       onBlur,
@@ -168,7 +170,14 @@ export const PhoneInput = forwardRef(
 
     return (
       <>
-        <Box position="relative">
+        <Box
+          position="relative"
+          onClick={() => {
+            if (disableDropdown) {
+              inputRef.current?.focus()
+            }
+          }}
+        >
           {/* If size is xs then the label is above the input box */}
           {size === 'xs' && label && (
             <label
@@ -239,7 +248,7 @@ export const PhoneInput = forwardRef(
                     (x) => x.value === defaultCountryCode,
                   )}
                   options={countryCodes}
-                  disabled={disabled || readOnly}
+                  disabled={disabled || readOnly || disableDropdown}
                   backgroundColor={backgroundColor}
                   inputHasLabel={!!label}
                   size={size}

--- a/libs/shared/form-fields/src/lib/PhoneInputController/PhoneInputController.tsx
+++ b/libs/shared/form-fields/src/lib/PhoneInputController/PhoneInputController.tsx
@@ -2,7 +2,6 @@ import React, { forwardRef } from 'react'
 import { InputBackgroundColor, PhoneInput } from '@island.is/island-ui/core'
 import { Controller, Control, RegisterOptions } from 'react-hook-form'
 import { TestSupport } from '@island.is/island-ui/utils'
-import { useFeatureFlag } from '@island.is/react/feature-flags'
 
 interface Props {
   autoFocus?: boolean
@@ -26,6 +25,7 @@ interface Props {
   size?: 'xs' | 'sm' | 'md'
   autoComplete?: 'off' | 'on'
   allowedCountryCodes?: string[]
+  disableDropdown?: boolean
 }
 
 interface ChildParams {
@@ -61,12 +61,8 @@ export const PhoneInputController = forwardRef(
       dataTestId,
       autoComplete,
       allowedCountryCodes,
+      disableDropdown,
     } = props
-
-    const { value: isPhoneInputV2Enabled } = useFeatureFlag(
-      'isPhoneInputV2Enabled',
-      false,
-    )
 
     function renderChildInput(c: ChildParams & TestSupport) {
       const { value, onChange, ...props } = c
@@ -90,7 +86,7 @@ export const PhoneInputController = forwardRef(
           hasError={error !== undefined}
           errorMessage={error}
           required={required}
-          disableDropdown={!isPhoneInputV2Enabled}
+          disableDropdown={disableDropdown}
           ref={ref}
           onFormatValueChange={onChange}
           allowedCountryCodes={allowedCountryCodes}

--- a/libs/shared/form-fields/src/lib/PhoneInputController/PhoneInputController.tsx
+++ b/libs/shared/form-fields/src/lib/PhoneInputController/PhoneInputController.tsx
@@ -90,7 +90,7 @@ export const PhoneInputController = forwardRef(
           hasError={error !== undefined}
           errorMessage={error}
           required={required}
-          disableDropdown={isPhoneInputV2Enabled}
+          disableDropdown={!isPhoneInputV2Enabled}
           ref={ref}
           onFormatValueChange={onChange}
           allowedCountryCodes={allowedCountryCodes}

--- a/libs/shared/form-fields/src/lib/PhoneInputController/PhoneInputController.tsx
+++ b/libs/shared/form-fields/src/lib/PhoneInputController/PhoneInputController.tsx
@@ -78,6 +78,7 @@ export const PhoneInputController = forwardRef(
           placeholder={placeholder}
           label={label}
           value={value}
+          defaultValue={defaultValue}
           autoComplete={autoComplete}
           loading={loading}
           hasError={error !== undefined}

--- a/libs/shared/form-fields/src/lib/PhoneInputController/PhoneInputController.tsx
+++ b/libs/shared/form-fields/src/lib/PhoneInputController/PhoneInputController.tsx
@@ -2,6 +2,7 @@ import React, { forwardRef } from 'react'
 import { InputBackgroundColor, PhoneInput } from '@island.is/island-ui/core'
 import { Controller, Control, RegisterOptions } from 'react-hook-form'
 import { TestSupport } from '@island.is/island-ui/utils'
+import { useFeatureFlag } from '@island.is/react/feature-flags'
 
 interface Props {
   autoFocus?: boolean
@@ -62,6 +63,11 @@ export const PhoneInputController = forwardRef(
       allowedCountryCodes,
     } = props
 
+    const { value: isPhoneInputV2Enabled } = useFeatureFlag(
+      'isPhoneInputV2Enabled',
+      false,
+    )
+
     function renderChildInput(c: ChildParams & TestSupport) {
       const { value, onChange, ...props } = c
 
@@ -84,6 +90,7 @@ export const PhoneInputController = forwardRef(
           hasError={error !== undefined}
           errorMessage={error}
           required={required}
+          disableDropdown={isPhoneInputV2Enabled}
           ref={ref}
           onFormatValueChange={onChange}
           allowedCountryCodes={allowedCountryCodes}

--- a/libs/shared/form-fields/src/lib/PhoneInputController/PhoneInputController.tsx
+++ b/libs/shared/form-fields/src/lib/PhoneInputController/PhoneInputController.tsx
@@ -78,7 +78,6 @@ export const PhoneInputController = forwardRef(
           placeholder={placeholder}
           label={label}
           value={value}
-          defaultValue={defaultValue}
           autoComplete={autoComplete}
           loading={loading}
           hasError={error !== undefined}


### PR DESCRIPTION
# Change PhoneInput feature flag functionality

Attach a link to issue if relevant

## What

Feature flag now disables the country code dropdown instead of rendering a normal text input.

## Why

It was causing major problems because of zod schema validation between the two different inputs.
The PhoneInput prefixes the value with a country code, so it needs a different validation than a normal text input, and using a feature-flag to differentiate between two zod-schemas seems impossible

Also, adding the option to disable the dropdown with a prop e.g. 
```ts
buildPhoneField({
  id: 'applicant.phoneNumber',
  title: "Phone",
  disableDropdown: true,
}),
```

## Screenshots / Gifs


https://user-images.githubusercontent.com/16031201/226647386-d57f61c7-08c2-4cb9-aed3-6fbf301e726d.mp4



### Dropdown disabled
![image](https://user-images.githubusercontent.com/16031201/226646375-91283b61-cb03-4130-b44c-c5c3bfa18851.png)

### Dropdown enabled
![image](https://user-images.githubusercontent.com/16031201/226646592-947b2026-507f-407a-b366-2626613610ab.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
