### PR TITLE
fix(service-portal): Don't render button element inside anchors

### DIFF
--- a/libs/service-portal/assets/src/screens/AssetsOverview/AssetsOverview.tsx
+++ b/libs/service-portal/assets/src/screens/AssetsOverview/AssetsOverview.tsx
@@ -127,11 +127,11 @@ export const AssetsOverview = () => {
                   rel="noreferrer"
                 >
                   <Button
+                    as="span"
                     colorScheme="default"
                     icon="document"
                     iconType="filled"
                     size="default"
-                    type="button"
                     variant="utility"
                   >
                     {formatMessage(m.mortageCertificate)}

--- a/libs/service-portal/assets/src/screens/Overview/Overview.tsx
+++ b/libs/service-portal/assets/src/screens/Overview/Overview.tsx
@@ -181,11 +181,11 @@ const VehiclesOverview = () => {
               rel="noopener noreferrer"
             >
               <Button
+                as="span"
                 colorScheme="default"
                 icon="open"
                 iconType="outline"
                 size="default"
-                type="button"
                 variant="utility"
               >
                 {formatMessage(messages.changeOfOwnership)}
@@ -199,6 +199,7 @@ const VehiclesOverview = () => {
               rel="noopener noreferrer"
             >
               <Button
+                as="span"
                 variant="utility"
                 size="small"
                 icon="reader"
@@ -215,6 +216,7 @@ const VehiclesOverview = () => {
               rel="noopener noreferrer"
             >
               <Button
+                as="span"
                 variant="utility"
                 size="small"
                 icon="eyeOff"

--- a/libs/service-portal/assets/src/screens/WorkMachinesDetail/WorkMachinesDetail.tsx
+++ b/libs/service-portal/assets/src/screens/WorkMachinesDetail/WorkMachinesDetail.tsx
@@ -87,6 +87,7 @@ const WorkMachinesDetail = () => {
 
       const button = (
         <Button
+          as={url ? 'span' : undefined}
           size="medium"
           disabled={!url}
           icon={icon}

--- a/libs/service-portal/core/src/components/LinkButton/LinkButton.tsx
+++ b/libs/service-portal/core/src/components/LinkButton/LinkButton.tsx
@@ -29,11 +29,17 @@ export const LinkButton: FC<React.PropsWithChildren<Props>> = ({
       rel="noreferrer"
     >
       {skipIcon ? (
-        <Button size="small" variant="text">
+        <Button as="span" size="small" variant="text">
           {text}
         </Button>
       ) : (
-        <Button size="small" variant="text" icon="open" iconType="outline">
+        <Button
+          as="span"
+          size="small"
+          variant="text"
+          icon="open"
+          iconType="outline"
+        >
           {text}
         </Button>
       )}

--- a/libs/service-portal/core/src/screens/NoDataScreen/NoDataScreen.tsx
+++ b/libs/service-portal/core/src/screens/NoDataScreen/NoDataScreen.tsx
@@ -46,6 +46,7 @@ export const NoDataScreen: FC<React.PropsWithChildren<Props>> = ({
         {button.type === 'internal' && button.link && (
           <Link to={button.link}>
             <Button
+              as="span"
               variant={button.variant}
               size="small"
               icon={button.icon ? button.icon.icon : undefined}
@@ -58,6 +59,7 @@ export const NoDataScreen: FC<React.PropsWithChildren<Props>> = ({
         {button.type === 'external' && button.link && (
           <a href={button.link}>
             <Button
+              as="span"
               variant={button.variant}
               size="small"
               icon={button.icon ? button.icon.icon : undefined}

--- a/libs/service-portal/documents/src/components/DocumentActionBar/DocumentActionBar.tsx
+++ b/libs/service-portal/documents/src/components/DocumentActionBar/DocumentActionBar.tsx
@@ -133,6 +133,7 @@ export const DocumentActionBar: React.FC<DocumentActionBarProps> = ({
                 aria-label={formatMessage(m.getDocument)}
               >
                 <Button
+                  as="span"
                   circle
                   icon="download"
                   iconType="outline"

--- a/libs/service-portal/documents/src/components/DocumentRenderer/UrlDocment.tsx
+++ b/libs/service-portal/documents/src/components/DocumentRenderer/UrlDocment.tsx
@@ -10,7 +10,13 @@ export const UrlDocument: React.FC<UrlDocumentProps> = ({ url }) => {
 
   return (
     <LinkResolver href={url}>
-      <Button variant="utility" icon="open" iconType="outline" unfocusable>
+      <Button
+        as="span"
+        variant="utility"
+        icon="open"
+        iconType="outline"
+        unfocusable
+      >
         {formatMessage(m.getDocument)}
       </Button>
     </LinkResolver>

--- a/libs/service-portal/education/src/screens/DrivingLessonsBook/DrivingLessonsBook.tsx
+++ b/libs/service-portal/education/src/screens/DrivingLessonsBook/DrivingLessonsBook.tsx
@@ -205,7 +205,7 @@ const DrivingLessonsBook = () => {
           <EmptyState />
           <Box display="flex" alignItems="center" justifyContent="center">
             <LinkResolver href={formatMessage(urls.licenseApplication)}>
-              <Button type="button">
+              <Button as="span">
                 {formatMessage(messages.signupToDrivingSchool)}
               </Button>
             </LinkResolver>

--- a/libs/service-portal/health/src/screens/HealthOverview/HealthOverview.tsx
+++ b/libs/service-portal/health/src/screens/HealthOverview/HealthOverview.tsx
@@ -154,6 +154,7 @@ export const HealthOverview = () => {
                     {enabledPaymentPage && (
                       <Link to={HealthPaths.HealthPaymentOverview}>
                         <Button
+                          as="span"
                           icon="open"
                           iconType="outline"
                           variant="text"

--- a/libs/service-portal/information/src/components/PersonalInformation/Forms/ProfileForm/components/FormButton.tsx
+++ b/libs/service-portal/information/src/components/PersonalInformation/Forms/ProfileForm/components/FormButton.tsx
@@ -27,11 +27,15 @@ export const FormButton: FC<React.PropsWithChildren<Props>> = ({
         {children}
       </Button>
     ) : (
-      <button type="submit" disabled={disabled}>
-        <Button variant="text" size="small" disabled={disabled}>
-          {children}
-        </Button>
-      </button>
+      <Button
+        as="button"
+        type="submit"
+        variant="text"
+        size="small"
+        disabled={disabled}
+      >
+        {children}
+      </Button>
     )
   }
   return (

--- a/libs/service-portal/licenses/src/screens/LicenseDetail/LicenseDetail.tsx
+++ b/libs/service-portal/licenses/src/screens/LicenseDetail/LicenseDetail.tsx
@@ -430,6 +430,7 @@ const LicenseDetail = () => {
                       key={licenseType + '_link_' + index}
                     >
                       <Button
+                        as="span"
                         variant="utility"
                         size="small"
                         icon={


### PR DESCRIPTION
## What

Render <Button> component as span when inside links

## Why

<button> inside link is not valid

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
