### PR TITLE
fix(web): Hotfix - Remove autoAuth for PensionCalculatorApi due to 500 error when calculating pension #15211

### DIFF
--- a/libs/clients/social-insurance-administration/src/lib/apiProvider.ts
+++ b/libs/clients/social-insurance-administration/src/lib/apiProvider.ts
@@ -22,38 +22,50 @@ import {
 import { ConfigFactory } from './configFactory'
 import { SocialInsuranceAdministrationClientConfig } from './socialInsuranceAdministrationClient.config'
 
-const apiCollection: Array<{ api: Api; scopes: Array<Scope> }> = [
+const apiCollection: Array<{
+  api: Api
+  scopes: Array<Scope>
+  autoAuth: boolean
+}> = [
   {
     api: ApplicationWriteApi,
     scopes: ['@tr.is/umsoknir:write'],
+    autoAuth: true,
   },
   {
     api: ApplicationApi,
     scopes: ['@tr.is/umsoknir:read'],
+    autoAuth: true,
   },
   {
     api: ApplicantApi,
     scopes: ['@tr.is/umsaekjandi:read'],
+    autoAuth: true,
   },
   {
     api: GeneralApi,
     scopes: ['@tr.is/almennt:read'],
+    autoAuth: true,
   },
   {
     api: DocumentsApi,
     scopes: ['@tr.is/fylgiskjol:write'],
+    autoAuth: true,
   },
   {
     api: IncomePlanApi,
     scopes: ['@tr.is/tekjuaetlun:read'],
+    autoAuth: true,
   },
   {
     api: PaymentPlanApi,
     scopes: ['@tr.is/greidsluaetlun:read'],
+    autoAuth: true,
   },
   {
     api: PensionCalculatorApi,
     scopes: ['@tr.is/stadgreidsla:read'],
+    autoAuth: false,
   },
 ]
 
@@ -67,7 +79,13 @@ export const apiProvider = apiCollection.map((apiRecord) => ({
   ) => {
     return new apiRecord.api(
       new Configuration(
-        ConfigFactory(xroadConfig, config, idsClientConfig, apiRecord.scopes),
+        ConfigFactory(
+          xroadConfig,
+          config,
+          idsClientConfig,
+          apiRecord.scopes,
+          apiRecord.autoAuth,
+        ),
       ),
     )
   },

--- a/libs/clients/social-insurance-administration/src/lib/configFactory.ts
+++ b/libs/clients/social-insurance-administration/src/lib/configFactory.ts
@@ -12,19 +12,21 @@ export const ConfigFactory = (
   config: ConfigType<typeof SocialInsuranceAdministrationClientConfig>,
   idsClientConfig: ConfigType<typeof IdsClientConfig>,
   scopes: Array<Scope>,
+  autoAuth: boolean,
 ) => ({
   fetchApi: createEnhancedFetch({
     name: 'clients-tr',
     organizationSlug: 'tryggingastofnun',
-    autoAuth: idsClientConfig.isConfigured
-      ? {
-          mode: 'tokenExchange',
-          issuer: idsClientConfig.issuer,
-          clientId: idsClientConfig.clientId,
-          clientSecret: idsClientConfig.clientSecret,
-          scope: scopes,
-        }
-      : undefined,
+    autoAuth:
+      autoAuth && idsClientConfig.isConfigured
+        ? {
+            mode: 'tokenExchange',
+            issuer: idsClientConfig.issuer,
+            clientId: idsClientConfig.clientId,
+            clientSecret: idsClientConfig.clientSecret,
+            scope: scopes,
+          }
+        : undefined,
   }),
   basePath: `${xroadConfig.xRoadBasePath}/r1/${config.xRoadServicePath}`,
   headers: {


### PR DESCRIPTION
# Hotfix - Remove autoAuth for PensionCalculatorApi due to 500 error when calculating pension #15211