### PR TITLE
fix(j-s): Fix duplicate CF string id

### DIFF
--- a/apps/judicial-system/web/src/routes/Shared/AppealToCourtOfAppeals/AppealToCourtOfAppeals.strings.ts
+++ b/apps/judicial-system/web/src/routes/Shared/AppealToCourtOfAppeals/AppealToCourtOfAppeals.strings.ts
@@ -23,7 +23,7 @@ export const appealToCourtOfAppeals = defineMessages({
     description: 'Undirtitill á Gögn hluta á Kæra til Landsréttar síðu',
   },
   appealCaseFilesCOASubtitle: {
-    id: 'judicial.system.core:appeal_case_files.appeal_case_files_coa_subtitle',
+    id: 'judicial.system.core:appeal_to_court_of_appeals.appeal_case_files_coa_subtitle',
     defaultMessage:
       'Athugið að gögn sem hér er hlaðið upp verða einungis sýnileg Landsrétti.',
     description: 'Undirtitill á Gögn hluta á Kæra til Landsréttar síðu',

--- a/apps/judicial-system/web/src/routes/Shared/Statement/Statement.strings.ts
+++ b/apps/judicial-system/web/src/routes/Shared/Statement/Statement.strings.ts
@@ -35,7 +35,7 @@ export const statement = defineMessages({
     description: 'Lýsing á Hlaða upp gögnum á greinargerðarskjá',
   },
   appealCaseFilesCOASubtitle: {
-    id: 'judicial.system.core:appeal_case_files.appeal_case_files_coa_subtitle',
+    id: 'judicial.system.core:statement.appeal_case_files_coa_subtitle',
     defaultMessage:
       'Athugið að gögn sem hér er hlaðið upp verða einungis sýnileg Landsrétti.',
     description: 'Lýsing á Hlaða upp gögnum á greinargerðarskjá',


### PR DESCRIPTION
# Fix duplicate CF string id

[Asana](https://app.asana.com/0/1199153462262248/1206408738524084/f)

## What

There were three contentful strings with the same ID, which gives the following error when trying to publish them

<img width="1195" alt="Screenshot 2024-01-22 at 21 57 21" src="https://github.com/island-is/island.is/assets/3789875/1d9a41db-4ea7-43b2-9da1-f7c488e9db29">

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
