### PR TITLE
fix(history-application-system): Using the last history message as the date for the pending action

### DIFF
--- a/libs/application/ui-components/src/components/ApplicationCard/utils/history.tsx
+++ b/libs/application/ui-components/src/components/ApplicationCard/utils/history.tsx
@@ -14,15 +14,20 @@ export const buildHistoryItems = (
 ): ApplicationCardHistoryItem[] | undefined => {
   if (application.status === ApplicationStatus.DRAFT) return
 
-  let history: {
-    title: string
-    date?: string
-    content?: React.ReactNode
-  }[] = []
+  let historyItems: ApplicationCardHistoryItem[] = []
+
+  const actionCardHistory = application.actionCard?.history
+  const lastHistoryItem = actionCardHistory
+    ? actionCardHistory[actionCardHistory.length - 1]
+    : undefined
+  const lastHistoryDate = lastHistoryItem?.date
 
   if (application.actionCard?.pendingAction?.title) {
-    history.push({
-      date: format(new Date(), dateFormat),
+    historyItems.push({
+      date: format(
+        lastHistoryDate ? new Date(lastHistoryDate) : new Date(),
+        dateFormat,
+      ),
       title: formatMessage(application.actionCard.pendingAction.title ?? ''),
       content: application.actionCard.pendingAction.content ? (
         <AlertMessage
@@ -50,14 +55,14 @@ export const buildHistoryItems = (
     })
   }
 
-  if (application.actionCard?.history) {
-    history = history.concat(
-      application.actionCard?.history.map((x) => ({
+  if (actionCardHistory) {
+    historyItems = historyItems.concat(
+      actionCardHistory.map((x) => ({
         date: format(new Date(x.date), dateFormat),
         title: formatMessage(x.log),
       })),
     )
   }
 
-  return history
+  return historyItems
 }

--- a/libs/portals/admin/application-system/src/components/ApplicationDetails/ApplicationDetails.tsx
+++ b/libs/portals/admin/application-system/src/components/ApplicationDetails/ApplicationDetails.tsx
@@ -28,6 +28,12 @@ interface ValueLineProps {
   title?: string
 }
 
+export type ApplicationCardHistoryItem = {
+  date?: string
+  title: string
+  content?: React.ReactNode
+}
+
 const ValueLine = ({ title, children }: PropsWithChildren<ValueLineProps>) => {
   return (
     <>
@@ -51,15 +57,20 @@ const buildHistoryItems = (
   const displayStatus = application.actionCard?.pendingAction
     ?.displayStatus as AlertMessageType
 
-  let history: {
-    title: string
-    date?: string
-    content?: ReactNode
-  }[] = []
+  let historyItems: ApplicationCardHistoryItem[] = []
+
+  const actionCardHistory = application.actionCard?.history
+  const lastHistoryItem = actionCardHistory
+    ? actionCardHistory[actionCardHistory.length - 1]
+    : undefined
+  const lastHistoryDate = lastHistoryItem?.date
 
   if (application.actionCard?.pendingAction?.title) {
-    history.push({
-      date: format(new Date(), 'dd.MM.yyyy'),
+    historyItems.push({
+      date: format(
+        lastHistoryDate ? new Date(lastHistoryDate) : new Date(),
+        'dd.MM.yyyy',
+      ),
       title: formatMessage(application.actionCard.pendingAction.title ?? ''),
       content: application.actionCard.pendingAction.content ? (
         <AlertMessage
@@ -73,7 +84,7 @@ const buildHistoryItems = (
   }
 
   if (application.actionCard?.history) {
-    history = history.concat(
+    historyItems = historyItems.concat(
       application.actionCard?.history.map((x) => ({
         date: format(new Date(x.date), 'dd.MM.yyyy'),
         title: x.log ? formatMessage(x.log) : '',
@@ -81,7 +92,7 @@ const buildHistoryItems = (
     )
   }
 
-  return history
+  return historyItems
 }
 
 interface Props {


### PR DESCRIPTION
# Using the last history message as the date for the pending action

Attach a link to issue if relevant

## What

Stop using the date today as the date value for pending action. It should be the last history message date.

## Why

Users would probably get confused by the always changing date, thinking that the application is getting updated daily.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
