### PR TITLE
fix(parental-leave): alert message and period length fix

### DIFF
--- a/libs/application/templates/parental-leave/src/fields/UnEmploymentBenefits/index.tsx
+++ b/libs/application/templates/parental-leave/src/fields/UnEmploymentBenefits/index.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react'
 import { useFormContext } from 'react-hook-form'
 
-import { Box, Text } from '@island.is/island-ui/core'
+import { AlertMessage, Box, Text } from '@island.is/island-ui/core'
 import { formatText, getErrorViaPath } from '@island.is/application/core'
 import {
   FieldBaseProps,
@@ -29,13 +29,29 @@ export const UnEmploymentBenefits: FC<
       <Text variant="h2" as="h2">
         {formatText(title, application, formatMessage)}
       </Text>
+      <Text variant="default" marginTop={1}>
+        {formatText(
+          parentalLeaveFormMessages.employer
+            .isReceivingUnemploymentBenefitsDescription,
+          application,
+          formatMessage,
+        )}
+      </Text>
+      <Box component="section" marginTop={2} marginBottom={5}>
+        <AlertMessage
+          title={formatMessage(parentalLeaveFormMessages.employer.alertTitle)}
+          message={formatMessage(
+            parentalLeaveFormMessages.employer.alertDescription,
+          )}
+          type="info"
+        />
+      </Box>
       <RadioFormField
         error={errors && getErrorViaPath(errors, id)}
         application={application}
         field={{
           id: id,
           title: title,
-          description,
           type: FieldTypes.RADIO,
           component: FieldComponents.RADIO,
           children: undefined,

--- a/libs/application/templates/parental-leave/src/lib/messages.ts
+++ b/libs/application/templates/parental-leave/src/lib/messages.ts
@@ -1549,6 +1549,18 @@ export const parentalLeaveFormMessages: MessageDir = {
       defaultMessage: `Hvaðan ertu að þiggja bætur?`,
       description: 'Where are you receiving benefits from?',
     },
+    alertTitle: {
+      id: 'pl.application:employer.alert.title',
+      defaultMessage: 'Athugið',
+      description: 'Attention',
+    },
+    alertDescription: {
+      id: 'pl.application:employer.alert.description',
+      defaultMessage:
+        'Aðeins þeir sem eru ekki í ráðningu og eru ekki með neinn vinnuveitanda merkja við „Já“ hér að neðan.',
+      description:
+        'Only those who are not employed and do not have an employer tick "Yes" below.',
+    },
     addEmployer: {
       id: 'pl.application:employer.add',
       defaultMessage: 'Bæta við vinnuveitanda',

--- a/libs/application/templates/parental-leave/src/lib/parentalLeaveUtils.ts
+++ b/libs/application/templates/parental-leave/src/lib/parentalLeaveUtils.ts
@@ -1348,10 +1348,11 @@ export const calculateDaysUsedByPeriods = (periods: Period[]) =>
       const start = parseISO(period.startDate)
       const end = parseISO(period.endDate)
       const percentage = Number(period.ratio) / 100
+      const periodLength = calculatePeriodLength(start, end)
 
       const calculatedLength = period.daysToUse
         ? Number(period.daysToUse)
-        : calculatePeriodLength(start, end, percentage)
+        : Math.round(periodLength * percentage)
 
       return total + calculatedLength
     }, 0),


### PR DESCRIPTION
## What

Add alert message for the time being because applicant can't register employee if he is receiving unemployment benefits.
Two different period length calculation that was causing validation error.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
