### PR TITLE
fix(digital tachograph): Fix shared template api currentLicense when using validCategories param

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/shared/api/driving-license/driving-license.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/shared/api/driving-license/driving-license.service.ts
@@ -158,7 +158,9 @@ export class DrivingLicenseProviderService extends BaseTemplateApiService {
       params?.validCategories &&
       (!drivingLicense?.categories ||
         !drivingLicense.categories.some((x) =>
-          params.validCategories?.includes(x.name),
+          params.validCategories?.includes(
+            params?.useLegacyVersion ? x.name : x.nr || '',
+          ),
         ))
     ) {
       throw new TemplateApiError(


### PR DESCRIPTION
## What

After changes in API version, the license is now under "nr" field and not "name" field

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
