### PR TITLE
fix(j-s): Spacing fix

### DIFF
--- a/apps/judicial-system/web/src/routes/Prison/IndictmentOverview/IndictmentOverview.tsx
+++ b/apps/judicial-system/web/src/routes/Prison/IndictmentOverview/IndictmentOverview.tsx
@@ -54,24 +54,24 @@ const IndictmentOverview = () => {
             {formatMessage(strings.title)}
           </Text>
         </Box>
-        {workingCase.courtCaseNumber && (
-          <Box marginBottom={1}>
-            <Text variant="h2" as="h2">
-              {formatMessage(core.caseNumber, {
-                caseNumber: workingCase.courtCaseNumber,
-              })}
-            </Text>
-          </Box>
-        )}
-        {workingCase.indictmentCompletedDate && (
-          <Box marginBottom={5}>
+        <Box marginBottom={5}>
+          {workingCase.courtCaseNumber && (
+            <Box marginBottom={1}>
+              <Text variant="h2" as="h2">
+                {formatMessage(core.caseNumber, {
+                  caseNumber: workingCase.courtCaseNumber,
+                })}
+              </Text>
+            </Box>
+          )}
+          {workingCase.indictmentCompletedDate && (
             <Text variant="h4" as="h3">
               {formatMessage(strings.indictmentCompletedTitle, {
                 date: formatDate(workingCase.indictmentCompletedDate, 'PPP'),
               })}
             </Text>
-          </Box>
-        )}
+          )}
+        </Box>
         <Box marginBottom={5}>
           <InfoCardClosedIndictment
             displayVerdictViewDate


### PR DESCRIPTION
# Spacing fix

[Asana](https://app.asana.com/0/1199153462262248/1207539443130911/f)

## What

Add a space between the titles and the info card on IndictmentOverview screen

## Why

If `indictmentCompletedDate` is not set, there is no space between the title and the info card. This PR makes sure that there is always some space between the title and the info card.

<img width="571" alt="Screenshot 2024-07-08 at 10 37 22" src="https://github.com/island-is/island.is/assets/3789875/b3349e58-1928-4607-adac-44276488350a">

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the display of `courtCaseNumber` and `indictmentCompletedDate` in the Indictment Overview to ensure accurate conditional rendering based on available data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->