### PR TITLE
fix(service-portal): Adding property to response

### DIFF
--- a/libs/api/domains/rights-portal/src/lib/healthCenter/healthCenter.service.ts
+++ b/libs/api/domains/rights-portal/src/lib/healthCenter/healthCenter.service.ts
@@ -99,6 +99,7 @@ export class HealthCenterService {
       : []
 
     return {
+      canRegister: healthCenterRes.canRegister ?? false,
       current: {
         ...res[0],
         healthCenterName: healthCenterRes.healthCenter ?? undefined,


### PR DESCRIPTION
## What

Adding can register property to the response

## Why

So that users can change their health center registration
 
## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
