### PR TITLE
chore(search-indexer): Log what endpoints are being cache invalidated

### DIFF
--- a/libs/content-search-indexer/src/lib/cache-invalidation.service.ts
+++ b/libs/content-search-indexer/src/lib/cache-invalidation.service.ts
@@ -180,8 +180,10 @@ export class CacheInvalidationService {
         continue
       }
 
-      for (const url of urls) {
-        promises.push(fetch(`${url}?bypass-cache=${bypassSecret}`))
+      for (const urlWithoutPostfix of urls) {
+        const url = `${urlWithoutPostfix}?bypass-cache=${bypassSecret}`
+        promises.push(fetch(url))
+        logger.info(`Invalidating: ${url}`)
         if (promises.length > MAX_REQUEST_COUNT) {
           await handleRequests()
         }

--- a/libs/content-search-indexer/src/lib/indexing.service.ts
+++ b/libs/content-search-indexer/src/lib/indexing.service.ts
@@ -91,7 +91,7 @@ export class IndexingService {
               elasticData.add,
               options.locale,
             )
-          }, 2000)
+          }, 2500)
         }
 
         nextPageToken = importerResponseNextPageToken


### PR DESCRIPTION
# Log what endpoints are being cache invalidated

## What

* For a better debugging experience I've added logs and increased the wait time until we start cache invalidating

## Why

* This is a new feature that's currently being tested on dev and this PR would help regarding seeing the cache invalidation progress

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
