### PR TITLE
chore(core): Upgrade PostgreSQL from 11.14 to 15.3

### DIFF
--- a/apps/air-discount-scheme/backend/docker-compose.yml
+++ b/apps/air-discount-scheme/backend/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   db_ads_backend:
-    image: public.ecr.aws/docker/library/postgres:11.14-alpine
+    image: public.ecr.aws/docker/library/postgres:15.3-alpine
     container_name: db_ads_backend
     networks:
       - local

--- a/apps/application-system/api/docker-compose.yml
+++ b/apps/application-system/api/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   db_application_system:
-    image: public.ecr.aws/docker/library/postgres:11.14-alpine
+    image: public.ecr.aws/docker/library/postgres:15.3-alpine
     container_name: db_application_system
     networks:
       - local

--- a/apps/financial-aid/backend/docker-compose.yml
+++ b/apps/financial-aid/backend/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   db_financial_aid:
-    image: public.ecr.aws/docker/library/postgres:11.14-alpine
+    image: public.ecr.aws/docker/library/postgres:15.3-alpine
     container_name: db_financial_aid
     networks:
       - local

--- a/apps/icelandic-names-registry/backend/docker-compose.yml
+++ b/apps/icelandic-names-registry/backend/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   db_icelandic_names_registry:
-    image: public.ecr.aws/docker/library/postgres:11.14-alpine
+    image: public.ecr.aws/docker/library/postgres:15.3-alpine
     container_name: db_icelandic_names_registry
     networks:
       - local

--- a/apps/reference-backend/docker-compose.yml
+++ b/apps/reference-backend/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   db_reference_backend:
-    image: public.ecr.aws/docker/library/postgres:11.14-alpine
+    image: public.ecr.aws/docker/library/postgres:15.3-alpine
     container_name: db_reference_backend
     networks:
       - local

--- a/apps/services/auth/ids-api/docker-compose.yml
+++ b/apps/services/auth/ids-api/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   db_services_auth_api:
-    image: public.ecr.aws/docker/library/postgres:11.14-alpine
+    image: public.ecr.aws/docker/library/postgres:15.3-alpine
     container_name: db_services_auth_api
     networks:
       - local

--- a/apps/services/documents/docker-compose.yml
+++ b/apps/services/documents/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   db_documents:
-    image: public.ecr.aws/docker/library/postgres:11.14-alpine
+    image: public.ecr.aws/docker/library/postgres:15.3-alpine
     container_name: db_documents
     networks:
       - local

--- a/apps/services/endorsements/api/docker-compose.yml
+++ b/apps/services/endorsements/api/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   db_endorsements:
-    image: public.ecr.aws/docker/library/postgres:11.14-alpine
+    image: public.ecr.aws/docker/library/postgres:15.3-alpine
     container_name: db_endorsements
     networks:
       - local

--- a/apps/services/regulations-admin-backend/docker-compose.yml
+++ b/apps/services/regulations-admin-backend/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   db_regulations_admin_backend:
-    image: public.ecr.aws/docker/library/postgres:11.14-alpine
+    image: public.ecr.aws/docker/library/postgres:15.3-alpine
     container_name: db_regulations_admin_backend
     networks:
       - local

--- a/apps/services/sessions/docker-compose.yml
+++ b/apps/services/sessions/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   db_sessions:
-    image: public.ecr.aws/docker/library/postgres:11.14-alpine
+    image: public.ecr.aws/docker/library/postgres:15.3-alpine
     container_name: db_sessions
     networks:
       - local

--- a/apps/services/university-gateway/docker-compose.yml
+++ b/apps/services/university-gateway/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   db_university_gateway:
-    image: public.ecr.aws/docker/library/postgres:11.14-alpine
+    image: public.ecr.aws/docker/library/postgres:15.3-alpine
     container_name: db_university_gateway
     networks:
       - local

--- a/apps/services/user-notification/docker-compose.yml
+++ b/apps/services/user-notification/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     environment:
       - SERVICES=sqs
   db_user_notification:
-    image: public.ecr.aws/docker/library/postgres:11.14-alpine
+    image: public.ecr.aws/docker/library/postgres:15.3-alpine
     container_name: db_user_notification
     networks:
       - local

--- a/apps/services/user-profile/docker-compose.yml
+++ b/apps/services/user-profile/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   db_user_profile:
-    image: public.ecr.aws/docker/library/postgres:11.14-alpine
+    image: public.ecr.aws/docker/library/postgres:15.3-alpine
     container_name: db_user_profile
     networks:
       - local

--- a/apps/skilavottord/ws/docker-compose.yml
+++ b/apps/skilavottord/ws/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   db_skilavottord_backend:
-    image: public.ecr.aws/docker/library/postgres:11.14-alpine
+    image: public.ecr.aws/docker/library/postgres:15.3-alpine
     container_name: db_skilavottord_backend
     networks:
       - local

--- a/libs/testing/containers/src/lib/testing-containers.ts
+++ b/libs/testing/containers/src/lib/testing-containers.ts
@@ -6,7 +6,7 @@ let redisClusterContainer: StartedTestContainer
 export const startPostgres = async () => {
   const name = 'test_db'
   postgresContainer = await new GenericContainer(
-    'public.ecr.aws/docker/library/postgres:11.14-alpine',
+    'public.ecr.aws/docker/library/postgres:15.3-alpine',
   )
     .withEnv('POSTGRES_DB', name)
     .withEnv('POSTGRES_USER', name)


### PR DESCRIPTION
## What

Upgrade version of PostgreSQL used ƒor local development and CI.

This is the first step in our [upgrade plan](https://www.notion.so/Upgrade-Postgres-to-15-3-c5913fb32aa44e119608ce09c5b3b842?pvs=4).

## Why

Because we're 3 majors out of date and version 11 is not supported anymore (since Nov 9, 2023).

## Checklist:

- [x] Make sure CI (and all API tests) pass.
- [x] Test local development with 1-2 services.
- [ ] Merge

See the [upgrade plan](https://www.notion.so/Upgrade-Postgres-to-15-3-c5913fb32aa44e119608ce09c5b3b842?pvs=4) for next steps.