### PR TITLE
fix(cms): Include query params in relative url mapping

### DIFF
--- a/libs/cms/src/lib/models/utils.ts
+++ b/libs/cms/src/lib/models/utils.ts
@@ -1,7 +1,7 @@
 /** Make sure that links are relative in case someone links to production directly */
 export const getRelativeUrl = (url: string) => {
   const urlObject = new URL(url.trim(), 'https://island.is')
-  if (urlObject.host === 'island.is') {
+  if (urlObject.host === 'island.is' || urlObject.host === 'www.island.is') {
     return `${urlObject.pathname}${urlObject.search}${urlObject.hash}`
   }
   return urlObject.href

--- a/libs/cms/src/lib/models/utils.ts
+++ b/libs/cms/src/lib/models/utils.ts
@@ -2,7 +2,7 @@
 export const getRelativeUrl = (url: string) => {
   const urlObject = new URL(url.trim(), 'https://island.is')
   if (urlObject.host === 'island.is') {
-    return urlObject.pathname
+    return `${urlObject.pathname}${urlObject.search}${urlObject.hash}`
   }
   return urlObject.href
 }


### PR DESCRIPTION
# Include query params in relative url mapping

## What

* Previously only the pathname was returned but that cut off the query params and hash value in the url, which is something we want to keep, so that's what this PR is for :) 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
