### PR TITLE
fix(search-indexer): Embedded content type fields not appearing below article

### DIFF
--- a/libs/cms/src/lib/search/importers/article.service.ts
+++ b/libs/cms/src/lib/search/importers/article.service.ts
@@ -75,19 +75,12 @@ export class ArticleSyncService implements CmsSyncProvider<IArticle> {
               return undefined
             }
 
-            const parent = {
-              ...fields.parent,
-              fields: { ...fields.parent.fields },
-            }
-
-            delete parent['fields']['subArticles']
+            fields.parent.fields = { ...fields.parent.fields }
+            delete fields.parent.fields['subArticles']
 
             return {
               sys,
-              fields: {
-                ...fields,
-                parent,
-              },
+              fields,
             }
           })
           .filter((subArticle) => Boolean(subArticle))


### PR DESCRIPTION
# Embedded content type fields not appearing below article

## What

* A process entry was embedded in the content field of an article but it's fields were missing (alll an empty string), this change for whatever reason fixed that issue

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
