### PR TITLE
chore(web): Add handle_all_urls to assetlinks [HOTFIX]

### DIFF
--- a/apps/web/public/.well-known/assetlinks.json
+++ b/apps/web/public/.well-known/assetlinks.json
@@ -1,6 +1,6 @@
 [
   {
-    "relation" : [
+    "relation": [
       "delegate_permission/common.handle_all_urls",
       "delegate_permission/common.get_login_creds"
     ],
@@ -14,7 +14,7 @@
     }
   },
   {
-    "relation" : [
+    "relation": [
       "delegate_permission/common.handle_all_urls",
       "delegate_permission/common.get_login_creds"
     ],

--- a/apps/web/public/.well-known/assetlinks.json
+++ b/apps/web/public/.well-known/assetlinks.json
@@ -1,6 +1,9 @@
 [
   {
-    "relation": ["delegate_permission/common.get_login_creds"],
+    "relation" : [
+      "delegate_permission/common.handle_all_urls",
+      "delegate_permission/common.get_login_creds"
+    ],
     "target": {
       "namespace": "android_app",
       "package_name": "is.island.app",
@@ -11,7 +14,10 @@
     }
   },
   {
-    "relation": ["delegate_permission/common.get_login_creds"],
+    "relation" : [
+      "delegate_permission/common.handle_all_urls",
+      "delegate_permission/common.get_login_creds"
+    ],
     "target": {
       "namespace": "android_app",
       "package_name": "is.island.app.dev",


### PR DESCRIPTION
## What

See title

## Why

Apparently this might be needed to share sign-in credentials between the website and app. The goal is to register and use island.is passkeys in the app. Android needs to validate that the domain allows this.