### PR TITLE
fix(auth): Speed up delegation queries HOTFIX

### DIFF
--- a/libs/auth-api-lib/src/lib/delegations/delegations-outgoing.service.ts
+++ b/libs/auth-api-lib/src/lib/delegations/delegations-outgoing.service.ts
@@ -59,11 +59,11 @@ export class DelegationsOutgoingService {
         },
         domainName ? { domainName } : {},
         getDelegationNoActorWhereClause(user),
-        ...this.delegationResourceService.apiScopeFilter({
+        ...(await this.delegationResourceService.apiScopeFilter({
           user,
           prefix: 'delegationScopes->apiScope',
           direction: DelegationDirection.OUTGOING,
-        }),
+        })),
       ),
       include: [
         {

--- a/libs/auth-api-lib/src/lib/resources/delegation-resources.service.ts
+++ b/libs/auth-api-lib/src/lib/resources/delegation-resources.service.ts
@@ -1,5 +1,6 @@
 import { ForbiddenException, Inject, Injectable } from '@nestjs/common'
 import { InjectModel } from '@nestjs/sequelize'
+import startOfDay from 'date-fns/startOfDay'
 import { isCompany } from 'kennitala'
 import { and, Op, or } from 'sequelize'
 import { Includeable } from 'sequelize/types/model'
@@ -38,6 +39,8 @@ export class DelegationResourcesService {
     private apiScopeModel: typeof ApiScope,
     @InjectModel(Domain)
     private domainModel: typeof Domain,
+    @InjectModel(DelegationScope)
+    private delegationScopeModel: typeof DelegationScope,
     private resourceTranslationService: ResourceTranslationService,
     @Inject(DelegationConfig.KEY)
     private delegationConfig: ConfigType<typeof DelegationConfig>,
@@ -67,7 +70,11 @@ export class DelegationResourcesService {
     const domains = await this.domainModel.findAll({
       where: onlyDelegations
         ? and(
-            ...this.apiScopeFilter({ user, prefix: 'scopes', direction }),
+            ...(await this.apiScopeFilter({
+              user,
+              prefix: 'scopes',
+              direction,
+            })),
             domainNameFilter,
           )
         : domainNameFilter,
@@ -101,7 +108,7 @@ export class DelegationResourcesService {
         {
           name: domainName,
         },
-        ...this.apiScopeFilter({ user, prefix: 'scopes' }),
+        ...(await this.apiScopeFilter({ user, prefix: 'scopes' })),
       ),
       include: [
         {
@@ -185,7 +192,7 @@ export class DelegationResourcesService {
     return scopesToCheck.every((scopeName) => userScopes.includes(scopeName))
   }
 
-  apiScopeFilter({
+  async apiScopeFilter({
     user,
     prefix,
     direction,
@@ -205,7 +212,7 @@ export class DelegationResourcesService {
       apiScopeFilter.push(
         ...this.skipScopeFilter(user, prefix),
         ...this.accessControlFilter(user, prefix),
-        ...this.delegationTypeFilter(user, prefix),
+        ...(await this.delegationTypeFilter(user, prefix)),
         ...this.grantToAuthenticatedUserFilter(user, prefix),
       )
     }
@@ -215,10 +222,7 @@ export class DelegationResourcesService {
 
   apiScopeInclude(user: User, direction?: DelegationDirection) {
     if (direction === DelegationDirection.OUTGOING) {
-      return [
-        this.accessControlInclude(user),
-        ...this.delegationTypeInclude(user),
-      ]
+      return [this.accessControlInclude(user)]
     } else {
       return []
     }
@@ -243,7 +247,7 @@ export class DelegationResourcesService {
         {
           domainName,
         },
-        ...this.apiScopeFilter({ user, direction }),
+        ...(await this.apiScopeFilter({ user, direction })),
       ),
       include: [ApiScopeGroup, ...this.apiScopeInclude(user, direction)],
       order: [
@@ -298,38 +302,7 @@ export class DelegationResourcesService {
     ]
   }
 
-  private delegationTypeInclude(user: User): Includeable[] {
-    if (
-      !user.delegationType ||
-      !user.actor ||
-      !user.delegationType.includes(AuthDelegationType.Custom)
-    ) {
-      return []
-    }
-
-    return [
-      {
-        attributes: [],
-        model: DelegationScope,
-        required: false,
-        duplicating: false,
-        include: [
-          {
-            attributes: [],
-            model: Delegation,
-            where: {
-              fromNationalId: user.nationalId,
-              toNationalId: user.actor.nationalId,
-            },
-            required: false,
-            duplicating: false,
-          },
-        ],
-      },
-    ]
-  }
-
-  private delegationTypeFilter(user: User, prefix?: string) {
+  private async delegationTypeFilter(user: User, prefix?: string) {
     if (!user.delegationType || !user.actor) {
       return []
     }
@@ -348,9 +321,9 @@ export class DelegationResourcesService {
       delegationOr.push({ [col(prefix, 'grantToProcuringHolders')]: true })
     }
     if (user.delegationType.includes(AuthDelegationType.Custom)) {
+      const scopeNames = await this.findActorCustomDelegationScopes(user)
       delegationOr.push({
-        [col(prefix, 'delegationScopes', 'delegation', 'toNationalId')]:
-          user.actor.nationalId,
+        [col(prefix, 'name')]: scopeNames,
       })
     }
     return [or(...delegationOr)]
@@ -387,5 +360,29 @@ export class DelegationResourcesService {
       }
     }
     return false
+  }
+
+  private async findActorCustomDelegationScopes(user: User): Promise<string[]> {
+    if (!user.actor) {
+      return []
+    }
+
+    const today = startOfDay(new Date())
+    const delegationScopes = await this.delegationScopeModel.findAll({
+      attributes: ['scopeName'],
+      include: {
+        model: Delegation,
+        where: {
+          fromNationalId: user.nationalId,
+          toNationalId: user.actor.nationalId,
+        },
+      },
+      where: {
+        validFrom: { [Op.lte]: today },
+        validTo: or({ [Op.is]: undefined }, { [Op.gte]: today }),
+      },
+      group: 'scopeName',
+    })
+    return delegationScopes.map((delegationScope) => delegationScope.scopeName)
   }
 }


### PR DESCRIPTION
Hotfix of #13821

These queries are super slow in production because they have a LEFT OUTER JOIN against all delegations in the system containing the respective api scopes.

The original goal is to filter api scopes based on custom delegations which the authenticated user has against the current subject. So this PR changes removes the offending joins and instead conditionally queries the list of custom delegation scopes before the main query, which can then match against them with a simple IN filter.
