### PR TITLE
fix(services-sessions): Fix serve buildTarget to fix yarn start for the service.

### DIFF
--- a/apps/services/sessions/project.json
+++ b/apps/services/sessions/project.json
@@ -47,7 +47,7 @@
     "serve": {
       "executor": "@nx/js:node",
       "options": {
-        "buildTarget": "services-sessions:esbuild"
+        "buildTarget": "services-sessions:build"
       }
     },
     "lint": {


### PR DESCRIPTION
## What

After #12152 the build target changed as it was simplified. This broke the `yarn start` command for the service.

## Why

To fix the start command for the service.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
