### PR TITLE
fix(island-ui): Textarea font size.

### DIFF
--- a/libs/island-ui/core/src/lib/Input/Input.tsx
+++ b/libs/island-ui/core/src/lib/Input/Input.tsx
@@ -192,7 +192,7 @@ export const Input = forwardRef(
                   styles.inputBackgroundLg,
                   styles.inputBackgroundXl,
                 ),
-                styles.inputSize[size],
+                { [styles.inputSize[size]]: !textarea },
               )}
               id={id}
               disabled={disabled}


### PR DESCRIPTION
## What

The regular input styles with media queries had higher specificity than the textarea styles. Now the input styles are not applied if the component is a textarea.

This is a fix for a bug that was introduced in #10656 .

## Screenshots / Gifs

<img width="975" alt="Screenshot 2023-03-31 at 15 31 21" src="https://user-images.githubusercontent.com/7573694/229165389-f66546ca-97eb-45e4-b60d-68584c1304b1.png">



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
