### PR TITLE
fix(application-estate): Share-parsing function for icelandic commas

### DIFF
--- a/libs/clients/syslumenn/src/lib/syslumennClient.utils.spec.ts
+++ b/libs/clients/syslumenn/src/lib/syslumennClient.utils.spec.ts
@@ -1,0 +1,28 @@
+import { parseShare } from './syslumennClient.utils'
+
+describe('syslumennClient.utils.parseShare', () => {
+  it('Should handle commas', () => {
+    expect(parseShare('1,5')).toStrictEqual(1.5)
+    expect(parseShare('50,002')).toStrictEqual(50.002)
+  })
+
+  it('Should handle normal floating point numbers', () => {
+    expect(parseShare('1.5')).toStrictEqual(1.5)
+    expect(parseShare('50.002')).toStrictEqual(50.002)
+  })
+
+  it('Should handle integers', () => {
+    expect(parseShare('1')).toStrictEqual(1)
+    expect(parseShare('50')).toStrictEqual(50)
+  })
+
+  it('Should handle edge cases', () => {
+    expect(parseShare('0')).toStrictEqual(0)
+    expect(parseShare('0.0')).toStrictEqual(0)
+    expect(parseShare('0,0')).toStrictEqual(0)
+
+    expect(parseShare('100')).toStrictEqual(100)
+    expect(parseShare('100.0')).toStrictEqual(100)
+    expect(parseShare('100,0')).toStrictEqual(100)
+  })
+})

--- a/libs/clients/syslumenn/src/lib/syslumennClient.utils.ts
+++ b/libs/clients/syslumenn/src/lib/syslumennClient.utils.ts
@@ -338,7 +338,9 @@ export const assetMapper = (assetRaw: EignirDanarbus): EstateAsset => {
     description: assetRaw.lysing ?? '',
     assetNumber: assetRaw.fastanumer ?? '',
     share:
-      assetRaw.eignarhlutfall !== undefined ? assetRaw.eignarhlutfall : 100,
+      assetRaw.eignarhlutfall !== undefined
+        ? parseShare(assetRaw.eignarhlutfall)
+        : 100,
   }
 }
 
@@ -486,4 +488,11 @@ export const mapDepartedToRegistryPerson = (
     nationalId: departed.kennitala ?? '',
     postalCode: departed.postaritun?.split('-')[0] ?? '',
   }
+}
+
+// This has untested behaviour if share is outside of [0, 100].
+// That should be fine since it is the DC's responsibility to return
+// valid percentages.
+export const parseShare = (share: string | number): number => {
+  return typeof share === 'string' ? parseFloat(share.replace(',', '.')) : share
 }


### PR DESCRIPTION
Invalid data was reaching the pre-filled state of the application due to `50,02` being cast into string in the DC's respsonse instead of passing `50.02` as float.

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206670473640411