### PR TITLE
fix(j-s): Add required fields to appealed cases CaseList query

### DIFF
--- a/apps/judicial-system/web/src/utils/mutations.ts
+++ b/apps/judicial-system/web/src/utils/mutations.ts
@@ -59,6 +59,8 @@ export const AppealedCasesQuery = gql`
   query AppealedCases($input: CaseListQueryInput) {
     cases(input: $input) {
       appealedDate
+      initialRulingDate
+      rulingDate
       ...CoreCaseListFields
     }
   }

--- a/libs/api/domains/rights-portal/src/lib/rightsPortal.service.ts
+++ b/libs/api/domains/rights-portal/src/lib/rightsPortal.service.ts
@@ -51,12 +51,12 @@ export class RightsPortalService {
       const nutrition: Array<AidOrNutrition> | null =
         res.nutrition
           ?.map((c) => generateAidOrNutrition(c, AidOrNutritionType.NUTRITION))
-          .filter((Boolean as unknown) as ExcludesFalse) ?? []
+          .filter(Boolean as unknown as ExcludesFalse) ?? []
 
       const aids: Array<AidOrNutrition> | null =
         res.aids
           ?.map((c) => generateAidOrNutrition(c, AidOrNutritionType.AID))
-          .filter((Boolean as unknown) as ExcludesFalse) ?? []
+          .filter(Boolean as unknown as ExcludesFalse) ?? []
 
       return {
         data: [...aids, ...nutrition],


### PR DESCRIPTION
So that the duration field in the case list table for appealed cases works correctly.

[Landsréttur málalisti - undefined í gildistíma](https://app.asana.com/0/1199153462262248/1205336076594260/f)

## What

Added missing fields from appealed case list query

## Why

So we can display the duration period of a case in the appealed cases table

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
