### PR TITLE
fix(j-s): Use courtEndTime for appeal calculations

### DIFF
--- a/apps/judicial-system/api/src/app/modules/case/interceptors/case.transformer.spec.ts
+++ b/apps/judicial-system/api/src/app/modules/case/interceptors/case.transformer.spec.ts
@@ -98,7 +98,7 @@ describe('transformCase', () => {
   })
 
   describe('isAppealDeadlineExpired', () => {
-    it('should be false when no ruling date is set', () => {
+    it('should be false when no court date is set', () => {
       // Arrange
       const theCase = {} as Case
 
@@ -111,10 +111,10 @@ describe('transformCase', () => {
 
     it('should be false while the appeal window is open', () => {
       // Arrange
-      const rulingDate = new Date()
-      rulingDate.setDate(rulingDate.getDate() - 3)
-      rulingDate.setSeconds(rulingDate.getSeconds() + 1)
-      const theCase = { rulingDate: rulingDate.toISOString() } as Case
+      const courtEndTime = new Date()
+      courtEndTime.setDate(courtEndTime.getDate() - 3)
+      courtEndTime.setSeconds(courtEndTime.getSeconds() + 1)
+      const theCase = { courtEndTime: courtEndTime.toISOString() } as Case
 
       // Act
       const res = transformCase(theCase)
@@ -125,9 +125,9 @@ describe('transformCase', () => {
 
     it('should be true when the appeal window has closed', () => {
       // Arrange
-      const rulingDate = new Date()
-      rulingDate.setDate(rulingDate.getDate() - 3)
-      const theCase = { rulingDate: rulingDate.toISOString() } as Case
+      const courtEndTime = new Date()
+      courtEndTime.setDate(courtEndTime.getDate() - 3)
+      const theCase = { courtEndTime: courtEndTime.toISOString() } as Case
 
       // Act
       const res = transformCase(theCase)
@@ -138,7 +138,7 @@ describe('transformCase', () => {
   })
 
   describe('isAppealGracePeriodExpired', () => {
-    it('should be false when no ruling date is set', () => {
+    it('should be false when no court end time is set', () => {
       // Arrange
       const theCase = {} as Case
 
@@ -151,10 +151,10 @@ describe('transformCase', () => {
 
     it('should be false while the appeal window is open', () => {
       // Arrange
-      const rulingDate = new Date()
-      rulingDate.setDate(rulingDate.getDate() - 7)
-      rulingDate.setSeconds(rulingDate.getSeconds() + 1)
-      const theCase = { rulingDate: rulingDate.toISOString() } as Case
+      const courtEndTime = new Date()
+      courtEndTime.setDate(courtEndTime.getDate() - 7)
+      courtEndTime.setSeconds(courtEndTime.getSeconds() + 1)
+      const theCase = { courtEndTime: courtEndTime.toISOString() } as Case
 
       // Act
       const res = transformCase(theCase)
@@ -165,9 +165,9 @@ describe('transformCase', () => {
 
     it('should be true when the appeal window has closed', () => {
       // Arrange
-      const rulingDate = new Date()
-      rulingDate.setDate(rulingDate.getDate() - 7)
-      const theCase = { rulingDate: rulingDate.toISOString() } as Case
+      const courtEndTime = new Date()
+      courtEndTime.setDate(courtEndTime.getDate() - 7)
+      const theCase = { courtEndTime: courtEndTime.toISOString() } as Case
 
       // Act
       const res = transformCase(theCase)

--- a/apps/judicial-system/api/src/app/modules/case/interceptors/case.transformer.ts
+++ b/apps/judicial-system/api/src/app/modules/case/interceptors/case.transformer.ts
@@ -13,11 +13,11 @@ export function transformCase(theCase: Case): Case {
     isValidToDateInThePast: theCase.validToDate
       ? Date.now() > new Date(theCase.validToDate).getTime()
       : theCase.isValidToDateInThePast,
-    isAppealDeadlineExpired: theCase.rulingDate
-      ? Date.now() >= new Date(theCase.rulingDate).getTime() + threeDays
+    isAppealDeadlineExpired: theCase.courtEndTime
+      ? Date.now() >= new Date(theCase.courtEndTime).getTime() + threeDays
       : false,
-    isAppealGracePeriodExpired: theCase.rulingDate
-      ? Date.now() >= new Date(theCase.rulingDate).getTime() + sevenDays
+    isAppealGracePeriodExpired: theCase.courtEndTime
+      ? Date.now() >= new Date(theCase.courtEndTime).getTime() + sevenDays
       : false,
   }
 }

--- a/apps/judicial-system/web/src/utils/stepHelper.ts
+++ b/apps/judicial-system/web/src/utils/stepHelper.ts
@@ -58,9 +58,9 @@ export const kb = (bytes?: number) => {
   return bytes ? Math.ceil(bytes / 1024) : ''
 }
 
-export const getAppealEndDate = (rulingDate: string) => {
-  const rulingDateToDate = parseISO(rulingDate)
-  const appealEndDate = addDays(rulingDateToDate, 3)
+export const getAppealEndDate = (courtEndTime: string) => {
+  const courtEndTimeToDate = parseISO(courtEndTime)
+  const appealEndDate = addDays(courtEndTimeToDate, 3)
   return formatDate(appealEndDate, 'PPPp')
 }
 


### PR DESCRIPTION
# Use courtEndTime instead of rulingDate for appeal calculations

[Asana](https://app.asana.com/0/1199153462262248/1204078995402542/f)

## What

Use courtEndTime instead of rulingDate to calculate appealDeadline and appealGracePeriod

## Why

The appeal deadline and grace period should be three days after when court ends according to the court record.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
