### PR TITLE
fix(consultation-portal): KAM-1857: fix wording in statuses (#12662)

### DIFF
--- a/apps/consultation-portal/lib/shared.json
+++ b/apps/consultation-portal/lib/shared.json
@@ -15,13 +15,17 @@
     "publishLaw": {
       "text": "Upplýsingalög gilda, sjá nánar í",
       "link": {
-        "label": "um samráðsgáttina.",
+        "label": "Um samráðsgáttina.",
         "href": "/samradsgatt/um"
       }
     },
     "hiddenName": {
       "present": "Þátttakendum í þessu samráðsferli er þó heimilt að óska eftir að efni umsagnar og nafn sendanda birtist ekki í gáttinni.",
       "past": "Þátttakendum í þessu samráðsferli var þó heimilt að óska eftir því að efni umsagnar og nafn sendanda birtist ekki í gáttinni."
+    },
+    "viewAdvices": {
+      "text": "Skoða umsagnir",
+      "href": "#view-advices"
     }
   }
 }

--- a/apps/consultation-portal/screens/Case/Case.json
+++ b/apps/consultation-portal/screens/Case/Case.json
@@ -177,7 +177,7 @@
   "adviceCard": {
     "privateContent": "Umsagnaraðili hefur valið að sýna ekki umsögn sína.",
     "hiddenContent": "Umsögn barst en birtist ekki í gáttinni samkvæmt ákvörðun umsjónaraðila samráðsmáls. Upplýsingalög gilda, sjá nánar í",
-    "hiddenContentLink": "um samráðsgáttina",
+    "hiddenContentLink": "Um samráðsgáttina",
     "hiddenContentHref": "/um"
   },
   "caseDocuments": {

--- a/apps/consultation-portal/screens/Case/components/AdviceForm/AdviceForm.tsx
+++ b/apps/consultation-portal/screens/Case/components/AdviceForm/AdviceForm.tsx
@@ -1,3 +1,5 @@
+import { useContext, useState } from 'react'
+import { PresignedPost } from '@island.is/api/schema'
 import { Case } from '../../../../types/interfaces'
 import {
   getDateBeginDateEnd,
@@ -17,11 +19,7 @@ import {
   Checkbox,
   Stack,
 } from '@island.is/island-ui/core'
-
-import Link from 'next/link'
-import { useContext, useState } from 'react'
 import { useIsMobile, useLogIn, usePostAdvice } from '../../../../hooks'
-import { PresignedPost } from '@island.is/api/schema'
 import {
   REVIEW_FILENAME_MAXIMUM_LENGTH,
   REVIEW_MAXIMUM_LENGTH,
@@ -33,6 +31,7 @@ import { advicePublishTypeKeyHelper } from '../../../../types/enums'
 import localization from '../../Case.json'
 import sharedLocalization from '../../../../lib/shared.json'
 import { UserContext } from '../../../../context'
+import { CaseStatusText } from '../../components'
 
 interface Props {
   case: Case
@@ -195,17 +194,9 @@ export const AdviceForm = ({ case: _case, refetchAdvices }: Props) => {
     const newFileList = fileList.filter((file) => file.key !== fileToRemove.key)
     setFileList(newFileList)
   }
-
-  const publishRuleText =
-    _case.statusName === 'Til umsagnar'
-      ? sloc[advicePublishTypeKeyHelper[_case.advicePublishTypeId]].present
-      : sloc[advicePublishTypeKeyHelper[_case.advicePublishTypeId]].past
   const shouldDisplayHidden =
-    _case.allowUsersToSendPrivateAdvices && _case.advicePublishTypeId !== 3
-  const hiddenText =
-    _case.statusName === 'Til umsagnar'
-      ? sloc.hiddenName.present
-      : sloc.hiddenName.past
+    _case.allowUsersToSendPrivateAdvices &&
+    advicePublishTypeKeyHelper[_case.advicePublishTypeId] !== 'publishNever'
 
   return isAuthenticated ? (
     <Box
@@ -247,13 +238,18 @@ export const AdviceForm = ({ case: _case, refetchAdvices }: Props) => {
       </Text>
 
       <Text marginBottom={2}>
-        {loc.card.description.textBefore}
-        {` ${publishRuleText} `}
-        {shouldDisplayHidden && hiddenText}
-        {` ${sloc.publishLaw.text} `}
-        <Link href={sloc.publishLaw.link.href} legacyBehavior>
-          {sloc.publishLaw.link.label}
-        </Link>
+        <CaseStatusText
+          isAdviceForm
+          sloc={sloc}
+          status={_case.statusName}
+          shouldDisplayHidden={shouldDisplayHidden}
+          advicePublishTypeId={_case.advicePublishTypeId}
+          linkProps={{
+            href: sloc.publishLaw.link.href,
+            label: sloc.publishLaw.link.label,
+          }}
+          textBefore={loc.card.description.textBefore}
+        />
       </Text>
 
       <Text marginBottom={2}>

--- a/apps/consultation-portal/screens/Case/components/AdviceList/AdviceList.tsx
+++ b/apps/consultation-portal/screens/Case/components/AdviceList/AdviceList.tsx
@@ -24,7 +24,7 @@ export const AdviceList = ({ advices, chosenCase }: Props) => {
   const [showAll, setShowAll] = useState<boolean>(false)
   const { advicePublishTypeId, processEnds } = chosenCase
   return (
-    <Box dataTestId="advices-list">
+    <Box dataTestId="advices-list" id="view-advices">
       {renderAdvices(advicePublishTypeId, processEnds) && (
         <Stack space={3}>
           {advices?.map((advice: AdviceResult, index) => {

--- a/apps/consultation-portal/screens/Case/components/CaseStatusBox/CaseStatusBox.tsx
+++ b/apps/consultation-portal/screens/Case/components/CaseStatusBox/CaseStatusBox.tsx
@@ -1,16 +1,17 @@
+import Link from 'next/link'
+import { Box, Button, Text } from '@island.is/island-ui/core'
 import { CardSkeleton } from '../../../../components'
 import StackedTitleAndDescription from '../Stacked/Stacked'
-import { Box, Button, Text } from '@island.is/island-ui/core'
-import Link from 'next/link'
 import localization from '../../Case.json'
 import sharedLocalization from '../../../../lib/shared.json'
-import { advicePublishTypeKeyHelper } from '../../../../types/enums'
+import { CaseStatusText } from '../../components'
 
 interface Props {
   status: string
   advicePublishTypeId: number
   shouldDisplayHidden?: boolean
 }
+
 export const CaseStatusBox = ({
   status,
   advicePublishTypeId,
@@ -18,12 +19,6 @@ export const CaseStatusBox = ({
 }: Props) => {
   const loc = localization['caseStatusBox']
   const sloc = sharedLocalization['publishingRules']
-  const publishRuleText =
-    status == 'Til umsagnar'
-      ? sloc[advicePublishTypeKeyHelper[advicePublishTypeId]].present
-      : sloc[advicePublishTypeKeyHelper[advicePublishTypeId]].past
-  const hiddenText =
-    status === 'Til umsagnar' ? sloc.hiddenName.present : sloc.hiddenName.past
 
   return (
     <CardSkeleton>
@@ -32,11 +27,16 @@ export const CaseStatusBox = ({
         title={loc[status].title}
       >
         <Text>
-          {`${loc[status].text} ${publishRuleText} `}
-          {shouldDisplayHidden && hiddenText}
+          <CaseStatusText
+            sloc={sloc}
+            status={status}
+            advicePublishTypeId={advicePublishTypeId}
+            shouldDisplayHidden={shouldDisplayHidden}
+            linkProps={{ href: '#view-advices', label: sloc.viewAdvices.text }}
+          />
         </Text>
       </StackedTitleAndDescription>
-      {status == 'Til umsagnar' && (
+      {status === 'Til umsagnar' && (
         <Box paddingTop={2}>
           <Link href="#write-review" shallow legacyBehavior>
             <Button fluid iconType="outline" nowrap as="a">

--- a/apps/consultation-portal/screens/Case/components/CaseStatusText/CaseStatusText.tsx
+++ b/apps/consultation-portal/screens/Case/components/CaseStatusText/CaseStatusText.tsx
@@ -1,0 +1,84 @@
+import { ReactNode } from 'react'
+import { LinkV2 } from '@island.is/island-ui/core'
+import sharedLocalization from '../../../../lib/shared.json'
+import { advicePublishTypeKeyHelper } from '../../../../types/enums'
+
+interface TextLinkProps {
+  children: ReactNode
+  href: string
+}
+
+interface CaseStatusText {
+  sloc: typeof sharedLocalization['publishingRules']
+  status: string
+  advicePublishTypeId: number
+  shouldDisplayHidden: boolean
+  linkProps: {
+    href: string
+    label: string
+  }
+  textBefore?: string
+  isAdviceForm?: boolean
+}
+
+const TextLink = ({ href, children }: TextLinkProps) => {
+  return (
+    <LinkV2
+      href={href}
+      color="blue400"
+      underline="normal"
+      underlineVisibility="always"
+      legacyBehavior
+      shallow
+    >
+      {children}
+    </LinkV2>
+  )
+}
+
+const CaseStatusText = ({
+  sloc,
+  status,
+  advicePublishTypeId,
+  shouldDisplayHidden,
+  linkProps,
+  textBefore,
+  isAdviceForm = false,
+}: CaseStatusText) => {
+  const publishRuleText =
+    status == 'Til umsagnar'
+      ? sloc[advicePublishTypeKeyHelper[advicePublishTypeId]].present
+      : sloc[advicePublishTypeKeyHelper[advicePublishTypeId]].past
+  const hiddenText =
+    status === 'Til umsagnar' ? sloc.hiddenName.present : sloc.hiddenName.past
+
+  const retComp = []
+  if (textBefore) {
+    retComp.push(textBefore)
+    retComp.push(' ')
+  }
+  retComp.push(publishRuleText)
+  if (
+    !isAdviceForm &&
+    advicePublishTypeKeyHelper[advicePublishTypeId] !== 'publishNever' &&
+    status !== 'Til umsagnar'
+  ) {
+    retComp.push(' ')
+    retComp.push(<TextLink href={linkProps.href}>{linkProps.label}</TextLink>)
+    retComp.push('.')
+  }
+  if (shouldDisplayHidden) {
+    retComp.push(' ')
+    retComp.push(hiddenText)
+  }
+  if (isAdviceForm) {
+    retComp.push(' ')
+    retComp.push(sloc.publishLaw.text)
+    retComp.push(' ')
+    retComp.push(<TextLink href={linkProps.href}>{linkProps.label}</TextLink>)
+  }
+
+  return retComp
+}
+
+export default CaseStatusText

--- a/apps/consultation-portal/screens/Case/components/index.ts
+++ b/apps/consultation-portal/screens/Case/components/index.ts
@@ -13,3 +13,4 @@ export { default as AdviceSkeletonLoader } from './AdviceSkeletonLoader/AdviceSk
 export { default as Stacked } from './Stacked/Stacked'
 export { default as RenderAdvices } from './RenderAdvices/RenderAdvices'
 export { default as DocFileName } from './DocFileName/DocFileName'
+export { default as CaseStatusText } from './CaseStatusText/CaseStatusText'


### PR DESCRIPTION
* KAM-1857: fix wording in statuses

* retComp as const

---------

# Fix status box

https://veflausnir.atlassian.net/browse/KAM-1857
https://github.com/island-is/island.is/pull/12662

## What

- Change wording in status box
- CaseStatusText returns an array so that we can get formatting on the link

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
