### PR TITLE
fix(delegations): Fix regression when switching domains

### DIFF
--- a/libs/portals/shared-modules/delegations/src/screens/GrantAccess/GrantAccess.tsx
+++ b/libs/portals/shared-modules/delegations/src/screens/GrantAccess/GrantAccess.tsx
@@ -82,12 +82,12 @@ const GrantAccess = () => {
     control,
     formState: { errors },
     watch,
-    reset,
+    setValue,
   } = methods
 
   useEffect(() => {
-    reset({ domainName: selectedOption?.value ?? null })
-  }, [selectedOption?.value, reset])
+    setValue('domainName', selectedOption?.value ?? null)
+  }, [selectedOption?.value, setValue])
 
   const watchToNationalId = watch('toNationalId')
   const domainNameWatcher = watch('domainName')
@@ -136,9 +136,7 @@ const GrantAccess = () => {
 
   const clearPersonState = () => {
     setName('')
-    reset({
-      toNationalId: '',
-    })
+    setValue('toNationalId', '')
 
     setTimeout(() => {
       if (inputRef.current) {


### PR DESCRIPTION
## What

It did not work to change domains on the grant access screen. The form would be silently invalid with an empty national id after reseting the form.

This is another RHF regression. :(

## Why

So we can launch.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
