### PR TITLE
fix(web): remove svg path styles

### DIFF
--- a/libs/island-ui/core/src/lib/Text/Text.css.ts
+++ b/libs/island-ui/core/src/lib/Text/Text.css.ts
@@ -213,4 +213,3 @@ globalStyle(`${base} mark`, {
   color: theme.color.dark400,
   fontWeight: theme.typography.regular,
 })
-

--- a/libs/island-ui/core/src/lib/Text/Text.css.ts
+++ b/libs/island-ui/core/src/lib/Text/Text.css.ts
@@ -214,11 +214,3 @@ globalStyle(`${base} mark`, {
   fontWeight: theme.typography.regular,
 })
 
-globalStyle(`${base} a svg path`, {
-  transition: 'fill .2s, box-shadow .2s',
-  fill: theme.color.blue400,
-})
-
-globalStyle(`${base} a:hover svg path`, {
-  fill: theme.color.blueberry400,
-})


### PR DESCRIPTION
## What

There are global styles in the core Text component that force an SVG's path to a specific color when rendered inside an anchor tag in specific contexts.

## Why

The SVG path should instead only inherit `currentColor` and be controlled by the DOM parent tree. This affects SVGs that may not intend on having a path rendered (for example, the Arrow icons).

## Screenshots / Gifs

<img width="252" alt="Screenshot 2023-10-25 at 09 11 44" src="https://github.com/island-is/island.is/assets/2931939/e8e61520-f0d3-4859-9913-b058d65bfe20">


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
