### PR TITLE
chore(communications): Add useNodemailerApp to communications domain options

### DIFF
--- a/libs/api/domains/communications/src/lib/environments/environment.ts
+++ b/libs/api/domains/communications/src/lib/environments/environment.ts
@@ -1,6 +1,7 @@
 export const environment = {
   emailOptions: {
     useTestAccount: false,
+    useNodemailerApp: process.env.USE_NODEMAILER_APP === 'true',
     options: {
       region: process.env.EMAIL_REGION,
     },


### PR DESCRIPTION
# Add useNodemailerApp to communications domain options

## What

* When testing out emails locally it's convenient to be able to set an environment variable whether or not we want emails to be sent to the "Nodemailer App" for us to be able to preview them

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
