### PR TITLE
feat(web): Pension Calculator - client side input validation

### DIFF
--- a/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculator.tsx
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculator.tsx
@@ -498,6 +498,12 @@ const PensionCalculator: CustomScreen<PensionCalculatorProps> = ({
     (option) => option.value === birthMonth,
   )?.label
 
+  const maxLivingConditionAbroadInYears: number =
+    customPageData?.configJson?.maxLivingConditionAbroadInYears ?? 52
+
+  const maxTaxCardRatio: number =
+    customPageData?.configJson?.maxTaxCardRatio ?? 100
+
   return (
     <PensionCalculatorWrapper
       organizationPage={organizationPage}
@@ -887,14 +893,22 @@ const PensionCalculator: CustomScreen<PensionCalculatorProps> = ({
                                   translationStrings.livingConditionAbroadInYearsPlaceholder,
                                 )}
                                 type="number"
-                                suffix={
-                                  ' ' +
-                                  formatMessage(translationStrings.yearsSuffix)
-                                }
-                                maxLength={
-                                  formatMessage(translationStrings.yearsSuffix)
-                                    .length + 3
-                                }
+                                suffix={` ${formatMessage(
+                                  translationStrings.yearsSuffix,
+                                )}`}
+                                format={(value) => {
+                                  if (
+                                    Number(value) >
+                                    maxLivingConditionAbroadInYears
+                                  ) {
+                                    value = String(
+                                      maxLivingConditionAbroadInYears,
+                                    )
+                                  }
+                                  return `${value} ${formatMessage(
+                                    translationStrings.yearsSuffix,
+                                  )}`
+                                }}
                               />
                             </Box>
                           )}
@@ -918,7 +932,12 @@ const PensionCalculator: CustomScreen<PensionCalculatorProps> = ({
                               placeholder="%"
                               type="number"
                               suffix="%"
-                              maxLength={4}
+                              format={(value) => {
+                                if (Number(value) > maxTaxCardRatio) {
+                                  value = String(maxTaxCardRatio)
+                                }
+                                return `${value}%`
+                              }}
                             />
                           </Box>
                         </NumericInputFieldWrapper>


### PR DESCRIPTION
# Pension Calculator - client side input validation

## What

* Users can no longer enter that they want to use more than 100% tax card ratio
* Users can no longer enter that they lived abroad for more than 52 years between the age of 16-67

## Why

* This was requested by the social insurance administration

## Screenshots / Gifs

https://github.com/island-is/island.is/assets/43557895/4c44c7f2-c473-43e5-9d8f-c7e12d61b005


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
