### PR TITLE
fix(web): Use <a> tag instead of nextlink for Link and LinkV2 components

### DIFF
--- a/libs/island-ui/core/src/lib/Link/Link.tsx
+++ b/libs/island-ui/core/src/lib/Link/Link.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import NextLink, { LinkProps as NextLinkProps } from 'next/link'
+import { LinkProps as NextLinkProps } from 'next/link'
 import cn from 'classnames'
 
 import { shouldLinkOpenInNewWindow } from '@island.is/shared/utils'
@@ -67,30 +67,16 @@ export const Link: React.FC<React.PropsWithChildren<LinkProps>> = ({
 
   if (isInternal) {
     return (
-      <NextLink
-        href={href}
-        as={as}
-        shallow={shallow}
-        scroll={scroll}
-        passHref
-        prefetch={prefetch}
+      <a
+        className={classNames}
         data-testid={dataTestId}
-        legacyBehavior
+        href={href as string}
+        {...linkProps}
+        {...(newTab && { target: '_blank' })}
+        tabIndex={skipTab ? -1 : undefined}
       >
-        {pureChildren ? (
-          children
-        ) : (
-          <a
-            className={classNames}
-            data-testid={dataTestId}
-            {...linkProps}
-            {...(newTab && { target: '_blank' })}
-            tabIndex={skipTab ? -1 : undefined}
-          >
-            {children}
-          </a>
-        )}
-      </NextLink>
+        {children}
+      </a>
     )
   } else {
     return (

--- a/libs/island-ui/core/src/lib/Link/LinkV2.tsx
+++ b/libs/island-ui/core/src/lib/Link/LinkV2.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import cn from 'classnames'
-import NextLink, { LinkProps as NextLinkProps } from 'next/link'
+import { LinkProps as NextLinkProps } from 'next/link'
 
 import { shouldLinkOpenInNewWindow } from '@island.is/shared/utils'
 
@@ -55,30 +55,16 @@ export const LinkV2: React.FC<React.PropsWithChildren<LinkProps>> = ({
 
   if (isInternal) {
     return (
-      <NextLink
-        href={href}
-        as={as}
-        shallow={shallow}
-        scroll={scroll}
-        passHref
-        prefetch={prefetch}
+      <a
+        className={classNames}
         data-testid={dataTestId}
-        legacyBehavior
+        href={href as string}
+        {...linkProps}
+        {...(newTab && { target: '_blank' })}
+        tabIndex={skipTab ? -1 : undefined}
       >
-        {pureChildren ? (
-          children
-        ) : (
-          <a
-            className={classNames}
-            data-testid={dataTestId}
-            {...linkProps}
-            {...(newTab && { target: '_blank' })}
-            tabIndex={skipTab ? -1 : undefined}
-          >
-            {children}
-          </a>
-        )}
-      </NextLink>
+        {children}
+      </a>
     )
   } else {
     return (


### PR DESCRIPTION
# Use <a> tag instead of nextlink for Link and LinkV2 components

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
