### PR TITLE
feat(search-indexer): Use feature flag instead of env variable for turning nested entry resolving on or off

### DIFF
--- a/apps/services/search-indexer/infra/search-indexer-service.ts
+++ b/apps/services/search-indexer/infra/search-indexer-service.ts
@@ -1,4 +1,4 @@
-import { ref, service, ServiceBuilder } from '../../../../infra/src/dsl/dsl'
+import { service, ServiceBuilder } from '../../../../infra/src/dsl/dsl'
 
 const envs = {
   APPLICATION_URL: 'http://search-indexer-service',
@@ -20,11 +20,6 @@ const envs = {
     dev: '20',
     staging: '40',
     prod: '40',
-  },
-  SHOULD_SEARCH_INDEXER_RESOLVE_NESTED_ENTRIES: {
-    dev: 'true',
-    staging: 'true',
-    prod: 'true',
   },
   AIR_DISCOUNT_SCHEME_FRONTEND_HOSTNAME: {
     dev: 'loftbru.dev01.devland.is',

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -1862,7 +1862,6 @@ search-indexer-service:
     ELASTIC_NODE: 'https://vpc-search-njkekqydiegezhr4vqpkfnw5la.eu-west-1.es.amazonaws.com'
     NODE_OPTIONS: '--max-old-space-size=2000'
     SERVERSIDE_FEATURES_ON: ''
-    SHOULD_SEARCH_INDEXER_RESOLVE_NESTED_ENTRIES: 'true'
   grantNamespaces: []
   grantNamespacesEnabled: false
   healthCheck:
@@ -1944,7 +1943,6 @@ search-indexer-service:
       NODE_OPTIONS: '--max-old-space-size=2048'
       S3_BUCKET: 'dev-es-custom-packages'
       SERVERSIDE_FEATURES_ON: ''
-      SHOULD_SEARCH_INDEXER_RESOLVE_NESTED_ENTRIES: 'true'
     secrets:
       CONTENTFUL_ACCESS_TOKEN: '/k8s/search-indexer/CONTENTFUL_ACCESS_TOKEN'
   namespace: 'search-indexer'

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -1609,7 +1609,6 @@ search-indexer-service:
     ELASTIC_NODE: 'https://vpc-search-mw4w5c2m2g5edjrtvwbpzhkw24.eu-west-1.es.amazonaws.com'
     NODE_OPTIONS: '--max-old-space-size=2000'
     SERVERSIDE_FEATURES_ON: 'driving-license-use-v1-endpoint-for-v2-comms'
-    SHOULD_SEARCH_INDEXER_RESOLVE_NESTED_ENTRIES: 'true'
   grantNamespaces: []
   grantNamespacesEnabled: false
   healthCheck:
@@ -1691,7 +1690,6 @@ search-indexer-service:
       NODE_OPTIONS: '--max-old-space-size=2048'
       S3_BUCKET: 'prod-es-custom-packages'
       SERVERSIDE_FEATURES_ON: 'driving-license-use-v1-endpoint-for-v2-comms'
-      SHOULD_SEARCH_INDEXER_RESOLVE_NESTED_ENTRIES: 'true'
     secrets:
       CONTENTFUL_ACCESS_TOKEN: '/k8s/search-indexer/CONTENTFUL_ACCESS_TOKEN'
   namespace: 'search-indexer'

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -1615,7 +1615,6 @@ search-indexer-service:
     ELASTIC_NODE: 'https://vpc-search-q6hdtjcdlhkffyxvrnmzfwphuq.eu-west-1.es.amazonaws.com'
     NODE_OPTIONS: '--max-old-space-size=2000'
     SERVERSIDE_FEATURES_ON: ''
-    SHOULD_SEARCH_INDEXER_RESOLVE_NESTED_ENTRIES: 'true'
   grantNamespaces: []
   grantNamespacesEnabled: false
   healthCheck:
@@ -1697,7 +1696,6 @@ search-indexer-service:
       NODE_OPTIONS: '--max-old-space-size=2048'
       S3_BUCKET: 'staging-es-custom-packages'
       SERVERSIDE_FEATURES_ON: ''
-      SHOULD_SEARCH_INDEXER_RESOLVE_NESTED_ENTRIES: 'true'
     secrets:
       CONTENTFUL_ACCESS_TOKEN: '/k8s/search-indexer/CONTENTFUL_ACCESS_TOKEN'
   namespace: 'search-indexer'

--- a/libs/cms/src/lib/search/cmsSync.module.ts
+++ b/libs/cms/src/lib/search/cmsSync.module.ts
@@ -1,5 +1,11 @@
 import { Module } from '@nestjs/common'
 import { ElasticService } from '@island.is/content-search-toolkit'
+import { ConfigModule } from '@island.is/nest/config'
+import {
+  FeatureFlagConfig,
+  FeatureFlagModule,
+} from '@island.is/nest/feature-flags'
+
 import { ContentfulService } from './contentful.service'
 import { ArticleSyncService } from './importers/article.service'
 import { CmsSyncService } from './cmsSync.service'
@@ -20,6 +26,13 @@ import { EnhancedAssetSyncService } from './importers/enhancedAsset.service'
 import { VacancySyncService } from './importers/vacancy.service'
 
 @Module({
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      load: [FeatureFlagConfig],
+    }),
+    FeatureFlagModule,
+  ],
   providers: [
     ElasticService,
     ContentfulService,

--- a/libs/cms/src/lib/search/contentful.service.ts
+++ b/libs/cms/src/lib/search/contentful.service.ts
@@ -8,6 +8,7 @@ import {
   Sys,
 } from 'contentful'
 import Bottleneck from 'bottleneck'
+import { FeatureFlagService, Features } from '@island.is/nest/feature-flags'
 import environment from '../environments/environment'
 import { logger } from '@island.is/logging'
 import { Injectable } from '@nestjs/common'
@@ -58,7 +59,10 @@ export class ContentfulService {
     en: 'en',
   }
 
-  constructor(private readonly elasticService: ElasticService) {
+  constructor(
+    private readonly elasticService: ElasticService,
+    private readonly featureFlagService: FeatureFlagService,
+  ) {
     const params: CreateClientParams = {
       space: environment.contentful.space,
       accessToken: environment.contentful.accessToken,
@@ -350,9 +354,6 @@ export class ContentfulService {
       process.env.CONTENTFUL_ENTRY_FETCH_CHUNK_SIZE ?? 40,
     )
 
-    const shouldResolveNestedEntries =
-      process.env.SHOULD_SEARCH_INDEXER_RESOLVE_NESTED_ENTRIES === 'true'
-
     logger.info(`Sync chunk size is: ${chunkSize}`)
 
     const populatedSyncEntriesResult = await this.getPopulatedSyncEntries(
@@ -366,6 +367,11 @@ export class ContentfulService {
     let { nestedEntryIds } = populatedSyncEntriesResult
 
     const isDeltaUpdate = syncType !== 'full'
+
+    const shouldResolveNestedEntries = await this.featureFlagService.getValue(
+      Features.shouldSearchIndexerResolveNestedEntries,
+      true,
+    )
 
     // In case of delta updates, we need to resolve embedded entries to their root model
     if (isDeltaUpdate && shouldResolveNestedEntries) {

--- a/libs/feature-flags/src/lib/features.ts
+++ b/libs/feature-flags/src/lib/features.ts
@@ -40,6 +40,9 @@ export enum Features {
 
   //Application system
   applicationSystemHistory = 'applicationSystemHistory',
+
+  // Search indexer
+  shouldSearchIndexerResolveNestedEntries = 'shouldSearchIndexerResolveNestedEntries',
 }
 
 export enum ServerSideFeature {


### PR DESCRIPTION
# Use feature flag instead of env variable for turning nested entry resolving on or off

## What

* We are storing CMS data in Elasticsearch so we can search through it and provide a backup in case the CMS goes down.
* The CMS calls an endpoint on the search-indexer service when content changes but when something nested gets changed (like an accordion) then we need to traverse up the tree to find the page (indexable entry) that we need to re-index so the update is displayed on the web. But this process is especially slow if something nested gets updated with a lot of backlinks then (with the current implementation) it takes a long time and can even make the search-indexer run out of memory. So when something like that happens it's good to be able to turn off the nested resolution so new content actually starts appearing on the web again

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
