### PR TITLE
feat(user-profile): Next-nudge interval (#14136)

### DIFF
--- a/apps/services/user-profile/migrations/20240313114633-next-nudge.js
+++ b/apps/services/user-profile/migrations/20240313114633-next-nudge.js
@@ -1,0 +1,14 @@
+'use strict'
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('user_profile', 'next_nudge', {
+      type: Sequelize.DATE,
+      allowNull: true,
+    })
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('user_profile', 'next_nudge')
+  },
+}

--- a/apps/services/user-profile/src/app/types/nudge-type.ts
+++ b/apps/services/user-profile/src/app/types/nudge-type.ts
@@ -1,0 +1,5 @@
+export enum NudgeType {
+  'NUDGE' = 'NUDGE',
+  'SKIP_EMAIL' = 'SKIP_EMAIL',
+  'SKIP_PHONE' = 'SKIP_PHONE',
+}

--- a/apps/services/user-profile/src/app/user-profile/userProfile.model.ts
+++ b/apps/services/user-profile/src/app/user-profile/userProfile.model.ts
@@ -119,4 +119,11 @@ export class UserProfile extends Model {
   })
   @ApiProperty()
   emailNotifications!: boolean
+
+  @Column({
+    type: DataType.DATE,
+    allowNull: true,
+  })
+  @ApiProperty()
+  nextNudge?: Date
 }

--- a/apps/services/user-profile/src/app/v2/dto/post-nudge.dto.ts
+++ b/apps/services/user-profile/src/app/v2/dto/post-nudge.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger'
+import { IsEnum } from 'class-validator'
+
+import { NudgeType } from '../../types/nudge-type'
+
+export class PostNudgeDto {
+  @IsEnum(NudgeType)
+  @ApiProperty({ enum: NudgeType })
+  nudgeType: NudgeType
+}

--- a/apps/services/user-profile/src/app/v2/me-user-profile.controller.ts
+++ b/apps/services/user-profile/src/app/v2/me-user-profile.controller.ts
@@ -6,9 +6,11 @@ import {
   Get,
   Patch,
   Post,
+  Query,
   UseGuards,
 } from '@nestjs/common'
 
+import type { User } from '@island.is/auth-nest-tools'
 import {
   CurrentUser,
   IdsUserGuard,
@@ -18,12 +20,13 @@ import {
 import { Audit, AuditService } from '@island.is/nest/audit'
 import { Documentation } from '@island.is/nest/swagger'
 import { UserProfileScope } from '@island.is/auth/scopes'
-import type { User } from '@island.is/auth-nest-tools'
 
 import { CreateVerificationDto } from './dto/create-verification.dto'
 import { PatchUserProfileDto } from './dto/patch-user-profile.dto'
 import { UserProfileDto } from './dto/user-profile.dto'
 import { UserProfileService } from './user-profile.service'
+import { NudgeType } from '../types/nudge-type'
+import { PostNudgeDto } from './dto/post-nudge.dto'
 
 const namespace = '@island.is/user-profile/v2/me'
 
@@ -120,10 +123,11 @@ export class MeUserProfileController {
   @Post('/nudge')
   @Scopes(UserProfileScope.write)
   @Documentation({
-    description: 'Confirms that the user has seen the nudge',
+    description:
+      'Confirms that the user has seen the nudge from a specific screen. Allowed screens are defined in NudgeFrom enum.',
     response: { status: 200 },
   })
-  confirmNudge(@CurrentUser() user: User) {
+  confirmNudge(@CurrentUser() user: User, @Body() input: PostNudgeDto) {
     return this.auditService.auditPromise(
       {
         auth: user,
@@ -131,7 +135,7 @@ export class MeUserProfileController {
         action: 'nudge',
         resources: user.nationalId,
       },
-      this.userProfileService.confirmNudge(user.nationalId),
+      this.userProfileService.confirmNudge(user.nationalId, input.nudgeType),
     )
   }
 }

--- a/apps/services/user-profile/src/app/v2/test/me-user-profile.controller.spec.ts
+++ b/apps/services/user-profile/src/app/v2/test/me-user-profile.controller.spec.ts
@@ -1,4 +1,5 @@
 import { getModelToken } from '@nestjs/sequelize'
+import addMonths from 'date-fns/addMonths'
 import subMonths from 'date-fns/subMonths'
 import faker from 'faker'
 import request, { SuperTest, Test } from 'supertest'
@@ -18,11 +19,15 @@ import { AppModule } from '../../app.module'
 import { SequelizeConfigService } from '../../sequelizeConfig.service'
 import { UserProfile } from '../../user-profile/userProfile.model'
 import { VerificationService } from '../../user-profile/verification.service'
-import { NUDGE_INTERVAL } from '../user-profile.service'
 import { formatPhoneNumber } from '../../utils/format-phone-number'
 import { SmsVerification } from '../../user-profile/smsVerification.model'
 import { EmailVerification } from '../../user-profile/emailVerification.model'
 import { DataStatus } from '../../user-profile/types/dataStatusTypes'
+import { NudgeType } from '../../types/nudge-type'
+import { PostNudgeDto } from '../dto/post-nudge.dto'
+import { NUDGE_INTERVAL, SKIP_INTERVAL } from '../user-profile.service'
+
+type StatusFieldType = 'emailStatus' | 'mobileStatus'
 
 const testUserProfile = {
   nationalId: createNationalId(),
@@ -105,39 +110,45 @@ describe('MeUserProfileController', () => {
     const expiredDate = subMonths(new Date(), NUDGE_INTERVAL + 1)
 
     it.each`
-      verifiedField                     | isVerified | lastNudge      | needsNudgeExpected
-      ${['email']}                      | ${true}    | ${null}        | ${true}
-      ${['email']}                      | ${true}    | ${currentDate} | ${false}
-      ${['email']}                      | ${true}    | ${expiredDate} | ${true}
-      ${['email']}                      | ${false}   | ${null}        | ${null}
-      ${['email']}                      | ${false}   | ${currentDate} | ${null}
-      ${['email']}                      | ${false}   | ${expiredDate} | ${null}
-      ${['mobilePhoneNumber']}          | ${true}    | ${null}        | ${true}
-      ${['mobilePhoneNumber']}          | ${true}    | ${currentDate} | ${false}
-      ${['mobilePhoneNumber']}          | ${true}    | ${expiredDate} | ${true}
-      ${['mobilePhoneNumber']}          | ${false}   | ${null}        | ${null}
-      ${['mobilePhoneNumber']}          | ${false}   | ${currentDate} | ${null}
-      ${['mobilePhoneNumber']}          | ${false}   | ${expiredDate} | ${null}
-      ${['email', 'mobilePhoneNumber']} | ${true}    | ${null}        | ${true}
-      ${['email', 'mobilePhoneNumber']} | ${true}    | ${currentDate} | ${false}
-      ${['email', 'mobilePhoneNumber']} | ${true}    | ${expiredDate} | ${true}
-      ${['email', 'mobilePhoneNumber']} | ${false}   | ${null}        | ${null}
-      ${['email', 'mobilePhoneNumber']} | ${false}   | ${currentDate} | ${null}
-      ${['email', 'mobilePhoneNumber']} | ${false}   | ${expiredDate} | ${null}
-      ${null}                           | ${false}   | ${null}        | ${null}
-      ${null}                           | ${false}   | ${currentDate} | ${false}
-      ${null}                           | ${false}   | ${expiredDate} | ${true}
+      verifiedField                     | isVerified | lastNudge      | nextNudgeLength   | needsNudgeExpected
+      ${['email']}                      | ${true}    | ${null}        | ${NUDGE_INTERVAL} | ${true}
+      ${['email']}                      | ${true}    | ${currentDate} | ${NUDGE_INTERVAL} | ${false}
+      ${['email']}                      | ${true}    | ${expiredDate} | ${NUDGE_INTERVAL} | ${true}
+      ${['email']}                      | ${false}   | ${null}        | ${NUDGE_INTERVAL} | ${null}
+      ${['email']}                      | ${false}   | ${currentDate} | ${NUDGE_INTERVAL} | ${null}
+      ${['email']}                      | ${false}   | ${expiredDate} | ${NUDGE_INTERVAL} | ${null}
+      ${['email']}                      | ${false}   | ${expiredDate} | ${SKIP_INTERVAL}  | ${null}
+      ${['mobilePhoneNumber']}          | ${true}    | ${null}        | ${NUDGE_INTERVAL} | ${true}
+      ${['mobilePhoneNumber']}          | ${true}    | ${currentDate} | ${NUDGE_INTERVAL} | ${false}
+      ${['mobilePhoneNumber']}          | ${true}    | ${expiredDate} | ${NUDGE_INTERVAL} | ${true}
+      ${['mobilePhoneNumber']}          | ${false}   | ${null}        | ${NUDGE_INTERVAL} | ${null}
+      ${['mobilePhoneNumber']}          | ${false}   | ${currentDate} | ${NUDGE_INTERVAL} | ${null}
+      ${['mobilePhoneNumber']}          | ${false}   | ${expiredDate} | ${NUDGE_INTERVAL} | ${null}
+      ${['mobilePhoneNumber']}          | ${false}   | ${expiredDate} | ${SKIP_INTERVAL}  | ${null}
+      ${['email', 'mobilePhoneNumber']} | ${true}    | ${null}        | ${NUDGE_INTERVAL} | ${true}
+      ${['email', 'mobilePhoneNumber']} | ${true}    | ${null}        | ${SKIP_INTERVAL}  | ${true}
+      ${['email', 'mobilePhoneNumber']} | ${true}    | ${currentDate} | ${NUDGE_INTERVAL} | ${false}
+      ${['email', 'mobilePhoneNumber']} | ${true}    | ${expiredDate} | ${NUDGE_INTERVAL} | ${true}
+      ${['email', 'mobilePhoneNumber']} | ${false}   | ${null}        | ${NUDGE_INTERVAL} | ${null}
+      ${['email', 'mobilePhoneNumber']} | ${false}   | ${currentDate} | ${NUDGE_INTERVAL} | ${null}
+      ${['email', 'mobilePhoneNumber']} | ${false}   | ${expiredDate} | ${NUDGE_INTERVAL} | ${null}
+      ${['email', 'mobilePhoneNumber']} | ${false}   | ${expiredDate} | ${SKIP_INTERVAL}  | ${null}
+      ${null}                           | ${false}   | ${null}        | ${NUDGE_INTERVAL} | ${null}
+      ${null}                           | ${false}   | ${currentDate} | ${NUDGE_INTERVAL} | ${false}
+      ${null}                           | ${false}   | ${expiredDate} | ${NUDGE_INTERVAL} | ${true}
     `(
       'should return needsNudge=$needsNudgeExpected when $verifiedField is set and lastNudge=$lastNudge',
       async ({
         verifiedField,
         isVerified,
         lastNudge,
+        nextNudgeLength,
         needsNudgeExpected,
       }: {
         verifiedField: string[] | null
         isVerified: boolean
         lastNudge: Date | null
+        nextNudgeLength: typeof SKIP_INTERVAL | typeof NUDGE_INTERVAL
         needsNudgeExpected: boolean | null
       }) => {
         // Arrange
@@ -154,6 +165,7 @@ describe('MeUserProfileController', () => {
           nationalId: testUserProfile.nationalId,
           ...expectedTestValues,
           lastNudge,
+          nextNudge: lastNudge ? addMonths(lastNudge, nextNudgeLength) : null,
         })
 
         // Act
@@ -170,6 +182,192 @@ describe('MeUserProfileController', () => {
         })
       },
     )
+  })
+
+  describe('PATCH user-profile - nudge dates', () => {
+    let app = null
+    let server = null
+    let fixtureFactory = null
+    let islyklarApi = null
+
+    beforeEach(async () => {
+      app = await setupApp({
+        AppModule,
+        SequelizeConfigService,
+        user: createCurrentUser({
+          nationalId: testUserProfile.nationalId,
+          scope: [UserProfileScope.read, UserProfileScope.write],
+          audkenniSimNumber,
+        }),
+        // Using postgres here because incrementing the tries field for verification is handled differently in sqlite
+        dbType: 'postgres',
+      })
+      server = request(app.getHttpServer())
+      fixtureFactory = new FixtureFactory(app)
+
+      await fixtureFactory.createEmailVerification({
+        ...testEmailVerification,
+        email: newEmail,
+      })
+      await fixtureFactory.createSmsVerification({
+        ...testSMSVerification,
+        mobilePhoneNumber: newPhoneNumber,
+      })
+
+      // Mock islyklar api responses
+      islyklarApi = app.get(IslyklarApi)
+      islyklarApi.islyklarPut = jest.fn()
+      islyklarApi.islyklarPost = jest
+        .fn()
+        .mockImplementation(({ user }: { user: PublicUser }) => {
+          return new Promise((resolve) => {
+            resolve(user)
+          })
+        })
+      islyklarApi.islyklarGet = jest.fn().mockResolvedValue({
+        ssn: testUserProfile.nationalId,
+        email: testUserProfile.email,
+        mobile: testUserProfile.mobilePhoneNumber,
+      })
+    })
+
+    afterEach(async () => {
+      fixtureFactory = null
+      await app.cleanUp()
+    })
+
+    it('PATCH /v2/me should update email and phone and push nextNudge by 6 months ', async () => {
+      await fixtureFactory.createUserProfile(testUserProfile)
+
+      const res = await server.patch('/v2/me').send({
+        email: newEmail,
+        mobilePhoneNumber: formattedNewPhoneNumber,
+        emailVerificationCode: emailVerificationCode,
+        mobilePhoneNumberVerificationCode: smsVerificationCode,
+      })
+
+      // Assert
+      expect(res.status).toEqual(200)
+
+      // Assert Db records
+      const userProfileModel = app.get(getModelToken(UserProfile))
+      const userProfile = await userProfileModel.findOne({
+        where: { nationalId: testUserProfile.nationalId },
+      })
+
+      expect(userProfile.email).toBe(newEmail)
+      expect(userProfile.mobilePhoneNumber).toBe(formattedNewPhoneNumber)
+      expect(userProfile.nextNudge.toString()).toBe(
+        addMonths(userProfile.lastNudge, NUDGE_INTERVAL).toString(),
+      )
+    })
+
+    it('PATCH /v2/me should update email and push nextNudge by 1 month ', async () => {
+      await fixtureFactory.createUserProfile({
+        ...testUserProfile,
+        mobilePhoneNumberVerified: false,
+      })
+
+      const res = await server.patch('/v2/me').send({
+        email: newEmail,
+        emailVerificationCode: emailVerificationCode,
+      })
+
+      // Assert
+      expect(res.status).toEqual(200)
+
+      // Assert Db records
+      const userProfileModel = app.get(getModelToken(UserProfile))
+      const userProfile = await userProfileModel.findOne({
+        where: { nationalId: testUserProfile.nationalId },
+      })
+
+      expect(userProfile.email).toBe(newEmail)
+      expect(userProfile.nextNudge.toString()).toBe(
+        addMonths(userProfile.lastNudge, SKIP_INTERVAL).toString(),
+      )
+    })
+
+    it('PATCH /v2/me should update phone and push nextNudge by 1 months ', async () => {
+      await fixtureFactory.createUserProfile({
+        ...testUserProfile,
+        emailVerified: false,
+      })
+
+      const res = await server.patch('/v2/me').send({
+        mobilePhoneNumber: formattedNewPhoneNumber,
+        mobilePhoneNumberVerificationCode: smsVerificationCode,
+      })
+
+      // Assert
+      expect(res.status).toEqual(200)
+
+      // Assert Db records
+      const userProfileModel = app.get(getModelToken(UserProfile))
+      const userProfile = await userProfileModel.findOne({
+        where: { nationalId: testUserProfile.nationalId },
+      })
+
+      expect(userProfile.mobilePhoneNumber).toBe(formattedNewPhoneNumber)
+      expect(userProfile.nextNudge.toString()).toBe(
+        addMonths(userProfile.lastNudge, SKIP_INTERVAL).toString(),
+      )
+    })
+
+    it('PATCH /v2/me should empty email and push nextNudge by 6 months ', async () => {
+      await fixtureFactory.createUserProfile({
+        ...testUserProfile,
+        mobilePhoneNumberVerified: true,
+        mobileStatus: DataStatus.VERIFIED,
+      })
+
+      const res = await server.patch('/v2/me').send({
+        email: '',
+      })
+
+      // Assert
+      expect(res.status).toEqual(200)
+
+      // Assert Db records
+      const userProfileModel = app.get(getModelToken(UserProfile))
+      const userProfile = await userProfileModel.findOne({
+        where: { nationalId: testUserProfile.nationalId },
+      })
+
+      expect(userProfile.email).toBe(null)
+      expect(userProfile.mobilePhoneNumber).toBe(
+        testUserProfile.mobilePhoneNumber,
+      )
+      expect(userProfile.nextNudge.toString()).toBe(
+        addMonths(userProfile.lastNudge, NUDGE_INTERVAL).toString(),
+      )
+    })
+
+    it('PATCH /v2/me should empty phoneNumber and push nextNudge by 6 month ', async () => {
+      await fixtureFactory.createUserProfile({
+        ...testUserProfile,
+        emailVerified: true,
+        emailStatus: DataStatus.VERIFIED,
+      })
+
+      const res = await server.patch('/v2/me').send({
+        mobilePhoneNumber: '',
+      })
+      // Assert
+      expect(res.status).toEqual(200)
+
+      // Assert Db records
+      const userProfileModel = app.get(getModelToken(UserProfile))
+      const userProfile = await userProfileModel.findOne({
+        where: { nationalId: testUserProfile.nationalId },
+      })
+
+      expect(userProfile.email).toBe(testUserProfile.email)
+      expect(userProfile.mobilePhoneNumber).toBe(null)
+      expect(userProfile.nextNudge.toString()).toBe(
+        addMonths(userProfile.lastNudge, NUDGE_INTERVAL).toString(),
+      )
+    })
   })
 
   describe('PATCH user-profile', () => {
@@ -529,6 +727,9 @@ describe('MeUserProfileController', () => {
       expect(userProfile.mobilePhoneNumberVerified).toBe(false)
       expect(userProfile.emailStatus).toBe(DataStatus.EMPTY)
       expect(userProfile.mobileStatus).toBe(DataStatus.EMPTY)
+      expect(userProfile.nextNudge.toString()).toBe(
+        addMonths(userProfile.lastNudge, NUDGE_INTERVAL).toString(),
+      )
 
       // Assert that islyklar api is called
       expect(islyklarApi.islyklarPut).toBeCalledWith({
@@ -721,14 +922,16 @@ describe('MeUserProfileController', () => {
       app.cleanUp()
     })
 
-    it('POST /v2/me/nudge should return 200 and update the lastNudge field when user confirms nudge', async () => {
+    it('POST /v2/me/nudge should return 200 and update the lastNudge and nextNudge field when user confirms nudge', async () => {
       // Arrange
       const fixtureFactory = new FixtureFactory(app)
 
       await fixtureFactory.createUserProfile(testUserProfile)
 
       // Act
-      const res = await server.post('/v2/me/nudge')
+      const res = await server.post('/v2/me/nudge').send({
+        nudgeType: NudgeType.NUDGE,
+      } as PostNudgeDto)
 
       // Assert
       expect(res.status).toEqual(200)
@@ -740,11 +943,14 @@ describe('MeUserProfileController', () => {
       })
 
       expect(userProfile.lastNudge).not.toBeNull()
+      expect(userProfile.nextNudge).not.toBeNull()
     })
 
     it(`POST /v2/me/nudge should return 200 and update the lastNudge field when user confirms nudge`, async () => {
       // Act
-      const res = await server.post('/v2/me/nudge')
+      const res = await server.post('/v2/me/nudge').send({
+        nudgeType: NudgeType.NUDGE,
+      } as PostNudgeDto)
 
       // Assert
       expect(res.status).toEqual(200)
@@ -758,5 +964,163 @@ describe('MeUserProfileController', () => {
       expect(userProfile).not.toBeNull()
       expect(userProfile.lastNudge).not.toBeNull()
     })
+
+    it('POST /v2/me/nudge with nudgeType=NudgeType.SKIP_EMAIL should return 200 and update the lastNudge and set nextNudge to 1 month after lastNudge', async () => {
+      // Arrange
+      const fixtureFactory = new FixtureFactory(app)
+
+      await fixtureFactory.createUserProfile(testUserProfile)
+
+      // Act
+      const res = await server.post(`/v2/me/nudge`).send({
+        nudgeType: NudgeType.SKIP_EMAIL,
+      } as PostNudgeDto)
+
+      // Assert
+      expect(res.status).toEqual(200)
+
+      // Assert that lastNudge is updated
+      const userProfileModel = app.get(getModelToken(UserProfile))
+      const userProfile = await userProfileModel.findOne({
+        where: { nationalId: testUserProfile.nationalId },
+      })
+
+      expect(userProfile.lastNudge).not.toBeNull()
+      expect(userProfile.nextNudge).toEqual(addMonths(userProfile.lastNudge, 1))
+      expect(userProfile.emailStatus).toBe(DataStatus.EMPTY)
+    })
+
+    it('POST /v2/me/nudge with  nudgeType=NudgeType.SKIP_PHONE should return 200 and update the lastNudge and set nextNudge to 1 month after lastNudge', async () => {
+      // Arrange
+      const fixtureFactory = new FixtureFactory(app)
+
+      await fixtureFactory.createUserProfile(testUserProfile)
+
+      // Act
+      const res = await server.post(`/v2/me/nudge`).send({
+        nudgeType: NudgeType.SKIP_PHONE,
+      } as PostNudgeDto)
+
+      // Assert
+      expect(res.status).toEqual(200)
+
+      // Assert that lastNudge is updated
+      const userProfileModel = app.get(getModelToken(UserProfile))
+      const userProfile = await userProfileModel.findOne({
+        where: { nationalId: testUserProfile.nationalId },
+      })
+
+      expect(userProfile.lastNudge).not.toBeNull()
+      expect(userProfile.nextNudge).toEqual(addMonths(userProfile.lastNudge, 1))
+      expect(userProfile.mobileStatus).toBe(DataStatus.EMPTY)
+    })
+
+    it('POST /v2/me/nudge with nudgeType=NudgeType.NUDGE should return 200 and update the lastNudge and set nextNudge to 6 month after lastNudge', async () => {
+      // Arrange
+      const fixtureFactory = new FixtureFactory(app)
+
+      await fixtureFactory.createUserProfile(testUserProfile)
+
+      // Act
+      const res = await server.post(`/v2/me/nudge`).send({
+        nudgeType: NudgeType.NUDGE,
+      } as PostNudgeDto)
+
+      // Assert
+      expect(res.status).toEqual(200)
+
+      // Assert that lastNudge is updated
+      const userProfileModel = app.get(getModelToken(UserProfile))
+      const userProfile = await userProfileModel.findOne({
+        where: { nationalId: testUserProfile.nationalId },
+      })
+
+      expect(userProfile.lastNudge).not.toBeNull()
+      expect(userProfile.nextNudge).toEqual(addMonths(userProfile.lastNudge, 6))
+    })
+
+    it.each`
+      nudgeType               | field
+      ${NudgeType.SKIP_EMAIL} | ${'emailStatus'}
+      ${NudgeType.SKIP_PHONE} | ${'mobileStatus'}
+      ${NudgeType.NUDGE}      | ${'emailStatus'}
+      ${NudgeType.NUDGE}      | ${'mobileStatus'}
+    `(
+      'POST /v2/me/nudge with nudgeType=$nudgeType should only update $field to EMPTY when it is NOT_DEFINED',
+      async ({
+        nudgeType,
+        field,
+      }: {
+        nudgeType: NudgeType
+        field: StatusFieldType
+      }) => {
+        // Arrange
+        const fixtureFactory = new FixtureFactory(app)
+        await fixtureFactory.createUserProfile({
+          ...testUserProfile,
+          [field]: DataStatus.NOT_DEFINED,
+        })
+
+        // Act
+        const res = await server.post(`/v2/me/nudge`).send({
+          nudgeType,
+        } as PostNudgeDto)
+
+        // Assert
+        expect(res.status).toEqual(200)
+
+        // Assert that $field status is updated
+        const userProfileModel = app.get(getModelToken(UserProfile))
+        const userProfile = await userProfileModel.findOne({
+          where: { nationalId: testUserProfile.nationalId },
+        })
+        expect(userProfile[field]).toBe(DataStatus.EMPTY)
+      },
+    )
+
+    it.each`
+      nudgeType               | field             | dbStatus
+      ${NudgeType.SKIP_EMAIL} | ${'emailStatus'}  | ${DataStatus.VERIFIED}
+      ${NudgeType.SKIP_EMAIL} | ${'emailStatus'}  | ${DataStatus.NOT_VERIFIED}
+      ${NudgeType.SKIP_PHONE} | ${'mobileStatus'} | ${DataStatus.VERIFIED}
+      ${NudgeType.SKIP_PHONE} | ${'mobileStatus'} | ${DataStatus.NOT_VERIFIED}
+      ${NudgeType.NUDGE}      | ${'emailStatus'}  | ${DataStatus.VERIFIED}
+      ${NudgeType.NUDGE}      | ${'emailStatus'}  | ${DataStatus.NOT_VERIFIED}
+      ${NudgeType.NUDGE}      | ${'mobileStatus'} | ${DataStatus.VERIFIED}
+      ${NudgeType.NUDGE}      | ${'mobileStatus'} | ${DataStatus.NOT_VERIFIED}
+    `(
+      `POST /v2/me/nudge with nudgeType=$nudgeType should not update $field to EMPTY when db status is $dbStatus`,
+      async ({
+        nudgeType,
+        field,
+        dbStatus,
+      }: {
+        nudgeType: NudgeType
+        field: StatusFieldType
+        dbStatus: DataStatus
+      }) => {
+        // Arrange
+        const fixtureFactory = new FixtureFactory(app)
+        await fixtureFactory.createUserProfile({
+          ...testUserProfile,
+          [field]: dbStatus,
+        })
+
+        // Act
+        const res = await server.post(`/v2/me/nudge`).send({
+          nudgeType,
+        } as PostNudgeDto)
+
+        // Assert
+        expect(res.status).toEqual(200)
+
+        // Assert that $field status is not updated
+        const userProfileModel = app.get(getModelToken(UserProfile))
+        const userProfile = await userProfileModel.findOne({
+          where: { nationalId: testUserProfile.nationalId },
+        })
+        expect(userProfile[field]).toBe(dbStatus)
+      },
+    )
   })
 })

--- a/apps/services/user-profile/test/fixture-factory.ts
+++ b/apps/services/user-profile/test/fixture-factory.ts
@@ -7,6 +7,7 @@ import { EmailVerification } from '../src/app/user-profile/emailVerification.mod
 import { SmsVerification } from '../src/app/user-profile/smsVerification.model'
 import { UserProfile } from '../src/app/user-profile/userProfile.model'
 import { UserDeviceTokens } from '../src/app/user-profile/userDeviceTokens.model'
+import { DataStatus } from '../src/app/user-profile/types/dataStatusTypes'
 
 export class FixtureFactory {
   constructor(private app: TestApp) {}
@@ -23,6 +24,9 @@ export class FixtureFactory {
     mobilePhoneNumberVerified = false,
     emailVerified = false,
     lastNudge = null,
+    nextNudge = null,
+    emailStatus = DataStatus.NOT_DEFINED,
+    mobileStatus = DataStatus.NOT_DEFINED,
   }) {
     const userProfileModel = this.get(UserProfile)
 
@@ -33,7 +37,10 @@ export class FixtureFactory {
       locale,
       mobilePhoneNumberVerified,
       emailVerified,
+      emailStatus,
+      mobileStatus,
       lastNudge: lastNudge && lastNudge.toISOString(),
+      nextNudge: nextNudge && nextNudge.toISOString(),
     })
   }
 


### PR DESCRIPTION
* nudge update with nextNudge

* next nudge tests and needsNudge changes

* wip interval to update and nudge

* refactor for nudge

* Move nudge skipField param to be a post body payload and rename to nudgeFrom.

* Remove import that was refactored.

* Fix tests

* minor bug fux for confirmNudge

* Rename NudgeFrom enum to NudgeType

* chore: nx format:write update dirty files

* Add happy path test for status updates on nudge

* Add tests to verify that emailStatus and mobileStatus are not changed to empty in other states.

* Use ApiPropertyOptional for optional properties on user profile model. Rename variable in userprofile service v2 for readability. Use SKIP_INTERVAL and NUDGE_INTERVAL in user profile spec file.

* Undo api property decorator fixes due to too big impact.

---------

# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
