### PR TITLE
fix(native-app): show personal info from cache if present

### DIFF
--- a/apps/native/app/src/screens/more/personal-info.tsx
+++ b/apps/native/app/src/screens/more/personal-info.tsx
@@ -1,7 +1,7 @@
 import { Alert, Button, Input, InputRow, NavigationBarSheet } from '@ui'
 import React from 'react'
 import { useIntl } from 'react-intl'
-import { ScrollView, View } from 'react-native'
+import { ScrollView, View, Alert as RNAlert } from 'react-native'
 import {
   Navigation,
   NavigationFunctionComponent,
@@ -28,7 +28,7 @@ export const PersonalInfoScreen: NavigationFunctionComponent = ({
   const { dismiss, dismissed } = usePreferencesStore()
   const natRegRes = useNationalRegistryUserQuery()
   const natRegData = natRegRes?.data?.nationalRegistryUser
-  const errorNatReg = !!natRegRes.error
+  const errorNatReg = !!natRegRes.error && !natRegData
   const loadingNatReg = natRegRes.loading && !natRegData
 
   return (

--- a/apps/native/app/src/screens/more/personal-info.tsx
+++ b/apps/native/app/src/screens/more/personal-info.tsx
@@ -1,7 +1,7 @@
 import { Alert, Button, Input, InputRow, NavigationBarSheet } from '@ui'
 import React from 'react'
 import { useIntl } from 'react-intl'
-import { ScrollView, View, Alert as RNAlert } from 'react-native'
+import { ScrollView, View } from 'react-native'
 import {
   Navigation,
   NavigationFunctionComponent,


### PR DESCRIPTION
The app was not showing personal info from cache since it was checking if there was an error and if there was an error the Input component shows a loading state. And when we are offline we get a network error.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling in the personal information screen to check for additional data conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->