### PR TITLE
fix(j-s): Long filenames overflow container

### DIFF
--- a/apps/judicial-system/web/src/components/AppealCaseFilesOverview/AppealCaseFilesOverview.tsx
+++ b/apps/judicial-system/web/src/components/AppealCaseFilesOverview/AppealCaseFilesOverview.tsx
@@ -102,8 +102,8 @@ const AppealCaseFilesOverview: React.FC<
     allFiles &&
     allFiles.length > 0 ? (
     <>
-      <Box marginBottom={2}>
-        <Text as="h3" variant="h3" marginBottom={3}>
+      <Box marginBottom={5}>
+        <Text as="h3" variant="h3" marginBottom={1}>
           {formatMessage(strings.title)}
         </Text>
         {allFiles.map((file) => (

--- a/apps/judicial-system/web/src/components/PdfButton/PdfButton.css.ts
+++ b/apps/judicial-system/web/src/components/PdfButton/PdfButton.css.ts
@@ -10,7 +10,7 @@ export const pdfRow = style({
   width: '100%',
   minHeight: `${theme.spacing[10]}px`,
   boxShadow: `inset 0 -1px 0 0 ${theme.color.blue200}`,
-  padding: `0 ${theme.spacing[2]}px`,
+  padding: theme.spacing[2],
 })
 
 export const cursor = style({ cursor: 'pointer' })
@@ -24,6 +24,8 @@ export const disabled = style({
 export const fileNameContainer = style({
   flexBasis: '50%',
   marginRight: theme.spacing[2],
+  wordBreak: 'break-all',
+
   '@media': {
     [`screen and (min-width: ${theme.breakpoints.md}px)`]: {
       flexBasis: '70%',

--- a/apps/judicial-system/web/src/routes/Defender/CaseOverview.tsx
+++ b/apps/judicial-system/web/src/routes/Defender/CaseOverview.tsx
@@ -259,7 +259,7 @@ export const CaseOverview: React.FC<React.PropsWithChildren<unknown>> = () => {
               RequestSharedWithDefender.COURT_DATE ||
             isCompletedCase(workingCase.state)) && (
             <Box marginBottom={10}>
-              <Text as="h3" variant="h3" marginBottom={3}>
+              <Text as="h3" variant="h3" marginBottom={1}>
                 {formatMessage(strings.documentHeading)}
               </Text>
               <Box>
@@ -269,7 +269,6 @@ export const CaseOverview: React.FC<React.PropsWithChildren<unknown>> = () => {
                   title={formatMessage(core.pdfButtonRequest)}
                   pdfType={'request'}
                 />
-
                 {isCompletedCase(workingCase.state) && (
                   <>
                     <PdfButton

--- a/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/Components/CaseDocuments/CaseDocuments.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/Components/CaseDocuments/CaseDocuments.tsx
@@ -81,7 +81,7 @@ const CaseDocuments: React.FC<React.PropsWithChildren<Props>> = ({
 
   return (
     <Box marginBottom={10}>
-      <Text as="h3" variant="h3" marginBottom={3}>
+      <Text as="h3" variant="h3" marginBottom={1}>
         {formatMessage(m.caseDocuments)}
       </Text>
       <Box marginBottom={2}>


### PR DESCRIPTION
# Long filenames overflow container

Asana

## What

Long filenames without a space overflow it's container. This is now fixed

## Screenshots / Gifs

### Before

<img width="1047" alt="Screenshot 2024-01-11 at 13 24 40" src="https://github.com/island-is/island.is/assets/3789875/11300bc4-00b6-49c2-b993-479647fd51c7">


### After

<img width="833" alt="Screenshot 2024-01-11 at 13 22 35" src="https://github.com/island-is/island.is/assets/3789875/7b5bc1b6-605d-4c38-8428-e935198d5e5a">

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
