### PR TITLE
Revert "chore: Change scaling nginx rate of increase metric for IDS"

### DIFF
--- a/apps/auth-admin-web/infra/auth-admin-web.ts
+++ b/apps/auth-admin-web/infra/auth-admin-web.ts
@@ -53,7 +53,6 @@ export const serviceSetup = (): ServiceBuilder<'auth-admin-web'> => {
       },
     })
     .replicaCount({
-      scalingMagicNumber: 10,
       default: 2,
       min: 2,
       max: 10,

--- a/apps/services/auth/admin-api/infra/auth-admin-api.ts
+++ b/apps/services/auth/admin-api/infra/auth-admin-api.ts
@@ -65,7 +65,6 @@ export const serviceSetup = (): ServiceBuilder<'services-auth-admin-api'> => {
       },
     })
     .replicaCount({
-      scalingMagicNumber: 10,
       default: 2,
       min: 2,
       max: 10,

--- a/apps/services/auth/ids-api/infra/identity-server.ts
+++ b/apps/services/auth/ids-api/infra/identity-server.ts
@@ -157,12 +157,6 @@ export const serviceSetup = (services: {
     })
     .healthPort(5010)
     .targetPort(5000)
-    .replicaCount({
-      scalingMagicNumber: 10,
-      default: 2,
-      min: 2,
-      max: 10,
-    })
     .serviceAccount('identity-server')
     .readiness('/readiness')
     .liveness('/liveness')

--- a/apps/services/auth/personal-representative-public/infra/personal-representative-public.ts
+++ b/apps/services/auth/personal-representative-public/infra/personal-representative-public.ts
@@ -49,7 +49,6 @@ export const serviceSetup =
         },
       })
       .replicaCount({
-        scalingMagicNumber: 10,
         default: 2,
         min: 2,
         max: 10,

--- a/apps/services/auth/personal-representative/infra/personal-representative.ts
+++ b/apps/services/auth/personal-representative/infra/personal-representative.ts
@@ -84,7 +84,6 @@ export const serviceSetup =
         },
       })
       .replicaCount({
-        scalingMagicNumber: 10,
         default: 2,
         min: 2,
         max: 10,

--- a/apps/services/auth/public-api/infra/auth-public-api.ts
+++ b/apps/services/auth/public-api/infra/auth-public-api.ts
@@ -94,7 +94,6 @@ export const serviceSetup = (): ServiceBuilder<'services-auth-public-api'> => {
     .readiness('/health/check')
     .liveness('/liveness')
     .replicaCount({
-      scalingMagicNumber: 10,
       default: 2,
       min: 2,
       max: 10,

--- a/charts/identity-server/values.dev.yaml
+++ b/charts/identity-server/values.dev.yaml
@@ -32,7 +32,7 @@ auth-admin-web:
     scaling:
       metric:
         cpuAverageUtilization: 90
-        nginxRequestsIrate: 10
+        nginxRequestsIrate: 5
       replicas:
         max: 10
         min: 2
@@ -139,10 +139,10 @@ identity-server:
     scaling:
       metric:
         cpuAverageUtilization: 90
-        nginxRequestsIrate: 10
+        nginxRequestsIrate: 5
       replicas:
-        max: 10
-        min: 2
+        max: 3
+        min: 1
   image:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/identity-server'
   ingress:
@@ -170,9 +170,9 @@ identity-server:
       storageClass: 'efs-csi'
       useExisting: false
   replicaCount:
-    default: 2
-    max: 10
-    min: 2
+    default: 1
+    max: 3
+    min: 1
   resources:
     limits:
       cpu: '4000m'
@@ -240,7 +240,7 @@ services-auth-admin-api:
     scaling:
       metric:
         cpuAverageUtilization: 90
-        nginxRequestsIrate: 10
+        nginxRequestsIrate: 5
       replicas:
         max: 10
         min: 2
@@ -579,7 +579,7 @@ services-auth-personal-representative:
     scaling:
       metric:
         cpuAverageUtilization: 90
-        nginxRequestsIrate: 10
+        nginxRequestsIrate: 5
       replicas:
         max: 10
         min: 2
@@ -650,7 +650,7 @@ services-auth-personal-representative-public:
     scaling:
       metric:
         cpuAverageUtilization: 90
-        nginxRequestsIrate: 10
+        nginxRequestsIrate: 5
       replicas:
         max: 10
         min: 2
@@ -742,7 +742,7 @@ services-auth-public-api:
     scaling:
       metric:
         cpuAverageUtilization: 90
-        nginxRequestsIrate: 10
+        nginxRequestsIrate: 5
       replicas:
         max: 10
         min: 2

--- a/charts/identity-server/values.prod.yaml
+++ b/charts/identity-server/values.prod.yaml
@@ -32,7 +32,7 @@ auth-admin-web:
     scaling:
       metric:
         cpuAverageUtilization: 90
-        nginxRequestsIrate: 10
+        nginxRequestsIrate: 5
       replicas:
         max: 10
         min: 2
@@ -137,10 +137,10 @@ identity-server:
     scaling:
       metric:
         cpuAverageUtilization: 90
-        nginxRequestsIrate: 10
+        nginxRequestsIrate: 5
       replicas:
         max: 10
-        min: 2
+        min: 3
   image:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/identity-server'
   ingress:
@@ -167,9 +167,9 @@ identity-server:
       storageClass: 'efs-csi'
       useExisting: false
   replicaCount:
-    default: 2
+    default: 3
     max: 10
-    min: 2
+    min: 3
   resources:
     limits:
       cpu: '4000m'
@@ -237,7 +237,7 @@ services-auth-admin-api:
     scaling:
       metric:
         cpuAverageUtilization: 90
-        nginxRequestsIrate: 10
+        nginxRequestsIrate: 5
       replicas:
         max: 10
         min: 2
@@ -576,7 +576,7 @@ services-auth-personal-representative:
     scaling:
       metric:
         cpuAverageUtilization: 90
-        nginxRequestsIrate: 10
+        nginxRequestsIrate: 5
       replicas:
         max: 10
         min: 2
@@ -639,7 +639,7 @@ services-auth-personal-representative-public:
     scaling:
       metric:
         cpuAverageUtilization: 90
-        nginxRequestsIrate: 10
+        nginxRequestsIrate: 5
       replicas:
         max: 10
         min: 2
@@ -731,7 +731,7 @@ services-auth-public-api:
     scaling:
       metric:
         cpuAverageUtilization: 90
-        nginxRequestsIrate: 10
+        nginxRequestsIrate: 5
       replicas:
         max: 10
         min: 2

--- a/charts/identity-server/values.staging.yaml
+++ b/charts/identity-server/values.staging.yaml
@@ -32,7 +32,7 @@ auth-admin-web:
     scaling:
       metric:
         cpuAverageUtilization: 90
-        nginxRequestsIrate: 10
+        nginxRequestsIrate: 5
       replicas:
         max: 10
         min: 2
@@ -139,10 +139,10 @@ identity-server:
     scaling:
       metric:
         cpuAverageUtilization: 90
-        nginxRequestsIrate: 10
+        nginxRequestsIrate: 5
       replicas:
-        max: 10
-        min: 2
+        max: 3
+        min: 1
   image:
     repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/identity-server'
   ingress:
@@ -170,9 +170,9 @@ identity-server:
       storageClass: 'efs-csi'
       useExisting: false
   replicaCount:
-    default: 2
-    max: 10
-    min: 2
+    default: 1
+    max: 3
+    min: 1
   resources:
     limits:
       cpu: '4000m'
@@ -240,7 +240,7 @@ services-auth-admin-api:
     scaling:
       metric:
         cpuAverageUtilization: 90
-        nginxRequestsIrate: 10
+        nginxRequestsIrate: 5
       replicas:
         max: 10
         min: 2
@@ -579,7 +579,7 @@ services-auth-personal-representative:
     scaling:
       metric:
         cpuAverageUtilization: 90
-        nginxRequestsIrate: 10
+        nginxRequestsIrate: 5
       replicas:
         max: 10
         min: 2
@@ -642,7 +642,7 @@ services-auth-personal-representative-public:
     scaling:
       metric:
         cpuAverageUtilization: 90
-        nginxRequestsIrate: 10
+        nginxRequestsIrate: 5
       replicas:
         max: 10
         min: 2
@@ -734,7 +734,7 @@ services-auth-public-api:
     scaling:
       metric:
         cpuAverageUtilization: 90
-        nginxRequestsIrate: 10
+        nginxRequestsIrate: 5
       replicas:
         max: 10
         min: 2


### PR DESCRIPTION
Reverts island-is/island.is#14646

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized scaling configurations across various services by removing the `scalingMagicNumber` parameter from the `replicaCount` settings.

- **Performance Improvements**
  - Adjusted `nginxRequestsIrate` metric values from 10 to 5 for more balanced load management.
  - Updated replica counts and resource limits for the `identity-server` service to improve efficiency and resource allocation in different environments (development, production, and staging).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->