### PR TITLE
fix(scripts): Adding zsh support for the clean script

### DIFF
--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -101,7 +101,7 @@ clean_yarn() {
 
 clean_all() {
   for job in generated caches yarn; do
-    job_uppercase="${job^^}"
+    job_uppercase=$(echo $job | tr '[:lower:]' '[:upper:]')
     job_variable="CLEAN_${job_uppercase}"
 
     # Run only if corresponding job variable is true


### PR DESCRIPTION
# Enhanced Shell Compatibility for clean.sh Script

Attach a link to issue if relevant

## What

The clean.sh script has been updated to support both bash and zsh, as well as older bash <4 shells, broadening the compatibility and usability of the script across different environments.

## Why

This change ensures that users running different shells can use the clean.sh script without any shell-specific issues. Previously, the script was only compatible with bash which could lead to potential issues for zsh users. By enabling support for zsh, I removed this limitation and increased the script's utility.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
