### PR TITLE
fix(service-portal): Update first reg date in get veichle search model

### DIFF
--- a/libs/api/domains/vehicles/src/models/getVehicleSearch.model.ts
+++ b/libs/api/domains/vehicles/src/models/getVehicleSearch.model.ts
@@ -27,7 +27,7 @@ export class VehiclesVehicleSearch {
   color?: string
 
   @Field({ nullable: true })
-  firstregdate?: string
+  firstregdate?: Date
 
   @Field({ nullable: true })
   latestregistration?: string


### PR DESCRIPTION
## What

Update the date field in search model to represent it's true value.

## Why

Otherwise it will be converted to a timestamp string, and therefore be different to other dates in the model.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
