### PR TITLE
fix(consultation-portal): remove padding in hero banner

### DIFF
--- a/apps/consultation-portal/components/HeroBanner/HeroBanner.css.ts
+++ b/apps/consultation-portal/components/HeroBanner/HeroBanner.css.ts
@@ -26,8 +26,8 @@ export const alignTiles = style({
 export const bg = style({
   display: 'block',
   position: 'relative',
-  maxHeight: '317px',
-  maxWidth: '317px',
+  // maxHeight: '317px',
+  // maxWidth: '317px',
   // top: 16,
   width: '100%',
 })

--- a/apps/consultation-portal/components/HeroBanner/HeroBanner.tsx
+++ b/apps/consultation-portal/components/HeroBanner/HeroBanner.tsx
@@ -17,6 +17,7 @@ import { StatisticBox } from '..'
 import HeroTiles from './HeroTiles'
 import SplashSmall from '../svg/SplashSmall'
 import { ArrOfStatistics } from '../../types/interfaces'
+import Splash from '../svg/Splash'
 
 interface HeroBannerProps {
   statistics: ArrOfStatistics
@@ -33,7 +34,7 @@ export const HeroBanner = ({ statistics }: HeroBannerProps) => {
       flexDirection={'column'}
     >
       <GridContainer>
-        <Box paddingX={[0, 0, 0, 0, 15]}>
+        <Box>
           <GridRow className={styles.rowAlign}>
             <Hidden above="md">
               <GridColumn span="12/12" order={[1, 1]}>
@@ -71,7 +72,7 @@ export const HeroBanner = ({ statistics }: HeroBannerProps) => {
               order={[1, 1, 1, 2, 2]}
             >
               <Box className={styles.bg}>
-                <SplashSmall />
+                <Splash />
               </Box>
               <Box className={styles.alignTiles}>
                 <HeroTiles space={2} columns={[1, 1, 1, 1, 1]}>


### PR DESCRIPTION
# ...

Attach a link to issue if relevant
https://veflausnir.atlassian.net/browse/KAM-1195

## What

remove padding in hero banner

## Why

Specify why you need to achieve this

## Screenshots / Gifs

![image](https://github.com/island-is/island.is/assets/64030465/717a8060-dc36-4fbe-961a-9604ac145392)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
