### PR TITLE
fix(service-portal): remove fixed color and use currentColor for icon

### DIFF
--- a/libs/island-ui/core/src/lib/IconRC/icons/HomeWithCar.tsx
+++ b/libs/island-ui/core/src/lib/IconRC/icons/HomeWithCar.tsx
@@ -16,19 +16,19 @@ const SvgHome = ({
       {title ? <title id={titleId}>{title}</title> : null}
       <path
         fill="none"
-        stroke="#0061ff"
+        stroke="currentColor"
         strokeLinecap="round"
         strokeLinejoin="round"
         strokeWidth={1.5}
         d="m12.78 19.705 1.45-3.384c.236-.551.838-.916 1.51-.916h7.594c.673 0 1.274.365 1.51.916l1.45 3.384m-13.515 0h13.516m-13.516 0v5.53m13.516-5.53v5.53m-13.516 0h13.516m-13.516 0v1.228h1.229v-1.229m12.287 0v1.229h-1.229v-1.229"
       />
       <path
-        fill="#0061ff"
+        fill="currentColor"
         d="M15.677 23.656a1.054 1.054 0 1 0 0-2.108 1.054 1.054 0 0 0 0 2.108ZM23.558 23.656a1.054 1.054 0 1 0 0-2.108 1.054 1.054 0 0 0 0 2.108Z"
       />
       <g
         fill="none"
-        stroke="#0061ff"
+        stroke="currentColor"
         strokeLinecap="round"
         strokeLinejoin="round"
         strokeWidth={1.5}
@@ -43,7 +43,7 @@ const SvgHome = ({
       <path
         id="ebYEDB473Vf10"
         fill="none"
-        stroke="#0061ff"
+        stroke="currentColor"
         strokeDasharray={8}
         strokeDashoffset={8}
         strokeLinecap="round"

--- a/libs/island-ui/core/src/lib/IconRC/icons/HomeWithCarOutline.tsx
+++ b/libs/island-ui/core/src/lib/IconRC/icons/HomeWithCarOutline.tsx
@@ -20,18 +20,18 @@ const SvgHomeOutline = ({
         <path
           d="M12.7793,19.7052l1.4506-3.3847c.2362-.5509.8379-.9157,1.5102-.9157h7.5941c.6723,0,1.274.3648,1.5101.9157l1.4506,3.3847m-13.5156,0h13.5156m-13.5156,0v5.5291m13.5156-5.5291v5.5291m-13.5156,0h13.5156m-13.5156,0v1.2287h1.2287v-1.2287m12.2869,0v1.2287h-1.2286v-1.2287"
           fill="none"
-          stroke="#0044b3"
+          stroke="currentColor"
           strokeWidth="1.5"
           strokeLinecap="round"
           strokeLinejoin="round"
         />
         <path
           d="M15.6767,23.6559c.582,0,1.0538-.4718,1.0538-1.0538s-.4718-1.0538-1.0538-1.0538-1.0537.4718-1.0537,1.0538.4718,1.0538,1.0537,1.0538Z"
-          fill="#0044b3"
+          fill="currentColor"
         />
         <path
           d="M23.5577,23.6559c.582,0,1.0538-.4718,1.0538-1.0538s-.4718-1.0538-1.0538-1.0538-1.0538.4718-1.0538,1.0538.4718,1.0538,1.0538,1.0538Z"
-          fill="#0044b3"
+          fill="currentColor"
         />
       </g>
       <g>
@@ -39,7 +39,7 @@ const SvgHomeOutline = ({
           id="ebYEDB473Vf7"
           d="M7.75,25v-11.0625"
           fill="none"
-          stroke="#0044b3"
+          stroke="currentColor"
           strokeWidth="1.5"
           strokeLinecap="round"
           strokeLinejoin="round"
@@ -48,7 +48,7 @@ const SvgHomeOutline = ({
           id="ebYEDB473Vf8"
           d="M5.5,16l9.9895-9.56253c.2344-.2475.7824-.25031,1.021,0L23,12.927"
           fill="none"
-          stroke="#0044b3"
+          stroke="currentColor"
           strokeWidth="1.5"
           strokeLinecap="round"
           strokeLinejoin="round"
@@ -57,7 +57,7 @@ const SvgHomeOutline = ({
           id="ebYEDB473Vf9"
           d="M9.25,12.3906L9.25,7h2.25v3.2344"
           fill="none"
-          stroke="#0044b3"
+          stroke="currentColor"
           strokeWidth="1.5"
           strokeLinecap="round"
           strokeLinejoin="round"
@@ -67,7 +67,7 @@ const SvgHomeOutline = ({
         id="ebYEDB473Vf10"
         d="M10.8937,6.76582c-2.72886-1.29005,1.9066-3.22779-.6517-4.9842"
         fill="none"
-        stroke="#0044b3"
+        stroke="currentColor"
         strokeWidth="1.5"
         strokeLinecap="round"
         strokeLinejoin="round"


### PR DESCRIPTION
# Service Portal - Remove color and use current color

Icons should not have fixed color, instead use current color. 

Fixing "HomeWithCar" icon.

![Screenshot 2024-05-21 at 14 47 15](https://github.com/island-is/island.is/assets/19873770/e6f4166d-0a65-4df1-a023-0352df93c8b4)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
