### PR TITLE
fix(documents-v2): Add filetype fallback

### DIFF
--- a/libs/clients/documents-v2/src/lib/dto/document.dto.ts
+++ b/libs/clients/documents-v2/src/lib/dto/document.dto.ts
@@ -16,6 +16,7 @@ export type DocumentDto = {
 }
 
 export const mapToDocument = (document: DocumentDTO): DocumentDto | null => {
+  console.log('MAP TO CONTENT: ', document)
   let fileType: FileType, content: string
   switch (document.fileType) {
     case 'pdf':
@@ -40,6 +41,17 @@ export const mapToDocument = (document: DocumentDTO): DocumentDto | null => {
       content = document.url
       break
     default:
+      // Some document providers can not explicitly set the fileType so we have to guess the fileType by checking for the content, in case the fileType is not set.
+      if (document.htmlContent) {
+        fileType = 'html'
+        content = document.htmlContent
+        break
+      }
+      if (document.url) {
+        fileType = 'url'
+        content = document.url
+        break
+      }
       return null
   }
 

--- a/libs/clients/documents-v2/src/lib/dto/document.dto.ts
+++ b/libs/clients/documents-v2/src/lib/dto/document.dto.ts
@@ -16,7 +16,6 @@ export type DocumentDto = {
 }
 
 export const mapToDocument = (document: DocumentDTO): DocumentDto | null => {
-  console.log('MAP TO CONTENT: ', document)
   let fileType: FileType, content: string
   switch (document.fileType) {
     case 'pdf':


### PR DESCRIPTION
## What

Add fallback for no set `fileType` in document-v2 service

## Why

Some document providers can not explicitly set the `fileType` so we have to guess the `fileType` by checking for the content, in case the `fileType` is not set

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced document handling to automatically guess `fileType` based on content or URL when not explicitly set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->