### PR TITLE
fix(documents): Document total count as number

### DIFF
--- a/libs/api/domains/documents/src/lib/documentV2.service.ts
+++ b/libs/api/domains/documents/src/lib/documentV2.service.ts
@@ -109,8 +109,11 @@ export class DocumentServiceV2 {
       categoryId: mutableCategoryIds.join(),
     })
 
-    if (!documents?.totalCount) {
-      throw new Error('Incomplete response')
+    if (typeof documents?.totalCount !== 'number') {
+      this.logger.warn('Document total count unavailable', {
+        category: LOG_CATEGORY,
+        totalCount: documents?.totalCount,
+      })
     }
 
     const documentData: Array<Document> =
@@ -134,7 +137,7 @@ export class DocumentServiceV2 {
 
     return {
       data: documentData,
-      totalCount: documents?.totalCount,
+      totalCount: documents?.totalCount ?? 0,
       unreadCount: documents?.unreadCount,
       pageInfo: {
         hasNextPage: false,


### PR DESCRIPTION
## What

Document total count should always return a number.

## Why

We were a bit too unforgiving in our approach for accepting `totalCount`. Now we return 0 when getting a falsy from the service.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of document counts by setting `totalCount` to 0 when undefined or null, preventing errors and ensuring smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->