### PR TITLE
chore(core): Fix broken links in root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This [GitHub organization](https://github.com/island-is) is the center of develo
 
 These solutions are [FOSS](https://en.wikipedia.org/wiki/Free_and_open-source_software) and open to contributions, but most development will be performed by teams that win tenders to develop new functionality for Digital Iceland.
 
-The repository is a [monorepo](../technical-overview/monorepo.md) that has multiple apps (something that can be built and run) and libraries (which other apps and libraries can depend on). All custom-written services are also stored there.
+The repository is a [monorepo](https://docs.devland.is/technical-overview/monorepo) that has multiple apps (something that can be built and run) and libraries (which other apps and libraries can depend on). All custom-written services are also stored there.
 
 ## Storybook
 
@@ -12,11 +12,11 @@ The Ísland.is design system is developed and showcased using [Storybook](https:
 
 ## Reading material
 
-To get more technical information about the project please make sure to read this [overview](handbook/technical-overview/README.md).
+To get more technical information about the project please make sure to read this [overview](https://docs.devland.is/technical-overview/technical-overview).
 
 ## External contributors
 
-If you want to contribute to the repository, please make sure to follow [this guide](handbook/repository/external-contribute.md).
+If you want to contribute to the repository, please make sure to follow [this guide](https://docs.devland.is/repository/external-contribute).
 
 ## Prerequisites
 
@@ -52,7 +52,7 @@ yarn schemas
 When you clone the repo for the first time, and whenever you change branches, you need to update your dependencies to match your current branch using `yarn install`.
 In addition, schemas change frequently, so you will also need to update the generated schemas and clients using `yarn schemas`.
 
-If you you want schemas to be generated on every install you can set the environment variable `GENERATE_SCHEMAS_ON_INSTALL=true`.
+If you want schemas to be generated on every install you can set the environment variable `GENERATE_SCHEMAS_ON_INSTALL=true`.
 Note that this will generate the schemas when rebuilding the workspace in the post-install phase, with no output, so the `install` script seems to hang.
 
 ### Development server
@@ -123,7 +123,7 @@ yarn affected:e2e
 
 ### Schemas
 
-If your project is generating schemas files from an OpenAPI, Codegen or is an API, check out [this documentation](handbook/repository/schemas.md).
+If your project is generating schemas files from an OpenAPI, Codegen or is an API, check out [this documentation](https://docs.devland.is/repository/schemas).
 
 ### Understand your workspace
 
@@ -135,7 +135,7 @@ yarn nx dep-graph
 
 ### AWS Secrets
 
-A dedicated documentation about fetching shared development secrets or creating new secrets, using AWS secrets is available [here](handbook/repository/aws-secrets.md).
+A dedicated documentation about fetching shared development secrets or creating new secrets, using AWS secrets is available [here](https://docs.devland.is/repository/aws-secrets).
 
 ### Running proxy against development service
 
@@ -147,7 +147,7 @@ To do so, you can run for example:
 ./scripts/run-db-proxy.sh
 ```
 
-It will try to get your AWS credentials from your environment variables and from your `~/.aws/credentials` file. You can find more instructions [here](handbook/repository/aws-secrets.md#using-aws-session).
+It will try to get your AWS credentials from your environment variables and from your `~/.aws/credentials` file. You can find more instructions [here](https://docs.devland.is/repository/aws-secrets#using-aws-session).
 
 {% hint style="info" %}
 If you want to run your app against one of this service (e.g. `db`), you may need to edit your app environment or sequelize config to pass the proxy credentials.


### PR DESCRIPTION
## What

Fix broken links in root README

## Why

Links to the handbook are broken after we removed the handbook from the repo.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
