### PR TITLE
feat(web): Add relative url mapping so CMS links can point to prod and code makes them relative

### DIFF
--- a/libs/cms/src/lib/models/link.model.ts
+++ b/libs/cms/src/lib/models/link.model.ts
@@ -1,5 +1,6 @@
 import { Field, ID, ObjectType } from '@nestjs/graphql'
 import { ILink } from '../generated/contentfulTypes'
+import { getRelativeUrl } from './utils'
 
 @ObjectType()
 export class Link {
@@ -26,7 +27,7 @@ export const mapLink = ({ sys, fields }: ILink): Link => {
   return {
     id: sys.id,
     text: fields?.text ?? '',
-    url: fields?.url?.trim() ?? '',
+    url: getRelativeUrl(fields?.url?.trim() ?? ''),
     intro: fields?.intro ?? '',
     labels: fields?.labels ?? [],
     date: fields?.date ?? '',

--- a/libs/cms/src/lib/models/processEntry.model.ts
+++ b/libs/cms/src/lib/models/processEntry.model.ts
@@ -1,6 +1,7 @@
 import { Field, ID, ObjectType } from '@nestjs/graphql'
 import { IProcessEntry } from '../generated/contentfulTypes'
 import { SystemMetadata } from '@island.is/shared/types'
+import { getRelativeUrl } from './utils'
 
 const AIR_DISCOUNT_SCHEME_FRONTEND_HOSTNAME =
   process.env.AIR_DISCOUNT_SCHEME_FRONTEND_HOSTNAME
@@ -30,7 +31,7 @@ export const mapProcessEntry = ({
   let processLink = ''
 
   if ((fields.processLink ?? []).length > 0) {
-    processLink = fields.processLink as string
+    processLink = getRelativeUrl(fields.processLink as string)
   } else if (fields.processAsset?.fields?.file?.url) {
     let prefix = ''
     if (fields.processAsset.fields.file.url.startsWith('//')) {

--- a/libs/cms/src/lib/models/referenceLink.model.ts
+++ b/libs/cms/src/lib/models/referenceLink.model.ts
@@ -1,6 +1,7 @@
 import { Field, ObjectType } from '@nestjs/graphql'
 import { ILinkUrl } from '../generated/contentfulTypes'
 import { PageTypes } from '../unions/page.union'
+import { getRelativeUrl } from './utils'
 
 @ObjectType()
 export class ReferenceLink {
@@ -20,10 +21,20 @@ const typeMap: { [key: string]: string } = {
 export const mapReferenceLink = ({
   sys,
   fields,
-}: PageTypes | ILinkUrl): ReferenceLink => ({
-  slug:
-    (fields as PageTypes['fields']).slug ??
-    (fields as ILinkUrl['fields']).url ??
-    '',
-  type: typeMap[sys.contentType.sys.id] ?? sys.contentType.sys.id,
-})
+}: PageTypes | ILinkUrl): ReferenceLink => {
+  let slugValue = ''
+
+  const slugField = (fields as PageTypes['fields']).slug
+  const urlField = (fields as ILinkUrl['fields']).url
+
+  if (slugField) {
+    slugValue = slugField
+  } else if (urlField) {
+    slugValue = getRelativeUrl(urlField)
+  }
+
+  return {
+    slug: slugValue,
+    type: typeMap[sys.contentType.sys.id] ?? sys.contentType.sys.id,
+  }
+}

--- a/libs/cms/src/lib/models/utils.ts
+++ b/libs/cms/src/lib/models/utils.ts
@@ -1,15 +1,3 @@
-const prefix = 'https://island.is'
-
 /** Make sure that links are relative in case someone links to production directly */
-export const getRelativeUrl = (url: string) => {
-  const trimmedUrl = url.trim()
-
-  if (trimmedUrl.startsWith(prefix)) {
-    if (trimmedUrl.length === prefix.length) {
-      return '/'
-    }
-    return trimmedUrl.slice(prefix.length)
-  }
-
-  return trimmedUrl
-}
+export const getRelativeUrl = (url: string) =>
+  new URL(url.trim(), 'https://island.is').pathname

--- a/libs/cms/src/lib/models/utils.ts
+++ b/libs/cms/src/lib/models/utils.ts
@@ -1,10 +1,8 @@
 /** Make sure that links are relative in case someone links to production directly */
 export const getRelativeUrl = (url: string) => {
   const urlObject = new URL(url.trim(), 'https://island.is')
-
   if (urlObject.host === 'island.is') {
     return urlObject.pathname
   }
-
   return urlObject.href
 }

--- a/libs/cms/src/lib/models/utils.ts
+++ b/libs/cms/src/lib/models/utils.ts
@@ -1,0 +1,15 @@
+const prefix = 'https://island.is'
+
+/** Make sure that links are relative in case someone links to production directly */
+export const getRelativeUrl = (url: string) => {
+  const trimmedUrl = url.trim()
+
+  if (trimmedUrl.startsWith(prefix)) {
+    if (trimmedUrl.length === prefix.length) {
+      return '/'
+    }
+    return trimmedUrl.slice(prefix.length)
+  }
+
+  return trimmedUrl
+}

--- a/libs/cms/src/lib/models/utils.ts
+++ b/libs/cms/src/lib/models/utils.ts
@@ -1,3 +1,10 @@
 /** Make sure that links are relative in case someone links to production directly */
-export const getRelativeUrl = (url: string) =>
-  new URL(url.trim(), 'https://island.is').pathname
+export const getRelativeUrl = (url: string) => {
+  const urlObject = new URL(url.trim(), 'https://island.is')
+
+  if (urlObject.host === 'island.is') {
+    return urlObject.pathname
+  }
+
+  return urlObject.href
+}


### PR DESCRIPTION
# Add relative url mapping so CMS links can point to prod and code makes them relative

## What

For E2E tests to not leave the environment they are testing once they navigate using a link, this was deemed the best approach. Instead of relying on CMS users to create relative links we can instead handle it so if they create an absolute link to prod then we'll automatically make that link relative

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
