### PR TITLE
fix(j-s): Truncate tags

### DIFF
--- a/apps/judicial-system/web/src/components/TagAppealState/TagAppealState.tsx
+++ b/apps/judicial-system/web/src/components/TagAppealState/TagAppealState.tsx
@@ -99,7 +99,7 @@ const TagAppealState: React.FC<React.PropsWithChildren<Props>> = ({
   if (!tagVariantRuling) return null
 
   return (
-    <Tag variant={tagVariantRuling?.color} outlined disabled>
+    <Tag variant={tagVariantRuling?.color} outlined disabled truncate>
       {tagVariantRuling.text}
     </Tag>
   )

--- a/apps/judicial-system/web/src/components/TagCaseState/TagCaseState.tsx
+++ b/apps/judicial-system/web/src/components/TagCaseState/TagCaseState.tsx
@@ -83,7 +83,7 @@ const TagCaseState: React.FC<React.PropsWithChildren<Props>> = (Props) => {
   if (!tagVariant) return null
 
   return (
-    <Tag variant={tagVariant?.color} outlined disabled>
+    <Tag variant={tagVariant?.color} outlined disabled truncate>
       {tagVariant.text}
     </Tag>
   )

--- a/libs/island-ui/core/src/lib/Tag/Tag.css.ts
+++ b/libs/island-ui/core/src/lib/Tag/Tag.css.ts
@@ -14,10 +14,6 @@ export const container = style({
   border: '1px solid transparent',
 })
 
-export const truncate = style({
-  whiteSpace: 'nowrap',
-})
-
 export const hyphenate = style({
   padding: '4px 8px',
   minHeight: 32,

--- a/libs/island-ui/core/src/lib/Tag/Tag.tsx
+++ b/libs/island-ui/core/src/lib/Tag/Tag.tsx
@@ -60,7 +60,6 @@ export const Tag = forwardRef<HTMLButtonElement & HTMLAnchorElement, TagProps>(
       [styles.outlined]: outlined,
       [styles.attention]: attention,
       [styles.focusable]: !disabled,
-      [styles.truncate]: truncate,
       [styles.hyphenate]: hyphenate,
       [styles.textLeft]: textLeft,
       [styles.disabled]: disabled,


### PR DESCRIPTION
# Truncate tags

[Asana](https://app.asana.com/0/1199153462262248/1205240225689036/f)

## What

Truncate tags in cases list. I also removed the `truncate` style from the Tag component in Island-ui because the same style was being added in the Text component if `truncate` was passed into Tag.

## Why

Tags with a space in them will wrap to two lines on smaller screens.

## Screenshots / Gifs

### Before

<img width="434" alt="Screenshot 2023-08-18 at 14 52 09" src="https://github.com/island-is/island.is/assets/3789875/530e2e07-23fe-4ff4-a3c3-7ddbf4aff743">

### After

<img width="423" alt="Screenshot 2023-08-18 at 14 50 18" src="https://github.com/island-is/island.is/assets/3789875/4237a76b-4fa1-4f6e-8229-19388a3b8238">


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
