### PR TITLE
fix(parental-leave): Spouse section rework

### DIFF
--- a/libs/application/templates/parental-leave/src/forms/ParentalLeaveForm.ts
+++ b/libs/application/templates/parental-leave/src/forms/ParentalLeaveForm.ts
@@ -78,6 +78,7 @@ import {
   getRatioTitle,
   getRightsDescTitle,
   getSelectedChild,
+  getSpouse,
   getStartDateDesc,
   getStartDateTitle,
   isParentWithoutBirthParent,
@@ -191,7 +192,47 @@ export const ParentalLeaveForm: Form = buildForm({
           },
           children: [
             buildMultiField({
+              id: 'otherParentSpouse',
+              condition: (_, externalData) => {
+                const application = { externalData } as Application
+                const spouse = getSpouse(application)
+                return !!spouse
+              },
+              title: parentalLeaveFormMessages.shared.otherParentTitle,
+              description: parentalLeaveFormMessages.shared.otherParentSpouse,
+              children: [
+                buildTextField({
+                  id: 'otherParentSpouse.otherParentName',
+                  dataTestId: 'other-parent-name',
+                  title: parentalLeaveFormMessages.shared.otherParentName,
+                  width: 'half',
+                  disabled: true,
+                  defaultValue: (application: Application) => {
+                    const spouse = getSpouse(application)
+                    return spouse?.name
+                  },
+                }),
+                buildTextField({
+                  id: 'otherParentSpouse.otherParentId',
+                  dataTestId: 'other-parent-kennitala',
+                  title: parentalLeaveFormMessages.shared.otherParentID,
+                  width: 'half',
+                  format: '######-####',
+                  disabled: true,
+                  defaultValue: (application: Application) => {
+                    const spouse = getSpouse(application)
+                    return spouse?.nationalId
+                  },
+                }),
+              ],
+            }),
+            buildMultiField({
               id: 'otherParentObj',
+              condition: (_, externalData) => {
+                const application = { externalData } as Application
+                const spouse = getSpouse(application)
+                return !spouse
+              },
               title: parentalLeaveFormMessages.shared.otherParentTitle,
               description:
                 parentalLeaveFormMessages.shared.otherParentDescription,
@@ -199,11 +240,7 @@ export const ParentalLeaveForm: Form = buildForm({
                 buildRadioField({
                   id: 'otherParentObj.chooseOtherParent',
                   title: '',
-                  options: (application) => getOtherParentOptions(application),
-                  defaultValue: (application: Application) =>
-                    getOtherParentOptions(application)[0].value === SPOUSE
-                      ? SPOUSE
-                      : '',
+                  options: getOtherParentOptions,
                 }),
                 buildTextField({
                   id: 'otherParentObj.otherParentName',

--- a/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.ts
+++ b/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.ts
@@ -67,6 +67,7 @@ import {
   otherParentApprovalStatePendingAction,
   employerApprovalStatePendingAction,
   calculatePruneDate,
+  getSpouse,
 } from '../lib/parentalLeaveUtils'
 import { ChildrenApi, GetPersonInformation } from '../dataProviders'
 
@@ -93,6 +94,7 @@ const ParentalLeaveTemplate: ApplicationTemplate<
     states: {
       [States.PREREQUISITES]: {
         exit: [
+          'otherParentToSpouse',
           'attemptToSetPrimaryParentAsOtherParent',
           'setRightsToOtherParent',
           'setMultipleBirthsIfNo',
@@ -1827,6 +1829,17 @@ const ParentalLeaveTemplate: ApplicationTemplate<
         )
 
         set(answers, 'otherParentObj.chooseOtherParent', MANUAL)
+
+        return context
+      }),
+      otherParentToSpouse: assign((context) => {
+        const { application } = context
+        const { answers } = application
+        const spouse = getSpouse(application)
+
+        if (spouse) {
+          set(answers, 'otherParentObj.chooseOtherParent', SPOUSE)
+        }
 
         return context
       }),

--- a/libs/application/templates/parental-leave/src/lib/messages.ts
+++ b/libs/application/templates/parental-leave/src/lib/messages.ts
@@ -206,9 +206,9 @@ export const parentalLeaveFormMessages = {
     otherParentDescription: {
       id: 'pl.application:otherParent.description',
       defaultMessage:
-        'Skráður maki í þjóðskrá er valinn sjálfkrafa. Finnist ekki maki í þjóðskrá getur þú haldið áfram án skráningar, skráð þig sem einstætt foreldri eða skráð hitt foreldrið handvirkt.',
+        'Enginn maki fannst í Þjóðskrá. Þú getur haldið áfram án skráningar, skráð þig sem einstætt foreldri eða skráð hitt foreldrið handvirkt.',
       description:
-        'Your spouse according to Registers Iceland is preselected. If no spouse is found, you can continue without registration, register as a single parent or register the other parent manually.',
+        'No spouse was found in the National Registry. You can continue without registration, register as a single parent or register the other parent manually.',
     },
     otherParentTitle: {
       id: 'pl.application:otherParent.title',
@@ -248,8 +248,10 @@ export const parentalLeaveFormMessages = {
     },
     otherParentSpouse: {
       id: 'pl.application:otherParent.spouse',
-      defaultMessage: 'Hitt foreldrið er {spouseName} (kt. {spouseId})',
-      description: `The other parent is {spouseName} (kt. {spouseId})`,
+      defaultMessage:
+        'Hérna eru upplýsingar um maka/sambúðaraðila. Athugið ef eftirfarandi upplýsingar eru ekki réttar þá þarf að breyta þeim í Þjóðskrá.',
+      description:
+        'Here is information about spouses/partners. Note that if the following information is not correct, it must be changed in the National Registry.',
     },
     otherParentEmailSubSection: {
       id: 'pl.application:otherParentEmail.subSection',

--- a/libs/application/templates/parental-leave/src/lib/parentalLeaveUtils.ts
+++ b/libs/application/templates/parental-leave/src/lib/parentalLeaveUtils.ts
@@ -405,7 +405,7 @@ export const getSpouse = (
   return null
 }
 
-export const getOtherParentOptions = (application: Application) => {
+export const getOtherParentOptions = () => {
   const options: Option[] = [
     {
       value: NO,
@@ -423,24 +423,6 @@ export const getOtherParentOptions = (application: Application) => {
       label: parentalLeaveFormMessages.shared.otherParentOption,
     },
   ]
-
-  const spouse = getSpouse(application)
-
-  if (spouse) {
-    options.forEach((o) => {
-      o.disabled = true
-    })
-    options.unshift({
-      value: SPOUSE,
-      label: {
-        ...parentalLeaveFormMessages.shared.otherParentSpouse,
-        values: {
-          spouseName: spouse.name,
-          spouseId: spouse.nationalId,
-        },
-      },
-    })
-  }
 
   return options
 }


### PR DESCRIPTION
Made the spouse section display different screens based on if spouse is present or not

UUFV-445

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

*Text will be updated in Contentful
<img width="874" alt="image" src="https://github.com/island-is/island.is/assets/25203781/324b0104-b9b3-42bc-8742-392e3bb31427">

<img width="826" alt="image" src="https://github.com/island-is/island.is/assets/25203781/54576f1b-80b6-49fb-be50-208ffa5db19a">



## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced Parental Leave Form with fields for other parent's spouse information, improving data completeness and user interaction.
- **Bug Fixes**
	- Improved conditional display logic for spouse-related fields in the form, ensuring accurate form behavior.
- **Documentation**
	- Updated form messages to provide clear instructions for users when spouse information is not registered, guiding manual registration or correction steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->