### PR TITLE
chore(university-gateway): Cache graphql calls

### DIFF
--- a/libs/api/domains/university-gateway/src/lib/graphql/main.resolver.ts
+++ b/libs/api/domains/university-gateway/src/lib/graphql/main.resolver.ts
@@ -1,4 +1,8 @@
 import { Args, Query, Resolver } from '@nestjs/graphql'
+import { CurrentUser } from '@island.is/auth-nest-tools'
+import type { User } from '@island.is/auth-nest-tools'
+import { CacheControl, CacheControlOptions } from '@island.is/nest/graphql'
+import { CACHE_CONTROL_MAX_AGE } from '@island.is/shared/constants'
 import { UniversityGatewayApi } from '../universityGateway.service'
 import {
   UniversityGatewayGetPogramInput,
@@ -9,18 +13,20 @@ import {
   UniversityGatewayProgramFilter,
   UniversityGatewayApplication,
 } from './models'
-import { CurrentUser } from '@island.is/auth-nest-tools'
-import type { User } from '@island.is/auth-nest-tools'
+
+const defaultCache: CacheControlOptions = { maxAge: CACHE_CONTROL_MAX_AGE }
 
 @Resolver()
 export class MainResolver {
   constructor(private readonly universityGatewayApi: UniversityGatewayApi) {}
 
+  @CacheControl(defaultCache)
   @Query(() => UniversityGatewayProgramsPaginated)
   universityGatewayPrograms() {
     return this.universityGatewayApi.getActivePrograms()
   }
 
+  @CacheControl(defaultCache)
   @Query(() => UniversityGatewayProgramDetails)
   universityGatewayProgram(
     @Args('input') input: UniversityGatewayGetPogramInput,
@@ -28,11 +34,13 @@ export class MainResolver {
     return this.universityGatewayApi.getProgramById(input)
   }
 
+  @CacheControl(defaultCache)
   @Query(() => [UniversityGatewayProgramFilter])
   universityGatewayProgramFilters() {
     return this.universityGatewayApi.getProgramFilters()
   }
 
+  @CacheControl(defaultCache)
   @Query(() => [UniversityGatewayApplication])
   universityGatewayApplicationById(
     @Args('id', { type: () => String }) id: string,

--- a/libs/api/domains/university-gateway/src/lib/graphql/models/program.model.ts
+++ b/libs/api/domains/university-gateway/src/lib/graphql/models/program.model.ts
@@ -1,3 +1,4 @@
+import { CacheField } from '@island.is/nest/graphql'
 import { Field, ObjectType } from '@nestjs/graphql'
 
 @ObjectType('UniversityGatewayProgram')
@@ -80,7 +81,7 @@ export class UniversityGatewayProgram {
   @Field()
   iscedCode!: string
 
-  @Field(() => [String])
+  @CacheField(() => [String])
   modeOfDelivery!: string[]
 }
 
@@ -122,10 +123,10 @@ export class UniversityGatewayProgramDetails extends UniversityGatewayProgram {
   @Field()
   allowThirdLevelQualification!: boolean
 
-  @Field(() => [UniversityGatewayProgramCourse])
+  @CacheField(() => [UniversityGatewayProgramCourse])
   courses!: UniversityGatewayProgramCourse[]
 
-  @Field(() => [UniversityGatewayProgramExtraApplicationField])
+  @CacheField(() => [UniversityGatewayProgramExtraApplicationField])
   extraApplicationFields!: UniversityGatewayProgramExtraApplicationField[]
 }
 

--- a/libs/api/domains/university-gateway/src/lib/graphql/models/programFilter.model.ts
+++ b/libs/api/domains/university-gateway/src/lib/graphql/models/programFilter.model.ts
@@ -1,3 +1,4 @@
+import { CacheField } from '@island.is/nest/graphql'
 import { Field, ObjectType } from '@nestjs/graphql'
 
 @ObjectType('UniversityGatewayProgramFilter')
@@ -5,6 +6,6 @@ export class UniversityGatewayProgramFilter {
   @Field()
   field!: string
 
-  @Field(() => [String])
+  @CacheField(() => [String])
   options!: string[]
 }

--- a/libs/api/domains/university-gateway/src/lib/graphql/university.resolver.ts
+++ b/libs/api/domains/university-gateway/src/lib/graphql/university.resolver.ts
@@ -1,7 +1,7 @@
 import { Parent, Query, ResolveField, Resolver } from '@nestjs/graphql'
-import { UniversityGatewayApi } from '../universityGateway.service'
-import { UniversityGatewayUniversity } from './models'
 import { Loader } from '@island.is/nest/dataloader'
+import { CacheControl, CacheControlOptions } from '@island.is/nest/graphql'
+import { CACHE_CONTROL_MAX_AGE } from '@island.is/shared/constants'
 import {
   OrganizationLinkByReferenceIdLoader,
   OrganizationLogoByReferenceIdLoader,
@@ -15,16 +15,22 @@ import type {
   OrganizationTitleByReferenceIdDataLoader,
   ShortTitle,
 } from '@island.is/cms'
+import { UniversityGatewayApi } from '../universityGateway.service'
+import { UniversityGatewayUniversity } from './models'
+
+const defaultCache: CacheControlOptions = { maxAge: CACHE_CONTROL_MAX_AGE }
 
 @Resolver(UniversityGatewayUniversity)
 export class UniversityResolver {
   constructor(private readonly universityGatewayApi: UniversityGatewayApi) {}
 
+  @CacheControl(defaultCache)
   @Query(() => [UniversityGatewayUniversity])
   universityGatewayUniversities() {
     return this.universityGatewayApi.getUniversities()
   }
 
+  @CacheControl(defaultCache)
   @ResolveField('contentfulLogoUrl', () => String, { nullable: true })
   async resolveContentfulLogoUrl(
     @Loader(OrganizationLogoByReferenceIdLoader)
@@ -34,6 +40,7 @@ export class UniversityResolver {
     return await organizationLogoLoader.load(university.contentfulKey)
   }
 
+  @CacheControl(defaultCache)
   @ResolveField('contentfulTitle', () => String, { nullable: true })
   async resolveContentfulTitle(
     @Loader(OrganizationTitleByReferenceIdLoader)
@@ -43,6 +50,7 @@ export class UniversityResolver {
     return organizationTitleLoader.load(university.contentfulKey)
   }
 
+  @CacheControl(defaultCache)
   @ResolveField('contentfulLink', () => String, { nullable: true })
   async resolveContentfulLink(
     @Loader(OrganizationLinkByReferenceIdLoader)

--- a/libs/nest/pagination/src/lib/graphql/paginated.response.ts
+++ b/libs/nest/pagination/src/lib/graphql/paginated.response.ts
@@ -1,4 +1,5 @@
 import { Field, ObjectType } from '@nestjs/graphql'
+import { CacheField } from '@island.is/nest/graphql'
 
 import { PageInfoDto } from '../dto/pageinfo.dto'
 
@@ -16,13 +17,13 @@ export function PaginatedResponse<TItemsFieldValue>(
 ) {
   @ObjectType({ isAbstract: true })
   abstract class PaginatedResponseClass {
-    @Field(() => [itemsFieldValue])
+    @CacheField(() => [itemsFieldValue])
     data!: TItemsFieldValue[]
 
     @Field()
     totalCount!: number
 
-    @Field(() => PageInfoDto)
+    @CacheField(() => PageInfoDto)
     pageInfo!: PageInfoDto
   }
 


### PR DESCRIPTION
# Cache graphql calls

## What

* Add caching support to the university gateway graphql endpoints
* Add caching support to the PaginatedResponse model

## Why

* island.is/haskolanam/leit is really slow since the graphql calls aren't cached

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
