### PR TITLE
fix(web): Add footerConfig to article query

### DIFF
--- a/apps/web/screens/queries/Article.ts
+++ b/apps/web/screens/queries/Article.ts
@@ -62,6 +62,7 @@ export const GET_ARTICLE_QUERY = gql`
         link
         hasALandingPage
         trackingDomain
+        footerConfig
         logo {
           url
           width


### PR DESCRIPTION
# Add footerConfig to article query

## What

* We noticed that the new default footer didn't have the correct color on the article page and it turns out it's because we weren't even querying for the footerConfig

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
