### PR TITLE
fix(web): Vacancies added in CMS not showing up on overview page

### DIFF
--- a/apps/web/screens/IcelandicGovernmentInstitutionVacancies/IcelandicGovernmentInstitutionVacanciesList.tsx
+++ b/apps/web/screens/IcelandicGovernmentInstitutionVacancies/IcelandicGovernmentInstitutionVacanciesList.tsx
@@ -46,6 +46,8 @@ const ITEMS_PER_PAGE = 8
 export const VACANCY_INTRO_MAX_LENGTH = 80
 
 export const shortenText = (text: string, maxLength: number) => {
+  if (!text) return text
+
   if (text.length <= maxLength) {
     return text
   }

--- a/libs/cms/src/lib/cms.elasticsearch.service.ts
+++ b/libs/cms/src/lib/cms.elasticsearch.service.ts
@@ -280,6 +280,7 @@ export class CmsElasticsearchService {
       index,
       {
         types: ['webVacancy'],
+        size: 1000,
       },
     )
     return vacanciesResponse.hits.hits

--- a/libs/cms/src/lib/search/importers/news.service.ts
+++ b/libs/cms/src/lib/search/importers/news.service.ts
@@ -68,7 +68,7 @@ export class NewsSyncService implements CmsSyncProvider<INews> {
             tags,
             dateCreated: mapped.date,
             dateUpdated: new Date().getTime().toString(),
-            releaseDate: mapped.initialPublishDate,
+            releaseDate: mapped.initialPublishDate || null,
           }
         } catch (error) {
           logger.warn('Failed to import news', {


### PR DESCRIPTION
# Vacancies added in CMS not showing up on overview page

## What

* Since there was max size parameter defined in the Elasticsearch query there seemed to be a cut off, meaning that not all vacancies got returned.
* This PR adds the max size limit to be a 1000 (since we need to set some number and 1000 is also used for the /s page it was deemed feasible, however it's not likely that vacancies entered in the CMS will ever be more than a 100 but it's best to be safe by setting it to a 1000).

Once the vacancies endpoint in xroad becomes paginated this code will also be updated so it allows for pagination but until that happens, this change is truly needed

* I also added a fail-safe for news that haven't been published yet (by setting the releaseDate field that gets stored in ES to null if the initialPublishDate is an empty string)
* And I noticed that the text value can indeed be null if left empty in the CMS so I simply added a fail-safe for that as well in the frontend

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
