### PR TITLE
chore(web): Add no-cache as fetchPolicy when fetching auctions

### DIFF
--- a/apps/web/screens/Organization/Syslumenn/Auctions.tsx
+++ b/apps/web/screens/Organization/Syslumenn/Auctions.tsx
@@ -1091,6 +1091,7 @@ Auctions.getProps = async ({ apolloClient, locale, req, res }) => {
     }),
     apolloClient.query<Query>({
       query: GET_SYSLUMENN_AUCTIONS_QUERY,
+      fetchPolicy: 'no-cache',
     }),
     apolloClient
       .query<Query, QueryGetNamespaceArgs>({


### PR DESCRIPTION
# Add no-cache as fetchPolicy when fetching auctions

## What

* The auctions page must not be cached in any way

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
