### PR TITLE
fix(delegation-api): Add http prefix to USER_NOTIFICATION_CLIENT_URL

### DIFF
--- a/apps/services/auth/delegation-api/infra/delegation-api.ts
+++ b/apps/services/auth/delegation-api/infra/delegation-api.ts
@@ -52,8 +52,8 @@ export const serviceSetup = (services: {
         ]),
       },
       USER_NOTIFICATION_CLIENT_URL: {
-        dev: ref((h) => h.svc(services.userNotification)),
-        staging: ref((h) => h.svc(services.userNotification)),
+        dev: ref((h) => `http://${h.svc(services.userNotification)}`),
+        staging: ref((h) => `http://${h.svc(services.userNotification)}`),
         prod: 'https://user-notification.internal.island.is',
       },
     })


### PR DESCRIPTION
## What

The value from `h.svc` is returning a relative url missing the `http://` prefix so that the generated user-notification is complaining.

## Why

To be able to successfully send notifications when delegations are created

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
