### PR TITLE
feat(web): Generic list - Items can now point to assets

### DIFF
--- a/apps/web/components/GenericList/GenericList.css.ts
+++ b/apps/web/components/GenericList/GenericList.css.ts
@@ -1,0 +1,5 @@
+import { style } from '@vanilla-extract/css'
+
+export const clickableItemTopRowContainer = style({
+  minHeight: '30px',
+})

--- a/apps/web/components/GenericList/GenericList.tsx
+++ b/apps/web/components/GenericList/GenericList.tsx
@@ -16,6 +16,7 @@ import {
   GridColumn,
   GridContainer,
   GridRow,
+  Icon,
   Inline,
   Pagination,
   Stack,
@@ -42,6 +43,7 @@ import { GET_GENERIC_LIST_ITEMS_QUERY } from '@island.is/web/screens/queries/Gen
 import { webRichText } from '@island.is/web/utils/richText'
 
 import { FilterTag } from '../FilterTag'
+import * as styles from './GenericList.css'
 
 const DEBOUNCE_TIME_IN_MS = 300
 const ITEMS_PER_PAGE = 10
@@ -111,36 +113,61 @@ const ClickableItem = ({ item }: ItemProps) => {
 
   const pathname = new URL(router.asPath, 'https://island.is').pathname
 
+  let href = item.slug ? `${pathname}/${item.slug}` : undefined
+  if (item.assetUrl) {
+    href = item.assetUrl
+  }
+
   return (
     <FocusableBox
       padding={[2, 2, 3]}
       border="standard"
       borderRadius="large"
-      href={item.slug ? `${pathname}/${item.slug}` : undefined}
+      href={href}
       height="full"
+      width="full"
     >
-      <Stack space={3}>
-        <Stack space={0}>
-          <Stack space={0}>
-            <Text variant="eyebrow" color="purple400">
-              {item.date && format(new Date(item.date), 'dd.MM.yyyy')}
-            </Text>
-            <Text variant="h3" as="span" color="blue400">
-              {item.title}
-            </Text>
-          </Stack>
-          {item.cardIntro?.length > 0 && (
-            <Box>{webRichText(item.cardIntro ?? [])}</Box>
-          )}
+      <Box width="full">
+        <Stack space={3}>
+          <Box width="full">
+            <Box width="full">
+              <Box className={styles.clickableItemTopRowContainer}>
+                <Inline space={2} justifyContent="spaceBetween">
+                  <Text variant="eyebrow" color="purple400">
+                    {item.date && format(new Date(item.date), 'dd.MM.yyyy')}
+                  </Text>
+                  {item.assetUrl && (
+                    <Icon
+                      size="medium"
+                      type="outline"
+                      color="blue400"
+                      icon="document"
+                    />
+                  )}
+                </Inline>
+              </Box>
+              <Text variant="h3" as="span" color="blue400">
+                {item.title}
+              </Text>
+            </Box>
+            {item.cardIntro?.length > 0 && (
+              <Box>{webRichText(item.cardIntro ?? [])}</Box>
+            )}
+          </Box>
+          <Inline space={1}>
+            {item.filterTags?.map((tag) => (
+              <Tag
+                disabled={true}
+                variant="purple"
+                outlined={true}
+                key={tag.id}
+              >
+                {tag.title}
+              </Tag>
+            ))}
+          </Inline>
         </Stack>
-        <Inline space={1}>
-          {item.filterTags?.map((tag) => (
-            <Tag disabled={true} variant="purple" outlined={true} key={tag.id}>
-              {tag.title}
-            </Tag>
-          ))}
-        </Inline>
-      </Stack>
+      </Box>
     </FocusableBox>
   )
 }

--- a/apps/web/screens/queries/GenericList.ts
+++ b/apps/web/screens/queries/GenericList.ts
@@ -23,6 +23,7 @@ export const GET_GENERIC_LIST_ITEMS_QUERY = gql`
           slug
         }
         slug
+        assetUrl
       }
       total
     }

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -1596,6 +1596,9 @@ export interface IGenericListItemFields {
 
   /** Filter Tags */
   filterTags?: IGenericTag[] | undefined
+
+  /** Asset */
+  asset?: Asset | undefined
 }
 
 /** An item that belongs to a generic list */

--- a/libs/cms/src/lib/models/genericListItem.model.ts
+++ b/libs/cms/src/lib/models/genericListItem.model.ts
@@ -28,6 +28,9 @@ export class GenericListItem {
   @Field(() => String, { nullable: true })
   slug?: string
 
+  @Field(() => String, { nullable: true })
+  assetUrl?: string
+
   @CacheField(() => [GenericTag], { nullable: true })
   filterTags?: GenericTag[]
 }
@@ -35,19 +38,30 @@ export class GenericListItem {
 export const mapGenericListItem = ({
   fields,
   sys,
-}: IGenericListItem): GenericListItem => ({
-  id: sys.id,
-  genericList: fields.genericList
-    ? mapGenericList(fields.genericList)
-    : undefined,
-  title: fields.title ?? '',
-  date: fields.date || null,
-  cardIntro: fields.cardIntro
-    ? mapDocument(fields.cardIntro, `${sys.id}:cardIntro`)
-    : [],
-  content: fields.content
-    ? mapDocument(fields.content, `${sys.id}:content`)
-    : [],
-  slug: fields.slug,
-  filterTags: fields.filterTags ? fields.filterTags.map(mapGenericTag) : [],
-})
+}: IGenericListItem): GenericListItem => {
+  let assetUrl = fields.asset?.fields?.file?.url ?? ''
+
+  // The asset url might not contain a protocol that's why we prepend https:
+  // https://www.contentful.com/developers/docs/concepts/images/
+  if (assetUrl.startsWith('//')) {
+    assetUrl = `https:${assetUrl}`
+  }
+
+  return {
+    id: sys.id,
+    genericList: fields.genericList
+      ? mapGenericList(fields.genericList)
+      : undefined,
+    title: fields.title ?? '',
+    date: fields.date || null,
+    cardIntro: fields.cardIntro
+      ? mapDocument(fields.cardIntro, `${sys.id}:cardIntro`)
+      : [],
+    content: fields.content
+      ? mapDocument(fields.content, `${sys.id}:content`)
+      : [],
+    slug: fields.slug,
+    assetUrl,
+    filterTags: fields.filterTags ? fields.filterTags.map(mapGenericTag) : [],
+  }
+}


### PR DESCRIPTION
# Generic list - Items can now point to assets

## What

* Generic list is a content type that allows us to create a list of cards that can either be clickable or not.
* When a card is clickable it leads the user to another page. 
* This PR introduces a way for cards to lead users to a given asset (like a pdf document for example)

## Screenshots / Gifs

### Before
![image](https://github.com/island-is/island.is/assets/43557895/6e89c6ab-0ecb-4bda-8527-7b73a36a2b38)


### After
![Screenshot 2024-06-24 at 10 30 40](https://github.com/island-is/island.is/assets/43557895/bfdd0a4b-b090-4d8a-bfbe-876937a61077)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
