### PR TITLE
feat(island-ui): VisuallyHidden

### DIFF
--- a/libs/island-ui/core/src/index.ts
+++ b/libs/island-ui/core/src/index.ts
@@ -56,6 +56,7 @@ export * from './lib/Filter/FilterMultiChoice/FilterMultiChoice'
 export * from './lib/Filter/FilterInput/FilterInput'
 export * from './lib/PdfViewer/PdfViewer'
 export * from './lib/PageLoader'
+export * from './lib/VisuallyHidden/VisuallyHidden'
 
 // Cards
 export * from './lib/LinkCard/LinkCard'

--- a/libs/island-ui/core/src/lib/VisuallyHidden/VisuallyHidden.stories.mdx
+++ b/libs/island-ui/core/src/lib/VisuallyHidden/VisuallyHidden.stories.mdx
@@ -1,10 +1,9 @@
-import {Meta, Story, Canvas} from '@storybook/addon-docs'
+import { Meta, Story, Canvas } from '@storybook/addon-docs'
 
-import {VisuallyHidden} from './VisuallyHidden'
-import {Button} from '../Button/Button'
+import { VisuallyHidden } from './VisuallyHidden'
+import { Button } from '../Button/Button'
 
-
-<Meta title="Components/VisuallyHidden" component={VisuallyHidden}/>
+<Meta title="Components/VisuallyHidden" component={VisuallyHidden} />
 
 # VisuallyHidden
 
@@ -13,20 +12,18 @@ This component wraps its children in a `span` and visually hides it.
 
 In some cases, using `VisuallyHidden` can be better than using `aria-label`.
 For example:
- - There can be variations in how screen readers announce `aria-label`.
- - Some users use automatic systems to translate pages (e.g., Google Translate), and these systems don't always translate `aria-label`.
 
-
+- There can be variations in how screen readers announce `aria-label`.
+- Some users use automatic systems to translate pages (e.g., Google Translate), and these systems don't always translate `aria-label`.
 
 export const Template = (args) => (
-    <Button icon='settings' circle>
-      <VisuallyHidden {...args} />
-    </Button>
-);
+  <Button icon="settings" circle>
+    <VisuallyHidden {...args} />
+  </Button>
+)
 
 <Canvas>
-  <Story name="Default" args={{children: 'Stillingar'}}>
+  <Story name="Default" args={{ children: 'Stillingar' }}>
     {Template.bind({})}
   </Story>
 </Canvas>
-

--- a/libs/island-ui/core/src/lib/VisuallyHidden/VisuallyHidden.stories.mdx
+++ b/libs/island-ui/core/src/lib/VisuallyHidden/VisuallyHidden.stories.mdx
@@ -1,0 +1,32 @@
+import {Meta, Story, Canvas} from '@storybook/addon-docs'
+
+import {VisuallyHidden} from './VisuallyHidden'
+import {Button} from '../Button/Button'
+
+
+<Meta title="Components/VisuallyHidden" component={VisuallyHidden}/>
+
+# VisuallyHidden
+
+Sometimes we need to give extra context to those who don't see the screen.
+This component wraps its children in a `span` and visually hides it.
+
+In some cases, using `VisuallyHidden` can be better than using `aria-label`.
+For example:
+ - There can be variations in how screen readers announce `aria-label`.
+ - Some users use automatic systems to translate pages (e.g., Google Translate), and these systems don't always translate `aria-label`.
+
+
+
+export const Template = (args) => (
+    <Button icon='settings' circle>
+      <VisuallyHidden {...args} />
+    </Button>
+);
+
+<Canvas>
+  <Story name="Default" args={{children: 'Stillingar'}}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+

--- a/libs/island-ui/core/src/lib/VisuallyHidden/VisuallyHidden.tsx
+++ b/libs/island-ui/core/src/lib/VisuallyHidden/VisuallyHidden.tsx
@@ -1,0 +1,33 @@
+import React, { CSSProperties, forwardRef, ReactNode } from 'react'
+
+const style: CSSProperties = {
+  border: 0,
+  clip: 'rect(0 0 0 0)',
+  height: '1px',
+  overflow: 'hidden',
+  padding: 0,
+  position: 'absolute',
+  whiteSpace: 'nowrap',
+  width: '1px',
+}
+
+interface VisuallyHiddenProps
+  extends Pick<
+    React.HTMLAttributes<HTMLElement>,
+    'aria-labelledby' | 'aria-describedby' | 'id'
+  > {
+  children?: ReactNode
+}
+
+const VisuallyHidden = forwardRef<HTMLSpanElement, VisuallyHiddenProps>(
+  function VisuallyHiddenInner({ children, ...restProps }, ref) {
+    return (
+      <span ref={ref} style={style} {...restProps}>
+        {children}
+      </span>
+    )
+  },
+)
+
+export { VisuallyHidden }
+export type { VisuallyHiddenProps }


### PR DESCRIPTION
## What

This PR adds a `<VisuallyHidden />` component to island-ui. 
VisuallyHidden is a common technique used in web accessibility to hide content from the visual client, but keep it readable for screen readers.

In some cases, using this technique can be better than using aria-label. For example:
- There can be variations in how screen readers announce aria-label.
- Some users use automatic systems to translate pages (e.g., Google Translate), and these systems don't always translate aria-label.


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
