### PR TITLE
feat(contentful-apps): Vacancy contacts custom contentful app field

### DIFF
--- a/apps/contentful-apps/pages/fields/vacancy-contacts-field.tsx
+++ b/apps/contentful-apps/pages/fields/vacancy-contacts-field.tsx
@@ -51,7 +51,7 @@ const VacancyContactsField = () => {
         {contacts.map((contact, index) => (
           <Box
             style={{
-              padding: '8px',
+              padding: '16px',
               border: '1px solid #cfd9e0',
               borderRadius: '4px',
             }}

--- a/apps/contentful-apps/pages/fields/vacancy-contacts-field.tsx
+++ b/apps/contentful-apps/pages/fields/vacancy-contacts-field.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useState } from 'react'
+import { Button, Box, TextInput, Text } from '@contentful/f36-components'
+import { PlusIcon, DeleteIcon } from '@contentful/f36-icons'
+import { FieldExtensionSDK } from '@contentful/app-sdk'
+import { useSDK } from '@contentful/react-apps-toolkit'
+import { useDebounce } from 'react-use'
+
+const DEBOUNCE_TIME = 300
+
+interface Contact {
+  name?: string
+  email?: string
+  phone?: string
+}
+
+const VacancyContactsField = () => {
+  const sdk = useSDK<FieldExtensionSDK>()
+  const [contacts, setContacts] = useState<Contact[]>(
+    sdk.field.getValue() ?? [],
+  )
+
+  useEffect(() => {
+    sdk.window.startAutoResizer()
+  }, [sdk.window])
+
+  useDebounce(
+    () => {
+      sdk.field.setValue(contacts)
+    },
+    DEBOUNCE_TIME,
+    [contacts],
+  )
+
+  return (
+    <Box>
+      <Box
+        marginBottom="spacing2Xl"
+        style={{ display: 'flex', justifyContent: 'flex-end' }}
+      >
+        <Button
+          onClick={() => {
+            const newValue = contacts.concat({ name: '', email: '', phone: '' })
+            setContacts(newValue)
+          }}
+          startIcon={<PlusIcon />}
+        >
+          Add Contact
+        </Button>
+      </Box>
+      <Box>
+        {contacts.map((contact, index) => (
+          <Box
+            style={{
+              padding: '8px',
+              border: '1px solid #cfd9e0',
+              borderRadius: '4px',
+            }}
+            marginBottom="spacing2Xl"
+            key={index}
+          >
+            <Box
+              marginBottom="spacingS"
+              style={{ display: 'flex', justifyContent: 'flex-end' }}
+            >
+              <Button
+                onClick={() => {
+                  setContacts((prevContacts) => {
+                    return prevContacts.filter(
+                      (_, prevIndex) => prevIndex !== index,
+                    )
+                  })
+                }}
+                startIcon={<DeleteIcon />}
+              >
+                Delete
+              </Button>
+            </Box>
+            <Box
+              style={{ display: 'flex', flexFlow: 'column nowrap', gap: '8px' }}
+            >
+              <Text>Name</Text>
+              <TextInput
+                value={contact.name}
+                onChange={(ev) => {
+                  setContacts((prevContacts) =>
+                    prevContacts.map((prevContact, prevIndex) => {
+                      if (prevIndex !== index) return prevContact
+                      return {
+                        ...prevContact,
+                        name: ev.target.value,
+                      }
+                    }),
+                  )
+                }}
+              />
+
+              <Text>Email</Text>
+              <TextInput
+                value={contact.email}
+                onChange={(ev) => {
+                  setContacts((prevContacts) =>
+                    prevContacts.map((prevContact, prevIndex) => {
+                      if (prevIndex !== index) return prevContact
+                      return {
+                        ...prevContact,
+                        email: ev.target.value,
+                      }
+                    }),
+                  )
+                }}
+              />
+
+              <Text>Phone</Text>
+              <TextInput
+                value={contact.phone}
+                onChange={(ev) => {
+                  setContacts((prevContacts) =>
+                    prevContacts.map((prevContact, prevIndex) => {
+                      if (prevIndex !== index) return prevContact
+                      return {
+                        ...prevContact,
+                        phone: ev.target.value,
+                      }
+                    }),
+                  )
+                }}
+              />
+            </Box>
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  )
+}
+
+export default VacancyContactsField


### PR DESCRIPTION
# Vacancy contacts custom contentful app field

## What

To not have to create a new content type I added a json field for the vacancy contacts. Here I am adding a contentful app that renders that json field in a more user friendly manner. Allowing users to press buttons to add or delete contacts from the list

## Screenshots / Gifs

![image](https://github.com/island-is/island.is/assets/43557895/8d3608fc-93aa-492c-977b-afa1745ff552)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
