### PR TITLE
fix(ids-api): mock delegation indexing in controller tests

### DIFF
--- a/apps/services/auth/ids-api/src/app/delegations/delegations.controller.spec.ts
+++ b/apps/services/auth/ids-api/src/app/delegations/delegations.controller.spec.ts
@@ -225,7 +225,6 @@ describe('DelegationsController', () => {
           nationalRegistryErrors: number,
         ) => {
           let nationalRegistryApiSpy: jest.SpyInstance
-          let delegationIndexServiceSpy: jest.SpyInstance
           const validRepresentedPersons: NameIdTuple[] = []
           const outdatedRepresentedPersons: NameIdTuple[] = []
           const unactivatedRepresentedPersons: NameIdTuple[] = []
@@ -381,10 +380,6 @@ describe('DelegationsController', () => {
 
                 return user ?? null
               })
-
-            delegationIndexServiceSpy = jest
-              .spyOn(delegationIndexService, 'indexDelegations')
-              .mockImplementation()
           })
 
           afterAll(async () => {
@@ -510,7 +505,7 @@ describe('DelegationsController', () => {
             })
 
             it('should index delegations', () => {
-              expect(delegationIndexServiceSpy).toHaveBeenCalled()
+              expect(delegationIndexService.indexDelegations).toHaveBeenCalled()
             })
           })
         },
@@ -911,13 +906,8 @@ describe('DelegationsController', () => {
             const path = '/delegations'
             let response: request.Response
             let body: DelegationDTO[]
-            let delegationIndexServiceSpy: jest.SpyInstance
 
             beforeAll(async () => {
-              delegationIndexServiceSpy = jest
-                .spyOn(delegationIndexService, 'indexDelegations')
-                .mockImplementation()
-
               response = await server.get(path)
               body = response.body
             })
@@ -1012,7 +1002,7 @@ describe('DelegationsController', () => {
             })
 
             it('should index delegations', () => {
-              expect(delegationIndexServiceSpy).toHaveBeenCalled()
+              expect(delegationIndexService.indexDelegations).toHaveBeenCalled()
             })
           })
         },

--- a/apps/services/auth/ids-api/src/app/delegations/test/delegations-filters-types.ts
+++ b/apps/services/auth/ids-api/src/app/delegations/test/delegations-filters-types.ts
@@ -6,7 +6,6 @@ import {
   CreateClient,
   CreateCustomDelegation,
   CreateDomain,
-  CreatePersonalRepresentativeDelegation,
 } from '@island.is/services/auth/testing'
 import { createCurrentUser } from '@island.is/testing/fixtures'
 import { GetIndividualRelationships } from '@island.is/clients-rsk-relationships'

--- a/apps/services/auth/ids-api/src/app/delegations/test/delegations-filters.spec.ts
+++ b/apps/services/auth/ids-api/src/app/delegations/test/delegations-filters.spec.ts
@@ -5,7 +5,7 @@ import faker from 'faker'
 import { setupWithAuth } from '../../../../test/setup'
 import { createNationalRegistryUser } from '@island.is/testing/fixtures'
 import { NationalRegistryClientService } from '@island.is/clients/national-registry-v2'
-import { DelegationDTO, DelegationsIndexService } from '@island.is/auth-api-lib'
+import { DelegationDTO } from '@island.is/auth-api-lib'
 import { RskRelationshipsClient } from '@island.is/clients-rsk-relationships'
 import { user } from './delegations-filters-types'
 import { Sequelize } from 'sequelize-typescript'
@@ -20,7 +20,6 @@ describe('DelegationsController', () => {
   let factory: FixtureFactory
   let nationalRegistryApi: NationalRegistryClientService
   let rskApi: RskRelationshipsClient
-  let delegationIndexService: DelegationsIndexService
   beforeAll(async () => {
     app = await setupWithAuth({
       user: user,

--- a/apps/services/auth/ids-api/src/app/delegations/test/delegations-filters.spec.ts
+++ b/apps/services/auth/ids-api/src/app/delegations/test/delegations-filters.spec.ts
@@ -21,7 +21,6 @@ describe('DelegationsController', () => {
   let nationalRegistryApi: NationalRegistryClientService
   let rskApi: RskRelationshipsClient
   let delegationIndexService: DelegationsIndexService
-
   beforeAll(async () => {
     app = await setupWithAuth({
       user: user,
@@ -30,7 +29,6 @@ describe('DelegationsController', () => {
 
     server = request(app.getHttpServer())
 
-    delegationIndexService = app.get(DelegationsIndexService)
     nationalRegistryApi = app.get(NationalRegistryClientService)
     jest
       .spyOn(nationalRegistryApi, 'getIndividual')
@@ -40,8 +38,6 @@ describe('DelegationsController', () => {
           name: faker.name.findName(),
         }),
       )
-    jest.spyOn(delegationIndexService, 'indexDelegations').mockImplementation()
-
     rskApi = app.get(RskRelationshipsClient)
 
     factory = new FixtureFactory(app)

--- a/apps/services/auth/ids-api/src/app/delegations/test/delegations-scopes.spec.ts
+++ b/apps/services/auth/ids-api/src/app/delegations/test/delegations-scopes.spec.ts
@@ -4,10 +4,7 @@ import faker from 'faker'
 import { Sequelize } from 'sequelize-typescript'
 import request from 'supertest'
 
-import {
-  DelegationsIndexService,
-  DelegationType,
-} from '@island.is/auth-api-lib'
+import { DelegationType } from '@island.is/auth-api-lib'
 import { FixtureFactory } from '@island.is/services/auth/testing'
 import {
   createCurrentUser,

--- a/apps/services/auth/ids-api/src/app/delegations/test/delegations-scopes.spec.ts
+++ b/apps/services/auth/ids-api/src/app/delegations/test/delegations-scopes.spec.ts
@@ -92,7 +92,6 @@ describe('DelegationsController', () => {
   let app: TestApp
   let server: request.SuperTest<request.Test>
   let factory: FixtureFactory
-  let delegationIndexService: DelegationsIndexService
 
   beforeAll(async () => {
     app = await setupWithAuth({
@@ -103,9 +102,6 @@ describe('DelegationsController', () => {
     server = request(app.getHttpServer())
 
     factory = new FixtureFactory(app)
-
-    delegationIndexService = app.get(DelegationsIndexService)
-    jest.spyOn(delegationIndexService, 'indexDelegations').mockImplementation()
   })
 
   afterAll(async () => {

--- a/apps/services/auth/ids-api/test/setup.ts
+++ b/apps/services/auth/ids-api/test/setup.ts
@@ -3,6 +3,7 @@ import { TestingModuleBuilder } from '@nestjs/testing'
 
 import {
   ApiScope,
+  DelegationsIndexService,
   Domain,
   SequelizeConfigService,
 } from '@island.is/auth-api-lib'
@@ -84,6 +85,10 @@ class MockUserProfile {
   meUserProfileControllerFindUserProfile = jest.fn().mockResolvedValue({})
 }
 
+class MockDelegationsIndexService {
+  indexDelegations = jest.fn().mockImplementation(() => Promise.resolve())
+}
+
 interface SetupOptions {
   user: User
   scopes?: Scopes
@@ -128,7 +133,9 @@ export const setupWithAuth = async ({
         .useValue({
           getValue: (feature: Features) =>
             !features || features.includes(feature),
-        }),
+        })
+        .overrideProvider(DelegationsIndexService)
+        .useClass(MockDelegationsIndexService),
     hooks: [
       useAuth({ auth: user }),
       useDatabase({ type: 'postgres', provider: SequelizeConfigService }),

--- a/libs/auth-api-lib/src/lib/delegations/delegations-index.service.ts
+++ b/libs/auth-api-lib/src/lib/delegations/delegations-index.service.ts
@@ -69,6 +69,11 @@ type FetchDelegationRecordsArgs = {
 
 const getTimeUntilEighteen = (nationalId: string) => {
   const birthDate = kennitala.info(nationalId).birthday
+
+  if (!birthDate) {
+    return null
+  }
+
   const now = startOfDay(new Date())
   const eighteen = startOfDay(
     new Date(


### PR DESCRIPTION
☝️ 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Refactored tests to replace `delegationIndexServiceSpy` with direct calls to `indexDelegations`.

- **Bug Fixes**
  - Improved `getTimeUntilEighteen` function to handle cases where `birthDate` is missing, returning `null` if `birthDate` is falsy.

- **Tests**
  - Updated test setup to use `MockDelegationsIndexService` for `DelegationsIndexService`.

- **Chores**
  - Removed unused imports and declarations related to `DelegationsIndexService` in various test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->