### PR TITLE
fix(system-e2e): Update finance bills e2e test

### DIFF
--- a/apps/system-e2e/src/tests/islandis/service-portal/smoke/financials.spec.ts
+++ b/apps/system-e2e/src/tests/islandis/service-portal/smoke/financials.spec.ts
@@ -84,15 +84,25 @@ test.describe('MS - Fjármál overview', () => {
       await page.goto('/minarsidur/fjarmal/greidslusedlar-og-greidslukvittanir')
 
       // Act
-      const inputField = page.getByRole('textbox', {
+      const filterButton = page
+        .locator(`role=button[name="${label(m.openFilter)}"]`)
+        .first()
+      await filterButton.click()
+
+      const inputField = page.getByPlaceholder(label(m.datepickLabel)).first()
+      await inputField.click()
+      await inputField.fill('')
+      await inputField.type('15.01.2023', { delay: 200 })
+
+      const filterInput = page.getByRole('textbox', {
         name: label(m.searchPlaceholder),
       })
-      await inputField.click()
-      await inputField.type('27.01.2023', { delay: 100 })
+      await filterInput.click()
+      await filterInput.type('27.01.2023', { delay: 100 })
 
       // Assert
       await expect(page.locator('role=table')).toContainText('27.01.2023')
-      await expect(page.locator('role=table')).not.toContainText('11.04.2023')
+      await expect(page.locator('role=table')).not.toContainText('10.01.2023')
     })
   })
 


### PR DESCRIPTION
## What

Update finance bills e2e test

## Why

The default data returned on this screen will only show about 3 months back in time. This will extend the search parameter to be before the expected text in the table.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
