### PR TITLE
fix(application-driving-license-duplicate): Too many strings, removing title

### DIFF
--- a/libs/application/templates/driving-license-duplicate/src/forms/applicationSections/sectionDelivery.ts
+++ b/libs/application/templates/driving-license-duplicate/src/forms/applicationSections/sectionDelivery.ts
@@ -5,9 +5,7 @@ import {
   buildSelectField,
 } from '@island.is/application/core'
 import { m } from '../../lib/messages'
-import {
-  Juristiction,
-} from '@island.is/api/schema'
+import { Juristiction } from '@island.is/api/schema'
 
 export const sectionDelivery = buildSection({
   id: 'delivery',

--- a/libs/application/templates/driving-license-duplicate/src/forms/applicationSections/sectionDelivery.ts
+++ b/libs/application/templates/driving-license-duplicate/src/forms/applicationSections/sectionDelivery.ts
@@ -6,7 +6,6 @@ import {
 } from '@island.is/application/core'
 import { m } from '../../lib/messages'
 import {
-  DistrictCommissionerAgencies,
   Juristiction,
 } from '@island.is/api/schema'
 
@@ -16,7 +15,7 @@ export const sectionDelivery = buildSection({
   children: [
     buildMultiField({
       id: 'deliverySection',
-      title: m.deliveryMethodSectionTitle,
+      title: '',
       children: [
         buildDescriptionField({
           id: 'deliveryDescription',


### PR DESCRIPTION
I don't know what to say. Very small changes.
Removing text from one place.
Key is reused.
Removed an unused import while I'm at it.

As small as these get.

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
