### PR TITLE
fix(j-s): Fix modal text

### DIFF
--- a/apps/judicial-system/web/src/routes/Shared/Statement/Statement.strings.ts
+++ b/apps/judicial-system/web/src/routes/Shared/Statement/Statement.strings.ts
@@ -39,9 +39,9 @@ export const statement = defineMessages({
       'Titill í Greinargerð hefur verið send Landsrétti héraðsdómstól modal',
   },
   statementSentModalText: {
-    id: 'judicial.system.core:statement_sent_text',
+    id: 'judicial.system.core:statement_sent_text_v2',
     defaultMessage:
-      'Tilkynning um greinargerð hefur verið send Landsrétti og sækjanda.',
+      'Tilkynning um greinargerð hefur verið send Landsrétti og {isDefender, select, true {sækjanda} other {verjanda}}.',
     description:
       'Texti í Greinargerð hefur verið send Landsrétti héraðsdómstól modal',
   },

--- a/apps/judicial-system/web/src/routes/Shared/Statement/Statement.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/Statement/Statement.tsx
@@ -222,7 +222,9 @@ const Statement = () => {
       {visibleModal === 'STATEMENT_SENT' && (
         <Modal
           title={formatMessage(strings.statementSentModalTitle)}
-          text={formatMessage(strings.statementSentModalText)}
+          text={formatMessage(strings.statementSentModalText, {
+            isDefender: limitedAccess,
+          })}
           secondaryButtonText={formatMessage(core.closeModal)}
           onSecondaryButtonClick={() => router.push(previousUrl)}
         />


### PR DESCRIPTION
# Fix modal text

[Laga modal texta](https://app.asana.com/0/1199153462262248/1204604047079808/f)

## What

Fix modal text on court of appeal statement screen so it considers whether the user is a prosecutor or defender

## Why

So that the displayed text is correct according to the user role
<img width="955" alt="image" src="https://github.com/island-is/island.is/assets/4820859/57cbf202-59bb-4450-856c-2450fc558a29">
<img width="955" alt="image" src="https://github.com/island-is/island.is/assets/4820859/9a6f0738-fa96-4de9-b42b-73da2e277d51">


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
