### PR TITLE
fix(application-estate): Comparison for finding correct estate on submit

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/estate/estate.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/estate/estate.service.ts
@@ -201,7 +201,9 @@ export class EstateTemplateService extends BaseTemplateApiService {
     const uploadDataId = 'danarbusskipti1.0'
     const answers = application.answers as unknown as EstateSchema
 
-    let estateData = externalData.estates?.find((estate) => estate.caseNumber)
+    let estateData = externalData.estates?.find(
+      (estate) => estate.caseNumber === answers.estateInfoSelection,
+    )
     // TODO: Remove the singular estate property in the future when
     //       legacy applications clear out of the system
     estateData = estateData ?? externalData.estate ?? undefined


### PR DESCRIPTION
A whoopsie. Need to find by estateInfoSelection. Was just selecting the first one since the find was evaluating `Boolean(estate.caseNumber)`.

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
