### PR TITLE
fix(user-notification): Grant islandis access to user notification

### DIFF
--- a/apps/services/user-notification/infra/user-notification.ts
+++ b/apps/services/user-notification/infra/user-notification.ts
@@ -104,7 +104,11 @@ export const userNotificationServiceSetup = (services: {
         memory: '256Mi',
       },
     })
-    .grantNamespaces('nginx-ingress-internal', 'identity-server-delegation')
+    .grantNamespaces(
+      'nginx-ingress-internal',
+      'islandis',
+      'identity-server-delegation',
+    )
 
 export const userNotificationWorkerSetup = (services: {
   userProfileApi: ServiceBuilder<typeof serviceWorkerName>

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -3046,6 +3046,7 @@ user-notification:
     XROAD_TLS_BASE_PATH_WITH_ENV: 'https://securityserver.dev01.devland.is/r1/IS-DEV'
   grantNamespaces:
     - 'nginx-ingress-internal'
+    - 'islandis'
     - 'identity-server-delegation'
   grantNamespacesEnabled: true
   healthCheck:
@@ -3129,6 +3130,7 @@ user-notification-cleanup-worker:
     SERVERSIDE_FEATURES_ON: ''
   grantNamespaces:
     - 'nginx-ingress-internal'
+    - 'islandis'
     - 'identity-server-delegation'
   grantNamespacesEnabled: true
   healthCheck:
@@ -3239,6 +3241,7 @@ user-notification-worker:
     XROAD_TLS_BASE_PATH_WITH_ENV: 'https://securityserver.dev01.devland.is/r1/IS-DEV'
   grantNamespaces:
     - 'nginx-ingress-internal'
+    - 'islandis'
     - 'identity-server-delegation'
   grantNamespacesEnabled: true
   healthCheck:

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -2852,6 +2852,7 @@ user-notification:
     XROAD_TLS_BASE_PATH_WITH_ENV: 'https://securityserver.island.is/r1/IS'
   grantNamespaces:
     - 'nginx-ingress-internal'
+    - 'islandis'
     - 'identity-server-delegation'
   grantNamespacesEnabled: true
   healthCheck:
@@ -2935,6 +2936,7 @@ user-notification-cleanup-worker:
     SERVERSIDE_FEATURES_ON: 'driving-license-use-v1-endpoint-for-v2-comms'
   grantNamespaces:
     - 'nginx-ingress-internal'
+    - 'islandis'
     - 'identity-server-delegation'
   grantNamespacesEnabled: true
   healthCheck:
@@ -3045,6 +3047,7 @@ user-notification-worker:
     XROAD_TLS_BASE_PATH_WITH_ENV: 'https://securityserver.island.is/r1/IS'
   grantNamespaces:
     - 'nginx-ingress-internal'
+    - 'islandis'
     - 'identity-server-delegation'
   grantNamespacesEnabled: true
   healthCheck:

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -2785,6 +2785,7 @@ user-notification:
     XROAD_TLS_BASE_PATH_WITH_ENV: 'https://securityserver.staging01.devland.is/r1/IS-TEST'
   grantNamespaces:
     - 'nginx-ingress-internal'
+    - 'islandis'
     - 'identity-server-delegation'
   grantNamespacesEnabled: true
   healthCheck:
@@ -2868,6 +2869,7 @@ user-notification-cleanup-worker:
     SERVERSIDE_FEATURES_ON: ''
   grantNamespaces:
     - 'nginx-ingress-internal'
+    - 'islandis'
     - 'identity-server-delegation'
   grantNamespacesEnabled: true
   healthCheck:
@@ -2978,6 +2980,7 @@ user-notification-worker:
     XROAD_TLS_BASE_PATH_WITH_ENV: 'https://securityserver.staging01.devland.is/r1/IS-TEST'
   grantNamespaces:
     - 'nginx-ingress-internal'
+    - 'islandis'
     - 'identity-server-delegation'
   grantNamespacesEnabled: true
   healthCheck:


### PR DESCRIPTION
## What

Allow `islandis` to call `user-notification` with internal cluster url.

## Why

To open communication internally on the cluster.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded access for the user notification services by including the 'islandis' namespace across development, staging, and production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->