### PR TITLE
fix(island-ui): DatePicker with time

### DIFF
--- a/libs/island-ui/core/src/lib/DatePicker/DatePicker.css.ts
+++ b/libs/island-ui/core/src/lib/DatePicker/DatePicker.css.ts
@@ -327,3 +327,28 @@ globalStyle(
     borderTop: 0,
   },
 )
+
+/* Time picker styles */
+
+globalStyle(
+  `${root} .react-datepicker__input-time-container .react-datepicker-time__input-container .react-datepicker-time__input input`,
+  {
+    fontFamily: 'IBM Plex Sans',
+    fontStyle: 'normal',
+    fontWeight: 400,
+    fontSize: `${theme.typography.baseFontSize}px`,
+    lineHeight: `${theme.typography.baseLineHeight}`,
+    textAlign: 'center',
+    color: `${theme.color.dark400}`,
+    padding: '10px 10px 10px 20px',
+    border: '1px solid #ccdfff',
+    borderRadius: '0.3rem',
+    marginLeft: '5px',
+  },
+)
+
+globalStyle(`${root} .react-datepicker__input-time-container`, {
+  marginTop: '15px',
+  float: 'none !important' as any,
+  margin: '30px 0px 0px 5px !important',
+})

--- a/libs/island-ui/core/src/lib/DatePicker/DatePicker.stories.tsx
+++ b/libs/island-ui/core/src/lib/DatePicker/DatePicker.stories.tsx
@@ -27,7 +27,7 @@ Default.args = {
 }
 
 const Wrap: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => (
-  <div style={{ height: 400 }}>{children}</div>
+  <div style={{ height: 450 }}>{children}</div>
 )
 
 export const Basic = () => {
@@ -206,5 +206,18 @@ export const AppearInline = () => (
       appearInline
     />
     <Text variant="intro">This stays below the date picker.</Text>
+  </Wrap>
+)
+
+export const WithTime = () => (
+  <Wrap>
+    <DatePicker
+      label="Date"
+      placeholderText="Pick a date"
+      handleChange={(date: Date) => console.log(date)}
+      selected={new Date()}
+      locale="is"
+      showTimeInput
+    />
   </Wrap>
 )

--- a/libs/island-ui/core/src/lib/DatePicker/DatePicker.tsx
+++ b/libs/island-ui/core/src/lib/DatePicker/DatePicker.tsx
@@ -9,7 +9,7 @@ import {
 import getYear from 'date-fns/getYear'
 import is from 'date-fns/locale/is'
 import en from 'date-fns/locale/en-US'
-import { dateFormat } from '@island.is/shared/constants'
+import { dateFormat, dateFormatWithTime } from '@island.is/shared/constants'
 import { VisuallyHidden } from 'reakit'
 import range from 'lodash/range'
 
@@ -26,10 +26,12 @@ import { DatePickerProps, DatePickerCustomHeaderProps } from './types'
 const languageConfig = {
   is: {
     format: dateFormat.is,
+    formatWithTime: dateFormatWithTime.is,
     locale: is,
   },
   en: {
     format: dateFormat.en,
+    formatWithTime: dateFormatWithTime.en,
     locale: en,
   },
 }
@@ -59,6 +61,8 @@ export const DatePicker: React.FC<React.PropsWithChildren<DatePickerProps>> = ({
   icon = { name: 'calendar', type: 'outline' },
   minYear,
   maxYear,
+  showTimeInput = false,
+  timeInputLabel = 'Tími:',
 }) => {
   const [startDate, setStartDate] = useState<Date | null>(selected ?? null)
   const [datePickerState, setDatePickerState] = useState<'open' | 'closed'>(
@@ -109,7 +113,11 @@ export const DatePicker: React.FC<React.PropsWithChildren<DatePickerProps>> = ({
           minDate={minDate}
           maxDate={maxDate}
           excludeDates={excludeDates}
-          dateFormat={currentLanguage.format}
+          dateFormat={
+            showTimeInput
+              ? currentLanguage.formatWithTime
+              : currentLanguage.format
+          }
           showPopperArrow={false}
           popperPlacement="bottom-start"
           onCalendarOpen={() => {
@@ -143,6 +151,9 @@ export const DatePicker: React.FC<React.PropsWithChildren<DatePickerProps>> = ({
               size={size}
             />
           }
+          timeFormat="HH:mm"
+          timeInputLabel={timeInputLabel}
+          showTimeInput={showTimeInput}
           renderCustomHeader={(props) => (
             <CustomHeader
               locale={currentLanguage.locale}

--- a/libs/island-ui/core/src/lib/DatePicker/types.ts
+++ b/libs/island-ui/core/src/lib/DatePicker/types.ts
@@ -44,7 +44,8 @@ export interface DatePickerProps {
   size?: DatePickerSize
   backgroundColor?: DatePickerBackgroundColor
   icon?: { name: IconType; type?: Type }
-
+  showTimeInput?: boolean
+  timeInputLabel?: string
   /**
    * Minimum selectable year inside datepicker
    */

--- a/libs/portals/admin/signature-collection/src/screens/List/components/actionExtendDeadline.tsx
+++ b/libs/portals/admin/signature-collection/src/screens/List/components/actionExtendDeadline.tsx
@@ -43,6 +43,7 @@ const ActionExtendDeadline = ({ endTime }: { endTime: string }) => {
             label={formatMessage(m.listEndTime)}
             selected={new Date(endTime)}
             placeholderText=""
+            showTimeInput
           />
           <Box display="flex" justifyContent="flexEnd" marginTop={5}>
             <Button onClick={() => setModalChangeDateIsOpen(false)}>

--- a/libs/shared/constants/src/lib/date.ts
+++ b/libs/shared/constants/src/lib/date.ts
@@ -4,6 +4,11 @@ export const dateFormat = {
   en: 'dd/MM/yyyy',
 }
 
+export const dateFormatWithTime = {
+  is: 'dd.MM.yyyy HH:mm',
+  en: 'dd/MM/yyyy hh:mm aaa',
+}
+
 export const timeFormat = {
   is: 'HH:mm',
   en: 'hh:mm aaa',


### PR DESCRIPTION
Within the Admin portal, we now have a case where user needs to be able to edit time. Minor changes to Datepicker adding a couple of props and styling for time input:

![Screenshot 2023-12-11 at 10 34 02](https://github.com/island-is/island.is/assets/47886428/0b2ad7c4-fa95-49d6-bf53-a8c6b973422e)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
