### PR TITLE
fix(search-indexer): Hotfix - Remove non primitive fields instead of everything except slug and url (#12243)

### DIFF
--- a/libs/cms/src/lib/search/importers/utils.ts
+++ b/libs/cms/src/lib/search/importers/utils.ts
@@ -110,7 +110,7 @@ const pruneEntryHyperlink = (node: any) => {
             slug: node.data.target.fields[field]?.fields?.slug,
           },
         }
-      } else if (field !== 'slug' && field !== 'url') {
+      } else if (typeof node.data.target.fields[field] === 'object') {
         delete node.data.target.fields[field]
       }
     }


### PR DESCRIPTION
# Hotfix - Remove non primitive fields instead of everything except slug and url (#12243)
