### PR TITLE
fix(web): Allow bypassing cache for web

### DIFF
--- a/apps/web/graphql/client.ts
+++ b/apps/web/graphql/client.ts
@@ -1,4 +1,3 @@
-import { NextPageContext } from 'next'
 import { InMemoryCache, NormalizedCacheObject } from '@apollo/client/cache'
 import { ApolloClient } from '@apollo/client/core'
 import { defaultLanguage } from '@island.is/shared/constants'
@@ -7,6 +6,7 @@ import { createHttpLink } from '@island.is/web/graphql/httpLink'
 
 import { ClientOptions, optionsFromContext, optionsFromWindow } from './options'
 import possibleTypes from './fragmentTypes.json'
+import type { ScreenContext } from '../types'
 
 const isBrowser: boolean = process.browser
 
@@ -31,7 +31,7 @@ function create(initialState?: any, options: ClientOptions = {}) {
 export default function initApollo(
   initialState?: any,
   clientLocale?: Locale,
-  ctx?: NextPageContext,
+  ctx?: Partial<ScreenContext>,
 ) {
   // Make sure to create a new client for every server-side request so that data
   // isn't shared between connections (which would be bad)

--- a/apps/web/graphql/options.ts
+++ b/apps/web/graphql/options.ts
@@ -1,10 +1,12 @@
-import { NextPageContext } from 'next'
+import type { ScreenContext } from '../types'
 
 export interface ClientOptions {
   bypassCache?: string
 }
 
-export function optionsFromContext(ctx?: NextPageContext): ClientOptions {
+export function optionsFromContext(
+  ctx?: Partial<ScreenContext>,
+): ClientOptions {
   return {
     bypassCache: ctx?.query?.['bypass-cache']?.toString(),
   }

--- a/apps/web/graphql/withApollo.tsx
+++ b/apps/web/graphql/withApollo.tsx
@@ -21,7 +21,7 @@ export const withApollo = (Component) => {
     const clientLocale = getLocaleFromPath(
       safelyExtractPathnameFromUrl(ctx.req?.url),
     )
-    const apolloClient = initApollo({}, clientLocale)
+    const apolloClient = initApollo({}, clientLocale, ctx)
     const newContext = { ...ctx, apolloClient }
     const props = Component.getProps ? await Component.getProps(newContext) : {}
     const cache = apolloClient.cache.extract()


### PR DESCRIPTION
# Allow bypassing cache for web

## What

* Content writers need to be able to preview what they are writing on the dev environment quickly so we've got a way to bypass the cache. But it stopped working due to an update resulting in the initApollo function not receiving the page context parameter, I simply added it and now the bypass works again 🙌 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
