### PR TITLE
fix(user-profile): Parse phone number to find match in confirmSMS

### DIFF
--- a/apps/services/user-profile/src/app/user-profile/verification.service.ts
+++ b/apps/services/user-profile/src/app/user-profile/verification.service.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable } from '@nestjs/common'
 import { InjectModel } from '@nestjs/sequelize'
 import { randomInt } from 'crypto'
 import addMilliseconds from 'date-fns/addMilliseconds'
+import { parsePhoneNumber } from 'libphonenumber-js'
 import { join } from 'path'
 import { Transaction } from 'sequelize'
 
@@ -181,8 +182,14 @@ export class VerificationService {
     nationalId: string,
     transaction?: Transaction,
   ): Promise<ConfirmationDtoResponse> {
+    const phoneNumber = parsePhoneNumber(confirmSmsDto.mobilePhoneNumber, 'IS')
+    const mobilePhoneNumber =
+      phoneNumber.country === 'IS'
+        ? (phoneNumber.nationalNumber as string)
+        : confirmSmsDto.mobilePhoneNumber
+
     const verification = await this.smsVerificationModel.findOne({
-      where: { nationalId, mobilePhoneNumber: confirmSmsDto.mobilePhoneNumber },
+      where: { nationalId, mobilePhoneNumber },
       order: [['created', 'DESC']],
       ...(transaction && { transaction }),
     })

--- a/apps/services/user-profile/src/app/v2/test/me-user-profile.controller.spec.ts
+++ b/apps/services/user-profile/src/app/v2/test/me-user-profile.controller.spec.ts
@@ -31,7 +31,8 @@ const smsVerificationCode = createVerificationCode()
 const emailVerificationCode = createVerificationCode()
 
 const newEmail = faker.internet.email()
-const newPhoneNumber = formatPhoneNumber(createPhoneNumber())
+const newPhoneNumber = createPhoneNumber()
+const formattedNewPhoneNumber = formatPhoneNumber(newPhoneNumber)
 
 const testEmailVerification = {
   nationalId: testUserProfile.nationalId,
@@ -222,7 +223,7 @@ describe('MeUserProfileController', () => {
       // Act
       const res = await server.patch('/v2/me').send({
         email: newEmail,
-        mobilePhoneNumber: newPhoneNumber,
+        mobilePhoneNumber: formattedNewPhoneNumber,
         emailVerificationCode: emailVerificationCode,
         mobilePhoneNumberVerificationCode: smsVerificationCode,
       })
@@ -232,7 +233,7 @@ describe('MeUserProfileController', () => {
       expect(res.body).toMatchObject({
         email: newEmail,
         emailVerified: true,
-        mobilePhoneNumber: newPhoneNumber,
+        mobilePhoneNumber: formattedNewPhoneNumber,
         mobilePhoneNumberVerified: true,
       })
 
@@ -243,13 +244,13 @@ describe('MeUserProfileController', () => {
       })
 
       expect(userProfile.email).toBe(newEmail)
-      expect(userProfile.mobilePhoneNumber).toBe(newPhoneNumber)
+      expect(userProfile.mobilePhoneNumber).toBe(formattedNewPhoneNumber)
     })
 
     it('PATCH /v2/me should return 200 with changed mobile data in response', async () => {
       // Act
       const res = await server.patch('/v2/me').send({
-        mobilePhoneNumber: newPhoneNumber,
+        mobilePhoneNumber: formattedNewPhoneNumber,
         mobilePhoneNumberVerificationCode: smsVerificationCode,
       })
 
@@ -257,7 +258,7 @@ describe('MeUserProfileController', () => {
       expect(res.status).toEqual(200)
       expect(res.body).toMatchObject({
         nationalId: testUserProfile.nationalId,
-        mobilePhoneNumber: newPhoneNumber,
+        mobilePhoneNumber: formattedNewPhoneNumber,
         mobilePhoneNumberVerified: true,
       })
 
@@ -267,7 +268,7 @@ describe('MeUserProfileController', () => {
         where: { nationalId: testUserProfile.nationalId },
       })
 
-      expect(userProfile.mobilePhoneNumber).toBe(newPhoneNumber)
+      expect(userProfile.mobilePhoneNumber).toBe(formattedNewPhoneNumber)
     })
 
     it('PATCH /v2/me should return 200 with changed email data in response', async () => {
@@ -322,7 +323,7 @@ describe('MeUserProfileController', () => {
     it('PATCH /v2/me should return 400 when mobile verification code is incorrect', async () => {
       // Act
       const res = await server.patch('/v2/me').send({
-        mobilePhoneNumber: newPhoneNumber,
+        mobilePhoneNumber: formattedNewPhoneNumber,
         mobilePhoneNumberVerificationCode: '000',
       })
 
@@ -365,7 +366,7 @@ describe('MeUserProfileController', () => {
     it('PATCH /v2/me should return 400 when there is no sms verification code', async () => {
       // Act
       const res = await server.patch('/v2/me').send({
-        mobilePhoneNumber: newPhoneNumber,
+        mobilePhoneNumber: formattedNewPhoneNumber,
       })
 
       // Assert
@@ -427,7 +428,7 @@ describe('MeUserProfileController', () => {
       const res = await server.patch('/v2/me').send({
         email: newEmail,
         emailVerificationCode: emailVerificationCode,
-        mobilePhoneNumber: newPhoneNumber,
+        mobilePhoneNumber: formattedNewPhoneNumber,
         mobilePhoneNumberVerificationCode: smsVerificationCode,
       })
 
@@ -438,7 +439,7 @@ describe('MeUserProfileController', () => {
         user: {
           ssn: testUserProfile.nationalId,
           email: newEmail,
-          mobile: newPhoneNumber,
+          mobile: formattedNewPhoneNumber,
         },
       })
     })
@@ -446,7 +447,7 @@ describe('MeUserProfileController', () => {
     it('PATCH /v2/me should return 200 and should call the islyklar put method and not post', async () => {
       // Act
       const res = await server.patch('/v2/me').send({
-        mobilePhoneNumber: newPhoneNumber,
+        mobilePhoneNumber: formattedNewPhoneNumber,
         mobilePhoneNumberVerificationCode: smsVerificationCode,
         email: newEmail,
         emailVerificationCode: emailVerificationCode,
@@ -459,7 +460,7 @@ describe('MeUserProfileController', () => {
         user: {
           ssn: testUserProfile.nationalId,
           email: newEmail,
-          mobile: newPhoneNumber,
+          mobile: formattedNewPhoneNumber,
         },
       })
     })
@@ -486,7 +487,7 @@ describe('MeUserProfileController', () => {
     it('PATCH /v2/me should return 200 and should call the islyklar put method with new mobilePhoneNumber and current email', async () => {
       // Act
       const res = await server.patch('/v2/me').send({
-        mobilePhoneNumber: newPhoneNumber,
+        mobilePhoneNumber: formattedNewPhoneNumber,
         mobilePhoneNumberVerificationCode: smsVerificationCode,
       })
 
@@ -497,7 +498,7 @@ describe('MeUserProfileController', () => {
         user: {
           ssn: testUserProfile.nationalId,
           email: testUserProfile.email,
-          mobile: newPhoneNumber,
+          mobile: formattedNewPhoneNumber,
         },
       })
     })


### PR DESCRIPTION
## What

Apply #12695 to release

## Why

So confirm sms finds the match.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
