### PR TITLE
fix(service-portal): wrong id in navigation message

### DIFF
--- a/libs/service-portal/health/src/lib/navigation.ts
+++ b/libs/service-portal/health/src/lib/navigation.ts
@@ -18,5 +18,5 @@ export const healthNavigation: PortalNavigationItem = {
       path: HealthPaths.HealthAidsAndNutrition,
     },
   ],
-  description: m.health,
+  description: m.healthDescription,
 }


### PR DESCRIPTION
## What

Set the right id

## Why

Its wrong

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
