### PR TITLE
fix: do not use yarn set version

### DIFF
--- a/scripts/ci/Dockerfile
+++ b/scripts/ci/Dockerfile
@@ -138,7 +138,8 @@ RUN chown -R pwuser:pwuser .
 
 USER pwuser
 ADD .yarnrc.yml ./
-COPY .yarn .yarn
+RUN mkdir ./.yarn
+COPY .yarn/releases ./.yarn/releases
 RUN yarn install
 
 ENV PLAYWRIGHT_BROWSER=chromium

--- a/scripts/ci/Dockerfile
+++ b/scripts/ci/Dockerfile
@@ -137,7 +137,8 @@ COPY ${APP_HOME}/package.json .
 RUN chown -R pwuser:pwuser .
 
 USER pwuser
-RUN yarn set version berry
+ADD .yarnrc.yml ./
+COPY .yarn .yarn
 RUN yarn install
 
 ENV PLAYWRIGHT_BROWSER=chromium


### PR DESCRIPTION
# ...

yarn set version fails on playwright since it always fetches the latest instead of using the version we have in the repo

## What

copying yarn files instead of using yarn set version


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
