### PR TITLE
fix(web): Webreader not loading correctly

### DIFF
--- a/apps/web/components/Webreader/Webreader.tsx
+++ b/apps/web/components/Webreader/Webreader.tsx
@@ -64,6 +64,7 @@ const Webreader: FC<React.PropsWithChildren<WebReaderProps>> = ({
   useEffect(() => {
     if (!window.rsConf) {
       const el = document.createElement('script')
+      el.id = 'rs_req_Init'
       el.src = SCRIPT_URL
       el.type = 'text/javascript'
       document.body.appendChild(el)

--- a/apps/web/components/Webreader/index.ts
+++ b/apps/web/components/Webreader/index.ts
@@ -1,3 +1,3 @@
 import dynamic from 'next/dynamic'
 
-export const Webreader = dynamic(() => import('./Webreader'), { ssr: false })
+export const Webreader = dynamic(() => import('./Webreader'), { ssr: true })


### PR DESCRIPTION
# Webreader not loading correctly

## What

* We are missing an id for the readspeaker script which is a likely cause for it sometimes not loading correctly
https://wrdev.readspeaker.com/index.php/get-started/implementation/dynamic-loading
* This PR adds that id as well as dynamically importing the webreader on the server side

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
