### PR TITLE
fix(web): Change social sharing image fallback when svg image is used

### DIFF
--- a/apps/web/screens/IcelandicGovernmentInstitutionVacancies/IcelandicGovernmentInstitutionVacancyDetails.tsx
+++ b/apps/web/screens/IcelandicGovernmentInstitutionVacancies/IcelandicGovernmentInstitutionVacancyDetails.tsx
@@ -129,6 +129,17 @@ const IcelandicGovernmentInstitutionVacancyDetails: Screen<
 
   const ogTitlePostfix = n('ogTitlePrefixForDetailsPage', ' | Ísland.is')
 
+  const getSocialImageUrl = (url: string | undefined | null) => {
+    const isSvg = url ? url.trim().toLocaleLowerCase().endsWith('svg') : false
+
+    return isSvg
+      ? n(
+          'ogImageUrl',
+          'https://images.ctfassets.net/8k0h54kbe6bj/5LqU9yD9nzO5oOijpZF0K0/b595e1cf3e72bc97b2f9d869a53f5da9/LE_-_Jobs_-_S3.png',
+        )
+      : url
+  }
+
   return (
     <Box>
       <HeadWithSocialSharing
@@ -137,7 +148,7 @@ const IcelandicGovernmentInstitutionVacancyDetails: Screen<
           vacancy?.plainTextIntro ?? '',
           VACANCY_INTRO_MAX_LENGTH,
         )}
-        imageUrl={n('ogDetailsImageUrl', vacancy?.logoUrl)}
+        imageUrl={getSocialImageUrl(vacancy?.logoUrl) ?? ''}
       >
         <meta name="robots" content="noindex, nofollow" />
       </HeadWithSocialSharing>


### PR DESCRIPTION
# Change social sharing image fallback when svg image is used

## What

Change fallback image when svg image is used for social sharing viewed item in starfatorg

## Why

So the fallback image is starfatorg icon not island.is default image


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
