### PR TITLE
fix(service-portal): Update accessibility in docs v2. Add rsk fallback.

### DIFF
--- a/apps/service-portal/src/components/Notifications/NotificationButton.tsx
+++ b/apps/service-portal/src/components/Notifications/NotificationButton.tsx
@@ -72,7 +72,11 @@ const NotificationButton = ({
             : setMenuState('notifications')
         }}
         ref={ref}
-        aria-label={formatMessage(m.notifications)}
+        aria-label={
+          showBadge
+            ? formatMessage(m.notificationsUnread)
+            : formatMessage(m.notifications)
+        }
       />
       {data?.userNotificationsOverview?.data.length ? (
         <Box

--- a/libs/clients/documents-v2/src/lib/documentsClientV2.service.ts
+++ b/libs/clients/documents-v2/src/lib/documentsClientV2.service.ts
@@ -46,6 +46,7 @@ export class DocumentsClientV2Service {
     const inputObject = sanitizeObject({
       ...input,
       kennitala: input.nationalId,
+      page: input.page ?? 1,
       senderKennitala:
         input.senderNationalId && input.senderNationalId.length > 0
           ? input.senderNationalId.join()

--- a/libs/clients/documents-v2/src/lib/dto/document.dto.ts
+++ b/libs/clients/documents-v2/src/lib/dto/document.dto.ts
@@ -1,6 +1,13 @@
 import sanitizeHtml from 'sanitize-html'
 import { DocumentDTO } from '../..'
 
+const customDocument = {
+  senderName: 'Ríkisskattstjóri',
+  senderNatReg: '5402696029',
+  subjectContains: 'Niðurstaða álagningar',
+  url: 'https://thjonustusidur.rsk.is/alagningarsedill',
+}
+
 export type FileType = 'pdf' | 'html' | 'url'
 
 export type DocumentDto = {
@@ -23,7 +30,16 @@ export const mapToDocument = (document: DocumentDTO): DocumentDto | null => {
     content = document.content
   } else if (document.url) {
     fileType = 'url'
-    content = document.url
+
+    // Handling edge case for documents that can't be presented due to requiring authentication through rsk.is
+    if (
+      document.senderKennitala === customDocument.senderNatReg &&
+      document?.subject?.includes(customDocument.subjectContains)
+    ) {
+      content = customDocument.url
+    } else {
+      content = document.url
+    }
   } else if (document.htmlContent) {
     fileType = 'html'
 

--- a/libs/service-portal/core/src/lib/messages.ts
+++ b/libs/service-portal/core/src/lib/messages.ts
@@ -508,6 +508,10 @@ export const m = defineMessages({
     id: 'service.portal:notifications',
     defaultMessage: 'Tilkynningar',
   },
+  notificationsUnread: {
+    id: 'service.portal:notifications-unread-a11y',
+    defaultMessage: 'Þú átt ólesnar tilkynningar',
+  },
   notificationsViewAll: {
     id: 'service.portal:notifications-view-all',
     defaultMessage: 'Sjá allar tilkynningar',

--- a/libs/service-portal/documents/src/components/DocumentLine/DocumentLine.tsx
+++ b/libs/service-portal/documents/src/components/DocumentLine/DocumentLine.tsx
@@ -9,7 +9,7 @@ import {
 } from '@island.is/api/schema'
 import { Box, Text, LoadingDots, Icon } from '@island.is/island-ui/core'
 import { dateFormat } from '@island.is/shared/constants'
-import { ServicePortalPaths, m } from '@island.is/service-portal/core'
+import { m } from '@island.is/service-portal/core'
 import * as styles from './DocumentLine.css'
 import { gql, useLazyQuery } from '@apollo/client'
 import { useLocale } from '@island.is/localization'

--- a/libs/service-portal/documents/src/components/NoPDF/NoPDF.tsx
+++ b/libs/service-portal/documents/src/components/NoPDF/NoPDF.tsx
@@ -5,6 +5,7 @@ import { Text, Box } from '@island.is/island-ui/core'
 import { EmptyImageSmall } from './EmptyImage'
 import { messages } from '../../utils/messages'
 import { Problem } from '@island.is/react-spa/shared'
+import { helperStyles } from '@island.is/island-ui/theme'
 import * as styles from '../OverviewDisplay/OverviewDisplay.css'
 
 type DocumentRendererProps = {
@@ -28,11 +29,16 @@ export const NoPDF: FC<DocumentRendererProps> = ({ text, error }) => {
       className={styles.docWrap}
     >
       {error ? (
-        <Problem
-          type="internal_service_error"
-          message={text}
-          title={formatMessage(m.errorFetch)}
-        />
+        <>
+          <Problem
+            type="internal_service_error"
+            message={text}
+            title={formatMessage(m.errorFetch)}
+          />
+          <p className={helperStyles.srOnly} role="alert">
+            {formatMessage(m.errorTitle)}. {formatMessage(m.errorFetch)}
+          </p>
+        </>
       ) : (
         <Box
           display="flex"


### PR DESCRIPTION
## What

Update accessibility in docs v2. Add rsk fallback.

## Why

Need rsk fallback for app. Accessibility updates in UI.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility Enhancements**
  - Improved the `aria-label` attribute in the `NotificationButton` to help users with screen readers identify the notification status.

- **Default Values**
  - Ensured the `page` property defaults to 1 in document service requests if not specified.

- **Document Handling**
  - Added custom document properties and updated mapping logic to handle special cases based on sender information and subject.

- **Messages**
  - Introduced a new message `notificationsUnread` for accessibility related to unread notifications.

- **Component Updates**
  - Removed an unused import in the `DocumentLine` component.
  - Improved error handling in the `NoPDF` component with additional accessibility support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->