### PR TITLE
chore(web): Service web - Add default placeholder text for search in other than icelandic locales

### DIFF
--- a/apps/web/screens/ServiceWeb/Forms/Forms.tsx
+++ b/apps/web/screens/ServiceWeb/Forms/Forms.tsx
@@ -38,6 +38,7 @@ import {
 import { useLinkResolver, useNamespace } from '@island.is/web/hooks'
 import useContentfulId from '@island.is/web/hooks/useContentfulId'
 import useLocalLinkTypeResolver from '@island.is/web/hooks/useLocalLinkTypeResolver'
+import { useI18n } from '@island.is/web/i18n'
 import { withMainLayout } from '@island.is/web/layouts/main'
 
 import { Screen } from '../../../types'
@@ -86,6 +87,7 @@ const ServiceWebFormsPage: Screen<ServiceWebFormsPageProps> = ({
     ServiceWebFormsMutation,
     ServiceWebFormsMutationVariables
   >(SERVICE_WEB_FORMS_MUTATION)
+  const { activeLocale } = useI18n()
 
   useContentfulId(organization?.id)
   useLocalLinkTypeResolver()
@@ -178,7 +180,9 @@ const ServiceWebFormsPage: Screen<ServiceWebFormsPageProps> = ({
       smallBackground
       searchPlaceholder={o(
         'serviceWebSearchPlaceholder',
-        'Leitaðu á þjónustuvefnum',
+        activeLocale === 'is'
+          ? 'Leitaðu á þjónustuvefnum'
+          : 'Search the service web',
       )}
       pageData={serviceWebPage}
     >

--- a/apps/web/screens/ServiceWeb/Home/Home.tsx
+++ b/apps/web/screens/ServiceWeb/Home/Home.tsx
@@ -38,6 +38,7 @@ import {
 } from '@island.is/web/hooks'
 import useContentfulId from '@island.is/web/hooks/useContentfulId'
 import useLocalLinkTypeResolver from '@island.is/web/hooks/useLocalLinkTypeResolver'
+import { useI18n } from '@island.is/web/i18n'
 import { withMainLayout } from '@island.is/web/layouts/main'
 import { CustomNextError } from '@island.is/web/units/errors'
 
@@ -81,6 +82,7 @@ const Home: Screen<HomeProps> = ({
   const n = useNamespace(namespace)
   const o = useNamespace(organizationNamespace)
   const { linkResolver } = useLinkResolver()
+  const { activeLocale } = useI18n()
 
   useContentfulId(organization?.id)
   useLocalLinkTypeResolver()
@@ -131,7 +133,9 @@ const Home: Screen<HomeProps> = ({
       searchTitle={searchTitle}
       searchPlaceholder={o(
         'serviceWebSearchPlaceholder',
-        'Leitaðu á þjónustuvefnum',
+        activeLocale === 'is'
+          ? 'Leitaðu á þjónustuvefnum'
+          : 'Search the service web',
       )}
       showLogoTitle={!institutionSlugBelongsToMannaudstorg}
       indexableBySearchEngine={institutionSlugBelongsToMannaudstorg}

--- a/apps/web/screens/ServiceWeb/Search/ServiceSearch.tsx
+++ b/apps/web/screens/ServiceWeb/Search/ServiceSearch.tsx
@@ -227,7 +227,9 @@ const ServiceSearch: Screen<ServiceSearchProps> = ({
                   initialInputValue={q}
                   placeholder={o(
                     'serviceWebSearchPlaceholder',
-                    'Leitaðu á þjónustuvefnum',
+                    activeLocale === 'is'
+                      ? 'Leitaðu á þjónustuvefnum'
+                      : 'Search the service web',
                   )}
                   nothingFoundText={n(
                     'nothingFoundText',

--- a/apps/web/screens/ServiceWeb/SubPage/SubPage.tsx
+++ b/apps/web/screens/ServiceWeb/SubPage/SubPage.tsx
@@ -39,6 +39,7 @@ import {
 } from '@island.is/web/hooks'
 import useContentfulId from '@island.is/web/hooks/useContentfulId'
 import useLocalLinkTypeResolver from '@island.is/web/hooks/useLocalLinkTypeResolver'
+import { useI18n } from '@island.is/web/i18n'
 import { withMainLayout } from '@island.is/web/layouts/main'
 import { webRichText } from '@island.is/web/utils/richText'
 
@@ -94,6 +95,7 @@ const SubPage: Screen<SubPageProps> = ({
     singleSupportQNA?.id,
   )
   useLocalLinkTypeResolver()
+  const { activeLocale } = useI18n()
 
   const organizationSlug = organization?.slug
   const question = singleSupportQNA
@@ -177,7 +179,9 @@ const SubPage: Screen<SubPageProps> = ({
       smallBackground
       searchPlaceholder={o(
         'serviceWebSearchPlaceholder',
-        'Leitaðu á þjónustuvefnum',
+        activeLocale === 'is'
+          ? 'Leitaðu á þjónustuvefnum'
+          : 'Search the service web',
       )}
       pageData={serviceWebPage}
     >


### PR DESCRIPTION
# Service web - Add default placeholder text for search in other than icelandic locales

## What

To avoid the issue of having to remember to set a translation text for english we instead would like to have a default text for english.

To prevent this issue:
![image](https://github.com/island-is/island.is/assets/43557895/c307c021-7367-42c1-b7ac-bcdaf76e05f2)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Implemented dynamic localization for search placeholder texts across the platform, adapting to user's selected language setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->