### PR TITLE
feat(web): Project page secondary sidebar option

### DIFF
--- a/apps/web/components/Project/Header/DefaultProjectHeader.css.ts
+++ b/apps/web/components/Project/Header/DefaultProjectHeader.css.ts
@@ -15,7 +15,6 @@ export const headerBg = style({
 
 export const headerWrapper = style({
   display: 'grid',
-  minHeight: '300px',
   height: 'fit-content',
   maxHeight: 'min-content',
   ...themeUtils.responsiveStyle({

--- a/apps/web/screens/Project/utils.tsx
+++ b/apps/web/screens/Project/utils.tsx
@@ -4,7 +4,12 @@ import {
   LinkGroup,
   ProjectPage,
 } from '@island.is/web/graphql/schema'
-import { Navigation, NavigationItem } from '@island.is/island-ui/core'
+import {
+  Box,
+  Navigation,
+  NavigationItem,
+  Stack,
+} from '@island.is/island-ui/core'
 import { LayoutProps } from '@island.is/web/layouts/main'
 
 const footerEnabled = ['opinbernyskopun', 'gagnasidur-fiskistofu']
@@ -116,28 +121,59 @@ export const getSidebarNavigationComponent = (
     convertLinkGroupsToNavigationItems(projectPage.sidebarLinks),
     baseRouterPath,
   )
+  const secondaryNavigationList =
+    projectPage.secondarySidebar?.childrenLinks.map(({ text, url }) => ({
+      title: text,
+      href: url,
+      active: baseRouterPath === url,
+    })) ?? []
 
   const activeNavigationItemTitle = getActiveNavigationItemTitle(
     navigationList,
     baseRouterPath,
   )
+  const activeSecondaryNavigationItemTitle = getActiveNavigationItemTitle(
+    secondaryNavigationList,
+    baseRouterPath,
+  )
 
   return (isMenuDialog = false) => (
-    <Navigation
-      isMenuDialog={isMenuDialog}
-      baseId="pageNav"
-      items={navigationList}
-      activeItemTitle={activeNavigationItemTitle}
-      title={navigationTitle}
-      renderLink={(link, item) => {
-        return item?.href ? (
-          <Link href={item?.href} legacyBehavior>
-            {link}
-          </Link>
-        ) : (
-          link
-        )
-      }}
-    />
+    <Stack space={2}>
+      <Navigation
+        isMenuDialog={isMenuDialog}
+        baseId="pageNav"
+        items={navigationList}
+        activeItemTitle={activeNavigationItemTitle}
+        title={navigationTitle}
+        renderLink={(link, item) => {
+          return item?.href ? (
+            <Link href={item.href} legacyBehavior>
+              {link}
+            </Link>
+          ) : (
+            link
+          )
+        }}
+      />
+      {projectPage.secondarySidebar?.name && (
+        <Navigation
+          baseId="secondaryPageNav"
+          colorScheme="purple"
+          isMenuDialog={isMenuDialog}
+          title={projectPage.secondarySidebar.name}
+          items={secondaryNavigationList}
+          activeItemTitle={activeSecondaryNavigationItemTitle}
+          renderLink={(link, item) => {
+            return item?.href ? (
+              <Link href={item.href} legacyBehavior>
+                {link}
+              </Link>
+            ) : (
+              link
+            )
+          }}
+        />
+      )}
+    </Stack>
   )
 }

--- a/apps/web/screens/queries/Project.tsx
+++ b/apps/web/screens/queries/Project.tsx
@@ -24,6 +24,13 @@ export const GET_PROJECT_PAGE_QUERY = gql`
           url
         }
       }
+      secondarySidebar {
+        name
+        childrenLinks {
+          text
+          url
+        }
+      }
       footerItems {
         title
         content {

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -2705,6 +2705,9 @@ export interface IProjectPageFields {
   /** Sidebar Links */
   sidebarLinks?: ILinkGroup[] | undefined
 
+  /** Secondary Sidebar */
+  secondarySidebar?: ILinkGroup | undefined
+
   /** Subtitle */
   subtitle?: string | undefined
 

--- a/libs/cms/src/lib/models/projectPage.model.ts
+++ b/libs/cms/src/lib/models/projectPage.model.ts
@@ -36,6 +36,9 @@ export class ProjectPage {
   @CacheField(() => [LinkGroup])
   sidebarLinks!: Array<LinkGroup>
 
+  @CacheField(() => LinkGroup, { nullable: true })
+  secondarySidebar?: LinkGroup | null
+
   @Field()
   subtitle!: string
 
@@ -94,6 +97,9 @@ export const mapProjectPage = ({ sys, fields }: IProjectPage): ProjectPage => ({
   sidebarLinks: (fields.sidebarLinks ?? [])
     .map(mapLinkGroup)
     .filter((link) => Boolean(link.primaryLink)),
+  secondarySidebar: fields.secondarySidebar
+    ? mapLinkGroup(fields.secondarySidebar)
+    : null,
   subtitle: fields.subtitle ?? '',
   intro: fields.intro ?? '',
   content: fields.content


### PR DESCRIPTION
# Project page secondary sidebar option

## What

* Add an option to display a secondary sidebar for project pages (similar to what organization pages can do today)
* Remove css forcing header to have a minimum height to prevent whitespace in case header content is smaller than that

## Screenshots / Gifs

Desktop
<img width="351" alt="image" src="https://github.com/island-is/island.is/assets/43557895/3219e95b-66bd-409a-887c-aeb450e94987">

Mobile
<img width="448" alt="image" src="https://github.com/island-is/island.is/assets/43557895/d3058f74-bdb7-4359-9302-455171ee4477">


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
