### PR TITLE
fix(web): Highlight menu links that include query params

### DIFF
--- a/apps/web/screens/Organization/OrganizationNewsList.tsx
+++ b/apps/web/screens/Organization/OrganizationNewsList.tsx
@@ -93,7 +93,7 @@ const OrganizationNewsList: Screen<OrganizationNewsListProps> = ({
     },
   ]
 
-  const baseRouterPath = router.asPath.split('?')[0].split('#')[0]
+  const baseRouterPath = router.asPath.split('#')[0]
 
   const currentNavItem =
     organizationPage.menuLinks.find(

--- a/apps/web/screens/Project/ProjectNewsList.tsx
+++ b/apps/web/screens/Project/ProjectNewsList.tsx
@@ -90,7 +90,7 @@ const ProjectNewsList: Screen<ProjectNewsListProps> = ({
     },
   ]
 
-  const baseRouterPath = router.asPath.split('?')[0].split('#')[0]
+  const baseRouterPath = router.asPath.split('#')[0]
 
   const currentNavItem = projectPage.sidebarLinks.find(
     ({ primaryLink }) => primaryLink?.url === baseRouterPath,


### PR DESCRIPTION
# Highlight menu links that include query params

## What

* https://island.is/s/stafraent-island/frett?tag=frettabref link wasn't getting highlighed even though it was clearly selected since the highlight check wasn't taking query params into consideration

## Screenshots / Gifs

### Before
![image](https://user-images.githubusercontent.com/43557895/229537821-e316997e-8ff4-46dd-9a8c-46eb5e33eb9a.png)

### After
![image](https://user-images.githubusercontent.com/43557895/229537966-0e110dfa-ed46-4116-8304-7511fc7d4bcc.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
