### PR TITLE
chore(core): Add lint warnings for preferred function style

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -217,6 +217,8 @@
             "skipTemplates": true
           }
         ],
+        "prefer-arrow-callback": "warn",
+        "func-style": ["warn", "expression"],
         "local-rules/require-reduce-defaults": "error",
         "local-rules/disallow-kennitalas": "warn",
         "local-rules/no-async-module-init": "error"


### PR DESCRIPTION
## What

Add eslint warning to encourage a shared function syntax.

## Why

https://www.notion.so/Code-standard-Function-syntax-86d5c6d562dd4ca88ea3a2ea7eecd80b?pvs=4 

## New warnings across monorepo

func-style: 720 warnings
prefer-arrow-callback: 39 warnings