### PR TITLE
chore(service-portal): Update link button service portal component

### DIFF
--- a/libs/service-portal/assets/src/screens/VehicleDetail/VehicleDetail.tsx
+++ b/libs/service-portal/assets/src/screens/VehicleDetail/VehicleDetail.tsx
@@ -25,8 +25,8 @@ import {
   m,
   FootNote,
   IntroHeader,
-  LinkResolver,
   SAMGONGUSTOFA_SLUG,
+  LinkButton,
 } from '@island.is/service-portal/core'
 
 import OwnersTable from '../../components/DetailTable/OwnersTable'
@@ -203,27 +203,19 @@ const VehicleDetail = () => {
               >
                 {reqMileageReg && (
                   <Box paddingRight={2} marginBottom={[1, 1, 1, 0]}>
-                    <Button
-                      colorScheme="default"
+                    <LinkButton
+                      to={
+                        id
+                          ? AssetsPaths.AssetsVehiclesDetailMileage.replace(
+                              ':id',
+                              id.toString(),
+                            )
+                          : ''
+                      }
                       icon="pencil"
-                      iconType="outline"
-                      size="default"
-                      type="button"
-                      variant="utility"
-                    >
-                      <LinkResolver
-                        href={
-                          id
-                            ? AssetsPaths.AssetsVehiclesDetailMileage.replace(
-                                ':id',
-                                id.toString(),
-                              )
-                            : ''
-                        }
-                      >
-                        {formatMessage(messages.vehicleMileageInputTitle)}
-                      </LinkResolver>
-                    </Button>
+                      variant="button"
+                      text={formatMessage(messages.vehicleMileageInputTitle)}
+                    />
                   </Box>
                 )}
                 {downloadServiceURL && (

--- a/libs/service-portal/assets/src/screens/VehicleMileage/VehicleMileage.tsx
+++ b/libs/service-portal/assets/src/screens/VehicleMileage/VehicleMileage.tsx
@@ -136,7 +136,7 @@ const VehicleMileage = () => {
         <IntroHeader
           title={m.vehicleMileage}
           introComponent={formatMessage(messages.vehicleMileageIntro, {
-            href: (str: any) => (
+            href: (str: React.ReactNode) => (
               <span>
                 <a
                   href={formatMessage(messages.mileageExtLink)}
@@ -206,6 +206,7 @@ const VehicleMileage = () => {
                     size="xs"
                     maxLength={12}
                     error={errors.odometerStatus?.message}
+                    disabled={!isFormEditable && !canRegisterMileage}
                     defaultValue={''}
                     onChange={(e) => setFormValue(e.target.value)}
                     rules={{

--- a/libs/service-portal/core/src/components/LinkButton/LinkButton.css.ts
+++ b/libs/service-portal/core/src/components/LinkButton/LinkButton.css.ts
@@ -1,0 +1,14 @@
+import { theme } from '@island.is/island-ui/theme'
+import { globalStyle, style } from '@vanilla-extract/css'
+
+export const link = style({})
+
+globalStyle(`${link}:focus > span`, {
+  color: theme.color.dark400,
+  backgroundColor: theme.color.mint400,
+})
+
+globalStyle(`${link}:focus`, {
+  outline: 0,
+  boxShadow: 'none',
+})

--- a/libs/service-portal/core/src/components/LinkButton/LinkButton.tsx
+++ b/libs/service-portal/core/src/components/LinkButton/LinkButton.tsx
@@ -1,49 +1,66 @@
-import { Button } from '@island.is/island-ui/core'
-import { useLocation } from 'react-router-dom'
+import { Button, ButtonProps } from '@island.is/island-ui/core'
 import { FC } from 'react'
-import { servicePortalOutboundLink } from '@island.is/plausible'
-import { formatPlausiblePathToParams } from '../../utils/formatPlausiblePathToParams'
+import { isExternalLink } from '../../utils/isExternalLink'
+import LinkResolver from '../LinkResolver/LinkResolver'
+import * as styles from './LinkButton.css'
 
 interface Props {
   to: string
-  text: Array<string> | string
-  skipIcon?: boolean
+  text: string
+  icon?: ButtonProps['icon']
+  skipOutboundTrack?: boolean
+  /**
+   * default variant is "text"
+   */
+  variant?: 'button' | 'text'
 }
 
 export const LinkButton: FC<React.PropsWithChildren<Props>> = ({
+  variant = 'text',
   to,
   text,
-  skipIcon = false,
+  icon,
+  skipOutboundTrack,
 }) => {
-  const { pathname } = useLocation()
-  return (
-    <a
-      href={to}
-      onClick={() =>
-        servicePortalOutboundLink({
-          url: formatPlausiblePathToParams(pathname).url,
-          outboundUrl: to,
-        })
-      }
-      target="_blank"
-      rel="noreferrer"
-    >
-      {skipIcon ? (
-        <Button as="span" size="small" variant="text" unfocusable>
-          {text}
-        </Button>
-      ) : (
+  const isExternal = isExternalLink(to)
+  if (variant === 'text') {
+    return (
+      <LinkResolver
+        className={styles.link}
+        skipOutboundTrack={skipOutboundTrack}
+        href={to}
+      >
         <Button
           as="span"
-          unfocusable
           size="small"
           variant="text"
-          icon="open"
-          iconType="outline"
+          unfocusable
+          icon={isExternal ? 'open' : undefined}
+          iconType={isExternal ? 'outline' : undefined}
         >
           {text}
         </Button>
-      )}
-    </a>
+      </LinkResolver>
+    )
+  }
+  return (
+    <LinkResolver
+      skipOutboundTrack={skipOutboundTrack}
+      className={styles.link}
+      href={to}
+    >
+      <Button
+        colorScheme="default"
+        icon={icon}
+        iconType="outline"
+        size="default"
+        type="text"
+        as="span"
+        variant="utility"
+        unfocusable
+      >
+        {text}
+      </Button>
+    </LinkResolver>
   )
 }

--- a/libs/service-portal/core/src/components/LinkResolver/LinkResolver.tsx
+++ b/libs/service-portal/core/src/components/LinkResolver/LinkResolver.tsx
@@ -8,9 +8,15 @@ interface Props {
   children?: ReactNode
   className?: string
   href: string
+  skipOutboundTrack?: boolean
 }
 
-export const LinkResolver = ({ href = '/', children, className }: Props) => {
+export const LinkResolver = ({
+  href = '/',
+  children,
+  className,
+  skipOutboundTrack,
+}: Props) => {
   const { pathname } = useLocation()
   if (isExternalLink(href)) {
     return (
@@ -18,12 +24,16 @@ export const LinkResolver = ({ href = '/', children, className }: Props) => {
         href={href}
         target="_blank"
         rel="noreferrer noopener"
-        className={styles.link}
+        className={cn(styles.link, {
+          [`${className}`]: className,
+        })}
         onClick={() =>
-          servicePortalOutboundLink({
-            url: formatPlausiblePathToParams(pathname).url,
-            outboundUrl: href,
-          })
+          skipOutboundTrack
+            ? undefined
+            : servicePortalOutboundLink({
+                url: formatPlausiblePathToParams(pathname).url,
+                outboundUrl: href,
+              })
         }
       >
         {children}

--- a/libs/service-portal/core/src/components/UserInfoLine/UserInfoLine.tsx
+++ b/libs/service-portal/core/src/components/UserInfoLine/UserInfoLine.tsx
@@ -2,7 +2,6 @@ import React, { FC } from 'react'
 import {
   Box,
   Text,
-  Button,
   GridRow,
   GridColumn,
   GridColumnProps,
@@ -13,13 +12,12 @@ import {
 } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
 import { MessageDescriptor } from 'react-intl'
-import { Link, useLocation } from 'react-router-dom'
-import { servicePortalOutboundLink } from '@island.is/plausible'
+import { useLocation } from 'react-router-dom'
 import { sharedMessages } from '@island.is/shared/translations'
 
 import * as styles from './UserInfoLine.css'
-import { formatPlausiblePathToParams } from '../../utils/formatPlausiblePathToParams'
 import cn from 'classnames'
+import { LinkButton } from '../LinkButton/LinkButton'
 
 export type EditLink = {
   external?: boolean
@@ -157,46 +155,15 @@ export const UserInfoLine: FC<React.PropsWithChildren<Props>> = ({
               height="full"
               printHidden
             >
-              {editLink.external ? (
-                <a
-                  href={editLink.url}
-                  rel="noopener noreferrer"
-                  onClick={
-                    editLink.skipOutboundTrack
-                      ? undefined
-                      : () =>
-                          servicePortalOutboundLink({
-                            url: formatPlausiblePathToParams(pathname).url,
-                            outboundUrl: editLink.url,
-                          })
-                  }
-                  target="_blank"
-                >
-                  <Button
-                    variant="text"
-                    size="small"
-                    icon="open"
-                    iconType="outline"
-                  >
-                    {editLink.title
-                      ? formatMessage(editLink.title)
-                      : formatMessage(sharedMessages.edit)}
-                  </Button>
-                </a>
-              ) : (
-                <Link to={editLink.url}>
-                  <Button
-                    variant="text"
-                    size="small"
-                    icon={editLink.icon}
-                    iconType="outline"
-                  >
-                    {editLink.title
-                      ? formatMessage(editLink.title)
-                      : formatMessage(sharedMessages.edit)}
-                  </Button>
-                </Link>
-              )}
+              <LinkButton
+                to={editLink.url}
+                text={
+                  editLink.title
+                    ? formatMessage(editLink.title)
+                    : formatMessage(sharedMessages.edit)
+                }
+                skipOutboundTrack={editLink.skipOutboundTrack}
+              />
             </Box>
           ) : null}
         </GridColumn>

--- a/libs/service-portal/health/src/components/FootNote/helper.tsx
+++ b/libs/service-portal/health/src/components/FootNote/helper.tsx
@@ -20,7 +20,6 @@ export const getFootNoteByType = (
         second: formatMessage(messages['physioDisclaimer2'], {
           link: (str: React.ReactNode) => (
             <LinkButton
-              skipIcon
               to={formatMessage(messages['physioDisclaimerLink'])}
               text={String(str ?? '')}
             />
@@ -34,7 +33,6 @@ export const getFootNoteByType = (
         second: formatMessage(messages['physioDisclaimer2'], {
           link: (str: React.ReactNode) => (
             <LinkButton
-              skipIcon
               to={formatMessage(messages['physioDisclaimerLink'])}
               text={String(str ?? '')}
             />
@@ -47,7 +45,6 @@ export const getFootNoteByType = (
         second: formatMessage(messages['physioDisclaimer2'], {
           link: (str: React.ReactNode) => (
             <LinkButton
-              skipIcon
               to={formatMessage(messages['physioDisclaimerLink'])}
               text={String(str ?? '')}
             />
@@ -64,7 +61,6 @@ export const getFootNoteByType = (
         first: formatMessage(messages['occupationalDisclaimer'], {
           link: (str: React.ReactNode) => (
             <LinkButton
-              skipIcon
               to={formatMessage(messages['occupationalDisclaimerLink'])}
               text={String(str ?? '')}
             />

--- a/libs/service-portal/licenses/src/utils/dataMapper.tsx
+++ b/libs/service-portal/licenses/src/utils/dataMapper.tsx
@@ -523,7 +523,6 @@ export const getLicenseDetailHeading = (
             {formatMessage(m.ehicDescription2, {
               link: (str: any) => (
                 <LinkButton
-                  skipIcon
                   to={formatMessage(m.ehicDescriptionLink)}
                   text={str ?? ''}
                 />


### PR DESCRIPTION
## What

Add a shared service-portal component that can be displayed as a button or text, and will resolve to react-router link or external link all on its own.

## Why

We've had to do this same thing too many times.

## Screenshots
![Screenshot 2023-11-29 at 14 09 04](https://github.com/island-is/island.is/assets/24840451/394a0ed9-6f63-438d-9156-c682670ebf79)

![Screenshot 2023-11-29 at 14 09 02](https://github.com/island-is/island.is/assets/24840451/8add82a3-674d-4dda-9051-c5978afbbd61)

![Screenshot 2023-11-29 at 14 09 00](https://github.com/island-is/island.is/assets/24840451/df72c109-d88d-4891-8824-df37c0744a1c)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
