### PR TITLE
fix(j-s): Court Record Signature Failure

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/case/case.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/case.service.ts
@@ -308,6 +308,23 @@ export class CaseService {
       })
   }
 
+  private async uploadSignedCourtRecordPdfToS3(
+    theCase: Case,
+    pdf: string,
+  ): Promise<boolean> {
+    return this.awsS3Service
+      .putObject(`generated/${theCase.id}/courtRecord.pdf`, pdf)
+      .then(() => true)
+      .catch((reason) => {
+        this.logger.error(
+          `Failed to upload signed court record pdf to AWS S3 for case ${theCase.id}`,
+          { reason },
+        )
+
+        return false
+      })
+  }
+
   private async throttleGetCaseFilesRecordPdf(
     theCase: Case,
     policeCaseNumber: string,
@@ -1162,16 +1179,26 @@ export class CaseService {
         'courtRecord.pdf',
         documentToken,
       )
+      const awsSuccess = await this.uploadSignedCourtRecordPdfToS3(
+        theCase,
+        courtRecordPdf,
+      )
 
-      this.awsS3Service
-        .putObject(`generated/${theCase.id}/courtRecord.pdf`, courtRecordPdf)
-        .catch((reason) => {
-          // Tolerate failure, but log error
-          this.logger.error(
-            `Failed to upload signed court record pdf to AWS S3 for case ${theCase.id}`,
-            { reason },
-          )
-        })
+      if (!awsSuccess) {
+        return { documentSigned: false, message: 'Failed to upload to S3' }
+      }
+
+      await this.update(
+        theCase,
+        {
+          courtRecordSignatoryId: user.id,
+          courtRecordSignatureDate: nowFactory(),
+        },
+        user,
+        false,
+      )
+
+      return { documentSigned: true }
     } catch (error) {
       this.eventService.postErrorEvent(
         'Failed to get a court record signature confirmation',
@@ -1195,18 +1222,6 @@ export class CaseService {
 
       throw error
     }
-
-    await this.update(
-      theCase,
-      {
-        courtRecordSignatoryId: user.id,
-        courtRecordSignatureDate: nowFactory(),
-      },
-      user,
-      false,
-    )
-
-    return { documentSigned: true }
   }
 
   async requestRulingSignature(theCase: Case): Promise<SigningServiceResponse> {

--- a/apps/judicial-system/backend/src/app/modules/case/test/caseController/getCourtRecordSignatureConfirmation.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/test/caseController/getCourtRecordSignatureConfirmation.spec.ts
@@ -74,13 +74,16 @@ describe('CaseController - Get court record signature confirmation', () => {
     const role = assignedRole === 'judgeId' ? 'JUDGE' : 'REGISTRAR'
     const user = { id: userId, role: role } as User
     const caseId = uuid()
-    const theCase = { id: caseId, judgeId: uuid(), registrarId: uuid() } as Case
+    const theCase = {
+      id: caseId,
+      policeCaseNumbers: [uuid()],
+      judgeId: uuid(),
+      registrarId: uuid(),
+    } as Case
     ;(theCase as unknown as { [key: string]: string })[assignedRole] = userId
     const documentToken = uuid()
 
     beforeEach(() => {
-      const mockPutObject = mockAwsS3Service.putObject as jest.Mock
-      mockPutObject.mockResolvedValueOnce(Promise.resolve())
       const mockFindOne = mockCaseModel.findOne as jest.Mock
       mockFindOne.mockResolvedValueOnce(theCase)
     })
@@ -89,6 +92,8 @@ describe('CaseController - Get court record signature confirmation', () => {
       let then: Then
 
       beforeEach(async () => {
+        const mockPutObject = mockAwsS3Service.putObject as jest.Mock
+        mockPutObject.mockResolvedValueOnce(Promise.resolve())
         const mockUpdate = mockCaseModel.update as jest.Mock
         mockUpdate.mockResolvedValueOnce([1, [theCase]])
 
@@ -106,7 +111,28 @@ describe('CaseController - Get court record signature confirmation', () => {
       })
 
       it('should return success', () => {
-        expect(then.result).toEqual({ documentSigned: true })
+        expect(then.result).toEqual({
+          documentSigned: true,
+        })
+      })
+    })
+
+    describe('AWS S3 upload fails', () => {
+      let then: Then
+
+      beforeEach(async () => {
+        const mockPutObject = mockAwsS3Service.putObject as jest.Mock
+        mockPutObject.mockRejectedValueOnce(new Error('Some error'))
+
+        then = await givenWhenThen(caseId, user, theCase, documentToken)
+        console.log(then)
+      })
+
+      it('return failure', () => {
+        expect(then.result).toEqual({
+          documentSigned: false,
+          message: 'Failed to upload to S3',
+        })
       })
     })
 
@@ -114,6 +140,8 @@ describe('CaseController - Get court record signature confirmation', () => {
       let then: Then
 
       beforeEach(async () => {
+        const mockPutObject = mockAwsS3Service.putObject as jest.Mock
+        mockPutObject.mockResolvedValueOnce(Promise.resolve())
         const mockUpdate = mockCaseModel.update as jest.Mock
         mockUpdate.mockRejectedValueOnce(new Error('Some error'))
 


### PR DESCRIPTION
# Court Record Signature Failure

[Ef ekki tekst að vista undirritaða þingbók í S3 þá á undirritun ekki að heppnast](https://app.asana.com/0/1199153462262248/1205393867190019/f)

## What

- Fails a court record signature if the signed court record cannot be uploaded to S3.

## Why

- If the upload fails, then the signed court record cannot be accessed.

## Screenshots / Gifs

![image](https://github.com/island-is/island.is/assets/795382/f2dec8c5-5b20-4919-ba32-322ab8e02641)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
