### PR TITLE
fix(ids-api): Fix flaky test in ids-api

### DIFF
--- a/apps/services/auth/ids-api/src/app/user-profile/user-profile.controller.spec.ts
+++ b/apps/services/auth/ids-api/src/app/user-profile/user-profile.controller.spec.ts
@@ -89,11 +89,6 @@ function createUserProfile(): UserProfile {
   }
 }
 
-const user = createCurrentUser({
-  nationalIdType: 'person',
-  scope: ['@identityserver.api/authentication'],
-})
-
 describe('UserProfileController', () => {
   const path = '/user-profile'
 
@@ -106,7 +101,12 @@ describe('UserProfileController', () => {
     let server: request.SuperTest<request.Test>
 
     beforeAll(async () => {
-      app = await setupWithAuth({ user })
+      app = await setupWithAuth({
+        user: createCurrentUser({
+          nationalIdType: 'person',
+          scope: ['@identityserver.api/authentication'],
+        }),
+      })
       server = request(app.getHttpServer())
     })
 

--- a/apps/services/auth/ids-api/src/app/user-profile/user-profile.controller.spec.ts
+++ b/apps/services/auth/ids-api/src/app/user-profile/user-profile.controller.spec.ts
@@ -89,6 +89,11 @@ function createUserProfile(): UserProfile {
   }
 }
 
+const user = createCurrentUser({
+  nationalIdType: 'person',
+  scope: ['@identityserver.api/authentication'],
+})
+
 describe('UserProfileController', () => {
   const path = '/user-profile'
 
@@ -101,10 +106,6 @@ describe('UserProfileController', () => {
     let server: request.SuperTest<request.Test>
 
     beforeAll(async () => {
-      const user = createCurrentUser({
-        nationalIdType: 'person',
-        scope: ['@identityserver.api/authentication'],
-      })
       app = await setupWithAuth({ user })
       server = request(app.getHttpServer())
     })

--- a/apps/services/auth/ids-api/test/setup.ts
+++ b/apps/services/auth/ids-api/test/setup.ts
@@ -1,3 +1,6 @@
+import { getModelToken } from '@nestjs/sequelize'
+import { TestingModuleBuilder } from '@nestjs/testing'
+
 import {
   ApiScope,
   Domain,
@@ -5,10 +8,15 @@ import {
 } from '@island.is/auth-api-lib'
 import { IdsUserGuard, MockAuthGuard, User } from '@island.is/auth-nest-tools'
 import { NationalRegistryClientService } from '@island.is/clients/national-registry-v2'
-import { RskRelationshipsClient } from '@island.is/clients-rsk-relationships'
 import { CompanyRegistryClientService } from '@island.is/clients/rsk/company-registry'
+import { RskRelationshipsClient } from '@island.is/clients-rsk-relationships'
 import { UserProfileApi } from '@island.is/clients/user-profile'
 import { FeatureFlagService } from '@island.is/nest/feature-flags'
+import {
+  createDomain,
+  createApiScope,
+  CreateDomain,
+} from '@island.is/services/auth/testing'
 import {
   createCurrentUser,
   createUniqueWords,
@@ -19,15 +27,8 @@ import {
   useAuth,
   useDatabase,
 } from '@island.is/testing/nest'
-import { TestingModuleBuilder } from '@nestjs/testing'
+
 import { AppModule } from '../src/app/app.module'
-import { getModelToken } from '@nestjs/sequelize'
-import {
-  createDomain,
-  createApiScope,
-  CreateDomain,
-} from '@island.is/services/auth/testing'
-import faker from 'faker'
 
 type Scopes = {
   [key: string]: {

--- a/apps/services/auth/ids-api/test/setup.ts
+++ b/apps/services/auth/ids-api/test/setup.ts
@@ -9,7 +9,10 @@ import { RskRelationshipsClient } from '@island.is/clients-rsk-relationships'
 import { CompanyRegistryClientService } from '@island.is/clients/rsk/company-registry'
 import { UserProfileApi } from '@island.is/clients/user-profile'
 import { FeatureFlagService } from '@island.is/nest/feature-flags'
-import { createCurrentUser } from '@island.is/testing/fixtures'
+import {
+  createCurrentUser,
+  createUniqueWords,
+} from '@island.is/testing/fixtures'
 import {
   TestApp,
   testServer,
@@ -33,7 +36,17 @@ type Scopes = {
   }
 }
 
-export const defaultDomains: CreateDomain[] = [createDomain(), createDomain()]
+const domainsSize = 3
+const uniqueDomainNames = createUniqueWords(domainsSize)
+
+export const defaultDomains: CreateDomain[] = [...Array(domainsSize)].map(
+  (_, index) =>
+    createDomain({
+      name: uniqueDomainNames[index],
+    }),
+)
+
+const randomWords = createUniqueWords(2)
 
 export const defaultScopes: Scopes = {
   // Test user has access to this scope
@@ -41,8 +54,14 @@ export const defaultScopes: Scopes = {
     name: '@identityserver.api/authentication',
     domainName: defaultDomains[0].name,
   },
-  scope1: { name: faker.lorem.word(), domainName: defaultDomains[0].name },
-  scope2: { name: faker.lorem.word(), domainName: defaultDomains[1].name },
+  scope1: {
+    name: randomWords[0],
+    domainName: defaultDomains[1].name,
+  },
+  scope2: {
+    name: randomWords[1],
+    domainName: defaultDomains[2].name,
+  },
 }
 
 class MockNationalRegistryClientService
@@ -104,14 +123,9 @@ export const setupWithAuth = async ({
   // Create domain
   const domainModel = app.get<typeof Domain>(getModelToken(Domain))
   await domainModel.bulkCreate(domains)
-
+  // Create scopes
   const apiScopeModel = app.get<typeof ApiScope>(getModelToken(ApiScope))
-
-  await apiScopeModel.bulkCreate(
-    Object.values(scopes).map((scope) => ({
-      ...createApiScope(scope),
-    })),
-  )
+  await apiScopeModel.bulkCreate(Object.values(scopes).map(createApiScope))
 
   return app
 }

--- a/libs/services/auth/testing/src/fixtures/apiScope.fixture.ts
+++ b/libs/services/auth/testing/src/fixtures/apiScope.fixture.ts
@@ -3,7 +3,6 @@ import * as faker from 'faker'
 
 /**
  * Private helper to create ApiScope with random values.
- * @returns
  */
 const createRandomApiScope = (): ApiScopeDTO => {
   return {
@@ -29,8 +28,7 @@ const createRandomApiScope = (): ApiScopeDTO => {
 /**
  * Creates ApiScope fixture to be used for testing.
  * @param apiScope Partial definition of the required ApiScopesDTO used for creating ApiScopes.
- *                 Give the user control to provide predfined values for some properties.
- * @returns
+ *                 Give the user control to provide predefined values for some properties.
  */
 export const createApiScope = (
   apiScope?: Partial<ApiScopeDTO>,

--- a/libs/testing/fixtures/src/index.ts
+++ b/libs/testing/fixtures/src/index.ts
@@ -1,5 +1,9 @@
+// libs
 export { createCurrentUser } from './lib/currentUser'
 export { createNationalRegistryUser } from './lib/nationalRegistryUser'
 export { createNationalId } from './lib/nationalId'
 export type { NationalIdType } from './lib/nationalId'
 export { createOpenIDUser } from './lib/openIDUser'
+
+// utils
+export { createUniqueWords } from './utils/createUniqueWords'

--- a/libs/testing/fixtures/src/utils/createUniqueWords.ts
+++ b/libs/testing/fixtures/src/utils/createUniqueWords.ts
@@ -1,0 +1,15 @@
+import faker from 'faker'
+
+/**
+ * Creates an array of unique words
+ * @param size The size of the words array
+ */
+export const createUniqueWords = (size: number): string[] => {
+  const randomWords = [...Array(size)].map(() => faker.random.word())
+
+  if (new Set(randomWords).size !== randomWords.length) {
+    return createUniqueWords(size)
+  }
+
+  return randomWords
+}


### PR DESCRIPTION
# Fix flaky test in ids-api

## What

Attempt to fix flaky test in ids-api. Most likely the reason for this flaky test is that faker will not generate unique scope names. At least that is my presumption.

This PR will ensure that those names are unique since they are used as primary keys in the scope model

## Why

Our CI has some flaky tests, i.e. https://github.com/island-is/island.is/actions/runs/5761331315/job/15619298536

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
