### PR TITLE
fix(application-ir): Minor parameter fix

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/inheritance-report/inheritance-report.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/inheritance-report/inheritance-report.service.ts
@@ -68,7 +68,7 @@ export class InheritanceReportService extends BaseTemplateApiService {
 
         return new Promise<void>((resolve) => {
           this.syslumennService
-            .getInheritanceTax(new Date())
+            .getInheritanceTax(inheritanceDate)
             .then((inheritanceTax) => {
               inheritanceReportInfo.inheritanceTax = inheritanceTax
               resolve()


### PR DESCRIPTION
The calculated deathday was not being used in the call to the service for applying inheritance tax.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced the inheritance tax calculation by allowing users to specify the inheritance date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->