### PR TITLE
feat(contentful-apps): Add preview link for vacancy content type

### DIFF
--- a/apps/contentful-apps/pages/sidebars/preview-link.tsx
+++ b/apps/contentful-apps/pages/sidebars/preview-link.tsx
@@ -10,6 +10,9 @@ import {
 } from '../../constants'
 
 const previewLinkHandler = {
+  vacancy: (entry: EntryProps<KeyValueMap>) => {
+    return `https://beta.dev01.devland.is/starfatorg/c-${entry.sys.id}`
+  },
   article: (entry: EntryProps<KeyValueMap>) => {
     return `https://beta.dev01.devland.is/${entry.fields.slug[DEFAULT_LOCALE]}`
   },


### PR DESCRIPTION
# Add preview link for vacancy content type

## What

Allow users in the CMS to open up a preview for the vacancy content type

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
