### PR TITLE
fix(portals-admin-icelandic-names-registry): Fix name update mutation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -82,6 +82,8 @@
 /libs/application/template-api-modules/src/lib/modules/templates/inheritance-report                      @island-is/juni
 /libs/api/domains/disability-license                                                                     @island-is/juni
 /libs/portals/admin/petition                                                                             @island-is/juni
+/libs/portals/admin/icelandic-names-registry                                                             @island-is/juni
+
 
 /apps/portals/admin/                                                                                     @island-is/aranja
 /libs/api/domains/auth-admin/                                                                            @island-is/aranja

--- a/libs/portals/admin/icelandic-names-registry/src/components/Editor/Editor.tsx
+++ b/libs/portals/admin/icelandic-names-registry/src/components/Editor/Editor.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useRef, useState } from 'react'
-import { useMutation, gql } from '@apollo/client'
+import { useMutation } from '@apollo/client'
+import omit from 'lodash/omit'
 import {
   Box,
   Input,
-  Text,
   ModalBase,
   Button,
   ToastContainer,
@@ -140,7 +140,7 @@ const Editor = () => {
   }, [currentName])
 
   const onSubmit = async (formState: IcelandicNameType) => {
-    const { id, ...rest } = formState
+    const { id, ...rest } = omit(formState, '__typename')
 
     const body: CreateIcelandicNameInput = {
       ...rest,


### PR DESCRIPTION
## What

Add #12706 to release to fix icelandic names registry admin module.

## Why

It's currently broken as employees of Þjóðskrá cannot edit names to add link to a ruling.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
