### PR TITLE
fix(web): Pension calculator, add one to month offset so it matches the frontend

### DIFF
--- a/libs/api/domains/social-insurance/src/lib/utils.ts
+++ b/libs/api/domains/social-insurance/src/lib/utils.ts
@@ -52,11 +52,12 @@ export const mapPensionCalculationInput = (
     typeof input.birthMonth === 'number' &&
     typeof input.birthYear === 'number'
   ) {
-    const birthdate = new Date(input.birthYear, input.birthMonth)
-
     const defaultPensionAge =
       (pageData?.configJson?.['defaultPensionAge'] as number) ?? 67
-    const defaultPensionDate = addYears(birthdate, defaultPensionAge)
+    const defaultPensionDate = addYears(
+      new Date(input.birthYear, input.birthMonth + 1),
+      defaultPensionAge,
+    )
 
     const startDate =
       typeof input.startMonth === 'number' &&


### PR DESCRIPTION
# Pension calculator, add one to month offset so it matches the frontend

## What

* The frontend month offset calculation got changed recently and now we are updating the backend so it matches

## Why

* Otherwise what gets calculated is off by one month

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the accuracy of default pension date calculations based on user's birth year and month.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->