### PR TITLE
chore(service-portal): Use pagination instead of displaying all documents inbox

### DIFF
--- a/libs/service-portal/documents/src/components/DocumentRenderer/PdfDocument.tsx
+++ b/libs/service-portal/documents/src/components/DocumentRenderer/PdfDocument.tsx
@@ -57,7 +57,6 @@ export const PdfDocument: React.FC<PdfDocumentProps> = ({ document }) => {
       >
         <PdfViewer
           file={`data:application/pdf;base64,${document.document.content}`}
-          showAllPages
           scale={scalePDF}
           autoWidth={false}
         />


### PR DESCRIPTION
## What

Use pagination instead of displaying all documents at once

## Why

Instead of displaying all pages at once.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
