### PR TITLE
fix(parental-leave): Move Additional documents and Comment to new section

### DIFF
--- a/libs/application/templates/parental-leave/src/fields/Review/Review.tsx
+++ b/libs/application/templates/parental-leave/src/fields/Review/Review.tsx
@@ -123,7 +123,6 @@ export const Review: FC<React.PropsWithChildren<ReviewScreenProps>> = ({
         ((applicationType === PARENTAL_GRANT ||
           applicationType === PARENTAL_GRANT_STUDENTS) &&
           employerLastSixMonths === YES)) && <Employment {...childProps} />}
-      <Comment {...childProps} />
       <ReviewGroup>
         <SummaryRights application={application} />
       </ReviewGroup>
@@ -148,6 +147,7 @@ export const Review: FC<React.PropsWithChildren<ReviewScreenProps>> = ({
           </GridColumn>
         </GridRow>
       </ReviewGroup>
+      <Comment {...childProps} />
       <Attachments {...childProps} />
 
       {/**

--- a/libs/application/templates/parental-leave/src/forms/ParentalLeaveForm.ts
+++ b/libs/application/templates/parental-leave/src/forms/ParentalLeaveForm.ts
@@ -902,6 +902,41 @@ export const ParentalLeaveForm: Form = buildForm({
         buildSubSection({
           id: 'fileUpload',
           title: parentalLeaveFormMessages.attachmentScreen.title,
+          condition: (answers) => {
+            const {
+              isReceivingUnemploymentBenefits,
+              isSelfEmployed,
+              unemploymentBenefits,
+              noChildrenFoundTypeOfApplication,
+              applicationType,
+              employerLastSixMonths,
+              isNotStillEmployed,
+              otherParent,
+            } = getApplicationAnswers(answers)
+
+            const benefitsFile =
+              isSelfEmployed === NO &&
+              isReceivingUnemploymentBenefits === YES &&
+              (unemploymentBenefits === UnEmployedBenefitTypes.union ||
+                unemploymentBenefits === UnEmployedBenefitTypes.healthInsurance)
+
+            const employmentTerminationCertificateFile =
+              (applicationType === PARENTAL_GRANT ||
+                applicationType === PARENTAL_GRANT_STUDENTS) &&
+              employerLastSixMonths === YES &&
+              isNotStillEmployed
+
+            return (
+              isSelfEmployed === YES ||
+              applicationType === PARENTAL_GRANT_STUDENTS ||
+              benefitsFile ||
+              otherParent === SINGLE ||
+              isParentWithoutBirthParent(answers) ||
+              noChildrenFoundTypeOfApplication === PERMANENT_FOSTER_CARE ||
+              noChildrenFoundTypeOfApplication === ADOPTION ||
+              employmentTerminationCertificateFile
+            )
+          },
           children: [
             buildFileUploadField({
               id: 'fileUpload.selfEmployedFile',
@@ -1100,38 +1135,6 @@ export const ParentalLeaveForm: Form = buildForm({
                 parentalLeaveFormMessages.selfEmployed.uploadDescription,
               uploadButtonLabel:
                 parentalLeaveFormMessages.selfEmployed.attachmentButton,
-            }),
-            buildFileUploadField({
-              id: 'fileUpload.file',
-              title: parentalLeaveFormMessages.attachmentScreen.title,
-              introduction:
-                parentalLeaveFormMessages.attachmentScreen.description,
-              maxSize: FILE_SIZE_LIMIT,
-              maxSizeErrorText:
-                parentalLeaveFormMessages.selfEmployed.attachmentMaxSizeError,
-              uploadAccept: '.pdf',
-              uploadHeader: parentalLeaveFormMessages.selfEmployed.uploadHeader,
-              uploadDescription:
-                parentalLeaveFormMessages.selfEmployed.uploadDescription,
-              uploadButtonLabel:
-                parentalLeaveFormMessages.selfEmployed.attachmentButton,
-            }),
-          ],
-        }),
-        buildSubSection({
-          id: 'commentSection',
-          title: parentalLeaveFormMessages.applicant.commentSection,
-          children: [
-            buildTextField({
-              id: 'comment',
-              title: parentalLeaveFormMessages.applicant.commentSection,
-              variant: 'textarea',
-              rows: 10,
-              maxLength: 1024,
-              description:
-                parentalLeaveFormMessages.applicant.commentDescription,
-              placeholder:
-                parentalLeaveFormMessages.applicant.commentPlaceholder,
             }),
           ],
         }),
@@ -1490,6 +1493,50 @@ export const ParentalLeaveForm: Form = buildForm({
         //     }),
         //   ],
         // }),
+      ],
+    }),
+    buildSection({
+      id: 'additionalInformation',
+      title: parentalLeaveFormMessages.shared.additionalInformationSection,
+      children: [
+        buildSubSection({
+          id: 'fileUploadSection',
+          title: parentalLeaveFormMessages.attachmentScreen.title,
+          children: [
+            buildFileUploadField({
+              id: 'fileUpload.file',
+              title: parentalLeaveFormMessages.attachmentScreen.title,
+              introduction:
+                parentalLeaveFormMessages.attachmentScreen.description,
+              maxSize: FILE_SIZE_LIMIT,
+              maxSizeErrorText:
+                parentalLeaveFormMessages.selfEmployed.attachmentMaxSizeError,
+              uploadAccept: '.pdf',
+              uploadHeader: parentalLeaveFormMessages.selfEmployed.uploadHeader,
+              uploadDescription:
+                parentalLeaveFormMessages.selfEmployed.uploadDescription,
+              uploadButtonLabel:
+                parentalLeaveFormMessages.selfEmployed.attachmentButton,
+            }),
+          ],
+        }),
+        buildSubSection({
+          id: 'commentSection',
+          title: parentalLeaveFormMessages.applicant.commentSection,
+          children: [
+            buildTextField({
+              id: 'comment',
+              title: parentalLeaveFormMessages.applicant.commentSection,
+              variant: 'textarea',
+              rows: 10,
+              maxLength: 1024,
+              description:
+                parentalLeaveFormMessages.applicant.commentDescription,
+              placeholder:
+                parentalLeaveFormMessages.applicant.commentPlaceholder,
+            }),
+          ],
+        }),
       ],
     }),
     buildSection({

--- a/libs/application/templates/parental-leave/src/forms/Prerequisites.ts
+++ b/libs/application/templates/parental-leave/src/forms/Prerequisites.ts
@@ -680,6 +680,11 @@ export const PrerequisitesForm: Form = buildForm({
       children: [],
     }),
     buildSection({
+      id: 'additionalInformation',
+      title: parentalLeaveFormMessages.shared.additionalInformationSection,
+      children: [],
+    }),
+    buildSection({
       id: 'confirmation',
       title: parentalLeaveFormMessages.confirmation.title,
       children: [],

--- a/libs/application/templates/parental-leave/src/lib/messages.ts
+++ b/libs/application/templates/parental-leave/src/lib/messages.ts
@@ -910,6 +910,11 @@ export const parentalLeaveFormMessages = {
       defaultMessage: 'Engar breytingar fundust.',
       description: 'No changes were found.',
     },
+    additionalInformationSection: {
+      id: 'pl.application:additional.information.section',
+      defaultMessage: 'Viðbótarupplýsingar',
+      description: 'Additional Information',
+    },
   }),
 
   selectChild: defineMessages({


### PR DESCRIPTION
[[UUFV-445] Move Additional documents and Comment to new section](https://dit-iceland.atlassian.net/jira/software/projects/UUFV/boards/71?selectedIssue=UUFV-445)

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new section for additional information in the parental leave form.
- **Enhancements**
	- Improved the organization of form fields in the parental leave application.
	- Updated conditions for file uploads based on user responses.
- **UI Changes**
	- Adjusted the placement of the Comment component in the Review section for better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->