### PR TITLE
fix(application-estate): Property mapping fixes

### DIFF
--- a/libs/application/templates/announcement-of-death/src/lib/dataSchema.ts
+++ b/libs/application/templates/announcement-of-death/src/lib/dataSchema.ts
@@ -82,7 +82,7 @@ export const dataSchema = z.object({
       .object({
         assetNumber: z.string().refine(
           (v) => {
-            return /^[fF]{0,1}\d{7}$/.test(v)
+            return /^[Ff]{0,1}\d{7}$|^[Ll]{0,1}\d{6}$/.test(v)
           },
           { params: m.errorAssetNumber },
         ),

--- a/libs/clients/syslumenn/src/lib/syslumennClient.utils.ts
+++ b/libs/clients/syslumenn/src/lib/syslumennClient.utils.ts
@@ -321,7 +321,7 @@ export const assetMapper = (assetRaw: EignirDanarbus): EstateAsset => {
   return {
     description: assetRaw.lysing ?? '',
     assetNumber: assetRaw.fastanumer ?? '',
-    share: assetRaw.eignarhlutfall ?? 1,
+    share: assetRaw.eignarhlutfall / 100.0 ?? 1,
   }
 }
 
@@ -339,7 +339,7 @@ export const mapEstateRegistrant = (
             (a) =>
               a.tegundAngalgs === TegundAndlags.NUMBER_0 &&
               a?.fastanumer &&
-              /^[fF]{0,1}\d{7}$/.test(a.fastanumer),
+              /^[Ff]{0,1}\d{7}$|^[Ll]{0,1}\d{6}$/.test(a.fastanumer),
           )
           .map(assetMapper)
       : [],
@@ -392,9 +392,9 @@ export const mapEstateInfo = (syslaData: DanarbuUppl): EstateInfo => {
       ? syslaData.eignir
           .filter(
             (a) =>
+              a?.tegundAngalgs !== undefined &&
               a.tegundAngalgs === TegundAndlags.NUMBER_0 &&
-              a?.tegundAngalgs &&
-              /^[fF]{0,1}\d{7}$/.test(a.fastanumer ?? ''),
+              /^[Ff]{0,1}\d{7}$|^[Ll]{0,1}\d{6}$/.test(a.fastanumer ?? ''),
           )
           .map(assetMapper)
       : [],

--- a/libs/clients/syslumenn/src/lib/syslumennClient.utils.ts
+++ b/libs/clients/syslumenn/src/lib/syslumennClient.utils.ts
@@ -321,7 +321,7 @@ export const assetMapper = (assetRaw: EignirDanarbus): EstateAsset => {
   return {
     description: assetRaw.lysing ?? '',
     assetNumber: assetRaw.fastanumer ?? '',
-    share: assetRaw.eignarhlutfall / 100.0 ?? 1,
+    share: assetRaw.eignarhlutfall ? assetRaw.eignarhlutfall / 100.0 : 1,
   }
 }
 

--- a/libs/clients/syslumenn/src/lib/syslumennClient.utils.ts
+++ b/libs/clients/syslumenn/src/lib/syslumennClient.utils.ts
@@ -321,7 +321,10 @@ export const assetMapper = (assetRaw: EignirDanarbus): EstateAsset => {
   return {
     description: assetRaw.lysing ?? '',
     assetNumber: assetRaw.fastanumer ?? '',
-    share: assetRaw.eignarhlutfall ? assetRaw.eignarhlutfall / 100.0 : 1,
+    share:
+      assetRaw.eignarhlutfall !== undefined
+        ? assetRaw.eignarhlutfall / 100.0
+        : 1,
   }
 }
 


### PR DESCRIPTION
Aggressive regex was filtering out legitimate properties, coming in as 6 or 7 digits (missing `F` prefix).
This is causing properties present in the District Commissioner's database to be lost when transitioting to our application system.

Note, that it may look strange to test the data coming from DC but since we're injecting them into the application's answers (for convenience) we validate data the same way we would in the application frontend with our dataschema.

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
