### PR TITLE
feat(contentful-apps): Bypass cache for preview links

### DIFF
--- a/apps/contentful-apps/pages/sidebars/preview-link.tsx
+++ b/apps/contentful-apps/pages/sidebars/preview-link.tsx
@@ -74,8 +74,17 @@ const PreviewLinkSidebar = () => {
               environmentId: CONTENTFUL_ENVIRONMENT,
               spaceId: CONTENTFUL_SPACE,
             })
+
+            const bypassCacheSecret =
+              sdk.parameters.instance['bypassCacheSecret']
+
+            const queryParams = bypassCacheSecret
+              ? `?bypass-cache=${bypassCacheSecret}`
+              : ''
+
             const url = await previewLinkHandler[contentTypeId](entry, cma)
-            window.open(url, '_blank')
+
+            window.open(`${url}${queryParams}`, '_blank')
           }
         }}
       >


### PR DESCRIPTION
# Bypass cache for preview links

## What

* A recent [PR](https://github.com/island-is/island.is/pull/11456) introduces caching for the public web but we still want content editors to be able to bypass it to see their changes on the dev web.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
