### PR TITLE
feat(auth-api-lib): Add delegation custom scope rule for @island.is/fishing-license scope.

### DIFF
--- a/libs/auth-api-lib/src/lib/delegations/DelegationConfig.ts
+++ b/libs/auth-api-lib/src/lib/delegations/DelegationConfig.ts
@@ -60,6 +60,10 @@ export const DelegationConfig = defineConfig<z.infer<typeof schema>>({
         scopeName: ApiScope.company,
         onlyForDelegationType: ['ProcurationHolder', 'Custom'],
       },
+      {
+        scopeName: ApiScope.fishingLicense,
+        onlyForDelegationType: ['ProcurationHolder', 'Custom'],
+      },
     ],
     userInfoUrl:
       env.required(


### PR DESCRIPTION
## What

Adding delegation custom scope rule for `@island.is/fishing-license` to have it only enabled for companies in the delegation system.

## Why

So individuals can't grant delegations with the fishing license scope.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
