### PR TITLE
fix(regulations-admin): Sorting for null fast track

### DIFF
--- a/apps/services/regulations-admin-backend/src/app/modules/draft_regulation/draft_regulation.service.ts
+++ b/apps/services/regulations-admin-backend/src/app/modules/draft_regulation/draft_regulation.service.ts
@@ -9,7 +9,7 @@ import { CreateDraftRegulationDto, UpdateDraftRegulationDto } from './dto'
 import { DraftRegulationModel } from './draft_regulation.model'
 import { DraftRegulationChangeModel } from '../draft_regulation_change'
 import { DraftRegulationCancelModel } from '../draft_regulation_cancel'
-import { Op } from 'sequelize'
+import { Op, Sequelize } from 'sequelize'
 import { DraftRegulationCancelService } from '../draft_regulation_cancel/draft_regulation_cancel.service'
 import { DraftRegulationChangeService } from '../draft_regulation_change/draft_regulation_change.service'
 import { DraftAuthorService } from '../draft_author/draft_author.service'
@@ -77,7 +77,10 @@ export class DraftRegulationService {
         offset: (page - 1) * count,
         order: [
           ['drafting_status', 'ASC'],
-          ['fast_track', 'DESC'],
+          [
+            Sequelize.literal('CASE WHEN fast_track IS TRUE THEN 1 ELSE 0 END'),
+            'DESC',
+          ],
           ['ideal_publish_date', 'ASC'],
           ['modified', 'DESC'],
           ['created', 'DESC'],


### PR DESCRIPTION
## What

Fix sorting for null fast track

## Why

Null is displaying before true/false. Handle null as false to sort correctly.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
	- Improved sorting logic to prioritize fast-track regulations for a better user experience when viewing drafts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->