### PR TITLE
fix(web): Use light theme for grindavik project page header

### DIFF
--- a/apps/web/screens/Project/utils.tsx
+++ b/apps/web/screens/Project/utils.tsx
@@ -1,15 +1,11 @@
 import Link from 'next/link'
+
+import { Navigation, NavigationItem, Stack } from '@island.is/island-ui/core'
 import {
   Link as LinkSchema,
   LinkGroup,
   ProjectPage,
 } from '@island.is/web/graphql/schema'
-import {
-  Box,
-  Navigation,
-  NavigationItem,
-  Stack,
-} from '@island.is/island-ui/core'
 import { LayoutProps } from '@island.is/web/layouts/main'
 
 const lightThemes = [
@@ -18,6 +14,7 @@ const lightThemes = [
   'ukraine',
   'default',
   'opinbernyskopun',
+  'grindavik',
 ]
 
 export const getThemeConfig = (


### PR DESCRIPTION
# Use light theme for grindavik project page header

So the buttons in the header have the correct color theme

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
