### PR TITLE
fix(operating-license-template): remove pruning on payment

### DIFF
--- a/libs/application/templates/operating-license/src/lib/OperatingLicenseTemplate.ts
+++ b/libs/application/templates/operating-license/src/lib/OperatingLicenseTemplate.ts
@@ -103,7 +103,7 @@ const OperatingLicenseTemplate: ApplicationTemplate<
             description: m.payment,
           },
           progress: 0.9,
-          lifecycle: pruneAfter(thirtyDays),
+          lifecycle: { shouldBeListed: true, shouldBePruned: false },
           onEntry: defineTemplateApi({
             action: ApiActions.createCharge,
           }),


### PR DESCRIPTION
Users have been forgetting to push "Áfram" after payment so removing pruning on payment step in case it comes up again.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
