### PR TITLE
feat(auth-admin): Allow colon in permission ID

### DIFF
--- a/libs/auth-api-lib/src/lib/resources/admin/admin-scope.service.ts
+++ b/libs/auth-api-lib/src/lib/resources/admin/admin-scope.service.ts
@@ -8,7 +8,7 @@ import { InjectModel } from '@nestjs/sequelize'
 import { Transaction } from 'sequelize'
 import omit from 'lodash/omit'
 
-import { validateClientId } from '@island.is/auth/shared'
+import { validatePermissionId } from '@island.is/auth/shared'
 import { isDefined } from '@island.is/shared/utils'
 
 import { ApiScope } from '../models/api-scope.model'
@@ -106,7 +106,7 @@ export class AdminScopeService {
     input: AdminCreateScopeDto,
   ): Promise<AdminScopeDTO> {
     if (
-      !validateClientId({
+      !validatePermissionId({
         prefix: tenantId,
         value: input.name,
       })

--- a/libs/auth/shared/src/index.ts
+++ b/libs/auth/shared/src/index.ts
@@ -1,1 +1,2 @@
 export { validateClientId } from './lib/utils/validateClientId'
+export { validatePermissionId } from './lib/utils/validatePermissionId'

--- a/libs/auth/shared/src/lib/utils/validateClientId.spec.ts
+++ b/libs/auth/shared/src/lib/utils/validateClientId.spec.ts
@@ -1,81 +1,16 @@
 import { validateClientId } from './validateClientId'
+import { invalidIds, validIds } from './validateIdMockData'
 
 describe('validateClientId', () => {
   it('should be valid client id', () => {
-    const validArr = [
-      {
-        prefix: '@island.is',
-        value: '@island.is/island',
-      },
-      {
-        prefix: '@island.is',
-        value: '@island.is/island-is',
-      },
-      {
-        prefix: '@island.is',
-        value: '@island.is/island-is-other',
-      },
-      {
-        prefix: '@island.is',
-        value: '@island.is/island_is',
-      },
-      {
-        prefix: '@island.is',
-        value: '@island.is/island_is_other',
-      },
-      {
-        prefix: '@island.is',
-        value: '@island.is/island.is',
-      },
-      {
-        prefix: '@island.is',
-        value: '@island.is/island.is.com',
-      },
-      {
-        prefix: '@island.is',
-        value: '@island.is/island_is.com-other',
-      },
-    ]
-
-    validArr.forEach((valid) => {
+    validIds.forEach((valid) => {
       expect(validateClientId(valid)).toBe(true)
     })
   })
 
   it('should be invalid client id', () => {
     const invalidArr = [
-      {
-        prefix: '@island.is',
-        value: '@island.isisland-is',
-      },
-      {
-        prefix: '@island.is',
-        value: '@island/islandis',
-      },
-      {
-        prefix: '@island.is',
-        value: '@island.is/islandis"',
-      },
-      {
-        prefix: '@island.is',
-        value: '@island.is/_islandis',
-      },
-      {
-        prefix: '@island.is',
-        value: '@island.is/.islandis',
-      },
-      {
-        prefix: '@island.is',
-        value: '@island.is/-islandis',
-      },
-      {
-        prefix: '@island.is',
-        value: '@island.is/island=is',
-      },
-      {
-        prefix: '@island.is',
-        value: '@island.is/island!is',
-      },
+      ...invalidIds,
       {
         prefix: '@island.is',
         value: '@island.is/island_is.com-other:other',

--- a/libs/auth/shared/src/lib/utils/validateIdMockData.ts
+++ b/libs/auth/shared/src/lib/utils/validateIdMockData.ts
@@ -1,0 +1,69 @@
+export const validIds = [
+  {
+    prefix: '@island.is',
+    value: '@island.is/island',
+  },
+  {
+    prefix: '@island.is',
+    value: '@island.is/island-is',
+  },
+  {
+    prefix: '@island.is',
+    value: '@island.is/island-is-other',
+  },
+  {
+    prefix: '@island.is',
+    value: '@island.is/island_is',
+  },
+  {
+    prefix: '@island.is',
+    value: '@island.is/island_is_other',
+  },
+  {
+    prefix: '@island.is',
+    value: '@island.is/island.is',
+  },
+  {
+    prefix: '@island.is',
+    value: '@island.is/island.is.com',
+  },
+  {
+    prefix: '@island.is',
+    value: '@island.is/island_is.com-other',
+  },
+]
+
+export const invalidIds = [
+  {
+    prefix: '@island.is',
+    value: '@island.isisland-is',
+  },
+  {
+    prefix: '@island.is',
+    value: '@island/islandis',
+  },
+  {
+    prefix: '@island.is',
+    value: '@island.is/islandis"',
+  },
+  {
+    prefix: '@island.is',
+    value: '@island.is/_islandis',
+  },
+  {
+    prefix: '@island.is',
+    value: '@island.is/.islandis',
+  },
+  {
+    prefix: '@island.is',
+    value: '@island.is/-islandis',
+  },
+  {
+    prefix: '@island.is',
+    value: '@island.is/island=is',
+  },
+  {
+    prefix: '@island.is',
+    value: '@island.is/island!is',
+  },
+]

--- a/libs/auth/shared/src/lib/utils/validatePermissionId.spec.ts
+++ b/libs/auth/shared/src/lib/utils/validatePermissionId.spec.ts
@@ -1,40 +1,10 @@
 import { validatePermissionId } from './validatePermissionId'
+import { invalidIds, validIds } from './validateIdMockData'
 
-describe('validateClientId', () => {
-  it('should be valid client id', () => {
+describe('validatePermissionId', () => {
+  it('should be valid permission id', () => {
     const validArr = [
-      {
-        prefix: '@island.is',
-        value: '@island.is/island',
-      },
-      {
-        prefix: '@island.is',
-        value: '@island.is/island-is',
-      },
-      {
-        prefix: '@island.is',
-        value: '@island.is/island-is-other',
-      },
-      {
-        prefix: '@island.is',
-        value: '@island.is/island_is',
-      },
-      {
-        prefix: '@island.is',
-        value: '@island.is/island_is_other',
-      },
-      {
-        prefix: '@island.is',
-        value: '@island.is/island.is',
-      },
-      {
-        prefix: '@island.is',
-        value: '@island.is/island.is.com',
-      },
-      {
-        prefix: '@island.is',
-        value: '@island.is/island_is.com-other',
-      },
+      ...validIds,
       {
         prefix: '@island.is',
         value: '@island.is/island_is.com-other:other',
@@ -46,43 +16,8 @@ describe('validateClientId', () => {
     })
   })
 
-  it('should be invalid client id', () => {
-    const invalidArr = [
-      {
-        prefix: '@island.is',
-        value: '@island.isisland-is',
-      },
-      {
-        prefix: '@island.is',
-        value: '@island/islandis',
-      },
-      {
-        prefix: '@island.is',
-        value: '@island.is/islandis"',
-      },
-      {
-        prefix: '@island.is',
-        value: '@island.is/_islandis',
-      },
-      {
-        prefix: '@island.is',
-        value: '@island.is/.islandis',
-      },
-      {
-        prefix: '@island.is',
-        value: '@island.is/-islandis',
-      },
-      {
-        prefix: '@island.is',
-        value: '@island.is/island=is',
-      },
-      {
-        prefix: '@island.is',
-        value: '@island.is/island!is',
-      },
-    ]
-
-    invalidArr.forEach((invalid) => {
+  it('should be invalid permission id', () => {
+    invalidIds.forEach((invalid) => {
       expect(validatePermissionId(invalid)).toBe(false)
     })
   })

--- a/libs/auth/shared/src/lib/utils/validatePermissionId.spec.ts
+++ b/libs/auth/shared/src/lib/utils/validatePermissionId.spec.ts
@@ -1,4 +1,4 @@
-import { validateClientId } from './validateClientId'
+import { validatePermissionId } from './validatePermissionId'
 
 describe('validateClientId', () => {
   it('should be valid client id', () => {
@@ -35,10 +35,14 @@ describe('validateClientId', () => {
         prefix: '@island.is',
         value: '@island.is/island_is.com-other',
       },
+      {
+        prefix: '@island.is',
+        value: '@island.is/island_is.com-other:other',
+      },
     ]
 
     validArr.forEach((valid) => {
-      expect(validateClientId(valid)).toBe(true)
+      expect(validatePermissionId(valid)).toBe(true)
     })
   })
 
@@ -76,14 +80,10 @@ describe('validateClientId', () => {
         prefix: '@island.is',
         value: '@island.is/island!is',
       },
-      {
-        prefix: '@island.is',
-        value: '@island.is/island_is.com-other:other',
-      },
     ]
 
     invalidArr.forEach((invalid) => {
-      expect(validateClientId(invalid)).toBe(false)
+      expect(validatePermissionId(invalid)).toBe(false)
     })
   })
 })

--- a/libs/auth/shared/src/lib/utils/validatePermissionId.ts
+++ b/libs/auth/shared/src/lib/utils/validatePermissionId.ts
@@ -1,0 +1,12 @@
+/**
+ * Validates that the client id is prefixed with the tenant and that it matches the regex
+ * Value can only contain alphanumeric characters, hyphens, underscores, periods and forward slashes.
+ * @returns true if valid, false otherwise
+ */
+export const validatePermissionId = ({
+  prefix,
+  value,
+}: {
+  prefix: string
+  value: string
+}) => new RegExp(`^${prefix}/[a-zA-Z0-9]+([-_/.:][a-zA-Z0-9]+)*$`).test(value)

--- a/libs/portals/admin/ids-admin/src/lib/messages.ts
+++ b/libs/portals/admin/ids-admin/src/lib/messages.ts
@@ -153,7 +153,7 @@ export const m = defineMessages({
   },
   errorScopeIdRegex: {
     id: 'ap.ids-admin:error-scope-id-regex',
-    defaultMessage: 'Allowed characters are A-Z a-z 0-9 . _ - /',
+    defaultMessage: 'Allowed characters are A-Z a-z 0-9 . _ - / :',
   },
   errorEnvironment: {
     id: 'ap.ids-admin:error-environment',

--- a/libs/portals/admin/ids-admin/src/screens/Permission/CreatePermission/CreatePermission.action.ts
+++ b/libs/portals/admin/ids-admin/src/screens/Permission/CreatePermission/CreatePermission.action.ts
@@ -8,7 +8,7 @@ import {
   validateFormData,
   ValidateFormDataResult,
 } from '@island.is/react-spa/shared'
-import { validateClientId } from '@island.is/auth/shared'
+import { validatePermissionId } from '@island.is/auth/shared'
 import { AuthAdminEnvironment } from '@island.is/api/schema'
 
 import { IDSAdminPaths } from '../../../lib/paths'
@@ -36,7 +36,7 @@ const schema = z
   // Second refine is to check if the scope id is prefixed with the tenant and matches the regex
   .refine(
     (data) =>
-      validateClientId({
+      validatePermissionId({
         prefix: data.tenantId,
         value: data.name,
       }),


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Allow colon in the permission id

## Why

To create a permission/scope with id format "@test.island.is/test:test"

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

Updated error message
![image](https://github.com/island-is/island.is/assets/34029342/5add9581-e02a-4836-a8bb-1b664db5d027)

Newly created permission
![image](https://github.com/island-is/island.is/assets/34029342/3cc8c587-9b56-49ed-82f9-d9547e5ff987)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
