### PR TITLE
fix(web): Change styling for NTí header

### DIFF
--- a/apps/web/components/Organization/Wrapper/Themes/IcelandicNaturalDisasterInsuranceTheme/IcelandicNaturalDisasterInsuranceHeader.css.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/IcelandicNaturalDisasterInsuranceTheme/IcelandicNaturalDisasterInsuranceHeader.css.ts
@@ -67,16 +67,16 @@ export const navigation = style({
 const titleStyles = themeUtils.responsiveStyle({
   md: {
     marginLeft: -48,
-    marginTop: 0,
+    marginTop: 30,
   },
   lg: {
-    width: '50%',
+    width: '60%',
     marginLeft: -80,
-    marginTop: -24,
+    marginTop: 24,
   },
   xl: {
     width: '50%',
-    marginLeft: -128,
+    marginLeft: -145,
     marginTop: 24,
   },
 })

--- a/apps/web/components/Organization/Wrapper/Themes/IcelandicNaturalDisasterInsuranceTheme/IcelandicNaturalDisasterInsuranceHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/IcelandicNaturalDisasterInsuranceTheme/IcelandicNaturalDisasterInsuranceHeader.tsx
@@ -1,7 +1,7 @@
 import type { CSSProperties } from '@vanilla-extract/css'
 import React, { useMemo } from 'react'
 import { OrganizationPage } from '@island.is/web/graphql/schema'
-import { Box, Hidden, Hyphen, Link, Text } from '@island.is/island-ui/core'
+import { Box, Hidden, Link, Text } from '@island.is/island-ui/core'
 import SidebarLayout from '@island.is/web/screens/Layouts/SidebarLayout'
 import { useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
 import { useNamespace } from '@island.is/web/hooks'
@@ -16,11 +16,20 @@ const townImageUrl =
   'https://images.ctfassets.net/8k0h54kbe6bj/eXqcbclteE88H5iQ6J3lo/bbc1d0c9d3abee93d34ec0aa718c833b/Group__1_.svg'
 
 const getDefaultStyle = (width: number): CSSProperties => {
+  if (width > theme.breakpoints.xl && width < 1650) {
+    return {
+      backgroundRepeat: 'no-repeat',
+      backgroundSize: 'auto 280px, auto 280px, cover',
+      backgroundPosition: '10% bottom, 130% bottom, center',
+      backgroundImage: `url('${treeImageUrl}'), url('${townImageUrl}'), linear-gradient(0deg, #FFFFFF -40.18%, #FAFDFD -23.09%, #ECF8F9 -4.3%, #D6F0F1 16.21%, #B7E5E7 36.72%, #8ED6DA 57.23%, #5DC4CA 77.74%, #23AFB8 100.93%, #00A3AD 113.54%)`,
+    }
+  }
+
   if (width > theme.breakpoints.xl) {
     return {
       backgroundRepeat: 'no-repeat',
       backgroundSize: 'auto 280px, auto 280px, cover',
-      backgroundPosition: '10% bottom, bottom right, center',
+      backgroundPosition: '10% bottom, 115% bottom, center',
       backgroundImage: `url('${treeImageUrl}'), url('${townImageUrl}'), linear-gradient(0deg, #FFFFFF -40.18%, #FAFDFD -23.09%, #ECF8F9 -4.3%, #D6F0F1 16.21%, #B7E5E7 36.72%, #8ED6DA 57.23%, #5DC4CA 77.74%, #23AFB8 100.93%, #00A3AD 113.54%)`,
     }
   }
@@ -121,7 +130,7 @@ const IcelandicNaturalDisasterInsuranceHeader: React.FC<HeaderProps> = ({
                 color="blueberry600"
                 fontWeight="semiBold"
               >
-                <Hyphen>{organizationPage.title}</Hyphen>
+                {organizationPage.title}
               </Text>
             </Link>
           </Box>


### PR DESCRIPTION
# Change styling for NTí header

## Why

* The title was overflowing above the background image

## Screenshots / Gifs

### Before
![image](https://github.com/island-is/island.is/assets/43557895/3bbe25b3-476c-48dd-accf-c2bba350b2fa)

### After
![image](https://github.com/island-is/island.is/assets/43557895/e4a46879-7bfe-4722-8360-6a8195dec774)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
