### PR TITLE
fix(core): Markdown display of note

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,8 @@ If you want to contribute to the repository, please make sure to follow [this gu
 - You have [direnv](https://direnv.net/) installed.
 - You have [Java](https://www.java.com/en/download/manual.jsp) `>= 1.8` installed (for schema generation).
 
-{% hint style="info" %}
-If you are running on Windows we recommend using [Docker and WSL2](https://docs.docker.com/desktop/windows/wsl/)
-{% endhint %}
+> [!NOTE]
+> If you are running on Windows we recommend using [Docker and WSL2](https://docs.docker.com/desktop/windows/wsl/)
 
 ### For fetching secrets
 


### PR DESCRIPTION
## What

Currently, there is a note in the README that is not being display correctly

## Why

This would make it easy to see the note and make it work as intended

## Screenshots

![image](https://github.com/island-is/island.is/assets/46012817/f410b736-4546-42e4-8d98-157a2925d728)

## Checklist:
there is node code changes, so I think I could check all of this

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Converted a hint block into a note block in the README.md to provide clearer guidance for Windows users regarding Docker and WSL2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->