### PR TITLE
feat(island-ui): ToggleSwitch color changes

### DIFF
--- a/libs/island-ui/core/src/lib/ToggleSwitch/ToggleSwitch.css.ts
+++ b/libs/island-ui/core/src/lib/ToggleSwitch/ToggleSwitch.css.ts
@@ -1,5 +1,6 @@
 import { style } from '@vanilla-extract/css'
 import { theme } from '@island.is/island-ui/theme'
+
 const { spacing, color, typography } = theme
 
 export const toggleSwitchLarge = style({})
@@ -63,11 +64,11 @@ export const knob = style({
   width: '5.5em',
   height: '3em',
   borderRadius: '1.5em',
-  color: color.blue400,
+  color: color.dark300,
 
   transition: 'all .1s linear',
-  border: `1px solid ${color.blue200}`,
-  backgroundColor: color.white,
+  border: `1px solid currentColor`,
+  backgroundColor: 'currentColor',
 
   order: 1,
   flexShrink: 0,
@@ -79,23 +80,39 @@ export const knob = style({
   alignItems: 'center',
 
   selectors: {
+    // Checked
+    [`${toggleSwitchChecked} > &`]: {
+      color: color.blue400,
+    },
+
+    // Large
     [`${toggleSwitchLarge} > &`]: {
       fontSize: spacing[2],
     },
-    [`${toggleSwitchChecked} > &`]: {
-      backgroundColor: 'currentColor',
+
+    // Hover
+    [`${toggleSwitch}:hover:not(${toggleSwitchDisabled}) > &`]: {
+      color: color.dark400,
     },
-    [`${toggleSwitch}:hover > &`]: {
+    [`${toggleSwitch}${toggleSwitchChecked}:hover:not(${toggleSwitchDisabled}) > &`]: {
       color: color.blueberry400,
-      borderColor: 'currentColor',
     },
+
+    // Focus
     [`${toggleSwitch}:focus > &, input[type="checkbox"]:focus + &`]: {
       outline: `3px solid ${color.mint400}`,
       borderColor: 'transparent',
     },
 
+    // Disabled
     [`${toggleSwitchDisabled} > &`]: {
-      color: color.blue200,
+      backgroundColor: color.white,
+      borderColor: color.dark200,
+    },
+    [`${toggleSwitchDisabled}${toggleSwitchChecked} > &`]: {
+      color: color.blue300,
+      backgroundColor: 'currentColor',
+      borderColor: 'currentColor',
     },
 
     '&::before': {
@@ -104,12 +121,20 @@ export const knob = style({
       height: '2em',
       flexShrink: 0,
       borderRadius: '1em',
-      backgroundColor: 'currentColor',
-      transition: 'margin-left 250ms ease-in-out',
+      backgroundColor: color.white,
+      transition:
+        'margin-left 250ms ease-in-out, background-color 250ms ease-in-out',
     },
     [`${toggleSwitchChecked} > &::before`]: {
       backgroundColor: color.white,
       marginLeft: 'calc(2.5em - 1px)',
+    },
+
+    [`${toggleSwitchDisabled} > &::before`]: {
+      backgroundColor: color.dark300,
+    },
+    [`${toggleSwitchDisabled}${toggleSwitchChecked} > &::before`]: {
+      backgroundColor: color.white,
     },
   },
 })

--- a/libs/island-ui/core/src/lib/ToggleSwitch/ToggleSwitch.stories.mdx
+++ b/libs/island-ui/core/src/lib/ToggleSwitch/ToggleSwitch.stories.mdx
@@ -5,6 +5,7 @@ import {
   ToggleSwitchButton,
   ToggleSwitchLink,
 } from './index'
+import { useState } from 'react'
 
 <Meta title="Form/ToggleSwitch" />
 
@@ -17,33 +18,43 @@ All three variant share some basic props, but each has a few props unique to it.
 
 <Canvas>
   <Story name="Default">
-    <ToggleSwitchCheckbox
-      label="Basic Toggle Switch"
-      checked={false}
-      onChange={(newChecked) => alert('Checked is now: ' + newChecked)}
-    />
-    <ToggleSwitchCheckbox
-      label="Large version (ckecked)"
-      large={true}
-      checked={true}
-      onChange={(newChecked) => alert('Checked is now: ' + newChecked)}
-    />
-    <ToggleSwitchCheckbox
-      label={
+    {() => {
+      const [checked, setChecked] = useState(false)
+      return (
         <>
-          Full-width version <strong>(disabled)</strong>
+          <ToggleSwitchCheckbox
+            label="Basic Toggle Switch"
+            checked={checked}
+            onChange={setChecked}
+          />
+          <ToggleSwitchCheckbox
+            label="Large version"
+            large
+            checked={checked}
+            onChange={setChecked}
+          />
+          <ToggleSwitchCheckbox
+            label="Full-width version"
+            wide
+            checked={checked}
+            onChange={setChecked}
+          />
+          <ToggleSwitchCheckbox
+            label="Disabled version"
+            disabled
+            checked={checked}
+            onChange={setChecked}
+          />
+          <p>In rare instances you may need to hide the label:</p>
+          <ToggleSwitchCheckbox
+            label="The label is still required!"
+            hiddenLabel={true}
+            checked={checked}
+            onChange={setChecked}
+          />
         </>
-      }
-      wide={true}
-      disabled={true}
-      onChange={(newChecked) => alert('Checked is now: ' + newChecked)}
-    />
-    <div>In rare instances you may need to hide the label:</div>
-    <ToggleSwitchCheckbox
-      label="The label is still required!"
-      hiddenLabel={true}
-      onChange={(newChecked) => alert('Checked is now: ' + newChecked)}
-    />
+      )
+    }}
   </Story>
 </Canvas>
 
@@ -84,6 +95,7 @@ if `expander` props is set. It accepts an optional `aria-controls` value.
     <ToggleSwitchButton
       label="Basic aria-expanded Switch"
       expander={true}
+      checked={false}
       onChange={(newChecked) => alert('Checked is now: ' + newChecked)}
       aria-controls="remote-content-area"
     />


### PR DESCRIPTION
## What

This implements the new design for the toggle switch. Now the unchecked state is grey to distinguish the states better.

Figma: https://www.figma.com/file/pDczqgdlWxgn3YugWZfe1v/UI-Library-%E2%80%93-%F0%9F%96%A5%EF%B8%8F-Desktop?node-id=1444-25&t=YrgEtvksjtSq7rTc-4


## Screenshots / Gifs

<img width="300" alt="Screenshot 2023-04-13 at 10 51 02" src="https://user-images.githubusercontent.com/7573694/231737005-075b0e13-fb23-4c92-a97d-0338a6e6084d.png">
<img width="300" alt="Screenshot 2023-04-13 at 10 50 21" src="https://user-images.githubusercontent.com/7573694/231737013-79308c49-4642-4d23-9cae-f35c5fdf1f15.png">


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
