### PR TITLE
fix(web): Use img instead of Box as img for InstitutionPanel

### DIFF
--- a/apps/web/components/InstitutionPanel/InstitutionPanel.tsx
+++ b/apps/web/components/InstitutionPanel/InstitutionPanel.tsx
@@ -40,11 +40,10 @@ export const InstitutionPanel = ({
           style={{ flex: '0 0 64px' }}
           marginRight={3}
         >
-          <Box
-            component="img"
-            alt=""
+          <img
+            width={64}
             src={img ? img : '/assets/skjaldarmerki.svg'}
-            width="full"
+            alt=""
           />
         </Box>
         <Box>


### PR DESCRIPTION
# Use img instead of Box as img for InstitutionPanel

## What

* On the dev web there seems to be an issue with images not appearing inside the institution panel and the likely cause is that the image does not have a set width.
* This code change replaces the Box component that is being rendered with an actual img tag instead that has a set width.

## Screenshots / Gifs

Dev
<img width="361" alt="image" src="https://github.com/island-is/island.is/assets/43557895/25106ebb-a2f7-49e8-9a0e-2f85dcfe027e">

Locally
<img width="346" alt="image" src="https://github.com/island-is/island.is/assets/43557895/91cdeb97-008d-4220-bfe3-47a58ea79532">


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
