### PR TITLE
fix(portals-shared-modules-delegations): Modal body scroll

### DIFF
--- a/libs/portals/shared-modules/delegations/src/components/Modal/Modal.tsx
+++ b/libs/portals/shared-modules/delegations/src/components/Modal/Modal.tsx
@@ -1,11 +1,5 @@
 import React, { useRef } from 'react'
-import {
-  Box,
-  Icon,
-  ModalBase,
-  Text,
-  useBreakpoint,
-} from '@island.is/island-ui/core'
+import { Box, Icon, ModalBase, Text } from '@island.is/island-ui/core'
 import * as styles from './Modal.css'
 
 export interface ModalProps {
@@ -28,7 +22,6 @@ export const Modal = ({
   noPaddingBottom,
 }: ModalProps) => {
   const headingRef = useRef<HTMLElement>(null)
-  const { md } = useBreakpoint()
   const handleOnVisibilityChange = (isVisible: boolean) => {
     if (isVisible) {
       headingRef.current?.focus()
@@ -45,7 +38,6 @@ export const Modal = ({
       modalLabel={label}
       hideOnClickOutside
       hideOnEsc
-      preventBodyScroll={md}
       onVisibilityChange={handleOnVisibilityChange}
     >
       <Box


### PR DESCRIPTION
## What

For some reason, the modal had a prop that allowed the body to scroll underneath the modal. This 🌭 removes this functionality. Modals should always block the body scroll. 
I tested all uses of this modal.

## Screenshots / Gifs

### With a sticky footer 
The scroll bar is only shown here to illustrate the problem.

#### Before
<img width="413" alt="Screenshot 2023-04-28 at 13 21 25" src="https://user-images.githubusercontent.com/7573694/235162348-e9fcbd79-c17d-4a79-b69c-cc08af35c5ac.png">
#### After
<img width="414" alt="Screenshot 2023-04-28 at 13 35 41" src="https://user-images.githubusercontent.com/7573694/235162801-f75f67b5-8444-42f4-b1ae-ce9354172841.png">


### Regular
#### Before 
<img width="413" alt="Screenshot 2023-04-28 at 13 20 09" src="https://user-images.githubusercontent.com/7573694/235162461-a4390dd8-eaa1-4ee8-aee6-64c5a6ff294c.png">

#### After
<img width="413" alt="Screenshot 2023-04-28 at 13 20 32" src="https://user-images.githubusercontent.com/7573694/235163156-224a08b1-2abc-404c-940c-d2604ece550f.png">



## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
