### PR TITLE
fix(web): Article subgroup matching

### DIFF
--- a/apps/web/screens/Category/Category/utils.ts
+++ b/apps/web/screens/Category/Category/utils.ts
@@ -82,7 +82,10 @@ type Subgroup =
   | undefined
 
 const isSameSubGroup = (subgroup1: Subgroup, subgroup2: Subgroup) => {
-  return subgroup1?.title === subgroup2?.title
+  return (
+    subgroup1?.title === subgroup2?.title ||
+    (!subgroup1?.title && !subgroup2?.title)
+  )
 }
 
 const sortPages = (pages: CategoryPages) => {


### PR DESCRIPTION
# Article subgroup matching

## What

* Articles are being placed in different subgroups if one subgroup has an empty string for a title and the other is undefined

## Screenshots / Gifs

### Before (There are two "Other" subgroups)
https://github.com/island-is/island.is/assets/43557895/003e8877-dfe5-4a00-b094-225feee1d672

### After (Now there is just one "Other" subgroup

https://github.com/island-is/island.is/assets/43557895/d38cdd19-540c-4107-88e6-f6996f144105



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the logic for subgroup comparison to handle cases where titles are undefined, enhancing the accuracy of category grouping in the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->