### PR TITLE
fix(web): life events indexer missing typename

### DIFF
--- a/libs/cms/src/lib/search/importers/lifeEventPage.service.ts
+++ b/libs/cms/src/lib/search/importers/lifeEventPage.service.ts
@@ -4,7 +4,7 @@ import { Injectable } from '@nestjs/common'
 import { Entry } from 'contentful'
 import isCircular from 'is-circular'
 import { ILifeEventPage } from '../../generated/contentfulTypes'
-import { mapAnchorPage } from '../../models/anchorPage.model'
+import { mapLifeEventPage } from '../../models/lifeEventPage.model'
 import { CmsSyncProvider, processSyncDataInput } from '../cmsSync.service'
 import { createTerms, extractStringsFromObject } from './utils'
 
@@ -13,7 +13,7 @@ export class LifeEventPageSyncService
   implements CmsSyncProvider<ILifeEventPage>
 {
   processSyncData(entries: processSyncDataInput<ILifeEventPage>) {
-    logger.info('Processing sync data for anchor pages')
+    logger.info('Processing sync data for life event pages')
 
     // only process life event pages that we consider not to be empty and dont have circular structures
     return entries.filter(
@@ -29,7 +29,7 @@ export class LifeEventPageSyncService
     return entries
       .map<MappedData | boolean>((entry) => {
         try {
-          const mapped = mapAnchorPage(entry)
+          const mapped = mapLifeEventPage(entry)
           const content = extractStringsFromObject(mapped.content)
 
           return {
@@ -39,13 +39,13 @@ export class LifeEventPageSyncService
             contentWordCount: content.split(/\s+/).length,
             type: 'webLifeEventPage',
             termPool: createTerms([mapped.title]),
-            response: JSON.stringify({ ...mapped, typename: 'AnchorPage' }),
+            response: JSON.stringify({ ...mapped, typename: 'LifeEventPage' }),
             tags: [],
             dateCreated: entry.sys.createdAt,
             dateUpdated: new Date().getTime().toString(),
           }
         } catch (error) {
-          logger.warn('Failed to import anchor page', {
+          logger.warn('Failed to import life event page', {
             error: error.message,
             id: entry?.sys?.id,
           })


### PR DESCRIPTION
## What

This fixes the typename for life events

## Why

Mapping of Life Events has incorrect typename.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
