### PR TITLE
fix(consultation-portal): KAM-2095: Check if id is a number before qu…

### DIFF
--- a/apps/consultation-portal/pages/mal/[slug].tsx
+++ b/apps/consultation-portal/pages/mal/[slug].tsx
@@ -13,6 +13,8 @@ interface CaseProps {
   is500: boolean
 }
 
+const isNumber = (str: string) => /^\d+$/.test(str)
+
 const CaseDetails: React.FC<React.PropsWithChildren<CaseProps>> = ({
   case: Case,
   caseId,
@@ -30,9 +32,17 @@ export default withApollo(CaseDetails)
 
 export const getServerSideProps = async (ctx) => {
   const client = initApollo()
-  const id = parseInt(await ctx.query.slug)
 
-  if (!id) console.error('id is not a number', id)
+  if (!isNumber(ctx.query.slug))
+    return {
+      props: {
+        case: null,
+        caseId: null,
+        is500: true,
+      },
+    }
+
+  const id = parseInt(ctx.query.slug)
 
   try {
     const [


### PR DESCRIPTION
…erying the API (#13644)

# Check if id is a number before querying the API

https://veflausnir.atlassian.net/browse/KAM-2095
https://github.com/island-is/island.is/pull/13644

## What

Check if the id from the slug is a number before querying the api

## Why

Google bots were trying to access pages here: https://www.google.com/search?q=samradsgatt.island.is+filetype%3Apdf and tried to use the id for mal => https://island.is/samradsgatt/c13fbf57-f69e-ec11-9baf-005056bcce7e which would result in querying the api with the id c13fbf57-f69e-ec11-9baf-005056bcce7e which should only be an integer

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
