### PR TITLE
fix(service-portal): Making company sessions using the onboarding modal inline edit and verification

### DIFF
--- a/libs/service-portal/information/src/components/PersonalInformation/Forms/ProfileForm/ProfileForm.tsx
+++ b/libs/service-portal/information/src/components/PersonalInformation/Forms/ProfileForm/ProfileForm.tsx
@@ -71,10 +71,11 @@ export const ProfileForm: FC<React.PropsWithChildren<Props>> = ({
     useUpdateOrCreateUserProfile()
   const { deleteIslykillValue, loading: deleteLoading } =
     useDeleteIslykillValue()
-  const { authority } = useAuth()
+  const { authority, userInfo } = useAuth()
   const { data: userProfile, loading: userLoading, refetch } = useUserProfile()
   const featureFlagClient: FeatureFlagClient = useFeatureFlagClient()
   const { formatMessage } = useLocale()
+  const isCompany = userInfo?.profile?.subjectType === 'legalEntity'
 
   const isV2UserProfileEnabled = async () => {
     const ffEnabled = await featureFlagClient.getValue(
@@ -82,7 +83,7 @@ export const ProfileForm: FC<React.PropsWithChildren<Props>> = ({
       false,
     )
 
-    if (ffEnabled) {
+    if (ffEnabled && !isCompany) {
       setV2UserProfileEnabled(ffEnabled as boolean)
     }
   }

--- a/libs/service-portal/information/src/components/PersonalInformation/Forms/ProfileForm/ProfileForm.tsx
+++ b/libs/service-portal/information/src/components/PersonalInformation/Forms/ProfileForm/ProfileForm.tsx
@@ -83,7 +83,9 @@ export const ProfileForm: FC<React.PropsWithChildren<Props>> = ({
       false,
     )
 
-    if (ffEnabled && !isCompany) {
+    if (ffEnabled) {
+      setV2UserProfileEnabled(!isCompany);
+    }
       setV2UserProfileEnabled(ffEnabled as boolean)
     }
   }

--- a/libs/service-portal/information/src/components/PersonalInformation/Forms/ProfileForm/ProfileForm.tsx
+++ b/libs/service-portal/information/src/components/PersonalInformation/Forms/ProfileForm/ProfileForm.tsx
@@ -84,9 +84,7 @@ export const ProfileForm: FC<React.PropsWithChildren<Props>> = ({
     )
 
     if (ffEnabled) {
-      setV2UserProfileEnabled(!isCompany);
-    }
-      setV2UserProfileEnabled(ffEnabled as boolean)
+      setV2UserProfileEnabled(!isCompany)
     }
   }
 


### PR DESCRIPTION
## What

Checking for company session in the onboarding modal to use the inline editing and verification.

## Why

The new user profile flow is not supported for companies or delegations.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved user profile forms to cater to company profiles with additional features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->