### PR TITLE
fix: iincluded types

### DIFF
--- a/libs/service-portal/licenses/src/screens/LicensesOverview/index.tsx
+++ b/libs/service-portal/licenses/src/screens/LicensesOverview/index.tsx
@@ -1,4 +1,3 @@
-import React, { useEffect, useState } from 'react'
 import { defineMessage } from 'react-intl'
 import { useLocale, useNamespaces } from '@island.is/localization'
 import {
@@ -13,6 +12,7 @@ import {
   GenericUserLicenseFetchStatus,
   useChildrenPassport,
   useUserProfile,
+  GenericLicenseType,
 } from '@island.is/service-portal/graphql'
 import { Query } from '@island.is/api/schema'
 import { Box, Tabs } from '@island.is/island-ui/core'
@@ -86,6 +86,15 @@ export const LicensesOverview = () => {
   const { data, loading, error } = useQuery<Query>(GenericLicensesQuery, {
     variables: {
       locale,
+      input: {
+        includedTypes: [
+          GenericLicenseType.DriversLicense,
+          GenericLicenseType.AdrLicense,
+          GenericLicenseType.MachineLicense,
+          GenericLicenseType.FirearmLicense,
+          GenericLicenseType.DisabilityLicense,
+        ],
+      },
     },
   })
   const { genericLicenses = [] } = data ?? {}


### PR DESCRIPTION
## What

Add all currently displayed licenses types to the input array

## Why

If no included types then only drivers license is fetched

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
