### PR TITLE
chore(search-indexer): Skip logging if no entries are being mapped

### DIFF
--- a/libs/cms/src/lib/search/importers/adgerdirPage.ts
+++ b/libs/cms/src/lib/search/importers/adgerdirPage.ts
@@ -29,7 +29,9 @@ export class AdgerdirPageSyncService
   }
 
   doMapping(entries: IVidspyrnaPage[]) {
-    logger.info('Mapping adgerdir page', { count: entries.length })
+    if (entries.length > 0) {
+      logger.info('Mapping adgerdir page', { count: entries.length })
+    }
 
     return entries
       .map<MappedData | boolean>((entry) => {

--- a/libs/cms/src/lib/search/importers/anchorPage.service.ts
+++ b/libs/cms/src/lib/search/importers/anchorPage.service.ts
@@ -11,8 +11,6 @@ import { createTerms, extractStringsFromObject } from './utils'
 @Injectable()
 export class AnchorPageSyncService implements CmsSyncProvider<IAnchorPage> {
   processSyncData(entries: processSyncDataInput<IAnchorPage>) {
-    logger.info('Processing sync data for anchor pages')
-
     // only process anchor pages that we consider not to be empty and dont have circular structures
     return entries.filter(
       (entry: Entry<any>): entry is IAnchorPage =>
@@ -23,7 +21,9 @@ export class AnchorPageSyncService implements CmsSyncProvider<IAnchorPage> {
   }
 
   doMapping(entries: IAnchorPage[]) {
-    logger.info('Mapping anchor pages', { count: entries.length })
+    if (entries.length > 0) {
+      logger.info('Mapping anchor pages', { count: entries.length })
+    }
     return entries
       .map<MappedData | boolean>((entry) => {
         try {

--- a/libs/cms/src/lib/search/importers/article.service.ts
+++ b/libs/cms/src/lib/search/importers/article.service.ts
@@ -146,7 +146,9 @@ export class ArticleSyncService implements CmsSyncProvider<IArticle> {
   }
 
   doMapping(entries: (IArticle & MetaData)[]) {
-    logger.info('Mapping articles', { count: entries.length })
+    if (entries.length > 0) {
+      logger.info('Mapping articles', { count: entries.length })
+    }
 
     return entries
       .map<MappedData | boolean>((entry) => {

--- a/libs/cms/src/lib/search/importers/articleCategory.service.ts
+++ b/libs/cms/src/lib/search/importers/articleCategory.service.ts
@@ -13,8 +13,6 @@ export class ArticleCategorySyncService
   implements CmsSyncProvider<IArticleCategory>
 {
   processSyncData(entries: processSyncDataInput<IArticleCategory>) {
-    logger.info('Processing sync data for article category')
-
     // only process articles that we consider not to be empty and dont have circular structures
     return entries.filter(
       (entry: Entry<any>): entry is IArticleCategory =>
@@ -25,7 +23,9 @@ export class ArticleCategorySyncService
   }
 
   doMapping(entries: IArticleCategory[]) {
-    logger.info('Mapping article category', { count: entries.length })
+    if (entries.length > 0) {
+      logger.info('Mapping article category', { count: entries.length })
+    }
 
     return entries
       .map<MappedData | boolean>((entry) => {

--- a/libs/cms/src/lib/search/importers/enhancedAsset.service.ts
+++ b/libs/cms/src/lib/search/importers/enhancedAsset.service.ts
@@ -19,7 +19,9 @@ export class EnhancedAssetSyncService
   }
 
   doMapping(entries: IEnhancedAsset[]) {
-    logger.info('Mapping enhanced asset', { count: entries.length })
+    if (entries.length > 0) {
+      logger.info('Mapping enhanced asset', { count: entries.length })
+    }
 
     return entries
       .map<MappedData | boolean>((entry) => {

--- a/libs/cms/src/lib/search/importers/event.service.ts
+++ b/libs/cms/src/lib/search/importers/event.service.ts
@@ -25,7 +25,9 @@ export class EventSyncService implements CmsSyncProvider<IEvent> {
   }
 
   doMapping(entries: IEvent[]) {
-    logger.info('Mapping Event', { count: entries.length })
+    if (entries.length > 0) {
+      logger.info('Mapping Event', { count: entries.length })
+    }
     return entries
       .map<MappedData | boolean>((entry) => {
         try {

--- a/libs/cms/src/lib/search/importers/frontpage.service.ts
+++ b/libs/cms/src/lib/search/importers/frontpage.service.ts
@@ -35,7 +35,9 @@ export class FrontpageSyncService implements CmsSyncProvider<IFrontpage> {
   }
 
   doMapping(entries: IFrontpage[]) {
-    logger.info('Mapping frontpage', { count: entries.length })
+    if (entries.length > 0) {
+      logger.info('Mapping frontpage', { count: entries.length })
+    }
 
     return entries
       .map<MappedData | boolean>((entry) => {

--- a/libs/cms/src/lib/search/importers/groupedMenu.service.ts
+++ b/libs/cms/src/lib/search/importers/groupedMenu.service.ts
@@ -17,7 +17,9 @@ export class GroupedMenuSyncService implements CmsSyncProvider<IGroupedMenu> {
   }
 
   doMapping(entries: IGroupedMenu[]) {
-    logger.info('Mapping grouped menu', { count: entries.length })
+    if (entries.length > 0) {
+      logger.info('Mapping grouped menu', { count: entries.length })
+    }
 
     return entries
       .map<MappedData | boolean>((entry) => {

--- a/libs/cms/src/lib/search/importers/link.service.ts
+++ b/libs/cms/src/lib/search/importers/link.service.ts
@@ -16,7 +16,9 @@ export class LinkSyncService implements CmsSyncProvider<ILink> {
   }
 
   doMapping(entries: ILink[]) {
-    logger.info('Mapping links', { count: entries.length })
+    if (entries.length > 0) {
+      logger.info('Mapping links', { count: entries.length })
+    }
 
     return entries
       .map<MappedData | boolean>((entry) => {

--- a/libs/cms/src/lib/search/importers/manual.service.ts
+++ b/libs/cms/src/lib/search/importers/manual.service.ts
@@ -23,7 +23,9 @@ export class ManualSyncService implements CmsSyncProvider<IManual> {
   }
 
   doMapping(entries: IManual[]) {
-    logger.info('Mapping manuals', { count: entries.length })
+    if (entries.length > 0) {
+      logger.info('Mapping manuals', { count: entries.length })
+    }
     return entries
       .map<MappedData | boolean>((entry) => {
         try {

--- a/libs/cms/src/lib/search/importers/manualChapterItem.service.ts
+++ b/libs/cms/src/lib/search/importers/manualChapterItem.service.ts
@@ -51,9 +51,11 @@ export class ManualChapterItemSyncService implements CmsSyncProvider<IManual> {
       }
     }
 
-    logger.info('Mapping manuals chapter items', {
-      count: chapterItems.length,
-    })
+    if (chapterItems.length > 0) {
+      logger.info('Mapping manuals chapter items', {
+        count: chapterItems.length,
+      })
+    }
 
     return chapterItems
       .map<MappedData | boolean>(({ item, manual, chapter }) => {

--- a/libs/cms/src/lib/search/importers/menu.service.ts
+++ b/libs/cms/src/lib/search/importers/menu.service.ts
@@ -16,8 +16,9 @@ export class MenuSyncService implements CmsSyncProvider<IMenu> {
   }
 
   doMapping(entries: IMenu[]) {
-    logger.info('Mapping menu', { count: entries.length })
-
+    if (entries.length > 0) {
+      logger.info('Mapping menu', { count: entries.length })
+    }
     return entries
       .map<MappedData | boolean>((entry) => {
         try {

--- a/libs/cms/src/lib/search/importers/news.service.ts
+++ b/libs/cms/src/lib/search/importers/news.service.ts
@@ -11,8 +11,6 @@ import { createTerms, extractStringsFromObject } from './utils'
 @Injectable()
 export class NewsSyncService implements CmsSyncProvider<INews> {
   processSyncData(entries: processSyncDataInput<INews>) {
-    logger.info('Processing sync data for news')
-
     // only process news that we consider not to be empty
     return entries.filter(
       (entry: Entry<any>): entry is INews =>
@@ -23,7 +21,9 @@ export class NewsSyncService implements CmsSyncProvider<INews> {
   }
 
   doMapping(entries: INews[]) {
-    logger.info('Mapping news', { count: entries.length })
+    if (entries.length > 0) {
+      logger.info('Mapping news', { count: entries.length })
+    }
     return entries
       .map<MappedData | boolean>((entry) => {
         try {

--- a/libs/cms/src/lib/search/importers/organizationPage.service.ts
+++ b/libs/cms/src/lib/search/importers/organizationPage.service.ts
@@ -19,7 +19,9 @@ export class OrganizationPageSyncService
   }
 
   doMapping(entries: IOrganizationPage[]) {
-    logger.info('Mapping organization page', { count: entries.length })
+    if (entries.length > 0) {
+      logger.info('Mapping organization page', { count: entries.length })
+    }
 
     return entries
       .map<MappedData | boolean>((entry) => {

--- a/libs/cms/src/lib/search/importers/organizationSubpage.service.ts
+++ b/libs/cms/src/lib/search/importers/organizationSubpage.service.ts
@@ -21,7 +21,9 @@ export class OrganizationSubpageSyncService
   }
 
   doMapping(entries: IOrganizationSubpage[]) {
-    logger.info('Mapping organization subpage', { count: entries.length })
+    if (entries.length > 0) {
+      logger.info('Mapping organization subpage', { count: entries.length })
+    }
 
     return entries
       .map<MappedData | boolean>((entry) => {

--- a/libs/cms/src/lib/search/importers/projectPage.service.ts
+++ b/libs/cms/src/lib/search/importers/projectPage.service.ts
@@ -16,7 +16,9 @@ export class ProjectPageSyncService implements CmsSyncProvider<IProjectPage> {
   }
 
   doMapping(entries: IProjectPage[]) {
-    logger.info('Mapping project page', { count: entries.length })
+    if (entries.length > 0) {
+      logger.info('Mapping project page', { count: entries.length })
+    }
 
     return entries
       .map<MappedData | boolean>((entry) => {

--- a/libs/cms/src/lib/search/importers/serviceWebPage.service.ts
+++ b/libs/cms/src/lib/search/importers/serviceWebPage.service.ts
@@ -19,7 +19,9 @@ export class ServiceWebPageSyncService
   }
 
   doMapping(entries: IServiceWebPage[]) {
-    logger.info('Mapping Service Web page', { count: entries.length })
+    if (entries.length > 0) {
+      logger.info('Mapping Service Web page', { count: entries.length })
+    }
 
     return entries
       .map<MappedData | boolean>((entry) => {

--- a/libs/cms/src/lib/search/importers/subArticle.service.ts
+++ b/libs/cms/src/lib/search/importers/subArticle.service.ts
@@ -27,7 +27,9 @@ export class SubArticleSyncService implements CmsSyncProvider<ISubArticle> {
   }
 
   processSyncData(entries: processSyncDataInput<ISubArticle>) {
-    logger.info('Processing sync data for subarticles')
+    if (entries.length > 0) {
+      logger.info('Processing sync data for subarticles')
+    }
     return entries.reduce(
       (processedEntries: ISubArticle[], entry: Entry<any>) => {
         if (this.validateSubArticle(entry)) {

--- a/libs/cms/src/lib/search/importers/supportQNA.service.ts
+++ b/libs/cms/src/lib/search/importers/supportQNA.service.ts
@@ -53,7 +53,9 @@ export class SupportQNASyncService implements CmsSyncProvider<ISupportQna> {
   }
 
   doMapping(entries: ISupportQna[]) {
-    logger.info('Mapping SupportQNAs', { count: entries.length })
+    if (entries.length > 0) {
+      logger.info('Mapping SupportQNAs', { count: entries.length })
+    }
 
     return entries
       .map<MappedData | boolean>((entry) => {


### PR DESCRIPTION
# Skip logging if no entries are being mapped

## What

* We want to skip logging in case there are no entries being mapped to reduce the amount of logs
* Remove "Processing sync data for ..." logs since they are not present for all types and after the paginated sync update they don't provide as much value

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
