### PR TITLE
feat(web): Add undertitle prop to Default Header component

### DIFF
--- a/apps/web/components/DefaultHeader/DefaultHeader.tsx
+++ b/apps/web/components/DefaultHeader/DefaultHeader.tsx
@@ -10,6 +10,7 @@ export interface DefaultHeaderProps {
   image?: string
   background?: string
   title: string
+  underTitle?: string
   logo?: string
   logoHref?: string
   titleColor?: TextProps['color']
@@ -27,6 +28,7 @@ export const DefaultHeader: React.FC<
   image,
   background,
   title,
+  underTitle,
   logo,
   logoHref,
   titleColor = 'dark400',
@@ -104,6 +106,11 @@ export const DefaultHeader: React.FC<
                 <Text variant="h1" as="h1" color={titleColor}>
                   {title}
                 </Text>
+                {underTitle && (
+                  <Text fontWeight="regular" color={titleColor}>
+                    {underTitle}
+                  </Text>
+                )}
               </div>
             </div>
           </div>

--- a/apps/web/components/Organization/Wrapper/Themes/HljodbokasafnIslandsTheme/HljodbokasafnIslandsHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/HljodbokasafnIslandsTheme/HljodbokasafnIslandsHeader.tsx
@@ -25,6 +25,10 @@ const HljodbokasafnIslandsHeader: React.FC<
   return (
     <DefaultHeader
       title={organizationPage.title}
+      underTitle={n(
+        'hljodbokasafnIslandsHeaderUnderTitle',
+        'Fyrir blinda, sjónskerta og fólk með lestrarhömlun',
+      )}
       image={n(
         'hljodbokasafnIslandsHeaderImage',
         'https://images.ctfassets.net/8k0h54kbe6bj/3tzrR4b3oS4x84sAfGfOlk/7a69079d123471048e6ef9130d962313/mynd_HBS_1.png',


### PR DESCRIPTION
# Add undertitle prop to Default Header component

## Screenshots / Gifs

![image](https://github.com/island-is/island.is/assets/43557895/f93948a4-bc91-46d1-8388-e8c0603ec52c)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
