### PR TITLE
fix(user-profile-worker): Set nextNudge to null when nudgeLastAsked has no value and remove islykill cert as dependency

### DIFF
--- a/apps/services/user-profile/infra/service-portal-api.ts
+++ b/apps/services/user-profile/infra/service-portal-api.ts
@@ -56,7 +56,6 @@ export const workerSetup = (): ServiceBuilder<typeof workerId> =>
     .image(imageId)
     .env(envVariables)
     .secrets(secrets)
-    .files({ filename: 'islyklar.p12', env: 'ISLYKILL_CERT' })
     .command('node')
     .args('main.js', '--job=worker')
     .resources({

--- a/apps/services/user-profile/src/app/worker/worker.service.ts
+++ b/apps/services/user-profile/src/app/worker/worker.service.ts
@@ -56,10 +56,9 @@ export class UserProfileWorkerService {
       return this.userProfileModel.upsert({
         nationalId: advaniaProfile.ssn,
         lastNudge: advaniaProfile.nudgeLastAsked,
-        nextNudge:
-          advaniaProfile.nudgeLastAsked !== null
-            ? addMonths(advaniaProfile.nudgeLastAsked, NUDGE_INTERVAL)
-            : null,
+        nextNudge: advaniaProfile.nudgeLastAsked
+          ? addMonths(advaniaProfile.nudgeLastAsked, NUDGE_INTERVAL)
+          : null,
       })
     }
 

--- a/apps/services/user-profile/src/app/worker/worker.service.ts
+++ b/apps/services/user-profile/src/app/worker/worker.service.ts
@@ -56,7 +56,10 @@ export class UserProfileWorkerService {
       return this.userProfileModel.upsert({
         nationalId: advaniaProfile.ssn,
         lastNudge: advaniaProfile.nudgeLastAsked,
-        nextNudge: addMonths(advaniaProfile.nudgeLastAsked, NUDGE_INTERVAL),
+        nextNudge:
+          advaniaProfile.nudgeLastAsked !== null
+            ? addMonths(advaniaProfile.nudgeLastAsked, NUDGE_INTERVAL)
+            : null,
       })
     }
 

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -2246,15 +2246,12 @@ service-portal-api-worker:
     DB_USER: 'service_portal_api'
     EMAIL_REGION: 'eu-west-1'
     IDENTITY_SERVER_ISSUER_URL: 'https://identity-server.dev01.devland.is'
-    ISLYKILL_CERT: '/etc/config/islyklar.p12'
     LOG_LEVEL: 'info'
     NODE_OPTIONS: '--max-old-space-size=921'
     NOVA_ACCEPT_UNAUTHORIZED: 'true'
     SERVERSIDE_FEATURES_ON: ''
     SERVICE_PORTAL_BASE_URL: 'https://beta.dev01.devland.is/minarsidur'
     USER_PROFILE_WORKER_PAGE_SIZE: '3000'
-  files:
-    - 'islyklar.p12'
   grantNamespaces:
     - 'nginx-ingress-internal'
     - 'nginx-ingress-external'

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -2046,15 +2046,12 @@ service-portal-api-worker:
     DB_USER: 'service_portal_api'
     EMAIL_REGION: 'eu-west-1'
     IDENTITY_SERVER_ISSUER_URL: 'https://innskra.island.is'
-    ISLYKILL_CERT: '/etc/config/islyklar.p12'
     LOG_LEVEL: 'info'
     NODE_OPTIONS: '--max-old-space-size=921'
     NOVA_ACCEPT_UNAUTHORIZED: 'false'
     SERVERSIDE_FEATURES_ON: 'driving-license-use-v1-endpoint-for-v2-comms'
     SERVICE_PORTAL_BASE_URL: 'https://island.is/minarsidur'
     USER_PROFILE_WORKER_PAGE_SIZE: '3000'
-  files:
-    - 'islyklar.p12'
   grantNamespaces:
     - 'nginx-ingress-internal'
     - 'nginx-ingress-external'

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -1985,15 +1985,12 @@ service-portal-api-worker:
     DB_USER: 'service_portal_api'
     EMAIL_REGION: 'eu-west-1'
     IDENTITY_SERVER_ISSUER_URL: 'https://identity-server.staging01.devland.is'
-    ISLYKILL_CERT: '/etc/config/islyklar.p12'
     LOG_LEVEL: 'info'
     NODE_OPTIONS: '--max-old-space-size=921'
     NOVA_ACCEPT_UNAUTHORIZED: 'false'
     SERVERSIDE_FEATURES_ON: ''
     SERVICE_PORTAL_BASE_URL: 'https://beta.staging01.devland.is/minarsidur'
     USER_PROFILE_WORKER_PAGE_SIZE: '3000'
-  files:
-    - 'islyklar.p12'
   grantNamespaces:
     - 'nginx-ingress-internal'
     - 'nginx-ingress-external'


### PR DESCRIPTION
## What

Fixing 'Invalid date' error when processing user profiles with nextNudge = `null` since `addMonths(nudgeLastAsked, 6)` results in `Invalid date` which cannot be set to `nextNudge` so it fails on the upsert.

## Why

To finish running the user-profile-worker without errors

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
