### PR TITLE
chore(system-e2e): Disable retries in CI

### DIFF
--- a/apps/system-e2e/src/playwright.config.ts
+++ b/apps/system-e2e/src/playwright.config.ts
@@ -30,7 +30,7 @@ const config: PlaywrightTestConfig = {
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 3 : 0,
+  retries: process.env.CI ? 0 : 0,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */


### PR DESCRIPTION
Retries are causing up to 90 minute CI runs. This is unacceptable.

Initially retries were added to catch flaky tests. It's debatable which is better. For now, test failures due to flaky test is better than ridiculous test times.


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
