### PR TITLE
fix(island-ui): Background-color specificity.

### DIFF
--- a/libs/island-ui/core/src/lib/Input/Input.mixins.ts
+++ b/libs/island-ui/core/src/lib/Input/Input.mixins.ts
@@ -65,7 +65,7 @@ export const container = {
 }
 
 export const containerWithBefore: StyleRule = {
-  ...omit(container, ['boxShadow', 'transition']),
+  ...omit(container, ['boxShadow', 'transition', 'backgroundColor']),
 
   // This is only for displaying the border.
   '::before': {


### PR DESCRIPTION
## What

The background color from Input.mixins.ts was overwriting the Box's background color. Now, the container only uses the box's background color.


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
