### PR TITLE
chore(driving-license-book): use warn instead of error

### DIFF
--- a/libs/clients/driving-license-book/src/lib/drivingLicenseBookClient.service.ts
+++ b/libs/clients/driving-license-book/src/lib/drivingLicenseBookClient.service.ts
@@ -208,7 +208,7 @@ export class DrivingLicenseBookClientApiFactory {
     const book = data?.books?.[0]
 
     if (!book || !data) {
-      this.logger.error(
+      this.logger.warn(
         `${LOGTAG} Error fetching student, student has no active book`,
       )
       throw new NotFoundException(


### PR DESCRIPTION
# Use warn instead of error

Requested by devops.