### PR TITLE
feat(web): Add shortTitle field to organizationSubpage and projectSubpage models

### DIFF
--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -3010,6 +3010,9 @@ export interface IOrganizationSubpageFields {
   /** Title */
   title: string
 
+  /** Short Title */
+  shortTitle?: string | undefined
+
   /** Slug */
   slug: string
 
@@ -3422,6 +3425,9 @@ export interface IProjectPage extends Entry<IProjectPageFields> {
 export interface IProjectSubpageFields {
   /** Title */
   title: string
+
+  /** Short Title */
+  shortTitle?: string | undefined
 
   /** Slug */
   slug: string

--- a/libs/cms/src/lib/models/linkGroup.model.ts
+++ b/libs/cms/src/lib/models/linkGroup.model.ts
@@ -88,7 +88,7 @@ const generateOrganizationSubpageLink = (subpage: IOrganizationSubpage) => {
       },
     },
     fields: {
-      text: subpage.fields.title,
+      text: subpage.fields.shortTitle || subpage.fields.title,
       url: `/${prefix}/${subpage.fields.organizationPage.fields.slug}/${subpage.fields.slug}`,
     },
   })
@@ -112,7 +112,7 @@ const generateProjectSubpageLink = (
       },
     },
     fields: {
-      text: subpage.fields.title,
+      text: subpage.fields.shortTitle || subpage.fields.title,
       url: `/${prefix}/${pageAbove?.fields.slug}/${subpage.fields.slug}`,
     },
   })

--- a/libs/cms/src/lib/models/organizationSubpage.model.ts
+++ b/libs/cms/src/lib/models/organizationSubpage.model.ts
@@ -20,6 +20,9 @@ export class OrganizationSubpage {
   @Field()
   title!: string
 
+  @Field(() => String, { nullable: true })
+  shortTitle?: string
+
   @Field()
   slug!: string
 
@@ -63,6 +66,7 @@ export const mapOrganizationSubpage = ({
 }: IOrganizationSubpage): OrganizationSubpage => ({
   id: sys.id,
   title: fields.title ?? '',
+  shortTitle: fields.shortTitle || fields.title,
   slug: (fields.slug ?? '').trim(),
   url: [fields.organizationPage?.fields?.slug, fields.slug],
   intro: fields.intro ?? '',

--- a/libs/cms/src/lib/models/projectSubpage.model.ts
+++ b/libs/cms/src/lib/models/projectSubpage.model.ts
@@ -16,6 +16,9 @@ export class ProjectSubpage {
   @Field()
   title!: string
 
+  @Field(() => String, { nullable: true })
+  shortTitle?: string
+
   @Field()
   slug!: string
 
@@ -41,6 +44,7 @@ export const mapProjectSubpage = ({
 }: IProjectSubpage): ProjectSubpage => ({
   id: sys.id,
   title: fields.title ?? '',
+  shortTitle: fields.shortTitle || fields.title,
   slug: (fields.slug ?? '').trim(),
   content: fields.content
     ? mapDocument(fields.content, sys.id + ':content')


### PR DESCRIPTION
# Add shortTitle field to organizationSubpage and projectSubpage models

## Why

* To be able to display a shorter title for links to organization subpages or project subpages

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added an optional 'shortTitle' field to organization and project subpages to allow for alternative, shorter titles.
- **Enhancements**
	- Updated link generation for organization and project subpages to prioritize 'shortTitle' when available, with a fallback to the standard 'title'.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->