### PR TITLE
fix(consultation-portal): bug fixed and added sort

### DIFF
--- a/apps/consultation-portal/screens/Case/components/CaseDocuments/CaseDocuments.tsx
+++ b/apps/consultation-portal/screens/Case/components/CaseDocuments/CaseDocuments.tsx
@@ -1,3 +1,4 @@
+import { sortLocale } from '../../../../utils/helpers'
 import { CardSkeleton } from '../../../../components'
 import { Document } from '../../../../types/interfaces'
 import { DocFileName, Stacked } from '../../components'
@@ -8,11 +9,16 @@ interface Props {
 }
 
 export const CaseDocuments = ({ title, documents }: Props) => {
+  const sortedDocuments = sortLocale({
+    list: documents,
+    sortOption: 'fileOrLink',
+  })
+
   return (
     <CardSkeleton>
       <Stacked title={title}>
-        {documents.map((doc, index) => {
-          return <DocFileName doc={doc} key={index} />
+        {sortedDocuments.map((doc: Document) => {
+          return <DocFileName doc={doc} key={doc.id} />
         })}
       </Stacked>
     </CardSkeleton>

--- a/apps/consultation-portal/screens/Case/components/DocFileName/DocFileName.tsx
+++ b/apps/consultation-portal/screens/Case/components/DocFileName/DocFileName.tsx
@@ -23,8 +23,6 @@ const DocFileName = ({ doc, isAdvice = false }: Props) => {
       : doc.link
     : fileNameOrDesc
 
-  
-
   const linkDesc = renderDocFileName({
     name: name,
     isAdvice: isAdvice,

--- a/apps/consultation-portal/screens/Case/components/DocFileName/DocFileName.tsx
+++ b/apps/consultation-portal/screens/Case/components/DocFileName/DocFileName.tsx
@@ -16,14 +16,22 @@ const DocFileName = ({ doc, isAdvice = false }: Props) => {
   const icon = isLink ? 'link' : 'document'
   const iconTitle = isLink ? loc.linkTitle : loc.documentTitle
   const linkHref = isLink ? doc.link : `${env.backendDownloadUrl}${doc.id}`
-  const fileNameOrDesc = isLink ? doc.description : doc.fileName
+  const fileNameOrDesc = doc.description ? doc.description : doc.fileName
+  const name = isLink
+    ? fileNameOrDesc
+      ? fileNameOrDesc
+      : doc.link
+    : fileNameOrDesc
+
+  
+
   const linkDesc = renderDocFileName({
-    name: fileNameOrDesc,
+    name: name,
     isAdvice: isAdvice,
   })
 
   return (
-    <Tooltip placement="right" as="span" text={fileNameOrDesc} fullWidth>
+    <Tooltip placement="right" as="span" text={name} fullWidth>
       <span>
         <LinkV2
           href={linkHref}

--- a/apps/consultation-portal/utils/helpers/sortLocale.ts
+++ b/apps/consultation-portal/utils/helpers/sortLocale.ts
@@ -1,13 +1,16 @@
-import { RelatedCase, Stakeholder } from '../../types/interfaces'
+import { Document, RelatedCase, Stakeholder } from '../../types/interfaces'
 
 interface ArrOfValueAndLabel {
   value: string
   label: string
 }
 
+type ListItem = Stakeholder | RelatedCase | ArrOfValueAndLabel | Document
+type List = Array<ListItem>
+
 interface Props {
-  list: Array<Stakeholder> | Array<RelatedCase> | Array<ArrOfValueAndLabel>
-  sortOption: 'name' | 'caseNumber' | 'label'
+  list: List
+  sortOption: 'name' | 'caseNumber' | 'label' | 'fileOrLink'
 }
 
 const IS_ALPHABET = [
@@ -46,6 +49,22 @@ const IS_ALPHABET = [
 ]
 
 export const sortLocale = ({ list, sortOption }: Props) => {
+  const getSortOption = (listItem: ListItem) => {
+    if (sortOption !== 'fileOrLink') {
+      return listItem[sortOption]
+    }
+
+    if (listItem['link']) {
+      return listItem['description']
+        ? listItem['description']
+        : listItem['link']
+    }
+
+    return listItem['description']
+      ? listItem['description']
+      : listItem['fileName']
+  }
+
   if (list.length < 1) {
     return []
   }
@@ -55,10 +74,14 @@ export const sortLocale = ({ list, sortOption }: Props) => {
       a[sortOption].localeCompare(b[sortOption], 'is'),
     )
   }
+
   return [...list].sort(
     (a, b) => {
-      const lowerCaseA = a[sortOption].toLowerCase()
-      const lowerCaseB = b[sortOption].toLowerCase()
+      const aSortOption = getSortOption(a)
+      const bSortOption = getSortOption(b)
+
+      const lowerCaseA = aSortOption.toLowerCase()
+      const lowerCaseB = bSortOption.toLowerCase()
       const minLen = Math.min(lowerCaseA.length, lowerCaseB.length)
 
       if (a === b) return 0

--- a/apps/consultation-portal/utils/helpers/sortLocale.ts
+++ b/apps/consultation-portal/utils/helpers/sortLocale.ts
@@ -79,7 +79,6 @@ export const sortLocale = ({ list, sortOption }: Props) => {
     (a, b) => {
       const aSortOption = getSortOption(a)
       const bSortOption = getSortOption(b)
-
       const lowerCaseA = aSortOption.toLowerCase()
       const lowerCaseB = bSortOption.toLowerCase()
       const minLen = Math.min(lowerCaseA.length, lowerCaseB.length)


### PR DESCRIPTION
# BUG: if link has no name, then the site crashes

https://veflausnir.atlassian.net/browse/KAM-1412

## What

- If link had no description the site crashed
- documentsBox is now sorted

## Why

Specify why you need to achieve this

## Screenshots / Gifs

![image](https://github.com/island-is/island.is/assets/24222622/2dc53aaf-6d8c-42e1-85a2-14c30c1fd1b7)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
