### PR TITLE
fix(j-s): Public Prosecutor Staff

### DIFF
--- a/apps/judicial-system/web/src/routes/Admin/Users/Users.tsx
+++ b/apps/judicial-system/web/src/routes/Admin/Users/Users.tsx
@@ -74,6 +74,8 @@ export const Users = () => {
         return 'Aðstoðarmaður dómara'
       case UserRole.PRISON_SYSTEM_STAFF:
         return 'Starfsmaður'
+      case UserRole.PUBLIC_PROSECUTOR_STAFF:
+        return 'Skrifstofa'
       default:
         return 'Óþekkt'
     }


### PR DESCRIPTION
# Public Prosecutor Staff

[Starfsfólk skrifstofu hjá RSAK eru með "Óþekkt" sem hlutverk í notendaumsjón](https://app.asana.com/0/1199153462262248/1207299689529114/f)

## What

- Displays a proper name for the public prosecutor staff role in user lists.

## Why

- Verified bug.

## Screenshots / Gifs

<img width="1342" alt="image" src="https://github.com/island-is/island.is/assets/795382/72661f6c-2e46-468f-9b7d-b5d99edd006c">

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for the `PUBLIC_PROSECUTOR_STAFF` role, displaying 'Skrifstofa' in the Users component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->