### PR TITLE
fix(services-sessions): Fix sessions column too large value

### DIFF
--- a/apps/services/sessions/migrations/20240216101538-change-user-agent-column-datatype.js
+++ b/apps/services/sessions/migrations/20240216101538-change-user-agent-column-datatype.js
@@ -1,0 +1,29 @@
+'use strict'
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    /**
+     * Add altering commands here.
+     *
+     * Example:
+     * await queryInterface.createTable('users', { id: Sequelize.INTEGER });
+     */
+    await queryInterface.changeColumn('session', 'user_agent', {
+      type: Sequelize.TEXT,
+      allowNull: false,
+    })
+  },
+
+  async down(queryInterface, Sequelize) {
+    /**
+     * Add reverting commands here.
+     *
+     * Example:
+     * await queryInterface.dropTable('users');
+     */
+    await queryInterface.changeColumn('session', 'user_agent', {
+      type: Sequelize.STRING,
+      allowNull: false,
+    })
+  },
+}

--- a/apps/services/sessions/src/app/sessions/constants.ts
+++ b/apps/services/sessions/src/app/sessions/constants.ts
@@ -1,0 +1,1 @@
+export const USER_AGENT_MAX_LENGTH = 1024

--- a/apps/services/sessions/src/app/sessions/session.model.ts
+++ b/apps/services/sessions/src/app/sessions/session.model.ts
@@ -67,7 +67,7 @@ export class Session extends Model<
 
   @ApiProperty()
   @Column({
-    type: DataType.STRING,
+    type: DataType.TEXT,
     allowNull: false,
   })
   userAgent!: string

--- a/apps/services/sessions/src/app/sessions/sessions.service.ts
+++ b/apps/services/sessions/src/app/sessions/sessions.service.ts
@@ -12,6 +12,7 @@ import { CreateSessionDto } from './create-session.dto'
 import { Session } from './session.model'
 import { SessionsQueryDto } from './sessions-query.dto'
 import { SessionsResultDto } from './sessions-result.dto'
+import { USER_AGENT_MAX_LENGTH } from './constants'
 
 @Injectable()
 export class SessionsService {
@@ -86,7 +87,7 @@ export class SessionsService {
   }
 
   create(session: CreateSessionDto): Promise<Session> {
-    const { id, sessionId, ...rest } = session
+    const { id, sessionId, userAgent, ...rest } = session
 
     // Todo: Remove this when we have migrated IDS to use sessionId
     const sid = sessionId || id
@@ -97,8 +98,9 @@ export class SessionsService {
 
     return this.sessionModel.create({
       ...rest,
+      userAgent: userAgent.substring(0, USER_AGENT_MAX_LENGTH),
       sessionId: sid,
-      device: this.formatUserAgent(session.userAgent),
+      device: this.formatUserAgent(userAgent),
       ipLocation: this.formatIp(session.ip),
     })
   }


### PR DESCRIPTION
## What

DataDog is reporting errors about a field being to long for database column.
So we migrate the user agent column to be TEXT so it allows Postgres unlimited varchar column.
We then take the first 1024 chars from the user agent string.

## Why

To fix error and lost session tracking due to these failures.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
