### PR TITLE
fix(contentful-apps): Subarticle url field validation

### DIFF
--- a/apps/contentful-apps/pages/fields/subarticle-url-field.tsx
+++ b/apps/contentful-apps/pages/fields/subarticle-url-field.tsx
@@ -109,8 +109,11 @@ const SubArticleUrlField = () => {
           return
         }
       }
-
-      sdk.field.setValue(`${prefix}/${value}`)
+      if (value.trim().length === 0) {
+        sdk.field.setValue('')
+      } else {
+        sdk.field.setValue(`${prefix}/${value}`)
+      }
       sdk.field.setInvalid(
         value.length === 0 && sdk.field.locale === defaultLocale,
       )


### PR DESCRIPTION
# Subarticle url field validation

## What

* If the url field was left empty for other locales than the default one then the entry could not be published since the code used a / value instead of allowing the field being empty and since the url value needs to be unique then the validation kicked in and prevented us from publishing, this is solved by simply allowing an empty value

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
