### PR TITLE
fix(consultation-portal): KAM-1866: Search getting filter value once filters are loaded

### DIFF
--- a/apps/consultation-portal/components/DebouncedSearch/DebouncedSearch.tsx
+++ b/apps/consultation-portal/components/DebouncedSearch/DebouncedSearch.tsx
@@ -14,6 +14,7 @@ interface Props {
   localStorageId?: string
   label?: string
   isSubscriptions?: boolean
+  filtersLoaded?: boolean
 }
 
 const loc = localization.debouncedSearch
@@ -27,10 +28,17 @@ const DebouncedSearch = ({
   localStorageId,
   label = loc.label,
   isSubscriptions,
+  filtersLoaded,
 }: Props) => {
   const [value, setValue] = useState(
     isSubscriptions ? searchValue : filters?.searchQuery,
   )
+
+  useEffect(() => {
+    if (filtersLoaded && !isSubscriptions) {
+      setValue(filters?.searchQuery)
+    }
+  }, [filtersLoaded])
 
   const debouncedHandleSearch = useDebounce(() => {
     if (isSubscriptions) {

--- a/apps/consultation-portal/components/Layout/Layout.tsx
+++ b/apps/consultation-portal/components/Layout/Layout.tsx
@@ -1,12 +1,11 @@
 import React, { FC } from 'react'
 import dynamic from 'next/dynamic'
 import { Box, Divider, ToastContainer } from '@island.is/island-ui/core'
-import { SEO } from './components'
+import { SEO, Menu } from './components'
 import * as styles from './Layout.css'
 import { SEOProps } from '../../types/interfaces'
 
 const Footer = dynamic(() => import('./components/Footer/Footer'))
-const Menu = dynamic(() => import('./components/Menu/Menu'))
 
 type LayoutProps = {
   isFrontPage?: boolean

--- a/apps/consultation-portal/hooks/useFrontPageFilters.ts
+++ b/apps/consultation-portal/hooks/useFrontPageFilters.ts
@@ -42,6 +42,8 @@ export const useFrontPageFilters = ({ types }: Props) => {
     ...initialValues,
   })
 
+  const [filtersLoaded, setFiltersLoaded] = useState(false)
+
   const _caseStatuses = getFilteredItemsOrAll({
     items: [...filters.caseStatuses.items],
     defaultItems: initialValues?.caseStatuses?.items,
@@ -106,6 +108,9 @@ export const useFrontPageFilters = ({ types }: Props) => {
   useEffect(() => {
     const nextFilters = getFiltersFromLocalStorage({ filters: filters })
     setFilters(nextFilters)
+    setFiltersLoaded(true)
+
+    return () => setFiltersLoaded(false)
   }, [])
 
   return {
@@ -119,5 +124,6 @@ export const useFrontPageFilters = ({ types }: Props) => {
     filters: filters,
     setFilters: setFilters,
     initialValues: initialValues,
+    filtersLoaded: filtersLoaded,
   }
 }

--- a/apps/consultation-portal/screens/Home/Home.tsx
+++ b/apps/consultation-portal/screens/Home/Home.tsx
@@ -1,6 +1,11 @@
 import dynamic from 'next/dynamic'
 import { GridColumn, GridContainer, GridRow } from '@island.is/island-ui/core'
-import { HeroBanner } from './components/'
+import {
+  HeroBanner,
+  MobileFilter,
+  Filter,
+  SearchAndFilter,
+} from './components/'
 import localization from './Home.json'
 import { ArrOfTypes, CaseFilter } from '../../types/interfaces'
 import { Layout } from '../../components'
@@ -11,17 +16,6 @@ import {
 } from '../../hooks'
 
 const Cards = dynamic(() => import('./components/Cards/Cards'), { ssr: false })
-const MobileFilter = dynamic(
-  () => import('./components/MobileFilter/MobileFilter'),
-  { ssr: false },
-)
-const Filter = dynamic(() => import('./components/Filter/Filter'), {
-  ssr: false,
-})
-const SearchAndFilter = dynamic(
-  () => import('./components/SearchAndFilter/SearchAndFilter'),
-  { ssr: false },
-)
 
 interface HomeProps {
   types: ArrOfTypes
@@ -43,6 +37,7 @@ export const Index = ({ types }: HomeProps) => {
     filters,
     setFilters,
     initialValues,
+    filtersLoaded
   } = useFrontPageFilters({
     types: types,
   })
@@ -75,6 +70,7 @@ export const Index = ({ types }: HomeProps) => {
           filters={filters}
           setFilters={(arr: CaseFilter) => setFilters(arr)}
           loading={getCasesLoading}
+          filtersLoaded={filtersLoaded}
         />
       )}
 

--- a/apps/consultation-portal/screens/Home/Home.tsx
+++ b/apps/consultation-portal/screens/Home/Home.tsx
@@ -37,7 +37,7 @@ export const Index = ({ types }: HomeProps) => {
     filters,
     setFilters,
     initialValues,
-    filtersLoaded
+    filtersLoaded,
   } = useFrontPageFilters({
     types: types,
   })

--- a/apps/consultation-portal/screens/Home/components/SearchAndFilter/SearchAndFilter.tsx
+++ b/apps/consultation-portal/screens/Home/components/SearchAndFilter/SearchAndFilter.tsx
@@ -31,7 +31,7 @@ const SearchAndFilter = ({
   filters,
   setFilters,
   loading,
-  filtersLoaded
+  filtersLoaded,
 }: SearchAndFilterProps) => {
   const loc = localization.searchAndFilter
 

--- a/apps/consultation-portal/screens/Home/components/SearchAndFilter/SearchAndFilter.tsx
+++ b/apps/consultation-portal/screens/Home/components/SearchAndFilter/SearchAndFilter.tsx
@@ -20,6 +20,7 @@ interface SearchAndFilterProps {
   filters: CaseFilter
   setFilters: (arr: CaseFilter) => void
   loading?: boolean
+  filtersLoaded?: boolean
 }
 
 const SearchAndFilter = ({
@@ -30,6 +31,7 @@ const SearchAndFilter = ({
   filters,
   setFilters,
   loading,
+  filtersLoaded
 }: SearchAndFilterProps) => {
   const loc = localization.searchAndFilter
 
@@ -64,6 +66,7 @@ const SearchAndFilter = ({
               setFilters={setFilters}
               name="front_page_search"
               localStorageId={FILTERS_FRONT_PAGE_KEY}
+              filtersLoaded={filtersLoaded}
             />
           </GridColumn>
           <GridColumn span={['2/12', '2/12', '3/12', '3/12', '3/12']}>


### PR DESCRIPTION
# Search does not show text from filters when reloading

https://veflausnir.atlassian.net/browse/KAM-1866

## What

On initial rendering, let search box wait for filters to load until populating the field
Removing dynamic for specific components

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
