### PR TITLE
Ensure we use cluster slot prefix.

### DIFF
--- a/apps/services/sessions/src/app/sessions/sessions.module.ts
+++ b/apps/services/sessions/src/app/sessions/sessions.module.ts
@@ -25,13 +25,12 @@ if (process.env.INIT_SCHEMA === 'true' || process.env.TESTS === 'true') {
   BullModule = NestBullModule.registerQueueAsync({
     name: sessionsQueueName,
     useFactory: (config: ConfigType<typeof SessionsConfig>) => ({
-      prefix: `{${bullModuleName}}`,
       createClient: () =>
         createRedisCluster({
-          name: bullModuleName,
+          name: `{${bullModuleName}}`,
           nodes: config.redis.nodes,
           ssl: config.redis.ssl,
-          noPrefix: true,
+          noPrefix: false,
         }),
     }),
     inject: [SessionsConfig.KEY],


### PR DESCRIPTION
https://www.notion.so/Look-into-redis-errors-in-datadog-when-queuing-login-history-jobs-753add22731645818dd9caca97799758?pvs=4

## What

Use "hash tag" prefix for redis keys.

## Why

To make the Bull queue compatible with Redis cluster.

See https://docs.bullmq.io/bull/patterns/redis-cluster.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
