### PR TITLE
chore(j-s): Fix sanitize function

### DIFF
--- a/libs/judicial-system/formatters/src/lib/formatters.spec.ts
+++ b/libs/judicial-system/formatters/src/lib/formatters.spec.ts
@@ -376,7 +376,7 @@ describe('sanitize', () => {
     expect(r).toBe('blabla.pdf')
   })
 
-  test('should work with nultiple instances of "', () => {
+  test('should work with multiple instances of "', () => {
     // Arrange
     const text = `bla"bl"a.pdf`
 

--- a/libs/judicial-system/formatters/src/lib/formatters.spec.ts
+++ b/libs/judicial-system/formatters/src/lib/formatters.spec.ts
@@ -356,7 +356,29 @@ describe('readableIndictmentSubtypes', () => {
 describe('sanitize', () => {
   test('should return empty string if text is empty', () => {
     // Arrange
+    const text = ``
+
+    // Act
+    const r = sanitize(text)
+
+    // Assert
+    expect(r).toBe('')
+  })
+
+  test('should work with one instance of "', () => {
+    // Arrange
     const text = `bla"bla.pdf`
+
+    // Act
+    const r = sanitize(text)
+
+    // Assert
+    expect(r).toBe('blabla.pdf')
+  })
+
+  test('should work with nultiple instances of "', () => {
+    // Arrange
+    const text = `bla"bl"a.pdf`
 
     // Act
     const r = sanitize(text)

--- a/libs/judicial-system/formatters/src/lib/formatters.ts
+++ b/libs/judicial-system/formatters/src/lib/formatters.ts
@@ -337,5 +337,5 @@ export const readableIndictmentSubtypes = (
 }
 
 export const sanitize = (str: string) => {
-  return str.replace('"', '')
+  return str.replace(/"/g, '')
 }


### PR DESCRIPTION
# Fix sanitize function

[Asana](https://app.asana.com/0/1199153462262248/1206046984488078/f)

## What

We have a `sanitize` function that replaces all instances of `"` with an empty string. There was a minor issue with our implementation in that we were only targeting the first instance.

## Why

This is both incorrectly implemented and is showing up in island.is code scanning tool.


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
