### PR TITLE
fix(service-portal): Heading as text

### DIFF
--- a/libs/service-portal/documents/src/screens/Overview/Overview.css.ts
+++ b/libs/service-portal/documents/src/screens/Overview/Overview.css.ts
@@ -31,8 +31,15 @@ globalStyle(`${checkboxWrap} label > div`, {
 
 globalStyle(`${btn} > span, ${btn} > h1`, {
   boxShadow: 'none',
+  cursor: 'pointer',
   marginTop: 4,
+  transition: 'color .2s, box-shadow .2s',
   ...themeUtils.responsiveStyle({
     md: { marginTop: 3 },
   }),
+})
+
+globalStyle(`${btn} > h1:hover`, {
+  color: theme.color.blueberry400,
+  boxShadow: `inset 0 -2px 0 0 ${theme.color.blueberry400}`,
 })

--- a/libs/service-portal/documents/src/screens/Overview/Overview.tsx
+++ b/libs/service-portal/documents/src/screens/Overview/Overview.tsx
@@ -319,9 +319,14 @@ export const ServicePortalDocuments = () => {
                 marginX={1}
                 className={styles.bullet}
               ></Box>
-              <Button unfocusable size="small" variant="text" truncate as="h1">
+              <Text
+                as="h1"
+                variant="eyebrow"
+                color="blue400"
+                fontWeight="semiBold"
+              >
                 {formatMessage(m.documents)}
-              </Button>
+              </Text>
             </Box>
           </Box>
           <DocumentsFilter


### PR DESCRIPTION
## What

Replace button as h1, with text as h1.

## Why

The button takes on a button role even though it is set `as=h1`.
We are using this as a heading but it is seen by the user as part of the breadcrumbs.

## Screenshots / Gifs

![Screenshot 2023-11-22 at 13 06 24](https://github.com/island-is/island.is/assets/24840451/89ef453a-95ed-43c6-80fd-3f7fb46ec69b)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
