### PR TITLE
feat(web): Chart number box - Add configuration so we can determine within the CMS if the value should be rounded or not

### DIFF
--- a/apps/web/components/Charts/v2/renderers/ChartNumberBox/ChartNumberBox.tsx
+++ b/apps/web/components/Charts/v2/renderers/ChartNumberBox/ChartNumberBox.tsx
@@ -83,6 +83,8 @@ export const ChartNumberBox = ({ slice }: ChartNumberBoxRendererProps) => {
     return <p>{messages[activeLocale].noDataForChart}</p>
   }
 
+  const reduceAndRoundValue = slice.reduceAndRoundValue ?? true
+
   return (
     <div
       role="group"
@@ -94,7 +96,7 @@ export const ChartNumberBox = ({ slice }: ChartNumberBoxRendererProps) => {
       })}
     >
       {boxData.map((data, index) => {
-        // We assume that the data that key that is provided is a valid number
+        // We assume that the data behind the key that is provided is a valid number
         const comparisonValue = queryResult.data?.[data.sourceDataIndex]?.[
           data.sourceDataKey
         ] as number
@@ -106,14 +108,22 @@ export const ChartNumberBox = ({ slice }: ChartNumberBoxRendererProps) => {
 
         const ariaValue =
           data.valueType === 'number'
-            ? formatValueForPresentation(activeLocale, mostRecentValue)
+            ? formatValueForPresentation(
+                activeLocale,
+                mostRecentValue,
+                reduceAndRoundValue,
+              )
             : formatPercentageForPresentation(
                 index === 0 ? mostRecentValue : change - 1,
               )
 
         const displayedValue =
           data.valueType === 'number'
-            ? formatValueForPresentation(activeLocale, mostRecentValue)
+            ? formatValueForPresentation(
+                activeLocale,
+                mostRecentValue,
+                reduceAndRoundValue,
+              )
             : formatPercentageForPresentation(
                 index === 0 ? mostRecentValue : Math.abs(change - 1),
               )

--- a/apps/web/screens/queries/fragments.ts
+++ b/apps/web/screens/queries/fragments.ts
@@ -846,6 +846,7 @@ export const slices = gql`
     displayChangeMonthOverMonth
     displayChangeYearOverYear
     numberBoxDate
+    reduceAndRoundValue
   }
 
   fragment GenericListFields on GenericList {

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -661,6 +661,9 @@ export interface IChartNumberBoxFields {
 
   /** Date */
   numberBoxDate?: string | undefined
+
+  /** Reduce and round value */
+  reduceAndRoundValue?: boolean | undefined
 }
 
 /** A standalone component to display a value for a data key and optionally how it has evolved over a period of time. */

--- a/libs/cms/src/lib/models/chartNumberBox.model.ts
+++ b/libs/cms/src/lib/models/chartNumberBox.model.ts
@@ -30,6 +30,9 @@ export class ChartNumberBox {
 
   @Field({ nullable: true })
   numberBoxDate?: string
+
+  @Field({ nullable: true })
+  reduceAndRoundValue?: boolean
 }
 
 export const mapChartNumberBox = ({
@@ -48,5 +51,6 @@ export const mapChartNumberBox = ({
       'displayChangeYearOverYear',
     ]),
     numberBoxDate: fields.numberBoxDate ?? undefined,
+    reduceAndRoundValue: fields.reduceAndRoundValue ?? true,
   }
 }


### PR DESCRIPTION
# Chart number box - Add configuration so we can determine within the CMS if the value should be rounded or not

## What

* By default the value displayed is always rounded, we want that to be configurable


## Screenshots / Gifs

### Before (3.6 gets rounded up to 4)
![image](https://github.com/island-is/island.is/assets/43557895/e3951f84-34e3-41c6-982a-3e16c8d57e76)

### After (Here we've set in the CMS that the value should not be rounded)
![image](https://github.com/island-is/island.is/assets/43557895/467cf923-13c7-47d2-b186-90a9c4fed2c5)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Added a `reduceAndRoundValue` setting to the `ChartNumberBox`, allowing for conditional formatting of values.
    
- **Enhancements**
    - Updated value formatting in `ChartNumberBox` to consider the `reduceAndRoundValue` setting for more flexible display options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->