### PR TITLE
fix(auth-api-lib): handle valid_to and valid_from null values in migration

### DIFF
--- a/libs/auth-api-lib/migrations/20240429164830-migrate-api-scopes-delegation-types-with-valid-to-null.js
+++ b/libs/auth-api-lib/migrations/20240429164830-migrate-api-scopes-delegation-types-with-valid-to-null.js
@@ -1,0 +1,43 @@
+'use strict'
+
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.query(`
+      BEGIN;
+
+        DELETE FROM api_scope_delegation_types;
+
+        INSERT INTO api_scope_delegation_types (api_scope_name, delegation_type)
+        SELECT name, 'Custom'
+        FROM api_scope
+        WHERE allow_explicit_delegation_grant = true;
+
+        INSERT INTO api_scope_delegation_types (api_scope_name, delegation_type)
+        SELECT name, 'LegalGuardian'
+        FROM api_scope
+        WHERE grant_to_legal_guardians = true;
+
+        INSERT INTO api_scope_delegation_types (api_scope_name, delegation_type)
+        SELECT name, 'ProcurationHolder'
+        FROM api_scope
+        WHERE grant_to_procuring_holders = true;
+
+        INSERT INTO api_scope_delegation_types (api_scope_name, delegation_type)
+        SELECT prsp.api_scope_name, CONCAT('PersonalRepresentative:', prrt.code)
+        FROM personal_representative_right_type prrt
+        JOIN personal_representative_scope_permission prsp ON prrt.code = prsp.right_type_code
+        JOIN api_scope apis ON prsp.api_scope_name = apis.name
+        WHERE (prrt.valid_from IS NULL OR prrt.valid_from < NOW()) AND (prrt.valid_to IS NULL OR prrt.valid_to > NOW()) AND apis.grant_to_personal_representatives = true;
+
+      COMMIT;
+    `)
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.query(`
+      BEGIN;
+        DELETE FROM api_scope_delegation_types;
+      COMMIT;
+    `)
+  },
+}

--- a/libs/auth-api-lib/src/lib/delegations/models/delegation-provider.model.ts
+++ b/libs/auth-api-lib/src/lib/delegations/models/delegation-provider.model.ts
@@ -7,11 +7,13 @@ import {
   Column,
   CreatedAt,
   DataType,
+  HasMany,
   Model,
   PrimaryKey,
   Table,
   UpdatedAt,
 } from 'sequelize-typescript'
+import { DelegationTypeModel } from './delegation-type.model'
 
 @Table({
   tableName: 'delegation_provider',
@@ -40,6 +42,9 @@ export class DelegationProviderModel extends Model<
     allowNull: false,
   })
   description!: string
+
+  @HasMany(() => DelegationTypeModel)
+  delegationTypes!: DelegationTypeModel[]
 
   @CreatedAt
   readonly created!: CreationOptional<Date>

--- a/libs/auth-api-lib/src/lib/delegations/models/delegation-type.model.ts
+++ b/libs/auth-api-lib/src/lib/delegations/models/delegation-type.model.ts
@@ -4,6 +4,7 @@ import type {
   InferCreationAttributes,
 } from 'sequelize'
 import {
+  BelongsTo,
   Column,
   CreatedAt,
   DataType,
@@ -35,9 +36,13 @@ export class DelegationTypeModel extends Model<
   @Column({
     type: DataType.STRING,
     allowNull: false,
+    field: 'provider',
   })
   @ForeignKey(() => DelegationProviderModel)
-  provider!: string
+  providerId!: string
+
+  @BelongsTo(() => DelegationProviderModel)
+  provider!: DelegationProviderModel
 
   @Column({
     type: DataType.STRING,


### PR DESCRIPTION
handle valid_to and valid_from null values in personal representative right type table in migration

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Enhanced the delegation management system for improved security and compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->