### PR TITLE
fix: revert chore upgrade sequelize (#14744)

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -8,3 +8,4 @@ bootstrap({
   stripNonClassValidatorInputs: false,
   jsonBodyLimit: '300kb',
 })
+// Force deploy

--- a/package.json
+++ b/package.json
@@ -222,7 +222,7 @@
     "node-gyp": "9.1.0",
     "node-html-markdown": "1.3.0",
     "nodemailer": "6.7.2",
-    "oidc-client-ts": "2.4.0",
+    "oidc-client-ts": "2.0.3",
     "openapi3-ts": "2.0.0",
     "opossum": "6.1.0",
     "passport": "0.6.0",
@@ -270,7 +270,7 @@
     "rosetta": "1.0.0",
     "rxjs": "7.8.1",
     "sanitize-html": "2.10.0",
-    "sequelize": "6.29.0",
+    "sequelize": "6.19.0",
     "sequelize-replace-enum-postgres": "1.6.0",
     "sequelize-typescript": "2.1.3",
     "short-unique-id": "5.0.3",
@@ -459,7 +459,6 @@
     "webpack-bundle-analyzer": "4.5.0"
   },
   "resolutions": {
-    "dottie": "2.0.4",
     "marked": "2.0.0",
     "elliptic": "6.5.4",
     "ssri": "8.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25511,7 +25511,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"crypto-js@npm:4.2.0, crypto-js@npm:^4.0.0, crypto-js@npm:^4.2.0":
+"crypto-js@npm:4.2.0, crypto-js@npm:^4.0.0, crypto-js@npm:^4.1.1":
   version: 4.2.0
   resolution: "crypto-js@npm:4.2.0"
   checksum: f051666dbc077c8324777f44fbd3aaea2986f198fe85092535130d17026c7c2ccf2d23ee5b29b36f7a4a07312db2fae23c9094b644cc35f7858b1b4fcaf27774
@@ -27323,10 +27323,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dottie@npm:2.0.4":
-  version: 2.0.4
-  resolution: "dottie@npm:2.0.4"
-  checksum: 9d25445a446f781aae275d36d3c88a6a94d4d8acf15403aa93f4118bcfc6547a5d7c71f9c533da6c6af5a55ffd2f0b3915999ecd80bb6bf447e476ff2be47cff
+"dottie@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "dottie@npm:2.0.2"
+  checksum: 046a5818033725a5a12b60270473cd9a19b0e88bd007a0c9a66be36983e53626de949aee9d0290fbfe0275aa31837491adbbbb8bf74ef09f78d21598793d6268
   languageName: node
   linkType: hard
 
@@ -34411,7 +34411,7 @@ __metadata:
     node-html-markdown: 1.3.0
     nodemailer: 6.7.2
     nx: 16.9.0
-    oidc-client-ts: 2.4.0
+    oidc-client-ts: 2.0.3
     openapi3-ts: 2.0.0
     opossum: 6.1.0
     passport: 0.6.0
@@ -34460,7 +34460,7 @@ __metadata:
     rosetta: 1.0.0
     rxjs: 7.8.1
     sanitize-html: 2.10.0
-    sequelize: 6.29.0
+    sequelize: 6.19.0
     sequelize-cli: 6.4.1
     sequelize-replace-enum-postgres: 1.6.0
     sequelize-typescript: 2.1.3
@@ -39785,26 +39785,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"moment-timezone@npm:^0.5.35":
-  version: 0.5.45
-  resolution: "moment-timezone@npm:0.5.45"
+"moment-timezone@npm:^0.5.34":
+  version: 0.5.34
+  resolution: "moment-timezone@npm:0.5.34"
   dependencies:
-    moment: ^2.29.4
-  checksum: a22e9f983fbe1a01757ce30685bce92e3f6efa692eb682afd47b82da3ff960b3c8c2c3883ec6715c124bc985a342b57cba1f6ba25a1c8b4c7ad766db3cd5e1d0
+    moment: ">= 2.9.0"
+  checksum: 12a1d3d52e4ba509cf1fa36bbda59d898a08fa80ab35f6c358747e93aec1f07e617cec647eaf2e8acf5f9132e581d4704d34a9edffa9a80c5cd04bf23b277595
   languageName: node
   linkType: hard
 
-"moment@npm:^2.18.1, moment@npm:^2.20.0, moment@npm:^2.22.2, moment@npm:^2.29.1":
+"moment@npm:>= 2.9.0, moment@npm:^2.18.1, moment@npm:^2.20.0, moment@npm:^2.22.2, moment@npm:^2.29.1":
   version: 2.29.4
   resolution: "moment@npm:2.29.4"
   checksum: 0ec3f9c2bcba38dc2451b1daed5daded747f17610b92427bebe1d08d48d8b7bdd8d9197500b072d14e326dd0ccf3e326b9e3d07c5895d3d49e39b6803b76e80e
-  languageName: node
-  linkType: hard
-
-"moment@npm:^2.29.4":
-  version: 2.30.1
-  resolution: "moment@npm:2.30.1"
-  checksum: 859236bab1e88c3e5802afcf797fc801acdbd0ee509d34ea3df6eea21eb6bcc2abd4ae4e4e64aa7c986aa6cba563c6e62806218e6412a765010712e5fa121ba6
   languageName: node
   linkType: hard
 
@@ -41292,13 +41285,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"oidc-client-ts@npm:2.4.0":
-  version: 2.4.0
-  resolution: "oidc-client-ts@npm:2.4.0"
+"oidc-client-ts@npm:2.0.3":
+  version: 2.0.3
+  resolution: "oidc-client-ts@npm:2.0.3"
   dependencies:
-    crypto-js: ^4.2.0
+    crypto-js: ^4.1.1
     jwt-decode: ^3.1.2
-  checksum: 8467db689298221f706d3358961efb0ddc789f6bd7d4765e71ae5fe62067999d2ce6e8e7584b9d991b8caa6f7fb383f75841e1cfa9e05808c34632de374f5e68
+  checksum: 84becba2400fcfadf83b445d1b54d9f48df9669f46c5f7209180040d54dd8c31bb45bf99100bb19fe5648d6eb32a9ad6dcd86974d81916be3d89ea4c026095d8
   languageName: node
   linkType: hard
 
@@ -46396,10 +46389,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"retry-as-promised@npm:^7.0.3":
-  version: 7.0.4
-  resolution: "retry-as-promised@npm:7.0.4"
-  checksum: 2b0dcddb06649d42b1384ec1f933c7cb4461939c28004460b0c4be0c8ae16cabaed2411aa5d46e734a320f33f4a1d480078a19b97c743c754bd32e896b3f8ea2
+"retry-as-promised@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "retry-as-promised@npm:5.0.0"
+  checksum: 4d17e0597f967db0516714f0f2b085e2d1e8ea592450b013a1e0cd41dad74a9c3d1eb3c45351887de4bca1c3ac5f74dd07ef9942a3fb0e4db996a83bb28cb46e
   languageName: node
   linkType: hard
 
@@ -47123,9 +47116,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sequelize@npm:6.29.0":
-  version: 6.29.0
-  resolution: "sequelize@npm:6.29.0"
+"sequelize@npm:6.19.0":
+  version: 6.19.0
+  resolution: "sequelize@npm:6.19.0"
   dependencies:
     "@types/debug": ^4.1.7
     "@types/validator": ^13.7.1
@@ -47134,9 +47127,9 @@ __metadata:
     inflection: ^1.13.2
     lodash: ^4.17.21
     moment: ^2.29.1
-    moment-timezone: ^0.5.35
+    moment-timezone: ^0.5.34
     pg-connection-string: ^2.5.0
-    retry-as-promised: ^7.0.3
+    retry-as-promised: ^5.0.0
     semver: ^7.3.5
     sequelize-pool: ^7.1.0
     toposort-class: ^1.0.1
@@ -47150,8 +47143,6 @@ __metadata:
       optional: true
     mysql2:
       optional: true
-    oracledb:
-      optional: true
     pg:
       optional: true
     pg-hstore:
@@ -47162,7 +47153,7 @@ __metadata:
       optional: true
     tedious:
       optional: true
-  checksum: 3b25ef91cdf828f987deca28d5b46a5771b225687485b2f34c7a0e85269952fb7bf26cf689d1e32c94908238d6968fbab4694350407f56820f879769339c62b6
+  checksum: e1faa389fe8bf4e58f4781763d313e6a28b5cf8376f9c34ba6a6af9f158a309d8fa30277706bbee004caa8068a5f3030cf1620735a2d9f84a33f204ab2dae2f2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This reverts commit 414bcb24782c081f7e54864ab4b4450ab0141df1.

# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
  - Downgraded `oidc-client-ts` dependency for improved compatibility.
  - Downgraded `sequelize` dependency to ensure stability.
  - Removed `dottie` dependency to reduce unused packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->