### PR TITLE
fix(j-s): Add rulingDate to CaseList Query

### DIFF
--- a/apps/judicial-system/web/src/utils/mutations.ts
+++ b/apps/judicial-system/web/src/utils/mutations.ts
@@ -44,6 +44,7 @@ export const CasesQuery = gql`
       courtDate
       isValidToDateInThePast
       initialRulingDate
+      rulingDate
       judge {
         id
       }


### PR DESCRIPTION
# Add rulingDate to CaseList Query

## What

Add rulingDate to CaseList Query 

## Why

Verified bug
To fix filtering of cases that broke when rulingDate stopped being returned by the CaseList Query


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
