### PR TITLE
fix(web): Tsconfig include block override

### DIFF
--- a/apps/web/tsconfig.server.json
+++ b/apps/web/tsconfig.server.json
@@ -7,5 +7,5 @@
     "tsBuildInfoFile": "../../tmp/buildcache/apps/web/server",
     "types": ["node"]
   },
-  "include": ["server.ts"]
+  "include": ["server.ts", "**/*.js", "**/*.ts", "**/*.tsx", "next-env.d.ts"]
 }


### PR DESCRIPTION
The include block was overridden in recent changes.
Side effects include "strict mode" not being listened to if turned on.

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
