### PR TITLE
fix(web): Use useEffect for layout calculation in default footer component

### DIFF
--- a/apps/web/components/Footer/Footer.tsx
+++ b/apps/web/components/Footer/Footer.tsx
@@ -1,5 +1,7 @@
+import { useEffect, useState } from 'react'
 import { BLOCKS } from '@contentful/rich-text-types'
-import { theme } from '@island.is/island-ui/theme'
+
+import type { SliceType } from '@island.is/island-ui/contentful'
 import {
   Box,
   GridColumn,
@@ -9,7 +11,7 @@ import {
   Text,
   TextProps,
 } from '@island.is/island-ui/core'
-import type { SliceType } from '@island.is/island-ui/contentful'
+import { theme } from '@island.is/island-ui/theme'
 import type { FooterItem } from '@island.is/web/graphql/schema'
 import { useWindowSize } from '@island.is/web/hooks/useViewport'
 import { webRichText } from '@island.is/web/utils/richText'
@@ -36,8 +38,11 @@ export const Footer = ({
   titleVariant = 'h3',
 }: FooterProps) => {
   const { width } = useWindowSize()
+  const [isMobileScreenWidth, setIsMobileScreenWidth] = useState(false)
 
-  const isMobileScreenWidth = width < theme.breakpoints.sm
+  useEffect(() => {
+    setIsMobileScreenWidth(width < theme.breakpoints.sm)
+  }, [width])
 
   return (
     <footer className={styles.footer} style={{ background }}>


### PR DESCRIPTION
# Use useEffect for layout calculation in default footer component

## What

* When opening up the web page on a desktop the footer flickers due to it's default layout being a single column

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
