### PR TITLE
fix(applications): GFL, Strandveiðileyfi has two chargecodes

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/general-fishing-license/general-fishing-license.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/general-fishing-license/general-fishing-license.service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from '@nestjs/common'
 import { TemplateApiModuleActionProps } from '../../../types'
 import { SharedTemplateApiService } from '../../shared'
 import { GeneralFishingLicenseAnswers } from '@island.is/application/templates/general-fishing-license'
-import { coreErrorMessages, getValueViaPath } from '@island.is/application/core'
+import { getValueViaPath } from '@island.is/application/core'
 import {
   FishingLicenseService,
   mapFishingLicenseToCode,
@@ -41,11 +41,14 @@ export class GeneralFishingLicenseService extends BaseTemplateApiService {
       throw new Error('Vörunúmer fyrir FJS vantar.')
     }
 
+    // If strandveiðileyfi, then we set the const to "Sérstakt gjald vegna strandleyfa", otherwise null.
+    const strandveidileyfi = chargeItemCode === 'L5108' ? 'L5112' : false
+
     const response = await this.sharedTemplateAPIService.createCharge(
       auth,
       application.id,
       FISKISTOFA_NATIONAL_ID,
-      [chargeItemCode],
+      strandveidileyfi ? [chargeItemCode, strandveidileyfi] : [chargeItemCode],
     )
 
     if (!response?.paymentUrl) {

--- a/libs/application/templates/general-fishing-license/src/fields/Overview/index.tsx
+++ b/libs/application/templates/general-fishing-license/src/fields/Overview/index.tsx
@@ -20,7 +20,6 @@ import {
 } from '../../lib/messages'
 import { formatIsk, formatPhonenumber } from '../../utils'
 import { FishingLicenseShip } from '@island.is/api/schema'
-import { useLocale } from '@island.is/localization'
 import {
   licenseHasAreaSelection,
   licenseHasRailNetAndRoeNetField,
@@ -31,7 +30,6 @@ import { Colors } from '@island.is/island-ui/theme'
 export const Overview: FC<FieldBaseProps> = ({ application, goToScreen }) => {
   const answers = application.answers as GeneralFishingLicense
   const [fishingLicensePrice, setFishingLicensePrice] = useState<number>(0)
-  const { formatMessage } = useLocale()
 
   // Ships
   const ships = getValueViaPath(
@@ -64,8 +62,17 @@ export const Overview: FC<FieldBaseProps> = ({ application, goToScreen }) => {
 
   useEffect(() => {
     catalogItems?.map((item) => {
-      if (item.chargeItemCode === chargeItemCode)
-        setFishingLicensePrice(item.priceAmount)
+      if (item.chargeItemCode === chargeItemCode) {
+        let price = item.priceAmount
+        // chargeItemCode for "Leyfi til strandveiða"
+        if (chargeItemCode === 'L5108') {
+          price +=
+            // chargeItemCode for "Sérstakt gjald vegna strandleyfa"
+            catalogItems.find((item) => item.chargeItemCode === 'L5112')
+              ?.priceAmount || 0
+        }
+        setFishingLicensePrice(price)
+      }
       return item
     })
   }, [chargeItemCode])


### PR DESCRIPTION
# Two charge codes

## What
Strandveiðileyfi has two charge codes, it is the only one that has more than one, so special case was created around that functionality. If we need this to be more robust for the future, if more licenses requires more than one type, then we need to get them grouped in some way from the fishing license api in order to avoid hard coding values on our end.


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
