### PR TITLE
feat(ids-admin): Tenant list grid width 

### DIFF
--- a/libs/portals/admin/ids-admin/src/components/TenantsList/TenantsList.tsx
+++ b/libs/portals/admin/ids-admin/src/components/TenantsList/TenantsList.tsx
@@ -56,15 +56,13 @@ const TenantsList = () => {
       <GridContainer className={styles.relative}>
         <Stack space={[2, 2, 3, 3]}>
           <GridRow>
-            <GridColumn>
-              <FilterInput
-                placeholder={formatMessage(m.searchPlaceholder)}
-                name="session-nationalId-input"
-                value={inputSearchValue}
-                onChange={handleSearch}
-                backgroundColor="blue"
-              />
-            </GridColumn>
+            <FilterInput
+              placeholder={formatMessage(m.searchPlaceholder)}
+              name="session-nationalId-input"
+              value={inputSearchValue}
+              onChange={handleSearch}
+              backgroundColor="blue"
+            />
           </GridRow>
           <Stack space={[1, 1, 2, 2]}>
             {tenantList.map((item) => (

--- a/libs/portals/admin/ids-admin/src/components/TenantsList/TenantsList.tsx
+++ b/libs/portals/admin/ids-admin/src/components/TenantsList/TenantsList.tsx
@@ -7,6 +7,7 @@ import {
   GridRow,
   Stack,
   Tag,
+  GridColumn,
   Text,
 } from '@island.is/island-ui/core'
 import * as styles from './TenantsList.css'
@@ -47,7 +48,7 @@ const TenantsList = () => {
   }
 
   return (
-    <>
+    <GridColumn span={['12/12', '12/12', '10/12']} offset={['0', '0', '1/12']}>
       <IntroHeader
         title={formatMessage(m.idsAdmin)}
         intro={formatMessage(m.idsAdminDescription)}
@@ -55,13 +56,15 @@ const TenantsList = () => {
       <GridContainer className={styles.relative}>
         <Stack space={[2, 2, 3, 3]}>
           <GridRow>
-            <FilterInput
-              placeholder={formatMessage(m.searchPlaceholder)}
-              name="session-nationalId-input"
-              value={inputSearchValue}
-              onChange={handleSearch}
-              backgroundColor="blue"
-            />
+            <GridColumn>
+              <FilterInput
+                placeholder={formatMessage(m.searchPlaceholder)}
+                name="session-nationalId-input"
+                value={inputSearchValue}
+                onChange={handleSearch}
+                backgroundColor="blue"
+              />
+            </GridColumn>
           </GridRow>
           <Stack space={[1, 1, 2, 2]}>
             {tenantList.map((item) => (
@@ -117,7 +120,7 @@ const TenantsList = () => {
           </Stack>
         </Stack>
       </GridContainer>
-    </>
+    </GridColumn>
   )
 }
 


### PR DESCRIPTION

## What

The tenant list is now a bit narrower. It has the same width as the dashboard.

## Why

More consistent with other islands.is pages.

## Screenshots / Gifs

<img width="1600" alt="Desktop" src="https://user-images.githubusercontent.com/7573694/230094350-4fddcfc3-98fb-45c4-b794-b1579a41b3fb.png">

<img width="387" alt="Mobile" src="https://user-images.githubusercontent.com/7573694/230095032-138107f3-718f-441a-93d3-540b73db619d.png">



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
