### PR TITLE
chore(ads): Remove juni and aranja from codeowners on ads

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -57,8 +57,8 @@
 /libs/shared/connected/src/lib/generalPetition/GeneralPetitionLists                                      @island-is/juni
 /libs/api/domains/communications/                                                                        @island-is/juni @island-is/stefna
 /apps/services/user-notification/                                                                        @island-is/juni
-/apps/air-discount-scheme/                                                                               @island-is/juni @island-is/aranja @island-is/hugsmidjan
-/libs/air-discount-scheme/                                                                               @island-is/juni @island-is/hugsmidjan
+/apps/air-discount-scheme/                                                                               @island-is/hugsmidjan
+/libs/air-discount-scheme/                                                                               @island-is/hugsmidjan
 /libs/application/templates/p-sign/                                                                      @island-is/juni
 /libs/application/template-api-modules/src/lib/modules/templates/p-sign-submission                       @island-is/juni
 /libs/application/templates/marriage-conditions/                                                         @island-is/juni


### PR DESCRIPTION

## What

Removing Júní and Aranja from codeowners for loftbrú

## Why

Júní is no longer maintaining Loftbrú, Hugsmiðjan is the sole maintainer.

Talking to Aranja devs, they see no reason to be codeowners.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
