### PR TITLE
fix(j-s): Use prosecutor instead of prosecutorPerson

### DIFF
--- a/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.tsx
+++ b/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { FC, PropsWithChildren } from 'react'
 import { IntlShape, useIntl } from 'react-intl'
 import flatMap from 'lodash/flatMap'
 
@@ -21,7 +21,7 @@ import { TempCase as Case } from '@island.is/judicial-system-web/src/types'
 
 import { strings } from './CaseInfo.strings'
 
-const PoliceCaseNumbersTags: React.FC<{
+const PoliceCaseNumbersTags: FC<{
   policeCaseNumbers?: string[] | null
 }> = ({ policeCaseNumbers }) => (
   <Box display="flex" flexWrap="wrap">
@@ -33,9 +33,10 @@ const PoliceCaseNumbersTags: React.FC<{
   </Box>
 )
 
-const Entry: React.FC<
-  React.PropsWithChildren<{ label: string; value: string }>
-> = ({ label, value }) => {
+const Entry: FC<PropsWithChildren<{ label: string; value: string }>> = ({
+  label,
+  value,
+}) => {
   return (
     <Text color="dark400" fontWeight="semiBold" paddingTop={'smallGutter'}>
       {`${label}: ${value}`}
@@ -67,9 +68,7 @@ interface Props {
   workingCase: Case
 }
 
-export const Defendants: React.FC<React.PropsWithChildren<Props>> = ({
-  workingCase,
-}) => {
+export const Defendants: FC<PropsWithChildren<Props>> = ({ workingCase }) => {
   const { defendants, type } = workingCase
   const { formatMessage } = useIntl()
 
@@ -86,18 +85,18 @@ export const Defendants: React.FC<React.PropsWithChildren<Props>> = ({
   )
 }
 
-export const Prosecutor: React.FC<Props> = ({ workingCase }) => {
+export const Prosecutor: FC<Props> = ({ workingCase }) => {
   const { formatMessage } = useIntl()
   return (
     <Entry
-      label={formatMessage(core.prosecutorPerson)}
+      label={formatMessage(core.prosecutor)}
       value={workingCase.prosecutorsOffice?.name ?? ''}
     />
   )
 }
 
-export const ProsecutorCaseInfo: React.FC<
-  React.PropsWithChildren<Props & { hideCourt?: boolean }>
+export const ProsecutorCaseInfo: FC<
+  PropsWithChildren<Props & { hideCourt?: boolean }>
 > = ({ workingCase, hideCourt = false }) => {
   const { policeCaseNumbers, court } = workingCase
   const { formatMessage } = useIntl()
@@ -115,7 +114,7 @@ export const ProsecutorCaseInfo: React.FC<
   )
 }
 
-export const CourtCaseInfo: React.FC<React.PropsWithChildren<Props>> = ({
+export const CourtCaseInfo: FC<PropsWithChildren<Props>> = ({
   workingCase,
 }) => {
   const { formatMessage } = useIntl()


### PR DESCRIPTION
# Use prosecutor instead of prosecutorPerson

[Asana](https://app.asana.com/0/1199153462262248/1207203926442896/f)

## What

On the newly created Summary page in indictments, we show who is the prosecutor in the indictment. We accidentally used prosecutorPerson (Sækjandi) instead of prosecutor (Sóknaraðili). This has now been fixed

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated component declarations to improve type safety and consistency.
  - Adjusted labels within various components for better clarity and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->