### PR TITLE
fix(service-portal): wrong license type

### DIFF
--- a/libs/service-portal/licenses/src/utils/dataMapper.tsx
+++ b/libs/service-portal/licenses/src/utils/dataMapper.tsx
@@ -624,7 +624,7 @@ export const getTypeFromPath = (path: string) => {
     case LicenseTypePath.vinnuvelarettindi:
       return LicenseType.MachineLicense
     case LicenseTypePath.ororkuskirteini:
-      return LicenseType.MachineLicense
+      return LicenseType.DisabilityLicense
     case LicenseTypePath.veidikort:
       return LicenseType.HuntingLicense
     case LicenseTypePath.pcard:


### PR DESCRIPTION
## What

Wrong mapping of license type

## Why

Self-explanatory

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the license type mapping for disability licenses in the service portal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->