### PR TITLE
feat(web): Social Insurance Administration - header title color change

### DIFF
--- a/apps/web/components/DefaultHeader/DefaultHeader.tsx
+++ b/apps/web/components/DefaultHeader/DefaultHeader.tsx
@@ -25,6 +25,7 @@ export interface DefaultHeaderProps {
   logo?: string
   logoHref?: string
   titleColor?: TextProps['color']
+  customTitleColor?: string
   imagePadding?: string
   imageIsFullHeight?: boolean
   imageObjectFit?: 'contain' | 'cover'
@@ -45,6 +46,7 @@ export const DefaultHeader: React.FC<
   logo,
   logoHref,
   titleColor = 'dark400',
+  customTitleColor,
   imagePadding = '20px',
   imageIsFullHeight = true,
   imageObjectFit = 'contain',
@@ -131,12 +133,21 @@ export const DefaultHeader: React.FC<
                 className={styles.title}
                 paddingLeft={!isMobile ? titleSectionPaddingLeft : 0}
               >
-                <Text variant="h1" as="h1" color={titleColor}>
-                  {title}
+                <Text
+                  variant="h1"
+                  as="h1"
+                  color={!customTitleColor ? titleColor : undefined}
+                >
+                  <span style={{ color: customTitleColor }}>{title}</span>
                 </Text>
                 {underTitle && (
-                  <Text fontWeight="regular" color={titleColor}>
-                    {underTitle}
+                  <Text
+                    fontWeight="regular"
+                    color={!customTitleColor ? titleColor : undefined}
+                  >
+                    <span style={{ color: customTitleColor }}>
+                      {underTitle}
+                    </span>
                   </Text>
                 )}
               </Box>

--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -217,6 +217,35 @@ export const OrganizationHeader: React.FC<
     ? organizationLogoAltText
     : organizationLogoAltTextFallback
 
+  const defaultProps: DefaultHeaderProps = {
+    fullWidth: organizationPage.themeProperties.fullWidth ?? false,
+    image: organizationPage.defaultHeaderImage?.url,
+    background: getBackgroundStyle(organizationPage.themeProperties),
+    title: organizationPage.title,
+    logo: organizationPage.organization?.logo?.url,
+    logoHref: linkResolver('organizationpage', [organizationPage.slug]).href,
+    titleColor:
+      (organizationPage.themeProperties
+        .textColor as DefaultHeaderProps['titleColor']) || 'dark400',
+    imagePadding: organizationPage.themeProperties.imagePadding || '20px',
+    imageIsFullHeight:
+      organizationPage.themeProperties.imageIsFullHeight ?? true,
+    imageObjectFit:
+      organizationPage.themeProperties.imageObjectFit === 'cover'
+        ? 'cover'
+        : 'contain',
+    imageObjectPosition:
+      organizationPage.themeProperties.imageObjectPosition === 'left'
+        ? 'left'
+        : organizationPage.themeProperties.imageObjectPosition === 'right'
+        ? 'right'
+        : 'center',
+    logoAltText: logoAltText,
+    titleSectionPaddingLeft: organizationPage.themeProperties
+      .titleSectionPaddingLeft as ResponsiveSpace,
+    mobileBackground: organizationPage.themeProperties.mobileBackgroundColor,
+  }
+
   switch (organizationPage.theme) {
     case 'syslumenn':
       return (
@@ -396,47 +425,15 @@ export const OrganizationHeader: React.FC<
           logoAltText={logoAltText}
         />
       )
-    default:
+    case 'tryggingastofnun':
       return (
         <DefaultHeader
-          fullWidth={organizationPage.themeProperties.fullWidth ?? false}
-          image={organizationPage.defaultHeaderImage?.url}
-          background={getBackgroundStyle(organizationPage.themeProperties)}
-          title={organizationPage.title}
-          logo={organizationPage.organization?.logo?.url}
-          logoHref={
-            linkResolver('organizationpage', [organizationPage.slug]).href
-          }
-          titleColor={
-            (organizationPage.themeProperties
-              .textColor as DefaultHeaderProps['titleColor']) ?? 'dark400'
-          }
-          imagePadding={organizationPage.themeProperties.imagePadding || '20px'}
-          imageIsFullHeight={
-            organizationPage.themeProperties.imageIsFullHeight ?? true
-          }
-          imageObjectFit={
-            organizationPage.themeProperties.imageObjectFit === 'cover'
-              ? 'cover'
-              : 'contain'
-          }
-          imageObjectPosition={
-            organizationPage.themeProperties.imageObjectPosition === 'left'
-              ? 'left'
-              : organizationPage.themeProperties.imageObjectPosition === 'right'
-              ? 'right'
-              : 'center'
-          }
-          logoAltText={logoAltText}
-          titleSectionPaddingLeft={
-            organizationPage.themeProperties
-              .titleSectionPaddingLeft as ResponsiveSpace
-          }
-          mobileBackground={
-            organizationPage.themeProperties.mobileBackgroundColor
-          }
+          {...defaultProps}
+          customTitleColor={n('tryggingastofnunHeaderTitleColor', '#007339')}
         />
       )
+    default:
+      return <DefaultHeader {...defaultProps} />
   }
 }
 


### PR DESCRIPTION
# Social Insurance Administration - header title color change

(The title color used to "dark400")
![image](https://github.com/island-is/island.is/assets/43557895/e4d94d28-3872-479a-8fbe-245bf2897077)
