### PR TITLE
fix(web): Hotfix - Use correct slug when querying service web slices

### DIFF
--- a/apps/web/screens/ServiceWeb/Home/Home.tsx
+++ b/apps/web/screens/ServiceWeb/Home/Home.tsx
@@ -370,7 +370,7 @@ Home.getProps = async ({ apolloClient, locale, query }) => {
       query: GET_SERVICE_WEB_PAGE_QUERY,
       variables: {
         input: {
-          slug: query.slug as string,
+          slug: slug,
           lang: locale as ContentLanguage,
         },
       },


### PR DESCRIPTION
# Hotfix - Use correct slug when querying service web slices

https://github.com/island-is/island.is/pull/12168
