### PR TITLE
fix(clients-statistics): Update stale-while-revalidate lifetime to 14 days so we can use cache.

### DIFF
--- a/apps/api/infra/api.ts
+++ b/apps/api/infra/api.ts
@@ -251,7 +251,6 @@ export const serviceSetup = (services: {
       UNIVERSITY_GATEWAY_API_URL: ref(
         (h) => `http://${h.svc(services.universityGatewayApi)}`,
       ),
-      ENHANCED_FETCH_DEBUG_CACHE: 'clients-statistics',
     })
 
     .secrets({

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -284,7 +284,6 @@ api:
     ELASTIC_NODE: 'https://vpc-search-njkekqydiegezhr4vqpkfnw5la.eu-west-1.es.amazonaws.com'
     ELECTRONIC_REGISTRATION_STATISTICS_API_URL: 'https://api-staging.thinglysing.is/business/tolfraedi'
     ENDORSEMENT_SYSTEM_BASE_API_URL: 'http://web-endorsement-system-api.endorsement-system.svc.cluster.local'
-    ENHANCED_FETCH_DEBUG_CACHE: 'clients-statistics'
     FILE_DOWNLOAD_BUCKET: 'island-is-dev-download-cache-api'
     FILE_STORAGE_UPLOAD_BUCKET: 'island-is-dev-upload-api'
     FINANCIAL_STATEMENTS_INAO_BASE_PATH: 'https://dev-re.crm4.dynamics.com/api/data/v9.1'

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -274,7 +274,6 @@ api:
     ELASTIC_NODE: 'https://vpc-search-mw4w5c2m2g5edjrtvwbpzhkw24.eu-west-1.es.amazonaws.com/'
     ELECTRONIC_REGISTRATION_STATISTICS_API_URL: 'https://api.thinglysing.is/business/tolfraedi'
     ENDORSEMENT_SYSTEM_BASE_API_URL: 'http://web-endorsement-system-api.endorsement-system.svc.cluster.local'
-    ENHANCED_FETCH_DEBUG_CACHE: 'clients-statistics'
     FILE_DOWNLOAD_BUCKET: 'island-is-prod-download-cache-api'
     FILE_STORAGE_UPLOAD_BUCKET: 'island-is-prod-upload-api'
     FINANCIAL_STATEMENTS_INAO_BASE_PATH: 'https://star-re.crm4.dynamics.com/api/data/v9.1'

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -284,7 +284,6 @@ api:
     ELASTIC_NODE: 'https://vpc-search-q6hdtjcdlhkffyxvrnmzfwphuq.eu-west-1.es.amazonaws.com/'
     ELECTRONIC_REGISTRATION_STATISTICS_API_URL: 'https://api-staging.thinglysing.is/business/tolfraedi'
     ENDORSEMENT_SYSTEM_BASE_API_URL: 'http://web-endorsement-system-api.endorsement-system.svc.cluster.local'
-    ENHANCED_FETCH_DEBUG_CACHE: 'clients-statistics'
     FILE_DOWNLOAD_BUCKET: 'island-is-staging-download-cache-api'
     FILE_STORAGE_UPLOAD_BUCKET: 'island-is-staging-upload-api'
     FINANCIAL_STATEMENTS_INAO_BASE_PATH: 'https://dev-re.crm4.dynamics.com/api/data/v9.1'

--- a/libs/clients/statistics/src/lib/fetchConfig.ts
+++ b/libs/clients/statistics/src/lib/fetchConfig.ts
@@ -35,7 +35,7 @@ const fetchFactory = async (
       overrideCacheControl: () =>
         buildCacheControl({
           maxAge: config.redis.cacheTtl / 1000, // cacheTtl is in milliseconds
-          staleWhileRevalidate: 3600 * 24, // 1 day
+          staleWhileRevalidate: 3600 * 24 * 14, // 14 days
           staleIfError: 3600 * 24 * 30, // 1 month
           public: true,
         }),


### PR DESCRIPTION
## What

Make stale-while-revalidate valid for 2 weeks so if the site receives a visit once every 2 weeks we should have data in cache.
Remove enhanced fetch debug log env variable.

## Why

To configure caching for prod.
Debugging is done so turnoff to remove log noice.

## Screenshots / Gifs


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
