### PR TITLE
feat(estate): add sum fields in estate overview

### DIFF
--- a/libs/application/templates/estate/src/forms/Forms.ts
+++ b/libs/application/templates/estate/src/forms/Forms.ts
@@ -30,9 +30,9 @@ export const privateDivisionForm: Form = buildForm({
     estateAssets,
     estateDebts,
     attachments,
+    overview,
     representative,
     approvePrivateDivisionSubmission,
-    overview,
   ],
 })
 

--- a/libs/application/templates/estate/src/forms/Forms.ts
+++ b/libs/application/templates/estate/src/forms/Forms.ts
@@ -30,9 +30,9 @@ export const privateDivisionForm: Form = buildForm({
     estateAssets,
     estateDebts,
     attachments,
-    overview,
     representative,
     approvePrivateDivisionSubmission,
+    overview,
   ],
 })
 

--- a/libs/application/templates/estate/src/forms/OverviewSections/assetsAndDebts.ts
+++ b/libs/application/templates/estate/src/forms/OverviewSections/assetsAndDebts.ts
@@ -49,6 +49,45 @@ export const overviewAssetsAndDebts = [
         })),
     },
   ),
+  buildDescriptionField({
+    id: 'estateAssetsTotal',
+    title: m.total,
+    description: ({ answers }: Application) => {
+      const sum = (answers.estate as unknown as EstateInfo).assets
+        ?.filter((asset) => asset.enabled)
+        .reduce((acc, cur) => {
+          const marketValue = Number(cur.marketValue) ?? 0
+
+          if (marketValue) {
+            return acc + marketValue
+          }
+
+          return acc
+        }, 0)
+
+      if (sum && sum > 0) {
+        return formatCurrency(String(sum))
+      }
+
+      return null
+    },
+    condition: (answers) => {
+      const sum = (answers.estate as unknown as EstateInfo).assets
+        ?.filter((asset) => asset.enabled)
+        .reduce((acc, cur) => {
+          const marketValue = Number(cur.marketValue) ?? 0
+
+          if (marketValue) {
+            return acc + marketValue
+          }
+
+          return acc
+        }, 0)
+
+      return sum > 0
+    },
+    titleVariant: 'h4',
+  }),
   buildDividerField({}),
   buildDescriptionField({
     id: 'overviewInventoryHeader',
@@ -122,6 +161,45 @@ export const overviewAssetsAndDebts = [
         })),
     },
   ),
+  buildDescriptionField({
+    id: 'estateVehicleTotal',
+    title: m.total,
+    description: ({ answers }: Application) => {
+      const sum = (answers.estate as unknown as EstateInfo).vehicles
+        ?.filter((vehicle) => vehicle.enabled)
+        .reduce((acc, cur) => {
+          const marketValue = Number(cur.marketValue) ?? 0
+
+          if (marketValue) {
+            return acc + marketValue
+          }
+
+          return acc
+        }, 0)
+
+      if (sum && sum > 0) {
+        return formatCurrency(String(sum))
+      }
+
+      return null
+    },
+    condition: (answers) => {
+      const sum = (answers.estate as unknown as EstateInfo).vehicles
+        ?.filter((vehicle) => vehicle.enabled)
+        .reduce((acc, cur) => {
+          const marketValue = Number(cur.marketValue) ?? 0
+
+          if (marketValue) {
+            return acc + marketValue
+          }
+
+          return acc
+        }, 0)
+
+      return sum > 0
+    },
+    titleVariant: 'h4',
+  }),
   buildDividerField({}),
   buildDescriptionField({
     id: 'overviewGuns',
@@ -154,6 +232,45 @@ export const overviewAssetsAndDebts = [
         })),
     },
   ),
+  buildDescriptionField({
+    id: 'estateGunsTotal',
+    title: m.total,
+    description: ({ answers }: Application) => {
+      const sum = (answers.estate as unknown as EstateInfo).guns
+        ?.filter((gun) => gun.enabled)
+        .reduce((acc, cur) => {
+          const marketValue = Number(cur.marketValue) ?? 0
+
+          if (marketValue) {
+            return acc + marketValue
+          }
+
+          return acc
+        }, 0)
+
+      if (sum && sum > 0) {
+        return formatCurrency(String(sum))
+      }
+
+      return null
+    },
+    condition: (answers) => {
+      const sum = (answers.estate as unknown as EstateInfo).guns
+        ?.filter((gun) => gun.enabled)
+        .reduce((acc, cur) => {
+          const marketValue = Number(cur.marketValue) ?? 0
+
+          if (marketValue) {
+            return acc + marketValue
+          }
+
+          return acc
+        }, 0)
+
+      return sum > 0
+    },
+    titleVariant: 'h4',
+  }),
   buildDividerField({}),
   buildDescriptionField({
     id: 'overviewEstateBankInfoTitle',
@@ -183,6 +300,50 @@ export const overviewAssetsAndDebts = [
         ),
     },
   ),
+  buildDescriptionField({
+    id: 'bankAccountsTotal',
+    title: m.total,
+    description: ({ answers }: Application) => {
+      const sum = (answers as unknown as EstateSchema).bankAccounts?.reduce(
+        (acc, cur) => {
+          const balance = Number(cur.balance) ?? 0
+
+          if (balance) {
+            return acc + balance
+          }
+
+          return acc
+        },
+        0,
+      )
+
+      if (sum && sum > 0) {
+        return formatCurrency(String(sum))
+      }
+
+      return null
+    },
+    condition: (answers) => {
+      const bankAccounts = answers?.bankAccounts
+        ? (answers as unknown as EstateSchema).bankAccounts
+        : null
+
+      if (!bankAccounts) return false
+
+      const sum = bankAccounts.reduce((acc, cur) => {
+        const balance = Number(cur.balance) ?? 0
+
+        if (balance) {
+          return acc + balance
+        }
+
+        return acc
+      }, 0)
+
+      return sum > 0
+    },
+    titleVariant: 'h4',
+  }),
   buildDividerField({
     condition: (answers) =>
       getValueViaPath(answers, 'selectedEstate') ===
@@ -226,6 +387,50 @@ export const overviewAssetsAndDebts = [
         })),
     },
   ),
+  buildDescriptionField({
+    id: 'claimsTotal',
+    title: m.total,
+    description: ({ answers }: Application) => {
+      const sum = (answers as unknown as EstateSchema).claims?.reduce(
+        (acc, cur) => {
+          const value = Number(cur.value) ?? 0
+
+          if (value) {
+            return acc + value
+          }
+
+          return acc
+        },
+        0,
+      )
+
+      if (sum && sum > 0) {
+        return formatCurrency(String(sum))
+      }
+
+      return null
+    },
+    condition: (answers) => {
+      const claims = answers?.claims
+        ? (answers as unknown as EstateSchema).claims
+        : null
+
+      if (!claims) return false
+
+      const sum = claims.reduce((acc, cur) => {
+        const value = Number(cur.value) ?? 0
+
+        if (value) {
+          return acc + value
+        }
+
+        return acc
+      }, 0)
+
+      return sum > 0
+    },
+    titleVariant: 'h4',
+  }),
   buildDividerField({
     condition: (answers) =>
       getValueViaPath(answers, 'selectedEstate') ===
@@ -271,6 +476,50 @@ export const overviewAssetsAndDebts = [
         })),
     },
   ),
+  buildDescriptionField({
+    id: 'stocksTotal',
+    title: m.total,
+    description: ({ answers }: Application) => {
+      const sum = (answers as unknown as EstateSchema).stocks?.reduce(
+        (acc, cur) => {
+          const value = Number(cur.value) ?? 0
+
+          if (value) {
+            return acc + value
+          }
+
+          return acc
+        },
+        0,
+      )
+
+      if (sum && sum > 0) {
+        return formatCurrency(String(sum))
+      }
+
+      return null
+    },
+    condition: (answers) => {
+      const stocks = answers?.stocks
+        ? (answers as unknown as EstateSchema).stocks
+        : null
+
+      if (!stocks) return false
+
+      const sum = stocks.reduce((acc, cur) => {
+        const value = Number(cur.value) ?? 0
+
+        if (value) {
+          return acc + value
+        }
+
+        return acc
+      }, 0)
+
+      return sum > 0
+    },
+    titleVariant: 'h4',
+  }),
   buildDividerField({}),
   buildDescriptionField({
     id: 'overviewOtherAssetsHeader',
@@ -382,5 +631,49 @@ export const overviewAssetsAndDebts = [
         })),
     },
   ),
+  buildDescriptionField({
+    id: 'debtsTotal',
+    title: m.total,
+    description: ({ answers }: Application) => {
+      const sum = (answers as unknown as EstateSchema).debts?.reduce(
+        (acc, cur) => {
+          const balance = Number(cur.balance) ?? 0
+
+          if (balance) {
+            return acc + balance
+          }
+
+          return acc
+        },
+        0,
+      )
+
+      if (sum && sum > 0) {
+        return formatCurrency(String(sum))
+      }
+
+      return null
+    },
+    condition: (answers) => {
+      const debts = answers?.debts
+        ? (answers as unknown as EstateSchema).debts
+        : null
+
+      if (!debts) return false
+
+      const sum = debts.reduce((acc, cur) => {
+        const balance = Number(cur.balance) ?? 0
+
+        if (balance) {
+          return acc + balance
+        }
+
+        return acc
+      }, 0)
+
+      return sum > 0
+    },
+    titleVariant: 'h4',
+  }),
   buildDividerField({}),
 ]

--- a/libs/application/templates/estate/src/forms/OverviewSections/assetsAndDebts.ts
+++ b/libs/application/templates/estate/src/forms/OverviewSections/assetsAndDebts.ts
@@ -56,13 +56,8 @@ export const overviewAssetsAndDebts = [
       const sum = (answers.estate as unknown as EstateInfo).assets
         ?.filter((asset) => asset.enabled)
         .reduce((acc, cur) => {
-          const marketValue = Number(cur.marketValue) ?? 0
-
-          if (marketValue) {
-            return acc + marketValue
-          }
-
-          return acc
+          const val = Number(cur.marketValue) ?? 0
+          return acc + val
         }, 0)
 
       if (sum && sum > 0) {
@@ -75,13 +70,8 @@ export const overviewAssetsAndDebts = [
       const sum = (answers.estate as unknown as EstateInfo).assets
         ?.filter((asset) => asset.enabled)
         .reduce((acc, cur) => {
-          const marketValue = Number(cur.marketValue) ?? 0
-
-          if (marketValue) {
-            return acc + marketValue
-          }
-
-          return acc
+          const val = Number(cur.marketValue) ?? 0
+          return acc + val
         }, 0)
 
       return sum > 0
@@ -168,13 +158,8 @@ export const overviewAssetsAndDebts = [
       const sum = (answers.estate as unknown as EstateInfo).vehicles
         ?.filter((vehicle) => vehicle.enabled)
         .reduce((acc, cur) => {
-          const marketValue = Number(cur.marketValue) ?? 0
-
-          if (marketValue) {
-            return acc + marketValue
-          }
-
-          return acc
+          const val = Number(cur.marketValue) ?? 0
+          return acc + val
         }, 0)
 
       if (sum && sum > 0) {
@@ -187,13 +172,8 @@ export const overviewAssetsAndDebts = [
       const sum = (answers.estate as unknown as EstateInfo).vehicles
         ?.filter((vehicle) => vehicle.enabled)
         .reduce((acc, cur) => {
-          const marketValue = Number(cur.marketValue) ?? 0
-
-          if (marketValue) {
-            return acc + marketValue
-          }
-
-          return acc
+          const val = Number(cur.marketValue) ?? 0
+          return acc + val
         }, 0)
 
       return sum > 0
@@ -239,13 +219,8 @@ export const overviewAssetsAndDebts = [
       const sum = (answers.estate as unknown as EstateInfo).guns
         ?.filter((gun) => gun.enabled)
         .reduce((acc, cur) => {
-          const marketValue = Number(cur.marketValue) ?? 0
-
-          if (marketValue) {
-            return acc + marketValue
-          }
-
-          return acc
+          const val = Number(cur.marketValue) ?? 0
+          return acc + val
         }, 0)
 
       if (sum && sum > 0) {
@@ -258,13 +233,8 @@ export const overviewAssetsAndDebts = [
       const sum = (answers.estate as unknown as EstateInfo).guns
         ?.filter((gun) => gun.enabled)
         .reduce((acc, cur) => {
-          const marketValue = Number(cur.marketValue) ?? 0
-
-          if (marketValue) {
-            return acc + marketValue
-          }
-
-          return acc
+          const val = Number(cur.marketValue) ?? 0
+          return acc + val
         }, 0)
 
       return sum > 0
@@ -306,13 +276,8 @@ export const overviewAssetsAndDebts = [
     description: ({ answers }: Application) => {
       const sum = (answers as unknown as EstateSchema).bankAccounts?.reduce(
         (acc, cur) => {
-          const balance = Number(cur.balance) ?? 0
-
-          if (balance) {
-            return acc + balance
-          }
-
-          return acc
+          const val = Number(cur.balance) ?? 0
+          return acc + val
         },
         0,
       )
@@ -331,13 +296,8 @@ export const overviewAssetsAndDebts = [
       if (!bankAccounts) return false
 
       const sum = bankAccounts.reduce((acc, cur) => {
-        const balance = Number(cur.balance) ?? 0
-
-        if (balance) {
-          return acc + balance
-        }
-
-        return acc
+        const val = Number(cur.balance) ?? 0
+        return acc + val
       }, 0)
 
       return sum > 0
@@ -393,13 +353,8 @@ export const overviewAssetsAndDebts = [
     description: ({ answers }: Application) => {
       const sum = (answers as unknown as EstateSchema).claims?.reduce(
         (acc, cur) => {
-          const value = Number(cur.value) ?? 0
-
-          if (value) {
-            return acc + value
-          }
-
-          return acc
+          const val = Number(cur.value) ?? 0
+          return acc + val
         },
         0,
       )
@@ -418,13 +373,8 @@ export const overviewAssetsAndDebts = [
       if (!claims) return false
 
       const sum = claims.reduce((acc, cur) => {
-        const value = Number(cur.value) ?? 0
-
-        if (value) {
-          return acc + value
-        }
-
-        return acc
+        const val = Number(cur.value) ?? 0
+        return acc + val
       }, 0)
 
       return sum > 0
@@ -482,13 +432,8 @@ export const overviewAssetsAndDebts = [
     description: ({ answers }: Application) => {
       const sum = (answers as unknown as EstateSchema).stocks?.reduce(
         (acc, cur) => {
-          const value = Number(cur.value) ?? 0
-
-          if (value) {
-            return acc + value
-          }
-
-          return acc
+          const val = Number(cur.value) ?? 0
+          return acc + val
         },
         0,
       )
@@ -507,13 +452,8 @@ export const overviewAssetsAndDebts = [
       if (!stocks) return false
 
       const sum = stocks.reduce((acc, cur) => {
-        const value = Number(cur.value) ?? 0
-
-        if (value) {
-          return acc + value
-        }
-
-        return acc
+        const val = Number(cur.value) ?? 0
+        return acc + val
       }, 0)
 
       return sum > 0
@@ -637,13 +577,8 @@ export const overviewAssetsAndDebts = [
     description: ({ answers }: Application) => {
       const sum = (answers as unknown as EstateSchema).debts?.reduce(
         (acc, cur) => {
-          const balance = Number(cur.balance) ?? 0
-
-          if (balance) {
-            return acc + balance
-          }
-
-          return acc
+          const val = Number(cur.balance) ?? 0
+          return acc + val
         },
         0,
       )
@@ -662,13 +597,8 @@ export const overviewAssetsAndDebts = [
       if (!debts) return false
 
       const sum = debts.reduce((acc, cur) => {
-        const balance = Number(cur.balance) ?? 0
-
-        if (balance) {
-          return acc + balance
-        }
-
-        return acc
+        const val = Number(cur.balance) ?? 0
+        return acc + val
       }, 0)
 
       return sum > 0

--- a/libs/application/templates/estate/src/forms/OverviewSections/assetsAndDebts.ts
+++ b/libs/application/templates/estate/src/forms/OverviewSections/assetsAndDebts.ts
@@ -4,8 +4,8 @@ import {
   buildDividerField,
   getValueViaPath,
 } from '@island.is/application/core'
-import { Application } from '@island.is/application/types'
-import { EstateInfo } from '@island.is/clients/syslumenn'
+import { Application, RecordObject } from '@island.is/application/types'
+import { EstateAsset, EstateInfo } from '@island.is/clients/syslumenn'
 import { m } from '../../lib/messages'
 import { format as formatNationalId } from 'kennitala'
 import {
@@ -52,30 +52,20 @@ export const overviewAssetsAndDebts = [
   buildDescriptionField({
     id: 'estateAssetsTotal',
     title: m.total,
-    description: ({ answers }: Application) => {
-      const sum = (answers.estate as unknown as EstateInfo).assets
-        ?.filter((asset) => asset.enabled)
-        .reduce((acc, cur) => {
-          const val = Number(cur.marketValue) ?? 0
-          return acc + val
-        }, 0)
-
-      if (sum && sum > 0) {
-        return formatCurrency(String(sum))
-      }
-
-      return null
-    },
-    condition: (answers) => {
-      const sum = (answers.estate as unknown as EstateInfo).assets
-        ?.filter((asset) => asset.enabled)
-        .reduce((acc, cur) => {
-          const val = Number(cur.marketValue) ?? 0
-          return acc + val
-        }, 0)
-
-      return sum > 0
-    },
+    description: ({ answers }: Application) =>
+      getSumFromAnswers<EstateAsset>(
+        answers,
+        'estate.assets',
+        'marketValue',
+        (asset) => !!asset?.enabled,
+      ),
+    condition: (answers) =>
+      !!getSumFromAnswers<EstateAsset>(
+        answers,
+        'estate.assets',
+        'marketValue',
+        (asset) => !!asset?.enabled,
+      ),
     titleVariant: 'h4',
   }),
   buildDividerField({}),
@@ -154,30 +144,20 @@ export const overviewAssetsAndDebts = [
   buildDescriptionField({
     id: 'estateVehicleTotal',
     title: m.total,
-    description: ({ answers }: Application) => {
-      const sum = (answers.estate as unknown as EstateInfo).vehicles
-        ?.filter((vehicle) => vehicle.enabled)
-        .reduce((acc, cur) => {
-          const val = Number(cur.marketValue) ?? 0
-          return acc + val
-        }, 0)
-
-      if (sum && sum > 0) {
-        return formatCurrency(String(sum))
-      }
-
-      return null
-    },
-    condition: (answers) => {
-      const sum = (answers.estate as unknown as EstateInfo).vehicles
-        ?.filter((vehicle) => vehicle.enabled)
-        .reduce((acc, cur) => {
-          const val = Number(cur.marketValue) ?? 0
-          return acc + val
-        }, 0)
-
-      return sum > 0
-    },
+    description: ({ answers }: Application) =>
+      getSumFromAnswers<EstateAsset>(
+        answers,
+        'estate.vehicles',
+        'marketValue',
+        (asset) => !!asset?.enabled,
+      ),
+    condition: (answers) =>
+      !!getSumFromAnswers<EstateAsset>(
+        answers,
+        'estate.vehicles',
+        'marketValue',
+        (asset) => !!asset?.enabled,
+      ),
     titleVariant: 'h4',
   }),
   buildDividerField({}),
@@ -215,30 +195,20 @@ export const overviewAssetsAndDebts = [
   buildDescriptionField({
     id: 'estateGunsTotal',
     title: m.total,
-    description: ({ answers }: Application) => {
-      const sum = (answers.estate as unknown as EstateInfo).guns
-        ?.filter((gun) => gun.enabled)
-        .reduce((acc, cur) => {
-          const val = Number(cur.marketValue) ?? 0
-          return acc + val
-        }, 0)
-
-      if (sum && sum > 0) {
-        return formatCurrency(String(sum))
-      }
-
-      return null
-    },
-    condition: (answers) => {
-      const sum = (answers.estate as unknown as EstateInfo).guns
-        ?.filter((gun) => gun.enabled)
-        .reduce((acc, cur) => {
-          const val = Number(cur.marketValue) ?? 0
-          return acc + val
-        }, 0)
-
-      return sum > 0
-    },
+    description: ({ answers }: Application) =>
+      getSumFromAnswers<EstateAsset>(
+        answers,
+        'estate.guns',
+        'marketValue',
+        (asset) => !!asset?.enabled,
+      ),
+    condition: (answers) =>
+      !!getSumFromAnswers<EstateAsset>(
+        answers,
+        'estate.guns',
+        'marketValue',
+        (asset) => !!asset?.enabled,
+      ),
     titleVariant: 'h4',
   }),
   buildDividerField({}),
@@ -273,36 +243,18 @@ export const overviewAssetsAndDebts = [
   buildDescriptionField({
     id: 'bankAccountsTotal',
     title: m.total,
-    description: ({ answers }: Application) => {
-      const sum = (answers as unknown as EstateSchema).bankAccounts?.reduce(
-        (acc, cur) => {
-          const val = Number(cur.balance) ?? 0
-          return acc + val
-        },
-        0,
-      )
-
-      if (sum && sum > 0) {
-        return formatCurrency(String(sum))
-      }
-
-      return null
-    },
-    condition: (answers) => {
-      const bankAccounts = answers?.bankAccounts
-        ? (answers as unknown as EstateSchema).bankAccounts
-        : null
-
-      if (!bankAccounts) return false
-
-      const sum = bankAccounts.reduce((acc, cur) => {
-        const val = Number(cur.balance) ?? 0
-        return acc + val
-      }, 0)
-
-      return sum > 0
-    },
-    titleVariant: 'h4',
+    description: ({ answers }: Application) =>
+      getSumFromAnswers<EstateSchema['bankAccounts']>(
+        answers,
+        'bankAccounts',
+        'balance',
+      ),
+    condition: (answers) =>
+      !!getSumFromAnswers<EstateSchema['bankAccounts']>(
+        answers,
+        'bankAccounts',
+        'balance',
+      ),
   }),
   buildDividerField({
     condition: (answers) =>
@@ -350,36 +302,10 @@ export const overviewAssetsAndDebts = [
   buildDescriptionField({
     id: 'claimsTotal',
     title: m.total,
-    description: ({ answers }: Application) => {
-      const sum = (answers as unknown as EstateSchema).claims?.reduce(
-        (acc, cur) => {
-          const val = Number(cur.value) ?? 0
-          return acc + val
-        },
-        0,
-      )
-
-      if (sum && sum > 0) {
-        return formatCurrency(String(sum))
-      }
-
-      return null
-    },
-    condition: (answers) => {
-      const claims = answers?.claims
-        ? (answers as unknown as EstateSchema).claims
-        : null
-
-      if (!claims) return false
-
-      const sum = claims.reduce((acc, cur) => {
-        const val = Number(cur.value) ?? 0
-        return acc + val
-      }, 0)
-
-      return sum > 0
-    },
-    titleVariant: 'h4',
+    description: ({ answers }: Application) =>
+      getSumFromAnswers<EstateSchema['claims']>(answers, 'claims', 'value'),
+    condition: (answers) =>
+      !!getSumFromAnswers<EstateSchema['claims']>(answers, 'claims', 'value'),
   }),
   buildDividerField({
     condition: (answers) =>
@@ -429,35 +355,10 @@ export const overviewAssetsAndDebts = [
   buildDescriptionField({
     id: 'stocksTotal',
     title: m.total,
-    description: ({ answers }: Application) => {
-      const sum = (answers as unknown as EstateSchema).stocks?.reduce(
-        (acc, cur) => {
-          const val = Number(cur.value) ?? 0
-          return acc + val
-        },
-        0,
-      )
-
-      if (sum && sum > 0) {
-        return formatCurrency(String(sum))
-      }
-
-      return null
-    },
-    condition: (answers) => {
-      const stocks = answers?.stocks
-        ? (answers as unknown as EstateSchema).stocks
-        : null
-
-      if (!stocks) return false
-
-      const sum = stocks.reduce((acc, cur) => {
-        const val = Number(cur.value) ?? 0
-        return acc + val
-      }, 0)
-
-      return sum > 0
-    },
+    description: ({ answers }: Application) =>
+      getSumFromAnswers<EstateSchema['stocks']>(answers, 'stocks', 'value'),
+    condition: (answers) =>
+      !!getSumFromAnswers<EstateSchema['stocks']>(answers, 'stocks', 'value'),
     titleVariant: 'h4',
   }),
   buildDividerField({}),
@@ -574,36 +475,37 @@ export const overviewAssetsAndDebts = [
   buildDescriptionField({
     id: 'debtsTotal',
     title: m.total,
-    description: ({ answers }: Application) => {
-      const sum = (answers as unknown as EstateSchema).debts?.reduce(
-        (acc, cur) => {
-          const val = Number(cur.balance) ?? 0
-          return acc + val
-        },
-        0,
-      )
-
-      if (sum && sum > 0) {
-        return formatCurrency(String(sum))
-      }
-
-      return null
-    },
-    condition: (answers) => {
-      const debts = answers?.debts
-        ? (answers as unknown as EstateSchema).debts
-        : null
-
-      if (!debts) return false
-
-      const sum = debts.reduce((acc, cur) => {
-        const val = Number(cur.balance) ?? 0
-        return acc + val
-      }, 0)
-
-      return sum > 0
-    },
+    description: ({ answers }: Application) =>
+      getSumFromAnswers<EstateSchema['debts']>(answers, 'debts', 'balance'),
+    condition: (answers) =>
+      !!getSumFromAnswers<EstateSchema['debts']>(answers, 'debts', 'balance'),
     titleVariant: 'h4',
   }),
   buildDividerField({}),
 ]
+
+const getSumFromAnswers = <T = unknown>(
+  answers: Application['answers'],
+  path: string,
+  field: string,
+  fn?: (item: T) => boolean,
+): string | null => {
+  let arr: T[] = getValueViaPath(answers, path) ?? []
+
+  if (Array.isArray(arr)) {
+    if (fn) {
+      arr = arr.filter(fn)
+    }
+
+    const value = arr.reduce((acc, cur) => {
+      const val = (getValueViaPath(cur as RecordObject, field) as number) ?? 0
+      return acc + Number(val)
+    }, 0)
+
+    if (value && value > 0) {
+      return formatCurrency(String(value))
+    }
+  }
+
+  return null
+}

--- a/libs/application/templates/estate/src/lib/messages.ts
+++ b/libs/application/templates/estate/src/lib/messages.ts
@@ -189,6 +189,13 @@ export const m = defineMessages({
     description: '',
   },
 
+  // General
+  total: {
+    id: 'es.application:total',
+    defaultMessage: 'Samtals',
+    description: '',
+  },
+
   // Applicant
   announcer: {
     id: 'es.application:announcer',


### PR DESCRIPTION
# Add sum fields in estate overview

https://app.asana.com/0/1204431115744096/1205939903295179

## What

Adds a total value field below each `Card` section

## Why

Requested in a task

## Screenshots / Gifs

<img width="608" alt="image" src="https://github.com/island-is/island.is/assets/8450096/7c986581-219e-4999-9d0b-ad7a40580457">

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
