### PR TITLE
fix(contentful-apps): Skip generating organization subpage slug from title on initial render

### DIFF
--- a/apps/contentful-apps/pages/fields/organization-subpage-slug-field.tsx
+++ b/apps/contentful-apps/pages/fields/organization-subpage-slug-field.tsx
@@ -39,7 +39,12 @@ const OrganizationSubpageSlugField = () => {
     return sdk.entry.fields.title
       .getForLocale(sdk.field.locale)
       .onValueChanged((newTitle) => {
-        if (hasEntryBeenPublished || initialTitleChange.current) {
+        if (hasEntryBeenPublished) {
+          return
+        }
+
+        // Callback gets called on initial render, so we  want to ignore that
+        if (initialTitleChange.current) {
           initialTitleChange.current = false
           return
         }

--- a/apps/contentful-apps/pages/fields/organization-subpage-slug-field.tsx
+++ b/apps/contentful-apps/pages/fields/organization-subpage-slug-field.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useDebounce } from 'react-use'
 import { FieldExtensionSDK } from '@contentful/app-sdk'
 import { Stack, Text, TextInput } from '@contentful/f36-components'
@@ -21,6 +21,7 @@ const OrganizationSubpageSlugField = () => {
   const [organizationPageId, setOrganizationPageId] = useState(
     sdk.entry.fields.organizationPage.getValue()?.sys?.id,
   )
+  const initialTitleChange = useRef(true)
   const [hasEntryBeenPublished, setHasEntryBeenPublished] = useState(
     Boolean(sdk.entry.getSys()?.firstPublishedAt),
   )
@@ -38,13 +39,13 @@ const OrganizationSubpageSlugField = () => {
     return sdk.entry.fields.title
       .getForLocale(sdk.field.locale)
       .onValueChanged((newTitle) => {
-        if (hasEntryBeenPublished) return
+        if (hasEntryBeenPublished || initialTitleChange.current) {
+          initialTitleChange.current = false
+          return
+        }
+
         if (newTitle) {
-          setValue(
-            slugify(String(newTitle), {
-              customReplacements: [['ö', 'o']],
-            }),
-          )
+          setValue(slugify(String(newTitle)))
         }
       })
   }, [hasEntryBeenPublished, sdk.entry.fields.title, sdk.field.locale])

--- a/apps/contentful-apps/pages/fields/organization-subpage-slug-field.tsx
+++ b/apps/contentful-apps/pages/fields/organization-subpage-slug-field.tsx
@@ -40,7 +40,11 @@ const OrganizationSubpageSlugField = () => {
       .onValueChanged((newTitle) => {
         if (hasEntryBeenPublished) return
         if (newTitle) {
-          setValue(slugify(String(newTitle)))
+          setValue(
+            slugify(String(newTitle), {
+              customReplacements: [['ö', 'o']],
+            }),
+          )
         }
       })
   }, [hasEntryBeenPublished, sdk.entry.fields.title, sdk.field.locale])


### PR DESCRIPTION
# Skip generating organization subpage slug from title on initial render

So that opening an entry doesn't accidentally change the slug

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
