### PR TITLE
fix(transfer of vehicle ownership): error if more than one co-owner

### DIFF
--- a/libs/application/templates/transport-authority/transfer-of-vehicle-ownership/src/utils/getApproveAnswers.ts
+++ b/libs/application/templates/transport-authority/transfer-of-vehicle-ownership/src/utils/getApproveAnswers.ts
@@ -8,12 +8,19 @@ export const getApproveAnswers = (
 ) => {
   const returnAnswers = {}
   // If reviewer is buyer
+  const buyerNationalId = getValueViaPath(
+    answers,
+    'buyer.nationalId',
+    '',
+  ) as string
+  const buyerApproved = getValueViaPath(
+    answers,
+    'buyer.approved',
+    undefined,
+  ) as boolean | undefined
   if (
-    (getValueViaPath(answers, 'buyer.nationalId', '') as string) ===
-      reviewerNationalId &&
-    (getValueViaPath(answers, 'buyer.approved', undefined) as
-      | boolean
-      | undefined) === undefined
+    buyerNationalId === reviewerNationalId &&
+    (buyerApproved === undefined || buyerApproved === false)
   ) {
     Object.assign(returnAnswers, {
       buyer: {
@@ -40,7 +47,8 @@ export const getApproveAnswers = (
     )
   if (
     buyerCoOwnerAndOperator &&
-    buyerCoOwnerAndOperator.approved === undefined
+    (buyerCoOwnerAndOperator.approved === undefined ||
+      buyerCoOwnerAndOperator.approved === false)
   ) {
     Object.assign(returnAnswers, {
       buyerCoOwnerAndOperator: buyerCoOwnersAndOperators.map(
@@ -71,7 +79,10 @@ export const getApproveAnswers = (
   const sellerCoOwner = sellerCoOwners.find(
     (coOwner) => coOwner.nationalId === reviewerNationalId,
   )
-  if (sellerCoOwner && sellerCoOwner.approved === undefined) {
+  if (
+    sellerCoOwner &&
+    (sellerCoOwner.approved === undefined || sellerCoOwner.approved === false)
+  ) {
     Object.assign(returnAnswers, {
       sellerCoOwner: sellerCoOwners.map((coOwner) => {
         return {


### PR DESCRIPTION
## What

Seller's co-owner is not able to approve if one other seller's co-owner has already approved (then approved=false, but the check for whether we should save the approved answer only continues if approved=undefined)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review