### PR TITLE
fix(native-app): Fix license ehic info alert

### DIFF
--- a/apps/native/app/src/screens/wallet-pass/wallet-pass.tsx
+++ b/apps/native/app/src/screens/wallet-pass/wallet-pass.tsx
@@ -321,7 +321,8 @@ export const WalletPassScreen: NavigationFunctionComponent<{
       >
         <SafeAreaView style={{ marginHorizontal: theme.spacing[2] }}>
           {/* Show info alert if PCard */}
-          {licenseType === GenericLicenseType.PCard && (
+          {(licenseType === GenericLicenseType.PCard ||
+            licenseType === GenericLicenseType.Ehic) && (
             <View
               style={{
                 paddingTop: theme.spacing[3],

--- a/apps/native/app/src/screens/wallet-pass/wallet-pass.tsx
+++ b/apps/native/app/src/screens/wallet-pass/wallet-pass.tsx
@@ -320,7 +320,7 @@ export const WalletPassScreen: NavigationFunctionComponent<{
         topSpacing={informationTopSpacing}
       >
         <SafeAreaView style={{ marginHorizontal: theme.spacing[2] }}>
-          {/* Show info alert if PCard */}
+          {/* Show info alert if PCard or Ehic */}
           {(licenseType === GenericLicenseType.PCard ||
             licenseType === GenericLicenseType.Ehic) && (
             <View


### PR DESCRIPTION
# Fix license ehic info alert

This got accidentally removed during merge

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the information alert in the Wallet Pass Screen to also recognize 'Ehic' as a valid license type alongside 'PCard'.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->