### PR TITLE
ci: fix workflow concurrency bug

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -10,7 +10,7 @@ defaults:
 
 concurrency:
   # See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value
-  group: pullrequest-${{ github.head_ref || github.run_id }}
+  group: pullrequest-${{ github.head_ref || github.run_id }}-${{ github.workflow }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -10,7 +10,7 @@ defaults:
 
 concurrency:
   # See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value
-  group: pullrequest-${{ github.head_ref || github.run_id }}-${{ github.workflow }}
+  group: ${{ github.event_name }}-${{ github.head_ref || github.run_id }}-${{ github.workflow }}-${{ join(github.event.pull_request.labels.*.name, '-') }}
   cancel-in-progress: true
 
 env:
@@ -51,11 +51,6 @@ jobs:
       - name: Setup yarn
         run: npm install -g yarn
 
-      - name: Check node version
-        run: |
-          node -v
-          ls -l `which node`
-
       - name: Checking out relevant branches
         run: |
           git checkout $GITHUB_HEAD_REF
@@ -68,6 +63,15 @@ jobs:
           HEAD_SHA=$(git merge-base HEAD $GITHUB_HEAD_REF)
           echo Current base SHA is $BASE_SHA and head SHA is $HEAD_SHA
           echo "{\"base_sha\": \"$BASE_SHA\", \"head_sha\":\"$HEAD_SHA\"}" > event.json
+
+      - name: Info log
+        id: info-log
+        run: |
+          echo "github.head_ref: ${{ github.head_ref }}"
+          echo "github.run_id: ${{ github.run_id }}"
+          echo "concurrency group: ${{ github.event_name }}-${{ github.head_ref || github.run_id }}-${{ github.workflow }}-${{ join(github.event.pull_request.labels.*.name, '-') }}"
+          node -v
+          ls -l `which node`
 
       - name: Keep PR run event
         uses: actions/upload-artifact@v2

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -24,7 +24,7 @@ defaults:
 
 concurrency:
   # See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value
-  group: pullrequest-${{ github.head_ref || github.run_id }}-${{ github.workflow }}
+  group: ${{ github.event_name }}-${{ github.head_ref || github.run_id }}-${{ github.workflow }}-${{ join(github.event.pull_request.labels.*.name, '-') }}
   cancel-in-progress: true
 
 env:
@@ -74,6 +74,13 @@ jobs:
           echo "GIT_BRANCH_DEPLOY=${GIT_BRANCH_DEPLOY}" >> $GITHUB_OUTPUT
           echo "GIT_BRANCH_DEPLOY=$GIT_BRANCH_DEPLOY" >> $GITHUB_ENV
           echo "FEATURE_NAME=$(echo $GIT_BRANCH_DEPLOY | cut -d"/" -f2- | tr -cd '[:alnum:]-' | tr '[:upper:]' '[:lower:]' | cut -c1-50)" >> $GITHUB_OUTPUT
+
+      - name: Info log
+        id: info-log
+        run: |
+          echo "github.head_ref: ${{ github.head_ref }}"
+          echo "github.run_id: ${{ github.run_id }}"
+          echo "concurrency group: ${{ github.event_name }}-${{ github.head_ref || github.run_id }}-${{ github.workflow }}-${{ join(github.event.pull_request.labels.*.name, '-') }}"
 
       - name: Check if we want to run workflow
         id: should-run

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -24,7 +24,7 @@ defaults:
 
 concurrency:
   # See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value
-  group: push-${{ github.head_ref || github.run_id }}
+  group: pullrequest-${{ github.head_ref || github.run_id }}-${{ github.workflow }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
# Fix concurrency bug on PR label

If labels are added to PRs, GHA will cancel running `pull-request` workflow as intended but should not happen when e.g. `automerge` is added since it's meant for kodiaq and doesn't run the `build` job, but will cancel current build.

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
