### PR TITLE
fix(web): Service web suggested search not displaying results

### DIFF
--- a/apps/web/components/ServiceWeb/SearchInput/SearchInput.tsx
+++ b/apps/web/components/ServiceWeb/SearchInput/SearchInput.tsx
@@ -77,8 +77,8 @@ export const SearchInput = ({
     GetSupportSearchResultsQuery,
     GetSupportSearchResultsQueryVariables
   >(GET_SUPPORT_SEARCH_RESULTS_QUERY, {
-    onCompleted: () => {
-      updateOptions()
+    onCompleted: (newData) => {
+      updateOptions(newData)
     },
   })
 
@@ -134,8 +134,10 @@ export const SearchInput = ({
     }
   }
 
-  const updateOptions = () => {
-    const options = ((data?.searchResults?.items as Array<SupportQna>) || [])
+  const updateOptions = (newData?: GetSupportSearchResultsQuery) => {
+    const options = (
+      ((newData ?? data)?.searchResults?.items as Array<SupportQna>) || []
+    )
       .filter(
         (item) => item.category?.slug && item.organization?.slug && item.slug,
       )


### PR DESCRIPTION
# Service web suggested search not displaying results

## What

After a monorepo package upgrade the suggested search results stopped appearing. This is due to the code relying on a data property being up to date when it's not.

## Screenshots / Gifs

### Before
https://github.com/island-is/island.is/assets/43557895/a3008de8-be65-4afd-b28b-7b3c23a6daf4

### After

https://github.com/island-is/island.is/assets/43557895/77cdbdfc-ff76-4a8a-bed3-0c451b5a17ad



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
