### PR TITLE
fix(web): Hotfix - Vacancies added in CMS not showing up on overview page (#11870)

### DIFF
--- a/apps/web/screens/IcelandicGovernmentInstitutionVacancies/IcelandicGovernmentInstitutionVacanciesList.tsx
+++ b/apps/web/screens/IcelandicGovernmentInstitutionVacancies/IcelandicGovernmentInstitutionVacanciesList.tsx
@@ -46,6 +46,8 @@ const ITEMS_PER_PAGE = 8
 export const VACANCY_INTRO_MAX_LENGTH = 80
 
 export const shortenText = (text: string, maxLength: number) => {
+  if (!text) return text
+
   if (text.length <= maxLength) {
     return text
   }

--- a/libs/cms/src/lib/cms.elasticsearch.service.ts
+++ b/libs/cms/src/lib/cms.elasticsearch.service.ts
@@ -280,6 +280,7 @@ export class CmsElasticsearchService {
       index,
       {
         types: ['webVacancy'],
+        size: 1000,
       },
     )
     return vacanciesResponse.hits.hits

--- a/libs/cms/src/lib/search/importers/news.service.ts
+++ b/libs/cms/src/lib/search/importers/news.service.ts
@@ -68,7 +68,7 @@ export class NewsSyncService implements CmsSyncProvider<INews> {
             tags,
             dateCreated: mapped.date,
             dateUpdated: new Date().getTime().toString(),
-            releaseDate: mapped.initialPublishDate,
+            releaseDate: mapped.initialPublishDate || null,
           }
         } catch (error) {
           logger.warn('Failed to import news', {

--- a/libs/cms/src/lib/search/importers/news.service.ts
+++ b/libs/cms/src/lib/search/importers/news.service.ts
@@ -68,7 +68,7 @@ export class NewsSyncService implements CmsSyncProvider<INews> {
             tags,
             dateCreated: mapped.date,
             dateUpdated: new Date().getTime().toString(),
-            releaseDate: mapped.initialPublishDate || null,
+            releaseDate: mapped.initialPublishDate,
           }
         } catch (error) {
           logger.warn('Failed to import news', {


### PR DESCRIPTION
# Hotfix - Vacancies added in CMS not showing up on overview page (#11870)
