### PR TITLE
feat(user-profile): Email notifications settings

### DIFF
--- a/apps/services/user-profile/migrations/20231129145943-email-notification.js
+++ b/apps/services/user-profile/migrations/20231129145943-email-notification.js
@@ -1,0 +1,15 @@
+'use strict'
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('user_profile', 'email_notifications', {
+      type: Sequelize.BOOLEAN,
+      defaultValue: true,
+      allowNull: false,
+    })
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('user_profile', 'email_notifications')
+  },
+}

--- a/apps/services/user-profile/src/app/user-profile/userProfile.model.ts
+++ b/apps/services/user-profile/src/app/user-profile/userProfile.model.ts
@@ -111,4 +111,12 @@ export class UserProfile extends Model {
   })
   @ApiProperty()
   lastNudge?: Date
+
+  @Column({
+    type: DataType.BOOLEAN,
+    defaultValue: true,
+    allowNull: true,
+  })
+  @ApiProperty()
+  emailNotifications?: boolean
 }

--- a/apps/services/user-profile/src/app/v2/dto/islyklar-upsert.dto.ts
+++ b/apps/services/user-profile/src/app/v2/dto/islyklar-upsert.dto.ts
@@ -4,4 +4,6 @@ export class IslyklarUpsertDto {
   email?: string
 
   phoneNumber?: string
+
+  canNudge?: boolean
 }

--- a/apps/services/user-profile/src/app/v2/dto/patch-user-profile.dto.ts
+++ b/apps/services/user-profile/src/app/v2/dto/patch-user-profile.dto.ts
@@ -1,5 +1,6 @@
 import { ApiPropertyOptional } from '@nestjs/swagger'
 import {
+  IsBoolean,
   IsEmail,
   IsEnum,
   IsOptional,
@@ -43,4 +44,14 @@ export class PatchUserProfileDto {
   @IsOptional()
   @IsEnum(Locale)
   locale?: Locale
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  documentNotifications?: boolean
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  emailNotifications?: boolean
 }

--- a/apps/services/user-profile/src/app/v2/dto/patch-user-profile.dto.ts
+++ b/apps/services/user-profile/src/app/v2/dto/patch-user-profile.dto.ts
@@ -48,10 +48,5 @@ export class PatchUserProfileDto {
   @ApiPropertyOptional()
   @IsOptional()
   @IsBoolean()
-  documentNotifications?: boolean
-
-  @ApiPropertyOptional()
-  @IsOptional()
-  @IsBoolean()
   emailNotifications?: boolean
 }

--- a/apps/services/user-profile/src/app/v2/dto/user-profile.dto.ts
+++ b/apps/services/user-profile/src/app/v2/dto/user-profile.dto.ts
@@ -53,4 +53,9 @@ export class UserProfileDto {
   @IsOptional()
   @IsBoolean()
   readonly needsNudge?: boolean | null
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  emailNotifications?: boolean
 }

--- a/apps/services/user-profile/src/app/v2/islykill.service.ts
+++ b/apps/services/user-profile/src/app/v2/islykill.service.ts
@@ -15,7 +15,6 @@ import { IslyklarUpsertDto } from './dto/islyklar-upsert.dto'
 export class IslykillService {
   constructor(
     private readonly islyklarApi: IslyklarApi,
-
     @Inject(LOGGER_PROVIDER)
     private readonly logger: Logger,
   ) {}
@@ -75,6 +74,7 @@ export class IslykillService {
     nationalId,
     email,
     phoneNumber,
+    canNudge,
   }: IslyklarUpsertDto): Promise<PublicUser> {
     const { userNotFound, ...publicUser } = await this.getIslykillSettings(
       nationalId,
@@ -85,12 +85,14 @@ export class IslykillService {
         ssn: nationalId,
         email,
         mobile: phoneNumber,
+        canNudge,
       })
     } else {
       return this.updateIslykillSettings({
         ...publicUser,
         ...(isDefined(email) && { email }),
         ...(isDefined(phoneNumber) && { mobile: phoneNumber }),
+        ...(isDefined(canNudge) && { canNudge }),
       })
     }
   }

--- a/apps/services/user-profile/src/app/v2/test/me-user-profile.controller.spec.ts
+++ b/apps/services/user-profile/src/app/v2/test/me-user-profile.controller.spec.ts
@@ -635,6 +635,16 @@ describe('MeUserProfileController', () => {
       })
 
       expect(userProfile.emailNotifications).toBe(false)
+
+      // Assert that islyklar api is called
+      expect(islyklarApi.islyklarPut).toBeCalledWith({
+        user: {
+          ssn: testUserProfile.nationalId,
+          email: testUserProfile.email,
+          mobile: testUserProfile.mobilePhoneNumber,
+          canNudge: false,
+        },
+      })
     })
 
     it('PATCH /v2/me should return 200 and update emailNotifications and email', async () => {
@@ -663,6 +673,16 @@ describe('MeUserProfileController', () => {
       expect(userProfile.emailNotifications).toBe(false)
       expect(userProfile.email).toBe(newEmail)
       expect(userProfile.emailVerified).toBe(true)
+
+      // Assert that islyklar api is called
+      expect(islyklarApi.islyklarPut).toBeCalledWith({
+        user: {
+          ssn: testUserProfile.nationalId,
+          email: newEmail,
+          mobile: testUserProfile.mobilePhoneNumber,
+          canNudge: false,
+        },
+      })
     })
   })
 

--- a/apps/services/user-profile/src/app/v2/test/me-user-profile.controller.spec.ts
+++ b/apps/services/user-profile/src/app/v2/test/me-user-profile.controller.spec.ts
@@ -165,6 +165,7 @@ describe('MeUserProfileController', () => {
           documentNotifications: true,
           ...expectedTestValues,
           needsNudge: needsNudgeExpected,
+          emailNotifications: true,
         })
       },
     )

--- a/apps/services/user-profile/src/app/v2/test/me-user-profile.controller.spec.ts
+++ b/apps/services/user-profile/src/app/v2/test/me-user-profile.controller.spec.ts
@@ -613,6 +613,56 @@ describe('MeUserProfileController', () => {
         },
       })
     })
+
+    it('PATCH /v2/me should return 200 and update emailNotifications', async () => {
+      // Act
+      const res = await server.patch('/v2/me').send({
+        emailNotifications: false,
+      })
+
+      // Assert
+      expect(res.status).toEqual(200)
+      expect(res.body).toMatchObject({
+        nationalId: testUserProfile.nationalId,
+        emailNotifications: false,
+      })
+
+      // Assert Db records
+      const userProfileModel = app.get(getModelToken(UserProfile))
+      const userProfile = await userProfileModel.findOne({
+        where: { nationalId: testUserProfile.nationalId },
+      })
+
+      expect(userProfile.emailNotifications).toBe(false)
+    })
+
+    it('PATCH /v2/me should return 200 and update emailNotifications and email', async () => {
+      // Act
+      const res = await server.patch('/v2/me').send({
+        emailNotifications: false,
+        email: newEmail,
+        emailVerificationCode: emailVerificationCode,
+      })
+
+      // Assert
+      expect(res.status).toEqual(200)
+      expect(res.body).toMatchObject({
+        nationalId: testUserProfile.nationalId,
+        emailNotifications: false,
+        email: newEmail,
+        emailVerified: true,
+      })
+
+      // Assert Db records
+      const userProfileModel = app.get(getModelToken(UserProfile))
+      const userProfile = await userProfileModel.findOne({
+        where: { nationalId: testUserProfile.nationalId },
+      })
+
+      expect(userProfile.emailNotifications).toBe(false)
+      expect(userProfile.email).toBe(newEmail)
+      expect(userProfile.emailVerified).toBe(true)
+    })
   })
 
   describe('Nudge confirmation', () => {

--- a/apps/services/user-profile/src/app/v2/user-profile.service.ts
+++ b/apps/services/user-profile/src/app/v2/user-profile.service.ts
@@ -47,6 +47,7 @@ export class UserProfileService {
         emailVerified: false,
         documentNotifications: true,
         needsNudge: null,
+        emailNotifications: true,
       }
     }
 
@@ -59,6 +60,7 @@ export class UserProfileService {
       emailVerified: userProfile.emailVerified,
       documentNotifications: userProfile.documentNotifications,
       needsNudge: this.checkNeedsNudge(userProfile),
+      emailNotifications: userProfile.emailNotifications,
     }
   }
 
@@ -160,6 +162,9 @@ export class UserProfileService {
         }),
         ...(isDefined(userProfile.locale) && {
           locale: userProfile.locale,
+        }),
+        ...(isDefined(userProfile.emailNotifications) && {
+          emailNotifications: userProfile.emailNotifications,
         }),
       }
 

--- a/apps/services/user-profile/src/app/v2/user-profile.service.ts
+++ b/apps/services/user-profile/src/app/v2/user-profile.service.ts
@@ -176,11 +176,16 @@ export class UserProfileService {
         { transaction },
       )
 
-      if (isEmailDefined || isMobilePhoneNumberDefined) {
+      if (
+        isEmailDefined ||
+        isMobilePhoneNumberDefined ||
+        isDefined(userProfile.emailNotifications)
+      ) {
         await this.islykillService.upsertIslykillSettings({
           nationalId,
           phoneNumber: formattedPhoneNumber,
           email: userProfile.email,
+          canNudge: userProfile.emailNotifications,
         })
       }
     })

--- a/libs/api/domains/user-profile/src/lib/V2UserProfile.model.ts
+++ b/libs/api/domains/user-profile/src/lib/V2UserProfile.model.ts
@@ -1,0 +1,34 @@
+import { Field, ID, ObjectType } from '@nestjs/graphql'
+
+@ObjectType()
+export class V2UserProfile {
+  @Field(() => ID)
+  nationalId!: string
+
+  @Field(() => String, { nullable: true })
+  mobilePhoneNumber?: string
+
+  @Field(() => String, { nullable: true })
+  locale?: string
+
+  @Field(() => String, { nullable: true })
+  email?: string
+
+  @Field(() => Boolean, { nullable: true })
+  emailVerified?: boolean
+
+  @Field(() => Boolean, { nullable: true })
+  mobilePhoneNumberVerified?: boolean
+
+  @Field(() => Boolean, { nullable: true })
+  documentNotifications?: boolean
+
+  @Field(() => String, { nullable: true })
+  profileImageUrl?: string
+
+  @Field(() => Boolean, { nullable: true })
+  emailNotifications?: boolean
+
+  @Field(() => Boolean, { nullable: true })
+  needsNudge?: boolean
+}

--- a/libs/api/domains/user-profile/src/lib/dto/updateEmailNotificationsInput.ts
+++ b/libs/api/domains/user-profile/src/lib/dto/updateEmailNotificationsInput.ts
@@ -1,0 +1,10 @@
+import { Field, InputType } from '@nestjs/graphql'
+import { IsBoolean, IsOptional } from 'class-validator'
+
+@InputType()
+export class UpdateEmailNotificationsInput {
+  @Field(() => Boolean, { nullable: true })
+  @IsOptional()
+  @IsBoolean()
+  emailNotifications?: boolean
+}

--- a/libs/api/domains/user-profile/src/lib/userProfile.module.ts
+++ b/libs/api/domains/user-profile/src/lib/userProfile.module.ts
@@ -1,5 +1,9 @@
 import { DynamicModule } from '@nestjs/common'
-import { Configuration, UserProfileApi } from '@island.is/clients/user-profile'
+import {
+  Configuration,
+  UserProfileApi,
+  V2MeApi,
+} from '@island.is/clients/user-profile'
 import { UserProfileResolver } from './userProfile.resolver'
 import { UserProfileService } from './userProfile.service'
 import { IslykillService } from './islykill.service'
@@ -21,16 +25,16 @@ export class UserProfileModule {
         UserProfileService,
         UserProfileResolver,
         IslykillService,
-        {
-          provide: UserProfileApi,
+        ...[UserProfileApi, V2MeApi].map((Api) => ({
+          provide: Api,
           useFactory: () =>
-            new UserProfileApi(
+            new Api(
               new Configuration({
                 fetchApi: fetch,
                 basePath: config.userProfileServiceBasePath,
               }),
             ),
-        },
+        })),
       ],
       imports: [
         IslykillApiModule.register({

--- a/libs/api/domains/user-profile/src/lib/userProfile.resolver.ts
+++ b/libs/api/domains/user-profile/src/lib/userProfile.resolver.ts
@@ -21,11 +21,14 @@ import { UserDeviceToken } from './userDeviceToken.model'
 import { UserDeviceTokenInput } from './dto/userDeviceTokenInput'
 import { DeleteTokenResponse } from './dto/deleteTokenResponse'
 import { UserProfileLocale } from './models/userProfileLocale.model'
+import { UpdateEmailNotificationsInput } from './dto/updateEmailNotificationsInput'
+import { V2UserProfile } from './V2UserProfile.model'
 
 @UseGuards(IdsUserGuard, ScopesGuard)
 @Resolver()
 export class UserProfileResolver {
   constructor(private readonly userUserProfileService: UserProfileService) {}
+
   @Query(() => UserProfile, { nullable: true })
   getUserProfile(
     @CurrentUser() user: User,
@@ -118,5 +121,16 @@ export class UserProfileResolver {
     @CurrentUser() user: User,
   ): Promise<DeleteTokenResponse> {
     return await this.userUserProfileService.deleteDeviceToken(input, user)
+  }
+
+  @Mutation(() => V2UserProfile, { name: 'updateEmailNotifications' })
+  async updateEmailNotifications(
+    @Args('input') input: UpdateEmailNotificationsInput,
+    @CurrentUser() user: User,
+  ): Promise<V2UserProfile> {
+    return await this.userUserProfileService.updateEmailNotifications(
+      input,
+      user,
+    )
   }
 }

--- a/libs/clients/user-profile/src/lib/apiConfiguration.ts
+++ b/libs/clients/user-profile/src/lib/apiConfiguration.ts
@@ -1,12 +1,12 @@
 import { createEnhancedFetch } from '@island.is/clients/middlewares'
 import { ConfigType } from '@island.is/nest/config'
-import { UserProfileApi, Configuration } from '../../gen/fetch'
+import { Configuration } from '../../gen/fetch'
 
 import { UserProfileClientConfig } from './userProfileClient.config'
 import { createRedisCacheManager } from '@island.is/cache'
 
-export const UserProfileApiProvider = {
-  provide: UserProfileApi,
+export const ApiConfiguration = {
+  provide: 'UserProfileCLientApiConfiguration',
   // Necessary because of cache-manager.
   // eslint-disable-next-line local-rules/no-async-module-init
   useFactory: async (config: ConfigType<typeof UserProfileClientConfig>) => {
@@ -25,16 +25,14 @@ export const UserProfileApiProvider = {
             overrideCacheControl: config.cacheControl,
           }
 
-    return new UserProfileApi(
-      new Configuration({
-        fetchApi: createEnhancedFetch({
-          name: 'clients-user-profile',
-          organizationSlug: 'stafraent-island',
-          cache,
-        }),
-        basePath: config.basePath,
+    return new Configuration({
+      fetchApi: createEnhancedFetch({
+        name: 'clients-user-profile',
+        organizationSlug: 'stafraent-island',
+        cache,
       }),
-    )
+      basePath: config.basePath,
+    })
   },
   inject: [UserProfileClientConfig.KEY],
 }

--- a/libs/clients/user-profile/src/lib/apis.ts
+++ b/libs/clients/user-profile/src/lib/apis.ts
@@ -1,0 +1,10 @@
+import { ApiConfiguration } from './apiConfiguration'
+import { Configuration, UserProfileApi, V2MeApi } from '../../gen/fetch'
+
+export const exportedApis = [UserProfileApi, V2MeApi].map((Api) => ({
+  provide: Api,
+  useFactory: (configuration: Configuration) => {
+    return new Api(configuration)
+  },
+  inject: [ApiConfiguration.provide],
+}))

--- a/libs/clients/user-profile/src/lib/userProfileClient.module.ts
+++ b/libs/clients/user-profile/src/lib/userProfileClient.module.ts
@@ -1,10 +1,10 @@
 import { Module } from '@nestjs/common'
-import { UserProfileApi } from '../../gen/fetch'
 
-import { UserProfileApiProvider } from './apiConfiguration'
+import { ApiConfiguration } from './apiConfiguration'
+import { exportedApis } from './apis'
 
 @Module({
-  providers: [UserProfileApiProvider],
-  exports: [UserProfileApi],
+  providers: [ApiConfiguration, ...exportedApis],
+  exports: [...exportedApis],
 })
 export class UserProfileClientModule {}

--- a/libs/service-portal/information/src/components/PersonalInformation/Forms/ProfileForm/ProfileForm.tsx
+++ b/libs/service-portal/information/src/components/PersonalInformation/Forms/ProfileForm/ProfileForm.tsx
@@ -20,7 +20,7 @@ import { InputEmail } from './components/Inputs/Email'
 import { InputPhone } from './components/Inputs/Phone'
 import { DropModal } from './components/DropModal'
 import { BankInfoForm } from './components/Inputs/BankInfoForm'
-import { Nudge } from './components/Inputs/Nudge'
+import { Nudge } from './components/Inputs/Nudge/Nudge'
 import { msg } from '../../../../lib/messages'
 import { DropModalType, DataStatus } from './types/form'
 import { bankInfoObject } from '../../../../utils/bankInfoHelper'
@@ -291,6 +291,7 @@ export const ProfileForm: FC<React.PropsWithChildren<Props>> = ({
             >
               {!userLoading && (
                 <Nudge
+                  isV2UserProfileEnabled={v2UserProfileEnabled}
                   refuseMail={
                     /**
                      * This checkbox block is being displayed as the opposite of canNudge.

--- a/libs/service-portal/information/src/components/PersonalInformation/Forms/ProfileForm/components/Inputs/Nudge/Nudge.graphql
+++ b/libs/service-portal/information/src/components/PersonalInformation/Forms/ProfileForm/components/Inputs/Nudge/Nudge.graphql
@@ -1,6 +1,6 @@
 mutation emailNotification($input: UpdateEmailNotificationsInput!) {
   updateEmailNotifications(input: $input) {
-    nationalId,
-    emailNotifications,
+    nationalId
+    emailNotifications
   }
 }

--- a/libs/service-portal/information/src/components/PersonalInformation/Forms/ProfileForm/components/Inputs/Nudge/Nudge.graphql
+++ b/libs/service-portal/information/src/components/PersonalInformation/Forms/ProfileForm/components/Inputs/Nudge/Nudge.graphql
@@ -1,0 +1,6 @@
+mutation emailNotification($input: UpdateEmailNotificationsInput!) {
+  updateEmailNotifications(input: $input) {
+    nationalId,
+    emailNotifications,
+  }
+}

--- a/libs/service-portal/information/src/components/PersonalInformation/Forms/ProfileForm/components/Inputs/Nudge/Nudge.tsx
+++ b/libs/service-portal/information/src/components/PersonalInformation/Forms/ProfileForm/components/Inputs/Nudge/Nudge.tsx
@@ -1,4 +1,6 @@
 import React, { FC, useState, useEffect } from 'react'
+import { Controller, useForm } from 'react-hook-form'
+
 import {
   Box,
   Columns,
@@ -11,12 +13,12 @@ import {
 } from '@island.is/island-ui/core'
 import { m } from '@island.is/service-portal/core'
 import { useUpdateOrCreateUserProfile } from '@island.is/service-portal/graphql'
-import { msg } from '@island.is/service-portal/information/messages'
 import { useLocale, useNamespaces } from '@island.is/localization'
-import { Controller, useForm } from 'react-hook-form'
+
 import { FormButton } from '../../FormButton'
 import * as styles from '../ProfileForms.css'
 import { useEmailNotificationMutation } from './Nudge.generated'
+import { msg } from '../../../../../../../lib/messages'
 
 interface Props {
   refuseMail: boolean


### PR DESCRIPTION
## What

Add settings for email notifications in UserProfile that the user can change in MínarSíður/Stillingar if he would like to receive emails from clients

## Why

So that settings will no longer be maintained in the Islyklar service.
- The UI is visually unchanged, only change in frontend is a feature flag controlled condition, that controls filed should be updated with V1 or V2 of the UserProfile.

## Screenshots / Gifs

<img width="1532" alt="image" src="https://github.com/island-is/island.is/assets/34029342/882d2b40-b573-4f06-a5c6-c096a5160598">


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
