### PR TITLE
fix(j-s): Defender Appeal Statement

### DIFF
--- a/apps/judicial-system/web/src/routes/Defender/CaseOverview.tsx
+++ b/apps/judicial-system/web/src/routes/Defender/CaseOverview.tsx
@@ -358,7 +358,9 @@ export const CaseOverview: React.FC<React.PropsWithChildren<unknown>> = () => {
               strings.confirmStatementAfterDeadlineModalSecondaryButtonText,
             )}
             onPrimaryButtonClick={() => {
-              router.push(`${constants.APPEAL_ROUTE}/${workingCase.id}`)
+              router.push(
+                `${constants.DEFENDER_STATEMENT_ROUTE}/${workingCase.id}`,
+              )
             }}
             onSecondaryButtonClick={() => {
               setModalVisible('NoModal')


### PR DESCRIPTION
# Defender Appeal Statement

[Verjandi getur ekki sent inn greinargerð eftir að greinargerðarfrestur er liðinn](https://app.asana.com/0/1199153462262248/1205833684526261/f)

## What

- When the statement deadline was expired the defender was routed to the appeal brief page rather than the appeal satement page. This has been fixed.

## Why

- Verified bug.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
