### PR TITLE
fix(consultation-portal): Boð um þátttöku has empty string

### DIFF
--- a/apps/consultation-portal/screens/Case/utils/getStakeholdersList.ts
+++ b/apps/consultation-portal/screens/Case/utils/getStakeholdersList.ts
@@ -10,7 +10,10 @@ const getStakeholdersList = ({ stakeholders, extraStakeholderList }: Props) => {
     return { name: stakeholder.name }
   })
 
-  const mappedExtraStakeholderList = extraStakeholderList
+  const cleanExtraStakeholderList =
+    extraStakeholderList !== '' ? extraStakeholderList : undefined
+
+  const mappedExtraStakeholderList = cleanExtraStakeholderList
     ?.split('\n')
     .map((stakeholder) => {
       return { name: stakeholder }


### PR DESCRIPTION
# Boð um þátttöku has empty string

https://veflausnir.atlassian.net/browse/KAM-1796

## What

- If extraStakeholderList is an empty string, it should not render the empty string in the stakeholder list

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
