### PR TITLE
Feat(license-client): optional drivers license photo check

### DIFF
--- a/libs/api/domains/license-service/src/lib/licenseService.resolver.ts
+++ b/libs/api/domains/license-service/src/lib/licenseService.resolver.ts
@@ -56,7 +56,7 @@ export class LicenseServiceResolver {
     })
   }
 
-  @Query(() => GenericUserLicense)
+  @Query(() => GenericUserLicense, { nullable: true })
   @Audit()
   async genericLicense(
     @CurrentUser() user: User,

--- a/libs/api/domains/license-service/src/lib/licenseService.service.ts
+++ b/libs/api/domains/license-service/src/lib/licenseService.service.ts
@@ -261,6 +261,7 @@ export class LicenseServiceService {
         licenseUserData.pkpassStatus = licenseService.clientSupportsPkPass
           ? (licenseService.licenseIsValidForPkPass?.(
               lp.rawData,
+              user,
             ) as unknown as GenericUserLicensePkPassStatus) ??
             GenericUserLicensePkPassStatus.Unknown
           : GenericUserLicensePkPassStatus.NotAvailable

--- a/libs/clients/license-client/src/lib/clients/adr-license-client/adrLicenseClient.service.ts
+++ b/libs/clients/license-client/src/lib/clients/adr-license-client/adrLicenseClient.service.ts
@@ -100,18 +100,22 @@ export class AdrLicenseClient implements LicenseClient<LicenseType.AdrLicense> {
     }
   }
 
-  licenseIsValidForPkPass(payload: unknown): LicensePkPassAvailability {
+  licenseIsValidForPkPass(
+    payload: unknown,
+  ): Promise<LicensePkPassAvailability> {
     if (typeof payload === 'string') {
       let jsonLicense: AdrDto
       try {
         jsonLicense = JSON.parse(payload)
       } catch (e) {
         this.logger.warn('Invalid raw data', { error: e, LOG_CATEGORY })
-        return LicensePkPassAvailability.Unknown
+        return Promise.resolve(LicensePkPassAvailability.Unknown)
       }
-      return this.checkLicenseValidityForPkPass(jsonLicense)
+      return Promise.resolve(this.checkLicenseValidityForPkPass(jsonLicense))
     }
-    return this.checkLicenseValidityForPkPass(payload as AdrDto)
+    return Promise.resolve(
+      this.checkLicenseValidityForPkPass(payload as AdrDto),
+    )
   }
 
   async getLicenses(user: User): Promise<Result<Array<FlattenedAdrDto>>> {
@@ -168,7 +172,7 @@ export class AdrLicenseClient implements LicenseClient<LicenseType.AdrLicense> {
       }
     }
 
-    const valid = this.licenseIsValidForPkPass(license.data)
+    const valid = await this.licenseIsValidForPkPass(license.data)
 
     if (!valid) {
       return {

--- a/libs/clients/license-client/src/lib/clients/disability-license-client/services/disabilityLicenseClient.service.ts
+++ b/libs/clients/license-client/src/lib/clients/disability-license-client/services/disabilityLicenseClient.service.ts
@@ -99,19 +99,23 @@ export class DisabilityLicenseClient
     }
   }
 
-  licenseIsValidForPkPass(payload: unknown): LicensePkPassAvailability {
+  licenseIsValidForPkPass(
+    payload: unknown,
+  ): Promise<LicensePkPassAvailability> {
     if (typeof payload === 'string') {
       let jsonLicense: OrorkuSkirteini
       try {
         jsonLicense = JSON.parse(payload)
       } catch (e) {
         this.logger.warn('Invalid raw data', { error: e, LOG_CATEGORY })
-        return LicensePkPassAvailability.Unknown
+        return Promise.resolve(LicensePkPassAvailability.Unknown)
       }
-      return this.checkLicenseValidityForPkPass(jsonLicense)
+      return Promise.resolve(this.checkLicenseValidityForPkPass(jsonLicense))
     }
 
-    return this.checkLicenseValidityForPkPass(payload as OrorkuSkirteini)
+    return Promise.resolve(
+      this.checkLicenseValidityForPkPass(payload as OrorkuSkirteini),
+    )
   }
 
   async getLicenses(user: User): Promise<Result<Array<OrorkuSkirteini>>> {

--- a/libs/clients/license-client/src/lib/clients/driving-license-client/modules/drivingLicenseClient.module.ts
+++ b/libs/clients/license-client/src/lib/clients/driving-license-client/modules/drivingLicenseClient.module.ts
@@ -4,10 +4,12 @@ import { Module } from '@nestjs/common'
 import { SmartSolutionsApiClientModule } from '@island.is/clients/smartsolutions'
 import { ConfigType } from '@nestjs/config'
 import { DrivingDigitalLicenseClientConfig } from '../drivingLicenseClient.config'
+import { FeatureFlagModule } from '@island.is/nest/feature-flags'
 
 @Module({
   imports: [
     DrivingLicenseApiModule,
+    FeatureFlagModule,
     SmartSolutionsApiClientModule.registerAsync({
       useFactory: (
         config: ConfigType<typeof DrivingDigitalLicenseClientConfig>,

--- a/libs/clients/license-client/src/lib/clients/firearm-license-client/services/firearmLicenseClient.service.ts
+++ b/libs/clients/license-client/src/lib/clients/firearm-license-client/services/firearmLicenseClient.service.ts
@@ -121,18 +121,22 @@ export class FirearmLicenseClient
     }
   }
 
-  licenseIsValidForPkPass(payload: unknown): LicensePkPassAvailability {
+  licenseIsValidForPkPass(
+    payload: unknown,
+  ): Promise<LicensePkPassAvailability> {
     if (typeof payload === 'string') {
       let jsonLicense: FirearmLicenseDto
       try {
         jsonLicense = JSON.parse(payload)
       } catch (e) {
         this.logger.warn('Invalid raw data', { error: e, LOG_CATEGORY })
-        return LicensePkPassAvailability.Unknown
+        return Promise.resolve(LicensePkPassAvailability.Unknown)
       }
-      return this.checkLicenseValidityForPkPass(jsonLicense)
+      return Promise.resolve(this.checkLicenseValidityForPkPass(jsonLicense))
     }
-    return this.checkLicenseValidityForPkPass(payload as FirearmLicenseDto)
+    return Promise.resolve(
+      this.checkLicenseValidityForPkPass(payload as FirearmLicenseDto),
+    )
   }
 
   async getLicenses(user: User): Promise<Result<Array<FirearmLicenseDto>>> {
@@ -198,7 +202,7 @@ export class FirearmLicenseClient
       }
     }
 
-    const valid = this.licenseIsValidForPkPass(license.data)
+    const valid = await this.licenseIsValidForPkPass(license.data)
 
     if (!valid) {
       return {

--- a/libs/clients/license-client/src/lib/clients/hunting-license-client/huntingLicenseClient.service.ts
+++ b/libs/clients/license-client/src/lib/clients/hunting-license-client/huntingLicenseClient.service.ts
@@ -94,18 +94,22 @@ export class HuntingLicenseClient
     }
   }
 
-  licenseIsValidForPkPass(payload: unknown): LicensePkPassAvailability {
+  licenseIsValidForPkPass(
+    payload: unknown,
+  ): Promise<LicensePkPassAvailability> {
     if (typeof payload === 'string') {
       let jsonLicense: HuntingLicenseDto
       try {
         jsonLicense = JSON.parse(payload)
       } catch (e) {
         this.logger.warn('Invalid raw data', { error: e, LOG_CATEGORY })
-        return LicensePkPassAvailability.Unknown
+        return Promise.resolve(LicensePkPassAvailability.Unknown)
       }
-      return this.checkLicenseValidityForPkPass(jsonLicense)
+      return Promise.resolve(this.checkLicenseValidityForPkPass(jsonLicense))
     }
-    return this.checkLicenseValidityForPkPass(payload as HuntingLicenseDto)
+    return Promise.resolve(
+      this.checkLicenseValidityForPkPass(payload as HuntingLicenseDto),
+    )
   }
 
   async getLicenses(user: User): Promise<Result<Array<HuntingLicenseDto>>> {
@@ -164,7 +168,7 @@ export class HuntingLicenseClient
       }
     }
 
-    const valid = this.licenseIsValidForPkPass(license.data)
+    const valid = await this.licenseIsValidForPkPass(license.data)
 
     if (!valid) {
       return {

--- a/libs/clients/license-client/src/lib/clients/machine-license-client/machineLicenseClient.service.ts
+++ b/libs/clients/license-client/src/lib/clients/machine-license-client/machineLicenseClient.service.ts
@@ -98,18 +98,22 @@ export class MachineLicenseClient
     }
   }
 
-  licenseIsValidForPkPass(payload: unknown): LicensePkPassAvailability {
+  licenseIsValidForPkPass(
+    payload: unknown,
+  ): Promise<LicensePkPassAvailability> {
     if (typeof payload === 'string') {
       let jsonLicense: VinnuvelaDto
       try {
         jsonLicense = JSON.parse(payload)
       } catch (e) {
         this.logger.warn('Invalid raw data', { error: e, LOG_CATEGORY })
-        return LicensePkPassAvailability.Unknown
+        return Promise.resolve(LicensePkPassAvailability.Unknown)
       }
-      return this.checkLicenseValidityForPkPass(jsonLicense)
+      return Promise.resolve(this.checkLicenseValidityForPkPass(jsonLicense))
     }
-    return this.checkLicenseValidityForPkPass(payload as VinnuvelaDto)
+    return Promise.resolve(
+      this.checkLicenseValidityForPkPass(payload as VinnuvelaDto),
+    )
   }
 
   async getLicenses(user: User): Promise<Result<Array<VinnuvelaDto>>> {
@@ -167,7 +171,7 @@ export class MachineLicenseClient
       }
     }
 
-    const valid = this.licenseIsValidForPkPass(license.data)
+    const valid = await this.licenseIsValidForPkPass(license.data)
 
     if (!valid) {
       return {

--- a/libs/clients/license-client/src/lib/licenseClient.type.ts
+++ b/libs/clients/license-client/src/lib/licenseClient.type.ts
@@ -178,7 +178,10 @@ export interface LicenseClient<Type extends LicenseType> {
   type: LicenseType
   clientSupportsPkPass: boolean
   getLicenses: (user: User) => Promise<Result<Array<LicenseResult<Type>>>>
-  licenseIsValidForPkPass?: (payload: unknown) => LicensePkPassAvailability
+  licenseIsValidForPkPass?: (
+    payload: unknown,
+    user?: User,
+  ) => Promise<LicensePkPassAvailability>
   getPkPassUrl?: (user: User, locale?: Locale) => Promise<Result<string>>
   getPkPassQRCode?: (user: User, locale?: Locale) => Promise<Result<string>>
   verifyPkPassDeprecated?: (data: string) => Promise<Result<PkPassVerification>>

--- a/libs/feature-flags/src/lib/features.ts
+++ b/libs/feature-flags/src/lib/features.ts
@@ -57,6 +57,7 @@ export enum Features {
 
   //License service new drivers license client enabled
   licenseServiceDrivingLicenseClient = 'isLicenseServiceDrivingLicenceClientV2Enabled',
+  licenseServiceDrivingLicencePhotoCheckDisabled = 'isLicenseServiceDrivingLicencePhotoCheckDisabled',
 
   //Enable intellectual properties fetch
   isIntellectualPropertyModuleEnabled = 'isIntellectualPropertyModuleEnabled',

--- a/libs/service-portal/licenses/src/screens/LicenseDetail/LicenseDetail.tsx
+++ b/libs/service-portal/licenses/src/screens/LicenseDetail/LicenseDetail.tsx
@@ -404,7 +404,6 @@ const LicenseDetail = () => {
             flexDirection={['column', 'row']}
             alignItems={['flexStart', 'center']}
             marginBottom={2}
-            columnGap={2}
             rowGap={2}
           >
             {!expired &&


### PR DESCRIPTION
## What

* Adds a feature flag for possible skipping of the photo check
* Nullable generic licenses query response
* Add user to license validity calls for feature flag integration

## Why

Remove the manual disabling of checks for driving license pkpass testing

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
