### PR TITLE
fix(search-indexer): Prune entry hyperlink node fields that are not primitive

### DIFF
--- a/libs/cms/src/lib/search/importers/utils.ts
+++ b/libs/cms/src/lib/search/importers/utils.ts
@@ -119,23 +119,32 @@ export const pruneEntryHyperlink = (node: any) => {
   const target = node?.data?.target
   const contentTypeId: CONTENT_TYPE = target?.sys?.contentType?.sys?.id
 
-  // Keep specific fields since we'll need them when creating the urls
+  // Keep specific non primitive fields since we'll need them when creating the urls
   if (contentTypeId === 'subArticle' && target.fields?.parent?.fields) {
-    const parentArticle = {
-      ...target.fields.parent,
-      fields: extractPrimitiveFields(target.fields.parent.fields),
+    node.data.target = {
+      ...target,
+      fields: {
+        ...extractPrimitiveFields(target.fields),
+        parent: {
+          ...target.fields.parent,
+          fields: extractPrimitiveFields(target.fields.parent.fields),
+        },
+      },
     }
-    target.fields.parent = parentArticle
   } else if (
     contentTypeId === 'organizationSubpage' &&
     target.fields?.organizationPage?.fields
   ) {
-    const organizationPage = {
-      ...target.fields.organizationPage,
-      fields: extractPrimitiveFields(target.fields.organizationPage.fields),
+    node.data.target = {
+      ...target,
+      fields: {
+        ...extractPrimitiveFields(target.fields),
+        organizationPage: {
+          ...target.fields.organizationPage,
+          fields: extractPrimitiveFields(target.fields.organizationPage.fields),
+        },
+      },
     }
-
-    target.fields.organizationPage = organizationPage
   }
   // In case there is no need to preserve non primitive fields we just remove them to prevent potential circularity
   else if (target?.fields) {


### PR DESCRIPTION
# Prune entry hyperlink node fields that are not primitive

## What

* Continuation for PR -> https://github.com/island-is/island.is/pull/12363
* If there was more than one way to make a circular loop in an entry-hyperlink node the code wouldn't index pages that had that state
* Add edge case test and fix for when there's more than one way to "close the circle"

### Visually the edge case looks like this
PR 12363 basically just removed the line on the left
<img width="1113" alt="image" src="https://github.com/island-is/island.is/assets/43557895/24f99646-1686-44b3-8f2a-299952fa5041">


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
