### PR TITLE
feat(ids-admin): Collapsable ContentCard

### DIFF
--- a/libs/portals/admin/ids-admin/src/components/Client/AdvancedSettings.tsx
+++ b/libs/portals/admin/ids-admin/src/components/Client/AdvancedSettings.tsx
@@ -60,6 +60,7 @@ const AdvancedSettings = ({
     <ContentCard
       title={formatMessage(m.advancedSettings)}
       intent={ClientFormTypes.advancedSettings}
+      accordionLabel={formatMessage(m.settings)}
     >
       <Stack space={3}>
         <Checkbox

--- a/libs/portals/admin/ids-admin/src/components/Client/Delegation.tsx
+++ b/libs/portals/admin/ids-admin/src/components/Client/Delegation.tsx
@@ -45,6 +45,7 @@ const Delegation = ({
       title={formatMessage(m.delegations)}
       description={formatMessage(m.delegationsDescription)}
       intent={ClientFormTypes.delegations}
+      accordionLabel={formatMessage(m.settings)}
     >
       <Stack space={2}>
         <Checkbox

--- a/libs/portals/admin/ids-admin/src/shared/components/ConditionalWrapper.tsx
+++ b/libs/portals/admin/ids-admin/src/shared/components/ConditionalWrapper.tsx
@@ -1,0 +1,18 @@
+import { ReactNode } from 'react'
+
+interface ConditionalWrapperProps {
+  condition?: boolean
+  children: ReactNode
+  trueWrapper: (children: ReactNode) => JSX.Element
+  falseWrapper?: (children: ReactNode) => JSX.Element
+}
+
+export function ConditionalWrapper({
+  condition = false,
+  children,
+  trueWrapper,
+  // eslint-disable-next-line react/jsx-no-useless-fragment
+  falseWrapper = (children) => <>{children}</>,
+}: ConditionalWrapperProps) {
+  return condition ? trueWrapper(children) : falseWrapper(children)
+}

--- a/libs/portals/admin/ids-admin/src/shared/components/ContentCard.css.ts
+++ b/libs/portals/admin/ids-admin/src/shared/components/ContentCard.css.ts
@@ -16,14 +16,6 @@ export const menuItem = style({
   },
 })
 
-export const title = style({
-  '@media': {
-    [`(max-width: ${theme.breakpoints.sm}px)`]: {
-      maxWidth: '200px',
-    },
-  },
-})
-
 export const syncButton = style({
   textDecorationLine: 'underline',
 })

--- a/libs/portals/admin/ids-admin/src/shared/components/ContentCard.tsx
+++ b/libs/portals/admin/ids-admin/src/shared/components/ContentCard.tsx
@@ -9,6 +9,7 @@ import {
   LoadingDots,
   Text,
   toast,
+  AccordionItem,
 } from '@island.is/island-ui/core'
 import { Form, useActionData } from 'react-router-dom'
 import { useLocale } from '@island.is/localization'
@@ -23,6 +24,7 @@ import * as styles from './ContentCard.css'
 import { ClientContext } from '../context/ClientContext'
 import { useSubmitting } from '@island.is/react-spa/shared'
 import isEqual from 'lodash/isEqual'
+import { ConditionalWrapper } from './ConditionalWrapper'
 
 interface ContentCardProps {
   title: string
@@ -30,6 +32,10 @@ interface ContentCardProps {
   isDirty?: (currentValue: FormData, originalValue: FormData) => boolean
   inSync?: boolean
   intent?: ClientFormTypes
+  /**
+   * The children will be wrapped in an accordion when a label is provided to the component.
+   */
+  accordionLabel?: string
 }
 
 function defaultIsDirty(newFormData: FormData, originalFormData: FormData) {
@@ -48,6 +54,7 @@ const ContentCard: FC<ContentCardProps> = ({
   description,
   isDirty = defaultIsDirty,
   intent = ClientFormTypes.none,
+  accordionLabel = false,
 }) => {
   const { formatMessage } = useLocale()
   const [allEnvironments, setAllEnvironments] = useState<boolean>(false)
@@ -100,6 +107,7 @@ const ContentCard: FC<ContentCardProps> = ({
     const intentToCheck = getIntentWithSyncCheck(formData)
     return (isSubmitting || isLoading) && intentToCheck.name === intent
   }
+  const isLoadingForIntent = checkIfLoadingForIntent()
 
   const inSync = checkIfInSync(
     variablesToCheckSync?.[intent as keyof typeof ClientFormTypes] ?? [],
@@ -141,12 +149,15 @@ const ContentCard: FC<ContentCardProps> = ({
       >
         <Box>
           <Box
-            className={styles.title}
             display="flex"
+            flexDirection={['column', 'row']}
+            rowGap={2}
             justifyContent="spaceBetween"
-            alignItems="baseline"
+            alignItems={['flexStart', 'center']}
+            marginTop={2}
+            marginBottom={4}
           >
-            <Text ref={titleRef} marginTop={2} marginBottom={4} variant="h3">
+            <Text ref={titleRef} variant="h3">
               {title}
             </Text>
             {intent !== 'none' && (
@@ -201,7 +212,7 @@ const ContentCard: FC<ContentCardProps> = ({
                                 justifyContent="center"
                                 padding={2}
                               >
-                                {checkIfLoadingForIntent() ? (
+                                {isLoadingForIntent ? (
                                   <LoadingDots large />
                                 ) : (
                                   <button
@@ -230,45 +241,58 @@ const ContentCard: FC<ContentCardProps> = ({
           </Box>
           {description && <Text marginBottom={4}>{description}</Text>}
         </Box>
-        {children}
-        {intent !== 'none' && (
-          <Box
-            alignItems="center"
-            marginTop="containerGutter"
-            display="flex"
-            justifyContent="spaceBetween"
-          >
-            <Checkbox
-              label={formatMessage(m.saveForAllEnvironments)}
-              value={`${allEnvironments}`}
-              disabled={!dirty}
-              name="allEnvironments"
-              onChange={() => setAllEnvironments(!allEnvironments)}
-            />
-            <Button
-              disabled={!dirty}
-              type="submit"
-              name="intent"
-              value={intent}
-              loading={checkIfLoadingForIntent()}
-            >
-              {formatMessage(m.saveSettings)}
-            </Button>
-            {/*hidden input to pass the selected environment to the form*/}
-            <input
-              type="hidden"
-              name="environment"
-              value={selectedEnvironment.environment}
-            />
-            <input
-              type="hidden"
-              name="syncEnvironments"
-              value={`${availableEnvironments
-                ?.filter((env) => env !== selectedEnvironment.environment)
-                .join(',')}`}
-            />
-          </Box>
-        )}
+        <ConditionalWrapper
+          condition={Boolean(accordionLabel)}
+          trueWrapper={(cld) => (
+            <AccordionItem label={accordionLabel} id={title}>
+              {cld}
+            </AccordionItem>
+          )}
+        >
+          <>
+            {children}
+            {intent !== 'none' && (
+              <Box
+                alignItems={['flexStart', 'center']}
+                marginTop="containerGutter"
+                display="flex"
+                justifyContent="spaceBetween"
+                rowGap={[2, 0]}
+                flexDirection={['column', 'row']}
+              >
+                <Checkbox
+                  label={formatMessage(m.saveForAllEnvironments)}
+                  value={`${allEnvironments}`}
+                  disabled={!dirty}
+                  name="allEnvironments"
+                  onChange={() => setAllEnvironments(!allEnvironments)}
+                />
+                <Button
+                  disabled={!dirty}
+                  type="submit"
+                  name="intent"
+                  value={intent}
+                  loading={isLoadingForIntent}
+                >
+                  {formatMessage(m.saveSettings)}
+                </Button>
+                {/*hidden input to pass the selected environment to the form*/}
+                <input
+                  type="hidden"
+                  name="environment"
+                  value={selectedEnvironment.environment}
+                />
+                <input
+                  type="hidden"
+                  name="syncEnvironments"
+                  value={`${availableEnvironments
+                    ?.filter((env) => env !== selectedEnvironment.environment)
+                    .join(',')}`}
+                />
+              </Box>
+            )}
+          </>
+        </ConditionalWrapper>
       </Box>
     </Form>
   )


### PR DESCRIPTION
## What

Add an additional prop that wraps the childrent of the <ContentCard /> in an Accordion. Also minor styling fixes.

## Screenshots / Gifs

<img width="990" alt="Screenshot 2023-04-24 at 14 38 21" src="https://user-images.githubusercontent.com/7573694/234030174-dbb7298a-80e8-45c0-8f57-765fa5fb75c5.png">
<img width="1058" alt="Screenshot 2023-04-24 at 14 38 32" src="https://user-images.githubusercontent.com/7573694/234030185-7fcaeb69-d84e-41c7-9cd7-30f6573ffbf6.png">


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
