### PR TITLE
fix(application-estate): Advocate Mapper

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/estate/utils/mappers.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/estate/utils/mappers.ts
@@ -8,6 +8,7 @@ import { estateSchema } from '@island.is/application/templates/estate'
 import { infer as zinfer } from 'zod'
 import { UploadData } from '../types'
 import { filterEmptyObjects } from './filters'
+import { info } from 'kennitala'
 
 type EstateSchema = zinfer<typeof estateSchema>
 type EstateData = EstateSchema['estate']
@@ -35,6 +36,8 @@ const estateMemberMapper = (element: EstateMember) => {
           phone: '',
           email: '',
         }
+      : info(element?.nationalId).age < 18
+      ? { nationalId: '', name: '', phone: '', email: '' }
       : undefined,
   }
 }


### PR DESCRIPTION
If there is no advocate recorded for a child (under 18) then we must attach an empty advocate object to the child in order for the frontend to pick up on that this should be rendered on first display.
The React frontend was populating the advocate object for an invisible member (on initial members) but those changes were not being shown until the user would update the array of members (by removing or appending).

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced estate templates to include conditional logic for members under the age of 18, improving data accuracy and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->