### PR TITLE
fix(system-e2e): Stop K8s HPA from scaling mountebank service

### DIFF
--- a/infra/src/dsl/output-generators/map-to-helm-values.ts
+++ b/infra/src/dsl/output-generators/map-to-helm-values.ts
@@ -453,6 +453,15 @@ const serviceMockDef = (options: {
       max: 1,
       default: 1,
     },
+    hpa: {
+      scaling: {
+        replicas: {
+          min: 1,
+          max: 1,
+        },
+        metric: { cpuAverageUtilization: 70 },
+      },
+    },
     securityContext: {
       privileged: false,
       allowPrivilegeEscalation: false,


### PR DESCRIPTION
HPA config is not coordinated with the desired replica count and is overriding it. Fixing that so now mountebank is just 1 instance.

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
