### PR TITLE
fix(application-system-api): Use withNx plugin in application-system-api webpack config

### DIFF
--- a/apps/application-system/api/webpack.config.js
+++ b/apps/application-system/api/webpack.config.js
@@ -1,10 +1,14 @@
 const { composePlugins, withNx } = require('@nx/webpack')
 const { withReact } = require('@nx/react')
 
-module.exports = composePlugins(withReact({ ssr: true }), (config) => {
-  // App specific config
-  config.stats.chunks = false
-  config.stats.modules = false
+module.exports = composePlugins(
+  withNx(),
+  withReact({ ssr: true }),
+  (config) => {
+    // App specific config
+    config.stats.chunks = false
+    config.stats.modules = false
 
-  return config
-})
+    return config
+  },
+)


### PR DESCRIPTION
## What

A misconfiguration in webpack was causing an error on startup.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved and streamlined the plugin composition in the webpack configuration for better maintainability and structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->