### PR TITLE
feat(web): Pension Calculator - Change default values and tweak visuals

### DIFF
--- a/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculator.tsx
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculator.tsx
@@ -66,6 +66,24 @@ const lowercaseFirstLetter = (value: string | undefined) => {
   return value[0].toLowerCase() + value.slice(1)
 }
 
+const hasDisabilityAssessment = (
+  typeOfBasePension: BasePensionType | null | undefined,
+) => {
+  return (
+    typeOfBasePension === BasePensionType.Disability ||
+    typeOfBasePension === BasePensionType.Rehabilitation
+  )
+}
+
+const hasStartDate = (
+  typeOfBasePension: BasePensionType | null | undefined,
+) => {
+  return (
+    typeOfBasePension === BasePensionType.Retirement ||
+    typeOfBasePension === BasePensionType.HalfRetirement
+  )
+}
+
 interface NumericInputFieldWrapperProps {
   heading: string
   description: string
@@ -325,6 +343,15 @@ const PensionCalculator: CustomScreen<PensionCalculatorProps> = ({
     const baseUrl = linkResolver('pensioncalculatorresults').href
     const queryParams = convertToQueryParams({
       ...data,
+      ...(!hasDisabilityAssessment(data.typeOfBasePension) && {
+        ageOfFirst75DisabilityAssessment: undefined,
+      }),
+      ...(!hasStartDate(data.typeOfBasePension) && {
+        birthMonth: undefined,
+        birthYear: undefined,
+        startMonth: undefined,
+        startYear: undefined,
+      }),
       dateOfCalculations: data.dateOfCalculations
         ? data.dateOfCalculations
         : dateOfCalculationsOptions[0].value,
@@ -556,9 +583,7 @@ const PensionCalculator: CustomScreen<PensionCalculatorProps> = ({
                     className={styles.fullWidth}
                   >
                     <Stack space={5}>
-                      {(typeOfBasePension === BasePensionType.Retirement ||
-                        typeOfBasePension ===
-                          BasePensionType.HalfRetirement) && (
+                      {hasStartDate(typeOfBasePension) && (
                         <Stack space={3}>
                           <Box className={styles.textMaxWidth}>
                             <Text variant="h2" as="h2">
@@ -801,7 +826,11 @@ const PensionCalculator: CustomScreen<PensionCalculatorProps> = ({
                                   )
                                 }
                                 type="number"
-                                maxLength={7}
+                                maxLength={
+                                  formatMessage(
+                                    translationStrings.ageOfFirst75DisabilityAssessmentSuffix,
+                                  ).length + 3
+                                }
                               />
                             </Box>
                           )}
@@ -862,7 +891,10 @@ const PensionCalculator: CustomScreen<PensionCalculatorProps> = ({
                                   ' ' +
                                   formatMessage(translationStrings.yearsSuffix)
                                 }
-                                maxLength={5}
+                                maxLength={
+                                  formatMessage(translationStrings.yearsSuffix)
+                                    .length + 3
+                                }
                               />
                             </Box>
                           )}
@@ -1218,8 +1250,6 @@ PensionCalculator.getProps = async ({
     typeOfPeriodIncome: defaultValues.typeOfPeriodIncome
       ? defaultValues.typeOfPeriodIncome
       : PeriodIncomeType.Month,
-    livingConditionRatio: 100,
-    taxCard: 0,
   }
 
   return {

--- a/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculatorResults.css.ts
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculatorResults.css.ts
@@ -2,8 +2,10 @@ import { globalStyle, style } from '@vanilla-extract/css'
 
 import { theme } from '@island.is/island-ui/theme'
 
+const lineWidth = '2px'
+
 export const line = style({
-  borderRight: `2px solid ${theme.color.blue200}`,
+  borderRight: `${lineWidth} solid ${theme.color.blue200}`,
   height: '86px',
 })
 
@@ -17,4 +19,17 @@ export const textMaxWidth = style({
 
 globalStyle('tbody', {
   borderBottom: '32px solid white',
+})
+
+export const grid = style({
+  display: 'grid',
+  gridTemplateColumns: `140px ${lineWidth} auto`,
+})
+
+export const fitContent = style({
+  width: 'fit-content',
+})
+
+export const alignSelfToFlexEnd = style({
+  alignSelf: 'flex-end',
 })

--- a/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculatorResults.tsx
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculatorResults.tsx
@@ -178,29 +178,47 @@ const PensionCalculatorResults: CustomScreen<PensionCalculatorResultsProps> = ({
                             )}
                           </Inline>
 
-                          <Box display="flex">
-                            <Box textAlign="right" paddingRight={4}>
-                              <Stack space={1}>
-                                <Text variant={numericVariant}>
-                                  {formatCurrency(
-                                    highlightedItem?.monthlyAmount,
-                                  )}
-                                </Text>
-                                <Text variant="small">{perMonthText}</Text>
-                              </Stack>
+                          <Box className={styles.grid}>
+                            <Box>
+                              <Box
+                                display="flex"
+                                flexDirection="column"
+                                rowGap={1}
+                                className={styles.fitContent}
+                              >
+                                <Box>
+                                  <Text variant={numericVariant}>
+                                    {formatCurrency(
+                                      highlightedItem?.monthlyAmount,
+                                    )}
+                                  </Text>
+                                </Box>
+                                <Box className={styles.alignSelfToFlexEnd}>
+                                  <Text variant="small">{perMonthText}</Text>
+                                </Box>
+                              </Box>
                             </Box>
                             <Box>
                               <Box className={styles.line} />
                             </Box>
-                            <Box textAlign="right" paddingLeft={4}>
-                              <Stack space={1}>
-                                <Text variant={numericVariant}>
-                                  {formatCurrency(
-                                    highlightedItem?.yearlyAmount,
-                                  )}
-                                </Text>
-                                <Text variant="small">{perYearText}</Text>
-                              </Stack>
+                            <Box paddingLeft={4}>
+                              <Box
+                                display="flex"
+                                flexDirection="column"
+                                rowGap={1}
+                                className={styles.fitContent}
+                              >
+                                <Box>
+                                  <Text variant={numericVariant}>
+                                    {formatCurrency(
+                                      highlightedItem?.yearlyAmount,
+                                    )}
+                                  </Text>
+                                </Box>
+                                <Box className={styles.alignSelfToFlexEnd}>
+                                  <Text variant="small">{perYearText}</Text>
+                                </Box>
+                              </Box>
                             </Box>
                           </Box>
                         </Stack>

--- a/apps/web/screens/Organization/SocialInsuranceAdministration/translationStrings.ts
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/translationStrings.ts
@@ -832,6 +832,11 @@ export const translationStrings = defineMessages({
     defaultMessage: 'Ellilífeyrir sjómanna',
     description: 'Niðurstöðuskjár, Ellilífeyrir sjómanna',
   },
+  'REIKNH.FRADRSKATTUR1': {
+    id: 'web.pensionCalculator:REIKNH.FRADRSKATTUR1',
+    defaultMessage: 'Frádreginn skattur',
+    description: 'Niðurstöðuskjár, Frádreginn skattur',
+  },
   highlighedResultItemHeadingForTotalAfterTaxFromTR: {
     id: 'web.pensionCalculator:REIKNH.highlighedResultItemHeadingForTotalAfterTaxFromTR',
     defaultMessage: 'Þar af greiðslur frá TR',


### PR DESCRIPTION
# Pension Calculator - Change default values and tweak visuals

## What

* Change default values for pension calculation form
* Skip sending fields to backend that aren't used in calculation depending on what pension type was selected
* Fix visuals

## Screenshots / Gifs

### Before (notice how the separation line isn't lined up)
![image](https://github.com/island-is/island.is/assets/43557895/3ad410df-7b20-4015-aee5-8486078c85c7)


### After
![image](https://github.com/island-is/island.is/assets/43557895/3a7b5e17-57af-4e49-9c16-b3cfbc531dab)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
