### PR TITLE
chore(j-s): Fix spacing in CaseFilesOverview component

### DIFF
--- a/apps/judicial-system/web/src/routes/CourtOfAppeal/components/CaseFilesOverview/CaseFilesOverview.tsx
+++ b/apps/judicial-system/web/src/routes/CourtOfAppeal/components/CaseFilesOverview/CaseFilesOverview.tsx
@@ -21,7 +21,7 @@ const CaseFilesOverview: React.FC<React.PropsWithChildren<unknown>> = () => {
     <>
       <AppealCaseFilesOverview />
       <Box marginBottom={6}>
-        <Text as="h3" variant="h3">
+        <Text as="h3" variant="h3" marginBottom={3}>
           {formatMessage(strings.courtCaseFilesTitle)}
         </Text>
         <PdfButton


### PR DESCRIPTION
# Fix spacing in CaseFilesOverview component

[Asana](https://app.asana.com/0/1199153462262248/1205950041984082/f)

## What

Fix spacing in CaseFilesOverview component

## Screenshots / Gifs

<img width="855" alt="Screenshot 2023-11-28 at 11 07 22" src="https://github.com/island-is/island.is/assets/3789875/f55acac2-8598-4e2b-9793-79a3bc7f7f9b">

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
