### PR TITLE
feat(island-ui): Hide spin buttons and add inputmode

### DIFF
--- a/libs/island-ui/core/src/lib/Input/Input.css.ts
+++ b/libs/island-ui/core/src/lib/Input/Input.css.ts
@@ -64,6 +64,15 @@ export const input = recipe({
     ...mixins.input,
     '::placeholder': mixins.inputPlaceholder,
     ':focus': mixins.inputFocus,
+    selectors: {
+      '&::-webkit-outer-spin-button, &::-webkit-inner-spin-button': {
+        margin: 0,
+        WebkitAppearance: 'none',
+      },
+      '&[type=number]': {
+        MozAppearance: 'textfield',
+      },
+    },
   },
 
   variants: {

--- a/libs/island-ui/core/src/lib/Input/Input.stories.tsx
+++ b/libs/island-ui/core/src/lib/Input/Input.stories.tsx
@@ -287,3 +287,19 @@ WithADisabledButton.args = {
     },
   ],
 }
+
+export const Numbers = Template.bind({})
+Numbers.args = {
+  label: 'Numbers Label',
+  placeholder: 'This is the placeholder for numbers',
+  name: 'numbers',
+  type: 'number',
+}
+
+export const InputMode = Template.bind({})
+InputMode.args = {
+  label: 'Kennital',
+  placeholder: 'Placeholder',
+  name: 'inputmode',
+  inputMode: 'numeric',
+}

--- a/libs/island-ui/core/src/lib/Input/types.ts
+++ b/libs/island-ui/core/src/lib/Input/types.ts
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { HTMLAttributes } from 'react'
 
 import * as styles from './Input.css'
 import { Icon as IconType, Type } from '../IconRC/iconMap'
@@ -52,7 +52,7 @@ export interface InputComponentProps {
     on: boolean
     maxHeight?: number
   }
-  inputMode?: string
+  inputMode?: HTMLAttributes<HTMLInputElement>['inputMode']
 }
 
 export type InputButton = {

--- a/libs/island-ui/core/src/lib/Input/types.ts
+++ b/libs/island-ui/core/src/lib/Input/types.ts
@@ -52,6 +52,7 @@ export interface InputComponentProps {
     on: boolean
     maxHeight?: number
   }
+  inputMode?: string
 }
 
 export type InputButton = {


### PR DESCRIPTION
## What

This PR does two things to increase the UX of the <Input /> component. 
1. Hides the spin buttons on input[type='number']. They are never used.
2. Add support for the `inputmode` ([MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode)) on inputs. This allows us to control what kind of keyboard is displayed on mobile devices.


## Screenshots / Gifs

Before removing the spin buttons:
![Screen Shot 2023-04-11 at 14 39 39](https://user-images.githubusercontent.com/7573694/231203497-8c6de01f-0c5f-4172-bd95-4c52ce70aa77.png)

After:
![Screen Shot 2023-04-11 at 14 40 31](https://user-images.githubusercontent.com/7573694/231203686-43ee332e-f7a0-418a-b824-989e2cd46005.png)

With `inputMode="numeric"`:
<img width="484" alt="Screenshot 2023-04-11 at 14 47 02" src="https://user-images.githubusercontent.com/7573694/231204048-94be3880-7398-4a94-9149-12400bb86221.png">

Without:

<img width="450" alt="Screenshot 2023-04-11 at 14 47 20" src="https://user-images.githubusercontent.com/7573694/231204106-4aa59503-868a-4020-9666-cbd44d439834.png">



## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
