### PR TITLE
fix(j-s): Handle court documents with the same name

### DIFF
--- a/apps/judicial-system/web/src/components/CourtDocuments/CourtDocuments.tsx
+++ b/apps/judicial-system/web/src/components/CourtDocuments/CourtDocuments.tsx
@@ -101,10 +101,14 @@ const CourtDocuments: FC<React.PropsWithChildren<Props>> = (props) => {
     )
   }
 
-  const handleRemoveDocument = (name: string) => {
-    const updatedCourtDocuments = workingCase.courtDocuments?.filter((doc) => {
-      return doc.name !== name
-    })
+  const handleRemoveDocument = (index: number) => {
+    const updatedCourtDocuments = workingCase.courtDocuments?.filter(
+      (_doc, i) => {
+        return index !== i
+      },
+    )
+
+    setUpdateIndex(index)
 
     setAndSendCaseToServer(
       [{ courtDocuments: updatedCourtDocuments, force: true }],
@@ -116,7 +120,7 @@ const CourtDocuments: FC<React.PropsWithChildren<Props>> = (props) => {
   const handleAddDocument = (document: string) => {
     const updatedCourtDocuments = [
       ...(workingCase.courtDocuments || []),
-      { name: document } as CourtDocument,
+      { name: document, submittedBy: undefined },
     ]
 
     setUpdateIndex(undefined)
@@ -178,7 +182,7 @@ const CourtDocuments: FC<React.PropsWithChildren<Props>> = (props) => {
           {workingCase.courtDocuments?.map((courtDocument, index) => {
             return (
               <div
-                key={`${courtDocument.name}-${courtDocument.submittedBy}`}
+                key={`${courtDocument.name}-${index}`}
                 className={styles.valueWrapper}
               >
                 <div className={styles.courtDocumentInfo}>
@@ -251,9 +255,14 @@ const CourtDocuments: FC<React.PropsWithChildren<Props>> = (props) => {
                           width: '100%',
                         }),
                       }}
-                      value={whoFiledOptions.find(
-                        (option) => option.value === courtDocument.submittedBy,
-                      )}
+                      value={
+                        courtDocument.submittedBy
+                          ? whoFiledOptions.find(
+                              (option) =>
+                                option.value === courtDocument.submittedBy,
+                            )
+                          : null
+                      }
                       onChange={(option) => {
                         handleSubmittedBy(
                           index,
@@ -284,7 +293,7 @@ const CourtDocuments: FC<React.PropsWithChildren<Props>> = (props) => {
                   </Box>
                 </div>
                 <button
-                  onClick={() => handleRemoveDocument(courtDocument.name)}
+                  onClick={() => handleRemoveDocument(index)}
                   className={styles.removeButton}
                 >
                   <Trash width={14} height={14} color={theme.color.blue400} />

--- a/apps/judicial-system/web/src/types/index.ts
+++ b/apps/judicial-system/web/src/types/index.ts
@@ -313,5 +313,5 @@ export interface TempCaseListEntry
 
 export interface CourtDocument {
   name: string
-  submittedBy: UserRole
+  submittedBy?: UserRole
 }


### PR DESCRIPTION
# Handle court documents with the same name

[Asana](https://app.asana.com/0/1199153462262248/1205991136769086/f)

## What

In the CourtDocuments component, you could not delete items with the same name. Now you can. Also, imporved the loading indication when deleting documents.

## Screenshots / Gifs

https://github.com/island-is/island.is/assets/3789875/6044d866-4320-4e99-a137-e71d5a2f287b

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
