### PR TITLE
ci(system-e2e): Disable System-e2e tests in CI

### DIFF
--- a/apps/system-e2e/entrypoint.sh
+++ b/apps/system-e2e/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+echo "Disable system-e2e" >&2
+exit 0
+
 set -euo pipefail
 
 : "${TEST_ENVIRONMENT:=local}"

--- a/scripts/ci/Dockerfile
+++ b/scripts/ci/Dockerfile
@@ -145,7 +145,7 @@ RUN echo "Disable system-e2e"
 # RUN yarn playwright install ${PLAYWRIGHT_BROWSER}
 #
 # COPY --chown=pwuser:pwuser ${APP_HOME}/entrypoint.sh .
-ENTRYPOINT ["./entrypoint.sh"]
+ENTRYPOINT ["echo", "DISABLED SYSTEM_E2E"]
 
 
 FROM playwright-base as output-local

--- a/scripts/ci/Dockerfile
+++ b/scripts/ci/Dockerfile
@@ -124,27 +124,27 @@ FROM mcr.microsoft.com/playwright:v${PLAYWRIGHT_VERSION}-focal as playwright-bas
 
 
 FROM playwright-base as output-playwright
+RUN echo "Disable system-e2e"
 # TODO: remove awscli dependency (157 MB extra)
-RUN apt-get update -y && apt-get install -y zip awscli && apt-get purge
-
-ARG APP_HOME
-ARG APP_DIST_HOME
-
-WORKDIR ${APP_DIST_HOME}
-
-COPY --from=builder /build/${APP_DIST_HOME} .
-COPY ${APP_HOME}/package.json .
-RUN chown -R pwuser:pwuser .
-
-USER pwuser
-RUN yarn set version berry
-RUN yarn install
-
-ENV PLAYWRIGHT_BROWSER=chromium
-RUN yarn playwright install ${PLAYWRIGHT_BROWSER}
-
-COPY --chown=pwuser:pwuser ${APP_HOME}/entrypoint.sh .
-
+# RUN apt-get update -y && apt-get install -y zip awscli && apt-get purge
+#
+# ARG APP_HOME
+# ARG APP_DIST_HOME
+#
+# WORKDIR ${APP_DIST_HOME}
+#
+# COPY --from=builder /build/${APP_DIST_HOME} .
+# COPY ${APP_HOME}/package.json .
+# RUN chown -R pwuser:pwuser .
+#
+# USER pwuser
+# RUN yarn set version berry
+# RUN yarn install
+#
+# ENV PLAYWRIGHT_BROWSER=chromium
+# RUN yarn playwright install ${PLAYWRIGHT_BROWSER}
+#
+# COPY --chown=pwuser:pwuser ${APP_HOME}/entrypoint.sh .
 ENTRYPOINT ["./entrypoint.sh"]
 
 


### PR DESCRIPTION
Currently the tests are breaking and are flaky

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
