### PR TITLE
fix(j-s): Hide judge and default string for court case number if empty

### DIFF
--- a/apps/judicial-system/web/src/routes/Defender/CaseOverview.strings.ts
+++ b/apps/judicial-system/web/src/routes/Defender/CaseOverview.strings.ts
@@ -74,4 +74,10 @@ export const strings = defineMessages({
     description:
       'Notaður sem texti í Hætta við takka í modal glugga hjá verjanda þegar frestur til greinargerðar er liðinn.',
   },
+  noCourtNumber: {
+    id: 'judicial.system.core:defender_case_overview.no_court_number',
+    defaultMessage: 'Ekki skráð',
+    description:
+      'Notaður sem texti ef ekkert málsnúmer héraðsdóms er skráð á yfirlitsskjá verjanda.',
+  },
 })

--- a/apps/judicial-system/web/src/routes/Defender/CaseOverview.tsx
+++ b/apps/judicial-system/web/src/routes/Defender/CaseOverview.tsx
@@ -15,7 +15,6 @@ import {
   Feature,
   isInvestigationCase,
   isRestrictionCase,
-  RequestSharedWithDefender,
 } from '@island.is/judicial-system/types'
 import { core, titles } from '@island.is/judicial-system-web/messages'
 import {
@@ -155,7 +154,9 @@ export const CaseOverview: React.FC<React.PropsWithChildren<unknown>> = () => {
                 },
                 {
                   title: formatMessage(core.courtCaseNumber),
-                  value: workingCase.courtCaseNumber,
+                  value:
+                    workingCase.courtCaseNumber ??
+                    formatMessage(strings.noCourtNumber),
                 },
                 {
                   title: formatMessage(core.prosecutor),
@@ -169,10 +170,14 @@ export const CaseOverview: React.FC<React.PropsWithChildren<unknown>> = () => {
                   title: formatMessage(core.prosecutorPerson),
                   value: workingCase.prosecutor?.name,
                 },
-                {
-                  title: formatMessage(core.judge),
-                  value: workingCase.judge?.name,
-                },
+                ...(workingCase.judge
+                  ? [
+                      {
+                        title: formatMessage(core.judge),
+                        value: workingCase.judge?.name,
+                      },
+                    ]
+                  : []),
                 // Conditionally add this field based on case type
                 ...(isInvestigationCase(workingCase.type)
                   ? [


### PR DESCRIPTION


[Breyta birtingu á óútfylltum svæðum í info card](https://app.asana.com/0/1199153462262248/1205537726590934/f)

## What

Hide judge field if empty and show default text if there is no court case number on case

## Why

To make the overview more clear

## Screenshots / Gifs

<img width="671" alt="image" src="https://github.com/island-is/island.is/assets/4820859/1f6fa3f2-baa2-4ec3-8b24-8b6e1e745b82">


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
