### PR TITLE
feat(web): Store search filters in url for published material pages

### DIFF
--- a/apps/web/screens/Organization/PublishedMaterial/PublishedMaterial.tsx
+++ b/apps/web/screens/Organization/PublishedMaterial/PublishedMaterial.tsx
@@ -40,7 +40,7 @@ import { useI18n } from '@island.is/web/i18n'
 import { withMainLayout } from '@island.is/web/layouts/main'
 import { CustomNextError } from '@island.is/web/units/errors'
 import { useRouter } from 'next/router'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useDebounce } from 'react-use'
 import { Screen } from '../../../types'
 import {
@@ -76,6 +76,7 @@ const PublishedMaterial: Screen<PublishedMaterialProps> = ({
   const router = useRouter()
   const { width } = useWindowSize()
   const [searchValue, setSearchValue] = useState('')
+  const filterValuesHaveBeenInitialized = useRef(false)
 
   const n = useNamespace(namespace)
 
@@ -237,6 +238,25 @@ const PublishedMaterial: Screen<PublishedMaterialProps> = ({
         },
       })
       setIsTyping(false)
+
+      const updatedQueryParams = { ...router.query }
+
+      if (!searchValue) {
+        if (filterValuesHaveBeenInitialized.current) {
+          delete updatedQueryParams['q']
+        } else if (updatedQueryParams['q']) {
+          setSearchValue(updatedQueryParams['q'] as string)
+        }
+      } else {
+        updatedQueryParams['q'] = searchValue
+      }
+
+      filterValuesHaveBeenInitialized.current = true
+
+      router.replace({
+        pathname: router.pathname,
+        query: updatedQueryParams,
+      })
     },
     DEBOUNCE_TIME_IN_MS,
     [parameters, activeLocale, searchValue, selectedOrderOption],
@@ -321,6 +341,14 @@ const PublishedMaterial: Screen<PublishedMaterialProps> = ({
                     ...prevParameters,
                     [categoryId]: selected,
                   }))
+
+                  // TODO: update queryparams
+                  // const updatedQueryParams = { ...router.query }
+                  // updatedQueryParams['filter']
+                  // router.replace({
+                  //   pathname: router.pathname,
+                  //   query: updatedQueryParams,
+                  // })
                 }}
                 onClear={(categoryId) => {
                   setIsTyping(true)
@@ -328,6 +356,13 @@ const PublishedMaterial: Screen<PublishedMaterialProps> = ({
                     ...prevParameters,
                     [categoryId]: [],
                   }))
+                  // TODO: update query params
+                  // const updatedQueryParams = { ...router.query }
+                  // delete updatedQueryParams['filter']
+                  // router.replace({
+                  //   pathname: router.pathname,
+                  //   query: updatedQueryParams,
+                  // })
                 }}
                 categories={filterCategories}
               ></FilterMultiChoice>

--- a/apps/web/screens/Organization/PublishedMaterial/PublishedMaterial.tsx
+++ b/apps/web/screens/Organization/PublishedMaterial/PublishedMaterial.tsx
@@ -381,14 +381,6 @@ const PublishedMaterial: Screen<PublishedMaterialProps> = ({
                     ...prevParameters,
                     [categoryId]: selected,
                   }))
-
-                  // TODO: update queryparams
-                  // const updatedQueryParams = { ...router.query }
-                  // updatedQueryParams['filter']
-                  // router.replace({
-                  //   pathname: router.pathname,
-                  //   query: updatedQueryParams,
-                  // })
                 }}
                 onClear={(categoryId) => {
                   setIsTyping(true)
@@ -396,13 +388,6 @@ const PublishedMaterial: Screen<PublishedMaterialProps> = ({
                     ...prevParameters,
                     [categoryId]: [],
                   }))
-                  // TODO: update query params
-                  // const updatedQueryParams = { ...router.query }
-                  // delete updatedQueryParams['filter']
-                  // router.replace({
-                  //   pathname: router.pathname,
-                  //   query: updatedQueryParams,
-                  // })
                 }}
                 categories={filterCategories}
               ></FilterMultiChoice>

--- a/apps/web/screens/Organization/PublishedMaterial/PublishedMaterial.tsx
+++ b/apps/web/screens/Organization/PublishedMaterial/PublishedMaterial.tsx
@@ -403,7 +403,7 @@ const PublishedMaterial: Screen<PublishedMaterialProps> = ({
                 options={orderByOptions}
                 value={selectedOrderOption}
                 onChange={(option) => {
-                  setSelectedOrderOption(option)
+                  setSelectedOrderOption(option as Option)
                 }}
               />
             </Box>

--- a/apps/web/screens/Organization/PublishedMaterial/PublishedMaterial.tsx
+++ b/apps/web/screens/Organization/PublishedMaterial/PublishedMaterial.tsx
@@ -243,6 +243,7 @@ const PublishedMaterial: Screen<PublishedMaterialProps> = ({
 
       const updatedQueryParams = { ...router.query }
 
+      // Update search input state and query params
       if (!searchValue) {
         if (filterValuesHaveBeenInitialized.current) {
           delete updatedQueryParams['q']
@@ -253,6 +254,7 @@ const PublishedMaterial: Screen<PublishedMaterialProps> = ({
         updatedQueryParams['q'] = searchValue
       }
 
+      // Update order dropdown state and query params
       if (!filterValuesHaveBeenInitialized.current) {
         if (updatedQueryParams.order) {
           const newOrder = orderByOptions.find(
@@ -260,7 +262,12 @@ const PublishedMaterial: Screen<PublishedMaterialProps> = ({
           )
           if (newOrder) setSelectedOrderOption(newOrder)
         }
+      } else {
+        updatedQueryParams.order = selectedOrderOption.value as string
+      }
 
+      // Update filter categories state and query params
+      if (!filterValuesHaveBeenInitialized.current) {
         if (updatedQueryParams.filters) {
           try {
             const updatedFilters = JSON.parse(
@@ -273,8 +280,6 @@ const PublishedMaterial: Screen<PublishedMaterialProps> = ({
           }
         }
       } else {
-        updatedQueryParams.order = selectedOrderOption.value as string
-
         if (Object.values(parameters).every((value) => !value?.length)) {
           delete updatedQueryParams.filters
         } else {


### PR DESCRIPTION
# Store search filters in url for published material pages

## What

* To be able to link a filtered search result page we'd like to store the selected filters in query params of the url
* Also in case the user refreshes the page his selected filters won't clear out anymore

## Why

* It's often handy to be able to link to specific types of documents and this change allows CMS users to do just that :)

## Screenshots / Gifs
(Look at the url)
![image](https://github.com/island-is/island.is/assets/43557895/4ca3e825-c527-44e7-b5a1-27c7713e019c)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
