### PR TITLE
fix(service-portal): Filter for unread. Loading state for total page count

### DIFF
--- a/libs/clients/documents-v2/src/lib/documentsClientV2.service.ts
+++ b/libs/clients/documents-v2/src/lib/documentsClientV2.service.ts
@@ -29,7 +29,7 @@ export class DocumentsClientV2Service {
     ): T {
       const sanitizedObj = {} as T
       for (const key in obj) {
-        if (obj[key]) {
+        if (obj[key] || key === 'opened') {
           sanitizedObj[key] = obj[key]
         }
       }

--- a/libs/service-portal/documents/src/hooks/useDocumentList.ts
+++ b/libs/service-portal/documents/src/hooks/useDocumentList.ts
@@ -75,10 +75,10 @@ export const useDocumentList = () => {
   const totalCount = data?.documentsV2?.totalCount || 0
   useEffect(() => {
     const pageCount = Math.ceil(totalCount / pageSize)
-    if (pageCount !== totalPages && pageCount !== 0) {
+    if (pageCount !== totalPages && !loading) {
       setTotalPages(pageCount)
     }
-  }, [pageSize, totalCount])
+  }, [pageSize, totalCount, loading])
 
   const filteredDocuments = data?.documentsV2?.data || []
   const activeArchive = filterValue.archived === true


### PR DESCRIPTION
## What

Filter for unread. Loading state for total page count

## Why

* unread messages were caught in the sanitation filter. Need to set an exception for special case for `opened` as we have three states:
    * `undefined` / `null` => Show all documents
    * `true` => Show only opened
    * `false` => Show only unopened
* pagination disappeared so there was no way to set 0 count on pagination.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
