### PR TITLE
fix(consultation-portal): KAM-1053 blow out function shows only if more than a line

### DIFF
--- a/apps/consultation-portal/components/ReviewCard/ReviewCard.tsx
+++ b/apps/consultation-portal/components/ReviewCard/ReviewCard.tsx
@@ -7,12 +7,29 @@ import {
   Text,
 } from '@island.is/island-ui/core'
 import { SimpleCardSkeleton } from '../Card'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import * as styles from './ReviewCard.css'
 import { getShortDate } from '../../utils/helpers/dateFormatter'
+import { UserAdvice } from '@island.is/consultation-portal/types/interfaces'
+
+// One line is 27
+const SCROLL_HEIGHT = 27
 
 export const ReviewCard = ({ advice }) => {
-  const [open, setOpen] = useState(false)
+  const [open, setOpen] = useState(true)
+  const [scrollHeight, setScrollHeight] = useState(null)
+
+  const ref = useRef(null)
+
+  useEffect(() => {
+    if (ref.current) {
+      setScrollHeight(ref.current.scrollHeight)
+      if (ref.current.scrollHeight > SCROLL_HEIGHT) {
+        setOpen(false)
+      }
+    }
+    ref.current && setScrollHeight(ref.current.scrollHeight)
+  }, [])
 
   return (
     <SimpleCardSkeleton>
@@ -21,7 +38,7 @@ export const ReviewCard = ({ advice }) => {
           <Text variant="eyebrow" color="purple400">
             {getShortDate(advice.created)}
           </Text>
-          {advice.content && advice.content.length > 50 && (
+          {scrollHeight > SCROLL_HEIGHT && (
             <FocusableBox onClick={() => setOpen(!open)}>
               <Icon
                 icon={open ? 'close' : 'open'}
@@ -35,7 +52,7 @@ export const ReviewCard = ({ advice }) => {
         <Text variant="h3">
           {advice?.number} - {advice?.participantName}
         </Text>
-        <Text variant="default" truncate={!open}>
+        <Text variant="default" truncate={!open} ref={ref}>
           {advice.content}
         </Text>
         {advice?.adviceDocuments &&


### PR DESCRIPTION
# Fix blow out function on advice box

https://veflausnir.atlassian.net/browse/KAM-1053

## What

Blow out function should only show if there are more than one line

## Why



## Screenshots / Gifs



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
