### PR TITLE
fix: KAM-1847: Subscription option should not show up until verified …

### DIFF
--- a/apps/consultation-portal/hooks/api/useFetchEmail.ts
+++ b/apps/consultation-portal/hooks/api/useFetchEmail.ts
@@ -2,14 +2,18 @@ import { useQuery } from '@apollo/client'
 import { SUB_GET_EMAIL } from '../../graphql/queries.graphql'
 
 interface Props {
-  isAuthenticated: boolean
+  isAuthenticated?: boolean
+  isMySubscriptions?: boolean
 }
 
-export const useFetchEmail = ({ isAuthenticated }: Props) => {
+export const useFetchEmail = ({
+  isAuthenticated = false,
+  isMySubscriptions = false,
+}: Props) => {
   const { data, loading } = useQuery(SUB_GET_EMAIL, {
     ssr: false,
     fetchPolicy: 'network-only',
-    skip: !isAuthenticated,
+    skip: !isAuthenticated || isMySubscriptions,
   })
 
   const { consultationPortalUserEmail: userEmail = [] } = data ?? {}

--- a/apps/consultation-portal/screens/Subscriptions/components/EmailBox/EmailBox.tsx
+++ b/apps/consultation-portal/screens/Subscriptions/components/EmailBox/EmailBox.tsx
@@ -9,11 +9,21 @@ import { useRouter } from 'next/router'
 import localization from '../../Subscriptions.json'
 import { ActionCard } from '../../../../components'
 
+interface EmailBoxProps {
+  email: string
+  emailVerified: boolean
+  getUserEmailLoading: boolean
+}
+
 const emailIsValid = (email: string) => {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
 }
 
-export const EmailBox = () => {
+export const EmailBox = ({
+  email,
+  emailVerified,
+  getUserEmailLoading,
+}: EmailBoxProps) => {
   const loc = localization['emailBox']
   const { isAuthenticated, userLoading } = useUser()
   const [isVerified, setIsVerified] = useState<boolean>(false)
@@ -29,9 +39,6 @@ export const EmailBox = () => {
     },
   )
   const router = useRouter()
-  const { email, emailVerified, getUserEmailLoading } = useFetchEmail({
-    isAuthenticated: isAuthenticated,
-  })
 
   useEffect(() => {
     if (!getUserEmailLoading) {

--- a/apps/consultation-portal/screens/Subscriptions/components/SubscriptionsSkeleton/SubscriptionsSkeleton.tsx
+++ b/apps/consultation-portal/screens/Subscriptions/components/SubscriptionsSkeleton/SubscriptionsSkeleton.tsx
@@ -14,6 +14,7 @@ import { Area } from '../../../../types/enums'
 import Link from 'next/link'
 import { useUser } from '../../../../hooks/useUser'
 import localization from '../../Subscriptions.json'
+import { useFetchEmail, useIsMobile } from '../../../../hooks'
 
 interface Props {
   children: ReactNode
@@ -63,11 +64,18 @@ const SubscriptionsSkeleton = ({
   getUserSubsLoading,
 }: Props) => {
   const { isAuthenticated, userLoading } = useUser()
+  const { isMobile } = useIsMobile()
+  const { email, emailVerified, getUserEmailLoading } = useFetchEmail({
+    isAuthenticated,
+    isMySubscriptions,
+  })
 
   return (
     <Layout
       seo={isMySubscriptions ? MY_SUBSCRIPTIONS : SUBSCRIPTIONS}
-      justifyContent={isAuthenticated ? 'flexStart' : 'spaceBetween'}
+      justifyContent={
+        isAuthenticated && isMobile ? 'flexStart' : 'spaceBetween'
+      }
     >
       <Divider />
       <Box background="blue100">
@@ -97,14 +105,20 @@ const SubscriptionsSkeleton = ({
                   )}
                 </Stack>
               </Stack>
-              {!isMySubscriptions && <EmailBox />}
+              {!isMySubscriptions && (
+                <EmailBox
+                  email={email}
+                  emailVerified={emailVerified}
+                  getUserEmailLoading={getUserEmailLoading}
+                />
+              )}
             </Stack>
             {children}
           </Box>
         </GridContainer>
       </Box>
       <Divider />
-      {isAuthenticated && !userLoading && (
+      {isAuthenticated && !userLoading && emailVerified && (
         <GridContainer>
           <Box paddingTop={[3, 3, 3, 5, 5]}>
             {isMySubscriptions && getUserSubsLoading ? (


### PR DESCRIPTION
…email (#12618)

# Hotfix: Should not be able to subscribe without email

https://github.com/island-is/island.is/pull/12618

## What

User can only view subscription options once his email has been verified

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
