### PR TITLE
chore(session-history): Clean up feature flag.

### DIFF
--- a/libs/feature-flags/src/lib/features.ts
+++ b/libs/feature-flags/src/lib/features.ts
@@ -29,7 +29,6 @@ export enum Features {
 
   // Service portal modules
   servicePortalPetitionsModule = 'isServicePortalPetitionsModuleEnabled',
-  sessionHistory = 'sessionHistory',
   servicePortalConsentModule = 'isServicePortalConsentModuleEnabled',
   servicePortalHealthRightsModule = 'isServicePortalHealthRightsModuleEnabled',
   servicePortalSecondaryEducationPages = 'isServicePortalSecondaryEducationPageEnabled',

--- a/libs/service-portal/sessions/src/module.tsx
+++ b/libs/service-portal/sessions/src/module.tsx
@@ -2,7 +2,6 @@ import { lazy } from 'react'
 
 import { ApiScope } from '@island.is/auth/scopes'
 import { PortalModule } from '@island.is/portals/core'
-import { Features } from '@island.is/react/feature-flags'
 import { m } from '@island.is/service-portal/core'
 
 import { SessionsPaths } from './lib/paths'
@@ -13,7 +12,6 @@ const Sessions = lazy(() => import('./screens/Sessions/Sessions'))
 
 export const sessionsModule: PortalModule = {
   name: m.sessions,
-  featureFlag: Features.sessionHistory,
   enabled({ userInfo }) {
     return userInfo.scopes.some((scope) => allowedScopes.includes(scope))
   },


### PR DESCRIPTION
# Session History - feature flag clean up

## What

Removing references to `sessionHistory` feature flag.

## Why

The module is live and the feature flag no long in use.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
