### PR TITLE
fix(application-system): Adjust answerValidators.ts to log info not error.

### DIFF
--- a/apps/application-system/api/src/app/modules/application/tools/applicationTemplateValidation.service.ts
+++ b/apps/application-system/api/src/app/modules/application/tools/applicationTemplateValidation.service.ts
@@ -194,7 +194,7 @@ export class ApplicationValidationService {
         throw new ValidationFailed(errorMap)
       }
     } catch (error) {
-      this.logger.error('Failed to validate answers', error)
+      this.logger.info('Failed to validate answers', error)
       throw error
     }
 

--- a/apps/application-system/api/src/environments/environment.ts
+++ b/apps/application-system/api/src/environments/environment.ts
@@ -53,7 +53,7 @@ const devConfig = {
       endorsementsApiBasePath: 'http://localhost:4246',
     },
     healthInsuranceV2: {
-      xRoadBaseUrl: process.env.XROAD_BASE_PATH ?? 'http://localhost:8080',
+      xRoadBaseUrl: process.env.XROAD_BASE_PATH ?? 'http://localhost:8081',
       xRoadProviderId:
         process.env.XROAD_HEALTH_INSURANCE_ID ??
         'IS-DEV/GOV/10007/SJUKRA-Protected',
@@ -67,7 +67,7 @@ const devConfig = {
       username: process.env.DATA_PROTECTION_COMPLAINT_API_USERNAME,
       XRoadProviderId: process.env.DATA_PROTECTION_COMPLAINT_XROAD_PROVIDER_ID,
       xRoadClientId: process.env.XROAD_CLIENT_ID,
-      xRoadBaseUrl: process.env.XROAD_BASE_PATH ?? 'http://localhost:8080',
+      xRoadBaseUrl: process.env.XROAD_BASE_PATH ?? 'http://localhost:8081',
     },
     userProfile: {
       serviceBasePath: 'http://localhost:3366',

--- a/libs/application/templates/health-insurance/src/lib/answerValidators.ts
+++ b/libs/application/templates/health-insurance/src/lib/answerValidators.ts
@@ -105,7 +105,7 @@ export const answerValidators: Record<string, AnswerValidator> = {
     } else {
       /* User that requires waiting period, should not be allowed to continue */
       const buildError = buildValidationError(`${FORMER_INSURANCE}`)
-      return buildError('')
+      return buildError('User needs to wait for the waiting period')
     }
 
     return undefined


### PR DESCRIPTION
# Adjust answerValidators.ts to log info not error.

## What

Adjust answerValidators.ts to log info not error.
Byproduct change port locally of umbodsman and sjukra services

## Why

Was logged as error now which doesnt make sense.
Ports locally should be set as 8081 instead of 8080

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
