### PR TITLE
fix(service-portal): empty state message for incoming deligations

### DIFF
--- a/libs/portals/shared-modules/delegations/src/components/delegations/DelegationsEmptyState.tsx
+++ b/libs/portals/shared-modules/delegations/src/components/delegations/DelegationsEmptyState.tsx
@@ -1,16 +1,20 @@
-import { useLocale } from '@island.is/localization'
 import { Problem } from '@island.is/react-spa/shared'
-import { m } from '../../lib/messages'
 
-export const DelegationsEmptyState = () => {
-  const { formatMessage } = useLocale()
+type DelegationsEmptyStateProps = {
+  message: string
+  imageAlt: string
+}
 
+export const DelegationsEmptyState = ({
+  message,
+  imageAlt,
+}: DelegationsEmptyStateProps) => {
   return (
     <Problem
       type="no_data"
-      message={formatMessage(m.noDelegations)}
+      message={message}
       imgSrc="./assets/images/educationDegree.svg"
-      imgAlt={formatMessage(m.noDelegationsImageAlt)}
+      imgAlt={imageAlt}
       data-testid="delegations-empty-state"
     />
   )

--- a/libs/portals/shared-modules/delegations/src/components/delegations/incoming/DelegationsIncoming.tsx
+++ b/libs/portals/shared-modules/delegations/src/components/delegations/incoming/DelegationsIncoming.tsx
@@ -7,7 +7,7 @@ import {
   AuthDelegationType,
 } from '@island.is/api/schema'
 import { useLocale } from '@island.is/localization'
-import { m } from '@island.is/portals/core'
+import { m } from '../../../lib/messages'
 import { AccessDeleteModal } from '../../access/AccessDeleteModal/AccessDeleteModal'
 import { AccessCard } from '../../access/AccessCard'
 import { DelegationsEmptyState } from '../DelegationsEmptyState'
@@ -50,7 +50,10 @@ export const DelegationsIncoming = () => {
       ) : error ? (
         <Problem error={error} />
       ) : delegations.length === 0 ? (
-        <DelegationsEmptyState />
+        <DelegationsEmptyState
+          message={formatMessage(m.noIncomingDelegations)}
+          imageAlt={formatMessage(m.noDelegationsImageAlt)}
+        />
       ) : (
         <Stack space={3}>
           {delegations.map(

--- a/libs/portals/shared-modules/delegations/src/components/delegations/outgoing/DelegationsOutgoing.tsx
+++ b/libs/portals/shared-modules/delegations/src/components/delegations/outgoing/DelegationsOutgoing.tsx
@@ -16,6 +16,7 @@ import { DomainOption, useDomains } from '../../../hooks/useDomains/useDomains'
 import { useAuthDelegationsOutgoingQuery } from './DelegationsOutgoing.generated'
 import { AuthCustomDelegationOutgoing } from '../../../types/customDelegation'
 import { ALL_DOMAINS } from '../../../constants/domain'
+import { m } from '../../../lib/messages'
 
 const prepareDomainName = (domainName: string | null) =>
   domainName === ALL_DOMAINS ? null : domainName
@@ -95,7 +96,10 @@ export const DelegationsOutgoing = () => {
           ) : error && (!delegations || delegations.length === 0) ? (
             <Problem error={error} />
           ) : delegations.length === 0 ? (
-            <DelegationsEmptyState />
+            <DelegationsEmptyState
+              message={formatMessage(m.noOutgoingDelegations)}
+              imageAlt={formatMessage(m.noDelegationsImageAlt)}
+            />
           ) : (
             <Stack space={3}>
               {filteredDelegations.map(

--- a/libs/portals/shared-modules/delegations/src/lib/messages.ts
+++ b/libs/portals/shared-modules/delegations/src/lib/messages.ts
@@ -6,9 +6,13 @@ export const m = defineMessages({
     defaultMessage: 'Veldu umboð',
     description: 'Choose delegation',
   },
-  noDelegations: {
-    id: 'sp.access-control-delegations:empty',
+  noOutgoingDelegations: {
+    id: 'sp.access-control-delegations-outgoing:empty',
     defaultMessage: 'Umboð sem þú hefur veitt öðrum munu birtast hér.',
+  },
+  noIncomingDelegations: {
+    id: 'sp.access-control-delegations-incoming:empty',
+    defaultMessage: 'Þegar aðrir hafa veitt þér umboð birtast þau hér.',
   },
   noDelegationsImageAlt: {
     id: 'sp.access-control-delegations:empty-image-alt',

--- a/libs/portals/shared-modules/delegations/src/lib/messages.ts
+++ b/libs/portals/shared-modules/delegations/src/lib/messages.ts
@@ -7,11 +7,11 @@ export const m = defineMessages({
     description: 'Choose delegation',
   },
   noOutgoingDelegations: {
-    id: 'sp.access-control-delegations-outgoing:empty',
+    id: 'sp.access-control-delegations:empty-outgoing',
     defaultMessage: 'Umboð sem þú hefur veitt öðrum munu birtast hér.',
   },
   noIncomingDelegations: {
-    id: 'sp.access-control-delegations-incoming:empty',
+    id: 'sp.access-control-delegations:empty-incoming',
     defaultMessage: 'Þegar aðrir hafa veitt þér umboð birtast þau hér.',
   },
   noDelegationsImageAlt: {


### PR DESCRIPTION
## What

Fix wrong empty state message for incoming delegations.

## Why

To show clearer message to user.

## Screenshots / Gifs

<img width="1076" alt="Screenshot 2024-02-16 at 08 28 04" src="https://github.com/island-is/island.is/assets/22525070/2da755d9-a3ed-4b2b-97db-5814001daa8b">


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
