### PR TITLE
fix(api-design-guide): Fix mismatch in param name

### DIFF
--- a/handbook/technical-overview/api-design-guide/rest-request.md
+++ b/handbook/technical-overview/api-design-guide/rest-request.md
@@ -43,7 +43,7 @@ When working with a REST resource where the resource ID is sensitive, it should 
 An API should prefer non-sensitive IDs like GUIDs as resource IDs.  
 {% endhint %}
 
-A placeholder is needed in the URL path instead of the sensitive resource ID. The placeholder should be prefixed with a dot (`.`) and the name of the path parameter, for example `.nationalId`. The header name should be the name of the path parameter prefixed with `X-Param-`, for example `X-Param-National-Id`.
+A placeholder is needed in the URL path instead of the sensitive resource ID. The placeholder should be prefixed with a dot (`.`) and the name of the path parameter, for example `.national-id`. The header name should be the name of the path parameter prefixed with `X-Param-`, for example `X-Param-National-Id`.
 
 For example instead of:
 


### PR DESCRIPTION
## What

Fix param name mismatch in rest-request chapter for sensitive path params.

## Why

For consistency.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
