### PR TITLE
fix(service-portal): Health path parents

### DIFF
--- a/libs/service-portal/health/src/lib/navigation.ts
+++ b/libs/service-portal/health/src/lib/navigation.ts
@@ -16,7 +16,7 @@ export const healthNavigation: PortalNavigationItem = {
     },
     {
       name: m.therapies,
-      path: HealthPaths.HealthTherapiesPhysical,
+      path: HealthPaths.HealthTherapies,
       children: [
         {
           name: messages.physicalTherapy,
@@ -37,7 +37,7 @@ export const healthNavigation: PortalNavigationItem = {
     },
     {
       name: m.payments,
-      path: HealthPaths.HealthPaymentParticipation,
+      path: HealthPaths.HealthPayments,
       children: [
         {
           name: messages.paymentParticipation,
@@ -79,7 +79,7 @@ export const healthNavigation: PortalNavigationItem = {
     },
     {
       name: messages.medicineTitle,
-      path: HealthPaths.HealthMedicinePurchase,
+      path: HealthPaths.HealthMedicine,
       children: [
         {
           name: messages.medicinePurchaseTitle,

--- a/libs/service-portal/information/src/lib/navigation.ts
+++ b/libs/service-portal/information/src/lib/navigation.ts
@@ -14,25 +14,27 @@ export const informationNavigation: PortalNavigationItem = {
     {
       name: m.myInfo,
       path: InformationPaths.MyInfoRootOverview,
+      children: [
+        {
+          name: m.detailInfo,
+          navHide: true,
+          path: InformationPaths.UserInfo,
+        },
+        {
+          name: m.familySpouse,
+          navHide: true,
+          path: InformationPaths.Spouse,
+        },
+        {
+          name: m.familyChild,
+          navHide: true,
+          path: InformationPaths.Child,
+        },
+      ],
     },
     {
       name: m.mySettings,
       path: InformationPaths.Settings,
-    },
-    {
-      name: m.detailInfo,
-      navHide: true,
-      path: InformationPaths.UserInfo,
-    },
-    {
-      name: m.familySpouse,
-      navHide: true,
-      path: InformationPaths.Spouse,
-    },
-    {
-      name: m.familyChild,
-      navHide: true,
-      path: InformationPaths.Child,
     },
     {
       name: m.petitions,


### PR DESCRIPTION
## What

* Update health path parents so they represent the correct path
* Bonus: Also happening on my-information. 

## Why

It was set to a sibling of the other children

## Screenshots / Gifs

So this (see sidenav):
![Screenshot 2023-12-14 at 10 43 18](https://github.com/island-is/island.is/assets/24840451/f6e92759-7488-4eb7-b584-8dfc8fdc2ca7)

Becomes this:
![Screenshot 2023-12-14 at 10 48 48](https://github.com/island-is/island.is/assets/24840451/c31b99d2-c082-4d92-b9da-0da809308a33)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
