### PR TITLE
fix(parental-leave): getAttachments for old applications

### DIFF
--- a/libs/application/templates/parental-leave/src/lib/parentalLeaveUtils.ts
+++ b/libs/application/templates/parental-leave/src/lib/parentalLeaveUtils.ts
@@ -2049,7 +2049,7 @@ export const getAttachments = (application: Application) => {
       AttachmentTypes.EMPLOYMENT_TERMINATION_CERTIFICATE,
     )
   }
-  if (commonFiles.length > 0) {
+  if (commonFiles?.length > 0) {
     getAttachmentDetails(fileUpload?.file, AttachmentTypes.FILE)
   }
 


### PR DESCRIPTION
## Why

Older applications created in 2022 don't have the `commonFiles` or `fileUpload.file` array when no attachment.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
