### PR TITLE
fix(system-e2e): Fix session creation

### DIFF
--- a/apps/system-e2e/src/addons.ts
+++ b/apps/system-e2e/src/addons.ts
@@ -31,7 +31,7 @@ expect.extend({
     const applicationRegExp = new RegExp(
       `^${protocol}${host}/umsoknir/${applicationType}${applicationId}$`,
     )
-    const pass = !!applicationRegExp.test(url)
+    const pass = applicationRegExp.test(url)
     const message = () =>
       `Current page is ${pass ? '' : '*not* '}an application
        Pattern ${applicationRegExp}

--- a/apps/system-e2e/src/support/login.ts
+++ b/apps/system-e2e/src/support/login.ts
@@ -34,7 +34,7 @@ export const cognitoLogin = async (
   if (home === JUDICIAL_SYSTEM_HOME_URL) {
     return
   }
-  await page.waitForURL(new RegExp(`${home}|${authUrl}/delegation`))
+  await page.waitForURL(new RegExp(`${home}|${authUrl}`))
 }
 
 export async function idsLogin(
@@ -71,10 +71,10 @@ export async function idsLogin(
 
       await filteredDelegations.first().click()
     }
+    await page.waitForURL(new RegExp(`${home}`), {
+      waitUntil: 'domcontentloaded',
+    })
   }
-  await page.waitForURL(new RegExp(`${home}`), {
-    waitUntil: 'domcontentloaded',
-  })
 }
 
 export const switchUser = async (

--- a/apps/system-e2e/src/tests/islandis/admin-portal/smoke/access-control.spec.ts
+++ b/apps/system-e2e/src/tests/islandis/admin-portal/smoke/access-control.spec.ts
@@ -1,5 +1,5 @@
 import { BrowserContext, expect, test } from '@playwright/test'
-import { urls, env } from '../../../../support/urls'
+import { urls } from '../../../../support/urls'
 import { session } from '../../../../support/session'
 
 const homeUrl = `${urls.islandisBaseUrl}/stjornbord/`
@@ -7,8 +7,6 @@ test.use({ baseURL: urls.islandisBaseUrl })
 
 test.describe('Admin portal access control', () => {
   let contextGranter: BrowserContext
-  const testCompanyName =
-    env === 'staging' ? 'Prófunarfélag GG og HEB' : 'ARTIC ehf.'
 
   test.beforeAll(async ({ browser }) => {
     contextGranter = await session({
@@ -16,7 +14,6 @@ test.describe('Admin portal access control', () => {
       storageState: 'service-portal-faereyjar.json',
       homeUrl,
       phoneNumber: '0102399',
-      delegation: testCompanyName,
     })
   })
 
@@ -114,7 +111,6 @@ test.describe('Admin portal access control', () => {
         browser,
         homeUrl,
         phoneNumber: '0103019',
-        delegation: testCompanyName,
       })
       const receiverPage = await contextReceiver.newPage()
       await receiverPage.goto(homeUrl)

--- a/apps/system-e2e/src/tests/islandis/admin-portal/smoke/endorsements.spec.ts
+++ b/apps/system-e2e/src/tests/islandis/admin-portal/smoke/endorsements.spec.ts
@@ -1,5 +1,5 @@
 import { BrowserContext, expect, test } from '@playwright/test'
-import { env, icelandicAndNoPopupUrl, urls } from '../../../../support/urls'
+import { icelandicAndNoPopupUrl, urls } from '../../../../support/urls'
 import { session } from '../../../../support/session'
 
 const homeUrl = `${urls.islandisBaseUrl}/stjornbord`
@@ -7,8 +7,6 @@ test.use({ baseURL: urls.islandisBaseUrl })
 
 test.describe('Admin portal (Endorsements)', () => {
   let contextGranter: BrowserContext
-  const testCompanyName =
-    env === 'staging' ? 'Prófunarfélag GG og HEB' : 'ARTIC ehf.'
 
   test.beforeAll(async ({ browser }) => {
     contextGranter = await session({
@@ -16,7 +14,6 @@ test.describe('Admin portal (Endorsements)', () => {
       storageState: 'service-portal-faereyjar.json',
       homeUrl,
       phoneNumber: '0102399',
-      delegation: testCompanyName,
     })
   })
 


### PR DESCRIPTION
## What

* Fix session creation which can get stuck after cognito login as it was waiting for /delegation but ended on /login.
* Remove specific delegation in access control and endorsement admin test to fallback to default behaviour of choosing first available delegation. 

## Why

To fix flaky tests.

## Screenshots / Gifs

```
TEST_ENVIRONMENT=dev yarn playwright test 'admin-portal/smoke/*' --config apps/system-e2e/src/playwright.config.ts

Running 36 tests using 4 workers

  Slow test file: [islandis] › islandis/admin-portal/smoke/endorsements.spec.ts (20s)
  Slow test file: [islandis] › islandis/admin-portal/smoke/access-control.spec.ts (19s)
  Slow test file: [everything] › islandis/admin-portal/smoke/endorsements.spec.ts (19s)
  Slow test file: [smoke] › islandis/admin-portal/smoke/endorsements.spec.ts (16s)
  Consider splitting slow test files to speed up parallel execution

  3 skipped
  33 passed (1m)
```

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
