### PR TITLE
fix(web): Clear both left and right float styles for embedded Table components

### DIFF
--- a/libs/island-ui/contentful/src/lib/RichTextRC/RichText.css.ts
+++ b/libs/island-ui/contentful/src/lib/RichTextRC/RichText.css.ts
@@ -106,3 +106,7 @@ export const heading = style({
     },
   },
 })
+
+export const clearBoth = style({
+  clear: 'both',
+})

--- a/libs/island-ui/contentful/src/lib/RichTextRC/defaultRenderNode.tsx
+++ b/libs/island-ui/contentful/src/lib/RichTextRC/defaultRenderNode.tsx
@@ -146,7 +146,11 @@ export const defaultRenderNodeObject: RenderNode = {
       <hr />
     </Box>
   ),
-  [BLOCKS.TABLE]: (_node, children) => <T.Table>{children}</T.Table>,
+  [BLOCKS.TABLE]: (_node, children) => (
+    <Box className={styles.clearBoth}>
+      <T.Table>{children}</T.Table>
+    </Box>
+  ),
   [BLOCKS.TABLE_ROW]: (_node, children) => {
     if (
       (children as { nodeType: string }[])?.every(


### PR DESCRIPTION
# Clear both left and right float styles for embedded Table components

## What

* If a Table component gets embedded inside a rich text field of the News content type in the CMS it can sometimes appear below the news image (depending on whether the news image is floated right or not).
* This PR fixes that issue by making sure all float styles are cleared before rendering the table

## Screenshots / Gifs

### Before
<img width="847" alt="image" src="https://github.com/island-is/island.is/assets/43557895/d82675ac-11a4-4a94-bec8-e45f48fda383">

### After
<img width="845" alt="image" src="https://github.com/island-is/island.is/assets/43557895/0be0e65b-09e9-49b4-90d5-fba28700fb20">


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the Rich Text component to improve the layout of tables by wrapping them in a styled container.
- **Style**
	- Introduced a new style rule to clear floats, enhancing text and media alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->