### PR TITLE
fix(web): 404 redirects don't trigger when user clicks a links

### DIFF
--- a/apps/web/pages/404.tsx
+++ b/apps/web/pages/404.tsx
@@ -58,14 +58,6 @@ const NotFoundPage: React.FC = () => {
     },
   })
 
-  // Temporary "fix", see https://github.com/vercel/next.js/issues/16931 for details
-  useEffect(() => {
-    const els = document.querySelectorAll('link[href*=".css"]')
-    Array.prototype.forEach.call(els, (el) => {
-      el.setAttribute('rel', 'stylesheet')
-    })
-  }, [])
-
   useEffect(() => {
     if (!activeLocale || !apolloClient) {
       return
@@ -75,10 +67,6 @@ const NotFoundPage: React.FC = () => {
       apolloClient: apolloClient as ApolloClient<NormalizedCacheObject>,
       locale: activeLocale,
       query,
-      req: {
-        url: window.location.href,
-      },
-      res: undefined,
     }).then((props) => setLayoutProps(props))
   }, [activeLocale, apolloClient, query])
 
@@ -99,7 +87,6 @@ const NotFoundPage: React.FC = () => {
       } else if (page) {
         if (!isRedirecting.current) {
           isRedirecting.current = true
-
           replace(linkResolver(page.type as LinkType, [page.slug]).href)
         }
       }
@@ -115,7 +102,6 @@ const NotFoundPage: React.FC = () => {
   return (
     <I18n locale={activeLocale} translations={layoutProps?.namespace ?? {}}>
       <Wrapper {...layoutProps}>
-        asdf
         {!errorPageDataLoading && (
           <ErrorScreen
             statusCode={STATUS_CODE}

--- a/apps/web/pages/404.tsx
+++ b/apps/web/pages/404.tsx
@@ -75,7 +75,9 @@ const NotFoundPage: React.FC = () => {
       apolloClient: apolloClient as ApolloClient<NormalizedCacheObject>,
       locale: activeLocale,
       query,
-      req: undefined,
+      req: {
+        url: window.location.href,
+      },
       res: undefined,
     }).then((props) => setLayoutProps(props))
   }, [activeLocale, apolloClient, query])

--- a/apps/web/pages/404.tsx
+++ b/apps/web/pages/404.tsx
@@ -1,0 +1,128 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { useRouter } from 'next/router'
+import {
+  ApolloClient,
+  NormalizedCacheObject,
+  useApolloClient,
+  useQuery,
+} from '@apollo/client'
+
+import { Box } from '@island.is/island-ui/core'
+import {
+  ErrorPageQuery,
+  GetUrlQuery,
+  QueryGetErrorPageArgs,
+  QueryGetUrlArgs,
+} from '@island.is/web/graphql/schema'
+import { LinkType, useLinkResolver } from '@island.is/web/hooks'
+import { getLocaleFromPath } from '@island.is/web/i18n'
+import I18n from '@island.is/web/i18n/I18n'
+import Layout, { LayoutProps } from '@island.is/web/layouts/main'
+
+import withApollo from '../graphql/withApollo'
+import { ErrorScreen } from '../screens/Error'
+import { GET_ERROR_PAGE, GET_URL_QUERY } from '../screens/queries'
+
+const STATUS_CODE = 404
+
+const NotFoundPage: React.FC = () => {
+  const { asPath, replace, query } = useRouter()
+  const activeLocale = getLocaleFromPath(asPath)
+  const isRedirecting = useRef(false)
+  const { linkResolver } = useLinkResolver()
+  const [layoutProps, setLayoutProps] = useState<LayoutProps | null>(null)
+
+  const apolloClient = useApolloClient()
+
+  const { data: urlData, loading: urlDataLoading } = useQuery<
+    GetUrlQuery,
+    QueryGetUrlArgs
+  >(GET_URL_QUERY, {
+    variables: {
+      input: {
+        slug: asPath,
+        lang: activeLocale,
+      },
+    },
+  })
+
+  const { data: errorPageData, loading: errorPageDataLoading } = useQuery<
+    ErrorPageQuery,
+    QueryGetErrorPageArgs
+  >(GET_ERROR_PAGE, {
+    variables: {
+      input: {
+        lang: activeLocale,
+        errorCode: STATUS_CODE.toString(),
+      },
+    },
+  })
+
+  // Temporary "fix", see https://github.com/vercel/next.js/issues/16931 for details
+  useEffect(() => {
+    const els = document.querySelectorAll('link[href*=".css"]')
+    Array.prototype.forEach.call(els, (el) => {
+      el.setAttribute('rel', 'stylesheet')
+    })
+  }, [])
+
+  useEffect(() => {
+    if (!activeLocale || !apolloClient) {
+      return
+    }
+
+    Layout.getProps?.({
+      apolloClient: apolloClient as ApolloClient<NormalizedCacheObject>,
+      locale: activeLocale,
+      query,
+      req: undefined,
+      res: undefined,
+    }).then((props) => setLayoutProps(props))
+  }, [activeLocale, apolloClient, query])
+
+  if (STATUS_CODE === 404) {
+    if (urlDataLoading) {
+      return null
+    }
+
+    if (urlData?.getUrl) {
+      const page = urlData.getUrl?.page
+      const explicitRedirect = urlData.getUrl?.explicitRedirect
+
+      if (!page && explicitRedirect) {
+        if (!isRedirecting.current) {
+          isRedirecting.current = true
+          replace(explicitRedirect)
+        }
+      } else if (page) {
+        if (!isRedirecting.current) {
+          isRedirecting.current = true
+
+          replace(linkResolver(page.type as LinkType, [page.slug]).href)
+        }
+      }
+
+      if (isRedirecting.current) {
+        return null
+      }
+    }
+  }
+
+  const Wrapper = layoutProps ? Layout : Box
+
+  return (
+    <I18n locale={activeLocale} translations={layoutProps?.namespace ?? {}}>
+      <Wrapper {...layoutProps}>
+        asdf
+        {!errorPageDataLoading && (
+          <ErrorScreen
+            statusCode={STATUS_CODE}
+            errPage={errorPageData?.getErrorPage}
+          />
+        )}
+      </Wrapper>
+    </I18n>
+  )
+}
+
+export default withApollo(() => <NotFoundPage />)

--- a/apps/web/types.tsx
+++ b/apps/web/types.tsx
@@ -8,7 +8,7 @@ export type ScreenContext = {
   apolloClient: ApolloClient<NormalizedCacheObject>
   locale: string
   res?: GetServerSidePropsContext['res']
-  req: GetServerSidePropsContext['req'] | { url: string }
+  req?: GetServerSidePropsContext['req']
 }
 
 export type Screen<Props = {}> = ComponentType<Props> & {

--- a/apps/web/types.tsx
+++ b/apps/web/types.tsx
@@ -1,14 +1,14 @@
 import { ComponentType } from 'react'
-import { ApolloClient } from '@apollo/client/core'
-import { NormalizedCacheObject } from '@apollo/client/cache'
 import { GetServerSidePropsContext } from 'next'
+import { NormalizedCacheObject } from '@apollo/client/cache'
+import { ApolloClient } from '@apollo/client/core'
 
 export type ScreenContext = {
   query: GetServerSidePropsContext['query']
   apolloClient: ApolloClient<NormalizedCacheObject>
   locale: string
-  res: GetServerSidePropsContext['res']
-  req: GetServerSidePropsContext['req']
+  res?: GetServerSidePropsContext['res']
+  req: GetServerSidePropsContext['req'] | { url: string }
 }
 
 export type Screen<Props = {}> = ComponentType<Props> & {


### PR DESCRIPTION
# 404 redirects don't trigger when user clicks a links

TODO: check if 500 error page is still working

## Screenshots / Gifs

### Before
https://github.com/island-is/island.is/assets/43557895/a98a3cf7-d4c7-46b6-910e-df86d632f568

### After

https://github.com/island-is/island.is/assets/43557895/0e228826-10b5-4a75-aebd-4945e42e3ec3




## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
