### PR TITLE
chore(occupational-licenses): fix

### DIFF
--- a/libs/service-portal/occupational-licenses/src/screens/v2/OccupationalLicensesDetail/OccupationalLicensesDetail.tsx
+++ b/libs/service-portal/occupational-licenses/src/screens/v2/OccupationalLicensesDetail/OccupationalLicensesDetail.tsx
@@ -177,48 +177,47 @@ const OccupationalLicenseDetail = () => {
               }
             />
           )}
-          {(license?.status || loading) &&
-            license?.type !== OccupationalLicenseV2LicenseType.EDUCATION && (
-              <UserInfoLine
-                loading={loading}
-                label={formatMessage(om.licenseStatus)}
-                content={
-                  <Box
-                    display="flex"
-                    justifyContent="center"
-                    alignItems="center"
-                    columnGap="p1"
-                  >
-                    <Text>
-                      {formatMessage(
-                        license?.status === 'VALID'
-                          ? om.validLicense
-                          : license?.status === 'LIMITED'
-                          ? om.validWithLimitationsLicense
-                          : om.invalidLicense,
-                      )}
-                    </Text>
-                    <Icon
-                      icon={
-                        license?.status === 'VALID'
-                          ? 'checkmarkCircle'
-                          : license?.status === 'LIMITED'
-                          ? 'warning'
-                          : 'closeCircle'
-                      }
-                      color={
-                        license?.status === 'VALID'
-                          ? 'mint600'
-                          : license?.status === 'LIMITED'
-                          ? 'yellow600'
-                          : 'red600'
-                      }
-                      type="filled"
-                    />
-                  </Box>
-                }
-              />
-            )}
+          {(license?.status || loading) && !isOldEducationLicense && (
+            <UserInfoLine
+              loading={loading}
+              label={formatMessage(om.licenseStatus)}
+              content={
+                <Box
+                  display="flex"
+                  justifyContent="center"
+                  alignItems="center"
+                  columnGap="p1"
+                >
+                  <Text>
+                    {formatMessage(
+                      license?.status === 'VALID'
+                        ? om.validLicense
+                        : license?.status === 'LIMITED'
+                        ? om.validWithLimitationsLicense
+                        : om.invalidLicense,
+                    )}
+                  </Text>
+                  <Icon
+                    icon={
+                      license?.status === 'VALID'
+                        ? 'checkmarkCircle'
+                        : license?.status === 'LIMITED'
+                        ? 'warning'
+                        : 'closeCircle'
+                    }
+                    color={
+                      license?.status === 'VALID'
+                        ? 'mint600'
+                        : license?.status === 'LIMITED'
+                        ? 'yellow600'
+                        : 'red600'
+                    }
+                    type="filled"
+                  />
+                </Box>
+              }
+            />
+          )}
           {license?.genericFields?.length &&
             license.genericFields.map((g, index) => (
               <UserInfoLine


### PR DESCRIPTION
## What

Hide validity only for old education licenses

## Why

Wrong

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
  - Improved the logic for displaying the license status on the Occupational Licenses Detail page.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->