### PR TITLE
fix(auth-admin): Permissions search

### DIFF
--- a/libs/portals/admin/ids-admin/src/hooks/useLooseSearch.tsx
+++ b/libs/portals/admin/ids-admin/src/hooks/useLooseSearch.tsx
@@ -53,7 +53,7 @@ export function useLooseSearch<T>(
       return
     }
 
-    const tokens = pseudolocalizeString(searchValue).toLowerCase().split(' ')
+    const tokens = pseudolocalizeString(searchValue).toLowerCase().split(/[\s-]+/)
 
     setFilteredList(
       fullList.filter((item) => {

--- a/libs/portals/admin/ids-admin/src/hooks/useLooseSearch.tsx
+++ b/libs/portals/admin/ids-admin/src/hooks/useLooseSearch.tsx
@@ -53,9 +53,7 @@ export function useLooseSearch<T>(
       return
     }
 
-    const tokens = pseudolocalizeString(searchValue)
-      .toLowerCase()
-      .split(/[\s-]+/)
+    const tokens = pseudolocalizeString(searchValue).toLowerCase().split(' ')
 
     setFilteredList(
       fullList.filter((item) => {

--- a/libs/portals/admin/ids-admin/src/hooks/useLooseSearch.tsx
+++ b/libs/portals/admin/ids-admin/src/hooks/useLooseSearch.tsx
@@ -53,7 +53,9 @@ export function useLooseSearch<T>(
       return
     }
 
-    const tokens = pseudolocalizeString(searchValue).toLowerCase().split(/[\s-]+/)
+    const tokens = pseudolocalizeString(searchValue)
+      .toLowerCase()
+      .split(/[\s-]+/)
 
     setFilteredList(
       fullList.filter((item) => {

--- a/libs/portals/admin/ids-admin/src/screens/Permissions/Permissions.tsx
+++ b/libs/portals/admin/ids-admin/src/screens/Permissions/Permissions.tsx
@@ -30,7 +30,7 @@ function Permissions() {
   const [filteredPermissions, filterPermissions] = useLooseSearch(
     permissionsList.data,
     ['environments[0].displayName[0].value', 'scopeName'],
-    'environments[0].displayName[0].value',
+    'scopeName',
   )
 
   const handleSearch = (value = '') => {


### PR DESCRIPTION
## What

Fix the search logic for permissions.
There was an issue in the search logic where a permission with the permissionID `@island.is/healt/health-care` was not in the filteredList when searching for `health-care` but was in the list when `healthcare` was in the list

## Why

So permissions that include `-` can be filtered correctly

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
