### PR TITLE
chore(web): Pension Calculator - Lowercase first letter for month when used in sentence

### DIFF
--- a/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculator.tsx
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculator.tsx
@@ -61,6 +61,11 @@ import * as styles from './PensionCalculator.css'
 
 const CURRENCY_INPUT_MAX_LENGTH = 15
 
+const lowercaseFirstLetter = (value: string | undefined) => {
+  if (!value) return value
+  return value[0].toLowerCase() + value.slice(1)
+}
+
 interface NumericInputFieldWrapperProps {
   heading: string
   description: string
@@ -462,6 +467,10 @@ const PensionCalculator: CustomScreen<PensionCalculatorProps> = ({
     startYearOptions,
   ])
 
+  const selectedBirthMonthLabel = monthOptions.find(
+    (option) => option.value === birthMonth,
+  )?.label
+
   return (
     <PensionCalculatorWrapper
       organizationPage={organizationPage}
@@ -619,9 +628,12 @@ const PensionCalculator: CustomScreen<PensionCalculatorProps> = ({
                                 {formatMessage(
                                   translationStrings.startMonthAndYearDescription,
                                   {
-                                    month: monthOptions.find(
-                                      (option) => option.value === birthMonth,
-                                    )?.label,
+                                    month:
+                                      activeLocale !== 'en'
+                                        ? lowercaseFirstLetter(
+                                            selectedBirthMonthLabel,
+                                          )
+                                        : selectedBirthMonthLabel,
                                     year: startYearOptions?.[2]?.label,
                                   },
                                 )}


### PR DESCRIPTION
#  Pension Calculator - Lowercase first letter for month when used in sentence

## What

* When the locale is set to something other than english we want to make sure the first letter of a month is lowercase when used in a sentence (janúar instead of Janúar)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
