### PR TITLE
feat(web): Clickable generic list items

### DIFF
--- a/apps/contentful-apps/constants/index.ts
+++ b/apps/contentful-apps/constants/index.ts
@@ -5,3 +5,8 @@ export const DEV_WEB_BASE_URL = 'https://beta.dev01.devland.is'
 
 export const TITLE_SEARCH_POSTFIX = '--title-search'
 export const SLUGIFIED_POSTFIX = '--slugified'
+
+export const CUSTOM_SLUGIFY_REPLACEMENTS: ReadonlyArray<[string, string]> = [
+  ['ö', 'o'],
+  ['þ', 'th'],
+]

--- a/apps/contentful-apps/pages/fields/event-slug-field.tsx
+++ b/apps/contentful-apps/pages/fields/event-slug-field.tsx
@@ -5,14 +5,7 @@ import { TextInput } from '@contentful/f36-components'
 import { useSDK } from '@contentful/react-apps-toolkit'
 import slugify from '@sindresorhus/slugify'
 
-const slugifyDate = (value: string) => {
-  try {
-    const date = new Date(value)
-    return `${date.getDate()}-${date.getMonth() + 1}-${date.getFullYear()}`
-  } catch {
-    return ''
-  }
-}
+import { slugifyDate } from '../../utils'
 
 const EventSlugField = () => {
   const sdk = useSDK<FieldExtensionSDK>()

--- a/apps/contentful-apps/pages/fields/generic-list-item-slug-field.tsx
+++ b/apps/contentful-apps/pages/fields/generic-list-item-slug-field.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useState } from 'react'
+import { useDebounce } from 'react-use'
+import type { FieldExtensionSDK } from '@contentful/app-sdk'
+import { Stack, Text, TextInput } from '@contentful/f36-components'
+import { useCMA, useSDK } from '@contentful/react-apps-toolkit'
+import slugify from '@sindresorhus/slugify'
+
+import { CUSTOM_SLUGIFY_REPLACEMENTS } from '../../constants'
+import { slugifyDate } from '../../utils'
+
+const DEBOUNCE_TIME = 100
+
+const GenericListItemSlugField = () => {
+  const sdk = useSDK<FieldExtensionSDK>()
+  const cma = useCMA()
+
+  const [genericList, setGenericList] = useState(null)
+  const [hasEntryBeenPublished, setHasEntryBeenPublished] = useState(
+    Boolean(sdk.entry.getSys()?.firstPublishedAt),
+  )
+
+  const [value, setValue] = useState(sdk.field.getValue() ?? '')
+  const [isValid, setIsValid] = useState(true)
+
+  useEffect(() => {
+    sdk.entry.onSysChanged((newSys) => {
+      setHasEntryBeenPublished(Boolean(newSys?.firstPublishedAt))
+    })
+  }, [sdk.entry])
+
+  useEffect(() => {
+    const unsubscribe = sdk.entry.fields.genericList.onValueChanged(
+      (updatedList) => {
+        if (updatedList?.sys?.id) {
+          cma.entry
+            .get({
+              entryId: updatedList.sys.id,
+            })
+            .then(setGenericList)
+        } else {
+          setGenericList(null)
+        }
+      },
+    )
+
+    return unsubscribe
+  }, [cma.entry, sdk.entry.fields.genericList])
+
+  useEffect(() => {
+    sdk.window.startAutoResizer()
+  }, [sdk.window])
+
+  useEffect(() => {
+    const unsubscribeFromTitleValueChanges = sdk.entry.fields.title
+      .getForLocale(sdk.field.locale)
+      .onValueChanged((newTitle) => {
+        if (!newTitle || hasEntryBeenPublished) {
+          return
+        }
+        const date = sdk.entry.fields.date.getValue()
+        setValue(
+          `${slugify(newTitle, {
+            customReplacements: CUSTOM_SLUGIFY_REPLACEMENTS,
+          })}${date ? '-' + slugifyDate(date) : ''}`,
+        )
+      })
+
+    const unsubscribeFromDateValueChanges =
+      sdk.entry.fields.date.onValueChanged((newDate) => {
+        const date = newDate
+        const title = sdk.entry.fields.title
+          .getForLocale(sdk.field.locale)
+          .getValue()
+        if (!title || hasEntryBeenPublished) {
+          return
+        }
+        setValue(
+          `${slugify(title, {
+            customReplacements: CUSTOM_SLUGIFY_REPLACEMENTS,
+          })}${date ? '-' + slugifyDate(date) : ''}`,
+        )
+      })
+
+    return () => {
+      unsubscribeFromTitleValueChanges()
+      unsubscribeFromDateValueChanges()
+    }
+  }, [
+    hasEntryBeenPublished,
+    sdk.entry.fields.date,
+    sdk.entry.fields.title,
+    sdk.field.locale,
+  ])
+
+  useDebounce(
+    async () => {
+      const genericListId = sdk.entry.fields.genericList.getValue()?.sys?.id
+      if (!genericListId || !value) {
+        return
+      }
+      const itemsInSameListWithSameSlug =
+        (
+          await cma.entry.getMany({
+            environmentId: sdk.ids.environment,
+            spaceId: sdk.ids.space,
+            query: {
+              locale: sdk.field.locale,
+              content_type: 'genericListItem',
+              'fields.slug': value,
+              'sys.id[ne]': sdk.entry.getSys().id,
+              'sys.archivedVersion[exists]': false,
+              'fields.genericList.sys.id': genericListId,
+            },
+          })
+        )?.items ?? []
+      console.log('eee', itemsInSameListWithSameSlug, value)
+      setIsValid(itemsInSameListWithSameSlug.length <= 0)
+    },
+    DEBOUNCE_TIME,
+    [value],
+  )
+
+  useDebounce(
+    () => {
+      if (isValid) {
+        sdk.field.setValue(value)
+      } else {
+        sdk.field.setValue(null) // Set to null to prevent entry publish
+      }
+      sdk.field.setInvalid(!isValid)
+    },
+    DEBOUNCE_TIME,
+    [isValid, value],
+  )
+
+  if (
+    genericList &&
+    genericList?.fields?.itemType?.[sdk.locales.default] !== 'Clickable'
+  ) {
+    return (
+      <Text>
+        Slug can only be changed if the list item type is {`"Clickable"`}
+      </Text>
+    )
+  }
+
+  const isInvalid = value.length === 0 || !isValid
+
+  return (
+    <Stack spacing="spacingXs" flexDirection="column" alignItems="flex-start">
+      <TextInput
+        value={value}
+        onChange={(ev) => {
+          setValue(ev.target.value)
+        }}
+        isInvalid={isInvalid}
+      />
+      {value.length === 0 && sdk.field.locale === sdk.locales.default && (
+        <Text fontColor="red400">Invalid slug</Text>
+      )}
+      {value.length > 0 && isInvalid && (
+        <Text fontColor="red400">Item already exists with this slug</Text>
+      )}
+    </Stack>
+  )
+}
+
+export default GenericListItemSlugField

--- a/apps/contentful-apps/utils/index.ts
+++ b/apps/contentful-apps/utils/index.ts
@@ -60,3 +60,13 @@ export const parseContentfulErrorMessage = (error: unknown) => {
   }
   return errorMessage
 }
+
+export const slugifyDate = (value: string) => {
+  if (!value) return ''
+  try {
+    const date = new Date(value)
+    return `${date.getDate()}-${date.getMonth() + 1}-${date.getFullYear()}`
+  } catch {
+    return ''
+  }
+}

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -1539,6 +1539,9 @@ export interface IGenericListFields {
 
   /** Search Input Placeholder */
   searchInputPlaceholder: string
+
+  /** Item Type */
+  itemType?: 'Non-clickable' | 'Clickable' | undefined
 }
 
 /** A list of items which can be embedded into rich text */
@@ -1575,6 +1578,12 @@ export interface IGenericListItemFields {
 
   /** Card Intro */
   cardIntro?: Document | undefined
+
+  /** Content */
+  content?: Document | undefined
+
+  /** Slug */
+  slug?: string | undefined
 }
 
 /** An item that belongs to a generic list */

--- a/libs/cms/src/lib/models/genericList.model.ts
+++ b/libs/cms/src/lib/models/genericList.model.ts
@@ -1,10 +1,19 @@
-import { Field, ID, ObjectType } from '@nestjs/graphql'
+import { Field, ID, ObjectType, registerEnumType } from '@nestjs/graphql'
 import { ElasticsearchIndexLocale } from '@island.is/content-search-index-manager'
 import { SystemMetadata } from '@island.is/shared/types'
 import { CacheField } from '@island.is/nest/graphql'
-import { IGenericList } from '../generated/contentfulTypes'
+import { IGenericList, IGenericListFields } from '../generated/contentfulTypes'
 import { GenericListItemResponse } from './genericListItemResponse.model'
 import { GetGenericListItemsInput } from '../dto/getGenericListItems.input'
+
+enum GenericListItemType {
+  NonClickable = 'NonClickable',
+  Clickable = 'Clickable',
+}
+
+registerEnumType(GenericListItemType, {
+  name: 'GenericListItemType',
+})
 
 @ObjectType()
 export class GenericList {
@@ -16,7 +25,15 @@ export class GenericList {
 
   @Field(() => String, { nullable: true })
   searchInputPlaceholder?: string
+
+  @CacheField(() => GenericListItemType, { nullable: true })
+  itemType?: GenericListItemType
 }
+
+const mapItemType = (itemType?: IGenericListFields['itemType']) =>
+  itemType === 'Clickable'
+    ? GenericListItemType.Clickable
+    : GenericListItemType.NonClickable
 
 export const mapGenericList = ({
   fields,
@@ -31,4 +48,5 @@ export const mapGenericList = ({
     page: 1,
   },
   searchInputPlaceholder: fields.searchInputPlaceholder,
+  itemType: mapItemType(fields.itemType),
 })

--- a/libs/cms/src/lib/models/genericListItem.model.ts
+++ b/libs/cms/src/lib/models/genericListItem.model.ts
@@ -20,21 +20,45 @@ export class GenericListItem {
 
   @CacheField(() => [SliceUnion])
   cardIntro: Array<typeof SliceUnion> = []
+
+  @CacheField(() => [SliceUnion], { nullable: true })
+  content?: Array<typeof SliceUnion>
+
+  @Field(() => String, { nullable: true })
+  slug?: string
+}
+
+const slugifyDate = (value: string | null) => {
+  if (!value) return ''
+  try {
+    const date = new Date(value)
+    return `${date.getDate()}-${date.getMonth() + 1}-${date.getFullYear()}`
+  } catch {
+    return ''
+  }
 }
 
 export const mapGenericListItem = ({
   fields,
   sys,
 }: IGenericListItem): GenericListItem => {
+  const date = fields.date || null
+  const slugifiedDate = slugifyDate(date)
   return {
     id: sys.id,
     genericList: fields.genericList
       ? mapGenericList(fields.genericList)
       : undefined,
     title: fields.title ?? '',
-    date: fields.date || null,
+    date,
     cardIntro: fields.cardIntro
       ? mapDocument(fields.cardIntro, sys.id + ':cardIntro')
       : [],
+    content: fields.content
+      ? mapDocument(fields.content, sys.id + ':content')
+      : [],
+    slug: fields.slug
+      ? `${fields.slug}${slugifiedDate ? '-' : ''}${slugifiedDate}`
+      : fields.slug,
   }
 }

--- a/libs/cms/src/lib/models/genericListItem.model.ts
+++ b/libs/cms/src/lib/models/genericListItem.model.ts
@@ -28,37 +28,21 @@ export class GenericListItem {
   slug?: string
 }
 
-const slugifyDate = (value: string | null) => {
-  if (!value) return ''
-  try {
-    const date = new Date(value)
-    return `${date.getDate()}-${date.getMonth() + 1}-${date.getFullYear()}`
-  } catch {
-    return ''
-  }
-}
-
 export const mapGenericListItem = ({
   fields,
   sys,
-}: IGenericListItem): GenericListItem => {
-  const date = fields.date || null
-  const slugifiedDate = slugifyDate(date)
-  return {
-    id: sys.id,
-    genericList: fields.genericList
-      ? mapGenericList(fields.genericList)
-      : undefined,
-    title: fields.title ?? '',
-    date,
-    cardIntro: fields.cardIntro
-      ? mapDocument(fields.cardIntro, sys.id + ':cardIntro')
-      : [],
-    content: fields.content
-      ? mapDocument(fields.content, sys.id + ':content')
-      : [],
-    slug: fields.slug
-      ? `${fields.slug}${slugifiedDate ? '-' : ''}${slugifiedDate}`
-      : fields.slug,
-  }
-}
+}: IGenericListItem): GenericListItem => ({
+  id: sys.id,
+  genericList: fields.genericList
+    ? mapGenericList(fields.genericList)
+    : undefined,
+  title: fields.title ?? '',
+  date: fields.date || null,
+  cardIntro: fields.cardIntro
+    ? mapDocument(fields.cardIntro, sys.id + ':cardIntro')
+    : [],
+  content: fields.content
+    ? mapDocument(fields.content, sys.id + ':content')
+    : [],
+  slug: fields.slug,
+})


### PR DESCRIPTION
# Clickable generic list items

TODO's:
1. Visually create a different card visual for clickable generic list items (blue title and hover effect)
2. On click navigate to a different url (most likely via query params)
3. Display different view and have a way to go back to the list view
4. Add a graphql endpoint for fetching a specific item and its contents
5. Test and self review

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
