### PR TITLE
feat(web): Change config for directorate of immigration chat

### DIFF
--- a/apps/web/components/ChatPanel/WatsonChatPanel/WatsonChatPanel.tsx
+++ b/apps/web/components/ChatPanel/WatsonChatPanel/WatsonChatPanel.tsx
@@ -91,25 +91,13 @@ export const WatsonChatPanel = (props: WatsonChatPanelProps) => {
         }
         if (
           // Askur - Útlendingastofnun
-          props.integrationID === '89a03e83-5c73-4642-b5ba-cd3771ceca54' ||
-          props.integrationID === '53c6e788-8178-448d-94c3-f5d71ec3b80e'
+          props.integrationID === '89a03e83-5c73-4642-b5ba-cd3771ceca54'
         ) {
           onAuthenticatedWatsonAssistantChatLoad(
             instance,
             namespace,
             activeLocale,
             'directorateOfImmigration',
-          )
-        } else if (
-          // Askur - Samgöngustofa
-          props.integrationID === 'fe12e960-329c-46d5-9ae1-8bd8b8219f43' ||
-          props.integrationID === '1e649a3f-9476-4995-ba24-0e72040b0cc0'
-        ) {
-          onAuthenticatedWatsonAssistantChatLoad(
-            instance,
-            namespace,
-            activeLocale,
-            'transportAuthority',
           )
         }
 

--- a/apps/web/components/ChatPanel/WatsonChatPanel/utils.ts
+++ b/apps/web/components/ChatPanel/WatsonChatPanel/utils.ts
@@ -17,7 +17,7 @@ const submitButtonId = 'watson-assistant-chat-submit-button'
 const storageForSession = storageFactory(() => sessionStorage)
 const storageForReturningUsers = storageFactory(() => localStorage)
 
-type TranslationVariant = 'directorateOfImmigration' | 'transportAuthority'
+type TranslationVariant = 'directorateOfImmigration'
 
 const getTranslations = (
   namespace: Record<string, string>,

--- a/apps/web/components/ChatPanel/types.ts
+++ b/apps/web/components/ChatPanel/types.ts
@@ -46,9 +46,6 @@ export type WatsonIntegration =
   // Útlendingastofnun
   | '89a03e83-5c73-4642-b5ba-cd3771ceca54'
 
-  // Útlendingastofnun - english
-  | '53c6e788-8178-448d-94c3-f5d71ec3b80e'
-
   // Sjúkratryggingar
   | 'e625e707-c9ce-4048-802c-c12b905c28be'
 

--- a/apps/web/components/Organization/Wrapper/config.ts
+++ b/apps/web/components/Organization/Wrapper/config.ts
@@ -78,7 +78,7 @@ export const watsonConfig: Record<
     // Útlendingastofnun - Organization
     // https://app.contentful.com/spaces/8k0h54kbe6bj/entries/77rXck3sISbMsUv7BO1PG2
     '77rXck3sISbMsUv7BO1PG2': {
-      integrationID: '53c6e788-8178-448d-94c3-f5d71ec3b80e',
+      integrationID: '89a03e83-5c73-4642-b5ba-cd3771ceca54',
       region: 'eu-gb',
       serviceInstanceID: 'bc3d8312-d862-4750-b8bf-529db282050a',
       showLauncher: false,

--- a/apps/web/components/ServiceWeb/config.ts
+++ b/apps/web/components/ServiceWeb/config.ts
@@ -120,7 +120,7 @@ export const watsonConfig: Record<
       namespaceKey: 'default',
     },
     [Organization.DIRECTORATE_OF_IMMIGRATION]: {
-      integrationID: '53c6e788-8178-448d-94c3-f5d71ec3b80e',
+      integrationID: '89a03e83-5c73-4642-b5ba-cd3771ceca54',
       region: 'eu-gb',
       serviceInstanceID: 'bc3d8312-d862-4750-b8bf-529db282050a',
       showLauncher: false,

--- a/apps/web/screens/Article/components/ArticleChatPanel/config.ts
+++ b/apps/web/screens/Article/components/ArticleChatPanel/config.ts
@@ -188,7 +188,7 @@ export const watsonConfig: Record<
     // Útlendingastofnun - Organization
     // https://app.contentful.com/spaces/8k0h54kbe6bj/entries/77rXck3sISbMsUv7BO1PG2
     '77rXck3sISbMsUv7BO1PG2': {
-      integrationID: '53c6e788-8178-448d-94c3-f5d71ec3b80e',
+      integrationID: '89a03e83-5c73-4642-b5ba-cd3771ceca54',
       region: 'eu-gb',
       serviceInstanceID: 'bc3d8312-d862-4750-b8bf-529db282050a',
       showLauncher: false,

--- a/apps/web/screens/Project/components/ProjectChatPanel/config.ts
+++ b/apps/web/screens/Project/components/ProjectChatPanel/config.ts
@@ -24,7 +24,7 @@ export const watsonConfig: Record<
     // Information for Ukrainian citizens
     // https://app.contentful.com/spaces/8k0h54kbe6bj/entries/7GtuCCd7MEZhZKe0oXcHdb
     '7GtuCCd7MEZhZKe0oXcHdb': {
-      integrationID: '53c6e788-8178-448d-94c3-f5d71ec3b80e',
+      integrationID: '89a03e83-5c73-4642-b5ba-cd3771ceca54',
       region: 'eu-gb',
       serviceInstanceID: 'bc3d8312-d862-4750-b8bf-529db282050a',
       showLauncher: true,
@@ -58,7 +58,7 @@ export const watsonConfig: Record<
     // Information for Ukrainian citizens
     // https://app.contentful.com/spaces/8k0h54kbe6bj/entries/7GtuCCd7MEZhZKe0oXcHdb
     '7GtuCCd7MEZhZKe0oXcHdb': {
-      integrationID: '53c6e788-8178-448d-94c3-f5d71ec3b80e',
+      integrationID: '89a03e83-5c73-4642-b5ba-cd3771ceca54',
       region: 'eu-gb',
       serviceInstanceID: 'bc3d8312-d862-4750-b8bf-529db282050a',
       showLauncher: true,


### PR DESCRIPTION
# Change config for directorate of immigration chat

## What

* Stop using 2 seperate instances for both locales for directorate of immigration chat (just use one)
* Stop displaying a pop up window for Samgöngustofa web chat where users have to type in their email and name

## Why

* This was requested by Digital Iceland

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
