### PR TITLE
feat(contentful-apps): Disable global auth on prod

### DIFF
--- a/apps/contentful-apps/infra/contentful-apps.ts
+++ b/apps/contentful-apps/infra/contentful-apps.ts
@@ -16,9 +16,7 @@ export const serviceSetup = (): ServiceBuilder<'contentful-apps'> =>
           dev: {
             'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
           },
-          staging: {
-            'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
-          },
+          staging: {},
           prod: {
             'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
           },

--- a/apps/contentful-apps/infra/contentful-apps.ts
+++ b/apps/contentful-apps/infra/contentful-apps.ts
@@ -16,8 +16,12 @@ export const serviceSetup = (): ServiceBuilder<'contentful-apps'> =>
           dev: {
             'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
           },
-          staging: {},
-          prod: {},
+          staging: {
+            'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
+          },
+          prod: {
+            'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
+          },
         },
       },
     })

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -1028,6 +1028,7 @@ contentful-apps:
     primary-alb:
       annotations:
         kubernetes.io/ingress.class: 'nginx-external-alb'
+        nginx.ingress.kubernetes.io/enable-global-auth: 'false'
         nginx.ingress.kubernetes.io/service-upstream: 'true'
       hosts:
         - host: 'contentful-apps.island.is'


### PR DESCRIPTION
# Disable global auth on prod

## Why

* We are currently only pointing contentful to our dev environment but we want to change it to be prod since dev is too unstable
