### PR TITLE
fix(application-driving-license-duplicate): Add markdown to description field

### DIFF
--- a/libs/application/templates/driving-license-duplicate/src/lib/messages.ts
+++ b/libs/application/templates/driving-license-duplicate/src/lib/messages.ts
@@ -241,7 +241,7 @@ export const m = defineMessages({
     description: 'Title for delivery method section',
   },
   deliveryMethodDescription: {
-    id: 'dld.application:deliveryMethodDescription',
+    id: 'dld.application:deliveryMethodDescription#markdown',
     defaultMessage:
       'Fljótlegast er að sækja samrit hjá Þjóðskrá Íslands í Borgartúni 21, 105 Reykjavík. Á öðrum afhendingarstöðum getur afhending tekið allt að 6 til 10 daga. Sjá afgreiðslutíma.',
     description: 'Description for delivery method section',


### PR DESCRIPTION
One field requires markdown for styling purposes

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
