### PR TITLE
fix(web): Pension Calculator - Swap values for yearOfBirth parameter …

### DIFF
--- a/libs/api/domains/social-insurance/src/lib/utils.ts
+++ b/libs/api/domains/social-insurance/src/lib/utils.ts
@@ -114,8 +114,8 @@ export const mapPensionCalculationInput = (
     yearOfBirth:
       typeof input.birthYear === 'number'
         ? input.birthYear >= 1952
-          ? 1
-          : 2
+          ? 2
+          : 1
         : 2,
     typeOfPeriodIncome: input.typeOfPeriodIncome
       ? periodIncomeTypeMapping[input.typeOfPeriodIncome]


### PR DESCRIPTION
# Hotfix - Pension calculator year of birth parameter value (#14171)
