### PR TITLE
fix(finances): Increase finance timeout

### DIFF
--- a/apps/api/infra/api.ts
+++ b/apps/api/infra/api.ts
@@ -147,7 +147,7 @@ export const serviceSetup = (services: {
       XROAD_PROPERTIES_TIMEOUT: '35000',
       SYSLUMENN_TIMEOUT: '40000',
       XROAD_DRIVING_LICENSE_BOOK_TIMEOUT: '20000',
-      XROAD_FINANCES_TIMEOUT: '20000',
+      XROAD_FINANCES_TIMEOUT: '60000',
       XROAD_CHARGE_FJS_V2_TIMEOUT: '20000',
       AUTH_DELEGATION_API_URL: {
         dev: 'http://web-services-auth-delegation-api.identity-server-delegation.svc.cluster.local',

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -331,7 +331,7 @@ api:
     XROAD_DRIVING_LICENSE_V5_PATH: 'r1/IS-DEV/GOV/10005/Logreglan-Protected/Okuskirteini-v5'
     XROAD_ENERGY_FUNDS_PATH: 'IS-DEV/GOV/10021/FJS-Public/ElectricCarSubSidyService_v1'
     XROAD_FINANCES_PATH: 'IS-DEV/GOV/10021/FJS-Public/financeIsland'
-    XROAD_FINANCES_TIMEOUT: '20000'
+    XROAD_FINANCES_TIMEOUT: '60000'
     XROAD_FINANCES_V2_PATH: 'IS-DEV/GOV/10021/FJS-Public/financeServicesFJS_v2'
     XROAD_FINANCIAL_AID_BACKEND_PATH: 'IS-DEV/MUN/10023/samband-sveitarfelaga/financial-aid-backend'
     XROAD_FIREARM_LICENSE_PATH: 'IS-DEV/GOV/10005/Logreglan-Protected/island-api-v1'

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -321,7 +321,7 @@ api:
     XROAD_DRIVING_LICENSE_V5_PATH: 'r1/IS/GOV/5309672079/Logreglan-Protected/Okuskirteini-v5'
     XROAD_ENERGY_FUNDS_PATH: 'IS/GOV/5402697509/FJS-Public/ElectricCarSubSidyService_v1'
     XROAD_FINANCES_PATH: 'IS/GOV/5402697509/FJS-Public/financeIsland'
-    XROAD_FINANCES_TIMEOUT: '20000'
+    XROAD_FINANCES_TIMEOUT: '60000'
     XROAD_FINANCES_V2_PATH: 'IS/GOV/5402697509/FJS-Public/financeServicesFJS_v2'
     XROAD_FINANCIAL_AID_BACKEND_PATH: 'IS/MUN/5502694739/samband-sveitarfelaga/financial-aid-backend'
     XROAD_FIREARM_LICENSE_PATH: 'IS/GOV/5309672079/Logreglan-Protected/island-api-v1'

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -331,7 +331,7 @@ api:
     XROAD_DRIVING_LICENSE_V5_PATH: 'r1/IS/GOV/5309672079/Logreglan-Protected/Okuskirteini-v5'
     XROAD_ENERGY_FUNDS_PATH: 'IS-DEV/GOV/10021/FJS-Public/ElectricCarSubSidyService_v1'
     XROAD_FINANCES_PATH: 'IS-DEV/GOV/10021/FJS-Public/financeIsland'
-    XROAD_FINANCES_TIMEOUT: '20000'
+    XROAD_FINANCES_TIMEOUT: '60000'
     XROAD_FINANCES_V2_PATH: 'IS-DEV/GOV/10021/FJS-Public/financeServicesFJS_v2'
     XROAD_FINANCIAL_AID_BACKEND_PATH: 'IS-TEST/MUN/5502694739/samband-sveitarfelaga/financial-aid-backend'
     XROAD_FIREARM_LICENSE_PATH: 'IS/GOV/5309672079/Logreglan-Protected/island-api-v1'

--- a/libs/clients/finance/src/lib/FinanceClientConfig.ts
+++ b/libs/clients/finance/src/lib/FinanceClientConfig.ts
@@ -20,6 +20,6 @@ export const FinanceClientConfig = defineConfig({
       // TODO: Remove when fjs has migrated to the scope above.
       'api_resource.scope',
     ],
-    fetchTimeout: env.optionalJSON('XROAD_FINANCES_TIMEOUT') ?? 20000,
+    fetchTimeout: env.optionalJSON('XROAD_FINANCES_TIMEOUT') ?? 60000,
   }),
 })


### PR DESCRIPTION
## What

60 sec Increase finance timeout as recommended by sp.

## Why

Recommended by service provider as some clients have *complex* datasets, so they time out at 20sec.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
