### PR TITLE
fix(web): Use correct slug when querying service web slices

### DIFF
--- a/apps/web/screens/ServiceWeb/Home/Home.tsx
+++ b/apps/web/screens/ServiceWeb/Home/Home.tsx
@@ -370,7 +370,7 @@ Home.getProps = async ({ apolloClient, locale, query }) => {
       query: GET_SERVICE_WEB_PAGE_QUERY,
       variables: {
         input: {
-          slug: query.slug as string,
+          slug: slug,
           lang: locale as ContentLanguage,
         },
       },


### PR DESCRIPTION
# Use correct slug when querying service web slices


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
