### PR TITLE
feat(native-app): add scan result background in scanner for Veiðikort

### DIFF
--- a/apps/native/app/src/ui/lib/scan-result-card/scan-result-card.tsx
+++ b/apps/native/app/src/ui/lib/scan-result-card/scan-result-card.tsx
@@ -12,8 +12,10 @@ import BackgroundDriversLicense from '../../assets/card/okuskirteini.png'
 import DisabilityLicenseBg from '../../assets/card/ororka_bg.png'
 import BackgroundWeaponLicense from '../../assets/card/skotvopnaleyfi.png'
 import DisabilityLicenseLogo from '../../assets/card/tryggingastofnun_logo.png'
+import LogoEnvironmentAgency from '../../assets/card/ust.png'
 import LogoAOSH from '../../assets/card/vinnueftirlitid-logo.png'
 import BackgroundVinnuvelar from '../../assets/card/vinnuvelar-bg.png'
+import BackgroundHuntingCard from '../../assets/card/veidikort.png'
 import { font } from '../../utils'
 
 const Host = styled.View<{ backgroundColor: string }>`
@@ -210,6 +212,12 @@ const ScanResultCardPresets = {
     logo: DisabilityLicenseLogo,
     backgroundImage: DisabilityLicenseBg,
     backgroundColor: '#C5D5C8',
+  },
+  HuntingLicense: {
+    title: 'Veiðikort',
+    logo: LogoEnvironmentAgency,
+    backgroundImage: BackgroundHuntingCard,
+    backgroundColor: '#E2EDFF',
   },
   Unknown: {
     title: 'Ekki þekkt',


### PR DESCRIPTION
## What

Update scanner app to show correct background, title and logo for scanning Veiðikort

## Why

Not launch blocking, scanning works without it but only shows the result (Í gildi/ekki í gildi) on a pink background with no title.

## Screenshots / Gifs
Before and after:
<div><img height = "800" src="https://github.com/island-is/island.is/assets/19665778/31fe6731-29fe-4a45-b17f-dc208b905f77">
<img height = "800" src="https://github.com/island-is/island.is/assets/19665778/88bf4d3e-d9d5-4e7e-a30a-38fff4bb660b)"></div>


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
