### PR TITLE
fix(services-auth-public-api): Fix how max age days is set in passkey config

### DIFF
--- a/libs/auth-api-lib/src/lib/passkeys-core/passkeys-core.config.ts
+++ b/libs/auth-api-lib/src/lib/passkeys-core/passkeys-core.config.ts
@@ -44,7 +44,7 @@ export const PasskeysCoreConfig = defineConfig({
             (2 * 60 * 1000).toString(),
           ),
         ),
-        maxAgeDays: Number(env.optional('PASSKEY_CORE_MAX_AGE_DAYS', '365')),
+        maxAgeDays: env.optionalJSON('PASSKEY_CORE_MAX_AGE_DAYS') ?? 365,
       },
     }
 


### PR DESCRIPTION
## What

When attempting to deplooy auth-public-api an error occured

```
Failed loading configuration for PasskeysCoreModuleCache. Validation failed:
- passkey.maxAgeDays: Expected number, received nan
```

## Why

To read the value correctly and be able to deploy

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced configuration handling for `maxAgeDays` to provide a more robust fallback mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->