### PR TITLE
fix(web): Render <a> tags for menu links

### DIFF
--- a/apps/web/components/Menu/Menu.tsx
+++ b/apps/web/components/Menu/Menu.tsx
@@ -104,9 +104,9 @@ export const Menu = ({
       }
       renderLink={({ className, text, href }, closeModal) => {
         return (
-          <Link href={href} onClick={closeModal}>
+          <a href={href} onClick={closeModal}>
             <span className={className}>{text}</span>
-          </Link>
+          </a>
         )
       }}
       renderMyPagesButton={(button) => {


### PR DESCRIPTION
# Render <a> tags for menu links

## What

* So when users click on a link pointing to /minarsidur they'll open it up without seeing a 404 since the page used to get loaded within the web project

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
