### PR TITLE
fix(parental-leave): Employer doesn't have access to the application if applicant cancel changes

### DIFF
--- a/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.ts
+++ b/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.ts
@@ -998,6 +998,14 @@ const ParentalLeaveTemplate: ApplicationTemplate<
               target: States.VINNUMALASTOFNUN_APPROVAL,
             },
             {
+              cond: (application) =>
+                goToState(
+                  application,
+                  States.EMPLOYER_WAITING_TO_ASSIGN_FOR_EDITS,
+                ),
+              target: States.EMPLOYER_WAITING_TO_ASSIGN_FOR_EDITS,
+            },
+            {
               target: States.VINNUMALASTOFNUN_APPROVE_EDITS,
             },
           ],
@@ -1009,6 +1017,7 @@ const ParentalLeaveTemplate: ApplicationTemplate<
           'setEmployerReviewerNationalRegistryId',
           'restorePeriodsFromTemp',
           'restoreEmployersFromTemp',
+          'setPreviousState',
         ],
         meta: {
           name: States.EMPLOYER_WAITING_TO_ASSIGN_FOR_EDITS,
@@ -1943,6 +1952,7 @@ const ParentalLeaveTemplate: ApplicationTemplate<
           return context
         }
 
+        console.log('Previous state set to: ' + state)
         set(answers, 'previousState', state)
         return context
       }),


### PR DESCRIPTION
[TS-372](https://dit-iceland.atlassian.net/browse/TS-372)

## What
Make sure the employer has access to the application.

## Why

The employer doesn’t have access to the application if the applicant has done one or more changes to the periods or employers and then cancels his next changes.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
