### PR TITLE
ci: make checkout on helm always happen

### DIFF
--- a/.github/workflows/config-values.yaml
+++ b/.github/workflows/config-values.yaml
@@ -59,7 +59,7 @@ jobs:
           token: ${{ secrets.DIRTY_FIX_BOT_TOKEN }}
 
       - uses: actions/checkout@v3
-        if: ${{ github.ref == 'ref/heads/main' }}
+        if: ${{ github.event_name != 'pull_request' }}
 
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
# ...

Sometimes checkout is not run and the step fails. This makes sure that it is always run and only one step can be true. 