### PR TITLE
fix(service-portal): Update breadcrumbs

### DIFF
--- a/apps/service-portal/src/components/ContentBreadcrumbs/ContentBreadcrumbs.tsx
+++ b/apps/service-portal/src/components/ContentBreadcrumbs/ContentBreadcrumbs.tsx
@@ -69,11 +69,22 @@ const ContentBreadcrumbs: FC<React.PropsWithChildren<unknown>> = () => {
           )
         : null
 
+      // Use active ancestor to fill in parameter references for ancestors.
+      const activeAncestor = navItem.path
+        ? matchPath(
+            {
+              path: navItem.path,
+              end: false,
+            },
+            location.pathname,
+          )
+        : null
+
       // Push the nav item to the current array as we are currently located here in our search
       currentBreadcrumbs.push({
-        name: parseNavItemName(navItem, activePath),
+        name: parseNavItemName(navItem, activeAncestor),
         hidden: navItem.breadcrumbHide ?? false,
-        path: activePath ? location.pathname : navItem.path,
+        path: activeAncestor ? activeAncestor.pathname : navItem.path,
       })
 
       // Only update if we have found a deeper path
@@ -110,17 +121,17 @@ const ContentBreadcrumbs: FC<React.PropsWithChildren<unknown>> = () => {
       <Box className={styles.breadcrumbs} paddingTop={0} position="relative">
         <Breadcrumbs color="blue400" separatorColor="blue400">
           {items.map((item, index) =>
-            isDefined(item.path) &&
-            !item.hidden &&
-            !(isMobile && index === 0) ? (
-              <Link className={styles.link} key={index} to={item.path}>
-                {index === 0
-                  ? formatMessage(m.overview)
-                  : formatMessage(item.name)}
-              </Link>
-            ) : (
-              <GoBack noUnderline={true} display="inline" />
-            ),
+            isDefined(item.path) && !item.hidden ? (
+              isMobile && index === 0 ? (
+                <GoBack noUnderline={true} display="inline" />
+              ) : (
+                <Link className={styles.link} key={index} to={item.path}>
+                  {index === 0
+                    ? formatMessage(m.overview)
+                    : formatMessage(item.name)}
+                </Link>
+              )
+            ) : null,
           )}
         </Breadcrumbs>
       </Box>


### PR DESCRIPTION
## What

* Only display go back with arrow on mobile
* Use all ancestors to determine if an item in breadcrumbs has a parameter name

## Why

* Go back could be displayed in the middle of crumbs if middle item has breadCrumbsHidden=true
* Ancestors with param name will display the string, example 
`Yfirlit | id | Nánar` instead of `Yfirlit | 123 | Nánar`.

## Screenshots / Gifs

Was 😞 
![Screenshot 2023-10-31 at 10 37 03](https://github.com/island-is/island.is/assets/24840451/0ac71de8-ea97-41a6-99fb-64afdebdfa40)

Becomes 😃 
![Screenshot 2023-10-31 at 10 36 35](https://github.com/island-is/island.is/assets/24840451/70ea0f21-9181-4c80-937a-05ba2d3f7109)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
