### PR TITLE
fix(j-s): Notification Response

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/notification/notification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/notification.service.ts
@@ -1206,7 +1206,8 @@ export class NotificationService {
     const recipients = await Promise.all(promises)
 
     if (recipients.length === 0) {
-      return { notificationSent: false }
+      // Nothing to send
+      return { notificationSent: true }
     }
 
     return this.recordNotification(
@@ -1288,7 +1289,8 @@ export class NotificationService {
     const recipients = await Promise.all(promises)
 
     if (recipients.length === 0) {
-      return { notificationSent: false }
+      // Nothing to send
+      return { notificationSent: true }
     }
 
     return this.recordNotification(
@@ -1315,6 +1317,7 @@ export class NotificationService {
         theCase.registrar?.email,
       ))
     ) {
+      // Nothing to send
       return { notificationSent: true }
     }
 
@@ -1329,9 +1332,18 @@ export class NotificationService {
       { courtCaseNumber: theCase.courtCaseNumber },
     )
 
-    const promises = [
-      this.sendEmail(subject, html, theCase.judge?.name, theCase.judge?.email),
-    ]
+    const promises: Promise<Recipient>[] = []
+
+    if (theCase.judge) {
+      promises.push(
+        this.sendEmail(
+          subject,
+          html,
+          theCase.judge?.name,
+          theCase.judge?.email,
+        ),
+      )
+    }
 
     if (theCase.registrar) {
       promises.push(
@@ -1345,6 +1357,11 @@ export class NotificationService {
     }
 
     const recipients = await Promise.all(promises)
+
+    if (recipients.length === 0) {
+      // Nothing to send
+      return { notificationSent: true }
+    }
 
     return this.recordNotification(
       theCase.id,

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendAppealReceivedByCourtNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendAppealReceivedByCourtNotifications.spec.ts
@@ -1,5 +1,6 @@
 import { uuid } from 'uuidv4'
 
+import { ConfigType } from '@island.is/nest/config'
 import { EmailService } from '@island.is/email-service'
 import {
   getStatementDeadline,
@@ -9,6 +10,7 @@ import {
 import { formatDate } from '@island.is/judicial-system/formatters'
 
 import { Case } from '../../../case'
+import { notificationModuleConfig } from '../../notification.config'
 import { DeliverResponse } from '../../models/deliver.response'
 import { createTestingNotificationModule } from '../createTestingNotificationModule'
 
@@ -30,16 +32,18 @@ describe('InternalNotificationController - Send appeal received by court notific
   const receivedDate = new Date()
 
   let mockEmailService: EmailService
-
+  let mockConfig: ConfigType<typeof notificationModuleConfig>
   let givenWhenThen: GivenWhenThen
 
   beforeEach(async () => {
     const {
       emailService,
+      notificationConfig,
       internalNotificationController,
     } = await createTestingNotificationModule()
 
     mockEmailService = emailService
+    mockConfig = notificationConfig
 
     givenWhenThen = async (defenderNationalId?: string) => {
       const then = {} as Then
@@ -78,7 +82,13 @@ describe('InternalNotificationController - Send appeal received by court notific
     it('should send notification to prosecutor and defender', () => {
       expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
         expect.objectContaining({
-          to: [{ name: 'Landsréttur', address: '' }],
+          to: [
+            {
+              name: 'Landsréttur',
+              address:
+                mockConfig.email.courtsEmails[mockConfig.courtOfAppealsId],
+            },
+          ],
           subject: `Upplýsingar vegna kæru í máli ${courtCaseNumber}`,
           html: `Kæra í máli ${courtCaseNumber} hefur borist Landsrétti. Hægt er að nálgast gögn málsins í <a href="http://localhost:4200/landsrettur/yfirlit/${caseId}">Réttarvörslugátt</a> með rafrænum skilríkjum.`,
         }),

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendDefenderAssignedNotifications.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/sendDefenderAssignedNotifications.spec.ts
@@ -143,7 +143,7 @@ describe('InternalNotificationController - Send defender assigned notifications'
     it('should not send notification', () => {
       expect(mockEmailService.sendEmail).not.toHaveBeenCalled()
       expect(mockNotificationModel.create).not.toHaveBeenCalled()
-      expect(then.result).toStrictEqual({ delivered: false })
+      expect(then.result).toStrictEqual({ delivered: true })
     })
   })
 
@@ -251,7 +251,7 @@ describe('InternalNotificationController - Send defender assigned notifications'
     it('should return notification was not sent', () => {
       expect(mockNotificationModel.create).not.toHaveBeenCalled()
       expect(mockEmailService.sendEmail).not.toHaveBeenCalled()
-      expect(then.result).toEqual(expect.objectContaining({ delivered: false }))
+      expect(then.result).toEqual(expect.objectContaining({ delivered: true }))
     })
   })
 


### PR DESCRIPTION
# Notification Response

[Tómt tölvupóstfang í tilkynningu um skráningu varnaraðila](https://app.asana.com/0/1199153462262248/1204852144009141/f)
[Tilkynning vegna afturköllunar klikkaði](https://app.asana.com/0/1199153462262248/1204203804330800/f)

## What

- Does not attempt to send a defender not uploaded notification to a judge when there is no assigned judge.
- Modifies the notification response when there are no recipients so that retry will not be attempted.

## Why

- To avoid spamming the error event channel with issues that are not true errors.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
