### PR TITLE
fix(web): Add missing whitespace in form message

### DIFF
--- a/apps/web/components/Form/Form.tsx
+++ b/apps/web/components/Form/Form.tsx
@@ -367,7 +367,7 @@ export const Form = ({ form, namespace }: FormProps) => {
     if (data['name']) {
       firstLine += `Sendandi: ${data['name']}`
       if (data['email']) {
-        firstLine += `<${data['email']}`
+        firstLine += ` <${data['email']}>`
       }
       firstLine += '\n\n'
     } else if (data['email']) {


### PR DESCRIPTION
# Add missing whitespace in form message

## What

* I recently changed the form component a bit but forgot to add a space between the sender's name and his email
