### PR TITLE
Set rejectUnauthorized to false for nova on dev.

### DIFF
--- a/apps/services/auth/ids-api/infra/ids-api.ts
+++ b/apps/services/auth/ids-api/infra/ids-api.ts
@@ -68,6 +68,11 @@ export const serviceSetup = (): ServiceBuilder<'services-auth-ids-api'> => {
         dev: '10001',
         staging: '6503760649',
       },
+      NOVA_ACCEPT_UNAUTHORIZED: {
+        dev: 'true',
+        staging: 'false',
+        prod: 'false',
+      },
     })
     .secrets({
       IDENTITY_SERVER_CLIENT_SECRET:

--- a/apps/services/auth/ids-api/src/environments/environment.ts
+++ b/apps/services/auth/ids-api/src/environments/environment.ts
@@ -12,6 +12,7 @@ const devConfig = {
     url: 'https://smsapi.devnova.is',
     username: 'IslandIs_User_Development',
     password: process.env.NOVA_PASSWORD ?? '',
+    acceptUnauthorized: true
   },
 }
 
@@ -38,6 +39,7 @@ const prodConfig = {
     url: process.env.NOVA_URL ?? '',
     username: process.env.NOVA_USERNAME ?? '',
     password: process.env.NOVA_PASSWORD ?? '',
+    acceptUnauthorized: process.env.NOVA_ACCEPT_UNAUTHORIZED === 'true'
   },
 }
 

--- a/charts/identity-server/values.dev.yaml
+++ b/charts/identity-server/values.dev.yaml
@@ -352,6 +352,7 @@ services-auth-ids-api:
     IDENTITY_SERVER_CLIENT_ID: '@island.is/clients/auth-api'
     IDENTITY_SERVER_ISSUER_URL: 'https://identity-server.dev01.devland.is'
     NODE_OPTIONS: '--max-old-space-size=464'
+    NOVA_ACCEPT_UNAUTHORIZED: 'true'
     PUBLIC_URL: 'https://identity-server.dev01.devland.is/api'
     SERVERSIDE_FEATURES_ON: ''
     USER_PROFILE_CLIENT_URL: 'http://web-service-portal-api.service-portal.svc.cluster.local'

--- a/charts/identity-server/values.prod.yaml
+++ b/charts/identity-server/values.prod.yaml
@@ -349,6 +349,7 @@ services-auth-ids-api:
     IDENTITY_SERVER_CLIENT_ID: '@island.is/clients/auth-api'
     IDENTITY_SERVER_ISSUER_URL: 'https://innskra.island.is'
     NODE_OPTIONS: '--max-old-space-size=464'
+    NOVA_ACCEPT_UNAUTHORIZED: 'false'
     PUBLIC_URL: 'https://innskra.island.is/api'
     SERVERSIDE_FEATURES_ON: 'driving-license-use-v1-endpoint-for-v2-comms'
     USER_PROFILE_CLIENT_URL: 'https://service-portal-api.internal.island.is'

--- a/charts/identity-server/values.staging.yaml
+++ b/charts/identity-server/values.staging.yaml
@@ -352,6 +352,7 @@ services-auth-ids-api:
     IDENTITY_SERVER_CLIENT_ID: '@island.is/clients/auth-api'
     IDENTITY_SERVER_ISSUER_URL: 'https://identity-server.staging01.devland.is'
     NODE_OPTIONS: '--max-old-space-size=464'
+    NOVA_ACCEPT_UNAUTHORIZED: 'false'
     PUBLIC_URL: 'https://identity-server.staging01.devland.is/api'
     SERVERSIDE_FEATURES_ON: ''
     USER_PROFILE_CLIENT_URL: 'http://web-service-portal-api.service-portal.svc.cluster.local'

--- a/libs/nova-sms/src/lib/sms.service.ts
+++ b/libs/nova-sms/src/lib/sms.service.ts
@@ -1,11 +1,11 @@
+import { Inject, Injectable } from '@nestjs/common'
 import { DataSourceConfig } from 'apollo-datasource'
-import { RESTDataSource, RequestOptions } from 'apollo-datasource-rest'
+import { RequestOptions, RESTDataSource } from 'apollo-datasource-rest'
+import { Agent } from 'https'
 
-import { Injectable, Inject } from '@nestjs/common'
-
-import type { Logger } from '@island.is/logging'
 import { LOGGER_PROVIDER } from '@island.is/logging'
 
+import type { Logger } from '@island.is/logging'
 export interface NovaResponse {
   Code: number
   Message: string
@@ -43,6 +43,7 @@ export interface SmsServiceOptions {
   url: string
   username: string
   password: string
+  acceptUnauthorized?: boolean
 }
 
 interface SmsBody {
@@ -72,6 +73,9 @@ export class SmsService extends RESTDataSource {
   willSendRequest(request: RequestOptions) {
     this.memoizedResults.clear()
     request.headers.set('Content-Type', 'application/json')
+    request.agent = new Agent({
+      rejectUnauthorized: !this.options.acceptUnauthorized,
+    })
   }
 
   private async login(): Promise<string> {


### PR DESCRIPTION
https://www.notion.so/Set-up-basic-2FA-flow-behind-feature-flag-7550f7d1223d422baeb179012307ec4e?pvs=4

## What

Set rejectUnauthorized to false for the Nova SMS api on dev.

## Why

So we can call the api from ids-api even though it uses a self-signed certificate.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
