### PR TITLE
fix(license-api): re-enable the photo check

### DIFF
--- a/apps/services/license-api/src/app/modules/license/clients/drivingLicense/drivingLicenseApiClient.service.ts
+++ b/apps/services/license-api/src/app/modules/license/clients/drivingLicense/drivingLicenseApiClient.service.ts
@@ -105,19 +105,12 @@ export class DrivingLicenseApiClientService implements GenericLicenseClient {
     const name = license.name ?? ''
     const picture = license.photo?.image ?? ''
 
-    if (
-      !licenseNationalId ||
-      !name
-      //TODO: re-enable when testing is over!
-      //|| !picture
-    ) {
+    if (!licenseNationalId || !name || !picture) {
       return {
         ok: false,
         error: {
           code: 14,
-          //TODO: use when testing is over!
-          //message: 'Missing data. NationalId, name or photo missing',
-          message: 'Missing data. NationalId or name missing.',
+          message: 'Missing data. NationalId, name or photo missing',
         },
       }
     }


### PR DESCRIPTION
## What

Return error if a user's driving license doesn't contain a photo

## Why

Prod licenses must contain a photo

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
