### PR TITLE
fix(search-indexer): Set refresh to true when bulk indexing

### DIFF
--- a/libs/content-search-indexer/src/lib/indexing.service.ts
+++ b/libs/content-search-indexer/src/lib/indexing.service.ts
@@ -76,15 +76,21 @@ export class IndexingService {
           return true
         }
 
+        const isIncrementalUpdate = syncType === 'fromLast'
+
         const {
           nextPageToken: importerResponseNextPageToken,
           postSyncOptions: importerResponsePostSyncOptions,
           ...elasticData
         } = importerResponse
-        await this.elasticService.bulk(elasticIndex, elasticData)
+        await this.elasticService.bulk(
+          elasticIndex,
+          elasticData,
+          isIncrementalUpdate,
+        )
 
         // Invalidate cached pages in the background if we are performing an incremental update
-        if (syncType === 'fromLast') {
+        if (isIncrementalUpdate) {
           // Wait for some time to make sure data is properly indexed
           setTimeout(() => {
             this.cacheInvalidationService.invalidateCache(

--- a/libs/content-search-toolkit/src/services/elastic.service.ts
+++ b/libs/content-search-toolkit/src/services/elastic.service.ts
@@ -118,7 +118,7 @@ export class ElasticService {
         const response = await client.bulk({
           index: index,
           body: requestChunk,
-          refresh: 'wait_for',
+          refresh: 'true',
         })
 
         // not all errors are thrown log if the response has any errors

--- a/libs/content-search-toolkit/src/services/elastic.service.ts
+++ b/libs/content-search-toolkit/src/services/elastic.service.ts
@@ -65,7 +65,7 @@ export class ElasticService {
   }
 
   // this can partially succeed
-  async bulk(index: string, documents: SyncRequest) {
+  async bulk(index: string, documents: SyncRequest, refresh = false) {
     logger.info('Processing documents', {
       index,
       added: documents.add.length,
@@ -103,10 +103,14 @@ export class ElasticService {
       return false
     }
 
-    await this.bulkRequest(index, requests)
+    await this.bulkRequest(index, requests, refresh)
   }
 
-  async bulkRequest(index: string, requests: Record<string, unknown>[]) {
+  async bulkRequest(
+    index: string,
+    requests: Record<string, unknown>[],
+    refresh = false,
+  ) {
     try {
       // elasticsearch does not like big requests (above 5mb) so we limit the size to X entries just in case
       const client = await this.getClient()
@@ -118,7 +122,7 @@ export class ElasticService {
         const response = await client.bulk({
           index: index,
           body: requestChunk,
-          refresh: 'true',
+          refresh: refresh ? 'true' : undefined,
         })
 
         // not all errors are thrown log if the response has any errors


### PR DESCRIPTION
# Set refresh to true when bulk indexing

* We are trying to invalidate cached data when it gets re-indexed