### PR TITLE
fix(core): Add esbuild.json external to fix glob update regression

### DIFF
--- a/apps/api/esbuild.json
+++ b/apps/api/esbuild.json
@@ -61,7 +61,8 @@
     "decompress-response",
     "lowercase-keys",
     "mimic-response",
-    "pdfkit"
+    "pdfkit",
+    "path-scurry"
   ],
   "keepNames": true
 }

--- a/apps/application-system/api/esbuild.json
+++ b/apps/application-system/api/esbuild.json
@@ -61,7 +61,8 @@
     "to-readable-stream",
     "url-parse-lax",
     "safer-buffer",
-    "canvas"
+    "canvas",
+    "path-scurry"
   ],
   "keepNames": true
 }

--- a/apps/financial-aid/backend/esbuild.json
+++ b/apps/financial-aid/backend/esbuild.json
@@ -44,7 +44,8 @@
     "@protobufjs/path",
     "@protobufjs/pool",
     "@protobufjs/utf8",
-    "safer-buffer"
+    "safer-buffer",
+    "path-scurry"
   ],
   "keepNames": true
 }

--- a/apps/judicial-system/backend/esbuild.json
+++ b/apps/judicial-system/backend/esbuild.json
@@ -46,7 +46,8 @@
     "@protobufjs/path",
     "@protobufjs/pool",
     "@protobufjs/utf8",
-    "safer-buffer"
+    "safer-buffer",
+    "path-scurry"
   ],
   "keepNames": true
 }

--- a/apps/services/endorsements/api/esbuild.json
+++ b/apps/services/endorsements/api/esbuild.json
@@ -40,7 +40,8 @@
     "@protobufjs/path",
     "@protobufjs/pool",
     "@protobufjs/utf8",
-    "safer-buffer"
+    "safer-buffer",
+    "path-scurry"
   ],
   "keepNames": true
 }

--- a/apps/services/user-profile/esbuild.json
+++ b/apps/services/user-profile/esbuild.json
@@ -39,7 +39,8 @@
     "@protobufjs/path",
     "@protobufjs/pool",
     "@protobufjs/utf8",
-    "safer-buffer"
+    "safer-buffer",
+    "path-scurry"
   ],
   "keepNames": true
 }


### PR DESCRIPTION
## What

Due to recent upgrade of the glob package `path-scurry` package depends on a newer `lru-cache` version then most of our other package dependencies. Hence there is a version mismatch and `path-scurry` needs to be added as external dependency in esbuild for APIs using the `emailService`.

* judicial-system-backend
* api
* application-system-api
* financial-aid-backend
* services-endorsement-api
* services-user-profile

## Why

So APIs can start up again.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
