### PR TITLE
chore(delegation-api): Add ApiScope.samradsgatt to custom delegation scope list

### DIFF
--- a/libs/auth-api-lib/src/lib/delegations/DelegationConfig.ts
+++ b/libs/auth-api-lib/src/lib/delegations/DelegationConfig.ts
@@ -49,6 +49,10 @@ export const DelegationConfig = defineConfig<z.infer<typeof schema>>({
         onlyForDelegationType: ['ProcurationHolder'],
       },
       {
+        scopeName: ApiScope.samradsgatt,
+        onlyForDelegationType: ['ProcurationHolder'],
+      },
+      {
         scopeName: ApiScope.financeSalary,
         onlyForDelegationType: ['ProcurationHolder', 'Custom'],
       },


### PR DESCRIPTION
## What

Configuring `ApiScope.samradsgatt` to custom delegation scope list.

## Why

So only procuration holders of companies can grant a custom delegation with the scope.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
