### PR TITLE
feat(web): Pension Calculator - Fix translation strings and change UI according to new design

### DIFF
--- a/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculatorResults.css.ts
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculatorResults.css.ts
@@ -4,7 +4,7 @@ import { theme } from '@island.is/island-ui/theme'
 
 export const line = style({
   borderRight: `2px solid ${theme.color.blue200}`,
-  height: '148px',
+  height: '86px',
 })
 
 export const fullWidth = style({

--- a/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculatorResults.tsx
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculatorResults.tsx
@@ -71,6 +71,7 @@ const PensionCalculatorResults: CustomScreen<PensionCalculatorResultsProps> = ({
   calculationInput,
   queryParamString,
   dateOfCalculationsOptions,
+  customPageData,
 }) => {
   const { formatMessage } = useIntl()
   const { linkResolver } = useLinkResolver()
@@ -120,7 +121,7 @@ const PensionCalculatorResults: CustomScreen<PensionCalculatorResultsProps> = ({
                 {higlightedItemIsPresent && (
                   <Stack space={5}>
                     {highlightedItems.map((highlightedItem, index) => {
-                      const highlightedItemName =
+                      let highlightedItemName =
                         highlightedItem?.name &&
                         highlightedItem?.name in translationStrings
                           ? formatMessage(
@@ -129,6 +130,17 @@ const PensionCalculatorResults: CustomScreen<PensionCalculatorResultsProps> = ({
                               ],
                             )
                           : highlightedItem?.name
+
+                      if (
+                        index > 0 &&
+                        highlightedItem?.name ===
+                          (customPageData?.configJson?.totalFromTrAfterTaxKey ??
+                            'REIKNH.SAMTALSTREFTIRSK')
+                      ) {
+                        highlightedItemName = formatMessage(
+                          translationStrings.highlighedResultItemHeadingForTotalAfterTaxFromTR,
+                        )
+                      }
 
                       const titleVariant: TextProps['variant'] =
                         index === 0 ? 'h3' : 'h4'

--- a/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculatorResults.tsx
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculatorResults.tsx
@@ -17,6 +17,7 @@ import {
   Stack,
   Table,
   Text,
+  TextProps,
 } from '@island.is/island-ui/core'
 import { getThemeConfig } from '@island.is/web/components'
 import {
@@ -74,7 +75,7 @@ const PensionCalculatorResults: CustomScreen<PensionCalculatorResultsProps> = ({
   const { formatMessage } = useIntl()
   const { linkResolver } = useLinkResolver()
 
-  const highlightedItem = calculation.highlightedItem
+  const highlightedItems = calculation.highlightedItems ?? []
 
   const perMonthText = formatMessage(translationStrings.perMonth)
   const perYearText = formatMessage(translationStrings.perYear)
@@ -87,6 +88,8 @@ const PensionCalculatorResults: CustomScreen<PensionCalculatorResultsProps> = ({
   const calculationIsPresent =
     typeof calculation.groups?.length === 'number' &&
     calculation.groups.length > 0
+
+  const higlightedItemIsPresent = highlightedItems.length > 0
 
   return (
     <PensionCalculatorWrapper
@@ -114,46 +117,97 @@ const PensionCalculatorResults: CustomScreen<PensionCalculatorResultsProps> = ({
                     </Text>
                   </Box>
                 </Stack>
-                <Inline alignY="center" justifyContent="spaceBetween" space={5}>
-                  {highlightedItem && (
-                    <Text variant="h2" as="h2">
-                      {formatMessage(
-                        translationStrings.highlightedResultItemHeading,
-                      )}
-                    </Text>
-                  )}
-                  {!highlightedItem && <Box />}
-                  <Hidden print>
-                    <LinkV2
-                      href={`${
-                        linkResolver('pensioncalculator').href
-                      }?${queryParamString}`}
-                    >
-                      <Button unfocusable={true} size="small">
-                        {formatMessage(translationStrings.changeAssumptions)}
-                      </Button>
-                    </LinkV2>
-                  </Hidden>
-                </Inline>
-                {highlightedItem && (
-                  <Box display="flex" paddingLeft={5}>
-                    <Box textAlign="right" paddingTop={2} paddingRight={4}>
-                      <Text variant="h3">
-                        {formatCurrency(highlightedItem?.monthlyAmount)}
-                      </Text>
-                      <Text>{perMonthText}</Text>
-                    </Box>
-                    <Box>
-                      <Box className={styles.line} />
-                    </Box>
-                    <Box textAlign="right" paddingTop={2} paddingLeft={5}>
-                      <Text variant="h3">
-                        {formatCurrency(highlightedItem?.yearlyAmount)}
-                      </Text>
-                      <Text>{perYearText}</Text>
-                    </Box>
-                  </Box>
+                {higlightedItemIsPresent && (
+                  <Stack space={5}>
+                    {highlightedItems.map((highlightedItem, index) => {
+                      const highlightedItemName =
+                        highlightedItem?.name &&
+                        highlightedItem?.name in translationStrings
+                          ? formatMessage(
+                              translationStrings[
+                                highlightedItem?.name as keyof typeof translationStrings
+                              ],
+                            )
+                          : highlightedItem?.name
+
+                      const titleVariant: TextProps['variant'] =
+                        index === 0 ? 'h3' : 'h4'
+
+                      const numericVariant: TextProps['variant'] =
+                        index === 0 ? 'h5' : 'medium'
+
+                      return (
+                        <Stack key={index} space={2}>
+                          <Inline
+                            alignY="center"
+                            justifyContent="spaceBetween"
+                            space={5}
+                          >
+                            {higlightedItemIsPresent && (
+                              <Text variant={titleVariant} as="h2">
+                                {highlightedItemName}
+                              </Text>
+                            )}
+                            {!higlightedItemIsPresent && <Box />}
+                            {index === 0 && (
+                              <Hidden print below="md">
+                                <LinkV2
+                                  href={`${
+                                    linkResolver('pensioncalculator').href
+                                  }?${queryParamString}`}
+                                >
+                                  <Button unfocusable={true} size="small">
+                                    {formatMessage(
+                                      translationStrings.changeAssumptions,
+                                    )}
+                                  </Button>
+                                </LinkV2>
+                              </Hidden>
+                            )}
+                          </Inline>
+
+                          <Box display="flex">
+                            <Box textAlign="right" paddingRight={4}>
+                              <Stack space={1}>
+                                <Text variant={numericVariant}>
+                                  {formatCurrency(
+                                    highlightedItem?.monthlyAmount,
+                                  )}
+                                </Text>
+                                <Text variant="small">{perMonthText}</Text>
+                              </Stack>
+                            </Box>
+                            <Box>
+                              <Box className={styles.line} />
+                            </Box>
+                            <Box textAlign="right" paddingLeft={4}>
+                              <Stack space={1}>
+                                <Text variant={numericVariant}>
+                                  {formatCurrency(
+                                    highlightedItem?.yearlyAmount,
+                                  )}
+                                </Text>
+                                <Text variant="small">{perYearText}</Text>
+                              </Stack>
+                            </Box>
+                          </Box>
+                        </Stack>
+                      )
+                    })}
+                  </Stack>
                 )}
+
+                <Hidden print above="sm">
+                  <LinkV2
+                    href={`${
+                      linkResolver('pensioncalculator').href
+                    }?${queryParamString}`}
+                  >
+                    <Button unfocusable={true} size="small">
+                      {formatMessage(translationStrings.changeAssumptions)}
+                    </Button>
+                  </LinkV2>
+                </Hidden>
 
                 {!calculationIsPresent && (
                   <AlertMessage
@@ -167,8 +221,10 @@ const PensionCalculatorResults: CustomScreen<PensionCalculatorResultsProps> = ({
                 {calculationIsPresent && (
                   <Accordion dividerOnTop={false}>
                     <AccordionItem
-                      startExpanded={!highlightedItem}
+                      startExpanded={!higlightedItemIsPresent}
                       id="resultDetails"
+                      labelVariant="h3"
+                      labelUse="h3"
                       label={formatMessage(
                         translationStrings.resultDetailsLabel,
                       )}
@@ -253,6 +309,19 @@ const PensionCalculatorResults: CustomScreen<PensionCalculatorResultsProps> = ({
                             ))}
                           </Table.Table>
                         </Stack>
+                        <Hidden print>
+                          <LinkV2
+                            href={`${
+                              linkResolver('pensioncalculator').href
+                            }?${queryParamString}`}
+                          >
+                            <Button unfocusable={true} size="small">
+                              {formatMessage(
+                                translationStrings.changeAssumptions,
+                              )}
+                            </Button>
+                          </LinkV2>
+                        </Hidden>
                       </Box>
                     </AccordionItem>
                   </Accordion>

--- a/apps/web/screens/Organization/SocialInsuranceAdministration/translationStrings.ts
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/translationStrings.ts
@@ -787,4 +787,9 @@ export const translationStrings = defineMessages({
     defaultMessage: 'Samtals ráðstöfunartekjur eftir skatt',
     description: 'Niðurstöðuskjár, Samtals ráðstöfunartekjur eftir skatt',
   },
+  highlighedResultItemHeadingForTotalAfterTaxFromTR: {
+    id: 'web.pensionCalculator:REIKNH.highlighedResultItemHeadingForTotalAfterTaxFromTR',
+    defaultMessage: 'Þar af greiðslur frá TR',
+    description: 'Texti efst, Þar af greiðslur frá TR',
+  },
 })

--- a/apps/web/screens/Organization/SocialInsuranceAdministration/translationStrings.ts
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/translationStrings.ts
@@ -652,4 +652,139 @@ export const translationStrings = defineMessages({
     defaultMessage: 'Ár',
     description: 'Ár sem notandi hefur töku á lífeyri, placeholder',
   },
+  'REIKNH.GRUNNLIFELLI': {
+    id: 'web.pensionCalculator:REIKNH.GRUNNLIFELLI',
+    defaultMessage: 'Ellilífeyrir',
+    description: 'Niðurstöðuskjár, Ellilífeyrir',
+  },
+  'REIKNH.HEIMILISUPPBOT': {
+    id: 'web.pensionCalculator:REIKNH.HEIMILISUPPBOT',
+    defaultMessage: 'Heimilisuppbót',
+    description: 'Niðurstöðuskjár, Heimilisuppbót',
+  },
+  'REIKNH.ORLOFSDESEMBERUPPB': {
+    id: 'web.pensionCalculator:REIKNH.ORLOFSDESEMBERUPPB',
+    defaultMessage: 'Orlofs- og desemberuppbætur',
+    description: 'Niðurstöðuskjár, Orlofs- og desemberuppbætur',
+  },
+  'REIKNH.SAMTALSTRFYRIRSK': {
+    id: 'web.pensionCalculator:REIKNH.SAMTALSTRFYRIRSK',
+    defaultMessage: 'Samtals frá TR fyrir skatt',
+    description: 'Niðurstöðuskjár, Samtals frá TR fyrir skatt',
+  },
+  'REIKNH.FRADRSKATTURTR1': {
+    id: 'web.pensionCalculator:REIKNH.FRADRSKATTURTR1',
+    defaultMessage: 'Frádreginn skattur TR (1. og 2. skattþrep)',
+    description: 'Niðurstöðuskjár, Frádreginn skattur TR (1. og 2. skattþrep)',
+  },
+  'REIKNH.PERSAFSLTRMEIRA': {
+    id: 'web.pensionCalculator:REIKNH.PERSAFSLTRMEIRA',
+    defaultMessage: 'Persónuafsláttur af greiðslum TR (nýting skattkorts 22%)',
+    description: 'Niðurstöðuskjár, Persónuafsláttur',
+  },
+  'REIKNH.SAMTALSTREFTIRSK': {
+    id: 'web.pensionCalculator:REIKNH.SAMTALSTREFTIRSK',
+    defaultMessage: 'Samtals frá TR eftir skatt',
+    description: 'Niðurstöðuskjár, Samtals frá TR eftir skatt',
+  },
+  'REIKNH.TEKJURAFATVINNU': {
+    id: 'web.pensionCalculator:REIKNH.TEKJURAFATVINNU',
+    defaultMessage: 'Tekjur af atvinnu',
+    description: 'Niðurstöðuskjár, Tekjur af atvinnu',
+  },
+  'REIKNH.GRFRALIFEYRISSJ': {
+    id: 'web.pensionCalculator:REIKNH.GRFRALIFEYRISSJ',
+    defaultMessage: 'Greiðslur frá lífeyrissjóðum',
+    description: 'Niðurstöðuskjár, Greiðslur frá lífeyrissjóðum',
+  },
+  'REIKNH.GRFRASEREIGNASJ': {
+    id: 'web.pensionCalculator:REIKNH.GRFRASEREIGNASJ',
+    defaultMessage: 'Greiðslur úr séreignarsjóðum',
+    description: 'Niðurstöðuskjár, Greiðslur úr séreignarsjóðum',
+  },
+  'REIKNH.ADRARTEKJUR': {
+    id: 'web.pensionCalculator:REIKNH.ADRARTEKJUR',
+    defaultMessage: 'Aðrar tekjur',
+    description: 'Niðurstöðuskjár, Aðrar tekjur',
+  },
+  'REIKNH.SKATTSKBAETURSV': {
+    id: 'web.pensionCalculator:REIKNH.SKATTSKBAETURSV',
+    defaultMessage: 'Skattskyldar bætur sveitarfélaga',
+    description: 'Niðurstöðuskjár, Skattskyldar bætur sveitarfélaga',
+  },
+  'REIKNH.FRADRIDGJLIFEYR': {
+    id: 'web.pensionCalculator:REIKNH.FRADRIDGJLIFEYR',
+    defaultMessage: 'Frádregin iðgjöld í lífeyrissjóði',
+    description: 'Niðurstöðuskjár, Frádregin iðgjöld í lífeyrissjóði',
+  },
+  'REIKNH.SAMTALSFYRIRSK': {
+    id: 'web.pensionCalculator:REIKNH.SAMTALSFYRIRSK',
+    defaultMessage: 'Samtals fyrir skatt',
+    description: 'Niðurstöðuskjár, Samtals fyrir skatt',
+  },
+  'REIKNH.PERSAFSLMEIRA': {
+    id: 'web.pensionCalculator:REIKNH.PERSAFSLMEIRA',
+    defaultMessage: 'Persónuafsláttur (nýting skattkorts 78%)',
+    description: 'Niðurstöðuskjár, Persónuafsláttur (nýting skattkorts 78%)',
+  },
+  'REIKNH.SAMTALSEFTIRSK': {
+    id: 'web.pensionCalculator:REIKNH.SAMTALSEFTIRSK',
+    defaultMessage: 'Samtals frá öðrum eftir skatt',
+    description: 'Niðurstöðuskjár, Samtals frá öðrum eftir skatt',
+  },
+  'REIKNH.FJARMAGNSTEKJUR': {
+    id: 'web.pensionCalculator:REIKNH.FJARMAGNSTEKJUR',
+    defaultMessage: 'Fjármagnstekjur',
+    description: 'Niðurstöðuskjár, Fjármagnstekjur',
+  },
+  'REIKNH.SAMTFJARMTEKESK': {
+    id: 'web.pensionCalculator:REIKNH.SAMTFJARMTEKESK',
+    defaultMessage: 'Samtals fjármagnstekjur eftir skatt',
+    description: 'Niðurstöðuskjár, Samtals fjármagnstekjur eftir skatt',
+  },
+  'REIKNH.GREIDSLURFRATR': {
+    id: 'web.pensionCalculator:REIKNH.GREIDSLURFRATR',
+    defaultMessage: 'Greiðslur frá Tryggingastofnun',
+    description: 'Niðurstöðuskjár, Greiðslur frá Tryggingastofnun',
+  },
+  'REIKNH.TEKJURFRAODRUM': {
+    id: 'web.pensionCalculator:REIKNH.TEKJURFRAODRUM',
+    defaultMessage: 'Tekjur frá öðrum',
+    description: 'Niðurstöðuskjár, Tekjur frá öðrum',
+  },
+  'REIKNH.FJARMTEKSAMANT': {
+    id: 'web.pensionCalculator:REIKNH.FJARMTEKSAMANT',
+    defaultMessage: 'Fjármagnstekjur samanteknar',
+    description: 'Niðurstöðuskjár, Fjármagnstekjur samanteknar',
+  },
+  'REIKNH.TEKJURSAMTALS': {
+    id: 'web.pensionCalculator:REIKNH.TEKJURSAMTALS',
+    defaultMessage: 'Tekjur samtals',
+    description: 'Niðurstöðuskjár, Tekjur samtals',
+  },
+  'REIKNH.FRADRSTADGR': {
+    id: 'web.pensionCalculator:REIKNH.FRADRSTADGR',
+    defaultMessage: 'Frádregin staðgreiðsla',
+    description: 'Niðurstöðuskjár, Frádregin staðgreiðsla',
+  },
+  'REIKNH.FRADRFJARMTEKSK': {
+    id: 'web.pensionCalculator:REIKNH.FRADRFJARMTEKSK',
+    defaultMessage: 'Frádreginn fjármagnstekjuskattur',
+    description: 'Niðurstöðuskjár, Frádreginn fjármagnstekjuskattur',
+  },
+  'REIKNH.FRADRSKATTSAMT': {
+    id: 'web.pensionCalculator:REIKNH.FRADRSKATTSAMT',
+    defaultMessage: 'Frádregnir skattar samtals',
+    description: 'Niðurstöðuskjár, Frádregnir skattar samtals',
+  },
+  'REIKNH.AFBORGKRAFNATR': {
+    id: 'web.pensionCalculator:REIKNH.AFBORGKRAFNATR',
+    defaultMessage: 'Afborganir krafna hjá TR',
+    description: 'Niðurstöðuskjár, Afborganir krafna hjá TR',
+  },
+  'REIKNH.SAMTRADSTTEKESK': {
+    id: 'web.pensionCalculator:REIKNH.SAMTRADSTTEKESK',
+    defaultMessage: 'Samtals ráðstöfunartekjur eftir skatt',
+    description: 'Niðurstöðuskjár, Samtals ráðstöfunartekjur eftir skatt',
+  },
 })

--- a/apps/web/screens/Organization/SocialInsuranceAdministration/translationStrings.ts
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/translationStrings.ts
@@ -371,9 +371,9 @@ export const translationStrings = defineMessages({
     description: ' ár',
   },
   ageOfFirst75DisabilityAssessment: {
-    id: 'web.pensionCalculator:yearsSuffix',
-    defaultMessage: ' ár',
-    description: ' ár',
+    id: 'web.pensionCalculator:ageOfFirst75DisabilityAssessment',
+    defaultMessage: 'Fyrsta örorkumat',
+    description: 'Fyrsta örorkumat',
   },
   livingConditionAbroadInYearsPlaceholder: {
     id: 'web.pensionCalculator:livingConditionAbroadInYearsPlaceholder',

--- a/apps/web/screens/Organization/SocialInsuranceAdministration/translationStrings.ts
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/translationStrings.ts
@@ -787,6 +787,51 @@ export const translationStrings = defineMessages({
     defaultMessage: 'Samtals ráðstöfunartekjur eftir skatt',
     description: 'Niðurstöðuskjár, Samtals ráðstöfunartekjur eftir skatt',
   },
+  'REIKNH.GRUNNLIFENDURH': {
+    id: 'web.pensionCalculator:REIKNH.GRUNNLIFENDURH',
+    defaultMessage: 'Endurhæfingarlífeyrir',
+    description: 'Niðurstöðuskjár, Endurhæfingarlífeyrir',
+  },
+  'REIKNH.ALDURSVIDBOT': {
+    id: 'web.pensionCalculator:REIKNH.ALDURSVIDBOT',
+    defaultMessage: 'Aldursviðbót',
+    description: 'Niðurstöðuskjár, Aldursviðbót',
+  },
+  'REIKNH.TEKJUTRYGGING': {
+    id: 'web.pensionCalculator:REIKNH.TEKJUTRYGGING',
+    defaultMessage: 'Tekjutrygging',
+    description: 'Niðurstöðuskjár, Tekjutrygging',
+  },
+  'REIKNH.FRAMFAERSLUUPPB': {
+    id: 'web.pensionCalculator:REIKNH.FRAMFAERSLUUPPB',
+    defaultMessage: 'Framfærsluuppbót',
+    description: 'Niðurstöðuskjár, Framfærsluuppbót',
+  },
+  'REIKNH.FRADRSKATTURTR2': {
+    id: 'web.pensionCalculator:REIKNH.FRADRSKATTURTR2',
+    defaultMessage: 'Frádreginn skattur (1. og 2. skattþrep)',
+    description: 'Niðurstöðuskjár, Frádreginn skattur (1. og 2. skattþrep)',
+  },
+  'REIKNH.GRUNNLIFORORKA': {
+    id: 'web.pensionCalculator:REIKNH.GRUNNLIFORORKA',
+    defaultMessage: 'Örorkulífeyrir',
+    description: 'Niðurstöðuskjár, Örorkulífeyrir',
+  },
+  'REIKNH.GRUNNLIFHALFURELLI': {
+    id: 'web.pensionCalculator:REIKNH.GRUNNLIFHALFURELLI',
+    defaultMessage: 'Hálfur ellilífeyrir',
+    description: 'Niðurstöðuskjár, Hálfur ellilífeyrir',
+  },
+  'REIKNHH.ALFHEIMILISUPPBOT': {
+    id: 'web.pensionCalculator:REIKNHH.ALFHEIMILISUPPBOT',
+    defaultMessage: 'Hálf heimilisuppbót',
+    description: 'Niðurstöðuskjár, Hálf heimilisuppbót',
+  },
+  'REIKNH.GRUNNLIFELLISJOM': {
+    id: 'web.pensionCalculator:REIKNH.GRUNNLIFELLISJOM',
+    defaultMessage: 'Ellilífeyrir sjómanna',
+    description: 'Niðurstöðuskjár, Ellilífeyrir sjómanna',
+  },
   highlighedResultItemHeadingForTotalAfterTaxFromTR: {
     id: 'web.pensionCalculator:REIKNH.highlighedResultItemHeadingForTotalAfterTaxFromTR',
     defaultMessage: 'Þar af greiðslur frá TR',

--- a/apps/web/screens/queries/PensionCalculator.ts
+++ b/apps/web/screens/queries/PensionCalculator.ts
@@ -3,7 +3,7 @@ import gql from 'graphql-tag'
 export const GET_PENSION_CALCULATION = gql`
   query GetPensionCalculation($input: SocialInsurancePensionCalculationInput!) {
     getPensionCalculation(input: $input) {
-      highlightedItem {
+      highlightedItems {
         name
         monthlyAmount
         yearlyAmount

--- a/libs/api/domains/social-insurance/src/lib/models/pensionCalculation.model.ts
+++ b/libs/api/domains/social-insurance/src/lib/models/pensionCalculation.model.ts
@@ -24,8 +24,8 @@ class PensionCalculationItemGroup {
 
 @ObjectType('SocialInsurancePensionCalculationResponse')
 export class PensionCalculationResponse {
-  @CacheField(() => PensionCalculationItem, { nullable: true })
-  highlightedItem?: PensionCalculationItem
+  @CacheField(() => [PensionCalculationItem], { nullable: true })
+  highlightedItems?: PensionCalculationItem[]
 
   @CacheField(() => [PensionCalculationItemGroup], { nullable: true })
   groups?: PensionCalculationItemGroup[]

--- a/libs/api/domains/social-insurance/src/lib/socialInsurance.service.ts
+++ b/libs/api/domains/social-insurance/src/lib/socialInsurance.service.ts
@@ -15,7 +15,7 @@ import { PensionCalculationResponse } from './models/pensionCalculation.model'
 import { PaymentPlan } from './models/paymentPlan.model'
 import { PaymentGroup } from './models/paymentGroup'
 import {
-  getPensionCalculationHighlightedItem,
+  getPensionCalculationHighlightedItems,
   groupPensionCalculationItems,
   mapPensionCalculationInput,
 } from './utils'
@@ -126,13 +126,13 @@ export class SocialInsuranceService {
     )
 
     const groups = groupPensionCalculationItems(calculation, pageData)
-    const highlightedItem = getPensionCalculationHighlightedItem(
+    const highlightedItems = getPensionCalculationHighlightedItems(
       calculation,
       pageData,
     )
 
     return {
-      highlightedItem,
+      highlightedItems,
       groups,
     }
   }

--- a/libs/api/domains/social-insurance/src/lib/utils.ts
+++ b/libs/api/domains/social-insurance/src/lib/utils.ts
@@ -141,12 +141,12 @@ export const groupPensionCalculationItems = (
   const groupCutoffValues = (pageData?.configJson?.[
     'groupCutOffValues'
   ] as string[]) ?? [
-    'Samtals frá TR fyrir skatt:',
-    'Samtals frá TR eftir skatt:',
-    'Samtals frá öðrum eftir skatt:',
-    'Samtals fjármagnstekjur eftir skatt:',
-    'Tekjur samtals:',
-    'Samtals ráðstöfunartekjur eftir skatt:',
+    'REIKNH.SAMTALSTRFYRIRSK',
+    'REIKNH.SAMTALSTREFTIRSK',
+    'REIKNH.SAMTALSEFTIRSK',
+    'REIKNH.SAMTFJARMTEKESK',
+    'REIKNH.TEKJURSAMTALS',
+    'REIKNH.SAMTRADSTTEKESK',
   ]
 
   // These values are used as keys in the frontend to display translations
@@ -185,14 +185,22 @@ export const groupPensionCalculationItems = (
   return groups
 }
 
-export const getPensionCalculationHighlightedItem = (
+export const getPensionCalculationHighlightedItems = (
   calculation: TrWebCommonsExternalPortalsApiModelsPensionCalculatorPensionCalculatorOutput[],
   pageData: CustomPage | null,
-) => {
-  return calculation?.find(
-    (item) =>
-      item?.name ===
-      (pageData?.configJson?.['highlightedItemName'] ??
-        'Samtals frá TR eftir skatt:'),
-  )
+): PensionCalculationResponse['highlightedItems'] => {
+  const higlightedItemNames = (pageData?.configJson?.[
+    'higlightedItemNames'
+  ] as string[]) ?? ['REIKNH.SAMTRADSTTEKESK', 'REIKNH.SAMTALSTREFTIRSK']
+
+  const highlightedItems = []
+
+  for (const itemName of higlightedItemNames) {
+    const item = calculation.find((item) => item?.name === itemName)
+    if (item) {
+      highlightedItems.push(item)
+    }
+  }
+
+  return highlightedItems
 }


### PR DESCRIPTION
# Pension Calculator - Fix translation strings and change UI according to new design

The social insurance administration backend is now returning id's instead of Icelandic text

This PR
* Uses those id's to fetch translation strings
* Now also displays the total payment after tax at the top of the results page
* Minor visual changes regarding heading levels and button placements

## Screenshots / Gifs

### Before
![image](https://github.com/island-is/island.is/assets/43557895/9455993f-0dc7-40e8-8ced-74d49e38835b)


### After
![image](https://github.com/island-is/island.is/assets/43557895/c3be044f-33f7-4b34-8df4-0cb5a5f0790e)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
