### PR TITLE
chore(application-system-api): Remove xroad-proxy as explicit dependency in dev target

### DIFF
--- a/apps/application-system/api/project.json
+++ b/apps/application-system/api/project.json
@@ -179,8 +179,7 @@
           "yarn nx run api:dev",
           "yarn nx run services-user-profile:dev",
           "yarn start application-system-api",
-          "scripts/run-soffia-proxy.sh",
-          "scripts/run-xroad-proxy.sh"
+          "scripts/run-soffia-proxy.sh"
         ],
         "parallel": true
       }


### PR DESCRIPTION
## What

Removing the xroad-proxy script from `application-system-api` dev target

## Why

The `application-system-api` starts the `services-user-profile` which starts xroad-proxy, so this is race condition and one will fail.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
