### PR TITLE
chore(j-s): Only accept .pdf files for court record and ruling in indictments

### DIFF
--- a/apps/judicial-system/web/src/routes/Court/Indictments/CourtRecord/CourtRecord.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/CourtRecord/CourtRecord.tsx
@@ -44,7 +44,6 @@ import {
   mapCaseFileToUploadFile,
   stepValidationsType,
 } from '@island.is/judicial-system-web/src/utils/formHelper'
-import { fileExtensionWhitelist } from '@island.is/island-ui/core/types'
 import * as constants from '@island.is/judicial-system/consts'
 
 import { courtRecord as m } from './CourtRecord.strings'
@@ -135,8 +134,11 @@ const CourtRecord: React.FC = () => {
             fileList={displayFiles.filter(
               (file) => file.category === CaseFileCategory.COURT_RECORD,
             )}
-            accept={Object.values(fileExtensionWhitelist)}
+            accept="application/pdf"
             header={formatMessage(m.inputFieldLabel)}
+            description={formatMessage(core.uploadBoxDescription, {
+              fileEndings: '.pdf',
+            })}
             buttonLabel={formatMessage(m.uploadButtonText)}
             onChange={(files) => {
               handleChange(
@@ -156,8 +158,11 @@ const CourtRecord: React.FC = () => {
             fileList={displayFiles.filter(
               (file) => file.category === CaseFileCategory.RULING,
             )}
-            accept={Object.values(fileExtensionWhitelist)}
+            accept="application/pdf"
             header={formatMessage(m.inputFieldLabel)}
+            description={formatMessage(core.uploadBoxDescription, {
+              fileEndings: '.pdf',
+            })}
             buttonLabel={formatMessage(m.uploadButtonText)}
             onChange={(files) =>
               handleChange(


### PR DESCRIPTION
# Only accept .pdf files for court record and ruling in indictments

[Asana](https://app.asana.com/0/1199153462262248/1203966424106781/f)

## What

Only accept .pdf files for court record and ruling in indictments

## Why

We want to limit the use of other file extensions being uploaded to RVG. Most of these files are written as Word documents and can easily be exported as pdfs.

## Screenshots / Gifs

![image](https://user-images.githubusercontent.com/3789875/228065942-6ff4476b-46ee-4e01-88a0-b0873681fcb4.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
