### PR TITLE
fix: fail early on codegen errors

### DIFF
--- a/apps/services/user-profile/project.json
+++ b/apps/services/user-profile/project.json
@@ -84,7 +84,7 @@
     "codegen/backend-schema": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cross-env INIT_SCHEMA=true yarn ts-node -P apps/services/user-profile/tsconfig.app.json apps/services/user-profile/src/buildOpenApi.ts"
+        "command": "cross-env ISLYKILL_CERT=tmp/islyklar.empty INIT_SCHEMA=true yarn ts-node -P apps/services/user-profile/tsconfig.app.json apps/services/user-profile/src/buildOpenApi.ts"
       },
       "outputs": ["{projectRoot}/src/openapi.yaml"]
     },

--- a/libs/clients/islykill/project.json
+++ b/libs/clients/islykill/project.json
@@ -22,7 +22,11 @@
     "codegen/backend-client": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "yarn openapi-generator -o libs/clients/islykill/gen/fetch -i libs/clients/islykill/src/clientConfig.yaml"
+        "commands": [
+          "touch tmp/islyklar.empty",
+          "ISLYKILL_CERT=tmp/islyklar.empty yarn openapi-generator -o libs/clients/islykill/gen/fetch -i libs/clients/islykill/src/clientConfig.yaml"
+        ],
+        "parallel": false
       },
       "outputs": ["{projectRoot}/gen/fetch"]
     }

--- a/libs/clients/islykill/src/lib/islykill.module.ts
+++ b/libs/clients/islykill/src/lib/islykill.module.ts
@@ -2,7 +2,6 @@ import fs from 'fs'
 import { DynamicModule } from '@nestjs/common'
 
 import { createEnhancedFetch } from '@island.is/clients/middlewares'
-import { logger } from '@island.is/logging'
 
 import { Configuration, IslyklarApi } from '../../gen/fetch'
 
@@ -14,52 +13,38 @@ export interface IslykillApiModuleConfig {
 
 export class IslykillApiModule {
   static register(config: IslykillApiModuleConfig): DynamicModule {
-    function lykillError(errorMsg: any) {
-      logger.error(errorMsg)
+    if (!config.cert) {
+      throw new Error('IslykillApiModule certificate not provided')
+    }
+    if (!config.passphrase) {
+      throw new Error('IslykillApiModule passphrase not provided')
     }
 
-    let pfx: Buffer | undefined
+    let pfx: Buffer
     try {
-      if (!config.cert) {
-        throw Error('IslykillApiModule certificate not provided')
-      }
-
-      const data = fs.readFileSync(config.cert, {
-        encoding: 'base64',
-      })
-
+      const data = fs.readFileSync(config.cert, { encoding: 'base64' })
       pfx = Buffer.from(data, 'base64')
     } catch (err) {
-      lykillError(err)
+      throw new Error(`Failed to read certificate: ${err.message}`)
     }
 
-    if (!config.passphrase) {
-      logger.error('IslykillApiModule secret not provided.')
-    }
-    const passphrase = config.passphrase
+    const enhancedFetch = createEnhancedFetch({
+      name: 'clients-islykill',
+      organizationSlug: 'stafraent-island',
+      timeout: 20000,
+      clientCertificate: { pfx, passphrase: config.passphrase },
+    })
+
+    const api = new IslyklarApi(
+      new Configuration({
+        basePath: config.basePath,
+        fetchApi: enhancedFetch,
+      }),
+    )
 
     return {
       module: IslykillApiModule,
-      providers: [
-        {
-          provide: IslyklarApi,
-          useFactory: () =>
-            new IslyklarApi(
-              new Configuration({
-                basePath: config.basePath,
-                fetchApi: createEnhancedFetch({
-                  name: 'clients-islykill',
-                  organizationSlug: 'stafraent-island',
-                  timeout: 20000,
-                  clientCertificate: pfx && {
-                    pfx,
-                    passphrase,
-                  },
-                }),
-              }),
-            ),
-        },
-      ],
+      providers: [{ provide: IslyklarApi, useFactory: () => api }],
       exports: [IslyklarApi],
     }
   }


### PR DESCRIPTION
# Codegen fail on error

- Return exit 1 on codegen errors
- Use --nx-bail for early exit on codegen parallel jobs
- Mock the islyklar.p12 path to prevent codegen errors
- House chores

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
