### PR TITLE
chore(auth-admin-api): Load encryption key from env variable on localhost.

### DIFF
--- a/apps/services/auth/admin-api/src/environments/environment.ts
+++ b/apps/services/auth/admin-api/src/environments/environment.ts
@@ -10,7 +10,8 @@ const devConfig = {
     issuer: 'https://identity-server.dev01.devland.is',
   },
   port: 6333,
-  clientSecretEncryptionKey: 'secret',
+  clientSecretEncryptionKey:
+    process.env.CLIENT_SECRET_ENCRYPTION_KEY ?? 'secret',
 }
 
 const prodConfig = {


### PR DESCRIPTION
## What

When creating client the admin api uses the encryption key to encrypt the generated secret.
If the secret from DEV environment is not used locally then the secret is not viewable in dev.

## Why

To simplify client creation testing between localhost and dev.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
