### PR TITLE
feat(web): Add table of contents to project subpage

### DIFF
--- a/apps/web/screens/Project/Project.tsx
+++ b/apps/web/screens/Project/Project.tsx
@@ -38,6 +38,7 @@ import { ProjectWrapper } from './components/ProjectWrapper'
 import { Locale } from 'locale'
 import { ProjectFooter } from './components/ProjectFooter'
 import { webRichText } from '@island.is/web/utils/richText'
+import { TOC } from './ProjectTableOfContentes'
 
 interface PageProps {
   projectPage: Query['getProjectPage']
@@ -48,7 +49,6 @@ interface PageProps {
   stepperNamespace: Record<string, string>
   locale: Locale
 }
-
 const ProjectPage: Screen<PageProps> = ({
   projectPage,
   namespace,
@@ -170,6 +170,9 @@ const ProjectPage: Screen<PageProps> = ({
                 readId={null}
                 readClass="rs_read"
               />
+            )}
+            {subpage.showTableOfContents && (
+              <TOC slices={subpage.slices} title={navigationTitle} />
             )}
             {subpage.content &&
               webRichText(subpage.content as SliceType[], {

--- a/apps/web/screens/Project/Project.tsx
+++ b/apps/web/screens/Project/Project.tsx
@@ -38,7 +38,7 @@ import { ProjectWrapper } from './components/ProjectWrapper'
 import { Locale } from 'locale'
 import { ProjectFooter } from './components/ProjectFooter'
 import { webRichText } from '@island.is/web/utils/richText'
-import { TOC } from './ProjectTableOfContentes'
+import { TOC } from './ProjectTableOfContents'
 
 interface PageProps {
   projectPage: Query['getProjectPage']

--- a/apps/web/screens/Project/ProjectTableOfContents.tsx
+++ b/apps/web/screens/Project/ProjectTableOfContents.tsx
@@ -23,7 +23,7 @@ export const TOC: FC<
     return null
   }
   return (
-    <Box marginY={6} marginBottom={10}>
+    <Box marginY={6}>
       <TableOfContents
         tableOfContentsTitle={title}
         headings={navigation.map(({ id, text }) => ({

--- a/apps/web/screens/Project/ProjectTableOfContents.tsx
+++ b/apps/web/screens/Project/ProjectTableOfContents.tsx
@@ -1,0 +1,37 @@
+import { Slice } from '@island.is/api/schema'
+import { TableOfContents } from '@island.is/island-ui/core'
+import { FC, useMemo } from 'react'
+import { Box } from '@island.is/island-ui/core'
+import { scrollTo } from '@island.is/web/hooks/useScrollSpy'
+
+export const TOC: FC<
+  React.PropsWithChildren<{ slices: Slice[]; title: string }>
+> = ({ slices, title }) => {
+  const navigation = useMemo(
+    () =>
+      slices
+        .map((slice) => ({
+          id: slice.id,
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore make web strict
+          text: slice['title'] ?? slice['leftTitle'] ?? '',
+        }))
+        .filter((item) => !!item.text),
+    [slices],
+  )
+  if (navigation.length === 0) {
+    return null
+  }
+  return (
+    <Box marginY={6} marginBottom={10}>
+      <TableOfContents
+        tableOfContentsTitle={title}
+        headings={navigation.map(({ id, text }) => ({
+          headingTitle: text,
+          headingId: id,
+        }))}
+        onClick={(id) => scrollTo(id, { smooth: true })}
+      />
+    </Box>
+  )
+}

--- a/apps/web/screens/queries/Project.tsx
+++ b/apps/web/screens/queries/Project.tsx
@@ -92,6 +92,7 @@ export const GET_PROJECT_PAGE_QUERY = gql`
           ...NestedOneColumnTextFields
           ${nestedFields}
         }
+        showTableOfContents
         bottomSlices {
           ...AllSlices
           ...NestedOneColumnTextFields

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -1489,9 +1489,6 @@ export interface ILatestNewsSliceFields {
 
   /** Read more link */
   readMoreLink?: ILink | undefined
-
-  /** Filter Tags */
-  filterTags?: IGenericTag[] | undefined
 }
 
 /** Slice to show latest news entries */

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -75,7 +75,6 @@ export interface IAlertBannerFields {
         | 'umsoknir'
         | 'min-gogn'
         | 'skirteini'
-        | 'leyfisbref'
         | 'menntun'
         | 'fasteignir'
         | 'fjarmal'
@@ -1490,6 +1489,9 @@ export interface ILatestNewsSliceFields {
 
   /** Read more link */
   readMoreLink?: ILink | undefined
+
+  /** Filter Tags */
+  filterTags?: IGenericTag[] | undefined
 }
 
 /** Slice to show latest news entries */
@@ -2872,6 +2874,9 @@ export interface IProjectSubpageFields {
         | ITwoColumnText
       )[]
     | undefined
+
+  /** Show Table of Contents */
+  showTableOfContents?: boolean | undefined
 
   /** Bottom Slices */
   bottomSlices?: (IPowerBiSlice | IOneColumnText)[] | undefined

--- a/libs/cms/src/lib/models/projectSubpage.model.ts
+++ b/libs/cms/src/lib/models/projectSubpage.model.ts
@@ -28,6 +28,9 @@ export class ProjectSubpage {
   @CacheField(() => [SliceUnion])
   slices!: Array<typeof SliceUnion | null>
 
+  @Field(() => Boolean)
+  showTableOfContents?: boolean
+
   @CacheField(() => [SliceUnion], { nullable: true })
   bottomSlices?: Array<typeof SliceUnion | null> | null
 }
@@ -44,6 +47,7 @@ export const mapProjectSubpage = ({
     : [],
   renderSlicesAsTabs: fields.renderSlicesAsTabs ?? false,
   slices: (fields.slices ?? []).map(safelyMapSliceUnion).filter(Boolean),
+  showTableOfContents: fields.showTableOfContents ?? false,
   bottomSlices: (fields.bottomSlices ?? [])
     .map(safelyMapSliceUnion)
     .filter(Boolean),


### PR DESCRIPTION
# Add table of contents option to project subpage

## What

* Add a boolean field to the project subpage content type which displays a table of contents component if toggled on

## Why

* This feature is already present on organization subpages and is needed for project subpages as well

## Screenshots / Gifs

![image](https://github.com/island-is/island.is/assets/43557895/9b0b9dbd-5e8e-405f-bc01-09591c19efff)
## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
