### PR TITLE
fix(web): Disable SSR for Directorate of Fisheries footer

### DIFF
--- a/apps/web/components/Organization/Wrapper/Themes/FiskistofaTheme/index.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/FiskistofaTheme/index.ts
@@ -3,7 +3,7 @@ import dynamic from 'next/dynamic'
 import Header from './FiskistofaHeader'
 
 export const FiskistofaFooter = dynamic(() => import('./FiskistofaFooter'), {
-  ssr: true,
+  ssr: false,
 })
 
 export const FiskistofaHeader = Header


### PR DESCRIPTION
# Disable SSR for Directorate of Fisheries footer

## What

* When client side routing, the footer styles get messed up (also see PR: https://github.com/island-is/island.is/pull/14634)

## Why

* Disabling SSR when dynamically importing fixes the isssue

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
