### PR TITLE
chore: Remove generated `dist/` files

### DIFF
--- a/apps/api/dist/.nx-results
+++ b/apps/api/dist/.nx-results
@@ -1,6 +1,0 @@
-{
-  "command": "codegen",
-  "results": {
-    "api-domains-application": false
-  }
-}

--- a/apps/application-system/form/dist/.nx-results
+++ b/apps/application-system/form/dist/.nx-results
@@ -1,6 +1,0 @@
-{
-  "command": "serve",
-  "results": {
-    "application-system-form": false
-  }
-}

--- a/apps/financial-aid/web-osk/dist/.nx-results
+++ b/apps/financial-aid/web-osk/dist/.nx-results
@@ -1,6 +1,0 @@
-{
-  "command": "serve",
-  "results": {
-    "financial-aid-web-osk": false
-  }
-}

--- a/apps/financial-aid/web-veita/dist/.nx-results
+++ b/apps/financial-aid/web-veita/dist/.nx-results
@@ -1,6 +1,0 @@
-{
-  "command": "serve",
-  "results": {
-    "financial-aid-web-veita": false
-  }
-}

--- a/apps/judicial-system/web/dist/.nx-results
+++ b/apps/judicial-system/web/dist/.nx-results
@@ -1,6 +1,0 @@
-{
-  "command": "serve",
-  "results": {
-    "judicial-system-web": false
-  }
-}


### PR DESCRIPTION
I found while working on `clean.mjs` (see https://github.com/island-is/island.is/pull/15337) that we have some `.nx-results` files in `dist/` folders. This suggests they are generated and not needed in our git repo.