### PR TITLE
feat(web): Chart improvements and fixes

### DIFF
--- a/apps/web/components/Charts/v2/hooks/data.ts
+++ b/apps/web/components/Charts/v2/hooks/data.ts
@@ -6,6 +6,7 @@ import {
   Chart,
   GetMultipleStatisticsQuery,
   GetMultipleStatisticsQueryVariables,
+  Maybe,
 } from '@island.is/web/graphql/schema'
 import { GET_MULTIPLE_STATISTICS } from '@island.is/web/screens/queries/Statistics'
 
@@ -21,6 +22,7 @@ interface UseGetChartDataProps {
   numberOfDataPoints?: Chart['numberOfDataPoints']
   components: {
     sourceDataKey: string
+    interval?: Maybe<number>
   }[]
   chartType: ChartType | null
 }
@@ -36,6 +38,20 @@ export const useGetChartData = ({
     variables: {
       input: {
         sourceDataKeys: components.map((c) => c.sourceDataKey),
+        // TODO: move interval out of chart components and
+        // into chart settings, one interval to control all components.
+        // Meanwhile, let the smallest defined (if any) interval control the rest
+        interval: components.reduce((interval, component) => {
+          if (typeof component.interval !== 'number') {
+            return interval
+          }
+
+          if (typeof interval !== 'number') {
+            return component.interval
+          }
+
+          return component.interval < interval ? component.interval : interval
+        }, undefined as undefined | number),
         dateFrom: dateFrom ?? undefined,
         dateTo: dateTo ?? undefined,
         numberOfDataPoints: numberOfDataPoints ?? undefined,

--- a/apps/web/components/Charts/v2/renderers/ChartComponentRenderer.tsx
+++ b/apps/web/components/Charts/v2/renderers/ChartComponentRenderer.tsx
@@ -9,7 +9,10 @@ import {
   ChartData,
   ChartType,
 } from '../types'
-import { formatValueForPresentation } from '../utils'
+import {
+  formatPercentageForPresentation,
+  formatValueForPresentation,
+} from '../utils'
 
 interface ChartComponentRendererProps {
   component: ChartComponentWithRenderProps
@@ -78,9 +81,10 @@ const renderCustomizedLabel = ({
   outerRadius,
   innerRadius,
   payload,
+  percent,
   activeLocale,
 }: CustomLabelProps) => {
-  const radius = innerRadius + (outerRadius - innerRadius) * 1.6
+  const radius = innerRadius + (outerRadius - innerRadius) * 1.7
   const x = cx + radius * Math.cos(-midAngle * RADIAN)
   const y = cy + radius * Math.sin(-midAngle * RADIAN)
 
@@ -88,17 +92,17 @@ const renderCustomizedLabel = ({
 
   return (
     <g>
-      <text
-        x={x}
-        y={y}
-        fill="#00003C"
-        textAnchor={x > outerRadius ? 'middle' : 'end'}
-        dominantBaseline="central"
-        fontSize="12px"
-        fontWeight={500}
-      >
-        {`${value ? formatValueForPresentation(activeLocale, value) : ''}`}{' '}
-        {payload?.name?.toLowerCase()}
+      <text x={x} y={y} fill="#00003C" textAnchor="middle" fontSize="12px">
+        <tspan x={x} dy="0" fontWeight={500}>{`${
+          percent
+            ? formatPercentageForPresentation(percent)
+            : value
+            ? formatValueForPresentation(activeLocale, value)
+            : ''
+        }`}</tspan>
+        <tspan x={x} dy="1.2em">
+          {payload?.name?.toLowerCase()}
+        </tspan>
       </text>
     </g>
   )
@@ -109,7 +113,11 @@ export const renderPieChartComponents = (
   data: ChartData,
   activeLocale: Locale,
 ) => {
-  const pieData = data?.[0]?.statisticsForDate
+  const pieData = data?.[0]?.statisticsForDate ?? []
+  const total = pieData.reduce(
+    (total, { value }) => total + (value ? value : 0),
+    0,
+  )
 
   return (
     <Pie
@@ -119,25 +127,18 @@ export const renderPieChartComponents = (
       cx="50%"
       cy="50%"
       innerRadius="30%"
-      outerRadius="60%"
+      outerRadius="65%"
       label={(props) =>
         renderCustomizedLabel({
           ...props,
           activeLocale,
+          total,
         })
       }
       startAngle={90}
       endAngle={360 + 90}
     >
-      <Label
-        fontSize={24}
-        fontWeight="bold"
-        value={pieData.reduce(
-          (total, { value }) => total + (value ? value : 0),
-          0,
-        )}
-        position="center"
-      />
+      <Label fontSize={24} fontWeight="bold" value={total} position="center" />
       {components.map((c, i) => (
         <Cell
           key={i}

--- a/apps/web/components/Charts/v2/renderers/ChartNumberBox/ChartNumberBox.css.ts
+++ b/apps/web/components/Charts/v2/renderers/ChartNumberBox/ChartNumberBox.css.ts
@@ -62,7 +62,12 @@ export const value = style({
   alignItems: 'center',
   color: theme.color.blue400,
   display: 'flex',
-  fontSize: '42px',
+  fontSize: '34px',
   fontWeight: theme.typography.semiBold,
   gap: theme.spacing[1],
+  ...themeUtils.responsiveStyle({
+    lg: {
+      fontSize: '42px',
+    },
+  }),
 })

--- a/apps/web/components/Charts/v2/renderers/ChartNumberBox/ChartNumberBox.tsx
+++ b/apps/web/components/Charts/v2/renderers/ChartNumberBox/ChartNumberBox.tsx
@@ -9,7 +9,10 @@ import { useI18n } from '@island.is/web/i18n'
 import { useGetChartData } from '../../hooks'
 import { messages } from '../../messages'
 import { ChartType } from '../../types'
-import { formatValueForPresentation } from '../../utils'
+import {
+  formatPercentageForPresentation,
+  formatValueForPresentation,
+} from '../../utils'
 import * as styles from './ChartNumberBox.css'
 
 type ChartNumberBoxRendererProps = {
@@ -91,16 +94,14 @@ export const ChartNumberBox = ({ slice }: ChartNumberBoxRendererProps) => {
     >
       {boxData.map((data, index) => {
         // We assume that the data that key that is provided is a valid number
-        const value = queryResult.data?.[data.sourceDataIndex]?.[
+        const comparisonValue = queryResult.data?.[data.sourceDataIndex]?.[
           data.sourceDataKey
         ] as number
         const mostRecentValue = queryResult.data[queryResult.data.length - 1][
           data.sourceDataKey
         ] as number
 
-        const divider = index === 0 ? 1 : mostRecentValue
-
-        const result = index === 0 ? value : round(1 - value / divider, 2)
+        const change = index === 0 ? 1 : mostRecentValue / comparisonValue
 
         return (
           <div
@@ -111,19 +112,26 @@ export const ChartNumberBox = ({ slice }: ChartNumberBoxRendererProps) => {
           >
             <div className={styles.titleWrapper}>
               <h3 className={styles.title}>{data.title}</h3>
-              {index === 0 && <Tooltip text={slice.numberBoxDescription} />}
+              {index === 0 && (
+                <Tooltip
+                  text={slice.numberBoxDescription}
+                  placement={boxData.length === 1 ? 'left' : undefined}
+                />
+              )}
             </div>
             <p className={styles.value}>
-              {index > 0 && result !== 0 && (
+              {index > 0 && change !== 0 && (
                 <Icon
                   type="outline"
-                  icon={result > 0 ? 'arrowUp' : 'arrowDown'}
+                  icon={change > 1 ? 'arrowUp' : 'arrowDown'}
                 />
               )}
               <span>
                 {data.valueType === 'number'
-                  ? formatValueForPresentation(activeLocale, result)
-                  : `${Math.abs(result) * 100}%`}
+                  ? formatValueForPresentation(activeLocale, mostRecentValue)
+                  : formatPercentageForPresentation(
+                      index === 0 ? mostRecentValue : change - 1,
+                    )}
               </span>
             </p>
           </div>

--- a/apps/web/components/Charts/v2/renderers/ChartRenderer.tsx
+++ b/apps/web/components/Charts/v2/renderers/ChartRenderer.tsx
@@ -18,7 +18,7 @@ import {
   useGetChartData,
 } from '../hooks'
 import { messages } from '../messages'
-import { ChartType } from '../types'
+import { ChartType, DataItem } from '../types'
 import {
   calculateChartSkeletonLoaderHeight,
   decideChartBase,
@@ -67,7 +67,11 @@ export const Chart = ({ slice }: ChartProps) => {
     )
   }
 
-  if (!queryResult.data || queryResult.data.length === 0) {
+  const data = slice.sourceData
+    ? JSON.parse(slice.sourceData)
+    : queryResult.data ?? []
+
+  if (!data || data.length === 0) {
     return messages[activeLocale].noDataForChart
   }
 
@@ -100,15 +104,11 @@ export const Chart = ({ slice }: ChartProps) => {
       >
         <Box width="full" height="full" marginTop={2}>
           <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
-            <BaseChartComponent
-              data={queryResult.data}
-              width={400}
-              height={400}
-            >
+            <BaseChartComponent data={data} width={400} height={400}>
               {cartesianGridComponents}
               {renderLegend({
                 componentsWithAddedProps,
-                data: queryResult.data,
+                data: data,
               })}
               {renderTooltip({
                 componentsWithAddedProps,
@@ -121,7 +121,7 @@ export const Chart = ({ slice }: ChartProps) => {
               {renderChartComponents({
                 componentsWithAddedProps,
                 chartType,
-                data: queryResult.data,
+                data: data,
                 activeLocale,
               })}
             </BaseChartComponent>

--- a/apps/web/components/Charts/v2/utils/format.ts
+++ b/apps/web/components/Charts/v2/utils/format.ts
@@ -31,16 +31,18 @@ export const formatValueForPresentation = (
 
       let divider = 1
       let postfix = ''
+      let precision = 0
 
       if (reduceAndRoundValue && value >= 1e6) {
         divider = 1e6
         postfix = messages[activeLocale].millionPostfix
+        precision = 1
       } else if (reduceAndRoundValue && value >= 1e4) {
         divider = 1e3
         postfix = messages[activeLocale].thousandPostfix
       }
 
-      const v = round(value / divider, 2)
+      const v = round(value / divider, precision)
 
       return `${v.toString().replace(/\B(?=(\d{3})+(?!\d))/g, '.')}${postfix}`
     }
@@ -49,4 +51,11 @@ export const formatValueForPresentation = (
   }
 
   return possiblyRawValue?.toString()
+}
+
+export const formatPercentageForPresentation = (
+  percentage: number,
+  precision: number | undefined = undefined,
+) => {
+  return `${round(percentage * 100, precision ?? percentage < 0.1 ? 1 : 0)}%`
 }

--- a/libs/clients/statistics/src/lib/statistics.utils.ts
+++ b/libs/clients/statistics/src/lib/statistics.utils.ts
@@ -14,7 +14,6 @@ import {
   MONTH_NAMES,
 } from './statistics.constants'
 import { EnhancedFetchAPI } from '@island.is/clients/middlewares'
-import type { Unwrap } from '@island.is/shared/types'
 
 export const _tryToGetDate = (value: string | null) => {
   if (!value) {


### PR DESCRIPTION
## What

Chart Number Box:
- Fixing floating point rendering issue (28.9999997% vs 29%)
- Reducing font size for main value on small devices
- Fixed error in YoY / MoM calculation

Pie chart:
- Increasing chart size
- Improving labels

General:
- Improving formatting for number and percentages displayed in charts
- Made it possible to use the `sourceData` field to use custom data (JSON blob) rather than the statistic data source
- Connected the interval field to result filtering so it is now possible to skip every n-th entry in the results
  - _For example if you want to get 36 months of data but only show every 12th month to show difference between years_

Left for later:
- Refactor the `interval` property that is now located on `Chart Component` contentful model up and into the `Chart` model to control all components

## Why

To improve UX and DX.

## Screenshots / Gifs
Some examples

### Before / after
#### Before
![image](https://github.com/island-is/island.is/assets/6312838/d58a3ba1-bee1-435f-8350-29133a2b36b4)
_This floating point issue has been fixed_

#### After
![image](https://github.com/island-is/island.is/assets/6312838/33214b31-e29d-4867-8f4d-7a622c25c28f)
_Percentages differ from an incorrect division that has now been fixed_

#### Before
![image](https://github.com/island-is/island.is/assets/6312838/8eed10b1-f1fd-4af1-9bf9-178be56a0e22)

#### After
![image](https://github.com/island-is/island.is/assets/6312838/cc19a451-77f0-46a0-b5d8-395e22bf3d81)

#### Before
![image](https://github.com/island-is/island.is/assets/6312838/3d5b2fc9-e996-46a9-9301-fff9de25684d)

#### After
![image](https://github.com/island-is/island.is/assets/6312838/f166934d-e7ed-43c7-8196-a09d638bc806)
_Reduced font size on mobile and an example of formatting change, not showing such precision unless we have a low number_

#### Before
![image](https://github.com/island-is/island.is/assets/6312838/ff984187-e6ee-4cb0-89d2-d07abe9b4efe)
_Using the interval field (=12) in Contentful with 24 months of data but nothing happens_

#### After
![image](https://github.com/island-is/island.is/assets/6312838/4c60003f-1e3b-4f63-90ac-7288fa92a29b)
_Interval fields (=12) now skips everything but the `i % 12 === 0` entries_

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
