### PR TITLE
feat(web): Fix ordering for support categories in service web contact form dropdown

### DIFF
--- a/apps/web/components/ServiceWeb/Forms/StandardForm/StandardForm.tsx
+++ b/apps/web/components/ServiceWeb/Forms/StandardForm/StandardForm.tsx
@@ -37,7 +37,6 @@ import {
   SearchableTags,
   SupportQna,
 } from '@island.is/web/graphql/schema'
-import orderBy from 'lodash/orderBy'
 import { useNamespace } from '@island.is/web/hooks'
 import slugify from '@sindresorhus/slugify'
 import { FormNamespace } from '../../types'
@@ -45,6 +44,7 @@ import { useI18n } from '@island.is/web/i18n'
 import { CategoryId, SyslumennCategories } from './types'
 import { SjukratryggingarCategories } from '@island.is/web/screens/ServiceWeb/Forms/utils'
 import { getServiceWebSearchTagQuery } from '@island.is/web/screens/ServiceWeb/utils'
+import { sortAlpha } from '@island.is/shared/utils'
 
 type FormState = {
   message: string
@@ -523,6 +523,13 @@ export const StandardForm = ({
 
   const isBusy = loadingSuggestions || isChangingSubject
 
+  const categoryOptions = supportCategories
+    .map((x) => ({
+      label: x.title?.trim(),
+      value: x.id,
+    }))
+    .sort(sortAlpha('label'))
+
   return (
     <>
       <GridContainer>
@@ -538,10 +545,7 @@ export const StandardForm = ({
                 setCategoryLabel(label as string)
                 setCategoryId(value as string)
               }}
-              options={orderBy(supportCategories, 'title', 'asc').map((x) => ({
-                label: x.title,
-                value: x.id,
-              }))}
+              options={categoryOptions}
               placeholder={fn('malaflokkur', 'placeholder', 'Veldu flokk')}
               size="md"
             />


### PR DESCRIPTION
# Fix ordering for support categories in service web contact form dropdown

## What

* The ordering wasn't correct since it didn't order icelandic characters correctly (that's what this change addresses)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
