### PR TITLE
chore(j-s): Robot Case File Email

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/court/court.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/court/court.service.ts
@@ -697,7 +697,7 @@ export class CourtService {
   ): Promise<unknown> {
     try {
       const subject = `Landsréttur - ${appealCaseNumber} - skjal`
-      const content = JSON.stringify({ category, name, url, dateSent })
+      const content = JSON.stringify({ category, name, dateSent, url })
 
       return this.sendToRobot(
         subject,


### PR DESCRIPTION
# Robot Case File Email

[Breyta röðun svæða í robot skjalapósti](https://app.asana.com/0/1199153462262248/1207469880923047/f)

## What

- Moves the case file URL to the end of the JSON body.

## Why

- When the robot receives emails, Outlook endoces the URL as a safety precaution. The encoding seems to be too eager a swallows up the fields following the URL.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the order of properties in court-related notifications to ensure consistent formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->