### PR TITLE
chore(web): Hide frontpage news tag on latest news card

### DIFF
--- a/apps/web/components/NewsItems/NewsItems.tsx
+++ b/apps/web/components/NewsItems/NewsItems.tsx
@@ -11,6 +11,7 @@ import { GridItems } from '@island.is/web/components'
 import { GetNewsQuery } from '@island.is/web/graphql/schema'
 import cn from 'classnames'
 import { LinkType, useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
+import { FRONTPAGE_NEWS_TAG_ID } from '@island.is/web/constants'
 import Item from './Item'
 import * as styles from './NewsItems.css'
 
@@ -117,15 +118,17 @@ export const NewsItems = ({
                   ]).href
                 }
                 image={image}
-                tags={genericTags.map(({ slug, title, __typename: tn }) => {
-                  return {
-                    label: title,
-                    href: linkResolver(linkType ?? (tn as LinkType), [
-                      ...parameters,
-                      slug,
-                    ]).href,
-                  }
-                })}
+                tags={genericTags
+                  .filter((tag) => tag.slug !== FRONTPAGE_NEWS_TAG_ID)
+                  .map(({ slug, title, __typename: tn }) => {
+                    return {
+                      label: title,
+                      href: linkResolver(linkType ?? (tn as LinkType), [
+                        ...parameters,
+                        slug,
+                      ]).href,
+                    }
+                  })}
               />
             ),
           )}

--- a/apps/web/screens/queries/fragments.ts
+++ b/apps/web/screens/queries/fragments.ts
@@ -77,6 +77,7 @@ export const slices = gql`
       genericTags {
         id
         title
+        slug
       }
     }
     readMoreText


### PR DESCRIPTION
# Hide frontpage news tag on latest news card

## What

* We don't want the "Forsíðufréttir" news tag to be visible on news cards (since it's an internal functionality to make news appear on the frontpage)

## Screenshots / Gifs

### Before
![image](https://github.com/island-is/island.is/assets/43557895/74b57ea0-6f51-41d0-a8d5-7496a4a189a3)

### After
![image](https://github.com/island-is/island.is/assets/43557895/93907ebe-818a-4c5f-8d88-66bb2a44551d)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
