### PR TITLE
fix(native-app): use login_hint correctly

### DIFF
--- a/apps/native/app/src/lib/passkeys/helpers.ts
+++ b/apps/native/app/src/lib/passkeys/helpers.ts
@@ -125,13 +125,13 @@ export const addPasskeyAsLoginHint = (
   }
 
   if (url.includes('/minarsidur')) {
-    return `${origin}/minarsidur/login?login_hint=${authenticationResponse}&target_link_uri=${encodeURIComponent(
+    return `${origin}/minarsidur/login?login_hint=passkey:${authenticationResponse}&target_link_uri=${encodeURIComponent(
       url,
     )}`
   }
 
   if (url.includes('/umsoknir')) {
-    return `${origin}/umsoknir/login?login_hint=${authenticationResponse}&target_link_uri=${encodeURIComponent(
+    return `${origin}/umsoknir/login?login_hint=passkey:${authenticationResponse}&target_link_uri=${encodeURIComponent(
       url,
     )}`
   }


### PR DESCRIPTION
Apparently the ids wants the login_hint on the form `passkey:passkey_here`.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Passkeys now include a "passkey:" prefix in the login hint for improved security and clarity based on URL conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->