### PR TITLE
fix(application-passport): Domicile requirements change followup

### DIFF
--- a/libs/application/templates/passport/src/fields/PassportSelection/index.tsx
+++ b/libs/application/templates/passport/src/fields/PassportSelection/index.tsx
@@ -64,14 +64,7 @@ export const PassportSelection: FC<React.PropsWithChildren<FieldBaseProps>> = ({
     let tagObject = {} as Tag
     let isDisabled = false
 
-    if ((!domicileCode || domicileCode.substring(0, 2) === '99') && !isChild) {
-      isDisabled = true
-      tagObject = {
-        label: formatMessage(m.incorrectDomicileTage),
-        variant: 'red',
-        outlined: true,
-      }
-    } else if (!identityDocument) {
+    if (!identityDocument) {
       tagObject = {
         label: formatMessage(m.noPassport),
         variant: 'blue',

--- a/libs/application/templates/passport/src/forms/overviewSection/personalOverview.ts
+++ b/libs/application/templates/passport/src/forms/overviewSection/personalOverview.ts
@@ -94,7 +94,7 @@ export const personalOverview = buildMultiField({
           application.externalData.identityDocument.data as IdentityDocumentData
         ).userPassport?.expirationDate
         return date
-          ? m.validTag + ' ' + format(new Date(date), 'dd/MM/yy')
+          ? m.validTag.defaultMessage + ' ' + format(new Date(date), 'dd/MM/yy')
           : m.noPassport.defaultMessage
       },
     }),


### PR DESCRIPTION
A domicile check was hanging around in the frontend (after DataProviders).
Also fixed a small bug where a message was being rendered as [object Object].

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
