### PR TITLE
fix(rsk-client-scope): Fix rsk admin scope issue

### DIFF
--- a/libs/clients/rsk/relationships/src/lib/RskRelationshipsClientConfig.ts
+++ b/libs/clients/rsk/relationships/src/lib/RskRelationshipsClientConfig.ts
@@ -21,6 +21,7 @@ export const RskRelationshipsClientConfig = defineConfig({
     ),
     tokenExchangeScope: env.optionalJSON('XROAD_RSK_PROCURING_SCOPE') ?? [
       '@rsk.is/prokura',
+      '@rsk.is/prokura:admin',
     ],
     redis: {
       nodes: env.optionalJSON('XROAD_RSK_PROCURING_REDIS_NODES') ?? [],


### PR DESCRIPTION
# Fixes invalid scope error with rsk service

https://app.datadoghq.eu/logs?query=service%3Aservices-auth-ids-api%20env%3Adev%20&cols=host%2Cservice&event=AgAAAYkh3JVdimzZ5QAAAAAAAAAYAAAAAEFZa2gzSjY5QUFBbGx4ZVhTa1h4eEFBQgAAACQAAAAAMDE4OTIxZGMtOWY0Yy00MmY1LTllNTUtMDlkOGNjNThjN2Rm&index=%2A&messageDisplay=inline&sort=time&spanID=6696878756866365426&stream_sort=desc&viz=stream&from_ts=1688484539957&to_ts=1688485439957&live=true

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
