### PR TITLE
chore(web): Scale down sidebar card image on organization pages

### DIFF
--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -38,6 +38,7 @@ import SidebarLayout from '@island.is/web/screens/Layouts/SidebarLayout'
 import { useNamespace, usePlausiblePageview } from '@island.is/web/hooks'
 import { useI18n } from '@island.is/web/i18n'
 import { WatsonChatPanel } from '@island.is/web/components'
+import { STICKY_NAV_MAX_WIDTH } from '@island.is/web/constants'
 
 import { SyslumennHeader, SyslumennFooter } from './Themes/SyslumennTheme'
 import {
@@ -762,6 +763,12 @@ export const OrganizationWrapper: React.FC<
                   >
                     {(organizationPage.sidebarCards ?? []).map((card) => {
                       if (card.__typename === 'SidebarCard') {
+                        let imageUrl =
+                          card.image?.url ||
+                          'https://images.ctfassets.net/8k0h54kbe6bj/6jpT5mePCNk02nVrzVLzt2/6adca7c10cc927d25597452d59c2a873/bitmap.png'
+
+                        imageUrl += `?w=${STICKY_NAV_MAX_WIDTH}`
+
                         return (
                           <ProfileCard
                             key={card.id}
@@ -770,10 +777,7 @@ export const OrganizationWrapper: React.FC<
                             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                             // @ts-ignore make web strict
                             link={card.link}
-                            image={
-                              card.image?.url ||
-                              'https://images.ctfassets.net/8k0h54kbe6bj/6jpT5mePCNk02nVrzVLzt2/6adca7c10cc927d25597452d59c2a873/bitmap.png'
-                            }
+                            image={imageUrl}
                             size="small"
                           />
                         )

--- a/apps/web/constants/index.ts
+++ b/apps/web/constants/index.ts
@@ -1,4 +1,5 @@
 export const STICKY_NAV_HEIGHT = 64
+export const STICKY_NAV_MAX_WIDTH = 318
 export const PROJECT_STORIES_TAG_ID = '9yqOTwQYzgyej5kItFTtd'
 export const ADGERDIR_INDIVIDUALS_TAG_ID = '4kLt3eRht5yJoakIHWsusb'
 export const ADGERDIR_COMPANIES_TAG_ID = '4ZWcwoW2IiB2AhtzQpzdIW'

--- a/apps/web/screens/Layouts/SidebarLayout.css.ts
+++ b/apps/web/screens/Layouts/SidebarLayout.css.ts
@@ -1,6 +1,9 @@
 import { style } from '@vanilla-extract/css'
 import { theme, themeUtils } from '@island.is/island-ui/theme'
-import { STICKY_NAV_HEIGHT } from '@island.is/web/constants'
+import {
+  STICKY_NAV_HEIGHT,
+  STICKY_NAV_MAX_WIDTH,
+} from '@island.is/web/constants'
 
 const top = STICKY_NAV_HEIGHT + theme.spacing[1]
 
@@ -10,8 +13,8 @@ export const sidebarWrapper = style({
   minWidth: '230px',
   ...themeUtils.responsiveStyle({
     lg: {
-      minWidth: '318px',
-      maxWidth: '318px',
+      minWidth: `${STICKY_NAV_MAX_WIDTH}px`,
+      maxWidth: `${STICKY_NAV_MAX_WIDTH}px`,
     },
   }),
 })


### PR DESCRIPTION
# Scale down sidebar card image on organization pages

## What

* As pointed out here: https://islandis.slack.com/archives/C01C7C3M2J3/p1696851519318459 there was an image used in the cms that was very large (4800 x 3202) and it wasn't being downscaled at all. This PR adds a query param to the image url and sets its size accordingly which should reduce the image width to the size it's being rendered as

## Why

* We don't want our network payload to be unnecessarily large
<img width="944" alt="image" src="https://github.com/island-is/island.is/assets/43557895/ed336200-5b79-4fb2-ab5f-3c5afae21dab">

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
