### PR TITLE
fix(documents): Remove type check. Add content detection

### DIFF
--- a/libs/api/domains/documents/src/lib/documentV2.service.ts
+++ b/libs/api/domains/documents/src/lib/documentV2.service.ts
@@ -26,7 +26,7 @@ export class DocumentServiceV2 {
     @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
     @Inject(DownloadServiceConfig.KEY)
     private downloadServiceConfig: ConfigType<typeof DownloadServiceConfig>,
-  ) { }
+  ) {}
 
   async findDocumentById(
     nationalId: string,

--- a/libs/api/domains/documents/src/lib/documentV2.service.ts
+++ b/libs/api/domains/documents/src/lib/documentV2.service.ts
@@ -26,7 +26,7 @@ export class DocumentServiceV2 {
     @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
     @Inject(DownloadServiceConfig.KEY)
     private downloadServiceConfig: ConfigType<typeof DownloadServiceConfig>,
-  ) {}
+  ) { }
 
   async findDocumentById(
     nationalId: string,
@@ -45,7 +45,7 @@ export class DocumentServiceV2 {
     }
 
     if (!document) {
-      this.logger.error('No document content', {
+      this.logger.warn('No document content', {
         category: LOG_CATEGORY,
         documentId,
       })

--- a/libs/clients/documents-v2/src/lib/dto/document.dto.ts
+++ b/libs/clients/documents-v2/src/lib/dto/document.dto.ts
@@ -17,41 +17,17 @@ export type DocumentDto = {
 
 export const mapToDocument = (document: DocumentDTO): DocumentDto | null => {
   let fileType: FileType, content: string
-  switch (document.fileType) {
-    case 'pdf':
-      if (!document.content) {
-        return null
-      }
-      fileType = 'pdf'
-      content = document.content
-      break
-    case 'html':
-      if (!document.htmlContent) {
-        return null
-      }
-      fileType = 'html'
-      content = document.htmlContent
-      break
-    case 'url':
-      if (!document.url) {
-        return null
-      }
-      fileType = 'url'
-      content = document.url
-      break
-    default:
-      // Some document providers can not explicitly set the fileType so we have to guess the fileType by checking for the content, in case the fileType is not set.
-      if (document.htmlContent) {
-        fileType = 'html'
-        content = document.htmlContent
-        break
-      }
-      if (document.url) {
-        fileType = 'url'
-        content = document.url
-        break
-      }
-      return null
+  if (document.content) {
+    fileType = 'pdf'
+    content = document.content
+  } else if (document.url) {
+    fileType = 'url'
+    content = document.url
+  } else if (document.htmlContent) {
+    fileType = 'html'
+    content = document.htmlContent
+  } else {
+    return null
   }
 
   return {


### PR DESCRIPTION
## What

Remove type check. Add content detection

## Why

We can't rely on the content type. We need to check for the content before setting the type.
Error logging for this is too much. Should be a warning.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted logging levels to provide warnings instead of errors when no document content is found.

- **Refactor**
  - Improved file type assignment logic for documents, enhancing efficiency and accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->