### PR TITLE
fix(j-s): Fix traffic violation feature hiding

### DIFF
--- a/apps/judicial-system/web/src/components/IndictmentCaseFilesList/IndictmentCaseFilesList.tsx
+++ b/apps/judicial-system/web/src/components/IndictmentCaseFilesList/IndictmentCaseFilesList.tsx
@@ -6,8 +6,6 @@ import {
   CaseFile,
   CaseFileCategory,
   completedCaseStates,
-  Feature,
-  isCourtRole,
   isExtendedCourtRole,
 } from '@island.is/judicial-system/types'
 import { TempCase as Case } from '@island.is/judicial-system-web/src/types'

--- a/apps/judicial-system/web/src/components/IndictmentCaseFilesList/IndictmentCaseFilesList.tsx
+++ b/apps/judicial-system/web/src/components/IndictmentCaseFilesList/IndictmentCaseFilesList.tsx
@@ -7,6 +7,7 @@ import {
   CaseFileCategory,
   completedCaseStates,
   Feature,
+  isCourtRole,
   isExtendedCourtRole,
 } from '@island.is/judicial-system/types'
 import { TempCase as Case } from '@island.is/judicial-system-web/src/types'
@@ -67,12 +68,11 @@ const IndictmentCaseFilesList: React.FC<Props> = (props) => {
     caseId: workingCase.id,
   })
 
-  const isTrafficViolationCaseCheck =
-    (features.includes(Feature.INDICTMENT_ROUTE) ||
-      user?.institution?.id === '26136a67-c3d6-4b73-82e2-3265669a36d3' || // Lögreglustjórinn á Suðurlandi
-      user?.institution?.id === '53581d7b-0591-45e5-9cbe-c96b2f82da85' || // Lögreglustjórinn á höfuðborgarsvæðinu
-      user?.name === 'Ásmundur Jónsson') &&
-    isTrafficViolationCase(workingCase.indictmentSubtypes)
+  const showTrafficViolationCaseFiles = isTrafficViolationCase(
+    workingCase,
+    features,
+    user,
+  )
 
   const cf = workingCase.caseFiles
 
@@ -127,7 +127,7 @@ const IndictmentCaseFilesList: React.FC<Props> = (props) => {
             />
           </Box>
         )}
-        {isTrafficViolationCaseCheck && (
+        {showTrafficViolationCaseFiles && (
           <Box marginBottom={5}>
             <Text variant="h4" as="h4" marginBottom={1}>
               {formatMessage(caseFiles.indictmentSection)}

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/CaseFiles/CaseFiles.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/CaseFiles/CaseFiles.tsx
@@ -57,12 +57,11 @@ const CaseFiles: React.FC = () => {
   const { features } = useContext(FeatureContext)
   const { user } = useContext(UserContext)
 
-  const isTrafficViolationCaseCheck =
-    (features.includes(Feature.INDICTMENT_ROUTE) ||
-      user?.institution?.id === '26136a67-c3d6-4b73-82e2-3265669a36d3' || // Lögreglustjórinn á Suðurlandi
-      user?.institution?.id === '53581d7b-0591-45e5-9cbe-c96b2f82da85' || // Lögreglustjórinn á höfuðborgarsvæðinu
-      user?.name === 'Ásmundur Jónsson') &&
-    isTrafficViolationCase(workingCase.indictmentSubtypes)
+  const isTrafficViolationCaseCheck = isTrafficViolationCase(
+    workingCase,
+    features,
+    user,
+  )
 
   useEffect(() => {
     if (workingCase.caseFiles) {

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Overview/Overview.tsx
@@ -49,12 +49,11 @@ const Overview: React.FC = () => {
   const router = useRouter()
   const { transitionCase } = useCase()
 
-  const isTrafficViolationCaseCheck =
-    (features.includes(Feature.INDICTMENT_ROUTE) ||
-      user?.institution?.id === '26136a67-c3d6-4b73-82e2-3265669a36d3' || // Lögreglustjórinn á Suðurlandi
-      user?.institution?.id === '53581d7b-0591-45e5-9cbe-c96b2f82da85' || // Lögreglustjórinn á höfuðborgarsvæðinu
-      user?.name === 'Ásmundur Jónsson') &&
-    isTrafficViolationCase(workingCase.indictmentSubtypes)
+  const isTrafficViolationCaseCheck = isTrafficViolationCase(
+    workingCase,
+    features,
+    user,
+  )
 
   const isNewIndictment =
     workingCase.state === CaseState.NEW || workingCase.state === CaseState.DRAFT

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Processing/Processing.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Processing/Processing.tsx
@@ -52,12 +52,11 @@ const Processing: React.FC = () => {
   const { features } = useContext(FeatureContext)
   const { user } = useContext(UserContext)
 
-  const isTrafficViolationCaseCheck =
-    (features.includes(Feature.INDICTMENT_ROUTE) ||
-      user?.institution?.id === '26136a67-c3d6-4b73-82e2-3265669a36d3' || // Lögreglustjórinn á Suðurlandi
-      user?.institution?.id === '53581d7b-0591-45e5-9cbe-c96b2f82da85' || // Lögreglustjórinn á höfuðborgarsvæðinu
-      user?.name === 'Ásmundur Jónsson') &&
-    isTrafficViolationCase(workingCase.indictmentSubtypes)
+  const isTrafficViolationCaseCheck = isTrafficViolationCase(
+    workingCase,
+    features,
+    user,
+  )
 
   const handleCourtChange = (court: Institution) => {
     if (workingCase) {

--- a/apps/judicial-system/web/src/utils/hooks/useCase/updateCaseGql.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useCase/updateCaseGql.ts
@@ -148,8 +148,15 @@ export const UpdateCaseMutation = gql`
         name
         size
         created
+        modified
         state
         key
+        category
+        policeCaseNumber
+        chapter
+        orderWithinChapter
+        userGeneratedFilename
+        displayDate
       }
       isAppealDeadlineExpired
       isAppealGracePeriodExpired

--- a/apps/judicial-system/web/src/utils/hooks/useSections/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useSections/index.ts
@@ -396,14 +396,8 @@ const useSections = (
                       )
                   : undefined,
             },
-            ...((features.includes(Feature.INDICTMENT_ROUTE) ||
-              user?.institution?.id ===
-                '26136a67-c3d6-4b73-82e2-3265669a36d3' || // Lögreglustjórinn á Suðurlandi
-              user?.institution?.id ===
-                '53581d7b-0591-45e5-9cbe-c96b2f82da85' || // Lögreglustjórinn á höfuðborgarsvæðinu
-              user?.name === 'Ásmundur Jónsson') &&
-            workingCase.type === CaseType.Indictment &&
-            isTrafficViolationCase(workingCase.indictmentSubtypes)
+            ...(workingCase.type === CaseType.Indictment &&
+            isTrafficViolationCase(workingCase, features, user)
               ? [
                   {
                     name: formatMessage(

--- a/apps/judicial-system/web/src/utils/stepHelper.ts
+++ b/apps/judicial-system/web/src/utils/stepHelper.ts
@@ -6,13 +6,16 @@ import { TagVariant } from '@island.is/island-ui/core'
 import { formatDate } from '@island.is/judicial-system/formatters'
 import {
   CaseCustodyRestrictions,
+  CaseFileCategory,
+  Feature,
   Gender,
   IndictmentSubtype,
-  IndictmentSubtypeMap,
+  isCourtRole,
   Notification,
   NotificationType,
 } from '@island.is/judicial-system/types'
 import { TempCase as Case } from '@island.is/judicial-system-web/src/types'
+import { User } from '@island.is/judicial-system-web/src/graphql/schema'
 
 export const getShortGender = (gender?: Gender): string => {
   switch (gender) {
@@ -86,16 +89,31 @@ export const createCaseResentExplanation = (
 }
 
 export const isTrafficViolationCase = (
-  indictmentSubtypes: IndictmentSubtypeMap | undefined,
+  workingCase: Case,
+  features: Feature[],
+  user?: User,
 ): boolean => {
-  if (!indictmentSubtypes) {
+  if (!workingCase.indictmentSubtypes) {
     return false
   }
 
-  const flatIndictmentSubtypes = flatten(Object.values(indictmentSubtypes))
+  const flatIndictmentSubtypes = flatten(
+    Object.values(workingCase.indictmentSubtypes),
+  )
 
   return Boolean(
-    flatIndictmentSubtypes.length > 0 &&
+    (features.includes(Feature.INDICTMENT_ROUTE) ||
+      user?.institution?.id === '26136a67-c3d6-4b73-82e2-3265669a36d3' || // Lögreglustjórinn á Suðu
+      user?.institution?.id === '53581d7b-0591-45e5-9cbe-c96b2f82da85' || // Lögreglustjórinn á höfuðborgarsvæðinu
+      user?.name === 'Ásmundur Jónsson' ||
+      (user && isCourtRole(user.role))) &&
+      !(
+        workingCase.caseFiles &&
+        workingCase.caseFiles.find(
+          (file) => file.category === CaseFileCategory.INDICTMENT,
+        )
+      ) &&
+      flatIndictmentSubtypes.length > 0 &&
       flatIndictmentSubtypes.every(
         (val) => val === IndictmentSubtype.TRAFFIC_VIOLATION,
       ),

--- a/apps/judicial-system/web/src/utils/stepHelper.ts
+++ b/apps/judicial-system/web/src/utils/stepHelper.ts
@@ -103,7 +103,7 @@ export const isTrafficViolationCase = (
 
   return Boolean(
     (features.includes(Feature.INDICTMENT_ROUTE) ||
-      user?.institution?.id === '26136a67-c3d6-4b73-82e2-3265669a36d3' || // Lögreglustjórinn á Suðu
+      user?.institution?.id === '26136a67-c3d6-4b73-82e2-3265669a36d3' || // Lögreglustjórinn á Suðurlandi
       user?.institution?.id === '53581d7b-0591-45e5-9cbe-c96b2f82da85' || // Lögreglustjórinn á höfuðborgarsvæðinu
       user?.name === 'Ásmundur Jónsson' ||
       (user && isCourtRole(user.role))) &&


### PR DESCRIPTION
# Fix feature hiding mechanism for traffic violation cases

[Asana](https://app.asana.com/0/1199153462262248/1204272649743961)

## What

Move all logic to one function and hide traffic violation indictment step if user has already uploaded an indictment file in the old flow

## Why

Because with the old functionality we could create a confusing situation where a user might have began working on a case within the old user flow but is forced in to the new one. 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
