### PR TITLE
fix(native-app): use correct openBrowser function for login screen

### DIFF
--- a/apps/native/app/src/screens/login/login.tsx
+++ b/apps/native/app/src/screens/login/login.tsx
@@ -16,7 +16,7 @@ import {
 import { NavigationFunctionComponent } from 'react-native-navigation'
 import styled from 'styled-components/native'
 import logo from '../../assets/logo/logo-64w.png'
-import { openBrowser } from '../../lib/rn-island'
+import { useBrowser } from '../../lib/useBrowser'
 import { useAuthStore } from '../../stores/auth-store'
 import { preferencesStore } from '../../stores/preferences-store'
 import { nextOnboardingStep } from '../../utils/onboarding'
@@ -68,6 +68,7 @@ function getChromeVersion(): Promise<number> {
 
 export const LoginScreen: NavigationFunctionComponent = ({ componentId }) => {
   const authStore = useAuthStore()
+  const { openBrowser } = useBrowser()
   const intl = useIntl()
   const [isLoggingIn, setIsLoggingIn] = useState(false)
   const [authState, setAuthState] = useState<{


### PR DESCRIPTION
## What

Use correct openBrowser function for opening help page on login screen

## Why

The other one is old and does not work anymore

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the `LoginScreen` to use the `useBrowser` hook instead of `openBrowser` for improved browser functionality integration.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->