### PR TITLE
fix(web): Add fail-safe when mapping assets from CMS

### DIFF
--- a/libs/cms/src/lib/unions/slice.union.ts
+++ b/libs/cms/src/lib/unions/slice.union.ts
@@ -300,7 +300,7 @@ export const mapDocument = (
         slices.push(safelyMapSliceUnion(block.data.target))
         break
       case BLOCKS.EMBEDDED_ASSET:
-        if (block.data.target.fields?.file) {
+        if (block.data.target?.fields?.file) {
           block.data.target.fields.file.details?.image
             ? slices.push(mapImage(block.data.target))
             : slices.push(mapAsset(block.data.target))


### PR DESCRIPTION
# Add fail-safe when mapping assets from CMS

## What

* It turns out that a user can in fact embed an empty asset in the CMS causing the code that maps the asset to fail, this is something we want to be fixed

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
