### PR TITLE
feat(react-spa-shared): make third party default small

### DIFF
--- a/libs/react-spa/shared/src/components/problems/Problem.tsx
+++ b/libs/react-spa/shared/src/components/problems/Problem.tsx
@@ -62,10 +62,9 @@ interface NoDataProps extends ProblemBaseProps {
 }
 
 type ProblemProps = InternalServiceErrorProps | NotFoundProps | NoDataProps
-
 export const Problem = ({
   type = ProblemTypes.internalServiceError,
-  size = 'large',
+  size,
   error,
   title,
   titleSize,
@@ -114,7 +113,7 @@ export const Problem = ({
           return (
             <ThirdPartyServiceError
               organizationSlug={organizationSlug}
-              size={size}
+              size={size ?? 'small'}
               dataTestId={dataTestId}
               expand={expand}
             />
@@ -125,7 +124,7 @@ export const Problem = ({
       return (
         <InternalServiceError
           {...defaultProps}
-          size={size}
+          size={size ?? 'large'}
           tag={tag ?? formatMessage(m.error)}
         />
       )
@@ -135,7 +134,12 @@ export const Problem = ({
 
     case ProblemTypes.noData:
       return (
-        <NoData {...defaultProps} size={size} tag={tag} titleSize={titleSize} />
+        <NoData
+          {...defaultProps}
+          size={size ?? 'large'}
+          tag={tag}
+          titleSize={titleSize}
+        />
       )
 
     default:


### PR DESCRIPTION
## What

* Updated `<Problem>` size defaults

## Why

The alert for third party service errors should be small by default

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
