### PR TITLE
fix(auth-api-lib): Fix syntax error

### DIFF
--- a/libs/auth-api-lib/migrations/20240227133212-migrate-application-admin-scope.js
+++ b/libs/auth-api-lib/migrations/20240227133212-migrate-application-admin-scope.js
@@ -14,7 +14,7 @@ module.exports = {
           AND NOT EXISTS (
             SELECT 1 FROM public.api_scope_user_access t2
             WHERE t2.scope = '@admin.island.is/application-system:admin' and t2.national_id = t.national_id
-          )
+          );
 
       COMMIT;
     `)


### PR DESCRIPTION
## What

Add `;` in the lates migration script in auth api lib.  

## Why

It is causing syntax error and failure in initContainer migrations. 

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
