### PR TITLE
fix(service-portal): Update validation rule for mileage input

### DIFF
--- a/libs/service-portal/assets/src/screens/VehicleMileage/VehicleMileage.tsx
+++ b/libs/service-portal/assets/src/screens/VehicleMileage/VehicleMileage.tsx
@@ -23,6 +23,7 @@ import {
   icelandLocalTime,
 } from '@island.is/service-portal/core'
 
+import { isReadDateToday } from '../../utils/readDate'
 import { vehicleMessage as messages } from '../../lib/messages'
 import {
   useGetUsersMileageQuery,
@@ -226,10 +227,21 @@ const VehicleMileage = () => {
                           // Input number must be higher than the highest known mileage registration value
 
                           if (details) {
-                            // If we're in editing mode, we want to find the highest number ignoring the most recent one.
-                            const [, ...rest] = details
+                            // If we're in editing mode, we want to find the highest confirmed registered number, ignoring all Island.is registrations from today.
+                            const confirmedRegistrations = details.filter(
+                              (item) => {
+                                if (item.readDate) {
+                                  const isIslandIsReadingToday =
+                                    item.originCode === ORIGIN_CODE &&
+                                    isReadDateToday(new Date(item.readDate))
+                                  return !isIslandIsReadingToday
+                                }
+                                return true
+                              },
+                            )
+
                             const detailArray = isFormEditable
-                              ? rest
+                              ? confirmedRegistrations
                               : [...details]
 
                             const highestRegistration = Math.max(

--- a/libs/service-portal/assets/src/utils/readDate.ts
+++ b/libs/service-portal/assets/src/utils/readDate.ts
@@ -1,0 +1,12 @@
+import isSameDay from 'date-fns/isSameDay'
+
+export const isReadDateToday = (d?: Date) => {
+  if (!d) {
+    return false
+  }
+
+  const today = new Date()
+  const inputDate = new Date(d)
+
+  return isSameDay(today, inputDate)
+}


### PR DESCRIPTION
## What

Update validation rule for mileage input

## Why

If we're in editing mode, we want to find the highest confirmed registered number, ignoring all Island.is registrations from today.

API was updated to add new transactions instead of updating the current one, so we need to make changes in the UI to reflect that.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
