### PR TITLE
fix(application-system): Fix submit callback bug

### DIFF
--- a/libs/application/ui-shell/src/components/Screen.tsx
+++ b/libs/application/ui-shell/src/components/Screen.tsx
@@ -266,13 +266,15 @@ const Screen: FC<React.PropsWithChildren<ScreenProps>> = ({
   }, [width])
 
   useEffect(() => {
-    const target = isMobile ? headerHeight : 0
-    window.scrollTo(0, target)
-
     if (beforeSubmitCallback.current !== null) {
       setBeforeSubmitCallback(null)
     }
-  }, [activeScreenIndex, isMobile, setBeforeSubmitCallback])
+  }, [activeScreenIndex, setBeforeSubmitCallback])
+
+  useEffect(() => {
+    const target = isMobile ? headerHeight : 0
+    window.scrollTo(0, target)
+  }, [activeScreenIndex, isMobile])
 
   const onUpdateRepeater = async (newRepeaterItems: unknown[]) => {
     if (!screen.id) {


### PR DESCRIPTION
# Fix submit callback bug

Attach a link to issue if relevant

## What

Move scroll-to-top logic to a separate `useEffect`

## Why

When submitting a screen and getting an error, specifically the data-providers screen, you could reduce the screen down to mobile size and submit again, and it would let you through even though there were errors from data-provdider

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review