### PR TITLE
fix(web): Default footer causes layout shift on desktop screens

### DIFF
--- a/apps/web/components/Footer/Footer.tsx
+++ b/apps/web/components/Footer/Footer.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import { BLOCKS } from '@contentful/rich-text-types'
 import { theme } from '@island.is/island-ui/theme'
 import {
@@ -37,7 +38,11 @@ export const Footer = ({
 }: FooterProps) => {
   const { width } = useWindowSize()
 
-  const isMobileScreenWidth = width < theme.breakpoints.sm
+  const [isMobileScreenWidth, setIsMobileScreenWidth] = useState(false)
+
+  useEffect(() => {
+    setIsMobileScreenWidth(width < theme.breakpoints.sm)
+  }, [width])
 
   return (
     <footer className={styles.footer} style={{ background }}>


### PR DESCRIPTION
# Default footer causes layout shift on desktop screens

## What

* Changed initial page render to be a non mobile screen width for the footer

## Screenshots / Gifs

### Before

https://github.com/island-is/island.is/assets/43557895/dc7082b6-4935-4b6e-91b9-7690eee5ddbd


### After
https://github.com/island-is/island.is/assets/43557895/c1881d01-f316-4594-a284-bb7fd379cdcf



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
