### PR TITLE
fix(contentful-apps): Dynamically import component instead of entire page

### DIFF
--- a/apps/contentful-apps/components/lists/GenericListEditor/GenericListEditor.tsx
+++ b/apps/contentful-apps/components/lists/GenericListEditor/GenericListEditor.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useRef, useState } from 'react'
 import { useDebounce } from 'react-use'
 import { CollectionProp, EntryProps, KeyValueMap } from 'contentful-management'
+import dynamic from 'next/dynamic'
 import { EditorExtensionSDK } from '@contentful/app-sdk'
 import {
   Box,
@@ -16,7 +17,6 @@ import {
 import { PlusIcon } from '@contentful/f36-icons'
 import { useCMA, useSDK } from '@contentful/react-apps-toolkit'
 
-import { ContentfulField } from '../ContentfulField'
 import { mapLocalesToFieldApis } from '../utils'
 
 const SEARCH_DEBOUNCE_TIME_IN_MS = 300
@@ -43,7 +43,16 @@ const createLocaleToFieldMapping = (sdk: EditorExtensionSDK) => {
   }
 }
 
-const GenericListEditor = () => {
+const ContentfulField = dynamic(
+  () =>
+    // Dynamically import via client side rendering since the @contentful/default-field-editors package accesses the window and navigator global objects
+    import('../ContentfulField').then(({ ContentfulField }) => ContentfulField),
+  {
+    ssr: false,
+  },
+)
+
+export const GenericListEditor = () => {
   const sdk = useSDK<EditorExtensionSDK>()
   const cma = useCMA()
 
@@ -244,5 +253,3 @@ const GenericListEditor = () => {
     </Box>
   )
 }
-
-export default GenericListEditor

--- a/apps/contentful-apps/components/lists/GenericListItemEditor/GenericListItemEditor.tsx
+++ b/apps/contentful-apps/components/lists/GenericListItemEditor/GenericListItemEditor.tsx
@@ -1,9 +1,9 @@
 import { useMemo } from 'react'
+import dynamic from 'next/dynamic'
 import { EditorExtensionSDK } from '@contentful/app-sdk'
 import { Box } from '@contentful/f36-components'
 import { useSDK } from '@contentful/react-apps-toolkit'
 
-import { ContentfulField } from '../ContentfulField'
 import { mapLocalesToFieldApis } from '../utils'
 
 const createLocaleToFieldMapping = (sdk: EditorExtensionSDK) => {
@@ -23,7 +23,16 @@ const createLocaleToFieldMapping = (sdk: EditorExtensionSDK) => {
   }
 }
 
-const GenericListItemEditor = () => {
+const ContentfulField = dynamic(
+  () =>
+    // Dynamically import via client side rendering since the @contentful/default-field-editors package accesses the window and navigator global objects
+    import('../ContentfulField').then(({ ContentfulField }) => ContentfulField),
+  {
+    ssr: false,
+  },
+)
+
+export const GenericListItemEditor = () => {
   const sdk = useSDK<EditorExtensionSDK>()
 
   const localeToFieldMapping = useMemo(() => {
@@ -73,5 +82,3 @@ const GenericListItemEditor = () => {
     </Box>
   )
 }
-
-export default GenericListItemEditor

--- a/apps/contentful-apps/pages/editors/generic-list-editor.ts
+++ b/apps/contentful-apps/pages/editors/generic-list-editor.ts
@@ -1,9 +1,3 @@
-import dynamic from 'next/dynamic'
+import { GenericListEditor } from '../../components/lists/GenericListEditor/GenericListEditor'
 
-export default dynamic(
-  () => import('../../components/lists/GenericListEditor/GenericListEditor'),
-  {
-    // Dynamically exported with client side rendering since the @contentful/default-field-editors package accesses the window and navigator global objects
-    ssr: false,
-  },
-)
+export default GenericListEditor

--- a/apps/contentful-apps/pages/editors/generic-list-item-editor.ts
+++ b/apps/contentful-apps/pages/editors/generic-list-item-editor.ts
@@ -1,10 +1,3 @@
-import dynamic from 'next/dynamic'
+import { GenericListItemEditor } from '../../components/lists/GenericListItemEditor/GenericListItemEditor'
 
-export default dynamic(
-  () =>
-    import(
-      '../../components/lists/GenericListItemEditor/GenericListItemEditor'
-    ),
-  // Dynamically exported with client side rendering since the @contentful/default-field-editors package accesses window and navigator global objects
-  { ssr: false },
-)
+export default GenericListItemEditor


### PR DESCRIPTION
# Dynamically import component instead of entire page

## What

* When setting the app url to the deployed service url we only see a blank page
* To address this issue we'll be dynamically importing the component that has a client side dependency (accesses navigator object and more) which'll hopefully allow the app to render properly

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the loading efficiency of components within the app by introducing dynamic imports for key components in the editors.
- **Refactor**
	- Improved the structure and export method of `GenericListEditor` and `GenericListItemEditor` for better maintainability and performance.
- **Chores**
	- Updated import methods in editor pages to streamline component loading and reduce unnecessary dynamic behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->