### PR TITLE
fix(search-indexer): Remove non primitive fields instead of everything except slug and url

### DIFF
--- a/libs/cms/src/lib/search/importers/utils.ts
+++ b/libs/cms/src/lib/search/importers/utils.ts
@@ -110,7 +110,7 @@ const pruneEntryHyperlink = (node: any) => {
             slug: node.data.target.fields[field]?.fields?.slug,
           },
         }
-      } else if (field !== 'slug' && field !== 'url') {
+      } else if (typeof node.data.target.fields[field] === 'object') {
         delete node.data.target.fields[field]
       }
     }


### PR DESCRIPTION
# Remove non primitive fields instead of everything except slug and url

## What

* We are trimming away too much data from entry-hyperlinks, we'd like to keep fields like the title of an entry and so forth
* This change stops removing everything other than slug and url named fields and instead removes all object fields

## Why

* This'll address an issue on the web where links appear without a title

## Screenshots / Gifs

![image](https://github.com/island-is/island.is/assets/43557895/4e5aed59-afad-47fb-90f7-e31943a4a66a)
## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
