### PR TITLE
fix(application-dir): Exams passed filter

### DIFF
--- a/libs/application/templates/driving-instructor-registrations/src/fields/ViewStudent/index.tsx
+++ b/libs/application/templates/driving-instructor-registrations/src/fields/ViewStudent/index.tsx
@@ -344,22 +344,26 @@ const ViewStudent = ({
                   <Text variant="h4">
                     {formatMessage(m.viewStudentExamsComplete)}
                   </Text>
-                  {student.book?.testResults.length > 0 ? (
-                    student.book?.testResults.map((test, key) => {
-                      const textStr = getExamString({
-                        name: test.testTypeName,
-                        examDate: test.examDate,
+                  {student.book?.testResults.filter(
+                    (result) => result.hasPassed,
+                  ).length > 0 ? (
+                    student.book?.testResults
+                      .filter((result) => result.hasPassed)
+                      .map((test, key) => {
+                        const textStr = getExamString({
+                          name: test.testTypeName,
+                          examDate: test.examDate,
+                        })
+                        return (
+                          <BulletList type="ul" color="dark300">
+                            <Bullet>
+                              <Text key={key} variant="default">
+                                {textStr}
+                              </Text>
+                            </Bullet>
+                          </BulletList>
+                        )
                       })
-                      return (
-                        <BulletList type="ul" color="dark300">
-                          <Bullet>
-                            <Text key={key} variant="default">
-                              {textStr}
-                            </Text>
-                          </Bullet>
-                        </BulletList>
-                      )
-                    })
                   ) : (
                     <BulletList type="ul" color="dark300">
                       <Bullet>


### PR DESCRIPTION
Previously all test restuls were being treated as passed.
We simply filter them now

## Screenshots / Gifs

Visual aid for 010130-2129, a test student who has test results but has not passed the exam.
Notice bottom right for `Skriflegm prófum lokið`

### After changes
![image (5)](https://github.com/island-is/island.is/assets/77672665/7e1d8db3-d1f2-46e3-882d-8d1b3a2d0bd7)


### Before changes 
![image (6)](https://github.com/island-is/island.is/assets/77672665/5e5c950f-f35c-44ae-9b5c-6987749e284a)

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
