### PR TITLE
fix(service-portal): Add max monthly amount health nutrition

### DIFF
--- a/libs/api/domains/rights-portal/src/lib/aidOrNutrition/models/aidOrNutrition.model.ts
+++ b/libs/api/domains/rights-portal/src/lib/aidOrNutrition/models/aidOrNutrition.model.ts
@@ -24,6 +24,9 @@ export class AidOrNutrition {
   @Field({ nullable: true })
   maxUnitRefund?: string
 
+  @Field({ nullable: true })
+  maxMonthlyAmount?: number
+
   @Field(() => Refund)
   refund!: Refund
 

--- a/libs/api/domains/rights-portal/src/lib/aidOrNutrition/utils/generateAidOrNutrition.ts
+++ b/libs/api/domains/rights-portal/src/lib/aidOrNutrition/utils/generateAidOrNutrition.ts
@@ -24,6 +24,7 @@ export function generateAidOrNutrition(
     iso: data.iso,
     name: data.name,
     maxUnitRefund: data.maxUnitRefund ?? undefined,
+    maxMonthlyAmount: data.maxMonthlyAmount ?? undefined,
     refund: {
       type: data.refund.type,
       value: data.refund.value,

--- a/libs/clients/icelandic-health-insurance/rights-portal/src/clientConfig.json
+++ b/libs/clients/icelandic-health-insurance/rights-portal/src/clientConfig.json
@@ -1649,6 +1649,11 @@
           "refund": {
             "$ref": "#/components/schemas/AidOrNutritionRefundDTO"
           },
+          "maxMonthlyAmount": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
           "available": {
             "type": "string",
             "nullable": true

--- a/libs/service-portal/health/src/screens/AidsAndNutrition/AidsAndNutrition.graphql
+++ b/libs/service-portal/health/src/screens/AidsAndNutrition/AidsAndNutrition.graphql
@@ -12,6 +12,7 @@ query GetAidsAndNutrition {
       nextAllowedMonth
       location
       maxUnitRefund
+      maxMonthlyAmount
       allowed12MonthPeriod
       refund {
         type

--- a/libs/service-portal/health/src/screens/AidsAndNutrition/NutritionTable.tsx
+++ b/libs/service-portal/health/src/screens/AidsAndNutrition/NutritionTable.tsx
@@ -50,7 +50,9 @@ const NutritionTable = ({ data, footnote, link, linkText }: Props) => {
           expiring={rowItem.expiring}
           visibleValues={[
             rowItem.name ?? '',
-            rowItem.maxUnitRefund ?? '',
+            rowItem.maxMonthlyAmount
+              ? amountFormat(rowItem.maxMonthlyAmount)
+              : '',
             rowItem.refund.type === 'amount'
               ? rowItem.refund.value
                 ? amountFormat(rowItem.refund.value)


### PR DESCRIPTION
## What

Remove `maxUnitRefund` from nutrition table. Add `maxMonthlyAmount` instead.

## Why

The current implementation is displaying the wrong value.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
