### PR TITLE
fix(j-s): Only show appeal option for prosecutors and defenders

### DIFF
--- a/apps/judicial-system/web/src/components/ContextMenu/ContextMenu.tsx
+++ b/apps/judicial-system/web/src/components/ContextMenu/ContextMenu.tsx
@@ -12,7 +12,10 @@ import {
   useBoxStyles,
 } from '@island.is/island-ui/core'
 import { TestSupport } from '@island.is/island-ui/utils'
-import { isProsecutionUser } from '@island.is/judicial-system/types'
+import {
+  isDefenceUser,
+  isProsecutionUser,
+} from '@island.is/judicial-system/types'
 
 import {
   CaseAppealState,
@@ -31,6 +34,10 @@ export const useContextMenu = () => {
 
   const shouldDisplayWithdrawAppealOption = useCallback(
     (caseEntry: CaseListEntry) => {
+      if (!isProsecutionUser(user) && !isDefenceUser(user)) {
+        return false
+      }
+
       return Boolean(
         (caseEntry.appealState === CaseAppealState.APPEALED ||
           caseEntry.appealState === CaseAppealState.RECEIVED) &&


### PR DESCRIPTION
# Only show appeal option for prosecutors and defenders

[Asana](https://app.asana.com/0/1199153462262248/1205942829380443/f)

## What

Only show appeal option for prosecutors and defenders

## Why

Only these roles can withdraw an appeal


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
