### PR TITLE
Fix error when revalidate is called twice.

### DIFF
--- a/libs/portals/admin/ids-admin/src/screens/Client/components/RotateSecret/RotateSecret.tsx
+++ b/libs/portals/admin/ids-admin/src/screens/Client/components/RotateSecret/RotateSecret.tsx
@@ -70,10 +70,13 @@ export const RotateSecret = ({
   }
 
   const handleClose = useCallback(() => {
+    if (newSecret) {
+      revalidate()
+    }
+
     setNewSecret('')
     onClose?.()
-    revalidate()
-  }, [onClose, revalidate])
+  }, [onClose, newSecret, revalidate])
 
   return (
     <Modal


### PR DESCRIPTION
[Notion task](https://www.notion.so/Bug-Rotate-secret-modal-causes-error-994fedb3dc9a464e838737084e550efa?pvs=4)

## What

Fix error caused by `handleClose` being called twice so revalidate is called when active.

## Why

To fix error.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
