### PR TITLE
feat(web): Filter rss feed by organization

### DIFF
--- a/apps/web/i18n/I18n.tsx
+++ b/apps/web/i18n/I18n.tsx
@@ -3,7 +3,7 @@ import rosetta from 'rosetta'
 import { defaultLanguage } from '@island.is/shared/constants'
 import { Locale } from '@island.is/shared/types'
 
-export const isLocale = (x: string): x is Locale => {
+export const isLocale = (x?: string): x is Locale => {
   return x === 'is' || x === 'en'
 }
 

--- a/apps/web/pages/api/rss/index.ts
+++ b/apps/web/pages/api/rss/index.ts
@@ -31,6 +31,7 @@ export default async function handler(req, res) {
         lang: locale as ContentLanguage,
         size: 25,
         tags,
+        organization,
       },
     },
   })

--- a/apps/web/pages/api/rss/index.ts
+++ b/apps/web/pages/api/rss/index.ts
@@ -12,10 +12,18 @@ import { isLocale } from '@island.is/web/i18n/I18n'
 import { defaultLanguage } from '@island.is/shared/constants'
 import { linkResolver } from '@island.is/web/hooks'
 
-const extractTagsFromQuery = (query?: NextApiRequest['query']) => {
-  if (typeof query?.tags === 'string') return [query.tags]
-  if (typeof query?.tags?.length === 'number' && query.tags.length > 0)
+const extractTagsFromQuery = (query: NextApiRequest['query']) => {
+  if (typeof query?.tags === 'string') {
+    return [query.tags]
+  }
+  if (typeof query?.tags?.length === 'number' && query.tags.length > 0) {
     return query.tags
+  }
+  if (query?.organization) {
+    return []
+  }
+
+  // If nothing is defined in query we'll show frontpage news
   return [FRONTPAGE_NEWS_TAG_ID]
 }
 

--- a/apps/web/pages/api/rss/index.ts
+++ b/apps/web/pages/api/rss/index.ts
@@ -1,3 +1,5 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import type { Locale } from 'locale'
 import {
   ContentLanguage,
   GetNewsQuery,
@@ -10,17 +12,22 @@ import { isLocale } from '@island.is/web/i18n/I18n'
 import { defaultLanguage } from '@island.is/shared/constants'
 import { linkResolver } from '@island.is/web/hooks'
 
-const extractTagsFromQuery = (query: Record<string, string | string[]>) => {
-  if (typeof query.tags === 'string') return [query.tags]
-  if (query.tags?.length > 0) return query.tags
+const extractTagsFromQuery = (query?: NextApiRequest['query']) => {
+  if (typeof query?.tags === 'string') return [query.tags]
+  if (typeof query?.tags?.length === 'number' && query.tags.length > 0)
+    return query.tags
   return [FRONTPAGE_NEWS_TAG_ID]
 }
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore make web strict
-export default async function handler(req, res) {
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
   const tags = extractTagsFromQuery(req.query)
-  const locale = isLocale(req.query?.lang) ? req.query.lang : defaultLanguage
-  const organization = req.query?.organization
+  const locale = isLocale(req.query?.lang as string)
+    ? (req.query.lang as Locale)
+    : defaultLanguage
+  const organization = req.query?.organization as string | undefined
 
   const apolloClient = initApollo({}, locale)
 
@@ -36,14 +43,14 @@ export default async function handler(req, res) {
     },
   })
 
-  const host: string = req.headers.host
-  const protocol = `http${host.startsWith('localhost') ? '' : 's'}://`
+  const host = req.headers?.host
+  const protocol = `http${host?.startsWith('localhost') ? '' : 's'}://`
   const baseUrl = `${protocol}${host}`
 
   const newsItem = (item: GetNewsQuery['getNews']['items'][0]) => {
     const url = organization
-      ? linkResolver('organizationnews', [organization, item.slug]).href
-      : linkResolver('news', [item.slug]).href
+      ? linkResolver('organizationnews', [organization, item.slug], locale).href
+      : linkResolver('news', [item.slug], locale).href
     const date = new Date(item.date).toUTCString()
 
     return `<item>
@@ -64,6 +71,6 @@ export default async function handler(req, res) {
       </channel>
     </rss>`
 
-  res.set('Content-Type', 'text/xml;charset=UTF-8')
+  res.setHeader('Content-Type', 'text/xml;charset=UTF-8')
   return res.status(200).send(feed)
 }


### PR DESCRIPTION
# Filter rss feed by organization

## What

* We no longer rely on a specific tag per news item but instead there is now an organization field that news can have. We need to start utilizing that field in the rss feed so we can fetch all news that a specific organization owns (previously this was done using a tag but that isn't necessarily the case anymore since you could skip having tags and only filling out the organization field in the cms for news)
* Add types for api route since previously there was a ts-ignore comment

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
