### PR TITLE
Revert adding dd runtime metrics env.

### DIFF
--- a/apps/services/auth/ids-api/infra/identity-server.ts
+++ b/apps/services/auth/ids-api/infra/identity-server.ts
@@ -17,7 +17,6 @@ export const serviceSetup = (services: {
       CORECLR_PROFILER_PATH: '/opt/datadog/Datadog.Trace.ClrProfiler.Native.so',
       DD_INTEGRATIONS: '/opt/datadog/integrations.json',
       DD_DOTNET_TRACER_HOME: '/opt/datadog',
-      DD_RUNTIME_METRICS_ENABLED: 'true',
       Datadog__Metrics__Port: '5003',
       AudkenniSettings__Retries: '24',
 


### PR DESCRIPTION
## What
Revert setting `DD_RUNTIME_METRICS_ENABLED ` environment variable in infra.

## Why
Specifying it in infra config does not sit well with the deployment. Maybe it is already set somewhere else.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
