### PR TITLE
feat(contentful-apps): Refetch parent on sys change for Baby Article url field extension

### DIFF
--- a/apps/contentful-apps/pages/fields/subarticle-url-field.tsx
+++ b/apps/contentful-apps/pages/fields/subarticle-url-field.tsx
@@ -30,16 +30,18 @@ const SubArticleUrlField = () => {
   )
   const [loading, setLoading] = useState(true)
   const [firstRender, setFirstRender] = useState(true)
-  const parentHasBeenSet = useRef<boolean | null>(null)
+  const parentArticleIsPresent = useRef<boolean | null>(null)
 
   const fetchParentArticle = useCallback(() => {
     const parentArticleId = sdk.entry.fields['parent']?.getValue()?.sys?.id
 
     if (!parentArticleId) {
-      parentHasBeenSet.current = false
+      parentArticleIsPresent.current = false
       setLoading(false)
       return
     }
+
+    parentArticleIsPresent.current = true
 
     cma.entry
       .get({
@@ -76,7 +78,7 @@ const SubArticleUrlField = () => {
 
   useEffect(() => {
     sdk.entry.onSysChanged(() => {
-      if (parentHasBeenSet.current !== false) return
+      if (parentArticleIsPresent.current !== false) return
 
       const parentId = sdk.entry.fields?.['parent']?.getValue()?.sys?.id
 


### PR DESCRIPTION
# Refetch parent on sys change for Baby Article url field extension

## What

* The url field of a baby article in the cms consists of the parent article's slug and the baby article's slug seperated by a slash. 

`${parentArticle.slug}/${babyArticle.slug}`.

When a baby article is created it doesn't have any parent assigned to it so fetch the parent's slug doesn't work since there is none. But once there is a parent set, then we'd like to refetch it to be able to form the url field of the baby article (which is what this PR is for).

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
