### PR TITLE
fix(j-s): Handle no defender assigned in indictment case InfoCard

### DIFF
--- a/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.strings.ts
+++ b/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.strings.ts
@@ -23,4 +23,10 @@ export const strings = defineMessages({
     defaultMessage: 'Verjandi',
     description: 'Notað til að birta titil á verjanda í ákæru.',
   },
+  noDefenderAssigned: {
+    id: 'judicial.system.core:info_card.defendant_info.no_defender_assigned',
+    defaultMessage: 'Ekki skráður',
+    description:
+      'Notað til að láta vita að enginn verjandi er skráður í ákæru.',
+  },
 })

--- a/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.tsx
+++ b/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.tsx
@@ -85,10 +85,10 @@ export const DefendantInfo: FC<DefendantInfoProps> = ({
           </Box>
         )}
 
-        {defendant.defenderName && displayDefenderInfo && (
+        {displayDefenderInfo && (
           <Box display="flex" key={defendant.defenderName} role="paragraph">
             <Text as="span">{`${formatMessage(strings.defender)}: ${
-              defendant.defenderName
+              defendant.defenderName ?? formatMessage(strings.noDefenderAssigned)
             }`}</Text>
             {defendant.defenderEmail && (
               <>

--- a/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.tsx
+++ b/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.tsx
@@ -88,7 +88,8 @@ export const DefendantInfo: FC<DefendantInfoProps> = ({
         {displayDefenderInfo && (
           <Box display="flex" key={defendant.defenderName} role="paragraph">
             <Text as="span">{`${formatMessage(strings.defender)}: ${
-              defendant.defenderName ?? formatMessage(strings.noDefenderAssigned)
+              defendant.defenderName ??
+              formatMessage(strings.noDefenderAssigned)
             }`}</Text>
             {defendant.defenderEmail && (
               <>


### PR DESCRIPTION
[Birta "Ekki skráður" á Info Card ef varnaraðili er ekki með verjanda skráðan](https://app.asana.com/0/1199153462262248/1207655636212966)

## What

Display text that indicates that a defendant has no assigned defender on an indictment Info Card

## Why

So that it's apparent that there was no defender assigned, not that the field is missing from the info card

## Screenshots / Gifs

<img width="851" alt="image" src="https://github.com/island-is/island.is/assets/4820859/e60455c2-1488-421f-a804-a9ed24bbfcb6">


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a message to display when no defender is assigned in the prosecution.

- **Bug Fixes**
  - Updated the condition for displaying defender information to correctly handle cases where `defenderName` is not defined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->