### PR TITLE
fix(service-portal): Add back tooltip split name

### DIFF
--- a/libs/service-portal/information/src/screens/Child/Child.tsx
+++ b/libs/service-portal/information/src/screens/Child/Child.tsx
@@ -186,14 +186,11 @@ const Child = () => {
             translate="no"
             printable
             content={child?.fullName || '...'}
-            tooltip={formatNameBreaks(
-              (child as NationalRegistryName) ?? undefined,
-              {
-                givenName: formatMessage(spmm.givenName),
-                middleName: formatMessage(spmm.middleName),
-                lastName: formatMessage(spmm.lastName),
-              },
-            )}
+            tooltip={formatNameBreaks(child?.name ?? undefined, {
+              givenName: formatMessage(spmm.givenName),
+              middleName: formatMessage(spmm.middleName),
+              lastName: formatMessage(spmm.lastName),
+            })}
             loading={loading}
             editLink={
               !isChild
@@ -201,7 +198,8 @@ const Child = () => {
                     title: editLink,
                     external: true,
                     skipOutboundTrack: true,
-                    url: 'https://www.skra.is/umsoknir/eydublod-umsoknir-og-vottord/stok-vara/?productid=703760ac-686f-11e6-943e-005056851dd2',
+                    url:
+                      'https://www.skra.is/umsoknir/eydublod-umsoknir-og-vottord/stok-vara/?productid=703760ac-686f-11e6-943e-005056851dd2',
                   }
                 : undefined
             }
@@ -268,7 +266,8 @@ const Child = () => {
                     title: editLink,
                     external: true,
                     skipOutboundTrack: true,
-                    url: 'https://www.skra.is/umsoknir/rafraen-skil/tru-eda-lifsskodunarfelag-barna-15-ara-og-yngri/',
+                    url:
+                      'https://www.skra.is/umsoknir/rafraen-skil/tru-eda-lifsskodunarfelag-barna-15-ara-og-yngri/',
                   }
                 : undefined
             }

--- a/libs/service-portal/information/src/screens/Child/Child.tsx
+++ b/libs/service-portal/information/src/screens/Child/Child.tsx
@@ -198,8 +198,7 @@ const Child = () => {
                     title: editLink,
                     external: true,
                     skipOutboundTrack: true,
-                    url:
-                      'https://www.skra.is/umsoknir/eydublod-umsoknir-og-vottord/stok-vara/?productid=703760ac-686f-11e6-943e-005056851dd2',
+                    url: 'https://www.skra.is/umsoknir/eydublod-umsoknir-og-vottord/stok-vara/?productid=703760ac-686f-11e6-943e-005056851dd2',
                   }
                 : undefined
             }
@@ -266,8 +265,7 @@ const Child = () => {
                     title: editLink,
                     external: true,
                     skipOutboundTrack: true,
-                    url:
-                      'https://www.skra.is/umsoknir/rafraen-skil/tru-eda-lifsskodunarfelag-barna-15-ara-og-yngri/',
+                    url: 'https://www.skra.is/umsoknir/rafraen-skil/tru-eda-lifsskodunarfelag-barna-15-ara-og-yngri/',
                   }
                 : undefined
             }

--- a/libs/service-portal/information/src/screens/UserInfo/UserInfo.graphql
+++ b/libs/service-portal/information/src/screens/UserInfo/UserInfo.graphql
@@ -5,6 +5,11 @@ query NationalRegistryPerson($api: String) {
     gender
     exceptionFromDirectMarketing
     religion
+    name {
+      firstName
+      middleName
+      lastName
+    }
     maritalStatus
     citizenship {
       code

--- a/libs/service-portal/information/src/screens/UserInfo/UserInfo.tsx
+++ b/libs/service-portal/information/src/screens/UserInfo/UserInfo.tsx
@@ -78,14 +78,11 @@ const SubjectInfo = () => {
           loading={loading}
           content={nationalRegistryPerson?.fullName ?? ''}
           translate="no"
-          tooltip={formatNameBreaks(
-            (nationalRegistryPerson as NationalRegistryName) ?? undefined,
-            {
-              givenName: formatMessage(spmm.givenName),
-              middleName: formatMessage(spmm.middleName),
-              lastName: formatMessage(spmm.lastName),
-            },
-          )}
+          tooltip={formatNameBreaks(nationalRegistryPerson?.name ?? undefined, {
+            givenName: formatMessage(spmm.givenName),
+            middleName: formatMessage(spmm.middleName),
+            lastName: formatMessage(spmm.lastName),
+          })}
           editLink={{
             external: true,
             title: spmm.changeInNationalReg,


### PR DESCRIPTION
## What

Add back tooltip split name

## Why

It's not active after service change as the data has been updated.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
