### PR TITLE
fix(servie-portal): Fix styling for alert banner on Special Pages™️

### DIFF
--- a/apps/service-portal/src/components/Layout/FullWidthLayout.tsx
+++ b/apps/service-portal/src/components/Layout/FullWidthLayout.tsx
@@ -21,18 +21,24 @@ import { ServicePortalPaths } from '../../lib/paths'
 import { DocumentsPaths } from '@island.is/service-portal/documents'
 import { theme } from '@island.is/island-ui/theme'
 
-interface FullWidthLayoutProps {
+interface FullWidthLayoutWrapperProps {
   activeParent?: PortalNavigationItem
   height: number
   pathname: string
   children: ReactNode
 }
+type FullWidthLayoutProps = {
+  isDashboard: boolean
+  isDocuments: boolean
+} & FullWidthLayoutWrapperProps
 
 export const FullWidthLayout: FC<FullWidthLayoutProps> = ({
   activeParent,
   height,
   pathname,
   children,
+  isDashboard,
+  isDocuments,
 }) => {
   const navigate = useNavigate()
   const { formatMessage } = useLocale()
@@ -43,16 +49,6 @@ export const FullWidthLayout: FC<FullWidthLayoutProps> = ({
       activeParent?.children?.filter((item) => !item.navHide) || undefined,
     )
   }, [activeParent?.children])
-
-  // Dashboard has a special "no top navigation view"
-  const isDashboard = Object.values(ServicePortalPaths).find((route) =>
-    matchPath(route, pathname),
-  )
-
-  // Documents has a special "split screen view"
-  const isDocuments = Object.values(DocumentsPaths).find((route) =>
-    matchPath(route, pathname),
-  )
 
   return (
     <Box
@@ -150,10 +146,26 @@ export const FullWidthLayout: FC<FullWidthLayoutProps> = ({
   )
 }
 
-const FullWidthLayoutWrapper: FC<FullWidthLayoutProps> = (props) => {
+const FullWidthLayoutWrapper: FC<FullWidthLayoutWrapperProps> = (props) => {
+  // Dashboard has a special "no top navigation view"
+  const isDashboard = Object.values(ServicePortalPaths).find((route) =>
+    matchPath(route, props.pathname),
+  )
+
+  // Documents has a special "split screen view"
+  const isDocuments = Object.values(DocumentsPaths).find((route) =>
+    matchPath(route, props.pathname),
+  )
+
+  const isSpecialView = !!isDashboard || !!isDocuments
+
   return (
-    <FullWidthLayout {...props}>
-      <ModuleAlertBannerSection paddingTop={2} />
+    <FullWidthLayout
+      isDashboard={!!isDashboard}
+      isDocuments={!!isDocuments}
+      {...props}
+    >
+      <ModuleAlertBannerSection paddingTop={isSpecialView ? 0 : 2} />
       {props.children}
     </FullWidthLayout>
   )


### PR DESCRIPTION
## What

Fix styling for alert banner on Special Pages™️

## Why

Full width pages have a certain padding as they render the navigation above the content.
Special Pages™️ have no nav. So they need no padding.

## Screenshots

😞 
![Untitled](https://github.com/island-is/island.is/assets/24840451/1c14b9cf-7429-4aa2-9793-29b0b861e9c7)

😺 
![Screenshot 2023-12-01 at 13 12 32](https://github.com/island-is/island.is/assets/24840451/7f80269b-eaad-4af9-9553-561b1d8059b7)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
