### PR TITLE
fix(web): Make sure only footer items with values are shown for organization landing page footer

### DIFF
--- a/apps/web/screens/Organization/Home/LandingPage/LandingPage.tsx
+++ b/apps/web/screens/Organization/Home/LandingPage/LandingPage.tsx
@@ -1,6 +1,22 @@
 import { useMemo } from 'react'
 import NextLink from 'next/link'
+import { useQuery } from '@apollo/client'
 
+import {
+  Box,
+  Breadcrumbs,
+  GridColumn,
+  GridContainer,
+  GridRow,
+  Inline,
+  Stack,
+  Text,
+} from '@island.is/island-ui/core'
+import {
+  FeaturedArticlesSlice,
+  HeadWithSocialSharing,
+  IconTitleCard,
+} from '@island.is/web/components'
 import {
   Article,
   GetArticlesQuery,
@@ -9,25 +25,11 @@ import {
   SortField,
 } from '@island.is/web/graphql/schema'
 import { useLinkResolver, useNamespace } from '@island.is/web/hooks'
-import {
-  Box,
-  Breadcrumbs,
-  GridColumn,
-  GridContainer,
-  GridRow,
-  Inline,
-  Text,
-} from '@island.is/island-ui/core'
-import {
-  FeaturedArticlesSlice,
-  HeadWithSocialSharing,
-  IconTitleCard,
-} from '@island.is/web/components'
-import { useQuery } from '@apollo/client'
-import { GET_ARTICLES_QUERY } from '@island.is/web/screens/queries'
-import { useI18n } from '@island.is/web/i18n'
 import useContentfulId from '@island.is/web/hooks/useContentfulId'
 import useLocalLinkTypeResolver from '@island.is/web/hooks/useLocalLinkTypeResolver'
+import { useI18n } from '@island.is/web/i18n'
+import { GET_ARTICLES_QUERY } from '@island.is/web/screens/queries'
+
 import { LandingPageFooter } from './index'
 
 const ARTICLES_PAGE_SIZE = 10
@@ -90,7 +92,7 @@ const LandingPage = ({ organization, namespace }: LandingPageProps) => {
         // @ts-ignore make web strict
         description={organization?.description}
       />
-      <Box marginBottom={5}>
+      <Stack space={5}>
         <GridContainer>
           <GridRow>
             <GridColumn
@@ -203,7 +205,7 @@ const LandingPage = ({ organization, namespace }: LandingPageProps) => {
           </GridRow>
         </GridContainer>
         <LandingPageFooter footerItems={organization?.footerItems} />
-      </Box>
+      </Stack>
     </>
   )
 }

--- a/apps/web/screens/Organization/Home/LandingPage/LandingPageFooter.tsx
+++ b/apps/web/screens/Organization/Home/LandingPage/LandingPageFooter.tsx
@@ -1,9 +1,10 @@
-import cn from 'classnames'
 import { ReactNode } from 'react'
+import cn from 'classnames'
 import { INLINES } from '@contentful/rich-text-types'
+
+import { SliceType } from '@island.is/island-ui/contentful'
 import { Box, GridContainer, Link, Text } from '@island.is/island-ui/core'
 import { FooterItem } from '@island.is/web/graphql/schema'
-import { SliceType } from '@island.is/island-ui/contentful'
 import { webRichText } from '@island.is/web/utils/richText'
 
 import * as styles from './LandingPageFooter.css'
@@ -15,24 +16,29 @@ interface LandingPageFooterProps {
 const LandingPageFooter: React.FC<
   React.PropsWithChildren<LandingPageFooterProps>
 > = ({ footerItems }) => {
-  if (!footerItems?.length) return null
+  if (
+    !footerItems?.length ||
+    !footerItems?.some((item) => item?.content && item?.content?.length > 0)
+  )
+    return null
 
   return (
     <Box background="blue200" paddingY={2}>
       <GridContainer>
         <Box className={styles.container}>
-          {footerItems.map((item, index) =>
-            index === 0 ? (
-              <Box key={`${item.id}-${index}`} className={styles.item}>
-                <Text fontWeight="semiBold">{item.title}</Text>
-              </Box>
-            ) : (
-              <Box
-                className={cn({ [styles.dotBefore]: index > 0 }, styles.item)}
-                key={`${item.id}-${index}`}
-              >
-                {item.content?.length &&
-                  webRichText(item.content as SliceType[], {
+          {footerItems
+            .filter((item) => item.content && item.content.length > 0)
+            .map((item, index) =>
+              index === 0 ? (
+                <Box key={`${item.id}-${index}`} className={styles.item}>
+                  <Text fontWeight="semiBold">{item.title}</Text>
+                </Box>
+              ) : (
+                <Box
+                  className={cn({ [styles.dotBefore]: index > 0 }, styles.item)}
+                  key={`${item.id}-${index}`}
+                >
+                  {webRichText((item.content ?? []) as SliceType[], {
                     renderNode: {
                       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                       // @ts-ignore make web strict
@@ -48,9 +54,9 @@ const LandingPageFooter: React.FC<
                       ),
                     },
                   })}
-              </Box>
-            ),
-          )}
+                </Box>
+              ),
+            )}
         </Box>
       </GridContainer>
     </Box>


### PR DESCRIPTION
# Make sure only footer items with values are shown for organization landing page footer

## What

* Often english fields in the cms are not populated so we want to prevent an empty footer from being shown
* I also fixed the spacing between the content and the footer

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
