### PR TITLE
fix(service-portal): Update get for documents

### DIFF
--- a/libs/api/domains/documents/src/lib/documentV2.service.ts
+++ b/libs/api/domains/documents/src/lib/documentV2.service.ts
@@ -108,6 +108,7 @@ export class DocumentServiceV2 {
     const documents = await this.documentService.getDocumentList({
       ...restOfInput,
       categoryId: mutableCategoryIds.join(),
+      nationalId,
     })
 
     if (typeof documents?.totalCount !== 'number') {

--- a/libs/api/domains/documents/src/lib/models/v2/documents.input.ts
+++ b/libs/api/domains/documents/src/lib/models/v2/documents.input.ts
@@ -34,10 +34,6 @@ registerEnumType(DocumentPageOrder, { name: 'DocumentsV2PageOrder' })
 
 @InputType('DocumentsV2DocumentsInput')
 export class DocumentsInput {
-  @Field()
-  @IsNationalId()
-  readonly nationalId!: string
-
   @Field(() => [String], { nullable: true })
   @IsOptional()
   @IsArray()

--- a/libs/service-portal/documents/src/hooks/useDocumentList.ts
+++ b/libs/service-portal/documents/src/hooks/useDocumentList.ts
@@ -34,7 +34,6 @@ export const useDocumentList = () => {
   const fetchObject = {
     input: {
       senderNationalId: filterValue.activeSenders,
-      nationalId: userInfo.profile.nationalId,
       dateFrom: filterValue.dateFrom?.toISOString(),
       dateTo: filterValue.dateTo?.toISOString(),
       categoryIds: filterValue.activeCategories,


### PR DESCRIPTION
## What

Update document list get

## Why

No need for sending id

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the document retrieval process to remove the `nationalId` parameter from various components and services. This change streamlines the handling of document lists and enhances data processing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->