### PR TITLE
feat(web): Add alert banner option to /starfatorg

### DIFF
--- a/apps/web/layouts/main.tsx
+++ b/apps/web/layouts/main.tsx
@@ -1,23 +1,25 @@
 import React, { useEffect, useState } from 'react'
+import Cookies from 'js-cookie'
+import getConfig from 'next/config'
 import Head from 'next/head'
+import { useRouter } from 'next/router'
+
 import {
-  Page,
-  Box,
-  FooterLinkProps,
-  Footer,
   AlertBanner,
   AlertBannerVariants,
-  Hidden,
+  Box,
   ButtonTypes,
   ColorSchemeContext,
   ColorSchemes,
+  Footer,
+  FooterLinkProps,
+  Hidden,
+  Page,
 } from '@island.is/island-ui/core'
-import getConfig from 'next/config'
-import { Screen } from '../types'
-import Cookies from 'js-cookie'
 import { CACHE_CONTROL_HEADER } from '@island.is/shared/constants'
+import { Locale } from '@island.is/shared/types'
+import { stringHash } from '@island.is/shared/utils'
 import { userMonitoring } from '@island.is/user-monitoring'
-import { useRouter } from 'next/router'
 import {
   Header,
   Main,
@@ -25,40 +27,40 @@ import {
   PageLoader,
   SkipToMainContent,
 } from '@island.is/web/components'
-import { GET_GROUPED_MENU_QUERY } from '../screens/queries/Menu'
-import { GET_CATEGORIES_QUERY, GET_NAMESPACE_QUERY } from '../screens/queries'
-import {
-  GetGroupedMenuQuery,
-  GetNamespaceQuery,
-  QueryGetNamespaceArgs,
-  ContentLanguage,
-  GetAlertBannerQuery,
-  QueryGetAlertBannerArgs,
-  GetArticleCategoriesQuery,
-  QueryGetArticleCategoriesArgs,
-  QueryGetGroupedMenuArgs,
-  Menu,
-  GetOrganizationPageQuery,
-  GetSingleArticleQuery,
-} from '../graphql/schema'
+
+import { OrganizationIslandFooter } from '../components/Organization/OrganizationIslandFooter'
 import { GlobalContextProvider } from '../context'
 import { MenuTabsContext } from '../context/MenuTabsContext/MenuTabsContext'
-import { getLocaleFromPath, useI18n } from '../i18n'
-import { GET_ALERT_BANNER_QUERY } from '../screens/queries/AlertBanner'
+import {
+  ContentLanguage,
+  GetAlertBannerQuery,
+  GetArticleCategoriesQuery,
+  GetGroupedMenuQuery,
+  GetNamespaceQuery,
+  GetOrganizationPageQuery,
+  GetSingleArticleQuery,
+  Menu,
+  QueryGetAlertBannerArgs,
+  QueryGetArticleCategoriesArgs,
+  QueryGetGroupedMenuArgs,
+  QueryGetNamespaceArgs,
+} from '../graphql/schema'
 import { useNamespace } from '../hooks'
+import {
+  linkResolver as LinkResolver,
+  LinkType,
+  pathIsRoute,
+  useLinkResolver,
+} from '../hooks/useLinkResolver'
+import { getLocaleFromPath, useI18n } from '../i18n'
+import { GET_CATEGORIES_QUERY, GET_NAMESPACE_QUERY } from '../screens/queries'
+import { GET_ALERT_BANNER_QUERY } from '../screens/queries/AlertBanner'
+import { GET_GROUPED_MENU_QUERY } from '../screens/queries/Menu'
+import { Screen } from '../types'
 import {
   formatMegaMenuCategoryLinks,
   formatMegaMenuLinks,
 } from '../utils/processMenuData'
-import { stringHash } from '@island.is/shared/utils'
-import { Locale } from '@island.is/shared/types'
-import {
-  LinkType,
-  useLinkResolver,
-  linkResolver as LinkResolver,
-  pathIsRoute,
-} from '../hooks/useLinkResolver'
-import { OrganizationIslandFooter } from '../components/Organization/OrganizationIslandFooter'
 import Illustration from './Illustration'
 import * as styles from './main.css'
 
@@ -103,6 +105,7 @@ export interface LayoutProps {
   alertBannerContent?: GetAlertBannerQuery['getAlertBanner']
   organizationAlertBannerContent?: GetAlertBannerQuery['getAlertBanner']
   articleAlertBannerContent?: GetAlertBannerQuery['getAlertBanner']
+  customAlertBannerContent?: GetAlertBannerQuery['getAlertBanner']
   languageToggleQueryParams?: Record<Locale, Record<string, string>>
   footerVersion?: 'default' | 'organization'
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -147,6 +150,7 @@ const Layout: Screen<LayoutProps> = ({
   alertBannerContent,
   organizationAlertBannerContent,
   articleAlertBannerContent,
+  customAlertBannerContent,
   languageToggleQueryParams,
   footerVersion = 'default',
   respOrigin,
@@ -203,6 +207,12 @@ const Layout: Screen<LayoutProps> = ({
           )}`,
           ...articleAlertBannerContent,
         },
+        {
+          bannerId: `custom-alert-${stringHash(
+            JSON.stringify(customAlertBannerContent ?? {}),
+          )}`,
+          ...customAlertBannerContent,
+        },
       ].filter(
         (banner) => !Cookies.get(banner.bannerId) && banner?.showAlertBanner,
       ),
@@ -211,6 +221,7 @@ const Layout: Screen<LayoutProps> = ({
     alertBannerContent,
     articleAlertBannerContent,
     organizationAlertBannerContent,
+    customAlertBannerContent,
   ])
 
   // Update html lang in case a route change leads us to a new locale
@@ -664,6 +675,7 @@ interface LayoutComponentProps {
   themeConfig?: Partial<LayoutProps>
   organizationPage?: GetOrganizationPageQuery['getOrganizationPage']
   article?: GetSingleArticleQuery['getSingleArticle']
+  customAlertBanner?: GetAlertBannerQuery['getAlertBanner']
   languageToggleQueryParams?: LayoutProps['languageToggleQueryParams']
 }
 
@@ -706,6 +718,7 @@ export const withMainLayout = <T,>(
     const organizationAlertBannerContent =
       layoutComponentProps.organizationPage?.alertBanner
     const articleAlertBannerContent = layoutComponentProps.article?.alertBanner
+    const customAlertBannerContent = layoutComponentProps.customAlertBanner
     const languageToggleQueryParams =
       layoutComponentProps.languageToggleQueryParams
 
@@ -716,6 +729,7 @@ export const withMainLayout = <T,>(
         ...themeConfig,
         organizationAlertBannerContent,
         articleAlertBannerContent,
+        customAlertBannerContent,
         languageToggleQueryParams,
       },
       componentProps,

--- a/apps/web/screens/IcelandicGovernmentInstitutionVacancies/IcelandicGovernmentInstitutionVacanciesList.tsx
+++ b/apps/web/screens/IcelandicGovernmentInstitutionVacancies/IcelandicGovernmentInstitutionVacanciesList.tsx
@@ -1,25 +1,27 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { useRouter } from 'next/router'
 import isEqual from 'lodash/isEqual'
+import { useRouter } from 'next/router'
+
 import {
-  Text,
-  FocusableBox,
-  GridContainer,
-  GridColumn,
   Box,
-  GridRow,
   Breadcrumbs,
-  Stack,
-  Pagination,
-  Hidden,
   Filter,
-  FilterMultiChoice,
   FilterInput,
+  FilterMultiChoice,
+  FocusableBox,
+  GridColumn,
+  GridContainer,
+  GridRow,
+  Hidden,
   Inline,
+  Pagination,
+  Stack,
   Tag,
+  Text,
 } from '@island.is/island-ui/core'
-import { Screen } from '@island.is/web/types'
-import { withMainLayout } from '@island.is/web/layouts/main'
+import { theme } from '@island.is/island-ui/theme'
+import { sortAlpha } from '@island.is/shared/utils'
+import { FilterTag, HeadWithSocialSharing } from '@island.is/web/components'
 import {
   GetIcelandicGovernmentInstitutionVacanciesQuery,
   GetIcelandicGovernmentInstitutionVacanciesQueryVariables,
@@ -28,15 +30,14 @@ import {
   IcelandicGovernmentInstitutionVacanciesResponse,
 } from '@island.is/web/graphql/schema'
 import { useLinkResolver, useNamespace } from '@island.is/web/hooks'
-import { GET_ICELANDIC_GOVERNMENT_INSTITUTION_VACANCIES } from '../queries/IcelandicGovernmentInstitutionVacancies'
-import { GET_NAMESPACE_QUERY } from '../queries'
 import { useWindowSize } from '@island.is/web/hooks/useViewport'
-import { theme } from '@island.is/island-ui/theme'
-import { FilterTag, HeadWithSocialSharing } from '@island.is/web/components'
-import { sortAlpha } from '@island.is/shared/utils'
-import { extractFilterTags } from '../Organization/PublishedMaterial/utils'
+import { withMainLayout } from '@island.is/web/layouts/main'
+import { Screen } from '@island.is/web/types'
 import { CustomNextError } from '@island.is/web/units/errors'
 
+import { extractFilterTags } from '../Organization/PublishedMaterial/utils'
+import { GET_NAMESPACE_QUERY } from '../queries'
+import { GET_ICELANDIC_GOVERNMENT_INSTITUTION_VACANCIES } from '../queries/IcelandicGovernmentInstitutionVacancies'
 import * as styles from './IcelandicGovernmentInstitutionVacanciesList.css'
 
 type Vacancy =
@@ -686,6 +687,7 @@ IcelandicGovernmentInstitutionVacanciesList.getProps = async ({
   return {
     vacancies,
     namespace,
+    customAlertBanner: namespace['customAlertBanner'],
   }
 }
 

--- a/apps/web/screens/IcelandicGovernmentInstitutionVacancies/IcelandicGovernmentInstitutionVacancyDetails.tsx
+++ b/apps/web/screens/IcelandicGovernmentInstitutionVacancies/IcelandicGovernmentInstitutionVacancyDetails.tsx
@@ -1,5 +1,18 @@
-import { Screen } from '@island.is/web/types'
-import { withMainLayout } from '@island.is/web/layouts/main'
+import { SliceType } from '@island.is/island-ui/contentful'
+import {
+  Box,
+  Breadcrumbs,
+  Button,
+  Hidden,
+  Inline,
+  LinkV2,
+  Stack,
+  Text,
+} from '@island.is/island-ui/core'
+import {
+  HeadWithSocialSharing,
+  InstitutionPanel,
+} from '@island.is/web/components'
 import {
   GetIcelandicGovernmentInstitutionVacancyDetailsQuery,
   GetIcelandicGovernmentInstitutionVacancyDetailsQueryVariables,
@@ -7,31 +20,19 @@ import {
   GetNamespaceQueryVariables,
   IcelandicGovernmentInstitutionVacancyByIdResponse,
 } from '@island.is/web/graphql/schema'
+import { useLinkResolver, useNamespace } from '@island.is/web/hooks'
+import { useI18n } from '@island.is/web/i18n'
+import { withMainLayout } from '@island.is/web/layouts/main'
+import { Screen } from '@island.is/web/types'
+import { CustomNextError } from '@island.is/web/units/errors'
+import { webRichText } from '@island.is/web/utils/richText'
+
+import SidebarLayout from '../Layouts/SidebarLayout'
+import { GET_NAMESPACE_QUERY } from '../queries'
 import { GET_ICELANDIC_GOVERNMENT_INSTITUTION_VACANCY_DETAILS } from '../queries/IcelandicGovernmentInstitutionVacancies'
 import {
-  Text,
-  Box,
-  Stack,
-  LinkV2,
-  Breadcrumbs,
-  Button,
-  Inline,
-  Hidden,
-} from '@island.is/island-ui/core'
-import { useLinkResolver, useNamespace } from '@island.is/web/hooks'
-import { CustomNextError } from '@island.is/web/units/errors'
-import SidebarLayout from '../Layouts/SidebarLayout'
-import {
-  HeadWithSocialSharing,
-  InstitutionPanel,
-} from '@island.is/web/components'
-import { useI18n } from '@island.is/web/i18n'
-import { GET_NAMESPACE_QUERY } from '../queries'
-import { webRichText } from '@island.is/web/utils/richText'
-import { SliceType } from '@island.is/island-ui/contentful'
-import {
-  VACANCY_INTRO_MAX_LENGTH,
   shortenText,
+  VACANCY_INTRO_MAX_LENGTH,
 } from './IcelandicGovernmentInstitutionVacanciesList'
 
 type Vacancy = IcelandicGovernmentInstitutionVacancyByIdResponse['vacancy']
@@ -355,6 +356,7 @@ IcelandicGovernmentInstitutionVacancyDetails.getProps = async ({
   return {
     vacancy,
     namespace,
+    customAlertBanner: namespace['customAlertBanner'],
   }
 }
 

--- a/libs/api/domains/icelandic-government-institution-vacancies/src/lib/icelandic-government-institution-vacancies.resolver.ts
+++ b/libs/api/domains/icelandic-government-institution-vacancies/src/lib/icelandic-government-institution-vacancies.resolver.ts
@@ -25,7 +25,8 @@ import {
   sortVacancyList,
 } from './utils'
 import { getElasticsearchIndex } from '@island.is/content-search-index-manager'
-import { LOGGER_PROVIDER, Logger } from '@island.is/logging'
+import { LOGGER_PROVIDER } from '@island.is/logging'
+import type { Logger } from '@island.is/logging'
 import { FetchError } from '@island.is/clients/middlewares'
 
 const defaultCache: CacheControlOptions = { maxAge: CACHE_CONTROL_MAX_AGE }

--- a/libs/api/domains/icelandic-government-institution-vacancies/src/lib/icelandic-government-institution-vacancies.resolver.ts
+++ b/libs/api/domains/icelandic-government-institution-vacancies/src/lib/icelandic-government-institution-vacancies.resolver.ts
@@ -1,4 +1,5 @@
 import { Args, Query, Resolver } from '@nestjs/graphql'
+import { Inject } from '@nestjs/common'
 import {
   DefaultApi,
   VacanciesGetAcceptEnum,
@@ -24,6 +25,8 @@ import {
   sortVacancyList,
 } from './utils'
 import { getElasticsearchIndex } from '@island.is/content-search-index-manager'
+import { LOGGER_PROVIDER, Logger } from '@island.is/logging'
+import { FetchError } from '@island.is/clients/middlewares'
 
 const defaultCache: CacheControlOptions = { maxAge: CACHE_CONTROL_MAX_AGE }
 const defaultLang = 'is'
@@ -34,16 +37,36 @@ export class IcelandicGovernmentInstitutionVacanciesResolver {
     private readonly api: DefaultApi,
     private readonly cmsElasticService: CmsElasticsearchService,
     private readonly cmsContentfulService: CmsContentfulService,
+    @Inject(LOGGER_PROVIDER) private logger: Logger,
   ) {}
 
   private async getVacanciesFromExternalSystem(
     input: IcelandicGovernmentInstitutionVacanciesInput,
   ) {
-    const vacancies = (await this.api.vacanciesGet({
-      accept: VacanciesGetAcceptEnum.Json,
-      language: input.language,
-      stofnun: input.institution,
-    })) as DefaultApiVacanciesListItem[]
+    let vacancies: DefaultApiVacanciesListItem[] = []
+
+    try {
+      vacancies = (await this.api.vacanciesGet({
+        accept: VacanciesGetAcceptEnum.Json,
+        language: input.language,
+        stofnun: input.institution,
+      })) as DefaultApiVacanciesListItem[]
+    } catch (error) {
+      if (error instanceof FetchError) {
+        this.logger.error(
+          'Fetch error occurred when getting vacancies from xroad',
+          {
+            message: error.message,
+            statusCode: error.status,
+          },
+        )
+      } else {
+        this.logger.error(
+          'Error occurred when getting vacancies from xroad',
+          error,
+        )
+      }
+    }
 
     const mappedVacancies =
       await mapIcelandicGovernmentInstitutionVacanciesFromExternalSystem(


### PR DESCRIPTION
# Add alert banner option to /starfatorg

## What

* Orri (the system used to apply for jobs and post jobs) will be down due to maintenance in the upcoming days.
* This PR adds an option to display an alert banner and also we now catch the error if the xroad vacancies endpoint fails and simply return no jobs if that is the case

## Why

* This was requested by Fjársýslan

## Screenshots / Gifs

<img width="1437" alt="image" src="https://github.com/island-is/island.is/assets/43557895/7436b659-bdae-4d81-9f42-b785553322ab">

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
