### PR TITLE
fix(scripts): Get secrets only "working" when debugging

### DIFF
--- a/infra/src/cli/render-secrets.ts
+++ b/infra/src/cli/render-secrets.ts
@@ -71,7 +71,7 @@ export const renderSecrets = async (service: string) => {
     const escapedValue = (value ?? '')
       .replace(/\n/g, '\\n')
       .replace(/"/g, '\\"')
-    logger.debug(`export ${key}='${escapedValue}'`)
+    console.log(`export ${key}='${escapedValue}'`)
   })
   return envMap
 }

--- a/infra/src/common.ts
+++ b/infra/src/common.ts
@@ -91,7 +91,8 @@ export class Logger {
       error: 40,
     }
     if (l2l[level] >= l2l[this.logLevel]) {
-      return console[level]
+      return console.error
+      // return console[level]
     }
     return () => {}
   }

--- a/scripts/get-secrets.sh
+++ b/scripts/get-secrets.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 ROOT=$(git rev-parse --show-toplevel)
+. "$ROOT/scripts/utils.sh"
 env_secret_file="$ROOT/.env.secret"
 
 function show-help() {
@@ -20,8 +21,10 @@ function get-secrets {
   echo "Fetching secret environment variables for '$*'"
 
   pre=$(wc -l "$env_secret_file")
+  debug "Project '$*' has $pre secrets before render-secrets"
   ts-node --dir "$ROOT"/infra "$ROOT"/infra/src/cli/cli render-secrets --service="$*" >>"$env_secret_file"
   post=$(wc -l "$env_secret_file")
+  debug "Project '$*' has $post secrets after render-secrets"
 
   if [ "$pre" == "$post" ]; then
     echo "No secrets found for project '$*'"


### PR DESCRIPTION
`yarn get-secrets my-project` was broken. Here we fix it.

The logger updates made all `console.log` use `logger.debug`. Now the logger uses `console.error` for all logs to send them all stderr, and the secrets rendering uses `console.log` (stdout) so we can redirect to the secrets file.


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
