### PR TITLE
fix(service-portal): Udpate education graduation overview card

### DIFF
--- a/libs/service-portal/core/src/components/ActionCard/ActionCard.tsx
+++ b/libs/service-portal/core/src/components/ActionCard/ActionCard.tsx
@@ -20,6 +20,7 @@ type ActionCardProps = {
   date?: string
   heading?: string
   text?: string
+  subText?: string
   secondaryText?: string
   eyebrow?: string
   loading?: boolean
@@ -72,6 +73,7 @@ export const ActionCard: React.FC<ActionCardProps> = ({
   date,
   heading,
   text,
+  subText,
   secondaryText,
   eyebrow,
   loading,
@@ -328,6 +330,7 @@ export const ActionCard: React.FC<ActionCardProps> = ({
             </Box>
           )}
           {text && <Text paddingTop={heading ? 1 : 0}>{text}</Text>}
+          {subText && <Text>{subText}</Text>}
         </Box>
         <Box
           display="flex"

--- a/libs/service-portal/education/src/screens/EducationGraduation/EducationGraduation.tsx
+++ b/libs/service-portal/education/src/screens/EducationGraduation/EducationGraduation.tsx
@@ -100,9 +100,8 @@ export const EducationGraduation = () => {
               <ActionCard
                 key={`education-graduation-${index}`}
                 heading={item.institution?.displayName}
-                text={
-                  item.faculty + ' - ' + item.studyProgram + ' ' + item.degree
-                }
+                text={item.faculty}
+                subText={`${item.studyProgram} ${item.degree}`}
                 cta={{
                   label: defineMessage({
                     id: 'sp.education-graduation:details',
@@ -123,6 +122,7 @@ export const EducationGraduation = () => {
                         url: getOrganizationLogoUrl(
                           item.institution.displayName,
                           organizations,
+                          120,
                         ),
                       }
                     : undefined

--- a/libs/shared/utils/src/lib/getOrganizationLogoUrl.ts
+++ b/libs/shared/utils/src/lib/getOrganizationLogoUrl.ts
@@ -3,10 +3,11 @@ import { Organization } from '@island.is/shared/types'
 export const getOrganizationLogoUrl = (
   forName: string,
   orgs: Array<Organization>,
+  size = 60,
 ): string => {
   const fallBackImage =
     'https://images.ctfassets.net/8k0h54kbe6bj/6XhCz5Ss17OVLxpXNVDxAO/d3d6716bdb9ecdc5041e6baf68b92ba6/coat_of_arms.svg'
-  const parameters = '?w=60&h=60&fit=pad&bg=white&fm=png'
+  const parameters = `?w=${size}&h=${size}&fit=pad&bg=white&fm=png`
   if (orgs.length > 0) {
     const qs = String(forName).trim().toLocaleLowerCase()
     const match =


### PR DESCRIPTION
## What

Update education graduation overview card style
Increase image size
Split title by study and degree

## Why

Image was blurry.
Title was to long.

## Screenshots / Gifs

Before:
![Screenshot 2023-04-19 at 14 21 23](https://user-images.githubusercontent.com/24840451/233107441-8ecdef6e-30f5-4d6f-9126-48ff66fc6612.png)

After:
![Screenshot 2023-04-19 at 14 27 13](https://user-images.githubusercontent.com/24840451/233107513-c3ec9f24-53eb-4348-b72c-0c2abce83972.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
