### PR TITLE
chore(cms): Mark big bullet list and related content types as nested

### DIFF
--- a/libs/cms/src/lib/environments/environment.ts
+++ b/libs/cms/src/lib/environments/environment.ts
@@ -95,6 +95,10 @@ export default {
     'chart',
     'chartComponent',
     'featuredEvents',
+    'bigBulletList',
+    'iconBullet',
+    'numberBulletSection',
+    'numberBullet',
   ],
   // Content types that have the 'activeTranslations' JSON field
   localizedContentTypes: ['article'],


### PR DESCRIPTION
# Mark big bullet list and related content types as nested

## What

* When syncing updates from the cms to elasticsearch we need to know if each content type is nested or not to decide if we need to go up a level to find what to re-index
