### PR TITLE
feat(consultation-portal): Kam 1770 layout in case details and login is persisting too long

### DIFF
--- a/apps/consultation-portal/hooks/useUser.ts
+++ b/apps/consultation-portal/hooks/useUser.ts
@@ -6,14 +6,26 @@ export const useUser = () => {
   const [user, setUser] = useState<User>()
   const [session, loading] = useSession()
 
+  const timeNow = Math.floor(Date.now() / 1000)
+  const expiryStr = new Date(session?.expires?.replace(/['"]+/g, '')).getTime()
+  const expiry = Math.floor(expiryStr / 1000)
+
+  const hasNotExpired = timeNow < expiry
+
   const [isAuthenticated, setIsAuthenticated] = useState<boolean>(
-    Boolean(session?.user),
+    Boolean(hasNotExpired),
   )
 
   useEffect(() => {
-    if (!user && session?.user) {
-      setUser(session?.user)
-      setIsAuthenticated(Boolean(session?.user))
+    if (!hasNotExpired) {
+      setUser(undefined)
+      setIsAuthenticated(false)
+      sessionStorage.clear()
+    } else {
+      if (!user && session?.user) {
+        setUser(session?.user)
+        setIsAuthenticated(true)
+      }
     }
   }, [setUser, session, user])
 

--- a/apps/consultation-portal/screens/Case/components/AdviceCard/AdviceCard.css.ts
+++ b/apps/consultation-portal/screens/Case/components/AdviceCard/AdviceCard.css.ts
@@ -1,5 +1,0 @@
-import { style } from '@vanilla-extract/css'
-
-export const divStyle = style({
-  whiteSpace: 'pre-wrap',
-})

--- a/apps/consultation-portal/screens/Case/components/AdviceCard/AdviceCard.tsx
+++ b/apps/consultation-portal/screens/Case/components/AdviceCard/AdviceCard.tsx
@@ -8,7 +8,6 @@ import {
 } from '@island.is/island-ui/core'
 import { CardSkeleton } from '../../../../components/'
 import { ReactNode, useEffect, useRef, useState } from 'react'
-import * as styles from './AdviceCard.css'
 import { getShortDate } from '../../../../utils/helpers/dateFunctions'
 import { REVIEW_CARD_SCROLL_HEIGHT } from '../../../../utils/consts/consts'
 import localization from '../../Case.json'
@@ -60,8 +59,19 @@ const RenderAdvice = ({ advice, loc, isOpen = false }: RenderAdviceProps) => {
     retComp.push('.')
     return retComp
   }
+
   const content = advice?.content
-  return isOpen ? <span className={styles.divStyle}>{content}</span> : content
+  const splitContent = content?.split('\n')
+  
+  return isOpen ? (
+    <Stack space={1}>
+      {splitContent?.map((text) => (
+        <Text>{text}</Text>
+      ))}
+    </Stack>
+  ) : (
+    content
+  )
 }
 
 export const AdviceCard = ({ advice }: Props) => {

--- a/apps/consultation-portal/screens/Case/components/CaseOverview/CaseOverview.tsx
+++ b/apps/consultation-portal/screens/Case/components/CaseOverview/CaseOverview.tsx
@@ -68,7 +68,7 @@ export const CaseOverview = ({ chosenCase }: CaseOverviewProps) => {
           {chosenCaseSplitted && (
             <Stack space={1}>
               {chosenCaseSplitted.map((split) => {
-                return <Text variant="default">{split}</Text>
+                return <Text>{split}</Text>
               })}
             </Stack>
           )}

--- a/apps/consultation-portal/screens/Case/components/CaseOverview/CaseOverview.tsx
+++ b/apps/consultation-portal/screens/Case/components/CaseOverview/CaseOverview.tsx
@@ -28,6 +28,9 @@ export const CaseOverview = ({ chosenCase }: CaseOverviewProps) => {
     `${chosenCase?.institutionName}`,
     `${chosenCase?.policyAreaName}`,
   ]
+
+  const chosenCaseSplitted = chosenCase?.detailedDescription?.split('\n')
+
   return (
     <Stack space={[4, 4, 4, 6, 6]}>
       <Stack space={3}>
@@ -62,9 +65,13 @@ export const CaseOverview = ({ chosenCase }: CaseOverviewProps) => {
         </Box>
         <Box>
           <Text variant="h4">{loc.detailedDescriptionTitle}</Text>
-          <Text variant="default" whiteSpace="preWrap">
-            {chosenCase.detailedDescription}
-          </Text>
+          {chosenCaseSplitted && (
+            <Stack space={1}>
+              {chosenCaseSplitted.map((split) => {
+                return <Text variant="default">{split}</Text>
+              })}
+            </Stack>
+          )}
         </Box>
       </Stack>
     </Stack>


### PR DESCRIPTION
# Kam 1770 layout in case details and login is persisting too long

https://veflausnir.atlassian.net/browse/KAM-1770

## What

- When "\n" in text, then it renders a stack with spacing of 8px between text parts
- user is now authenticated if the token has not expired

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
