### PR TITLE
chore(search-indexer): Increase memory limit

### DIFF
--- a/apps/services/search-indexer/infra/search-indexer-service.ts
+++ b/apps/services/search-indexer/infra/search-indexer-service.ts
@@ -62,11 +62,11 @@ export const serviceSetup = (): ServiceBuilder<'search-indexer-service'> =>
           resources: {
             requests: {
               cpu: '300m',
-              memory: '2048Mi',
+              memory: '3072Mi',
             },
             limits: {
               cpu: '700m',
-              memory: '3072Mi',
+              memory: '4096Mi',
             },
           },
         },

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -1946,10 +1946,10 @@ search-indexer-service:
         resources:
           limits:
             cpu: '700m'
-            memory: '3072Mi'
+            memory: '4096Mi'
           requests:
             cpu: '300m'
-            memory: '2048Mi'
+            memory: '3072Mi'
       - args:
           - '/webapp/migrateKibana.js'
         command:

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -1690,10 +1690,10 @@ search-indexer-service:
         resources:
           limits:
             cpu: '700m'
-            memory: '3072Mi'
+            memory: '4096Mi'
           requests:
             cpu: '300m'
-            memory: '2048Mi'
+            memory: '3072Mi'
       - args:
           - '/webapp/migrateKibana.js'
         command:

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -1696,10 +1696,10 @@ search-indexer-service:
         resources:
           limits:
             cpu: '700m'
-            memory: '3072Mi'
+            memory: '4096Mi'
           requests:
             cpu: '300m'
-            memory: '2048Mi'
+            memory: '3072Mi'
       - args:
           - '/webapp/migrateKibana.js'
         command:


### PR DESCRIPTION
## What

Search indexer is running out of memory in dev (which is using Contentful's preview API). This causes content not to be synced to Elastic and hence not able to test new components in dev.

Current memory increase: 
- request: 3gb
- limit: 4gb

## Why

To unblock syncing from Contentful to Elasticsearch.

**Note** This has been done couple of times due to increasing content in Contentful. We need to refactor how search indexer is requesting content from Contentful as current implementation is not scaling with growing content. But we don't want to do that in a rush, hence increasing memory to unblock testing while we properly refactor the indexer.

## Screenshots / Gifs

n/a

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
