### PR TITLE
fix(tr-applications): removed faked form steppers

### DIFF
--- a/libs/application/templates/social-insurance-administration/additional-support-for-the-elderly/src/forms/AdditionalSupportForTheElderlyForm.ts
+++ b/libs/application/templates/social-insurance-administration/additional-support-for-the-elderly/src/forms/AdditionalSupportForTheElderlyForm.ts
@@ -55,11 +55,6 @@ export const AdditionalSupportForTheElderlyForm: Form = buildForm({
   mode: FormModes.DRAFT,
   children: [
     buildSection({
-      id: 'prerequisites',
-      title: socialInsuranceAdministrationMessage.pre.externalDataSection,
-      children: [],
-    }),
-    buildSection({
       id: 'infoSection',
       title: socialInsuranceAdministrationMessage.info.section,
       children: [

--- a/libs/application/templates/social-insurance-administration/additional-support-for-the-elderly/src/forms/Prerequisites.ts
+++ b/libs/application/templates/social-insurance-administration/additional-support-for-the-elderly/src/forms/Prerequisites.ts
@@ -134,30 +134,5 @@ export const PrerequisitesForm: Form = buildForm({
         }),
       ],
     }),
-    buildSection({
-      id: 'infoSection',
-      title: socialInsuranceAdministrationMessage.info.section,
-      children: [],
-    }),
-    buildSection({
-      id: 'periodSection',
-      title: socialInsuranceAdministrationMessage.period.overviewTitle,
-      children: [],
-    }),
-    buildSection({
-      id: 'additionalInformation',
-      title: socialInsuranceAdministrationMessage.additionalInfo.section,
-      children: [],
-    }),
-    buildSection({
-      id: 'confirm',
-      title: socialInsuranceAdministrationMessage.confirm.overviewTitle,
-      children: [],
-    }),
-    buildSection({
-      id: 'conclusion',
-      title: socialInsuranceAdministrationMessage.conclusionScreen.section,
-      children: [],
-    }),
   ],
 })

--- a/libs/application/templates/social-insurance-administration/household-supplement/src/forms/HouseholdSupplementForm.ts
+++ b/libs/application/templates/social-insurance-administration/household-supplement/src/forms/HouseholdSupplementForm.ts
@@ -56,11 +56,6 @@ export const HouseholdSupplementForm: Form = buildForm({
   mode: FormModes.DRAFT,
   children: [
     buildSection({
-      id: 'externalData',
-      title: socialInsuranceAdministrationMessage.pre.externalDataSection,
-      children: [],
-    }),
-    buildSection({
       id: 'infoSection',
       title: socialInsuranceAdministrationMessage.info.section,
       children: [

--- a/libs/application/templates/social-insurance-administration/household-supplement/src/forms/Prerequisites.ts
+++ b/libs/application/templates/social-insurance-administration/household-supplement/src/forms/Prerequisites.ts
@@ -140,40 +140,5 @@ export const PrerequisitesForm: Form = buildForm({
         }),
       ],
     }),
-    buildSection({
-      id: 'infoSection',
-      title: socialInsuranceAdministrationMessage.info.section,
-      children: [],
-    }),
-    buildSection({
-      id: 'householdSupplementSection',
-      title: householdSupplementFormMessage.shared.householdSupplement,
-      children: [],
-    }),
-    buildSection({
-      id: 'periodSection',
-      title: socialInsuranceAdministrationMessage.period.overviewTitle,
-      children: [],
-    }),
-    buildSection({
-      id: 'fileUpload',
-      title: socialInsuranceAdministrationMessage.fileUpload.title,
-      children: [],
-    }),
-    buildSection({
-      id: 'additionalInfo',
-      title: socialInsuranceAdministrationMessage.additionalInfo.section,
-      children: [],
-    }),
-    buildSection({
-      id: 'confirm',
-      title: socialInsuranceAdministrationMessage.confirm.overviewTitle,
-      children: [],
-    }),
-    buildSection({
-      id: 'conclusion',
-      title: socialInsuranceAdministrationMessage.conclusionScreen.section,
-      children: [],
-    }),
   ],
 })

--- a/libs/application/templates/social-insurance-administration/old-age-pension/src/forms/OldAgePensionForm.ts
+++ b/libs/application/templates/social-insurance-administration/old-age-pension/src/forms/OldAgePensionForm.ts
@@ -60,11 +60,6 @@ export const OldAgePensionForm: Form = buildForm({
   mode: FormModes.DRAFT,
   children: [
     buildSection({
-      id: 'prerequisites',
-      title: oldAgePensionFormMessage.pre.prerequisitesSection,
-      children: [],
-    }),
-    buildSection({
       id: 'applicant',
       title: socialInsuranceAdministrationMessage.info.section,
       children: [

--- a/libs/application/templates/social-insurance-administration/old-age-pension/src/forms/Prerequisites.ts
+++ b/libs/application/templates/social-insurance-administration/old-age-pension/src/forms/Prerequisites.ts
@@ -246,35 +246,5 @@ export const PrerequisitesForm: Form = buildForm({
         }),
       ],
     }),
-    buildSection({
-      id: 'applicant',
-      title: socialInsuranceAdministrationMessage.info.section,
-      children: [],
-    }),
-    buildSection({
-      id: 'periodSection',
-      title: socialInsuranceAdministrationMessage.period.overviewTitle,
-      children: [],
-    }),
-    buildSection({
-      id: 'fileUpload',
-      title: socialInsuranceAdministrationMessage.fileUpload.title,
-      children: [],
-    }),
-    buildSection({
-      id: 'additionalInformation',
-      title: socialInsuranceAdministrationMessage.additionalInfo.section,
-      children: [],
-    }),
-    buildSection({
-      id: 'confirm',
-      title: socialInsuranceAdministrationMessage.confirm.overviewTitle,
-      children: [],
-    }),
-    buildSection({
-      id: 'conclusion',
-      title: socialInsuranceAdministrationMessage.conclusionScreen.section,
-      children: [],
-    }),
   ],
 })

--- a/libs/application/templates/social-insurance-administration/pension-supplement/src/forms/PensionSupplementForm.ts
+++ b/libs/application/templates/social-insurance-administration/pension-supplement/src/forms/PensionSupplementForm.ts
@@ -54,11 +54,6 @@ export const PensionSupplementForm: Form = buildForm({
   mode: FormModes.DRAFT,
   children: [
     buildSection({
-      id: 'prerequisites',
-      title: socialInsuranceAdministrationMessage.pre.externalDataSection,
-      children: [],
-    }),
-    buildSection({
       id: 'infoSection',
       title: socialInsuranceAdministrationMessage.info.section,
       children: [

--- a/libs/application/templates/social-insurance-administration/pension-supplement/src/forms/Prerequisites.ts
+++ b/libs/application/templates/social-insurance-administration/pension-supplement/src/forms/Prerequisites.ts
@@ -122,25 +122,5 @@ export const PrerequisitesForm: Form = buildForm({
         }),
       ],
     }),
-    buildSection({
-      id: 'info',
-      title: socialInsuranceAdministrationMessage.info.section,
-      children: [],
-    }),
-    buildSection({
-      id: 'additionalInfo',
-      title: socialInsuranceAdministrationMessage.additionalInfo.section,
-      children: [],
-    }),
-    buildSection({
-      id: 'confirm',
-      title: socialInsuranceAdministrationMessage.confirm.overviewTitle,
-      children: [],
-    }),
-    buildSection({
-      id: 'conclusion',
-      title: socialInsuranceAdministrationMessage.conclusionScreen.section,
-      children: [],
-    }),
   ],
 })


### PR DESCRIPTION
## What

Removed fake form steppers from tr applications

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes to Forms**
  - Simplified form structures by removing various sections from multiple forms, including:
    - Additional Support for the Elderly
    - Household Supplement
    - Old Age Pension
    - Pension Supplement
  - Removed sections include applicant information, period overview, file upload, additional information, confirmation, and conclusion.

These changes aim to streamline the user experience by simplifying the application forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->