### PR TITLE
fix(application-system): Delegations screen stuck in loading state

### DIFF
--- a/apps/application-system/form/src/routes/Applications.tsx
+++ b/apps/application-system/form/src/routes/Applications.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useEffect, useState } from 'react'
+import React, { FC, useEffect, useState } from 'react'
 
 import { useParams, useLocation, useNavigate } from 'react-router-dom'
 import { useMutation } from '@apollo/client'
@@ -62,9 +62,6 @@ export const Applications: FC<React.PropsWithChildren<unknown>> = () => {
       >
     | undefined
   >(undefined)
-  const checkDelegation = useCallback(() => {
-    setDelegationsChecked((d) => !d)
-  }, [])
 
   useApplicationNamespaces(type)
 
@@ -148,7 +145,7 @@ export const Applications: FC<React.PropsWithChildren<unknown>> = () => {
         <DelegationsScreen
           slug={slug}
           alternativeSubjects={foundError.alternativeSubjects}
-          checkDelegation={checkDelegation}
+          checkDelegation={setDelegationsChecked}
         />
       )
     }
@@ -168,7 +165,9 @@ export const Applications: FC<React.PropsWithChildren<unknown>> = () => {
   }
 
   if (!delegationsChecked && type && slug) {
-    return <DelegationsScreen checkDelegation={checkDelegation} slug={slug} />
+    return (
+      <DelegationsScreen checkDelegation={setDelegationsChecked} slug={slug} />
+    )
   }
 
   const numberOfApplicationsInDraft = data?.applicationApplications.filter(

--- a/libs/application/ui-shell/src/lib/ApplicationForm.tsx
+++ b/libs/application/ui-shell/src/lib/ApplicationForm.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState, useCallback } from 'react'
+import React, { FC, useEffect, useState } from 'react'
 import { useQuery } from '@apollo/client'
 
 import { APPLICATION_APPLICATION } from '@island.is/application/graphql'
@@ -44,9 +44,6 @@ const ApplicationLoader: FC<
   const [delegationsChecked, setDelegationsChecked] = useState(
     type ? false : true,
   )
-  const checkDelegation = useCallback(() => {
-    setDelegationsChecked((d) => !d)
-  }, [])
 
   const { lang: locale } = useLocale()
   const { data, error, loading, refetch } = useQuery(APPLICATION_APPLICATION, {
@@ -88,7 +85,7 @@ const ApplicationLoader: FC<
         <DelegationsScreen
           slug={slug}
           alternativeSubjects={foundError.alternativeSubjects}
-          checkDelegation={checkDelegation}
+          checkDelegation={setDelegationsChecked}
         />
       )
     }


### PR DESCRIPTION
# Delegations screen stuck in loading state



## What

React 18 `StrictMode` exposed a bug (local development only) in the applications screen where the delegations check gets stuck because we were  setting a `delegationCheck` by toggling it on/off instead of directly setting it to true. Because of the double render of StrictMode in development mode this check was always being toggled twice and therefore never changed to the correct value.

## Why

Fixes regression after big NX update 

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
