### PR TITLE
fix(j-s): Parallel Upload

### DIFF
--- a/apps/judicial-system/web/src/components/AppealCaseFilesOverview/AppealCaseFilesOverview.tsx
+++ b/apps/judicial-system/web/src/components/AppealCaseFilesOverview/AppealCaseFilesOverview.tsx
@@ -52,38 +52,38 @@ const AppealCaseFilesOverview = () => {
       setAllFiles(
         workingCase.caseFiles.filter((caseFile) => {
           return (
-            (caseFile.category &&
-              ((workingCase.prosecutorPostponedAppealDate &&
+            caseFile.category &&
+            ((workingCase.prosecutorPostponedAppealDate &&
+              [
+                CaseFileCategory.PROSECUTOR_APPEAL_BRIEF,
+                CaseFileCategory.PROSECUTOR_APPEAL_BRIEF_CASE_FILE,
+              ].includes(caseFile.category)) ||
+              (workingCase.prosecutorStatementDate &&
                 [
-                  CaseFileCategory.PROSECUTOR_APPEAL_BRIEF,
-                  CaseFileCategory.PROSECUTOR_APPEAL_BRIEF_CASE_FILE,
+                  CaseFileCategory.PROSECUTOR_APPEAL_STATEMENT,
+                  CaseFileCategory.PROSECUTOR_APPEAL_STATEMENT_CASE_FILE,
                 ].includes(caseFile.category)) ||
-                (workingCase.prosecutorStatementDate &&
-                  [
-                    CaseFileCategory.PROSECUTOR_APPEAL_STATEMENT,
-                    CaseFileCategory.PROSECUTOR_APPEAL_STATEMENT_CASE_FILE,
-                  ].includes(caseFile.category)) ||
-                (workingCase.accusedPostponedAppealDate &&
-                  [
-                    CaseFileCategory.DEFENDANT_APPEAL_BRIEF,
-                    CaseFileCategory.DEFENDANT_APPEAL_BRIEF_CASE_FILE,
-                  ].includes(caseFile.category)) ||
-                (workingCase.defendantStatementDate &&
-                  [
-                    CaseFileCategory.DEFENDANT_APPEAL_STATEMENT,
-                    CaseFileCategory.DEFENDANT_APPEAL_STATEMENT_CASE_FILE,
-                  ].includes(caseFile.category)) ||
+              (workingCase.accusedPostponedAppealDate &&
                 [
-                  CaseFileCategory.PROSECUTOR_APPEAL_CASE_FILE,
-                  CaseFileCategory.DEFENDANT_APPEAL_CASE_FILE,
-                ].includes(caseFile.category) ||
-                ((workingCase.appealState === CaseAppealState.COMPLETED ||
-                  isCourtOfAppealsUser(user)) &&
-                  [CaseFileCategory.APPEAL_RULING].includes(
-                    caseFile.category,
-                  )))) ||
-            (caseFile.category === CaseFileCategory.APPEAL_COURT_RECORD &&
-              (isCourtOfAppealsUser(user) || isDefenceUser(user)))
+                  CaseFileCategory.DEFENDANT_APPEAL_BRIEF,
+                  CaseFileCategory.DEFENDANT_APPEAL_BRIEF_CASE_FILE,
+                ].includes(caseFile.category)) ||
+              (workingCase.defendantStatementDate &&
+                [
+                  CaseFileCategory.DEFENDANT_APPEAL_STATEMENT,
+                  CaseFileCategory.DEFENDANT_APPEAL_STATEMENT_CASE_FILE,
+                ].includes(caseFile.category)) ||
+              [
+                CaseFileCategory.PROSECUTOR_APPEAL_CASE_FILE,
+                CaseFileCategory.DEFENDANT_APPEAL_CASE_FILE,
+              ].includes(caseFile.category) ||
+              ((workingCase.appealState === CaseAppealState.COMPLETED ||
+                isCourtOfAppealsUser(user)) &&
+                caseFile.category === CaseFileCategory.APPEAL_RULING) ||
+              (((workingCase.appealState === CaseAppealState.COMPLETED &&
+                isDefenceUser(user)) ||
+                isCourtOfAppealsUser(user)) &&
+                caseFile.category === CaseFileCategory.APPEAL_COURT_RECORD))
           )
         }),
       )

--- a/apps/judicial-system/web/src/routes/Court/Indictments/CourtRecord/CourtRecord.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/CourtRecord/CourtRecord.tsx
@@ -40,11 +40,11 @@ const CourtRecord: React.FC<React.PropsWithChildren<unknown>> = () => {
   const [navigateTo, setNavigateTo] = useState<keyof stepValidationsType>()
 
   const { formatMessage } = useIntl()
-  const { transitionCase } = useCase()
+  const { transitionCase, isTransitioningCase } = useCase()
 
   const {
     uploadFiles,
-    allFilesUploaded,
+    allFilesDoneOrError,
     addUploadFiles,
     updateUploadFile,
     removeUploadFile,
@@ -74,7 +74,7 @@ const CourtRecord: React.FC<React.PropsWithChildren<unknown>> = () => {
       workingCase={workingCase}
       isLoading={isLoadingWorkingCase}
       notFound={caseNotFound}
-      isValid={allFilesUploaded}
+      isValid={allFilesDoneOrError}
       onNavigationTo={handleNavigationTo}
     >
       <PageHeader title={formatMessage(titles.court.indictments.courtRecord)} />
@@ -139,8 +139,8 @@ const CourtRecord: React.FC<React.PropsWithChildren<unknown>> = () => {
           onNextButtonClick={() =>
             handleNavigationTo(constants.CLOSED_INDICTMENT_OVERVIEW_ROUTE)
           }
-          nextIsDisabled={!allFilesUploaded}
-          nextIsLoading={isLoadingWorkingCase}
+          nextIsDisabled={!allFilesDoneOrError}
+          nextIsLoading={isTransitioningCase}
           nextButtonText={formatMessage(m.nextButtonText)}
         />
       </FormContentContainer>

--- a/apps/judicial-system/web/src/routes/CourtOfAppeal/Ruling/Ruling.tsx
+++ b/apps/judicial-system/web/src/routes/CourtOfAppeal/Ruling/Ruling.tsx
@@ -55,7 +55,7 @@ const CourtOfAppealRuling: React.FC<React.PropsWithChildren<unknown>> = () => {
   } = useContext(FormContext)
   const {
     uploadFiles,
-    allFilesUploaded,
+    allFilesDoneOrError,
     addUploadFiles,
     updateUploadFile,
     removeUploadFile,
@@ -95,13 +95,13 @@ const CourtOfAppealRuling: React.FC<React.PropsWithChildren<unknown>> = () => {
 
   const isStepValid =
     workingCase.appealRulingDecision === CaseAppealRulingDecision.DISCONTINUED
-      ? allFilesUploaded
+      ? allFilesDoneOrError
       : uploadFiles.some(
           (file) =>
             file.category === CaseFileCategory.APPEAL_RULING &&
             file.status === 'done',
         ) &&
-        allFilesUploaded &&
+        allFilesDoneOrError &&
         isCourtOfAppealRulingStepValid(workingCase)
 
   const handleRulingDecisionChange = (

--- a/apps/judicial-system/web/src/routes/CourtOfAppeal/WithdrawnAppealCase/WithdrawnAppealCase.tsx
+++ b/apps/judicial-system/web/src/routes/CourtOfAppeal/WithdrawnAppealCase/WithdrawnAppealCase.tsx
@@ -28,7 +28,7 @@ const WithdrawnAppealCase = () => {
   const router = useRouter()
   const {
     uploadFiles,
-    allFilesUploaded,
+    allFilesDoneOrError,
     addUploadFiles,
     updateUploadFile,
     removeUploadFile,
@@ -37,7 +37,7 @@ const WithdrawnAppealCase = () => {
     workingCase.id,
   )
 
-  const isStepValid = allFilesUploaded && workingCase.appealCaseNumber
+  const isStepValid = allFilesDoneOrError && workingCase.appealCaseNumber
 
   return (
     <PageLayout workingCase={workingCase} isLoading={false} notFound={false}>

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/CaseFiles/CaseFiles.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/CaseFiles/CaseFiles.tsx
@@ -31,7 +31,7 @@ const CaseFiles: React.FC<React.PropsWithChildren<unknown>> = () => {
   const { formatMessage } = useIntl()
   const {
     uploadFiles,
-    allFilesUploaded,
+    allFilesDoneOrError,
     addUploadFiles,
     updateUploadFile,
     removeUploadFile,
@@ -59,7 +59,7 @@ const CaseFiles: React.FC<React.PropsWithChildren<unknown>> = () => {
         file.category === CaseFileCategory.CRIMINAL_RECORD &&
         file.status === 'done',
     ) &&
-    allFilesUploaded
+    allFilesDoneOrError
   const handleNavigationTo = useCallback(
     (destination: string) => router.push(`${destination}/${workingCase.id}`),
     [workingCase.id],

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/PoliceCaseFiles/PoliceCaseFilesRoute.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/PoliceCaseFiles/PoliceCaseFilesRoute.tsx
@@ -65,7 +65,7 @@ const UploadFilesToPoliceCase: React.FC<
   const { formatMessage } = useIntl()
   const {
     uploadFiles,
-    allFilesUploaded,
+    allFilesDoneOrError,
     addUploadFile,
     addUploadFiles,
     updateUploadFile,
@@ -83,7 +83,8 @@ const UploadFilesToPoliceCase: React.FC<
     fetchPolicy: 'no-cache',
     errorPolicy: 'all',
   })
-  const [isUploading, setIsUploading] = useState<boolean>(false)
+  const [isUploadingPoliceCaseFiles, setIsUploadingPoliceCaseFiles] =
+    useState<boolean>(false)
   const [policeCaseFiles, setPoliceCaseFiles] = useState<PoliceCaseFilesData>()
   const [policeCaseFileList, setPoliceCaseFileList] = useState<
     PoliceCaseFileCheck[]
@@ -98,8 +99,8 @@ const UploadFilesToPoliceCase: React.FC<
   }, [uploadFiles, formatMessage])
 
   useEffect(() => {
-    setAllUploaded(allFilesUploaded && !isUploading)
-  }, [allFilesUploaded, isUploading, setAllUploaded])
+    setAllUploaded(allFilesDoneOrError && !isUploadingPoliceCaseFiles)
+  }, [allFilesDoneOrError, isUploadingPoliceCaseFiles, setAllUploaded])
 
   useEffect(() => {
     if (caseOrigin !== CaseOrigin.LOKE) {
@@ -225,11 +226,11 @@ const UploadFilesToPoliceCase: React.FC<
         }
       })
 
-    setIsUploading(true)
+    setIsUploadingPoliceCaseFiles(true)
 
     await handleUploadFromPolice(filesToUpload, uploadPoliceCaseFileCallback)
 
-    setIsUploading(false)
+    setIsUploadingPoliceCaseFiles(false)
   }
 
   return (
@@ -248,7 +249,12 @@ const UploadFilesToPoliceCase: React.FC<
         buttonLabel={formatMessage(strings.inputFileUpload.buttonLabel)}
         onChange={(files) =>
           handleUpload(
-            addUploadFiles(files, CaseFileCategory.CASE_FILE, policeCaseNumber),
+            addUploadFiles(
+              files,
+              CaseFileCategory.CASE_FILE,
+              undefined,
+              policeCaseNumber,
+            ),
             updateUploadFile,
           )
         }

--- a/apps/judicial-system/web/src/routes/Prosecutor/components/CaseFiles/CaseFiles.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/components/CaseFiles/CaseFiles.tsx
@@ -59,14 +59,15 @@ export const CaseFiles: React.FC<React.PropsWithChildren<unknown>> = () => {
   })
   const router = useRouter()
   const { formatMessage } = useIntl()
-  const [isUploading, setIsUploading] = useState<boolean>(false)
+  const [isUploadingPoliceCaseFiles, setIsUploadingPoliceCaseFiles] =
+    useState<boolean>(false)
   const [policeCaseFileList, setPoliceCaseFileList] = useState<
     PoliceCaseFileCheck[]
   >([])
   const [policeCaseFiles, setPoliceCaseFiles] = useState<PoliceCaseFilesData>()
   const {
     uploadFiles,
-    allFilesUploaded,
+    allFilesDoneOrError,
     addUploadFile,
     addUploadFiles,
     updateUploadFile,
@@ -132,7 +133,7 @@ export const CaseFiles: React.FC<React.PropsWithChildren<unknown>> = () => {
     }
   }, [uploadFiles, formatMessage])
 
-  const stepIsValid = !isUploading && allFilesUploaded
+  const stepIsValid = !isUploadingPoliceCaseFiles && allFilesDoneOrError
   const handleNavigationTo = (destination: string) =>
     router.push(`${destination}/${workingCase.id}`)
 
@@ -164,11 +165,11 @@ export const CaseFiles: React.FC<React.PropsWithChildren<unknown>> = () => {
       return
     }
 
-    setIsUploading(true)
+    setIsUploadingPoliceCaseFiles(true)
 
     await handleUploadFromPolice(filesToUpload, uploadPoliceCaseFileCallback)
 
-    setIsUploading(false)
+    setIsUploadingPoliceCaseFiles(false)
   }
 
   const removeFileCB = (file: TUploadFile) => {
@@ -232,7 +233,7 @@ export const CaseFiles: React.FC<React.PropsWithChildren<unknown>> = () => {
               onRemove={(file) => handleRemove(file, removeFileCB)}
               onRetry={(file) => handleRetry(file, updateUploadFile)}
               errorMessage={uploadErrorMessage}
-              disabled={isUploading}
+              disabled={isUploadingPoliceCaseFiles}
               showFileSize
             />
           </ContentBlock>

--- a/apps/judicial-system/web/src/routes/Shared/AppealToCourtOfAppeals/AppealCaseFiles.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/AppealToCourtOfAppeals/AppealCaseFiles.tsx
@@ -37,7 +37,6 @@ import {
   useS3Upload,
   useUploadFiles,
 } from '@island.is/judicial-system-web/src/utils/hooks'
-import { UploadFileState } from '@island.is/judicial-system-web/src/utils/hooks/useS3Upload/useS3Upload'
 
 import { strings } from './AppealCaseFiles.strings'
 
@@ -48,15 +47,16 @@ const AppealFiles = () => {
   const router = useRouter()
   const { id } = router.query
   const [visibleModal, setVisibleModal] = useState<boolean>(false)
-  const { uploadFiles, addUploadFiles, removeUploadFile, updateUploadFile } =
-    useUploadFiles(workingCase.caseFiles)
-
+  const {
+    uploadFiles,
+    allFilesDoneOrError,
+    someFilesError,
+    addUploadFiles,
+    removeUploadFile,
+    updateUploadFile,
+  } = useUploadFiles()
   const { handleUpload, handleRemove } = useS3Upload(workingCase.id)
   const { sendNotification } = useCase()
-  const [uploadState, setUploadState] = useState<UploadFileState>({
-    isUploading: false,
-    error: false,
-  })
 
   const appealCaseFilesType = isDefenceUser(user)
     ? CaseFileCategory.DEFENDANT_APPEAL_CASE_FILE
@@ -80,45 +80,26 @@ const AppealFiles = () => {
       : constants.SIGNED_VERDICT_OVERVIEW_ROUTE
   }/${id}`
 
-  const newUploadFiles = uploadFiles.filter((file) => {
-    return (
-      workingCase.caseFiles?.find((caseFile) => caseFile.id === file.id) ===
-      undefined
-    )
-  })
-
-  const handleNextButtonClick = useCallback(
-    async (isRetry: boolean) => {
-      setUploadState({ isUploading: true, error: false })
-
-      const uploadSuccess = await handleUpload(
-        newUploadFiles.filter((uf) =>
-          isRetry ? uf.status === 'error' : !uf.key,
-        ),
-        updateUploadFile,
-      )
-
-      if (!uploadSuccess) {
-        setUploadState({ isUploading: false, error: true })
-        return
-      }
-
-      await sendNotification(
-        workingCase.id,
-        NotificationType.APPEAL_CASE_FILES_UPDATED,
-      )
-
-      setVisibleModal(true)
-      setUploadState({ isUploading: false, error: false })
-    },
-    [
-      handleUpload,
-      newUploadFiles,
-      sendNotification,
+  const handleNextButtonClick = useCallback(async () => {
+    const allSucceeded = await handleUpload(
+      uploadFiles.filter((file) => !file.key),
       updateUploadFile,
-      workingCase.id,
-    ],
-  )
+    )
+
+    if (!allSucceeded) {
+      return
+    }
+
+    sendNotification(workingCase.id, NotificationType.APPEAL_CASE_FILES_UPDATED)
+
+    setVisibleModal(true)
+  }, [
+    handleUpload,
+    uploadFiles,
+    sendNotification,
+    updateUploadFile,
+    workingCase.id,
+  ])
 
   const handleRemoveFile = (file: UploadFile) => {
     if (file.key) {
@@ -126,16 +107,10 @@ const AppealFiles = () => {
     } else {
       removeUploadFile(file)
     }
-
-    setUploadState({ isUploading: false, error: false })
   }
 
   const handleChange = (files: File[], type: CaseFileCategory) => {
-    setUploadState({ isUploading: false, error: false })
-    addUploadFiles(files, type, undefined, {
-      status: 'done',
-      percent: 0,
-    })
+    addUploadFiles(files, type, 'done')
   }
 
   return (
@@ -193,7 +168,7 @@ const AppealFiles = () => {
               `${formatMessage(strings.appealCaseFilesCOASubtitle)}`}
           </Text>
           <InputFileUpload
-            fileList={newUploadFiles.filter(
+            fileList={uploadFiles.filter(
               (file) =>
                 file.category &&
                 caseFilesTypesToDisplay.includes(file.category),
@@ -208,10 +183,8 @@ const AppealFiles = () => {
               handleChange(files, appealCaseFilesType)
             }}
             onRemove={(file) => handleRemoveFile(file)}
-            hideIcons={newUploadFiles
-              .filter((file) => file.category === appealCaseFilesType)
-              .every((file) => file.status === 'uploading')}
-            disabled={uploadState.isUploading}
+            hideIcons={!allFilesDoneOrError}
+            disabled={!allFilesDoneOrError}
           />
         </Box>
         {isProsecutionUser(user) && (
@@ -223,16 +196,16 @@ const AppealFiles = () => {
       <FormContentContainer isFooter>
         <FormFooter
           previousUrl={previousUrl}
-          onNextButtonClick={() => handleNextButtonClick(uploadState.error)}
+          onNextButtonClick={handleNextButtonClick}
           nextButtonText={formatMessage(
-            uploadState.error
+            someFilesError
               ? strings.uploadFailedNextButtonText
               : strings.nextButtonText,
           )}
           nextButtonIcon={undefined}
-          nextIsLoading={uploadState.isUploading}
-          nextIsDisabled={newUploadFiles.length === 0}
-          nextButtonColorScheme={uploadState.error ? 'destructive' : 'default'}
+          nextIsLoading={!allFilesDoneOrError}
+          nextIsDisabled={uploadFiles.length === 0}
+          nextButtonColorScheme={someFilesError ? 'destructive' : 'default'}
         />
       </FormContentContainer>
       {visibleModal === true && (

--- a/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/SignedVerdictOverview.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/SignedVerdictOverview.tsx
@@ -662,14 +662,15 @@ export const SignedVerdictOverview: React.FC = () => {
               judgeName={workingCase.judge?.name}
             />
           </Box>
-          {workingCase.appealConclusion && (
-            <Box marginBottom={6}>
-              <Conclusion
-                title={formatMessage(conclusion.appealTitle)}
-                conclusionText={workingCase.appealConclusion}
-              />
-            </Box>
-          )}
+          {workingCase.appealState === CaseAppealState.COMPLETED &&
+            workingCase.appealConclusion && (
+              <Box marginBottom={6}>
+                <Conclusion
+                  title={formatMessage(conclusion.appealTitle)}
+                  conclusionText={workingCase.appealConclusion}
+                />
+              </Box>
+            )}
           <Box marginBottom={5}>
             <AppealCaseFilesOverview />
           </Box>


### PR DESCRIPTION
# Parallel Upload

[Fjarlægja serialization í S3 upload](https://app.asana.com/0/1199153462262248/1206513722291111/f)

## What

- Uploads files from client to S3 in parallel. An earlier change resulted in serial upload.
- Fixes a suttle bug that inadvertently hid some appeal files until the appeal case entered a given state. For example, if a prosecutor appealed a case, tried to upload files but only some of the files were upload, cancelled the appeal, then decided again to appeal, the files that were actually uploaded in the first attempt were not visible to the prosecutor during the appeal step. However, they appeared again when he has successfully appealed. Now any previously uploaded files are visible during the second attempt.
- Finally, court records in appeal cases are not shown to the defender unless the appeal case has been completed.

## Why

- Improved user experience.
## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
