### PR TITLE
chore(nest-problem): Fix OpenAPI typing for details on HttpProblem

### DIFF
--- a/libs/nest/problem/src/lib/httpProblemResponse.ts
+++ b/libs/nest/problem/src/lib/httpProblemResponse.ts
@@ -25,8 +25,25 @@ export class HttpProblemResponse implements HttpProblem {
   @ApiPropertyOptional({
     description:
       'A human-readable explanation specific to this occurrence of the problem',
+    oneOf: [
+      {
+        type: 'string',
+      },
+      {
+        type: 'array',
+        items: {
+          type: 'string',
+        },
+      },
+    ],
   })
-  detail?: string
+
+  /**
+   * The RFC describes this fields only as a string https://datatracker.ietf.org/doc/html/rfc7807#section-3.1
+   * But due to how class-validator work for our NestJS APIs it can respond with array of string,
+   * where each string indicates a validation error for a specific field.
+   */
+  detail?: string | string[]
 
   @ApiPropertyOptional({
     description:

--- a/libs/shared/problem/src/BaseProblem.ts
+++ b/libs/shared/problem/src/BaseProblem.ts
@@ -2,6 +2,6 @@ export interface BaseProblem {
   type: string
   title: string
   status?: number
-  detail?: string
+  detail?: string | string[]
   instance?: string
 }


### PR DESCRIPTION
## What

Adding typing to generated OpenAPI schemas as our NestJS apis can set the detail fields as string array due to how class-validator works.

## Why

So generated clients have appropriate typing for this field.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
