### PR TITLE
test(system-e2e): Fix delegation test failure

### DIFF
--- a/apps/system-e2e/src/tests/islandis/web/smoke/endorsements.spec.ts
+++ b/apps/system-e2e/src/tests/islandis/web/smoke/endorsements.spec.ts
@@ -17,6 +17,7 @@ test.describe('Endorsements', () => {
       browser,
       storageState: 'service-portal-faereyjar.json',
       homeUrl: '/undirskriftalistar',
+      authUrl: '/minarsidur',
       phoneNumber: '0102399',
       delegation: '65° Arctic ehf',
     })


### PR DESCRIPTION
The test expects to be logged in, but was missing `authUrl`, since `/homeUrl` is public.

## Checklist:

- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
