### PR TITLE
fix(core): Add @nestjs/axios in esbuild.json externalDependencies.

### DIFF
--- a/apps/judicial-system/api/esbuild.json
+++ b/apps/judicial-system/api/esbuild.json
@@ -14,6 +14,7 @@
     "fastify-swagger",
     "@nestjs/mongoose",
     "@nestjs/typeorm",
+    "@nestjs/axios",
     "dd-trace",
     "express",
     "util-deprecate",

--- a/apps/judicial-system/backend/esbuild.json
+++ b/apps/judicial-system/backend/esbuild.json
@@ -18,6 +18,7 @@
     "fastify-swagger",
     "@nestjs/mongoose",
     "@nestjs/typeorm",
+    "@nestjs/axios",
     "dd-trace",
     "express",
     "http-errors",

--- a/apps/services/user-notification/esbuild.json
+++ b/apps/services/user-notification/esbuild.json
@@ -14,6 +14,7 @@
     "fastify-swagger",
     "@nestjs/mongoose",
     "@nestjs/typeorm",
+    "@nestjs/axios",
     "dd-trace",
     "express",
     "http-errors",


### PR DESCRIPTION
## What

Adding `@nestjs/axios` as `externalDependencies` in `esbuild.json` for
* `judicial-system-api`
* `judicial-system-backend`
* `user-notification` which applies also for the worker.

## Why

These services are using `cms-translations` library that uses the `CmsModule` which includes `HttpHealthIndocator` from `@nestjs/axios`. Needed to fix regression from the monorepo upgrade.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
