### PR TITLE
fix(web): Trim .json from pathname extraction function

### DIFF
--- a/apps/web/utils/safelyExtractPathnameFromUrl.ts
+++ b/apps/web/utils/safelyExtractPathnameFromUrl.ts
@@ -1,8 +1,16 @@
 // Use fallback domain in case url is relative since we just want the pathname
 const FALLBACK_DOMAIN = 'https://island.is'
 
+const JSON_ENDING = '.json'
+
 export const safelyExtractPathnameFromUrl = (url?: string) => {
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore make web strict
-  return new URL(url, FALLBACK_DOMAIN).pathname
+  if (!url) return ''
+
+  let pathname = new URL(url, FALLBACK_DOMAIN).pathname
+
+  if (pathname.endsWith(JSON_ENDING)) {
+    pathname = pathname.slice(0, pathname.indexOf(JSON_ENDING))
+  }
+
+  return pathname
 }


### PR DESCRIPTION
# Trim .json from pathname extraction function

Attach a link to issue if relevant

## What

* req.url string can be /next/data/.../something.json if a user requests a page client side by clicking a link. We don't want that to affect how we are extracting the url pathname so the fix here is to trim .json away from the url

## Why

* This is causing a 500 error when clicking links for pages that rely on the pathname to specifically not end in .json

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
