### PR TITLE
feat(license-client): make the license client more generic

### DIFF
--- a/libs/api/domains/license-service/src/lib/licenseService.service.ts
+++ b/libs/api/domains/license-service/src/lib/licenseService.service.ts
@@ -96,7 +96,7 @@ export class LicenseServiceService {
       throw new InternalServerErrorException('License service failed')
     }
 
-    const licenseRes = await licenseClient.getLicenseDetail(user)
+    const licenseRes = await licenseClient.getLicense(user)
 
     if (!licenseRes.ok) {
       fetchStatus = GenericUserLicenseFetchStatus.Error
@@ -117,12 +117,7 @@ export class LicenseServiceService {
   async getAllLicenses(
     user: User,
     locale: Locale,
-    {
-      includedTypes,
-      excludedTypes,
-      force,
-      onlyList,
-    }: GetGenericLicenseOptions = {},
+    { includedTypes, excludedTypes, onlyList }: GetGenericLicenseOptions = {},
   ): Promise<GenericUserLicense[]> {
     const licenses: GenericUserLicense[] = []
 
@@ -192,9 +187,12 @@ export class LicenseServiceService {
       )
 
       if (licensePayload) {
-        licenseUserData.pkpassStatus = licenseService.licenseIsValidForPkPass(
-          licenseRes.data,
-        ) as unknown as GenericUserLicensePkPassStatus
+        licenseUserData.pkpassStatus = licenseService.clientSupportsPkPass
+          ? (licenseService.licenseIsValidForPkPass?.(
+              licenseRes.data,
+            ) as unknown as GenericUserLicensePkPassStatus) ??
+            GenericUserLicensePkPassStatus.Unknown
+          : GenericUserLicensePkPassStatus.NotAvailable
         licenseUserData.status = GenericUserLicenseStatus.HasLicense
       } else {
         licenseUserData.status = GenericUserLicenseStatus.NotAvailable
@@ -234,6 +232,25 @@ export class LicenseServiceService {
         `Invalid license type. type: ${licenseType}`,
       )
     }
+    if (!client.clientSupportsPkPass) {
+      this.logger.warn('client does not support pkpass', {
+        category: LOG_CATEGORY,
+        type: licenseType,
+      })
+      throw new BadRequestException(
+        `License client does not support pkpass, type: ${licenseType}`,
+      )
+    }
+
+    if (!client.getPkPassUrl) {
+      this.logger.error('License client has no getPkPassUrl implementation', {
+        category: LOG_CATEGORY,
+        type: licenseType,
+      })
+      throw new BadRequestException(
+        `License client has no getPkPassUrl implementation, type: ${licenseType}`,
+      )
+    }
 
     const pkPassRes = await client.getPkPassUrl(user)
 
@@ -259,6 +276,29 @@ export class LicenseServiceService {
       })
       throw new InternalServerErrorException(
         `Invalid license type. type: ${licenseType}`,
+      )
+    }
+
+    if (!client.clientSupportsPkPass) {
+      this.logger.warn('client does not support pkpass', {
+        category: LOG_CATEGORY,
+        type: licenseType,
+      })
+      throw new BadRequestException(
+        `License client does not support pkpass, type: ${licenseType}`,
+      )
+    }
+
+    if (!client.getPkPassQRCode) {
+      this.logger.error(
+        'License client has no getPkPassQRCode implementation',
+        {
+          category: LOG_CATEGORY,
+          type: licenseType,
+        },
+      )
+      throw new BadRequestException(
+        `License client has no getPkPassQRCode implementation, type: ${licenseType}`,
       )
     }
 
@@ -299,6 +339,26 @@ export class LicenseServiceService {
     )
     if (!licenseService) {
       throw new Error(`Invalid pass template id: ${passTemplateId}`)
+    }
+
+    if (!licenseService.clientSupportsPkPass) {
+      this.logger.warn('client does not support pkpass', {
+        category: LOG_CATEGORY,
+        passTemplateId,
+      })
+      throw new BadRequestException(
+        `License client does not support pkpass, passTemplateId: ${passTemplateId}`,
+      )
+    }
+
+    if (!licenseService.verifyPkPass) {
+      this.logger.error('License client has no verifyPkPass implementation', {
+        category: LOG_CATEGORY,
+        passTemplateId,
+      })
+      throw new BadRequestException(
+        `License client has no verifyPkPass implementation, passTemplateId: ${passTemplateId}`,
+      )
     }
 
     const verification = await licenseService.verifyPkPass(data, passTemplateId)

--- a/libs/clients/license-client/src/lib/clients/adr-license-client/adrLicenseClient.service.ts
+++ b/libs/clients/license-client/src/lib/clients/adr-license-client/adrLicenseClient.service.ts
@@ -32,6 +32,9 @@ export class AdrLicenseClient implements LicenseClient<FlattenedAdrDto> {
     private adrApi: AdrApi,
     private smartApi: SmartSolutionsApi,
   ) {}
+
+  clientSupportsPkPass = true
+
   private checkLicenseValidityForPkPass(
     licenseInfo: AdrDto,
   ): LicensePkPassAvailability {

--- a/libs/clients/license-client/src/lib/clients/disability-license-client/services/disabilityLicenseClient.service.ts
+++ b/libs/clients/license-client/src/lib/clients/disability-license-client/services/disabilityLicenseClient.service.ts
@@ -33,6 +33,8 @@ export class DisabilityLicenseClient implements LicenseClient<OrorkuSkirteini> {
     private smartApi: SmartSolutionsApi,
   ) {}
 
+  clientSupportsPkPass = true
+
   private checkLicenseValidityForPkPass(
     licenseInfo: OrorkuSkirteini,
   ): LicensePkPassAvailability {

--- a/libs/clients/license-client/src/lib/clients/driving-license-client/services/drivingLicenseClient.service.ts
+++ b/libs/clients/license-client/src/lib/clients/driving-license-client/services/drivingLicenseClient.service.ts
@@ -32,6 +32,8 @@ export class DrivingLicenseClient implements LicenseClient<DriversLicense> {
     private smartApi: SmartSolutionsApi,
   ) {}
 
+  clientSupportsPkPass = true
+
   private checkLicenseValidity(
     license: DriversLicense,
   ): LicensePkPassAvailability {

--- a/libs/clients/license-client/src/lib/clients/firearm-license-client/services/firearmLicenseClient.service.ts
+++ b/libs/clients/license-client/src/lib/clients/firearm-license-client/services/firearmLicenseClient.service.ts
@@ -28,6 +28,8 @@ export class FirearmLicenseClient implements LicenseClient<FirearmLicenseDto> {
     private smartApi: SmartSolutionsApi,
   ) {}
 
+  clientSupportsPkPass = true
+
   private checkLicenseValidityForPkPass(
     data: FirearmLicenseDto,
   ): LicensePkPassAvailability {

--- a/libs/clients/license-client/src/lib/clients/machine-license-client/machineLicenseClient.service.ts
+++ b/libs/clients/license-client/src/lib/clients/machine-license-client/machineLicenseClient.service.ts
@@ -36,6 +36,8 @@ export class MachineLicenseClient implements LicenseClient<VinnuvelaDto> {
     private smartApi: SmartSolutionsApi,
   ) {}
 
+  clientSupportsPkPass = true
+
   private checkLicenseValidityForPkPass(
     licenseInfo: VinnuvelaDto,
   ): LicensePkPassAvailability {

--- a/libs/clients/license-client/src/lib/licenseClient.type.ts
+++ b/libs/clients/license-client/src/lib/licenseClient.type.ts
@@ -11,6 +11,7 @@ export enum LicenseType {
   MachineLicense = 'MachineLicense',
   DisabilityLicense = 'DisabilityLicense',
   DrivingLicense = 'DrivingLicense',
+  PCard = 'PCard',
 }
 
 export type LicenseTypeType = keyof typeof LicenseType
@@ -114,19 +115,17 @@ export type ServiceErrorCode =
   | 99
 
 export interface LicenseClient<ResultType> {
-  // This might be cached
+  clientSupportsPkPass: boolean
+
   getLicense: (user: User) => Promise<Result<ResultType | null>>
 
-  // This will never be cached
-  getLicenseDetail: (user: User) => Promise<Result<ResultType | null>>
+  licenseIsValidForPkPass?: (payload: unknown) => LicensePkPassAvailability
 
-  licenseIsValidForPkPass: (payload: unknown) => LicensePkPassAvailability
+  getPkPassUrl?: (user: User, locale?: Locale) => Promise<Result<string>>
 
-  getPkPassUrl: (user: User, locale?: Locale) => Promise<Result<string>>
+  getPkPassQRCode?: (user: User, locale?: Locale) => Promise<Result<string>>
 
-  getPkPassQRCode: (user: User, locale?: Locale) => Promise<Result<string>>
-
-  verifyPkPass: (
+  verifyPkPass?: (
     data: string,
     passTemplateId: string,
   ) => Promise<Result<PkPassVerification>>


### PR DESCRIPTION
## What

Have the pkpass functionality in the license client optional

## Why

Makes it more usable for non-pkpass licenses

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
