### PR TITLE
Update prettier to v2.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -430,7 +430,7 @@
     "mailparser": "3.5.0",
     "next-secure-headers": "2.1.0",
     "nx": "16.5.0",
-    "prettier": "2.2.1",
+    "prettier": "2.5.0",
     "quicktype": "15.0.258",
     "sequelize-cli": "6.4.1",
     "sort-paths": "1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -31502,7 +31502,7 @@ __metadata:
     pg-hstore: 2.3.3
     powerbi-client: 2.21.1
     powerbi-client-react: 1.3.5
-    prettier: 2.2.1
+    prettier: 2.5.0
     prom-client: 14.1.0
     pubsub-js: 1.8.0
     quicktype: 15.0.258
@@ -41394,12 +41394,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:2.2.1":
-  version: 2.2.1
-  resolution: "prettier@npm:2.2.1"
+"prettier@npm:2.5.0":
+  version: 2.5.0
+  resolution: "prettier@npm:2.5.0"
   bin:
     prettier: bin-prettier.js
-  checksum: 800de2df3d37067ab24478c7f32c60ca0c57b01742133287829feeb4a70d239a7bf6bccb56196784777af591ad80fb9ba70c1a49b0fcecf9f5622a764d513edb
+  checksum: aad1b35b73e7c14596d389d90977a83dad0db689ba5802a0ef319c357b7867f55b885db197972aa6a56c30f53088c9f8e0d7f7930ae074c275a4e9cbe091d21d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Update prettier to v.2.5.0

## What

Update prettier to v.2.5.0

## Why

Version 2.5.0 implements support for TypeScript 4.5, which includes type Modifiers on imports. 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
