### PR TITLE
fix(user-notifications): In memory cache fix

### DIFF
--- a/apps/services/user-notification/src/app/modules/notifications/notificationsWorker.service.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/notificationsWorker.service.ts
@@ -212,7 +212,11 @@ export class NotificationsWorkerService implements OnApplicationBootstrap {
 
     const formattedTemplate = this.notificationsService.formatArguments(
       message.args,
-      template,
+      // We need to shallow copy the template here so that the
+      // in-memory cache is not modified.
+      {
+        ...template,
+      },
     )
 
     try {


### PR DESCRIPTION
The template was being rewritten according to arguments and therefore the in-memory representation of the object would have its template string overwritten. This would/could result in the template being written to cache with argument replacements already in place.


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
