### PR TITLE
chore(CODEOWNERS): Take ownership of `.githooks/`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -335,6 +335,7 @@ libs/clients/rsk/relationships/                                                 
 
 # DevOps
 /.github/                                                                                                @island-is/devops
+/.githooks/                                                                                              @island-is/devops
 /apps/reference-backend/                                                                                 @island-is/devops
 /apps/github-actions-cache/                                                                              @island-is/devops
 /infra/                                                                                                  @island-is/devops


### PR DESCRIPTION
@island-is/core needlessly has ownership of `.githooks/`, because of defaulting.

Here, I'm taking ownership for @island-is/devops to increase speeeeeed and lessen the burden on @island-is/core 

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
