### PR TITLE
feat(search-indexer-service): Add env variable for disabling nested resolution of entries from CMS

### DIFF
--- a/apps/services/search-indexer/infra/search-indexer-service.ts
+++ b/apps/services/search-indexer/infra/search-indexer-service.ts
@@ -23,6 +23,11 @@ const envs = {
     staging: '40',
     prod: '40',
   },
+  SHOULD_SEARCH_INDEXER_RESOLVE_NESTED_ENTRIES: {
+    dev: 'false',
+    staging: 'false',
+    prod: 'false',
+  },
   AIR_DISCOUNT_SCHEME_FRONTEND_HOSTNAME: {
     dev: 'loftbru.dev01.devland.is',
     staging: 'loftbru.staging01.devland.is',

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -1852,6 +1852,7 @@ search-indexer-service:
     ELASTIC_NODE: 'https://vpc-search-njkekqydiegezhr4vqpkfnw5la.eu-west-1.es.amazonaws.com'
     NODE_OPTIONS: '--max-old-space-size=2000'
     SERVERSIDE_FEATURES_ON: ''
+    SHOULD_SEARCH_INDEXER_RESOLVE_NESTED_ENTRIES: 'false'
   grantNamespaces: []
   grantNamespacesEnabled: false
   healthCheck:
@@ -1933,6 +1934,7 @@ search-indexer-service:
       NODE_OPTIONS: '--max-old-space-size=2048'
       S3_BUCKET: 'dev-es-custom-packages'
       SERVERSIDE_FEATURES_ON: ''
+      SHOULD_SEARCH_INDEXER_RESOLVE_NESTED_ENTRIES: 'false'
     secrets:
       CONTENTFUL_ACCESS_TOKEN: '/k8s/search-indexer/CONTENTFUL_ACCESS_TOKEN'
   namespace: 'search-indexer'

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -1599,6 +1599,7 @@ search-indexer-service:
     ELASTIC_NODE: 'https://vpc-search-mw4w5c2m2g5edjrtvwbpzhkw24.eu-west-1.es.amazonaws.com'
     NODE_OPTIONS: '--max-old-space-size=2000'
     SERVERSIDE_FEATURES_ON: 'driving-license-use-v1-endpoint-for-v2-comms'
+    SHOULD_SEARCH_INDEXER_RESOLVE_NESTED_ENTRIES: 'false'
   grantNamespaces: []
   grantNamespacesEnabled: false
   healthCheck:
@@ -1680,6 +1681,7 @@ search-indexer-service:
       NODE_OPTIONS: '--max-old-space-size=2048'
       S3_BUCKET: 'prod-es-custom-packages'
       SERVERSIDE_FEATURES_ON: 'driving-license-use-v1-endpoint-for-v2-comms'
+      SHOULD_SEARCH_INDEXER_RESOLVE_NESTED_ENTRIES: 'false'
     secrets:
       CONTENTFUL_ACCESS_TOKEN: '/k8s/search-indexer/CONTENTFUL_ACCESS_TOKEN'
   namespace: 'search-indexer'

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -1605,6 +1605,7 @@ search-indexer-service:
     ELASTIC_NODE: 'https://vpc-search-q6hdtjcdlhkffyxvrnmzfwphuq.eu-west-1.es.amazonaws.com'
     NODE_OPTIONS: '--max-old-space-size=2000'
     SERVERSIDE_FEATURES_ON: ''
+    SHOULD_SEARCH_INDEXER_RESOLVE_NESTED_ENTRIES: 'false'
   grantNamespaces: []
   grantNamespacesEnabled: false
   healthCheck:
@@ -1686,6 +1687,7 @@ search-indexer-service:
       NODE_OPTIONS: '--max-old-space-size=2048'
       S3_BUCKET: 'staging-es-custom-packages'
       SERVERSIDE_FEATURES_ON: ''
+      SHOULD_SEARCH_INDEXER_RESOLVE_NESTED_ENTRIES: 'false'
     secrets:
       CONTENTFUL_ACCESS_TOKEN: '/k8s/search-indexer/CONTENTFUL_ACCESS_TOKEN'
   namespace: 'search-indexer'

--- a/libs/cms/src/lib/search/contentful.service.ts
+++ b/libs/cms/src/lib/search/contentful.service.ts
@@ -327,6 +327,9 @@ export class ContentfulService {
       process.env.CONTENTFUL_ENTRY_FETCH_CHUNK_SIZE ?? 40,
     )
 
+    const shouldResolveNestedEntries =
+      process.env.SHOULD_SEARCH_INDEXER_RESOLVE_NESTED_ENTRIES === 'true'
+
     logger.info(`Sync chunk size is: ${chunkSize}`)
 
     const populatedSyncEntriesResult = await this.getPopulatedSyncEntries(
@@ -345,7 +348,7 @@ export class ContentfulService {
     const isDeltaUpdate = syncType !== 'full'
 
     // In case of delta updates, we need to resolve embedded entries to their root model
-    if (isDeltaUpdate) {
+    if (isDeltaUpdate && shouldResolveNestedEntries) {
       logger.info('Finding root entries from nestedEntries')
 
       const visitedEntryIds = new Set<string>()


### PR DESCRIPTION
# Add env variable for disabling nested resolution of entries from CMS

https://islandis.slack.com/archives/C01J3ANCF55/p1689177698836069

## What

* The nested logic is getting out of hand due to too many linked entry references in the CMS and our 3 year old indexing code can't deal with it anymore.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
