### PR TITLE
feat(documents): Add toast success to archive

### DIFF
--- a/libs/service-portal/documents/src/hooks/useMailActionV2.ts
+++ b/libs/service-portal/documents/src/hooks/useMailActionV2.ts
@@ -6,6 +6,7 @@ import { m } from '@island.is/service-portal/core'
 import { useMailActionV2Mutation } from '../screens/Overview/Overview.generated'
 import { MailActions } from '../utils/types'
 import { useDocumentList } from './useDocumentList'
+import { messages as docMessages } from '../utils/messages'
 
 export const useMailAction = () => {
   const { formatMessage } = useLocale()
@@ -55,6 +56,7 @@ export const useMailAction = () => {
         }
         if (actionName === 'archive') {
           setArchiveSuccess(true)
+          toast.success(formatMessage(docMessages.successArchive))
           setDataSuccess({
             ...dataSuccess,
             archive: true,
@@ -62,6 +64,7 @@ export const useMailAction = () => {
         }
         if (actionName === 'unarchive') {
           setArchiveSuccess(false)
+          toast.success(formatMessage(docMessages.successUnarchive))
           setDataSuccess({
             ...dataSuccess,
             unarchive: true,
@@ -88,6 +91,7 @@ export const useMailAction = () => {
             if (refetch) {
               refetch(fetchObject)
             }
+            toast.success(formatMessage(docMessages.successArchiveMulti))
           } else {
             toast.error(formatMessage(m.errorTitle))
           }

--- a/libs/service-portal/documents/src/screens/Overview/Overview.tsx
+++ b/libs/service-portal/documents/src/screens/Overview/Overview.tsx
@@ -415,6 +415,14 @@ export const ServicePortalDocuments = () => {
                         },
                       },
                     })
+                      .then(() => {
+                        toast.success(
+                          formatMessage(messages.successArchiveMulti),
+                        )
+                      })
+                      .catch((e) => {
+                        toast.error(formatMessage(m.errorTitle))
+                      })
                   }
                   onFav={() =>
                     bulkMailAction({

--- a/libs/service-portal/documents/src/utils/messages.ts
+++ b/libs/service-portal/documents/src/utils/messages.ts
@@ -92,4 +92,16 @@ export const messages = defineMessages({
     id: 'sp.documents:mark-as-bulk-selection',
     defaultMessage: 'Merkja skjal fyrir fjöldaframkvæmd',
   },
+  successArchiveMulti: {
+    id: 'sp.documents:success-archive-messages',
+    defaultMessage: 'Skjöl sett í geymslu',
+  },
+  successArchive: {
+    id: 'sp.documents:success-archive-message',
+    defaultMessage: 'Skjal sett í geymslu',
+  },
+  successUnarchive: {
+    id: 'sp.documents:success-unarchive-message',
+    defaultMessage: 'Skjal tekið úr geymslu',
+  },
 })

--- a/libs/service-portal/documents/src/utils/useSubmitMailAction.ts
+++ b/libs/service-portal/documents/src/utils/useSubmitMailAction.ts
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { toast } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
 import { m } from '@island.is/service-portal/core'
+import { messages } from './messages'
 
 const POST_MAIL_ACTION = gql`
   mutation PostMailActionMutation($input: PostMailActionResolverInput!) {
@@ -61,6 +62,7 @@ export const useSubmitMailAction = (input?: { messageId: string }) => {
         }
         if (actionName === 'archive') {
           setArchiveSuccess(true)
+          toast.success(formatMessage(messages.successArchive))
           setDataSuccess({
             ...dataSuccess,
             archive: true,
@@ -68,6 +70,7 @@ export const useSubmitMailAction = (input?: { messageId: string }) => {
         }
         if (actionName === 'unarchive') {
           setArchiveSuccess(false)
+          toast.success(formatMessage(messages.successUnarchive))
           setDataSuccess({
             ...dataSuccess,
             unarchive: true,


### PR DESCRIPTION
## What

Add toast success to archive

## Why

some people push by accident, dont notice.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added success toast notifications for archiving, unarchiving, and multi-archiving documents.
  
- **Bug Fixes**
  - Improved user feedback with error toast messages for document operations in case of failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->