### PR TITLE
fix(web): Add locale prefix to subarticle entry hyperlink url

### DIFF
--- a/libs/island-ui/contentful/src/lib/RichTextRC/defaultRenderNode.tsx
+++ b/libs/island-ui/contentful/src/lib/RichTextRC/defaultRenderNode.tsx
@@ -248,7 +248,17 @@ export const defaultRenderNodeObject: RenderNode = {
           href = `/${href}`
         }
 
-        return href ? <Hyperlink href={href}>{children}</Hyperlink> : null
+        return href ? (
+          <Hyperlink
+            href={`${
+              !entry?.sys?.locale || entry?.sys?.locale !== 'is-IS'
+                ? ''
+                : `/${entry.sys.locale}`
+            }${href}`}
+          >
+            {children}
+          </Hyperlink>
+        ) : null
       }
       case 'organizationPage': {
         const prefix = getOrganizationPageUrlPrefix(entry?.sys?.locale)


### PR DESCRIPTION
# Add locale prefix to subarticle entry hyperlink url

## Why

The locale prefix was missing, resulting in entry hyperlink urls not pointing to a correct url

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
