### PR TITLE
chore(web): Change width of University studies header for larger screens

### DIFF
--- a/apps/web/components/Organization/Wrapper/Themes/UniversityStudiesTheme/UniversityStudies.css.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/UniversityStudiesTheme/UniversityStudies.css.ts
@@ -71,3 +71,13 @@ export const navigation = style({
     },
   }),
 })
+
+export const desktopTitle = style({
+  ...themeUtils.responsiveStyle({
+    xl: {
+      position: 'absolute',
+      left: '400px',
+      top: '280px',
+    },
+  }),
+})

--- a/apps/web/components/Organization/Wrapper/Themes/UniversityStudiesTheme/UniversityStudiesHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/UniversityStudiesTheme/UniversityStudiesHeader.tsx
@@ -7,12 +7,20 @@ import { useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
 import { useNamespace } from '@island.is/web/hooks'
 import { useWindowSize } from '@island.is/web/hooks/useViewport'
 import { getScreenWidthString } from '@island.is/web/utils/screenWidth'
+import { theme } from '@island.is/island-ui/theme'
 import * as styles from './UniversityStudies.css'
 
 const backgroundImageUrl =
   'https://images.ctfassets.net/8k0h54kbe6bj/1F4J4R4GxCkQezDQhHPjaT/71b4afc65e6184bb42341785bb2fc539/haskolanam.svg'
 
-const getDefaultStyle = (): CSSProperties => {
+const getDefaultStyle = (width: number): CSSProperties => {
+  if (width > theme.breakpoints.xl) {
+    return {
+      backgroundImage: `url(${backgroundImageUrl})`,
+      backgroundRepeat: 'no-repeat',
+      backgroundSize: '1350px',
+    }
+  }
   return {
     backgroundImage: `url(${backgroundImageUrl})`,
     backgroundRepeat: 'no-repeat',
@@ -39,9 +47,31 @@ const UniversityStudiesHeader: React.FC<HeaderProps> = ({
 
   return (
     <div
-      style={n(`universityStudiesHeader-${screenWidth}`, getDefaultStyle())}
+      style={n(
+        `universityStudiesHeader-${screenWidth}`,
+        getDefaultStyle(width),
+      )}
       className={styles.headerBg}
     >
+      <Hidden below="xl">
+        <Box className={styles.desktopTitle}>
+          <Link
+            href={
+              linkResolver('organizationpage', [organizationPage.slug]).href
+            }
+          >
+            <Text color="white" variant="h1" fontWeight="semiBold">
+              {organizationPage.title}
+            </Text>
+          </Link>
+          <Text fontWeight="regular" color="white">
+            {n(
+              'allUniversityStudiesInIcelandAtTheSamePlace',
+              'Allt háskólanám á Íslandi á sama stað',
+            )}
+          </Text>
+        </Box>
+      </Hidden>
       <div className={styles.headerWrapper}>
         <SidebarLayout
           sidebarContent={
@@ -61,8 +91,14 @@ const UniversityStudiesHeader: React.FC<HeaderProps> = ({
             )
           }
         >
-          {!!organizationPage.organization.logo && (
-            <Hidden above="sm">
+          <Hidden above="sm">
+            <Box
+              style={{
+                visibility: organizationPage.organization.logo
+                  ? 'visible'
+                  : 'hidden',
+              }}
+            >
               <Link
                 href={
                   linkResolver('organizationpage', [organizationPage.slug]).href
@@ -70,31 +106,36 @@ const UniversityStudiesHeader: React.FC<HeaderProps> = ({
                 className={styles.iconCircle}
               >
                 <img
-                  src={organizationPage.organization.logo.url}
+                  src={organizationPage.organization.logo?.url}
                   className={styles.headerLogo}
                   alt=""
                 />
               </Link>
-            </Hidden>
-          )}
+            </Box>
+          </Hidden>
 
-          <Box marginTop={[2, 2, 15]} textAlign={['center', 'center', 'left']}>
-            <Link
-              href={
-                linkResolver('organizationpage', [organizationPage.slug]).href
-              }
+          <Hidden above="lg">
+            <Box
+              marginTop={[2, 2, 15]}
+              textAlign={['center', 'center', 'left']}
             >
-              <Text color="white" variant="h1" fontWeight="semiBold">
-                {organizationPage.title}
+              <Link
+                href={
+                  linkResolver('organizationpage', [organizationPage.slug]).href
+                }
+              >
+                <Text color="white" variant="h1" fontWeight="semiBold">
+                  {organizationPage.title}
+                </Text>
+              </Link>
+              <Text fontWeight="regular" color="white">
+                {n(
+                  'allUniversityStudiesInIcelandAtTheSamePlace',
+                  'Allt háskólanám á Íslandi á sama stað',
+                )}
               </Text>
-            </Link>
-            <Text fontWeight="regular" color="white">
-              {n(
-                'allUniversityStudiesInIcelandAtTheSamePlace',
-                'Allt háskólanám á Íslandi á sama stað',
-              )}
-            </Text>
-          </Box>
+            </Box>
+          </Hidden>
         </SidebarLayout>
       </div>
     </div>


### PR DESCRIPTION
# Change width of University studies header for larger screens

## What

* Here's an attempt to improve the scaling for the university studies header for larger screens

## Screenshots / Gifs

<img width="1659" alt="image" src="https://github.com/island-is/island.is/assets/43557895/069747c5-f947-4a7a-b952-a3a38c8bd7b3">

https://github.com/island-is/island.is/assets/43557895/e0de7565-835b-45e0-ac6b-39c85f08bd12




## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
