### PR TITLE
feat(web): Query nested fields for life event pages

### DIFF
--- a/apps/web/screens/queries/LifeEvents.tsx
+++ b/apps/web/screens/queries/LifeEvents.tsx
@@ -1,5 +1,5 @@
 import gql from 'graphql-tag'
-import { slices } from './fragments'
+import { nestedFields, slices } from './fragments'
 
 export const GET_LIFE_EVENT_QUERY = gql`
   query GetLifeEvent($input: GetLifeEventPageInput!) {
@@ -13,6 +13,7 @@ export const GET_LIFE_EVENT_QUERY = gql`
       }
       content {
         ...AllSlices
+        ${nestedFields}
       }
       featuredImage {
         ...ImageFields


### PR DESCRIPTION
# Query nested fields for life event pages

## What

* The life event pages aren't able to display nested accordions since it's missing from the query

## Why

* This was requested by Digital Iceland

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
