### PR TITLE
fix(service-portal): Only show subnav items on tabnav when more than 1

### DIFF
--- a/libs/service-portal/core/src/components/TabNavigation/TabNavigation.tsx
+++ b/libs/service-portal/core/src/components/TabNavigation/TabNavigation.tsx
@@ -77,7 +77,7 @@ export const TabNavigation: React.FC<Props> = ({ items, pathname, label }) => {
           />
         </Box>
       )}
-      {activeItem && activeItemChildren?.length ? (
+      {activeItem && activeItemChildren && activeItemChildren?.length > 1 ? (
         <Box
           display="flex"
           flexDirection="row"


### PR DESCRIPTION
## What

Only show subnav items on tabnav when more than 1 is available.

## Why

No need for a single subnav button that does nothing.

## Screenshots / Gifs

This is how it is today:
![Screenshot 2023-12-13 at 13 08 36](https://github.com/island-is/island.is/assets/24840451/fbbd75bc-b5ae-4722-9ee2-80b05f72d882)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
