### PR TITLE
feat(web): Driving instructors on public web

### DIFF
--- a/apps/web/components/connected/DrivingInstructorList/DrivingInstructorList.tsx
+++ b/apps/web/components/connected/DrivingInstructorList/DrivingInstructorList.tsx
@@ -3,6 +3,7 @@ import {
   AlertMessage,
   Box,
   Input,
+  LoadingDots,
   Pagination,
   Table as T,
   Text,
@@ -125,6 +126,12 @@ const DrivingInstructorList = ({ slice }: DrivingInstructorListProps) => {
           <Text fontWeight="semiBold">
             {n('noResultsFound', 'Engir ökukennarar fundust')}
           </Text>
+        </Box>
+      )}
+
+      {!called && loading && (
+        <Box display="flex" justifyContent="center">
+          <LoadingDots />
         </Box>
       )}
 

--- a/apps/web/components/connected/DrivingInstructorList/DrivingInstructorList.tsx
+++ b/apps/web/components/connected/DrivingInstructorList/DrivingInstructorList.tsx
@@ -40,7 +40,9 @@ const getSortedAndFilteredDrivingInstructors = (
   ): boolean => {
     return (
       instructor.name?.trim().toLowerCase().startsWith(fullSearchString) ||
-      instructor.nationalId?.trim().toLowerCase().startsWith(fullSearchString)
+      instructor.nationalId?.trim().startsWith(fullSearchString) ||
+      (instructor.driverLicenseId &&
+        String(instructor.driverLicenseId).startsWith(fullSearchString))
     )
   }
 
@@ -48,8 +50,9 @@ const getSortedAndFilteredDrivingInstructors = (
     return searchTerms.every((searchTerm) => {
       return (
         instructor.name?.trim().toLowerCase().includes(searchTerm) ||
-        instructor.nationalId?.trim().toLowerCase().includes(searchTerm) ||
-        String(instructor.driverLicenseId).includes(searchTerm)
+        instructor.nationalId?.trim().includes(searchTerm) ||
+        (instructor.driverLicenseId &&
+          String(instructor.driverLicenseId).includes(searchTerm))
       )
     })
   }

--- a/apps/web/components/connected/DrivingInstructorList/DrivingInstructorList.tsx
+++ b/apps/web/components/connected/DrivingInstructorList/DrivingInstructorList.tsx
@@ -1,0 +1,175 @@
+import { useQuery } from '@apollo/client'
+import {
+  AlertMessage,
+  Box,
+  Input,
+  Pagination,
+  Table as T,
+  Text,
+} from '@island.is/island-ui/core'
+import {
+  ConnectedComponent,
+  GetDrivingInstructorsQuery,
+  GetDrivingInstructorsQueryVariables,
+} from '@island.is/web/graphql/schema'
+import { useNamespace } from '@island.is/web/hooks'
+import { GET_DRIVING_INSTRUCTORS_QUERY } from '@island.is/web/screens/queries/DrivingInstructors'
+import { useState } from 'react'
+
+const DEFAULT_ITEMS_PER_PAGE = 10
+
+type DrivingInstructor = GetDrivingInstructorsQuery['drivingLicenseTeachersV4'][number]
+
+const getSortedAndFilteredDrivingInstructors = (
+  instructors: DrivingInstructor[],
+  searchValue: string,
+): DrivingInstructor[] => {
+  const searchTerms = searchValue
+    .replace('´', '')
+    .trim()
+    .toLowerCase()
+    .split(' ')
+
+  const fullSearchString: string = searchTerms.join(' ')
+  const brokersStartingWithFullSearchString: DrivingInstructor[] = []
+  const brokersContainingAllTerm: DrivingInstructor[] = []
+
+  const startsWithFullSearchString = (
+    instructor: DrivingInstructor,
+  ): boolean => {
+    return (
+      instructor.name?.trim().toLowerCase().startsWith(fullSearchString) ||
+      instructor.nationalId?.trim().toLowerCase().startsWith(fullSearchString)
+    )
+  }
+
+  const containsAllTerms = (instructor: DrivingInstructor): boolean => {
+    return searchTerms.every(
+      (searchTerm) =>
+        instructor.name?.trim().toLowerCase().includes(searchTerm) ||
+        instructor.nationalId?.trim().toLowerCase().includes(searchTerm),
+    )
+  }
+
+  // Categorize the instructors into two arrays based on the matching criteria
+  for (const instructor of instructors) {
+    if (startsWithFullSearchString(instructor)) {
+      brokersStartingWithFullSearchString.push(instructor)
+    } else if (containsAllTerms(instructor)) {
+      brokersContainingAllTerm.push(instructor)
+    }
+  }
+
+  // Concatenate the arrays with, starting with the instructors that start with the full search string.
+  return brokersStartingWithFullSearchString.concat(brokersContainingAllTerm)
+}
+
+interface DrivingInstructorListProps {
+  slice: ConnectedComponent
+}
+
+const DrivingInstructorList = ({ slice }: DrivingInstructorListProps) => {
+  const [selectedPage, setSelectedPage] = useState(1)
+  const n = useNamespace(slice?.json ?? {})
+  const [searchValue, setSearchValue] = useState('')
+
+  const { data, error, loading, called } = useQuery<
+    GetDrivingInstructorsQuery,
+    GetDrivingInstructorsQueryVariables
+  >(GET_DRIVING_INSTRUCTORS_QUERY)
+
+  const instructorsPerPage =
+    slice?.configJson?.itemsPerPage ?? DEFAULT_ITEMS_PER_PAGE
+
+  const instructors = data?.drivingLicenseTeachersV4 ?? []
+
+  const filteredInstructors = getSortedAndFilteredDrivingInstructors(
+    instructors,
+    searchValue,
+  )
+
+  const totalInstructorCount = filteredInstructors.length
+
+  return (
+    <Box>
+      <Box marginBottom={4}>
+        <Input
+          name="driving-license-input"
+          placeholder={n('searchPlaceholder', 'Leita')}
+          backgroundColor={['blue', 'blue', 'white']}
+          size="sm"
+          icon={{
+            name: 'search',
+            type: 'outline',
+          }}
+          value={searchValue}
+          onChange={(event) => {
+            setSelectedPage(1)
+            setSearchValue(event.target.value)
+          }}
+        />
+      </Box>
+
+      {called && !loading && error && (
+        <AlertMessage
+          type="error"
+          title={n('errorOccurredTitle', 'Villa kom upp')}
+          message={n('errorOccurredMessage', 'Ekki tókst að sækja ökukennara')}
+        />
+      )}
+      {filteredInstructors?.length > 0 && !error && (
+        <Box>
+          <T.Table>
+            <T.Head>
+              <T.HeadData>
+                <Text fontWeight="semiBold">{n('name', 'Nafn')}</Text>
+              </T.HeadData>
+              <T.HeadData>
+                <Text fontWeight="semiBold">
+                  {n('nationalId', 'Kennitala')}
+                </Text>
+              </T.HeadData>
+              <T.HeadData>
+                <Text fontWeight="semiBold">
+                  {n('driverLicenseId', 'Ökuréttindisnúmer')}
+                </Text>
+              </T.HeadData>
+            </T.Head>
+            <T.Body>
+              {filteredInstructors
+                .slice(
+                  (selectedPage - 1) * instructorsPerPage,
+                  (selectedPage - 1) * instructorsPerPage + instructorsPerPage,
+                )
+                .map((instructor) => (
+                  <T.Row key={instructor.name}>
+                    <T.Data>{instructor.name}</T.Data>
+                    <T.Data>{instructor.nationalId}</T.Data>
+                    <T.Data>{instructor.driverLicenseId}</T.Data>
+                  </T.Row>
+                ))}
+            </T.Body>
+          </T.Table>
+          <Box marginTop={3}>
+            <Pagination
+              page={selectedPage}
+              itemsPerPage={instructorsPerPage}
+              totalItems={totalInstructorCount}
+              renderLink={(page, className, children) => (
+                <button
+                  onClick={() => {
+                    setSelectedPage(page)
+                  }}
+                >
+                  <span className={className}>{children}</span>
+                </button>
+              )}
+            />
+          </Box>
+        </Box>
+      )}
+    </Box>
+  )
+}
+
+export default DrivingInstructorList

--- a/apps/web/components/connected/DrivingInstructorList/DrivingInstructorList.tsx
+++ b/apps/web/components/connected/DrivingInstructorList/DrivingInstructorList.tsx
@@ -44,11 +44,13 @@ const getSortedAndFilteredDrivingInstructors = (
   }
 
   const containsAllTerms = (instructor: DrivingInstructor): boolean => {
-    return searchTerms.every(
-      (searchTerm) =>
+    return searchTerms.every((searchTerm) => {
+      return (
         instructor.name?.trim().toLowerCase().includes(searchTerm) ||
-        instructor.nationalId?.trim().toLowerCase().includes(searchTerm),
-    )
+        instructor.nationalId?.trim().toLowerCase().includes(searchTerm) ||
+        String(instructor.driverLicenseId).includes(searchTerm)
+      )
+    })
   }
 
   // Categorize the instructors into two arrays based on the matching criteria
@@ -117,6 +119,15 @@ const DrivingInstructorList = ({ slice }: DrivingInstructorListProps) => {
           message={n('errorOccurredMessage', 'Ekki tókst að sækja ökukennara')}
         />
       )}
+
+      {called && !loading && !error && !filteredInstructors?.length && (
+        <Box display="flex" justifyContent="center">
+          <Text fontWeight="semiBold">
+            {n('noResultsFound', 'Engir ökukennarar fundust')}
+          </Text>
+        </Box>
+      )}
+
       {filteredInstructors?.length > 0 && !error && (
         <Box>
           <T.Table>

--- a/apps/web/components/connected/DrivingInstructorList/index.ts
+++ b/apps/web/components/connected/DrivingInstructorList/index.ts
@@ -1,0 +1,6 @@
+import dynamic from 'next/dynamic'
+
+export const DrivingInstructorList = dynamic(
+  () => import('./DrivingInstructorList'),
+  { ssr: true },
+)

--- a/apps/web/components/connected/index.ts
+++ b/apps/web/components/connected/index.ts
@@ -1,3 +1,4 @@
 export * from './fiskistofa'
 export * from './syslumenn'
 export * from './vehicles'
+export * from './DrivingInstructorList'

--- a/apps/web/screens/queries/DrivingInstructors.ts
+++ b/apps/web/screens/queries/DrivingInstructors.ts
@@ -1,0 +1,11 @@
+import gql from 'graphql-tag'
+
+export const GET_DRIVING_INSTRUCTORS_QUERY = gql`
+  query GetDrivingInstructors {
+    drivingLicenseTeachersV4 {
+      name
+      nationalId
+      driverLicenseId
+    }
+  }
+`

--- a/apps/web/utils/richText.tsx
+++ b/apps/web/utils/richText.tsx
@@ -29,6 +29,7 @@ import {
   SliceDropdown,
   PublicVehicleSearch,
   AircraftSearch,
+  DrivingInstructorList,
 } from '@island.is/web/components'
 import {
   PowerBiSlice as PowerBiSliceSchema,
@@ -69,6 +70,8 @@ export const webRenderConnectedComponent = (slice) => {
       return <PublicVehicleSearch slice={slice} />
     case 'AircraftSearch':
       return <AircraftSearch slice={slice} />
+    case 'DrivingInstructorList':
+      return <DrivingInstructorList slice={slice} />
     default:
       break
   }

--- a/libs/api/domains/driving-license/src/lib/drivingLicense.service.ts
+++ b/libs/api/domains/driving-license/src/lib/drivingLicense.service.ts
@@ -23,6 +23,7 @@ import {
   DrivingAssessment,
   DrivingLicenseApi,
   Teacher,
+  TeacherV4,
 } from '@island.is/clients/driving-license'
 import {
   BLACKLISTED_JURISTICTION,
@@ -139,6 +140,12 @@ export class DrivingLicenseService {
 
   async getTeachers(): Promise<Teacher[]> {
     const teachers = await this.drivingLicenseApi.getTeachers()
+
+    return teachers.sort(sortTeachers)
+  }
+
+  async getTeachersV4(): Promise<TeacherV4[]> {
+    const teachers = await this.drivingLicenseApi.getTeachersV4()
 
     return teachers.sort(sortTeachers)
   }

--- a/libs/api/domains/driving-license/src/lib/graphql/main.resolver.ts
+++ b/libs/api/domains/driving-license/src/lib/graphql/main.resolver.ts
@@ -39,6 +39,7 @@ export class MainResolver {
     private readonly drivingLicenseService: DrivingLicenseService,
     private readonly auditService: AuditService,
   ) {}
+
   @Scopes(ApiScope.internal)
   @Query(() => DrivingLicense, { nullable: true })
   drivingLicense(@CurrentUser() user: User) {

--- a/libs/api/domains/driving-license/src/lib/graphql/main.resolver.ts
+++ b/libs/api/domains/driving-license/src/lib/graphql/main.resolver.ts
@@ -33,13 +33,13 @@ const defaultCache: CacheControlOptions = { maxAge: CACHE_CONTROL_MAX_AGE }
 const namespace = '@island.is/api/driving-license'
 
 @UseGuards(IdsUserGuard, ScopesGuard)
-@Scopes(ApiScope.internal)
 @Resolver()
 export class MainResolver {
   constructor(
     private readonly drivingLicenseService: DrivingLicenseService,
     private readonly auditService: AuditService,
   ) {}
+  @Scopes(ApiScope.internal)
   @Query(() => DrivingLicense, { nullable: true })
   drivingLicense(@CurrentUser() user: User) {
     return this.auditService.auditPromise(
@@ -53,6 +53,7 @@ export class MainResolver {
     )
   }
 
+  @Scopes(ApiScope.internal)
   @Query(() => DrivingLicense, { nullable: true })
   legacyDrivingLicense(@CurrentUser() user: User) {
     return this.auditService.auditPromise(
@@ -66,6 +67,7 @@ export class MainResolver {
     )
   }
 
+  @Scopes(ApiScope.internal)
   @Query(() => [Teacher])
   drivingLicenseTeachers() {
     return this.drivingLicenseService.getTeachers()
@@ -78,6 +80,7 @@ export class MainResolver {
     return this.drivingLicenseService.getTeachersV4()
   }
 
+  @Scopes(ApiScope.internal)
   @Query(() => HasTeachingRights)
   drivingLicenseTeachingRights(@CurrentUser() user: User) {
     return this.auditService.auditPromise(
@@ -91,6 +94,7 @@ export class MainResolver {
     )
   }
 
+  @Scopes(ApiScope.internal)
   @UseGuards(DrivingInstructorGuard)
   @Query(() => StudentInformationResult)
   async drivingLicenseStudentInformation(
@@ -113,6 +117,7 @@ export class MainResolver {
     }
   }
 
+  @Scopes(ApiScope.internal)
   @Query(() => ApplicationEligibility)
   drivingLicenseApplicationEligibility(
     @CurrentUser() user: User,
@@ -125,6 +130,7 @@ export class MainResolver {
     )
   }
 
+  @Scopes(ApiScope.internal)
   @Query(() => ApplicationEligibility)
   learnerMentorEligibility(@CurrentUser() user: User) {
     return this.drivingLicenseService.getLearnerMentorEligibility(
@@ -133,16 +139,19 @@ export class MainResolver {
     )
   }
 
+  @Scopes(ApiScope.internal)
   @Query(() => [Juristiction])
   drivingLicenseListOfJuristictions() {
     return this.drivingLicenseService.getListOfJuristictions()
   }
 
+  @Scopes(ApiScope.internal)
   @Query(() => StudentAssessment, { nullable: true })
   drivingLicenseStudentAssessment(@CurrentUser() user: User) {
     return this.drivingLicenseService.getDrivingAssessment(user.nationalId)
   }
 
+  @Scopes(ApiScope.internal)
   @Query(() => StudentCanGetPracticePermit, { nullable: true })
   drivingLicenseStudentCanGetPracticePermit(
     @CurrentUser() user: User,

--- a/libs/api/domains/driving-license/src/lib/graphql/main.resolver.ts
+++ b/libs/api/domains/driving-license/src/lib/graphql/main.resolver.ts
@@ -1,5 +1,7 @@
 import { Args, Query, Resolver } from '@nestjs/graphql'
 import { UseGuards } from '@nestjs/common'
+import { CacheControl, CacheControlOptions } from '@island.is/nest/graphql'
+import { CACHE_CONTROL_MAX_AGE } from '@island.is/shared/constants'
 import { ApiScope } from '@island.is/auth/scopes'
 import type { User } from '@island.is/auth-nest-tools'
 import {
@@ -7,6 +9,7 @@ import {
   ScopesGuard,
   CurrentUser,
   Scopes,
+  BypassAuth,
 } from '@island.is/auth-nest-tools'
 import { DrivingLicenseService } from '../drivingLicense.service'
 export * from '@island.is/nest/audit'
@@ -19,12 +22,14 @@ import {
   StudentAssessment,
   ApplicationEligibilityInput,
   Teacher,
+  TeacherV4,
 } from './models'
 import { AuditService } from '@island.is/nest/audit'
 import { DrivingInstructorGuard } from './guards/drivingInstructor.guard'
 import { StudentCanGetPracticePermitInput } from './models/studentCanGetPracticePermit.input'
 import { StudentCanGetPracticePermit } from './models/studentCanGetPracticePermit.model'
 
+const defaultCache: CacheControlOptions = { maxAge: CACHE_CONTROL_MAX_AGE }
 const namespace = '@island.is/api/driving-license'
 
 @UseGuards(IdsUserGuard, ScopesGuard)
@@ -64,6 +69,13 @@ export class MainResolver {
   @Query(() => [Teacher])
   drivingLicenseTeachers() {
     return this.drivingLicenseService.getTeachers()
+  }
+
+  @BypassAuth()
+  @CacheControl(defaultCache)
+  @Query(() => [TeacherV4])
+  drivingLicenseTeachersV4() {
+    return this.drivingLicenseService.getTeachersV4()
   }
 
   @Query(() => HasTeachingRights)

--- a/libs/api/domains/driving-license/src/lib/graphql/models/teacher.model.ts
+++ b/libs/api/domains/driving-license/src/lib/graphql/models/teacher.model.ts
@@ -8,3 +8,15 @@ export class Teacher {
   @Field()
   name!: string
 }
+
+@ObjectType()
+export class TeacherV4 {
+  @Field(() => ID)
+  nationalId!: string
+
+  @Field()
+  name!: string
+
+  @Field(() => Number, { nullable: true })
+  driverLicenseId?: number | null
+}

--- a/libs/application/template-api-modules/src/lib/modules/shared/api/driving-license/driving-license.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/shared/api/driving-license/driving-license.service.ts
@@ -18,7 +18,6 @@ import {
 import {
   DrivingLicenseApi,
   Juristiction,
-  QualitySignature,
   Teacher,
 } from '@island.is/clients/driving-license'
 import sortTeachers from './sortTeachers'

--- a/libs/application/template-api-modules/src/lib/modules/shared/api/driving-license/driving-license.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/shared/api/driving-license/driving-license.service.ts
@@ -18,6 +18,7 @@ import {
 import {
   DrivingLicenseApi,
   Juristiction,
+  QualitySignature,
   Teacher,
 } from '@island.is/clients/driving-license'
 import sortTeachers from './sortTeachers'

--- a/libs/clients/driving-license/src/lib/drivingLicenseApi.service.ts
+++ b/libs/clients/driving-license/src/lib/drivingLicenseApi.service.ts
@@ -250,6 +250,19 @@ export class DrivingLicenseApi {
     }))
   }
 
+  public async getTeachersV4() {
+    const teachers = await this.v4.apiDrivinglicenseV4DrivinginstructorsGet({
+      apiVersion: v4.DRIVING_LICENSE_API_VERSION_V4,
+      apiVersion2: v4.DRIVING_LICENSE_API_VERSION_V4,
+    })
+
+    return teachers.map((teacher) => ({
+      name: teacher?.name ?? '',
+      nationalId: teacher?.ssn ?? '',
+      driverLicenseId: teacher.driverLicenseId,
+    }))
+  }
+
   public async getDeprivation(input: {
     nationalId: string
     token?: string

--- a/libs/clients/driving-license/src/lib/drivingLicenseApi.service.ts
+++ b/libs/clients/driving-license/src/lib/drivingLicenseApi.service.ts
@@ -259,7 +259,7 @@ export class DrivingLicenseApi {
     return teachers.map((teacher) => ({
       name: teacher?.name ?? '',
       nationalId: teacher?.ssn ?? '',
-      driverLicenseId: teacher.driverLicenseId,
+      driverLicenseId: teacher?.driverLicenseId,
     }))
   }
 

--- a/libs/clients/driving-license/src/lib/drivingLicenseApi.types.ts
+++ b/libs/clients/driving-license/src/lib/drivingLicenseApi.types.ts
@@ -35,6 +35,12 @@ export interface Teacher {
   name: string
 }
 
+export interface TeacherV4 {
+  name: string
+  nationalId: string
+  driverLicenseId: number | null | undefined
+}
+
 export interface Juristiction {
   id: number
   name: string


### PR DESCRIPTION
# Driving instructors on public web

## What

* Add an embeddable component in richtext for the CMS that displays a table containing driving instructors

## Why

* This was requested by Digital Iceland

## Screenshots / Gifs

![image](https://github.com/island-is/island.is/assets/43557895/717cae68-27f7-4ae6-872e-cd2c0df5e2fd)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
