### PR TITLE
feat(web): Display organization.shortTitle in article institution panel if present

### DIFF
--- a/apps/web/screens/Article/Article.tsx
+++ b/apps/web/screens/Article/Article.tsx
@@ -293,7 +293,9 @@ const ArticleSidebar: FC<React.PropsWithChildren<ArticleSidebarProps>> = ({
         <InstitutionPanel
           img={article.organization[0].logo?.url}
           institutionTitle={n('organization')}
-          institution={article.organization[0].title}
+          institution={
+            article.organization[0].shortTitle || article.organization[0].title
+          }
           locale={activeLocale}
           linkProps={{
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment


### PR DESCRIPTION
# Display organization.shortTitle in article institution panel if present

## Screenshots / Gifs
So that we have the option to display a shorter version of the organization name in this card:
![image](https://github.com/island-is/island.is/assets/43557895/966afade-c589-42ae-a27e-6ef1105daad3)
