### PR TITLE
feat(download-service): Serve contentful assets through download service

### DIFF
--- a/apps/download-service/src/app/app.module.ts
+++ b/apps/download-service/src/app/app.module.ts
@@ -60,6 +60,7 @@ import {
   DistrictCommissionersLicensesClientConfig,
   DistrictCommissionersLicensesClientModule,
 } from '@island.is/clients/district-commissioners-licenses'
+import { ContentfulAssetController } from './modules/contentful-assets/contentful-assets.controller'
 @Module({
   controllers: [
     DocumentController,
@@ -71,6 +72,7 @@ import {
     WorkMachinesController,
     OccupationalLicensesController,
     HealthPaymentsOverviewController,
+    ContentfulAssetController,
   ],
   imports: [
     AuditModule.forRoot(environment.audit),

--- a/apps/download-service/src/app/modules/contentful-assets/contentful-assets.controller.ts
+++ b/apps/download-service/src/app/modules/contentful-assets/contentful-assets.controller.ts
@@ -1,0 +1,26 @@
+import { Controller, Get, Param, Res } from '@nestjs/common'
+import { Response } from 'express'
+
+@Controller('contentful-assets')
+export class ContentfulAssetController {
+  @Get('/:spaceId/:assetId/:randomId/:assetFilename')
+  async getAsset(
+    @Param('spaceId') spaceId: string,
+    @Param('assetId') assetId: string,
+    @Param('randomId') randomId: string,
+    @Param('assetFilename') assetFilename: string,
+    @Res() res: Response,
+  ) {
+    const assetUrl = `https://assets.ctfassets.net/${spaceId}/${assetId}/${randomId}/${assetFilename}`
+
+    const assetResponse = await fetch(assetUrl)
+
+    // https://stackoverflow.com/questions/52665103/using-express-how-to-send-blob-object-as-response
+    const assetBlob = await assetResponse.blob()
+    res.type(assetBlob.type)
+    const buffer = await assetBlob.arrayBuffer()
+    res.send(Buffer.from(buffer))
+
+    res.end()
+  }
+}


### PR DESCRIPTION
# Serve contentful assets through download service

## What

* Endpoint added to download-service that forwards contentful assets

## Why

* So we can serve contentful assets from our own domain

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
