### PR TITLE
fix(consultation-portal): KAM-2095: await ctx (#13631)

### DIFF
--- a/apps/consultation-portal/pages/mal/[slug].tsx
+++ b/apps/consultation-portal/pages/mal/[slug].tsx
@@ -30,6 +30,10 @@ export default withApollo(CaseDetails)
 
 export const getServerSideProps = async (ctx) => {
   const client = initApollo()
+  const id = parseInt(await ctx.query.slug)
+
+  if (!id) console.error('id is not a number', id)
+
   try {
     const [
       {
@@ -40,7 +44,7 @@ export const getServerSideProps = async (ctx) => {
         query: CASE_GET_CASE_BY_ID,
         variables: {
           input: {
-            caseId: parseInt(ctx.query['slug']),
+            caseId: id,
           },
         },
       }),
@@ -49,7 +53,7 @@ export const getServerSideProps = async (ctx) => {
     return {
       props: {
         case: consultationPortalCaseById,
-        caseId: parseInt(ctx.query['slug']),
+        caseId: id,
         is500: false,
       },
     }


### PR DESCRIPTION
# slug is sometimes null in serversideprops

https://veflausnir.atlassian.net/browse/KAM-2095
https://github.com/island-is/island.is/pull/13631

## What

Sometimes when serversideprops is fetching data, the ctx.query.slug is null, so we will try to await the ctx.query.slug
We will also console.error the id just in case

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
