### PR TITLE
fix(occupational-licenses): Fix old education license teacher cutoff

### DIFF
--- a/libs/service-portal/occupational-licenses/src/components/LicenseDetail.tsx
+++ b/libs/service-portal/occupational-licenses/src/components/LicenseDetail.tsx
@@ -1,4 +1,4 @@
-import { Stack, Box, Icon, Text } from '@island.is/island-ui/core'
+import { Stack, Box, Icon, Text, AlertMessage } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
 import {
   IntroHeader,
@@ -14,6 +14,7 @@ type LicenseDetailProps = {
   intro?: string | null
   serviceProviderSlug?: OrganizationSlugType
   serviceProviderTooltip?: string
+  isOldEducationLicense?: boolean
   name?: string | null
   dateOfBirth?: string | null
   profession?: string | null
@@ -29,6 +30,7 @@ export const LicenseDetail: React.FC<LicenseDetailProps> = ({
   intro,
   serviceProviderSlug,
   serviceProviderTooltip,
+  isOldEducationLicense,
   buttonGroup,
   name,
   dateOfBirth,
@@ -47,8 +49,17 @@ export const LicenseDetail: React.FC<LicenseDetailProps> = ({
         intro={intro ? intro : undefined}
         serviceProviderSlug={serviceProviderSlug}
         serviceProviderTooltip={serviceProviderTooltip}
-        children={buttonGroup}
+        children={!isOldEducationLicense ? buttonGroup : undefined}
       />
+      {isOldEducationLicense && (
+        <AlertMessage
+          type="warning"
+          title={formatMessage(om.educationLicenseDigitalUnavailable)}
+          message={formatMessage(
+            om.educationLicenseDigitalUnavailableDescription,
+          )}
+        />
+      )}
       <Stack dividers space="auto">
         {name && (
           <UserInfoLine
@@ -104,7 +115,7 @@ export const LicenseDetail: React.FC<LicenseDetailProps> = ({
             valueColumnSpan={['6/12']}
           />
         )}
-        {status && (
+        {!isOldEducationLicense && status && (
           <UserInfoLine
             paddingY={3}
             label={formatMessage(om.licenseStatus)}

--- a/libs/service-portal/occupational-licenses/src/screens/v1/EducationalDetail/EducationalDetail.tsx
+++ b/libs/service-portal/occupational-licenses/src/screens/v1/EducationalDetail/EducationalDetail.tsx
@@ -36,7 +36,13 @@ export const EducationDetail = () => {
     },
   })
 
+  const EDUCATION_LICENSE_SIGNED_CERTIFICATE_CUTOFF = new Date('01.01.2020')
+
   const license = data?.occupationalLicensesEducationalLicense?.items[0]
+
+  const isOldEducationLicense =
+    license?.__typename === 'OccupationalLicensesEducationalLicense' &&
+    new Date(license.validFrom) < EDUCATION_LICENSE_SIGNED_CERTIFICATE_CUTOFF
 
   const downloadUrl =
     license?.__typename === 'OccupationalLicensesEducationalLicense'
@@ -91,6 +97,7 @@ export const EducationDetail = () => {
           </Box>
         ) : undefined
       }
+      isOldEducationLicense={isOldEducationLicense}
       name={user.profile.name}
       dateOfBirth={birthday ? formatDateFns(birthday, 'dd.MM.yyyy') : undefined}
       profession={programme}

--- a/libs/service-portal/occupational-licenses/src/screens/v1/EducationalDetail/EducationalDetail.tsx
+++ b/libs/service-portal/occupational-licenses/src/screens/v1/EducationalDetail/EducationalDetail.tsx
@@ -19,6 +19,8 @@ type UseParams = {
   id: string
 }
 
+const EDUCATION_LICENSE_SIGNED_CERTIFICATE_CUTOFF = new Date('01.01.2020')
+
 export const EducationDetail = () => {
   const { id } = useParams() as UseParams
   useNamespaces('sp.occupational-licenses')
@@ -36,12 +38,11 @@ export const EducationDetail = () => {
     },
   })
 
-  const EDUCATION_LICENSE_SIGNED_CERTIFICATE_CUTOFF = new Date('01.01.2020')
-
   const license = data?.occupationalLicensesEducationalLicense?.items[0]
 
   const isOldEducationLicense =
     license?.__typename === 'OccupationalLicensesEducationalLicense' &&
+    !!license.validFrom &&
     new Date(license.validFrom) < EDUCATION_LICENSE_SIGNED_CERTIFICATE_CUTOFF
 
   const downloadUrl =


### PR DESCRIPTION
## What

* Dont allow download of old teacher licenses

## Why

* Not allowed


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new alert message in the License Detail view for old education licenses.
  - Added a cutoff date to identify and mark old education licenses in the Educational Detail view.

- **Improvements**
  - The License Detail and Educational Detail views now conditionally display alerts based on the age of the education license.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->