### PR TITLE
feat(web): Display alert message if /starfatorg endpoint throws an error

### DIFF
--- a/apps/web/screens/IcelandicGovernmentInstitutionVacancies/IcelandicGovernmentInstitutionVacanciesList.tsx
+++ b/apps/web/screens/IcelandicGovernmentInstitutionVacancies/IcelandicGovernmentInstitutionVacanciesList.tsx
@@ -490,7 +490,7 @@ const IcelandicGovernmentInstitutionVacanciesList: Screen<
                 title={n('fetchErrorTitle', 'Ekki tókst að sækja öll störf')}
                 message={n(
                   'fetchErrorMessage',
-                  'Villa kom upp við að sækja störf frá ytri kerfum og því er möguleiki að ekki öll auglýst séu sýnileg',
+                  'Villa kom upp við að sækja störf frá ytri kerfum og því er möguleiki að ekki öll auglýst störf séu sýnileg',
                 )}
               />
             </Box>

--- a/apps/web/screens/IcelandicGovernmentInstitutionVacancies/IcelandicGovernmentInstitutionVacanciesList.tsx
+++ b/apps/web/screens/IcelandicGovernmentInstitutionVacancies/IcelandicGovernmentInstitutionVacanciesList.tsx
@@ -3,6 +3,7 @@ import isEqual from 'lodash/isEqual'
 import { useRouter } from 'next/router'
 
 import {
+  AlertMessage,
   Box,
   Breadcrumbs,
   Filter,
@@ -112,12 +113,13 @@ const mapVacanciesField = (
 
 interface IcelandicGovernmentInstitutionVacanciesListProps {
   vacancies: Vacancy[]
+  fetchErrorOccured?: boolean
   namespace: Record<string, string>
 }
 
 const IcelandicGovernmentInstitutionVacanciesList: Screen<
   IcelandicGovernmentInstitutionVacanciesListProps
-> = ({ vacancies, namespace }) => {
+> = ({ vacancies, fetchErrorOccured, namespace }) => {
   const { query, replace, isReady } = useRouter()
   const n = useNamespace(namespace)
   const { linkResolver } = useLinkResolver()
@@ -352,6 +354,7 @@ const IcelandicGovernmentInstitutionVacanciesList: Screen<
 
   const mainTitle = n('mainTitle', 'Starfatorg - laus störf hjá ríkinu')
   const ogTitle = n('ogTitle', 'Starfatorg - laus störf hjá ríkinu | Ísland.is')
+  const displayFetchErrorIfPresent = n('displayFetchErrorIfPresent', true)
 
   return (
     <Box paddingTop={[0, 0, 8]}>
@@ -453,7 +456,7 @@ const IcelandicGovernmentInstitutionVacanciesList: Screen<
                 }))
               }}
               categories={filterCategories}
-            ></FilterMultiChoice>
+            />
           </Filter>
 
           <GridRow className={styles.filterTagRow} alignItems="center">
@@ -479,6 +482,19 @@ const IcelandicGovernmentInstitutionVacanciesList: Screen<
               </Inline>
             </GridColumn>
           </GridRow>
+
+          {fetchErrorOccured && displayFetchErrorIfPresent && (
+            <Box paddingBottom={5}>
+              <AlertMessage
+                type="warning"
+                title={n('fetchErrorTitle', 'Ekki tókst að sækja öll störf')}
+                message={n(
+                  'fetchErrorMessage',
+                  'Villa kom upp við að sækja störf frá ytri kerfum og því er möguleiki að ekki öll auglýst séu sýnileg',
+                )}
+              />
+            </Box>
+          )}
         </Box>
       </GridContainer>
       <Box paddingTop={3} paddingBottom={6} background="blue100">
@@ -681,12 +697,13 @@ IcelandicGovernmentInstitutionVacanciesList.getProps = async ({
     },
   })
 
-  const vacancies =
-    vacanciesResponse.data.icelandicGovernmentInstitutionVacancies.vacancies
+  const { vacancies, fetchErrorOccurred } =
+    vacanciesResponse.data.icelandicGovernmentInstitutionVacancies
 
   return {
     vacancies,
     namespace,
+    fetchErrorOccurred,
     customAlertBanner: namespace['customAlertBanner'],
   }
 }

--- a/apps/web/screens/queries/IcelandicGovernmentInstitutionVacancies.ts
+++ b/apps/web/screens/queries/IcelandicGovernmentInstitutionVacancies.ts
@@ -5,6 +5,7 @@ export const GET_ICELANDIC_GOVERNMENT_INSTITUTION_VACANCIES = gql`
     $input: IcelandicGovernmentInstitutionVacanciesInput!
   ) {
     icelandicGovernmentInstitutionVacancies(input: $input) {
+      fetchErrorOccurred
       vacancies {
         id
         fieldOfWork

--- a/libs/api/domains/icelandic-government-institution-vacancies/src/lib/dto/icelandicGovernmentInstitutionVacanciesResponse.ts
+++ b/libs/api/domains/icelandic-government-institution-vacancies/src/lib/dto/icelandicGovernmentInstitutionVacanciesResponse.ts
@@ -1,4 +1,4 @@
-import { ObjectType } from '@nestjs/graphql'
+import { Field, ObjectType } from '@nestjs/graphql'
 import { IcelandicGovernmentInstitutionVacancyListItem } from '../models/icelandicGovernmentInstitutionVacancy.model'
 import { CacheField } from '@island.is/nest/graphql'
 
@@ -6,4 +6,7 @@ import { CacheField } from '@island.is/nest/graphql'
 export class IcelandicGovernmentInstitutionVacanciesResponse {
   @CacheField(() => [IcelandicGovernmentInstitutionVacancyListItem])
   vacancies!: IcelandicGovernmentInstitutionVacancyListItem[]
+
+  @Field(() => Boolean, { nullable: true })
+  fetchErrorOccurred?: boolean
 }

--- a/libs/api/domains/icelandic-government-institution-vacancies/src/lib/icelandic-government-institution-vacancies.resolver.ts
+++ b/libs/api/domains/icelandic-government-institution-vacancies/src/lib/icelandic-government-institution-vacancies.resolver.ts
@@ -8,7 +8,11 @@ import {
 } from '@island.is/clients/icelandic-government-institution-vacancies'
 import { CacheControl, CacheControlOptions } from '@island.is/nest/graphql'
 import { CACHE_CONTROL_MAX_AGE } from '@island.is/shared/constants'
-import { CmsContentfulService, CmsElasticsearchService } from '@island.is/cms'
+import {
+  CmsContentfulService,
+  CmsElasticsearchService,
+  Vacancy,
+} from '@island.is/cms'
 import { IcelandicGovernmentInstitutionVacanciesInput } from './dto/icelandicGovernmentInstitutionVacancies.input'
 import { IcelandicGovernmentInstitutionVacanciesResponse } from './dto/icelandicGovernmentInstitutionVacanciesResponse'
 import { IcelandicGovernmentInstitutionVacancyByIdInput } from './dto/icelandicGovernmentInstitutionVacancyById.input'
@@ -44,6 +48,7 @@ export class IcelandicGovernmentInstitutionVacanciesResolver {
   private async getVacanciesFromExternalSystem(
     input: IcelandicGovernmentInstitutionVacanciesInput,
   ) {
+    let errorOccurred = false
     let vacancies: DefaultApiVacanciesListItem[] = []
 
     try {
@@ -53,6 +58,7 @@ export class IcelandicGovernmentInstitutionVacanciesResolver {
         stofnun: input.institution,
       })) as DefaultApiVacanciesListItem[]
     } catch (error) {
+      errorOccurred = true
       if (error instanceof FetchError) {
         this.logger.error(
           'Fetch error occurred when getting vacancies from xroad',
@@ -128,14 +134,26 @@ export class IcelandicGovernmentInstitutionVacanciesResolver {
       }
     }
 
-    return mappedVacancies
+    return { vacancies: mappedVacancies, errorOccurred }
   }
 
   private async getVacanciesFromCms() {
-    const vacanciesFromCms = await this.cmsElasticService.getVacancies(
-      getElasticsearchIndex(defaultLang),
-    )
-    return vacanciesFromCms.map(mapVacancyListItemFromCms)
+    let errorOccurred = false
+    let vacanciesFromCms: Vacancy[] = []
+
+    try {
+      vacanciesFromCms = await this.cmsElasticService.getVacancies(
+        getElasticsearchIndex(defaultLang),
+      )
+    } catch (error) {
+      errorOccurred = true
+      this.logger.error(error)
+    }
+
+    return {
+      vacancies: vacanciesFromCms.map(mapVacancyListItemFromCms),
+      errorOccurred,
+    }
   }
 
   @CacheControl({ maxAge: 600 })
@@ -143,15 +161,20 @@ export class IcelandicGovernmentInstitutionVacanciesResolver {
   async icelandicGovernmentInstitutionVacancies(
     @Args('input') input: IcelandicGovernmentInstitutionVacanciesInput,
   ): Promise<IcelandicGovernmentInstitutionVacanciesResponse> {
-    const vacanciesFromExternalSystem =
-      await this.getVacanciesFromExternalSystem(input)
-    const vacanciesFromCms = await this.getVacanciesFromCms()
+    const {
+      vacancies: vacanciesFromExternalSystem,
+      errorOccurred: externalSystemErrorOccurred,
+    } = await this.getVacanciesFromExternalSystem(input)
+
+    const { vacancies: vacanciesFromCms, errorOccurred: cmsErrorOccurred } =
+      await this.getVacanciesFromCms()
 
     const allVacancies = vacanciesFromExternalSystem.concat(vacanciesFromCms)
     sortVacancyList(allVacancies)
 
     return {
       vacancies: allVacancies,
+      fetchErrorOccurred: externalSystemErrorOccurred || cmsErrorOccurred,
     }
   }
 


### PR DESCRIPTION
# Display alert message if /starfatorg endpoint throws an error

## What

* As of right now we don't display any alert to the user in case there was an error fetching vacancies

## Screenshots / Gifs

<img width="1400" alt="image" src="https://github.com/island-is/island.is/assets/43557895/6f371da2-726b-4726-bf3d-41285a4e1c60">


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
