### PR TITLE
fix(web): Stop using useEffect for deciding whether to display alert banners

### DIFF
--- a/apps/web/layouts/main.tsx
+++ b/apps/web/layouts/main.tsx
@@ -182,47 +182,30 @@ const Layout: Screen<LayoutProps> = ({
     },
   ]
 
-  const [alertBanners, setAlertBanners] = useState([])
-
-  useEffect(() => {
-    setAlertBanners(
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore make web strict
-      [
-        {
-          bannerId: `alert-${stringHash(
-            JSON.stringify(alertBannerContent ?? {}),
-          )}`,
-          ...alertBannerContent,
-        },
-        {
-          bannerId: `organization-alert-${stringHash(
-            JSON.stringify(organizationAlertBannerContent ?? {}),
-          )}`,
-          ...organizationAlertBannerContent,
-        },
-        {
-          bannerId: `article-alert-${stringHash(
-            JSON.stringify(articleAlertBannerContent ?? {}),
-          )}`,
-          ...articleAlertBannerContent,
-        },
-        {
-          bannerId: `custom-alert-${stringHash(
-            JSON.stringify(customAlertBannerContent ?? {}),
-          )}`,
-          ...customAlertBannerContent,
-        },
-      ].filter(
-        (banner) => !Cookies.get(banner.bannerId) && banner?.showAlertBanner,
-      ),
-    )
-  }, [
-    alertBannerContent,
-    articleAlertBannerContent,
-    organizationAlertBannerContent,
-    customAlertBannerContent,
-  ])
+  const alertBanners = [
+    {
+      bannerId: `alert-${stringHash(JSON.stringify(alertBannerContent ?? {}))}`,
+      ...alertBannerContent,
+    },
+    {
+      bannerId: `organization-alert-${stringHash(
+        JSON.stringify(organizationAlertBannerContent ?? {}),
+      )}`,
+      ...organizationAlertBannerContent,
+    },
+    {
+      bannerId: `article-alert-${stringHash(
+        JSON.stringify(articleAlertBannerContent ?? {}),
+      )}`,
+      ...articleAlertBannerContent,
+    },
+    {
+      bannerId: `custom-alert-${stringHash(
+        JSON.stringify(customAlertBannerContent ?? {}),
+      )}`,
+      ...customAlertBannerContent,
+    },
+  ].filter((banner) => !Cookies.get(banner.bannerId) && banner?.showAlertBanner)
 
   // Update html lang in case a route change leads us to a new locale
   useEffect(() => {


### PR DESCRIPTION
# Stop using useEffect for deciding whether to display alert banners

Attach a link to issue if relevant

## What

* useEffect causes the banners to not be present in the server html and therefore when the banners to appear they cause a layout shift and that can lead to server side rendered headers to be positioned incorrectly

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
