### PR TITLE
fix(web): Add failsafe for when mapping project pages

### DIFF
--- a/libs/cms/src/lib/models/linkGroup.model.ts
+++ b/libs/cms/src/lib/models/linkGroup.model.ts
@@ -56,19 +56,21 @@ export const mapLinkGroup = ({
   id: sys.id,
   name: fields.name ?? '',
   primaryLink: mapLinkWrapper(fields.primaryLink, pageAbove),
-  childrenLinks: (fields.childrenLinks ?? []).map((link) =>
-    mapLinkWrapper(link, pageAbove),
-  ),
+  childrenLinks: (fields.childrenLinks ?? [])
+    .map((link) => mapLinkWrapper(link, pageAbove))
+    .filter((childLink): childLink is Link => Boolean(childLink)),
 })
 
 const mapLinkWrapper = (link: LinkType, pageAbove: PageAbove | undefined) => {
-  if (link.sys?.contentType?.sys?.id === 'organizationSubpage') {
+  const contentTypeId = link?.sys?.contentType?.sys?.id
+  if (contentTypeId === 'organizationSubpage') {
     return generateOrganizationSubpageLink(link as IOrganizationSubpage)
-  } else if (link.sys.contentType.sys.id === 'projectSubpage') {
+  } else if (contentTypeId === 'projectSubpage') {
     return generateProjectSubpageLink(link as IProjectSubpage, pageAbove)
-  } else {
+  } else if (contentTypeId === 'link') {
     return mapLink(link as ILink)
   }
+  return null
 }
 
 const generateOrganizationSubpageLink = (subpage: IOrganizationSubpage) => {

--- a/libs/cms/src/lib/models/projectPage.model.ts
+++ b/libs/cms/src/lib/models/projectPage.model.ts
@@ -119,7 +119,11 @@ const processSidebarLinks = (projectPage: IProjectPage) => {
     projectPage.fields.sidebarLinks ?? []
   ).filter((linkGroup) => {
     const linkGroupContentTypeId =
-      linkGroup.fields.primaryLink.sys.contentType.sys.id
+      linkGroup?.fields?.primaryLink?.sys?.contentType?.sys?.id
+
+    if (!linkGroupContentTypeId) {
+      return false
+    }
 
     if (
       projectPage.fields.sidebarFrontpageLink &&
@@ -192,11 +196,16 @@ const processSidebarLinks = (projectPage: IProjectPage) => {
   for (const item of filteredItems) {
     item.fields.childrenLinks =
       item.fields.childrenLinks?.filter((childLink) => {
-        if (childLink.sys.contentType.sys.id === 'link') {
+        const childLinkContentTypeId = childLink?.sys?.contentType?.sys?.id
+        if (!childLinkContentTypeId) {
+          return false
+        }
+
+        if (childLinkContentTypeId === 'link') {
           return true
         }
         return (
-          childLink.sys.contentType.sys.id === 'projectSubpage' &&
+          childLinkContentTypeId === 'projectSubpage' &&
           projectPage.fields.projectSubpages?.some(
             (subpage) => subpage.sys.id === childLink.sys.id,
           )


### PR DESCRIPTION
# Project page mapping fails if link group references are missing

## What

* Fail safe added in case fields are missing

## Why

* Because this was causing a 500 error on english versions of project pages that had missing link group references in the cms

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
