### PR TITLE
fix(j-s): Fix noNationalId check in defendant info component

### DIFF
--- a/apps/judicial-system/web/src/routes/Prosecutor/components/DefendantInfo/DefendantInfo.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/components/DefendantInfo/DefendantInfo.tsx
@@ -159,7 +159,7 @@ const DefendantInfo: React.FC<React.PropsWithChildren<Props>> = (props) => {
               isIndictment: isIndictmentCase(workingCase.type),
             },
           )}
-          checked={defendant.noNationalId || undefined}
+          checked={Boolean(defendant.noNationalId)}
           onChange={() => {
             setNationalIdNotFound(false)
             setNationalIdErrorMessage('')


### PR DESCRIPTION
# Fix noNationalId check in defendant info component

[Asana](https://app.asana.com/0/1199153462262248/1205537886876638/f)

## What

Fix an issue with the "Defendant does not have an icelandic SSN" checkbox. The issue was if you checked it and tried to uncheck it, it wouldn't uncheck until you'd push it again.

## Why

It's a bug

## Screenshots / Gifs

### Before

https://github.com/island-is/island.is/assets/3789875/70cf77dc-c98e-4c6c-80a6-0bf67c227e9c

### After

https://github.com/island-is/island.is/assets/3789875/ec8c97ed-5b10-4a0b-9aa0-6a14d52253c8

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
