### PR TITLE
fix(native-app): offline mode more fixes

### DIFF
--- a/apps/native/app/src/stores/auth-store.ts
+++ b/apps/native/app/src/stores/auth-store.ts
@@ -1,3 +1,4 @@
+import AsyncStorage from '@react-native-community/async-storage'
 import { Alert } from 'react-native'
 import {
   authorize,
@@ -9,6 +10,7 @@ import {
 import Keychain from 'react-native-keychain'
 import createUse from 'zustand'
 import create, { State } from 'zustand/vanilla'
+import { persist } from 'zustand/middleware'
 import { bundleId, getConfig } from '../config'
 import { getIntl } from '../contexts/i18n-provider'
 import { getApolloClientAsync } from '../graphql/client'
@@ -59,134 +61,143 @@ const getAppAuthConfig = () => {
   }
 }
 
-export const authStore = create<AuthStore>((set, get) => ({
-  authorizeResult: undefined,
-  userInfo: undefined,
-  lockScreenActivatedAt: undefined,
-  lockScreenComponentId: undefined,
-  noLockScreenUntilNextAppStateActive: false,
-  isCogitoAuth: false,
-  cognitoDismissCount: 0,
-  cognitoAuthUrl: undefined,
-  cookies: '',
-  async fetchUserInfo(skipRefresh = false) {
-    const appAuthConfig = getAppAuthConfig()
-    // Detect expired token
-    const expiresAt = get().authorizeResult?.accessTokenExpirationDate ?? 0
+export const authStore = create<AuthStore>(
+  persist(
+    (set, get) => ({
+      authorizeResult: undefined,
+      userInfo: undefined,
+      lockScreenActivatedAt: undefined,
+      lockScreenComponentId: undefined,
+      noLockScreenUntilNextAppStateActive: false,
+      isCogitoAuth: false,
+      cognitoDismissCount: 0,
+      cognitoAuthUrl: undefined,
+      cookies: '',
+      async fetchUserInfo(skipRefresh = false) {
+        const appAuthConfig = getAppAuthConfig()
+        // Detect expired token
+        const expiresAt = get().authorizeResult?.accessTokenExpirationDate ?? 0
 
-    if (!skipRefresh && new Date(expiresAt) < new Date()) {
-      await get().refresh()
-    }
+        if (!skipRefresh && new Date(expiresAt) < new Date()) {
+          await get().refresh()
+        }
 
-    const res = await fetch(
-      `${appAuthConfig.issuer.replace(/\/$/, '')}/connect/userinfo`,
-      {
-        headers: {
-          Authorization: `Bearer ${get().authorizeResult?.accessToken}`,
-        },
+        const res = await fetch(
+          `${appAuthConfig.issuer.replace(/\/$/, '')}/connect/userinfo`,
+          {
+            headers: {
+              Authorization: `Bearer ${get().authorizeResult?.accessToken}`,
+            },
+          },
+        )
+
+        if (res.status === 401) {
+          // Attempt to refresh the access token
+          if (!skipRefresh) {
+            await get().refresh()
+            // Retry the userInfo call
+            return get().fetchUserInfo(true)
+          }
+          throw new Error(UNAUTHORIZED_USER_INFO)
+        } else if (res.status === 200) {
+          const userInfo = await res.json()
+          set({ userInfo })
+
+          return userInfo
+        }
       },
-    )
+      async refresh() {
+        const appAuthConfig = getAppAuthConfig()
+        const refreshToken = get().authorizeResult?.refreshToken
 
-    if (res.status === 401) {
-      // Attempt to refresh the access token
-      if (!skipRefresh) {
-        await get().refresh()
-        // Retry the userInfo call
-        return get().fetchUserInfo(true)
-      }
-      throw new Error(UNAUTHORIZED_USER_INFO)
-    } else if (res.status === 200) {
-      const userInfo = await res.json()
-      set({ userInfo })
+        if (!refreshToken) {
+          return
+        }
 
-      return userInfo
-    }
-  },
-  async refresh() {
-    const appAuthConfig = getAppAuthConfig()
-    const refreshToken = get().authorizeResult?.refreshToken
+        const newAuthorizeResult = await authRefresh(appAuthConfig, {
+          refreshToken,
+        })
 
-    if (!refreshToken) {
-      return
-    }
+        const authorizeResult = {
+          ...get().authorizeResult,
+          ...newAuthorizeResult,
+        }
 
-    const newAuthorizeResult = await authRefresh(appAuthConfig, {
-      refreshToken,
-    })
-
-    const authorizeResult = {
-      ...get().authorizeResult,
-      ...newAuthorizeResult,
-    }
-
-    await Keychain.setGenericPassword(
-      KEYCHAIN_AUTH_KEY,
-      JSON.stringify(authorizeResult),
-      { service: KEYCHAIN_AUTH_KEY },
-    )
-    set({ authorizeResult })
-  },
-  async login() {
-    const appAuthConfig = getAppAuthConfig()
-    const authorizeResult = await authorize({
-      ...appAuthConfig,
-      additionalParameters: {
-        prompt: 'login',
-        prompt_delegations: 'true',
-        ui_locales: preferencesStore.getState().locale,
-        externalUserAgent: 'yes',
+        await Keychain.setGenericPassword(
+          KEYCHAIN_AUTH_KEY,
+          JSON.stringify(authorizeResult),
+          { service: KEYCHAIN_AUTH_KEY },
+        )
+        set({ authorizeResult })
       },
-    })
+      async login() {
+        const appAuthConfig = getAppAuthConfig()
+        const authorizeResult = await authorize({
+          ...appAuthConfig,
+          additionalParameters: {
+            prompt: 'login',
+            prompt_delegations: 'true',
+            ui_locales: preferencesStore.getState().locale,
+            externalUserAgent: 'yes',
+          },
+        })
 
-    if (authorizeResult) {
-      await Keychain.setGenericPassword(
-        KEYCHAIN_AUTH_KEY,
-        JSON.stringify(authorizeResult),
-        { service: KEYCHAIN_AUTH_KEY },
-      )
-      set({ authorizeResult })
-      return true
-    }
-    return false
-  },
-  async logout() {
-    // Clear all MMKV storages
-    clearAllStorages()
+        if (authorizeResult) {
+          await Keychain.setGenericPassword(
+            KEYCHAIN_AUTH_KEY,
+            JSON.stringify(authorizeResult),
+            { service: KEYCHAIN_AUTH_KEY },
+          )
+          set({ authorizeResult })
+          return true
+        }
+        return false
+      },
+      async logout() {
+        // Clear all MMKV storages
+        clearAllStorages()
 
-    // Clear push token if exists
-    const pushToken = notificationsStore.getState().pushToken
-    if (pushToken) {
-      notificationsStore.getState().deletePushToken(pushToken)
-    }
-    notificationsStore.getState().reset()
+        // Clear push token if exists
+        const pushToken = notificationsStore.getState().pushToken
+        if (pushToken) {
+          notificationsStore.getState().deletePushToken(pushToken)
+        }
+        notificationsStore.getState().reset()
 
-    const appAuthConfig = getAppAuthConfig()
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const tokenToRevoke = get().authorizeResult!.accessToken!
-    try {
-      await revoke(appAuthConfig, {
-        tokenToRevoke,
-        includeBasicAuth: true,
-        sendClientId: true,
-      })
-    } catch (e) {
-      // NOOP
-    }
+        const appAuthConfig = getAppAuthConfig()
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const tokenToRevoke = get().authorizeResult!.accessToken!
+        try {
+          await revoke(appAuthConfig, {
+            tokenToRevoke,
+            includeBasicAuth: true,
+            sendClientId: true,
+          })
+        } catch (e) {
+          // NOOP
+        }
 
-    const client = await getApolloClientAsync()
-    await client.cache.reset()
-    await Keychain.resetGenericPassword({ service: KEYCHAIN_AUTH_KEY })
-    set(
-      (state) => ({
-        ...state,
-        authorizeResult: undefined,
-        userInfo: undefined,
-      }),
-      true,
-    )
-    return true
-  },
-}))
+        const client = await getApolloClientAsync()
+        await client.cache.reset()
+        await Keychain.resetGenericPassword({ service: KEYCHAIN_AUTH_KEY })
+        set(
+          (state) => ({
+            ...state,
+            authorizeResult: undefined,
+            userInfo: undefined,
+          }),
+          true,
+        )
+        return true
+      },
+    }),
+    {
+      name: 'auth_01',
+      getStorage: () => AsyncStorage,
+      whitelist: ['userInfo'],
+    },
+  ),
+)
 
 export const useAuthStore = createUse(authStore)
 

--- a/apps/native/app/src/utils/app-lock.ts
+++ b/apps/native/app/src/utils/app-lock.ts
@@ -55,13 +55,13 @@ export function showAppLockOverlay({
   })
 }
 
-export function hideAppLockOverlay() {
-  // Dismiss all overlays
-  Navigation.dismissAllOverlays()
+export function hideAppLockOverlay(lockScreenComponentId: string) {
+  // Dismiss the lock screen
+  Navigation.dismissOverlay(lockScreenComponentId)
 
   // reset lockscreen parameters
   authStore.setState({
-    lockScreenActivatedAt: undefined,
+    lockScreenActivatedAt: null,
     lockScreenComponentId: undefined,
   })
 }

--- a/apps/native/app/src/utils/lifecycle/setup-event-handlers.ts
+++ b/apps/native/app/src/utils/lifecycle/setup-event-handlers.ts
@@ -126,9 +126,10 @@ export function setupEventHandlers() {
         if (lockScreenComponentId) {
           if (
             lockScreenActivatedAt !== undefined &&
+            lockScreenActivatedAt !== null &&
             lockScreenActivatedAt + appLockTimeout > Date.now()
           ) {
-            hideAppLockOverlay()
+            hideAppLockOverlay(lockScreenComponentId)
           } else {
             Navigation.updateProps(lockScreenComponentId, { status })
           }


### PR DESCRIPTION
## What

* Fix offline mode when you go offline with app open
* Persist userInfo in app so we show it correctly when offline. 
I tried to only persist userInfo.name and userInfo.nationalId but did not find a proper way to do it (zustand whitelist only accepts keys of the store). 

This is the info that is stored: 
Is something of this too delicate to persist? E.g. the sub? @eirikurn 
```  
{
  "auth_01": {
    "state": {
      "userInfo": {
        "sub": "E5D3E5E081EC4BB765D25485030499577E0F5FC10A89599DBDEB5CD6231DB9BD",
        "nationalId": "0101303019",
        "subjectType": "person",
        "name": "Gervimaður Afríka",
        "gender": "male",
        "birthdate": "1930-01-01",
        "locale": "en"
      }
    },
    "version": 0
  }
}

```
## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced authentication store with token persistency, auto-refresh, login, and logout capabilities.
  - Improved app lock screen functionality with more precise overlay dismissal using lock screen component ID.

- **Bug Fixes**
  - Corrected the handling of the `lockScreenActivatedAt` parameter, ensuring it is set to `null` properly.

- **Refactor**
  - Added a condition to `setupEventHandlers()` to improve app lock screen behavior based on `lockScreenActivatedAt` status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->