### PR TITLE
fix(web): Fix content width for SectionWithImage content type

### DIFF
--- a/apps/web/components/Organization/Slice/SliceMachine.tsx
+++ b/apps/web/components/Organization/Slice/SliceMachine.tsx
@@ -1,5 +1,6 @@
 import dynamic from 'next/dynamic'
 
+import { SectionWithImage, SliceType } from '@island.is/island-ui/contentful'
 import {
   Box,
   GridColumn,
@@ -166,6 +167,15 @@ const renderSlice = (
           slug={slug}
           namespace={namespace}
           {...params}
+        />
+      )
+    case 'SectionWithImage':
+      return (
+        <SectionWithImage
+          title={slice.title}
+          content={slice.content as SliceType[]}
+          image={slice.image ?? undefined}
+          contain={true}
         />
       )
     default:

--- a/apps/web/utils/richText.tsx
+++ b/apps/web/utils/richText.tsx
@@ -3,6 +3,7 @@ import {
   FaqListProps,
   renderConnectedComponent,
   richText,
+  SectionWithImage,
   SliceType,
 } from '@island.is/island-ui/contentful'
 import {
@@ -53,6 +54,7 @@ import {
   OneColumnText,
   OverviewLinks as OverviewLinksSliceSchema,
   PowerBiSlice as PowerBiSliceSchema,
+  SectionWithImage as SectionWithImageSchema,
   SectionWithVideo as SectionWithVideoSchema,
   Slice,
   SliceDropdown as SliceDropdownSchema,
@@ -155,6 +157,14 @@ const defaultRenderComponent = {
   Chart: (slice: ChartSchema) => <Chart slice={slice} />,
   ChartNumberBox: (slice: ChartNumberBoxSchema) => (
     <ChartNumberBox slice={slice} />
+  ),
+  SectionWithImage: (slice: SectionWithImageSchema) => (
+    <SectionWithImage
+      title={slice.title}
+      content={slice.content as SliceType[]}
+      image={slice.image ?? undefined}
+      contain={true}
+    />
   ),
 }
 


### PR DESCRIPTION
# Fix content width for SectionWithImage content type

## Screenshots / Gifs

### Before
![image](https://github.com/island-is/island.is/assets/43557895/32d569fa-084b-41b7-8bc8-3fdbc851ead0)


### After
![image](https://github.com/island-is/island.is/assets/43557895/643ce06f-9f2a-4c9b-a427-353ab74ee2dc)