### PR TITLE
fix(consultation-portal): text should have breaks

### DIFF
--- a/apps/consultation-portal/screens/Case/components/CaseOverview/CaseOverview.tsx
+++ b/apps/consultation-portal/screens/Case/components/CaseOverview/CaseOverview.tsx
@@ -62,7 +62,9 @@ export const CaseOverview = ({ chosenCase }: CaseOverviewProps) => {
         </Box>
         <Box>
           <Text variant="h4">{loc.detailedDescriptionTitle}</Text>
-          <Text variant="default">{chosenCase.detailedDescription}</Text>
+          <Text variant="default" whiteSpace="preWrap">
+            {chosenCase.detailedDescription}
+          </Text>
         </Box>
       </Stack>
     </Stack>


### PR DESCRIPTION
# text should have breaks

https://veflausnir.atlassian.net/browse/KAM-1366

## What

- Text in detailed descripion comes with \n, should show breaks in frontend

## Why

Specify why you need to achieve this

## Screenshots / Gifs

![image](https://github.com/island-is/island.is/assets/24222622/6989061c-56b9-486f-8609-dbe1f8f9b004)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
