### PR TITLE
fix(web): Use flex-end instead of end for SAk header css

### DIFF
--- a/apps/web/components/Organization/Wrapper/Themes/SAkTheme/SAkHeader.css.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/SAkTheme/SAkHeader.css.ts
@@ -88,7 +88,7 @@ export const titleWrapper = style({
   ...themeUtils.responsiveStyle({
     lg: {
       display: 'flex',
-      justifyContent: 'end',
+      justifyContent: 'flex-end',
     },
   }),
 })


### PR DESCRIPTION
# Use flex-end instead of end for SAk header css

## What

* I saw a warning in the terminal when running web locally

## Screenshots / Gifs
![image](https://github.com/island-is/island.is/assets/43557895/4323d05d-dc3b-4089-a7e9-4b5e589b81c3)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
