### PR TITLE
chore(search-indexer): Wrap cache invalidation log in an object

### DIFF
--- a/libs/content-search-indexer/src/lib/cache-invalidation.service.ts
+++ b/libs/content-search-indexer/src/lib/cache-invalidation.service.ts
@@ -152,7 +152,7 @@ export class CacheInvalidationService {
         const url = promises[i].url
         if (response.status === 'fulfilled') {
           ;(response.value as Response).text().then((value) => {
-            logger.info(`Received response for: ${url}`, value)
+            logger.info(`Received response for: ${url}`, { data: value })
           })
           successfulCacheInvalidationCount += 1
         } else {


### PR DESCRIPTION
# Wrap cache invalidation log in an object
