### PR TITLE
fix(auth-admin-web): Allow arbitrary length of domain extensions in email validation

### DIFF
--- a/apps/auth-admin-web/utils/validation.utils.ts
+++ b/apps/auth-admin-web/utils/validation.utils.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-useless-escape */
 class ValidationUtils {
-  public static emailPattern = /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/
+  public static emailPattern = /^[\w-\.]+@([\w-]+\.)+[\w-]+$/
 
   public static identifierPattern = /^[a-zA-Z0-9_.-]*$/
 
@@ -146,4 +146,5 @@ class ValidationUtils {
     return regex.test(input)
   }
 }
+
 export default ValidationUtils


### PR DESCRIPTION
## What

![image](https://user-images.githubusercontent.com/54210288/234994335-9fd3abe0-fe43-4b3c-8651-0c59783c4ff6.png)


## Why

To allow management of users with longer than 4 char domain extension.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
