### PR TITLE
fix(application-system): Get status fetchpolicy

### DIFF
--- a/libs/application/ui-components/src/components/PaymentPending/hooks/usePaymentStatus.ts
+++ b/libs/application/ui-components/src/components/PaymentPending/hooks/usePaymentStatus.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useState } from 'react'
 import { ApolloError, useQuery } from '@apollo/client'
 import { PAYMENT_STATUS } from '@island.is/application/graphql'
 
@@ -22,19 +22,17 @@ export const usePaymentStatus = (applicationId: string): UsePaymentStatus => {
     },
     skip: !continuePolling,
     pollInterval: 4000,
+    //Using the default fetchPolicy 'cache-first' will cache the paymentUrl that results in an error from ARK when a payment is requested for a deleted charge.
+    fetchPolicy: 'network-only',
   })
 
-  const paymentStatus: ApplicationPayment = useMemo(() => {
-    return (
-      data?.applicationPaymentStatus ?? {
-        fulfilled: false,
-      }
-    )
-  }, [data])
-  const stopPolling = useCallback(() => setContinuePolling(false), [])
+  const paymentStatus: ApplicationPayment = data?.applicationPaymentStatus ?? {
+    fulfilled: false,
+  }
+
   return {
     pollingError: error,
-    stopPolling,
+    stopPolling: () => setContinuePolling(false),
     paymentStatus,
   }
 }

--- a/libs/application/ui-components/src/components/PaymentPending/hooks/usePaymentStatus.ts
+++ b/libs/application/ui-components/src/components/PaymentPending/hooks/usePaymentStatus.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { ApolloError, useQuery } from '@apollo/client'
 import { PAYMENT_STATUS } from '@island.is/application/graphql'
 
@@ -26,13 +26,17 @@ export const usePaymentStatus = (applicationId: string): UsePaymentStatus => {
     fetchPolicy: 'network-only',
   })
 
-  const paymentStatus: ApplicationPayment = data?.applicationPaymentStatus ?? {
-    fulfilled: false,
-  }
-
+  const paymentStatus: ApplicationPayment = useMemo(() => {
+    return (
+      data?.applicationPaymentStatus ?? {
+        fulfilled: false,
+      }
+    )
+  }, [data])
+  const stopPolling = useCallback(() => setContinuePolling(false), [])
   return {
     pollingError: error,
-    stopPolling: () => setContinuePolling(false),
+    stopPolling,
     paymentStatus,
   }
 }


### PR DESCRIPTION

## What

Changed the fetch policy for `getstatus` to `network-only`

## Why

Using the default fetchPolicy `cache-first` will cache the paymentUrl that results in an error from ARK when a payment is requested for a deleted charge.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
