### PR TITLE
chore(CI): Use default Cypress cache dir

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -163,6 +163,7 @@ jobs:
       - name: Verify cypress
         id: cypress-check
         run: npx cypress verify
+        continue-on-error: true
 
       - name: Install cypress
         if: steps.cypress-check.outcome != 'success'

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -166,6 +166,7 @@ jobs:
         continue-on-error: true
 
       - name: Install cypress
+        # Should use the cache success to install, and verify additionally
         if: steps.cypress-check.outcome != 'success'
         run: npx cypress install
 

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -163,7 +163,6 @@ jobs:
       - name: Verify cypress
         id: cypress-check
         run: npx cypress verify
-        continue-on-error: true
 
       - name: Install cypress
         if: steps.cypress-check.outcome != 'success'

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -16,7 +16,14 @@ concurrency:
 env:
   COMPOSE_HTTP_TIMEOUT: 180
   SKIP_GENERATED_CACHE: ${{ contains(github.event.pull_request.labels.*.name, 'skip-generated-cache') }}
-  CYPRESS_CACHE_DIR: ${{ github.workspace }}/.cypress
+
+  # Cypress searches for the Cypress binary in $HOME/.cache/cypress/, even though we set CYPRESS_CACHE_DIR,
+  # so here we set it "back to old" home dir, the same as the default.
+  #
+  # Here's the error message we get if CYPRESS_CACHE_DIR is something else:
+  # > The cypress npm package is installed, but the Cypress binary is missing.
+  # > We expected the binary to be installed here: /github/home/.cache/Cypress/13.0.0/Cypress/Cypress
+  CYPRESS_CACHE_DIR: /github/home/.cypress
 
 jobs:
   prepare:


### PR DESCRIPTION
If we use a `CYPRESS_CACHE_DIR` other than the runners homedir, we get
CI errors every time.

cf. https://github.com/island-is/island.is/actions/runs/8376829768/job/22940173208#step:17:16

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
