### PR TITLE
fix(service-portal): Nullable customer records

### DIFF
--- a/apps/service-portal/src/components/Layout/Layout.tsx
+++ b/apps/service-portal/src/components/Layout/Layout.tsx
@@ -12,7 +12,10 @@ import {
 import ContentBreadcrumbs from '../../components/ContentBreadcrumbs/ContentBreadcrumbs'
 import * as styles from './Layout.css'
 import AuthOverlay from '../Loaders/AuthOverlay/AuthOverlay'
-import { useScrollTopOnUpdate } from '@island.is/service-portal/core'
+import {
+  ModuleAlertBannerSection,
+  useScrollTopOnUpdate,
+} from '@island.is/service-portal/core'
 import { useLocation } from 'react-router-dom'
 import MobileMenu from '../MobileMenu/MobileMenu'
 import { useNamespaces } from '@island.is/localization'
@@ -70,6 +73,7 @@ export const Layout: FC = ({ children }) => {
                 <Hidden print>
                   <ContentBreadcrumbs />
                 </Hidden>
+                <ModuleAlertBannerSection />
                 {children}
               </GridColumn>
             </GridRow>

--- a/libs/api/domains/finance/src/lib/models/customerRecords.model.ts
+++ b/libs/api/domains/finance/src/lib/models/customerRecords.model.ts
@@ -3,6 +3,6 @@ import { CustomerRecordsItem } from './customerRecordsItem.model'
 
 @ObjectType()
 export class CustomerRecords {
-  @Field(() => [CustomerRecordsItem])
-  records!: CustomerRecordsItem[]
+  @Field(() => [CustomerRecordsItem], { nullable: true })
+  records?: CustomerRecordsItem[]
 }

--- a/libs/service-portal/air-discount/src/screens/AirDiscountOverview/AirDiscountOverview.tsx
+++ b/libs/service-portal/air-discount/src/screens/AirDiscountOverview/AirDiscountOverview.tsx
@@ -24,7 +24,6 @@ import {
 } from '@island.is/island-ui/core'
 import { messages as m } from '../../lib/messages'
 import copyToClipboard from 'copy-to-clipboard'
-import { ModuleAlertBannerSection } from '@island.is/service-portal/core'
 import UsageTable from '../../components/UsageTable'
 import { formatDateWithTime } from '@island.is/service-portal/core'
 import { AirDiscountSchemeDiscount } from '@island.is/service-portal/graphql'
@@ -154,9 +153,6 @@ export const AirDiscountOverview = () => {
               <Bullet>{formatMessage(m.discountTextFirst)}</Bullet>
               <Bullet>{formatMessage(m.discountTextSecond)}</Bullet>
             </BulletList>
-          </GridColumn>
-          <GridColumn span={['12/12', '12/12', '6/8']} order={3} paddingTop={4}>
-            <ModuleAlertBannerSection />
           </GridColumn>
         </GridRow>
 

--- a/libs/service-portal/core/src/components/IntroHeader/IntroHeader.tsx
+++ b/libs/service-portal/core/src/components/IntroHeader/IntroHeader.tsx
@@ -1,5 +1,3 @@
-import { GridColumn } from '@island.is/island-ui/core'
-import { ModuleAlertBannerSection } from '../AlertMessage/ModuleAlertMessageSection'
 import {
   IntroHeader as IntroHeaderBase,
   IntroHeaderProps,
@@ -12,11 +10,7 @@ export const IntroHeader = (props: Omit<IntroHeaderProps, 'children'>) => {
     <IntroHeaderBase
       {...props}
       marginBottom={marginBottom ? marginBottom : [0, 0, 2]}
-    >
-      <GridColumn span={['12/12', '12/12', '6/8']} order={3} paddingTop={4}>
-        <ModuleAlertBannerSection />
-      </GridColumn>
-    </IntroHeaderBase>
+    />
   )
 }
 


### PR DESCRIPTION
## What

* Nullable customer records
* Move alert banner section from intro header to layout

## Why

* customer records can be empty
* Intro header is not always rendered

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
