### PR TITLE
feat(web): Allow search-indexer to call web

### DIFF
--- a/apps/services/search-indexer/infra/search-indexer-service.ts
+++ b/apps/services/search-indexer/infra/search-indexer-service.ts
@@ -141,4 +141,3 @@ export const serviceSetup = (): ServiceBuilder<'search-indexer-service'> =>
       staging: { progressDeadlineSeconds: 25 * 60 },
       prod: { progressDeadlineSeconds: 25 * 60 },
     })
-    .grantNamespaces('nginx-ingress-external', 'islandis')

--- a/apps/web/infra/web.ts
+++ b/apps/web/infra/web.ts
@@ -67,5 +67,12 @@ export const serviceSetup = (services: {
       staging: { basicAuth: '/k8s/web/basic_auth' },
       prod: {},
     })
+    .grantNamespaces(
+      'nginx-ingress-external',
+      'api-catalogue',
+      'application-system',
+      'consultation-portal',
+      'search-indexer',
+    )
   return web
 }

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -1908,10 +1908,8 @@ search-indexer-service:
     ENVIRONMENT: 'dev'
     NODE_OPTIONS: '--max-old-space-size=3686'
     SERVERSIDE_FEATURES_ON: ''
-  grantNamespaces:
-    - 'nginx-ingress-external'
-    - 'islandis'
-  grantNamespacesEnabled: true
+  grantNamespaces: []
+  grantNamespacesEnabled: false
   healthCheck:
     liveness:
       initialDelaySeconds: 3
@@ -3156,6 +3154,7 @@ web:
     - 'api-catalogue'
     - 'application-system'
     - 'consultation-portal'
+    - 'search-indexer'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -1651,10 +1651,8 @@ search-indexer-service:
     ENVIRONMENT: 'prod'
     NODE_OPTIONS: '--max-old-space-size=3686'
     SERVERSIDE_FEATURES_ON: 'driving-license-use-v1-endpoint-for-v2-comms'
-  grantNamespaces:
-    - 'nginx-ingress-external'
-    - 'islandis'
-  grantNamespacesEnabled: true
+  grantNamespaces: []
+  grantNamespacesEnabled: false
   healthCheck:
     liveness:
       initialDelaySeconds: 3
@@ -2708,6 +2706,7 @@ web:
     - 'api-catalogue'
     - 'application-system'
     - 'consultation-portal'
+    - 'search-indexer'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -1657,10 +1657,8 @@ search-indexer-service:
     ENVIRONMENT: 'staging'
     NODE_OPTIONS: '--max-old-space-size=3686'
     SERVERSIDE_FEATURES_ON: ''
-  grantNamespaces:
-    - 'nginx-ingress-external'
-    - 'islandis'
-  grantNamespacesEnabled: true
+  grantNamespaces: []
+  grantNamespacesEnabled: false
   healthCheck:
     liveness:
       initialDelaySeconds: 3
@@ -2707,6 +2705,7 @@ web:
     - 'api-catalogue'
     - 'application-system'
     - 'consultation-portal'
+    - 'search-indexer'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:


### PR DESCRIPTION
# Allow search-indexer to call web

search-indexer service needs to be able to call web so we can invalidate the redis cache for web graphql queries