### PR TITLE
fix(web): Published material page prop refetching loop

### DIFF
--- a/apps/web/screens/Organization/PublishedMaterial/PublishedMaterial.tsx
+++ b/apps/web/screens/Organization/PublishedMaterial/PublishedMaterial.tsx
@@ -57,6 +57,7 @@ import {
   getInitialParameters,
 } from './utils'
 import * as styles from './PublishedMaterial.css'
+import { isEqual } from 'lodash'
 
 const ASSETS_PER_PAGE = 20
 const DEBOUNCE_TIME_IN_MS = 300
@@ -296,14 +297,16 @@ const PublishedMaterial: Screen<PublishedMaterialProps> = ({
 
       filterValuesHaveBeenInitialized.current = true
 
-      router.replace(
-        {
-          pathname: router.pathname,
-          query: updatedQueryParams,
-        },
-        undefined,
-        { scroll: false, shallow: true },
-      )
+      if (!isEqual(router.query, updatedQueryParams)) {
+        router.replace(
+          {
+            pathname: router.pathname,
+            query: updatedQueryParams,
+          },
+          undefined,
+          { scroll: false, shallow: true },
+        )
+      }
     },
     DEBOUNCE_TIME_IN_MS,
     [parameters, activeLocale, searchValue, selectedOrderOption],

--- a/apps/web/screens/Organization/PublishedMaterial/PublishedMaterial.tsx
+++ b/apps/web/screens/Organization/PublishedMaterial/PublishedMaterial.tsx
@@ -302,7 +302,7 @@ const PublishedMaterial: Screen<PublishedMaterialProps> = ({
           query: updatedQueryParams,
         },
         undefined,
-        { scroll: false },
+        { scroll: false, shallow: true },
       )
     },
     DEBOUNCE_TIME_IN_MS,

--- a/apps/web/screens/Organization/PublishedMaterial/PublishedMaterial.tsx
+++ b/apps/web/screens/Organization/PublishedMaterial/PublishedMaterial.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@apollo/client'
+import isEqual from 'lodash/isEqual'
 import {
   Box,
   Button,
@@ -57,7 +58,6 @@ import {
   getInitialParameters,
 } from './utils'
 import * as styles from './PublishedMaterial.css'
-import { isEqual } from 'lodash'
 
 const ASSETS_PER_PAGE = 20
 const DEBOUNCE_TIME_IN_MS = 300


### PR DESCRIPTION
#  Published material page prop refetching loop

## What

* The published material page (utgefid-efni) was being infinitely re-rendered due to props being refetched when the url got updated

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
