### PR TITLE
fix(j-s): Updating margin between text in alert banner

### DIFF
--- a/apps/judicial-system/web/src/components/AlertBanner/index.tsx
+++ b/apps/judicial-system/web/src/components/AlertBanner/index.tsx
@@ -116,7 +116,7 @@ export const AlertBanner: FC<AlertBannerProps> = ({
         </Box>
       )}
       {description && (
-        <Box marginRight={[0, 0, 0, 2]}>
+        <Box marginRight={2}>
           <Text>{description}</Text>
         </Box>
       )}


### PR DESCRIPTION
# ... 🆙 

[Landsréttur - Laga texta, tilkynning um móttöku textinn fer yfir frestur til að skila greinargerð](https://app.asana.com/0/1199153462262248/1204456504011111)

## What

- Set margin on text, always no matter the size of screen

## Why

- make sure the text doesnt stick together

## Screenshots / Gifs
![Screenshot 2023-05-08 at 12 49 38](https://user-images.githubusercontent.com/62568905/236828507-0e9bc25f-6256-4a82-9c15-39caf849f7a2.png)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
