### PR TITLE
fix(web): Hotfix - Change what reductions field is displayed in housing benefit calculator (#12238)

### DIFF
--- a/apps/web/components/connected/HousingBenefitCalculator/HousingBenefitCalculator.tsx
+++ b/apps/web/components/connected/HousingBenefitCalculator/HousingBenefitCalculator.tsx
@@ -76,8 +76,9 @@ const HousingBenefitCalculator = ({ slice }: HousingBenefitCalculatorProps) => {
   }
 
   const maximumHousingBenefits =
-    data?.housingBenefitCalculatorCalculation.maximumHousingBenefits
-  const reduction = data?.housingBenefitCalculatorCalculation.reductions
+    data?.housingBenefitCalculatorCalculation?.maximumHousingBenefits
+  const reductionsDueToIncome =
+    data?.housingBenefitCalculatorCalculation?.reductionsDueToIncome
   const estimatedHousingBenefits =
     data?.housingBenefitCalculatorCalculation?.estimatedHousingBenefits
 
@@ -260,13 +261,11 @@ const HousingBenefitCalculator = ({ slice }: HousingBenefitCalculatorProps) => {
               {n('perMonth', 'á mánuði.')}
             </Text>
           )}
-          {typeof reduction === 'number' && (
+          {typeof reductionsDueToIncome === 'number' && (
             <Text variant="medium" fontWeight="light" paddingBottom={5}>
-              {n(
-                'reductionDueToHousingCosts',
-                'Skerðing vegna húsnæðiskostnaðar eru',
-              )}{' '}
-              {formatCurrency(reduction)} {n('perMonth', 'á mánuði.')}
+              {n('reductionDueToIncome', 'Skerðing vegna tekna eru')}{' '}
+              {formatCurrency(reductionsDueToIncome)}{' '}
+              {n('perMonth', 'á mánuði.')}
             </Text>
           )}
 

--- a/apps/web/screens/queries/HousingBenefitCalculator.ts
+++ b/apps/web/screens/queries/HousingBenefitCalculator.ts
@@ -6,7 +6,7 @@ export const GET_HOUSING_BENEFIT_CALCULATION = gql`
   ) {
     housingBenefitCalculatorCalculation(input: $input) {
       maximumHousingBenefits
-      reductions
+      reductionsDueToIncome
       estimatedHousingBenefits
     }
   }

--- a/libs/api/domains/housing-benefit-calculator/src/lib/models/calculation.model.ts
+++ b/libs/api/domains/housing-benefit-calculator/src/lib/models/calculation.model.ts
@@ -6,7 +6,13 @@ export class Calculation {
   maximumHousingBenefits?: number | null
 
   @Field(() => Number, { nullable: true })
-  reductions?: number | null
+  reductionsDueToIncome?: number | null
+
+  @Field(() => Number, { nullable: true })
+  reductionsDueToAssets?: number | null
+
+  @Field(() => Number, { nullable: true })
+  reductionsDueToHousingCosts?: number | null
 
   @Field(() => Number, { nullable: true })
   estimatedHousingBenefits?: number | null

--- a/libs/clients/housing-benefit-calculator/src/lib/housing-benefit-calculator.service.ts
+++ b/libs/clients/housing-benefit-calculator/src/lib/housing-benefit-calculator.service.ts
@@ -59,7 +59,11 @@ export class HousingBenefitCalculatorClientService {
       })
     return {
       maximumHousingBenefits: round(calculationData.manadarlegarHamarksBaetur),
-      reductions: round(calculationData.manadarlegHusnaedisKostnadarSkerding),
+      reductionsDueToIncome: round(calculationData.manadarlegTekjuSkerding),
+      reductionsDueToAssets: round(calculationData.manadarlegEignaSkerding),
+      reductionsDueToHousingCosts: round(
+        calculationData.manadarlegHusnaedisKostnadarSkerding,
+      ),
       estimatedHousingBenefits: round(
         calculationData.manadarlegarHusnaedisbaetur,
       ),


### PR DESCRIPTION
# Hotfix - Change what reductions field is displayed in housing benefit calculator (#12238)