### PR TITLE
chore(api): Update codeowners for ultraviolet radiation client

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -258,6 +258,7 @@ codemagic.yaml                                                                  
 /libs/api/domains/ship-registry/                                                                         @island-is/stefna
 /libs/clients/administration-of-occupational-safety-and-health/                                          @island-is/stefna
 /libs/api/domains/administration-of-occupational-safety-and-health/                                      @island-is/stefna
+/libs/clients/ultraviolet-radiation/                                                                     @island-is/stefna
 
 /libs/island-ui/                                                                                         @island-is/island-ui
 


### PR DESCRIPTION
# Update codeowners for ultraviolet radiation client

## What

* Stefna should be marked as the codeowner for the ultraviolet radiation client code
