### PR TITLE
fix(j-s): Wait for Case Load

### DIFF
--- a/apps/system-e2e/src/tests/judicial-system/smoke/custody-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/smoke/custody-tests.spec.ts
@@ -156,7 +156,10 @@ test.describe.serial('Custody tests', () => {
 
   test('court should submit decision in case', async ({ judgePage }) => {
     const page = judgePage
-    await page.goto(`/domur/mottaka/${caseId}`)
+    await Promise.all([
+      page.goto(`/domur/mottaka/${caseId}`),
+      verifyRequestCompletion(page, '/api/graphql', 'Case'),
+    ])
 
     // Reception and assignment
     await expect(page).toHaveURL(`/domur/mottaka/${caseId}`)
@@ -238,7 +241,10 @@ test.describe.serial('Custody tests', () => {
     defenderPage,
   }) => {
     const page = defenderPage
-    await page.goto(`/verjandi/krafa/${caseId}`)
+    await Promise.all([
+      page.goto(`/verjandi/krafa/${caseId}`),
+      verifyRequestCompletion(page, '/api/graphql', 'Case'),
+    ])
     await expect(page).toHaveURL(`/verjandi/krafa/${caseId}`)
     await expect(page.getByText('TestKaerugognSaekjanda.pdf')).toHaveCount(0)
     await expect(
@@ -285,7 +291,10 @@ test.describe.serial('Custody tests', () => {
 
   test('prosecutor asks for extension', async ({ prosecutorPage }) => {
     const page = prosecutorPage
-    await page.goto(`/krafa/yfirlit/${caseId}`)
+    await Promise.all([
+      page.goto(`/krafa/yfirlit/${caseId}`),
+      verifyRequestCompletion(page, '/api/graphql', 'Case'),
+    ])
     await expect(page).toHaveURL(`/krafa/yfirlit/${caseId}`)
     await Promise.all([
       page.getByTestId('continueButton').click(),

--- a/apps/system-e2e/src/tests/judicial-system/smoke/search-warrant-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/smoke/search-warrant-tests.spec.ts
@@ -119,7 +119,10 @@ test.describe.serial('Search warrant tests', () => {
     const page = judgePage
 
     // Reception and assignment
-    await page.goto(`domur/rannsoknarheimild/mottaka/${caseId}`)
+    await Promise.all([
+      page.goto(`domur/rannsoknarheimild/mottaka/${caseId}`),
+      verifyRequestCompletion(page, '/api/graphql', 'Case'),
+    ])
     await page.getByTestId('courtCaseNumber').click()
     await page.getByTestId('courtCaseNumber').fill(randomCourtCaseNumber())
     await page

--- a/apps/system-e2e/src/tests/judicial-system/smoke/shared-steps/complete-appeal.ts
+++ b/apps/system-e2e/src/tests/judicial-system/smoke/shared-steps/complete-appeal.ts
@@ -2,11 +2,14 @@ import { Page, expect } from '@playwright/test'
 import { verifyRequestCompletion } from '../../../../support/api-tools'
 import { randomAppealCaseNumber, uploadDocument } from '../../utils/helpers'
 
-export async function coaJudgesCompleteAppealCaseTest(
+export const coaJudgesCompleteAppealCaseTest = async (
   page: Page,
   caseId: string,
-) {
-  await page.goto(`/landsrettur/yfirlit/${caseId}`)
+) => {
+  await Promise.all([
+    page.goto(`/landsrettur/yfirlit/${caseId}`),
+    verifyRequestCompletion(page, '/api/graphql', 'Case'),
+  ])
 
   // Overview
   await expect(page).toHaveURL(`/landsrettur/yfirlit/${caseId}`)
@@ -22,6 +25,7 @@ export async function coaJudgesCompleteAppealCaseTest(
   await page.getByText('Mál nr. *').press('Tab')
   await page.getByTestId('select-assistant').click()
   await page.locator('#react-select-assistant-option-0').click()
+  // TODO: Make sure we select different judges - wait for dropdown updates?
   await page.getByTestId('icon-chevronDown').nth(2).click()
   await page.locator('#react-select-judge-option-0').click()
   await page.getByTestId('icon-chevronDown').nth(3).click()

--- a/apps/system-e2e/src/tests/judicial-system/smoke/shared-steps/receive-appeal.ts
+++ b/apps/system-e2e/src/tests/judicial-system/smoke/shared-steps/receive-appeal.ts
@@ -1,7 +1,11 @@
 import { Page } from '@playwright/test'
+import { verifyRequestCompletion } from '../../../../support/api-tools'
 
-export async function judgeReceivesAppealTest(page: Page, caseId: string) {
-  await page.goto(`krafa/yfirlit/${caseId}`)
+export const judgeReceivesAppealTest = async (page: Page, caseId: string) => {
+  await Promise.all([
+    page.goto(`krafa/yfirlit/${caseId}`),
+    verifyRequestCompletion(page, '/api/graphql', 'Case'),
+  ])
   await page
     .getByRole('button', {
       name: 'Senda tilkynningu um kæru til Landsréttar',

--- a/apps/system-e2e/src/tests/judicial-system/smoke/shared-steps/send-appeal.ts
+++ b/apps/system-e2e/src/tests/judicial-system/smoke/shared-steps/send-appeal.ts
@@ -2,8 +2,11 @@ import { Page, expect } from '@playwright/test'
 import { chooseDocument, verifyUpload } from '../../utils/helpers'
 import { verifyRequestCompletion } from '../../../../support/api-tools'
 
-export async function prosecutorAppealsCaseTest(page: Page, caseId: string) {
-  await page.goto(`krafa/yfirlit/${caseId}`)
+export const prosecutorAppealsCaseTest = async (page: Page, caseId: string) => {
+  await Promise.all([
+    page.goto(`krafa/yfirlit/${caseId}`),
+    verifyRequestCompletion(page, '/api/graphql', 'Case'),
+  ])
   await expect(page).toHaveURL(`/krafa/yfirlit/${caseId}`)
   await Promise.all([
     page.getByRole('button', { name: 'Senda inn kæru' }).click(),

--- a/apps/system-e2e/src/tests/judicial-system/smoke/travel-ban-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/smoke/travel-ban-tests.spec.ts
@@ -99,7 +99,10 @@ test.describe.serial('Travel ban tests', () => {
     judgePage,
   }) => {
     const page = judgePage
-    await page.goto(`/domur/mottaka/${caseId}`)
+    await Promise.all([
+      page.goto(`/domur/mottaka/${caseId}`),
+      verifyRequestCompletion(page, '/api/graphql', 'Case'),
+    ])
 
     // Reception and assignment
     await expect(page).toHaveURL(`/domur/mottaka/${caseId}`)


### PR DESCRIPTION
# Wait for Case Load

[Laga E2E test](https://app.asana.com/0/1199153462262248/1206633722897051/f)

## What

- Wait for case load when navigating directly to a case page.

## Why

- If the tests do not wait for case load on each page, then the tests sometimes fail on subsequent pages.

## Screenshots / Gifs

- I was planning to add a screen recording, but it is very bug.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
