### PR TITLE
fix(user-profile): Reverting using formatted phone number in sms verification

### DIFF
--- a/apps/services/user-profile/src/app/user-profile/e2e/userProfile.spec.ts
+++ b/apps/services/user-profile/src/app/user-profile/e2e/userProfile.spec.ts
@@ -250,7 +250,7 @@ describe('User profile API', () => {
   })
 
   describe('POST /emailVerification/:nationalId', () => {
-    it('POST /emailVerification/:nationalId re-creates an email verfication in db', async () => {
+    it('POST /emailVerification/:nationalId re-creates an email verification in db', async () => {
       const sutProfile = {
         ...mockProfileNoEmailNoPhone,
         email,
@@ -505,7 +505,7 @@ describe('User profile API', () => {
   })
 
   describe('POST /smsVerification', () => {
-    it('POST /smsVerification/ creates a sms verfication in db', async () => {
+    it('POST /smsVerification/ creates a sms verification in db', async () => {
       // Act
       const spy = jest.spyOn(smsService, 'sendSms')
       await request(app.getHttpServer())
@@ -519,7 +519,7 @@ describe('User profile API', () => {
       const verification = await SmsVerification.findOne({
         where: {
           nationalId: mockProfile.nationalId,
-          mobilePhoneNumber: formatPhoneNumber(mockProfile.mobilePhoneNumber),
+          mobilePhoneNumber: mockProfile.mobilePhoneNumber,
         },
       })
 
@@ -542,7 +542,7 @@ describe('User profile API', () => {
       const verification = await SmsVerification.findOne({
         where: {
           nationalId: mockProfile.nationalId,
-          mobilePhoneNumber: formatPhoneNumber(mockProfile.mobilePhoneNumber),
+          mobilePhoneNumber: mockProfile.mobilePhoneNumber,
         },
       })
 
@@ -577,7 +577,7 @@ describe('User profile API', () => {
       const verification = await SmsVerification.findOne({
         where: {
           nationalId: mockProfile.nationalId,
-          mobilePhoneNumber: formatPhoneNumber(mockProfile.mobilePhoneNumber),
+          mobilePhoneNumber: mockProfile.mobilePhoneNumber,
         },
       })
 
@@ -625,7 +625,7 @@ describe('User profile API', () => {
       const verification = await SmsVerification.findOne({
         where: {
           nationalId: mockProfile.nationalId,
-          mobilePhoneNumber: formatPhoneNumber(mockProfile.mobilePhoneNumber),
+          mobilePhoneNumber: mockProfile.mobilePhoneNumber,
         },
       })
       jest.setSystemTime(new Date(2020, 5, 2))
@@ -660,7 +660,7 @@ describe('User profile API', () => {
       const verification = await SmsVerification.findOne({
         where: {
           nationalId: mockProfile.nationalId,
-          mobilePhoneNumber: formatPhoneNumber(mockProfile.mobilePhoneNumber),
+          mobilePhoneNumber: mockProfile.mobilePhoneNumber,
         },
       })
 
@@ -728,7 +728,7 @@ describe('User profile API', () => {
       const verification = await SmsVerification.findOne({
         where: {
           nationalId: mockProfile.nationalId,
-          mobilePhoneNumber: formatPhoneNumber(mockProfile.mobilePhoneNumber),
+          mobilePhoneNumber: mockProfile.mobilePhoneNumber,
         },
       })
       const response = await request(app.getHttpServer())
@@ -761,7 +761,7 @@ describe('User profile API', () => {
       const verification = await SmsVerification.findOne({
         where: {
           nationalId: mockProfile.nationalId,
-          mobilePhoneNumber: formatPhoneNumber(mockProfile.mobilePhoneNumber),
+          mobilePhoneNumber: mockProfile.mobilePhoneNumber,
         },
       })
 

--- a/apps/services/user-profile/src/app/user-profile/verification.service.ts
+++ b/apps/services/user-profile/src/app/user-profile/verification.service.ts
@@ -11,7 +11,6 @@ import type { Logger } from '@island.is/logging'
 import { SmsService } from '@island.is/nova-sms'
 
 import environment from '../../environments/environment'
-import { formatPhoneNumber } from '../utils/format-phone-number'
 import { ConfirmEmailDto } from './dto/confirmEmailDto'
 import { ConfirmSmsDto } from './dto/confirmSmsDto'
 import { ConfirmationDtoResponse } from './dto/confirmationResponseDto'
@@ -91,10 +90,7 @@ export class VerificationService {
   ): Promise<SmsVerification | null> {
     const code = this.generateVerificationCode(codeLength)
     const verification = {
-      nationalId: createSmsVerification.nationalId,
-      mobilePhoneNumber: formatPhoneNumber(
-        createSmsVerification.mobilePhoneNumber,
-      ),
+      ...createSmsVerification,
       tries: 0,
       smsCode: code,
       created: new Date(),
@@ -202,12 +198,8 @@ export class VerificationService {
   ): Promise<ConfirmationDtoResponse> {
     const { transaction, maxTries = SMS_VERIFICATION_MAX_TRIES } = options ?? {}
 
-    const formattedPhoneNumber = formatPhoneNumber(
-      confirmSmsDto.mobilePhoneNumber,
-    )
-
     let verification = await this.smsVerificationModel.findOne({
-      where: { nationalId, mobilePhoneNumber: formattedPhoneNumber },
+      where: { nationalId, mobilePhoneNumber: confirmSmsDto.mobilePhoneNumber },
       order: [['created', 'DESC']],
       ...(transaction && { transaction }),
     })

--- a/apps/services/user-profile/src/app/v2/user-profile.service.ts
+++ b/apps/services/user-profile/src/app/v2/user-profile.service.ts
@@ -85,10 +85,6 @@ export class UserProfileService {
       )
     }
 
-    const formattedPhoneNumber = isMobilePhoneNumberDefined
-      ? formatPhoneNumber(userProfile.mobilePhoneNumber)
-      : undefined
-
     await this.sequelize.transaction(async (transaction) => {
       const commonArgs = [nationalId, { transaction, maxTries: 3 }] as const
 
@@ -118,7 +114,7 @@ export class UserProfileService {
         const { confirmed, message, remainingAttempts } =
           await this.verificationService.confirmSms(
             {
-              mobilePhoneNumber: formattedPhoneNumber,
+              mobilePhoneNumber: userProfile.mobilePhoneNumber,
               code: userProfile.mobilePhoneNumberVerificationCode,
             },
             ...commonArgs,
@@ -137,6 +133,10 @@ export class UserProfileService {
           }
         }
       }
+
+      const formattedPhoneNumber = isMobilePhoneNumberDefined
+        ? formatPhoneNumber(userProfile.mobilePhoneNumber)
+        : undefined
 
       const update = {
         nationalId,


### PR DESCRIPTION
## What

Revert using formatted phone number in sms verification as Nova SMS service throws and error on the formatted number.

## Why

To fix error in sending sms with Nova.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
