### PR TITLE
feat(web): Add header and footer for NTÍ organization

### DIFF
--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -83,7 +83,7 @@ import {
 import { UniversityStudiesHeader } from './Themes/UniversityStudiesTheme'
 import {
   IcelandicNaturalDisasterInsuranceHeader,
-  IcelandicNaturalDisasterInsuranceHeaderFooter,
+  IcelandicNaturalDisasterInsuranceFooter,
 } from './Themes/IcelandicNaturalDisasterInsuranceTheme'
 
 import * as styles from './OrganizationWrapper.css'
@@ -523,7 +523,7 @@ export const OrganizationFooter: React.FC<FooterProps> = ({
       break
     case 'nti':
       OrganizationFooterComponent = (
-        <IcelandicNaturalDisasterInsuranceHeaderFooter
+        <IcelandicNaturalDisasterInsuranceFooter
           footerItems={organization.footerItems}
           namespace={namespace}
         />

--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -81,6 +81,10 @@ import {
   HeilbrigdisstofnunAusturlandsHeader,
 } from './Themes/HeilbrigdisstofnunAusturlandsTheme'
 import { UniversityStudiesHeader } from './Themes/UniversityStudiesTheme'
+import {
+  IcelandicNaturalDisasterInsuranceHeader,
+  IcelandicNaturalDisasterInsuranceHeaderFooter,
+} from './Themes/IcelandicNaturalDisasterInsuranceTheme'
 
 import * as styles from './OrganizationWrapper.css'
 
@@ -120,6 +124,7 @@ export const lightThemes = [
   'hve',
   'hsa',
   'haskolanam',
+  'nti',
 ]
 export const footerEnabled = [
   'syslumenn',
@@ -162,6 +167,8 @@ export const footerEnabled = [
   'shh',
 
   'hsa',
+
+  'nti',
 ]
 
 export const getThemeConfig = (
@@ -177,7 +184,8 @@ export const getThemeConfig = (
   if (
     theme === 'sjukratryggingar' ||
     theme === 'rikislogmadur' ||
-    theme === 'tryggingastofnun'
+    theme === 'tryggingastofnun' ||
+    theme === 'nti'
   )
     return {
       themeConfig: {
@@ -253,6 +261,12 @@ export const OrganizationHeader: React.FC<HeaderProps> = ({
       )
     case 'haskolanam':
       return <UniversityStudiesHeader organizationPage={organizationPage} />
+    case 'nti':
+      return (
+        <IcelandicNaturalDisasterInsuranceHeader
+          organizationPage={organizationPage}
+        />
+      )
     default:
       return <DefaultHeader organizationPage={organizationPage} />
   }
@@ -504,6 +518,14 @@ export const OrganizationFooter: React.FC<FooterProps> = ({
           title={organization.title}
           namespace={namespace}
           footerItems={organization.footerItems}
+        />
+      )
+      break
+    case 'nti':
+      OrganizationFooterComponent = (
+        <IcelandicNaturalDisasterInsuranceHeaderFooter
+          footerItems={organization.footerItems}
+          namespace={namespace}
         />
       )
       break

--- a/apps/web/components/Organization/Wrapper/Themes/IcelandicNaturalDisasterInsuranceTheme/IcelandicNaturalDisasterInsuranceFooter.css.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/IcelandicNaturalDisasterInsuranceTheme/IcelandicNaturalDisasterInsuranceFooter.css.ts
@@ -1,0 +1,6 @@
+import { style } from '@vanilla-extract/css'
+
+export const footer = style({
+  paddingTop: '64px',
+  paddingBottom: '64px',
+})

--- a/apps/web/components/Organization/Wrapper/Themes/IcelandicNaturalDisasterInsuranceTheme/IcelandicNaturalDisasterInsuranceFooter.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/IcelandicNaturalDisasterInsuranceTheme/IcelandicNaturalDisasterInsuranceFooter.tsx
@@ -1,0 +1,56 @@
+import { SliceType } from '@island.is/island-ui/contentful'
+import {
+  Box,
+  GridColumn,
+  GridContainer,
+  GridRow,
+  Text,
+} from '@island.is/island-ui/core'
+import { FooterItem } from '@island.is/web/graphql/schema'
+import { useNamespace } from '@island.is/web/hooks'
+import { webRichText } from '@island.is/web/utils/richText'
+
+import * as styles from './IcelandicNaturalDisasterInsuranceFooter.css'
+
+interface IcelandicNaturalDisasterInsuranceFooterProps {
+  namespace: Record<string, string>
+  footerItems?: FooterItem[]
+}
+
+const IcelandicNaturalDisasterInsuranceFooter = ({
+  namespace,
+  footerItems,
+}: IcelandicNaturalDisasterInsuranceFooterProps) => {
+  const n = useNamespace(namespace)
+
+  return (
+    <footer className={styles.footer} aria-labelledby="nti-footer">
+      <GridContainer>
+        <GridRow>
+          <GridColumn>
+            <Box marginBottom={2} marginRight={2}>
+              <img
+                src={n(
+                  'ntiFooterLogo',
+                  'https://images.ctfassets.net/8k0h54kbe6bj/1J7KjOH1so3QXE0Zu8kVMG/8de93a53cf62f91970b40edd51b4493d/nti-footer.svg',
+                )}
+                alt=""
+              />
+            </Box>
+          </GridColumn>
+
+          {footerItems.map((item, index) => (
+            <GridColumn key={index}>
+              <Box marginRight={12} marginBottom={2}>
+                <Text fontWeight="semiBold">{item.title}</Text>
+              </Box>
+              {webRichText(item.content as SliceType[])}
+            </GridColumn>
+          ))}
+        </GridRow>
+      </GridContainer>
+    </footer>
+  )
+}
+
+export default IcelandicNaturalDisasterInsuranceFooter

--- a/apps/web/components/Organization/Wrapper/Themes/IcelandicNaturalDisasterInsuranceTheme/IcelandicNaturalDisasterInsuranceFooter.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/IcelandicNaturalDisasterInsuranceTheme/IcelandicNaturalDisasterInsuranceFooter.tsx
@@ -9,6 +9,8 @@ import {
 import { FooterItem } from '@island.is/web/graphql/schema'
 import { useNamespace } from '@island.is/web/hooks'
 import { webRichText } from '@island.is/web/utils/richText'
+import { useWindowSize } from '@island.is/web/hooks/useViewport'
+import { theme } from '@island.is/island-ui/theme'
 
 import * as styles from './IcelandicNaturalDisasterInsuranceFooter.css'
 
@@ -22,6 +24,8 @@ const IcelandicNaturalDisasterInsuranceFooter = ({
   footerItems,
 }: IcelandicNaturalDisasterInsuranceFooterProps) => {
   const n = useNamespace(namespace)
+  const { width } = useWindowSize()
+  const shouldWrap = width < theme.breakpoints.xl
 
   return (
     <footer className={styles.footer} aria-labelledby="nti-footer">
@@ -40,11 +44,17 @@ const IcelandicNaturalDisasterInsuranceFooter = ({
           </GridColumn>
 
           {footerItems.map((item, index) => (
-            <GridColumn key={index}>
-              <Box marginRight={12} marginBottom={2}>
-                <Text fontWeight="semiBold">{item.title}</Text>
+            <GridColumn span={shouldWrap ? '1/1' : undefined} key={index}>
+              <Box
+                marginTop={index === 0 && shouldWrap ? 3 : 0}
+                marginLeft={shouldWrap ? 7 : undefined}
+                marginRight={shouldWrap ? null : 12}
+              >
+                <Box marginBottom={2}>
+                  <Text fontWeight="semiBold">{item.title}</Text>
+                </Box>
+                {webRichText(item.content as SliceType[])}
               </Box>
-              {webRichText(item.content as SliceType[])}
             </GridColumn>
           ))}
         </GridRow>

--- a/apps/web/components/Organization/Wrapper/Themes/IcelandicNaturalDisasterInsuranceTheme/IcelandicNaturalDisasterInsuranceHeader.css.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/IcelandicNaturalDisasterInsuranceTheme/IcelandicNaturalDisasterInsuranceHeader.css.ts
@@ -1,0 +1,85 @@
+import { style } from '@vanilla-extract/css'
+import { themeUtils } from '@island.is/island-ui/theme'
+
+export const headerBg = style({
+  height: 385,
+  marginTop: -130,
+  paddingTop: 130,
+})
+
+export const iconCircle = style({
+  height: 136,
+  width: 136,
+  background: '#fff',
+  borderRadius: '50%',
+  margin: '0 auto',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  boxShadow: '0px 4px 30px rgba(0, 97, 255, 0.08)',
+  ...themeUtils.responsiveStyle({
+    xs: {
+      marginTop: 32,
+    },
+    md: {
+      marginTop: 104,
+      position: 'relative',
+    },
+  }),
+})
+
+export const headerBorder = style({
+  ...themeUtils.responsiveStyle({
+    xs: {
+      marginTop: 32,
+    },
+    md: {
+      borderBottom: '4px solid #ffbe43',
+    },
+  }),
+})
+
+export const headerWrapper = style({
+  marginTop: -20,
+})
+
+export const headerLogo = style({
+  width: 70,
+  maxHeight: 70,
+})
+
+export const navigation = style({
+  ...themeUtils.responsiveStyle({
+    md: {
+      background: 'none',
+      paddingTop: 0,
+    },
+    xs: {
+      marginLeft: -24,
+      marginRight: -24,
+      paddingLeft: 24,
+      paddingRight: 24,
+      paddingTop: 32,
+    },
+  }),
+})
+
+export const title = style({
+  ...themeUtils.responsiveStyle({
+    md: {
+      marginLeft: -48,
+      marginTop: -48,
+      width: '80%',
+    },
+    lg: {
+      width: '50%',
+      marginLeft: -80,
+      marginTop: -48,
+    },
+    xl: {
+      width: '50%',
+      marginLeft: -128,
+      marginTop: -48,
+    },
+  }),
+})

--- a/apps/web/components/Organization/Wrapper/Themes/IcelandicNaturalDisasterInsuranceTheme/IcelandicNaturalDisasterInsuranceHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/IcelandicNaturalDisasterInsuranceTheme/IcelandicNaturalDisasterInsuranceHeader.tsx
@@ -1,0 +1,118 @@
+import { OrganizationPage } from '@island.is/web/graphql/schema'
+import React, { useMemo } from 'react'
+import { Box, Hidden, Hyphen, Link, Text } from '@island.is/island-ui/core'
+import SidebarLayout from '@island.is/web/screens/Layouts/SidebarLayout'
+import { useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
+import { useNamespace } from '@island.is/web/hooks'
+import { useWindowSize } from '@island.is/web/hooks/useViewport'
+import { getScreenWidthString } from '@island.is/web/utils/screenWidth'
+import { theme } from '@island.is/island-ui/theme'
+import * as styles from './IcelandicNaturalDisasterInsuranceHeader.css'
+
+const getDefaultStyle = (width: number) => {
+  if (width > theme.breakpoints.lg)
+    return {
+      backgroundRepeat: 'no-repeat',
+      backgroundSize: '100% 340px, cover',
+      backgroundPosition: 'bottom',
+      backgroundImage:
+        "url('https://images.ctfassets.net/8k0h54kbe6bj/2urQfUGjA4HrUVAqIqJPp/ff94bb07a9922141d9f2dd96ae5be370/Vefsi____a_mynd_1440x385pix__1_.png'), linear-gradient(#25afb9, #25afb9)",
+    }
+  if (width > theme.breakpoints.md)
+    return {
+      backgroundRepeat: 'no-repeat',
+      backgroundSize: 'cover',
+      backgroundImage:
+        "url('https://images.ctfassets.net/8k0h54kbe6bj/2urQfUGjA4HrUVAqIqJPp/ff94bb07a9922141d9f2dd96ae5be370/Vefsi____a_mynd_1440x385pix__1_.png')",
+    }
+  return {
+    backgroundRepeat: 'no-repeat',
+    backgroundSize: 'cover',
+    backgroundImage: 'linear-gradient(#6bcacf, #25afb9)',
+  }
+}
+
+interface HeaderProps {
+  organizationPage: OrganizationPage
+}
+
+const IcelandicNaturalDisasterInsuranceHeader: React.FC<HeaderProps> = ({
+  organizationPage,
+}) => {
+  const { linkResolver } = useLinkResolver()
+  const namespace = useMemo(
+    () => JSON.parse(organizationPage.organization.namespace?.fields ?? '{}'),
+    [organizationPage.organization.namespace?.fields],
+  )
+  const n = useNamespace(namespace)
+  const { width } = useWindowSize()
+
+  const screenWidth = getScreenWidthString(width)
+
+  return (
+    <div
+      style={n(`ntiHeader-${screenWidth}`, getDefaultStyle(width))}
+      className={styles.headerBg}
+    >
+      <div className={styles.headerWrapper}>
+        <SidebarLayout
+          sidebarContent={
+            !!organizationPage.organization.logo && (
+              <Link
+                href={
+                  linkResolver('organizationpage', [organizationPage.slug]).href
+                }
+                className={styles.iconCircle}
+              >
+                <img
+                  src={organizationPage.organization.logo.url}
+                  className={styles.headerLogo}
+                  alt="nti-logo"
+                />
+              </Link>
+            )
+          }
+        >
+          {!!organizationPage.organization.logo && (
+            <Hidden above="sm">
+              <Link
+                href={
+                  linkResolver('organizationpage', [organizationPage.slug]).href
+                }
+                className={styles.iconCircle}
+              >
+                <img
+                  src={organizationPage.organization.logo.url}
+                  className={styles.headerLogo}
+                  alt=""
+                />
+              </Link>
+            </Hidden>
+          )}
+          <Box
+            className={styles.title}
+            marginTop={[2, 2, 6]}
+            textAlign={['center', 'center', 'left']}
+          >
+            <Link
+              href={
+                linkResolver('organizationpage', [organizationPage.slug]).href
+              }
+            >
+              <Text
+                variant={width > theme.breakpoints.sm ? 'h1' : 'h3'}
+                as="h1"
+                color="blueberry600"
+                fontWeight="semiBold"
+              >
+                <Hyphen>{organizationPage.title}</Hyphen>
+              </Text>
+            </Link>
+          </Box>
+        </SidebarLayout>
+      </div>
+    </div>
+  )
+}
+
+export default IcelandicNaturalDisasterInsuranceHeader

--- a/apps/web/components/Organization/Wrapper/Themes/IcelandicNaturalDisasterInsuranceTheme/IcelandicNaturalDisasterInsuranceHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/IcelandicNaturalDisasterInsuranceTheme/IcelandicNaturalDisasterInsuranceHeader.tsx
@@ -19,16 +19,24 @@ const getDefaultStyle = (width: number) => {
     return {
       backgroundRepeat: 'no-repeat',
       backgroundSize: 'auto 280px, auto 280px, cover',
-      backgroundPosition: 'bottom left, bottom right, center',
+      backgroundPosition: '10% bottom, bottom right, center',
+      backgroundImage: `url('${treeImageUrl}'), url('${townImageUrl}'), linear-gradient(0deg, #FFFFFF -40.18%, #FAFDFD -23.09%, #ECF8F9 -4.3%, #D6F0F1 16.21%, #B7E5E7 36.72%, #8ED6DA 57.23%, #5DC4CA 77.74%, #23AFB8 100.93%, #00A3AD 113.54%)`,
+    }
+  }
+  if (width > theme.breakpoints.lg) {
+    return {
+      backgroundRepeat: 'no-repeat',
+      backgroundSize: 'auto 280px, auto 280px, cover',
+      backgroundPosition: '5% bottom, 240% bottom, center',
       backgroundImage: `url('${treeImageUrl}'), url('${townImageUrl}'), linear-gradient(0deg, #FFFFFF -40.18%, #FAFDFD -23.09%, #ECF8F9 -4.3%, #D6F0F1 16.21%, #B7E5E7 36.72%, #8ED6DA 57.23%, #5DC4CA 77.74%, #23AFB8 100.93%, #00A3AD 113.54%)`,
     }
   }
   if (width > theme.breakpoints.md) {
     return {
       backgroundRepeat: 'no-repeat',
-      backgroundSize: 'cover',
-      backgroundImage:
-        "url('https://images.ctfassets.net/8k0h54kbe6bj/2urQfUGjA4HrUVAqIqJPp/ff94bb07a9922141d9f2dd96ae5be370/Vefsi____a_mynd_1440x385pix__1_.png')",
+      backgroundSize: 'auto 280px, cover',
+      backgroundPosition: '5% bottom, center',
+      backgroundImage: `url('${treeImageUrl}'), linear-gradient(0deg, #FFFFFF -40.18%, #FAFDFD -23.09%, #ECF8F9 -4.3%, #D6F0F1 16.21%, #B7E5E7 36.72%, #8ED6DA 57.23%, #5DC4CA 77.74%, #23AFB8 100.93%, #00A3AD 113.54%)`,
     }
   }
   return {

--- a/apps/web/components/Organization/Wrapper/Themes/IcelandicNaturalDisasterInsuranceTheme/IcelandicNaturalDisasterInsuranceHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/IcelandicNaturalDisasterInsuranceTheme/IcelandicNaturalDisasterInsuranceHeader.tsx
@@ -9,26 +9,33 @@ import { getScreenWidthString } from '@island.is/web/utils/screenWidth'
 import { theme } from '@island.is/island-ui/theme'
 import * as styles from './IcelandicNaturalDisasterInsuranceHeader.css'
 
+const treeImageUrl =
+  'https://images.ctfassets.net/8k0h54kbe6bj/52r9AXIIGj5d3VxfQA2yQL/ff654c88c6309ad799ccc5668754371d/nti-trees.svg'
+const townImageUrl =
+  'https://images.ctfassets.net/8k0h54kbe6bj/7ryH2zTpjxid0iakBnSgKV/37daf02f0c0051b9ddb1327b0a83ec59/nti-town.svg'
+
 const getDefaultStyle = (width: number) => {
-  if (width > theme.breakpoints.lg)
+  if (width > theme.breakpoints.xl) {
     return {
       backgroundRepeat: 'no-repeat',
-      backgroundSize: '100% 340px, cover',
-      backgroundPosition: 'bottom',
-      backgroundImage:
-        "url('https://images.ctfassets.net/8k0h54kbe6bj/2urQfUGjA4HrUVAqIqJPp/ff94bb07a9922141d9f2dd96ae5be370/Vefsi____a_mynd_1440x385pix__1_.png'), linear-gradient(#25afb9, #25afb9)",
+      backgroundSize: 'auto 280px, auto 280px, cover',
+      backgroundPosition: 'bottom left, bottom right, center',
+      backgroundImage: `url('${treeImageUrl}'), url('${townImageUrl}'), linear-gradient(0deg, #FFFFFF -40.18%, #FAFDFD -23.09%, #ECF8F9 -4.3%, #D6F0F1 16.21%, #B7E5E7 36.72%, #8ED6DA 57.23%, #5DC4CA 77.74%, #23AFB8 100.93%, #00A3AD 113.54%)`,
     }
-  if (width > theme.breakpoints.md)
+  }
+  if (width > theme.breakpoints.md) {
     return {
       backgroundRepeat: 'no-repeat',
       backgroundSize: 'cover',
       backgroundImage:
         "url('https://images.ctfassets.net/8k0h54kbe6bj/2urQfUGjA4HrUVAqIqJPp/ff94bb07a9922141d9f2dd96ae5be370/Vefsi____a_mynd_1440x385pix__1_.png')",
     }
+  }
   return {
     backgroundRepeat: 'no-repeat',
     backgroundSize: 'cover',
-    backgroundImage: 'linear-gradient(#6bcacf, #25afb9)',
+    backgroundImage:
+      'linear-gradient(0deg, #FFFFFF -40.18%, #FAFDFD -23.09%, #ECF8F9 -4.3%, #D6F0F1 16.21%, #B7E5E7 36.72%, #8ED6DA 57.23%, #5DC4CA 77.74%, #23AFB8 100.93%, #00A3AD 113.54%)',
   }
 }
 

--- a/apps/web/components/Organization/Wrapper/Themes/IcelandicNaturalDisasterInsuranceTheme/index.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/IcelandicNaturalDisasterInsuranceTheme/index.ts
@@ -4,7 +4,7 @@ export const IcelandicNaturalDisasterInsuranceHeader = dynamic(
   () => import('./IcelandicNaturalDisasterInsuranceHeader'),
   { ssr: false },
 )
-export const IcelandicNaturalDisasterInsuranceHeaderFooter = dynamic(
+export const IcelandicNaturalDisasterInsuranceFooter = dynamic(
   () => import('./IcelandicNaturalDisasterInsuranceFooter'),
   { ssr: false },
 )

--- a/apps/web/components/Organization/Wrapper/Themes/IcelandicNaturalDisasterInsuranceTheme/index.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/IcelandicNaturalDisasterInsuranceTheme/index.ts
@@ -1,0 +1,10 @@
+import dynamic from 'next/dynamic'
+
+export const IcelandicNaturalDisasterInsuranceHeader = dynamic(
+  () => import('./IcelandicNaturalDisasterInsuranceHeader'),
+  { ssr: false },
+)
+export const IcelandicNaturalDisasterInsuranceHeaderFooter = dynamic(
+  () => import('./IcelandicNaturalDisasterInsuranceFooter'),
+  { ssr: false },
+)


### PR DESCRIPTION
# Add header and footer for NTÍ organization

## Screenshots / Gifs

<img width="1464" alt="image" src="https://github.com/island-is/island.is/assets/43557895/ed53ee98-1dd3-4cdd-ae2e-f74191880591">
<img width="1360" alt="image" src="https://github.com/island-is/island.is/assets/43557895/177e765b-443e-4212-9942-a29ad4a6a3cf">


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
