### PR TITLE
fix(j-s): Use compare locale IS for alphabetized sorting

### DIFF
--- a/apps/judicial-system/web/src/routes/Shared/Cases/ActiveCases.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/Cases/ActiveCases.tsx
@@ -38,6 +38,7 @@ import {
   TempCaseListEntry as CaseListEntry,
 } from '@island.is/judicial-system-web/src/types'
 import { useViewport } from '@island.is/judicial-system-web/src/utils/hooks'
+import { compareLocaleIS } from '@island.is/judicial-system-web/src/utils/sortHelper'
 
 import MobileCase from './MobileCase'
 import { cases as m } from './Cases.strings'
@@ -91,8 +92,10 @@ const ActiveCases: React.FC<React.PropsWithChildren<Props>> = (props) => {
           }
           return entry.created
         }
-
-        const compareResult = getColumnValue(a).localeCompare(getColumnValue(b))
+        const compareResult = compareLocaleIS(
+          getColumnValue(a),
+          getColumnValue(b),
+        )
 
         return sortConfig.direction === 'ascending'
           ? compareResult

--- a/apps/judicial-system/web/src/utils/hooks/useSort/useSortAppealCases.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useSort/useSortAppealCases.ts
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 
 import { CaseListEntry } from '@island.is/judicial-system-web/src/graphql/schema'
+import { compareLocaleIS } from '@island.is/judicial-system-web/src/utils/sortHelper'
 
 const useSortAppealCases = (
   defaultColumn: string,
@@ -49,8 +50,10 @@ const useSortAppealCases = (
           }
           return entry.appealedDate ?? ''
         }
-        const compareResult = getColumnValue(a).localeCompare(getColumnValue(b))
-
+        const compareResult = compareLocaleIS(
+          getColumnValue(a),
+          getColumnValue(b),
+        )
         return sortConfig.direction === 'ascending'
           ? compareResult
           : -compareResult

--- a/apps/judicial-system/web/src/utils/hooks/useSort/useSortCases.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useSort/useSortCases.ts
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react'
 
 import { CaseListEntry } from '@island.is/judicial-system/types'
 import { sortableTableColumn } from '@island.is/judicial-system-web/src/types'
+import { compareLocaleIS } from '@island.is/judicial-system-web/src/utils/sortHelper'
 
 const useSortCases = (
   defaultColumn: string,
@@ -51,7 +52,10 @@ const useSortCases = (
           return entry.created
         }
 
-        const compareResult = getColumnValue(a).localeCompare(getColumnValue(b))
+        const compareResult = compareLocaleIS(
+          getColumnValue(a),
+          getColumnValue(b),
+        )
 
         return sortConfig.direction === 'ascending'
           ? compareResult


### PR DESCRIPTION


[Laga stafrófsröð í málalistum vegna Chrome](https://app.asana.com/0/1199153462262248/1205417850909473/f)

## What

Change how we sort lists 

## Why

Because sorting by Icelandic letters doesn't work in Chrome as is

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
