### PR TITLE
fix(search-indexer): Imports failing due to missing deleted entry ids

### DIFF
--- a/libs/cms/src/lib/search/contentful.service.ts
+++ b/libs/cms/src/lib/search/contentful.service.ts
@@ -224,17 +224,6 @@ export class ContentfulService {
       }
     }
 
-    // Remove unnecessary fields to save memory
-    const keys = ['deletedEntries', 'assets', 'deletedAssets'] as const
-    for (const key of keys) {
-      for (let i = 0; i < syncData[key].length; i += 1) {
-        syncData[key][i] = {
-          ...syncData.entries[i],
-          fields: null,
-        }
-      }
-    }
-
     return syncData
   }
 


### PR DESCRIPTION
# Imports failing due to missing deleted entry ids

## What

* I removed code that was stripping away fields to save up memory but since the deletedEntries don't have a fields property there is very little gain in having that code there and it even had a typo in it which was indexing the wrong array to begin with

## Why

* This fixes the `Importer failed Cannot read properties of undefined (reading 'id')` error we've been seeing in logs

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
