### PR TITLE
fix(parental-leave): Fixed dataschema validation

### DIFF
--- a/libs/application/templates/parental-leave/src/lib/dataSchema.ts
+++ b/libs/application/templates/parental-leave/src/lib/dataSchema.ts
@@ -119,12 +119,16 @@ export const dataSchema = z.object({
         },
         { params: errorMessages.bank },
       ),
-      useUnion: z.enum([YES, NO]),
-      usePrivatePensionFund: z.enum([YES, NO]),
-      pensionFund: z.string(),
+      useUnion: z.enum([YES, NO]).optional(),
+      usePrivatePensionFund: z.enum([YES, NO]).optional(),
+      pensionFund: z.string().optional(),
       privatePensionFund: z.string().optional(),
       privatePensionFundPercentage: z.enum(['0', '2', '4', '']).optional(),
       union: z.string().optional(),
+    })
+    .refine((p) => ('pensionFund' in p ? !!p.pensionFund : true), {
+      path: ['pensionFund'],
+      params: coreErrorMessages.missingAnswer,
     })
     .refine(
       ({ useUnion, union }) =>
@@ -202,6 +206,7 @@ export const dataSchema = z.object({
           : true,
       { path: ['unemploymentBenefits'] },
     ),
+  employerLastSixMonths: z.enum([YES, NO]),
   requestRights: z.object({
     isRequestingRights: z.enum([YES, NO]),
     requestDays: z


### PR DESCRIPTION
Validation failed when parental grant application, should not be validated
- `useUnion` 
- `usePrivatePensionFund`
- `pensionFund`

Required
- `employerLastSixMonths`

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
