### PR TITLE
chore(contentful-apps): Link group - Allow using pre existing links

### DIFF
--- a/apps/contentful-apps/pages/fields/link-group-link-field.tsx
+++ b/apps/contentful-apps/pages/fields/link-group-link-field.tsx
@@ -157,7 +157,9 @@ const LinkGroupLinkField = () => {
         : sdk.dialogs.selectMultipleEntries
 
     selectEntriesFunction({
-      contentTypes: contentTypeToSelect ? [contentTypeToSelect] : [],
+      contentTypes: contentTypeToSelect
+        ? [contentTypeToSelect, 'link']
+        : ['link'],
     }).then((entries: EntryProps[]) => {
       entries = Array.isArray(entries) ? entries : [entries]
       entries = entries.filter((entry) => entry?.sys?.id) // Make sure the entries are non-empty


### PR DESCRIPTION
# Link group - Allow using pre existing links

## What

* The link group contentful app only allows users to create links but not add existing ones

## Why

* We want to be able to reuse links between locales in the cms

## Screenshots / Gifs

### Before
![image](https://github.com/island-is/island.is/assets/43557895/3556407a-0e27-4e99-9e5f-f3ff7ce27aad)


### After
![image](https://github.com/island-is/island.is/assets/43557895/50c1627d-8276-4544-b46b-7707390f6fc9)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
