### PR TITLE
fix(web): Map vacancy contacts field

### DIFF
--- a/libs/cms/src/lib/models/vacancy.model.ts
+++ b/libs/cms/src/lib/models/vacancy.model.ts
@@ -87,4 +87,5 @@ export const mapVacancy = ({ fields, sys }: IVacancy): Vacancy => ({
         `${sys.id}:tasksAndResponsibilities`,
       )) ??
     null,
+  contacts: (fields.contacts as Vacancy['contacts']) ?? [],
 })


### PR DESCRIPTION
# Map vacancy contacts field

## What

I forgot to map the contacts field for a vacancy stored in the cms

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
