### PR TITLE
fix(web): Remove paddingBottom from BulletList component

### DIFF
--- a/apps/web/components/Organization/Slice/BulletList/BulletList.tsx
+++ b/apps/web/components/Organization/Slice/BulletList/BulletList.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { BulletListSlice as BulletListProps } from '@island.is/web/graphql/schema'
-import { Box } from '@island.is/island-ui/core'
 import { BulletList } from '@island.is/web/components'
 
 interface SliceProps {
@@ -16,26 +15,24 @@ export const BulletListSlice: React.FC<React.PropsWithChildren<SliceProps>> = ({
       id={slice.id}
       aria-labelledby={'sliceTitle-' + slice.id}
     >
-      <Box paddingBottom={[8, 5, 10]}>
-        <BulletList
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore make web strict
-          bullets={slice.bullets.map((bullet) => {
-            switch (bullet.__typename) {
-              case 'IconBullet':
-                return {
-                  ...bullet,
-                  type: 'IconBullet',
-                  icon: bullet.icon.url,
-                }
-              case 'NumberBulletGroup':
-                return { ...bullet, type: 'NumberBulletGroup' }
-              default:
-                return null
-            }
-          })}
-        />
-      </Box>
+      <BulletList
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore make web strict
+        bullets={slice.bullets.map((bullet) => {
+          switch (bullet.__typename) {
+            case 'IconBullet':
+              return {
+                ...bullet,
+                type: 'IconBullet',
+                icon: bullet.icon.url,
+              }
+            case 'NumberBulletGroup':
+              return { ...bullet, type: 'NumberBulletGroup' }
+            default:
+              return null
+          }
+        })}
+      />
     </section>
   )
 }


### PR DESCRIPTION
# Remove paddingBottom from BulletList component

## What

* After the spacing update we did a few weeks ago there's no need for components to have their own margin or padding around themselves

## Screenshots / Gifs

### Before
![image](https://github.com/island-is/island.is/assets/43557895/d0bf962f-8409-4d45-a0f3-75307bf73f38)


### After
![image](https://github.com/island-is/island.is/assets/43557895/bd0320b3-d3a8-48c3-957d-30b9a9cd7e69)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
