### PR TITLE
Add inlang to simplify i18n workflows

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["esbenp.prettier-vscode", "firsttris.vscode-jest-runner"]
+  "recommendations": ["esbenp.prettier-vscode", "firsttris.vscode-jest-runner", "inlang.vs-code-extension"]
 }

--- a/project.inlang.json
+++ b/project.inlang.json
@@ -13,6 +13,6 @@
     "https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-identical-pattern@latest/dist/index.js"
   ],
   "plugin.inlang.i18next": {
-    "pathPattern": "./apps/skilavottord/web/i18n/locales/{languageTags}.json"
-  }
+		"pathPattern": "./apps/skilavottord/web/i18n/locales/{languageTag}.json"
+	}
 }

--- a/project.inlang.json
+++ b/project.inlang.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://inlang.com/schema/project-settings",
+  "sourceLanguageTag": "en",
+  "languageTags": [
+    "de",
+    "en"
+  ],
+  "modules": [
+    "https://cdn.jsdelivr.net/npm/@inlang/plugin-i18next@latest/dist/index.js",
+    "https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-missing-translation@latest/dist/index.js",
+    "https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-empty-pattern@latest/dist/index.js",
+    "https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-without-source@latest/dist/index.js",
+    "https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-identical-pattern@latest/dist/index.js"
+  ],
+  "plugin.inlang.i18next": {
+    "pathPattern": "./apps/skilavottord/web/i18n/locales/{languageTags}.json"
+  }
+}

--- a/project.inlang.json
+++ b/project.inlang.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://inlang.com/schema/project-settings",
-  "sourceLanguageTag": "en",
+  "sourceLanguageTag": "is",
   "languageTags": [
-    "de",
-    "en"
+    "en",
+    "is"
   ],
   "modules": [
     "https://cdn.jsdelivr.net/npm/@inlang/plugin-i18next@latest/dist/index.js",


### PR DESCRIPTION
# Setup inlang for island.is website

I'm from the inlang team and our i18n tooling could help you manage the translations of island.is.

## What changed

- add inlang project file
- add i18n VS code extension to workspace recommendations

## Why

That will help with:
- managing translations in code (VS code extension)
- edit translations in a visual editor using PR workflows (see screenshot and link below)
- run `npx @inlang/cli@latest lint` to check for missing messages

## Screenshots / Gifs

<img width="1512" alt="Bildschirm­foto 2023-11-20 um 17 37 01" src="https://github.com/island-is/island.is/assets/59048346/1f8df0d5-1716-4c0a-a32b-8bb144c35aa8">

Preview with my fork: https://inlang.com/editor/github.com/NiklasBuchfink/island.is

---

Let me know if this is useful or if I should change anything :)

PS: I would like to see a project like this in my home country 🥲 