### PR TITLE
fix(estate): only check heir age for divisionOfEstate

### DIFF
--- a/libs/application/templates/estate/src/fields/EstateMembersRepeater/AdditionalEstateMember.tsx
+++ b/libs/application/templates/estate/src/fields/EstateMembersRepeater/AdditionalEstateMember.tsx
@@ -52,6 +52,8 @@ export const AdditionalEstateMember = ({
   const phoneField = `${fieldIndex}.phone`
   const emailField = `${fieldIndex}.email`
 
+  const selectedEstate = application.answers.selectedEstate
+
   const foreignCitizenship = useWatch({
     name: foreignCitizenshipField,
     defaultValue: hasYes(field.foreignCitizenship) ? [YES] : '',
@@ -131,7 +133,7 @@ export const AdditionalEstateMember = ({
       ) : (
         <Box paddingY={2}>
           <LookupPerson
-            field={{ id: fieldIndex, props: { alertWhenUnder18: true } }}
+            field={{ id: fieldIndex, props: { alertWhenUnder18: selectedEstate === EstateTypes.divisionOfEstateByHeirs } }}
             error={error}
           />
         </Box>


### PR DESCRIPTION

## What

lookupperson should only show warning for division of estate by heirs

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
