### PR TITLE
fix(user-profile): Parse phone number to find match in confirmSMS

### DIFF
--- a/apps/services/user-profile/src/app/user-profile/verification.service.ts
+++ b/apps/services/user-profile/src/app/user-profile/verification.service.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable } from '@nestjs/common'
 import { InjectModel } from '@nestjs/sequelize'
 import { randomInt } from 'crypto'
 import addMilliseconds from 'date-fns/addMilliseconds'
+import { parsePhoneNumber } from 'libphonenumber-js'
 import { join } from 'path'
 import { Transaction } from 'sequelize'
 
@@ -198,8 +199,14 @@ export class VerificationService {
   ): Promise<ConfirmationDtoResponse> {
     const { transaction, maxTries = SMS_VERIFICATION_MAX_TRIES } = options ?? {}
 
+    const phoneNumber = parsePhoneNumber(confirmSmsDto.mobilePhoneNumber, 'IS')
+    const mobilePhoneNumber =
+      phoneNumber.country === 'IS'
+        ? (phoneNumber.nationalNumber as string)
+        : confirmSmsDto.mobilePhoneNumber
+
     let verification = await this.smsVerificationModel.findOne({
-      where: { nationalId, mobilePhoneNumber: confirmSmsDto.mobilePhoneNumber },
+      where: { nationalId, mobilePhoneNumber },
       order: [['created', 'DESC']],
       ...(transaction && { transaction }),
     })

--- a/apps/services/user-profile/src/app/v2/test/me-user-profile.controller.spec.ts
+++ b/apps/services/user-profile/src/app/v2/test/me-user-profile.controller.spec.ts
@@ -33,7 +33,8 @@ const smsVerificationCode = createVerificationCode()
 const emailVerificationCode = createVerificationCode()
 
 const newEmail = faker.internet.email()
-const newPhoneNumber = formatPhoneNumber(createPhoneNumber())
+const newPhoneNumber = createPhoneNumber()
+const formattedNewPhoneNumber = formatPhoneNumber(newPhoneNumber)
 
 const testEmailVerification = {
   nationalId: testUserProfile.nationalId,
@@ -226,7 +227,7 @@ describe('MeUserProfileController', () => {
       // Act
       const res = await server.patch('/v2/me').send({
         email: newEmail,
-        mobilePhoneNumber: newPhoneNumber,
+        mobilePhoneNumber: formattedNewPhoneNumber,
         emailVerificationCode: emailVerificationCode,
         mobilePhoneNumberVerificationCode: smsVerificationCode,
       })
@@ -236,7 +237,7 @@ describe('MeUserProfileController', () => {
       expect(res.body).toMatchObject({
         email: newEmail,
         emailVerified: true,
-        mobilePhoneNumber: newPhoneNumber,
+        mobilePhoneNumber: formattedNewPhoneNumber,
         mobilePhoneNumberVerified: true,
       })
 
@@ -247,13 +248,13 @@ describe('MeUserProfileController', () => {
       })
 
       expect(userProfile.email).toBe(newEmail)
-      expect(userProfile.mobilePhoneNumber).toBe(newPhoneNumber)
+      expect(userProfile.mobilePhoneNumber).toBe(formattedNewPhoneNumber)
     })
 
     it('PATCH /v2/me should return 200 with changed mobile data in response', async () => {
       // Act
       const res = await server.patch('/v2/me').send({
-        mobilePhoneNumber: newPhoneNumber,
+        mobilePhoneNumber: formattedNewPhoneNumber,
         mobilePhoneNumberVerificationCode: smsVerificationCode,
       })
 
@@ -261,7 +262,7 @@ describe('MeUserProfileController', () => {
       expect(res.status).toEqual(200)
       expect(res.body).toMatchObject({
         nationalId: testUserProfile.nationalId,
-        mobilePhoneNumber: newPhoneNumber,
+        mobilePhoneNumber: formattedNewPhoneNumber,
         mobilePhoneNumberVerified: true,
       })
 
@@ -271,7 +272,7 @@ describe('MeUserProfileController', () => {
         where: { nationalId: testUserProfile.nationalId },
       })
 
-      expect(userProfile.mobilePhoneNumber).toBe(newPhoneNumber)
+      expect(userProfile.mobilePhoneNumber).toBe(formattedNewPhoneNumber)
     })
 
     it('PATCH /v2/me should return 200 with changed email data in response', async () => {
@@ -334,7 +335,7 @@ describe('MeUserProfileController', () => {
     it('PATCH /v2/me should return 400 when mobile verification code is incorrect', async () => {
       // Act
       const res = await server.patch('/v2/me').send({
-        mobilePhoneNumber: newPhoneNumber,
+        mobilePhoneNumber: formattedNewPhoneNumber,
         mobilePhoneNumberVerificationCode: '000',
       })
 
@@ -386,7 +387,7 @@ describe('MeUserProfileController', () => {
     it('PATCH /v2/me should return 400 when there is no sms verification code', async () => {
       // Act
       const res = await server.patch('/v2/me').send({
-        mobilePhoneNumber: newPhoneNumber,
+        mobilePhoneNumber: formattedNewPhoneNumber,
       })
 
       // Assert
@@ -411,7 +412,7 @@ describe('MeUserProfileController', () => {
 
       // Act
       const res = await server.patch('/v2/me').send({
-        mobilePhoneNumber: newPhoneNumber,
+        mobilePhoneNumber: formattedNewPhoneNumber,
         mobilePhoneNumberVerificationCode: '000',
       })
 
@@ -501,7 +502,7 @@ describe('MeUserProfileController', () => {
       const res = await server.patch('/v2/me').send({
         email: newEmail,
         emailVerificationCode: emailVerificationCode,
-        mobilePhoneNumber: newPhoneNumber,
+        mobilePhoneNumber: formattedNewPhoneNumber,
         mobilePhoneNumberVerificationCode: smsVerificationCode,
       })
 
@@ -512,7 +513,7 @@ describe('MeUserProfileController', () => {
         user: {
           ssn: testUserProfile.nationalId,
           email: newEmail,
-          mobile: newPhoneNumber,
+          mobile: formattedNewPhoneNumber,
         },
       })
     })
@@ -520,7 +521,7 @@ describe('MeUserProfileController', () => {
     it('PATCH /v2/me should return 200 and should call the islyklar put method and not post', async () => {
       // Act
       const res = await server.patch('/v2/me').send({
-        mobilePhoneNumber: newPhoneNumber,
+        mobilePhoneNumber: formattedNewPhoneNumber,
         mobilePhoneNumberVerificationCode: smsVerificationCode,
         email: newEmail,
         emailVerificationCode: emailVerificationCode,
@@ -533,7 +534,7 @@ describe('MeUserProfileController', () => {
         user: {
           ssn: testUserProfile.nationalId,
           email: newEmail,
-          mobile: newPhoneNumber,
+          mobile: formattedNewPhoneNumber,
         },
       })
     })
@@ -560,7 +561,7 @@ describe('MeUserProfileController', () => {
     it('PATCH /v2/me should return 200 and should call the islyklar put method with new mobilePhoneNumber and current email', async () => {
       // Act
       const res = await server.patch('/v2/me').send({
-        mobilePhoneNumber: newPhoneNumber,
+        mobilePhoneNumber: formattedNewPhoneNumber,
         mobilePhoneNumberVerificationCode: smsVerificationCode,
       })
 
@@ -571,7 +572,7 @@ describe('MeUserProfileController', () => {
         user: {
           ssn: testUserProfile.nationalId,
           email: testUserProfile.email,
-          mobile: newPhoneNumber,
+          mobile: formattedNewPhoneNumber,
         },
       })
     })


### PR DESCRIPTION
## What

Continue fix in #12693 that the phonenumber  needs to be parsed in confirmSMS

## Why

So confirmSMS finds the match and succeeds to confirm the sms code.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
