### PR TITLE
feat(web): Add field to use only left title and some styles

### DIFF
--- a/apps/web/components/Organization/Slice/TwoColumnText/TwoColumnTextSlice.tsx
+++ b/apps/web/components/Organization/Slice/TwoColumnText/TwoColumnTextSlice.tsx
@@ -1,4 +1,5 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+import { useWindowSize } from 'react-use'
 
 import { SliceType } from '@island.is/island-ui/contentful'
 import {
@@ -13,6 +14,7 @@ import {
   Text,
 } from '@island.is/island-ui/core'
 import { SpanType } from '@island.is/island-ui/core/types'
+import { theme } from '@island.is/island-ui/theme'
 import { BorderAbove } from '@island.is/web/components'
 import { TwoColumnText } from '@island.is/web/graphql/schema'
 import { useI18n } from '@island.is/web/i18n'
@@ -28,6 +30,12 @@ export const TwoColumnTextSlice: React.FC<
   React.PropsWithChildren<SliceProps>
 > = ({ slice }) => {
   const { activeLocale } = useI18n()
+  const { width } = useWindowSize()
+  const [isMobile, setIsMobile] = useState(false)
+
+  useEffect(() => {
+    setIsMobile(width < theme.breakpoints.lg)
+  }, [width])
 
   const leftId = 'sliceLeftTitle-' + slice.id
   const rightId = 'sliceRightTitle-' + slice.id
@@ -41,6 +49,14 @@ export const TwoColumnTextSlice: React.FC<
     sliceLabelIds.push(rightId)
   }
 
+  const rightContentCloserToLeftContentMobile =
+    (slice.rightTitle === '' ||
+      slice.rightTitle === undefined ||
+      slice.onlyUseOneTitle) &&
+    slice.leftTitle !== '' &&
+    !slice.leftLink?.url &&
+    isMobile
+
   const ariaLabelledBy = sliceLabelIds.join(' ')
 
   return (
@@ -53,20 +69,25 @@ export const TwoColumnTextSlice: React.FC<
         {slice.dividerOnTop && <BorderAbove />}
         <Box>
           <GridRow>
-            <GridColumn span={columnSpan} hiddenBelow="lg">
+            <GridColumn
+              span={slice.onlyUseOneTitle ? '12/12' : columnSpan}
+              hiddenBelow="lg"
+            >
               {slice.leftTitle && (
                 <Text variant="h2" as="h2" id={leftId}>
                   <Hyphen>{slice.leftTitle}</Hyphen>
                 </Text>
               )}
             </GridColumn>
-            <GridColumn span={columnSpan} hiddenBelow="lg">
-              {slice.rightTitle && (
-                <Text variant="h2" as="h2" id={rightId}>
-                  <Hyphen>{slice.rightTitle}</Hyphen>
-                </Text>
-              )}
-            </GridColumn>
+            {!slice.onlyUseOneTitle && (
+              <GridColumn span={columnSpan} hiddenBelow="lg">
+                {slice.rightTitle && (
+                  <Text variant="h2" as="h2" id={rightId}>
+                    <Hyphen>{slice.rightTitle}</Hyphen>
+                  </Text>
+                )}
+              </GridColumn>
+            )}
           </GridRow>
           <GridRow>
             <GridColumn span={columnSpan}>
@@ -83,42 +104,61 @@ export const TwoColumnTextSlice: React.FC<
                 activeLocale,
               )}
               {slice.leftLink && slice.leftLink.url && (
-                <Link href={slice.leftLink.url}>
-                  <Button
-                    icon="arrowForward"
-                    iconType="filled"
-                    type="button"
-                    variant="text"
-                  >
-                    {slice.leftLink.text}
-                  </Button>
-                </Link>
+                <Box paddingTop={2}>
+                  <Link href={slice.leftLink.url}>
+                    <Button
+                      icon="arrowForward"
+                      iconType="filled"
+                      type="button"
+                      variant="text"
+                    >
+                      {slice.leftLink.text}
+                    </Button>
+                  </Link>
+                </Box>
               )}
             </GridColumn>
-            <GridColumn span={columnSpan} paddingTop={[4, 4, 4, 0]}>
-              {slice.rightTitle && (
+            <GridColumn
+              span={columnSpan}
+              paddingTop={
+                rightContentCloserToLeftContentMobile
+                  ? [0, 0, 0, 0]
+                  : [2, 2, 2, 0]
+              }
+            >
+              {!slice.onlyUseOneTitle && slice.rightTitle && (
                 <Hidden above="md">
                   <Text variant="h2" as="h2">
                     {slice.rightTitle}
                   </Text>
                 </Hidden>
               )}
-              {webRichText(
-                slice.rightContent as SliceType[],
-                undefined,
-                activeLocale,
-              )}
+              <Box
+                style={
+                  rightContentCloserToLeftContentMobile
+                    ? { marginTop: '-10px' }
+                    : {}
+                }
+              >
+                {webRichText(
+                  slice.rightContent as SliceType[],
+                  undefined,
+                  activeLocale,
+                )}
+              </Box>
               {slice.rightLink && slice.rightLink.url && (
-                <Link href={slice.rightLink.url}>
-                  <Button
-                    icon="arrowForward"
-                    iconType="filled"
-                    type="button"
-                    variant="text"
-                  >
-                    {slice.rightLink.text}
-                  </Button>
-                </Link>
+                <Box paddingTop={2}>
+                  <Link href={slice.rightLink.url}>
+                    <Button
+                      icon="arrowForward"
+                      iconType="filled"
+                      type="button"
+                      variant="text"
+                    >
+                      {slice.rightLink.text}
+                    </Button>
+                  </Link>
+                </Box>
               )}
             </GridColumn>
           </GridRow>

--- a/apps/web/screens/queries/fragments.ts
+++ b/apps/web/screens/queries/fragments.ts
@@ -420,6 +420,7 @@ export const slices = gql`
       url
     }
     dividerOnTop
+    onlyUseOneTitle
   }
 
   fragment MultipleStatisticsFields on MultipleStatistics {

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -4570,6 +4570,9 @@ export interface ITwoColumnTextFields {
   /** Left Title */
   leftTitle?: string | undefined
 
+  /** Only use one title */
+  onlyUseOneTitle?: boolean | undefined
+
   /** Left Content */
   leftContent?: Document | undefined
 

--- a/libs/cms/src/lib/models/twoColumnText.model.ts
+++ b/libs/cms/src/lib/models/twoColumnText.model.ts
@@ -32,6 +32,9 @@ export class TwoColumnText {
 
   @Field(() => Boolean, { nullable: true })
   dividerOnTop?: boolean
+
+  @Field(() => Boolean, { nullable: true })
+  onlyUseOneTitle?: boolean
 }
 
 export const mapTwoColumnText = ({
@@ -51,4 +54,5 @@ export const mapTwoColumnText = ({
     : [],
   leftLink: fields.leftLink ? mapLink(fields.leftLink) : null,
   dividerOnTop: fields.dividerOnTop ?? true,
+  onlyUseOneTitle: fields.onlyUseOneTitle ?? false,
 })


### PR DESCRIPTION
# Add field to use only left title and some styles

## What

- If only use one title is true then right title in two-column-text is skipped
- Fix mobile styles gap between columns
- Fix minor desktop styles

## Why

To make it possible to let left title span over both columns

## Screenshots / Gifs

### Before
![image](https://github.com/island-is/island.is/assets/135017126/d1d1eab6-2c46-44e2-9898-a51bccd597ec)


### After
![image](https://github.com/island-is/island.is/assets/135017126/244f5230-5b0a-4224-9822-00cf21d2a86f)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
