### PR TITLE
fix(consultation-portal): logo with same size as island.is (#12801)

### DIFF
--- a/apps/consultation-portal/components/Layout/components/Menu/Menu.tsx
+++ b/apps/consultation-portal/components/Layout/components/Menu/Menu.tsx
@@ -49,7 +49,11 @@ const Menu = ({ isFrontPage = false }: MenuProps) => {
                 {isFrontPage && (
                   <Column width="content">
                     <FocusableBox href="https://island.is">
-                      <Logo />
+                      <Logo
+                        iconOnly={isMobile ? true : false}
+                        width={isMobile ? 28 : 160}
+                        height={isMobile ? 28 : 28}
+                      />
                     </FocusableBox>
                   </Column>
                 )}
@@ -59,7 +63,7 @@ const Menu = ({ isFrontPage = false }: MenuProps) => {
                       <>
                         <Column width="content">
                           <FocusableBox href="https://island.is">
-                            <Logo iconOnly />
+                            <Logo iconOnly height={28} width={28} />
                           </FocusableBox>
                         </Column>
                         <Column width="content">
@@ -77,7 +81,7 @@ const Menu = ({ isFrontPage = false }: MenuProps) => {
                     )}
                     <Column width="content">
                       <FocusableBox href="/" alignItems="center">
-                        <LogoText isSmall={isMobile ? true : false} />
+                        <LogoText isSmall />
                       </FocusableBox>
                     </Column>
                   </>

--- a/apps/consultation-portal/components/Layout/components/Menu/components/MenuModal/MenuModal.tsx
+++ b/apps/consultation-portal/components/Layout/components/Menu/components/MenuModal/MenuModal.tsx
@@ -79,7 +79,7 @@ const MenuModal = ({ baseId, modalLabel, isLoggedIn, isFrontPage }: Props) => {
                           href="https://island.is/"
                           alignItems="center"
                         >
-                          <Logo iconOnly width={26} />
+                          <Logo width={28} height={28} iconOnly />
                         </FocusableBox>
                       ) : (
                         <FocusableBox href="/" alignItems="center">


### PR DESCRIPTION
# Logo in header should follow the island.is page

https://veflausnir.atlassian.net/browse/KAM-1894
https://veflausnir.atlassian.net/browse/KAM-1894

## What

Large logo has 160x28 size and small logo has 28x28 size
Small logo should always be on mobile applications

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
