### PR TITLE
fix(service-portal): Update finance messages

### DIFF
--- a/libs/service-portal/finance/src/lib/messages.ts
+++ b/libs/service-portal/finance/src/lib/messages.ts
@@ -20,7 +20,7 @@ export const m = defineMessages({
   },
 
   transactionsYear: {
-    id: 'sp.finance:finance-transactions-label',
+    id: 'sp.finance:finance-transactions-year',
     defaultMessage: 'Ár',
   },
 
@@ -158,7 +158,7 @@ export const m = defineMessages({
     defaultMessage: 'Fjöldi gjalddaga eftir',
   },
   loanOwner: {
-    id: 'sp.finance-loans:number-of-payment-dates-remaining',
+    id: 'sp.finance-loans:loan-owner',
     defaultMessage: 'Lántakandi',
   },
 
@@ -238,5 +238,9 @@ export const m = defineMessages({
   propertyId: {
     id: 'sp.finance-loans:property-id',
     defaultMessage: 'Fastanúmer',
+  },
+  noResultMessage: {
+    id: 'sp.finance-loans:no-result-message',
+    defaultMessage: 'Engar lánafærslur fundust innan þessa skilyrða',
   },
 })

--- a/libs/service-portal/finance/src/screens/FinanceLoans/FinanceLoans.tsx
+++ b/libs/service-portal/finance/src/screens/FinanceLoans/FinanceLoans.tsx
@@ -2,6 +2,7 @@ import { useLocale, useNamespaces } from '@island.is/localization'
 
 import { AlertBanner, Box, SkeletonLoader } from '@island.is/island-ui/core'
 import { m } from '@island.is/service-portal/core'
+import { m as messages } from '../../lib/messages'
 import FinanceIntro from '../../components/FinanceIntro'
 import { useGetHmsLoansHistoryQuery } from './FinanceLoans.generated'
 import { FinanceLoansTable } from '../../components/FinanceLoans/FinanceLoansTable'
@@ -42,7 +43,7 @@ const FinanceLoans = () => {
           !loanOverviewLoading &&
           !loanOverviewError && (
             <AlertBanner
-              description={formatMessage(m.noResultsTryAgain)}
+              description={formatMessage(messages.noResultMessage)}
               variant="warning"
             />
           )}


### PR DESCRIPTION
## What

* Remove duplicates
* Add specific no content string for loans

## Why

* NO DUPLICATES ALLOWED
* No content for loans is not the same as other finance pages.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
