### PR TITLE
fix(native-app): Add to wallet button fix

### DIFF
--- a/apps/native/app/src/screens/wallet-pass/wallet-pass.tsx
+++ b/apps/native/app/src/screens/wallet-pass/wallet-pass.tsx
@@ -5,12 +5,14 @@ import {
   LicenseCard,
 } from '@ui'
 import * as FileSystem from 'expo-file-system'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { useIntl } from 'react-intl'
 import {
   ActivityIndicator,
   Alert,
+  Animated,
   Button,
+  Easing,
   Linking,
   NativeModules,
   Platform,
@@ -71,9 +73,19 @@ const LicenseCardWrapper = styled(SafeAreaView)`
   z-index: 100;
 `
 
-const ButtonWrapper = styled(SafeAreaView)`
+const ButtonWrapper = styled(SafeAreaView)<{ floating?: boolean }>`
   margin-left: ${({ theme }) => theme.spacing[2]}px;
   margin-right: ${({ theme }) => theme.spacing[2]}px;
+
+  ${({ floating, theme }) =>
+    floating &&
+    `
+    position: absolute;
+    bottom: ${theme.spacing[2]}px;
+    left: 0;
+    right: 0;
+    z-index: 100;
+    `}
 `
 
 const LoadingOverlay = styled.View`
@@ -129,6 +141,7 @@ export const WalletPassScreen: NavigationFunctionComponent<{
   const intl = useIntl()
   const [addingToWallet, setAddingToWallet] = useState(false)
   const isBarcodeEnabled = useFeatureFlag('isBarcodeEnabled', false)
+  const fadeInAnim = useRef(new Animated.Value(0)).current
 
   const [generatePkPass] = useGeneratePkPassMutation()
   const res = useGetLicenseQuery({
@@ -151,6 +164,22 @@ export const WalletPassScreen: NavigationFunctionComponent<{
     screenWidth - theme.spacing[4] * 2 - theme.spacing.smallGutter * 2
   const barcodeHeight = barcodeWidth / 3
   const updated = data?.fetch?.updated
+
+  const fadeIn = () => {
+    Animated.timing(fadeInAnim, {
+      toValue: 1,
+      duration: 200,
+      useNativeDriver: true,
+      delay: 300,
+      easing: Easing.in(Easing.ease),
+    }).start()
+  }
+
+  useEffect(() => {
+    if (pkPassAllowed && !isBarcodeEnabled) {
+      fadeIn()
+    }
+  }, [pkPassAllowed, isBarcodeEnabled])
 
   const onAddPkPass = async () => {
     const { canAddPasses, addPass } = Platform.select({
@@ -291,6 +320,26 @@ export const WalletPassScreen: NavigationFunctionComponent<{
       ? barcodeHeight + LICENSE_CARD_ROW_GAP
       : 0
 
+  const renderButtons = () => {
+    if (isIos) {
+      return (
+        <AddPassButton
+          style={{ height: 52 }}
+          addPassButtonStyle={
+            theme.isDark
+              ? PassKit.AddPassButtonStyle.blackOutline
+              : PassKit.AddPassButtonStyle.black
+          }
+          onPress={onAddPkPass}
+        />
+      )
+    }
+
+    return (
+      <Button title="Add to Wallet" onPress={onAddPkPass} color="#111111" />
+    )
+  }
+
   return (
     <View style={{ flex: 1 }}>
       <View style={{ height: cardHeight }} />
@@ -358,29 +407,24 @@ export const WalletPassScreen: NavigationFunctionComponent<{
             <FieldRender data={fields} licenseType={licenseType} />
           )}
         </SafeAreaView>
-        {isAndroid && <Spacer />}
-        {pkPassAllowed && (
-          <ButtonWrapper>
-            {isIos ? (
-              <AddPassButton
-                style={{ height: 52 }}
-                addPassButtonStyle={
-                  theme.isDark
-                    ? PassKit.AddPassButtonStyle.blackOutline
-                    : PassKit.AddPassButtonStyle.black
-                }
-                onPress={onAddPkPass}
-              />
-            ) : (
-              <Button
-                title="Add to Wallet"
-                onPress={onAddPkPass}
-                color="#111111"
-              />
-            )}
-          </ButtonWrapper>
+
+        {pkPassAllowed && isBarcodeEnabled && (
+          <ButtonWrapper>{renderButtons()}</ButtonWrapper>
         )}
+        {isAndroid && <Spacer />}
       </Information>
+      {/*
+          Remove once isBarcodeEnabled will be removed. This is only temporary.
+          The reason for the animation is to avoid rendering flicker.
+          The component will on first render the isBarcodeEnabled flag to be false and then set it to true after Configcat has fetched the flag.
+       */}
+      {pkPassAllowed && !isBarcodeEnabled && (
+        <ButtonWrapper floating>
+          <Animated.View style={{ opacity: fadeInAnim }}>
+            {renderButtons()}
+          </Animated.View>
+        </ButtonWrapper>
+      )}
 
       {addingToWallet && (
         <LoadingOverlay>


### PR DESCRIPTION
# Add to wallet button fix

## What

Buttons where not visible on Android. This PR fixes that
It also makes the add to wallet button floating if the isBarcodeEnabled feature flag is disabled.


## Screenshots / Gifs

Android
![image](https://github.com/island-is/island.is/assets/112904566/7d3f5475-9b1e-46b8-8603-817e6f23c5ca)


IPhone
![Screenshot 2024-04-24 at 11 25 35](https://github.com/island-is/island.is/assets/112904566/a868e9b6-c020-4da3-bb0c-678d65a8b6e7)
![IMG_24F838C573BA-1](https://github.com/island-is/island.is/assets/112904566/5026782c-442f-4fa8-8dbe-46062104a5b2)

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
