### PR TITLE
fix(service-portal): Update notification icon styling

### DIFF
--- a/apps/service-portal/src/components/Notifications/NotificationLine.tsx
+++ b/apps/service-portal/src/components/Notifications/NotificationLine.tsx
@@ -51,6 +51,8 @@ export const NotificationLine = ({ data, onClickCallback }: Props) => {
             <AvatarImage
               img={data.sender.logoUrl}
               background={!isRead ? 'white' : 'blue100'}
+              ariaLabel="Sender"
+              imageClass={styles.img}
             />
           ) : undefined}
           <Box

--- a/apps/service-portal/src/components/Notifications/NotificationLine.tsx
+++ b/apps/service-portal/src/components/Notifications/NotificationLine.tsx
@@ -51,7 +51,7 @@ export const NotificationLine = ({ data, onClickCallback }: Props) => {
             <AvatarImage
               img={data.sender.logoUrl}
               background={!isRead ? 'white' : 'blue100'}
-              ariaLabel="Sender"
+              as="div"
               imageClass={styles.img}
             />
           ) : undefined}

--- a/apps/service-portal/src/components/Notifications/Notifications.css.ts
+++ b/apps/service-portal/src/components/Notifications/Notifications.css.ts
@@ -9,6 +9,14 @@ export const link = style({
   overflow: 'hidden',
 })
 
+export const img = style({
+  height: 'auto',
+  width: 'auto',
+  display: 'flex',
+  maxHeight: 28,
+  maxWidth: 28,
+})
+
 globalStyle(`${link} > span`, {
   boxShadow: 'none',
 })

--- a/libs/service-portal/core/src/components/ActionCard/ActionCard.css.ts
+++ b/libs/service-portal/core/src/components/ActionCard/ActionCard.css.ts
@@ -30,9 +30,11 @@ export const avatar = style({
 })
 
 export const circleImg = style({
-  width: '28px',
   height: 'auto',
+  width: 'auto',
   display: 'flex',
+  maxHeight: 38,
+  maxWidth: 38,
 })
 
 export const button = style({

--- a/libs/service-portal/documents/src/components/DocumentLine/AvatarImage.tsx
+++ b/libs/service-portal/documents/src/components/DocumentLine/AvatarImage.tsx
@@ -13,7 +13,7 @@ interface Props {
   avatar?: ReactNode
   onClick?: (event: MouseEvent<HTMLElement>) => void
   large?: boolean
-  ariaLabel?: string
+  as?: 'div' | 'button'
   imageClass?: string
 }
 
@@ -23,7 +23,7 @@ export const AvatarImage: FC<Props> = ({
   avatar,
   large,
   imageClass,
-  ariaLabel,
+  as = 'button',
   onClick,
 }) => {
   const { formatMessage } = useLocale()
@@ -42,8 +42,12 @@ export const AvatarImage: FC<Props> = ({
       className={cn(styles.imageContainer, {
         [styles.largeAvatar]: large,
       })}
-      component="button"
-      aria-label={ariaLabel ?? formatMessage(messages.markAsBulkSelection)}
+      component={as}
+      aria-label={
+        as === 'button'
+          ? formatMessage(messages.markAsBulkSelection)
+          : undefined
+      }
       onClick={onClick}
     >
       {avatar ? (

--- a/libs/service-portal/documents/src/components/DocumentLine/AvatarImage.tsx
+++ b/libs/service-portal/documents/src/components/DocumentLine/AvatarImage.tsx
@@ -13,6 +13,8 @@ interface Props {
   avatar?: ReactNode
   onClick?: (event: MouseEvent<HTMLElement>) => void
   large?: boolean
+  ariaLabel?: string
+  imageClass?: string
 }
 
 export const AvatarImage: FC<Props> = ({
@@ -20,6 +22,8 @@ export const AvatarImage: FC<Props> = ({
   background,
   avatar,
   large,
+  imageClass,
+  ariaLabel,
   onClick,
 }) => {
   const { formatMessage } = useLocale()
@@ -39,13 +43,19 @@ export const AvatarImage: FC<Props> = ({
         [styles.largeAvatar]: large,
       })}
       component="button"
-      aria-label={formatMessage(messages.markAsBulkSelection)}
+      aria-label={ariaLabel ?? formatMessage(messages.markAsBulkSelection)}
       onClick={onClick}
     >
       {avatar ? (
         avatar
       ) : (
-        <img className={styles.image} src={img} alt="document" />
+        <img
+          className={cn(styles.image, {
+            [`${imageClass}`]: imageClass,
+          })}
+          src={img}
+          alt="document"
+        />
       )}
     </Box>
   )


### PR DESCRIPTION
## What

Fix logo styling for notifications

## Why

Looks bad now.
Looks good with this PR ✨ 

## Screenshots / Gifs

Currently 😞 

**Header**
![Screenshot 2024-06-13 at 10 09 48](https://github.com/island-is/island.is/assets/24840451/b6fac45f-e538-4f3d-87e6-bc8722bf2a57)

**Page**
![Screenshot 2024-06-13 at 10 10 46](https://github.com/island-is/island.is/assets/24840451/8a33ff71-847c-4f68-bcd4-f598644a38ed)

This PR 👍 

**Header**
![Screenshot 2024-06-13 at 10 08 07](https://github.com/island-is/island.is/assets/24840451/2872a290-a971-4b46-bfef-97a95ffa66c1)

**Page**
![Screenshot 2024-06-13 at 10 08 10](https://github.com/island-is/island.is/assets/24840451/23a09861-3cd6-45fe-8bd5-b638e4eeeefc)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the avatar image styling and rendering in notifications, allowing more flexibility with new prop options.
- **Style**
  - Updated CSS for avatar images to include dimensions and display properties, ensuring consistent visual presentation.
- **Refactor**
  - Adjusted the `AvatarImage` component to support additional props for customization of element type and CSS classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->