### PR TITLE
fix: create-db.sh feature deploy script now supports readonly users (#14195)

### DIFF
--- a/infra/scripts/container-scripts/create-db.sh
+++ b/infra/scripts/container-scripts/create-db.sh
@@ -1,39 +1,102 @@
 #!/bin/bash
+
+# This script creates or updates database users with appropriate permissions and passwords in PostgreSQL.
+# It also handles read-only and write users based on the naming convention and enables specified Postgres extensions.
+
 set -euo pipefail
 shopt -s inherit_errexit
+
+function create_or_update_user {
+  local user=$1
+  local password_key=$2
+  local db_name=$3
+  local is_read_only=$4
+
+  echo "Configuring user: $user"
+
+  # Attempt to fetch existing password
+  set +e # Disable script stopping for this command
+  local password
+  password=$(node secrets get "$password_key")
+  local fetch_status=$?
+  set -e # Re-enable script stopping on errors
+
+  local password_generated="false"
+  if [[ $fetch_status -ne 0 || -z "$password" ]]; then
+    echo "Generating new password for $user."
+    # Generate a new password if it doesn't exist in SSM
+    set +e
+    password=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 27)
+    set -e
+    password_generated="true"
+  else
+    echo "Using existing password for $user."
+  fi
+
+  # Create or update user with password
+  echo "Creating or updating database user."
+  psql -c "DO
+    \$do\$
+      BEGIN
+        IF NOT EXISTS (
+            SELECT FROM pg_catalog.pg_roles
+            WHERE  rolname = '$user') THEN
+
+            CREATE ROLE $user LOGIN ENCRYPTED PASSWORD '$password';
+        ELSE
+            ALTER ROLE $user WITH ENCRYPTED PASSWORD '$password';
+        END IF;
+      END
+    \$do\$;"
+
+  if [[ "$password_generated" == "true" ]]; then
+    echo "Storing new password in AWS SSM."
+    # Store the new password in AWS SSM if it was generated
+    node secrets store "$password_key" "$password" || {
+      echo "Failed to store password for $user in AWS SSM."
+      return 1 # Return with error
+    }
+  fi
+
+  if [[ "$is_read_only" == "true" ]]; then
+    # Grant read-only access
+    psql -c "GRANT CONNECT ON DATABASE $db_name TO $user"
+    psql -c "GRANT USAGE ON SCHEMA public TO $user"
+    psql -c "GRANT SELECT ON ALL TABLES IN SCHEMA public TO $user"
+    psql -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO $user"
+    echo "Configured $user with read-only access."
+  else
+    # Grant full privileges
+    psql -c "GRANT ALL PRIVILEGES ON DATABASE $db_name TO $user"
+    echo "Configured $user with full access."
+  fi
+}
 
 PGPASSWORD=$(node secrets get "$PGPASSWORD_KEY")
 export PGPASSWORD
 
-psql -c "CREATE DATABASE $DB_NAME" || true
+echo "Creating database if it doesn't exist."
+psql -c "CREATE DATABASE $db_name" || true
 
-set +e
-DB_PASSWORD=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 27)
-set -e
-
-psql -c "create user $DB_USER with encrypted password '$DB_PASSWORD'" || true
-
-if node secrets store "$DB_PASSWORD_KEY" "$DB_PASSWORD"; then
-    psql -c "alter user $DB_USER with password '$DB_PASSWORD'"
-fi
-
-# idempotent
-psql -c "grant all privileges on database $DB_NAME to $DB_USER"
-
-echo "checking if postgres extensions should be installed ..."
-if [[ -z $DB_EXTENSIONS ]]; then
-    echo "DB_EXTENSIONS env var is empty, nothing to enable."
+# Determine if $DB_USER is a read-only user and adjust DB_PASSWORD_KEY for the write user accordingly
+if [[ "$DB_USER" == *"_read" ]]; then
+  # The DB_PASSWORD_KEY for the read-only user is correct, so use it as is
+  create_or_update_user "$DB_USER" "$DB_PASSWORD_KEY" "$DB_NAME" "true"
+  # Remove "readonly/" to create the write user's DB_PASSWORD_KEY
+  WRITE_DB_PASSWORD_KEY="${DB_PASSWORD_KEY/readonly\//}"
+  WRITE_USER="${DB_USER%_read}"
+  create_or_update_user "$WRITE_USER" "$WRITE_DB_PASSWORD_KEY" "$DB_NAME" "false"
 else
-    for i in ${DB_EXTENSIONS//,/ }
-    do
-        echo "enabling $i"
-        psql -d "$DB_NAME" -c 'CREATE extension IF NOT EXISTS '"\"$i\""'';
-        if [ "$?" -lt 1 ];
-        then
-            echo "extension $i enabled"
-        else
-            echo "Failed to enable extension $i"
-        fi
-    done
+  # Handle write user only
+  create_or_update_user "$DB_USER" "$DB_PASSWORD_KEY" "$DB_NAME" "false"
 fi
 
+echo "Checking if Postgres extensions should be installed..."
+if [[ -z "$DB_EXTENSIONS" ]]; then
+  echo "DB_EXTENSIONS environment variable is empty, nothing to enable."
+else
+  for extension in ${DB_EXTENSIONS//,/ }; do
+    echo "Enabling $extension"
+    psql -d "$DB_NAME" -c "CREATE EXTENSION IF NOT EXISTS \"$extension\";"
+  done
+fi


### PR DESCRIPTION
* fix: create-db.sh feature deploy script now supports readonly users

* fix: shellcheck

* chore: fix shellcheck errors

---------

Co-authored-by: kodiakhq[bot] <49736102+kodiakhq[bot]@users.noreply.github.com>

# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
