### PR TITLE
fix(j-s): E2E, Verify update requests completion before continuing

### DIFF
--- a/apps/system-e2e/src/support/api-tools.ts
+++ b/apps/system-e2e/src/support/api-tools.ts
@@ -38,3 +38,20 @@ export async function mockApi(page: Page, url: string, response: any) {
     })
   })
 }
+
+export async function verifyRequestCompletion(
+  page: Page,
+  url: string,
+  op: string,
+  status?: number,
+) {
+  const response = await page.waitForResponse((resp) =>
+    resp.url().includes(url) &&
+    resp.request().postDataJSON().operationName === op &&
+    status
+      ? resp.status() === status
+      : true,
+  )
+
+  return response
+}

--- a/apps/system-e2e/src/support/api-tools.ts
+++ b/apps/system-e2e/src/support/api-tools.ts
@@ -43,14 +43,11 @@ export async function verifyRequestCompletion(
   page: Page,
   url: string,
   op: string,
-  status?: number,
 ) {
-  const response = await page.waitForResponse((resp) =>
-    resp.url().includes(url) &&
-    resp.request().postDataJSON().operationName === op &&
-    status
-      ? resp.status() === status
-      : true,
+  const response = await page.waitForResponse(
+    (resp) =>
+      resp.url().includes(url) &&
+      resp.request().postDataJSON().operationName === op,
   )
 
   return response

--- a/apps/system-e2e/src/tests/judicial-system/smoke/custody-court.ts
+++ b/apps/system-e2e/src/tests/judicial-system/smoke/custody-court.ts
@@ -53,7 +53,6 @@ export function addTests() {
       await page.keyboard.press('Escape')
       await page.locator('input[id=courtDate-time]').fill('09:00')
       await page.keyboard.press('Tab')
-      await verifyRequestCompletion(page, '/api/graphql', 'UpdateCase', 200)
       await page
         .locator('input[id=react-select-defenderName-input]')
         .fill('Saul Goodmann')
@@ -62,7 +61,7 @@ export function addTests() {
         .locator('input[name=defenderEmail]')
         .fill('jl-auto-defender@kolibri.is')
       await page.keyboard.press('Tab')
-      await verifyRequestCompletion(page, '/api/graphql', 'UpdateCase', 200)
+      await verifyRequestCompletion(page, '/api/graphql', 'UpdateCase')
       await page.getByTestId('continueButton').click()
       await page.getByTestId('modalSecondaryButton').click()
 
@@ -75,7 +74,6 @@ export function addTests() {
       await page.keyboard.press('Escape')
       await page.locator('input[id=validToDate-time]').fill('16:00')
       await page.keyboard.press('Tab')
-      await verifyRequestCompletion(page, '/api/graphql', 'UpdateCase', 200)
       await page.getByTestId('continueButton').click()
 
       // Court record
@@ -84,10 +82,8 @@ export function addTests() {
       await page.getByText('Sækjandi unir úrskurðinum').click()
       await page.locator('input[id=courtEndTime]').fill(today)
       await page.keyboard.press('Escape')
-      await verifyRequestCompletion(page, '/api/graphql', 'UpdateCase')
       await page.locator('input[id=courtEndTime-time]').fill('10:00')
       await page.keyboard.press('Tab')
-      await verifyRequestCompletion(page, '/api/graphql', 'UpdateCase', 200)
       await page.getByTestId('continueButton').click()
 
       // Confirmation

--- a/apps/system-e2e/src/tests/judicial-system/smoke/custody-court.ts
+++ b/apps/system-e2e/src/tests/judicial-system/smoke/custody-court.ts
@@ -2,6 +2,7 @@ import { BrowserContext, expect, test } from '@playwright/test'
 
 import { JUDICIAL_SYSTEM_JUDGE_HOME_URL, urls } from '../../../support/urls'
 import { judicialSystemSession } from '../../../support/session'
+import { verifyRequestCompletion } from '../../../support/api-tools'
 
 export function addTests() {
   test.use({ baseURL: urls.judicialSystemBaseUrl })
@@ -32,8 +33,11 @@ export function addTests() {
       // Reception and assignment
       await expect(page).toHaveURL(/.*\/domur\/mottaka\/.*/)
       await page.getByTestId('courtCaseNumber').fill('R-63/2023')
+      await page.keyboard.press('Tab')
+      await verifyRequestCompletion(page, '/api/graphql', 'UpdateCase')
       await page.getByText('Veldu dómara/aðstoðarmann').click()
       await page.getByTestId('select-judge').getByText('Test Dómari').click()
+      await verifyRequestCompletion(page, '/api/graphql', 'UpdateCase')
       await page.getByTestId('continueButton').click()
 
       // Overview
@@ -48,6 +52,8 @@ export function addTests() {
       await page.locator('input[id=courtDate]').fill(today)
       await page.keyboard.press('Escape')
       await page.locator('input[id=courtDate-time]').fill('09:00')
+      await page.keyboard.press('Tab')
+      await verifyRequestCompletion(page, '/api/graphql', 'UpdateCase')
       await page
         .locator('input[id=react-select-defenderName-input]')
         .fill('Saul Goodmann')
@@ -55,6 +61,8 @@ export function addTests() {
       await page
         .locator('input[name=defenderEmail]')
         .fill('jl-auto-defender@kolibri.is')
+      await page.keyboard.press('Tab')
+      await verifyRequestCompletion(page, '/api/graphql', 'UpdateCase')
       await page.getByTestId('continueButton').click()
       await page.getByTestId('modalSecondaryButton').click()
 
@@ -66,6 +74,8 @@ export function addTests() {
       await page.locator('input[id=validToDate]').fill(custodyEndDate)
       await page.keyboard.press('Escape')
       await page.locator('input[id=validToDate-time]').fill('16:00')
+      await page.keyboard.press('Tab')
+      await verifyRequestCompletion(page, '/api/graphql', 'UpdateCase')
       await page.getByTestId('continueButton').click()
 
       // Court record
@@ -74,14 +84,20 @@ export function addTests() {
       await page.getByText('Sækjandi unir úrskurðinum').click()
       await page.locator('input[id=courtEndTime]').fill(today)
       await page.keyboard.press('Escape')
+      await verifyRequestCompletion(page, '/api/graphql', 'UpdateCase')
       await page.locator('input[id=courtEndTime-time]').fill('10:00')
-      await page.keyboard.press('Escape')
+      await page.keyboard.press('Tab')
+      await verifyRequestCompletion(page, '/api/graphql', 'UpdateCase')
       await page.getByTestId('continueButton').click()
 
       // Confirmation
       await expect(page).toHaveURL(/.*\/domur\/stadfesta\/.*/)
       await page.getByTestId('continueButton').click()
-      await page.getByTestId('modalPrimaryButton').click({ timeout: 9000 })
+      await verifyRequestCompletion(
+        page,
+        '/api/graphql',
+        'RequestRulingSignature',
+      )
     })
   })
 }

--- a/apps/system-e2e/src/tests/judicial-system/smoke/custody-court.ts
+++ b/apps/system-e2e/src/tests/judicial-system/smoke/custody-court.ts
@@ -3,6 +3,7 @@ import { BrowserContext, expect, test } from '@playwright/test'
 import { JUDICIAL_SYSTEM_JUDGE_HOME_URL, urls } from '../../../support/urls'
 import { judicialSystemSession } from '../../../support/session'
 import { verifyRequestCompletion } from '../../../support/api-tools'
+import { verify } from 'crypto'
 
 export function addTests() {
   test.use({ baseURL: urls.judicialSystemBaseUrl })
@@ -33,8 +34,10 @@ export function addTests() {
       // Reception and assignment
       await expect(page).toHaveURL(/.*\/domur\/mottaka\/.*/)
       await page.getByTestId('courtCaseNumber').fill('R-63/2023')
-      await page.keyboard.press('Tab')
-      await verifyRequestCompletion(page, '/api/graphql', 'UpdateCase')
+      await Promise.all([
+        verifyRequestCompletion(page, '/api/graphql', 'UpdateCase'),
+        page.keyboard.press('Tab'),
+      ])
       await page.getByText('Veldu dómara/aðstoðarmann').click()
       await page.getByTestId('select-judge').getByText('Test Dómari').click()
       await page.getByTestId('continueButton').click()
@@ -59,8 +62,10 @@ export function addTests() {
       await page
         .locator('input[name=defenderEmail]')
         .fill('jl-auto-defender@kolibri.is')
-      await page.keyboard.press('Tab')
-      await verifyRequestCompletion(page, '/api/graphql', 'UpdateCase')
+      await Promise.all([
+        verifyRequestCompletion(page, '/api/graphql', 'UpdateCase'),
+        page.keyboard.press('Tab'),
+      ])
       await page.getByTestId('continueButton').click()
       await page.getByTestId('modalSecondaryButton').click()
 
@@ -72,7 +77,10 @@ export function addTests() {
       await page.locator('input[id=validToDate]').fill(custodyEndDate)
       await page.keyboard.press('Escape')
       await page.locator('input[id=validToDate-time]').fill('16:00')
-      await page.keyboard.press('Tab')
+      await Promise.all([
+        verifyRequestCompletion(page, '/api/graphql', 'UpdateCase'),
+        page.keyboard.press('Tab'),
+      ])
       await page.getByTestId('continueButton').click()
 
       // Court record
@@ -82,17 +90,18 @@ export function addTests() {
       await page.locator('input[id=courtEndTime]').fill(today)
       await page.keyboard.press('Escape')
       await page.locator('input[id=courtEndTime-time]').fill('10:00')
-      await page.keyboard.press('Tab')
+      await Promise.all([
+        verifyRequestCompletion(page, '/api/graphql', 'UpdateCase'),
+        page.keyboard.press('Tab'),
+      ])
       await page.getByTestId('continueButton').click()
 
       // Confirmation
       await expect(page).toHaveURL(/.*\/domur\/stadfesta\/.*/)
-      await page.getByTestId('continueButton').click()
-      await verifyRequestCompletion(
-        page,
-        '/api/graphql',
-        'RequestRulingSignature',
-      )
+      await Promise.all([
+        verifyRequestCompletion(page, '/api/graphql', 'RequestRulingSignature'),
+        page.getByTestId('continueButton').click(),
+      ])
     })
   })
 }

--- a/apps/system-e2e/src/tests/judicial-system/smoke/custody-court.ts
+++ b/apps/system-e2e/src/tests/judicial-system/smoke/custody-court.ts
@@ -37,7 +37,6 @@ export function addTests() {
       await verifyRequestCompletion(page, '/api/graphql', 'UpdateCase')
       await page.getByText('Veldu dómara/aðstoðarmann').click()
       await page.getByTestId('select-judge').getByText('Test Dómari').click()
-      await verifyRequestCompletion(page, '/api/graphql', 'UpdateCase', 200)
       await page.getByTestId('continueButton').click()
 
       // Overview

--- a/apps/system-e2e/src/tests/judicial-system/smoke/custody-court.ts
+++ b/apps/system-e2e/src/tests/judicial-system/smoke/custody-court.ts
@@ -37,7 +37,7 @@ export function addTests() {
       await verifyRequestCompletion(page, '/api/graphql', 'UpdateCase')
       await page.getByText('Veldu dómara/aðstoðarmann').click()
       await page.getByTestId('select-judge').getByText('Test Dómari').click()
-      await verifyRequestCompletion(page, '/api/graphql', 'UpdateCase')
+      await verifyRequestCompletion(page, '/api/graphql', 'UpdateCase', 200)
       await page.getByTestId('continueButton').click()
 
       // Overview
@@ -53,7 +53,7 @@ export function addTests() {
       await page.keyboard.press('Escape')
       await page.locator('input[id=courtDate-time]').fill('09:00')
       await page.keyboard.press('Tab')
-      await verifyRequestCompletion(page, '/api/graphql', 'UpdateCase')
+      await verifyRequestCompletion(page, '/api/graphql', 'UpdateCase', 200)
       await page
         .locator('input[id=react-select-defenderName-input]')
         .fill('Saul Goodmann')
@@ -62,7 +62,7 @@ export function addTests() {
         .locator('input[name=defenderEmail]')
         .fill('jl-auto-defender@kolibri.is')
       await page.keyboard.press('Tab')
-      await verifyRequestCompletion(page, '/api/graphql', 'UpdateCase')
+      await verifyRequestCompletion(page, '/api/graphql', 'UpdateCase', 200)
       await page.getByTestId('continueButton').click()
       await page.getByTestId('modalSecondaryButton').click()
 
@@ -75,7 +75,7 @@ export function addTests() {
       await page.keyboard.press('Escape')
       await page.locator('input[id=validToDate-time]').fill('16:00')
       await page.keyboard.press('Tab')
-      await verifyRequestCompletion(page, '/api/graphql', 'UpdateCase')
+      await verifyRequestCompletion(page, '/api/graphql', 'UpdateCase', 200)
       await page.getByTestId('continueButton').click()
 
       // Court record
@@ -87,7 +87,7 @@ export function addTests() {
       await verifyRequestCompletion(page, '/api/graphql', 'UpdateCase')
       await page.locator('input[id=courtEndTime-time]').fill('10:00')
       await page.keyboard.press('Tab')
-      await verifyRequestCompletion(page, '/api/graphql', 'UpdateCase')
+      await verifyRequestCompletion(page, '/api/graphql', 'UpdateCase', 200)
       await page.getByTestId('continueButton').click()
 
       // Confirmation

--- a/apps/system-e2e/src/tests/judicial-system/smoke/custody-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/smoke/custody-tests.spec.ts
@@ -3,6 +3,8 @@ import * as prosecutor from './custody-prosecutor'
 import * as court from './custody-court'
 
 test.describe.serial('Custody tests', () => {
+  // These tests are run serially because they are a part of
+  // a chain of events that need to happen in a specific order.
   prosecutor.addTests()
   court.addTests()
 })


### PR DESCRIPTION
## What

Waiting for update responses before continuing in our court e2e test

## Why

If there's a delay in response time then some steps prematurely fire and create a race condition, often breaking the test when run on dev


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
