### PR TITLE
fix(application): Driving License Client needs to listen to legacy params

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/shared/api/driving-license/driving-license.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/shared/api/driving-license/driving-license.service.ts
@@ -134,9 +134,19 @@ export class DrivingLicenseProviderService extends BaseTemplateApiService {
       }
     }
 
-    const drivingLicense = await this.drivingLicenseService.getCurrentLicense({
-      token: auth.authorization,
-    })
+    let drivingLicense
+    if (params?.useLegacyVersion) {
+      drivingLicense = await this.drivingLicenseService.legacyGetCurrentLicense(
+        {
+          nationalId: auth.nationalId,
+          token: auth.authorization,
+        },
+      )
+    } else {
+      drivingLicense = await this.drivingLicenseService.getCurrentLicense({
+        token: auth.authorization,
+      })
+    }
 
     const categoryB = (drivingLicense?.categories ?? []).find(
       (cat) => cat.name === 'B' || cat.nr === 'B',


### PR DESCRIPTION
Mistakenly removed legacy params when refactoring.
The function, albeit called legacy, only consists of v4/v5 endpoints. There are some special cases being handled in there and need to be addressed at a later refactor. Hence we re-introduce the legacy pathway here.

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
