### PR TITLE
fix(j-s): Wait for Accept Test

### DIFF
--- a/apps/system-e2e/src/tests/judicial-system/smoke/custody-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/smoke/custody-tests.spec.ts
@@ -220,7 +220,10 @@ test.describe.serial('Custody tests', () => {
 
     // Confirmation
     await expect(page).toHaveURL(`/domur/stadfesta/${caseId}`)
-    await page.getByTestId('continueButton').click()
+    await Promise.all([
+      await page.getByTestId('continueButton').click(),
+      verifyRequestCompletion(page, '/api/graphql', 'TransitionCase'),
+    ])
   })
 
   test('prosecutor should appeal case', async ({ prosecutorPage }) => {

--- a/apps/system-e2e/src/tests/judicial-system/smoke/custody-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/smoke/custody-tests.spec.ts
@@ -221,7 +221,7 @@ test.describe.serial('Custody tests', () => {
     // Confirmation
     await expect(page).toHaveURL(`/domur/stadfesta/${caseId}`)
     await Promise.all([
-      await page.getByTestId('continueButton').click(),
+      page.getByTestId('continueButton').click(),
       verifyRequestCompletion(page, '/api/graphql', 'TransitionCase'),
     ])
   })

--- a/apps/system-e2e/src/tests/judicial-system/utils/helpers.ts
+++ b/apps/system-e2e/src/tests/judicial-system/utils/helpers.ts
@@ -1,26 +1,26 @@
 import { Page } from '@playwright/test'
 import { verifyRequestCompletion } from '../../../support/api-tools'
 
-export function randomPoliceCaseNumber() {
+export const randomPoliceCaseNumber = () => {
   return `007-${new Date().getFullYear()}-${Math.floor(Math.random() * 100000)}`
 }
 
-export function randomCourtCaseNumber() {
+export const randomCourtCaseNumber = () => {
   return `R-${Math.floor(Math.random() * 1000)}/${new Date().getFullYear()}`
 }
 
-export function randomAppealCaseNumber() {
+export const randomAppealCaseNumber = () => {
   return `${Math.floor(Math.random() * 1000)}/${new Date().getFullYear()}`
 }
 
-export function getDaysFromNow(days = 0) {
+export const getDaysFromNow = (days = 0) => {
   const day = 24 * 60 * 60 * 1000
   const daysAdded = day * days
 
   return new Date(new Date().getTime() + daysAdded).toLocaleDateString('is-IS')
 }
 
-async function createFakePdf(title: string) {
+const createFakePdf = (title: string) => {
   return {
     name: title,
     mimeType: 'application/pdf',
@@ -30,19 +30,20 @@ async function createFakePdf(title: string) {
   }
 }
 
-export async function chooseDocument(
+export const chooseDocument = async (
   page: Page,
   clickButton: () => Promise<void>,
   fileName: string,
-) {
+) => {
   const fileChooserPromise = page.waitForEvent('filechooser')
   await clickButton()
 
   const fileChooser = await fileChooserPromise
-  await fileChooser.setFiles(await createFakePdf(fileName))
+  await page.waitForTimeout(1000)
+  await fileChooser.setFiles(createFakePdf(fileName))
 }
 
-export async function verifyUpload(page: Page, isLimitedAccess = false) {
+export const verifyUpload = async (page: Page, isLimitedAccess = false) => {
   await Promise.all([
     verifyRequestCompletion(
       page,
@@ -59,12 +60,12 @@ export async function verifyUpload(page: Page, isLimitedAccess = false) {
   ])
 }
 
-export async function uploadDocument(
+export const uploadDocument = async (
   page: Page,
   clickButton: () => Promise<void>,
   fileName: string,
   isLimitedAccess = false,
-) {
+) => {
   return Promise.all([
     chooseDocument(page, clickButton, fileName),
     verifyUpload(page, isLimitedAccess),


### PR DESCRIPTION
# Wait for Accept Test

[Laga E2E test](Laga E2E test)

## What

- Waits for case acceptance in judge flow to make sure the request leaves the server before the test quits.
- Waits for file selection in file picker.

## Why

- Sometimes the test quits before the request to accept the case leaves the server.
- We tried removing the file picker dealy, but that caused file picking to fail in some cases. Further investigation needed.

## Screenshots / Gifs

The following screen shot indicates that the "prosecutor should appeal case" test failed but the real failure is in "court should submit decision in case":

![image](https://github.com/island-is/island.is/assets/795382/68411f7b-07c7-4fcb-9400-2c73db80e8f0)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
