### PR TITLE
feat(web): Custom Page - OpenGraph fields and rich text field added

### DIFF
--- a/apps/web/screens/CustomPage/CustomPageWrapper.tsx
+++ b/apps/web/screens/CustomPage/CustomPageWrapper.tsx
@@ -1,6 +1,7 @@
 import { ComponentType } from 'react'
 import { IntlProvider } from 'react-intl'
 
+import { HeadWithSocialSharing } from '@island.is/web/components'
 import {
   CustomPage,
   CustomPageUniqueIdentifier,
@@ -45,6 +46,14 @@ export const withCustomPageWrapper = <Props,>(
         locale={activeLocale}
         messages={customPageData?.translationStrings}
       >
+        <HeadWithSocialSharing
+          title={customPageData?.ogTitle ?? ''}
+          description={customPageData?.ogDescription ?? undefined}
+          imageContentType={customPageData?.ogImage?.contentType}
+          imageWidth={customPageData?.ogImage?.width?.toString()}
+          imageHeight={customPageData?.ogImage?.height?.toString()}
+          imageUrl={customPageData?.ogImage?.url}
+        />
         <Component {...pageProps} customPageData={customPageData} />
       </IntlProvider>
     )

--- a/apps/web/screens/queries/CustomPage.ts
+++ b/apps/web/screens/queries/CustomPage.ts
@@ -1,10 +1,21 @@
 import gql from 'graphql-tag'
 
+import { nestedFields, slices } from './fragments'
+
 export const GET_CUSTOM_PAGE_QUERY = gql`
   query GetCustomPage($input: GetCustomPageInput!) {
     getCustomPage(input: $input) {
       configJson
       translationStrings
+      content {
+        ...AllSlices
+        ${nestedFields}
+      }
+      ogTitle
+      ogDescription
+      ogImage {
+        ...ImageFields
+      }
       alertBanner {
         showAlertBanner
         bannerVariant
@@ -20,4 +31,5 @@ export const GET_CUSTOM_PAGE_QUERY = gql`
       }
     }
   }
+  ${slices}
 `

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -739,7 +739,10 @@ export interface ICustomPageFields {
   title?: string | undefined
 
   /** Unique Identifier */
-  uniqueIdentifier: 'PensionCalculator' | 'OfficialJournalOfIceland'
+  uniqueIdentifier:
+    | 'PensionCalculator'
+    | 'OfficialJournalOfIceland'
+    | 'Vacancies'
 
   /** Alert Banner */
   alertBanner?: IAlertBanner | undefined
@@ -749,6 +752,18 @@ export interface ICustomPageFields {
 
   /** Configuration */
   configJson?: Record<string, any> | undefined
+
+  /** Content */
+  content?: Document | undefined
+
+  /** Open Graph Title */
+  ogTitle?: string | undefined
+
+  /** Open Graph Description */
+  ogDescription?: string | undefined
+
+  /** Open Graph Image */
+  ogImage?: Asset | undefined
 }
 
 /** This content type is meant to represent a custom made page. Examples include (/starfatorg, /reglugerdir and many more).

--- a/libs/cms/src/lib/models/customPage.model.ts
+++ b/libs/cms/src/lib/models/customPage.model.ts
@@ -3,7 +3,9 @@ import type { SystemMetadata } from 'api-cms-domain'
 import { Field, ObjectType, ID } from '@nestjs/graphql'
 import { CacheField } from '@island.is/nest/graphql'
 import { AlertBanner, mapAlertBanner } from './alertBanner.model'
+import { Image, mapImage } from './image.model'
 import type { ICustomPage } from '../generated/contentfulTypes'
+import { SliceUnion, mapDocument } from '../unions/slice.union'
 
 @ObjectType()
 export class CustomPage {
@@ -21,6 +23,18 @@ export class CustomPage {
 
   @CacheField(() => GraphQLJSONObject)
   translationStrings!: Record<string, string>
+
+  @CacheField(() => [SliceUnion], { nullable: true })
+  content?: Array<typeof SliceUnion>
+
+  @Field(() => String, { nullable: true })
+  ogTitle?: string
+
+  @Field(() => String, { nullable: true })
+  ogDescription?: string
+
+  @CacheField(() => Image, { nullable: true })
+  ogImage?: Image | null
 }
 
 export const mapCustomPage = ({
@@ -34,5 +48,11 @@ export const mapCustomPage = ({
     alertBanner: fields.alertBanner ? mapAlertBanner(fields.alertBanner) : null,
     configJson: fields.configJson,
     translationStrings: fields.translationNamespace?.fields?.strings || {},
+    content: fields.content
+      ? mapDocument(fields.content, sys.id + ':content')
+      : [],
+    ogTitle: fields.title,
+    ogDescription: fields.ogDescription,
+    ogImage: fields.ogImage ? mapImage(fields.ogImage) : null,
   }
 }


### PR DESCRIPTION
# Custom Page - OpenGraph fields and rich text field added

## What

* Custom pages might have a custom og:image, og:title or og:description so those fields were added to the CMS content type
* Also a content field was added to the Custom Page content type which will allow for rich text

## Why

* This is an expansion for the Custom Page content type to provide fields and functionality shared between custom pages

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
