### PR TITLE
fix(application-system): Complaints to althingi ombudsman QA fixes 

### DIFF
--- a/libs/application/templates/complaints-to-althingi-ombudsman/src/forms/ComplaintsToAlthingiOmbudsmanApplication.ts
+++ b/libs/application/templates/complaints-to-althingi-ombudsman/src/forms/ComplaintsToAlthingiOmbudsmanApplication.ts
@@ -362,19 +362,19 @@ export const ComplaintsToAlthingiOmbudsmanApplication: Form = buildForm({
             }),
           ],
         }),
-        buildSubSection({
-          id: 'complaint.section.appeals',
-          title: complaintInformation.appealsSectionTitle,
-          children: [
-            buildRadioField({
-              id: 'appeals',
-              title: complaintInformation.appealsHeader,
-              width: 'half',
-              options: [
-                { label: shared.general.yes, value: YES },
-                { label: shared.general.no, value: NO },
-              ],
-            }),
+      ],
+    }),
+    buildSection({
+      id: 'complaint.section.appeals',
+      title: complaintInformation.appealsSectionTitle,
+      children: [
+        buildRadioField({
+          id: 'appeals',
+          title: complaintInformation.appealsHeader,
+          width: 'half',
+          options: [
+            { label: shared.general.yes, value: YES },
+            { label: shared.general.no, value: NO },
           ],
         }),
       ],
@@ -485,7 +485,7 @@ export const ComplaintsToAlthingiOmbudsmanApplication: Form = buildForm({
       expandableHeader: confirmation.information.title,
       expandableIntro: confirmation.information.intro,
       expandableDescription: confirmation.information.bulletList,
-      sectionTitle: confirmation.general.title
+      sectionTitle: confirmation.general.title,
     }),
   ],
 })

--- a/libs/application/templates/complaints-to-althingi-ombudsman/src/forms/ComplaintsToAlthingiOmbudsmanApplication.ts
+++ b/libs/application/templates/complaints-to-althingi-ombudsman/src/forms/ComplaintsToAlthingiOmbudsmanApplication.ts
@@ -485,6 +485,7 @@ export const ComplaintsToAlthingiOmbudsmanApplication: Form = buildForm({
       expandableHeader: confirmation.information.title,
       expandableIntro: confirmation.information.intro,
       expandableDescription: confirmation.information.bulletList,
+      sectionTitle: confirmation.general.title
     }),
   ],
 })

--- a/libs/application/templates/complaints-to-althingi-ombudsman/src/forms/ComplaintsToAlthingiOmbudsmanApplication.ts
+++ b/libs/application/templates/complaints-to-althingi-ombudsman/src/forms/ComplaintsToAlthingiOmbudsmanApplication.ts
@@ -406,6 +406,17 @@ export const ComplaintsToAlthingiOmbudsmanApplication: Form = buildForm({
               condition: (answers: FormValue) =>
                 answers.preexistingComplaint === YES,
             }),
+            buildCustomField({
+              id:
+                'preexistingComplaint.preexistingComplaintAlternativeAlertMessage',
+              title: preexistingComplaint.alternativeAlertMessage.title,
+              component: 'FieldAlertMessage',
+              description:
+                preexistingComplaint.alternativeAlertMessage.description,
+              doesNotRequireAnswer: true,
+              condition: (answers: FormValue) =>
+                answers.preexistingComplaint === NO,
+            }),
           ],
         }),
         buildMultiField({

--- a/libs/application/templates/complaints-to-althingi-ombudsman/src/forms/ComplaintsToAlthingiOmbudsmanSubmitted.ts
+++ b/libs/application/templates/complaints-to-althingi-ombudsman/src/forms/ComplaintsToAlthingiOmbudsmanSubmitted.ts
@@ -13,6 +13,7 @@ export const ComplaintsToAlthingiOmbudsmanSubmitted: Form = buildForm({
       expandableHeader: confirmation.information.title,
       expandableIntro: confirmation.information.intro,
       expandableDescription: confirmation.information.bulletList,
+      sectionTitle: confirmation.general.title
     }),
   ],
 })

--- a/libs/application/templates/complaints-to-althingi-ombudsman/src/forms/ComplaintsToAlthingiOmbudsmanSubmitted.ts
+++ b/libs/application/templates/complaints-to-althingi-ombudsman/src/forms/ComplaintsToAlthingiOmbudsmanSubmitted.ts
@@ -13,7 +13,7 @@ export const ComplaintsToAlthingiOmbudsmanSubmitted: Form = buildForm({
       expandableHeader: confirmation.information.title,
       expandableIntro: confirmation.information.intro,
       expandableDescription: confirmation.information.bulletList,
-      sectionTitle: confirmation.general.title
+      sectionTitle: confirmation.general.title,
     }),
   ],
 })

--- a/libs/application/templates/complaints-to-althingi-ombudsman/src/lib/dataSchema.ts
+++ b/libs/application/templates/complaints-to-althingi-ombudsman/src/lib/dataSchema.ts
@@ -41,9 +41,7 @@ export const ComplaintsToAlthingiOmbudsmanSchema = z.object({
     email: z.string().refine((v) => v, { params: error.required }),
     phone: z.string().refine((v) => v, { params: error.required }),
     connection: z.string().refine((v) => v, { params: error.required }),
-    powerOfAttorney: z
-      .array(FileSchema)
-      .refine((v) => v && v.length > 0, { params: error.document }),
+    powerOfAttorney: z.array(FileSchema).optional(),
   }),
   complaintDescription: z.object({
     decisionDate: z.string().optional(),

--- a/libs/application/templates/complaints-to-althingi-ombudsman/src/lib/messages/complainee.ts
+++ b/libs/application/templates/complaints-to-althingi-ombudsman/src/lib/messages/complainee.ts
@@ -28,7 +28,8 @@ export const complainee = {
     },
     complaineeNameGovernmentTitle: {
       id: 'ctao.application:complainee.complaineeName.government.title',
-      defaultMessage: 'Nafn stjórnvalds sem kvörtun beinist að',
+      defaultMessage:
+        'Heiti stjórnvalds eða annars aðila sem kvörtun beinist að',
       description: 'Government complainee name input title',
     },
     complaineeNameGovernmentPlaceholder: {

--- a/libs/application/templates/complaints-to-althingi-ombudsman/src/lib/messages/complaintDescription.ts
+++ b/libs/application/templates/complaints-to-althingi-ombudsman/src/lib/messages/complaintDescription.ts
@@ -10,7 +10,7 @@ export const complaintDescription = {
     decisionInfo: {
       id: 'ctao.application:complaintDescription.decisionInfo',
       defaultMessage:
-        'Eitt af skilyrðunum fyrir því að umboðsmaður Alþingis geti tekið kvörtun til meðferðar er að hún sé borin fram innan árs frá niðurstöðu stjórnvalds í máli.',
+        'Í kvörtun á að lýsa þeirri úrlausn eða háttsemi sem er tilefni kvörtunar. Hér skalt þú reyna að lýsa því hvað í meðferð stjórnvalda eða annarra á máli þínu þú ert ósátt/-ur við. Lýsing kvörtunar þarf ekki að vera flókin, t.d. er ekki nauðsynlegt að vísa til lagareglna.',
       description: 'Page description when complaint type is decision',
     },
     alertTitle: {
@@ -21,7 +21,7 @@ export const complaintDescription = {
     alertMessage: {
       id: 'ctao.application:complaintDescription.alertMessage',
       defaultMessage:
-        'Yfirleitt eru umsóknir um ákvarðanir lengra en ár aftur í tímann ekki teknar fyrir.',
+        'Kvörtun þarf að berast innan árs frá því að niðurstaða stjórnvalds liggur fyrir',
       description: 'Description alert message',
     },
   }),

--- a/libs/application/templates/complaints-to-althingi-ombudsman/src/lib/messages/complaintInformation.ts
+++ b/libs/application/templates/complaints-to-althingi-ombudsman/src/lib/messages/complaintInformation.ts
@@ -41,7 +41,7 @@ export const complaintInformation = defineMessages({
   },
   appealsHeader: {
     id: 'ctao.application:complaintInformation.appeals.header',
-    defaultMessage: 'Hafa kæruleiðir verið tæmdar',
+    defaultMessage: 'Hafa kæruleiðir verið nýttar',
     description: 'The header of the appeals section',
   },
   appealsSectionTitle: {

--- a/libs/application/templates/complaints-to-althingi-ombudsman/src/lib/messages/complaintInformation.ts
+++ b/libs/application/templates/complaints-to-althingi-ombudsman/src/lib/messages/complaintInformation.ts
@@ -18,10 +18,10 @@ export const complaintInformation = defineMessages({
   },
   decisionAlertMessage: {
     id: 'ctao.application:section.complaintInformation.decision.alertMessage',
-    defaultMessage: `Ef kvörtunin varðar ákvörðun eða úrskurð stjórnvalds skalt þú haka
-      við þennan reit og skrifa viðeigandi dagsetningu. Eitt af skilyrðunum fyrir því
-       að umboðsmaður Alþingis geti tekið kvörtun til meðferðar er að hún sé borin fram innan árs 
-       frá niðurstöðu stjórnvalds í máli.`,
+    defaultMessage: `Ef kvörtunin varðar ákvörðun eða úrskurð stjórnvalds skalt þú haka við þennan reit og skrifa 
+    viðeigandi dagsetningu á næstu síðu. Eitt af skilyrðunum fyrir því að umboðsmaður Alþingis 
+    geti tekið kvörtun til meðferðar er að hún sé borin fram innan árs frá niðurstöðu stjórnvalds í 
+    máli.`,
     description:
       'The message that appears in the alert when decision is selected',
   },

--- a/libs/application/templates/complaints-to-althingi-ombudsman/src/lib/messages/confirmation.ts
+++ b/libs/application/templates/complaints-to-althingi-ombudsman/src/lib/messages/confirmation.ts
@@ -3,29 +3,29 @@ import { defineMessages } from 'react-intl'
 export const confirmation = {
   general: defineMessages({
     title: {
-      id: 'ctao.application:conclusion.general.title',
-      defaultMessage: 'Umsókn staðfest',
+      id: 'ctao.application:confirmation.general.title',
+      defaultMessage: 'Kvörtun staðfest',
       description: 'Title of conclusion screen',
     },
     alertTitle: {
-      id: 'ctao.application:conclusion.general.alertTitle',
+      id: 'ctao.application:confirmation.general.alertTitle',
       defaultMessage: 'Takk fyrir umsóknina!',
       description: 'Conclusion screen alert title',
     },
   }),
   information: defineMessages({
     title: {
-      id: 'ctao.application:conclusion.general.title',
+      id: 'ctao.application:confirmation.information.title',
       defaultMessage: 'Hvað gerist næst?',
       description: 'Title of conclusion information box',
     },
     intro: {
-      id: 'ctao.application:conclusion.general.intro#markdown',
+      id: 'ctao.application:confirmation.information.intro#markdown',
       defaultMessage: 'Umsókn þín hefur verið móttekin',
       description: 'Conclusion information box intro',
     },
     bulletList: {
-      id: 'ctao.application:conclusion.general.bulletPoints#markdown',
+      id: 'ctao.application:confirmation.information.bulletPoints#markdown',
       defaultMessage: `* Við munum nú fara yfir verkefnið og við sendum á þig svör innan tíðar.\n* Við verðum í sambandi ef okkur vantar frekari upplýsingar.\n* Ef þú þarft frekari upplýsingar þá getur þú haft samband í síma 847 3759 eða á netfangið island@island.is`,
       description: 'Bullettpoints of information box',
     },

--- a/libs/application/templates/complaints-to-althingi-ombudsman/src/lib/messages/preexistingComplaint.ts
+++ b/libs/application/templates/complaints-to-althingi-ombudsman/src/lib/messages/preexistingComplaint.ts
@@ -15,7 +15,7 @@ export const preexistingComplaint = {
     description: {
       id: `ctao.application:general.preexistingComplaint.description`,
       defaultMessage:
-        'Hefur áður verið kvartað yfir þeim ákvörðunum eða öðru því sem lýst er hér að framan, t.d. með kæru eða öðru málskoti til annars stjórnvalds?',
+        'Hefur þú kvartað yfir þeim ákvörðunum eða öðru því sem lýst er hér að framan, t.d. með kæru eða öðru málskoti til annars stjórnvalds?',
       description:
         'Have there been previous complaints about the decisions or other things described above, e.g. with a complaint or other appeal to another authority?',
     },
@@ -29,9 +29,23 @@ export const preexistingComplaint = {
     description: {
       id: `ctao.application:alertMessage.preexistingComplaint.description`,
       defaultMessage:
-        'Ef skjóta má máli til æðra stjórnvalds er ekki unnt að kvarta til umboðsmanns fyrr en æðra stjórnvald hefur fellt úrskurð sinn í málinu.',
+        'Ef málinu var skotið til annars stjórnvalds, t.d. úrskurðarnefndar eða ráðuneytis, verður niðurstaða þess að liggja fyrir áður en umboðsmaður getur tekið kvörtun til meðferðar. Ef niðurstaða liggur fyrir er þess óskað að afrit af henni fylgi kvörtuninni.',
       description:
         'If a case can be referred to a higher authority, it is not possible to complain to the Ombudsman until a higher authority has given its ruling in the case.',
+    },
+  }),
+  alternativeAlertMessage: defineMessages({
+    title: {
+      id: `ctao.application:alternativeAlertMessage.preexistingComplaint.title`,
+      defaultMessage: 'Athugið',
+      description: 'Notice',
+    },
+    description: {
+      id: `ctao.application:alternativeAlertMessage.preexistingComplaint.description`,
+      defaultMessage:
+        'Til þess að umboðsmaður geti tekið kvörtun til meðferðar verða kæruleiðir innan stjórnsýslunnar að hafa verið nýttar og niðurstaða að liggja fyrir. Stjórnvöld leiðbeina oft um kæruleiðir í niðurlagi ákvarðana sinna.',
+      description:
+        'Prior to submitting this complaint to the Ombudsman, all other appeal options must be exhausted. Higher authorities specify the appeal process in their rulings.',
     },
   }),
 }

--- a/libs/application/ui-forms/src/lib/formConclusionSection/formConclusionSection.ts
+++ b/libs/application/ui-forms/src/lib/formConclusionSection/formConclusionSection.ts
@@ -21,7 +21,7 @@ type props = {
   s3FileKey?: FormText
   link?: string
   buttonText?: MessageDescriptor
-  sectionTitle?: MessageDescriptor 
+  sectionTitle?: MessageDescriptor
 }
 
 /**
@@ -36,12 +36,14 @@ type props = {
  * @param  s3FileKey The key of file in s3.
  * @param  link Link that user can click on.
  * @param  buttonText The text of the button that links to a url
- * @param  secitonTitle The title for the section 
+ * @param  secitonTitle The title for the section
  */
 export const buildFormConclusionSection = (props: props) =>
   buildSection({
     id: 'uiForms.conclusionSection',
-    title: props.sectionTitle ? props.sectionTitle : conclusion.information.sectionTitle,
+    title: props.sectionTitle
+      ? props.sectionTitle
+      : conclusion.information.sectionTitle,
     children: [
       buildMultiField({
         id: 'uiForms.conclusionMultifield',

--- a/libs/application/ui-forms/src/lib/formConclusionSection/formConclusionSection.ts
+++ b/libs/application/ui-forms/src/lib/formConclusionSection/formConclusionSection.ts
@@ -21,6 +21,7 @@ type props = {
   s3FileKey?: FormText
   link?: string
   buttonText?: MessageDescriptor
+  sectionTitle?: MessageDescriptor 
 }
 
 /**
@@ -35,11 +36,12 @@ type props = {
  * @param  s3FileKey The key of file in s3.
  * @param  link Link that user can click on.
  * @param  buttonText The text of the button that links to a url
+ * @param  secitonTitle The title for the section 
  */
 export const buildFormConclusionSection = (props: props) =>
   buildSection({
     id: 'uiForms.conclusionSection',
-    title: conclusion.information.sectionTitle,
+    title: props.sectionTitle ? props.sectionTitle : conclusion.information.sectionTitle,
     children: [
       buildMultiField({
         id: 'uiForms.conclusionMultifield',


### PR DESCRIPTION
# Complaints to althingi ombudsman QA fixes

Attach a link to issue if relevant

## What

Text updated in multiple locations.
Conclusion section title is now overridable.
Power of attorney file upload is now optional.
Appeals moved from subsection to its own section.
Alternative alert message for preexistingComplaints.

## Why

Feedback from QA

## Screenshots / Gifs

Appeals section:
![image](https://github.com/island-is/island.is/assets/42970319/c76136e2-4609-4eab-8234-5b8e76f858e7)

Conclusion section title override:
![image](https://github.com/island-is/island.is/assets/42970319/bc4bf942-c279-4617-bce8-1bf97303b271)

Alternative alertMessage:
![image](https://github.com/island-is/island.is/assets/42970319/15d1c5f6-1b82-4d28-8295-f9d8c2713830)



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
