### PR TITLE
fix(j-s): Only add prison system staff in Prison institutions to event log

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/case/interceptors/case.interceptor.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/interceptors/case.interceptor.ts
@@ -11,6 +11,7 @@ import {
 import {
   CaseAppealState,
   EventType,
+  InstitutionType,
   User,
   UserRole,
 } from '@island.is/judicial-system/types'
@@ -30,11 +31,9 @@ export class CaseInterceptor implements NestInterceptor {
       map((data: Case) => {
         if (
           data.appealState === CaseAppealState.COMPLETED &&
-          [
-            UserRole.PROSECUTOR,
-            UserRole.DEFENDER,
-            UserRole.PRISON_SYSTEM_STAFF,
-          ].includes(user.role)
+          ([UserRole.PROSECUTOR, UserRole.DEFENDER].includes(user.role) ||
+            (user.role === UserRole.PRISON_SYSTEM_STAFF &&
+              user.institution?.type === InstitutionType.PRISON))
         ) {
           this.eventLogService.create({
             eventType: EventType.APPEAL_RESULT_ACCESSED,


### PR DESCRIPTION
[Sía FMST starfsmenn út úr virkni sem merkir hvort fangelsi hafi opnað úrskurð Landsréttar](https://app.asana.com/0/1199153462262248/1205805678997183)

## What
Only log "prison system staff" roles that are in institution type "prison"

## Why

Because other prison staff having opened the appeal result isn't relevant to our use case

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
