### PR TITLE
fix(web): Add org page to query for org subpage in search

### DIFF
--- a/apps/web/screens/queries/Search.tsx
+++ b/apps/web/screens/queries/Search.tsx
@@ -39,6 +39,9 @@ export const GET_SEARCH_RESULTS_QUERY = gql`
           id
           title
           slug
+          organizationPage {
+            slug
+          }
         }
       }
     }


### PR DESCRIPTION
# Add org page to query for org subpage in search

## What

* If you open up island.is right now (when this PR was created) and search for an org subpage then if you click on a suggested search result you'll always see a 404 since there is missing data required to form the link

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
