### PR TITLE
fix: check if isInsured is false for determining insurance status

### DIFF
--- a/libs/service-portal/health/src/screens/HealthOverview/HealthOverview.tsx
+++ b/libs/service-portal/health/src/screens/HealthOverview/HealthOverview.tsx
@@ -10,6 +10,7 @@ import {
   UserInfoLine,
   amountFormat,
   m,
+  SJUKRATRYGGINGAR_SLUG,
 } from '@island.is/service-portal/core'
 import { messages } from '../../lib/messages'
 import {
@@ -93,7 +94,8 @@ export const HealthOverview = () => {
         <IntroHeader
           title={formatMessage(user.profile.name)}
           intro={formatMessage(messages.overviewIntro)}
-          serviceProviderSlug={SYSLUMENN_SLUG}
+          serviceProviderSlug={SJUKRATRYGGINGAR_SLUG}
+          serviceProviderTooltip={formatMessage(messages.healthTooltip)}
         />
       </Box>
       {loading ? (

--- a/libs/service-portal/health/src/screens/HealthOverview/HealthOverview.tsx
+++ b/libs/service-portal/health/src/screens/HealthOverview/HealthOverview.tsx
@@ -89,7 +89,7 @@ export const HealthOverview = () => {
   }
 
   return (
-    <Box paddingY={4}>
+    <Box>
       <Box marginBottom={SECTION_GAP}>
         <IntroHeader
           title={formatMessage(user.profile.name)}

--- a/libs/service-portal/health/src/screens/HealthOverview/HealthOverview.tsx
+++ b/libs/service-portal/health/src/screens/HealthOverview/HealthOverview.tsx
@@ -103,10 +103,11 @@ export const HealthOverview = () => {
           height={24}
           borderRadius="standard"
         />
-      ) : !insurance ? (
+      ) : !insurance || !insurance.isInsured ? (
         <AlertMessage
           type="info"
-          message={formatMessage(messages.noHealthInsurance)}
+          title={formatMessage(messages.noHealthInsurance)}
+          message={insurance?.explanation}
         />
       ) : (
         <Box>

--- a/libs/service-portal/health/src/screens/Medicine/wrapper/MedicineWrapper.tsx
+++ b/libs/service-portal/health/src/screens/Medicine/wrapper/MedicineWrapper.tsx
@@ -23,6 +23,7 @@ export const MedicineWrapper = ({
         title={formatMessage(m.medicineTitle)}
         intro={formatMessage(m.medicineTitleIntro)}
         serviceProviderSlug={SJUKRATRYGGINGAR_SLUG}
+        serviceProviderTooltip={formatMessage(m.healthTooltip)}
       />
       <TabNavigation
         label={formatMessage(m.medicineTitle)}

--- a/libs/service-portal/health/src/screens/Payments/wrapper/PaymentsWrapper.tsx
+++ b/libs/service-portal/health/src/screens/Payments/wrapper/PaymentsWrapper.tsx
@@ -24,6 +24,7 @@ export const PaymentsWrapper = ({ children, pathname }: Props) => {
           title={formatMessage(messages.payments)}
           intro={formatMessage(messages.paymentsIntro)}
           serviceProviderSlug={SJUKRATRYGGINGAR_SLUG}
+          serviceProviderTooltip={formatMessage(messages.healthTooltip)}
         />
         <LinkV2
           href={formatMessage(


### PR DESCRIPTION
## What

Make sure user has insurance before displaying insurance status

## Why

So people without insurance don't get confused

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
