### PR TITLE
fix(parental-leave): useEffectOnce when assigning application to employer and add another abort option to a state

### DIFF
--- a/apps/application-system/form/src/routes/AssignApplication.tsx
+++ b/apps/application-system/form/src/routes/AssignApplication.tsx
@@ -7,6 +7,7 @@ import qs from 'qs'
 import { ErrorShell, LoadingShell } from '@island.is/application/ui-shell'
 import { ASSIGN_APPLICATION } from '@island.is/application/graphql'
 import { getSlugFromType, coreErrorMessages } from '@island.is/application/core'
+import { useEffectOnce } from '@island.is/react-spa/shared'
 
 const parseGraphQLError = (
   error?: GraphQLError,
@@ -41,7 +42,7 @@ export const AssignApplication = () => {
     },
   )
 
-  useEffect(() => {
+  useEffectOnce(() => {
     const init = async () => {
       if (isMissingToken) {
         console.error(
@@ -64,7 +65,7 @@ export const AssignApplication = () => {
 
     init()
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  })
 
   if (loading) {
     return <LoadingShell />

--- a/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.ts
+++ b/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.ts
@@ -1180,6 +1180,14 @@ const ParentalLeaveTemplate: ApplicationTemplate<
               cond: (application) =>
                 goToState(
                   application,
+                  States.EMPLOYER_WAITING_TO_ASSIGN_FOR_EDITS,
+                ),
+              target: States.VINNUMALASTOFNUN_APPROVE_EDITS,
+            },
+            {
+              cond: (application) =>
+                goToState(
+                  application,
                   States.APPROVED,
                 ),
               target: States.APPROVED,


### PR DESCRIPTION
## What

add abort option when prev state is `employerWaitingToAssignForEdits` and change to useEffectOnce when assigning application to the employer. Locally it called it twice so the state history was wrong. 

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
