### PR TITLE
fix(service-portal): Add missing education navigation detail

### DIFF
--- a/libs/service-portal/education/src/lib/navigation.ts
+++ b/libs/service-portal/education/src/lib/navigation.ts
@@ -17,6 +17,13 @@ export const educationNavigation: PortalNavigationItem = {
     {
       name: m.educationGraduation,
       path: EducationPaths.EducationHaskoliGraduation,
+      children: [
+        {
+          name: m.overview,
+          navHide: true,
+          path: EducationPaths.EducationHaskoliGraduationDetail,
+        },
+      ],
     },
   ],
 }


### PR DESCRIPTION
## What

* Add missing education detail navigation item

## Why

* It's missing, missing navigation item causes breadcrumbs to not show up, as well as some other minor issues.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
