### PR TITLE
chore(contentful-role-permissions): Update default permissions

### DIFF
--- a/apps/tools/contentful-role-permissions/constants/index.ts
+++ b/apps/tools/contentful-role-permissions/constants/index.ts
@@ -49,6 +49,15 @@ export const DEFAULT_EDITABLE_ENTRY_TYPE_IDS = [
   'organization',
   'chart',
   'chartComponent',
+  'event',
+  'latestEventsSlice',
+  'featuredEvents',
+  'price',
+  'sectionWithImage',
+  'sliceDropdown',
+  'teamList',
+  'teamMember',
+  'namespace',
 ]
 
 export const DEFAULT_READ_ONLY_ENTRY_IDS = [
@@ -59,4 +68,5 @@ export const DEFAULT_READ_ONLY_ENTRY_IDS = [
   'subArticle',
   'organizationTag',
   'uiConfiguration',
+  'featuredSupportQNAs',
 ]


### PR DESCRIPTION
# Update default permissions

## What

* There are new content types (and old ones) that were missing from the default permission list

## Why

* So that when we create a new role it'll get a different default ruleset

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
