### PR TITLE
chore(contentful-apps): Use environment variables instead of runtime config for Contentful Apps

### DIFF
--- a/apps/contentful-apps/components/MideindTranslationSidebar/api/index.tsx
+++ b/apps/contentful-apps/components/MideindTranslationSidebar/api/index.tsx
@@ -1,13 +1,10 @@
-import getConfig from 'next/config'
-
 const defaultParams = {
   sourceLanguageCode: 'is',
   targetLanguageCode: 'en',
 }
 
 async function translateTexts(texts: string[]) {
-  const { publicRuntimeConfig } = getConfig()
-  const baseUrl = publicRuntimeConfig.MIDEIND_TRANSLATION_API_BASE_URL
+  const baseUrl = process.env.MIDEIND_TRANSLATION_API_BASE_URL
 
   const translations = []
   const body = {
@@ -19,7 +16,7 @@ async function translateTexts(texts: string[]) {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'X-API-Key': publicRuntimeConfig.MIDEIND_TRANSLATION_API_KEY,
+      'X-API-Key': process.env.MIDEIND_TRANSLATION_API_KEY,
     },
     body: JSON.stringify(body),
   }).then((res) => res.json())
@@ -36,8 +33,7 @@ async function sendTexts(
   enTexts: string[],
   reference: string,
 ) {
-  const { publicRuntimeConfig } = getConfig()
-  const baseUrl = publicRuntimeConfig.MIDEIND_TRANSLATION_API_BASE_URL
+  const baseUrl = process.env.MIDEIND_TRANSLATION_API_BASE_URL
 
   const body = {
     machineTranslatedText: '', // Required even if empty
@@ -52,7 +48,7 @@ async function sendTexts(
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'X-API-Key': publicRuntimeConfig.MIDEIND_TRANSLATION_API_KEY,
+      'X-API-Key': process.env.MIDEIND_TRANSLATION_API_KEY,
     },
     body: JSON.stringify(body),
   })

--- a/apps/contentful-apps/next.config.js
+++ b/apps/contentful-apps/next.config.js
@@ -1,13 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const withNx = require('@nrwl/next/plugins/with-nx')
 
-const {
-  MIDEIND_TRANSLATION_API_KEY,
-  CONTENTFUL_ENVIRONMENT,
-  CONTENTFUL_SPACE,
-  MIDEIND_TRANSLATION_API_BASE_URL,
-} = process.env
-
 /**
  * @type {import('@nrwl/next/plugins/with-nx').WithNxOptions}
  **/
@@ -17,11 +10,12 @@ const nextConfig = {
     // See: https://github.com/gregberge/svgr
     svgr: false,
   },
-  publicRuntimeConfig: {
-    MIDEIND_TRANSLATION_API_KEY,
-    CONTENTFUL_ENVIRONMENT,
-    CONTENTFUL_SPACE,
-    MIDEIND_TRANSLATION_API_BASE_URL,
+  env: {
+    MIDEIND_TRANSLATION_API_KEY: process.env.MIDEIND_TRANSLATION_API_KEY,
+    CONTENTFUL_ENVIRONMENT: process.env.CONTENTFUL_ENVIRONMENT,
+    CONTENTFUL_SPACE: process.env.CONTENTFUL_SPACE,
+    MIDEIND_TRANSLATION_API_BASE_URL:
+      process.env.MIDEIND_TRANSLATION_API_BASE_URL,
   },
 }
 

--- a/apps/contentful-apps/pages/fields/subarticle-url-field.tsx
+++ b/apps/contentful-apps/pages/fields/subarticle-url-field.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react'
-import getConfig from 'next/config'
 import { useDebounce } from 'react-use'
 import { FieldExtensionSDK } from '@contentful/app-sdk'
 import { useCMA, useSDK } from '@contentful/react-apps-toolkit'
@@ -15,10 +14,6 @@ type Article = EntryProps<{
 }>
 
 const SubArticleUrlField = () => {
-  const { publicRuntimeConfig } = getConfig()
-  const environmentId = publicRuntimeConfig.CONTENTFUL_ENVIRONMENT
-  const spaceId = publicRuntimeConfig.CONTENTFUL_SPACE
-
   const sdk = useSDK<FieldExtensionSDK>()
   const cma = useCMA()
 
@@ -50,8 +45,8 @@ const SubArticleUrlField = () => {
     cma.entry
       .get({
         entryId: parentArticleId,
-        environmentId,
-        spaceId,
+        environmentId: process.env.CONTENTFUL_ENVIRONMENT,
+        spaceId: process.env.CONTENTFUL_SPACE,
       })
       .then((parentArticle: Article) => {
         const subArticles =


### PR DESCRIPTION
# Use environment variables instead of runtime config for Contentful Apps

## What

* Previously there was a public runtime config setup to expose variables within the Next.js project used to host Contentful apps. It turns out that due to the static generation the variables weren't exposed to the browser. So the only way to use runtime configs would be to render the pages at request time which is not something we want to do due to the performance loss and all of the variables are only used in the browser so until we have something that should only be setup server side we'd like to use environment variables instead.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
