### PR TITLE
fix(regulations): add color to link in appendixes

### DIFF
--- a/libs/regulations/src/lib/styling.ts
+++ b/libs/regulations/src/lib/styling.ts
@@ -79,8 +79,11 @@ export const regulationContentStyling = (wrapper: string) => {
   styleRegulation('p,ul,ol,pre,table,blockquote', {
     fontFamily: 'inherit',
     marginBottom: typography.baseLineHeight + 'em',
-
     '@media': { print: { marginBottom: '.5em' } },
+  })
+
+  styleRegulation('a', {
+    color: theme.color.blue400,
   })
 
   styleRegulation(


### PR DESCRIPTION
## What

* Links in appendix content have color now

## Why

To distinguish from regular text

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
