### PR TITLE
ci: increase nx parallel 1 -> 3 for tests in push workflow

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ec2-runners
     container:
       image: public.ecr.aws/m3u4c4h9/island-is/actions-runner-public:latest
-    timeout-minutes: 25
+    timeout-minutes: 35
 
     env:
       AFFECTED_ALL: ${{ secrets.AFFECTED_ALL }}
@@ -208,7 +208,7 @@ jobs:
     runs-on: ec2-runners
     container:
       image: public.ecr.aws/m3u4c4h9/island-is/actions-runner-public:latest
-    timeout-minutes: 25
+    timeout-minutes: 35
     env:
       AFFECTED_PROJECTS: ${{ matrix.projects }}
       MAX_JOBS: 3
@@ -267,7 +267,7 @@ jobs:
     runs-on: ec2-runners
     container:
       image: public.ecr.aws/m3u4c4h9/island-is/actions-runner-public:latest
-    timeout-minutes: 25
+    timeout-minutes: 35
     env:
       AFFECTED_PROJECT: ${{ matrix.projects }}
       CYPRESS_PROJECT_ID: 4q7jz8
@@ -416,7 +416,7 @@ jobs:
     runs-on: ec2-runners
     container:
       image: public.ecr.aws/m3u4c4h9/island-is/actions-runner-public:latest
-    timeout-minutes: 25
+    timeout-minutes: 35
     if: needs.prepare.outputs.LINT_CHUNKS
     env:
       AFFECTED_PROJECTS: ${{ matrix.projects }}
@@ -466,7 +466,7 @@ jobs:
     runs-on: ec2-runners
     container:
       image: public.ecr.aws/m3u4c4h9/island-is/actions-runner-public:latest
-    timeout-minutes: 25
+    timeout-minutes: 35
     env:
       AFFECTED_PROJECTS: ${{ matrix.projects }}
       MAX_JOBS: 2

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -421,7 +421,7 @@ jobs:
     env:
       AFFECTED_PROJECTS: ${{ matrix.projects }}
       NODE_OPTIONS: --max-old-space-size=4096
-      MAX_JOBS: 1
+      MAX_JOBS: 3
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare.outputs.LINT_CHUNKS) }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -430,7 +430,7 @@ jobs:
     timeout-minutes: 25
     env:
       AFFECTED_PROJECTS: ${{ matrix.projects }}
-      MAX_JOBS: 1
+      MAX_JOBS: 3
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare.outputs.TEST_CHUNKS) }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -427,7 +427,7 @@ jobs:
     runs-on: ec2-runners
     container:
       image: public.ecr.aws/m3u4c4h9/island-is/actions-runner-public:latest
-    timeout-minutes: 25
+    timeout-minutes: 35
     env:
       AFFECTED_PROJECTS: ${{ matrix.projects }}
       MAX_JOBS: 3

--- a/libs/cms/src/lib/models/powerBiSlice.model.ts
+++ b/libs/cms/src/lib/models/powerBiSlice.model.ts
@@ -1,4 +1,3 @@
-import { CacheField } from '@island.is/nest/graphql'
 import { Field, ID, ObjectType } from '@nestjs/graphql'
 import graphqlTypeJson from 'graphql-type-json'
 import { SystemMetadata } from '@island.is/shared/types'
@@ -25,7 +24,9 @@ export class PowerBiSlice {
   @Field({ nullable: true })
   owner?: 'Fiskistofa'
 
-  @CacheField(() => GetPowerBiEmbedPropsFromServerResponse, { nullable: true })
+  // Make sure that this doesn't get cached since we want users to get a fresh embed token
+  // eslint-disable-next-line local-rules/require-cache-control
+  @Field(() => GetPowerBiEmbedPropsFromServerResponse, { nullable: true })
   powerBiEmbedPropsFromServer?: GetPowerBiEmbedPropsFromServerResponse | null
 }
 


### PR DESCRIPTION
# NX parallel for tests

- We are running NX parallel=3 for tests in PRs but parallel=1 on push.
- PR checks are green and therefore are merged
- Tests running after merged are failing due to timeouts

This sets the same parallelism on PRs and merge (push) workflows


## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
