### PR TITLE
chore(web): Pension Calculator - Read currency input max length from config

### DIFF
--- a/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculator.tsx
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculator.tsx
@@ -59,8 +59,6 @@ import {
 } from './utils'
 import * as styles from './PensionCalculator.css'
 
-const CURRENCY_INPUT_MAX_LENGTH = 15
-
 const lowercaseFirstLetter = (value: string | undefined) => {
   if (!value) return value
   return value[0].toLowerCase() + value.slice(1)
@@ -131,6 +129,9 @@ const PensionCalculator: CustomScreen<PensionCalculatorProps> = ({
   const methods = useForm<CalculationInput>({
     defaultValues,
   })
+
+  const currencyInputMaxLength =
+    customPageData?.configJson?.currencyInputMaxLength ?? 14
 
   const maxMonthPensionDelay =
     customPageData?.configJson?.maxMonthPensionDelay ?? 156
@@ -940,7 +941,7 @@ const PensionCalculator: CustomScreen<PensionCalculatorProps> = ({
                               )}
                               placeholder="kr."
                               currency={true}
-                              maxLength={CURRENCY_INPUT_MAX_LENGTH}
+                              maxLength={currencyInputMaxLength}
                             />
                           </Box>
                         </NumericInputFieldWrapper>
@@ -962,7 +963,7 @@ const PensionCalculator: CustomScreen<PensionCalculatorProps> = ({
                               )}
                               placeholder="kr."
                               currency={true}
-                              maxLength={CURRENCY_INPUT_MAX_LENGTH}
+                              maxLength={currencyInputMaxLength}
                             />
                           </Box>
                         </NumericInputFieldWrapper>
@@ -988,7 +989,7 @@ const PensionCalculator: CustomScreen<PensionCalculatorProps> = ({
                               )}
                               placeholder="kr."
                               currency={true}
-                              maxLength={CURRENCY_INPUT_MAX_LENGTH}
+                              maxLength={currencyInputMaxLength}
                             />
                           </Box>
                         </NumericInputFieldWrapper>
@@ -1010,7 +1011,7 @@ const PensionCalculator: CustomScreen<PensionCalculatorProps> = ({
                               )}
                               placeholder="kr."
                               currency={true}
-                              maxLength={CURRENCY_INPUT_MAX_LENGTH}
+                              maxLength={currencyInputMaxLength}
                             />
                           </Box>
                         </NumericInputFieldWrapper>
@@ -1032,7 +1033,7 @@ const PensionCalculator: CustomScreen<PensionCalculatorProps> = ({
                               )}
                               placeholder="kr."
                               currency={true}
-                              maxLength={CURRENCY_INPUT_MAX_LENGTH}
+                              maxLength={currencyInputMaxLength}
                             />
                           </Box>
                         </NumericInputFieldWrapper>
@@ -1058,7 +1059,7 @@ const PensionCalculator: CustomScreen<PensionCalculatorProps> = ({
                               )}
                               placeholder="kr."
                               currency={true}
-                              maxLength={CURRENCY_INPUT_MAX_LENGTH}
+                              maxLength={currencyInputMaxLength}
                             />
                           </Box>
                         </NumericInputFieldWrapper>
@@ -1084,7 +1085,7 @@ const PensionCalculator: CustomScreen<PensionCalculatorProps> = ({
                               )}
                               placeholder="kr."
                               currency={true}
-                              maxLength={CURRENCY_INPUT_MAX_LENGTH}
+                              maxLength={currencyInputMaxLength}
                             />
                           </Box>
                         </NumericInputFieldWrapper>
@@ -1106,7 +1107,7 @@ const PensionCalculator: CustomScreen<PensionCalculatorProps> = ({
                               )}
                               placeholder="kr."
                               currency={true}
-                              maxLength={CURRENCY_INPUT_MAX_LENGTH}
+                              maxLength={currencyInputMaxLength}
                             />
                           </Box>
                         </NumericInputFieldWrapper>


### PR DESCRIPTION
# Pension Calculator - Read maxLength from config

## What

* Allow tweaking the currency input max length property in the cms
* Set the default value to 14 (requested by the social insurance administration)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the Pension Calculator to support dynamic maximum input lengths for currency fields, enhancing flexibility based on configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->