### PR TITLE
feat(native-app): Add info alert to ehic cards

### DIFF
--- a/apps/native/app/src/messages/en.ts
+++ b/apps/native/app/src/messages/en.ts
@@ -267,6 +267,9 @@ export const en: TranslatedMessages = {
   'licenseDetail.pcard.alert.title': 'Remember the parking card!',
   'licenseDetail.pcard.alert.description':
     'This summary is not valid as a parking card.',
+  'licenseDetail.ehic.alert.title': 'Remember the card!',
+  'licenseDetail.ehic.alert.description':
+    'This summary is not valid as an European Health Insurance card.',
 
   // notifications
   'notifications.screenTitle': 'Notifications',

--- a/apps/native/app/src/messages/en.ts
+++ b/apps/native/app/src/messages/en.ts
@@ -269,7 +269,7 @@ export const en: TranslatedMessages = {
     'This summary is not valid as a parking card.',
   'licenseDetail.ehic.alert.title': 'Remember the card!',
   'licenseDetail.ehic.alert.description':
-    'This summary is not valid as an European Health Insurance card.',
+    'This summary is not valid as a European Health Insurance card.',
 
   // notifications
   'notifications.screenTitle': 'Notifications',

--- a/apps/native/app/src/messages/is.ts
+++ b/apps/native/app/src/messages/is.ts
@@ -401,6 +401,9 @@ export const is = {
   'licenseDetail.pcard.alert.title': 'Mundu eftir stæðiskortinu!',
   'licenseDetail.pcard.alert.description':
     'Þetta yfirlit gildir ekki sem stæðiskort.',
+  'licenseDetail.ehic.alert.title': 'Mundu eftir kortinu!',
+  'licenseDetail.ehic.alert.description':
+    'Þetta yfirlit gildir ekki sem sjúkratryggingakort.',
 
   // notifications
   'notifications.screenTitle': 'Tilkynningar',

--- a/apps/native/app/src/screens/wallet-pass/wallet-pass.tsx
+++ b/apps/native/app/src/screens/wallet-pass/wallet-pass.tsx
@@ -226,15 +226,22 @@ export const WalletPassScreen: NavigationFunctionComponent<{
       <View style={{ height: cardHeight }} />
       <Information contentInset={{ bottom: 162 }}>
         <SafeAreaView style={{ marginHorizontal: 16 }}>
-          {/* Show info alert if PCard */}
-          {data?.license?.type === GenericLicenseType.PCard && (
+          {/* Show info alert if PCard or Ehic */}
+          {(data?.license?.type === GenericLicenseType.PCard ||
+            data?.license?.type === GenericLicenseType.Ehic) && (
             <View style={{ paddingTop: 24 }}>
               <InfoAlert
                 title={intl.formatMessage({
-                  id: 'licenseDetail.pcard.alert.title',
+                  id:
+                    data?.license?.type === GenericLicenseType.PCard
+                      ? 'licenseDetail.pcard.alert.title'
+                      : 'licenseDetail.ehic.alert.title',
                 })}
                 message={intl.formatMessage({
-                  id: 'licenseDetail.pcard.alert.description',
+                  id:
+                    data?.license?.type === GenericLicenseType.PCard
+                      ? 'licenseDetail.pcard.alert.description'
+                      : 'licenseDetail.ehic.alert.description',
                 })}
                 type="info"
                 hasBorder


### PR DESCRIPTION
## What

Add usage disclaimer to Ehic cards in app.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request
![Simulator Screenshot - iPhone 15 Pro - 2024-04-05 at 14 10 45](https://github.com/island-is/island.is/assets/19665778/a4c75456-89aa-4816-9e3b-ec16efe2beb5)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Enhanced multilingual support for displaying alerts related to the European Health Insurance card in the `licenseDetail` section.
    - Improved information alerts display for PCard and EHIC license types in the `WalletPassScreen` component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->