### PR TITLE
fix(web): Only update /starfatorg url page param if page is not set to 1

### DIFF
--- a/apps/web/screens/IcelandicGovernmentInstitutionVacancies/IcelandicGovernmentInstitutionVacanciesList.tsx
+++ b/apps/web/screens/IcelandicGovernmentInstitutionVacancies/IcelandicGovernmentInstitutionVacanciesList.tsx
@@ -271,7 +271,7 @@ const IcelandicGovernmentInstitutionVacanciesList: Screen<IcelandicGovernmentIns
 
     let shouldScroll = false
 
-    if (!selectedPage) {
+    if (selectedPage === 1) {
       if ('page' in updatedQuery) delete updatedQuery['page']
     } else {
       shouldScroll = updatedQuery.page !== selectedPage.toString()


### PR DESCRIPTION
# Only update /starfatorg url page param if page is not set to 1

## What

* Opening the /starfatorg page without any filters selected should not cause the url the change
* When you open island.is/starfatorg then the url gets changed to island.is/starfatorg?page=1 which won't happen anymore once this PR gets merged and this code gets deployed

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
