### PR TITLE
feat(island-ui): Color variants on AccordionCard

### DIFF
--- a/libs/island-ui/core/src/lib/Accordion/Accordion.stories.mdx
+++ b/libs/island-ui/core/src/lib/Accordion/Accordion.stories.mdx
@@ -205,7 +205,8 @@ We use the standalone `<AccordionCard />` component
           labelColor="red600"
         >
           <Text color="red600">
-            Danger Zone is a 1986 song by Kenny Loggins written exclusively for the movie Top Gun starring Tom Cruise.
+            Danger Zone is a 1986 song by Kenny Loggins written exclusively for
+            the movie Top Gun starring Tom Cruise.
           </Text>
         </AccordionCard>
       </Box>

--- a/libs/island-ui/core/src/lib/Accordion/Accordion.stories.mdx
+++ b/libs/island-ui/core/src/lib/Accordion/Accordion.stories.mdx
@@ -190,6 +190,29 @@ We use the standalone `<AccordionCard />` component
   </Story>
 </Canvas>
 
+### With single red card
+
+We use the standalone `<AccordionCard />` component
+
+<Canvas>
+  <Story name="Single red card">
+    <ContentBlock>
+      <Box paddingY={[1, 2]}>
+        <AccordionCard
+          colorVariant="red"
+          id="id_1"
+          label="Danger zone"
+          labelColor="red600"
+        >
+          <Text color="red600">
+            Danger Zone is a 1986 song by Kenny Loggins written exclusively for the movie Top Gun starring Tom Cruise.
+          </Text>
+        </AccordionCard>
+      </Box>
+    </ContentBlock>
+  </Story>
+</Canvas>
+
 ### As a sidebar
 
 We use the standalone `<SidebarAccordion />` component

--- a/libs/island-ui/core/src/lib/Accordion/AccordionItem/AccordionItem.css.ts
+++ b/libs/island-ui/core/src/lib/Accordion/AccordionItem/AccordionItem.css.ts
@@ -1,5 +1,6 @@
 import { style, styleVariants } from '@vanilla-extract/css'
 import { theme } from '@island.is/island-ui/theme'
+import { recipe } from '@vanilla-extract/recipes'
 
 export const button = style({})
 
@@ -23,53 +24,72 @@ export const focusRing = [
   }),
 ]
 
-export const card = style({
-  display: 'flex',
-  height: '100%',
-  flexDirection: 'column',
-  borderWidth: 1,
-  boxSizing: 'border-box',
-  borderStyle: 'solid',
-  borderColor: theme.color.blue200,
-  transition: 'border-color 150ms ease',
-  borderRadius: theme.border.radius.large,
-  textDecoration: 'none',
-  position: 'relative',
-  ':hover': {
+export const card = recipe({
+  base: {
+    display: 'flex',
+    height: '100%',
+    flexDirection: 'column',
     borderWidth: 1,
-    borderColor: theme.color.blue400,
-    textDecoration: 'none',
-  },
-  ':focus': {
-    outline: 0,
-  },
-  '::before': {
-    content: "''",
-    display: 'inline-block',
-    position: 'absolute',
-    pointerEvents: 'none',
+    boxSizing: 'border-box',
     borderStyle: 'solid',
-    borderWidth: 3,
-    borderColor: theme.color.transparent,
-    borderRadius: 10,
-    top: -3,
-    left: -3,
-    bottom: -3,
-    right: -3,
-    opacity: 0,
-    transition: 'border-color 150ms ease, opacity 150ms ease',
-  },
-  selectors: {
-    [`&:focus::before`]: {
-      borderWidth: 3,
-      borderStyle: 'solid',
-      borderColor: theme.color.mint400,
-      opacity: 1,
+    transition: 'border-color 150ms ease',
+    borderRadius: theme.border.radius.large,
+    textDecoration: 'none',
+    position: 'relative',
+    ':hover': {
+      borderWidth: 1,
+      textDecoration: 'none',
+    },
+    ':focus': {
       outline: 0,
     },
-    [`&:focus:hover`]: {
-      borderColor: theme.color.white,
+    '::before': {
+      content: "''",
+      display: 'inline-block',
+      position: 'absolute',
+      pointerEvents: 'none',
+      borderStyle: 'solid',
+      borderWidth: 3,
+      borderColor: theme.color.transparent,
+      borderRadius: 10,
+      top: -3,
+      left: -3,
+      bottom: -3,
+      right: -3,
+      opacity: 0,
+      transition: 'border-color 150ms ease, opacity 150ms ease',
     },
+    selectors: {
+      [`&:focus::before`]: {
+        borderWidth: 3,
+        borderStyle: 'solid',
+        borderColor: theme.color.mint400,
+        opacity: 1,
+        outline: 0,
+      },
+      [`&:focus:hover`]: {
+        borderColor: theme.color.white,
+      },
+    },
+  },
+  variants: {
+    color: {
+      blue: {
+        borderColor: theme.color.blue200,
+        ':hover': {
+          borderColor: theme.color.blue400,
+        },
+      },
+      red: {
+        borderColor: theme.color.red200,
+        ':hover': {
+          borderColor: theme.color.red600,
+        },
+      },
+    },
+  },
+  defaultVariants: {
+    color: 'blue',
   },
 })
 
@@ -86,39 +106,54 @@ export const focused = style({
   },
 })
 
-export const plusIconWrap = style({
-  backgroundColor: theme.color.blue100,
-  borderRadius: '50%',
-  display: 'flex',
-  justifyContent: 'center',
-  alignItems: 'center',
-  position: 'relative',
-})
-
 const iconWrapSizes = {
   default: 40,
   small: 24,
   sidebar: 20,
 }
 
-export const iconWrapVariants = styleVariants({
-  default: {
-    backgroundColor: theme.color.blue100,
-    color: theme.color.blue400,
-    width: iconWrapSizes.default,
-    height: iconWrapSizes.default,
+export const plusIconWrap = recipe({
+  base: {
+    borderRadius: '50%',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    position: 'relative',
   },
-  small: {
-    backgroundColor: theme.color.blue100,
-    color: theme.color.blue400,
-    width: iconWrapSizes.small,
-    height: iconWrapSizes.small,
+
+  variants: {
+    color: {
+      blue: {
+        backgroundColor: theme.color.blue100,
+        color: theme.color.blue400,
+      },
+      red: {
+        backgroundColor: theme.color.red100,
+        color: theme.color.red600,
+      },
+      purple: {
+        backgroundColor: theme.color.purple200,
+        color: theme.color.purple400,
+      },
+    },
+    iconVariant: {
+      default: {
+        width: iconWrapSizes.default,
+        height: iconWrapSizes.default,
+      },
+      small: {
+        width: iconWrapSizes.small,
+        height: iconWrapSizes.small,
+      },
+      sidebar: {
+        width: iconWrapSizes.sidebar,
+        height: iconWrapSizes.sidebar,
+      },
+    },
   },
-  sidebar: {
-    backgroundColor: theme.color.purple200,
-    color: theme.color.purple400,
-    width: iconWrapSizes.sidebar,
-    height: iconWrapSizes.sidebar,
+  defaultVariants: {
+    color: 'blue',
+    iconVariant: 'default',
   },
 })
 

--- a/libs/island-ui/core/src/lib/Accordion/AccordionItem/AccordionItem.tsx
+++ b/libs/island-ui/core/src/lib/Accordion/AccordionItem/AccordionItem.tsx
@@ -16,12 +16,13 @@ import { hideFocusRingsClassName } from '../../private/hideFocusRings/hideFocusR
 import { Overlay } from '../../private/Overlay/Overlay'
 import { Text } from '../../Text/Text'
 import { TextVariants } from '../../Text/Text.css'
-import { AccordionContext } from '../../Accordion/Accordion'
+import { AccordionContext } from '../Accordion'
 import { Icon } from '../../IconRC/Icon'
 import * as styles from './AccordionItem.css'
 import { Colors } from '@island.is/island-ui/theme'
 
 type IconVariantTypes = 'default' | 'small' | 'sidebar'
+type ColorVariants = 'blue' | 'red'
 
 export type AccordionItemLabelTags = 'p' | 'h2' | 'h3' | 'h4' | 'h5'
 
@@ -36,6 +37,7 @@ type BaseProps = {
   children: ReactNode
   onBlur?: () => void
   onFocus?: () => void
+  colorVariant?: ColorVariants
 }
 
 type StateProps =
@@ -73,6 +75,7 @@ export const AccordionItem = forwardRef<HTMLButtonElement, AccordionItemProps>(
       onClick,
       onBlur,
       onFocus,
+      colorVariant,
     },
     forwardedRef,
   ) => {
@@ -120,6 +123,12 @@ export const AccordionItem = forwardRef<HTMLButtonElement, AccordionItemProps>(
       [], // Only run when component mounts!
     )
 
+    const plusColor = colorVariant
+      ? colorVariant
+      : iconVariant === 'sidebar'
+      ? 'purple'
+      : 'blue'
+
     return (
       <Box>
         <Box position="relative" display="flex">
@@ -164,10 +173,10 @@ export const AccordionItem = forwardRef<HTMLButtonElement, AccordionItemProps>(
                 </Column>
                 <Column width="content">
                   <span
-                    className={cn(
-                      styles.plusIconWrap,
-                      styles.iconWrapVariants[iconVariant],
-                    )}
+                    className={styles.plusIconWrap({
+                      iconVariant,
+                      color: plusColor,
+                    })}
                   >
                     <span
                       className={cn(styles.icon, styles.removeIcon, {
@@ -223,7 +232,9 @@ export const AccordionCard = (props: AccordionCardProps) => {
       height="full"
       background="white"
       borderRadius="large"
-      className={cn(styles.card, { [styles.focused]: isFocused })}
+      className={cn(styles.card({ color: props.colorVariant }), {
+        [styles.focused]: isFocused,
+      })}
       padding={[2, 2, 4]}
     >
       <AccordionItem {...props} onFocus={handleFocus} onBlur={handleBlur}>


### PR DESCRIPTION
## What

The PR adds an optional color variant prop to the <AccordionCard />. 

Figma design:
https://www.figma.com/file/pDczqgdlWxgn3YugWZfe1v/UI-Library-%E2%80%93-%F0%9F%96%A5%EF%B8%8F-Desktop?node-id=96-654&t=qjjZIxsQvSAPq3tp-4

## Screenshots / Gifs
<img width="998" alt="Screenshot 2023-04-19 at 09 39 48" src="https://user-images.githubusercontent.com/7573694/233037533-37a9f139-c64c-4e27-9ee0-14ef4d22b73d.png">
<img width="996" alt="Screenshot 2023-04-19 at 09 40 04" src="https://user-images.githubusercontent.com/7573694/233037556-89e5f0e1-5f04-418b-b153-d8f1dbf69a10.png">


## Checklist:

- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
