### PR TITLE
fix: add private registration number renewals to vehicle info

### DIFF
--- a/libs/service-portal/assets/src/components/Dropdown/Dropdown.tsx
+++ b/libs/service-portal/assets/src/components/Dropdown/Dropdown.tsx
@@ -5,6 +5,7 @@ import * as styles from './Dropdown.css'
 import { vehicleMessage as messages } from '../../lib/messages'
 
 interface Props {
+  label?: string
   dropdownItems?: {
     href?: string
     onClick?: () => void
@@ -17,6 +18,7 @@ interface Props {
   }[]
 }
 const Dropdown: FC<React.PropsWithChildren<Props>> = ({
+  label,
   dropdownItems = [],
 }) => {
   const { formatMessage } = useLocale()
@@ -25,9 +27,9 @@ const Dropdown: FC<React.PropsWithChildren<Props>> = ({
       <DropdownMenu
         menuClassName={styles.container}
         icon="ellipsisHorizontal"
-        menuLabel={formatMessage(messages.more)}
+        menuLabel={label ?? formatMessage(messages.more)}
         items={dropdownItems}
-        title={formatMessage(messages.more)}
+        title={label ?? formatMessage(messages.more)}
       />
     </Box>
   )

--- a/libs/service-portal/assets/src/lib/messages.ts
+++ b/libs/service-portal/assets/src/lib/messages.ts
@@ -753,6 +753,10 @@ export const vehicleMessage = defineMessages({
     id: 'sp.vehicles:more',
     defaultMessage: 'Meira',
   },
+  actions: {
+    id: 'sp.vehicles:actions',
+    defaultMessage: 'Aðgerðir',
+  },
   orderRegistrationNumber: {
     id: 'sp.vehicles:order-registration-number',
     defaultMessage: 'Panta skráningarmerki',
@@ -814,7 +818,7 @@ export const urls = defineMessages({
   },
   renewPrivate: {
     id: 'sp.vehicles:url-renew-private',
-    defaultMessage: 'https://island.is/endurnyjun-a-einkamerki',
+    defaultMessage: 'https://island.is/umsoknir/endurnyja-einkanumer',
   },
   hideName: {
     id: 'sp.vehicles:url-hide-private-name',

--- a/libs/service-portal/assets/src/screens/VehicleDetail/VehicleDetail.tsx
+++ b/libs/service-portal/assets/src/screens/VehicleDetail/VehicleDetail.tsx
@@ -230,11 +230,9 @@ const VehicleDetail = () => {
   const technicalArr =
     technicalInfo && technicalInfoArray(technicalInfo, formatMessage)
 
+  const hasPrivateRegistration = basicInfo?.permno !== basicInfo?.regno
+
   const dropdownArray = [
-    {
-      title: formatMessage(messages.orderRegistrationNumber),
-      href: formatMessage(urls.regNumber),
-    },
     {
       title: formatMessage(messages.orderRegistrationLicense),
       href: formatMessage(urls.regCert),
@@ -248,12 +246,19 @@ const VehicleDetail = () => {
       href: formatMessage(urls.operator),
     },
   ]
-  if (basicInfo?.permno !== basicInfo?.regno) {
-    dropdownArray.push({
+
+  if (hasPrivateRegistration) {
+    dropdownArray.unshift({
       title: formatMessage(messages.renewPrivateRegistration),
-      href: formatMessage(urls.operator),
+      href: formatMessage(urls.renewPrivate),
+    })
+  } else {
+    dropdownArray.unshift({
+      title: formatMessage(messages.orderRegistrationNumber),
+      href: formatMessage(urls.regNumber),
     })
   }
+
   return (
     <>
       <Box marginBottom={[2, 2, 6]}>
@@ -298,7 +303,10 @@ const VehicleDetail = () => {
                   </Button>
                 </Box>
                 <Box paddingRight={2}>
-                  <Dropdown dropdownItems={dropdownArray} />
+                  <Dropdown
+                    label={formatMessage(messages.actions)}
+                    dropdownItems={dropdownArray}
+                  />
                 </Box>
               </Box>
             </GridColumn>
@@ -306,16 +314,29 @@ const VehicleDetail = () => {
         )}
       </Box>
       <Stack space={2}>
-        <UserInfoLine
-          label={formatMessage(messages.numberPlate)}
-          content={mainInfo?.regno ?? ''}
-          editLink={{
-            title: messages.orderRegistrationNumber,
-            url: formatMessage(urls.regNumber),
-            external: true,
-          }}
-          loading={loading}
-        />
+        {hasPrivateRegistration ? (
+          <UserInfoLine
+            label={formatMessage(messages.numberPlate)}
+            content={basicInfo?.permno ?? ''}
+            editLink={{
+              title: messages.renewPrivateRegistration,
+              url: formatMessage(urls.renewPrivate),
+              external: true,
+            }}
+            loading={loading}
+          />
+        ) : (
+          <UserInfoLine
+            label={formatMessage(messages.numberPlate)}
+            content={mainInfo?.regno ?? ''}
+            editLink={{
+              title: messages.orderRegistrationNumber,
+              url: formatMessage(urls.regNumber),
+              external: true,
+            }}
+            loading={loading}
+          />
+        )}
         <Divider />
         <UserInfoLine
           label={formatMessage(messages.trailerWithBrakes)}


### PR DESCRIPTION
## What

Add correct links to renew private license number registrations

## Why

They were missing

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
