### PR TITLE
feat(web): ChartNumberBox - Display timestamp for latest datapoint

### DIFF
--- a/apps/web/components/Charts/v2/renderers/ChartNumberBox/ChartNumberBox.tsx
+++ b/apps/web/components/Charts/v2/renderers/ChartNumberBox/ChartNumberBox.tsx
@@ -1,9 +1,16 @@
 import { useMemo } from 'react'
 import cn from 'classnames'
 
-import { Icon, SkeletonLoader, Tooltip } from '@island.is/island-ui/core'
+import {
+  Icon,
+  Inline,
+  SkeletonLoader,
+  Text,
+  Tooltip,
+} from '@island.is/island-ui/core'
 import { ChartNumberBox as IChartNumberBox } from '@island.is/web/graphql/schema'
 import { useI18n } from '@island.is/web/i18n'
+import { useDateUtils } from '@island.is/web/i18n/useDateUtils'
 
 import { useGetChartData } from '../../hooks'
 import { messages } from '../../messages'
@@ -41,6 +48,7 @@ export const ChartNumberBox = ({ slice }: ChartNumberBoxRendererProps) => {
     components: [slice],
   })
   const { activeLocale } = useI18n()
+  const { format } = useDateUtils()
 
   const boxData = useMemo(() => {
     const result: ChartNumberBoxData[] = [
@@ -131,6 +139,16 @@ export const ChartNumberBox = ({ slice }: ChartNumberBoxRendererProps) => {
                 index === 0 ? mostRecentValue : Math.abs(change - 1),
               )
 
+        const timestamp =
+          boxData.length === 1 &&
+          slice.displayTimestamp &&
+          queryResult?.data?.[data.sourceDataIndex]?.header
+            ? format(
+                new Date(Number(queryResult.data[data.sourceDataIndex].header)),
+                'do MMM YYY HH:MM',
+              )
+            : ''
+
         return (
           <div
             key={index}
@@ -143,7 +161,10 @@ export const ChartNumberBox = ({ slice }: ChartNumberBoxRendererProps) => {
             tabIndex={0}
           >
             <div className={styles.titleWrapper} id={`${slice.id}.title`}>
-              <h3 className={styles.title}>{data.title}</h3>
+              <Inline space={1} alignY="center" justifyContent="spaceBetween">
+                <h3 className={styles.title}>{data.title}</h3>
+                {timestamp && <Text variant="small">({timestamp})</Text>}
+              </Inline>
               {index === 0 && (
                 <Tooltip
                   text={slice.numberBoxDescription}

--- a/apps/web/screens/queries/fragments.ts
+++ b/apps/web/screens/queries/fragments.ts
@@ -847,6 +847,7 @@ export const slices = gql`
     displayChangeYearOverYear
     numberBoxDate
     reduceAndRoundValue
+    displayTimestamp
   }
 
   fragment GenericListFields on GenericList {

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -664,6 +664,9 @@ export interface IChartNumberBoxFields {
 
   /** Reduce and round value */
   reduceAndRoundValue?: boolean | undefined
+
+  /** Display Timestamp */
+  displayTimestamp?: boolean | undefined
 }
 
 /** A standalone component to display a value for a data key and optionally how it has evolved over a period of time. */

--- a/libs/cms/src/lib/models/chartNumberBox.model.ts
+++ b/libs/cms/src/lib/models/chartNumberBox.model.ts
@@ -33,6 +33,9 @@ export class ChartNumberBox {
 
   @Field({ nullable: true })
   reduceAndRoundValue?: boolean
+
+  @Field({ nullable: true })
+  displayTimestamp?: boolean
 }
 
 export const mapChartNumberBox = ({
@@ -52,5 +55,6 @@ export const mapChartNumberBox = ({
     ]),
     numberBoxDate: fields.numberBoxDate ?? undefined,
     reduceAndRoundValue: fields.reduceAndRoundValue ?? true,
+    displayTimestamp: fields.displayTimestamp ?? false,
   }
 }


### PR DESCRIPTION
# ChartNumberBox - display timestamp for latest datapoint

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

### Before
![image](https://github.com/island-is/island.is/assets/43557895/143b1dde-a7b2-4503-bd1c-e1656ba428e4)

### After
![image](https://github.com/island-is/island.is/assets/43557895/5ff55d34-0b97-4a2c-8c25-0de42a8c1548)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review