### PR TITLE
fix(service-portal): user information child

### DIFF
--- a/libs/service-portal/information/src/screens/Child/Child.tsx
+++ b/libs/service-portal/information/src/screens/Child/Child.tsx
@@ -104,7 +104,7 @@ const Child = () => {
       />
     )
 
-  if (error) {
+  if (error && !loading && !child) {
     return (
       <ErrorScreen
         figure="./assets/images/hourglass.svg"

--- a/libs/service-portal/information/src/screens/Child/Child.tsx
+++ b/libs/service-portal/information/src/screens/Child/Child.tsx
@@ -11,6 +11,7 @@ import {
   NotFound,
   UserInfoLine,
   m,
+  ErrorScreen,
   IntroHeader,
 } from '@island.is/service-portal/core'
 import { defineMessage } from 'react-intl'
@@ -93,7 +94,7 @@ const Child = () => {
   )
 
   const isChildOrChildOfUser = isChild || isChildOfUser
-  if (!nationalId || error || (!loading && !isChildOrChildOfUser))
+  if (!nationalId || (!loading && !isChildOrChildOfUser && !error))
     return (
       <NotFound
         title={defineMessage({
@@ -102,6 +103,20 @@ const Child = () => {
         })}
       />
     )
+
+  if (error) {
+    return (
+      <ErrorScreen
+        figure="./assets/images/hourglass.svg"
+        tagVariant="red"
+        tag={formatMessage(m.errorTitle)}
+        title={formatMessage(m.somethingWrong)}
+        children={formatMessage(m.errorFetchModule, {
+          module: formatMessage(m.familyChild).toLowerCase(),
+        })}
+      />
+    )
+  }
 
   return (
     <ChildView>


### PR DESCRIPTION
## What

Only return error / not found screen if there's no cached data

## Why

 The graphql error trumps all other data


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
