### PR TITLE
fix(service-portal): add correct statuses to medicine certificates

### DIFF
--- a/libs/api/domains/rights-portal/src/lib/drug/models/drugCertificate.model.ts
+++ b/libs/api/domains/rights-portal/src/lib/drug/models/drugCertificate.model.ts
@@ -1,4 +1,4 @@
-import { Field, ID, ObjectType } from '@nestjs/graphql'
+import { Field, ObjectType } from '@nestjs/graphql'
 
 @ObjectType('RightsPortalMethylDoctor')
 export class MethylDoctor {
@@ -33,7 +33,19 @@ export class DrugCertificate {
   doctor?: string
 
   @Field(() => Boolean, { nullable: true })
+  processed?: boolean
+
+  @Field(() => Boolean, { nullable: true })
   approved?: boolean
+
+  @Field(() => Boolean, { nullable: true })
+  rejected?: boolean
+
+  @Field(() => Boolean, { nullable: true })
+  expired?: boolean
+
+  @Field(() => Boolean, { nullable: true })
+  valid?: boolean
 
   @Field(() => String, { nullable: true })
   comment?: string

--- a/libs/clients/icelandic-health-insurance/rights-portal/src/clientConfig.json
+++ b/libs/clients/icelandic-health-insurance/rights-portal/src/clientConfig.json
@@ -2332,9 +2332,29 @@
             "type": "string",
             "nullable": true
           },
+          "processed": {
+            "type": "boolean",
+            "nullable": true,
+            "readOnly": true
+          },
           "approved": {
             "type": "boolean",
             "nullable": true
+          },
+          "rejected": {
+            "type": "boolean",
+            "nullable": true,
+            "readOnly": true
+          },
+          "expired": {
+            "type": "boolean",
+            "nullable": true,
+            "readOnly": true
+          },
+          "valid": {
+            "type": "boolean",
+            "nullable": true,
+            "readOnly": true
           },
           "comment": {
             "type": "string",

--- a/libs/service-portal/health/src/lib/messages.ts
+++ b/libs/service-portal/health/src/lib/messages.ts
@@ -830,6 +830,18 @@ export const messages = defineMessages({
     id: 'sp.health:medicine-is-valid-certificate',
     defaultMessage: 'Í gildi',
   },
+  medicineIsRejectedCertificate: {
+    id: 'sp.health:medicine-is-rejected-certificate',
+    defaultMessage: 'Hafnað',
+  },
+  medicineIsExpiredCertificate: {
+    id: 'sp.health:medicine-is-expired-certificate',
+    defaultMessage: 'Útrunnið',
+  },
+  medicineIsProcessedCertificate: {
+    id: 'sp.health:medicine-is-processed-certificate',
+    defaultMessage: 'Í vinnslu',
+  },
   medicineIsNotValidCertificate: {
     id: 'sp.health:medicine-is-not-valid-certificate',
     defaultMessage: 'Ekki í gildi',

--- a/libs/service-portal/health/src/screens/Medicine/Medicine.graphql
+++ b/libs/service-portal/health/src/screens/Medicine/Medicine.graphql
@@ -89,7 +89,11 @@ query getDrugCertificates {
     validFrom
     validTo
     doctor
+    processed
     approved
+    rejected
+    expired
+    valid
     comment
     documentId
     methylDoctors {

--- a/libs/service-portal/health/src/screens/Medicine/MedicineLicense.tsx
+++ b/libs/service-portal/health/src/screens/Medicine/MedicineLicense.tsx
@@ -51,11 +51,17 @@ export const MedicineLicense = () => {
                     heading={certificate.drugName ?? undefined}
                     tag={{
                       label: formatMessage(
-                        certificate.approved
+                        certificate.valid
                           ? messages.medicineIsValidCertificate
+                          : certificate.rejected
+                          ? messages.medicineIsRejectedCertificate
+                          : certificate.expired
+                          ? messages.medicineIsExpiredCertificate
+                          : certificate.processed && !certificate.approved
+                          ? messages.medicineIsProcessedCertificate
                           : messages.medicineIsNotValidCertificate,
                       ),
-                      variant: certificate?.approved ? 'blue' : 'red',
+                      variant: certificate?.valid ? 'blue' : 'red',
                     }}
                     text={certificate.atcName ?? undefined}
                     cta={{

--- a/libs/service-portal/health/src/screens/MedicineCertificate/MedicineCertificate.graphql
+++ b/libs/service-portal/health/src/screens/MedicineCertificate/MedicineCertificate.graphql
@@ -8,7 +8,11 @@ query getCertificateById($input: RightsPortalDrugCertificateInput!) {
     validFrom
     validTo
     doctor
+    processed
     approved
+    rejected
+    expired
+    valid
     comment
     documentId
     methylDoctors {

--- a/libs/service-portal/health/src/screens/MedicineCertificate/MedicineCertificate.tsx
+++ b/libs/service-portal/health/src/screens/MedicineCertificate/MedicineCertificate.tsx
@@ -102,16 +102,22 @@ export const MedicineCertificate = () => {
                   >
                     <Text>
                       {formatMessage(
-                        certificate.approved
+                        certificate.valid
                           ? messages.medicineIsValidCertificate
+                          : certificate.rejected
+                          ? messages.medicineIsRejectedCertificate
+                          : certificate.expired
+                          ? messages.medicineIsExpiredCertificate
+                          : certificate.processed && !certificate.approved
+                          ? messages.medicineIsProcessedCertificate
                           : messages.medicineIsNotValidCertificate,
                       )}
                     </Text>
                     <Icon
                       icon={
-                        certificate.approved ? 'checkmarkCircle' : 'closeCircle'
+                        certificate.valid ? 'checkmarkCircle' : 'closeCircle'
                       }
-                      color={certificate.approved ? 'mint600' : 'red600'}
+                      color={certificate.valid ? 'mint600' : 'red600'}
                       type="filled"
                     />
                   </Box>


### PR DESCRIPTION
## What

Display more detailed medicine certificate status

## Why

TO show correct certificate status

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
