### PR TITLE
fix(auth-ids-api): String needs to be json string for user profile client scope.

### DIFF
--- a/apps/services/auth/ids-api/infra/ids-api.ts
+++ b/apps/services/auth/ids-api/infra/ids-api.ts
@@ -32,7 +32,7 @@ export const serviceSetup = (): ServiceBuilder<'services-auth-ids-api'> => {
           'http://web-service-portal-api.service-portal.svc.cluster.local',
         prod: 'https://service-portal-api.internal.island.is',
       },
-      USER_PROFILE_CLIENT_SCOPE: UserProfileScope.read,
+      USER_PROFILE_CLIENT_SCOPE: json([UserProfileScope.read]),
       XROAD_NATIONAL_REGISTRY_SERVICE_PATH: {
         dev: 'IS-DEV/GOV/10001/SKRA-Protected/Einstaklingar-v1',
         staging: 'IS-TEST/GOV/6503760649/SKRA-Protected/Einstaklingar-v1',

--- a/charts/identity-server/values.dev.yaml
+++ b/charts/identity-server/values.dev.yaml
@@ -359,7 +359,7 @@ services-auth-ids-api:
     NOVA_ACCEPT_UNAUTHORIZED: 'true'
     PUBLIC_URL: 'https://identity-server.dev01.devland.is/api'
     SERVERSIDE_FEATURES_ON: ''
-    USER_PROFILE_CLIENT_SCOPE: '@island.is/user-profile:read'
+    USER_PROFILE_CLIENT_SCOPE: '["@island.is/user-profile:read"]'
     USER_PROFILE_CLIENT_URL: 'http://web-service-portal-api.service-portal.svc.cluster.local'
     XROAD_BASE_PATH: 'http://securityserver.dev01.devland.is'
     XROAD_BASE_PATH_WITH_ENV: 'http://securityserver.dev01.devland.is/r1/IS-DEV'

--- a/charts/identity-server/values.prod.yaml
+++ b/charts/identity-server/values.prod.yaml
@@ -356,7 +356,7 @@ services-auth-ids-api:
     NOVA_ACCEPT_UNAUTHORIZED: 'false'
     PUBLIC_URL: 'https://innskra.island.is/api'
     SERVERSIDE_FEATURES_ON: 'driving-license-use-v1-endpoint-for-v2-comms'
-    USER_PROFILE_CLIENT_SCOPE: '@island.is/user-profile:read'
+    USER_PROFILE_CLIENT_SCOPE: '["@island.is/user-profile:read"]'
     USER_PROFILE_CLIENT_URL: 'https://service-portal-api.internal.island.is'
     XROAD_BASE_PATH: 'http://securityserver.island.is'
     XROAD_BASE_PATH_WITH_ENV: 'http://securityserver.island.is/r1/IS'

--- a/charts/identity-server/values.staging.yaml
+++ b/charts/identity-server/values.staging.yaml
@@ -359,7 +359,7 @@ services-auth-ids-api:
     NOVA_ACCEPT_UNAUTHORIZED: 'false'
     PUBLIC_URL: 'https://identity-server.staging01.devland.is/api'
     SERVERSIDE_FEATURES_ON: ''
-    USER_PROFILE_CLIENT_SCOPE: '@island.is/user-profile:read'
+    USER_PROFILE_CLIENT_SCOPE: '["@island.is/user-profile:read"]'
     USER_PROFILE_CLIENT_URL: 'http://web-service-portal-api.service-portal.svc.cluster.local'
     XROAD_BASE_PATH: 'http://securityserver.staging01.devland.is'
     XROAD_BASE_PATH_WITH_ENV: 'http://securityserver.staging01.devland.is/r1/IS-TEST'


### PR DESCRIPTION
## What

User profile client scope needs to be a valid json string

## Why

So the service can load the variable using json loader.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
