### PR TITLE
fix(contentful-apps): Publish date field should publish entry again to store it's value

### DIFF
--- a/apps/contentful-apps/pages/fields/publish-date-field.tsx
+++ b/apps/contentful-apps/pages/fields/publish-date-field.tsx
@@ -9,12 +9,18 @@ const PublishDateField = () => {
 
   useEffect(() => {
     const initialSys = sdk.entry.getSys()
-    if (initialSys?.firstPublishedAt) {
+    if (
+      initialSys?.firstPublishedAt &&
+      initialSys.firstPublishedAt !== sdk.field.getValue()
+    ) {
       sdk.field.setValue(initialSys.firstPublishedAt)
       setValue(initialSys.firstPublishedAt)
     }
     sdk.entry.onSysChanged((sys) => {
-      if (sys.firstPublishedAt) {
+      if (
+        sys?.firstPublishedAt &&
+        sys.firstPublishedAt !== sdk.field.getValue()
+      ) {
         sdk.field.setValue(sys.firstPublishedAt)
         setValue(sys.firstPublishedAt)
       }

--- a/apps/contentful-apps/pages/fields/publish-date-field.tsx
+++ b/apps/contentful-apps/pages/fields/publish-date-field.tsx
@@ -9,20 +9,17 @@ const PublishDateField = () => {
 
   useEffect(() => {
     const initialSys = sdk.entry.getSys()
-    if (
-      initialSys?.firstPublishedAt &&
-      initialSys.firstPublishedAt !== sdk.field.getValue()
-    ) {
+    if (initialSys?.firstPublishedAt && !sdk.field.getValue()) {
       sdk.field.setValue(initialSys.firstPublishedAt)
       setValue(initialSys.firstPublishedAt)
     }
     sdk.entry.onSysChanged((sys) => {
-      if (
-        sys?.firstPublishedAt &&
-        sys.firstPublishedAt !== sdk.field.getValue()
-      ) {
-        sdk.field.setValue(sys.firstPublishedAt)
+      if (sys?.firstPublishedAt && !sdk.field.getValue()) {
         setValue(sys.firstPublishedAt)
+        sdk.field.setValue(sys.firstPublishedAt).then(() => {
+          // Since the entry was just published, we publish it again so the initial publish date gets saved as well
+          sdk.entry.publish()
+        })
       }
     })
   }, [sdk.entry, sdk.field])


### PR DESCRIPTION
# Publish date field should publish entry again to store it's value

## What

* If a user publishes an entry in the CMS then the publish date field receives a value (the initial publish date timestamp) but since the entry just got published without the publish date being populated we need to publish the entry again to store this value with the published entry.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
