### PR TITLE
fix(application-system): Remove default delete from payment state builder

### DIFF
--- a/libs/application/utils/src/lib/builders/paymentStateBuilder.ts
+++ b/libs/application/utils/src/lib/builders/paymentStateBuilder.ts
@@ -130,7 +130,6 @@ export function buildPaymentState<
       status: 'inprogress',
       lifecycle: {
         ...pruneAfterDays(1),
-        shouldDeleteChargeIfPaymentFulfilled: true,
         ...options.lifecycle,
       },
       actionCard: {


### PR DESCRIPTION

## What

Remove  `shouldDeleteChargeIfPaymentFulfilled: true,`  to be default
## Why

Was causing problems with a Driving licence application where the application could not advance due to an error from an on entry api but the application was still being sent. Then the  user deleted the application within the payment state and got refunded.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
