### PR TITLE
fix(accident-notification): Parse phone number before submitting document

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/accident-notification/accident-notification.utils.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/accident-notification/accident-notification.utils.ts
@@ -25,6 +25,7 @@ import {
 } from './types/applicationSubmit'
 import { AccidentNotificationAttachment } from './types/attachments'
 import { objectToXML } from '../../shared/shared.utils'
+import { parse } from 'libphonenumber-js'
 
 export const pathToAsset = (file: string) => {
   if (isRunningOnEnvironment('local')) {
@@ -61,6 +62,9 @@ export const applictionAnswersToXml = (
     },
   }
 
+  const phone = getValueViaPath(answers, 'applicant.phoneNumber') as string
+  const parsedPhone = parse(phone ?? '')
+
   const applicationJson: ApplicationSubmit = {
     slysatilkynning: {
       tilkynnandi: {
@@ -76,7 +80,7 @@ export const applictionAnswersToXml = (
             'whoIsTheNotificationFor.answer',
           ) as WhoIsTheNotificationForEnum,
         ),
-        simi: getValueViaPath(answers, 'applicant.phoneNumber') as string,
+        simi: parsedPhone.phone?.toString() || phone,
       },
       slasadi: injuredPerson(answers),
       slys: accident(answers),

--- a/libs/application/templates/accident-notification/src/fields/FormOverview/index.tsx
+++ b/libs/application/templates/accident-notification/src/fields/FormOverview/index.tsx
@@ -1,6 +1,9 @@
 import { formatText } from '@island.is/application/core'
 import { FieldBaseProps, FormValue } from '@island.is/application/types'
-import { ReviewGroup } from '@island.is/application/ui-components'
+import {
+  formatPhoneNumber,
+  ReviewGroup,
+} from '@island.is/application/ui-components'
 import {
   AlertMessage,
   Box,
@@ -36,7 +39,6 @@ import {
   workMachine,
 } from '../../lib/messages'
 import {
-  formatPhonenumber,
   getAttachmentTitles,
   getWorkplaceData,
   hideLocationAndPurpose,
@@ -167,7 +169,7 @@ export const FormOverview: FC<FieldBaseProps & FormOverviewProps> = ({
             <GridColumn span={['9/12', '9/12', '9/12', '5/12']}>
               <ValueLine
                 label={applicantInformation.labels.tel}
-                value={formatPhonenumber(answers.applicant.phoneNumber)}
+                value={formatPhoneNumber(answers.applicant.phoneNumber)}
               />
             </GridColumn>
           )}
@@ -213,7 +215,7 @@ export const FormOverview: FC<FieldBaseProps & FormOverviewProps> = ({
                 <GridColumn span={['9/12', '9/12', '9/12', '5/12']}>
                   <ValueLine
                     label={injuredPersonInformation.labels.tel}
-                    value={formatPhonenumber(
+                    value={formatPhoneNumber(
                       answers.injuredPersonInformation.phoneNumber,
                     )}
                   />
@@ -447,7 +449,7 @@ export const FormOverview: FC<FieldBaseProps & FormOverviewProps> = ({
                     <GridColumn span={['9/12', '9/12', '9/12', '5/12']}>
                       <ValueLine
                         label={workplaceData.representitiveMsg.labels.tel}
-                        value={formatPhonenumber(
+                        value={formatPhoneNumber(
                           workplaceData.representitive.phoneNumber,
                         )}
                       />


### PR DESCRIPTION
# Parse phone number before submitting document

[Attach a link to issue if relevant](https://app.clickup.com/t/861mmcwa5)

## What

Submitting is failing because health-insurance API expects a 7-letter phoneNumber but after recent phone-input update we added area-code to the number

Solution was to strip the area-code from the phone before submitting the document to health-insurance api

Also fix incorrect phone formatting in overview

## Why

So that users can submit their notification

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
