### PR TITLE
fix(sessions): Add uuid id column and move session id to new column. Configure redis keyPrefix as false to prevent job stalling.

### DIFF
--- a/apps/services/sessions/migrations/20230420082120-add-uuid-ossp-extension.js
+++ b/apps/services/sessions/migrations/20230420082120-add-uuid-ossp-extension.js
@@ -1,0 +1,15 @@
+'use strict'
+
+module.exports = {
+  async up(queryInterface) {
+    return queryInterface.sequelize.query(`
+      CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+  `)
+  },
+
+  async down(queryInterface) {
+    return queryInterface.sequelize.query(`
+      DROP EXTENSION IF EXISTS "uuid-ossp";
+  `)
+  },
+}

--- a/apps/services/sessions/migrations/20230420082220-add-autogen-uuid.js
+++ b/apps/services/sessions/migrations/20230420082220-add-autogen-uuid.js
@@ -1,0 +1,44 @@
+'use strict'
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.removeConstraint('session', 'session_pkey', {
+        transaction,
+      })
+
+      await queryInterface.renameColumn('session', 'id', 'session_id', {
+        transaction,
+      })
+
+      await queryInterface.addColumn(
+        'session',
+        'id',
+        {
+          type: Sequelize.UUID,
+          defaultValue: Sequelize.fn('uuid_generate_v4'),
+          allowNull: false,
+          primaryKey: true,
+        },
+        { transaction },
+      )
+    })
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.removeColumn('session', 'id', { transaction })
+
+      await queryInterface.renameColumn('session', 'session_id', 'id', {
+        transaction,
+      })
+
+      await queryInterface.addConstraint('session', {
+        fields: ['id'],
+        type: 'primary key',
+        name: 'sessions_pkey',
+        transaction,
+      })
+    })
+  },
+}

--- a/apps/services/sessions/src/app/sessions/create-session.dto.ts
+++ b/apps/services/sessions/src/app/sessions/create-session.dto.ts
@@ -1,10 +1,22 @@
-import { ApiProperty } from '@nestjs/swagger'
-import { IsDateString, IsString } from 'class-validator'
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
+import { IsDateString, IsOptional, IsString } from 'class-validator'
 
 export class CreateSessionDto {
   @IsString()
-  @ApiProperty()
-  id!: string
+  @IsOptional()
+  @ApiPropertyOptional({
+    description: 'The IDS session ID. Deprecated, use sessionId instead.',
+    deprecated: true,
+  })
+  // Todo: Remove when we have migrated IDS to use sessionId
+  id?: string
+
+  @IsString()
+  @IsOptional()
+  @ApiPropertyOptional({
+    description: 'The IDS session ID',
+  })
+  sessionId!: string
 
   @IsString()
   @ApiProperty()

--- a/apps/services/sessions/src/app/sessions/session.model.ts
+++ b/apps/services/sessions/src/app/sessions/session.model.ts
@@ -24,10 +24,18 @@ export class Session extends Model<
   @ApiProperty()
   @PrimaryKey
   @Column({
+    type: DataType.UUIDV4,
+    allowNull: false,
+    defaultValue: DataType.UUIDV4,
+  })
+  id!: CreationOptional<string>
+
+  @ApiProperty()
+  @Column({
     type: DataType.STRING,
     allowNull: false,
   })
-  id!: string
+  sessionId!: string
 
   @ApiProperty()
   @Column({

--- a/apps/services/sessions/src/app/sessions/sessions.controller.spec.ts
+++ b/apps/services/sessions/src/app/sessions/sessions.controller.spec.ts
@@ -1,9 +1,11 @@
 import { getQueueToken } from '@nestjs/bull'
+import assert from 'assert'
 import faker from 'faker'
 import sortBy from 'lodash/sortBy'
 import request from 'supertest'
 
 import { ApiScope, SessionsScope } from '@island.is/auth/scopes'
+import type { User } from '@island.is/auth-nest-tools'
 import { AuthDelegationType } from '@island.is/shared/types'
 import { createCurrentUser } from '@island.is/testing/fixtures'
 import {
@@ -21,6 +23,16 @@ import {
 } from '../../../test/setup'
 import { sessionsQueueName } from '../sessions.config'
 import { Session } from './session.model'
+
+const filterRelatedSession = (user: User, otherUser?: string) => {
+  const nationalId = user.nationalId
+
+  return (session: Session) =>
+    (session.actorNationalId === nationalId &&
+      (!otherUser || session.subjectNationalId === otherUser)) ||
+    (session.subjectNationalId === nationalId &&
+      (!otherUser || session.actorNationalId === otherUser))
+}
 
 describe('SessionsController', () => {
   describe('with the authenticated user', () => {
@@ -46,7 +58,7 @@ describe('SessionsController', () => {
         const sessionsQueue = app.get(getQueueToken(sessionsQueueName))
         sessionsQueueAddSpy = jest
           .spyOn(sessionsQueue, 'add')
-          .mockImplementation(() => Promise.resolve())
+          .mockImplementation(() => Promise.resolve({ id: 1 }))
 
         server = request(app.getHttpServer())
       })
@@ -65,23 +77,13 @@ describe('SessionsController', () => {
 
         // Assert
         expect(res.status).toEqual(200)
-        expect(
-          res.body.data.every(
-            (session: Session) =>
-              session.actorNationalId === user.nationalId ||
-              session.subjectNationalId == user.nationalId,
-          ),
-        )
+        expect(res.body.data.every(filterRelatedSession(user)))
         expect(res.body.data).toMatchObject(
           sortBy(sessions, 'timestamp')
             .reverse()
-            .filter(
-              (session) =>
-                session.actorNationalId === user.nationalId ||
-                session.subjectNationalId == user.nationalId,
-            )
+            .filter(filterRelatedSession(user))
             .map((session) => ({
-              id: session.id,
+              sessionId: session.sessionId,
               actorNationalId: session.actorNationalId,
               subjectNationalId: session.subjectNationalId,
               clientId: session.clientId,
@@ -92,11 +94,7 @@ describe('SessionsController', () => {
             .slice(0, 10),
         )
         expect(res.body.totalCount).toEqual(
-          sessions.filter(
-            (session) =>
-              session.actorNationalId === user.nationalId ||
-              session.subjectNationalId == user.nationalId,
-          ).length,
+          sessions.filter(filterRelatedSession(user)).length,
         )
       })
 
@@ -110,21 +108,11 @@ describe('SessionsController', () => {
         // Assert
         expect(res1.status).toEqual(200)
         expect(res2.status).toEqual(200)
-        expect(
-          res2.body.data.every(
-            (session: Session) =>
-              session.actorNationalId === user.nationalId ||
-              session.subjectNationalId == user.nationalId,
-          ),
-        )
+        expect(res2.body.data.every(filterRelatedSession(user)))
         expect(res2.body.data).toMatchObject(
           sortBy(sessions, 'timestamp')
             .reverse()
-            .filter(
-              (session) =>
-                session.actorNationalId === user.nationalId ||
-                session.subjectNationalId == user.nationalId,
-            )
+            .filter(filterRelatedSession(user))
             .map((session) => ({ id: session.id }))
             .slice(10, 20),
         )
@@ -152,11 +140,7 @@ describe('SessionsController', () => {
         expect(res3.body.data).toMatchObject(
           sortBy(sessions, 'timestamp')
             .reverse()
-            .filter(
-              (session) =>
-                session.actorNationalId === user.nationalId ||
-                session.subjectNationalId == user.nationalId,
-            )
+            .filter(filterRelatedSession(user))
             .map((session) => ({ id: session.id }))
             .slice(0, 10),
         )
@@ -180,11 +164,7 @@ describe('SessionsController', () => {
         expect(res2.body.data).toMatchObject(
           sortBy(sessions, 'timestamp')
             .reverse()
-            .filter(
-              (session) =>
-                session.actorNationalId === user.nationalId ||
-                session.subjectNationalId == user.nationalId,
-            )
+            .filter(filterRelatedSession(user))
             .map((session) => ({ id: session.id }))
             .slice(10, 15),
         )
@@ -208,11 +188,7 @@ describe('SessionsController', () => {
         expect(res2.body.data).toMatchObject(
           sortBy(sessions, 'timestamp')
             .reverse()
-            .filter(
-              (session) =>
-                session.actorNationalId === user.nationalId ||
-                session.subjectNationalId == user.nationalId,
-            )
+            .filter(filterRelatedSession(user))
             .map((session) => ({ id: session.id }))
             .slice(10, 110),
         )
@@ -224,39 +200,36 @@ describe('SessionsController', () => {
 
         // Assert
         expect(res.status).toEqual(200)
-        expect(
-          res.body.data.every(
-            (session: Session) =>
-              session.actorNationalId === user.nationalId ||
-              session.subjectNationalId == user.nationalId,
-          ),
-        )
+        expect(res.body.data.every(filterRelatedSession(user)))
         expect(res.body.data).toMatchObject(
           sortBy(sessions, 'timestamp')
-            .filter(
-              (session) =>
-                session.actorNationalId === user.nationalId ||
-                session.subjectNationalId == user.nationalId,
-            )
+            // .filter(
+            //   (session) =>
+            //     session.actorNationalId === user.nationalId ||
+            //     session.subjectNationalId === user.nationalId,
+            // )
+            .filter(filterRelatedSession(user))
             .map((session) => ({ id: session.id }))
             .slice(0, 10),
         )
         expect(res.body.totalCount).toEqual(
-          sessions.filter(
-            (session) =>
-              session.actorNationalId === user.nationalId ||
-              session.subjectNationalId == user.nationalId,
-          ).length,
+          // sessions.filter(
+          //   (session) =>
+          //     session.actorNationalId === user.nationalId ||
+          //     session.subjectNationalId == user.nationalId,
+          // ).length,
+          sessions.filter(filterRelatedSession(user)).length,
         )
       })
 
       it('GET /v1/me/sessions should support otheruser parameter', async () => {
         // Arrange
-        const otherUser = sessions.filter(
+        const otherUser = sessions.find(
           (session) =>
             session.actorNationalId === user.nationalId &&
             session.subjectNationalId !== user.nationalId,
-        )[0].subjectNationalId
+        )?.subjectNationalId
+        assert(otherUser)
 
         // Act
         const res = await server
@@ -265,22 +238,10 @@ describe('SessionsController', () => {
 
         // Assert
         expect(res.status).toEqual(200)
-        expect(
-          res.body.data.every(
-            (session: Session) =>
-              session.actorNationalId === user.nationalId ||
-              session.subjectNationalId === user.nationalId,
-          ),
-        )
+        expect(res.body.data.every(filterRelatedSession(user)))
         expect(res.body.data).toMatchObject(
           sortBy(sessions, 'timestamp')
-            .filter(
-              (session) =>
-                (session.actorNationalId === user.nationalId &&
-                  session.subjectNationalId == otherUser) ||
-                (session.actorNationalId == otherUser &&
-                  session.subjectNationalId === user.nationalId),
-            )
+            .filter(filterRelatedSession(user, otherUser))
             .map((session) => ({ id: session.id }))
             .slice(0, 10),
         )
@@ -288,8 +249,8 @@ describe('SessionsController', () => {
           sessions.filter(
             (session) =>
               (session.actorNationalId === user.nationalId &&
-                session.subjectNationalId == otherUser) ||
-              (session.actorNationalId == otherUser &&
+                session.subjectNationalId === otherUser) ||
+              (session.actorNationalId === otherUser &&
                 session.subjectNationalId === user.nationalId),
           ).length,
         )
@@ -300,6 +261,8 @@ describe('SessionsController', () => {
         const res = await server
           .post(`/v1/me/sessions`)
           .send(createSessionDto({ actorNationalId: user.nationalId }))
+
+        console.log(res.body)
 
         // Assert
         expect(res.status).toEqual(202)
@@ -454,7 +417,7 @@ describe('SessionsController', () => {
       )
       expect(res.body.totalCount).toEqual(
         sessions.filter(
-          (session) => session.subjectNationalId == user.nationalId,
+          (session) => session.subjectNationalId === user.nationalId,
         ).length,
       )
     })
@@ -471,10 +434,9 @@ describe('SessionsController', () => {
         // Arrange
         const app = await setupWithoutAuth()
         const server = request(app.getHttpServer())
-        const url = endpoint
 
         // Act
-        const res = await getRequestMethod(server, method)(url)
+        const res = await getRequestMethod(server, method)(endpoint)
 
         // Assert
         expect(res.status).toEqual(401)
@@ -499,10 +461,9 @@ describe('SessionsController', () => {
         // Arrange
         const app = await setupWithoutPermission()
         const server = request(app.getHttpServer())
-        const url = endpoint
 
         // Act
-        const res = await getRequestMethod(server, method)(url)
+        const res = await getRequestMethod(server, method)(endpoint)
 
         // Assert
         expect(res.status).toEqual(403)

--- a/apps/services/sessions/src/app/sessions/sessions.module.ts
+++ b/apps/services/sessions/src/app/sessions/sessions.module.ts
@@ -28,10 +28,10 @@ if (process.env.INIT_SCHEMA === 'true' || process.env.TESTS === 'true') {
       prefix: `{${bullModuleName}}`,
       createClient: () =>
         createRedisCluster({
-          name: `{${bullModuleName}}`,
+          name: bullModuleName,
           nodes: config.redis.nodes,
           ssl: config.redis.ssl,
-          noPrefix: false,
+          noPrefix: true,
         }),
     }),
     inject: [SessionsConfig.KEY],

--- a/apps/services/sessions/src/app/sessions/sessions.service.spec.ts
+++ b/apps/services/sessions/src/app/sessions/sessions.service.spec.ts
@@ -9,7 +9,7 @@ import { Session } from '../sessions/session.model'
 import { SessionsService } from './sessions.service'
 
 const mockSession = {
-  id: '1',
+  sessionId: '1',
   actorNationalId: createNationalId(),
   subjectNationalId: createNationalId(),
   clientId: 'clientId',

--- a/apps/services/sessions/src/app/sessions/sessions.service.ts
+++ b/apps/services/sessions/src/app/sessions/sessions.service.ts
@@ -8,6 +8,7 @@ import uaParser from 'ua-parser-js'
 import { User } from '@island.is/auth-nest-tools'
 import { paginate } from '@island.is/nest/pagination'
 
+import { CreateSessionDto } from './create-session.dto'
 import { Session } from './session.model'
 import { SessionsQueryDto } from './sessions-query.dto'
 import { SessionsResultDto } from './sessions-result.dto'
@@ -84,7 +85,7 @@ export class SessionsService {
     })
   }
 
-  create(session: Session): Promise<Session> {
+  create(session: CreateSessionDto): Promise<Session> {
     return this.sessionModel.create({
       ...session,
       device: this.formatUserAgent(session.userAgent),

--- a/apps/services/sessions/src/app/sessions/sessions.service.ts
+++ b/apps/services/sessions/src/app/sessions/sessions.service.ts
@@ -86,8 +86,18 @@ export class SessionsService {
   }
 
   create(session: CreateSessionDto): Promise<Session> {
+    const { id, sessionId, ...rest } = session
+
+    // Todo: Remove this when we have migrated IDS to use sessionId
+    const sid = sessionId || id
+
+    if (!sid) {
+      throw new Error('Missing sessionId.')
+    }
+
     return this.sessionModel.create({
-      ...session,
+      ...rest,
+      sessionId: sid,
       device: this.formatUserAgent(session.userAgent),
       ipLocation: this.formatIp(session.ip),
     })

--- a/apps/services/sessions/src/app/worker/sessions-processor.ts
+++ b/apps/services/sessions/src/app/worker/sessions-processor.ts
@@ -1,16 +1,63 @@
-import { Process, Processor } from '@nestjs/bull'
+import {
+  OnQueueCompleted,
+  OnQueueError,
+  OnQueueFailed,
+  OnQueueStalled,
+  Process,
+  Processor,
+} from '@nestjs/bull'
+import { Inject } from '@nestjs/common'
 import { Job } from 'bull'
 
+import { AuditService } from '@island.is/nest/audit'
+import type { Logger } from '@island.is/logging'
+import { LOGGER_PROVIDER } from '@island.is/logging'
+
 import { sessionsQueueName, sessionJobName } from '../sessions.config'
-import { Session } from '../sessions/session.model'
 import { SessionsService } from '../sessions/sessions.service'
+import { CreateSessionDto } from '../sessions/create-session.dto'
 
 @Processor(sessionsQueueName)
 export class SessionsProcessor {
-  constructor(private readonly sessionsService: SessionsService) {}
+  constructor(
+    private readonly sessionsService: SessionsService,
+    @Inject(LOGGER_PROVIDER)
+    private readonly logger: Logger,
+    private readonly auditService: AuditService,
+  ) {}
 
   @Process(sessionJobName)
-  handleSessionActivity(job: Job<Session>): Promise<Session> {
+  handleSessionActivity(job: Job<CreateSessionDto>) {
+    this.logger.debug(`Processing job ${job.id}`, { job })
     return this.sessionsService.create(job.data)
+  }
+
+  @OnQueueCompleted()
+  onQueueCompleted(job: Job) {
+    this.logger.debug(`Job ${job.id} completed`, { job })
+  }
+
+  @OnQueueFailed()
+  onQueueFailed(job: Job, error: Error) {
+    this.logger.error(`Job ${job.id} failed with error: ${error.message}`)
+    this.auditService.audit({
+      system: true,
+      namespace: '@island.is/sessions/worker',
+      action: 'queue-job-failed',
+      resources: job.id.toString(),
+      meta: {
+        job,
+      },
+    })
+  }
+
+  @OnQueueError()
+  onQueueError(error: Error) {
+    this.logger.error(`Queue error: ${error.message}`, { error })
+  }
+
+  @OnQueueStalled()
+  onQueueStalled(job: Job) {
+    this.logger.error(`Job ${job.id} stalled`, { job })
   }
 }

--- a/apps/services/sessions/src/app/worker/worker.module.ts
+++ b/apps/services/sessions/src/app/worker/worker.module.ts
@@ -2,15 +2,18 @@ import { Module } from '@nestjs/common'
 import { ConfigModule } from '@nestjs/config'
 import { SequelizeModule } from '@nestjs/sequelize'
 
+import { AuditModule } from '@island.is/nest/audit'
 import { LoggingModule } from '@island.is/logging'
 
 import { SequelizeConfigService } from '../../sequelizeConfig.service'
 import { SessionsConfig } from '../sessions.config'
 import { SessionsModule } from '../sessions/sessions.module'
 import { SessionsProcessor } from './sessions-processor'
+import { environment } from '../../environments'
 
 @Module({
   imports: [
+    AuditModule.forRoot(environment.audit),
     LoggingModule,
     SequelizeModule.forRootAsync({
       useClass: SequelizeConfigService,

--- a/apps/services/sessions/test/fixture.factory.ts
+++ b/apps/services/sessions/test/fixture.factory.ts
@@ -7,6 +7,7 @@ import { Session } from '../src/app/sessions/session.model'
 import { createSessionDto } from './session.fixture'
 
 import addDays from 'date-fns/addDays'
+import { CreateSessionDto } from '../../../../libs/clients/sessions/gen/fetch'
 
 export class FixtureFactory {
   constructor(private app: TestApp) {}

--- a/apps/services/sessions/test/session.fixture.ts
+++ b/apps/services/sessions/test/session.fixture.ts
@@ -14,7 +14,7 @@ export interface CreateSessionDtoOptions {
 export const createSessionDto = (
   options?: CreateSessionDtoOptions,
 ): CreateSessionDto => ({
-  id: faker.datatype.uuid(),
+  sessionId: faker.datatype.uuid(),
   actorNationalId: options?.actorNationalId ?? createNationalId('person'),
   subjectNationalId:
     options?.subjectNationalId ??


### PR DESCRIPTION
[Notion Task](https://www.notion.so/Sessions-duplicate-primary-key-violation-on-insert-85978af2442b40a3a8428710977cb786?pvs=4)

## What

Set `noPrefix` to `false`
Create new `id` column as auto generated uuid and move session IDs to new column.

## Why

We are seeing lot of pkey errors in DataDog. With the `noPrefix: false` property overrides the Bull queue `prefix` causing Bull api to be unable to complete jobs, making them go to stalled queue and retried once.

When we will start logging sessions from SSO between clients the session is not unique.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
