### PR TITLE
fix(user-notification): Fix notifications service startup due to lru cache dependency issue

### DIFF
--- a/apps/services/user-notification/esbuild.json
+++ b/apps/services/user-notification/esbuild.json
@@ -46,7 +46,8 @@
     "buffer-equal-constant-time",
     "safer-buffer",
     "jwa",
-    "sequelize"
+    "sequelize",
+    "path-scurry"
   ],
   "keepNames": true
 }


### PR DESCRIPTION
## What

Fixing lru cache dependency isssue

## Why

To fix service startup.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
