### PR TITLE
feat(web): Added SliceDropdown content type

### DIFF
--- a/apps/web/components/Organization/Slice/Render/SliceDropdown.tsx
+++ b/apps/web/components/Organization/Slice/Render/SliceDropdown.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react'
 import { Slice } from '@island.is/web/graphql/schema'
 import { SliceMachine } from '@island.is/web/components'
 import {
+  BoxProps,
   GridColumn,
   GridContainer,
   GridRow,
@@ -10,15 +11,24 @@ import {
 } from '@island.is/island-ui/core'
 import { useRouter } from 'next/router'
 import slugify from '@sindresorhus/slugify'
+import { SpanType } from '@island.is/island-ui/core/types'
 
 interface SliceProps {
   slices: Slice[]
   sliceExtraText: string
+  gridSpan?: SpanType
+  gridOffset?: SpanType
+  slicesAreFullWidth?: boolean
+  dropdownMarginBottom?: BoxProps['marginBottom']
 }
 
 export const SliceDropdown: React.FC<SliceProps> = ({
   slices,
   sliceExtraText,
+  gridSpan = ['9/9', '9/9', '7/9', '7/9', '4/9'],
+  gridOffset = ['0', '0', '1/9'],
+  slicesAreFullWidth = false,
+  dropdownMarginBottom = 0,
 }) => {
   const Router = useRouter()
   const [selectedId, setSelectedId] = useState<string>('')
@@ -54,11 +64,8 @@ export const SliceDropdown: React.FC<SliceProps> = ({
   return (
     <>
       <GridContainer>
-        <GridRow>
-          <GridColumn
-            span={['9/9', '9/9', '7/9', '7/9', '4/9']}
-            offset={['0', '0', '1/9']}
-          >
+        <GridRow marginBottom={dropdownMarginBottom}>
+          <GridColumn span={gridSpan} offset={gridOffset}>
             <Select
               backgroundColor="white"
               icon="chevronDown"
@@ -89,6 +96,7 @@ export const SliceDropdown: React.FC<SliceProps> = ({
           key={selectedSlice.id}
           slice={selectedSlice}
           namespace={null}
+          fullWidth={slicesAreFullWidth}
         />
       )}
     </>

--- a/apps/web/screens/queries/fragments.ts
+++ b/apps/web/screens/queries/fragments.ts
@@ -616,6 +616,15 @@ export const slices = gql`
     translations
   }
 
+  fragment SliceDropdownFields on SliceDropdown {
+    __typename
+    id
+    dropdownLabel
+    slices {
+      ...OneColumnTextFields
+    }
+  }
+
   fragment FeaturedSupportQNAsFields on FeaturedSupportQNAs {
     __typename
     id
@@ -708,6 +717,7 @@ export const slices = gql`
     ...PowerBiSliceFields
     ...TableSliceFields
     ...EmailSignupFields
+    ...SliceDropdownFields
   }
 
   fragment AllSlices on Slice {
@@ -759,6 +769,17 @@ const nestedContainerFields = `
       }
       body {
         ...AllSlices
+      }
+    }
+  }
+  ... on SliceDropdown {
+    ...SliceDropdownFields
+    slices {
+      ... on OneColumnText {
+        ...OneColumnTextFields
+        content {
+          ...AllSlices
+        }
       }
     }
   }

--- a/apps/web/utils/richText.tsx
+++ b/apps/web/utils/richText.tsx
@@ -26,12 +26,14 @@ import {
   AlcoholLicencesList,
   TemporaryEventLicencesList,
   BrokersList,
+  SliceDropdown,
 } from '@island.is/web/components'
 import {
   PowerBiSlice as PowerBiSliceSchema,
   Slice,
   AccordionSlice as AccordionSliceSchema,
   FeaturedSupportQnAs as FeaturedSupportQNAsSchema,
+  SliceDropdown as SliceDropdownSchema,
 } from '@island.is/web/graphql/schema'
 import { Locale } from '@island.is/shared/types'
 import { MonthlyStatistics } from '../components/connected/electronicRegistrationStatistics'
@@ -80,6 +82,16 @@ const defaultRenderComponent = {
   FaqList: (slice: FaqListProps) => slice?.questions && <FaqList {...slice} />,
   FeaturedSupportQNAs: (slice: FeaturedSupportQNAsSchema) => (
     <FeaturedSupportQNAs slice={slice} />
+  ),
+  SliceDropdown: (slice: SliceDropdownSchema) => (
+    <SliceDropdown
+      slices={slice.slices}
+      sliceExtraText={slice.dropdownLabel}
+      gridSpan="1/1"
+      gridOffset="0"
+      slicesAreFullWidth={true}
+      dropdownMarginBottom={5}
+    />
   ),
 }
 

--- a/libs/cms/src/lib/environments/environment.ts
+++ b/libs/cms/src/lib/environments/environment.ts
@@ -76,6 +76,7 @@ export default {
     'price',
     'teamList',
     'teamMember',
+    'sliceDropdown',
   ],
   // Content types that have the 'activeTranslations' JSON field
   localizedContentTypes: ['article'],

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -1500,8 +1500,11 @@ export interface ILifeEventPageFields {
   /** see more text */
   seeMoreText?: string | undefined
 
-  /** Page Type */
+  /** page type */
   pageType?: 'Life Event' | 'Digital Iceland Service' | undefined
+
+  /** featured image */
+  featuredImage?: Asset | undefined
 }
 
 export interface ILifeEventPage extends Entry<ILifeEventPageFields> {
@@ -2604,6 +2607,7 @@ export interface IProcessEntryFields {
     | 'Drop and sign'
     | 'Paper'
     | 'Ísland.is mínar síður'
+    | 'Umsoknarkerfi'
 
   /** Process title */
   processTitle: string
@@ -2975,6 +2979,34 @@ export interface ISliceConnectedComponent
     contentType: {
       sys: {
         id: 'sliceConnectedComponent'
+        linkType: 'ContentType'
+        type: 'Link'
+      }
+    }
+  }
+}
+
+export interface ISliceDropdownFields {
+  /** Title */
+  title?: string | undefined
+
+  /** Dropdown Label */
+  dropdownLabel?: string | undefined
+
+  /** Slices */
+  slices?: IOneColumnText[] | undefined
+}
+
+export interface ISliceDropdown extends Entry<ISliceDropdownFields> {
+  sys: {
+    id: string
+    type: string
+    createdAt: string
+    updatedAt: string
+    locale: string
+    contentType: {
+      sys: {
+        id: 'sliceDropdown'
         linkType: 'ContentType'
         type: 'Link'
       }
@@ -4091,6 +4123,7 @@ export type CONTENT_TYPE =
   | 'sectionWithImage'
   | 'sidebarCard'
   | 'sliceConnectedComponent'
+  | 'sliceDropdown'
   | 'statistic'
   | 'statistics'
   | 'statisticsCard'

--- a/libs/cms/src/lib/models/sliceDropdown.model.ts
+++ b/libs/cms/src/lib/models/sliceDropdown.model.ts
@@ -1,0 +1,26 @@
+import { Field, ID, ObjectType } from '@nestjs/graphql'
+import { ISliceDropdown } from '../generated/contentfulTypes'
+import { SystemMetadata } from 'api-cms-domain'
+import { mapOneColumnText, OneColumnText } from './oneColumnText.model'
+
+@ObjectType()
+export class SliceDropdown {
+  @Field(() => ID)
+  id!: string
+
+  @Field(() => String, { nullable: true })
+  dropdownLabel?: string
+
+  @Field(() => [OneColumnText])
+  slices!: OneColumnText[]
+}
+
+export const mapSliceDropdown = ({
+  sys,
+  fields,
+}: ISliceDropdown): SystemMetadata<SliceDropdown> => ({
+  typename: 'SliceDropdown',
+  id: sys.id,
+  dropdownLabel: fields.dropdownLabel,
+  slices: fields?.slices?.map(mapOneColumnText) ?? [],
+})

--- a/libs/cms/src/lib/unions/slice.union.ts
+++ b/libs/cms/src/lib/unions/slice.union.ts
@@ -37,6 +37,7 @@ import {
   ITableSlice,
   IEmailSignup,
   IFeaturedSupportQnAs,
+  ISliceDropdown,
 } from '../generated/contentfulTypes'
 import { Image, mapImage } from '../models/image.model'
 import { Asset, mapAsset } from '../models/asset.model'
@@ -102,6 +103,7 @@ import {
   FeaturedSupportQNAs,
   mapFeaturedSupportQNAs,
 } from '../models/featuredSupportQNAs.model'
+import { mapSliceDropdown, SliceDropdown } from '../models/sliceDropdown.model'
 
 type SliceTypes =
   | ITimeline
@@ -138,6 +140,7 @@ type SliceTypes =
   | ITableSlice
   | IEmailSignup
   | IFeaturedSupportQnAs
+  | ISliceDropdown
 
 export const SliceUnion = createUnionType({
   name: 'Slice',
@@ -179,6 +182,7 @@ export const SliceUnion = createUnionType({
     TableSlice,
     EmailSignup,
     FeaturedSupportQNAs,
+    SliceDropdown,
   ],
   resolveType: (document) => document.typename, // typename is appended to request on indexing
 })
@@ -254,6 +258,8 @@ export const mapSliceUnion = (slice: SliceTypes): typeof SliceUnion => {
       return mapEmailSignup(slice as IEmailSignup)
     case 'featuredSupportQNAs':
       return mapFeaturedSupportQNAs(slice as IFeaturedSupportQnAs)
+    case 'sliceDropdown':
+      return mapSliceDropdown(slice as ISliceDropdown)
     default:
       throw new ApolloError(`Can not convert to slice: ${contentType}`)
   }


### PR DESCRIPTION
# Added SliceDropdown content type

## What

* We have a slice dropdown functionality for Organization subpages (where you pick an option from the dropdown and that selection will be displayed below the dropdown) but we want this feature for articles and other pages on the web as well

## Screenshots / Gifs

Simple test scheenshots:
![image](https://user-images.githubusercontent.com/43557895/234845601-152de0de-14ab-4fa9-a130-33d1192486f2.png)

![image](https://user-images.githubusercontent.com/43557895/234844753-9d3ef5d2-461b-48bf-b760-61286de93b75.png)
![image](https://user-images.githubusercontent.com/43557895/234844830-19bda977-cef5-455a-813c-13ae73e67d21.png)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
