### PR TITLE
fix(j-s): Allow prison system user COA result access

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/file/file.controller.ts
+++ b/apps/judicial-system/backend/src/app/modules/file/file.controller.ts
@@ -30,6 +30,7 @@ import {
 import {
   assistantRule,
   judgeRule,
+  prisonSystemStaffRule,
   prosecutorRepresentativeRule,
   prosecutorRule,
   registrarRule,
@@ -125,6 +126,7 @@ export class FileController {
     judgeRule,
     registrarRule,
     assistantRule,
+    prisonSystemStaffRule,
   )
   @Get('file/:fileId/url')
   @ApiOkResponse({

--- a/apps/judicial-system/backend/src/app/modules/file/guards/viewCaseFile.guard.ts
+++ b/apps/judicial-system/backend/src/app/modules/file/guards/viewCaseFile.guard.ts
@@ -62,6 +62,6 @@ export class ViewCaseFileGuard implements CanActivate {
       return true
     }
 
-    throw new ForbiddenException(`Forbidden for test ${user.role}`)
+    throw new ForbiddenException(`Forbidden for ${user.role}`)
   }
 }

--- a/apps/judicial-system/backend/src/app/modules/file/guards/viewCaseFile.guard.ts
+++ b/apps/judicial-system/backend/src/app/modules/file/guards/viewCaseFile.guard.ts
@@ -7,9 +7,11 @@ import {
 } from '@nestjs/common'
 
 import {
+  CaseAppealState,
   CaseState,
   completedCaseStates,
   isExtendedCourtRole,
+  isPrisonSystemUser,
   isProsecutionRole,
   User,
 } from '@island.is/judicial-system/types'
@@ -52,6 +54,14 @@ export class ViewCaseFileGuard implements CanActivate {
       return true
     }
 
-    throw new ForbiddenException(`Forbidden for ${user.role}`)
+    if (
+      isPrisonSystemUser(user) &&
+      theCase.appealState &&
+      [CaseAppealState.COMPLETED].includes(theCase.appealState)
+    ) {
+      return true
+    }
+
+    throw new ForbiddenException(`Forbidden for test ${user.role}`)
   }
 }

--- a/apps/judicial-system/backend/src/app/modules/file/test/fileController/getCaseFileSignedUrlRolesRules.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/file/test/fileController/getCaseFileSignedUrlRolesRules.spec.ts
@@ -1,6 +1,7 @@
 import {
   assistantRule,
   judgeRule,
+  prisonSystemStaffRule,
   prosecutorRepresentativeRule,
   prosecutorRule,
   registrarRule,
@@ -18,12 +19,13 @@ describe('FileController - Get case file signed url rules', () => {
     )
   })
 
-  it('should give permission to five roles', () => {
-    expect(rules).toHaveLength(5)
+  it('should give permission to six roles', () => {
+    expect(rules).toHaveLength(6)
     expect(rules).toContain(prosecutorRule)
     expect(rules).toContain(prosecutorRepresentativeRule)
     expect(rules).toContain(judgeRule)
     expect(rules).toContain(registrarRule)
     expect(rules).toContain(assistantRule)
+    expect(rules).toContain(prisonSystemStaffRule)
   })
 })


### PR DESCRIPTION


## What
Allow prison system staff to open COA results

## Why

Because they should see it

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
