### PR TITLE
fix(j-s): Disabling rows in case list in court of appeal

### DIFF
--- a/apps/judicial-system/web/src/components/Table/Table.tsx
+++ b/apps/judicial-system/web/src/components/Table/Table.tsx
@@ -159,7 +159,7 @@ const Table = <T extends object>(
                     'Header',
                   )} `}</Text>
                   <span>
-                    {props.sortableColumnIds?.includes(column.id) ? (
+                    {!column.disableSortBy ? (
                       column.isSorted ? (
                         column.isSortedDesc ? (
                           <Icon icon="caretDown" size="small" />

--- a/apps/judicial-system/web/src/routes/CourtOfAppeal/Cases/Cases.tsx
+++ b/apps/judicial-system/web/src/routes/CourtOfAppeal/Cases/Cases.tsx
@@ -67,6 +67,7 @@ const CourtOfAppealCases = () => {
     {
       Header: formatMessage(tables.caseNumber),
       accessor: 'courtCaseNumber' as keyof AppealedCasesQueryResponse,
+      disableSortBy: true,
       Cell: (row: {
         row: {
           original: { courtCaseNumber: string; policeCaseNumbers: string[] }
@@ -111,6 +112,7 @@ const CourtOfAppealCases = () => {
     {
       Header: formatMessage(tables.type),
       accessor: 'type' as keyof AppealedCasesQueryResponse,
+      disableSortBy: true,
       Cell: (row: {
         row: {
           original: {
@@ -139,6 +141,7 @@ const CourtOfAppealCases = () => {
     {
       Header: formatMessage(tables.state),
       accessor: 'state' as keyof AppealedCasesQueryResponse,
+      disableSortBy: true,
       Cell: (row: {
         row: {
           original: {
@@ -225,7 +228,6 @@ const CourtOfAppealCases = () => {
               (a) => a.appealState !== CaseAppealState.COMPLETED,
             ) || []
           }
-          sortableColumnIds={['defendants', 'appealedDate']}
         />
       </Box>
       <SectionHeading title={formatMessage(tables.completedCasesTitle)} />
@@ -241,7 +243,6 @@ const CourtOfAppealCases = () => {
             (a) => a.appealState === CaseAppealState.COMPLETED,
           ) || []
         }
-        sortableColumnIds={['defendants', 'duration']}
       />
     </SharedPageLayout>
   )

--- a/apps/judicial-system/web/src/routes/Shared/Cases/PastCases.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/Cases/PastCases.tsx
@@ -88,8 +88,6 @@ const PastCases: React.FC<Props> = (props) => {
   const { user } = useContext(UserContext)
   const { formatMessage } = useIntl()
 
-  const sortableColumnIds = ['courtCaseNumber', 'accusedName', 'type']
-
   const pastCasesColumns = useMemo(() => {
     return [
       {
@@ -271,7 +269,6 @@ const PastCases: React.FC<Props> = (props) => {
       data={pastCasesData ?? []}
       handleRowClick={onRowClick}
       className={styles.table}
-      sortableColumnIds={sortableColumnIds}
     />
   )
 }


### PR DESCRIPTION
# Disabling certain rows in case list in court of appeal

[Málalisti Landsréttur - Röðun í síu falin](https://app.asana.com/0/1199153462262248/1204559062187683)

## What

- disabling rows to not be sortable

## Why

- rows should not be sortable


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
