### PR TITLE
fix(search-indexer): Update docker files for local development

### DIFF
--- a/apps/services/search-indexer/dev-services/docker-compose.yml
+++ b/apps/services/search-indexer/dev-services/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     volumes:
       - ./data/data01:/usr/share/elasticsearch/data
     ports:
-      - 127.0.0.1:9200:9200
+      - 9200:9200
     networks:
       - elastic
 

--- a/apps/services/search-indexer/dev-services/elasticsearch/Dockerfile
+++ b/apps/services/search-indexer/dev-services/elasticsearch/Dockerfile
@@ -4,11 +4,14 @@ FROM $DOCKER_IMAGE_REGISTRY/elasticsearch:7.4.2
 # adding ICO for unicode support
 RUN bin/elasticsearch-plugin install analysis-icu
 
+RUN yum -y install unzip wget
+
 # get dictionaries
-ADD https://github.com/island-is/elasticsearch-dictionaries/archive/master.zip /usr/share/elasticsearch/config/
+RUN wget -O master.zip https://github.com/island-is/elasticsearch-dictionaries/archive/master.zip
+
+RUN mv master.zip /usr/share/elasticsearch/config/
 
 # unzip git repo
-RUN yum -y install unzip
 RUN unzip /usr/share/elasticsearch/config/master.zip -d /usr/share/elasticsearch/config
 
 # move analyzers to correct folder


### PR DESCRIPTION
# Update docker files for local development

## What

* I've been struggling with running `yarn dev-services services-search-indexer` after I recently updated Docker Desktop on an intel mac. The changes in this PR fixed that issue

## Screenshots / Gifs

![image](https://github.com/island-is/island.is/assets/43557895/97487531-33db-4a13-84bd-a1c19b92d34f)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
