### PR TITLE
fix(service-portal): avoid double tabbing on button links

### DIFF
--- a/libs/service-portal/assets/src/screens/AssetsOverview/AssetsOverview.tsx
+++ b/libs/service-portal/assets/src/screens/AssetsOverview/AssetsOverview.tsx
@@ -128,6 +128,7 @@ export const AssetsOverview = () => {
                 >
                   <Button
                     as="span"
+                    unfocusable
                     colorScheme="default"
                     icon="document"
                     iconType="filled"

--- a/libs/service-portal/assets/src/screens/Overview/Overview.tsx
+++ b/libs/service-portal/assets/src/screens/Overview/Overview.tsx
@@ -182,6 +182,7 @@ const VehiclesOverview = () => {
             >
               <Button
                 as="span"
+                unfocusable
                 colorScheme="default"
                 icon="open"
                 iconType="outline"
@@ -200,6 +201,7 @@ const VehiclesOverview = () => {
             >
               <Button
                 as="span"
+                unfocusable
                 variant="utility"
                 size="small"
                 icon="reader"
@@ -217,6 +219,7 @@ const VehiclesOverview = () => {
             >
               <Button
                 as="span"
+                unfocusable
                 variant="utility"
                 size="small"
                 icon="eyeOff"

--- a/libs/service-portal/core/src/components/GoBack/GoBack.tsx
+++ b/libs/service-portal/core/src/components/GoBack/GoBack.tsx
@@ -44,6 +44,7 @@ export const GoBack = ({
           variant="text"
           truncate={truncate}
           as="span"
+          unfocusable
         >
           {label ?? formatMessage(m.goBackToDashboard)}
         </Button>

--- a/libs/service-portal/core/src/components/LinkButton/LinkButton.tsx
+++ b/libs/service-portal/core/src/components/LinkButton/LinkButton.tsx
@@ -29,12 +29,13 @@ export const LinkButton: FC<React.PropsWithChildren<Props>> = ({
       rel="noreferrer"
     >
       {skipIcon ? (
-        <Button as="span" size="small" variant="text">
+        <Button as="span" size="small" variant="text" unfocusable>
           {text}
         </Button>
       ) : (
         <Button
           as="span"
+          unfocusable
           size="small"
           variant="text"
           icon="open"

--- a/libs/service-portal/core/src/screens/NoDataScreen/NoDataScreen.tsx
+++ b/libs/service-portal/core/src/screens/NoDataScreen/NoDataScreen.tsx
@@ -47,6 +47,7 @@ export const NoDataScreen: FC<React.PropsWithChildren<Props>> = ({
           <Link to={button.link}>
             <Button
               as="span"
+              unfocusable
               variant={button.variant}
               size="small"
               icon={button.icon ? button.icon.icon : undefined}
@@ -60,6 +61,7 @@ export const NoDataScreen: FC<React.PropsWithChildren<Props>> = ({
           <a href={button.link}>
             <Button
               as="span"
+              unfocusable
               variant={button.variant}
               size="small"
               icon={button.icon ? button.icon.icon : undefined}

--- a/libs/service-portal/documents/src/components/DocumentActionBar/DocumentActionBar.tsx
+++ b/libs/service-portal/documents/src/components/DocumentActionBar/DocumentActionBar.tsx
@@ -134,6 +134,7 @@ export const DocumentActionBar: React.FC<DocumentActionBarProps> = ({
               >
                 <Button
                   as="span"
+                  unfocusable
                   circle
                   icon="download"
                   iconType="outline"

--- a/libs/service-portal/education/src/screens/DrivingLessonsBook/DrivingLessonsBook.tsx
+++ b/libs/service-portal/education/src/screens/DrivingLessonsBook/DrivingLessonsBook.tsx
@@ -205,7 +205,7 @@ const DrivingLessonsBook = () => {
           <EmptyState />
           <Box display="flex" alignItems="center" justifyContent="center">
             <LinkResolver href={formatMessage(urls.licenseApplication)}>
-              <Button as="span">
+              <Button as="span" unfocusable>
                 {formatMessage(messages.signupToDrivingSchool)}
               </Button>
             </LinkResolver>

--- a/libs/service-portal/finance/src/screens/FinanceSchedule/FinanceSchedule.tsx
+++ b/libs/service-portal/finance/src/screens/FinanceSchedule/FinanceSchedule.tsx
@@ -113,6 +113,7 @@ const FinanceSchedule = () => {
                     type="button"
                     variant="utility"
                     as="span"
+                    unfocusable
                   >
                     {applicationButtonText}
                   </Button>

--- a/libs/service-portal/finance/src/screens/FinanceStatus/FinanceStatus.tsx
+++ b/libs/service-portal/finance/src/screens/FinanceStatus/FinanceStatus.tsx
@@ -135,6 +135,7 @@ const FinanceStatus = () => {
                         type="button"
                         variant="utility"
                         as="span"
+                        unfocusable
                       >
                         {formatMessage({
                           id: 'sp.finance-status:make-payment-schedule',

--- a/libs/service-portal/health/src/screens/HealthOverview/HealthOverview.tsx
+++ b/libs/service-portal/health/src/screens/HealthOverview/HealthOverview.tsx
@@ -155,6 +155,7 @@ export const HealthOverview = () => {
                       <Link to={HealthPaths.HealthPaymentOverview}>
                         <Button
                           as="span"
+                          unfocusable
                           icon="open"
                           iconType="outline"
                           variant="text"

--- a/libs/service-portal/health/src/screens/Medicine/MedicinePurchase.tsx
+++ b/libs/service-portal/health/src/screens/Medicine/MedicinePurchase.tsx
@@ -196,7 +196,13 @@ export const MedicinePurchase = () => {
         columnGap={2}
       >
         <LinkV2 href={formatMessage(messages.medicinePriceListLink)} newTab>
-          <Button variant="utility" icon="open" iconType="outline" as="span">
+          <Button
+            variant="utility"
+            icon="open"
+            iconType="outline"
+            as="span"
+            unfocusable
+          >
             {formatMessage(messages.medicinePriceList)}
           </Button>
         </LinkV2>
@@ -207,6 +213,7 @@ export const MedicinePurchase = () => {
             icon="calculator"
             iconType="outline"
             as="span"
+            unfocusable
           >
             {formatMessage(messages.medicineCalculatorTitle)}
           </Button>

--- a/libs/service-portal/health/src/screens/Payments/wrapper/PaymentsWrapper.tsx
+++ b/libs/service-portal/health/src/screens/Payments/wrapper/PaymentsWrapper.tsx
@@ -35,6 +35,7 @@ export const PaymentsWrapper = ({ children }: Props) => {
             icon="open"
             iconType="outline"
             as="span"
+            unfocusable
           >
             {formatMessage(messages.readAboutPaymentParticipationSystems)}
           </Button>

--- a/libs/service-portal/licenses/src/screens/LicenseDetail/LicenseDetail.tsx
+++ b/libs/service-portal/licenses/src/screens/LicenseDetail/LicenseDetail.tsx
@@ -431,6 +431,7 @@ const LicenseDetail = () => {
                     >
                       <Button
                         as="span"
+                        unfocusable
                         variant="utility"
                         size="small"
                         icon={

--- a/libs/service-portal/licenses/src/screens/PassportDetail/PassportDetail.tsx
+++ b/libs/service-portal/licenses/src/screens/PassportDetail/PassportDetail.tsx
@@ -46,6 +46,7 @@ const NotifyLostLink = (text: string, link: string) => (
   <LinkResolver href={link}>
     <Button
       as="span"
+      unfocusable
       variant="utility"
       size="small"
       icon="open"
@@ -138,6 +139,7 @@ const PassportDetail = () => {
                         icon="open"
                         iconType="outline"
                         as="span"
+                        unfocusable
                       >
                         {formatMessage(m.passportRenew)}
                       </Button>


### PR DESCRIPTION
## What

Button component always has tabindex=0 for some reason, need to take  that off when rendered as span inside link

## Why

To avoid doubple tabbing inside links

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
