### PR TITLE
feat(contentful-apps): Organization subpage slug contentful app

### DIFF
--- a/apps/contentful-apps/pages/fields/organization-subpage-slug-field.tsx
+++ b/apps/contentful-apps/pages/fields/organization-subpage-slug-field.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useState } from 'react'
+import { useDebounce } from 'react-use'
+import { FieldExtensionSDK } from '@contentful/app-sdk'
+import { Stack, Text, TextInput } from '@contentful/f36-components'
+import { useCMA, useSDK } from '@contentful/react-apps-toolkit'
+
+import { CONTENTFUL_ENVIRONMENT, CONTENTFUL_SPACE } from '../../constants'
+
+const DEBOUNCE_TIME = 100
+const config = {
+  environmentId: CONTENTFUL_ENVIRONMENT,
+  spaceId: CONTENTFUL_SPACE,
+}
+
+const OrganizationSubpageSlugField = () => {
+  const sdk = useSDK<FieldExtensionSDK>()
+  const cma = useCMA()
+  const [value, setValue] = useState(sdk.field?.getValue() ?? '')
+  const [isValid, setIsValid] = useState(true)
+
+  const defaultLocale = sdk.locales.default
+
+  useEffect(() => {
+    sdk.window.startAutoResizer()
+  }, [sdk.window])
+
+  useDebounce(
+    async () => {
+      const organizationPageId =
+        sdk.entry.fields.organizationPage.getValue()?.sys?.id
+      if (!organizationPageId || !value) {
+        setIsValid(true)
+        return
+      }
+      const subpagesWithSameSlug =
+        (
+          await cma.entry.getMany({
+            ...config,
+            query: {
+              locale: sdk.field.locale,
+              content_type: 'organizationSubpage',
+              'fields.slug': value,
+              'sys.id[ne]': sdk.entry.getSys().id,
+              limit: 1000,
+            },
+          })
+        )?.items ?? []
+
+      if (
+        subpagesWithSameSlug.some(
+          (subpage) =>
+            subpage.fields.organizationPage?.[sdk.locales.default]?.sys?.id ===
+            organizationPageId,
+        )
+      ) {
+        setIsValid(false)
+        return
+      }
+      setIsValid(true)
+    },
+    DEBOUNCE_TIME,
+    [value],
+  )
+
+  useDebounce(
+    () => {
+      if (isValid) {
+        sdk.field.setValue(value)
+      } else {
+        sdk.field.setValue(null)
+      }
+      sdk.field.setInvalid(!isValid)
+    },
+    DEBOUNCE_TIME,
+    [isValid, value],
+  )
+
+  const isInvalid = value.length === 0 || !isValid
+
+  return (
+    <Stack spacing="spacingXs" flexDirection="column" alignItems="flex-start">
+      <TextInput
+        value={value}
+        onChange={(ev) => {
+          setValue(ev.target.value)
+        }}
+        isInvalid={isInvalid}
+      />
+      {value.length === 0 && sdk.field.locale === defaultLocale && (
+        <Text fontColor="red400">Invalid slug</Text>
+      )}
+      {value.length > 0 && isInvalid && (
+        <Text fontColor="red400">
+          Organization subpage already exists with this slug
+        </Text>
+      )}
+    </Stack>
+  )
+}
+
+export default OrganizationSubpageSlugField


### PR DESCRIPTION
# Organization subpage slug contentful app

## What

* We don't want contentful users to be able to create organization subpages with other organization subpage slugs
* Organization subpage links are: `/s/${page.slug}/${subpage.slug}` so that's why we need an app since we want the slug to be unique given the parent page (we will allow /s/syslumenn/eitthvad and /s/vinnueftirlitid/eitthvad)

## Screenshots / Gifs

![image](https://github.com/island-is/island.is/assets/43557895/c3959ee7-3a3a-48c2-91f2-dd094033b52b)

https://github.com/island-is/island.is/assets/43557895/789e47c3-2c4f-4283-8150-a35b8d407772


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
