### PR TITLE
fix(web): HSN web form - Set "Content-Type" header to "application/json"

### DIFF
--- a/libs/api/domains/communications/src/lib/communications.service.ts
+++ b/libs/api/domains/communications/src/lib/communications.service.ts
@@ -160,12 +160,15 @@ export class CommunicationsService {
           {
             headers: {
               lykill: this.config.hsnWebFormResponseSecret,
+              'Content-Type': 'application/json',
             },
           },
         )
         return response.status === 200
       } catch (error) {
-        this.logger.error('Failed to send form response to HSN', error)
+        this.logger.error('Failed to send form response to HSN', {
+          message: error.message,
+        })
         return false
       }
     }


### PR DESCRIPTION
# HSN web form - Set "Content-Type" header to "application/json"

## What

* After a bit of debugging I figured out that the content type header is being set automatically by axios and that's why sometimes it was incorrect and other times it was application/json and got a successful response
* By setting it explicitly I'm hoping we can stop seeing form submit fails on prod like we've been seeing for the past couple of days
* Also we've now stopped logging the entire error object and have now moved back to logging just the message

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
