### PR TITLE
chore(infra): Tune down PDB strictness

### DIFF
--- a/charts/identity-server/values.dev.yaml
+++ b/charts/identity-server/values.dev.yaml
@@ -52,7 +52,7 @@ auth-admin-web:
             - '/admin'
   namespace: 'identity-server-admin'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   progressDeadlineSeconds: 1200
   pvcs: []
   replicaCount:
@@ -156,7 +156,7 @@ identity-server:
             - '/'
   namespace: 'identity-server'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs:
@@ -254,7 +254,7 @@ services-auth-admin-api:
             - '/backend'
   namespace: 'identity-server-admin'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -330,7 +330,7 @@ services-auth-delegation-api:
             - '/'
   namespace: 'identity-server-delegation'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -440,7 +440,7 @@ services-auth-ids-api:
       DB_PASS: '/k8s/services-auth/api/DB_PASSWORD'
   namespace: 'identity-server'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -513,7 +513,7 @@ services-auth-personal-representative:
             - '/'
   namespace: 'personal-representative'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -582,7 +582,7 @@ services-auth-personal-representative-public:
             - '/'
   namespace: 'personal-representative'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -665,7 +665,7 @@ services-auth-public-api:
             - '/api(/|$)(.*)'
   namespace: 'identity-server-admin'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2

--- a/charts/identity-server/values.prod.yaml
+++ b/charts/identity-server/values.prod.yaml
@@ -50,7 +50,7 @@ auth-admin-web:
             - '/admin'
   namespace: 'identity-server-admin'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   progressDeadlineSeconds: 1200
   pvcs: []
   replicaCount:
@@ -153,7 +153,7 @@ identity-server:
             - '/'
   namespace: 'identity-server'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs:
@@ -251,7 +251,7 @@ services-auth-admin-api:
             - '/backend'
   namespace: 'identity-server-admin'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -327,7 +327,7 @@ services-auth-delegation-api:
             - '/'
   namespace: 'identity-server-delegation'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -437,7 +437,7 @@ services-auth-ids-api:
       DB_PASS: '/k8s/services-auth/api/DB_PASSWORD'
   namespace: 'identity-server'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -502,7 +502,7 @@ services-auth-personal-representative:
             - '/'
   namespace: 'personal-representative'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -571,7 +571,7 @@ services-auth-personal-representative-public:
             - '/'
   namespace: 'personal-representative'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -654,7 +654,7 @@ services-auth-public-api:
             - '/api(/|$)(.*)'
   namespace: 'identity-server-admin'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2

--- a/charts/identity-server/values.staging.yaml
+++ b/charts/identity-server/values.staging.yaml
@@ -52,7 +52,7 @@ auth-admin-web:
             - '/admin'
   namespace: 'identity-server-admin'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   progressDeadlineSeconds: 1200
   pvcs: []
   replicaCount:
@@ -156,7 +156,7 @@ identity-server:
             - '/'
   namespace: 'identity-server'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs:
@@ -254,7 +254,7 @@ services-auth-admin-api:
             - '/backend'
   namespace: 'identity-server-admin'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -330,7 +330,7 @@ services-auth-delegation-api:
             - '/'
   namespace: 'identity-server-delegation'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -440,7 +440,7 @@ services-auth-ids-api:
       DB_PASS: '/k8s/services-auth/api/DB_PASSWORD'
   namespace: 'identity-server'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -505,7 +505,7 @@ services-auth-personal-representative:
             - '/'
   namespace: 'personal-representative'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -574,7 +574,7 @@ services-auth-personal-representative-public:
             - '/'
   namespace: 'personal-representative'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -657,7 +657,7 @@ services-auth-public-api:
             - '/api(/|$)(.*)'
   namespace: 'identity-server-admin'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -51,7 +51,7 @@ air-discount-scheme-api:
             - '/api/graphql'
   namespace: 'air-discount-scheme'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -163,7 +163,7 @@ air-discount-scheme-backend:
       DB_PASS: '/k8s/air-discount-scheme/backend/DB_PASSWORD'
   namespace: 'air-discount-scheme'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -240,7 +240,7 @@ air-discount-scheme-web:
             - '/'
   namespace: 'air-discount-scheme'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -429,7 +429,7 @@ api:
             - '/api'
   namespace: 'islandis'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -706,7 +706,7 @@ application-system-api:
       DB_PASS: '/k8s/application-system/api/DB_PASSWORD'
   namespace: 'application-system'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -828,7 +828,7 @@ application-system-api-worker:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/application-system-api'
   namespace: 'application-system'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -915,7 +915,7 @@ application-system-form:
             - '/umsoknir'
   namespace: 'application-system'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 1
@@ -981,7 +981,7 @@ consultation-portal:
             - '/samradsgatt'
   namespace: 'consultation-portal'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -1040,7 +1040,7 @@ contentful-apps:
             - '/'
   namespace: 'contentful-apps'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -1103,7 +1103,7 @@ contentful-entry-tagger-service:
             - '/'
   namespace: 'contentful-entry-tagger'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -1169,7 +1169,7 @@ contentful-translation-extension:
             - '/'
   namespace: 'contentful-translation-extension'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 1
@@ -1245,7 +1245,7 @@ download-service:
             - '/download'
   namespace: 'download-service'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 1
@@ -1353,7 +1353,7 @@ endorsement-system-api:
       DB_PASS: '/k8s/services-endorsements-api/DB_PASSWORD'
   namespace: 'endorsement-system'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -1420,7 +1420,7 @@ external-contracts-tests:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/external-contracts-tests'
   namespace: 'external-contracts-tests'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 1
@@ -1488,7 +1488,7 @@ github-actions-cache:
             - '/'
   namespace: 'github-actions-cache'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -1594,7 +1594,7 @@ icelandic-names-registry-backend:
       DB_PASS: '/k8s/icelandic-names-registry-backend/DB_PASSWORD'
   namespace: 'icelandic-names-registry'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 1
@@ -1652,7 +1652,7 @@ island-ui-storybook:
             - '/'
   namespace: 'storybook'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 1
@@ -1720,7 +1720,7 @@ license-api:
             - '/'
   namespace: 'license-api'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -1827,7 +1827,7 @@ portals-admin:
             - '/stjornbord'
   namespace: 'portals-admin'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -1915,7 +1915,7 @@ regulations-admin-backend:
       DB_PASS: '/k8s/regulations-admin-backend/DB_PASSWORD'
   namespace: 'regulations-admin'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 1
@@ -2041,7 +2041,7 @@ search-indexer-service:
       CONTENTFUL_ACCESS_TOKEN: '/k8s/search-indexer/CONTENTFUL_ACCESS_TOKEN'
   namespace: 'search-indexer'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   progressDeadlineSeconds: 1500
@@ -2119,7 +2119,7 @@ service-portal:
             - '/minarsidur'
   namespace: 'service-portal'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -2215,7 +2215,7 @@ service-portal-api:
       DB_PASS: '/k8s/service-portal/api/DB_PASSWORD'
   namespace: 'service-portal'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -2300,7 +2300,7 @@ service-portal-api-worker:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/services-user-profile'
   namespace: 'service-portal'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 1
@@ -2386,7 +2386,7 @@ services-documents:
       DB_PASS: '/k8s/services-documents/DB_PASSWORD'
   namespace: 'services-documents'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 1
@@ -2453,7 +2453,7 @@ services-sessions:
             - '/'
   namespace: 'services-sessions'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs:
     - accessModes: 'ReadWriteMany'
       mountPath: '/geoip-lite/data'
@@ -2520,7 +2520,7 @@ services-sessions-geoip-job:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/services-sessions'
   namespace: 'services-sessions'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs:
@@ -2620,7 +2620,7 @@ services-sessions-worker:
       DB_PASS: '/k8s/services-sessions/DB_PASSWORD'
   namespace: 'services-sessions'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -2743,7 +2743,7 @@ services-university-gateway:
       DB_PASS: '/k8s/services-university-gateway/DB_PASSWORD'
   namespace: 'services-university-gateway'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -2824,7 +2824,7 @@ services-university-gateway-worker:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/services-university-gateway'
   namespace: 'services-university-gateway'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -2894,7 +2894,7 @@ skilavottord-web:
             - '/app/skilavottord/'
   namespace: 'skilavottord'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 1
@@ -2983,7 +2983,7 @@ skilavottord-ws:
       DB_PASS: '/k8s/skilavottord/DB_PASSWORD'
   namespace: 'skilavottord'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 1
@@ -3074,7 +3074,7 @@ user-notification:
             - '/'
   namespace: 'user-notification'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -3166,7 +3166,7 @@ user-notification-cleanup-worker:
       DB_PASS: '/k8s/user-notification/DB_PASSWORD'
   namespace: 'user-notification'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -3270,7 +3270,7 @@ user-notification-worker:
       DB_PASS: '/k8s/user-notification/DB_PASSWORD'
   namespace: 'user-notification'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -3351,7 +3351,7 @@ web:
             - '/'
   namespace: 'islandis'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -3411,7 +3411,7 @@ xroad-collector:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/services-xroad-collector'
   namespace: 'xroad-collector'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -49,7 +49,7 @@ air-discount-scheme-api:
             - '/api/graphql'
   namespace: 'air-discount-scheme'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -157,7 +157,7 @@ air-discount-scheme-backend:
       DB_PASS: '/k8s/air-discount-scheme/backend/DB_PASSWORD'
   namespace: 'air-discount-scheme'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -230,7 +230,7 @@ air-discount-scheme-web:
             - '/'
   namespace: 'air-discount-scheme'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -419,7 +419,7 @@ api:
             - '/api'
   namespace: 'islandis'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -696,7 +696,7 @@ application-system-api:
       DB_PASS: '/k8s/application-system/api/DB_PASSWORD'
   namespace: 'application-system'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -818,7 +818,7 @@ application-system-api-worker:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/application-system-api'
   namespace: 'application-system'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -908,7 +908,7 @@ application-system-form:
             - '/umsoknir'
   namespace: 'application-system'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 3
@@ -977,7 +977,7 @@ consultation-portal:
             - '/samradsgatt'
   namespace: 'consultation-portal'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -1035,7 +1035,7 @@ contentful-apps:
             - '/'
   namespace: 'contentful-apps'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -1098,7 +1098,7 @@ contentful-translation-extension:
             - '/'
   namespace: 'contentful-translation-extension'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 3
@@ -1174,7 +1174,7 @@ download-service:
             - '/download'
   namespace: 'download-service'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 3
@@ -1282,7 +1282,7 @@ endorsement-system-api:
       DB_PASS: '/k8s/services-endorsements-api/DB_PASSWORD'
   namespace: 'endorsement-system'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -1394,7 +1394,7 @@ icelandic-names-registry-backend:
       DB_PASS: '/k8s/icelandic-names-registry-backend/DB_PASSWORD'
   namespace: 'icelandic-names-registry'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 3
@@ -1451,7 +1451,7 @@ island-ui-storybook:
             - '/'
   namespace: 'storybook'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 3
@@ -1519,7 +1519,7 @@ license-api:
             - '/'
   namespace: 'license-api'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -1626,7 +1626,7 @@ portals-admin:
             - '/stjornbord'
   namespace: 'portals-admin'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -1714,7 +1714,7 @@ regulations-admin-backend:
       DB_PASS: '/k8s/regulations-admin-backend/DB_PASSWORD'
   namespace: 'regulations-admin'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 3
@@ -1840,7 +1840,7 @@ search-indexer-service:
       CONTENTFUL_ACCESS_TOKEN: '/k8s/search-indexer/CONTENTFUL_ACCESS_TOKEN'
   namespace: 'search-indexer'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   progressDeadlineSeconds: 1500
@@ -1921,7 +1921,7 @@ service-portal:
             - '/minarsidur'
   namespace: 'service-portal'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -2017,7 +2017,7 @@ service-portal-api:
       DB_PASS: '/k8s/service-portal/api/DB_PASSWORD'
   namespace: 'service-portal'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -2102,7 +2102,7 @@ service-portal-api-worker:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/services-user-profile'
   namespace: 'service-portal'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 3
@@ -2188,7 +2188,7 @@ services-documents:
       DB_PASS: '/k8s/services-documents/DB_PASSWORD'
   namespace: 'services-documents'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 3
@@ -2255,7 +2255,7 @@ services-sessions:
             - '/'
   namespace: 'services-sessions'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs:
     - accessModes: 'ReadWriteMany'
       mountPath: '/geoip-lite/data'
@@ -2322,7 +2322,7 @@ services-sessions-geoip-job:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/services-sessions'
   namespace: 'services-sessions'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs:
@@ -2422,7 +2422,7 @@ services-sessions-worker:
       DB_PASS: '/k8s/services-sessions/DB_PASSWORD'
   namespace: 'services-sessions'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -2545,7 +2545,7 @@ services-university-gateway:
       DB_PASS: '/k8s/services-university-gateway/DB_PASSWORD'
   namespace: 'services-university-gateway'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -2626,7 +2626,7 @@ services-university-gateway-worker:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/services-university-gateway'
   namespace: 'services-university-gateway'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -2699,7 +2699,7 @@ skilavottord-web:
             - '/app/skilavottord/'
   namespace: 'skilavottord'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 3
@@ -2791,7 +2791,7 @@ skilavottord-ws:
       DB_PASS: '/k8s/skilavottord/DB_PASSWORD'
   namespace: 'skilavottord'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 3
@@ -2882,7 +2882,7 @@ user-notification:
             - '/'
   namespace: 'user-notification'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -2974,7 +2974,7 @@ user-notification-cleanup-worker:
       DB_PASS: '/k8s/user-notification/DB_PASSWORD'
   namespace: 'user-notification'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -3078,7 +3078,7 @@ user-notification-worker:
       DB_PASS: '/k8s/user-notification/DB_PASSWORD'
   namespace: 'user-notification'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -3163,7 +3163,7 @@ web:
             - '/'
   namespace: 'islandis'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -3223,7 +3223,7 @@ xroad-collector:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/services-xroad-collector'
   namespace: 'xroad-collector'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -51,7 +51,7 @@ air-discount-scheme-api:
             - '/api/graphql'
   namespace: 'air-discount-scheme'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -163,7 +163,7 @@ air-discount-scheme-backend:
       DB_PASS: '/k8s/air-discount-scheme/backend/DB_PASSWORD'
   namespace: 'air-discount-scheme'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -240,7 +240,7 @@ air-discount-scheme-web:
             - '/'
   namespace: 'air-discount-scheme'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -427,7 +427,7 @@ api:
             - '/api'
   namespace: 'islandis'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -704,7 +704,7 @@ application-system-api:
       DB_PASS: '/k8s/application-system/api/DB_PASSWORD'
   namespace: 'application-system'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -826,7 +826,7 @@ application-system-api-worker:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/application-system-api'
   namespace: 'application-system'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -914,7 +914,7 @@ application-system-form:
             - '/umsoknir'
   namespace: 'application-system'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 1
@@ -981,7 +981,7 @@ consultation-portal:
             - '/samradsgatt'
   namespace: 'consultation-portal'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -1041,7 +1041,7 @@ contentful-translation-extension:
             - '/'
   namespace: 'contentful-translation-extension'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 1
@@ -1118,7 +1118,7 @@ download-service:
             - '/download'
   namespace: 'download-service'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 1
@@ -1226,7 +1226,7 @@ endorsement-system-api:
       DB_PASS: '/k8s/services-endorsements-api/DB_PASSWORD'
   namespace: 'endorsement-system'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -1338,7 +1338,7 @@ icelandic-names-registry-backend:
       DB_PASS: '/k8s/icelandic-names-registry-backend/DB_PASSWORD'
   namespace: 'icelandic-names-registry'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 1
@@ -1396,7 +1396,7 @@ island-ui-storybook:
             - '/'
   namespace: 'storybook'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 1
@@ -1465,7 +1465,7 @@ license-api:
             - '/'
   namespace: 'license-api'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -1569,7 +1569,7 @@ portals-admin:
             - '/stjornbord'
   namespace: 'portals-admin'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -1657,7 +1657,7 @@ regulations-admin-backend:
       DB_PASS: '/k8s/regulations-admin-backend/DB_PASSWORD'
   namespace: 'regulations-admin'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 1
@@ -1783,7 +1783,7 @@ search-indexer-service:
       CONTENTFUL_ACCESS_TOKEN: '/k8s/search-indexer/CONTENTFUL_ACCESS_TOKEN'
   namespace: 'search-indexer'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   progressDeadlineSeconds: 1500
@@ -1862,7 +1862,7 @@ service-portal:
             - '/minarsidur'
   namespace: 'service-portal'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -1958,7 +1958,7 @@ service-portal-api:
       DB_PASS: '/k8s/service-portal/api/DB_PASSWORD'
   namespace: 'service-portal'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -2043,7 +2043,7 @@ service-portal-api-worker:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/services-user-profile'
   namespace: 'service-portal'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 1
@@ -2129,7 +2129,7 @@ services-documents:
       DB_PASS: '/k8s/services-documents/DB_PASSWORD'
   namespace: 'services-documents'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 1
@@ -2196,7 +2196,7 @@ services-sessions:
             - '/'
   namespace: 'services-sessions'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs:
     - accessModes: 'ReadWriteMany'
       mountPath: '/geoip-lite/data'
@@ -2263,7 +2263,7 @@ services-sessions-geoip-job:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/services-sessions'
   namespace: 'services-sessions'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs:
@@ -2363,7 +2363,7 @@ services-sessions-worker:
       DB_PASS: '/k8s/services-sessions/DB_PASSWORD'
   namespace: 'services-sessions'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -2486,7 +2486,7 @@ services-university-gateway:
       DB_PASS: '/k8s/services-university-gateway/DB_PASSWORD'
   namespace: 'services-university-gateway'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -2567,7 +2567,7 @@ services-university-gateway-worker:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/services-university-gateway'
   namespace: 'services-university-gateway'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -2637,7 +2637,7 @@ skilavottord-web:
             - '/app/skilavottord/'
   namespace: 'skilavottord'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 1
@@ -2726,7 +2726,7 @@ skilavottord-ws:
       DB_PASS: '/k8s/skilavottord/DB_PASSWORD'
   namespace: 'skilavottord'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 1
@@ -2817,7 +2817,7 @@ user-notification:
             - '/'
   namespace: 'user-notification'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -2909,7 +2909,7 @@ user-notification-cleanup-worker:
       DB_PASS: '/k8s/user-notification/DB_PASSWORD'
   namespace: 'user-notification'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -3013,7 +3013,7 @@ user-notification-worker:
       DB_PASS: '/k8s/user-notification/DB_PASSWORD'
   namespace: 'user-notification'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -3095,7 +3095,7 @@ web:
             - '/'
   namespace: 'islandis'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 2
@@ -3155,7 +3155,7 @@ xroad-collector:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/services-xroad-collector'
   namespace: 'xroad-collector'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []

--- a/charts/judicial-system/values.dev.yaml
+++ b/charts/judicial-system/values.dev.yaml
@@ -71,7 +71,7 @@ judicial-system-api:
             - '/api/feature'
   namespace: 'judicial-system'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -179,7 +179,7 @@ judicial-system-backend:
       DB_PASS: '/k8s/judicial-system/DB_PASSWORD'
   namespace: 'judicial-system'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -269,7 +269,7 @@ judicial-system-message-handler:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/judicial-system-message-handler'
   namespace: 'judicial-system'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -331,7 +331,7 @@ judicial-system-scheduler:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/judicial-system-scheduler'
   namespace: 'judicial-system'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 1
@@ -393,7 +393,7 @@ judicial-system-web:
             - '/'
   namespace: 'judicial-system'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 1
@@ -456,7 +456,7 @@ judicial-system-xrd-api:
             - '/'
   namespace: 'judicial-system'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []

--- a/charts/judicial-system/values.prod.yaml
+++ b/charts/judicial-system/values.prod.yaml
@@ -71,7 +71,7 @@ judicial-system-api:
             - '/api/feature'
   namespace: 'judicial-system'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -179,7 +179,7 @@ judicial-system-backend:
       DB_PASS: '/k8s/judicial-system/DB_PASSWORD'
   namespace: 'judicial-system'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -269,7 +269,7 @@ judicial-system-message-handler:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/judicial-system-message-handler'
   namespace: 'judicial-system'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -331,7 +331,7 @@ judicial-system-scheduler:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/judicial-system-scheduler'
   namespace: 'judicial-system'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 1
@@ -393,7 +393,7 @@ judicial-system-web:
             - '/'
   namespace: 'judicial-system'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 3
@@ -456,7 +456,7 @@ judicial-system-xrd-api:
             - '/'
   namespace: 'judicial-system'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []

--- a/charts/judicial-system/values.staging.yaml
+++ b/charts/judicial-system/values.staging.yaml
@@ -71,7 +71,7 @@ judicial-system-api:
             - '/api/feature'
   namespace: 'judicial-system'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -179,7 +179,7 @@ judicial-system-backend:
       DB_PASS: '/k8s/judicial-system/DB_PASSWORD'
   namespace: 'judicial-system'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -269,7 +269,7 @@ judicial-system-message-handler:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/judicial-system-message-handler'
   namespace: 'judicial-system'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []
@@ -331,7 +331,7 @@ judicial-system-scheduler:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/judicial-system-scheduler'
   namespace: 'judicial-system'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 1
@@ -393,7 +393,7 @@ judicial-system-web:
             - '/'
   namespace: 'judicial-system'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   pvcs: []
   replicaCount:
     default: 1
@@ -456,7 +456,7 @@ judicial-system-xrd-api:
             - '/'
   namespace: 'judicial-system'
   podDisruptionBudget:
-    maxUnavailable: 0
+    maxUnavailable: 1
   podSecurityContext:
     fsGroup: 65534
   pvcs: []

--- a/infra/src/dsl/output-generators/map-to-helm-values.ts
+++ b/infra/src/dsl/output-generators/map-to-helm-values.ts
@@ -64,7 +64,7 @@ const serializeService: SerializeMethod<HelmService> = async (
     },
     secrets: {},
     podDisruptionBudget: serviceDef.podDisruptionBudget ?? {
-        maxUnavailable: 1,
+      maxUnavailable: 1,
     },
     healthCheck: {
       port: serviceDef.healthPort,

--- a/infra/src/dsl/output-generators/map-to-helm-values.ts
+++ b/infra/src/dsl/output-generators/map-to-helm-values.ts
@@ -64,7 +64,7 @@ const serializeService: SerializeMethod<HelmService> = async (
     },
     secrets: {},
     podDisruptionBudget: serviceDef.podDisruptionBudget ?? {
-      maxUnavailable: 0,
+        maxUnavailable: 1,
     },
     healthCheck: {
       port: serviceDef.healthPort,

--- a/infra/src/dsl/pdb.spec.ts
+++ b/infra/src/dsl/pdb.spec.ts
@@ -26,7 +26,7 @@ describe('PodDisruptionBudget definitions', () => {
     const serviceDef: Awaited<ReturnType<typeof renderHelmServiceFile>> =
       await renderHelmServiceFile(Staging, [sut], [sut], 'no-mocks')
     expect(serviceDef.services.api.podDisruptionBudget?.maxUnavailable).toEqual(
-      0,
+      1,
     )
   })
 


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

MaxUnavailable: 0 cause clusters to become too rigid during node autoscaling not allowing any pod evictions, changing it to 1 will allow autoscaling
## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
