### PR TITLE
fix(application-driving-license): Plaster for miscalculated phone

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/driving-license-submission/driving-license-submission.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/driving-license-submission/driving-license-submission.service.ts
@@ -73,7 +73,7 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
     application,
     auth,
   }: TemplateApiModuleActionProps): Promise<{ success: boolean }> {
-    const { answers } = application
+    const { answers, externalData } = application
     const nationalId = application.applicant
 
     const isPayment = await this.sharedTemplateAPIService.getPaymentStatus(
@@ -85,6 +85,17 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
       return {
         success: false,
       }
+    }
+
+    // HOTFIX PLASTER to ensure applications get through
+    // TODO: Ensure phone comes through all application paths
+    // This should be removed in the future when the frontend path for B-full has been made to include
+    // phone in its answers. In the meantime this is needed as a plaster to support older applications
+    // which had their data calculated before this fix.
+    if (!answers.phone) {
+      answers.phone =
+        (externalData?.userProfile?.data as { mobilePhoneNumber?: string })
+          ?.mobilePhoneNumber ?? ''
     }
 
     let result


### PR DESCRIPTION
# What?

A plaster to ensure that applications calculated for B-full will have phone numbers included, but this was causing the license creation to fail.

# What next?

After this plaster has launched we need to make sure the driving license application calculates phone numbers or accesses it in another way before submission.

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
