### PR TITLE
fix(user-notification): Shallow copy template object to avoid cache tampering.

### DIFF
--- a/apps/services/user-notification/src/app/modules/notifications/messageProcessor.service.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/messageProcessor.service.ts
@@ -24,7 +24,12 @@ export class MessageProcessorService {
     )
     const notification = this.notificationsService.formatArguments(
       message.args,
-      template,
+      // We need to pass the template as a new object to avoid tempering with
+      // the template object from the memory cache.
+      // Shallow copy is enough with the current definition of HnippTemplate (./dto/hnippTemplate.response.ts)
+      {
+        ...template,
+      },
     )
 
     return {


### PR DESCRIPTION
## What

User notification service uses in-memory cache to cache Contenful Hnipp templates. After PR #13013 the template object wasn't shallowed copied making the service write to the cached object values of a notification.

## Why

To fix the notification service.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
