### PR TITLE
fix(regulations-admin): Only display modal on amending regs

### DIFF
--- a/libs/portals/admin/regulations-admin/src/components/EditBasics.tsx
+++ b/libs/portals/admin/regulations-admin/src/components/EditBasics.tsx
@@ -227,7 +227,10 @@ export const EditBasics = () => {
         </Accordion>
         {!hasUpdated ? (
           <ConfirmModal
-            isVisible={isModalVisible}
+            isVisible={
+              draft.type.value === RegulationDraftTypes.amending &&
+              isModalVisible
+            }
             title="Uppfæra texta"
             message={
               'Uppfæra texta reglugerðar með breytingum frá fyrsta skrefi. Allur viðbættur texti í núverandi skrefi verður hreinsaður út.'


### PR DESCRIPTION
## What

Only display modal if regulation is amending

## Why

Base regulations need no modal for text update, there is no text to diff from 🤷 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Updated modal visibility condition in the EditBasics component to display only when the draft type is set to "amending".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->