### PR TITLE
fix(contentful-apps): Handle case when link group is created separately

### DIFF
--- a/apps/contentful-apps/pages/fields/link-group-link-field.tsx
+++ b/apps/contentful-apps/pages/fields/link-group-link-field.tsx
@@ -165,20 +165,17 @@ const LinkGroupLinkField = () => {
     })
   }
 
-  const selectableContentTypes =
-    subpageContentType && linkContentType
-      ? [subpageContentType, linkContentType]
-      : linkContentType
-      ? [linkContentType]
-      : []
-
-  if (!subpageContentType) {
+  if (!linkContentType) {
     return (
       <Flex paddingTop="spacingM" justifyContent="center">
         <Spinner />
       </Flex>
     )
   }
+
+  const selectableContentTypes = subpageContentType
+    ? [subpageContentType, linkContentType]
+    : [linkContentType]
 
   if (sdk.ids.field === 'primaryLink') {
     return (
@@ -190,7 +187,7 @@ const LinkGroupLinkField = () => {
         parameters={{
           instance: {
             showCreateEntityAction: true,
-            showLinkEntityAction: true,
+            showLinkEntityAction: selectableContentTypes.length > 1,
           },
         }}
         renderCustomActions={(props) => (
@@ -216,7 +213,7 @@ const LinkGroupLinkField = () => {
       parameters={{
         instance: {
           showCreateEntityAction: true,
-          showLinkEntityAction: true,
+          showLinkEntityAction: selectableContentTypes.length > 1,
         },
       }}
       renderCustomActions={(props) => (


### PR DESCRIPTION
# Handle case when link group is created separately

A link group is most often used to create a sidebar menu for organization pages or project pages. The newly created contentful app logic relies on the fact that a link group is referenced by either of those content types. However if a link group gets created and isn't being referenced it'll be stuck in a "loading state". In this PR we are fixing that issue.



## Screenshots / Gifs

### Before (if a link group is created and nothing references it, it'll be stuck in the loading state)
https://github.com/island-is/island.is/assets/43557895/692e3955-0988-4d91-856e-c7663bfc259b

### After
https://github.com/island-is/island.is/assets/43557895/e5c6341d-2d8e-4699-a34e-16c66306c717

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
