### PR TITLE
fix(system-e2e): Catch mock errors

### DIFF
--- a/apps/system-e2e/README.md
+++ b/apps/system-e2e/README.md
@@ -193,9 +193,11 @@ You will need a few things to set up your test so it can run with mountebank.
 
 Now that you are set up. You need to run a couple of commands.
 
+- Navigate to `/infra`
 - In your terminal run `yarn cli render-local-env --service=service-portal --service=api` .
   - This would show you commands how to start the mocking for `service-portal` and `api`. Replace with the services you want to test.
 - In the output you will see a docker output it will look something like this: `docker run -it --rm -p ...` copy that line and run in a new terminal window. Now your Mountebank impostor should be running.
+- Open a new terminal tab within the island.is root.
 - Now start your services, but make sure your services ports have been replaced by the ports provided by Mountebank. In this examples case that would be `XROAD_BASE_PATH=http://localhost:9388 yarn start api`
 - Run the test with Playwright and you should see your mocked data replace the API's data.
 

--- a/apps/system-e2e/src/tests/islandis/service-portal/acceptance/setup-xroad.mocks.ts
+++ b/apps/system-e2e/src/tests/islandis/service-portal/acceptance/setup-xroad.mocks.ts
@@ -14,11 +14,11 @@ export const setupXroadMocks = async () => {
 
   /** Xroad mocks */
   await Promise.all([
-    loadAssetsXroadMocks(),
-    loadHealthInsuranceXroadMocks(),
-    loadSocialInsuranceXroadMocks(),
-    loadLicensesXroadMocks(),
-    loadOccupationalLicensesXroadMocks(),
+    loadAssetsXroadMocks().catch((error) => ({ error })),
+    loadHealthInsuranceXroadMocks().catch((error) => ({ error })),
+    loadSocialInsuranceXroadMocks().catch((error) => ({ error })),
+    loadLicensesXroadMocks().catch((error) => ({ error })),
+    loadOccupationalLicensesXroadMocks().catch((error) => ({ error })),
   ])
 
   const { envs } = getEnvVariables(Base.getEnv(), 'system-e2e', env)


### PR DESCRIPTION
## What

Catch mock api response errors.
Update readme

## Why

* Our Mountebank mocking setup is wrapped in a promise all, which is fine, but If one fails, all fail. As the tests are individually run sometimes. It can be good to catch errors so it won't affect other tests.
* Update the readme a little bit, it was not quite obvious where to run the commands for mountebank setup.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added instructions for navigating to `/infra` and starting services with Mountebank impostors.

- **Bug Fixes**
  - Improved error handling in Xroad mock setup to capture and return errors during loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->