### PR TITLE
feat(web): Remove org logo from default footer

### DIFF
--- a/apps/web/components/Footer/Footer.tsx
+++ b/apps/web/components/Footer/Footer.tsx
@@ -24,6 +24,7 @@ interface FooterProps {
   columns: FooterItem[]
   color?: TextProps['color']
   background?: string
+  titleVariant?: TextProps['variant']
 }
 
 export const Footer = ({
@@ -32,6 +33,7 @@ export const Footer = ({
   columns,
   color,
   background,
+  titleVariant = 'h3',
 }: FooterProps) => {
   const { width } = useWindowSize()
 
@@ -53,7 +55,7 @@ export const Footer = ({
             >
               <GridRow marginBottom={3} marginTop={2}>
                 <GridColumn>
-                  <Text color={color} variant="h2">
+                  <Text color={color} variant={titleVariant} as="h2">
                     {heading}
                   </Text>
                 </GridColumn>

--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -528,17 +528,14 @@ export const OrganizationFooter: React.FC<
         />
       )
       break
-    case 'geislavarnir-rikisins':
-    case 'icelandic-radiation-safety-authority':
+    case 'samgongustofa':
+    case 'transport-authority':
       OrganizationFooterComponent = (
         <WebFooter
           imageUrl={organization.logo?.url}
           heading={organization.title}
           columns={organization.footerItems}
-          background={n(
-            'geislavarnirRikisinsFooterBackground',
-            'linear-gradient(360deg, rgba(182, 211, 216, 0.5092) -27.29%, rgba(138, 181, 185, 0.5776) 33.96%, rgba(69, 135, 138, 0.6384) 129.36%, rgba(19, 101, 103, 0.722) 198.86%)',
-          )}
+          titleVariant="h2"
         />
       )
       break
@@ -547,7 +544,6 @@ export const OrganizationFooter: React.FC<
       if (footerItems.length === 0) break
       OrganizationFooterComponent = (
         <WebFooter
-          imageUrl={organization?.logo?.url}
           heading={organization?.title ?? ''}
           columns={footerItems}
           background={organization?.footerConfig?.background}


### PR DESCRIPTION
# Remove org logo from default footer

## What

* By default there is now no logo displayed and the footer title is an h3 visually but always an h2 element

![image](https://github.com/island-is/island.is/assets/43557895/f723cb26-caa8-48a1-8934-db91767157f3)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
