### PR TITLE
chore(search-indexer): Allow fetching entries that link to nested entries again

### DIFF
--- a/apps/services/search-indexer/infra/search-indexer-service.ts
+++ b/apps/services/search-indexer/infra/search-indexer-service.ts
@@ -24,9 +24,9 @@ const envs = {
     prod: '40',
   },
   SHOULD_SEARCH_INDEXER_RESOLVE_NESTED_ENTRIES: {
-    dev: 'false',
-    staging: 'false',
-    prod: 'false',
+    dev: 'true',
+    staging: 'true',
+    prod: 'true',
   },
   AIR_DISCOUNT_SCHEME_FRONTEND_HOSTNAME: {
     dev: 'loftbru.dev01.devland.is',

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -1845,7 +1845,7 @@ search-indexer-service:
     ELASTIC_NODE: 'https://vpc-search-njkekqydiegezhr4vqpkfnw5la.eu-west-1.es.amazonaws.com'
     NODE_OPTIONS: '--max-old-space-size=2000'
     SERVERSIDE_FEATURES_ON: ''
-    SHOULD_SEARCH_INDEXER_RESOLVE_NESTED_ENTRIES: 'false'
+    SHOULD_SEARCH_INDEXER_RESOLVE_NESTED_ENTRIES: 'true'
   grantNamespaces: []
   grantNamespacesEnabled: false
   healthCheck:
@@ -1927,7 +1927,7 @@ search-indexer-service:
       NODE_OPTIONS: '--max-old-space-size=2048'
       S3_BUCKET: 'dev-es-custom-packages'
       SERVERSIDE_FEATURES_ON: ''
-      SHOULD_SEARCH_INDEXER_RESOLVE_NESTED_ENTRIES: 'false'
+      SHOULD_SEARCH_INDEXER_RESOLVE_NESTED_ENTRIES: 'true'
     secrets:
       CONTENTFUL_ACCESS_TOKEN: '/k8s/search-indexer/CONTENTFUL_ACCESS_TOKEN'
   namespace: 'search-indexer'

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -1592,7 +1592,7 @@ search-indexer-service:
     ELASTIC_NODE: 'https://vpc-search-mw4w5c2m2g5edjrtvwbpzhkw24.eu-west-1.es.amazonaws.com'
     NODE_OPTIONS: '--max-old-space-size=2000'
     SERVERSIDE_FEATURES_ON: 'driving-license-use-v1-endpoint-for-v2-comms'
-    SHOULD_SEARCH_INDEXER_RESOLVE_NESTED_ENTRIES: 'false'
+    SHOULD_SEARCH_INDEXER_RESOLVE_NESTED_ENTRIES: 'true'
   grantNamespaces: []
   grantNamespacesEnabled: false
   healthCheck:
@@ -1674,7 +1674,7 @@ search-indexer-service:
       NODE_OPTIONS: '--max-old-space-size=2048'
       S3_BUCKET: 'prod-es-custom-packages'
       SERVERSIDE_FEATURES_ON: 'driving-license-use-v1-endpoint-for-v2-comms'
-      SHOULD_SEARCH_INDEXER_RESOLVE_NESTED_ENTRIES: 'false'
+      SHOULD_SEARCH_INDEXER_RESOLVE_NESTED_ENTRIES: 'true'
     secrets:
       CONTENTFUL_ACCESS_TOKEN: '/k8s/search-indexer/CONTENTFUL_ACCESS_TOKEN'
   namespace: 'search-indexer'

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -1598,7 +1598,7 @@ search-indexer-service:
     ELASTIC_NODE: 'https://vpc-search-q6hdtjcdlhkffyxvrnmzfwphuq.eu-west-1.es.amazonaws.com'
     NODE_OPTIONS: '--max-old-space-size=2000'
     SERVERSIDE_FEATURES_ON: ''
-    SHOULD_SEARCH_INDEXER_RESOLVE_NESTED_ENTRIES: 'false'
+    SHOULD_SEARCH_INDEXER_RESOLVE_NESTED_ENTRIES: 'true'
   grantNamespaces: []
   grantNamespacesEnabled: false
   healthCheck:
@@ -1680,7 +1680,7 @@ search-indexer-service:
       NODE_OPTIONS: '--max-old-space-size=2048'
       S3_BUCKET: 'staging-es-custom-packages'
       SERVERSIDE_FEATURES_ON: ''
-      SHOULD_SEARCH_INDEXER_RESOLVE_NESTED_ENTRIES: 'false'
+      SHOULD_SEARCH_INDEXER_RESOLVE_NESTED_ENTRIES: 'true'
     secrets:
       CONTENTFUL_ACCESS_TOKEN: '/k8s/search-indexer/CONTENTFUL_ACCESS_TOKEN'
   namespace: 'search-indexer'


### PR DESCRIPTION
# Allow fetching entries that link to nested entries again

## What

* Recently a lot of entries that had many entries were linking to were published in the CMS, causing the indexing process to halt. That's when this env variable was introduced but we'd like to toggle the nested functionality back on again (meaning that if someone updates an accordion then the article it's on will be updated).
