### PR TITLE
feat(web): Add optional flipAxis field to Chart content model

### DIFF
--- a/apps/web/screens/queries/fragments.ts
+++ b/apps/web/screens/queries/fragments.ts
@@ -825,6 +825,7 @@ export const slices = gql`
       stackId
     }
     sourceData
+    flipAxis
     xAxisKey
     xAxisFormat
     xAxisValueType

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -565,6 +565,9 @@ export interface IChartFields {
   /** Source Data */
   sourceData?: Record<string, any> | undefined
 
+  /** Flip Axis */
+  flipAxis?: boolean | undefined
+
   /** X Axis Key */
   xAxisKey?: string | undefined
 

--- a/libs/cms/src/lib/models/chart.model.ts
+++ b/libs/cms/src/lib/models/chart.model.ts
@@ -43,6 +43,9 @@ export class Chart {
   sourceData?: string
 
   @Field({ nullable: true })
+  flipAxis?: boolean
+
+  @Field({ nullable: true })
   xAxisKey?: string
 
   @Field({ nullable: true })
@@ -60,6 +63,7 @@ export const mapChart = ({ sys, fields }: IChart): SystemMetadata<Chart> => {
     chartDescription: fields.chartDescription ?? '',
     alternativeDescription: fields.alternativeDescription ?? '',
     displayAsCard: fields.displayAsCard ?? true,
+    flipAxis: fields.flipAxis ?? false,
     xAxisKey: fields.xAxisKey ?? undefined,
     xAxisValueType: fields.xAxisValueType ?? undefined,
     xAxisFormat: fields.xAxisFormat ?? undefined,


### PR DESCRIPTION
## What

To allow content editors to flip the x and y-axis when displaying charts

- This PR is only adding it to the search indexer mapping and page querying the actual implementation will be in another PR

## Why

To match what is in the design system

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
