### PR TITLE
feat(web): Add divider check for bullet list

### DIFF
--- a/apps/web/components/BulletList/BulletList.tsx
+++ b/apps/web/components/BulletList/BulletList.tsx
@@ -26,10 +26,10 @@ type NumberBulletGroup = {
   bullets: NumberBullet[]
 }
 
-type Entry = IconBullet | NumberBulletGroup
+export type BulletEntry = IconBullet | NumberBulletGroup
 
 export interface BulletListProps {
-  bullets: Entry[]
+  bullets: BulletEntry[]
 }
 
 export const BulletList: FC<React.PropsWithChildren<BulletListProps>> = ({

--- a/apps/web/components/Organization/Slice/BulletList/BulletList.tsx
+++ b/apps/web/components/Organization/Slice/BulletList/BulletList.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
-import { BulletListSlice as BulletListProps } from '@island.is/web/graphql/schema'
+
 import { BulletList } from '@island.is/web/components'
+import { BorderAbove } from '@island.is/web/components'
+import { BulletListSlice as BulletListProps } from '@island.is/web/graphql/schema'
 
 interface SliceProps {
   slice: BulletListProps
@@ -15,6 +17,7 @@ export const BulletListSlice: React.FC<React.PropsWithChildren<SliceProps>> = ({
       id={slice.id}
       aria-labelledby={'sliceTitle-' + slice.id}
     >
+      {slice.dividerOnTop && <BorderAbove />}
       <BulletList
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore make web strict

--- a/apps/web/components/Organization/Slice/BulletList/BulletList.tsx
+++ b/apps/web/components/Organization/Slice/BulletList/BulletList.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { BulletList } from '@island.is/web/components'
+import { BulletEntry, BulletList } from '@island.is/web/components'
 import { BorderAbove } from '@island.is/web/components'
 import { BulletListSlice as BulletListProps } from '@island.is/web/graphql/schema'
 
@@ -19,22 +19,24 @@ export const BulletListSlice: React.FC<React.PropsWithChildren<SliceProps>> = ({
     >
       {slice.dividerOnTop && <BorderAbove />}
       <BulletList
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore make web strict
-        bullets={slice.bullets.map((bullet) => {
-          switch (bullet.__typename) {
-            case 'IconBullet':
-              return {
-                ...bullet,
-                type: 'IconBullet',
-                icon: bullet.icon.url,
+        bullets={
+          slice.bullets
+            .map((bullet) => {
+              switch (bullet.__typename) {
+                case 'IconBullet':
+                  return {
+                    ...bullet,
+                    type: 'IconBullet',
+                    icon: bullet.icon.url,
+                  }
+                case 'NumberBulletGroup':
+                  return { ...bullet, type: 'NumberBulletGroup' }
+                default:
+                  return null
               }
-            case 'NumberBulletGroup':
-              return { ...bullet, type: 'NumberBulletGroup' }
-            default:
-              return null
-          }
-        })}
+            })
+            .filter(Boolean) as BulletEntry[]
+        }
       />
     </section>
   )

--- a/apps/web/screens/queries/fragments.ts
+++ b/apps/web/screens/queries/fragments.ts
@@ -173,6 +173,7 @@ export const slices = gql`
         }
       }
     }
+    dividerOnTop
   }
 
   fragment FaqListFields on FaqList {

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -455,6 +455,9 @@ export interface IBigBulletListFields {
 
   /** Bullets */
   bullets: (IIconBullet | INumberBulletSection)[]
+
+  /** Divider On Top */
+  dividerOnTop?: boolean | undefined
 }
 
 export interface IBigBulletList extends Entry<IBigBulletListFields> {

--- a/libs/cms/src/lib/models/bulletListSlice.model.ts
+++ b/libs/cms/src/lib/models/bulletListSlice.model.ts
@@ -14,6 +14,9 @@ export class BulletListSlice {
 
   @CacheField(() => [BulletEntryUnion])
   bullets!: Array<typeof BulletEntryUnion>
+
+  @Field(() => Boolean, { nullable: true })
+  dividerOnTop?: boolean
 }
 
 export const mapBulletListSlice = ({
@@ -23,4 +26,5 @@ export const mapBulletListSlice = ({
   typename: 'BulletListSlice',
   id: sys.id,
   bullets: (fields.bullets ?? []).map(mapBulletEntryUnion),
+  dividerOnTop: fields.dividerOnTop ?? true,
 })


### PR DESCRIPTION
# Add divider check for bullet list

## What

Divider on top of bullet list

## Screenshots / Gifs

### Before
![image](https://github.com/island-is/island.is/assets/135017126/0b9c190c-66b8-4d4c-b947-644e6aa8ade2)


### After
![image](https://github.com/island-is/island.is/assets/135017126/2e793c7e-f956-4fd2-bdfd-f124178b01f3)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional border above the BulletList component, configurable through the `dividerOnTop` property.

- **Enhancements**
  - Updated the BulletList component to conditionally render a top border for improved visual separation.
  - Extended GraphQL queries and CMS models to support the new `dividerOnTop` property.
  - Improved type definitions for bullet entries in the BulletList component, enhancing clarity and type safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->