### PR TITLE
fix(j-s): Log in defender fix

### DIFF
--- a/apps/judicial-system/api/src/app/modules/auth/auth.controller.ts
+++ b/apps/judicial-system/api/src/app/modules/auth/auth.controller.ts
@@ -16,6 +16,7 @@ import {
   USERS_ROUTE,
   COURT_OF_APPEAL_CASES_ROUTE,
   IDS_ID_TOKEN,
+  DEFENDER_CASES_ROUTE,
 } from '@island.is/judicial-system/consts'
 import { InstitutionType, UserRole } from '@island.is/judicial-system/types'
 import { SharedAuthService } from '@island.is/judicial-system/auth'
@@ -224,7 +225,7 @@ export class AuthController {
         return {
           userId: defender.id,
           jwtToken: this.sharedAuthService.signJwt(defender, csrfToken),
-          redirectRoute: requestedRedirectRoute,
+          redirectRoute: requestedRedirectRoute ?? DEFENDER_CASES_ROUTE,
         }
       }
     }


### PR DESCRIPTION
## What

Redirect defendant to case list if no redirect link is sent with login request

## Why

So that defendants can log in through the main page


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
