### PR TITLE
fix(service-portal): Add fallback image to notifications

### DIFF
--- a/apps/service-portal/src/components/Notifications/NotificationLine.tsx
+++ b/apps/service-portal/src/components/Notifications/NotificationLine.tsx
@@ -11,7 +11,10 @@ import {
   NotificationSender,
 } from '@island.is/api/schema'
 import { AvatarImage } from '@island.is/service-portal/documents'
-import { resolveLink } from '@island.is/service-portal/information'
+import {
+  COAT_OF_ARMS,
+  resolveLink,
+} from '@island.is/service-portal/information'
 
 interface Props {
   data: {
@@ -47,14 +50,12 @@ export const NotificationLine = ({ data, onClickCallback }: Props) => {
             [styles.unread]: !isRead,
           })}
         >
-          {data.sender?.logoUrl ? (
-            <AvatarImage
-              img={data.sender.logoUrl}
-              background={!isRead ? 'white' : 'blue100'}
-              as="div"
-              imageClass={styles.img}
-            />
-          ) : undefined}
+          <AvatarImage
+            img={data.sender?.logoUrl ?? COAT_OF_ARMS}
+            background={!isRead ? 'white' : 'blue100'}
+            as="div"
+            imageClass={styles.img}
+          />
           <Box
             width="full"
             display="flex"

--- a/libs/service-portal/information/src/screens/Notifications/Notifications.tsx
+++ b/libs/service-portal/information/src/screens/Notifications/Notifications.tsx
@@ -26,7 +26,7 @@ import { mInformationNotifications } from '../../lib/messages'
 import { ActionCard, CardLoader } from '@island.is/service-portal/core'
 import { Problem } from '@island.is/react-spa/shared'
 import { InformationPaths } from '../../lib/paths'
-import { resolveLink } from '../../utils/notificationLinkResolver'
+import { COAT_OF_ARMS, resolveLink } from '../../utils/notificationLinkResolver'
 
 const DEFAULT_PAGE_SIZE = 5
 
@@ -161,15 +161,11 @@ const UserNotifications = () => {
                     },
                   }),
               }}
-              image={
-                item.sender?.logoUrl
-                  ? {
-                      type: 'circle',
-                      url: item.sender.logoUrl,
-                      active: !item.metadata.read,
-                    }
-                  : undefined
-              }
+              image={{
+                type: 'circle',
+                url: item.sender?.logoUrl ?? COAT_OF_ARMS,
+                active: !item.metadata.read,
+              }}
               key={item.notificationId}
             />
           ))}

--- a/libs/service-portal/information/src/utils/notificationLinkResolver.ts
+++ b/libs/service-portal/information/src/utils/notificationLinkResolver.ts
@@ -34,3 +34,6 @@ export const resolveLink = (link: NotificationLink): string => {
   }
   return link.url ?? ''
 }
+
+export const COAT_OF_ARMS =
+  'https://images.ctfassets.net/8k0h54kbe6bj/6XhCz5Ss17OVLxpXNVDxAO/d3d6716bdb9ecdc5041e6baf68b92ba6/coat_of_arms.svg'


### PR DESCRIPTION
## What

Add fallback image to 

## Why

No fallback means that notifications with no images don't look right.

## Screenshots / Gifs

![Screenshot 2024-06-26 at 09 34 48](https://github.com/island-is/island.is/assets/24840451/af211ce1-bb20-4a63-bb58-3e99f7a11068)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a fallback image (Coat of Arms) for notifications when the sender's logo is not available.

- **Enhancements**
  - Improved notification rendering by using a default image, ensuring a consistent look even if the sender’s logo is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->