### PR TITLE
fix(service-portal): Health fallback string and table empty

### DIFF
--- a/libs/service-portal/health/src/lib/messages.ts
+++ b/libs/service-portal/health/src/lib/messages.ts
@@ -640,6 +640,10 @@ export const messages = defineMessages({
     id: 'sp.health:health-center-no-doctor',
     defaultMessage: 'Enginn læknir skráður',
   },
+  healthCenterNoHealthCenterRegistered: {
+    id: 'sp.health:health-center-no-health-center',
+    defaultMessage: 'Enginn heilsugæsla skráð',
+  },
   healthRegistrationSave: {
     id: 'sp.health:health-registration-save',
     defaultMessage: 'Vista',

--- a/libs/service-portal/health/src/screens/HealthCenter/HealthCenter.tsx
+++ b/libs/service-portal/health/src/screens/HealthCenter/HealthCenter.tsx
@@ -81,14 +81,6 @@ const HealthCenter = () => {
         serviceProviderTooltip={formatMessage(messages.healthTooltip)}
       />
 
-      {!loading && !healthCenterData?.current && (
-        <Box width="full" marginTop={4} display="flex" justifyContent="center">
-          <Box marginTop={8}>
-            <EmptyState />
-          </Box>
-        </Box>
-      )}
-
       {wasSuccessfulTransfer && !loading && (
         <Box width="full" marginTop={4}>
           <AlertMessage
@@ -103,13 +95,24 @@ const HealthCenter = () => {
         </Box>
       )}
 
+      {!loading && !healthCenterData?.current && (
+        <Box width="full" marginTop={4} display="flex" justifyContent="center">
+          <Box marginTop={8}>
+            <EmptyState />
+          </Box>
+        </Box>
+      )}
+
       {healthCenterData?.current && (
         <Box width="full" marginTop={[1, 1, 4]}>
           <Stack space={2}>
             <UserInfoLine
               title={formatMessage(messages.myRegistration)}
               label={formatMessage(messages.healthCenterTitle)}
-              content={healthCenterData.current.healthCenterName ?? ''}
+              content={
+                healthCenterData.current.healthCenterName ??
+                formatMessage(messages.healthCenterNoHealthCenterRegistered)
+              }
               editLink={
                 canRegister
                   ? {
@@ -134,9 +137,9 @@ const HealthCenter = () => {
 
       {loading && <SkeletonLoader space={1} height={30} repeat={4} />}
 
-      {!loading && !error && healthCenterData?.history && (
+      {!loading && !error && healthCenterData?.history?.length ? (
         <HistoryTable history={healthCenterData.history} />
-      )}
+      ) : null}
     </Box>
   )
 }


### PR DESCRIPTION
## What

Update the health center front end:
* No table when empty
* Add fallback string to no center registration

## Why

Request from Sjúkra.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [X] I have rebased against main before asking for a review
