### PR TITLE
chore: prepare for upgrading to kubernetes 1.26

### DIFF
--- a/infra/helm/libs/api-template/templates/hpa.yaml
+++ b/infra/helm/libs/api-template/templates/hpa.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.enabled }}
 {{- $fullName := include "api-template.fullname" . -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "api-template.fullname" . }}


### PR DESCRIPTION
# Remove deprecated autoscaling/v2beta2

The autoscaling/v2beta2 API version of HorizontalPodAutoscaler [will no longer be served in v1.26](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v126). Users should migrate manifests and API clients to use the autoscaling/v2 API version, available since v1.23.

[Changelog for kubernetes 1.26](https://kubernetes.io/blog/2022/11/18/upcoming-changes-in-kubernetes-1-26/)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the API version in the HorizontalPodAutoscaler definition to enhance compatibility and future-proofing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->