### PR TITLE
feat(web): Re-index pages into ElasticSearch when nested content changes

### DIFF
--- a/apps/contentful-apps/pages/fields/subarticle-url-field.tsx
+++ b/apps/contentful-apps/pages/fields/subarticle-url-field.tsx
@@ -6,8 +6,6 @@ import { useCMA, useSDK } from '@contentful/react-apps-toolkit'
 import { TextInput, Text, Spinner } from '@contentful/f36-components'
 import { EntryProps, SysLink } from 'contentful-management'
 
-const { publicRuntimeConfig } = getConfig()
-
 type Article = EntryProps<{
   subArticles: { 'is-IS': SysLink[] }
   slug: {
@@ -16,10 +14,11 @@ type Article = EntryProps<{
   }
 }>
 
-const environmentId = publicRuntimeConfig.CONTENTFUL_ENVIRONMENT
-const spaceId = publicRuntimeConfig.CONTENTFUL_SPACE
-
 const SubArticleUrlField = () => {
+  const { publicRuntimeConfig } = getConfig()
+  const environmentId = publicRuntimeConfig.CONTENTFUL_ENVIRONMENT
+  const spaceId = publicRuntimeConfig.CONTENTFUL_SPACE
+
   const sdk = useSDK<FieldExtensionSDK>()
   const cma = useCMA()
 

--- a/libs/cms/src/lib/environments/environment.ts
+++ b/libs/cms/src/lib/environments/environment.ts
@@ -71,6 +71,8 @@ export default {
     'organizationTag',
     'logoListSlice',
     'article',
+    'overviewLinks',
+    'introLinkImage',
   ],
   // Content types that have the 'activeTranslations' JSON field
   localizedContentTypes: ['article'],


### PR DESCRIPTION
# Re-index pages into ElasticSearch when nested content changes

## What

* overViewLinks and introLinkImage are both nested content types which when changed didn't cause the Elastic search index to update for the page the the content was nested within. This is fixed by adding these two types as nestedContentTypes

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
