### PR TITLE
fix(web): Remove autoAuth for PensionCalculatorApi due to 500 error when calculating pension

### DIFF
--- a/libs/clients/social-insurance-administration/src/lib/apiProvider.ts
+++ b/libs/clients/social-insurance-administration/src/lib/apiProvider.ts
@@ -22,38 +22,50 @@ import {
 import { ConfigFactory } from './configFactory'
 import { SocialInsuranceAdministrationClientConfig } from './socialInsuranceAdministrationClient.config'
 
-const apiCollection: Array<{ api: Api; scopes: Array<Scope> }> = [
+const apiCollection: Array<{
+  api: Api
+  scopes: Array<Scope>
+  autoAuth: boolean
+}> = [
   {
     api: ApplicationWriteApi,
     scopes: ['@tr.is/umsoknir:write'],
+    autoAuth: true,
   },
   {
     api: ApplicationApi,
     scopes: ['@tr.is/umsoknir:read'],
+    autoAuth: true,
   },
   {
     api: ApplicantApi,
     scopes: ['@tr.is/umsaekjandi:read'],
+    autoAuth: true,
   },
   {
     api: GeneralApi,
     scopes: ['@tr.is/almennt:read'],
+    autoAuth: true,
   },
   {
     api: DocumentsApi,
     scopes: ['@tr.is/fylgiskjol:write'],
+    autoAuth: true,
   },
   {
     api: IncomePlanApi,
     scopes: ['@tr.is/tekjuaetlun:read'],
+    autoAuth: true,
   },
   {
     api: PaymentPlanApi,
     scopes: ['@tr.is/greidsluaetlun:read'],
+    autoAuth: true,
   },
   {
     api: PensionCalculatorApi,
     scopes: ['@tr.is/stadgreidsla:read'],
+    autoAuth: false,
   },
 ]
 
@@ -67,7 +79,13 @@ export const apiProvider = apiCollection.map((apiRecord) => ({
   ) => {
     return new apiRecord.api(
       new Configuration(
-        ConfigFactory(xroadConfig, config, idsClientConfig, apiRecord.scopes),
+        ConfigFactory(
+          xroadConfig,
+          config,
+          idsClientConfig,
+          apiRecord.scopes,
+          apiRecord.autoAuth,
+        ),
       ),
     )
   },

--- a/libs/clients/social-insurance-administration/src/lib/configFactory.ts
+++ b/libs/clients/social-insurance-administration/src/lib/configFactory.ts
@@ -12,19 +12,21 @@ export const ConfigFactory = (
   config: ConfigType<typeof SocialInsuranceAdministrationClientConfig>,
   idsClientConfig: ConfigType<typeof IdsClientConfig>,
   scopes: Array<Scope>,
+  autoAuth: boolean,
 ) => ({
   fetchApi: createEnhancedFetch({
     name: 'clients-tr',
     organizationSlug: 'tryggingastofnun',
-    autoAuth: idsClientConfig.isConfigured
-      ? {
-          mode: 'tokenExchange',
-          issuer: idsClientConfig.issuer,
-          clientId: idsClientConfig.clientId,
-          clientSecret: idsClientConfig.clientSecret,
-          scope: scopes,
-        }
-      : undefined,
+    autoAuth:
+      autoAuth && idsClientConfig.isConfigured
+        ? {
+            mode: 'tokenExchange',
+            issuer: idsClientConfig.issuer,
+            clientId: idsClientConfig.clientId,
+            clientSecret: idsClientConfig.clientSecret,
+            scope: scopes,
+          }
+        : undefined,
   }),
   basePath: `${xroadConfig.xRoadBasePath}/r1/${config.xRoadServicePath}`,
   headers: {


### PR DESCRIPTION
# Remove autoAuth for PensionCalculatorApi due to 500 error when calculating pension

## What

*A PR: https://github.com/island-is/island.is/pull/14812 caused an the calculation page to only display a 500 error due to a token exchange in the backend not being successful

This PR will address that issue and we'll not to hotfix it to production as well since the change in the PR mentioned above has reached prod

## Screenshots / Gifs

### Before
<img width="1384" alt="image" src="https://github.com/island-is/island.is/assets/43557895/0d68a2e1-4cb3-4796-a49a-3befe486ab31">

### After
<img width="1442" alt="image" src="https://github.com/island-is/island.is/assets/43557895/5f116619-9e2c-4bb4-bc08-ddd267afa2e3">


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an `autoAuth` property to enhance API configuration flexibility. This allows for conditional authentication based on the new `autoAuth` flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->