### PR TITLE
fix(delegation-index): stop using master db when indexing all delegations

### DIFF
--- a/libs/auth-api-lib/src/lib/delegations/delegations-index.service.ts
+++ b/libs/auth-api-lib/src/lib/delegations/delegations-index.service.ts
@@ -144,13 +144,16 @@ export class DelegationsIndexService {
 
   /* Index incoming custom delegations */
   async indexCustomDelegations(nationalId: string) {
-    const delegations = await this.getCustomDelegations(nationalId)
+    const delegations = await this.getCustomDelegations(nationalId, true)
     await this.saveToIndex(delegations)
   }
 
   /* Index incoming personal representative delegations */
   async indexRepresentativeDelegations(nationalId: string) {
-    const delegations = await this.getRepresentativeDelegations(nationalId)
+    const delegations = await this.getRepresentativeDelegations(
+      nationalId,
+      true,
+    )
     await this.saveToIndex(delegations)
   }
 
@@ -223,9 +226,9 @@ export class DelegationsIndexService {
     return { deleted, created, updated }
   }
 
-  private async getCustomDelegations(nationalId: string) {
+  private async getCustomDelegations(nationalId: string, useMaster = false) {
     const delegations = await this.delegationsIncomingCustomService
-      .findAllValidIncoming({ nationalId }, true)
+      .findAllValidIncoming({ nationalId }, useMaster)
       .then((d) => d.map(toDelegationIndexInfo))
 
     const currentDelegationIndexItems = await this.delegationIndexModel.findAll(
@@ -241,9 +244,12 @@ export class DelegationsIndexService {
     return this.sortDelegation(currentDelegationIndexItems, delegations)
   }
 
-  private async getRepresentativeDelegations(nationalId: string) {
+  private async getRepresentativeDelegations(
+    nationalId: string,
+    useMaster = false,
+  ) {
     const delegations = await this.delegationsIncomingRepresentativeService
-      .findAllIncoming({ nationalId }, true)
+      .findAllIncoming({ nationalId }, useMaster)
       .then((d) => d.map(toDelegationIndexInfo))
 
     const currentDelegationIndexItems = await this.delegationIndexModel.findAll(


### PR DESCRIPTION
## Why

Indexing all delegations doesn't happen right after db write, so there is no need to use master database when indexing. 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
