### PR TITLE
fix(j-s): Prevent text selection when dragging files in Safari

### DIFF
--- a/apps/judicial-system/web/src/components/AccordionItems/IndictmentsCaseFilesAccordionItem/IndictmentsCaseFilesAccordionItem.tsx
+++ b/apps/judicial-system/web/src/components/AccordionItems/IndictmentsCaseFilesAccordionItem/IndictmentsCaseFilesAccordionItem.tsx
@@ -214,12 +214,15 @@ const CaseFile: React.FC<React.PropsWithChildren<CaseFileProps>> = (props) => {
       style={{
         y,
         boxShadow,
-        // Prevents text selection when dragging
-        userSelect: isDragging ? 'none' : 'auto',
       }}
       className={styles.reorderItem}
       dragListener={false}
       dragControls={controls}
+      onPointerDown={(evt) => {
+        controls.start(evt)
+        // Prevents text selection when dragging
+        evt.preventDefault()
+      }}
     >
       {caseFile.isHeading && caseFile.chapter !== undefined ? (
         renderChapter(caseFile.chapter, caseFile.displayText)


### PR DESCRIPTION
# Prevent text selection when dragging files in Safari

[Asana](https://app.asana.com/0/1199153462262248/1206070267800546/f)

## What

Prevent text selection when dragging files in Safari

## Screenshots / Gifs

### Before

https://github.com/island-is/island.is/assets/3789875/c053a509-800e-4de4-a421-57843f917141

### After

https://github.com/island-is/island.is/assets/3789875/feeaf85f-7072-4b0a-9b63-4d3438d5711f

These screen recordings are shot on Safari


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
