### PR TITLE
fix(documents): Add url document details

### DIFF
--- a/libs/api/domains/documents/src/lib/documentBuilder.ts
+++ b/libs/api/domains/documents/src/lib/documentBuilder.ts
@@ -23,6 +23,13 @@ export class DocumentBuilder {
       url: 'https://thjonustusidur.rsk.is/alagningarsedill',
       fileType: FileType.URL,
     },
+    {
+      senderName: 'Ríkisskattstjóri',
+      senderNatReg: '5402696029',
+      subjectContains: 'Skjöl send í undirritun fyrir umsókn',
+      url: '',
+      fileType: FileType.URL,
+    },
   ]
 
   public buildDocument(documentDto: DocumentInfoDTO): Document {


### PR DESCRIPTION
## What

Add special case for url document in postholf

## Why

There is no way to get the type in the overview list call. So we need to get by title of doc, as with previous RSK document. 

NOTE: This is a temporary solution to get the url doc to work in the app. Already works on web. We have a new way to approach this, this is only for app compatibility for now. We will remove this soon when we will all be using the same way to display documents.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
