### PR TITLE
fix(web): Scroll to top on every page change (/starfatorg)

### DIFF
--- a/apps/web/screens/IcelandicGovernmentInstitutionVacancies/IcelandicGovernmentInstitutionVacanciesList.tsx
+++ b/apps/web/screens/IcelandicGovernmentInstitutionVacancies/IcelandicGovernmentInstitutionVacanciesList.tsx
@@ -271,12 +271,11 @@ const IcelandicGovernmentInstitutionVacanciesList: Screen<IcelandicGovernmentIns
   useEffect(() => {
     const updatedQuery = { ...query }
 
-    let shouldScroll = false
+    const shouldScroll = updatedQuery.page !== selectedPage.toString()
 
     if (selectedPage === 1) {
       if ('page' in updatedQuery) delete updatedQuery['page']
     } else {
-      shouldScroll = updatedQuery.page !== selectedPage.toString()
       updatedQuery.page = selectedPage.toString()
     }
 


### PR DESCRIPTION
# Scroll to top on every page change (/starfatorg)

Attach a link to issue if relevant

## What

* When clicking on page 1 you wouldn't be scrolled to the top which was inconsistant since all other page numbers did indeed scroll the user to the top of the page

## Screenshots / Gifs

### Before
https://github.com/island-is/island.is/assets/43557895/d54766f2-d479-40f5-8925-9c4382e12d77

### After

https://github.com/island-is/island.is/assets/43557895/dc71fb8e-30fc-44a6-ab51-ce9f679bc719


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
