### PR TITLE
fix(web): Hotfix - Trim .json from pathname extraction function (#12085)

### DIFF
--- a/apps/web/utils/safelyExtractPathnameFromUrl.ts
+++ b/apps/web/utils/safelyExtractPathnameFromUrl.ts
@@ -1,8 +1,16 @@
 // Use fallback domain in case url is relative since we just want the pathname
 const FALLBACK_DOMAIN = 'https://island.is'
 
+const JSON_ENDING = '.json'
+
 export const safelyExtractPathnameFromUrl = (url?: string) => {
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore make web strict
-  return new URL(url, FALLBACK_DOMAIN).pathname
+  if (!url) return ''
+
+  let pathname = new URL(url, FALLBACK_DOMAIN).pathname
+
+  if (pathname.endsWith(JSON_ENDING)) {
+    pathname = pathname.slice(0, pathname.indexOf(JSON_ENDING))
+  }
+
+  return pathname
 }


### PR DESCRIPTION
# Hotfix - Trim .json from pathname extraction function (#12085)
