### PR TITLE
chore(web): Allow process entry links to be relative

### DIFF
--- a/libs/cms/src/lib/search/importers/utils.ts
+++ b/libs/cms/src/lib/search/importers/utils.ts
@@ -58,7 +58,7 @@ const getProcessEntries = (contentList: object[]) =>
 
 export const numberOfLinks = (contentList: object[]) => {
   const processLinks = getProcessEntries(contentList).map(
-    (entry) => new URL(entry.processLink),
+    (entry) => new URL(entry.processLink, 'https://island.is'),
   )
   const fillAndSignProcessLinks = processLinks.filter((url) =>
     url.hostname.includes('dropandsign.is'),


### PR DESCRIPTION
# Allow process entry links to be relative

## What

* Since creating a new URL object doesn't work without it have a base url I simply provided it since it's only used here to count how many process entry links are external or not and since a relative link is basically an island.is link then it's appropriate that island.is would be it's base url.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
