### PR TITLE
feat(web): Service web - Add rich text field to service web page content type and display it in contact form

### DIFF
--- a/apps/web/screens/ServiceWeb/Forms/Forms.tsx
+++ b/apps/web/screens/ServiceWeb/Forms/Forms.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useMemo } from 'react'
+import { ReactNode, useEffect, useMemo } from 'react'
 import { Locale } from 'locale'
 import NextLink from 'next/link'
 import { useMutation } from '@apollo/client'
+import { BLOCKS, INLINES } from '@contentful/rich-text-types'
 
 import {
   AlertBanner,
@@ -13,6 +14,7 @@ import {
   GridRow,
   Link,
   LinkContext,
+  LinkV2,
   Text,
   toast,
   ToastContainer,
@@ -40,6 +42,7 @@ import useContentfulId from '@island.is/web/hooks/useContentfulId'
 import useLocalLinkTypeResolver from '@island.is/web/hooks/useLocalLinkTypeResolver'
 import { useI18n } from '@island.is/web/i18n'
 import { withMainLayout } from '@island.is/web/layouts/main'
+import { webRichText } from '@island.is/web/utils/richText'
 
 import { Screen } from '../../../types'
 import {
@@ -274,6 +277,48 @@ const ServiceWebFormsPage: Screen<ServiceWebFormsPageProps> = ({
                       )}
                     </Text>
                   </GridColumn>
+
+                  {typeof serviceWebPage?.contactFormDisclaimer?.length ===
+                    'number' &&
+                    serviceWebPage.contactFormDisclaimer.length > 0 && (
+                      <GridColumn paddingTop={2}>
+                        {webRichText(serviceWebPage.contactFormDisclaimer, {
+                          renderNode: {
+                            [BLOCKS.PARAGRAPH]: (
+                              _node: unknown,
+                              children: ReactNode,
+                            ) => {
+                              return (
+                                <GridRow>
+                                  <GridColumn span="12/12">
+                                    <Text as="div" variant="intro">
+                                      {children}
+                                    </Text>
+                                  </GridColumn>
+                                </GridRow>
+                              )
+                            },
+                            [INLINES.HYPERLINK]: (
+                              node: { data?: { uri?: string } },
+                              children: ReactNode,
+                            ) => {
+                              return (
+                                <Box display="inlineBlock">
+                                  <LinkV2
+                                    underlineVisibility="always"
+                                    underline="small"
+                                    color="blue400"
+                                    href={node?.data?.uri ?? ''}
+                                  >
+                                    {children}
+                                  </LinkV2>
+                                </Box>
+                              )
+                            },
+                          },
+                        })}
+                      </GridColumn>
+                    )}
                 </GridRow>
                 {successfullySent ? (
                   <Box marginTop={6}>

--- a/apps/web/screens/queries/ServiceWeb.ts
+++ b/apps/web/screens/queries/ServiceWeb.ts
@@ -8,6 +8,9 @@ export const GET_SERVICE_WEB_PAGE_QUERY = gql`
       slices {
         ...AllSlices
       }
+      contactFormDisclaimer {
+        ...HtmlFields
+      }
       footerItems {
         title
         content {

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -3509,6 +3509,9 @@ export interface IServiceWebPageFields {
 
   /** Email Config */
   emailConfig?: Record<string, any> | undefined
+
+  /** Contact Form Disclaimer */
+  contactFormDisclaimer?: Document | undefined
 }
 
 export interface IServiceWebPage extends Entry<IServiceWebPageFields> {

--- a/libs/cms/src/lib/models/serviceWebPage.model.ts
+++ b/libs/cms/src/lib/models/serviceWebPage.model.ts
@@ -3,7 +3,11 @@ import { CacheField } from '@island.is/nest/graphql'
 
 import { IServiceWebPage } from '../generated/contentfulTypes'
 import { mapOrganization, Organization } from './organization.model'
-import { safelyMapSliceUnion, SliceUnion } from '../unions/slice.union'
+import {
+  mapDocument,
+  safelyMapSliceUnion,
+  SliceUnion,
+} from '../unions/slice.union'
 import { FooterItem, mapFooterItem } from './footerItem.model'
 
 @ObjectType()
@@ -40,6 +44,9 @@ export class ServiceWebPage {
 
   @CacheField(() => ServiceWebPageEmailConfig, { nullable: true })
   emailConfig?: ServiceWebPageEmailConfig
+
+  @CacheField(() => [SliceUnion], { nullable: true })
+  contactFormDisclaimer?: Array<typeof SliceUnion | null>
 }
 
 const mapServiceWebPageEmailConfig = (
@@ -75,4 +82,10 @@ export const mapServiceWebPage = ({
   emailConfig: fields.emailConfig
     ? mapServiceWebPageEmailConfig(fields.emailConfig)
     : { emails: [] },
+  contactFormDisclaimer: fields.contactFormDisclaimer
+    ? mapDocument(
+        fields.contactFormDisclaimer,
+        sys.id + ':contactFormDisclaimer',
+      )
+    : [],
 })


### PR DESCRIPTION
# Service web - Add rich text field to service web page content type and display it in contact form

## What

* To be able to enter links and text as a disclaimer to the contact form on a given service web we've added a rich text field in the CMS and displayed it's contents on the web

## Why

* This was requested by Digital Iceland

## Screenshots / Gifs

### Before
![image](https://github.com/island-is/island.is/assets/43557895/30d6b738-cfff-457e-84c1-b9549db16196)

### After
![image](https://github.com/island-is/island.is/assets/43557895/1c16f35b-89aa-448d-8b90-41c5c46ab296)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
