### PR TITLE
feat(consultation-portal): show max amount of advices

### DIFF
--- a/apps/consultation-portal/components/Advices/Advices.tsx
+++ b/apps/consultation-portal/components/Advices/Advices.tsx
@@ -1,7 +1,8 @@
-import { SkeletonLoader, Stack, Text } from '@island.is/island-ui/core'
+import { Button, SkeletonLoader, Stack, Text } from '@island.is/island-ui/core'
 import { SimpleCardSkeleton } from '../Card'
 import ReviewCard from '../ReviewCard/ReviewCard'
 import { UserAdvice } from '../../types/interfaces'
+import { useState } from 'react'
 
 interface Props {
   advices: Array<UserAdvice>
@@ -9,6 +10,8 @@ interface Props {
 }
 
 const Advices = ({ advices, advicesLoading }: Props) => {
+  const [showAll, setShowAll] = useState<boolean>(false)
+  const showAmount = 4
   if (advicesLoading) {
     return (
       <SimpleCardSkeleton borderColor="blue200">
@@ -22,9 +25,21 @@ const Advices = ({ advices, advicesLoading }: Props) => {
 
   return (
     <Stack space={3}>
-      {advices.map((advice: UserAdvice) => {
-        return <ReviewCard advice={advice} key={advice.id} />
+      {advices.map((advice: UserAdvice, index) => {
+        if (!showAll && index < showAmount)
+          return <ReviewCard advice={advice} key={advice.id} />
+        else if (showAll) {
+          return <ReviewCard advice={advice} key={advice.id} />
+        }
       })}
+      <Button
+        onClick={() => setShowAll(!showAll)}
+        variant="text"
+        icon={showAll ? 'chevronUp' : 'chevronDown'}
+      >
+        {' '}
+        {showAll ? 'Fela umsagnir' : 'Sjá allar umsagnir'}
+      </Button>
     </Stack>
   )
 }


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Show only 4 advices on default, add button that reveals rest

## Why

Specify why you need to achieve this

## Screenshots / Gifs
![image](https://user-images.githubusercontent.com/64030465/236237871-86019e6c-3fdc-4de8-ae6d-8601e6a93640.png)

![image](https://user-images.githubusercontent.com/64030465/236237846-ef3abecd-d7f0-4986-9485-05551aba3640.png)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
