### PR TITLE
fix(web): Main menu graphql errors due to missing content in CMS

### DIFF
--- a/libs/cms/src/lib/models/menuLinkWithChildren.model.ts
+++ b/libs/cms/src/lib/models/menuLinkWithChildren.model.ts
@@ -20,5 +20,7 @@ export const mapMenuLinkWithChildren = ({
 }: IMenuLinkWithChildren): MenuLinkWithChildren => ({
   title: fields.title ?? '',
   link: fields.link ? mapReferenceLink(fields.link) : null,
-  childLinks: (fields.childLinks ?? []).map(mapMenuLink),
+  childLinks: (fields.childLinks ?? [])
+    .map(mapMenuLink)
+    .filter((childLink) => !!childLink?.link?.slug && !!childLink?.title),
 })


### PR DESCRIPTION
# Main menu graphql errors due to missing content in CMS

## What

* We want to add a fail-safe to the menu since we recently noticed that if there is a missing link then the web displays a 500 error due to a graphql validation failure since the link is required

## Why

* We want to prevent errors in the future

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
