### PR TITLE
fix(driving-learners-permit): Hook up error messages to descriptors

### DIFF
--- a/libs/application/templates/driving-learners-permit/src/fields/LookupStudent/index.tsx
+++ b/libs/application/templates/driving-learners-permit/src/fields/LookupStudent/index.tsx
@@ -23,6 +23,7 @@ import {
 import { IDENTITY_QUERY } from '../../graphql'
 import { LOOKUP_STUDENT_QUERY } from '../../graphql'
 import { LearnersPermitFakeData, YES } from '../../lib/constants'
+import { MessageDescriptor } from 'react-intl'
 
 const prefix = 'studentMentorability'
 
@@ -35,25 +36,22 @@ const fieldNames = {
   errorCode: `${prefix}.errorCode`,
 }
 
-const getErrorMessageFromErrorCode = (errorCode: string): string => {
-  const errorMessages: Record<string, string> = {
-    INSTRUCTOR_NOT_FOUND_IN_NATIONAL_REGISTRY:
-      m.errorNationalIdNoName.defaultMessage,
+const getErrorMessageFromErrorCode = (errorCode: string): MessageDescriptor => {
+  const errorMessages: Record<string, MessageDescriptor> = {
+    INSTRUCTOR_NOT_FOUND_IN_NATIONAL_REGISTRY: m.errorNationalIdNoName,
     INSTRUCTOR_DOES_NOT_MEET_AGE_LIMIT:
-      requirementsMessages.ageRequirementDescription.defaultMessage,
+      requirementsMessages.ageRequirementDescription,
     INSTRUCTOR_B_LICENSE_LESS_THAN_5_YEARS:
-      requirementsMessages.validForFiveYearsDescription.defaultMessage,
-    INSTRUCTOR_HAS_DEPRIVATION:
-      requirementsMessages.hasPointsOrDeprivation.defaultMessage,
+      requirementsMessages.validForFiveYearsDescription,
+    INSTRUCTOR_HAS_DEPRIVATION: requirementsMessages.hasPointsOrDeprivation,
     INSTRUCTOR_HAS_DEPRIVATION_WITHIN_LAST_12_MONTHS:
-      requirementsMessages.hasPointsOrDeprivation.defaultMessage,
-    'No license book found': m.studentNoLicenseBookDescription.defaultMessage,
-    'Not allowed practive driving':
-      m.studentIsNotMentorableDescription.defaultMessage,
+      requirementsMessages.hasPointsOrDeprivation,
+    'No license book found': m.studentNoLicenseBookDescription,
+    'Not allowed practive driving': m.studentIsNotMentorableDescription,
   }
 
   const errorMessage = errorMessages[errorCode]
-  return errorMessage ?? m.studentIsNotMentorableDescription.defaultMessage
+  return errorMessage ?? m.studentIsNotMentorableDescription
 }
 
 export const LookupStudent: FC<FieldBaseProps> = ({ application }) => {


### PR DESCRIPTION
# Whoops
It hardcoded defaultmessages

## Screenshots / Gifs
## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
