### PR TITLE
fix(web): Add spacing between slice dropdown and first element

### DIFF
--- a/apps/web/components/Organization/Slice/Render/SliceDropdown.tsx
+++ b/apps/web/components/Organization/Slice/Render/SliceDropdown.tsx
@@ -1,16 +1,18 @@
 import React, { useEffect, useMemo, useState } from 'react'
-import { Slice } from '@island.is/web/graphql/schema'
-import { SliceMachine } from '@island.is/web/components'
+import { useRouter } from 'next/router'
+import slugify from '@sindresorhus/slugify'
+
 import {
   BoxProps,
   GridColumn,
   GridContainer,
   GridRow,
   Select,
+  Stack,
 } from '@island.is/island-ui/core'
-import { useRouter } from 'next/router'
-import slugify from '@sindresorhus/slugify'
 import { SpanType } from '@island.is/island-ui/core/types'
+import { SliceMachine } from '@island.is/web/components'
+import { Slice } from '@island.is/web/graphql/schema'
 
 interface SliceProps {
   slices: Slice[]
@@ -61,7 +63,7 @@ export const SliceDropdown: React.FC<React.PropsWithChildren<SliceProps>> = ({
   const selectedSlice = slices.find((x) => x.id === selectedId)
 
   return (
-    <>
+    <Stack space={5}>
       <GridContainer>
         <GridRow marginBottom={dropdownMarginBottom}>
           <GridColumn span={gridSpan} offset={gridOffset}>
@@ -102,6 +104,6 @@ export const SliceDropdown: React.FC<React.PropsWithChildren<SliceProps>> = ({
           fullWidth={slicesAreFullWidth}
         />
       )}
-    </>
+    </Stack>
   )
 }


### PR DESCRIPTION
#  Add spacing between slice dropdown and first element

## Screenshots / Gifs

### Before
<img width="856" alt="image" src="https://github.com/island-is/island.is/assets/43557895/7f6b5553-6f88-40dd-bea4-affebfb91465">

### After
<img width="826" alt="image" src="https://github.com/island-is/island.is/assets/43557895/964825f5-0154-4c25-804e-94b8fcabc245">


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
