### PR TITLE
fix(web): Vacancy institution logo matching

### DIFF
--- a/libs/api/domains/icelandic-government-institution-vacancies/src/lib/icelandic-government-institution-vacancies.resolver.ts
+++ b/libs/api/domains/icelandic-government-institution-vacancies/src/lib/icelandic-government-institution-vacancies.resolver.ts
@@ -87,7 +87,7 @@ export class IcelandicGovernmentInstitutionVacanciesResolver {
     for (const vacancy of mappedVacancies) {
       if (
         vacancy.institutionReferenceIdentifier &&
-        referenceIdentifierSet.has(vacancy.institutionReferenceIdentifier)
+        organizationMap.has(vacancy.institutionReferenceIdentifier)
       ) {
         const organization = organizationMap.get(
           vacancy.institutionReferenceIdentifier,
@@ -97,8 +97,9 @@ export class IcelandicGovernmentInstitutionVacanciesResolver {
           vacancy.institutionName = organization.title
         }
       } else {
-        // In case the institution/organization does not exist in the cms we don't use the logo from the external service
+        // In case the institution/organization does not exist in the cms we don't use the logo or the name from the external service
         vacancy.logoUrl = undefined
+        vacancy.institutionName = undefined
       }
     }
 


### PR DESCRIPTION
# Vacancy institution logo matching

## What

* A set was being checked for values instead of a map which resulted in logos from external service being displayed instead of logos from the cms

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
