### PR TITLE
fix(web): Convert numeric "stofnunNr" field to string for vacancy institutions

### DIFF
--- a/libs/api/domains/icelandic-government-institution-vacancies/src/lib/icelandic-government-institution-vacancies.resolver.ts
+++ b/libs/api/domains/icelandic-government-institution-vacancies/src/lib/icelandic-government-institution-vacancies.resolver.ts
@@ -45,10 +45,9 @@ export class IcelandicGovernmentInstitutionVacanciesResolver {
       stofnun: input.institution,
     })) as DefaultApiVacanciesListItem[]
 
-    const mappedVacancies =
-      await mapIcelandicGovernmentInstitutionVacanciesFromExternalSystem(
-        vacancies,
-      )
+    const mappedVacancies = await mapIcelandicGovernmentInstitutionVacanciesFromExternalSystem(
+      vacancies,
+    )
 
     // Extract institution/organization reference identifiers from the vacancies
     const referenceIdentifierSet = new Set<string>()
@@ -63,11 +62,12 @@ export class IcelandicGovernmentInstitutionVacanciesResolver {
     }
 
     // Fetch organizations from cms that have the given reference identifiers so we can use their title and logo
-    const organizationsResponse =
-      await this.cmsContentfulService.getOrganizations({
+    const organizationsResponse = await this.cmsContentfulService.getOrganizations(
+      {
         lang: defaultLang,
         referenceIdentifiers: Array.from(referenceIdentifierSet),
-      })
+      },
+    )
 
     // Create a mapping for reference identifier -> organization data
     const organizationMap = new Map<
@@ -117,8 +117,9 @@ export class IcelandicGovernmentInstitutionVacanciesResolver {
   async icelandicGovernmentInstitutionVacancies(
     @Args('input') input: IcelandicGovernmentInstitutionVacanciesInput,
   ): Promise<IcelandicGovernmentInstitutionVacanciesResponse> {
-    const vacanciesFromExternalSystem =
-      await this.getVacanciesFromExternalSystem(input)
+    const vacanciesFromExternalSystem = await this.getVacanciesFromExternalSystem(
+      input,
+    )
     const vacanciesFromCms = await this.getVacanciesFromCms()
 
     const allVacancies = vacanciesFromExternalSystem.concat(vacanciesFromCms)
@@ -138,8 +139,9 @@ export class IcelandicGovernmentInstitutionVacanciesResolver {
       return { vacancy: null }
     }
     return {
-      vacancy:
-        mapIcelandicGovernmentInstitutionVacancyByIdResponseFromCms(item),
+      vacancy: mapIcelandicGovernmentInstitutionVacancyByIdResponseFromCms(
+        item,
+      ),
     }
   }
 
@@ -156,18 +158,18 @@ export class IcelandicGovernmentInstitutionVacanciesResolver {
       return { vacancy: null }
     }
 
-    const vacancy =
-      await mapIcelandicGovernmentInstitutionVacancyByIdResponseFromExternalSystem(
-        item,
-      )
+    const vacancy = await mapIcelandicGovernmentInstitutionVacancyByIdResponseFromExternalSystem(
+      item,
+    )
 
     // If we have a reference identifier we use that to get the institution/organization title and logo from cms
     if (vacancy?.institutionReferenceIdentifier) {
-      const organizationResponse =
-        await this.cmsContentfulService.getOrganizations({
+      const organizationResponse = await this.cmsContentfulService.getOrganizations(
+        {
           lang: defaultLang,
           referenceIdentifiers: [vacancy.institutionReferenceIdentifier],
-        })
+        },
+      )
 
       const organization = organizationResponse?.items?.[0]
 

--- a/libs/api/domains/icelandic-government-institution-vacancies/src/lib/icelandic-government-institution-vacancies.resolver.ts
+++ b/libs/api/domains/icelandic-government-institution-vacancies/src/lib/icelandic-government-institution-vacancies.resolver.ts
@@ -45,25 +45,29 @@ export class IcelandicGovernmentInstitutionVacanciesResolver {
       stofnun: input.institution,
     })) as DefaultApiVacanciesListItem[]
 
-    const mappedVacancies = await mapIcelandicGovernmentInstitutionVacanciesFromExternalSystem(
-      vacancies,
-    )
+    const mappedVacancies =
+      await mapIcelandicGovernmentInstitutionVacanciesFromExternalSystem(
+        vacancies,
+      )
 
     // Extract institution/organization reference identifiers from the vacancies
     const referenceIdentifierSet = new Set<string>()
     for (const vacancy of mappedVacancies) {
       if (vacancy.institutionReferenceIdentifier) {
         referenceIdentifierSet.add(vacancy.institutionReferenceIdentifier)
+      } else {
+        // In case there is no institutionReferenceIdentifier we don't indicate what institution is behind this vacancy
+        vacancy.logoUrl = undefined
+        vacancy.institutionName = undefined
       }
     }
 
     // Fetch organizations from cms that have the given reference identifiers so we can use their title and logo
-    const organizationsResponse = await this.cmsContentfulService.getOrganizations(
-      {
+    const organizationsResponse =
+      await this.cmsContentfulService.getOrganizations({
         lang: defaultLang,
         referenceIdentifiers: Array.from(referenceIdentifierSet),
-      },
-    )
+      })
 
     // Create a mapping for reference identifier -> organization data
     const organizationMap = new Map<
@@ -113,9 +117,8 @@ export class IcelandicGovernmentInstitutionVacanciesResolver {
   async icelandicGovernmentInstitutionVacancies(
     @Args('input') input: IcelandicGovernmentInstitutionVacanciesInput,
   ): Promise<IcelandicGovernmentInstitutionVacanciesResponse> {
-    const vacanciesFromExternalSystem = await this.getVacanciesFromExternalSystem(
-      input,
-    )
+    const vacanciesFromExternalSystem =
+      await this.getVacanciesFromExternalSystem(input)
     const vacanciesFromCms = await this.getVacanciesFromCms()
 
     const allVacancies = vacanciesFromExternalSystem.concat(vacanciesFromCms)
@@ -135,9 +138,8 @@ export class IcelandicGovernmentInstitutionVacanciesResolver {
       return { vacancy: null }
     }
     return {
-      vacancy: mapIcelandicGovernmentInstitutionVacancyByIdResponseFromCms(
-        item,
-      ),
+      vacancy:
+        mapIcelandicGovernmentInstitutionVacancyByIdResponseFromCms(item),
     }
   }
 
@@ -154,18 +156,18 @@ export class IcelandicGovernmentInstitutionVacanciesResolver {
       return { vacancy: null }
     }
 
-    const vacancy = await mapIcelandicGovernmentInstitutionVacancyByIdResponseFromExternalSystem(
-      item,
-    )
+    const vacancy =
+      await mapIcelandicGovernmentInstitutionVacancyByIdResponseFromExternalSystem(
+        item,
+      )
 
     // If we have a reference identifier we use that to get the institution/organization title and logo from cms
     if (vacancy?.institutionReferenceIdentifier) {
-      const organizationResponse = await this.cmsContentfulService.getOrganizations(
-        {
+      const organizationResponse =
+        await this.cmsContentfulService.getOrganizations({
           lang: defaultLang,
           referenceIdentifiers: [vacancy.institutionReferenceIdentifier],
-        },
-      )
+        })
 
       const organization = organizationResponse?.items?.[0]
 

--- a/libs/api/domains/icelandic-government-institution-vacancies/src/lib/utils.ts
+++ b/libs/api/domains/icelandic-government-institution-vacancies/src/lib/utils.ts
@@ -84,15 +84,12 @@ const convertHtmlToContentfulRichText = async (html: string, id?: string) => {
 }
 
 const mapLocations = (item: DefaultApiVacanciesListItem) => {
-  const locations: IcelandicGovernmentInstitutionVacanciesResponse['vacancies'][number]['locations'] =
-    []
+  const locations: IcelandicGovernmentInstitutionVacanciesResponse['vacancies'][number]['locations'] = []
 
   if ('stadsetning' in (item?.stadsetningar ?? {})) {
-    const location = (
-      item.stadsetningar as {
-        stadsetning?: DefaultApiVacancyLocation
-      }
-    )['stadsetning']
+    const location = (item.stadsetningar as {
+      stadsetning?: DefaultApiVacancyLocation
+    })['stadsetning']
 
     if (location) {
       locations.push({
@@ -117,11 +114,9 @@ const mapLocations = (item: DefaultApiVacanciesListItem) => {
 const mapContacts = (item: DefaultApiVacanciesListItem) => {
   const contacts: IcelandicGovernmentInstitutionVacancyContact[] = []
   if ('tengilidur' in (item?.tengilidir ?? {})) {
-    const contact = (
-      item.tengilidir as {
-        tengilidur?: DefaultApiVacancyContact
-      }
-    )['tengilidur']
+    const contact = (item.tengilidir as {
+      tengilidur?: DefaultApiVacancyContact
+    })['tengilidur']
 
     if (contact) {
       contacts.push({
@@ -177,83 +172,23 @@ export const sortVacancyList = (
   })
 }
 
-export const mapIcelandicGovernmentInstitutionVacanciesFromExternalSystem =
-  async (data: DefaultApiVacanciesListItem[]) => {
-    const mappedData: IcelandicGovernmentInstitutionVacanciesResponse['vacancies'] =
-      []
+export const mapIcelandicGovernmentInstitutionVacanciesFromExternalSystem = async (
+  data: DefaultApiVacanciesListItem[],
+) => {
+  const mappedData: IcelandicGovernmentInstitutionVacanciesResponse['vacancies'] = []
 
-    const introPromises: Promise<string>[] = []
+  const introPromises: Promise<string>[] = []
 
-    for (const item of data) {
-      const locations = mapLocations(item)
-      const introHtml = item.inngangur ?? ''
-      introPromises.push(convertHtmlToPlainText(introHtml))
-      mappedData.push({
-        id: `${EXTERNAL_SYSTEM_ID_PREFIX}${item.id}`,
-        title: item.fyrirsogn,
-        applicationDeadlineFrom: item.umsoknarfrestur_fra,
-        applicationDeadlineTo: item.umsoknarfrestur_til,
-        intro: '',
-        fieldOfWork: item.starfssvid,
-        institutionName: item.stofnunHeiti,
-        institutionReferenceIdentifier:
-          typeof item.stofnunNr === 'number'
-            ? String(item.stofnunNr)
-            : item.stofnunNr,
-        logoUrl: item.logoURL,
-        locations,
-      })
-    }
-
-    const intros = await Promise.all(introPromises)
-
-    for (let i = 0; i < mappedData.length; i += 1) {
-      if (intros[i]) {
-        mappedData[i].intro = intros[i]
-      }
-    }
-
-    return mappedData
-  }
-
-export const mapIcelandicGovernmentInstitutionVacancyByIdResponseFromExternalSystem =
-  async (
-    vacancy: DefaultApiVacancyDetails,
-  ): Promise<IcelandicGovernmentInstitutionVacancyByIdResponse['vacancy']> => {
-    const item = vacancy.starfsauglysing
-
-    const contacts = mapContacts(item)
+  for (const item of data) {
     const locations = mapLocations(item)
-
-    const [
-      intro,
-      qualificationRequirements,
-      tasksAndResponsibilities,
-      description,
-      salaryTerms,
-    ] = await Promise.all([
-      convertHtmlToContentfulRichText(item.inngangur ?? '', 'intro'),
-      convertHtmlToContentfulRichText(
-        item.haefnikrofur ?? '',
-        'qualificationRequirements',
-      ),
-      convertHtmlToContentfulRichText(
-        item.verkefni ?? '',
-        'tasksAndResponsibilities',
-      ),
-      convertHtmlToContentfulRichText(item.undirtexti ?? '', 'description'),
-      convertHtmlToContentfulRichText(
-        item.launaskilmaliFull ?? '',
-        'salaryTerms',
-      ),
-    ])
-
-    return {
+    const introHtml = item.inngangur ?? ''
+    introPromises.push(convertHtmlToPlainText(introHtml))
+    mappedData.push({
       id: `${EXTERNAL_SYSTEM_ID_PREFIX}${item.id}`,
       title: item.fyrirsogn,
       applicationDeadlineFrom: item.umsoknarfrestur_fra,
       applicationDeadlineTo: item.umsoknarfrestur_til,
-      intro,
+      intro: '',
       fieldOfWork: item.starfssvid,
       institutionName: item.stofnunHeiti,
       institutionReferenceIdentifier:
@@ -262,16 +197,75 @@ export const mapIcelandicGovernmentInstitutionVacancyByIdResponseFromExternalSys
           : item.stofnunNr,
       logoUrl: item.logoURL,
       locations,
-      contacts,
-      jobPercentage: item.starfshlutfall,
-      applicationHref: item.weblink?.url,
-      qualificationRequirements,
-      tasksAndResponsibilities,
-      description,
-      salaryTerms,
-      plainTextIntro: documentToPlainTextString(intro.document),
+    })
+  }
+
+  const intros = await Promise.all(introPromises)
+
+  for (let i = 0; i < mappedData.length; i += 1) {
+    if (intros[i]) {
+      mappedData[i].intro = intros[i]
     }
   }
+
+  return mappedData
+}
+
+export const mapIcelandicGovernmentInstitutionVacancyByIdResponseFromExternalSystem = async (
+  vacancy: DefaultApiVacancyDetails,
+): Promise<IcelandicGovernmentInstitutionVacancyByIdResponse['vacancy']> => {
+  const item = vacancy.starfsauglysing
+
+  const contacts = mapContacts(item)
+  const locations = mapLocations(item)
+
+  const [
+    intro,
+    qualificationRequirements,
+    tasksAndResponsibilities,
+    description,
+    salaryTerms,
+  ] = await Promise.all([
+    convertHtmlToContentfulRichText(item.inngangur ?? '', 'intro'),
+    convertHtmlToContentfulRichText(
+      item.haefnikrofur ?? '',
+      'qualificationRequirements',
+    ),
+    convertHtmlToContentfulRichText(
+      item.verkefni ?? '',
+      'tasksAndResponsibilities',
+    ),
+    convertHtmlToContentfulRichText(item.undirtexti ?? '', 'description'),
+    convertHtmlToContentfulRichText(
+      item.launaskilmaliFull ?? '',
+      'salaryTerms',
+    ),
+  ])
+
+  return {
+    id: `${EXTERNAL_SYSTEM_ID_PREFIX}${item.id}`,
+    title: item.fyrirsogn,
+    applicationDeadlineFrom: item.umsoknarfrestur_fra,
+    applicationDeadlineTo: item.umsoknarfrestur_til,
+    intro,
+    fieldOfWork: item.starfssvid,
+    institutionName: item.stofnunHeiti,
+    institutionReferenceIdentifier:
+      typeof item.stofnunNr === 'number'
+        ? String(item.stofnunNr)
+        : item.stofnunNr,
+    logoUrl: item.logoURL,
+    locations,
+    contacts,
+    jobPercentage: item.starfshlutfall,
+    applicationHref: item.weblink?.url,
+    qualificationRequirements,
+    tasksAndResponsibilities,
+    description,
+    salaryTerms,
+    plainTextIntro: documentToPlainTextString(intro.document),
+  }
+}
 
 export const mapRichTextField = (field: Html | null | undefined) => {
   return (

--- a/libs/api/domains/icelandic-government-institution-vacancies/src/lib/utils.ts
+++ b/libs/api/domains/icelandic-government-institution-vacancies/src/lib/utils.ts
@@ -14,7 +14,8 @@ interface DefaultApiVacancyContact {
   '@nr'?: number
   nafn?: string
   netfang?: string
-  simi?: string
+  simi?: string | number
+  starfsheiti?: string
 }
 
 interface DefaultApiVacancyLocation {
@@ -46,7 +47,7 @@ export interface DefaultApiVacanciesListItem {
   starfssvid?: string
   stettarfelagHeiti?: string
   stofnunHeiti?: string
-  stofnunNr?: string
+  stofnunNr?: string | number
   tengilidir?:
     | {
         tengilidur?: DefaultApiVacancyContact
@@ -54,7 +55,7 @@ export interface DefaultApiVacanciesListItem {
     | DefaultApiVacancyContact[]
   umsoknarfrestur_fra?: string
   umsoknarfrestur_til?: string
-  undirtexti?: null
+  undirtexti?: string | null
   verkefni?: string
   vinnutimaskipulag?: string
   weblink?: { url?: string; text?: string }
@@ -83,12 +84,15 @@ const convertHtmlToContentfulRichText = async (html: string, id?: string) => {
 }
 
 const mapLocations = (item: DefaultApiVacanciesListItem) => {
-  const locations: IcelandicGovernmentInstitutionVacanciesResponse['vacancies'][number]['locations'] = []
+  const locations: IcelandicGovernmentInstitutionVacanciesResponse['vacancies'][number]['locations'] =
+    []
 
   if ('stadsetning' in (item?.stadsetningar ?? {})) {
-    const location = (item.stadsetningar as {
-      stadsetning?: DefaultApiVacancyLocation
-    })['stadsetning']
+    const location = (
+      item.stadsetningar as {
+        stadsetning?: DefaultApiVacancyLocation
+      }
+    )['stadsetning']
 
     if (location) {
       locations.push({
@@ -113,15 +117,20 @@ const mapLocations = (item: DefaultApiVacanciesListItem) => {
 const mapContacts = (item: DefaultApiVacanciesListItem) => {
   const contacts: IcelandicGovernmentInstitutionVacancyContact[] = []
   if ('tengilidur' in (item?.tengilidir ?? {})) {
-    const contact = (item.tengilidir as {
-      tengilidur?: DefaultApiVacancyContact
-    })['tengilidur']
+    const contact = (
+      item.tengilidir as {
+        tengilidur?: DefaultApiVacancyContact
+      }
+    )['tengilidur']
 
     if (contact) {
       contacts.push({
         email: contact?.netfang,
         name: contact?.nafn,
-        phone: contact?.simi,
+        phone:
+          typeof contact?.simi === 'number'
+            ? String(contact?.simi)
+            : contact?.simi,
       })
     }
   } else {
@@ -131,7 +140,10 @@ const mapContacts = (item: DefaultApiVacanciesListItem) => {
         contacts.push({
           email: contact?.netfang,
           name: contact?.nafn,
-          phone: contact?.simi,
+          phone:
+            typeof contact?.simi === 'number'
+              ? String(contact?.simi)
+              : contact?.simi,
         })
       }
     }
@@ -165,94 +177,101 @@ export const sortVacancyList = (
   })
 }
 
-export const mapIcelandicGovernmentInstitutionVacanciesFromExternalSystem = async (
-  data: DefaultApiVacanciesListItem[],
-) => {
-  const mappedData: IcelandicGovernmentInstitutionVacanciesResponse['vacancies'] = []
+export const mapIcelandicGovernmentInstitutionVacanciesFromExternalSystem =
+  async (data: DefaultApiVacanciesListItem[]) => {
+    const mappedData: IcelandicGovernmentInstitutionVacanciesResponse['vacancies'] =
+      []
 
-  const introPromises: Promise<string>[] = []
+    const introPromises: Promise<string>[] = []
 
-  for (const item of data) {
+    for (const item of data) {
+      const locations = mapLocations(item)
+      const introHtml = item.inngangur ?? ''
+      introPromises.push(convertHtmlToPlainText(introHtml))
+      mappedData.push({
+        id: `${EXTERNAL_SYSTEM_ID_PREFIX}${item.id}`,
+        title: item.fyrirsogn,
+        applicationDeadlineFrom: item.umsoknarfrestur_fra,
+        applicationDeadlineTo: item.umsoknarfrestur_til,
+        intro: '',
+        fieldOfWork: item.starfssvid,
+        institutionName: item.stofnunHeiti,
+        institutionReferenceIdentifier:
+          typeof item.stofnunNr === 'number'
+            ? String(item.stofnunNr)
+            : item.stofnunNr,
+        logoUrl: item.logoURL,
+        locations,
+      })
+    }
+
+    const intros = await Promise.all(introPromises)
+
+    for (let i = 0; i < mappedData.length; i += 1) {
+      if (intros[i]) {
+        mappedData[i].intro = intros[i]
+      }
+    }
+
+    return mappedData
+  }
+
+export const mapIcelandicGovernmentInstitutionVacancyByIdResponseFromExternalSystem =
+  async (
+    vacancy: DefaultApiVacancyDetails,
+  ): Promise<IcelandicGovernmentInstitutionVacancyByIdResponse['vacancy']> => {
+    const item = vacancy.starfsauglysing
+
+    const contacts = mapContacts(item)
     const locations = mapLocations(item)
-    const introHtml = item.inngangur ?? ''
-    introPromises.push(convertHtmlToPlainText(introHtml))
-    mappedData.push({
+
+    const [
+      intro,
+      qualificationRequirements,
+      tasksAndResponsibilities,
+      description,
+      salaryTerms,
+    ] = await Promise.all([
+      convertHtmlToContentfulRichText(item.inngangur ?? '', 'intro'),
+      convertHtmlToContentfulRichText(
+        item.haefnikrofur ?? '',
+        'qualificationRequirements',
+      ),
+      convertHtmlToContentfulRichText(
+        item.verkefni ?? '',
+        'tasksAndResponsibilities',
+      ),
+      convertHtmlToContentfulRichText(item.undirtexti ?? '', 'description'),
+      convertHtmlToContentfulRichText(
+        item.launaskilmaliFull ?? '',
+        'salaryTerms',
+      ),
+    ])
+
+    return {
       id: `${EXTERNAL_SYSTEM_ID_PREFIX}${item.id}`,
       title: item.fyrirsogn,
       applicationDeadlineFrom: item.umsoknarfrestur_fra,
       applicationDeadlineTo: item.umsoknarfrestur_til,
-      intro: '',
+      intro,
       fieldOfWork: item.starfssvid,
       institutionName: item.stofnunHeiti,
-      institutionReferenceIdentifier: item.stofnunNr,
+      institutionReferenceIdentifier:
+        typeof item.stofnunNr === 'number'
+          ? String(item.stofnunNr)
+          : item.stofnunNr,
       logoUrl: item.logoURL,
       locations,
-    })
-  }
-
-  const intros = await Promise.all(introPromises)
-
-  for (let i = 0; i < mappedData.length; i += 1) {
-    if (intros[i]) {
-      mappedData[i].intro = intros[i]
+      contacts,
+      jobPercentage: item.starfshlutfall,
+      applicationHref: item.weblink?.url,
+      qualificationRequirements,
+      tasksAndResponsibilities,
+      description,
+      salaryTerms,
+      plainTextIntro: documentToPlainTextString(intro.document),
     }
   }
-
-  return mappedData
-}
-
-export const mapIcelandicGovernmentInstitutionVacancyByIdResponseFromExternalSystem = async (
-  vacancy: DefaultApiVacancyDetails,
-): Promise<IcelandicGovernmentInstitutionVacancyByIdResponse['vacancy']> => {
-  const item = vacancy.starfsauglysing
-
-  const contacts = mapContacts(item)
-  const locations = mapLocations(item)
-
-  const [
-    intro,
-    qualificationRequirements,
-    tasksAndResponsibilities,
-    description,
-    salaryTerms,
-  ] = await Promise.all([
-    convertHtmlToContentfulRichText(item.inngangur ?? '', 'intro'),
-    convertHtmlToContentfulRichText(
-      item.haefnikrofur ?? '',
-      'qualificationRequirements',
-    ),
-    convertHtmlToContentfulRichText(
-      item.verkefni ?? '',
-      'tasksAndResponsibilities',
-    ),
-    convertHtmlToContentfulRichText(item.undirtexti ?? '', 'description'),
-    convertHtmlToContentfulRichText(
-      item.launaskilmaliFull ?? '',
-      'salaryTerms',
-    ),
-  ])
-
-  return {
-    id: `${EXTERNAL_SYSTEM_ID_PREFIX}${item.id}`,
-    title: item.fyrirsogn,
-    applicationDeadlineFrom: item.umsoknarfrestur_fra,
-    applicationDeadlineTo: item.umsoknarfrestur_til,
-    intro,
-    fieldOfWork: item.starfssvid,
-    institutionName: item.stofnunHeiti,
-    institutionReferenceIdentifier: item.stofnunNr,
-    logoUrl: item.logoURL,
-    locations,
-    contacts,
-    jobPercentage: item.starfshlutfall,
-    applicationHref: item.weblink?.url,
-    qualificationRequirements,
-    tasksAndResponsibilities,
-    description,
-    salaryTerms,
-    plainTextIntro: documentToPlainTextString(intro.document),
-  }
-}
 
 export const mapRichTextField = (field: Html | null | undefined) => {
   return (


### PR DESCRIPTION
# Convert numeric "stofnunNr" field to string for vacancy institutions

## What

* The "stofnunNr" field coming from the vacancies endpoint is sometimes a string and other times a number so to have it behave correctly we convert it to a string
* I edited the types that the vacancies endpoint returns to correctly indicate what is returned

## Why

* It was previously indicated that the "stofnunNr" endpoint would always be a string (through email communication since there isn't an openapi definition for the web service that returns the vacancies) but it turns out not to be the case so that's why this change is necessary

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
