### PR TITLE
chore(web): Remove web reader feature flags that are set to true on prod

### DIFF
--- a/apps/web/components/NewsList/NewsList.tsx
+++ b/apps/web/components/NewsList/NewsList.tsx
@@ -9,12 +9,7 @@ import {
   Box,
   Link,
 } from '@island.is/island-ui/core'
-import {
-  LinkType,
-  useFeatureFlag,
-  useLinkResolver,
-  useNamespace,
-} from '@island.is/web/hooks'
+import { LinkType, useLinkResolver, useNamespace } from '@island.is/web/hooks'
 import { NewsCard, Webreader } from '@island.is/web/components'
 import { useRouter } from 'next/router'
 import { GetNewsQuery } from '@island.is/web/graphql/schema'
@@ -53,10 +48,6 @@ export const NewsList = ({
   newsPerPage = 10,
   monthOptions,
 }: NewsListProps) => {
-  const { value: isWebReaderEnabledForNews } = useFeatureFlag(
-    'isWebReaderEnabledForNews',
-    false,
-  )
   const router = useRouter()
   const n = useNamespace(namespace)
 
@@ -68,21 +59,17 @@ export const NewsList = ({
 
   return (
     <Stack space={[3, 3, 4]}>
-      <Text
-        variant="h1"
-        as="h1"
-        marginBottom={isWebReaderEnabledForNews ? 0 : 2}
-      >
+      <Text variant="h1" as="h1" marginBottom={0}>
         {title}
       </Text>
-      {isWebReaderEnabledForNews && (
-        <Webreader
-          marginTop={0}
-          marginBottom={0}
-          readId={null}
-          readClass="rs_read"
-        />
-      )}
+
+      <Webreader
+        marginTop={0}
+        marginBottom={0}
+        readId={null}
+        readClass="rs_read"
+      />
+
       {selectedYear && (
         <Hidden below="lg">
           <Text variant="h2" as="h2">

--- a/apps/web/components/Organization/NewsArticle/NewsArticle.tsx
+++ b/apps/web/components/Organization/NewsArticle/NewsArticle.tsx
@@ -4,7 +4,6 @@ import { Box, Text } from '@island.is/island-ui/core'
 import { useDateUtils } from '@island.is/web/i18n/useDateUtils'
 import { Slice as SliceType, Image } from '@island.is/island-ui/contentful'
 import { webRichText } from '@island.is/web/utils/richText'
-import { useFeatureFlag } from '@island.is/web/hooks'
 import { Webreader } from '@island.is/web/components'
 import { GetSingleNewsItemQuery } from '../../../graphql/schema'
 
@@ -15,10 +14,6 @@ interface NewsArticleProps {
 }
 
 export const NewsArticle: React.FC<NewsArticleProps> = ({ newsItem }) => {
-  const { value: isWebReaderEnabledForNews } = useFeatureFlag(
-    'isWebReaderEnabledForNews',
-    false,
-  )
   const { format } = useDateUtils()
 
   const formattedDate = newsItem.date
@@ -32,9 +27,9 @@ export const NewsArticle: React.FC<NewsArticleProps> = ({ newsItem }) => {
           {newsItem.title}
         </Text>
       </Box>
-      {isWebReaderEnabledForNews && (
-        <Webreader marginTop={0} readId={null} readClass="rs_read" />
-      )}
+
+      <Webreader marginTop={0} readId={null} readClass="rs_read" />
+
       <Box className="rs_read">
         <Text variant="h4" as="p" paddingBottom={2} color="blue400">
           {formattedDate}

--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -34,7 +34,7 @@ import {
   SearchBox,
 } from '@island.is/web/components'
 import SidebarLayout from '@island.is/web/screens/Layouts/SidebarLayout'
-import { useFeatureFlag, usePlausiblePageview } from '@island.is/web/hooks'
+import { usePlausiblePageview } from '@island.is/web/hooks'
 import { useI18n } from '@island.is/web/i18n'
 import { WatsonChatPanel } from '@island.is/web/components'
 
@@ -611,11 +611,6 @@ export const OrganizationWrapper: React.FC<WrapperProps> = ({
 
   usePlausiblePageview(organizationPage.organization?.trackingDomain)
 
-  const { value: isWebReaderEnabledForOrganizationPages } = useFeatureFlag(
-    'isWebReaderEnabledForOrganizationPages',
-    false,
-  )
-
   useEffect(() => setIsMobile(width < theme.breakpoints.md), [width])
 
   const secondaryNavList: NavigationItem[] =
@@ -785,7 +780,7 @@ export const OrganizationWrapper: React.FC<WrapperProps> = ({
                   />
                 )}
 
-                {showReadSpeaker && isWebReaderEnabledForOrganizationPages && (
+                {showReadSpeaker && (
                   <Webreader
                     marginTop={breadcrumbItems?.length ? 3 : 0}
                     marginBottom={breadcrumbItems?.length ? 0 : 3}

--- a/apps/web/screens/LifeEvent/LifeEvent.tsx
+++ b/apps/web/screens/LifeEvent/LifeEvent.tsx
@@ -31,11 +31,7 @@ import {
   QueryGetNamespaceArgs,
 } from '@island.is/web/graphql/schema'
 import { createNavigation } from '@island.is/web/utils/navigation'
-import {
-  useFeatureFlag,
-  useNamespace,
-  usePlausiblePageview,
-} from '@island.is/web/hooks'
+import { useNamespace, usePlausiblePageview } from '@island.is/web/hooks'
 import useContentfulId from '@island.is/web/hooks/useContentfulId'
 import { useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
 import { useRouter } from 'next/router'
@@ -56,11 +52,6 @@ export const LifeEvent: Screen<LifeEventProps> = ({
   namespace,
   locale,
 }) => {
-  const { value: isWebReaderEnabledForLifeEventPages } = useFeatureFlag(
-    'isWebReaderEnabledForLifeEventPages',
-    false,
-  )
-
   useContentfulId(id)
   useLocalLinkTypeResolver()
 
@@ -162,9 +153,9 @@ export const LifeEvent: Screen<LifeEventProps> = ({
                     {title}
                   </span>
                 </Text>
-                {isWebReaderEnabledForLifeEventPages && (
-                  <Webreader readId={null} readClass="rs_read" />
-                )}
+
+                <Webreader readId={null} readClass="rs_read" />
+
                 {intro && (
                   <Text variant="intro" as="p" paddingTop={2}>
                     <span className="rs_read" id={slugify(intro)}>

--- a/apps/web/screens/News.tsx
+++ b/apps/web/screens/News.tsx
@@ -47,7 +47,7 @@ import {
   HeadWithSocialSharing,
   Webreader,
 } from '@island.is/web/components'
-import { useFeatureFlag, useNamespace } from '@island.is/web/hooks'
+import { useNamespace } from '@island.is/web/hooks'
 import { LinkType, useLinkResolver } from '../hooks/useLinkResolver'
 import { FRONTPAGE_NEWS_TAG_ID } from '@island.is/web/constants'
 import { CustomNextError } from '../units/errors'
@@ -84,10 +84,6 @@ const NewsListNew: Screen<NewsListProps> = ({
   selectedTagSlug,
   namespace,
 }) => {
-  const { value: isWebReaderEnabledForNews } = useFeatureFlag(
-    'isWebReaderEnabledForNews',
-    false,
-  )
   const Router = useRouter()
   const { linkResolver } = useLinkResolver()
   const { format, getMonthByIndex } = useDateUtils()
@@ -223,9 +219,9 @@ const NewsListNew: Screen<NewsListProps> = ({
       <Text variant="h1" as="h1" paddingTop={[3, 3, 3, 5]} paddingBottom={2}>
         {newsItem.title}
       </Text>
-      {isWebReaderEnabledForNews && (
-        <Webreader marginTop={0} readId={null} readClass="rs_read" />
-      )}
+
+      <Webreader marginTop={0} readId={null} readClass="rs_read" />
+
       <Text variant="intro" as="p" paddingBottom={2}>
         {newsItem.intro}
       </Text>
@@ -355,9 +351,7 @@ const NewsListNew: Screen<NewsListProps> = ({
             {n('newsListEmptyMonth', 'Engar fréttir fundust í þessum mánuði.')}
           </Text>
         )}
-        {!newsItemContent && isWebReaderEnabledForNews && (
-          <Webreader readId={null} readClass="rs_read" />
-        )}
+        {!newsItemContent && <Webreader readId={null} readClass="rs_read" />}
         {newsItemContent && (
           <Box className="rs_read" width="full">
             {newsItemContent}

--- a/apps/web/screens/Organization/PublishedMaterial/PublishedMaterial.tsx
+++ b/apps/web/screens/Organization/PublishedMaterial/PublishedMaterial.tsx
@@ -31,11 +31,7 @@ import {
   QueryGetOrganizationPageArgs,
   QueryGetPublishedMaterialArgs,
 } from '@island.is/web/graphql/schema'
-import {
-  linkResolver,
-  useFeatureFlag,
-  useNamespace,
-} from '@island.is/web/hooks'
+import { linkResolver, useNamespace } from '@island.is/web/hooks'
 import useContentfulId from '@island.is/web/hooks/useContentfulId'
 import useLocalLinkTypeResolver from '@island.is/web/hooks/useLocalLinkTypeResolver'
 import { useWindowSize } from '@island.is/web/hooks/useViewport'
@@ -77,10 +73,6 @@ const PublishedMaterial: Screen<PublishedMaterialProps> = ({
   genericTagFilters,
   namespace,
 }) => {
-  const { value: isWebReaderEnabledForOrganizationPages } = useFeatureFlag(
-    'isWebReaderEnabledForOrganizationPages',
-    false,
-  )
   const router = useRouter()
   const { width } = useWindowSize()
   const [searchValue, setSearchValue] = useState('')
@@ -284,17 +276,10 @@ const PublishedMaterial: Screen<PublishedMaterialProps> = ({
         <GridColumn span="12/12">
           <GridRow>
             <GridColumn span={['12/12', '12/12', '6/12', '6/12', '8/12']}>
-              <Text
-                variant="h1"
-                as="h1"
-                marginBottom={isWebReaderEnabledForOrganizationPages ? 0 : 4}
-                marginTop={1}
-              >
+              <Text variant="h1" as="h1" marginBottom={0} marginTop={1}>
                 {pageTitle}
               </Text>
-              {isWebReaderEnabledForOrganizationPages && (
-                <Webreader readId={null} readClass="rs_read" />
-              )}
+              <Webreader readId={null} readClass="rs_read" />
             </GridColumn>
           </GridRow>
           <GridRow>

--- a/apps/web/screens/Organization/Services.tsx
+++ b/apps/web/screens/Organization/Services.tsx
@@ -32,7 +32,7 @@ import {
   GET_ORGANIZATION_SERVICES_QUERY,
 } from '../queries'
 import { Screen } from '../../types'
-import { useFeatureFlag, useNamespace } from '@island.is/web/hooks'
+import { useNamespace } from '@island.is/web/hooks'
 import { LinkType, useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
 import {
   getThemeConfig,
@@ -66,10 +66,6 @@ const ServicesPage: Screen<ServicesPageProps> = ({
   namespace,
 }) => {
   const router = useRouter()
-  const { value: isWebReaderEnabledForOrganizationPages } = useFeatureFlag(
-    'isWebReaderEnabledForOrganizationPages',
-    false,
-  )
   const n = useNamespace(namespace)
   const { linkResolver } = useLinkResolver()
 
@@ -152,17 +148,10 @@ const ServicesPage: Screen<ServicesPageProps> = ({
       <GridContainer>
         <GridRow>
           <GridColumn span={['12/12', '12/12', '6/12', '6/12', '8/12']}>
-            <Text
-              variant="h1"
-              as="h1"
-              marginBottom={isWebReaderEnabledForOrganizationPages ? 0 : 4}
-              marginTop={1}
-            >
+            <Text variant="h1" as="h1" marginBottom={0} marginTop={1}>
               {n('allServices', 'Öll þjónusta')}
             </Text>
-            {isWebReaderEnabledForOrganizationPages && (
-              <Webreader marginBottom={4} readId={null} readClass="rs_read" />
-            )}
+            <Webreader marginBottom={4} readId={null} readClass="rs_read" />
           </GridColumn>
         </GridRow>
         <GridRow marginBottom={4}>

--- a/apps/web/screens/Organization/StafraentIsland/ApiCatalogue.tsx
+++ b/apps/web/screens/Organization/StafraentIsland/ApiCatalogue.tsx
@@ -35,7 +35,7 @@ import {
 } from '@island.is/web/components'
 import { CustomNextError } from '@island.is/web/units/errors'
 import { SliceType } from '@island.is/island-ui/contentful'
-import { useFeatureFlag, useNamespace } from '@island.is/web/hooks'
+import { useNamespace } from '@island.is/web/hooks'
 import {
   GetApiCatalogueInput,
   QueryGetApiCatalogueArgs,
@@ -71,10 +71,6 @@ const ApiCatalogue: Screen<HomestayProps> = ({
   filterContent,
   navigationLinks,
 }) => {
-  const { value: isWebReaderEnabledForOrganizationPages } = useFeatureFlag(
-    'isWebReaderEnabledForOrganizationPages',
-    false,
-  )
   const { width } = useWindowSize()
   const [isMobile, setIsMobile] = useState(false)
   const Router = useRouter()
@@ -250,13 +246,11 @@ const ApiCatalogue: Screen<HomestayProps> = ({
         }}
         showSecondaryMenu={false}
       >
-        <Box paddingBottom={isWebReaderEnabledForOrganizationPages ? 0 : 4}>
+        <Box paddingBottom={0}>
           <Text variant="h1" as="h2">
             {subpage.title}
           </Text>
-          {isWebReaderEnabledForOrganizationPages && (
-            <Webreader readId={null} readClass="rs_read" />
-          )}
+          <Webreader readId={null} readClass="rs_read" />
         </Box>
         {webRichText(subpage.description as SliceType[], {
           renderNode: {

--- a/apps/web/screens/Organization/SubPage.tsx
+++ b/apps/web/screens/Organization/SubPage.tsx
@@ -26,7 +26,7 @@ import {
   GET_ORGANIZATION_SUBPAGE_QUERY,
 } from '../queries'
 import { Screen } from '../../types'
-import { useFeatureFlag, useNamespace } from '@island.is/web/hooks'
+import { useNamespace } from '@island.is/web/hooks'
 import { LinkType, useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
 import {
   getThemeConfig,
@@ -87,10 +87,6 @@ const SubPage: Screen<SubPageProps> = ({
   namespace,
   locale,
 }) => {
-  const { value: isWebReaderEnabledForOrganizationPages } = useFeatureFlag(
-    'isWebReaderEnabledForOrganizationPages',
-    false,
-  )
   const router = useRouter()
   const { activeLocale } = useI18n()
 
@@ -163,13 +159,11 @@ const SubPage: Screen<SubPageProps> = ({
                         {subpage.title}
                       </Text>
                     </Box>
-                    {isWebReaderEnabledForOrganizationPages && (
-                      <Webreader
-                        marginTop={0}
-                        readId={null}
-                        readClass="rs_read"
-                      />
-                    )}
+                    <Webreader
+                      marginTop={0}
+                      readId={null}
+                      readClass="rs_read"
+                    />
                   </GridColumn>
                 </GridRow>
                 {subpage.showTableOfContents && (

--- a/apps/web/screens/Organization/Syslumenn/Auctions.tsx
+++ b/apps/web/screens/Organization/Syslumenn/Auctions.tsx
@@ -33,7 +33,7 @@ import {
   GET_SYSLUMENN_AUCTIONS_QUERY,
 } from '../../queries'
 import { Screen } from '../../../types'
-import { useFeatureFlag, useNamespace } from '@island.is/web/hooks'
+import { useNamespace } from '@island.is/web/hooks'
 import { useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
 import { OrganizationWrapper, Webreader } from '@island.is/web/components'
 import { useQuery } from '@apollo/client'
@@ -397,10 +397,6 @@ const Auctions: Screen<AuctionsProps> = ({
   namespace,
   subpage,
 }) => {
-  const { value: isWebReaderEnabledForOrganizationPages } = useFeatureFlag(
-    'isWebReaderEnabledForOrganizationPages',
-    false,
-  )
   const n = useNamespace(namespace)
   const { linkResolver } = useLinkResolver()
   const { format } = useDateUtils()
@@ -662,9 +658,7 @@ const Auctions: Screen<AuctionsProps> = ({
         <Text variant="h1" as="h2">
           {subpage?.title ?? n('auctions', 'Uppboð')}
         </Text>
-        {isWebReaderEnabledForOrganizationPages && (
-          <Webreader readId={null} readClass="rs_read" />
-        )}
+        <Webreader readId={null} readClass="rs_read" />
       </Box>
       <GridContainer>
         <GridRow>

--- a/apps/web/screens/Organization/Syslumenn/Homestay.tsx
+++ b/apps/web/screens/Organization/Syslumenn/Homestay.tsx
@@ -26,7 +26,7 @@ import {
   GET_ORGANIZATION_SUBPAGE_QUERY,
 } from '../../queries'
 import { Screen } from '../../../types'
-import { useFeatureFlag, useNamespace } from '@island.is/web/hooks'
+import { useNamespace } from '@island.is/web/hooks'
 import { useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
 import {
   OrganizationWrapper,
@@ -66,10 +66,6 @@ const Homestay: Screen<HomestayProps> = ({
   homestays,
   namespace,
 }) => {
-  const { value: isWebReaderEnabledForOrganizationPages } = useFeatureFlag(
-    'isWebReaderEnabledForOrganizationPages',
-    false,
-  )
   useContentfulId(organizationPage.id, subpage.id)
   const n = useNamespace(namespace)
   const { linkResolver } = useLinkResolver()
@@ -173,13 +169,11 @@ const Homestay: Screen<HomestayProps> = ({
         items: navList,
       }}
     >
-      <Box paddingBottom={isWebReaderEnabledForOrganizationPages ? 0 : 4}>
+      <Box paddingBottom={0}>
         <Text variant="h1" as="h2">
           {subpage.title}
         </Text>
-        {isWebReaderEnabledForOrganizationPages && (
-          <Webreader readId={null} readClass="rs_read" />
-        )}
+        <Webreader readId={null} readClass="rs_read" />
       </Box>
       {webRichText(subpage.description as SliceType[])}
       <Box marginTop={4} marginBottom={6}>

--- a/apps/web/screens/Organization/Syslumenn/OperatingLicenses.tsx
+++ b/apps/web/screens/Organization/Syslumenn/OperatingLicenses.tsx
@@ -29,7 +29,7 @@ import {
   GET_OPERATING_LICENSES_CSV_QUERY,
 } from '../../queries'
 import { Screen } from '../../../types'
-import { useFeatureFlag, useNamespace } from '@island.is/web/hooks'
+import { useNamespace } from '@island.is/web/hooks'
 import { useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
 import {
   OrganizationWrapper,
@@ -240,10 +240,6 @@ const OperatingLicenses: Screen<OperatingLicensesProps> = ({
   subpage,
   namespace,
 }) => {
-  const { value: isWebReaderEnabledForOrganizationPages } = useFeatureFlag(
-    'isWebReaderEnabledForOrganizationPages',
-    false,
-  )
   const n = useNamespace(namespace)
   const { linkResolver } = useLinkResolver()
   const Router = useRouter()
@@ -367,13 +363,11 @@ const OperatingLicenses: Screen<OperatingLicensesProps> = ({
         items: navList,
       }}
     >
-      <Box paddingBottom={isWebReaderEnabledForOrganizationPages ? 0 : 2}>
+      <Box paddingBottom={0}>
         <Text variant="h1" as="h2">
           {subpage.title}
         </Text>
-        {isWebReaderEnabledForOrganizationPages && (
-          <Webreader readId={null} readClass="rs_read" />
-        )}
+        <Webreader readId={null} readClass="rs_read" />
       </Box>
       {webRichText(subpage.description as SliceType[])}
       <Box marginBottom={3}>


### PR DESCRIPTION
# Remove web reader feature flags that are set to true on prod

## What

* These web reader feature flags have been set to true on prod for a few months now so it's safe to simply remove them from the code

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
