### PR TITLE
fix(web): Change spacing between slices for organization pages

### DIFF
--- a/apps/web/components/Organization/Slice/AccordionSlice/AccordionSlice.tsx
+++ b/apps/web/components/Organization/Slice/AccordionSlice/AccordionSlice.tsx
@@ -34,12 +34,8 @@ export const AccordionSlice: React.FC<React.PropsWithChildren<SliceProps>> = ({
         borderTopWidth: 'standard',
         borderColor: 'standard',
         paddingTop: [4, 4, 6],
-        paddingBottom: [4, 4, 6],
       }
-    : {
-        paddingTop: 2,
-        paddingBottom: 2,
-      }
+    : {}
 
   const { titleHeading, childHeading } = extractHeadingLevels(slice)
 

--- a/apps/web/components/Organization/Slice/Districts/DistrictsSlice.tsx
+++ b/apps/web/components/Organization/Slice/Districts/DistrictsSlice.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Districts } from '@island.is/web/graphql/schema'
+
 import {
   Box,
   BoxProps,
@@ -9,6 +9,8 @@ import {
   Link,
   Text,
 } from '@island.is/island-ui/core'
+import { Districts } from '@island.is/web/graphql/schema'
+
 import * as styles from './DistrictsSlice.css'
 
 interface SliceProps {
@@ -23,12 +25,8 @@ export const DistrictsSlice: React.FC<React.PropsWithChildren<SliceProps>> = ({
         borderTopWidth: 'standard',
         borderColor: 'standard',
         paddingTop: [8, 6],
-        paddingBottom: [4, 5],
       }
-    : {
-        paddingTop: 2,
-        paddingBottom: 2,
-      }
+    : {}
 
   return (
     !!slice.links.length && (

--- a/apps/web/components/Organization/Slice/FeaturedArticles/FeaturedArticlesSlice.tsx
+++ b/apps/web/components/Organization/Slice/FeaturedArticles/FeaturedArticlesSlice.tsx
@@ -10,8 +10,7 @@ import {
   Text,
   TopicCard,
 } from '@island.is/island-ui/core'
-
-import { FeaturedArticles, Article } from '@island.is/web/graphql/schema'
+import { Article,FeaturedArticles } from '@island.is/web/graphql/schema'
 import { useNamespace } from '@island.is/web/hooks'
 import { LinkType, useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
 import { hasProcessEntries } from '@island.is/web/utils/article'
@@ -50,7 +49,6 @@ export const FeaturedArticlesSlice: React.FC<
         borderTopWidth: 'standard',
         borderColor: 'standard',
         paddingTop: [8, 6, 8],
-        paddingBottom: [8, 6, 6],
       }
     : {}
 

--- a/apps/web/components/Organization/Slice/Heading/HeadingSlice.tsx
+++ b/apps/web/components/Organization/Slice/Heading/HeadingSlice.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
-import { HeadingSlice as HeadlingSliceSchema } from '@island.is/web/graphql/schema'
+
 import { Box } from '@island.is/island-ui/core'
 import { Heading } from '@island.is/web/components'
+import { HeadingSlice as HeadlingSliceSchema } from '@island.is/web/graphql/schema'
 
 interface SliceProps {
   slice: HeadlingSliceSchema
@@ -12,7 +13,7 @@ export const HeadingSlice: React.FC<React.PropsWithChildren<SliceProps>> = ({
 }) => {
   return (
     <section key={slice.id} id={slice.id}>
-      <Box paddingTop={[8, 6, 6]} paddingBottom={[4, 5, 5]}>
+      <Box>
         <Heading {...slice} />
       </Box>
     </section>

--- a/apps/web/components/Organization/Slice/MultipleStatistics/MultipleStatistics.tsx
+++ b/apps/web/components/Organization/Slice/MultipleStatistics/MultipleStatistics.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+
 import {
   Box,
   BoxProps,
@@ -23,12 +24,8 @@ export const MultipleStatistics: React.FC<
         borderTopWidth: 'standard',
         borderColor: 'standard',
         paddingTop: [4, 4, 6],
-        paddingBottom: [4, 4, 6],
       }
-    : {
-        paddingTop: 2,
-        paddingBottom: 2,
-      }
+    : {}
 
   return (
     <section

--- a/apps/web/components/Organization/Slice/SliceMachine.tsx
+++ b/apps/web/components/Organization/Slice/SliceMachine.tsx
@@ -1,5 +1,5 @@
-import { Slice } from '@island.is/web/graphql/schema'
 import dynamic from 'next/dynamic'
+
 import {
   Box,
   GridColumn,
@@ -8,11 +8,13 @@ import {
   ResponsiveSpace,
 } from '@island.is/island-ui/core'
 import {
-  RichText,
   EmailSignup,
+  RichText,
   SectionWithVideo,
 } from '@island.is/web/components'
+import { Slice } from '@island.is/web/graphql/schema'
 import { webRenderConnectedComponent } from '@island.is/web/utils/richText'
+
 import { FeaturedSupportQNAs } from '../../FeaturedSupportQNAs'
 
 const DistrictsSlice = dynamic(() =>
@@ -178,14 +180,12 @@ export const SliceMachine = ({
   slug = '',
   marginBottom = 0,
   params,
-  paddingBottom = 6,
   wrapWithGridContainer = false,
 }: SliceMachineProps) => {
   return !fullWidth ? (
     <GridContainer>
-      <GridRow marginBottom={marginBottom}>
+      <GridRow>
         <GridColumn
-          paddingBottom={paddingBottom}
           span={
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-ignore make web strict

--- a/apps/web/components/Organization/Slice/TimelineSlice/TimelineSlice.tsx
+++ b/apps/web/components/Organization/Slice/TimelineSlice/TimelineSlice.tsx
@@ -1,15 +1,17 @@
 import React, {
-  useRef,
-  useState,
-  useEffect,
-  useMemo,
   Fragment,
   ReactNode,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
 } from 'react'
-import Link from 'next/link'
 import ReactDOM from 'react-dom'
-import flatten from 'lodash/flatten'
 import cn from 'classnames'
+import flatten from 'lodash/flatten'
+import Link from 'next/link'
+
+import { renderSlices, SliceType } from '@island.is/island-ui/contentful'
 import {
   Box,
   BoxProps,
@@ -26,15 +28,14 @@ import {
   Text,
 } from '@island.is/island-ui/core'
 import {
-  TimelineSlice as Timeline,
   TimelineEvent,
+  TimelineSlice as Timeline,
 } from '@island.is/web/graphql/schema'
-import { useDateUtils } from '@island.is/web/i18n/useDateUtils'
-import { renderSlices, SliceType } from '@island.is/island-ui/contentful'
 import { useNamespace } from '@island.is/web/hooks'
+import { useDateUtils } from '@island.is/web/i18n/useDateUtils'
 
-import * as timelineStyles from './TimelineSlice.css'
 import * as eventStyles from './Event.css'
+import * as timelineStyles from './TimelineSlice.css'
 
 const BUTTON_SCROLL_AMOUNT = 500
 
@@ -232,9 +233,7 @@ export const TimelineSlice: React.FC<React.PropsWithChildren<SliceProps>> = ({
         borderColor: 'standard',
         paddingTop: 6,
       }
-    : {
-        paddingTop: 3,
-      }
+    : {}
 
   const ref = useRef<HTMLDivElement | null>(null)
 

--- a/apps/web/components/Organization/Slice/TwoColumnText/TwoColumnTextSlice.tsx
+++ b/apps/web/components/Organization/Slice/TwoColumnText/TwoColumnTextSlice.tsx
@@ -37,14 +37,14 @@ export const TwoColumnTextSlice: React.FC<
       <GridContainer>
         <Box {...boxProps}>
           <GridRow>
-            <GridColumn span={columnSpan} paddingBottom={2} hiddenBelow="lg">
+            <GridColumn span={columnSpan}  hiddenBelow="lg">
               {slice.leftTitle && (
                 <Text variant="h2" as="h2" id={labelId}>
                   <Hyphen>{slice.leftTitle}</Hyphen>
                 </Text>
               )}
             </GridColumn>
-            <GridColumn span={columnSpan} paddingBottom={2} hiddenBelow="lg">
+            <GridColumn span={columnSpan} hiddenBelow="lg">
               {slice.rightTitle && (
                 <Text variant="h2" as="h2">
                   <Hyphen>{slice.rightTitle}</Hyphen>

--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -793,7 +793,7 @@ export const OrganizationWrapper: React.FC<
       {!minimal && (
         <SidebarLayout
           paddingTop={[2, 2, 9]}
-          paddingBottom={[4, 4, 4]}
+          paddingBottom={[4, 4, 9]}
           isSticky={false}
           fullWidthContent={fullWidthContent}
           sidebarContent={
@@ -914,7 +914,7 @@ export const OrganizationWrapper: React.FC<
               )}
             </Box>
           )}
-
+          
           <GridContainer>
             <GridRow>
               <GridColumn

--- a/apps/web/screens/Organization/Home/Home.tsx
+++ b/apps/web/screens/Organization/Home/Home.tsx
@@ -8,6 +8,7 @@ import {
   GridContainer,
   Inline,
   NavigationItem,
+  Stack,
   Text,
 } from '@island.is/island-ui/core'
 import {
@@ -171,45 +172,51 @@ const OrganizationHomePage: Screen<HomeProps> = ({
               )}
             </GridContainer>
           )}
-          {organizationPage?.slices?.map((slice, index) => {
-            return (
-              <SliceMachine
-                key={slice.id}
-                slice={slice}
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore make web strict
-                namespace={namespace}
-                slug={organizationPage.slug}
-                fullWidth={organizationPage.theme === 'landing_page'}
-                marginBottom={
-                  index === organizationPage.slices.length - 1 ? 5 : 0
-                }
-                paddingTop={
-                  !organizationPage.description && index === 0 ? 0 : 6
-                }
-              />
-            )
-          })}
+          <Stack space={8}>
+            {organizationPage?.slices?.map((slice, index) => {
+              return (
+                <SliceMachine
+                  key={slice.id}
+                  slice={slice}
+                  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                  // @ts-ignore make web strict
+                  namespace={namespace}
+                  slug={organizationPage.slug}
+                  fullWidth={organizationPage.theme === 'landing_page'}
+                  marginBottom={
+                    index === organizationPage.slices.length - 1 ? 5 : 0
+                  }
+                  paddingTop={
+                    !organizationPage.description && index === 0 ? 0 : 6
+                  }
+                />
+              )
+            })}
+          </Stack>
         </Box>
       }
     >
-      {organizationPage?.bottomSlices.map((slice) => (
-        <SliceMachine
-          key={slice.id}
-          slice={slice}
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore make web strict
-          namespace={namespace}
-          slug={organizationPage.slug}
-          fullWidth={true}
-          params={{
-            latestNewsSliceBackground:
-              organizationPage.theme === 'landing_page' ? 'white' : 'purple100',
-            latestNewsSliceColorVariant:
-              organizationPage.theme === 'landing_page' ? 'blue' : 'default',
-          }}
-        />
-      ))}
+      <Stack space={8}>
+        {organizationPage?.bottomSlices.map((slice) => (
+          <SliceMachine
+            key={slice.id}
+            slice={slice}
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore make web strict
+            namespace={namespace}
+            slug={organizationPage.slug}
+            fullWidth={true}
+            params={{
+              latestNewsSliceBackground:
+                organizationPage.theme === 'landing_page'
+                  ? 'white'
+                  : 'purple100',
+              latestNewsSliceColorVariant:
+                organizationPage.theme === 'landing_page' ? 'blue' : 'default',
+            }}
+          />
+        ))}
+      </Stack>
       {organizationPage?.theme === 'landing_page' && (
         <LandingPageFooter
           footerItems={organizationPage.organization?.footerItems}

--- a/apps/web/screens/Organization/SubPage.tsx
+++ b/apps/web/screens/Organization/SubPage.tsx
@@ -274,21 +274,23 @@ const SubPage: Screen<SubPageProps> = ({
           </GridRow>
         </Box>
       </GridContainer>
-      {renderSlices(
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore make web strict
-        subpage.slices,
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore make web strict
-        subpage.sliceCustomRenderer,
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore make web strict
-        subpage.sliceExtraText,
-        namespace,
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore make web strict
-        organizationPage.slug,
-      )}
+      <Stack space={8}>
+        {renderSlices(
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore make web strict
+          subpage.slices,
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore make web strict
+          subpage.sliceCustomRenderer,
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore make web strict
+          subpage.sliceExtraText,
+          namespace,
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore make web strict
+          organizationPage.slug,
+        )}
+      </Stack>
     </OrganizationWrapper>
   )
 }


### PR DESCRIPTION
# Change spacing between slices for organization pages

## What

Use stack when rendering slices and remove padding and margin from components

## Why

To have equal space between slices

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
