### PR TITLE
fix(portals-admin-icelandic-names-registry): Fix name update mutation

### DIFF
--- a/libs/portals/admin/icelandic-names-registry/src/components/Editor/Editor.tsx
+++ b/libs/portals/admin/icelandic-names-registry/src/components/Editor/Editor.tsx
@@ -140,7 +140,8 @@ const Editor = () => {
   }, [currentName])
 
   const onSubmit = async (formState: IcelandicNameType) => {
-    const { id, ...rest } = formState
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    const { id, __typename, ...rest } = formState
 
     const body: CreateIcelandicNameInput = {
       ...rest,


### PR DESCRIPTION
## What

As the query results from the formState contains the internal GQL `__typename` property it breaks the mutation as the input type of the mutation doesn't expect this field.

## Why

So users can update the name after it has been initally created.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
