### PR TITLE
feat(search-indexer): Fallback to using organization.slug for organizationPage.slug

### DIFF
--- a/libs/cms/src/lib/models/organizationPage.model.ts
+++ b/libs/cms/src/lib/models/organizationPage.model.ts
@@ -74,7 +74,7 @@ export const mapOrganizationPage = ({
 }: IOrganizationPage): OrganizationPage => ({
   id: sys.id,
   title: fields.title ?? '',
-  slug: fields.slug ?? '',
+  slug: fields.slug ?? fields.organization?.fields?.slug ?? '',
   description: fields.description ?? '',
   theme: fields.theme ?? 'default',
   themeProperties: mapOrganizationTheme(fields.themeProperties ?? {}),

--- a/libs/cms/src/lib/models/organizationPage.model.ts
+++ b/libs/cms/src/lib/models/organizationPage.model.ts
@@ -74,7 +74,7 @@ export const mapOrganizationPage = ({
 }: IOrganizationPage): OrganizationPage => ({
   id: sys.id,
   title: fields.title ?? '',
-  slug: fields.slug ?? fields.organization?.fields?.slug ?? '',
+  slug: (fields.slug || fields.organization?.fields?.slug) ?? '',
   description: fields.description ?? '',
   theme: fields.theme ?? 'default',
   themeProperties: mapOrganizationTheme(fields.themeProperties ?? {}),


### PR DESCRIPTION
# Fallback to using organization.slug for organizationPage.slug

## What

* It's always bothered me that we have an organizationPage.slug and an organization.slug that often are the same but when they are not weird things might happen
* This PR suggests that we fallback to using the organization.slug

## Why

* So that newer organization pages don't need to define a slug and will derive it from the organization content type

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
