### PR TITLE
fix(web): useEffect returned values are causing errors on route change

### DIFF
--- a/apps/web/components/IcelandicNamesSearcher/IcelandicNamesSearcher.tsx
+++ b/apps/web/components/IcelandicNamesSearcher/IcelandicNamesSearcher.tsx
@@ -59,7 +59,8 @@ export const IcelandicNamesSearcher = () => {
 
   useEffect(() => {
     if (width < theme.breakpoints.md) {
-      return setIsMobile(true)
+      setIsMobile(true)
+      return
     }
     setIsMobile(false)
   }, [width])

--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -679,7 +679,9 @@ export const OrganizationWrapper: React.FC<
 
   usePlausiblePageview(organizationPage.organization?.trackingDomain)
 
-  useEffect(() => setIsMobile(width < theme.breakpoints.md), [width])
+  useEffect(() => {
+    setIsMobile(width < theme.breakpoints.md)
+  }, [width])
 
   const secondaryNavList: NavigationItem[] =
     organizationPage.secondaryMenu?.childrenLinks.map(({ text, url }) => ({

--- a/apps/web/hooks/useContentfulId.ts
+++ b/apps/web/hooks/useContentfulId.ts
@@ -12,7 +12,9 @@ export const useContentfulId = (
     if (pageId) {
       setContentfulIds([pageId, subpageId, subSubPageId])
     }
-    return () => setContentfulIds([])
+    return () => {
+      setContentfulIds([])
+    }
   }, [pageId, subpageId, subSubPageId])
 }
 

--- a/apps/web/hooks/usePlausible.ts
+++ b/apps/web/hooks/usePlausible.ts
@@ -7,7 +7,7 @@ export const usePlausible = (eventName: string, params: unknown) => {
   useEffect(() => {
     const maybeWindow = process.browser ? window : undefined
 
-    if (!maybeWindow || !maybeWindow?.plausible) return null
+    if (!maybeWindow || !maybeWindow?.plausible) return
 
     if (!isEqual(currentParams, params)) {
       setCurrentParams(params)

--- a/apps/web/hooks/useViewport.ts
+++ b/apps/web/hooks/useViewport.ts
@@ -20,7 +20,9 @@ export const useScrollPosition = (): Position => {
   useEffect(() => {
     onScroll()
     window.addEventListener('scroll', onScroll, { passive: true })
-    return () => window.removeEventListener('scroll', onScroll)
+    return () => {
+      window.removeEventListener('scroll', onScroll)
+    }
   }, [onScroll])
 
   return position
@@ -45,7 +47,9 @@ export const useWindowSize = (): Rect => {
   useEffect(() => {
     onResize()
     window.addEventListener('resize', onResize, { passive: true })
-    return () => window.removeEventListener('resize', onResize)
+    return () => {
+      window.removeEventListener('resize', onResize)
+    }
   }, [onResize])
 
   return size

--- a/apps/web/screens/AboutPage/Sidebar.tsx
+++ b/apps/web/screens/AboutPage/Sidebar.tsx
@@ -33,7 +33,9 @@ const Sidebar = ({ children }: SidebarProps) => {
   useEffect(() => {
     onResize()
     window.addEventListener('resize', onResize, { passive: true })
-    return () => window.removeEventListener('resize', onResize)
+    return () => {
+      window.removeEventListener('resize', onResize)
+    }
   }, [onResize])
 
   return (

--- a/apps/web/screens/Adgerdir/components/AdgerdirArticles/AdgerdirArticles.tsx
+++ b/apps/web/screens/Adgerdir/components/AdgerdirArticles/AdgerdirArticles.tsx
@@ -165,7 +165,9 @@ export const AdgerdirArticles: FC<
 
   useEffect(() => {
     onUpdateFilters()
-    return () => clearTimeout(timerRef.current)
+    return () => {
+      clearTimeout(timerRef.current)
+    }
   }, [onUpdateFilters])
 
   const filteredItems = visibleItems.filter((_, index) => {

--- a/apps/web/screens/Adgerdir/components/CardsSlider/CardsSlider.tsx
+++ b/apps/web/screens/Adgerdir/components/CardsSlider/CardsSlider.tsx
@@ -86,7 +86,9 @@ export const CardsSlider: FC<React.PropsWithChildren<CardsSliderProps>> = ({
       setTimeout(handleResize, 0)
     }
 
-    return () => window.removeEventListener('resize', handleResize)
+    return () => {
+      window.removeEventListener('resize', handleResize)
+    }
   }, [handleResize])
 
   const slideNext = () => {

--- a/apps/web/screens/Organization/StafraentIsland/ApiCatalogue.tsx
+++ b/apps/web/screens/Organization/StafraentIsland/ApiCatalogue.tsx
@@ -82,7 +82,8 @@ const ApiCatalogue: Screen<HomestayProps> = ({
 
   useEffect(() => {
     if (width < theme.breakpoints.md) {
-      return setIsMobile(true)
+      setIsMobile(true)
+      return
     }
     setIsMobile(false)
   }, [width])

--- a/apps/web/screens/Organizations/Organizations.tsx
+++ b/apps/web/screens/Organizations/Organizations.tsx
@@ -72,7 +72,8 @@ const OrganizationPage: Screen<OrganizationProps> = ({
   const { width } = useWindowSize()
   useEffect(() => {
     if (width < theme.breakpoints.md) {
-      return setIsMobile(true)
+      setIsMobile(true)
+      return
     }
     setIsMobile(false)
   }, [width])

--- a/apps/web/screens/Search/Search.tsx
+++ b/apps/web/screens/Search/Search.tsx
@@ -375,7 +375,7 @@ const Search: Screen<CategoryProps> = ({
 
   useEffect(() => {
     if (state.searchLocked) {
-      return null
+      return
     }
 
     const newQuery = {


### PR DESCRIPTION
# useEffect returned values are causing errors on route change

## What

* I noticed errors on route changes (clicking a link) for some pages and it turns out it's due to values being returned in useEffect, see more here: https://stackoverflow.com/questions/72306420/typeerror-destroy-is-not-a-function-nextjs

## Screenshots / Gifs

![image](https://github.com/island-is/island.is/assets/43557895/b72935b5-8042-4add-b370-998020800b21)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
