### PR TITLE
feat(web): Pension Calculator - Set latest calculator date as default selection

### DIFF
--- a/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculator.tsx
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculator.tsx
@@ -1186,6 +1186,8 @@ PensionCalculator.getProps = async ({
 
   let defaultValues = convertQueryParametersToCalculationInput(query)
 
+  const dateOfCalculationsOptions = getDateOfCalculationsOptions(customPageData)
+
   defaultValues = {
     ...defaultValues,
     typeOfBasePension: defaultValues.typeOfBasePension
@@ -1194,13 +1196,16 @@ PensionCalculator.getProps = async ({
     typeOfPeriodIncome: defaultValues.typeOfPeriodIncome
       ? defaultValues.typeOfPeriodIncome
       : PeriodIncomeType.Month,
+    dateOfCalculations: defaultValues.dateOfCalculations
+      ? defaultValues.dateOfCalculations
+      : dateOfCalculationsOptions[0].value,
   }
 
   return {
     organizationPage: getOrganizationPage,
     organization: getOrganization,
     defaultValues,
-    dateOfCalculationsOptions: getDateOfCalculationsOptions(customPageData),
+    dateOfCalculationsOptions,
     ...getThemeConfig(
       getOrganizationPage?.theme,
       getOrganizationPage?.organization,


### PR DESCRIPTION
# Pension Calculator - Set latest calculator date as default selection

## Screenshots / Gifs

### Before

![image](https://github.com/island-is/island.is/assets/43557895/dbf49f0c-63a4-4d25-a109-ab3ab80b2ae6)


### After

![image](https://github.com/island-is/island.is/assets/43557895/be86d3b8-4c4b-48a9-bec7-3572d5988a39)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the Pension Calculator with new date options for calculations, providing users with updated choices to tailor their pension forecasts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->