### PR TITLE
feat(sessions): Allow different formatted National IDs in the filter.

### DIFF
--- a/libs/service-portal/sessions/src/screens/Sessions/Sessions.tsx
+++ b/libs/service-portal/sessions/src/screens/Sessions/Sessions.tsx
@@ -90,7 +90,7 @@ const Sessions = () => {
       refetch({
         ...getQueryVariables(
           nextCursor,
-          searchNationalId,
+          kennitala.format(searchNationalId, ''),
           filterDates.fromDate,
           filterDates.toDate,
         ),
@@ -111,7 +111,7 @@ const Sessions = () => {
     refetch({
       ...getQueryVariables(
         '',
-        searchNationalId,
+        kennitala.format(searchNationalId, ''),
         type === 'clear'
           ? initialDates.fromDate
           : type === 'from'
@@ -145,7 +145,7 @@ const Sessions = () => {
       refetch({
         ...getQueryVariables(
           '',
-          value,
+          kennitala.format(value, ''),
           filterDates.fromDate,
           filterDates.toDate,
         ),


### PR DESCRIPTION
## What

The search field now handles loosely formatted national IDs, such as those with a trailing space or with a dash in the middle.

## Why

UX

## Screenshots / Gifs

<img width="1295" alt="" src="https://user-images.githubusercontent.com/7573694/230048476-3ad74de8-5071-4924-9c68-ff03dcad901d.png">


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
