### PR TITLE
fix(service-portal): Hide shown document list mobile

### DIFF
--- a/libs/service-portal/documents/src/screens/Overview/Overview.tsx
+++ b/libs/service-portal/documents/src/screens/Overview/Overview.tsx
@@ -384,7 +384,10 @@ export const ServicePortalDocuments = () => {
         </GridRow>
       )}
       <GridRow>
-        <GridColumn span={['12/12', '12/12', '12/12', '5/12']}>
+        <GridColumn
+          hiddenBelow={activeDocument?.document ? 'lg' : undefined}
+          span={['12/12', '12/12', '12/12', '5/12']}
+        >
           <Box marginBottom={2} printHidden marginY={3}>
             <Box
               className={styles.btn}


### PR DESCRIPTION
## What

Hide docline list when active doc mobile

## Why

It should not be shown when a document is active.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
