### PR TITLE
fix(web): Order news with same date via initial time of publish

### DIFF
--- a/apps/contentful-apps/pages/fields/publish-date-field.tsx
+++ b/apps/contentful-apps/pages/fields/publish-date-field.tsx
@@ -21,6 +21,10 @@ const PublishDateField = () => {
     })
   }, [sdk.entry, sdk.field])
 
+  useEffect(() => {
+    sdk.window.startAutoResizer()
+  }, [sdk.window])
+
   return <Box>{value ? new Date(value).toLocaleDateString('is-IS') : null}</Box>
 }
 

--- a/libs/cms/src/lib/cms.elasticsearch.service.ts
+++ b/libs/cms/src/lib/cms.elasticsearch.service.ts
@@ -118,7 +118,10 @@ export class CmsElasticsearchService {
 
     const query = {
       types: ['webNews'],
-      sort: [{ dateCreated: { order } }] as sortRule[],
+      sort: [
+        { dateCreated: { order } },
+        { releaseDate: { order } },
+      ] as sortRule[],
       ...dateQuery,
       ...tagQuery,
       page,

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -1961,6 +1961,9 @@ export interface INewsFields {
 
   /** Generic tags */
   genericTags?: IGenericTag[] | undefined
+
+  /** Initial Publish Date */
+  initialPublishDate?: string | undefined
 }
 
 export interface INews extends Entry<INewsFields> {

--- a/libs/cms/src/lib/models/news.model.ts
+++ b/libs/cms/src/lib/models/news.model.ts
@@ -35,6 +35,9 @@ export class News {
 
   @Field(() => Boolean, { nullable: true })
   fullWidthImageInContent?: boolean
+
+  @Field({ nullable: true })
+  initialPublishDate?: string
 }
 
 export const mapNews = ({ fields, sys }: INews): News => ({
@@ -50,4 +53,5 @@ export const mapNews = ({ fields, sys }: INews): News => ({
     : [],
   genericTags: (fields.genericTags ?? []).map(mapGenericTag),
   fullWidthImageInContent: fields.fullWidthImageInContent ?? true,
+  initialPublishDate: fields.initialPublishDate ?? '',
 })

--- a/libs/cms/src/lib/search/importers/news.service.ts
+++ b/libs/cms/src/lib/search/importers/news.service.ts
@@ -58,6 +58,7 @@ export class NewsSyncService implements CmsSyncProvider<INews> {
             ],
             dateCreated: mapped.date,
             dateUpdated: new Date().getTime().toString(),
+            releaseDate: mapped.initialPublishDate,
           }
         } catch (error) {
           logger.warn('Failed to import news', {

--- a/libs/content-search-indexer/types/src/index.ts
+++ b/libs/content-search-indexer/types/src/index.ts
@@ -23,6 +23,7 @@ export interface MappedData {
   tags?: tag[]
   dateUpdated: string
   dateCreated: string
+  releaseDate?: string
 }
 
 export interface SyncOptions {


### PR DESCRIPTION
# Order news with same date via initial time of publish

## What

* If there are multiple news with the same date they seem to be ordered randomly, this change makes it so the order is based on the initial publish time so that the latest news is actually first in the list

## Why

* It's confusing for CMS users to publish multiple news entries but have them in a random order, this is something we'd like to fix

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
