### PR TITLE
fix(j-s): Display loading table for defender cases

### DIFF
--- a/apps/judicial-system/web/src/routes/Defender/Cases/Cases.tsx
+++ b/apps/judicial-system/web/src/routes/Defender/Cases/Cases.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { useIntl } from 'react-intl'
 import partition from 'lodash/partition'
 import { useQuery } from '@apollo/client'
@@ -10,13 +10,9 @@ import {
   isIndictmentCase,
 } from '@island.is/judicial-system/types'
 
-import {
-  PageHeader,
-  UserContext,
-} from '@island.is/judicial-system-web/src/components'
+import { PageHeader } from '@island.is/judicial-system-web/src/components'
 import { titles, errors } from '@island.is/judicial-system-web/messages'
 import { CasesQuery } from '@island.is/judicial-system-web/src/utils/mutations'
-import TableSkeleton from '@island.is/judicial-system-web/src/routes/Shared/Cases/TableSkeleton'
 import SharedPageLayout from '@island.is/judicial-system-web/src/components/SharedPageLayout/SharedPageLayout'
 
 import DefenderCasesTable from './DefenderCasesTable'
@@ -25,7 +21,6 @@ import * as styles from './Cases.css'
 
 export const Cases: React.FC = () => {
   const { formatMessage } = useIntl()
-  const { user } = useContext(UserContext)
 
   const availableTabs = ['active', 'completed']
 
@@ -78,8 +73,6 @@ export const Cases: React.FC = () => {
             type="error"
           />
         </div>
-      ) : loading || !user ? (
-        <TableSkeleton />
       ) : (
         <Box marginBottom={5}>
           <Text as="h1" variant="h1" marginBottom={1}>
@@ -101,7 +94,9 @@ export const Cases: React.FC = () => {
           {
             id: 'active',
             label: formatMessage(m.activeCasesTabLabel),
-            content: <DefenderCasesTable cases={activeCases} />,
+            content: (
+              <DefenderCasesTable cases={activeCases} loading={loading} />
+            ),
           },
           {
             id: 'completed',
@@ -110,6 +105,7 @@ export const Cases: React.FC = () => {
               <DefenderCasesTable
                 cases={completedCases}
                 showingCompletedCases={true}
+                loading={loading}
               />
             ),
           },

--- a/apps/judicial-system/web/src/routes/Defender/Cases/DefenderCasesTable.tsx
+++ b/apps/judicial-system/web/src/routes/Defender/Cases/DefenderCasesTable.tsx
@@ -26,15 +26,17 @@ import CourtCaseNumber from '@island.is/judicial-system-web/src/components/Table
 import * as styles from './DefenderCasesTable.css'
 import useSortCases from './useSortCases'
 import useFilterCases from './useFilterCases'
+import TableSkeleton from '../../Shared/Cases/TableSkeleton'
 
 interface Props {
   cases: CaseListEntry[]
   showingCompletedCases?: boolean
+  loading?: boolean
 }
 
 export const DefenderCasesTable: React.FC<Props> = (props) => {
   const { formatMessage } = useIntl()
-  const { cases, showingCompletedCases } = props
+  const { cases, showingCompletedCases, loading } = props
   const { sortedData, requestSort, getClassNamesFor } = useSortCases(
     'createdAt',
     'descending',
@@ -66,175 +68,178 @@ export const DefenderCasesTable: React.FC<Props> = (props) => {
           onChange={() => toggleFilter('investigationCaseFilter')}
         ></Checkbox>
       </Box>
-
-      <table className={styles.table}>
-        <thead className={styles.thead}>
-          <tr>
-            <th className={styles.th}>
-              <Text as="span" fontWeight="regular">
-                {formatMessage(tables.caseNumber)}
-              </Text>
-            </th>
-            <th className={styles.th}>
-              <Box
-                component="button"
-                display="flex"
-                alignItems="center"
-                className={styles.thButton}
-                onClick={() => requestSort('createdAt')}
-              >
-                <Text fontWeight="regular">
-                  {formatMessage(tables.created)}
-                </Text>
-                <Box
-                  className={cn(styles.sortIcon, {
-                    [styles.sortCreatedAsc]:
-                      getClassNamesFor('createdAt') === 'ascending',
-                    [styles.sortCreatedDes]:
-                      getClassNamesFor('createdAt') === 'descending',
-                  })}
-                  marginLeft={1}
-                  component="span"
-                  display="flex"
-                  alignItems="center"
-                >
-                  <Icon icon="caretUp" size="small" />
-                </Box>
-              </Box>
-            </th>
-            <th className={styles.th}>
-              <Text as="span" fontWeight="regular">
-                {formatMessage(tables.type)}
-              </Text>
-            </th>
-            <th className={cn(styles.th, styles.largeColumn)}>
-              <Box
-                component="button"
-                display="flex"
-                alignItems="center"
-                className={styles.thButton}
-                onClick={() => requestSort('defendant')}
-                data-testid="accusedNameSortButton"
-              >
-                <Text fontWeight="regular">
-                  {capitalize(formatMessage(core.defendant, { suffix: 'i' }))}
-                </Text>
-                <Box
-                  className={cn(styles.sortIcon, {
-                    [styles.sortAccusedNameAsc]:
-                      getClassNamesFor('defendant') === 'ascending',
-                    [styles.sortAccusedNameDes]:
-                      getClassNamesFor('defendant') === 'descending',
-                  })}
-                  marginLeft={1}
-                  component="span"
-                  display="flex"
-                  alignItems="center"
-                >
-                  <Icon icon="caretDown" size="small" />
-                </Box>
-              </Box>
-            </th>
-            <th className={cn(styles.th, styles.largeColumn)}>
-              <Text as="span" fontWeight="regular">
-                {formatMessage(tables.state)}
-              </Text>
-            </th>
-            {showingCompletedCases ? (
-              <th>
-                <Text fontWeight="regular">
-                  {formatMessage(tables.duration)}
+      {loading ? (
+        <TableSkeleton />
+      ) : (
+        <table className={styles.table}>
+          <thead className={styles.thead}>
+            <tr>
+              <th className={styles.th}>
+                <Text as="span" fontWeight="regular">
+                  {formatMessage(tables.caseNumber)}
                 </Text>
               </th>
-            ) : (
-              <th>
-                <Text fontWeight="regular">
-                  {formatMessage(tables.hearingArrangementDate)}
-                </Text>
-              </th>
-            )}
-          </tr>
-        </thead>
-
-        <tbody>
-          {filteredCases?.map((c: CaseListEntry) => (
-            <tr
-              className={cn(styles.tableRowContainer)}
-              key={c.id}
-              onClick={() => handleRowClick(c.id, c.type)}
-            >
-              <td className={styles.td}>
-                <CourtCaseNumber
-                  courtCaseNumber={c.courtCaseNumber}
-                  policeCaseNumbers={c.policeCaseNumbers}
-                />
-              </td>
-              <td className={cn(styles.td)}>
-                <Text as="span">
-                  {format(parseISO(c.created), 'd.M.y', {
-                    locale: localeIS,
-                  })}
-                </Text>
-              </td>
-              <td className={styles.td}>
-                <Text as="span">
-                  {displayCaseType(formatMessage, c.type, c.decision)}
-                </Text>
-              </td>
-              <td className={cn(styles.td)}>
-                <DefendantInfo defendants={c.defendants} />
-              </td>
-              <td className={styles.td} data-testid="tdTag">
-                <Box marginRight={1} marginBottom={1}>
-                  <TagCaseState
-                    caseState={c.state}
-                    caseType={c.type}
-                    isValidToDateInThePast={c.isValidToDateInThePast}
-                    courtDate={c.courtDate}
-                  />
-                </Box>
-                {c.appealState && (
-                  <TagAppealState
-                    appealState={c.appealState}
-                    appealRulingDecision={c.appealRulingDecision}
-                  />
-                )}
-              </td>
-              {showingCompletedCases ? (
-                <td className={styles.td}>
-                  <Text>
-                    {c.validToDate &&
-                      c.courtEndTime &&
-                      `${formatDate(c.courtEndTime, 'd.M.y')} - ${formatDate(
-                        c.validToDate,
-                        'd.M.y',
-                      )}`}
+              <th className={styles.th}>
+                <Box
+                  component="button"
+                  display="flex"
+                  alignItems="center"
+                  className={styles.thButton}
+                  onClick={() => requestSort('createdAt')}
+                >
+                  <Text fontWeight="regular">
+                    {formatMessage(tables.created)}
                   </Text>
-                </td>
+                  <Box
+                    className={cn(styles.sortIcon, {
+                      [styles.sortCreatedAsc]:
+                        getClassNamesFor('createdAt') === 'ascending',
+                      [styles.sortCreatedDes]:
+                        getClassNamesFor('createdAt') === 'descending',
+                    })}
+                    marginLeft={1}
+                    component="span"
+                    display="flex"
+                    alignItems="center"
+                  >
+                    <Icon icon="caretUp" size="small" />
+                  </Box>
+                </Box>
+              </th>
+              <th className={styles.th}>
+                <Text as="span" fontWeight="regular">
+                  {formatMessage(tables.type)}
+                </Text>
+              </th>
+              <th className={cn(styles.th, styles.largeColumn)}>
+                <Box
+                  component="button"
+                  display="flex"
+                  alignItems="center"
+                  className={styles.thButton}
+                  onClick={() => requestSort('defendant')}
+                  data-testid="accusedNameSortButton"
+                >
+                  <Text fontWeight="regular">
+                    {capitalize(formatMessage(core.defendant, { suffix: 'i' }))}
+                  </Text>
+                  <Box
+                    className={cn(styles.sortIcon, {
+                      [styles.sortAccusedNameAsc]:
+                        getClassNamesFor('defendant') === 'ascending',
+                      [styles.sortAccusedNameDes]:
+                        getClassNamesFor('defendant') === 'descending',
+                    })}
+                    marginLeft={1}
+                    component="span"
+                    display="flex"
+                    alignItems="center"
+                  >
+                    <Icon icon="caretDown" size="small" />
+                  </Box>
+                </Box>
+              </th>
+              <th className={cn(styles.th, styles.largeColumn)}>
+                <Text as="span" fontWeight="regular">
+                  {formatMessage(tables.state)}
+                </Text>
+              </th>
+              {showingCompletedCases ? (
+                <th>
+                  <Text fontWeight="regular">
+                    {formatMessage(tables.duration)}
+                  </Text>
+                </th>
               ) : (
-                <td className={styles.td}>
-                  {c.courtDate && (
-                    <>
-                      <Text>
-                        <Box component="span" className={styles.blockColumn}>
-                          {capitalize(
-                            format(parseISO(c.courtDate), 'EEEE d. LLLL y', {
-                              locale: localeIS,
-                            }),
-                          ).replace('dagur', 'd.')}
-                        </Box>
-                      </Text>
-                      <Text as="span" variant="small">
-                        kl. {format(parseISO(c.courtDate), 'kk:mm')}
-                      </Text>
-                    </>
-                  )}
-                </td>
+                <th>
+                  <Text fontWeight="regular">
+                    {formatMessage(tables.hearingArrangementDate)}
+                  </Text>
+                </th>
               )}
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+
+          <tbody>
+            {filteredCases?.map((c: CaseListEntry) => (
+              <tr
+                className={cn(styles.tableRowContainer)}
+                key={c.id}
+                onClick={() => handleRowClick(c.id, c.type)}
+              >
+                <td className={styles.td}>
+                  <CourtCaseNumber
+                    courtCaseNumber={c.courtCaseNumber}
+                    policeCaseNumbers={c.policeCaseNumbers}
+                  />
+                </td>
+                <td className={cn(styles.td)}>
+                  <Text as="span">
+                    {format(parseISO(c.created), 'd.M.y', {
+                      locale: localeIS,
+                    })}
+                  </Text>
+                </td>
+                <td className={styles.td}>
+                  <Text as="span">
+                    {displayCaseType(formatMessage, c.type, c.decision)}
+                  </Text>
+                </td>
+                <td className={cn(styles.td)}>
+                  <DefendantInfo defendants={c.defendants} />
+                </td>
+                <td className={styles.td} data-testid="tdTag">
+                  <Box marginRight={1} marginBottom={1}>
+                    <TagCaseState
+                      caseState={c.state}
+                      caseType={c.type}
+                      isValidToDateInThePast={c.isValidToDateInThePast}
+                      courtDate={c.courtDate}
+                    />
+                  </Box>
+                  {c.appealState && (
+                    <TagAppealState
+                      appealState={c.appealState}
+                      appealRulingDecision={c.appealRulingDecision}
+                    />
+                  )}
+                </td>
+                {showingCompletedCases ? (
+                  <td className={styles.td}>
+                    <Text>
+                      {c.validToDate &&
+                        c.courtEndTime &&
+                        `${formatDate(c.courtEndTime, 'd.M.y')} - ${formatDate(
+                          c.validToDate,
+                          'd.M.y',
+                        )}`}
+                    </Text>
+                  </td>
+                ) : (
+                  <td className={styles.td}>
+                    {c.courtDate && (
+                      <>
+                        <Text>
+                          <Box component="span" className={styles.blockColumn}>
+                            {capitalize(
+                              format(parseISO(c.courtDate), 'EEEE d. LLLL y', {
+                                locale: localeIS,
+                              }),
+                            ).replace('dagur', 'd.')}
+                          </Box>
+                        </Text>
+                        <Text as="span" variant="small">
+                          kl. {format(parseISO(c.courtDate), 'kk:mm')}
+                        </Text>
+                      </>
+                    )}
+                  </td>
+                )}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
     </Box>
   )
 }


### PR DESCRIPTION
# Display loading table for defender cases

[Hopp við load - meðan síðan lódast er hausinn neðarlega og hoppar svo upp](https://app.asana.com/0/1203322535526396/1204778264928402/f)

## What

Display loading table when page is fetching case list data

## Why

Better user experience

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
