### PR TITLE
fix(web): Fix redirect functionality by also redirecting if there is not a CustomNextError thrown

### DIFF
--- a/apps/web/utils/fetch404RedirectUrl.ts
+++ b/apps/web/utils/fetch404RedirectUrl.ts
@@ -1,0 +1,73 @@
+import {
+  ApolloClient,
+  ApolloQueryResult,
+  NormalizedCacheObject,
+} from '@apollo/client'
+
+import { defaultLanguage } from '@island.is/shared/constants'
+import { Locale } from '@island.is/shared/types'
+
+import { GetUrlQuery, GetUrlQueryVariables } from '../graphql/schema'
+import { linkResolver, LinkType } from '../hooks'
+import { GET_URL_QUERY } from '../screens/queries'
+
+export const fetch404RedirectUrl = async (
+  apolloClient: ApolloClient<NormalizedCacheObject>,
+  path: string,
+  locale: Locale,
+): Promise<string | null> => {
+  path = path.trim().replace(/\/\/+/g, '/').replace(/\/+$/, '').toLowerCase()
+
+  const [redirectPropsWithQueryParams, redirectPropsWithoutQueryParams] =
+    await Promise.all([
+      apolloClient.query<GetUrlQuery, GetUrlQueryVariables>({
+        query: GET_URL_QUERY,
+        variables: {
+          input: {
+            slug: path,
+            lang: locale,
+          },
+        },
+      }),
+      apolloClient.query<GetUrlQuery, GetUrlQueryVariables>({
+        query: GET_URL_QUERY,
+        variables: {
+          input: {
+            slug: path.split('?')[0],
+            lang: locale,
+          },
+        },
+      }),
+    ])
+
+  let redirectProps: ApolloQueryResult<GetUrlQuery> | null = null
+
+  if (redirectPropsWithQueryParams?.data?.getUrl) {
+    redirectProps = redirectPropsWithQueryParams
+  } else if (redirectPropsWithoutQueryParams?.data?.getUrl) {
+    redirectProps = redirectPropsWithoutQueryParams
+  }
+
+  if (redirectProps?.data?.getUrl) {
+    const page = redirectProps.data.getUrl.page
+    const explicitRedirect = redirectProps.data.getUrl.explicitRedirect
+    if (!page && explicitRedirect) {
+      return explicitRedirect
+    } else if (page) {
+      let url = linkResolver(page.type as LinkType, [page.slug], locale).href
+
+      if (!url) {
+        // Fallback to using default language if page isn't present in another language
+        url = linkResolver(
+          page.type as LinkType,
+          [page.slug],
+          defaultLanguage,
+        ).href
+      }
+
+      return url
+    }
+  }
+
+  return null
+}

--- a/apps/web/utils/getServerSidePropsWrapper.ts
+++ b/apps/web/utils/getServerSidePropsWrapper.ts
@@ -1,15 +1,13 @@
 import type { GetServerSideProps } from 'next'
-import { ApolloQueryResult, NormalizedCacheObject } from '@apollo/client'
+import { NormalizedCacheObject } from '@apollo/client'
 
 import { logger } from '@island.is/logging'
-import { defaultLanguage } from '@island.is/shared/constants'
+
 import initApollo from '../graphql/client'
-import { GetUrlQuery, GetUrlQueryVariables } from '../graphql/schema'
-import { linkResolver, LinkType } from '../hooks'
 import { getLocaleFromPath } from '../i18n'
-import { GET_URL_QUERY } from '../screens/queries'
 import type { ScreenContext } from '../types'
 import { CustomNextError } from '../units/errors'
+import { fetch404RedirectUrl } from './fetch404RedirectUrl'
 import { safelyExtractPathnameFromUrl } from './safelyExtractPathnameFromUrl'
 
 // Taken from here: https://github.com/vercel/next.js/discussions/11209#discussioncomment-38480
@@ -54,7 +52,7 @@ export const getServerSidePropsWrapper: (
       if (error.statusCode === 404) {
         logger.info(error.title || '404 error occurred on web', error)
 
-        let path = safelyExtractPathnameFromUrl(ctx.req.url)
+        const path = safelyExtractPathnameFromUrl(ctx.req.url)
         if (!path) {
           return {
             notFound: true,
@@ -65,79 +63,23 @@ export const getServerSidePropsWrapper: (
 
         const apolloClient = initApollo({}, clientLocale, ctx)
 
-        path = path
-          .trim()
-          .replace(/\/\/+/g, '/')
-          .replace(/\/+$/, '')
-          .toLowerCase()
+        const redirectUrl = await fetch404RedirectUrl(
+          apolloClient,
+          path,
+          clientLocale,
+        )
 
-        const [redirectPropsWithQueryParams, redirectPropsWithoutQueryParams] =
-          await Promise.all([
-            apolloClient.query<GetUrlQuery, GetUrlQueryVariables>({
-              query: GET_URL_QUERY,
-              variables: {
-                input: {
-                  slug: path,
-                  lang: clientLocale,
-                },
-              },
-            }),
-            apolloClient.query<GetUrlQuery, GetUrlQueryVariables>({
-              query: GET_URL_QUERY,
-              variables: {
-                input: {
-                  slug: path.split('?')[0],
-                  lang: clientLocale,
-                },
-              },
-            }),
-          ])
-
-        let redirectProps: ApolloQueryResult<GetUrlQuery> | null = null
-
-        if (redirectPropsWithQueryParams?.data?.getUrl) {
-          redirectProps = redirectPropsWithQueryParams
-        } else if (redirectPropsWithoutQueryParams?.data?.getUrl) {
-          redirectProps = redirectPropsWithoutQueryParams
-        }
-
-        if (redirectProps?.data?.getUrl) {
-          const page = redirectProps.data.getUrl.page
-          const explicitRedirect = redirectProps.data.getUrl.explicitRedirect
-          if (!page && explicitRedirect) {
-            return {
-              redirect: {
-                destination: explicitRedirect,
-                permanent: false,
-              },
-            }
-          } else if (page) {
-            let url = linkResolver(
-              page.type as LinkType,
-              [page.slug],
-              clientLocale,
-            ).href
-
-            if (!url) {
-              // Fallback to using default language if page isn't present in another language
-              url = linkResolver(
-                page.type as LinkType,
-                [page.slug],
-                defaultLanguage,
-              ).href
-            }
-
-            return {
-              redirect: {
-                destination: url,
-                permanent: false,
-              },
-            }
+        if (!redirectUrl) {
+          return {
+            notFound: true,
           }
         }
 
         return {
-          notFound: true,
+          redirect: {
+            destination: redirectUrl,
+            permanent: false,
+          },
         }
       }
     }


### PR DESCRIPTION
# Fix redirect functionality by also redirecting if there is not a CustomNextError thrown

## What

* It seems that the 404 redirect functionality as of right now only kicks in if there is a CustomNextError thrown in the code
* This PR fixes that issue by moving the logic into a shared util function and using that both when CustomNextError is thrown as well as for the more general error case (by simply checking if there was a 404 error in general)

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling with automatic redirection for 404 (Not Found) errors, improving user navigation experience.
- **Refactor**
	- Simplified error handling and redirection logic in server-side properties, enhancing code maintainability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->