### PR TITLE
fix(service-portal): Add local hasread doc support

### DIFF
--- a/libs/service-portal/documents/src/components/DocumentLine/DocumentLineV2.tsx
+++ b/libs/service-portal/documents/src/components/DocumentLine/DocumentLineV2.tsx
@@ -64,8 +64,13 @@ export const DocumentLine: FC<Props> = ({
 
   const { activeArchive, fetchObject, refetch } = useDocumentList()
 
-  const { setActiveDocument, setDocumentDisplayError, setDocLoading } =
-    useDocumentContext()
+  const {
+    setActiveDocument,
+    setDocumentDisplayError,
+    setDocLoading,
+    setLocalRead,
+    localRead,
+  } = useDocumentContext()
 
   const wrapperRef = useRef(null)
   const avatarRef = useRef(null)
@@ -124,6 +129,7 @@ export const DocumentLine: FC<Props> = ({
           if (docContent) {
             displayPdf(docContent)
             setDocumentDisplayError(undefined)
+            setLocalRead([...localRead, documentLine.id])
           } else {
             setDocumentDisplayError(formatMessage(messages.documentErrorLoad))
           }
@@ -162,7 +168,7 @@ export const DocumentLine: FC<Props> = ({
     getDocument()
   }
 
-  const unread = !documentLine.opened
+  const unread = !documentLine.opened && !localRead.includes(documentLine.id)
   const isBookmarked = bookmarked || bookmarkSuccess
   const isArchived = activeArchive || archiveSuccess
 

--- a/libs/service-portal/documents/src/screens/Overview/DocumentContext.tsx
+++ b/libs/service-portal/documents/src/screens/Overview/DocumentContext.tsx
@@ -1,9 +1,4 @@
-import {
-  DocumentProviderCategory,
-  DocumentProviderType,
-  DocumentsV2Category,
-  DocumentsV2Sender,
-} from '@island.is/api/schema'
+import { DocumentsV2Category, DocumentsV2Sender } from '@island.is/api/schema'
 import {
   createContext,
   Dispatch,
@@ -29,6 +24,7 @@ export type DocumentsStateProps = {
   categoriesAvailable: DocumentsV2Category[]
   docLoading: boolean
   documentDisplayError?: string
+  localRead: string[]
 
   setSelectedLines: Dispatch<SetStateAction<SelectedLineType>>
   setActiveDocument: Dispatch<SetStateAction<ActiveDocumentStateType>>
@@ -39,6 +35,7 @@ export type DocumentsStateProps = {
   setCategoriesAvailable: Dispatch<SetStateAction<DocumentsV2Category[]>>
   setDocLoading: Dispatch<SetStateAction<boolean>>
   setDocumentDisplayError: Dispatch<SetStateAction<string | undefined>>
+  setLocalRead: Dispatch<SetStateAction<string[]>>
 }
 
 export const DocumentsContext = createContext<DocumentsStateProps>({
@@ -51,6 +48,7 @@ export const DocumentsContext = createContext<DocumentsStateProps>({
   sendersAvailable: [],
   docLoading: false,
   documentDisplayError: undefined,
+  localRead: [],
 
   setSelectedLines: () => undefined,
   setActiveDocument: () => undefined,
@@ -61,6 +59,7 @@ export const DocumentsContext = createContext<DocumentsStateProps>({
   setCategoriesAvailable: () => undefined,
   setDocLoading: () => undefined,
   setDocumentDisplayError: () => undefined,
+  setLocalRead: () => undefined,
 })
 
 export const DocumentsProvider: FC<React.PropsWithChildren<unknown>> = ({
@@ -82,6 +81,7 @@ export const DocumentsProvider: FC<React.PropsWithChildren<unknown>> = ({
   const [totalPages, setTotalPages] = useState(0)
   const [docLoading, setDocLoading] = useState(false)
   const [documentDisplayError, setDocumentDisplayError] = useState<string>()
+  const [localRead, setLocalRead] = useState<string[]>([])
 
   return (
     <DocumentsContext.Provider
@@ -95,6 +95,7 @@ export const DocumentsProvider: FC<React.PropsWithChildren<unknown>> = ({
         sendersAvailable,
         docLoading,
         documentDisplayError,
+        localRead,
 
         setSelectedLines,
         setActiveDocument,
@@ -105,6 +106,7 @@ export const DocumentsProvider: FC<React.PropsWithChildren<unknown>> = ({
         setSendersAvailable,
         setDocLoading,
         setDocumentDisplayError,
+        setLocalRead,
       }}
     >
       {children}


### PR DESCRIPTION
## What

Add hasread to successfully fetched documents.

## Why

Currently when documents are fetched directly with a link, `/postholf/:id` we fetch the doc but the ui does not update to represent that.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a local read status feature for documents, allowing users to see which documents have been read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->