### PR TITLE
fix(application-system): Data provider bug hotfix

### DIFF
--- a/libs/application/ui-shell/src/components/FormExternalDataProvider.tsx
+++ b/libs/application/ui-shell/src/components/FormExternalDataProvider.tsx
@@ -270,6 +270,11 @@ const FormExternalDataProvider: FC<
     }
   }
 
+  useEffect(() => {
+    if (!id) return
+    setValue(id, false)
+  }, [id, setValue])
+
   return (
     <Box>
       <Box marginTop={2} marginBottom={5}>


### PR DESCRIPTION
# Data provider bug hotfix

Attach a link to issue if relevant

## What

Hotfix for bug that allows users to bypass the data-provider checks if the application has a screen before data-provider

Steps to reproduce:

Open up an application that has a screen before the dataprovider step
Click the checkbox to approve data collection
A dataprovider fails
Use the backbutton of your mouse or the browser to statelessly go back one screen
Then you can "Halda áfram" twice to bypass the dataproviders.

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
