### PR TITLE
feat(web): Contentful live preview inspector mode

### DIFF
--- a/apps/web/components/Organization/NewsArticle/NewsArticle.tsx
+++ b/apps/web/components/Organization/NewsArticle/NewsArticle.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
 import cn from 'classnames'
+import { useContentfulInspectorMode } from '@contentful/live-preview/react'
 import { Box, Text } from '@island.is/island-ui/core'
 import { useDateUtils } from '@island.is/web/i18n/useDateUtils'
 import { Slice as SliceType, Image } from '@island.is/island-ui/contentful'
 import { webRichText } from '@island.is/web/utils/richText'
 import { Webreader } from '@island.is/web/components'
+import { useI18n } from '@island.is/web/i18n'
 import { GetSingleNewsItemQuery } from '../../../graphql/schema'
 
 import * as styles from './NewsArticle.css'
@@ -15,6 +17,8 @@ interface NewsArticleProps {
 
 export const NewsArticle: React.FC<NewsArticleProps> = ({ newsItem }) => {
   const { format } = useDateUtils()
+  const { activeLocale } = useI18n()
+  const inspectorProps = useContentfulInspectorMode<null>()
 
   const formattedDate = newsItem.date
     ? format(new Date(newsItem.date), 'do MMMM yyyy')
@@ -22,7 +26,14 @@ export const NewsArticle: React.FC<NewsArticleProps> = ({ newsItem }) => {
 
   return (
     <Box paddingBottom={[0, 0, 4]}>
-      <Box className="rs_read">
+      <Box
+        className="rs_read"
+        {...inspectorProps({
+          entryId: newsItem.id,
+          fieldId: 'title',
+          locale: activeLocale,
+        })}
+      >
         <Text variant="h1" as="h1" paddingBottom={2}>
           {newsItem.title}
         </Text>
@@ -31,12 +42,31 @@ export const NewsArticle: React.FC<NewsArticleProps> = ({ newsItem }) => {
       <Webreader marginTop={0} readId={null} readClass="rs_read" />
 
       <Box className="rs_read">
-        <Text variant="h4" as="p" paddingBottom={2} color="blue400">
+        <Text
+          variant="h4"
+          as="p"
+          paddingBottom={2}
+          color="blue400"
+          {...inspectorProps({
+            entryId: newsItem.id,
+            fieldId: 'date',
+            locale: activeLocale,
+          })}
+        >
           {formattedDate}
         </Text>
       </Box>
       <Box className="rs_read">
-        <Text variant="intro" as="p" paddingBottom={2}>
+        <Text
+          variant="intro"
+          as="p"
+          paddingBottom={2}
+          {...inspectorProps({
+            entryId: newsItem.id,
+            fieldId: 'intro',
+            locale: activeLocale,
+          })}
+        >
           {newsItem.intro}
         </Text>
       </Box>
@@ -46,6 +76,11 @@ export const NewsArticle: React.FC<NewsArticleProps> = ({ newsItem }) => {
           className={cn({
             [styles.floatedImage]: newsItem.fullWidthImageInContent === false,
           })}
+          {...inspectorProps({
+            entryId: newsItem.id,
+            fieldId: 'image',
+            locale: activeLocale,
+          })}
         >
           <Image
             {...newsItem.image}
@@ -54,7 +89,16 @@ export const NewsArticle: React.FC<NewsArticleProps> = ({ newsItem }) => {
           />
         </Box>
       )}
-      <Box className="rs_read" paddingBottom={4} width="full">
+      <Box
+        className="rs_read"
+        paddingBottom={4}
+        width="full"
+        {...inspectorProps({
+          entryId: newsItem.id,
+          fieldId: 'content',
+          locale: activeLocale,
+        })}
+      >
         {webRichText(newsItem.content as SliceType[], {
           renderComponent: {
             // Make sure that images in the content are full width

--- a/apps/web/layouts/main.tsx
+++ b/apps/web/layouts/main.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import Head from 'next/head'
+import { ContentfulLivePreviewProvider } from '@contentful/live-preview/react'
 import {
   Page,
   Box,
@@ -60,6 +61,8 @@ import {
 } from '../hooks/useLinkResolver'
 import { OrganizationIslandFooter } from '../components/Organization/OrganizationIslandFooter'
 import Illustration from './Illustration'
+
+import '@contentful/live-preview/style.css'
 import * as styles from './main.css'
 
 const { publicRuntimeConfig = {} } = getConfig() ?? {}
@@ -219,223 +222,236 @@ const Layout: NextComponentType<
   const isServiceWeb = pathIsRoute(asPath, 'serviceweb', activeLocale)
 
   return (
-    <GlobalContextProvider namespace={namespace} isServiceWeb={isServiceWeb}>
-      <Page component="div">
-        <Head>
-          {preloadedFonts.map((href, index) => {
-            return (
-              <link
-                key={index}
-                rel="preload"
-                href={href}
-                as="font"
-                type="font/woff2"
-                crossOrigin="anonymous"
-              />
-            )
-          })}
-          <link
-            rel="apple-touch-icon"
-            sizes="180x180"
-            href="/apple-touch-icon.png"
-          />
-          <link
-            rel="icon"
-            type="image/png"
-            sizes="32x32"
-            href="/favicon-32x32.png"
-          />
-          <link
-            rel="icon"
-            type="image/png"
-            sizes="16x16"
-            href="/favicon-16x16.png"
-          />
-          <link rel="manifest" href="/site.webmanifest" />
-          <meta name="msapplication-TileColor" content="#da532c" />
-          <meta name="theme-color" content="#ffffff" />
-          <title>{n('title')}</title>
-          <meta name="title" content={n('title')} key="title" />
-          <meta
-            name="description"
-            content={n('description')}
-            key="description"
-          />
-          <meta property="og:title" content={n('title')} key="ogTitle" />
-          <meta
-            property="og:description"
-            content={n('description')}
-            key="ogDescription"
-          />
-          <meta property="og:type" content="website" key="ogWebsite" />
-          <meta property="og:url" content={fullUrl} key="ogUrl" />
-          <meta
-            property="og:image"
-            content="https://island.is/island-fb-1200x630.png"
-            key="ogImage"
-          />
-          <meta property="og:image:width" content="1200" key="ogImageWidth" />
-          <meta property="og:image:height" content="630" key="ogImageHeight" />
-          <meta
-            property="twitter:card"
-            content="summary_large_image"
-            key="twitterCard"
-          />
-          <meta property="twitter:url" content={fullUrl} key="twitterUrl" />
-          <meta
-            property="twitter:title"
-            content={n('title')}
-            key="twitterTitle"
-          />
-          <meta
-            property="twitter:description"
-            content={n('description')}
-            key="twitterDescription"
-          />
-          <meta
-            property="twitter:image"
-            content="https://island.is/island-fb-1200x630.png"
-            key="twitterImage"
-          />
-        </Head>
-        <SkipToMainContent
-          title={n('skipToMainContent', 'Fara beint í efnið')}
-        />
-        {alertBanners.map((banner) => (
-          <AlertBanner
-            key={banner.bannerId}
-            title={banner.title}
-            description={banner.description}
-            link={{
-              ...(!!banner.link &&
-                !!banner.linkTitle && {
-                  href: linkResolver(banner.link.type as LinkType, [
-                    banner.link.slug,
-                  ]).href,
-                  title: banner.linkTitle,
-                }),
-            }}
-            variant={banner.bannerVariant as AlertBannerVariants}
-            dismissable={banner.isDismissable}
-            onDismiss={() => {
-              if (banner.dismissedForDays !== 0) {
-                Cookies.set(banner.bannerId, 'hide', {
-                  expires: banner.dismissedForDays,
-                })
-              }
-            }}
-          />
-        ))}
-        <Hidden above="sm">
-          <MobileAppBanner namespace={namespace} />
-        </Hidden>
-        <PageLoader />
-        <MenuTabsContext.Provider
-          value={{
-            menuTabs,
-          }}
-        >
-          {showHeader && (
-            <ColorSchemeContext.Provider
-              value={{ colorScheme: headerColorScheme }}
-            >
-              <Header
-                buttonColorScheme={headerButtonColorScheme}
-                showSearchInHeader={showSearchInHeader}
-                megaMenuData={megaMenuData}
-                languageToggleQueryParams={languageToggleQueryParams}
-              />
-            </ColorSchemeContext.Provider>
-          )}
-          <Main>
-            {wrapContent ? <Box width="full">{children}</Box> : children}
-          </Main>
-        </MenuTabsContext.Provider>
-        {showFooter && (
-          <Hidden print={true}>
-            {footerVersion === 'default' && (
-              <>
-                {showFooterIllustration && (
-                  <Illustration className={styles.illustration} />
-                )}
-                <Footer
-                  topLinks={footerUpperInfo}
-                  topLinksContact={footerUpperContact}
-                  bottomLinks={footerLowerMenu}
-                  middleLinks={footerMiddleMenu}
-                  bottomLinksTitle={t.siteExternalTitle}
-                  middleLinksTitle={String(namespace.footerMiddleLabel)}
-                  languageSwitchLink={{
-                    title: activeLocale === 'en' ? 'Íslenska' : 'English',
-                    href: activeLocale === 'en' ? '/' : '/en',
-                  }}
-                  privacyPolicyLink={{
-                    title: n('privacyPolicyTitle', 'Persónuverndarstefna'),
-                    href: n(
-                      'privacyPolicyHref',
-                      '/personuverndarstefna-stafraent-islands',
-                    ),
-                  }}
-                  termsLink={{
-                    title: n('termsTitle', 'Skilmálar'),
-                    href: n('termsHref', '/skilmalar-island-is'),
-                  }}
-                  showMiddleLinks
+    <ContentfulLivePreviewProvider
+      locale={activeLocale}
+      enableInspectorMode={true}
+      enableLiveUpdates={false}
+    >
+      <GlobalContextProvider namespace={namespace} isServiceWeb={isServiceWeb}>
+        <Page component="div">
+          <Head>
+            {preloadedFonts.map((href, index) => {
+              return (
+                <link
+                  key={index}
+                  rel="preload"
+                  href={href}
+                  as="font"
+                  type="font/woff2"
+                  crossOrigin="anonymous"
                 />
-              </>
-            )}
-            {footerVersion === 'organization' && <OrganizationIslandFooter />}
+              )
+            })}
+            <link
+              rel="apple-touch-icon"
+              sizes="180x180"
+              href="/apple-touch-icon.png"
+            />
+            <link
+              rel="icon"
+              type="image/png"
+              sizes="32x32"
+              href="/favicon-32x32.png"
+            />
+            <link
+              rel="icon"
+              type="image/png"
+              sizes="16x16"
+              href="/favicon-16x16.png"
+            />
+            <link rel="manifest" href="/site.webmanifest" />
+            <meta name="msapplication-TileColor" content="#da532c" />
+            <meta name="theme-color" content="#ffffff" />
+            <title>{n('title')}</title>
+            <meta name="title" content={n('title')} key="title" />
+            <meta
+              name="description"
+              content={n('description')}
+              key="description"
+            />
+            <meta property="og:title" content={n('title')} key="ogTitle" />
+            <meta
+              property="og:description"
+              content={n('description')}
+              key="ogDescription"
+            />
+            <meta property="og:type" content="website" key="ogWebsite" />
+            <meta property="og:url" content={fullUrl} key="ogUrl" />
+            <meta
+              property="og:image"
+              content="https://island.is/island-fb-1200x630.png"
+              key="ogImage"
+            />
+            <meta property="og:image:width" content="1200" key="ogImageWidth" />
+            <meta
+              property="og:image:height"
+              content="630"
+              key="ogImageHeight"
+            />
+            <meta
+              property="twitter:card"
+              content="summary_large_image"
+              key="twitterCard"
+            />
+            <meta property="twitter:url" content={fullUrl} key="twitterUrl" />
+            <meta
+              property="twitter:title"
+              content={n('title')}
+              key="twitterTitle"
+            />
+            <meta
+              property="twitter:description"
+              content={n('description')}
+              key="twitterDescription"
+            />
+            <meta
+              property="twitter:image"
+              content="https://island.is/island-fb-1200x630.png"
+              key="twitterImage"
+            />
+          </Head>
+          <SkipToMainContent
+            title={n('skipToMainContent', 'Fara beint í efnið')}
+          />
+          {alertBanners.map((banner) => (
+            <AlertBanner
+              key={banner.bannerId}
+              title={banner.title}
+              description={banner.description}
+              link={{
+                ...(!!banner.link &&
+                  !!banner.linkTitle && {
+                    href: linkResolver(banner.link.type as LinkType, [
+                      banner.link.slug,
+                    ]).href,
+                    title: banner.linkTitle,
+                  }),
+              }}
+              variant={banner.bannerVariant as AlertBannerVariants}
+              dismissable={banner.isDismissable}
+              onDismiss={() => {
+                if (banner.dismissedForDays !== 0) {
+                  Cookies.set(banner.bannerId, 'hide', {
+                    expires: banner.dismissedForDays,
+                  })
+                }
+              }}
+            />
+          ))}
+          <Hidden above="sm">
+            <MobileAppBanner namespace={namespace} />
           </Hidden>
-        )}
-        <style jsx global>{`
-          @font-face {
-            font-family: 'IBM Plex Sans';
-            font-style: normal;
-            font-weight: 300;
-            font-display: swap;
-            src: local('IBM Plex Sans Light'), local('IBMPlexSans-Light'),
-              url('/fonts/ibm-plex-sans-v7-latin-300.woff2') format('woff2'),
-              url('/fonts/ibm-plex-sans-v7-latin-300.woff') format('woff');
-          }
-          @font-face {
-            font-family: 'IBM Plex Sans';
-            font-style: normal;
-            font-weight: 400;
-            font-display: swap;
-            src: local('IBM Plex Sans'), local('IBMPlexSans'),
-              url('/fonts/ibm-plex-sans-v7-latin-regular.woff2') format('woff2'),
-              url('/fonts/ibm-plex-sans-v7-latin-regular.woff') format('woff');
-          }
-          @font-face {
-            font-family: 'IBM Plex Sans';
-            font-style: italic;
-            font-weight: 400;
-            font-display: swap;
-            src: local('IBM Plex Sans Italic'), local('IBMPlexSans-Italic'),
-              url('/fonts/ibm-plex-sans-v7-latin-italic.woff2') format('woff2'),
-              url('/fonts/ibm-plex-sans-v7-latin-italic.woff') format('woff');
-          }
-          @font-face {
-            font-family: 'IBM Plex Sans';
-            font-style: normal;
-            font-weight: 500;
-            font-display: swap;
-            src: local('IBM Plex Sans Medium'), local('IBMPlexSans-Medium'),
-              url('/fonts/ibm-plex-sans-v7-latin-500.woff2') format('woff2'),
-              url('/fonts/ibm-plex-sans-v7-latin-500.woff') format('woff');
-          }
-          @font-face {
-            font-family: 'IBM Plex Sans';
-            font-style: normal;
-            font-weight: 600;
-            font-display: swap;
-            src: local('IBM Plex Sans SemiBold'), local('IBMPlexSans-SemiBold'),
-              url('/fonts/ibm-plex-sans-v7-latin-600.woff2') format('woff2'),
-              url('/fonts/ibm-plex-sans-v7-latin-600.woff') format('woff');
-          }
-        `}</style>
-      </Page>
-    </GlobalContextProvider>
+          <PageLoader />
+          <MenuTabsContext.Provider
+            value={{
+              menuTabs,
+            }}
+          >
+            {showHeader && (
+              <ColorSchemeContext.Provider
+                value={{ colorScheme: headerColorScheme }}
+              >
+                <Header
+                  buttonColorScheme={headerButtonColorScheme}
+                  showSearchInHeader={showSearchInHeader}
+                  megaMenuData={megaMenuData}
+                  languageToggleQueryParams={languageToggleQueryParams}
+                />
+              </ColorSchemeContext.Provider>
+            )}
+            <Main>
+              {wrapContent ? <Box width="full">{children}</Box> : children}
+            </Main>
+          </MenuTabsContext.Provider>
+          {showFooter && (
+            <Hidden print={true}>
+              {footerVersion === 'default' && (
+                <>
+                  {showFooterIllustration && (
+                    <Illustration className={styles.illustration} />
+                  )}
+                  <Footer
+                    topLinks={footerUpperInfo}
+                    topLinksContact={footerUpperContact}
+                    bottomLinks={footerLowerMenu}
+                    middleLinks={footerMiddleMenu}
+                    bottomLinksTitle={t.siteExternalTitle}
+                    middleLinksTitle={String(namespace.footerMiddleLabel)}
+                    languageSwitchLink={{
+                      title: activeLocale === 'en' ? 'Íslenska' : 'English',
+                      href: activeLocale === 'en' ? '/' : '/en',
+                    }}
+                    privacyPolicyLink={{
+                      title: n('privacyPolicyTitle', 'Persónuverndarstefna'),
+                      href: n(
+                        'privacyPolicyHref',
+                        '/personuverndarstefna-stafraent-islands',
+                      ),
+                    }}
+                    termsLink={{
+                      title: n('termsTitle', 'Skilmálar'),
+                      href: n('termsHref', '/skilmalar-island-is'),
+                    }}
+                    showMiddleLinks
+                  />
+                </>
+              )}
+              {footerVersion === 'organization' && <OrganizationIslandFooter />}
+            </Hidden>
+          )}
+          <style jsx global>{`
+            @font-face {
+              font-family: 'IBM Plex Sans';
+              font-style: normal;
+              font-weight: 300;
+              font-display: swap;
+              src: local('IBM Plex Sans Light'), local('IBMPlexSans-Light'),
+                url('/fonts/ibm-plex-sans-v7-latin-300.woff2') format('woff2'),
+                url('/fonts/ibm-plex-sans-v7-latin-300.woff') format('woff');
+            }
+            @font-face {
+              font-family: 'IBM Plex Sans';
+              font-style: normal;
+              font-weight: 400;
+              font-display: swap;
+              src: local('IBM Plex Sans'), local('IBMPlexSans'),
+                url('/fonts/ibm-plex-sans-v7-latin-regular.woff2')
+                  format('woff2'),
+                url('/fonts/ibm-plex-sans-v7-latin-regular.woff') format('woff');
+            }
+            @font-face {
+              font-family: 'IBM Plex Sans';
+              font-style: italic;
+              font-weight: 400;
+              font-display: swap;
+              src: local('IBM Plex Sans Italic'), local('IBMPlexSans-Italic'),
+                url('/fonts/ibm-plex-sans-v7-latin-italic.woff2')
+                  format('woff2'),
+                url('/fonts/ibm-plex-sans-v7-latin-italic.woff') format('woff');
+            }
+            @font-face {
+              font-family: 'IBM Plex Sans';
+              font-style: normal;
+              font-weight: 500;
+              font-display: swap;
+              src: local('IBM Plex Sans Medium'), local('IBMPlexSans-Medium'),
+                url('/fonts/ibm-plex-sans-v7-latin-500.woff2') format('woff2'),
+                url('/fonts/ibm-plex-sans-v7-latin-500.woff') format('woff');
+            }
+            @font-face {
+              font-family: 'IBM Plex Sans';
+              font-style: normal;
+              font-weight: 600;
+              font-display: swap;
+              src: local('IBM Plex Sans SemiBold'),
+                local('IBMPlexSans-SemiBold'),
+                url('/fonts/ibm-plex-sans-v7-latin-600.woff2') format('woff2'),
+                url('/fonts/ibm-plex-sans-v7-latin-600.woff') format('woff');
+            }
+          `}</style>
+        </Page>
+      </GlobalContextProvider>
+    </ContentfulLivePreviewProvider>
   )
 }
 

--- a/apps/web/screens/Article/Article.tsx
+++ b/apps/web/screens/Article/Article.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router'
 import NextLink from 'next/link'
 import { BLOCKS } from '@contentful/rich-text-types'
 import slugify from '@sindresorhus/slugify'
+import { useContentfulInspectorMode } from '@contentful/live-preview/react'
 import {
   Slice as SliceType,
   ProcessEntry,
@@ -253,11 +254,20 @@ const ArticleSidebar: FC<ArticleSidebarProps> = ({
 }) => {
   const { linkResolver } = useLinkResolver()
   const { activeLocale } = useI18n()
+  const inspectorProps = useContentfulInspectorMode<null>()
 
   return (
     <Stack space={3}>
       {!!article.category?.slug && (
-        <Box display={['none', 'none', 'block']} printHidden>
+        <Box
+          display={['none', 'none', 'block']}
+          printHidden
+          {...inspectorProps({
+            entryId: article.id,
+            locale: activeLocale,
+            fieldId: 'category',
+          })}
+        >
           <Link
             {...linkResolver('articlecategory', [article.category.slug])}
             skipTab
@@ -276,25 +286,49 @@ const ArticleSidebar: FC<ArticleSidebarProps> = ({
         </Box>
       )}
       {article.organization.length > 0 && (
-        <InstitutionPanel
-          img={article.organization[0].logo?.url}
-          institutionTitle={n('organization')}
-          institution={article.organization[0].title}
-          locale={activeLocale}
-          linkProps={{
-            href: getOrganizationLink(article.organization[0], activeLocale),
-          }}
-          imgContainerDisplay={['block', 'block', 'none', 'block']}
-        />
+        <Box
+          {...inspectorProps({
+            entryId: article.id,
+            locale: activeLocale,
+            fieldId: 'organization',
+          })}
+        >
+          <InstitutionPanel
+            img={article.organization[0].logo?.url}
+            institutionTitle={n('organization')}
+            institution={article.organization[0].title}
+            locale={activeLocale}
+            linkProps={{
+              href: getOrganizationLink(article.organization[0], activeLocale),
+            }}
+            imgContainerDisplay={['block', 'block', 'none', 'block']}
+          />
+        </Box>
       )}
       {article.subArticles.length > 0 && (
-        <ArticleNavigation article={article} activeSlug={activeSlug} n={n} />
+        <Box
+          {...inspectorProps({
+            entryId: article.id,
+            locale: activeLocale,
+            fieldId: 'subArticles',
+          })}
+        >
+          <ArticleNavigation article={article} activeSlug={activeSlug} n={n} />
+        </Box>
       )}
-      <RelatedContent
-        title={n('relatedMaterial')}
-        articles={article.relatedArticles}
-        otherContent={article.relatedContent}
-      />
+      <Box
+        {...inspectorProps({
+          entryId: article.id,
+          locale: activeLocale,
+          fieldId: 'relatedArticles',
+        })}
+      >
+        <RelatedContent
+          title={n('relatedMaterial')}
+          articles={article.relatedArticles}
+          otherContent={article.relatedContent}
+        />
+      </Box>
     </Stack>
   )
 }
@@ -330,6 +364,8 @@ const ArticleScreen: Screen<ArticleProps> = ({
   const subArticle = article.subArticles.find((sub) => {
     return sub.slug.split('/').pop() === query.subSlug
   })
+
+  const inspectorProps = useContentfulInspectorMode<null>()
 
   useContentfulId(article.id, subArticle?.id)
 
@@ -425,6 +461,9 @@ const ArticleScreen: Screen<ArticleProps> = ({
     [article.category, article.group, inStepperView],
   )
 
+  const shouldShowRelatedContent =
+    article.relatedArticles.length > 0 || article.relatedContent.length > 0
+
   return (
     <>
       <HeadWithSocialSharing
@@ -453,7 +492,15 @@ const ArticleScreen: Screen<ArticleProps> = ({
         >
           {inStepperView && (
             <Text color="blueberry600" variant="eyebrow" as="h2">
-              <span id={slugify(article.title)} className="rs_read">
+              <span
+                id={slugify(article.title)}
+                className="rs_read"
+                {...inspectorProps({
+                  entryId: article.id,
+                  fieldId: 'title',
+                  locale: activeLocale,
+                })}
+              >
                 {article.title}
               </span>
             </Text>
@@ -483,7 +530,16 @@ const ArticleScreen: Screen<ArticleProps> = ({
           printHidden
         >
           {!!article.category?.title && (
-            <Box flexGrow={1} marginRight={6} overflow={'hidden'}>
+            <Box
+              flexGrow={1}
+              marginRight={6}
+              overflow={'hidden'}
+              {...inspectorProps({
+                entryId: article.id,
+                fieldId: 'category',
+                locale: activeLocale,
+              })}
+            >
               <Link href={categoryHref} skipTab>
                 <Button
                   preTextIcon="arrowBack"
@@ -499,7 +555,14 @@ const ArticleScreen: Screen<ArticleProps> = ({
             </Box>
           )}
           {article.organization.length > 0 && (
-            <Box minWidth={0}>
+            <Box
+              minWidth={0}
+              {...inspectorProps({
+                entryId: article.id,
+                fieldId: 'organization',
+                locale: activeLocale,
+              })}
+            >
               {article.organization[0].link ? (
                 <Link href={article.organization[0].link} skipTab>
                   <Tag variant="purple" truncate>
@@ -516,8 +579,16 @@ const ArticleScreen: Screen<ArticleProps> = ({
         </Box>
         <Box>
           {!inStepperView && (
-            <Text variant="h1" as="h1">
-              <span id={slugify(article.title)} className="rs_read">
+            <Text variant="h1">
+              <span
+                id={slugify(article.title)}
+                className="rs_read"
+                {...inspectorProps({
+                  entryId: article.id,
+                  fieldId: 'title',
+                  locale: activeLocale,
+                })}
+              >
                 {article.title}
               </span>
             </Text>
@@ -547,6 +618,11 @@ const ArticleScreen: Screen<ArticleProps> = ({
               display={['none', 'none', 'block']}
               printHidden
               className="rs_read"
+              {...inspectorProps({
+                entryId: article.id,
+                fieldId: 'processEntry',
+                locale: activeLocale,
+              })}
             >
               <ProcessEntry {...processEntry} />
             </Box>
@@ -556,16 +632,32 @@ const ArticleScreen: Screen<ArticleProps> = ({
             : article.showTableOfContents) && (
             <GridRow>
               <GridColumn span={[null, '4/7', '5/7', '4/7', '3/7']}>
-                <TOC
-                  title={n('tableOfContentTitle')}
-                  body={subArticle ? subArticle.body : article.body}
-                />
+                <Box
+                  {...inspectorProps({
+                    entryId: (subArticle ?? article).id,
+                    fieldId: 'showTableOfContents',
+                    locale: activeLocale,
+                  })}
+                >
+                  <TOC
+                    title={n('tableOfContentTitle')}
+                    body={subArticle ? subArticle.body : article.body}
+                  />
+                </Box>
               </GridColumn>
             </GridRow>
           )}
           {subArticle && (
-            <Text variant="h2" as="h2" paddingTop={7}>
-              <span id={slugify(subArticle.title)} className="rs_read">
+            <Text variant="h2" paddingTop={7}>
+              <span
+                id={slugify(subArticle.title)}
+                className="rs_read"
+                {...inspectorProps({
+                  entryId: subArticle.id,
+                  fieldId: 'title',
+                  locale: activeLocale,
+                })}
+              >
                 {subArticle.title}
               </span>
             </Text>
@@ -573,7 +665,14 @@ const ArticleScreen: Screen<ArticleProps> = ({
         </Box>
         <Box paddingTop={subArticle ? 2 : 4}>
           {!inStepperView && (
-            <Box className="rs_read">
+            <Box
+              className="rs_read"
+              {...inspectorProps({
+                entryId: (subArticle ?? article).id,
+                fieldId: 'content',
+                locale: activeLocale,
+              })}
+            >
               {webRichText(
                 (subArticle ?? article).body as SliceType[],
                 {
@@ -607,6 +706,11 @@ const ArticleScreen: Screen<ArticleProps> = ({
             display={['block', 'block', 'none']}
             marginTop={7}
             printHidden
+            {...inspectorProps({
+              entryId: article.id,
+              fieldId: 'processEntry',
+              locale: activeLocale,
+            })}
           >
             {processEntry?.processLink && <ProcessEntry {...processEntry} />}
           </Box>
@@ -615,6 +719,11 @@ const ArticleScreen: Screen<ArticleProps> = ({
               marginTop={[3, 3, 3, 10, 20]}
               marginBottom={[3, 3, 3, 10, 20]}
               printHidden
+              {...inspectorProps({
+                entryId: article.id,
+                fieldId: 'organization',
+                locale: activeLocale,
+              })}
             >
               <InstitutionsPanel
                 img={article.organization[0].logo?.url ?? ''}
@@ -648,9 +757,17 @@ const ArticleScreen: Screen<ArticleProps> = ({
               />
             </Box>
           )}
-          <Box display={['block', 'block', 'none']} printHidden>
-            {(article.relatedArticles.length > 0 ||
-              article.relatedContent.length > 0) && (
+          <Box
+            display={['block', 'block', 'none']}
+            printHidden
+            {...(shouldShowRelatedContent &&
+              inspectorProps({
+                entryId: article.id,
+                fieldId: 'relatedArticles',
+                locale: activeLocale,
+              }))}
+          >
+            {shouldShowRelatedContent && (
               <RelatedContent
                 title={n('relatedMaterial')}
                 articles={article.relatedArticles}
@@ -663,7 +780,16 @@ const ArticleScreen: Screen<ArticleProps> = ({
           mounted &&
           isVisible &&
           createPortal(
-            <Box marginTop={5} display={['block', 'block', 'none']} printHidden>
+            <Box
+              marginTop={5}
+              display={['block', 'block', 'none']}
+              printHidden
+              {...inspectorProps({
+                entryId: article.id,
+                fieldId: 'processEntry',
+                locale: activeLocale,
+              })}
+            >
               <ProcessEntry fixed {...processEntry} />
             </Box>,
             portalRef.current,

--- a/apps/web/screens/Category/Category/Category.tsx
+++ b/apps/web/screens/Category/Category/Category.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router'
 import Head from 'next/head'
 import intersection from 'lodash/intersection'
 import NextLink from 'next/link'
+import { useContentfulInspectorMode } from '@contentful/live-preview/react'
 import {
   Text,
   Stack,
@@ -45,6 +46,7 @@ import {
 import { CustomNextError } from '@island.is/web/units/errors'
 import { LinkType, useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
 import { scrollTo } from '@island.is/web/hooks/useScrollSpy'
+import { useI18n } from '@island.is/web/i18n'
 
 type Articles = GetArticlesQuery['getArticles']
 type LifeEvents = GetLifeEventsInCategoryQuery['getLifeEventsInCategory']
@@ -108,10 +110,12 @@ const Category: Screen<CategoryProps> = ({
 }) => {
   const itemsRef = useRef<Array<HTMLElement | null>>([])
   const [hashArray, setHashArray] = useState<string[]>([])
+  const { activeLocale } = useI18n()
 
   const Router = useRouter()
   const n = useNamespace(namespace)
   const { linkResolver } = useLinkResolver()
+  const inspectorProps = useContentfulInspectorMode<null>()
 
   const getCurrentCategory = () => categories.find((x) => x.slug === slug)
 
@@ -504,12 +508,28 @@ const Category: Screen<CategoryProps> = ({
           />
         </Box>
         <Box paddingBottom={[5, 5, 10]}>
-          <Text variant="h1" as="h1" paddingTop={[4, 4, 0]} paddingBottom={2}>
-            {category.title}
-          </Text>
-          <Text variant="intro" as="p">
-            {category.description}
-          </Text>
+          <Box
+            {...inspectorProps({
+              entryId: category.id,
+              fieldId: 'title',
+              locale: activeLocale,
+            })}
+          >
+            <Text variant="h1" as="h1" paddingTop={[4, 4, 0]} paddingBottom={2}>
+              {category.title}
+            </Text>
+          </Box>
+          <Box
+            {...inspectorProps({
+              entryId: category.id,
+              fieldId: 'description',
+              locale: activeLocale,
+            })}
+          >
+            <Text variant="intro" as="p">
+              {category.description}
+            </Text>
+          </Box>
         </Box>
         <Stack space={2}>
           {sortedGroups.map(({ groupSlug }, index) => (

--- a/apps/web/screens/LifeEvent/LifeEvent.tsx
+++ b/apps/web/screens/LifeEvent/LifeEvent.tsx
@@ -3,6 +3,7 @@ import { Screen } from '@island.is/web/types'
 import { CustomNextError } from '@island.is/web/units/errors'
 import slugify from '@sindresorhus/slugify'
 import NextLink from 'next/link'
+import { useContentfulInspectorMode } from '@contentful/live-preview/react'
 import { Slice as SliceType } from '@island.is/island-ui/contentful'
 import {
   GridRow,
@@ -40,6 +41,7 @@ import { useLocalLinkTypeResolver } from '@island.is/web/hooks/useLocalLinkTypeR
 import { webRichText } from '@island.is/web/utils/richText'
 import { Webreader } from '@island.is/web/components'
 import { DIGITAL_ICELAND_PLAUSIBLE_TRACKING_DOMAIN } from '@island.is/web/constants'
+import { useI18n } from '@island.is/web/i18n'
 
 interface LifeEventProps {
   lifeEvent: GetLifeEventQuery['getLifeEventPage']
@@ -54,12 +56,14 @@ export const LifeEvent: Screen<LifeEventProps> = ({
 }) => {
   useContentfulId(id)
   useLocalLinkTypeResolver()
+  const { activeLocale } = useI18n()
 
   usePlausiblePageview(DIGITAL_ICELAND_PLAUSIBLE_TRACKING_DOMAIN)
 
   const n = useNamespace(namespace)
   const { linkResolver } = useLinkResolver()
   const router = useRouter()
+  const inspectorProps = useContentfulInspectorMode<null>()
 
   const navigation = useMemo(() => {
     return createNavigation(content, { title })
@@ -118,6 +122,11 @@ export const LifeEvent: Screen<LifeEventProps> = ({
             display="inlineBlock"
             width="full"
             printHidden
+            {...inspectorProps({
+              entryId: id,
+              fieldId: 'image',
+              locale: activeLocale,
+            })}
           >
             {image && (
               <BackgroundImage
@@ -149,7 +158,15 @@ export const LifeEvent: Screen<LifeEventProps> = ({
                   />
                 </Box>
                 <Text variant="h1" as="h1">
-                  <span className="rs_read" id={slugify(title)}>
+                  <span
+                    className="rs_read"
+                    id={slugify(title)}
+                    {...inspectorProps({
+                      entryId: id,
+                      fieldId: 'title',
+                      locale: activeLocale,
+                    })}
+                  >
                     {title}
                   </span>
                 </Text>
@@ -158,7 +175,15 @@ export const LifeEvent: Screen<LifeEventProps> = ({
 
                 {intro && (
                   <Text variant="intro" as="p" paddingTop={2}>
-                    <span className="rs_read" id={slugify(intro)}>
+                    <span
+                      className="rs_read"
+                      id={slugify(intro)}
+                      {...inspectorProps({
+                        entryId: id,
+                        fieldId: 'intro',
+                        locale: activeLocale,
+                      })}
+                    >
                       {intro}
                     </span>
                   </Text>
@@ -175,7 +200,15 @@ export const LifeEvent: Screen<LifeEventProps> = ({
                     position="right"
                   />
                 </Box>
-                <Box className="rs_read" paddingTop={[3, 3, 4]}>
+                <Box
+                  className="rs_read"
+                  paddingTop={[3, 3, 4]}
+                  {...inspectorProps({
+                    entryId: id,
+                    fieldId: 'content',
+                    locale: activeLocale,
+                  })}
+                >
                   {webRichText(content as SliceType[])}
                 </Box>
               </GridColumn>

--- a/apps/web/screens/News.tsx
+++ b/apps/web/screens/News.tsx
@@ -54,9 +54,9 @@ import { FRONTPAGE_NEWS_TAG_ID } from '@island.is/web/constants'
 import { CustomNextError } from '../units/errors'
 import useContentfulId from '../hooks/useContentfulId'
 import { webRichText } from '../utils/richText'
+import { useI18n } from '../i18n'
 
 import * as styles from './News.css'
-import { useI18n } from '../i18n'
 
 const PERPAGE = 10
 

--- a/apps/web/screens/News.tsx
+++ b/apps/web/screens/News.tsx
@@ -3,6 +3,7 @@ import capitalize from 'lodash/capitalize'
 import cn from 'classnames'
 import { useRouter } from 'next/router'
 import NextLink from 'next/link'
+import { useContentfulInspectorMode } from '@contentful/live-preview/react'
 import { Screen } from '../types'
 import { Image, Slice as SliceType } from '@island.is/island-ui/contentful'
 import { useDateUtils } from '@island.is/web/i18n/useDateUtils'
@@ -55,6 +56,7 @@ import useContentfulId from '../hooks/useContentfulId'
 import { webRichText } from '../utils/richText'
 
 import * as styles from './News.css'
+import { useI18n } from '../i18n'
 
 const PERPAGE = 10
 
@@ -89,6 +91,9 @@ const NewsListNew: Screen<NewsListProps> = ({
   const { format, getMonthByIndex } = useDateUtils()
   const n = useNamespace(namespace)
   useContentfulId(newsItem?.id)
+  const { activeLocale } = useI18n()
+
+  const inspectorProps = useContentfulInspectorMode<null>()
 
   const years = Object.keys(datesMap)
     .map((x) => parseInt(x, 10))
@@ -213,23 +218,49 @@ const NewsListNew: Screen<NewsListProps> = ({
         display={['block', 'block', 'block', 'none']}
         paddingTop={5}
         width="full"
+        {...inspectorProps({
+          entryId: newsItem.id,
+          fieldId: 'date',
+          locale: activeLocale,
+        })}
       >
         <Text variant="eyebrow">{newsItemDate}</Text>
       </Box>
-      <Text variant="h1" as="h1" paddingTop={[3, 3, 3, 5]} paddingBottom={2}>
-        {newsItem.title}
-      </Text>
+      <Box
+        {...inspectorProps({
+          entryId: newsItem.id,
+          fieldId: 'title',
+          locale: activeLocale,
+        })}
+      >
+        <Text variant="h1" as="h1" paddingTop={[3, 3, 3, 5]} paddingBottom={2}>
+          {newsItem.title}
+        </Text>
+      </Box>
 
       <Webreader marginTop={0} readId={null} readClass="rs_read" />
 
-      <Text variant="intro" as="p" paddingBottom={2}>
-        {newsItem.intro}
-      </Text>
+      <Box
+        {...inspectorProps({
+          entryId: newsItem.id,
+          fieldId: 'intro',
+          locale: activeLocale,
+        })}
+      >
+        <Text variant="intro" as="p" paddingBottom={2}>
+          {newsItem.intro}
+        </Text>
+      </Box>
       {Boolean(newsItem.image) && (
         <Box
           paddingY={2}
           className={cn({
             [styles.floatedImage]: newsItem.fullWidthImageInContent === false,
+          })}
+          {...inspectorProps({
+            entryId: newsItem.id,
+            fieldId: 'image',
+            locale: activeLocale,
           })}
         >
           <Image
@@ -239,7 +270,15 @@ const NewsListNew: Screen<NewsListProps> = ({
           />
         </Box>
       )}
-      <Box paddingBottom={4} width="full">
+      <Box
+        paddingBottom={4}
+        width="full"
+        {...inspectorProps({
+          entryId: newsItem.id,
+          fieldId: 'content',
+          locale: activeLocale,
+        })}
+      >
         {webRichText(newsItem.content as SliceType[], {
           renderComponent: {
             // Make sure that images in the content are full width
@@ -304,7 +343,14 @@ const NewsListNew: Screen<NewsListProps> = ({
             }}
           />
           {!!newsItemDate && (
-            <Box display={['none', 'none', 'none', 'block']}>
+            <Box
+              display={['none', 'none', 'none', 'block']}
+              {...inspectorProps({
+                entryId: newsItem.id,
+                fieldId: 'date',
+                locale: activeLocale,
+              })}
+            >
               <Text variant="eyebrow">{newsItemDate}</Text>
             </Box>
           )}

--- a/apps/web/screens/Project/components/ProjectWrapper/ProjectWrapper.tsx
+++ b/apps/web/screens/Project/components/ProjectWrapper/ProjectWrapper.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement, useMemo } from 'react'
+import { useContentfulInspectorMode } from '@contentful/live-preview/react'
 import {
   Box,
   BreadCrumbItem,
@@ -18,6 +19,7 @@ import { getSidebarNavigationComponent } from '../../utils'
 import { useRouter } from 'next/router'
 
 import * as styles from './ProjectWrapper.css'
+import { useI18n } from '@island.is/web/i18n'
 
 interface ProjectWrapperProps {
   withSidebar?: boolean
@@ -36,6 +38,8 @@ export const ProjectWrapper: React.FC<ProjectWrapperProps> = ({
   children,
 }) => {
   const router = useRouter()
+  const { activeLocale } = useI18n()
+  const inspectorProps = useContentfulInspectorMode<null>()
 
   const baseRouterPath = router.asPath.split('?')[0].split('#')[0]
   const projectPageSidebarNavigationComponent = useMemo(
@@ -90,7 +94,14 @@ export const ProjectWrapper: React.FC<ProjectWrapperProps> = ({
           sidebarContent={
             <>
               {showBackLink && (
-                <Box marginBottom={3}>
+                <Box
+                  marginBottom={3}
+                  {...inspectorProps({
+                    entryId: projectPage.id,
+                    fieldId: 'backLink',
+                    locale: activeLocale,
+                  })}
+                >
                   <Link
                     href={projectPage.backLink.url}
                     underlineVisibility="always"
@@ -102,8 +113,17 @@ export const ProjectWrapper: React.FC<ProjectWrapperProps> = ({
                   </Link>
                 </Box>
               )}
-              {projectPage.sidebarLinks?.length > 0 &&
-                projectPageSidebarNavigationComponent()}
+              {projectPage.sidebarLinks?.length > 0 && (
+                <Box
+                  {...inspectorProps({
+                    entryId: projectPage.id,
+                    fieldId: 'projectSubpages',
+                    locale: activeLocale,
+                  })}
+                >
+                  {projectPageSidebarNavigationComponent()}
+                </Box>
+              )}
               {sidebarContent}
             </>
           }
@@ -115,22 +135,37 @@ export const ProjectWrapper: React.FC<ProjectWrapperProps> = ({
         <Box className={styles.fullWidthContainer}>
           {showBackLink && (
             <Hidden below="md">
-              <Link
-                href={projectPage.backLink.url}
-                underlineVisibility="always"
-                underline="normal"
-                color="blue400"
-                className={styles.linkContainer}
+              <Box
+                {...inspectorProps({
+                  entryId: projectPage.id,
+                  fieldId: 'backLink',
+                  locale: activeLocale,
+                })}
               >
-                <Icon size="small" icon="arrowBack" />
-                {projectPage.backLink.text}
-              </Link>
+                <Link
+                  href={projectPage.backLink.url}
+                  underlineVisibility="always"
+                  underline="normal"
+                  color="blue400"
+                  className={styles.linkContainer}
+                >
+                  <Icon size="small" icon="arrowBack" />
+                  {projectPage.backLink.text}
+                </Link>
+              </Box>
             </Hidden>
           )}
           <GridContainer>
             {showBackLink && (
               <Hidden above="sm">
-                <Box marginTop={4}>
+                <Box
+                  marginTop={4}
+                  {...inspectorProps({
+                    entryId: projectPage.id,
+                    fieldId: 'backLink',
+                    locale: activeLocale,
+                  })}
+                >
                   <Link
                     href={projectPage.backLink.url}
                     underlineVisibility="always"
@@ -160,7 +195,6 @@ export const ProjectWrapper: React.FC<ProjectWrapperProps> = ({
                 ]}
               >
                 {aboveChildren}
-
                 {children}
               </GridColumn>
             </GridRow>

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@contentful/field-editor-single-line": "1.1.8",
     "@contentful/forma-36-react-components": "3.78.4",
     "@contentful/forma-36-tokens": "0.10.1",
+    "@contentful/live-preview": "2.3.1",
     "@contentful/node-apps-toolkit": "2.0.2",
     "@contentful/react-apps-toolkit": "1.2.15",
     "@contentful/rich-text-html-renderer": "15.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5450,6 +5450,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@contentful/live-preview@npm:2.3.1":
+  version: 2.3.1
+  resolution: "@contentful/live-preview@npm:2.3.1"
+  dependencies:
+    use-deep-compare-effect: ^1.8.1
+  peerDependencies:
+    react: ^18.2.0
+    react-dom: ^18.2.0
+  checksum: 2593c13128713e4d2f67718f9925080e692011d3a17e5c34ee6eeec42b8f1d8a72afa25ba0ff5cdd81237e695079d1045466fe5a9d7e09ada9942c785b183957
+  languageName: node
+  linkType: hard
+
 "@contentful/mimetype@npm:^1.4.0":
   version: 1.4.45
   resolution: "@contentful/mimetype@npm:1.4.45"
@@ -23083,6 +23095,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dequal@npm:^2.0.2":
+  version: 2.0.3
+  resolution: "dequal@npm:2.0.3"
+  checksum: 8679b850e1a3d0ebbc46ee780d5df7b478c23f335887464023a631d1b9af051ad4a6595a44220f9ff8ff95a8ddccf019b5ad778a976fd7bbf77383d36f412f90
+  languageName: node
+  linkType: hard
+
 "des.js@npm:^1.0.0":
   version: 1.0.1
   resolution: "des.js@npm:1.0.1"
@@ -30520,6 +30539,7 @@ __metadata:
     "@contentful/field-editor-single-line": 1.1.8
     "@contentful/forma-36-react-components": 3.78.4
     "@contentful/forma-36-tokens": 0.10.1
+    "@contentful/live-preview": 2.3.1
     "@contentful/node-apps-toolkit": 2.0.2
     "@contentful/react-apps-toolkit": 1.2.15
     "@contentful/rich-text-html-renderer": 15.13.1
@@ -48860,6 +48880,18 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 7913df383a5a6fcb399212eedefaac2e0c6f843555202d4e3010bac3848afe38ecaa3d0d6500ad1d936fbeffd637e6c517e68edb024af5e6beca7f27f3ce7b21
+  languageName: node
+  linkType: hard
+
+"use-deep-compare-effect@npm:^1.8.1":
+  version: 1.8.1
+  resolution: "use-deep-compare-effect@npm:1.8.1"
+  dependencies:
+    "@babel/runtime": ^7.12.5
+    dequal: ^2.0.2
+  peerDependencies:
+    react: ">=16.13"
+  checksum: 2b9b6291df3f772f44d259b352e5d998963ccee0db2efeb76bb05525d928064aeeb69bb0dee5a5e428fea7cf3db67c097a770ebd30caa080662b565f6ef02b2e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Contentful live preview inspector mode

TODO's:
1. Maybe try and get the live updates working https://github.com/contentful/live-preview#init-configuration (it doesn't seem to support transformed data so perhaps we'll have to wait for that feature to be nicer to implement)

One issue is that it seems since our dev environment uses cognito that the iframe used for the live preview feature is being blocked :/

## What

* Contentful recently added an sdk to allow us to preview content while editing within Contentful.
* This code change adds metadata to content on the web so Contentful's inspector mode works correctly (it can tell us what content leads to what field in Contentful and so forth) 

## Why

* We want to improve the editing experience inside of Contentful

## Screenshots / Gifs

![image](https://github.com/island-is/island.is/assets/43557895/cbcf0faa-652a-4835-8469-52cece2a153c)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
