### PR TITLE
fix(web): Ignore query params when redirecting

### DIFF
--- a/apps/web/pages/_error.tsx
+++ b/apps/web/pages/_error.tsx
@@ -1,19 +1,20 @@
 import React from 'react'
 import type { GetServerSidePropsContext, NextPageContext } from 'next'
 import { ApolloClient, NormalizedCacheObject } from '@apollo/client'
+
 import {
   ErrorPageQuery,
   ErrorPageQueryVariables,
   GetUrlQuery,
   GetUrlQueryVariables,
 } from '../graphql/schema'
+import withApollo from '../graphql/withApollo'
+import { linkResolver, LinkType } from '../hooks'
+import { getLocaleFromPath } from '../i18n'
+import I18n from '../i18n/I18n'
 import Layout, { LayoutProps } from '../layouts/main'
 import { ErrorScreen } from '../screens/Error'
-import { getLocaleFromPath } from '../i18n'
 import { GET_ERROR_PAGE, GET_URL_QUERY } from '../screens/queries'
-import { LinkType, linkResolver } from '../hooks'
-import withApollo from '../graphql/withApollo'
-import I18n from '../i18n/I18n'
 
 type ErrorPageProps = {
   statusCode: number
@@ -70,6 +71,7 @@ class ErrorPage extends React.Component<ErrorPageProps> {
         .replace(/\/\/+/g, '/')
         .replace(/\/+$/, '')
         .toLowerCase()
+        .split('?')[0]
 
       const redirectProps = await props.apolloClient.query<
         GetUrlQuery,


### PR DESCRIPTION
# Ignore query params when redirecting

## What

* https://island.is/grindavik redirects to https://island.is/v/fyrir-grindavik
* https://island.is/grindavik?fbclid=123 doesn't get redirected and displays a 404 page

https://islandis.slack.com/archives/C01C7C3M2J3/p1706530493554269

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
