### PR TITLE
fix(chore): Fix db-proxy scripts after yargs update

### DIFF
--- a/scripts/_run-aws-eks-commands.js
+++ b/scripts/_run-aws-eks-commands.js
@@ -34,89 +34,99 @@ function buildDockerImage(containerImage, builder, target) {
   )
 }
 
-const args = argv
-  .command(
-    'proxy',
-    'Run proxy',
-    (yargs) =>
-      yargs
-        .option('port', {
-          description:
-            'Port number on which the Kubernetes service is listening on',
-          default: 80,
-        })
-        .option('proxy-port', {
-          description: 'Port number the local proxy is listening on',
-          default: 8080,
-        })
-        .option('cluster', {
-          description: 'Name of Kubernetes cluster',
-          default: 'dev-cluster01',
-        })
-        .option('builder', {
-          description: 'docker or podman',
-          default: 'docker',
-        })
-        .demandOption(
-          'namespace',
-          'Name of the Kubernetes namespace the service is part of',
-        )
-        .option('profile', {
-          description: 'AWS profile to use',
-        })
-        .demandOption('service', 'Name of the Kubernetes service')
-        .check(function (argv) {
-          if (!['docker', 'podman'].includes(argv.builder)) {
-            throw new Error('Only docker or podman allowed')
-          }
-          return true
-        }),
-    async (args) => {
-      const credentials = await getCredentials(args.profile)
-      const dockerBuild = `proxy-${args.service}`
-      buildDockerImage(dockerBuild, args.builder, 'proxy')
-      console.log(`Now running the proxy - \uD83D\uDE31`)
-      console.log(
-        `Proxy will be listening on http://localhost:${args['proxy-port']} - \uD83D\uDC42`,
+async function main() {
+  try {
+    await argv
+      .command(
+        'proxy',
+        'Run proxy',
+        (yargs) =>
+          yargs
+            .option('port', {
+              description:
+                'Port number on which the Kubernetes service is listening on',
+              default: 80,
+            })
+            .option('proxy-port', {
+              description: 'Port number the local proxy is listening on',
+              default: 8080,
+            })
+            .option('cluster', {
+              description: 'Name of Kubernetes cluster',
+              default: 'dev-cluster01',
+            })
+            .option('builder', {
+              description: 'docker or podman',
+              default: 'docker',
+            })
+            .demandOption(
+              'namespace',
+              'Name of the Kubernetes namespace the service is part of',
+            )
+            .option('profile', {
+              description: 'AWS profile to use',
+            })
+            .demandOption('service', 'Name of the Kubernetes service')
+            .check(function (argv) {
+              if (!['docker', 'podman'].includes(argv.builder)) {
+                throw new Error('Only docker or podman allowed')
+              }
+              return true
+            }),
+        async (args) => {
+          const credentials = await getCredentials(args.profile)
+          const dockerBuild = `proxy-${args.service}`
+          buildDockerImage(dockerBuild, args.builder, 'proxy')
+          console.log(`Now running the proxy - \uD83D\uDE31`)
+          console.log(
+            `Proxy will be listening on http://localhost:${args['proxy-port']} - \uD83D\uDC42`,
+          )
+          execSync(
+            `${args.builder} run --name ${args.service} --rm -e AWS_ACCESS_KEY_ID=${credentials.accessKeyId} -e AWS_SECRET_ACCESS_KEY=${credentials.secretAccessKey} -e AWS_SESSION_TOKEN="${credentials.sessionToken}" -e CLUSTER=${args.cluster} -e TARGET_SVC=${args.service} -e TARGET_NAMESPACE=${args.namespace} -e TARGET_PORT=${args.port} -p ${args['proxy-port']}:8080 ${dockerBuild}`,
+            { stdio: 'inherit' },
+          )
+        },
       )
-      execSync(
-        `${args.builder} run --name ${args.service} --rm -e AWS_ACCESS_KEY_ID=${credentials.accessKeyId} -e AWS_SECRET_ACCESS_KEY=${credentials.secretAccessKey} -e AWS_SESSION_TOKEN="${credentials.sessionToken}" -e CLUSTER=${args.cluster} -e TARGET_SVC=${args.service} -e TARGET_NAMESPACE=${args.namespace} -e TARGET_PORT=${args.port} -p ${args['proxy-port']}:8080 ${dockerBuild}`,
-        { stdio: 'inherit' },
+      .command(
+        'restart-service',
+        'Restart service (rolling update on the deployment)',
+        (yargs) =>
+          yargs
+            .option('cluster', {
+              description: 'Name of Kubernetes cluster',
+              default: 'dev-cluster01',
+            })
+            .option('profile', {
+              description: 'AWS profile to use',
+            })
+            .option('builder', {
+              description: 'docker or podman',
+              default: 'docker',
+            })
+            .demandOption(
+              'namespace',
+              'Name of the Kubernetes namespace the service is part of',
+            )
+            .demandOption('service', 'Name of the Kubernetes service'),
+        async (args) => {
+          const credentials = await getCredentials(args.profile)
+          let containerImage = `restart-${args.service}`
+          buildDockerImage(containerImage, `restart-deployment`)
+          console.log(`Now running the restart - \uD83D\uDE31`)
+          execSync(
+            `${args.builder} run --rm --name ${args.service} -e AWS_ACCESS_KEY_ID=${credentials.accessKeyId} -e AWS_SECRET_ACCESS_KEY=${credentials.secretAccessKey} -e AWS_SESSION_TOKEN=${credentials.sessionToken} -e CLUSTER=${args.cluster} -e TARGET_SVC=${args.service} -e TARGET_NAMESPACE=${args.namespace} ${containerImage}`,
+            { stdio: 'inherit' },
+          )
+        },
       )
-    },
-  )
-  .command(
-    'restart-service',
-    'Restart service (rolling update on the deployment)',
-    (yargs) =>
-      yargs
-        .option('cluster', {
-          description: 'Name of Kubernetes cluster',
-          default: 'dev-cluster01',
-        })
-        .option('profile', {
-          description: 'AWS profile to use',
-        })
-        .option('builder', {
-          description: 'docker or podman',
-          default: 'docker',
-        })
-        .demandOption(
-          'namespace',
-          'Name of the Kubernetes namespace the service is part of',
-        )
-        .demandOption('service', 'Name of the Kubernetes service'),
-    async (args) => {
-      const credentials = await getCredentials(args.profile)
-      let containerImage = `restart-${args.service}`
-      buildDockerImage(containerImage, `restart-deployment`)
-      console.log(`Now running the restart - \uD83D\uDE31`)
-      execSync(
-        `${args.builder} run --rm --name ${args.service} -e AWS_ACCESS_KEY_ID=${credentials.accessKeyId} -e AWS_SECRET_ACCESS_KEY=${credentials.secretAccessKey} -e AWS_SESSION_TOKEN=${credentials.sessionToken} -e CLUSTER=${args.cluster} -e TARGET_SVC=${args.service} -e TARGET_NAMESPACE=${args.namespace} ${containerImage}`,
-        { stdio: 'inherit' },
-      )
-    },
-  )
-  .onFinishCommand((_) => console.log(`done`))
-  .showHelpOnFail(true)
-  .demandCommand().argv
+      .showHelpOnFail(true)
+      .demandCommand().argv
+  } catch (e) {
+    throw e
+  }
+}
+
+main().then(() => {
+  console.log('Success')
+  process.exit(0)
+})


### PR DESCRIPTION
# Fix db-proxy scripts after yargs update

## What

Removes the removed method `onFinishCommand` in-favour of promise

## Why

`yargs` dependency was updated yesterday, which broke the db-proxy script. They removed `onFinishCommand` from the package.
[issue](https://github.com/yargs/yargs/issues/1947)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
