### PR TITLE
fix(web): IntroLinkImage image alt text should be empty string since images are decorative

### DIFF
--- a/apps/web/components/Organization/Slice/OverviewLinks/OverviewLinks.tsx
+++ b/apps/web/components/Organization/Slice/OverviewLinks/OverviewLinks.tsx
@@ -69,6 +69,7 @@ export const OverviewLinksSlice: React.FC<
                           url={image?.url + '?w=774&fm=webp&q=80'}
                           thumbnail={image?.url + '?w=50&fm=webp&q=80'}
                           {...image}
+                          title=""
                         />
                       </Box>
                     </GridColumn>


### PR DESCRIPTION
#  IntroLinkImage image alt text should be empty string since images are decorative
