### PR TITLE
fix(web): Make sure that subarticle entry hyperlink href starts with a slash

### DIFF
--- a/libs/island-ui/contentful/src/lib/RichTextRC/defaultRenderNode.tsx
+++ b/libs/island-ui/contentful/src/lib/RichTextRC/defaultRenderNode.tsx
@@ -237,6 +237,12 @@ export const defaultRenderNodeObject: RenderNode = {
         if (parentSlug) {
           href = `${parentSlug}/${entry?.fields.url?.split('/')?.pop() ?? ''}`
         }
+
+        // Make sure that the href start with a slash
+        if (href && !href.startsWith('/')) {
+          href = `/${href}`
+        }
+
         return href ? <Hyperlink href={href}>{children}</Hyperlink> : null
       }
       case 'organizationPage': {

--- a/libs/island-ui/contentful/src/lib/RichTextRC/defaultRenderNode.tsx
+++ b/libs/island-ui/contentful/src/lib/RichTextRC/defaultRenderNode.tsx
@@ -238,7 +238,7 @@ export const defaultRenderNodeObject: RenderNode = {
           href = `${parentSlug}/${entry?.fields.url?.split('/')?.pop() ?? ''}`
         }
 
-        // Make sure that the href start with a slash
+        // Make sure that the href starts with a slash
         if (href && !href.startsWith('/')) {
           href = `/${href}`
         }


### PR DESCRIPTION
# Make sure that subarticle entry hyperlink href starts with a slash

## Why

* Otherwise the link ends up being /[slug]/something/something-else

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
