### PR TITLE
fix(libs+sessions): Add 202 response code handling to document decorator.

### DIFF
--- a/libs/nest/swagger/src/lib/documentation.decorator.ts
+++ b/libs/nest/swagger/src/lib/documentation.decorator.ts
@@ -1,5 +1,6 @@
 import { applyDecorators, HttpCode } from '@nestjs/common'
 import {
+  ApiAcceptedResponse,
   ApiBadRequestResponse,
   ApiConflictResponse,
   ApiCreatedResponse,
@@ -58,6 +59,8 @@ const getResponseDecorators = ({
         ApiCreatedResponse(response),
         ApiConflictResponse({ type: HttpProblemResponse }),
       ]
+    case 202:
+      return [ApiAcceptedResponse(response)]
     case 204:
       return [ApiNoContentResponse(response)]
     default:


### PR DESCRIPTION
## What

Add 202 to possible response codes in openapi generation.

## Why

So codegen works for services with 202 status code.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for 202 status code responses in API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->