### PR TITLE
feat(web): Add price content type

### DIFF
--- a/libs/cms/src/lib/environments/environment.ts
+++ b/libs/cms/src/lib/environments/environment.ts
@@ -73,6 +73,7 @@ export default {
     'article',
     'overviewLinks',
     'introLinkImage',
+    'price',
   ],
   // Content types that have the 'activeTranslations' JSON field
   localizedContentTypes: ['article'],

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -2563,6 +2563,37 @@ export interface IPowerBiSlice extends Entry<IPowerBiSliceFields> {
   }
 }
 
+export interface IPriceFields {
+  /** Title */
+  title: string
+
+  /** Reference Identifier */
+  referenceIdentifier: string
+
+  /** Amount */
+  amount: number
+
+  /** Organization */
+  organization: IOrganization
+}
+
+export interface IPrice extends Entry<IPriceFields> {
+  sys: {
+    id: string
+    type: string
+    createdAt: string
+    updatedAt: string
+    locale: string
+    contentType: {
+      sys: {
+        id: 'price'
+        linkType: 'ContentType'
+        type: 'Link'
+      }
+    }
+  }
+}
+
 export interface IProcessEntryFields {
   /** Type */
   type:
@@ -4047,6 +4078,7 @@ export type CONTENT_TYPE =
   | 'overviewLinks'
   | 'pageHeader'
   | 'powerBiSlice'
+  | 'price'
   | 'processEntry'
   | 'projectPage'
   | 'projectSubpage'

--- a/libs/cms/src/lib/models/price.model.ts
+++ b/libs/cms/src/lib/models/price.model.ts
@@ -1,0 +1,18 @@
+import { Field, ID, ObjectType } from '@nestjs/graphql'
+import { IPrice } from '../generated/contentfulTypes'
+
+@ObjectType()
+export class Price {
+  @Field(() => ID)
+  id!: string
+
+  @Field()
+  amount!: number
+}
+
+export const mapPrice = ({ sys, fields }: IPrice): Price => {
+  return {
+    id: sys.id,
+    amount: fields.amount,
+  }
+}

--- a/libs/island-ui/contentful/src/lib/RichTextRC/defaultRenderNode.tsx
+++ b/libs/island-ui/contentful/src/lib/RichTextRC/defaultRenderNode.tsx
@@ -169,6 +169,27 @@ export const defaultRenderNodeObject: RenderNode = {
       </Box>
     )
   },
+  [INLINES.EMBEDDED_ENTRY]: (node) => {
+    const amount = node?.data?.target?.fields?.amount
+    if (typeof amount !== 'number') return null
+
+    let postfix = 'krónur'
+
+    const amountString = String(amount)
+
+    if (amountString.endsWith('1') && !amountString.endsWith('11')) {
+      postfix = 'króna'
+    }
+
+    // Format the amount so it displays dots (Example of a displayed value: 2.700 krónur)
+    const formatter = new Intl.NumberFormat('de-DE')
+
+    return (
+      <span>
+        {formatter.format(amount)} {postfix}{' '}
+      </span>
+    )
+  },
   [INLINES.HYPERLINK]: (node, children) => (
     <Hyperlink href={node.data.uri}>{children}</Hyperlink>
   ),


### PR DESCRIPTION
# Add price content type

## What

* We need a way to have prices at a single place in the CMS since as of right now multiple articles may talk about the price for the same thing but if for example that price would change then we'd have to remember every single article that references that price and update it. This change introduces a new content type which can be inline embedded inside of rich text. This way users in the CMS will be encouraged to create a price entry and inline embed it instead if the previously mentioned method.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
