### PR TITLE
fix(system-e2e): Test work license path and name

### DIFF
--- a/apps/system-e2e/src/tests/islandis/service-portal/smoke/work-license.spec.ts
+++ b/apps/system-e2e/src/tests/islandis/service-portal/smoke/work-license.spec.ts
@@ -31,7 +31,7 @@ test.describe('Work licenses', () => {
 
     await test.step('Renders the page', async () => {
       // Arrange
-      await page.goto(icelandicAndNoPopupUrl('/minarsidur/leyfisbref'))
+      await page.goto(icelandicAndNoPopupUrl('/minarsidur/starfsleyfi'))
       await page.waitForLoadState('networkidle')
 
       // Act
@@ -43,8 +43,8 @@ test.describe('Work licenses', () => {
         .getByRole('button')
         .first()
 
-      // "Leyfisbréf - kennari" comes from the api - not translateable
-      const licenseName = page.getByText('Leyfisbréf - kennari').first()
+      // "Leyfisbréf - Kennari" comes from the api - not translateable
+      const licenseName = page.getByText('Kennari').first()
 
       // Assert
       await expect(headline).toBeVisible()


### PR DESCRIPTION
## What

Fix e2e test work license

## Why

Response + path changed

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
