### PR TITLE
fix(passport): Passport lifecycle fix

### DIFF
--- a/libs/application/templates/passport/src/lib/PassportTemplate.ts
+++ b/libs/application/templates/passport/src/lib/PassportTemplate.ts
@@ -44,7 +44,6 @@ const pruneAfter = (time: number) => {
     shouldBeListed: true,
     shouldBePruned: true,
     whenToPrune: time,
-    shouldDeleteChargeIfPaymentFulfilled: true,
   }
 }
 const getCode = (application: Application) => {
@@ -147,7 +146,10 @@ const PassportTemplate: ApplicationTemplate<
         meta: {
           name: 'ParentB',
           status: 'inprogress',
-          lifecycle: pruneAfter(sevenDays),
+          lifecycle: {
+            ...pruneAfter(sevenDays),
+            shouldDeleteChargeIfPaymentFulfilled: true,
+          },
           onEntry: defineTemplateApi({
             action: ApiActions.assignParentB,
           }),


### PR DESCRIPTION

## What

Removed `shouldDeleteChargeIfPaymentFulfilled: true` for all states exluding `ParentB`.

## Why

Payments were being refunded when the payment had been fulfilled and the passport had been processed


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
