### PR TITLE
fix(web): Remove dynamic imports for headers

### DIFF
--- a/apps/web/components/Organization/Wrapper/Themes/DefaultTheme/index.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/DefaultTheme/index.ts
@@ -1,5 +1,3 @@
-import dynamic from 'next/dynamic'
+import Header from './DefaultHeader'
 
-export const DefaultHeader = dynamic(() => import('./DefaultHeader'), {
-  ssr: true,
-})
+export const DefaultHeader = Header

--- a/apps/web/components/Organization/Wrapper/Themes/DigitalIcelandTheme/index.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/DigitalIcelandTheme/index.ts
@@ -1,6 +1,3 @@
-import dynamic from 'next/dynamic'
+import Header from './DigitalIcelandHeader'
 
-export const DigitalIcelandHeader = dynamic(
-  () => import('./DigitalIcelandHeader'),
-  { ssr: true },
-)
+export const DigitalIcelandHeader = Header

--- a/apps/web/components/Organization/Wrapper/Themes/FiskistofaTheme/index.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/FiskistofaTheme/index.ts
@@ -1,9 +1,9 @@
 import dynamic from 'next/dynamic'
 
+import Header from './FiskistofaHeader'
+
 export const FiskistofaFooter = dynamic(() => import('./FiskistofaFooter'), {
   ssr: true,
 })
 
-export const FiskistofaHeader = dynamic(() => import('./FiskistofaHeader'), {
-  ssr: true,
-})
+export const FiskistofaHeader = Header

--- a/apps/web/components/Organization/Wrapper/Themes/FjarsyslaRikisinsTheme/index.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/FjarsyslaRikisinsTheme/index.ts
@@ -1,11 +1,10 @@
 import dynamic from 'next/dynamic'
 
+import Header from './FjarsyslaRikisinsHeader'
+
 export const FjarsyslaRikisinsFooter = dynamic(
   () => import('./FjarsyslaRikisinsFooter'),
   { ssr: true },
 )
 
-export const FjarsyslaRikisinsHeader = dynamic(
-  () => import('./FjarsyslaRikisinsHeader'),
-  { ssr: true },
-)
+export const FjarsyslaRikisinsHeader = Header

--- a/apps/web/components/Organization/Wrapper/Themes/GevTheme/index.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/GevTheme/index.ts
@@ -1,4 +1,6 @@
 import dynamic from 'next/dynamic'
 
-export const GevHeader = dynamic(() => import('./GevHeader'), { ssr: true })
+import Header from './GevHeader'
+
+export const GevHeader = Header
 export const GevFooter = dynamic(() => import('./GevFooter'), { ssr: true })

--- a/apps/web/components/Organization/Wrapper/Themes/HeilbrigdisstofnunAusturlandsTheme/index.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/HeilbrigdisstofnunAusturlandsTheme/index.ts
@@ -1,11 +1,10 @@
 import dynamic from 'next/dynamic'
 
+import Header from './HeilbrigdisstofnunAusturlandsHeader'
+
 export const HeilbrigdisstofnunAusturlandsFooter = dynamic(
   () => import('./HeilbrigdisstofnunAusturlandsFooter'),
   { ssr: true },
 )
 
-export const HeilbrigdisstofnunAusturlandsHeader = dynamic(
-  () => import('./HeilbrigdisstofnunAusturlandsHeader'),
-  { ssr: true },
-)
+export const HeilbrigdisstofnunAusturlandsHeader = Header

--- a/apps/web/components/Organization/Wrapper/Themes/HeilbrigdisstofnunNordurlandsTheme/index.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/HeilbrigdisstofnunNordurlandsTheme/index.ts
@@ -1,9 +1,8 @@
 import dynamic from 'next/dynamic'
 
-export const HeilbrigdisstofnunNordurlandsHeader = dynamic(
-  () => import('./HeilbrigdisstofnunNordurlandsHeader'),
-  { ssr: true },
-)
+import Header from './HeilbrigdisstofnunNordurlandsHeader'
+
+export const HeilbrigdisstofnunNordurlandsHeader = Header
 
 export const HeilbrigdisstofnunNordurlandsFooter = dynamic(
   () => import('./HeilbrigdisstofnunNordurlandsFooter'),

--- a/apps/web/components/Organization/Wrapper/Themes/HeilbrigdisstofnunSudurlandsTheme/index.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/HeilbrigdisstofnunSudurlandsTheme/index.ts
@@ -1,9 +1,8 @@
 import dynamic from 'next/dynamic'
 
-export const HeilbrigdisstofnunSudurlandsHeader = dynamic(
-  () => import('./HeilbrigdisstofnunSudurlandsHeader'),
-  { ssr: true },
-)
+import Header from './HeilbrigdisstofnunSudurlandsHeader'
+
+export const HeilbrigdisstofnunSudurlandsHeader = Header
 
 export const HeilbrigdisstofnunSudurlandsFooter = dynamic(
   () => import('./HeilbrigdisstofnunSudurlandsFooter'),

--- a/apps/web/components/Organization/Wrapper/Themes/HmsTheme/index.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/HmsTheme/index.ts
@@ -1,3 +1,3 @@
-import dynamic from 'next/dynamic'
+import Header from './HmsHeader'
 
-export const HmsHeader = dynamic(() => import('./HmsHeader'), { ssr: true })
+export const HmsHeader = Header

--- a/apps/web/components/Organization/Wrapper/Themes/HveTheme/index.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/HveTheme/index.ts
@@ -1,4 +1,6 @@
 import dynamic from 'next/dynamic'
 
-export const HveHeader = dynamic(() => import('./HveHeader'), { ssr: true })
+import Header from './HveHeader'
+
+export const HveHeader = Header
 export const HveFooter = dynamic(() => import('./HveFooter'), { ssr: true })

--- a/apps/web/components/Organization/Wrapper/Themes/IcelandicNaturalDisasterInsuranceTheme/index.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/IcelandicNaturalDisasterInsuranceTheme/index.ts
@@ -1,9 +1,8 @@
 import dynamic from 'next/dynamic'
 
-export const IcelandicNaturalDisasterInsuranceHeader = dynamic(
-  () => import('./IcelandicNaturalDisasterInsuranceHeader'),
-  { ssr: true },
-)
+import Header from './IcelandicNaturalDisasterInsuranceHeader'
+
+export const IcelandicNaturalDisasterInsuranceHeader = Header
 export const IcelandicNaturalDisasterInsuranceFooter = dynamic(
   () => import('./IcelandicNaturalDisasterInsuranceFooter'),
   { ssr: true },

--- a/apps/web/components/Organization/Wrapper/Themes/IcelandicRadiationSafetyAuthority/index.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/IcelandicRadiationSafetyAuthority/index.ts
@@ -1,6 +1,3 @@
-import dynamic from 'next/dynamic'
+import Header from './IcelandicRadiationSafetyAuthorityHeader'
 
-export const IcelandicRadiationSafetyAuthorityHeader = dynamic(
-  () => import('./IcelandicRadiationSafetyAuthorityHeader'),
-  { ssr: true },
-)
+export const IcelandicRadiationSafetyAuthorityHeader = Header

--- a/apps/web/components/Organization/Wrapper/Themes/LandkjorstjornTheme/index.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/LandkjorstjornTheme/index.ts
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic'
 
-import Header from './LandkjorstjornHeader'
+import Header from './LandskjorstjornHeader'
 
 export const LandskjorstjornFooter = dynamic(
   () => import('./LandkjorstjornFooter'),

--- a/apps/web/components/Organization/Wrapper/Themes/LandkjorstjornTheme/index.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/LandkjorstjornTheme/index.ts
@@ -1,11 +1,10 @@
 import dynamic from 'next/dynamic'
 
+import Header from './LandkjorstjornHeader'
+
 export const LandskjorstjornFooter = dynamic(
   () => import('./LandkjorstjornFooter'),
   { ssr: true },
 )
 
-export const LandskjorstjornHeader = dynamic(
-  () => import('./LandskjorstjornHeader'),
-  { ssr: true },
-)
+export const LandskjorstjornHeader = Header

--- a/apps/web/components/Organization/Wrapper/Themes/LandlaeknirTheme/index.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/LandlaeknirTheme/index.ts
@@ -1,9 +1,9 @@
 import dynamic from 'next/dynamic'
 
+import Header from './LandlaeknirHeader'
+
 export const LandlaeknirFooter = dynamic(() => import('./LandlaeknirFooter'), {
   ssr: true,
 })
 
-export const LandlaeknirHeader = dynamic(() => import('./LandlaeknirHeader'), {
-  ssr: true,
-})
+export const LandlaeknirHeader = Header

--- a/apps/web/components/Organization/Wrapper/Themes/RettindagaeslaFatladsFolksTheme/index.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/RettindagaeslaFatladsFolksTheme/index.ts
@@ -1,6 +1,3 @@
-import dynamic from 'next/dynamic'
+import Header from './RettindagaeslaFatladsFolksHeader'
 
-export const RettindagaeslaFatladsFolksHeader = dynamic(
-  () => import('./RettindagaeslaFatladsFolksHeader'),
-  { ssr: true },
-)
+export const RettindagaeslaFatladsFolksHeader = Header

--- a/apps/web/components/Organization/Wrapper/Themes/RikislogmadurTheme/index.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/RikislogmadurTheme/index.ts
@@ -1,9 +1,8 @@
 import dynamic from 'next/dynamic'
 
-export const RikislogmadurHeader = dynamic(
-  () => import('./RikislogmadurHeader'),
-  { ssr: true },
-)
+import Header from './RikislogmadurHeader'
+
+export const RikislogmadurHeader = Header
 
 export const RikislogmadurFooter = dynamic(
   () => import('./RikislogmadurFooter'),

--- a/apps/web/components/Organization/Wrapper/Themes/RikissaksoknariTheme/index.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/RikissaksoknariTheme/index.ts
@@ -1,6 +1,3 @@
-import dynamic from 'next/dynamic'
+import Header from './RikissaksoknariHeader'
 
-export const RikissaksoknariHeader = dynamic(
-  () => import('./RikissaksoknariHeader'),
-  { ssr: true },
-)
+export const RikissaksoknariHeader = Header

--- a/apps/web/components/Organization/Wrapper/Themes/SAkTheme/index.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/SAkTheme/index.ts
@@ -1,4 +1,6 @@
 import dynamic from 'next/dynamic'
 
-export const SAkHeader = dynamic(() => import('./SAkHeader'), { ssr: true })
+import Header from './SAkHeader'
+
+export const SAkHeader = Header
 export const SAkFooter = dynamic(() => import('./SAkFooter'), { ssr: true })

--- a/apps/web/components/Organization/Wrapper/Themes/SHHTheme/index.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/SHHTheme/index.ts
@@ -1,4 +1,6 @@
 import dynamic from 'next/dynamic'
 
+import Header from './ShhHeader'
+
 export const ShhFooter = dynamic(() => import('./ShhFooter'), { ssr: true })
-export const ShhHeader = dynamic(() => import('./ShhHeader'), { ssr: true })
+export const ShhHeader = Header

--- a/apps/web/components/Organization/Wrapper/Themes/SjukratryggingarTheme/index.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/SjukratryggingarTheme/index.ts
@@ -1,9 +1,8 @@
 import dynamic from 'next/dynamic'
 
-export const SjukratryggingarHeader = dynamic(
-  () => import('./SjukratryggingarHeader'),
-  { ssr: true },
-)
+import Header from './SjukratryggingarHeader'
+
+export const SjukratryggingarHeader = Header
 
 export const SjukratryggingarFooter = dynamic(
   () => import('./SjukratryggingarFooter'),

--- a/apps/web/components/Organization/Wrapper/Themes/SyslumennTheme/index.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/SyslumennTheme/index.ts
@@ -1,8 +1,8 @@
 import dynamic from 'next/dynamic'
 
-export const SyslumennHeader = dynamic(() => import('./SyslumennHeader'), {
-  ssr: true,
-})
+import Header from './SyslumennHeader'
+
+export const SyslumennHeader = Header
 
 export const SyslumennFooter = dynamic(() => import('./SyslumennFooter'), {
   ssr: true,

--- a/apps/web/components/Organization/Wrapper/Themes/TryggingastofnunTheme/index.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/TryggingastofnunTheme/index.ts
@@ -1,9 +1,8 @@
 import dynamic from 'next/dynamic'
 
-export const TryggingastofnunHeader = dynamic(
-  () => import('./TryggingastofnunHeader'),
-  { ssr: true },
-)
+import Header from './TryggingastofnunHeader'
+
+export const TryggingastofnunHeader = Header
 
 export const TryggingastofnunFooter = dynamic(
   () => import('./TryggingastofnunFooter'),

--- a/apps/web/components/Organization/Wrapper/Themes/UniversityStudiesTheme/index.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/UniversityStudiesTheme/index.ts
@@ -1,8 +1,3 @@
-import dynamic from 'next/dynamic'
+import Header from './UniversityStudiesHeader'
 
-export const UniversityStudiesHeader = dynamic(
-  () => import('./UniversityStudiesHeader'),
-  {
-    ssr: true,
-  },
-)
+export const UniversityStudiesHeader = Header

--- a/apps/web/components/Organization/Wrapper/Themes/UtlendingastofnunTheme/index.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/UtlendingastofnunTheme/index.ts
@@ -1,9 +1,8 @@
 import dynamic from 'next/dynamic'
 
-export const UtlendingastofnunHeader = dynamic(
-  () => import('./UtlendingastofnunHeader'),
-  { ssr: true },
-)
+import Header from './UtlendingastofnunHeader'
+
+export const UtlendingastofnunHeader = Header
 
 export const UtlendingastofnunFooter = dynamic(
   () => import('./UtlendingastofnunFooter'),

--- a/apps/web/layouts/main.tsx
+++ b/apps/web/layouts/main.tsx
@@ -182,47 +182,30 @@ const Layout: Screen<LayoutProps> = ({
     },
   ]
 
-  const [alertBanners, setAlertBanners] = useState([])
-
-  useEffect(() => {
-    setAlertBanners(
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore make web strict
-      [
-        {
-          bannerId: `alert-${stringHash(
-            JSON.stringify(alertBannerContent ?? {}),
-          )}`,
-          ...alertBannerContent,
-        },
-        {
-          bannerId: `organization-alert-${stringHash(
-            JSON.stringify(organizationAlertBannerContent ?? {}),
-          )}`,
-          ...organizationAlertBannerContent,
-        },
-        {
-          bannerId: `article-alert-${stringHash(
-            JSON.stringify(articleAlertBannerContent ?? {}),
-          )}`,
-          ...articleAlertBannerContent,
-        },
-        {
-          bannerId: `custom-alert-${stringHash(
-            JSON.stringify(customAlertBannerContent ?? {}),
-          )}`,
-          ...customAlertBannerContent,
-        },
-      ].filter(
-        (banner) => !Cookies.get(banner.bannerId) && banner?.showAlertBanner,
-      ),
-    )
-  }, [
-    alertBannerContent,
-    articleAlertBannerContent,
-    organizationAlertBannerContent,
-    customAlertBannerContent,
-  ])
+  const alertBanners = [
+    {
+      bannerId: `alert-${stringHash(JSON.stringify(alertBannerContent ?? {}))}`,
+      ...alertBannerContent,
+    },
+    {
+      bannerId: `organization-alert-${stringHash(
+        JSON.stringify(organizationAlertBannerContent ?? {}),
+      )}`,
+      ...organizationAlertBannerContent,
+    },
+    {
+      bannerId: `article-alert-${stringHash(
+        JSON.stringify(articleAlertBannerContent ?? {}),
+      )}`,
+      ...articleAlertBannerContent,
+    },
+    {
+      bannerId: `custom-alert-${stringHash(
+        JSON.stringify(customAlertBannerContent ?? {}),
+      )}`,
+      ...customAlertBannerContent,
+    },
+  ].filter((banner) => !Cookies.get(banner.bannerId) && banner?.showAlertBanner)
 
   // Update html lang in case a route change leads us to a new locale
   useEffect(() => {

--- a/apps/web/layouts/main.tsx
+++ b/apps/web/layouts/main.tsx
@@ -182,30 +182,47 @@ const Layout: Screen<LayoutProps> = ({
     },
   ]
 
-  const alertBanners = [
-    {
-      bannerId: `alert-${stringHash(JSON.stringify(alertBannerContent ?? {}))}`,
-      ...alertBannerContent,
-    },
-    {
-      bannerId: `organization-alert-${stringHash(
-        JSON.stringify(organizationAlertBannerContent ?? {}),
-      )}`,
-      ...organizationAlertBannerContent,
-    },
-    {
-      bannerId: `article-alert-${stringHash(
-        JSON.stringify(articleAlertBannerContent ?? {}),
-      )}`,
-      ...articleAlertBannerContent,
-    },
-    {
-      bannerId: `custom-alert-${stringHash(
-        JSON.stringify(customAlertBannerContent ?? {}),
-      )}`,
-      ...customAlertBannerContent,
-    },
-  ].filter((banner) => !Cookies.get(banner.bannerId) && banner?.showAlertBanner)
+  const [alertBanners, setAlertBanners] = useState([])
+
+  useEffect(() => {
+    setAlertBanners(
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore make web strict
+      [
+        {
+          bannerId: `alert-${stringHash(
+            JSON.stringify(alertBannerContent ?? {}),
+          )}`,
+          ...alertBannerContent,
+        },
+        {
+          bannerId: `organization-alert-${stringHash(
+            JSON.stringify(organizationAlertBannerContent ?? {}),
+          )}`,
+          ...organizationAlertBannerContent,
+        },
+        {
+          bannerId: `article-alert-${stringHash(
+            JSON.stringify(articleAlertBannerContent ?? {}),
+          )}`,
+          ...articleAlertBannerContent,
+        },
+        {
+          bannerId: `custom-alert-${stringHash(
+            JSON.stringify(customAlertBannerContent ?? {}),
+          )}`,
+          ...customAlertBannerContent,
+        },
+      ].filter(
+        (banner) => !Cookies.get(banner.bannerId) && banner?.showAlertBanner,
+      ),
+    )
+  }, [
+    alertBannerContent,
+    articleAlertBannerContent,
+    organizationAlertBannerContent,
+    customAlertBannerContent,
+  ])
 
   // Update html lang in case a route change leads us to a new locale
   useEffect(() => {

--- a/libs/cms/src/lib/cms.resolver.ts
+++ b/libs/cms/src/lib/cms.resolver.ts
@@ -103,8 +103,6 @@ import { GetSingleManualInput } from './dto/getSingleManual.input'
 
 const defaultCache: CacheControlOptions = { maxAge: CACHE_CONTROL_MAX_AGE }
 
-// TODO: remove this comment
-
 @Resolver()
 export class CmsResolver {
   constructor(

--- a/libs/cms/src/lib/cms.resolver.ts
+++ b/libs/cms/src/lib/cms.resolver.ts
@@ -103,6 +103,8 @@ import { GetSingleManualInput } from './dto/getSingleManual.input'
 
 const defaultCache: CacheControlOptions = { maxAge: CACHE_CONTROL_MAX_AGE }
 
+// TODO: remove this comment
+
 @Resolver()
 export class CmsResolver {
   constructor(


### PR DESCRIPTION
# Remove dynamic imports for headers

## What

* Dynamically imported headers via SSR are not working well with alert banners since that causes them to "bug out" (see video below)

## Why

* To prevent layout shift and headers bugging out if there is an alert banner above them

## Screenshots / Gifs

https://github.com/island-is/island.is/assets/43557895/2ca6d1ee-a34b-49cc-9b26-062159c9fec0


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
