### PR TITLE
fix(j-s): Zod error when street number is null

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/police/police.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/police.service.ts
@@ -63,7 +63,7 @@ const getChapter = (category?: string): number | undefined => {
 
 const formatCrimeScenePlace = (
   street?: string,
-  streetNumber?: string,
+  streetNumber?: string | null,
   municipality?: string,
 ) => {
   if (!street && !municipality) {
@@ -337,7 +337,7 @@ export class PoliceService {
               brotFra?: string
               licencePlate?: string
               gotuHeiti?: string
-              gotuNumer?: string
+              gotuNumer?: string | null
               sveitafelag?: string
             }) => {
               const policeCaseNumber = info.upprunalegtMalsnumer

--- a/apps/judicial-system/backend/src/app/modules/police/police.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/police.service.ts
@@ -102,7 +102,7 @@ export class PoliceService {
     upprunalegtMalsnumer: z.string(),
     licencePlate: z.optional(z.string()),
     gotuHeiti: z.optional(z.string()),
-    gotuNumer: z.optional(z.string()),
+    gotuNumer: z.string().nullish(),
     sveitafelag: z.optional(z.string()),
     postnumer: z.optional(z.string()),
   })

--- a/apps/judicial-system/backend/src/app/modules/police/police.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/police.service.ts
@@ -62,9 +62,9 @@ const getChapter = (category?: string): number | undefined => {
 }
 
 const formatCrimeScenePlace = (
-  street?: string,
+  street?: string | null,
   streetNumber?: string | null,
-  municipality?: string,
+  municipality?: string | null,
 ) => {
   if (!street && !municipality) {
     return ''
@@ -103,8 +103,8 @@ export class PoliceService {
     licencePlate: z.optional(z.string()),
     gotuHeiti: z.optional(z.string()),
     gotuNumer: z.string().nullish(),
-    sveitafelag: z.optional(z.string()),
-    postnumer: z.optional(z.string()),
+    sveitafelag: z.string().nullish(),
+    postnumer: z.string().nullish(),
   })
   private responseStructure = z.object({
     malsnumer: z.string(),
@@ -336,9 +336,9 @@ export class PoliceService {
               vettvangur?: string
               brotFra?: string
               licencePlate?: string
-              gotuHeiti?: string
+              gotuHeiti?: string | null
               gotuNumer?: string | null
-              sveitafelag?: string
+              sveitafelag?: string | null
             }) => {
               const policeCaseNumber = info.upprunalegtMalsnumer
 

--- a/apps/judicial-system/backend/src/app/modules/police/test/getPoliceCaseInfo.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/test/getPoliceCaseInfo.spec.ts
@@ -106,6 +106,7 @@ describe('PoliceController - Get police case info', () => {
               upprunalegtMalsnumer: '007-2020-000103',
               brotFra: '2021-02-23T13:17:00',
               gotuHeiti: 'Teststígur',
+              gotuNumer: null,
               sveitafelag: 'Testbær',
               licencePlate: 'CDE-123',
             },

--- a/apps/judicial-system/backend/src/app/modules/police/test/getPoliceCaseInfo.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/test/getPoliceCaseInfo.spec.ts
@@ -114,6 +114,7 @@ describe('PoliceController - Get police case info', () => {
               upprunalegtMalsnumer: '007-2020-000057',
               brotFra: '2021-02-23T13:17:00',
               gotuHeiti: 'Teststígur',
+              sveitafelag: null,
             },
           ],
         }),


### PR DESCRIPTION


[ZOD villa](https://app.asana.com/0/1199153462262248/1207179409041849)

## What

Allow a null value for street number in police case info

## Why

Because sometimes the value is null instead of undefined


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved handling of address details in crime scene reports, allowing for optional street numbers.
	- Ensured consistent data entry for police case identifiers, even when information is unavailable.
	- Updated test data for police case information to reflect changes in field values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->