### PR TITLE
fix(regulations-admin): Signature formatting

### DIFF
--- a/libs/application/templates/official-journal-of-iceland/src/components/htmlEditor/templates/signatures.ts
+++ b/libs/application/templates/official-journal-of-iceland/src/components/htmlEditor/templates/signatures.ts
@@ -51,7 +51,7 @@ const titleTemplate = (title?: string, date?: string, locale = 'is') => {
   return `
   <p class="signature__title">${title}${title && date ? ', ' : ''}${
     date
-      ? format(new Date(date), 'dd. MMMM yyyy', {
+      ? format(new Date(date), 'd. MMMM yyyy', {
           locale: locale === 'is' ? is : en,
         })
       : ''

--- a/libs/portals/admin/regulations-admin/src/components/EditSignature.tsx
+++ b/libs/portals/admin/regulations-admin/src/components/EditSignature.tsx
@@ -28,7 +28,7 @@ import { useS3Upload } from '../utils/dataHooks'
 
 const defaultSignatureText = `
   <p class="Dags" align="center"><em>{ministry}nu, {dags}.</em></p>
-  <p class="FHUndirskr" align="center">f.h.r.</p>
+  <p class="FHUndirskr" align="center">F.h.r.</p>
   <p class="Undirritun" align="center"><strong>NAFN</strong></p>
   <p class="Undirritun" align="right"><em>NAFN.</em></p>
 ` as HTMLText


### PR DESCRIPTION
## What

Fix Signature formatting

## Why

Fhr should be capitalized. Within the text, a date should only display a single digit for day, example: 1. Júní instead of 01 Júní.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated date format in signatures to improve consistency (from 'dd. MMMM yyyy' to 'd. MMMM yyyy').

- **Style**
  - Capitalized "f.h.r." to "F.h.r." in the default signature text for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->