### PR TITLE
fix(service-portal): Only show driving school exam with status 2

### DIFF
--- a/libs/service-portal/vehicles/src/screens/DrivingLessonsBook/DrivingLessonsBook.tsx
+++ b/libs/service-portal/vehicles/src/screens/DrivingLessonsBook/DrivingLessonsBook.tsx
@@ -46,6 +46,7 @@ export const GET_STUDENT_BOOK = gql`
           schoolName
           schoolTypeName
           comments
+          status
         }
         testResults {
           examDate
@@ -179,7 +180,7 @@ const DrivingLessonsBook = () => {
           {book?.drivingSchoolExams && (
             <DrivingLessonsSchools
               title={formatMessage(messages.vehicleDrivingLessonsSchools)}
-              data={book.drivingSchoolExams}
+              data={book.drivingSchoolExams.filter((item) => item.status === 2)}
             />
           )}
 


### PR DESCRIPTION
## What

Only show driving schools with status of `2` in driving lesson school table

## Why

Comment from Samgöngustofa:

> Ámínum síðum fyrir Ökunámið undir Ökuskóla er ekki verið að athuga stöðuna á Ökuskólanum. (þ.e. hann getur verið hætt við eða útrunninn)
Þannig undir drivingSchoolExams í GetStudentOverview ætti bara að birta ökuskóla sem eru "status": 2

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
