### PR TITLE
fix(delegation-api): Read domainName from client and fallback to parse from clientId.

### DIFF
--- a/apps/services/auth/delegation-api/src/app/clients/clients.controller.ts
+++ b/apps/services/auth/delegation-api/src/app/clients/clients.controller.ts
@@ -58,8 +58,8 @@ export class ClientsController {
     }
 
     return clients.map((client) => {
-      // Todo: This is a temporary solution until we have linked clients to domains
-      const domainName = client.clientId.split('/')[0]
+      // While we have clients without the domainName property set we have a fallback to parse it from the clientId
+      const domainName = client.domainName || client.clientId.split('/')[0]
 
       return {
         clientId: client.clientId,

--- a/libs/auth-api-lib/src/lib/clients/clients.service.ts
+++ b/libs/auth-api-lib/src/lib/clients/clients.service.ts
@@ -81,7 +81,7 @@ export class ClientsService {
       where: {
         ...(clientIds && clientIds.length > 0 ? { clientId: clientIds } : {}),
       },
-      attributes: ['clientId', 'clientName'],
+      attributes: ['clientId', 'clientName', 'domainName'],
     })
 
     if (lang) {


### PR DESCRIPTION
## What

Read the domain name from the client model and fallback to try to parse it from the client ID if not configured.

## Why

We recently added the domainName field to the client model and this uses that to read the domain name. It can be missing so we continue to fallback to the client id.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
