### PR TITLE
feat(ui-fields): table repeater updates

### DIFF
--- a/libs/application/types/src/lib/Fields.ts
+++ b/libs/application/types/src/lib/Fields.ts
@@ -61,22 +61,14 @@ export type TableRepeaterFields =
   | 'checkbox'
   | 'date'
 
-export type TableRepeaterOptions =
-  | {
-      label: StaticText
-      value: string
-      tooltip?: StaticText
-    }[]
+type RepeaterOption = { label: StaticText; value: string; tooltip?: StaticText }
+
+type TableRepeaterOptions =
+  | RepeaterOption[]
   | ((
       application: Application,
       activeField: Record<string, string>,
-    ) =>
-      | {
-          label: StaticText
-          value: string
-          tooltip?: StaticText
-        }[]
-      | [])
+    ) => RepeaterOption[] | [])
 
 export type TableRepeaterItem = {
   component: TableRepeaterFields
@@ -126,7 +118,6 @@ export type TableRepeaterItem = {
   | {
       component: 'select'
       label: StaticText
-      options?: TableRepeaterOptions
       isSearchable?: boolean
     }
   | {

--- a/libs/application/types/src/lib/Fields.ts
+++ b/libs/application/types/src/lib/Fields.ts
@@ -84,7 +84,7 @@ export type TableRepeaterItem = {
             value: string
             tooltip?: StaticText
           }[]
-        | void)
+        | undefined)
   backgroundColor?: 'blue' | 'white'
   width?: 'half' | 'full' | 'third'
   required?: boolean

--- a/libs/application/types/src/lib/Fields.ts
+++ b/libs/application/types/src/lib/Fields.ts
@@ -139,7 +139,7 @@ export type TableRepeaterItem = {
                 value: string
                 tooltip?: StaticText
               }[]
-            | void)
+            | undefined)
       isSearchable?: boolean
     }
   | {

--- a/libs/application/types/src/lib/Fields.ts
+++ b/libs/application/types/src/lib/Fields.ts
@@ -61,6 +61,23 @@ export type TableRepeaterFields =
   | 'checkbox'
   | 'date'
 
+export type TableRepeaterOptions = 
+| {
+    label: StaticText
+    value: string
+    tooltip?: StaticText
+  }[]
+| ((
+    application: Application,
+    activeField: Record<string, string>,
+  ) =>
+    | {
+        label: StaticText
+        value: string
+        tooltip?: StaticText
+      }[]
+    | [])
+
 export type TableRepeaterItem = {
   component: TableRepeaterFields
   /**
@@ -69,22 +86,7 @@ export type TableRepeaterItem = {
   displayInTable?: boolean
   label?: StaticText
   placeholder?: StaticText
-  options?:
-    | {
-        label: StaticText
-        value: string
-        tooltip?: StaticText
-      }[]
-    | ((
-        application: Application,
-        activeField: Record<string, string>,
-      ) =>
-        | {
-            label: StaticText
-            value: string
-            tooltip?: StaticText
-          }[]
-        | undefined)
+  options?: TableRepeaterOptions
   backgroundColor?: 'blue' | 'white'
   width?: 'half' | 'full' | 'third'
   required?: boolean
@@ -124,22 +126,7 @@ export type TableRepeaterItem = {
   | {
       component: 'select'
       label: StaticText
-      options?:
-        | {
-            label: StaticText
-            value: string
-            tooltip?: StaticText
-          }[]
-        | ((
-            application: Application,
-            activeField: Record<string, string>,
-          ) =>
-            | {
-                label: StaticText
-                value: string
-                tooltip?: StaticText
-              }[]
-            | undefined)
+      options?: TableRepeaterOptions
       isSearchable?: boolean
     }
   | {

--- a/libs/application/types/src/lib/Fields.ts
+++ b/libs/application/types/src/lib/Fields.ts
@@ -61,22 +61,22 @@ export type TableRepeaterFields =
   | 'checkbox'
   | 'date'
 
-export type TableRepeaterOptions = 
-| {
-    label: StaticText
-    value: string
-    tooltip?: StaticText
-  }[]
-| ((
-    application: Application,
-    activeField: Record<string, string>,
-  ) =>
-    | {
-        label: StaticText
-        value: string
-        tooltip?: StaticText
-      }[]
-    | [])
+export type TableRepeaterOptions =
+  | {
+      label: StaticText
+      value: string
+      tooltip?: StaticText
+    }[]
+  | ((
+      application: Application,
+      activeField: Record<string, string>,
+    ) =>
+      | {
+          label: StaticText
+          value: string
+          tooltip?: StaticText
+        }[]
+      | [])
 
 export type TableRepeaterItem = {
   component: TableRepeaterFields

--- a/libs/application/types/src/lib/Fields.ts
+++ b/libs/application/types/src/lib/Fields.ts
@@ -69,15 +69,36 @@ export type TableRepeaterItem = {
   displayInTable?: boolean
   label?: StaticText
   placeholder?: StaticText
-  options?: { label: StaticText; value: string }[]
+  options?:
+    | {
+        label: StaticText
+        value: string
+        tooltip?: StaticText
+      }[]
+    | ((
+        application: Application,
+        activeField: Record<string, string>,
+      ) =>
+        | {
+            label: StaticText
+            value: string
+            tooltip?: StaticText
+          }[]
+        | void)
   backgroundColor?: 'blue' | 'white'
-  width?: 'half' | 'full'
+  width?: 'half' | 'full' | 'third'
   required?: boolean
   condition?: (
     application: Application,
     activeField?: Record<string, string>,
   ) => boolean
   dataTestId?: string
+  readonly?:
+    | boolean
+    | ((
+        application: Application,
+        activeField?: Record<string, string>,
+      ) => boolean)
 } & (
   | {
       component: 'input'
@@ -88,6 +109,7 @@ export type TableRepeaterItem = {
       rows?: number
       maxLength?: number
       currency?: boolean
+      suffix?: string
     }
   | {
       component: 'date'
@@ -102,7 +124,22 @@ export type TableRepeaterItem = {
   | {
       component: 'select'
       label: StaticText
-      options: { label: StaticText; value: string }[]
+      options?:
+        | {
+            label: StaticText
+            value: string
+            tooltip?: StaticText
+          }[]
+        | ((
+            application: Application,
+            activeField: Record<string, string>,
+          ) =>
+            | {
+                label: StaticText
+                value: string
+                tooltip?: StaticText
+              }[]
+            | void)
       isSearchable?: boolean
     }
   | {

--- a/libs/application/ui-fields/src/lib/TableRepeaterFormField/TableRepeaterFormField.tsx
+++ b/libs/application/ui-fields/src/lib/TableRepeaterFormField/TableRepeaterFormField.tsx
@@ -241,19 +241,49 @@ export const TableRepeaterFormField: FC<Props> = ({
                     options,
                     width = 'full',
                     condition,
+                    readonly = false,
                     ...props
                   } = item
                   const isHalfColumn = component !== 'radio' && width === 'half'
-                  const span = isHalfColumn ? '1/2' : '1/1'
+                  const isThirdColumn =
+                    component !== 'radio' && width === 'third'
+                  const span = isHalfColumn
+                    ? '1/2'
+                    : isThirdColumn
+                    ? '1/3'
+                    : '1/1'
                   const Component = componentMapper[component]
                   const id = `${data.id}[${activeIndex}].${itemId}`
                   const activeValues =
                     activeIndex >= 0 && values ? values[activeIndex] : undefined
 
-                  const translatedOptions = options?.map((option) => ({
-                    ...option,
-                    label: formatText(option.label, application, formatMessage),
-                  }))
+                  let translatedOptions: any = []
+                  if (typeof options === 'function') {
+                    translatedOptions = options(application, activeValues)
+                  } else {
+                    translatedOptions = options?.map((option) => ({
+                      ...option,
+                      label: formatText(
+                        option.label,
+                        application,
+                        formatMessage,
+                      ),
+                      ...(option.tooltip && {
+                        tooltip: formatText(
+                          option.tooltip,
+                          application,
+                          formatMessage,
+                        ),
+                      }),
+                    }))
+                  }
+
+                  let Readonly: boolean | undefined
+                  if (typeof readonly === 'function') {
+                    Readonly = readonly(application, activeValues)
+                  } else {
+                    Readonly = readonly
+                  }
 
                   if (condition && !condition(application, activeValues)) {
                     return null
@@ -284,6 +314,7 @@ export const TableRepeaterFormField: FC<Props> = ({
                         split={width === 'half' ? '1/2' : '1/1'}
                         error={getFieldError(itemId)}
                         control={methods.control}
+                        readOnly={Readonly}
                         backgroundColor={backgroundColor}
                         onChange={() => {
                           if (error) {


### PR DESCRIPTION
## What

add readonly, be able to use application and activeField for options and third column.

## Screenshots / Gifs

third column example displaying the months and readonly (tekjur á ári)
<img width="318" alt="Screenshot 2024-06-28 at 13 20 46" src="https://github.com/island-is/island.is/assets/102811817/041adba6-16de-4172-ac29-4c90257472d1">

be able to populate dropdown with application data
<img width="569" alt="Screenshot 2024-06-28 at 13 22 50" src="https://github.com/island-is/island.is/assets/102811817/2c884c65-77b0-456a-a4c9-d8c23eaa4017">

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced `TableRepeaterItem` with more complex and dynamic options, including optional tooltips and function-based option generation.
  - Added `readonly` functionality that can be a boolean or a function, providing flexible control over the read-only state.
  - Introduced a new width option 'third' for better layout customization.
  - Added a `suffix` field for the `input` component, allowing additional text to be appended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->