### PR TITLE
fix(service-portal): Add session storage hide modal on param

### DIFF
--- a/libs/service-portal/settings/personal-information/src/utils/showUserOnboardingModal.ts
+++ b/libs/service-portal/settings/personal-information/src/utils/showUserOnboardingModal.ts
@@ -35,7 +35,16 @@ export const hideModalWithQueryParam = (): boolean => {
       urlSearchParams.get('hide_onboarding_modal') ?? '',
     )
 
-    return queryParam === 'true'
+    const shouldHideModal = queryParam === 'true'
+
+    if (shouldHideModal) {
+      sessionStorage.setItem(
+        onboardingModalStorage.key,
+        onboardingModalStorage.value,
+      )
+    }
+
+    return shouldHideModal
   } catch {
     return false
   }


### PR DESCRIPTION
## What

* When `hide_onboarding_modal` query param is visible, add to session storage.

## Why

* For testing, disable once then the whole session is disabled, avoiding the popup if user is redirected.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
