### PR TITLE
feat(web): Default header - text offset and have the option to set different background on mobile screens

### DIFF
--- a/apps/web/components/DefaultHeader/DefaultHeader.tsx
+++ b/apps/web/components/DefaultHeader/DefaultHeader.tsx
@@ -1,7 +1,14 @@
 import React from 'react'
 import cn from 'classnames'
 
-import { Box, Hidden, Link, Text, TextProps } from '@island.is/island-ui/core'
+import {
+  Box,
+  Hidden,
+  Link,
+  ResponsiveSpace,
+  Text,
+  TextProps,
+} from '@island.is/island-ui/core'
 
 import * as styles from './DefaultHeader.css'
 
@@ -11,6 +18,7 @@ export interface DefaultHeaderProps {
   background?: string
   title: string
   underTitle?: string
+  titleSectionPaddingLeft?: ResponsiveSpace
   logo?: string
   logoHref?: string
   titleColor?: TextProps['color']
@@ -39,6 +47,7 @@ export const DefaultHeader: React.FC<
   imageObjectPosition = 'center',
   className,
   logoAltText,
+  titleSectionPaddingLeft,
 }) => {
   const imageProvided = !!image
   const logoProvided = !!logo
@@ -108,7 +117,10 @@ export const DefaultHeader: React.FC<
                   </LinkWrapper>
                 </Hidden>
               )}
-              <div className={styles.title}>
+              <Box
+                className={styles.title}
+                paddingLeft={titleSectionPaddingLeft}
+              >
                 <Text variant="h1" as="h1" color={titleColor}>
                   {title}
                 </Text>
@@ -117,7 +129,7 @@ export const DefaultHeader: React.FC<
                     {underTitle}
                   </Text>
                 )}
-              </div>
+              </Box>
             </div>
           </div>
           {imageProvided && (

--- a/apps/web/components/DefaultHeader/DefaultHeader.tsx
+++ b/apps/web/components/DefaultHeader/DefaultHeader.tsx
@@ -18,7 +18,7 @@ export interface DefaultHeaderProps {
   fullWidth?: boolean
   image?: string
   background?: string
-  mobileBackground?: string
+  mobileBackground?: string | null
   title: string
   underTitle?: string
   titleSectionPaddingLeft?: ResponsiveSpace

--- a/apps/web/components/DefaultHeader/DefaultHeader.tsx
+++ b/apps/web/components/DefaultHeader/DefaultHeader.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import cn from 'classnames'
 
 import {
@@ -9,6 +9,8 @@ import {
   Text,
   TextProps,
 } from '@island.is/island-ui/core'
+import { theme } from '@island.is/island-ui/theme'
+import { useWindowSize } from '@island.is/web/hooks/useViewport'
 
 import * as styles from './DefaultHeader.css'
 
@@ -16,6 +18,7 @@ export interface DefaultHeaderProps {
   fullWidth?: boolean
   image?: string
   background?: string
+  mobileBackground?: string
   title: string
   underTitle?: string
   titleSectionPaddingLeft?: ResponsiveSpace
@@ -36,6 +39,7 @@ export const DefaultHeader: React.FC<
   fullWidth,
   image,
   background,
+  mobileBackground,
   title,
   underTitle,
   logo,
@@ -49,10 +53,16 @@ export const DefaultHeader: React.FC<
   logoAltText,
   titleSectionPaddingLeft,
 }) => {
+  const { width } = useWindowSize()
   const imageProvided = !!image
   const logoProvided = !!logo
-
   const LinkWrapper = logoHref ? Link : Box
+
+  const [isMobile, setIsMobile] = useState(false)
+
+  useEffect(() => {
+    setIsMobile(width < theme.breakpoints.lg)
+  }, [width])
 
   return (
     <>
@@ -76,7 +86,7 @@ export const DefaultHeader: React.FC<
       <div
         className={cn({ [styles.gridContainerWidth]: !fullWidth })}
         style={{
-          background: background,
+          background: isMobile ? mobileBackground || background : background,
         }}
       >
         <div
@@ -119,7 +129,7 @@ export const DefaultHeader: React.FC<
               )}
               <Box
                 className={styles.title}
-                paddingLeft={titleSectionPaddingLeft}
+                paddingLeft={!isMobile ? titleSectionPaddingLeft : 0}
               >
                 <Text variant="h1" as="h1" color={titleColor}>
                   {title}

--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -425,6 +425,9 @@ export const OrganizationHeader: React.FC<
               : 'center'
           }
           logoAltText={logoAltText}
+          titleSectionPaddingLeft={
+            organizationPage.themeProperties.titleSectionPaddingLeft
+          }
         />
       )
   }

--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -428,6 +428,9 @@ export const OrganizationHeader: React.FC<
           titleSectionPaddingLeft={
             organizationPage.themeProperties.titleSectionPaddingLeft
           }
+          mobileBackground={
+            organizationPage.themeProperties.mobileBackgroundColor
+          }
         />
       )
   }

--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -17,6 +17,7 @@ import {
   Navigation,
   NavigationItem,
   ProfileCard,
+  ResponsiveSpace,
   Stack,
   Text,
 } from '@island.is/island-ui/core'
@@ -426,7 +427,8 @@ export const OrganizationHeader: React.FC<
           }
           logoAltText={logoAltText}
           titleSectionPaddingLeft={
-            organizationPage.themeProperties.titleSectionPaddingLeft
+            organizationPage.themeProperties
+              .titleSectionPaddingLeft as ResponsiveSpace
           }
           mobileBackground={
             organizationPage.themeProperties.mobileBackgroundColor

--- a/apps/web/components/Organization/Wrapper/Themes/HljodbokasafnIslandsTheme/HljodbokasafnIslandsHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/HljodbokasafnIslandsTheme/HljodbokasafnIslandsHeader.tsx
@@ -54,6 +54,9 @@ const HljodbokasafnIslandsHeader: React.FC<
       logoHref={linkResolver('organizationpage', [organizationPage.slug]).href}
       className={styles.gridContainer}
       logoAltText={logoAltText}
+      titleSectionPaddingLeft={
+        organizationPage.themeProperties.titleSectionPaddingLeft
+      }
     />
   )
 }

--- a/apps/web/components/Organization/Wrapper/Themes/HljodbokasafnIslandsTheme/HljodbokasafnIslandsHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/HljodbokasafnIslandsTheme/HljodbokasafnIslandsHeader.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react'
 
+import { ResponsiveSpace } from '@island.is/island-ui/core'
 import { DefaultHeader, DefaultHeaderProps } from '@island.is/web/components'
 import { OrganizationPage } from '@island.is/web/graphql/schema'
 import { useLinkResolver, useNamespace } from '@island.is/web/hooks'
@@ -55,7 +56,8 @@ const HljodbokasafnIslandsHeader: React.FC<
       className={styles.gridContainer}
       logoAltText={logoAltText}
       titleSectionPaddingLeft={
-        organizationPage.themeProperties.titleSectionPaddingLeft
+        organizationPage.themeProperties
+          .titleSectionPaddingLeft as ResponsiveSpace
       }
       mobileBackground={organizationPage.themeProperties.mobileBackgroundColor}
     />

--- a/apps/web/components/Organization/Wrapper/Themes/HljodbokasafnIslandsTheme/HljodbokasafnIslandsHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/HljodbokasafnIslandsTheme/HljodbokasafnIslandsHeader.tsx
@@ -57,6 +57,7 @@ const HljodbokasafnIslandsHeader: React.FC<
       titleSectionPaddingLeft={
         organizationPage.themeProperties.titleSectionPaddingLeft
       }
+      mobileBackground={organizationPage.themeProperties.mobileBackgroundColor}
     />
   )
 }

--- a/apps/web/components/Organization/Wrapper/Themes/VinnueftirlitidTheme/VinnueftirlitidHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/VinnueftirlitidTheme/VinnueftirlitidHeader.tsx
@@ -54,6 +54,9 @@ const VinnueftilitidHeader: React.FC<React.PropsWithChildren<HeaderProps>> = ({
         }
         className={styles.gridContainer}
         logoAltText={logoAltText}
+        titleSectionPaddingLeft={
+          organizationPage.themeProperties.titleSectionPaddingLeft
+        }
       />
     </div>
   )

--- a/apps/web/components/Organization/Wrapper/Themes/VinnueftirlitidTheme/VinnueftirlitidHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/VinnueftirlitidTheme/VinnueftirlitidHeader.tsx
@@ -57,6 +57,9 @@ const VinnueftilitidHeader: React.FC<React.PropsWithChildren<HeaderProps>> = ({
         titleSectionPaddingLeft={
           organizationPage.themeProperties.titleSectionPaddingLeft
         }
+        mobileBackground={
+          organizationPage.themeProperties.mobileBackgroundColor
+        }
       />
     </div>
   )

--- a/apps/web/components/Organization/Wrapper/Themes/VinnueftirlitidTheme/VinnueftirlitidHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/VinnueftirlitidTheme/VinnueftirlitidHeader.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react'
 import cn from 'classnames'
 
+import { ResponsiveSpace } from '@island.is/island-ui/core'
 import { DefaultHeader } from '@island.is/web/components'
 import { OrganizationPage } from '@island.is/web/graphql/schema'
 import { useLinkResolver, useNamespace } from '@island.is/web/hooks'
@@ -55,7 +56,8 @@ const VinnueftilitidHeader: React.FC<React.PropsWithChildren<HeaderProps>> = ({
         className={styles.gridContainer}
         logoAltText={logoAltText}
         titleSectionPaddingLeft={
-          organizationPage.themeProperties.titleSectionPaddingLeft
+          organizationPage.themeProperties
+            .titleSectionPaddingLeft as ResponsiveSpace
         }
         mobileBackground={
           organizationPage.themeProperties.mobileBackgroundColor

--- a/apps/web/screens/Project/components/ProjectHeader/ProjectHeader.tsx
+++ b/apps/web/screens/Project/components/ProjectHeader/ProjectHeader.tsx
@@ -1,3 +1,4 @@
+import { ResponsiveSpace } from '@island.is/island-ui/core'
 import {
   DefaultHeader,
   DefaultHeaderProps,
@@ -65,7 +66,8 @@ export const ProjectHeader = ({ projectPage }: ProjectHeaderProps) => {
               : 'center'
           }
           titleSectionPaddingLeft={
-            projectPage.themeProperties?.titleSectionPaddingLeft
+            projectPage.themeProperties
+              ?.titleSectionPaddingLeft as ResponsiveSpace
           }
           mobileBackground={projectPage.themeProperties?.mobileBackgroundColor}
         />

--- a/apps/web/screens/Project/components/ProjectHeader/ProjectHeader.tsx
+++ b/apps/web/screens/Project/components/ProjectHeader/ProjectHeader.tsx
@@ -64,6 +64,9 @@ export const ProjectHeader = ({ projectPage }: ProjectHeaderProps) => {
               ? 'right'
               : 'center'
           }
+          titleSectionPaddingLeft={
+            projectPage.themeProperties?.titleSectionPaddingLeft
+          }
         />
       )
     default: {

--- a/apps/web/screens/Project/components/ProjectHeader/ProjectHeader.tsx
+++ b/apps/web/screens/Project/components/ProjectHeader/ProjectHeader.tsx
@@ -67,6 +67,7 @@ export const ProjectHeader = ({ projectPage }: ProjectHeaderProps) => {
           titleSectionPaddingLeft={
             projectPage.themeProperties?.titleSectionPaddingLeft
           }
+          mobileBackground={projectPage.themeProperties?.mobileBackgroundColor}
         />
       )
     default: {

--- a/libs/cms/src/lib/models/organizationTheme.model.ts
+++ b/libs/cms/src/lib/models/organizationTheme.model.ts
@@ -1,4 +1,4 @@
-import { Field, ObjectType } from '@nestjs/graphql'
+import { Field, Int, ObjectType } from '@nestjs/graphql'
 
 interface IOrganizationTheme {
   gradientStartColor?: string
@@ -12,6 +12,7 @@ interface IOrganizationTheme {
   imageIsFullHeight?: boolean
   imageObjectFit?: 'contain' | 'cover'
   imageObjectPosition?: 'left' | 'center' | 'right'
+  titleSectionPaddingLeft?: number
 }
 
 @ObjectType()
@@ -45,6 +46,9 @@ export class OrganizationTheme {
 
   @Field(() => String, { nullable: true })
   imageObjectPosition?: string
+
+  @Field(() => Int, { nullable: true })
+  titleSectionPaddingLeft?: number
 }
 
 export const mapOrganizationTheme = (
@@ -67,5 +71,6 @@ export const mapOrganizationTheme = (
     imageIsFullHeight: theme.imageIsFullHeight ?? true,
     imageObjectFit: theme.imageObjectFit ?? 'cover',
     imageObjectPosition: theme.imageObjectPosition ?? 'center',
+    titleSectionPaddingLeft: theme.titleSectionPaddingLeft,
   }
 }

--- a/libs/cms/src/lib/models/organizationTheme.model.ts
+++ b/libs/cms/src/lib/models/organizationTheme.model.ts
@@ -5,6 +5,7 @@ interface IOrganizationTheme {
   gradientEndColor?: string
   useGradientColor?: boolean
   backgroundColor?: string
+  mobileBackgroundColor?: string
   darkText?: boolean
   fullWidth?: boolean
   textColor?: string
@@ -28,6 +29,9 @@ export class OrganizationTheme {
 
   @Field(() => String, { nullable: true })
   backgroundColor?: string
+
+  @Field(() => String, { nullable: true })
+  mobileBackgroundColor?: string
 
   @Field(() => Boolean, { nullable: true })
   fullWidth?: boolean
@@ -65,6 +69,7 @@ export const mapOrganizationTheme = (
     gradientEndColor: theme.gradientEndColor ?? '',
     useGradientColor: !theme.useGradientColor ? false : true,
     backgroundColor: theme.backgroundColor ?? '',
+    mobileBackgroundColor: theme.mobileBackgroundColor ?? '',
     fullWidth: !theme.fullWidth ? false : true,
     textColor,
     imagePadding: theme.imagePadding || '0px',


### PR DESCRIPTION
# Default header - text offset and have the option to set different background on mobile screens

### Before
![image](https://github.com/island-is/island.is/assets/43557895/0f231ad0-f298-4a5f-9c6b-b896574d702c)
![image](https://github.com/island-is/island.is/assets/43557895/3f6d5785-91d3-4d26-92d2-5a05bf4ceb69)


### After
![image](https://github.com/island-is/island.is/assets/43557895/9cf086c4-6b37-4cfb-b4ef-f113b7bafc6f)
![image](https://github.com/island-is/island.is/assets/43557895/da1d3c1c-a828-401e-91cd-a65de797b130)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
