### PR TITLE
chore(service-portal): Add tab navigation as button navigation

### DIFF
--- a/apps/service-portal/src/components/Layout/FullWidthLayout.tsx
+++ b/apps/service-portal/src/components/Layout/FullWidthLayout.tsx
@@ -17,6 +17,7 @@ import { Link, matchPath, useNavigate } from 'react-router-dom'
 import { ServicePortalPaths } from '../../lib/paths'
 import { DocumentsPaths } from '@island.is/service-portal/documents'
 import { theme } from '@island.is/island-ui/theme'
+import { TabNavigation } from '../TabNavigation/TabNavigation'
 
 interface FullWidthLayoutProps {
   activeParent?: PortalNavigationItem
@@ -50,12 +51,6 @@ export const FullWidthLayout: FC<FullWidthLayoutProps> = ({
   const isDocuments = Object.values(DocumentsPaths).find((route) =>
     matchPath(route, pathname),
   )
-
-  const tabChangeHandler = (id: string) => {
-    if (id !== pathname) {
-      navigate(id)
-    }
-  }
 
   return (
     <Box
@@ -128,25 +123,18 @@ export const FullWidthLayout: FC<FullWidthLayoutProps> = ({
           </>
         )}
         {navItems && navItems?.length > 0 ? (
-          <Box paddingTop={4}>
+          <Box paddingTop={[0, 0, 4]}>
             <GridContainer position="none">
               <GridRow>
                 <GridColumn span="12/12">
-                  <Tabs
-                    selected={pathname}
-                    key={navItems?.length}
-                    onChange={tabChangeHandler}
+                  <TabNavigation
                     label={
                       activeParent?.name ? formatMessage(activeParent.name) : ''
                     }
-                    tabs={navItems?.map((item) => ({
-                      id: item.path,
-                      label: formatMessage(item.name),
-                      content: children,
-                    }))}
-                    contentBackground="white"
-                    onlyRenderSelectedTab
+                    pathname={pathname}
+                    items={navItems}
                   />
+                  {children}
                 </GridColumn>
               </GridRow>
             </GridContainer>

--- a/apps/service-portal/src/components/Layout/FullWidthLayout.tsx
+++ b/apps/service-portal/src/components/Layout/FullWidthLayout.tsx
@@ -4,7 +4,6 @@ import {
   GridContainer,
   GridRow,
   GridColumn,
-  Tabs,
   BreadcrumbsDeprecated as Breadcrumbs,
   Button,
 } from '@island.is/island-ui/core'

--- a/apps/service-portal/src/components/TabNavigation/SubTabItem.tsx
+++ b/apps/service-portal/src/components/TabNavigation/SubTabItem.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { Box, Button, ResponsiveSpace } from '@island.is/island-ui/core'
+
+interface Props {
+  onClick?: () => void
+  colorScheme: 'default' | 'light'
+  title: string
+  marginLeft?: ResponsiveSpace
+}
+
+export const SubTabItem: React.FC<Props> = ({
+  onClick,
+  colorScheme,
+  title,
+  marginLeft = 2,
+}) => {
+  return (
+    <Box marginLeft={marginLeft}>
+      <Button
+        type="button"
+        aria-label={title}
+        size="small"
+        colorScheme={colorScheme}
+        onClick={onClick}
+      >
+        {title}
+      </Button>
+    </Box>
+  )
+}

--- a/apps/service-portal/src/components/TabNavigation/TabNavigation.css.ts
+++ b/apps/service-portal/src/components/TabNavigation/TabNavigation.css.ts
@@ -1,0 +1,47 @@
+import { style } from '@vanilla-extract/css'
+import { theme } from '@island.is/island-ui/theme'
+
+export const tab = style({
+  position: 'relative',
+  padding: '10px',
+  width: '100%',
+  outline: 0,
+  backgroundColor: theme.color.white,
+  ':after': {
+    content: '""',
+    position: 'absolute',
+    height: '1px',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    backgroundColor: theme.color.blue200,
+  },
+})
+
+export const tabSelected = style({
+  color: theme.color.blue400,
+  ':after': {
+    backgroundColor: theme.color.blue400,
+  },
+})
+
+export const select = style({
+  '@media': {
+    [`screen and (min-width: ${theme.breakpoints.md + 1}px)`]: {
+      height: 0,
+      overflow: 'hidden',
+    },
+  },
+})
+
+export const tabList = style({
+  display: 'inline-flex',
+  width: '100%',
+  '@media': {
+    [`screen and (max-width: ${theme.breakpoints.md}px)`]: {
+      height: 0,
+      overflow: 'hidden',
+      display: 'none',
+    },
+  },
+})

--- a/apps/service-portal/src/components/TabNavigation/TabNavigation.tsx
+++ b/apps/service-portal/src/components/TabNavigation/TabNavigation.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { PortalNavigationItem } from '@island.is/portals/core'
 import { Box, Button, FocusableBox, Select } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
@@ -17,8 +17,15 @@ interface Props {
 
 export const TabNavigation: React.FC<Props> = ({ items, pathname, label }) => {
   const { formatMessage } = useLocale()
+  const [activeItem, setActiveItem] = useState<
+    PortalNavigationItem | undefined
+  >()
   const navigate = useNavigate()
   const { width } = useWindowSize()
+
+  useEffect(() => {
+    setActiveItem(items.filter((item) => item.active)?.[0] ?? undefined)
+  }, [items])
 
   const tabChangeHandler = (id?: string) => {
     if (id && id !== pathname) {
@@ -27,7 +34,6 @@ export const TabNavigation: React.FC<Props> = ({ items, pathname, label }) => {
   }
 
   const isMobile = width < theme.breakpoints.md
-  const activeItem = items.filter((item) => item.active)?.[0]
   return (
     <>
       <Box className={styles.tabList}>

--- a/apps/service-portal/src/components/TabNavigation/TabNavigation.tsx
+++ b/apps/service-portal/src/components/TabNavigation/TabNavigation.tsx
@@ -1,0 +1,117 @@
+import React from 'react'
+import { PortalNavigationItem } from '@island.is/portals/core'
+import { Box, Button, FocusableBox, Select } from '@island.is/island-ui/core'
+import { useLocale } from '@island.is/localization'
+import { theme } from '@island.is/island-ui/theme'
+import cn from 'classnames'
+import { useNavigate } from 'react-router-dom'
+import { useWindowSize } from 'react-use'
+import { SubTabItem } from './SubTabItem'
+import * as styles from './TabNavigation.css'
+
+interface Props {
+  pathname?: string
+  label: string
+  items: PortalNavigationItem[]
+}
+
+export const TabNavigation: React.FC<Props> = ({ items, pathname, label }) => {
+  const { formatMessage } = useLocale()
+  const navigate = useNavigate()
+  const { width } = useWindowSize()
+
+  const tabChangeHandler = (id?: string) => {
+    if (id && id !== pathname) {
+      navigate(id)
+    }
+  }
+
+  const isMobile = width < theme.breakpoints.md
+  const activeItem = items.filter((item) => item.active)?.[0]
+  return (
+    <>
+      <Box className={styles.tabList}>
+        {items?.map((item, index) => (
+          <>
+            <FocusableBox
+              component={Button}
+              type="button"
+              key={index}
+              id={item.path}
+              justifyContent="center"
+              aria-label={formatMessage(item.name)}
+              className={cn(styles.tab, {
+                [styles.tabSelected]: item.active,
+              })}
+              onClick={
+                item.path ? () => tabChangeHandler(item.path) : undefined
+              }
+            >
+              {formatMessage(item.name)}
+            </FocusableBox>
+          </>
+        ))}
+      </Box>
+      {activeItem && activeItem.path && isMobile && (
+        <Box className={styles.select}>
+          <Select
+            size="sm"
+            name={label}
+            label={label}
+            onChange={(opt) => {
+              opt ? tabChangeHandler(opt.value) : undefined
+            }}
+            options={items.map((item) => ({
+              label: formatMessage(item.name),
+              value: item.path,
+            }))}
+            defaultValue={{
+              value: activeItem.path,
+              label: formatMessage(activeItem.name),
+            }}
+            isSearchable={false}
+          />
+        </Box>
+      )}
+      {activeItem && activeItem?.children && activeItem.children.length > 0 ? (
+        <Box
+          display="flex"
+          flexDirection="row"
+          marginTop={5}
+          marginBottom={[2, 1, 0]}
+        >
+          <SubTabItem
+            colorScheme={
+              activeItem.children.filter((item) => item.active).length === 0
+                ? 'default'
+                : 'light'
+            }
+            title={formatMessage(activeItem.name)}
+            onClick={
+              activeItem.path
+                ? () => tabChangeHandler(activeItem.path)
+                : undefined
+            }
+            marginLeft={0}
+          />
+          {activeItem.children?.map((itemChild, ii) => (
+            <SubTabItem
+              key={`subnav-${ii}`}
+              onClick={
+                itemChild.path
+                  ? () => tabChangeHandler(itemChild.path)
+                  : undefined
+              }
+              title={formatMessage(itemChild.name)}
+              colorScheme={
+                itemChild.active && activeItem.path !== itemChild.path
+                  ? 'default'
+                  : 'light'
+              }
+            />
+          ))}
+        </Box>
+      ) : null}
+    </>
+  )
+}

--- a/apps/service-portal/src/components/TabNavigation/TabNavigation.tsx
+++ b/apps/service-portal/src/components/TabNavigation/TabNavigation.tsx
@@ -58,9 +58,7 @@ export const TabNavigation: React.FC<Props> = ({ items, pathname, label }) => {
             size="sm"
             name={label}
             label={label}
-            onChange={(opt) => {
-              opt ? tabChangeHandler(opt.value) : undefined
-            }}
+            onChange={(opt) => tabChangeHandler(opt?.value)}
             options={items.map((item) => ({
               label: formatMessage(item.name),
               value: item.path,


### PR DESCRIPTION
## What

Add tab navigation as button navigation
Add subnav support for tabnav

## Why

There is no support in the <Tabs /> component to support nested navigation.
And this approach is more natural for a nav + screen rendering instead of using the <Tabs />

## Screenshot

![Screenshot 2023-11-01 at 15 36 56](https://github.com/island-is/island.is/assets/24840451/4cb176a3-4eb2-4790-86c9-59b6aa3a4044)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
