### PR TITLE
fix(native-app): Fixes not to show loading on details screens when offline

### DIFF
--- a/apps/native/app/src/screens/assets/assets-detail.tsx
+++ b/apps/native/app/src/screens/assets/assets-detail.tsx
@@ -52,7 +52,6 @@ export const AssetsDetailScreen: NavigationFunctionComponent<{ item: any }> = ({
           <InputRow>
             <Input
               loading={isLoading}
-              error={isError}
               label={intl.formatMessage({ id: 'assetsDetail.propertyNumber' })}
               value={item?.propertyNumber}
               size="big"
@@ -63,7 +62,6 @@ export const AssetsDetailScreen: NavigationFunctionComponent<{ item: any }> = ({
           <InputRow>
             <Input
               loading={isLoading}
-              error={isError}
               label={intl.formatMessage(
                 { id: 'assetsDetail.activeAppraisal' },
                 { activeYear: appraisal?.activeYear },
@@ -79,7 +77,6 @@ export const AssetsDetailScreen: NavigationFunctionComponent<{ item: any }> = ({
             />
             <Input
               loading={isLoading}
-              error={isError}
               label={intl.formatMessage(
                 { id: 'assetsDetail.plannedAppraisal' },
                 { plannedYear: appraisal?.plannedYear },
@@ -103,7 +100,6 @@ export const AssetsDetailScreen: NavigationFunctionComponent<{ item: any }> = ({
                 <InputRow>
                   <Input
                     loading={isLoading}
-                    error={isError}
                     label={intl.formatMessage({
                       id: 'assetsDetail.explanation',
                     })}
@@ -113,7 +109,6 @@ export const AssetsDetailScreen: NavigationFunctionComponent<{ item: any }> = ({
                   />
                   <Input
                     loading={isLoading}
-                    error={isError}
                     label={intl.formatMessage({
                       id: 'assetsDetail.displaySize',
                     })}
@@ -126,7 +121,6 @@ export const AssetsDetailScreen: NavigationFunctionComponent<{ item: any }> = ({
                 <InputRow>
                   <Input
                     loading={isLoading}
-                    error={isError}
                     label={intl.formatMessage({
                       id: 'assetsDetail.municipality',
                     })}
@@ -136,7 +130,6 @@ export const AssetsDetailScreen: NavigationFunctionComponent<{ item: any }> = ({
                   />
                   <Input
                     loading={isLoading}
-                    error={isError}
                     label={intl.formatMessage({
                       id: 'assetsDetail.postNumber',
                     })}
@@ -150,7 +143,6 @@ export const AssetsDetailScreen: NavigationFunctionComponent<{ item: any }> = ({
                   {unit?.buildYearDisplay ? (
                     <Input
                       loading={isLoading}
-                      error={isError}
                       label={intl.formatMessage({
                         id: 'assetsDetail.buildYearDisplay',
                       })}
@@ -161,7 +153,6 @@ export const AssetsDetailScreen: NavigationFunctionComponent<{ item: any }> = ({
                   ) : null}
                   <Input
                     loading={isLoading}
-                    error={isError}
                     label={intl.formatMessage({ id: 'assetsDetail.marking' })}
                     value={unit?.marking}
                     noBorder

--- a/apps/native/app/src/screens/vehicles/vehicle-mileage.screen.tsx
+++ b/apps/native/app/src/screens/vehicles/vehicle-mileage.screen.tsx
@@ -68,7 +68,6 @@ export const VehicleMileageScreen: NavigationFunctionComponent<{
     },
   })
   const res = useGetVehicleMileageQuery({
-    fetchPolicy: 'cache-and-network',
     variables: {
       input: {
         permno: id,

--- a/apps/native/app/src/screens/vehicles/vehicles-detail.tsx
+++ b/apps/native/app/src/screens/vehicles/vehicles-detail.tsx
@@ -71,7 +71,7 @@ export const VehicleDetailScreen: NavigationFunctionComponent<{
     )
   }
 
-  const inputLoading = loading && data === undefined
+  const inputLoading = loading && !data
 
   return (
     <View style={{ flex: 1 }} testID={testIDs.SCREEN_VEHICLE_DETAIL}>
@@ -80,13 +80,11 @@ export const VehicleDetailScreen: NavigationFunctionComponent<{
           <InputRow>
             <Input
               loading={inputLoading}
-              error={isError}
               label={intl.formatMessage({ id: 'vehicleDetail.regno' })}
               value={mainInfo?.regno}
             />
             <Input
               loading={inputLoading}
-              error={isError}
               label={intl.formatMessage({ id: 'vehicleDetail.permno' })}
               value={basicInfo?.permno}
             />
@@ -94,7 +92,6 @@ export const VehicleDetailScreen: NavigationFunctionComponent<{
           <InputRow>
             <Input
               loading={inputLoading}
-              error={isError}
               label={intl.formatMessage({ id: 'vehicleDetail.firstReg' })}
               value={
                 registrationInfo?.firstRegistrationDate
@@ -106,7 +103,6 @@ export const VehicleDetailScreen: NavigationFunctionComponent<{
             />
             <Input
               loading={inputLoading}
-              error={isError}
               label={intl.formatMessage({ id: 'vehicleDetail.color' })}
               value={registrationInfo?.color}
             />
@@ -114,7 +110,6 @@ export const VehicleDetailScreen: NavigationFunctionComponent<{
           <InputRow>
             <Input
               loading={inputLoading}
-              error={isError}
               label={intl.formatMessage({
                 id: 'vehicleDetail.nextInspectionDate',
               })}
@@ -131,7 +126,6 @@ export const VehicleDetailScreen: NavigationFunctionComponent<{
               <Input
                 noBorder
                 loading={inputLoading}
-                error={isError}
                 label={intl.formatMessage({ id: 'vehicleDetail.odometer' })}
                 value={
                   data?.vehiclesDetail?.lastMileage?.mileage
@@ -168,14 +162,12 @@ export const VehicleDetailScreen: NavigationFunctionComponent<{
           <InputRow>
             <Input
               loading={inputLoading}
-              error={isError}
               label={intl.formatMessage({ id: 'vehicleDetail.vehicleWeight' })}
               value={`${technicalInfo?.vehicleWeight} kg`}
             />
             {technicalInfo?.totalWeight ? (
               <Input
                 loading={inputLoading}
-                error={isError}
                 label={intl.formatMessage({ id: 'vehicleDetail.totalWeight' })}
                 value={`${technicalInfo?.totalWeight ?? '-'} kg`}
               />
@@ -185,7 +177,6 @@ export const VehicleDetailScreen: NavigationFunctionComponent<{
           <InputRow>
             <Input
               loading={inputLoading}
-              error={isError}
               label={intl.formatMessage({ id: 'vehicleDetail.insured' })}
               value={intl.formatMessage(
                 { id: 'vehicleDetail.insuredValue' },
@@ -194,7 +185,6 @@ export const VehicleDetailScreen: NavigationFunctionComponent<{
             />
             <Input
               loading={inputLoading}
-              error={isError}
               label={intl.formatMessage({
                 id: 'vehicleDetail.unpaidVehicleFee',
               })}
@@ -212,7 +202,6 @@ export const VehicleDetailScreen: NavigationFunctionComponent<{
               {mainInfo?.trailerWithBrakesWeight ? (
                 <Input
                   loading={inputLoading}
-                  error={isError}
                   label={intl.formatMessage({
                     id: 'vehicleDetail.trailerWithBrakes',
                   })}
@@ -222,7 +211,6 @@ export const VehicleDetailScreen: NavigationFunctionComponent<{
               {mainInfo?.trailerWithoutBrakesWeight ? (
                 <Input
                   loading={inputLoading}
-                  error={isError}
                   label={intl.formatMessage({
                     id: 'vehicleDetail.trailerWithoutBrakes',
                   })}
@@ -236,7 +224,6 @@ export const VehicleDetailScreen: NavigationFunctionComponent<{
             {technicalInfo?.capacityWeight ? (
               <Input
                 loading={inputLoading}
-                error={isError}
                 label={intl.formatMessage({
                   id: 'vehicleDetail.capacityWeight',
                 })}
@@ -246,7 +233,6 @@ export const VehicleDetailScreen: NavigationFunctionComponent<{
             {mainInfo?.co2 ? (
               <Input
                 loading={inputLoading}
-                error={isError}
                 label={intl.formatMessage({ id: 'vehicleDetail.nedc' })}
                 value={`${mainInfo?.co2 ?? 0} g/km`}
               />


### PR DESCRIPTION
# Fixes not to show loading on details screens when offline

## What

Assets and vehicles details screens where showing loading instead of cached data in offline mode.
The reason was the error prop in the input that was not doing anything and is currently broken.
It should display a red skeleton in stead which is still a bad UX for the user. 

We will update those screens once the proper error handling UX/UI components are ready.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling in the `AssetsDetailScreen` and `VehicleDetailScreen` by removing redundant error props from input fields.
  - Enhanced data fetching strategy in `VehicleMileageScreen` for better performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->