### PR TITLE
fix(j-s): Add word break to court document names

### DIFF
--- a/apps/judicial-system/web/src/components/CourtDocuments/CourtDocuments.css.ts
+++ b/apps/judicial-system/web/src/components/CourtDocuments/CourtDocuments.css.ts
@@ -21,10 +21,12 @@ export const courtDocumentInfo = style({
   display: 'flex',
   flexDirection: 'column',
   flex: 1,
+  marginRight: theme.spacing[2],
 
   '@media': {
     [`screen and (min-width: ${theme.breakpoints.lg}px)`]: {
       flexDirection: 'row',
+      marginRight: 0,
     },
   },
 })
@@ -34,6 +36,7 @@ export const nameContainer = style({
   alignItems: 'center',
   flex: 1,
   minHeight: '34px',
+  wordBreak: 'break-all',
 
   '@media': {
     [`screen and (min-width: ${theme.breakpoints.lg}px)`]: {


### PR DESCRIPTION
# Add word break to court document names

[Asana](https://app.asana.com/0/1199153462262248/1205991136769086/f)

## What

Add css property word-break to court document names.

## Why

So really long names without spaces are shown correctly

## Screenshots / Gifs

<img width="770" alt="Screenshot 2023-12-06 at 13 36 49" src="https://github.com/island-is/island.is/assets/3789875/5056b75a-113b-4dd3-a339-725ac5275c42">

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
