### PR TITLE
fix(service-portal): User settings adds encoding to returnUrl

### DIFF
--- a/libs/service-portal/information/src/components/PersonalInformation/Forms/ProfileForm/ProfileForm.tsx
+++ b/libs/service-portal/information/src/components/PersonalInformation/Forms/ProfileForm/ProfileForm.tsx
@@ -98,8 +98,13 @@ export const ProfileForm: FC<React.PropsWithChildren<Props>> = ({
    * Creates a link to the IDS user profile page.
    * By setting the continue_onboarding to false, the user won´t be forced to finish the onboarding.
    */
-  const getIDSLink = (linkPath: IdsUserProfileLinks) =>
-    `${authority}${linkPath}?returnUrl=${window.location}&continue_onboarding=false`
+  const getIDSLink = (linkPath: IdsUserProfileLinks) => {
+    const returnUrl = encodeURIComponent(
+      `${window.location}&continue_onboarding=false`,
+    )
+
+    return `${authority}${linkPath}?returnUrl=${returnUrl}`
+  }
 
   const isFlagEnabled = async () => {
     const ffEnabled = await featureFlagClient.getValue(


### PR DESCRIPTION
# Adds encoding to IDS returnUrl

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
