### PR TITLE
chore(ads): removing many flights option

### DIFF
--- a/apps/air-discount-scheme/backend/src/app/modules/discount/discount.service.ts
+++ b/apps/air-discount-scheme/backend/src/app/modules/discount/discount.service.ts
@@ -213,12 +213,10 @@ export class DiscountService {
       })
 
       if (allExplicit === null || allExplicit.length <= 5) {
-        user.fund.credit = flightLegs
+        user.fund.credit = 2 //making sure we can get flight from and to
       } else {
         return null
       }
-      // need to query explicit code to count how many explicit codes user has received,
-      // add one or two credits?
     } else {
       user.fund.credit = user.fund.total - user.fund.used
     }
@@ -481,18 +479,6 @@ export class DiscountService {
       ],
     }
 
-    const backFlight: ExplicitFlight = {
-      connectable: true,
-      id: 'explicit',
-      flightLegs: [
-        {
-          origin: AKUREYRI_FLIGHT_CODES[0],
-          destination: REYKJAVIK_FLIGHT_CODES[0],
-          date,
-        },
-      ],
-    }
-
     const discount = await this.createExplicitDiscountCode(
       auth,
       body.nationalId,
@@ -500,13 +486,9 @@ export class DiscountService {
       auth.nationalId,
       body.comment,
       body.numberOfDaysUntilExpiration,
-      body.needsConnectionFlight
-        ? body.flightLegs === 2
-          ? [flight, backFlight]
-          : [flight]
-        : [],
+      body.needsConnectionFlight ? [flight] : [],
       isExplicit,
-      body.flightLegs,
+      1,
     )
     if (!discount) {
       throw new Error(`Could not create explicit discount`)

--- a/apps/air-discount-scheme/backend/src/app/modules/discount/dto/params.dto.ts
+++ b/apps/air-discount-scheme/backend/src/app/modules/discount/dto/params.dto.ts
@@ -34,9 +34,6 @@ export class CreateExplicitDiscountCodeParams {
 
   @IsBoolean()
   readonly isExplicit!: boolean
-
-  @IsNumber()
-  readonly flightLegs!: number
 }
 
 export class CreateSuperExplicitDiscountCodeParams {
@@ -58,7 +55,4 @@ export class CreateSuperExplicitDiscountCodeParams {
 
   @IsBoolean()
   readonly isExplicit!: boolean
-
-  @IsNumber()
-  readonly flightLegs!: number
 }

--- a/libs/api/domains/air-discount-scheme/src/lib/discount-admin/dto/createExplicitDiscountCode.input.ts
+++ b/libs/api/domains/air-discount-scheme/src/lib/discount-admin/dto/createExplicitDiscountCode.input.ts
@@ -19,7 +19,4 @@ export class CreateExplicitDiscountCodeInput {
 
   @Field((_) => Boolean)
   isExplicit!: boolean
-
-  @Field((_) => Int)
-  flightLegs!: number
 }

--- a/libs/portals/admin/air-discount-scheme/src/screens/CreateDiscount/CreateDiscount.tsx
+++ b/libs/portals/admin/air-discount-scheme/src/screens/CreateDiscount/CreateDiscount.tsx
@@ -39,17 +39,12 @@ const AdminCreateDiscount = () => {
     },
   ]
 
-  const possibleFlightLegs = [
-    { label: 'Aðra leið', value: 1 },
-    { label: 'Báðar leiðir', value: 2 },
-  ]
-
   const [createExplicitDiscountCode] = useCreateExplicitDiscountCodeMutation()
   const [nationalId, setNationalId] = useState('')
   const [postalcode, setPostalcode] = useState('')
   const [comment, setComment] = useState('')
   const [length, setLength] = useState(options[0])
-  const [flightLegs, setFlightLegs] = useState(possibleFlightLegs[0])
+
   const [needsConnecting, setNeedsConnecting] = useState(typeOptions[0])
   const [discountCode, setDiscountCode] = useState<
     CreateExplicitDiscountCodeMutation | undefined | null
@@ -76,10 +71,9 @@ const AdminCreateDiscount = () => {
               {discountCode ? (
                 <>
                   {discountCode?.createAirDiscountSchemeExplicitDiscountCode?.map(
-                    (item, i) => {
+                    (item) => {
                       return (
                         <>
-                          <Text variant="h2">Leið {i + 1}</Text>
                           <Text variant="h3">
                             Venjulegur kóði: {item.discountCode}
                           </Text>
@@ -108,6 +102,7 @@ const AdminCreateDiscount = () => {
                       setPostalcode('')
                       setComment('')
                       setDiscountCode(null)
+                      setNeedsConnecting(typeOptions[0])
                     }}
                   >
                     Búa til nýjan kóða
@@ -159,20 +154,6 @@ const AdminCreateDiscount = () => {
                     options={typeOptions}
                   />
                   <Select
-                    name="flightLegs"
-                    label="Leið"
-                    required
-                    onChange={(opt) => {
-                      setFlightLegs(
-                        possibleFlightLegs.find(
-                          (item) => item.value === opt?.value,
-                        ) ?? possibleFlightLegs[0],
-                      )
-                    }}
-                    value={flightLegs}
-                    options={possibleFlightLegs}
-                  />
-                  <Select
                     name="length"
                     label="Tímalengd"
                     required
@@ -214,7 +195,6 @@ const AdminCreateDiscount = () => {
                 comment,
                 numberOfDaysUntilExpiration: parseInt(length.value, 10),
                 isExplicit: false,
-                flightLegs: flightLegs.value,
                 needsConnectionFlight: needsConnecting.value,
               },
             },

--- a/libs/portals/admin/air-discount-scheme/src/screens/SuperDiscount/SuperDiscount.tsx
+++ b/libs/portals/admin/air-discount-scheme/src/screens/SuperDiscount/SuperDiscount.tsx
@@ -41,18 +41,12 @@ const AdminCreateDiscount = () => {
     },
   ]
 
-  const possibleFlightLegs = [
-    { label: 'Aðra leið', value: 1 },
-    { label: 'Báðar leiðir', value: 2 },
-  ]
-
   const [createSuperExplicitDiscountCode] =
     useCreateSuperExplicitDiscountCodeMutation()
   const [nationalId, setNationalId] = useState('')
   const [postalcode, setPostalcode] = useState('')
   const [comment, setComment] = useState('')
   const [length, setLength] = useState(options[0])
-  const [flightLegs, setFlightLegs] = useState(possibleFlightLegs[0])
   const [needsConnecting, setNeedsConnecting] = useState(typeOptions[0])
   const [discountCode, setDiscountCode] = useState<
     CreateSuperExplicitDiscountCodeMutation | undefined | null
@@ -80,10 +74,9 @@ const AdminCreateDiscount = () => {
               {discountCode ? (
                 <>
                   {discountCode?.createAirDiscountSchemeSuperExplicitDiscountCode?.map(
-                    (item, i) => {
+                    (item) => {
                       return (
                         <>
-                          <Text variant="h2">Leið {i + 1}</Text>
                           <Text variant="h3">
                             Venjulegur kóði: {item.discountCode}
                           </Text>
@@ -112,7 +105,7 @@ const AdminCreateDiscount = () => {
                       setPostalcode('')
                       setComment('')
                       setDiscountCode(null)
-                      setFlightLegs(possibleFlightLegs[0])
+                      setNeedsConnecting(typeOptions[0])
                     }}
                   >
                     Búa til nýjan kóða
@@ -164,20 +157,6 @@ const AdminCreateDiscount = () => {
                     options={typeOptions}
                   />
                   <Select
-                    name="flightLegs"
-                    label="Leið"
-                    required
-                    onChange={(opt) => {
-                      setFlightLegs(
-                        possibleFlightLegs.find(
-                          (item) => item.value === opt?.value,
-                        ) ?? possibleFlightLegs[0],
-                      )
-                    }}
-                    value={flightLegs}
-                    options={possibleFlightLegs}
-                  />
-                  <Select
                     name="length"
                     label="Tímalengd"
                     required
@@ -219,7 +198,6 @@ const AdminCreateDiscount = () => {
                 comment,
                 numberOfDaysUntilExpiration: Number.parseInt(length.value, 10),
                 isExplicit: true,
-                flightLegs: flightLegs.value,
                 needsConnectionFlight: needsConnecting.value,
               },
             },


### PR DESCRIPTION

## What

We dont want anymore to use two flightlegs.

## Why

Because using two codes is more expensive than using one code to order two flights with.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
