### PR TITLE
fix(j-s): Case Files to Robot

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/file/file.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/file/file.service.ts
@@ -233,6 +233,7 @@ export class FileService {
     })
 
     if (
+      theCase.appealCaseNumber &&
       file.category &&
       [
         CaseFileCategory.PROSECUTOR_APPEAL_STATEMENT,

--- a/apps/judicial-system/backend/src/app/modules/file/test/fileController/createCaseFile.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/file/test/fileController/createCaseFile.spec.ts
@@ -64,7 +64,7 @@ describe('FileController - Create case file', () => {
     'case file created for %s case',
     (type) => {
       const caseId = uuid()
-      const theCase = { id: caseId, type } as Case
+      const theCase = { id: caseId, type, appealCaseNumber: uuid() } as Case
       const uuId = uuid()
       const createCaseFile: CreateFileDto = {
         type: 'text/plain',

--- a/apps/judicial-system/backend/src/app/modules/file/test/limitedAccessFileController/createCaseFile.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/file/test/limitedAccessFileController/createCaseFile.spec.ts
@@ -64,7 +64,7 @@ describe('limitedAccessFileController - Create case file', () => {
     'case file created for %s case',
     (type) => {
       const caseId = uuid()
-      const theCase = { id: caseId, type } as Case
+      const theCase = { id: caseId, type, appealCaseNumber: uuid() } as Case
       const uuId = uuid()
       const createCaseFile: CreateFileDto = {
         type: 'text/plain',


### PR DESCRIPTION
# Case Files to Robot

[Róbot - stundum vantar málsnúmer Landsréttar](https://app.asana.com/0/1199153462262248/1207196589726152/f)

## What

- Only send appeal case files to court of appeals robot after an appeal case number has been assigned.

## Why

- The appeal case number is necessary for linking the case file to the case at the court of appeals.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced file handling in the judicial system to include checks for `appealCaseNumber` ensuring more accurate processing of appeal cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->