### PR TITLE
fix(user-notifications): Update env variable name

### DIFF
--- a/apps/api/infra/api.ts
+++ b/apps/api/infra/api.ts
@@ -161,11 +161,6 @@ export const serviceSetup = (services: {
           'http://web-services-auth-delegation-api.identity-server-delegation.svc.cluster.local',
         prod: 'https://auth-delegation-api.internal.innskra.island.is',
       },
-      USER_NOTIFICATION_CLIENT_URL: {
-        dev: 'http://user-notification-xrd.internal.dev01.devland.is',
-        staging: 'http://user-notification-xrd.internal.staging01.devland.is',
-        prod: 'https://user-notification-xrd.internal.island.is',
-      },
       IDENTITY_SERVER_ISSUER_URL: {
         dev: 'https://identity-server.dev01.devland.is',
         staging: 'https://identity-server.staging01.devland.is',

--- a/apps/services/auth/delegation-api/infra/delegation-api.ts
+++ b/apps/services/auth/delegation-api/infra/delegation-api.ts
@@ -51,7 +51,7 @@ export const serviceSetup = (services: {
           'clustercfg.general-redis-cluster-group.dnugi2.euw1.cache.amazonaws.com:6379',
         ]),
       },
-      USER_NOTIFICATION_CLIENT_URL: {
+      USER_NOTIFICATION_API_URL: {
         dev: ref((h) => `http://${h.svc(services.userNotification)}`),
         staging: ref((h) => `http://${h.svc(services.userNotification)}`),
         prod: 'https://user-notification.internal.island.is',

--- a/charts/identity-server/values.dev.yaml
+++ b/charts/identity-server/values.dev.yaml
@@ -290,7 +290,7 @@ services-auth-delegation-api:
     LOG_LEVEL: 'info'
     NODE_OPTIONS: '--max-old-space-size=460'
     SERVERSIDE_FEATURES_ON: ''
-    USER_NOTIFICATION_CLIENT_URL: 'http://web-user-notification.user-notification.svc.cluster.local'
+    USER_NOTIFICATION_API_URL: 'http://web-user-notification.user-notification.svc.cluster.local'
     XROAD_BASE_PATH: 'http://securityserver.dev01.devland.is'
     XROAD_BASE_PATH_WITH_ENV: 'http://securityserver.dev01.devland.is/r1/IS-DEV'
     XROAD_CLIENT_ID: 'IS-DEV/GOV/10000/island-is-client'

--- a/charts/identity-server/values.prod.yaml
+++ b/charts/identity-server/values.prod.yaml
@@ -287,7 +287,7 @@ services-auth-delegation-api:
     LOG_LEVEL: 'info'
     NODE_OPTIONS: '--max-old-space-size=460'
     SERVERSIDE_FEATURES_ON: 'driving-license-use-v1-endpoint-for-v2-comms'
-    USER_NOTIFICATION_CLIENT_URL: 'https://user-notification.internal.island.is'
+    USER_NOTIFICATION_API_URL: 'https://user-notification.internal.island.is'
     XROAD_BASE_PATH: 'http://securityserver.island.is'
     XROAD_BASE_PATH_WITH_ENV: 'http://securityserver.island.is/r1/IS'
     XROAD_CLIENT_ID: 'IS/GOV/5501692829/island-is-client'

--- a/charts/identity-server/values.staging.yaml
+++ b/charts/identity-server/values.staging.yaml
@@ -290,7 +290,7 @@ services-auth-delegation-api:
     LOG_LEVEL: 'info'
     NODE_OPTIONS: '--max-old-space-size=460'
     SERVERSIDE_FEATURES_ON: ''
-    USER_NOTIFICATION_CLIENT_URL: 'http://web-user-notification.user-notification.svc.cluster.local'
+    USER_NOTIFICATION_API_URL: 'http://web-user-notification.user-notification.svc.cluster.local'
     XROAD_BASE_PATH: 'http://securityserver.staging01.devland.is'
     XROAD_BASE_PATH_WITH_ENV: 'http://securityserver.staging01.devland.is/r1/IS-TEST'
     XROAD_CLIENT_ID: 'IS-TEST/GOV/5501692829/island-is-client'

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -324,7 +324,6 @@ api:
     TELL_US_A_STORY_EMAIL: 's@kogk.is'
     UNIVERSITY_GATEWAY_API_URL: 'http://web-services-university-gateway.services-university-gateway.svc.cluster.local'
     USER_NOTIFICATION_API_URL: 'http://web-user-notification.user-notification.svc.cluster.local'
-    USER_NOTIFICATION_CLIENT_URL: 'http://user-notification-xrd.internal.dev01.devland.is'
     USER_PROFILE_CLIENT_URL: 'http://web-service-portal-api.service-portal.svc.cluster.local'
     XROAD_ADR_MACHINE_LICENSE_PATH: 'IS-DEV/GOV/10013/Vinnueftirlitid-Protected/rettindi-token-v1'
     XROAD_AIRCRAFT_REGISTRY_PATH: 'IS-DEV/GOV/10017/Samgongustofa-Protected/Loftfaraskra-V1'

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -314,7 +314,6 @@ api:
     TELL_US_A_STORY_EMAIL: 'sogur@island.is'
     UNIVERSITY_GATEWAY_API_URL: 'http://web-services-university-gateway.services-university-gateway.svc.cluster.local'
     USER_NOTIFICATION_API_URL: 'http://web-user-notification.user-notification.svc.cluster.local'
-    USER_NOTIFICATION_CLIENT_URL: 'https://user-notification-xrd.internal.island.is'
     USER_PROFILE_CLIENT_URL: 'http://web-service-portal-api.service-portal.svc.cluster.local'
     XROAD_ADR_MACHINE_LICENSE_PATH: 'IS/GOV/4201810439/Vinnueftirlitid-Protected/rettindi-token-v1'
     XROAD_AIRCRAFT_REGISTRY_PATH: 'IS/GOV/5405131040/Samgongustofa-Protected/Loftfaraskra-V1'

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -324,7 +324,6 @@ api:
     TELL_US_A_STORY_EMAIL: 'sogur@island.is'
     UNIVERSITY_GATEWAY_API_URL: 'http://web-services-university-gateway.services-university-gateway.svc.cluster.local'
     USER_NOTIFICATION_API_URL: 'http://web-user-notification.user-notification.svc.cluster.local'
-    USER_NOTIFICATION_CLIENT_URL: 'http://user-notification-xrd.internal.staging01.devland.is'
     USER_PROFILE_CLIENT_URL: 'http://web-service-portal-api.service-portal.svc.cluster.local'
     XROAD_ADR_MACHINE_LICENSE_PATH: 'IS-TEST/GOV/4201810439/Vinnueftirlitid-Protected/rettindi-token-v1'
     XROAD_AIRCRAFT_REGISTRY_PATH: 'IS-DEV/GOV/10017/Samgongustofa-Protected/Loftfaraskra-V1'

--- a/libs/auth-api-lib/src/lib/user-notification/user-system-notification.config.ts
+++ b/libs/auth-api-lib/src/lib/user-notification/user-system-notification.config.ts
@@ -11,7 +11,7 @@ export const DelegationApiUserSystemNotificationConfig = defineConfig({
   load(env) {
     return {
       basePath: env.required(
-        'USER_NOTIFICATION_CLIENT_URL',
+        'USER_NOTIFICATION_API_URL',
         'http://localhost:3333',
       ),
     }

--- a/libs/clients/user-notification/src/lib/userNotificationClient.config.ts
+++ b/libs/clients/user-notification/src/lib/userNotificationClient.config.ts
@@ -15,7 +15,7 @@ export const UserNotificationSystemClientConfig = defineConfig({
   load(env) {
     return {
       basePath: env.required(
-        'USER_NOTIFICATION_CLIENT_URL',
+        'USER_NOTIFICATION_API_URL',
         'http://localhost:3333',
       ),
     }


### PR DESCRIPTION
## What

Sync env variable for user notification API

## Why

USER_NOTIFICATION_CLIENT_URL was not really the right name. So it [was changed](https://github.com/island-is/island.is/pull/13566), in the meantime another PR was added so we [have two variables for the same path](https://github.com/island-is/island.is/pull/14571).

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Updated configuration settings across various services and environments by changing the variable name from `USER_NOTIFICATION_CLIENT_URL` to `USER_NOTIFICATION_API_URL`. This change ensures consistency and clarity in configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->