### PR TITLE
fix(contentful-apps): Adjust subarticles field height depending on item count

### DIFF
--- a/apps/contentful-apps/pages/fields/article-subarticles-field.tsx
+++ b/apps/contentful-apps/pages/fields/article-subarticles-field.tsx
@@ -12,12 +12,27 @@ const ArticleSubArticlesField = () => {
   const cma = useCMA()
 
   useEffect(() => {
-    sdk.window.startAutoResizer()
-  }, [sdk.window])
+    const unregister = sdk.field.onValueChanged((items) => {
+      if (items?.length > 1) {
+        sdk.window.startAutoResizer()
+      } else {
+        if (!items?.length) {
+          sdk.window.stopAutoResizer()
+          sdk.window.updateHeight(210)
+        } else {
+          sdk.window.stopAutoResizer()
+          sdk.window.updateHeight(300)
+        }
+      }
+    })
+
+    return () => {
+      unregister()
+    }
+  }, [sdk.field, sdk.window])
 
   return (
     <MultipleEntryReferenceEditor
-      css={{ overflow: 'hidden' }}
       hasCardEditActions={false}
       viewType="link"
       sdk={sdk}


### PR DESCRIPTION
# Adjust subarticles field height depending on item count

## Before

https://github.com/island-is/island.is/assets/43557895/b00da7a2-0208-4c2e-aae9-379ee7701c37

## After
https://github.com/island-is/island.is/assets/43557895/740f5b70-8c08-47f3-8c45-f05322f252ea
