### PR TITLE
fix(web): Remove image from project page footers using default variant footer

### DIFF
--- a/apps/web/screens/Project/components/ProjectFooter/ProjectFooter.tsx
+++ b/apps/web/screens/Project/components/ProjectFooter/ProjectFooter.tsx
@@ -48,7 +48,6 @@ export const ProjectFooter = ({
           <Footer
             columns={footerItems}
             heading={projectPage.title}
-            imageUrl={projectPage.defaultHeaderImage?.url}
             background={projectPage.footerConfig?.background}
             color={projectPage.footerConfig?.textColor}
           />


### PR DESCRIPTION
# Remove image from project page footers using default variant footer

## What

* Default header image field on Project pages should not be shown in the footer

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
