### PR TITLE
fix(service-portal): Occupational license fix download service and date format

### DIFF
--- a/apps/download-service/src/app/modules/occupational-licenses/education-license.controller.ts
+++ b/apps/download-service/src/app/modules/occupational-licenses/education-license.controller.ts
@@ -21,7 +21,7 @@ export class OccupationalLicensesEducationController {
     private readonly auditService: AuditService,
   ) {}
 
-  @Post('/education')
+  @Post('/education/:licenceId')
   @Header('Content-Type', 'application/pdf')
   @ApiOkResponse({
     content: { 'application/pdf': {} },
@@ -29,20 +29,20 @@ export class OccupationalLicensesEducationController {
       'Get a occupational license from Directorate of Education service',
   })
   async getOccupationalLicenseEducationPdf(
-    @Param('id') id: string,
+    @Param('licenceId') licenceId: string,
     @CurrentUser() user: User,
     @Res() res: Response,
   ) {
     const documentResponse = await this.mmsApi.downloadLicensePDF(
       user.nationalId,
-      id,
+      licenceId,
     )
 
     if (documentResponse) {
       this.auditService.audit({
         action: 'getOccupationalLicenseEducationPdf',
         auth: user,
-        resources: id,
+        resources: licenceId,
       })
 
       const contentArrayBuffer = await documentResponse.arrayBuffer()
@@ -51,7 +51,7 @@ export class OccupationalLicensesEducationController {
       res.header('Content-length', buffer.length.toString())
       res.header(
         'Content-Disposition',
-        `inline; filename=${user.nationalId}-starfsleyfi-${id}.pdf`,
+        `inline; filename=${user.nationalId}-starfsleyfi-${licenceId}.pdf`,
       )
       res.header('Content-Type: application/pdf')
       res.header('Pragma: no-cache')

--- a/libs/api/domains/occupational-licenses/src/lib/occupationalLicenses.resolver.ts
+++ b/libs/api/domains/occupational-licenses/src/lib/occupationalLicenses.resolver.ts
@@ -71,7 +71,7 @@ export class OccupationalLicensesResolver {
     @CurrentUser() user: User,
     @Args('id', { type: () => String }) id: string,
   ) {
-    const documentUrl = `${this.downloadService.baseUrl}/download/v1/occupational-licenses/education?id=${id}`
+    const documentUrl = `${this.downloadService.baseUrl}/download/v1/occupational-licenses/education/${id}`
     const license = await this.occupationalLicensesApi
       .getEducationalLicensesById(user, id)
       .catch(handle404)

--- a/libs/service-portal/occupational-licenses/src/screens/EducationalDetail/EducationalDetail.tsx
+++ b/libs/service-portal/occupational-licenses/src/screens/EducationalDetail/EducationalDetail.tsx
@@ -94,13 +94,13 @@ export const EducationDetail = () => {
         ) : undefined
       }
       name={user.profile.name}
-      dateOfBirth={birthday ? formatDateFns(birthday, 'dd.mm.yyyy') : undefined}
+      dateOfBirth={birthday ? formatDateFns(birthday, 'dd.MM.yyyy') : undefined}
       profession={programme}
       licenseType={programme}
       publisher={license.type}
       dateOfIssue={
         !Number.isNaN(Date.parse(license.validFrom))
-          ? formatDateFns(license.validFrom, 'dd.mm.yyyy')
+          ? formatDateFns(license.validFrom, 'dd.MM.yyyy')
           : undefined
       }
       isValid={license.isValid}

--- a/libs/service-portal/occupational-licenses/src/screens/HealthDirectorateDetail/HealthDirectorateDetail.tsx
+++ b/libs/service-portal/occupational-licenses/src/screens/HealthDirectorateDetail/HealthDirectorateDetail.tsx
@@ -65,13 +65,13 @@ export const EducationDetail = () => {
       intro={formatMessage(om.healthDirectorateIntro)}
       img={organizationImage}
       name={user.profile.name}
-      dateOfBirth={birthday ? formatDateFns(birthday, 'dd.mm.yyyy') : undefined}
+      dateOfBirth={birthday ? formatDateFns(birthday, 'dd.MM.yyyy') : undefined}
       profession={license.profession}
       licenseType={license.type}
       publisher={formatMessage(om.theDirectorateOfHealth)}
       dateOfIssue={
         license.validFrom
-          ? formatDateFns(license.validFrom, 'dd.mm.yyyy')
+          ? formatDateFns(license.validFrom, 'dd.MM.yyyy')
           : undefined
       }
       isValid={license.isValid}

--- a/libs/service-portal/occupational-licenses/src/screens/OccupationalLicensesOverview/OccupationalLicensesOverview.tsx
+++ b/libs/service-portal/occupational-licenses/src/screens/OccupationalLicensesOverview/OccupationalLicensesOverview.tsx
@@ -64,7 +64,7 @@ const OccupationalLicensesOverview = () => {
               <LicenceActionCard
                 key={index}
                 type={license.profession}
-                validFrom={formatDateFns(license.validFrom, 'dd.mm.yyyy')}
+                validFrom={formatDateFns(license.validFrom, 'dd.MM.yyyy')}
                 url={generateUrl(
                   license.__typename ===
                     'OccupationalLicensesEducationalLicense'


### PR DESCRIPTION

## What

Fixed download service controller so that now it receives the parameter from the URL. Fixed incorrect date format displayed in the occupation license UI

## Why

For teacher to see correct dates and be able to download their license from the web.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
