### PR TITLE
chore(web): Add namespace feature flag for vacancies list page

### DIFF
--- a/apps/web/screens/IcelandicGovernmentInstitutionVacancies/IcelandicGovernmentInstitutionVacancyDetails.tsx
+++ b/apps/web/screens/IcelandicGovernmentInstitutionVacancies/IcelandicGovernmentInstitutionVacancyDetails.tsx
@@ -295,6 +295,10 @@ IcelandicGovernmentInstitutionVacancyDetails.getInitialProps = async ({
     namespaceResponse?.data?.getNamespace?.fields || '{}',
   ) as Record<string, string>
 
+  if (namespace['display404']) {
+    throw new CustomNextError(404, 'Vacancies on Ísland.is are turned off')
+  }
+
   return {
     vacancy,
     namespace,


### PR DESCRIPTION
# Add namespace feature flag for vacancies list page

## What

A new page displaying a list of vacancies is gonna go live in the next release and we want to have a way to manually start displaying the page

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
