### PR TITLE
chore(Codeowners): Remove Core as Codeowner of **/infra changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -334,7 +334,7 @@ libs/clients/rsk/relationships/                                                 
 /apps/reference-backend/                                                                                 @island-is/devops
 /apps/github-actions-cache/                                                                              @island-is/devops
 /infra/                                                                                                  @island-is/devops
-**/infra/                                                                                                @island-is/devops @island-is/core
+**/infra/                                                                                                @island-is/devops
 /libs/logging/                                                                                           @island-is/devops
 /scripts/                                                                                                @island-is/devops
 /scripts/postinstall.js                                                                                  @island-is/devops @island-is/core


### PR DESCRIPTION
## What

Removing the Core team as Codeowner of `**/infra` changes

## Why

Those always require devops review due to changed charts so unnecessary to require Core as well.

## Screenshots / Gifs

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
