### PR TITLE
fix(core): Update @nestjs/sequelize to v10 to match our major NestJS version. Patch nestjs/terminus.

### DIFF
--- a/.yarn/patches/@nestjs-terminus-npm-10.2.0-9e24c129e0.patch
+++ b/.yarn/patches/@nestjs-terminus-npm-10.2.0-9e24c129e0.patch
@@ -1,0 +1,12 @@
+diff --git a/dist/health-indicator/database/sequelize.health.js b/dist/health-indicator/database/sequelize.health.js
+index f34c37b6d2b8d9b2f0ba2b6fbe1ef7bc4b8da389..c664fc1070337090de44833e83549c995943d9de 100644
+--- a/dist/health-indicator/database/sequelize.health.js
++++ b/dist/health-indicator/database/sequelize.health.js
+@@ -41,7 +41,6 @@ let SequelizeHealthIndicator = class SequelizeHealthIndicator extends health_ind
+     constructor(moduleRef) {
+         super();
+         this.moduleRef = moduleRef;
+-        this.checkDependantPackages();
+     }
+     /**
+      * Checks if the dependant packages are present

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "@nestjs/jwt": "8.0.1",
     "@nestjs/passport": "8.2.2",
     "@nestjs/platform-express": "10.0.5",
-    "@nestjs/sequelize": "9.0.2",
+    "@nestjs/sequelize": "10.0.0",
     "@nestjs/swagger": "7.1.1",
     "@nestjs/terminus": "10.2.0",
     "@react-pdf/renderer": "^3.1.9",
@@ -476,7 +476,8 @@
     "cache-manager-ioredis-yet@1.1.0": "patch:cache-manager-ioredis-yet@npm%3A1.1.0#./.yarn/patches/cache-manager-ioredis-yet-npm-1.1.0-da7d1a9865.patch",
     "dd-trace@3.32.1": "patch:dd-trace@npm%3A3.32.1#./.yarn/patches/dd-trace-npm-3.29.1-4e4e5d3a0c.patch",
     "jest-config": "patch:jest-config@npm%3A29.7.0#./.yarn/patches/jest-config-npm-29.7.0-97d8544d74.patch",
-    "geoip-lite@1.4.7": "patch:geoip-lite@npm%3A1.4.7#./.yarn/patches/geoip-lite-npm-1.4.7-e0ef6cefb0.patch"
+    "geoip-lite@1.4.7": "patch:geoip-lite@npm%3A1.4.7#./.yarn/patches/geoip-lite-npm-1.4.7-e0ef6cefb0.patch",
+    "@nestjs/terminus@10.2.0": "patch:@nestjs/terminus@npm%3A10.2.0#./.yarn/patches/@nestjs-terminus-npm-10.2.0-9e24c129e0.patch"
   },
   "volta": {
     "node": "18.16.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11557,19 +11557,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nestjs/sequelize@npm:9.0.2":
-  version: 9.0.2
-  resolution: "@nestjs/sequelize@npm:9.0.2"
+"@nestjs/sequelize@npm:10.0.0":
+  version: 10.0.0
+  resolution: "@nestjs/sequelize@npm:10.0.0"
   dependencies:
     uuid: 9.0.0
   peerDependencies:
-    "@nestjs/common": ^8.0.0 || ^9.0.0
-    "@nestjs/core": ^8.0.0 || ^9.0.0
+    "@nestjs/common": ^8.0.0 || ^9.0.0 || ^10.0.0
+    "@nestjs/core": ^8.0.0 || ^9.0.0 || ^10.0.0
     reflect-metadata: ^0.1.13
     rxjs: ^7.2.0
     sequelize: ^6.3.5
     sequelize-typescript: ^2.0.0
-  checksum: f7d6aaf257619b502cab0eac5cd45b554a2c3eed2bfd511b4ac24621f949f600bd58ca236b8de1e864d8c4ac07fa80aabded98c16b263612306e5d00b4450e1e
+  checksum: b1fdb54d2cbeac1080419bdd00fba45798d40938c7b5ee1a2c4f805d260b9b5aa15ec8e7e979ecffea11809199044b179e2045849772a26ec80f0badbe3ea478
   languageName: node
   linkType: hard
 
@@ -11652,6 +11652,61 @@ __metadata:
     typeorm:
       optional: true
   checksum: 16e060b56d4e655ba80a397cf45727a15df4537ab1531e1a1b54be02ff0f03c1101904c68783d9dfbd284fff464131677a8f3989b54bff620edcdfdb99b36adc
+  languageName: node
+  linkType: hard
+
+"@nestjs/terminus@patch:@nestjs/terminus@npm%3A10.2.0#./.yarn/patches/@nestjs-terminus-npm-10.2.0-9e24c129e0.patch::locator=island.is%40workspace%3A.":
+  version: 10.2.0
+  resolution: "@nestjs/terminus@patch:@nestjs/terminus@npm%3A10.2.0#./.yarn/patches/@nestjs-terminus-npm-10.2.0-9e24c129e0.patch::version=10.2.0&hash=293b8c&locator=island.is%40workspace%3A."
+  dependencies:
+    boxen: 5.1.2
+    check-disk-space: 3.4.0
+  peerDependencies:
+    "@grpc/grpc-js": "*"
+    "@grpc/proto-loader": "*"
+    "@mikro-orm/core": "*"
+    "@mikro-orm/nestjs": "*"
+    "@nestjs/axios": ^1.0.0 || ^2.0.0 || ^3.0.0
+    "@nestjs/common": ^9.0.0 || ^10.0.0
+    "@nestjs/core": ^9.0.0 || ^10.0.0
+    "@nestjs/microservices": ^9.0.0 || ^10.0.0
+    "@nestjs/mongoose": ^9.0.0 || ^10.0.0
+    "@nestjs/sequelize": ^9.0.0 || ^10.0.0
+    "@nestjs/typeorm": ^9.0.0 || ^10.0.0
+    "@prisma/client": "*"
+    mongoose: "*"
+    reflect-metadata: 0.1.x
+    rxjs: 7.x
+    sequelize: "*"
+    typeorm: "*"
+  peerDependenciesMeta:
+    "@grpc/grpc-js":
+      optional: true
+    "@grpc/proto-loader":
+      optional: true
+    "@mikro-orm/core":
+      optional: true
+    "@mikro-orm/nestjs":
+      optional: true
+    "@nestjs/axios":
+      optional: true
+    "@nestjs/microservices":
+      optional: true
+    "@nestjs/mongoose":
+      optional: true
+    "@nestjs/sequelize":
+      optional: true
+    "@nestjs/typeorm":
+      optional: true
+    "@prisma/client":
+      optional: true
+    mongoose:
+      optional: true
+    sequelize:
+      optional: true
+    typeorm:
+      optional: true
+  checksum: 9a9f4351c14c1b663ffd528620764fb2a125c2b9c0532caeb59e1c3509496bb1f7bc929da729eade12dcbfdc11d36312ea0376e5755861d690c55320e93a900d
   languageName: node
   linkType: hard
 
@@ -33767,7 +33822,7 @@ __metadata:
     "@nestjs/passport": 8.2.2
     "@nestjs/platform-express": 10.0.5
     "@nestjs/schematics": 10.0.1
-    "@nestjs/sequelize": 9.0.2
+    "@nestjs/sequelize": 10.0.0
     "@nestjs/swagger": 7.1.1
     "@nestjs/terminus": 10.2.0
     "@nestjs/testing": 10.0.5


### PR DESCRIPTION
## What

* Update @nestjs/sequelize package to mach NestJS major version.
* Yarn patch @nestjs/terminus package to remove `checkDependantPackages` check which is failing for `SequelizeHealthIndicator` due to the nestjs/sequelize and sequelize packages being bundled in main.js.

## Why

To fix bundled production builds.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
