### PR TITLE
fix(service-portal): No logo when no provider provided

### DIFF
--- a/libs/service-portal/core/src/components/IntroHeader/IntroHeader.tsx
+++ b/libs/service-portal/core/src/components/IntroHeader/IntroHeader.tsx
@@ -59,7 +59,7 @@ export const IntroHeader = (props: IntroHeaderProps & Props) => {
         )}
         {props.children}
       </GridColumn>
-      {!isMobile && organization && (
+      {!isMobile && props.serviceProviderSlug && organization && (
         <GridColumn span={'2/8'} offset={'1/8'}>
           <InstitutionPanel
             loading={loading}


### PR DESCRIPTION
## What

No logo when no provider provided

## Why

There should be no logo displayed when no provider is provided to the introheader component.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
