### PR TITLE
chore(auth-apis): Auth APIs readiness health check

### DIFF
--- a/.yarn/patches/@nestjs-terminus-npm-10.2.0-9e24c129e0.patch
+++ b/.yarn/patches/@nestjs-terminus-npm-10.2.0-9e24c129e0.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/health-indicator/database/sequelize.health.js b/dist/health-indicator/database/sequelize.health.js
-index f34c37b6d2b8d9b2f0ba2b6fbe1ef7bc4b8da389..c664fc1070337090de44833e83549c995943d9de 100644
+index f34c37b6d2b8d9b2f0ba2b6fbe1ef7bc4b8da389..90265aa07914c626d4fd068287004d780f4564cd 100644
 --- a/dist/health-indicator/database/sequelize.health.js
 +++ b/dist/health-indicator/database/sequelize.health.js
 @@ -41,7 +41,6 @@ let SequelizeHealthIndicator = class SequelizeHealthIndicator extends health_ind
@@ -10,3 +10,11 @@ index f34c37b6d2b8d9b2f0ba2b6fbe1ef7bc4b8da389..c664fc1070337090de44833e83549c99
      }
      /**
       * Checks if the dependant packages are present
+@@ -89,7 +88,6 @@ let SequelizeHealthIndicator = class SequelizeHealthIndicator extends health_ind
+     pingCheck(key, options = {}) {
+         return __awaiter(this, void 0, void 0, function* () {
+             let isHealthy = false;
+-            this.checkDependantPackages();
+             const connection = options.connection || this.getContextConnection();
+             const timeout = options.timeout || 1000;
+             if (!connection) {

--- a/apps/services/auth/admin-api/infra/auth-admin-api.ts
+++ b/apps/services/auth/admin-api/infra/auth-admin-api.ts
@@ -54,7 +54,7 @@ export const serviceSetup = (): ServiceBuilder<'services-auth-admin-api'> => {
         },
       },
     })
-    .readiness('/backend/liveness')
+    .readiness('/backend/health/check')
     .liveness('/backend/liveness')
     .resources({
       limits: {

--- a/apps/services/auth/delegation-api/infra/delegation-api.ts
+++ b/apps/services/auth/delegation-api/infra/delegation-api.ts
@@ -55,7 +55,7 @@ export const serviceSetup =
           '/k8s/xroad/client/NATIONAL-REGISTRY/IDENTITYSERVER_SECRET',
       })
       .xroad(Base, Client, RskProcuring)
-      .readiness('/liveness')
+      .readiness('/health/check')
       .liveness('/liveness')
       .replicaCount({
         default: 2,

--- a/apps/services/auth/ids-api/infra/ids-api.ts
+++ b/apps/services/auth/ids-api/infra/ids-api.ts
@@ -96,7 +96,7 @@ export const serviceSetup = (): ServiceBuilder<'services-auth-ids-api'> => {
       NOVA_PASSWORD: '/k8s/services-auth/NOVA_PASSWORD',
     })
     .xroad(Base, Client, RskProcuring)
-    .readiness('/liveness')
+    .readiness('/health/check')
     .liveness('/liveness')
     .initContainer({
       postgres: postgresInfo,

--- a/apps/services/auth/personal-representative-public/infra/personal-representative-public.ts
+++ b/apps/services/auth/personal-representative-public/infra/personal-representative-public.ts
@@ -38,7 +38,7 @@ export const serviceSetup =
           public: true,
         },
       })
-      .readiness('/liveness')
+      .readiness('/health/check')
       .liveness('/liveness')
       .resources({
         limits: {

--- a/apps/services/auth/personal-representative/infra/personal-representative.ts
+++ b/apps/services/auth/personal-representative/infra/personal-representative.ts
@@ -38,7 +38,7 @@ export const serviceSetup =
           public: true,
         },
       })
-      .readiness('/liveness')
+      .readiness('/health/check')
       .liveness('/liveness')
       .resources({
         limits: {

--- a/apps/services/auth/public-api/infra/auth-public-api.ts
+++ b/apps/services/auth/public-api/infra/auth-public-api.ts
@@ -97,7 +97,7 @@ export const serviceSetup = (): ServiceBuilder<'services-auth-public-api'> => {
         },
       },
     })
-    .readiness('/liveness')
+    .readiness('/health/check')
     .liveness('/liveness')
     .replicaCount({
       default: 2,

--- a/charts/identity-server/values.dev.yaml
+++ b/charts/identity-server/values.dev.yaml
@@ -230,7 +230,7 @@ services-auth-admin-api:
       timeoutSeconds: 3
     readiness:
       initialDelaySeconds: 3
-      path: '/backend/liveness'
+      path: '/backend/health/check'
       timeoutSeconds: 3
   hpa:
     scaling:
@@ -307,7 +307,7 @@ services-auth-delegation-api:
       timeoutSeconds: 3
     readiness:
       initialDelaySeconds: 3
-      path: '/liveness'
+      path: '/health/check'
       timeoutSeconds: 3
   hpa:
     scaling:
@@ -389,7 +389,7 @@ services-auth-ids-api:
       timeoutSeconds: 3
     readiness:
       initialDelaySeconds: 3
-      path: '/liveness'
+      path: '/health/check'
       timeoutSeconds: 3
   hpa:
     scaling:
@@ -482,7 +482,7 @@ services-auth-personal-representative:
       timeoutSeconds: 3
     readiness:
       initialDelaySeconds: 3
-      path: '/liveness'
+      path: '/health/check'
       timeoutSeconds: 3
   hpa:
     scaling:
@@ -551,7 +551,7 @@ services-auth-personal-representative-public:
       timeoutSeconds: 3
     readiness:
       initialDelaySeconds: 3
-      path: '/liveness'
+      path: '/health/check'
       timeoutSeconds: 3
   hpa:
     scaling:
@@ -638,7 +638,7 @@ services-auth-public-api:
       timeoutSeconds: 3
     readiness:
       initialDelaySeconds: 3
-      path: '/liveness'
+      path: '/health/check'
       timeoutSeconds: 3
   hpa:
     scaling:

--- a/charts/identity-server/values.prod.yaml
+++ b/charts/identity-server/values.prod.yaml
@@ -227,7 +227,7 @@ services-auth-admin-api:
       timeoutSeconds: 3
     readiness:
       initialDelaySeconds: 3
-      path: '/backend/liveness'
+      path: '/backend/health/check'
       timeoutSeconds: 3
   hpa:
     scaling:
@@ -304,7 +304,7 @@ services-auth-delegation-api:
       timeoutSeconds: 3
     readiness:
       initialDelaySeconds: 3
-      path: '/liveness'
+      path: '/health/check'
       timeoutSeconds: 3
   hpa:
     scaling:
@@ -386,7 +386,7 @@ services-auth-ids-api:
       timeoutSeconds: 3
     readiness:
       initialDelaySeconds: 3
-      path: '/liveness'
+      path: '/health/check'
       timeoutSeconds: 3
   hpa:
     scaling:
@@ -479,7 +479,7 @@ services-auth-personal-representative:
       timeoutSeconds: 3
     readiness:
       initialDelaySeconds: 3
-      path: '/liveness'
+      path: '/health/check'
       timeoutSeconds: 3
   hpa:
     scaling:
@@ -540,7 +540,7 @@ services-auth-personal-representative-public:
       timeoutSeconds: 3
     readiness:
       initialDelaySeconds: 3
-      path: '/liveness'
+      path: '/health/check'
       timeoutSeconds: 3
   hpa:
     scaling:
@@ -627,7 +627,7 @@ services-auth-public-api:
       timeoutSeconds: 3
     readiness:
       initialDelaySeconds: 3
-      path: '/liveness'
+      path: '/health/check'
       timeoutSeconds: 3
   hpa:
     scaling:

--- a/charts/identity-server/values.staging.yaml
+++ b/charts/identity-server/values.staging.yaml
@@ -230,7 +230,7 @@ services-auth-admin-api:
       timeoutSeconds: 3
     readiness:
       initialDelaySeconds: 3
-      path: '/backend/liveness'
+      path: '/backend/health/check'
       timeoutSeconds: 3
   hpa:
     scaling:
@@ -307,7 +307,7 @@ services-auth-delegation-api:
       timeoutSeconds: 3
     readiness:
       initialDelaySeconds: 3
-      path: '/liveness'
+      path: '/health/check'
       timeoutSeconds: 3
   hpa:
     scaling:
@@ -389,7 +389,7 @@ services-auth-ids-api:
       timeoutSeconds: 3
     readiness:
       initialDelaySeconds: 3
-      path: '/liveness'
+      path: '/health/check'
       timeoutSeconds: 3
   hpa:
     scaling:
@@ -482,7 +482,7 @@ services-auth-personal-representative:
       timeoutSeconds: 3
     readiness:
       initialDelaySeconds: 3
-      path: '/liveness'
+      path: '/health/check'
       timeoutSeconds: 3
   hpa:
     scaling:
@@ -543,7 +543,7 @@ services-auth-personal-representative-public:
       timeoutSeconds: 3
     readiness:
       initialDelaySeconds: 3
-      path: '/liveness'
+      path: '/health/check'
       timeoutSeconds: 3
   hpa:
     scaling:
@@ -630,7 +630,7 @@ services-auth-public-api:
       timeoutSeconds: 3
     readiness:
       initialDelaySeconds: 3
-      path: '/liveness'
+      path: '/health/check'
       timeoutSeconds: 3
   hpa:
     scaling:

--- a/yarn.lock
+++ b/yarn.lock
@@ -11657,7 +11657,7 @@ __metadata:
 
 "@nestjs/terminus@patch:@nestjs/terminus@npm%3A10.2.0#./.yarn/patches/@nestjs-terminus-npm-10.2.0-9e24c129e0.patch::locator=island.is%40workspace%3A.":
   version: 10.2.0
-  resolution: "@nestjs/terminus@patch:@nestjs/terminus@npm%3A10.2.0#./.yarn/patches/@nestjs-terminus-npm-10.2.0-9e24c129e0.patch::version=10.2.0&hash=293b8c&locator=island.is%40workspace%3A."
+  resolution: "@nestjs/terminus@patch:@nestjs/terminus@npm%3A10.2.0#./.yarn/patches/@nestjs-terminus-npm-10.2.0-9e24c129e0.patch::version=10.2.0&hash=aeebab&locator=island.is%40workspace%3A."
   dependencies:
     boxen: 5.1.2
     check-disk-space: 3.4.0
@@ -11706,7 +11706,7 @@ __metadata:
       optional: true
     typeorm:
       optional: true
-  checksum: 9a9f4351c14c1b663ffd528620764fb2a125c2b9c0532caeb59e1c3509496bb1f7bc929da729eade12dcbfdc11d36312ea0376e5755861d690c55320e93a900d
+  checksum: e7d412de26628e132bb255e89744ccd4bad72468a1b8247c77e4f556a959e26db2d4f72474c0b799ad5fcd87d79a92b678996aca665b941e01556803d499ee39
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

* Remove `checkDependentPackages` also called during runtime in `pingCheck` and crashed the apis due to it not finding packages and aggressively calling process.exit(1).
* Add `/health/check` route as the readiness probe for all the Auth APIs.

## Why

To test if propper readiness indicator indicating that the services can query the db helps stabalizing APIs during auto scaling.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
