### PR TITLE
feat(web): Redirect /en/o/icelandic-health insurance to /en/o/iceland-health

### DIFF
--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -346,7 +346,8 @@ export const OrganizationExternalLinks: React.FC<
             // Sjukratryggingar's external links have custom styled buttons
             const isSjukratryggingar =
               organizationPage.slug === 'sjukratryggingar' ||
-              organizationPage.slug === 'icelandic-health-insurance'
+              organizationPage.slug === 'icelandic-health-insurance' ||
+              organizationPage.slug === 'iceland-health'
 
             let variant = undefined
             if (
@@ -420,6 +421,7 @@ export const OrganizationFooter: React.FC<
       break
     case 'sjukratryggingar':
     case 'icelandic-health-insurance':
+    case 'iceland-health':
       OrganizationFooterComponent = (
         <SjukratryggingarFooter
           footerItems={organization.footerItems}

--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -346,8 +346,7 @@ export const OrganizationExternalLinks: React.FC<
             // Sjukratryggingar's external links have custom styled buttons
             const isSjukratryggingar =
               organizationPage.slug === 'sjukratryggingar' ||
-              organizationPage.slug === 'icelandic-health-insurance' ||
-              organizationPage.slug === 'iceland-health'
+              organizationPage.slug === 'icelandic-health-insurance'
 
             let variant = undefined
             if (
@@ -421,7 +420,6 @@ export const OrganizationFooter: React.FC<
       break
     case 'sjukratryggingar':
     case 'icelandic-health-insurance':
-    case 'iceland-health':
       OrganizationFooterComponent = (
         <SjukratryggingarFooter
           footerItems={organization.footerItems}

--- a/apps/web/components/ServiceWeb/Background/Background.tsx
+++ b/apps/web/components/ServiceWeb/Background/Background.tsx
@@ -66,6 +66,7 @@ export const Background = ({
         break
       case 'sjukratryggingar':
       case 'icelandic-health-insurance':
+      case 'iceland-health':
         setComponent(<Sjukratryggingar namespace={namespace} />)
         break
       case 'utlendingastofnun':

--- a/apps/web/components/ServiceWeb/Background/Background.tsx
+++ b/apps/web/components/ServiceWeb/Background/Background.tsx
@@ -66,7 +66,6 @@ export const Background = ({
         break
       case 'sjukratryggingar':
       case 'icelandic-health-insurance':
-      case 'iceland-health':
         setComponent(<Sjukratryggingar namespace={namespace} />)
         break
       case 'utlendingastofnun':

--- a/apps/web/components/ServiceWeb/DynamicFooter/DynamicFooter.tsx
+++ b/apps/web/components/ServiceWeb/DynamicFooter/DynamicFooter.tsx
@@ -1,7 +1,6 @@
-import { Organization } from '@island.is/web/graphql/schema'
-
-import { useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
 import { OrganizationFooter, ServiceWebFooter } from '@island.is/web/components'
+import { Organization } from '@island.is/web/graphql/schema'
+import { useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
 
 interface DynamicFooterProps {
   organization: Organization
@@ -24,13 +23,13 @@ export const DynamicFooter = ({
 
   const contactLink = linkResolver('servicewebcontact', [slug]).href
 
-  return organization.footerItems?.length > 0 ? (
+  return organization?.footerItems?.length > 0 ? (
     <OrganizationFooter organizations={[organization]} />
   ) : (
     <ServiceWebFooter
-      title={organization.title}
-      logoSrc={organization.logo?.url}
-      phone={organization.phone}
+      title={organization?.title ?? ''}
+      logoSrc={organization?.logo?.url}
+      phone={organization?.phone}
       contactLink={contactLink}
       namespace={namespace}
     />

--- a/apps/web/components/ServiceWeb/Header/Header.tsx
+++ b/apps/web/components/ServiceWeb/Header/Header.tsx
@@ -1,19 +1,20 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import NextLink from 'next/link'
 import cn from 'classnames'
+import NextLink from 'next/link'
+
 import {
   Box,
+  Button,
   Column,
   Columns,
+  getTextStyles,
   GridColumn,
   GridContainer,
   GridRow,
   Hidden,
+  Link,
   Logo,
   ResponsiveSpace,
-  Link,
-  getTextStyles,
-  Button,
 } from '@island.is/island-ui/core'
 import {
   LanguageToggler,
@@ -22,8 +23,8 @@ import {
 } from '@island.is/web/components'
 import { useLinkResolver, useNamespace } from '@island.is/web/hooks'
 import { useI18n } from '@island.is/web/i18n'
-import { TextModes } from '../types'
 
+import { TextModes } from '../types'
 import * as styles from './Header.css'
 
 const marginLeft = [1, 1, 1, 2] as ResponsiveSpace
@@ -45,7 +46,7 @@ export const Header = ({
   namespace,
 }: HeaderProps) => {
   const { linkResolver } = useLinkResolver()
-  const { t } = useI18n()
+  const { t, activeLocale } = useI18n()
 
   const n = useNamespace(namespace)
 
@@ -140,7 +141,9 @@ export const Header = ({
                               placeholder={searchPlaceholder}
                               nothingFoundText={n(
                                 'nothingFoundText',
-                                'Ekkert fannst',
+                                activeLocale === 'is'
+                                  ? 'Ekkert fannst'
+                                  : 'Nothing was found',
                               )}
                             />
                           </Box>

--- a/apps/web/components/ServiceWeb/SearchSection/SearchSection.tsx
+++ b/apps/web/components/ServiceWeb/SearchSection/SearchSection.tsx
@@ -1,10 +1,12 @@
 import cn from 'classnames'
-import { Box, Text, Hidden } from '@island.is/island-ui/core'
+
+import { Box, Hidden, Text } from '@island.is/island-ui/core'
 import { Colors } from '@island.is/island-ui/theme'
 import { ServiceWebSearchInput } from '@island.is/web/components'
 import { useNamespace } from '@island.is/web/hooks'
-import { TextModes } from '../types'
+import { useI18n } from '@island.is/web/i18n'
 
+import { TextModes } from '../types'
 import * as styles from './SearchSection.css'
 
 interface SearchSectionProps {
@@ -27,6 +29,7 @@ export const SearchSection = ({
   showLogoOnMobileDisplays = true,
 }: SearchSectionProps) => {
   const n = useNamespace(namespace)
+  const { activeLocale } = useI18n()
 
   const textProps: { color?: Colors } =
     textMode === 'dark'
@@ -70,7 +73,10 @@ export const SearchSection = ({
       )}
       <ServiceWebSearchInput
         placeholder={searchPlaceholder}
-        nothingFoundText={n('nothingFoundText', 'Ekkert fannst')}
+        nothingFoundText={n(
+          'nothingFoundText',
+          activeLocale === 'is' ? 'Ekkert fannst' : 'Nothing was found',
+        )}
       />
     </Box>
   )

--- a/apps/web/components/ServiceWeb/config.ts
+++ b/apps/web/components/ServiceWeb/config.ts
@@ -27,6 +27,9 @@ export const options: Record<BackgroundVariations, Options> = {
   'icelandic-health-insurance': {
     textMode: 'blueberry',
   },
+  'iceland-health': {
+    textMode: 'blueberry',
+  },
 
   utlendingastofnun: {
     textMode: 'light',

--- a/apps/web/components/ServiceWeb/config.ts
+++ b/apps/web/components/ServiceWeb/config.ts
@@ -27,9 +27,6 @@ export const options: Record<BackgroundVariations, Options> = {
   'icelandic-health-insurance': {
     textMode: 'blueberry',
   },
-  'iceland-health': {
-    textMode: 'blueberry',
-  },
 
   utlendingastofnun: {
     textMode: 'light',

--- a/apps/web/components/ServiceWeb/types.ts
+++ b/apps/web/components/ServiceWeb/types.ts
@@ -6,6 +6,7 @@ export type BackgroundVariations =
   | 'default'
   | 'sjukratryggingar'
   | 'icelandic-health-insurance'
+  | 'iceland-health'
   | string
 
 export type VariationProps = {

--- a/apps/web/components/ServiceWeb/types.ts
+++ b/apps/web/components/ServiceWeb/types.ts
@@ -6,7 +6,6 @@ export type BackgroundVariations =
   | 'default'
   | 'sjukratryggingar'
   | 'icelandic-health-insurance'
-  | 'iceland-health'
   | string
 
 export type VariationProps = {

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -80,6 +80,26 @@ const nextConfig = {
         destination: '/en/search?q=*&type=webManual',
         permanent: true,
       },
+      {
+        source: '/en/o/icelandic-health-insurance',
+        destination: '/en/o/iceland-health',
+        permanent: true,
+      },
+      {
+        source: '/en/help/icelandic-health-insurance',
+        destination: '/en/help/iceland-health',
+        permanent: true,
+      },
+      {
+        source: '/en/o/icelandic-health-insurance/:subSlug*',
+        destination: '/en/o/iceland-health/:subSlug*',
+        permanent: true,
+      },
+      {
+        source: '/en/help/icelandic-health-insurance/:subSlug*',
+        destination: '/en/help/iceland-health/:subSlug*',
+        permanent: true,
+      },
     ]
   },
   webpack: (config, { isServer }) => {

--- a/apps/web/screens/Organization/Home/Home.tsx
+++ b/apps/web/screens/Organization/Home/Home.tsx
@@ -20,12 +20,12 @@ import {
   ContentLanguage,
   Query,
   QueryGetNamespaceArgs,
-  QueryGetOrganizationPageArgs,
 } from '@island.is/web/graphql/schema'
 import { useLinkResolver, useNamespace } from '@island.is/web/hooks'
 import useContentfulId from '@island.is/web/hooks/useContentfulId'
 import { withMainLayout } from '@island.is/web/layouts/main'
 import { CustomNextError } from '@island.is/web/units/errors'
+import { retriedQueryIfOrganizationSlugRedirect } from '@island.is/web/utils/organization'
 
 import { Screen } from '../../../types'
 import {
@@ -260,24 +260,24 @@ Home.getProps = async ({ apolloClient, locale, query }) => {
     },
     namespace,
   ] = await Promise.all([
-    apolloClient.query<Query, QueryGetOrganizationPageArgs>({
-      query: GET_ORGANIZATION_PAGE_QUERY,
-      variables: {
-        input: {
-          slug: query.slug as string,
-          lang: locale as ContentLanguage,
-        },
+    retriedQueryIfOrganizationSlugRedirect(
+      apolloClient,
+      GET_ORGANIZATION_PAGE_QUERY,
+      'getOrganizationPage',
+      {
+        slug: query.slug as string,
+        lang: locale as ContentLanguage,
       },
-    }),
-    apolloClient.query<Query, QueryGetOrganizationPageArgs>({
-      query: GET_ORGANIZATION_QUERY,
-      variables: {
-        input: {
-          slug: query.slug as string,
-          lang: locale as ContentLanguage,
-        },
+    ),
+    retriedQueryIfOrganizationSlugRedirect(
+      apolloClient,
+      GET_ORGANIZATION_QUERY,
+      'getOrganization',
+      {
+        slug: query.slug as string,
+        lang: locale as ContentLanguage,
       },
-    }),
+    ),
     apolloClient
       .query<Query, QueryGetNamespaceArgs>({
         query: GET_NAMESPACE_QUERY,

--- a/apps/web/screens/Organization/Home/Home.tsx
+++ b/apps/web/screens/Organization/Home/Home.tsx
@@ -25,7 +25,7 @@ import { useLinkResolver, useNamespace } from '@island.is/web/hooks'
 import useContentfulId from '@island.is/web/hooks/useContentfulId'
 import { withMainLayout } from '@island.is/web/layouts/main'
 import { CustomNextError } from '@island.is/web/units/errors'
-import { retriedQueryIfOrganizationSlugRedirect } from '@island.is/web/utils/organization'
+import { icelandHealthQueryWrapper } from '@island.is/web/utils/organization'
 
 import { Screen } from '../../../types'
 import {
@@ -260,7 +260,7 @@ Home.getProps = async ({ apolloClient, locale, query }) => {
     },
     namespace,
   ] = await Promise.all([
-    retriedQueryIfOrganizationSlugRedirect(
+    icelandHealthQueryWrapper(
       apolloClient,
       GET_ORGANIZATION_PAGE_QUERY,
       'getOrganizationPage',
@@ -269,7 +269,7 @@ Home.getProps = async ({ apolloClient, locale, query }) => {
         lang: locale as ContentLanguage,
       },
     ),
-    retriedQueryIfOrganizationSlugRedirect(
+    icelandHealthQueryWrapper(
       apolloClient,
       GET_ORGANIZATION_QUERY,
       'getOrganization',

--- a/apps/web/screens/Organization/Home/Home.tsx
+++ b/apps/web/screens/Organization/Home/Home.tsx
@@ -293,16 +293,10 @@ Home.getProps = async ({ apolloClient, locale, query }) => {
   const { organizationPage, organization } =
     await handleOrganizationSlugRedirect(
       apolloClient,
-      query.slug,
+      query,
       locale,
-      {
-        data: responses[0].data.getOrganizationPage,
-        fetchIfMissing: true,
-      },
-      {
-        data: responses[1].data.getOrganization,
-        fetchIfMissing: true,
-      },
+      responses[0].data.getOrganizationPage,
+      responses[1].data.getOrganization,
     )
 
   if (!organizationPage && !organization?.hasALandingPage) {

--- a/apps/web/screens/Organization/Home/Home.tsx
+++ b/apps/web/screens/Organization/Home/Home.tsx
@@ -293,10 +293,16 @@ Home.getProps = async ({ apolloClient, locale, query }) => {
   const { organizationPage, organization } =
     await handleOrganizationSlugRedirect(
       apolloClient,
-      query,
+      query.slug,
       locale,
-      responses[0].data.getOrganizationPage,
-      responses[1].data.getOrganization,
+      {
+        data: responses[0].data.getOrganizationPage,
+        fetchIfMissing: true,
+      },
+      {
+        data: responses[1].data.getOrganization,
+        fetchIfMissing: true,
+      },
     )
 
   if (!organizationPage && !organization?.hasALandingPage) {

--- a/apps/web/screens/Organization/Services.tsx
+++ b/apps/web/screens/Organization/Services.tsx
@@ -1,48 +1,51 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import React, { useState } from 'react'
 import { useRouter } from 'next/router'
+
 import {
-  Text,
-  NavigationItem,
-  LinkCard,
-  FocusableBox,
-  Stack,
   Box,
+  FocusableBox,
   GridColumn,
   GridContainer,
   GridRow,
-  Select,
-  Input,
   Inline,
+  Input,
+  LinkCard,
+  NavigationItem,
+  Select,
+  Stack,
   Tag,
+  Text,
 } from '@island.is/island-ui/core'
-import { withMainLayout } from '@island.is/web/layouts/main'
 import {
+  getThemeConfig,
+  OrganizationWrapper,
+  Webreader,
+} from '@island.is/web/components'
+import {
+  Article,
   ContentLanguage,
   Query,
   QueryGetArticlesArgs,
   QueryGetNamespaceArgs,
   QueryGetOrganizationPageArgs,
   SortField,
-  Article,
 } from '@island.is/web/graphql/schema'
+import { useNamespace } from '@island.is/web/hooks'
+import useContentfulId from '@island.is/web/hooks/useContentfulId'
+import { LinkType, useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
+import { useLocalLinkTypeResolver } from '@island.is/web/hooks/useLocalLinkTypeResolver'
+import { withMainLayout } from '@island.is/web/layouts/main'
+import { CustomNextError } from '@island.is/web/units/errors'
+import { hasProcessEntries } from '@island.is/web/utils/article'
+import { handleOrganizationSlugRedirect } from '@island.is/web/utils/organization'
+
+import { Screen } from '../../types'
 import {
   GET_NAMESPACE_QUERY,
   GET_ORGANIZATION_PAGE_QUERY,
   GET_ORGANIZATION_SERVICES_QUERY,
 } from '../queries'
-import { Screen } from '../../types'
-import { useNamespace } from '@island.is/web/hooks'
-import { LinkType, useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
-import {
-  getThemeConfig,
-  OrganizationWrapper,
-  Webreader,
-} from '@island.is/web/components'
-import { CustomNextError } from '@island.is/web/units/errors'
-import useContentfulId from '@island.is/web/hooks/useContentfulId'
-import { useLocalLinkTypeResolver } from '@island.is/web/hooks/useLocalLinkTypeResolver'
-import { hasProcessEntries } from '@island.is/web/utils/article'
 
 interface ServicesPageProps {
   organizationPage: Query['getOrganizationPage']
@@ -288,12 +291,7 @@ const ServicesPage: Screen<ServicesPageProps> = ({
 }
 
 ServicesPage.getProps = async ({ apolloClient, locale, query }) => {
-  const [
-    {
-      data: { getOrganizationPage },
-    },
-    namespace,
-  ] = await Promise.all([
+  const responses = await Promise.all([
     apolloClient.query<Query, QueryGetOrganizationPageArgs>({
       query: GET_ORGANIZATION_PAGE_QUERY,
       variables: {
@@ -319,6 +317,16 @@ ServicesPage.getProps = async ({ apolloClient, locale, query }) => {
           : {},
       ),
   ])
+
+  const namespace = responses[1]
+
+  const { organizationPage: getOrganizationPage } =
+    await handleOrganizationSlugRedirect(
+      apolloClient,
+      query,
+      locale,
+      responses[0].data.getOrganizationPage,
+    )
 
   const {
     data: { getArticles },

--- a/apps/web/screens/Organization/Services.tsx
+++ b/apps/web/screens/Organization/Services.tsx
@@ -1,51 +1,48 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import React, { useState } from 'react'
 import { useRouter } from 'next/router'
-
 import {
-  Box,
+  Text,
+  NavigationItem,
+  LinkCard,
   FocusableBox,
+  Stack,
+  Box,
   GridColumn,
   GridContainer,
   GridRow,
-  Inline,
-  Input,
-  LinkCard,
-  NavigationItem,
   Select,
-  Stack,
+  Input,
+  Inline,
   Tag,
-  Text,
 } from '@island.is/island-ui/core'
+import { withMainLayout } from '@island.is/web/layouts/main'
 import {
-  getThemeConfig,
-  OrganizationWrapper,
-  Webreader,
-} from '@island.is/web/components'
-import {
-  Article,
   ContentLanguage,
   Query,
   QueryGetArticlesArgs,
   QueryGetNamespaceArgs,
   QueryGetOrganizationPageArgs,
   SortField,
+  Article,
 } from '@island.is/web/graphql/schema'
-import { useNamespace } from '@island.is/web/hooks'
-import useContentfulId from '@island.is/web/hooks/useContentfulId'
-import { LinkType, useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
-import { useLocalLinkTypeResolver } from '@island.is/web/hooks/useLocalLinkTypeResolver'
-import { withMainLayout } from '@island.is/web/layouts/main'
-import { CustomNextError } from '@island.is/web/units/errors'
-import { hasProcessEntries } from '@island.is/web/utils/article'
-import { handleOrganizationSlugRedirect } from '@island.is/web/utils/organization'
-
-import { Screen } from '../../types'
 import {
   GET_NAMESPACE_QUERY,
   GET_ORGANIZATION_PAGE_QUERY,
   GET_ORGANIZATION_SERVICES_QUERY,
 } from '../queries'
+import { Screen } from '../../types'
+import { useNamespace } from '@island.is/web/hooks'
+import { LinkType, useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
+import {
+  getThemeConfig,
+  OrganizationWrapper,
+  Webreader,
+} from '@island.is/web/components'
+import { CustomNextError } from '@island.is/web/units/errors'
+import useContentfulId from '@island.is/web/hooks/useContentfulId'
+import { useLocalLinkTypeResolver } from '@island.is/web/hooks/useLocalLinkTypeResolver'
+import { hasProcessEntries } from '@island.is/web/utils/article'
 
 interface ServicesPageProps {
   organizationPage: Query['getOrganizationPage']
@@ -291,7 +288,12 @@ const ServicesPage: Screen<ServicesPageProps> = ({
 }
 
 ServicesPage.getProps = async ({ apolloClient, locale, query }) => {
-  const responses = await Promise.all([
+  const [
+    {
+      data: { getOrganizationPage },
+    },
+    namespace,
+  ] = await Promise.all([
     apolloClient.query<Query, QueryGetOrganizationPageArgs>({
       query: GET_ORGANIZATION_PAGE_QUERY,
       variables: {
@@ -317,16 +319,6 @@ ServicesPage.getProps = async ({ apolloClient, locale, query }) => {
           : {},
       ),
   ])
-
-  const namespace = responses[1]
-
-  const { organizationPage: getOrganizationPage } =
-    await handleOrganizationSlugRedirect(
-      apolloClient,
-      query,
-      locale,
-      responses[0].data.getOrganizationPage,
-    )
 
   const {
     data: { getArticles },

--- a/apps/web/screens/Organization/Services.tsx
+++ b/apps/web/screens/Organization/Services.tsx
@@ -1,48 +1,50 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import React, { useState } from 'react'
 import { useRouter } from 'next/router'
+
 import {
-  Text,
-  NavigationItem,
-  LinkCard,
-  FocusableBox,
-  Stack,
   Box,
+  FocusableBox,
   GridColumn,
   GridContainer,
   GridRow,
-  Select,
-  Input,
   Inline,
+  Input,
+  LinkCard,
+  NavigationItem,
+  Select,
+  Stack,
   Tag,
+  Text,
 } from '@island.is/island-ui/core'
-import { withMainLayout } from '@island.is/web/layouts/main'
-import {
-  ContentLanguage,
-  Query,
-  QueryGetArticlesArgs,
-  QueryGetNamespaceArgs,
-  QueryGetOrganizationPageArgs,
-  SortField,
-  Article,
-} from '@island.is/web/graphql/schema'
-import {
-  GET_NAMESPACE_QUERY,
-  GET_ORGANIZATION_PAGE_QUERY,
-  GET_ORGANIZATION_SERVICES_QUERY,
-} from '../queries'
-import { Screen } from '../../types'
-import { useNamespace } from '@island.is/web/hooks'
-import { LinkType, useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
 import {
   getThemeConfig,
   OrganizationWrapper,
   Webreader,
 } from '@island.is/web/components'
-import { CustomNextError } from '@island.is/web/units/errors'
+import {
+  Article,
+  ContentLanguage,
+  Query,
+  QueryGetArticlesArgs,
+  QueryGetNamespaceArgs,
+  SortField,
+} from '@island.is/web/graphql/schema'
+import { useNamespace } from '@island.is/web/hooks'
 import useContentfulId from '@island.is/web/hooks/useContentfulId'
+import { LinkType, useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
 import { useLocalLinkTypeResolver } from '@island.is/web/hooks/useLocalLinkTypeResolver'
+import { withMainLayout } from '@island.is/web/layouts/main'
+import { CustomNextError } from '@island.is/web/units/errors'
 import { hasProcessEntries } from '@island.is/web/utils/article'
+import { retriedQueryIfOrganizationSlugRedirect } from '@island.is/web/utils/organization'
+
+import { Screen } from '../../types'
+import {
+  GET_NAMESPACE_QUERY,
+  GET_ORGANIZATION_PAGE_QUERY,
+  GET_ORGANIZATION_SERVICES_QUERY,
+} from '../queries'
 
 interface ServicesPageProps {
   organizationPage: Query['getOrganizationPage']
@@ -294,15 +296,15 @@ ServicesPage.getProps = async ({ apolloClient, locale, query }) => {
     },
     namespace,
   ] = await Promise.all([
-    apolloClient.query<Query, QueryGetOrganizationPageArgs>({
-      query: GET_ORGANIZATION_PAGE_QUERY,
-      variables: {
-        input: {
-          slug: query.slug as string,
-          lang: locale as ContentLanguage,
-        },
+    retriedQueryIfOrganizationSlugRedirect(
+      apolloClient,
+      GET_ORGANIZATION_PAGE_QUERY,
+      'getOrganizationPage',
+      {
+        slug: query.slug as string,
+        lang: locale as ContentLanguage,
       },
-    }),
+    ),
     apolloClient
       .query<Query, QueryGetNamespaceArgs>({
         query: GET_NAMESPACE_QUERY,

--- a/apps/web/screens/Organization/Services.tsx
+++ b/apps/web/screens/Organization/Services.tsx
@@ -37,7 +37,7 @@ import { useLocalLinkTypeResolver } from '@island.is/web/hooks/useLocalLinkTypeR
 import { withMainLayout } from '@island.is/web/layouts/main'
 import { CustomNextError } from '@island.is/web/units/errors'
 import { hasProcessEntries } from '@island.is/web/utils/article'
-import { retriedQueryIfOrganizationSlugRedirect } from '@island.is/web/utils/organization'
+import { icelandHealthQueryWrapper } from '@island.is/web/utils/organization'
 
 import { Screen } from '../../types'
 import {
@@ -296,7 +296,7 @@ ServicesPage.getProps = async ({ apolloClient, locale, query }) => {
     },
     namespace,
   ] = await Promise.all([
-    retriedQueryIfOrganizationSlugRedirect(
+    icelandHealthQueryWrapper(
       apolloClient,
       GET_ORGANIZATION_PAGE_QUERY,
       'getOrganizationPage',

--- a/apps/web/screens/Organization/Services.tsx
+++ b/apps/web/screens/Organization/Services.tsx
@@ -323,16 +323,9 @@ ServicesPage.getProps = async ({ apolloClient, locale, query }) => {
   const { organizationPage: getOrganizationPage } =
     await handleOrganizationSlugRedirect(
       apolloClient,
-      query.slug,
+      query,
       locale,
-      {
-        data: responses[0].data.getOrganizationPage,
-        fetchIfMissing: true,
-      },
-      {
-        data: null,
-        fetchIfMissing: false,
-      },
+      responses[0].data.getOrganizationPage,
     )
 
   const {

--- a/apps/web/screens/Organization/Services.tsx
+++ b/apps/web/screens/Organization/Services.tsx
@@ -323,9 +323,16 @@ ServicesPage.getProps = async ({ apolloClient, locale, query }) => {
   const { organizationPage: getOrganizationPage } =
     await handleOrganizationSlugRedirect(
       apolloClient,
-      query,
+      query.slug,
       locale,
-      responses[0].data.getOrganizationPage,
+      {
+        data: responses[0].data.getOrganizationPage,
+        fetchIfMissing: true,
+      },
+      {
+        data: null,
+        fetchIfMissing: false,
+      },
     )
 
   const {

--- a/apps/web/screens/Organization/SubPage.tsx
+++ b/apps/web/screens/Organization/SubPage.tsx
@@ -398,16 +398,9 @@ SubPage.getProps = async ({ apolloClient, locale, query, req }) => {
   const { organizationPage: getOrganizationPage } =
     await handleOrganizationSlugRedirect(
       apolloClient,
-      query.slug,
+      query,
       locale,
-      {
-        data: responses[0].data.getOrganizationPage,
-        fetchIfMissing: true,
-      },
-      {
-        data: null,
-        fetchIfMissing: false,
-      },
+      responses[0].data.getOrganizationPage,
     )
 
   if (!getOrganizationPage) {

--- a/apps/web/screens/Organization/SubPage.tsx
+++ b/apps/web/screens/Organization/SubPage.tsx
@@ -39,7 +39,7 @@ import { scrollTo } from '@island.is/web/hooks/useScrollSpy'
 import { useI18n } from '@island.is/web/i18n'
 import { withMainLayout } from '@island.is/web/layouts/main'
 import { CustomNextError } from '@island.is/web/units/errors'
-import { retriedQueryIfOrganizationSlugRedirect } from '@island.is/web/utils/organization'
+import { icelandHealthQueryWrapper } from '@island.is/web/utils/organization'
 import { webRichText } from '@island.is/web/utils/richText'
 import { safelyExtractPathnameFromUrl } from '@island.is/web/utils/safelyExtractPathnameFromUrl'
 
@@ -357,7 +357,7 @@ SubPage.getProps = async ({ apolloClient, locale, query, req }) => {
     },
     namespace,
   ] = await Promise.all([
-    retriedQueryIfOrganizationSlugRedirect(
+    icelandHealthQueryWrapper(
       apolloClient,
       GET_ORGANIZATION_PAGE_QUERY,
       'getOrganizationPage',

--- a/apps/web/screens/Organization/SubPage.tsx
+++ b/apps/web/screens/Organization/SubPage.tsx
@@ -398,9 +398,16 @@ SubPage.getProps = async ({ apolloClient, locale, query, req }) => {
   const { organizationPage: getOrganizationPage } =
     await handleOrganizationSlugRedirect(
       apolloClient,
-      query,
+      query.slug,
       locale,
-      responses[0].data.getOrganizationPage,
+      {
+        data: responses[0].data.getOrganizationPage,
+        fetchIfMissing: true,
+      },
+      {
+        data: null,
+        fetchIfMissing: false,
+      },
     )
 
   if (!getOrganizationPage) {

--- a/apps/web/screens/Organization/SubPage.tsx
+++ b/apps/web/screens/Organization/SubPage.tsx
@@ -40,6 +40,7 @@ import { scrollTo } from '@island.is/web/hooks/useScrollSpy'
 import { useI18n } from '@island.is/web/i18n'
 import { withMainLayout } from '@island.is/web/layouts/main'
 import { CustomNextError } from '@island.is/web/units/errors'
+import { handleOrganizationSlugRedirect } from '@island.is/web/utils/organization'
 import { webRichText } from '@island.is/web/utils/richText'
 import { safelyExtractPathnameFromUrl } from '@island.is/web/utils/safelyExtractPathnameFromUrl'
 
@@ -348,15 +349,7 @@ SubPage.getProps = async ({ apolloClient, locale, query, req }) => {
   const pathname = safelyExtractPathnameFromUrl(req.url)
 
   const { slug, subSlug } = getSlugAndSubSlug(query, pathname)
-  const [
-    {
-      data: { getOrganizationPage },
-    },
-    {
-      data: { getOrganizationSubpage },
-    },
-    namespace,
-  ] = await Promise.all([
+  const responses = await Promise.all([
     apolloClient.query<Query, QueryGetOrganizationPageArgs>({
       query: GET_ORGANIZATION_PAGE_QUERY,
       variables: {
@@ -393,9 +386,22 @@ SubPage.getProps = async ({ apolloClient, locale, query, req }) => {
       ),
   ])
 
+  const {
+    data: { getOrganizationSubpage },
+  } = responses[1]
+  const namespace = responses[2]
+
   if (!getOrganizationSubpage) {
     throw new CustomNextError(404, 'Organization subpage not found')
   }
+
+  const { organizationPage: getOrganizationPage } =
+    await handleOrganizationSlugRedirect(
+      apolloClient,
+      query,
+      locale,
+      responses[0].data.getOrganizationPage,
+    )
 
   if (!getOrganizationPage) {
     throw new CustomNextError(

--- a/apps/web/screens/Organization/SubPage.tsx
+++ b/apps/web/screens/Organization/SubPage.tsx
@@ -29,7 +29,6 @@ import {
   ContentLanguage,
   Query,
   QueryGetNamespaceArgs,
-  QueryGetOrganizationPageArgs,
   QueryGetOrganizationSubpageArgs,
   Slice,
 } from '@island.is/web/graphql/schema'
@@ -40,6 +39,7 @@ import { scrollTo } from '@island.is/web/hooks/useScrollSpy'
 import { useI18n } from '@island.is/web/i18n'
 import { withMainLayout } from '@island.is/web/layouts/main'
 import { CustomNextError } from '@island.is/web/units/errors'
+import { retriedQueryIfOrganizationSlugRedirect } from '@island.is/web/utils/organization'
 import { webRichText } from '@island.is/web/utils/richText'
 import { safelyExtractPathnameFromUrl } from '@island.is/web/utils/safelyExtractPathnameFromUrl'
 
@@ -357,15 +357,15 @@ SubPage.getProps = async ({ apolloClient, locale, query, req }) => {
     },
     namespace,
   ] = await Promise.all([
-    apolloClient.query<Query, QueryGetOrganizationPageArgs>({
-      query: GET_ORGANIZATION_PAGE_QUERY,
-      variables: {
-        input: {
-          slug: slug as string,
-          lang: locale as ContentLanguage,
-        },
+    retriedQueryIfOrganizationSlugRedirect(
+      apolloClient,
+      GET_ORGANIZATION_PAGE_QUERY,
+      'getOrganizationPage',
+      {
+        slug: slug as string,
+        lang: locale as ContentLanguage,
       },
-    }),
+    ),
     apolloClient.query<Query, QueryGetOrganizationSubpageArgs>({
       query: GET_ORGANIZATION_SUBPAGE_QUERY,
       variables: {

--- a/apps/web/screens/Organization/SubPage.tsx
+++ b/apps/web/screens/Organization/SubPage.tsx
@@ -40,7 +40,6 @@ import { scrollTo } from '@island.is/web/hooks/useScrollSpy'
 import { useI18n } from '@island.is/web/i18n'
 import { withMainLayout } from '@island.is/web/layouts/main'
 import { CustomNextError } from '@island.is/web/units/errors'
-import { handleOrganizationSlugRedirect } from '@island.is/web/utils/organization'
 import { webRichText } from '@island.is/web/utils/richText'
 import { safelyExtractPathnameFromUrl } from '@island.is/web/utils/safelyExtractPathnameFromUrl'
 
@@ -349,7 +348,15 @@ SubPage.getProps = async ({ apolloClient, locale, query, req }) => {
   const pathname = safelyExtractPathnameFromUrl(req.url)
 
   const { slug, subSlug } = getSlugAndSubSlug(query, pathname)
-  const responses = await Promise.all([
+  const [
+    {
+      data: { getOrganizationPage },
+    },
+    {
+      data: { getOrganizationSubpage },
+    },
+    namespace,
+  ] = await Promise.all([
     apolloClient.query<Query, QueryGetOrganizationPageArgs>({
       query: GET_ORGANIZATION_PAGE_QUERY,
       variables: {
@@ -386,22 +393,9 @@ SubPage.getProps = async ({ apolloClient, locale, query, req }) => {
       ),
   ])
 
-  const {
-    data: { getOrganizationSubpage },
-  } = responses[1]
-  const namespace = responses[2]
-
   if (!getOrganizationSubpage) {
     throw new CustomNextError(404, 'Organization subpage not found')
   }
-
-  const { organizationPage: getOrganizationPage } =
-    await handleOrganizationSlugRedirect(
-      apolloClient,
-      query,
-      locale,
-      responses[0].data.getOrganizationPage,
-    )
 
   if (!getOrganizationPage) {
     throw new CustomNextError(

--- a/apps/web/screens/ServiceWeb/Forms/utils.ts
+++ b/apps/web/screens/ServiceWeb/Forms/utils.ts
@@ -92,7 +92,11 @@ export const filterSupportCategories = (
   locale: string,
   namespace: Record<string, string> | undefined,
 ) => {
-  if (slug === 'sjukratryggingar' || slug === 'icelandic-health-insurance') {
+  if (
+    slug === 'sjukratryggingar' ||
+    slug === 'icelandic-health-insurance' ||
+    slug === 'iceland-health'
+  ) {
     return supportCategories
       ?.filter(
         (c) =>

--- a/apps/web/screens/ServiceWeb/Forms/utils.ts
+++ b/apps/web/screens/ServiceWeb/Forms/utils.ts
@@ -92,11 +92,7 @@ export const filterSupportCategories = (
   locale: string,
   namespace: Record<string, string> | undefined,
 ) => {
-  if (
-    slug === 'sjukratryggingar' ||
-    slug === 'icelandic-health-insurance' ||
-    slug === 'iceland-health'
-  ) {
+  if (slug === 'sjukratryggingar' || slug === 'icelandic-health-insurance') {
     return supportCategories
       ?.filter(
         (c) =>

--- a/apps/web/screens/ServiceWeb/Home/Home.tsx
+++ b/apps/web/screens/ServiceWeb/Home/Home.tsx
@@ -390,6 +390,7 @@ Home.getProps = async ({ apolloClient, locale, query }) => {
     {
       data: responses[0] !== false ? responses[0]?.data?.getOrganization : null,
       fetchIfMissing: true,
+      fetchServiceWebFields: true,
     },
   )
 

--- a/apps/web/screens/ServiceWeb/Home/Home.tsx
+++ b/apps/web/screens/ServiceWeb/Home/Home.tsx
@@ -390,7 +390,6 @@ Home.getProps = async ({ apolloClient, locale, query }) => {
     {
       data: responses[0] !== false ? responses[0]?.data?.getOrganization : null,
       fetchIfMissing: true,
-      fetchServiceWebFields: true,
     },
   )
 

--- a/apps/web/screens/ServiceWeb/Home/Home.tsx
+++ b/apps/web/screens/ServiceWeb/Home/Home.tsx
@@ -1,26 +1,6 @@
+import { Locale } from 'locale'
 import { useRouter } from 'next/router'
-import { withMainLayout } from '@island.is/web/layouts/main'
-import {
-  ContentLanguage,
-  Organization,
-  Query,
-  QueryGetFeaturedSupportQnAsArgs,
-  QueryGetNamespaceArgs,
-  QueryGetOrganizationArgs,
-  QueryGetSupportCategoriesInOrganizationArgs,
-  QueryGetSupportQnAsArgs,
-  SupportCategory,
-  QueryGetServiceWebPageArgs,
-} from '@island.is/web/graphql/schema'
-import {
-  GET_FEATURED_SUPPORT_QNAS,
-  GET_NAMESPACE_QUERY,
-  GET_SERVICE_WEB_ORGANIZATION,
-  GET_SERVICE_WEB_PAGE_QUERY,
-  GET_SUPPORT_CATEGORIES,
-  GET_SUPPORT_CATEGORIES_IN_ORGANIZATION,
-} from '../../queries'
-import { Screen } from '../../../types'
+
 import {
   Box,
   GridColumn,
@@ -30,29 +10,49 @@ import {
   Text,
   TopicCard,
 } from '@island.is/island-ui/core'
+import { Colors } from '@island.is/island-ui/theme'
 import { sortAlpha } from '@island.is/shared/utils'
-
-import { CustomNextError } from '@island.is/web/units/errors'
 import {
   Card,
-  SimpleStackedSlider,
-  ServiceWebWrapper,
   ServiceWebContext,
+  ServiceWebWrapper,
+  SimpleStackedSlider,
   SliceMachine,
 } from '@island.is/web/components'
 import {
-  useNamespace,
+  ContentLanguage,
+  Organization,
+  Query,
+  QueryGetFeaturedSupportQnAsArgs,
+  QueryGetNamespaceArgs,
+  QueryGetOrganizationArgs,
+  QueryGetServiceWebPageArgs,
+  QueryGetSupportCategoriesInOrganizationArgs,
+  QueryGetSupportQnAsArgs,
+  SupportCategory,
+} from '@island.is/web/graphql/schema'
+import {
   LinkResolverResponse,
   useLinkResolver,
-  LinkType,
+  useNamespace,
 } from '@island.is/web/hooks'
-import ContactBanner from '../ContactBanner/ContactBanner'
-import { getSlugPart } from '../utils'
-import { Locale } from 'locale'
 import useContentfulId from '@island.is/web/hooks/useContentfulId'
 import useLocalLinkTypeResolver from '@island.is/web/hooks/useLocalLinkTypeResolver'
-import { Colors } from '@island.is/island-ui/theme'
+import { withMainLayout } from '@island.is/web/layouts/main'
+import { CustomNextError } from '@island.is/web/units/errors'
+import { handleOrganizationSlugRedirect } from '@island.is/web/utils/organization'
 
+import { Screen } from '../../../types'
+import {
+  GET_FEATURED_SUPPORT_QNAS,
+  GET_NAMESPACE_QUERY,
+  GET_SERVICE_WEB_ORGANIZATION,
+  GET_SERVICE_WEB_PAGE_QUERY,
+  GET_SUPPORT_CATEGORIES,
+  GET_SUPPORT_CATEGORIES_IN_ORGANIZATION,
+} from '../../queries'
+import ContactBanner from '../ContactBanner/ContactBanner'
+import { getSlugPart } from '../utils'
 import * as styles from './Home.css'
 
 interface HomeProps {
@@ -315,14 +315,7 @@ Home.getProps = async ({ apolloClient, locale, query }) => {
   const defaultSlug = locale === 'en' ? 'digital-iceland' : 'stafraent-island'
   const slug = query.slug ? (query.slug as string) : defaultSlug
 
-  const [
-    organization,
-    namespace,
-    supportCategories,
-    {
-      data: { getServiceWebPage },
-    },
-  ] = await Promise.all([
+  const responses = await Promise.all([
     !!slug &&
       apolloClient.query<Query, QueryGetOrganizationArgs>({
         query: GET_SERVICE_WEB_ORGANIZATION,
@@ -377,10 +370,37 @@ Home.getProps = async ({ apolloClient, locale, query }) => {
     }),
   ])
 
-  const popularQuestionCount =
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore make web strict
-    organization?.data?.getOrganization?.serviceWebPopularQuestionCount
+  const [
+    _,
+    namespace,
+    supportCategories,
+    {
+      data: { getServiceWebPage },
+    },
+  ] = responses
+
+  const { organization } = await handleOrganizationSlugRedirect(
+    apolloClient,
+    slug,
+    locale,
+    {
+      data: null,
+      fetchIfMissing: false,
+    },
+    {
+      data: responses[0] !== false ? responses[0]?.data?.getOrganization : null,
+      fetchIfMissing: true,
+    },
+  )
+
+  if (!organization || !organization?.serviceWebEnabled) {
+    throw new CustomNextError(
+      404,
+      'Service web not active for this organization',
+    )
+  }
+
+  const popularQuestionCount = organization?.serviceWebPopularQuestionCount
   const featuredQNAs = popularQuestionCount
     ? await apolloClient.query<Query, QueryGetFeaturedSupportQnAsArgs>({
         query: GET_FEATURED_SUPPORT_QNAS,
@@ -402,22 +422,13 @@ Home.getProps = async ({ apolloClient, locale, query }) => {
   processedCategories = processedCategories.filter(
     (item) => !!item.organization,
   )
-  if (
-    !organization ||
-    !organization?.data?.getOrganization?.serviceWebEnabled
-  ) {
-    throw new CustomNextError(
-      404,
-      'Service web not active for this organization',
-    )
-  }
 
   const organizationNamespace = JSON.parse(
-    organization?.data?.getOrganization?.namespace?.fields ?? '{}',
+    organization?.namespace?.fields ?? '{}',
   )
 
   return {
-    organization: organization?.data?.getOrganization,
+    organization,
     namespace,
     organizationNamespace,
     supportCategories: processedCategories,

--- a/apps/web/screens/ServiceWeb/Home/Home.tsx
+++ b/apps/web/screens/ServiceWeb/Home/Home.tsx
@@ -37,7 +37,7 @@ import useContentfulId from '@island.is/web/hooks/useContentfulId'
 import useLocalLinkTypeResolver from '@island.is/web/hooks/useLocalLinkTypeResolver'
 import { withMainLayout } from '@island.is/web/layouts/main'
 import { CustomNextError } from '@island.is/web/units/errors'
-import { retriedQueryIfOrganizationSlugRedirect } from '@island.is/web/utils/organization'
+import { icelandHealthQueryWrapper } from '@island.is/web/utils/organization'
 
 import { Screen } from '../../../types'
 import {
@@ -321,7 +321,7 @@ Home.getProps = async ({ apolloClient, locale, query }) => {
     },
   ] = await Promise.all([
     !!slug &&
-      retriedQueryIfOrganizationSlugRedirect(
+      icelandHealthQueryWrapper(
         apolloClient,
         GET_SERVICE_WEB_ORGANIZATION,
         'getOrganization',
@@ -346,7 +346,7 @@ Home.getProps = async ({ apolloClient, locale, query }) => {
           : {},
       ),
     slug
-      ? retriedQueryIfOrganizationSlugRedirect(
+      ? icelandHealthQueryWrapper(
           apolloClient,
           GET_SUPPORT_CATEGORIES_IN_ORGANIZATION,
           'getSupportCategoriesInOrganization',
@@ -363,7 +363,7 @@ Home.getProps = async ({ apolloClient, locale, query }) => {
             },
           },
         }),
-    retriedQueryIfOrganizationSlugRedirect(
+    icelandHealthQueryWrapper(
       apolloClient,
       GET_SERVICE_WEB_PAGE_QUERY,
       'getServiceWebPage',

--- a/apps/web/utils/organization.ts
+++ b/apps/web/utils/organization.ts
@@ -17,6 +17,7 @@ import { linkResolver } from '../hooks'
 import {
   GET_ORGANIZATION_PAGE_QUERY,
   GET_ORGANIZATION_QUERY,
+  GET_SERVICE_WEB_ORGANIZATION,
 } from '../screens/queries'
 
 // TODO: Perhaps add this functionality to the linkResolver
@@ -75,6 +76,7 @@ export const handleOrganizationSlugRedirect = async (
   organization: {
     data: ApolloQueryResult<Query>['data']['getOrganization']
     fetchIfMissing: boolean
+    fetchServiceWebFields?: boolean
   },
 ) => {
   const icelandicHealthInsuranceSlug = 'icelandic-health-insurance'
@@ -101,7 +103,9 @@ export const handleOrganizationSlugRedirect = async (
         : { data: { getOrganizationPage: organizationPageData } },
       organization.fetchIfMissing
         ? apolloClient.query<Query, QueryGetOrganizationArgs>({
-            query: GET_ORGANIZATION_QUERY,
+            query: organization.fetchServiceWebFields
+              ? GET_SERVICE_WEB_ORGANIZATION
+              : GET_ORGANIZATION_QUERY,
             variables: {
               input: {
                 slug: icelandicHealthInsuranceSlug,

--- a/apps/web/utils/organization.ts
+++ b/apps/web/utils/organization.ts
@@ -18,7 +18,6 @@ import { linkResolver } from '../hooks'
 import {
   GET_ORGANIZATION_PAGE_QUERY,
   GET_ORGANIZATION_QUERY,
-  GET_SERVICE_WEB_ORGANIZATION,
 } from '../screens/queries'
 
 // TODO: Perhaps add this functionality to the linkResolver
@@ -116,7 +115,6 @@ export const handleOrganizationSlugRedirect = async (
   organization: {
     data: ApolloQueryResult<Query>['data']['getOrganization']
     fetchIfMissing: boolean
-    fetchServiceWebFields?: boolean
   },
 ) => {
   const icelandicHealthInsuranceSlug = 'icelandic-health-insurance'
@@ -143,9 +141,7 @@ export const handleOrganizationSlugRedirect = async (
         : { data: { getOrganizationPage: organizationPageData } },
       organization.fetchIfMissing
         ? apolloClient.query<Query, QueryGetOrganizationArgs>({
-            query: organization.fetchServiceWebFields
-              ? GET_SERVICE_WEB_ORGANIZATION
-              : GET_ORGANIZATION_QUERY,
+            query: GET_ORGANIZATION_QUERY,
             variables: {
               input: {
                 slug: icelandicHealthInsuranceSlug,

--- a/apps/web/utils/organization.ts
+++ b/apps/web/utils/organization.ts
@@ -55,7 +55,7 @@ export const getBackgroundStyle = (
 }
 
 /** Since "/en/o/icelandic-health-insurance" should now redirect to "/en/o/iceland-health" we make sure that if the cms is still referencing the old slug we fallback to fetching that data instead */
-export const retriedQueryIfOrganizationSlugRedirect = async (
+export const icelandHealthQueryWrapper = async (
   apolloClient: ApolloClient<NormalizedCacheObject>,
   query: DocumentNode,
   responseDataKey: keyof Query,

--- a/apps/web/utils/organization.ts
+++ b/apps/web/utils/organization.ts
@@ -1,7 +1,23 @@
 import { Locale } from 'locale'
+import {
+  ApolloClient,
+  ApolloQueryResult,
+  NormalizedCacheObject,
+} from '@apollo/client'
 
-import { OrganizationPage, OrganizationTheme } from '../graphql/schema'
+import {
+  ContentLanguage,
+  OrganizationPage,
+  OrganizationTheme,
+  Query,
+  QueryGetOrganizationArgs,
+  QueryGetOrganizationPageArgs,
+} from '../graphql/schema'
 import { linkResolver } from '../hooks'
+import {
+  GET_ORGANIZATION_PAGE_QUERY,
+  GET_ORGANIZATION_QUERY,
+} from '../screens/queries'
 
 // TODO: Perhaps add this functionality to the linkResolver
 export const getOrganizationLink = (
@@ -45,4 +61,50 @@ export const getBackgroundStyle = (
       ${background.gradientEndColor} 123.07%),
       linear-gradient(180deg, rgba(0,0,0,0.5) 0%, rgba(0, 0, 0, 0) 70%)`
   return background.backgroundColor ?? ''
+}
+
+/** Since "/en/o/icelandic-health-insurance" should now redirect to "/en/o/iceland-health" we make sure that if the cms is still referencing the old slug we fallback to fetching that data instead */
+export const handleOrganizationSlugRedirect = async (
+  apolloClient: ApolloClient<NormalizedCacheObject>,
+  query: { slug?: string },
+  locale: string,
+  organizationPage: ApolloQueryResult<Query>['data']['getOrganizationPage'],
+  organization:
+    | ApolloQueryResult<Query>['data']['getOrganization']
+    | false = false,
+) => {
+  const icelandicHealthInsuranceSlug = 'icelandic-health-insurance'
+
+  // Refetch data in case the "iceland-health" slug didn't get a match
+  if (query.slug === 'iceland-health' && !organizationPage && !organization) {
+    const responses = await Promise.all([
+      apolloClient.query<Query, QueryGetOrganizationPageArgs>({
+        query: GET_ORGANIZATION_PAGE_QUERY,
+        variables: {
+          input: {
+            slug: icelandicHealthInsuranceSlug,
+            lang: locale as ContentLanguage,
+          },
+        },
+      }),
+      organization !== false
+        ? apolloClient.query<Query, QueryGetOrganizationArgs>({
+            query: GET_ORGANIZATION_QUERY,
+            variables: {
+              input: {
+                slug: icelandicHealthInsuranceSlug,
+                lang: locale as ContentLanguage,
+              },
+            },
+          })
+        : { data: { getOrganization: null } },
+    ])
+    organizationPage = responses[0].data.getOrganizationPage
+    organization = responses[1].data.getOrganization
+  }
+
+  return {
+    organizationPage,
+    organization: organization === false ? null : organization,
+  }
 }

--- a/apps/web/utils/organization.ts
+++ b/apps/web/utils/organization.ts
@@ -1,7 +1,6 @@
 import { Locale } from 'locale'
 import {
   ApolloClient,
-  ApolloQueryResult,
   DocumentNode,
   NormalizedCacheObject,
 } from '@apollo/client'

--- a/libs/api/domains/communications/src/lib/emailTemplates/serviceWebForms.ts
+++ b/libs/api/domains/communications/src/lib/emailTemplates/serviceWebForms.ts
@@ -355,8 +355,7 @@ export const getTemplate = (
     }
   } else if (
     input.institutionSlug === 'sjukratryggingar' ||
-    input.institutionSlug === 'icelandic-health-insurance' ||
-    input.institutionSlug === 'iceland-health'
+    input.institutionSlug === 'icelandic-health-insurance'
   ) {
     toAddress =
       sjukratryggingarEmails[categoryId as SjukratryggingarCategories] ??

--- a/libs/api/domains/communications/src/lib/emailTemplates/serviceWebForms.ts
+++ b/libs/api/domains/communications/src/lib/emailTemplates/serviceWebForms.ts
@@ -355,7 +355,8 @@ export const getTemplate = (
     }
   } else if (
     input.institutionSlug === 'sjukratryggingar' ||
-    input.institutionSlug === 'icelandic-health-insurance'
+    input.institutionSlug === 'icelandic-health-insurance' ||
+    input.institutionSlug === 'iceland-health'
   ) {
     toAddress =
       sjukratryggingarEmails[categoryId as SjukratryggingarCategories] ??


### PR DESCRIPTION
# Redirect /en/o/icelandic-health insurance to /en/o/iceland-health

## What

* Add redirects to next.config.js file
* Add fail-safe in case cms still points to older slug
* Add default translations to when no search results are found

## Why

* This was requested by "Sjúkratryggingar"

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
