### PR TITLE
fix(auth-nest-tools): Fix add nestjs jwt clocktolorance

### DIFF
--- a/libs/auth-nest-tools/src/lib/jwt.strategy.ts
+++ b/libs/auth-nest-tools/src/lib/jwt.strategy.ts
@@ -23,6 +23,10 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       algorithms: ['RS256'],
       ignoreExpiration: false,
       passReqToCallback: true,
+      jsonWebTokenOptions: {
+        // Add default clockTolerance of 60 seconds to allow for small time differences between servers
+        clockTolerance: 60,
+      },
     })
   }
 


### PR DESCRIPTION
## What

Add #14603 

## Why

Test to see if server timeskew can be causing 401 between IDS and service portal api (user profile api)

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
