### PR TITLE
fix(application-p-sign): Fix duplicate message id

### DIFF
--- a/libs/application/templates/p-sign/src/lib/messages.ts
+++ b/libs/application/templates/p-sign/src/lib/messages.ts
@@ -322,7 +322,7 @@ export const m = defineMessages({
     description: 'Validation error for attachment',
   },
   missingDistrictValidationError: {
-    id: 'ps.application:error.missingAttachment',
+    id: 'ps.application:error.missingDistrict',
     defaultMessage: 'Vinsamlegast veldu embætti',
     description: 'Validation error for district',
   },


### PR DESCRIPTION
# Why?

Want string extraction to not fail.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
