### PR TITLE
chore(j-s): Remove attachment sent to prisons when a case is modified

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/custodyNoticePdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/custodyNoticePdf.ts
@@ -180,20 +180,6 @@ function constructCustodyNoticePdf(
   return stream
 }
 
-export function getCustodyNoticePdfAsString(
-  theCase: Case,
-  formatMessage: FormatMessage,
-): Promise<string> {
-  const stream = constructCustodyNoticePdf(theCase, formatMessage)
-
-  // wait for the writing to finish
-  return new Promise<string>(function (resolve) {
-    stream.on('finish', () => {
-      resolve(stream.getContentsAsString('binary') as string)
-    })
-  })
-}
-
 export function getCustodyNoticePdfAsBuffer(
   theCase: Case,
   formatMessage: FormatMessage,

--- a/apps/judicial-system/backend/src/app/formatters/index.ts
+++ b/apps/judicial-system/backend/src/app/formatters/index.ts
@@ -2,10 +2,7 @@ export {
   getCourtRecordPdfAsBuffer,
   getCourtRecordPdfAsString,
 } from './courtRecordPdf'
-export {
-  getCustodyNoticePdfAsBuffer,
-  getCustodyNoticePdfAsString,
-} from './custodyNoticePdf'
+export { getCustodyNoticePdfAsBuffer } from './custodyNoticePdf'
 export {
   formatCourtHeadsUpSmsNotification,
   formatCourtReadyForCourtSmsNotification,

--- a/apps/judicial-system/backend/src/app/modules/notification/notification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/notification.service.ts
@@ -55,7 +55,6 @@ import {
   formatCourtRevokedSmsNotification,
   formatPrisonRevokedEmailNotification,
   formatDefenderRevokedEmailNotification,
-  getCustodyNoticePdfAsString,
   formatProsecutorReceivedByCourtSmsNotification,
   formatCourtResubmittedToCourtSmsNotification,
   formatProsecutorReadyForCourtEmailNotification,
@@ -978,26 +977,12 @@ export class NotificationService {
     )
 
     if (shouldSendCustodyNoticeToPrison) {
-      const custodyNoticePdf = await getCustodyNoticePdfAsString(
-        theCase,
-        this.formatMessage,
-      )
-
-      const attachments = [
-        {
-          filename: `Vistunarseðill ${theCase.courtCaseNumber}.pdf`,
-          content: custodyNoticePdf,
-          encoding: 'binary',
-        },
-      ]
-
       promises.push(
         this.sendEmail(
           subject,
           html,
           'Gæsluvarðhaldsfangelsi',
           this.config.email.prisonEmail,
-          attachments,
         ),
       )
     }


### PR DESCRIPTION
# Remove attachment sent to prisons when a case is modified

[Asana](https://app.asana.com/0/1199153462262248/1204215592179230/f)

## What

Remove attachment sent to prisons when a case is modified

## Why

Attachments with info on cases are now a deprecated feature. Emails now have a link to RVG that should be used instead. We had forgotten to remove this one.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
