### PR TITLE
chore(system-tests): Show which project failed

### DIFF
--- a/apps/system-e2e/entrypoint.sh
+++ b/apps/system-e2e/entrypoint.sh
@@ -6,13 +6,14 @@ set -euo pipefail
 : "${TEST_TYPE:=smoke}"
 : "${TEST_PROJECT:=everything}"
 : "${TEST_RESULTS_S3:=}"
+: "${TEST_FILTER:=$*}"
 
 if [[ "$*" =~ --project ]]; then
   TEST_PROJECT="$(echo "$*" | grep -oP -- '--project[= ](\S+)')"
   TEST_PROJECT="${TEST_PROJECT##--project?}"
 fi
 
-export TEST_PROJECT TEST_ENVIRONMENT TEST_TYPE TEST_RESULTS_S3
+export TEST_PROJECT TEST_ENVIRONMENT TEST_TYPE TEST_RESULTS_S3 TEST_FILTER
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 

--- a/apps/system-e2e/src/notifications/notify.ts
+++ b/apps/system-e2e/src/notifications/notify.ts
@@ -3,15 +3,19 @@ import SlackNotify from 'slack-notify'
   const webhookUrl = process.env.SLACK_WEBHOOK
   if (webhookUrl) {
     const slack = SlackNotify(webhookUrl)
+    const user = process.env.TRIGGER_USER
+    const filter = process.env.TEST_FILTER ?? ''
+    const project = process.env.TEST_PROJECT
+    const likelyProject = filter.split('/')[0]
     slack
       .send({
         channel: '#acceptance-tests-status',
         icon_emoji: ':boom:',
-        text: `System tests in ${
-          process.env.TEST_PROJECT ?? 'islandis'
-        } have failed (triggered by ${
-          process.env.TRIGGER_USER
-        }).\nCheck https://www.tesults.com/digital-iceland/monorepo`,
+        text: [
+          `System tests have failed in ${likelyProject} (triggered by ${user}).`,
+          `  Project=${project}, filter=${filter}`,
+          `Check https://www.tesults.com/digital-iceland/monorepo`,
+        ].join('\n'),
       })
       .then((_: unknown) => console.log('done'))
       .catch((e: unknown) => console.error(e))


### PR DESCRIPTION
In #12328 I tried setting the project which failed in the Slack message. I incorrectly assumed that `TEST_PROJECT` was the project which failed, but didn't check what the actual value was. Trying again with this PR, basing on the reality.

From CI logs:
```
Current test environment: dev
Playwright args: judicial-system/smoke
Playwright project: everything
```

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
