### PR TITLE
fix(parental-leave): selected child index for adoption / foster care / other

### DIFF
--- a/libs/application/templates/parental-leave/src/lib/parentalLeaveUtils.ts
+++ b/libs/application/templates/parental-leave/src/lib/parentalLeaveUtils.ts
@@ -34,6 +34,7 @@ import {
   SINGLE,
   PERMANENT_FOSTER_CARE,
   ADOPTION,
+  OTHER_NO_CHILDREN_FOUND,
 } from '../constants'
 import { SchemaFormValues } from '../lib/dataSchema'
 
@@ -824,7 +825,12 @@ export function getApplicationAnswers(answers: Application['answers']) {
 
   // default value as 0 for adoption, foster care and father without mother
   // since primary parent doesn't choose a child
-  const selectedChild = getValueViaPath(answers, 'selectedChild', '0') as string
+  const selectedChild =
+    noChildrenFoundTypeOfApplication === PERMANENT_FOSTER_CARE ||
+    noChildrenFoundTypeOfApplication === ADOPTION ||
+    noChildrenFoundTypeOfApplication === OTHER_NO_CHILDREN_FOUND
+      ? '0'
+      : (getValueViaPath(answers, 'selectedChild') as string)
 
   const transferRights = getValueViaPath(
     answers,


### PR DESCRIPTION
## What

Fix selected child index for adoption / foster care / other so that child in list for "normal" application isn't pre selected

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
