### PR TITLE
fix(island-ui): Update react-pdf

### DIFF
--- a/apps/financial-aid/web-veita/src/components/PrintableFiles/PrintableFiles.tsx
+++ b/apps/financial-aid/web-veita/src/components/PrintableFiles/PrintableFiles.tsx
@@ -41,11 +41,7 @@ const PrintableFiles = ({ applicationId }: Props) => {
               )}
 
               {getFileType(file.key) === 'pdf' && (
-                <PdfViewer
-                  file={file.url}
-                  renderMode="canvas"
-                  showAllPages={true}
-                />
+                <PdfViewer file={file.url} showAllPages={true} />
               )}
             </Box>
           )

--- a/libs/application/templates/mortgage-certificate/src/fields/ConfirmationField/index.tsx
+++ b/libs/application/templates/mortgage-certificate/src/fields/ConfirmationField/index.tsx
@@ -102,7 +102,6 @@ export const ConfirmationField: FC<
 
         <PdfViewer
           file={`data:application/pdf;base64,${externalData.getMortgageCertificate.data.contentBase64}`}
-          renderMode="canvas"
         />
         {renderFooter()}
       </>

--- a/libs/application/templates/no-debt-certificate/src/fields/ConfirmationField/index.tsx
+++ b/libs/application/templates/no-debt-certificate/src/fields/ConfirmationField/index.tsx
@@ -105,10 +105,7 @@ export const ConfirmationField: FC<
             </Button>
           </a>
         </Box>
-        <PdfViewer
-          renderMode="svg"
-          file={`data:application/pdf;base64,${document}`}
-        />
+        <PdfViewer file={`data:application/pdf;base64,${document}`} />
         {renderFooter()}
       </>
     )

--- a/libs/island-ui/core/src/lib/PdfViewer/PdfViewer.tsx
+++ b/libs/island-ui/core/src/lib/PdfViewer/PdfViewer.tsx
@@ -9,7 +9,6 @@ import cn from 'classnames'
 
 export interface PdfViewerProps {
   file: string
-  renderMode?: 'svg' | 'canvas'
   showAllPages?: boolean
   scale?: number
   autoWidth?: boolean
@@ -28,7 +27,6 @@ interface IPdfLib {
 
 export const PdfViewer: FC<React.PropsWithChildren<PdfViewerProps>> = ({
   file,
-  renderMode = 'svg',
   showAllPages = false,
   scale = 1,
   autoWidth = true,
@@ -76,7 +74,6 @@ export const PdfViewer: FC<React.PropsWithChildren<PdfViewerProps>> = ({
         <pdfLib.Document
           file={file}
           onLoadSuccess={onDocumentLoadSuccess}
-          renderMode={renderMode}
           className={cn(styles.pdfViewer, { [styles.pdfSvgPage]: autoWidth })}
           loading={() => loadingView()}
         >
@@ -91,7 +88,12 @@ export const PdfViewer: FC<React.PropsWithChildren<PdfViewerProps>> = ({
               />
             ))
           ) : (
-            <pdfLib.Page pageNumber={pageNumber} scale={scale} />
+            <pdfLib.Page
+              renderTextLayer={false}
+              renderAnnotationLayer={false}
+              pageNumber={pageNumber}
+              scale={scale}
+            />
           )}
         </pdfLib.Document>
 

--- a/package.json
+++ b/package.json
@@ -245,7 +245,7 @@
     "react-keyed-flatten-children": "1.2.0",
     "react-modal": "3.15.1",
     "react-number-format": "4.9.1",
-    "react-pdf": "5.2.0",
+    "react-pdf": "7.5.0",
     "react-popper": "2.3.0",
     "react-remove-scroll": "2.5.6",
     "react-router-dom": "6.11.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22478,6 +22478,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"canvas@npm:^2.11.2":
+  version: 2.11.2
+  resolution: "canvas@npm:2.11.2"
+  dependencies:
+    "@mapbox/node-pre-gyp": ^1.0.0
+    nan: ^2.17.0
+    node-gyp: latest
+    simple-get: ^3.0.3
+  checksum: 61e554aef80022841dc836964534082ec21435928498032562089dfb7736215f039c7d99ee546b0cf10780232d9bf310950f8b4d489dc394e0fb6f6adfc97994
+  languageName: node
+  linkType: hard
+
 "capital-case@npm:^1.0.4":
   version: 1.0.4
   resolution: "capital-case@npm:1.0.4"
@@ -23218,6 +23230,13 @@ __metadata:
   version: 1.1.1
   resolution: "clsx@npm:1.1.1"
   checksum: ff052650329773b9b245177305fc4c4dc3129f7b2be84af4f58dc5defa99538c61d4207be7419405a5f8f3d92007c954f4daba5a7b74e563d5de71c28c830063
+  languageName: node
+  linkType: hard
+
+"clsx@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "clsx@npm:2.0.0"
+  checksum: a2cfb2351b254611acf92faa0daf15220f4cd648bdf96ce369d729813b85336993871a4bf6978ddea2b81b5a130478339c20d9d0b5c6fc287e5147f0c059276e
   languageName: node
   linkType: hard
 
@@ -33825,7 +33844,7 @@ __metadata:
     react-keyed-flatten-children: 1.2.0
     react-modal: 3.15.1
     react-number-format: 4.9.1
-    react-pdf: 5.2.0
+    react-pdf: 7.5.0
     react-popper: 2.3.0
     react-remove-scroll: 2.5.6
     react-router-dom: 6.11.2
@@ -37460,10 +37479,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"make-cancellable-promise@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "make-cancellable-promise@npm:1.1.0"
-  checksum: e036fa6164acb52b0e6298c4d5f4e0ba887e4c96de15ef1e316fcc8374995c29543e8a3ea48d38e1c2c767e985c8869c744774af5881700a90d21128b7535a68
+"make-cancellable-promise@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "make-cancellable-promise@npm:1.3.1"
+  checksum: f7ca52cdf6f22381600406c05a332e776bf9b71085d17e62a5f9860351de4fc696a9ed03e7bfdd36d3058c0307d33e97166bc210f5e8c842921a92986158361d
   languageName: node
   linkType: hard
 
@@ -37493,10 +37512,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"make-event-props@npm:^1.1.0":
-  version: 1.3.0
-  resolution: "make-event-props@npm:1.3.0"
-  checksum: 92b8845f63a25fc7da80ed2a5cc5055fba30066b83ad88e4f8c090cd99ae53a13297156df0bd0487d340507994362deaed5580266f73dfe142dc46163b5b8a6a
+"make-event-props@npm:^1.6.0":
+  version: 1.6.1
+  resolution: "make-event-props@npm:1.6.1"
+  checksum: 0457abdaf0c5edea1a284ec58ca5afed0e3de96efd3754dca02fbe767b6d17607eb28862802bc769656e06bb6374cd0b568e960d23996798dc872d09de537f71
   languageName: node
   linkType: hard
 
@@ -38140,13 +38159,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"merge-class-names@npm:^1.1.1":
-  version: 1.4.2
-  resolution: "merge-class-names@npm:1.4.2"
-  checksum: 569c333ab0d7fa1e06ae6e637d58e0d4623d7b165ea78d085c1bbd042568d8793bb7ce54ec55580679416046b11fc6eaf4956d68d19964cb320edc034e182c1d
-  languageName: node
-  linkType: hard
-
 "merge-descriptors@npm:1.0.1":
   version: 1.0.1
   resolution: "merge-descriptors@npm:1.0.1"
@@ -38154,10 +38166,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"merge-refs@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "merge-refs@npm:1.0.0"
-  checksum: 3b4ea1a178c52349a0e725281aa34b130fb6819d22f8e616ae30da6f4da223d9c3a53f6e1a427c5ba56bf6b162c98de95a53f76e01a343e10162823fee33f64a
+"merge-refs@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "merge-refs@npm:1.2.1"
+  dependencies:
+    "@types/react": "*"
+  checksum: 22b1177105b112f34753eb6b899a9c1f7ad06f47c06b16173d16ba3f183f37c557a2f837fea69d3997e0f8c0643d942f3068138993790c800601bae62acde070
   languageName: node
   linkType: hard
 
@@ -39792,6 +39806,15 @@ __metadata:
   dependencies:
     node-gyp: latest
   checksum: 33e1bb4dfca447fe37d4bb5889be55de154828632c8d38646db67293a21afd61ed9909cdf1b886214a64707d935926c4e60e2b09de9edfc2ad58de31d6ce8f39
+  languageName: node
+  linkType: hard
+
+"nan@npm:^2.17.0":
+  version: 2.18.0
+  resolution: "nan@npm:2.18.0"
+  dependencies:
+    node-gyp: latest
+  checksum: 4fe42f58456504eab3105c04a5cffb72066b5f22bd45decf33523cb17e7d6abc33cca2a19829407b9000539c5cb25f410312d4dc5b30220167a3594896ea6a0a
   languageName: node
   linkType: hard
 
@@ -42159,6 +42182,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path2d-polyfill@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "path2d-polyfill@npm:2.0.1"
+  checksum: e38a4f920be3550e8334b899cc56f4fca0a976ca69404ee10d656a45d422996b7e27e294e2cf0aac2e410ce59d6977cde9f95586e62a24e6c904716695e059f8
+  languageName: node
+  linkType: hard
+
 "path@npm:^0.12.7":
   version: 0.12.7
   resolution: "path@npm:0.12.7"
@@ -42208,10 +42238,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pdfjs-dist@npm:2.5.207":
-  version: 2.5.207
-  resolution: "pdfjs-dist@npm:2.5.207"
-  checksum: 253c7f44e7412d96b373162928b4ab820a4c1589e684c8cb8beb6306ffd62416402006edbe4a817789cb3f2f25ac21f217478aa335bb18bf66ca94d8fe65186e
+"pdfjs-dist@npm:3.11.174":
+  version: 3.11.174
+  resolution: "pdfjs-dist@npm:3.11.174"
+  dependencies:
+    canvas: ^2.11.2
+    path2d-polyfill: ^2.0.1
+  dependenciesMeta:
+    canvas:
+      optional: true
+    path2d-polyfill:
+      optional: true
+  checksum: 62f5a64ca0b2dbc855701ebf9a65c3e48c3c9aa5d64c50eb42bb9ff50a326f3eddab7f2a134ef0398398b1ccff9d842935b9f31358c9103bdc71406632d1a7fa
   languageName: node
   linkType: hard
 
@@ -45165,22 +45203,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-pdf@npm:5.2.0":
-  version: 5.2.0
-  resolution: "react-pdf@npm:5.2.0"
+"react-pdf@npm:7.5.0":
+  version: 7.5.0
+  resolution: "react-pdf@npm:7.5.0"
   dependencies:
-    "@babel/runtime": ^7.0.0
-    make-cancellable-promise: ^1.0.0
-    make-event-props: ^1.1.0
-    merge-class-names: ^1.1.1
-    merge-refs: ^1.0.0
-    pdfjs-dist: 2.5.207
+    clsx: ^2.0.0
+    make-cancellable-promise: ^1.3.1
+    make-event-props: ^1.6.0
+    merge-refs: ^1.2.1
+    pdfjs-dist: 3.11.174
     prop-types: ^15.6.2
-    worker-loader: ^3.0.0
+    tiny-invariant: ^1.0.0
+    tiny-warning: ^1.0.0
   peerDependencies:
-    react: ^16.3.0 || ^17.0.0-0
-    react-dom: ^16.3.0 || ^17.0.0-0
-  checksum: 14002f405e671af094fa4255e9e12c8b6c1c8b0884e18e83a2818e274aae261e078ebf3c9be8239f546968e5aaf8b6c4b117a822555eae975115b69fdf0930cf
+    "@types/react": ^16.8.0 || ^17.0.0 || ^18.0.0
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 53d6ebe47f4562409c47ff99bc133b83abe6d12d0c63266e4f1b9e7bf630cdca7da5b0a7545f40ec0dd207d0d3944b94ef5d7863bffd9cb8a4162e734367ff42
   languageName: node
   linkType: hard
 
@@ -47977,6 +48019,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"simple-concat@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "simple-concat@npm:1.0.1"
+  checksum: 4d211042cc3d73a718c21ac6c4e7d7a0363e184be6a5ad25c8a1502e49df6d0a0253979e3d50dbdd3f60ef6c6c58d756b5d66ac1e05cda9cacd2e9fc59e3876a
+  languageName: node
+  linkType: hard
+
+"simple-get@npm:^3.0.3":
+  version: 3.1.1
+  resolution: "simple-get@npm:3.1.1"
+  dependencies:
+    decompress-response: ^4.2.0
+    once: ^1.3.1
+    simple-concat: ^1.0.0
+  checksum: 80195e70bf171486e75c31e28e5485468195cc42f85940f8b45c4a68472160144d223eb4d07bc82ef80cb974b7c401db021a540deb2d34ac4b3b8883da2d6401
+  languageName: node
+  linkType: hard
+
 "simple-plist@npm:^1.1.0":
   version: 1.4.0
   resolution: "simple-plist@npm:1.4.0"
@@ -50387,14 +50447,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tiny-invariant@npm:^1.3.1":
+"tiny-invariant@npm:^1.0.0, tiny-invariant@npm:^1.3.1":
   version: 1.3.1
   resolution: "tiny-invariant@npm:1.3.1"
   checksum: 872dbd1ff20a21303a2fd20ce3a15602cfa7fcf9b228bd694a52e2938224313b5385a1078cb667ed7375d1612194feaca81c4ecbe93121ca1baebe344de4f84c
   languageName: node
   linkType: hard
 
-"tiny-warning@npm:^1.0.2, tiny-warning@npm:^1.0.3":
+"tiny-warning@npm:^1.0.0, tiny-warning@npm:^1.0.2, tiny-warning@npm:^1.0.3":
   version: 1.0.3
   resolution: "tiny-warning@npm:1.0.3"
   checksum: da62c4acac565902f0624b123eed6dd3509bc9a8d30c06e017104bedcf5d35810da8ff72864400ad19c5c7806fc0a8323c68baf3e326af7cb7d969f846100d71
@@ -53269,18 +53329,6 @@ __metadata:
     reduce-flatten: ^1.0.1
     typical: ^2.6.1
   checksum: 953322ec8dd8b634a1a07a611760b0473e258073fd3bcab473082c6f0f30cdc48e641310209973d8557b9893bc291e32587f6dce05ea675242e21f8b0b0877bc
-  languageName: node
-  linkType: hard
-
-"worker-loader@npm:^3.0.0":
-  version: 3.0.8
-  resolution: "worker-loader@npm:3.0.8"
-  dependencies:
-    loader-utils: ^2.0.0
-    schema-utils: ^3.0.0
-  peerDependencies:
-    webpack: ^4.0.0 || ^5.0.0
-  checksum: 84f4a7eeb2a1d8b9704425837e017c91eedfae67ac89e0b866a2dcf283323c1dcabe0258196278b7d5fd0041392da895c8a0c59ddf3a94f1b2e003df68ddfec3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

Now that we display all pdfs in the inbox on minar sidur, we get all kinds of pdf documents from all sorts of different providers. When testing the new inbox we noticed some issues regarding different PDF files where some PDF's would be buggy while rendered. With the new version of this package and rendering always as `canvas` we have not ran into any noticeable issues. 

* Update [react-pdf](https://github.com/wojtekmaj/react-pdf) package.
* Remove display as svg for PDF files.

## Why

* Update react-pdf for better support.
* Remove svg display: SVG render mode is no longer maintained and may be [removed in the future](https://github.com/wojtekmaj/react-pdf/blob/main/packages/react-pdf/README.md#props).
The maintainer of the package cited [less support for different browsers](https://github.com/wojtekmaj/react-pdf/discussions/1222) when displaying pdf's as SVG.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] ~I have made corresponding changes to the documentation~
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
