### PR TITLE
feat(consultation-portal): fix extra margin shown

### DIFF
--- a/apps/consultation-portal/screens/Case/components/BlowoutList/BlowoutList.tsx
+++ b/apps/consultation-portal/screens/Case/components/BlowoutList/BlowoutList.tsx
@@ -55,32 +55,38 @@ export const BlowoutList = ({
           {showList && (
             <>
               {isStakeholder && <Text>{loc.description}</Text>}
-              {isEmpty && <Text>{loc.noList}</Text>}
-              <Box padding="smallGutter">
-                <BulletList type="ul">
-                  {isStakeholder
-                    ? sortedList.map((item: Stakeholder, index: number) => {
-                        return <Bullet key={index}>{item.name}</Bullet>
-                      })
-                    : sortedList.map((item: RelatedCase, index: number) => {
-                        return (
-                          <Bullet key={index}>
-                            <Inline flexWrap="nowrap" alignY="bottom" space={1}>
-                              <LinkV2
-                                href={`/mal/${item.id}`}
-                                color="blue400"
-                                underline="small"
-                                underlineVisibility="hover"
+              {isStakeholder && isEmpty && <Text>{loc.noList}</Text>}
+              {!isEmpty && (
+                <Box padding="smallGutter">
+                  <BulletList type="ul">
+                    {isStakeholder
+                      ? sortedList.map((item: Stakeholder, index: number) => {
+                          return <Bullet key={index}>{item.name}</Bullet>
+                        })
+                      : sortedList.map((item: RelatedCase, index: number) => {
+                          return (
+                            <Bullet key={index}>
+                              <Inline
+                                flexWrap="nowrap"
+                                alignY="bottom"
+                                space={1}
                               >
-                                {item.caseNumber}
-                              </LinkV2>
-                              <Tooltip placement="bottom" text={item.name} />
-                            </Inline>
-                          </Bullet>
-                        )
-                      })}
-                </BulletList>
-              </Box>
+                                <LinkV2
+                                  href={`/mal/${item.id}`}
+                                  color="blue400"
+                                  underline="small"
+                                  underlineVisibility="hover"
+                                >
+                                  {item.caseNumber}
+                                </LinkV2>
+                                <Tooltip placement="bottom" text={item.name} />
+                              </Inline>
+                            </Bullet>
+                          )
+                        })}
+                  </BulletList>
+                </Box>
+              )}
             </>
           )}
         </StackedTitleAndDescription>


### PR DESCRIPTION
# Fix empty box in stakeholders

https://veflausnir.atlassian.net/browse/KAM-1666

## What

- There was extra margin in the box when there where no stakeholders

## Why

Specify why you need to achieve this

## Screenshots / Gifs
![image](https://github.com/island-is/island.is/assets/24222622/79827a09-2de1-46e2-a042-c5624324ee7d)

![image](https://github.com/island-is/island.is/assets/24222622/b574273b-d87f-4a26-a20b-f962e71146f4)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
