### PR TITLE
fix(core): Support Fish shell in the clean.sh script

### DIFF
--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -155,7 +155,8 @@ clean_all() {
   local jobs=("generated" "caches" "yarn" "node_modules")
 
   for job in "${jobs[@]}"; do
-    local job_var="CLEAN_$(echo $job | tr '[:lower:]' '[:upper:]')"
+    local job_var
+    job_var="CLEAN_$(echo $job | tr '[:lower:]' '[:upper:]')"
     if [[ "${!job_var}" == "true" ]]; then
       log "Cleaning $job files"
       "clean_$job"

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -155,7 +155,7 @@ clean_all() {
   local jobs=("generated" "caches" "yarn" "node_modules")
 
   for job in "${jobs[@]}"; do
-    local job_var="CLEAN_${job^^}"
+    local job_var="CLEAN_$(echo $job | tr '[:lower:]' '[:upper:]')"
     if [[ "${!job_var}" == "true" ]]; then
       log "Cleaning $job files"
       "clean_$job"


### PR DESCRIPTION
## What

The `^^` operator in bash for uppercasing isn´t supported in fish, making the clean.sh script fail. So using the tr instead.

## Why

So the same script can work on both bash and fish.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the script for cleaning tasks to dynamically convert job names to uppercase for better consistency and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->