### PR TITLE
feat(web): Add header for transport authority service web

### DIFF
--- a/apps/web/components/ServiceWeb/Background/Background.tsx
+++ b/apps/web/components/ServiceWeb/Background/Background.tsx
@@ -1,9 +1,10 @@
 import React, { ReactNode, useEffect, useState } from 'react'
 import cn from 'classnames'
 import dynamic from 'next/dynamic'
-import { Hidden } from '@island.is/island-ui/core'
-import { BackgroundProps } from '../types'
 
+import { Hidden } from '@island.is/island-ui/core'
+
+import { BackgroundProps } from '../types'
 import * as styles from './Background.css'
 
 const Default = dynamic(() => import('./Variations/Default/Default'), {
@@ -38,6 +39,11 @@ const Utlendingastofnun = dynamic(
   { ssr: false },
 )
 
+const TransportAuthority = dynamic(
+  () => import('./Variations/TransportAuthority/TransportAuthority'),
+  { ssr: false },
+)
+
 export const Background = ({
   variation,
   small,
@@ -65,6 +71,10 @@ export const Background = ({
       case 'utlendingastofnun':
       case 'directorate-of-immigration':
         setComponent(<Utlendingastofnun namespace={namespace} />)
+        break
+      case 'samgongustofa':
+      case 'transport-authority':
+        setComponent(<TransportAuthority namespace={namespace} />)
         break
       case 'default':
       default:

--- a/apps/web/components/ServiceWeb/Background/Variations/TransportAuthority/TransportAuthority.css.ts
+++ b/apps/web/components/ServiceWeb/Background/Variations/TransportAuthority/TransportAuthority.css.ts
@@ -1,0 +1,9 @@
+import { style } from '@vanilla-extract/css'
+
+export const bg = style({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  bottom: 0,
+  right: 0,
+})

--- a/apps/web/components/ServiceWeb/Background/Variations/TransportAuthority/TransportAuthority.tsx
+++ b/apps/web/components/ServiceWeb/Background/Variations/TransportAuthority/TransportAuthority.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+
+import { Box } from '@island.is/island-ui/core'
+import { useNamespace } from '@island.is/web/hooks'
+
+import * as styles from './TransportAuthority.css'
+
+export const TransportAuthority = ({
+  namespace,
+}: {
+  namespace: Record<string, string>
+}) => {
+  const n = useNamespace(namespace)
+  return (
+    <Box
+      className={styles.bg}
+      style={{
+        backgroundImage: n(
+          'transportAuthorityServiceWebHeaderBackgroundImage',
+          'url(https://images.ctfassets.net/8k0h54kbe6bj/4HQGy5lUXf17EEbsgQ6liC/5a37594d436c4ef591dc2723297461a4/Rectangle_713.png)',
+        ),
+        backgroundRepeat: 'no-repeat',
+        backgroundSize: 'cover',
+      }}
+    />
+  )
+}
+
+export default TransportAuthority

--- a/apps/web/components/ServiceWeb/config.ts
+++ b/apps/web/components/ServiceWeb/config.ts
@@ -35,6 +35,13 @@ export const options: Record<BackgroundVariations, Options> = {
     textMode: 'light',
   },
 
+  samgongustofa: {
+    textMode: 'light',
+  },
+  'transport-authority': {
+    textMode: 'light',
+  },
+
   default: {
     textMode: 'dark',
   },


### PR DESCRIPTION
# Add header for transport authority service web


![image (11)](https://github.com/island-is/island.is/assets/43557895/3cca4a1d-1911-4266-9e61-4331190120b4)
