### PR TITLE
fix(application-system): empty title for formStepper

### DIFF
--- a/libs/application/ui-shell/src/components/FormStepper.tsx
+++ b/libs/application/ui-shell/src/components/FormStepper.tsx
@@ -67,7 +67,7 @@ const FormStepper = ({
             fontWeight={isChildActive ? 'semiBold' : 'regular'}
             key={`formStepperChild-${i}`}
           >
-            {formatText(child.title, application, formatMessage)}
+            {childText}
           </Text>
         )
       })

--- a/libs/application/ui-shell/src/components/FormStepper.tsx
+++ b/libs/application/ui-shell/src/components/FormStepper.tsx
@@ -53,20 +53,25 @@ const FormStepper = ({
       childrenToParse.push(child)
     })
 
-    return childrenToParse.map((child, i) => {
-      const isChildActive =
-        isParentActive && currentScreen.subSectionIndex === i
+    return childrenToParse
+      .map((child, i) => {
+        const isChildActive =
+          isParentActive && currentScreen.subSectionIndex === i
+        const childText = formatText(child.title, application, formatMessage)
 
-      return (
-        <Text
-          variant="medium"
-          fontWeight={isChildActive ? 'semiBold' : 'regular'}
-          key={`formStepperChild-${i}`}
-        >
-          {formatText(child.title, application, formatMessage)}
-        </Text>
-      )
-    })
+        if (!childText) return null
+
+        return (
+          <Text
+            variant="medium"
+            fontWeight={isChildActive ? 'semiBold' : 'regular'}
+            key={`formStepperChild-${i}`}
+          >
+            {formatText(child.title, application, formatMessage)}
+          </Text>
+        )
+      })
+      .filter(Boolean as unknown as ExcludesFalse)
   }
 
   const stepperTitle = isMobile ? null : (
@@ -85,23 +90,33 @@ const FormStepper = ({
         sections &&
         [
           stepperTitle,
-          ...sections.map((section, i) => (
-            <Section
-              key={`formStepper-${i}`}
-              isActive={currentScreen.sectionIndex === i}
-              section={formatText(section.title, application, formatMessage)}
-              sectionIndex={i}
-              subSections={
-                section.children.length > 1
-                  ? parseSubsections(
-                      section.children,
-                      currentScreen.sectionIndex === i,
-                    )
-                  : undefined
-              }
-              isComplete={currentScreen.sectionIndex > i}
-            />
-          )),
+          ...sections.map((section, i) => {
+            const sectionTitle = formatText(
+              section.title,
+              application,
+              formatMessage,
+            )
+
+            if (!sectionTitle) return null
+
+            return (
+              <Section
+                key={`formStepper-${i}`}
+                isActive={currentScreen.sectionIndex === i}
+                section={sectionTitle}
+                sectionIndex={i}
+                subSections={
+                  section.children.length > 1
+                    ? parseSubsections(
+                        section.children,
+                        currentScreen.sectionIndex === i,
+                      )
+                    : undefined
+                }
+                isComplete={currentScreen.sectionIndex > i}
+              />
+            )
+          }),
         ].filter(Boolean as unknown as ExcludesFalse)
       }
     />


### PR DESCRIPTION
## What

Don't render out steps in the formStepper if the title is empty

## Why

To have the same behaviour as the discontinued core formStepper 

## Screenshots / Gifs

Previously: 
![Screenshot 2024-06-11 at 12 50 04](https://github.com/island-is/island.is/assets/25332655/aa4da081-e1ed-4811-8af2-aaae323012fd)

Now: 
![image](https://github.com/island-is/island.is/assets/25332655/9728ffaa-123f-4f2c-9866-4a743e88d096)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the `FormStepper` component to handle cases where text elements are null, ensuring proper conditional rendering based on the presence of valid text content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->