### PR TITLE
fix(ghb): Remove statement checkbox and add loan providers check

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/grindavik-housing-buyout/grindavik-housing-buyout.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/grindavik-housing-buyout/grindavik-housing-buyout.service.ts
@@ -75,6 +75,8 @@ export class GrindavikHousingBuyoutService extends BaseTemplateApiService {
 
     const confirmsLoanTakeover =
       answers.confirmLoanTakeover?.includes(YES) ?? false
+    const hasLoanFromOtherProvider =
+      answers.loanProviders.hasOtherLoanProvider?.includes(YES) ?? false
     const wishesForPreemptiveRights = answers.preemptiveRightWish === YES
 
     const extraData: { [key: string]: string } = {
@@ -85,7 +87,8 @@ export class GrindavikHousingBuyoutService extends BaseTemplateApiService {
       propertyData: JSON.stringify(
         application.externalData.getGrindavikHousing.data,
       ),
-      loans: JSON.stringify(answers.loans),
+      loans: JSON.stringify(answers.loanProviders.loans),
+      hasLoanFromOtherProvider: hasLoanFromOtherProvider.toString(),
       confirmsLoanTakeover: confirmsLoanTakeover.toString(),
       wishesForPreemptiveRights: wishesForPreemptiveRights.toString(),
     }

--- a/libs/application/templates/grindavik-housing-buyout/src/forms/GrindavikHousingBuyoutForm.ts
+++ b/libs/application/templates/grindavik-housing-buyout/src/forms/GrindavikHousingBuyoutForm.ts
@@ -125,9 +125,10 @@ export const GrindavikHousingBuyoutForm: Form = buildForm({
           id: 'loanStatusMultiField',
           title: m.application.loanStatus.sectionTitle,
           description: m.application.loanStatus.addLoanDescription,
+          space: [4, 6],
           children: [
             buildTableRepeaterField({
-              id: 'loans',
+              id: 'loanProviders.loans',
               marginTop: 2,
               title: '',
               addItemButtonText: m.application.loanStatus.addNewLoan,
@@ -153,11 +154,15 @@ export const GrindavikHousingBuyoutForm: Form = buildForm({
                 },
               },
             }),
-            buildDescriptionField({
-              id: 'loanStatusAdditionalInfo',
+            buildCheckboxField({
+              id: 'loanProviders.hasOtherLoanProvider',
               title: '',
-              marginTop: [4, 6],
-              description: m.application.loanStatus.additionalInfo,
+              options: [
+                {
+                  label: m.application.loanStatus.checkboxText,
+                  value: YES,
+                },
+              ],
             }),
           ],
         }),
@@ -247,18 +252,11 @@ export const GrindavikHousingBuyoutForm: Form = buildForm({
         buildMultiField({
           id: 'sellerStatementMultiField',
           title: m.application.sellerStatement.sectionTitle,
-          description: m.application.sellerStatement.text,
           children: [
-            buildCheckboxField({
-              id: 'userConfirmation',
+            buildDescriptionField({
+              id: 'sellerStatementText',
               title: '',
-              defaultValue: [],
-              options: [
-                {
-                  label: m.application.sellerStatement.confirmationLabel,
-                  value: YES,
-                },
-              ],
+              description: m.application.sellerStatement.text,
             }),
           ],
         }),
@@ -389,25 +387,6 @@ export const GrindavikHousingBuyoutForm: Form = buildForm({
                 return (
                   answers as GrindavikHousingBuyout
                 ).confirmLoanTakeover?.includes(YES)
-                  ? coreMessages.radioYes
-                  : coreMessages.radioNo
-              },
-            }),
-            buildDividerField({}),
-
-            // Seller statement
-            buildDescriptionField({
-              id: 'sellerStatementOverview',
-              title: m.application.sellerStatement.sectionTitle,
-              titleVariant: 'h3',
-            }),
-            buildKeyValueField({
-              label: m.application.sellerStatement.confirmationLabel,
-              colSpan: '1/1',
-              value: ({ answers }) => {
-                return (
-                  answers as GrindavikHousingBuyout
-                ).userConfirmation?.includes(YES)
                   ? coreMessages.radioYes
                   : coreMessages.radioNo
               },

--- a/libs/application/templates/grindavik-housing-buyout/src/lib/dataSchema.ts
+++ b/libs/application/templates/grindavik-housing-buyout/src/lib/dataSchema.ts
@@ -32,22 +32,42 @@ export const GrindavikHousingBuyoutSchema = z.object({
       }),
     )
     .optional(),
-  loans: z
-    .array(
-      z.object({
-        status: z
-          .string()
-          .or(z.undefined())
-          .refine((v) => !!v, required),
-        provider: z
-          .string()
-          .or(z.undefined())
-          .refine((v) => !!v, required),
-      }),
-    )
-    .optional(),
+  loanProviders: z
+    .object({
+      loans: z
+        .array(
+          z.object({
+            status: z
+              .string()
+              .or(z.undefined())
+              .refine((v) => !!v, required),
+            provider: z
+              .string()
+              .or(z.undefined())
+              .refine((v) => !!v, required),
+          }),
+        )
+        .optional(),
+      hasOtherLoanProvider: z.array(z.enum([YES])),
+    })
+    .superRefine((v, ctx) => {
+      /**
+       * If no loans are added and the user has not selected that
+       * they have loans from other providers we need to show a
+       * custom error message
+       */
+      if (
+        (!v.loans || v.loans.length === 0) &&
+        !v.hasOtherLoanProvider?.includes(YES)
+      ) {
+        return ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['hasOtherLoanProvider'],
+          params: errors.fields.otherLoanProviders,
+        })
+      }
+    }),
   confirmLoanTakeover: z.array(z.enum([YES])),
-  userConfirmation: z.array(z.enum([YES])),
   preemptiveRightWish: z.string(z.enum([YES, NO])).refine((v) => !!v, required),
 })
 

--- a/libs/application/templates/grindavik-housing-buyout/src/lib/messages/application.ts
+++ b/libs/application/templates/grindavik-housing-buyout/src/lib/messages/application.ts
@@ -129,6 +129,12 @@ export const application = {
         'Ef þú ert ekki með lán hjá neinum lánveitanda hér fyrir ofan þá getur þú xxx ...',
       description: 'Loan status info',
     },
+    checkboxText: {
+      id: 'ghb.application:loanStatus.checkboxText',
+      defaultMessage:
+        'Ég er með húsnæðislán hjá lánveitanda sem er ekki í felliglugganum hér fyrir ofan',
+      description: 'Loan status screen checkbox text',
+    },
   }),
   results: defineMessages({
     sectionTitle: {

--- a/libs/application/templates/grindavik-housing-buyout/src/lib/messages/errors.ts
+++ b/libs/application/templates/grindavik-housing-buyout/src/lib/messages/errors.ts
@@ -12,5 +12,11 @@ export const errors = {
       defaultMessage: 'Vantar samþykki',
       description: 'Error message a required checkbox is not checked',
     },
+    otherLoanProviders: {
+      id: 'ghb.application:errors.otherLoanProviders',
+      defaultMessage:
+        'Skylda er að annaðhvort fylla út stöðu lána hér fyrir ofan eða staðfesta að þú sért með lán frá öðrum lánveitanda',
+      description: 'Error message when no loan providers are added',
+    },
   }),
 }

--- a/libs/application/templates/grindavik-housing-buyout/src/utils/loan.ts
+++ b/libs/application/templates/grindavik-housing-buyout/src/utils/loan.ts
@@ -2,6 +2,6 @@ import { FormValue } from '@island.is/application/types'
 import { GrindavikHousingBuyout } from '../lib/dataSchema'
 
 export const calculateTotalLoanFromAnswers = (answers: FormValue) => {
-  const loans = answers.loans as GrindavikHousingBuyout['loans']
+  const loans = (answers as GrindavikHousingBuyout).loanProviders.loans
   return loans?.reduce((acc, loan) => acc + (Number(loan.status) || 0), 0) ?? 0
 }


### PR DESCRIPTION
# Remove statement checkbox and add loan providers check

Attach a link to issue if relevant

## What

- Remove checkbox on user statement screen
- Add a checkbox on loan providers screen that confirms if user has no loans on the property

## Why

Specify why you need to achieve this

## Screenshots / Gifs

![image](https://github.com/island-is/island.is/assets/16031201/b15bc395-91e5-4516-a073-5615b1692180)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
