### PR TITLE
chore(search-indexer): Add support categories as nested types

### DIFF
--- a/libs/cms/src/lib/environments/environment.ts
+++ b/libs/cms/src/lib/environments/environment.ts
@@ -79,6 +79,8 @@ export default {
     'sidebarCard',
     'genericTag',
     'latestNewsSlice',
+    'supportCategory',
+    'supportSubCategory',
   ],
   // Content types that have the 'activeTranslations' JSON field
   localizedContentTypes: ['article'],


### PR DESCRIPTION
# Add support categories as nested types

## What

* The elastic search mapper keeps track of what content types are nested so we can update the corresponding document in ElasticSearch when a change happens in the CMS
* The SupportCategory and SupportSubCategory content types weren't tagged as being nested which resulted in ElasticSearch documents not being updated when the category name would be changed

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
