### PR TITLE
fix(service-portal): display correct chargeType in xls/csv export

### DIFF
--- a/libs/service-portal/finance/src/components/FinanceStatusDetailTable/FinanceStatusDetailTable.tsx
+++ b/libs/service-portal/finance/src/components/FinanceStatusDetailTable/FinanceStatusDetailTable.tsx
@@ -19,6 +19,7 @@ import {
 
 import {
   FinanceStatusDetailsType,
+  FinanceStatusOrganizationChargeType,
   FinanceStatusOrganizationType,
 } from '../../screens/FinanceStatus/FinanceStatusData.types'
 import { exportGjoldSundurlidunFile } from '../../utils/filesGjoldSundurlidun'
@@ -26,12 +27,14 @@ import * as styles from './FinanceStatusDetailTable.css'
 
 interface Props {
   organization: FinanceStatusOrganizationType
+  chargeType: FinanceStatusOrganizationChargeType
   financeStatusDetails: FinanceStatusDetailsType
   downloadURL: string
 }
 
 const FinanceStatusDetailTable: FC<React.PropsWithChildren<Props>> = ({
   organization,
+  chargeType,
   financeStatusDetails,
   downloadURL,
 }) => {
@@ -192,7 +195,7 @@ const FinanceStatusDetailTable: FC<React.PropsWithChildren<Props>> = ({
           onClick={() =>
             exportGjoldSundurlidunFile(
               financeStatusDetails,
-              organization?.chargeTypes?.[0].name || 'details',
+              chargeType.name || 'details',
               'xlsx',
             )
           }
@@ -211,7 +214,7 @@ const FinanceStatusDetailTable: FC<React.PropsWithChildren<Props>> = ({
             onClick={() =>
               exportGjoldSundurlidunFile(
                 financeStatusDetails,
-                organization?.chargeTypes?.[0].name || 'details',
+                chargeType.name || 'details',
                 'csv',
               )
             }

--- a/libs/service-portal/finance/src/components/FinanceStatusTableRow/FinanceStatusTableRow.tsx
+++ b/libs/service-portal/finance/src/components/FinanceStatusTableRow/FinanceStatusTableRow.tsx
@@ -57,6 +57,7 @@ const FinanceStatusTableRow: FC<React.PropsWithChildren<Props>> = ({
       {financeStatusDetails?.chargeItemSubjects?.length > 0 ? (
         <FinanceStatusDetailTable
           organization={organization}
+          chargeType={chargeType}
           financeStatusDetails={financeStatusDetails}
           downloadURL={downloadURL}
         />


### PR DESCRIPTION
## What

Incorrect chargeType name was being displayed in Finance status when exporting

## Why

To get correct data

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
