### PR TITLE
fix(j-s): Extend Case

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/case/case.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/case.service.ts
@@ -38,6 +38,7 @@ import {
   EventType,
   isIndictmentCase,
   isRestrictionCase,
+  prosecutorShouldSelectDefenderForInvestigationCase,
   UserRole,
 } from '@island.is/judicial-system/types'
 
@@ -1160,16 +1161,26 @@ export class CaseService {
   async extend(theCase: Case, user: TUser): Promise<Case> {
     return this.sequelize
       .transaction(async (transaction) => {
+        const shouldCopyDefender =
+          isRestrictionCase(theCase.type) ||
+          prosecutorShouldSelectDefenderForInvestigationCase(theCase.type)
+
         const caseId = await this.createCase(
           {
             origin: theCase.origin,
             type: theCase.type,
             description: theCase.description,
             policeCaseNumbers: theCase.policeCaseNumbers,
-            defenderName: theCase.defenderName,
-            defenderNationalId: theCase.defenderNationalId,
-            defenderEmail: theCase.defenderEmail,
-            defenderPhoneNumber: theCase.defenderPhoneNumber,
+            defenderName: shouldCopyDefender ? theCase.defenderName : undefined,
+            defenderNationalId: shouldCopyDefender
+              ? theCase.defenderNationalId
+              : undefined,
+            defenderEmail: shouldCopyDefender
+              ? theCase.defenderEmail
+              : undefined,
+            defenderPhoneNumber: shouldCopyDefender
+              ? theCase.defenderPhoneNumber
+              : undefined,
             leadInvestigator: theCase.leadInvestigator,
             courtId: theCase.courtId,
             translator: theCase.translator,

--- a/apps/judicial-system/web/src/routes/Prosecutor/InvestigationCase/Defendant/Defendant.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/InvestigationCase/Defendant/Defendant.tsx
@@ -15,6 +15,7 @@ import {
 import { theme } from '@island.is/island-ui/theme'
 import * as constants from '@island.is/judicial-system/consts'
 import { capitalize, caseTypes } from '@island.is/judicial-system/formatters'
+import { prosecutorShouldSelectDefenderForInvestigationCase } from '@island.is/judicial-system/types'
 import {
   core,
   defendant as m,
@@ -404,15 +405,9 @@ const Defendant = () => {
             </Box>
           </Box>
           <AnimatePresence>
-            {[
-              CaseType.ELECTRONIC_DATA_DISCOVERY_INVESTIGATION,
-              CaseType.EXPULSION_FROM_HOME,
-              CaseType.PAROLE_REVOCATION,
-              CaseType.PSYCHIATRIC_EXAMINATION,
-              CaseType.RESTRAINING_ORDER,
-              CaseType.RESTRAINING_ORDER_AND_EXPULSION_FROM_HOME,
-              CaseType.OTHER,
-            ].includes(workingCase.type) && (
+            {prosecutorShouldSelectDefenderForInvestigationCase(
+              workingCase.type,
+            ) && (
               <motion.section
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}

--- a/libs/judicial-system/types/src/index.ts
+++ b/libs/judicial-system/types/src/index.ts
@@ -82,6 +82,7 @@ export {
   getAppealedDate,
   defenderAccessCaseFileCategoriesForIndictmentCases as defenderCaseFileCategoriesForIndictmentCases,
   defenderCaseFileCategoriesForRestrictionAndInvestigationCases as defenderCaseFileCategoriesForRestrictionAndInvestigationCases,
+  prosecutorShouldSelectDefenderForInvestigationCase,
 } from './lib/case'
 export type {
   Case,

--- a/libs/judicial-system/types/src/lib/case.ts
+++ b/libs/judicial-system/types/src/lib/case.ts
@@ -617,3 +617,17 @@ export function getAppealedDate(
 ): string | undefined {
   return prosecutorPostponedAppealDate ?? accusedPostponedAppealDate
 }
+
+export function prosecutorShouldSelectDefenderForInvestigationCase(
+  type: CaseType,
+) {
+  return [
+    CaseType.ELECTRONIC_DATA_DISCOVERY_INVESTIGATION,
+    CaseType.EXPULSION_FROM_HOME,
+    CaseType.PAROLE_REVOCATION,
+    CaseType.PSYCHIATRIC_EXAMINATION,
+    CaseType.RESTRAINING_ORDER,
+    CaseType.RESTRAINING_ORDER_AND_EXPULSION_FROM_HOME,
+    CaseType.OTHER,
+  ].includes(type)
+}


### PR DESCRIPTION
# Extend Case

[Ekki hægt að halda áfram með framlengt rannsóknarmál sem dómur hefur skráð verjanda á](https://app.asana.com/0/1199153462262248/1206070142593618/f)

## What

- Does not copy defender info to extended investigation cases that do not allow prosecutors to add defender information.

## Why

- Copying defender info to these cases makes it impossible for prosecutors to fill in the case and send it to the district court.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
