### PR TITLE
chore(ci): Increase node memory limits

### DIFF
--- a/.github/actions/unit-test/action.yml
+++ b/.github/actions/unit-test/action.yml
@@ -41,7 +41,7 @@ runs:
       shell: bash
       env:
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}
-        NODE_OPTIONS: --max-old-space-size=4096
+        NODE_OPTIONS: --max-old-space-size=8192
 
     - name: Cached codecov uploader
       id: codecov-cache


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What
Increase runner node memory limits to 8GiB when running tests
## Why
application-system-api tests are running out of memory.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
