### PR TITLE
fix(island-ui): Error state in Input component

### DIFF
--- a/libs/island-ui/core/src/lib/Input/Input.mixins.ts
+++ b/libs/island-ui/core/src/lib/Input/Input.mixins.ts
@@ -221,7 +221,6 @@ export const errorMessage = {
 
 export const inputErrorState = {
   boxShadow: `inset 0 0 0 1px ${theme.color.red600}`,
-  backgroundColor: theme.color.red100,
 }
 
 // For elements where the


### PR DESCRIPTION
# Error state in Input component

## What

#14793 had a code change where `background-color` was set on the `before` element on input's that have an error. The background color overtakes the rest of the input, making this a bug.

## Screenshots / Gifs


Uploading Screen Recording 2024-05-16 at 12.59.59.mov…



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the styling of input error states by removing the red background color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->