### PR TITLE
fix(service-portal): Use overview url as fallback for detailurl

### DIFF
--- a/libs/service-portal/documents/src/components/DocumentRenderer/DocumentRenderer.tsx
+++ b/libs/service-portal/documents/src/components/DocumentRenderer/DocumentRenderer.tsx
@@ -8,14 +8,17 @@ import { ActiveDocumentType } from '../../lib/types'
 import { useLocale } from '@island.is/localization'
 import { customUrl } from '../../utils/customUrlHandler'
 
-const parseDocmentType = (doc: DocumentDetails) => {
+const parseDocmentType = (document: ActiveDocumentType) => {
+  const doc = document.document
+  const overviewUrl = document.downloadUrl
+
   if (doc.html && doc.html.length > 0) {
     return 'html'
   }
   if (doc.content && doc.content.length > 0) {
     return 'pdf'
   }
-  if (doc.url && doc.url.length > 0) {
+  if ((doc.url && doc.url.length > 0) || overviewUrl) {
     return 'url'
   }
   return 'unknown'
@@ -29,7 +32,7 @@ export const DocumentRenderer: React.FC<DocumentRendererProps> = ({
   document,
 }) => {
   const { formatMessage } = useLocale()
-  const type = parseDocmentType(document.document)
+  const type = parseDocmentType(document)
 
   if (type === 'unknown') return <NoPDF text={formatMessage(messages.error)} />
 


### PR DESCRIPTION
## What

Use overview url as fallback for detail-url

## Why

We have seen instances of documents not containing a url in detail, when there is in fact a url in overview.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
