### PR TITLE
fix(web): Language toggle not working for organization news

### DIFF
--- a/apps/web/hooks/useLinkResolver/useLinkResolver.ts
+++ b/apps/web/hooks/useLinkResolver/useLinkResolver.ts
@@ -39,14 +39,6 @@ export const routesTemplate = {
     is: '/s/[organization]/vidburdir',
     en: '/en/o/[organization]/events',
   },
-  organizationsubpagelistitem: {
-    is: '/s/[organization]/[slug]/[listItemSlug]',
-    en: '/en/o/[organization]/[slug]/[listItemSlug]',
-  },
-  projectsubpagelistitem: {
-    is: '/v/[project]/[slug]/[listItemSlug]',
-    en: '/en/p/[project]/[slug]/[listItemSlug]',
-  },
   aboutsubpage: {
     is: '/s/stafraent-island/[slug]',
     en: '',
@@ -194,6 +186,14 @@ export const routesTemplate = {
   projectpage: {
     is: '/v/[slug]',
     en: '/en/p/[slug]',
+  },
+  organizationsubpagelistitem: {
+    is: '/s/[organization]/[slug]/[listItemSlug]',
+    en: '/en/o/[organization]/[slug]/[listItemSlug]',
+  },
+  projectsubpagelistitem: {
+    is: '/v/[project]/[slug]/[listItemSlug]',
+    en: '/en/p/[project]/[slug]/[listItemSlug]',
   },
   lifeevents: {
     is: '/lifsvidburdir',


### PR DESCRIPTION
# Language toggle not working for organization news

## What

* A recent addition to the linkResolver object caused the news language toggle to break, the fix was to move the keys further down in the linkResolver object
* This changes in what order links are looked through and therefore addresses the issue

## Screenshots / Gifs

### Before

https://github.com/island-is/island.is/assets/43557895/5da2d2c5-df77-4724-9531-a5adaca66252



### After

https://github.com/island-is/island.is/assets/43557895/c1ec73e8-adc6-4ebe-a5f7-50962a4ddbe0


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restored navigation links for organization subpages and project subpages, ensuring correct routing for multi-language support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->