### PR TITLE
fix(application-driving-license): Remarks revamped and bugfixes

### DIFF
--- a/libs/api/domains/driving-license/src/lib/graphql/models/drivingLicense.model.ts
+++ b/libs/api/domains/driving-license/src/lib/graphql/models/drivingLicense.model.ts
@@ -2,6 +2,7 @@ import { Field, ObjectType, ID } from '@nestjs/graphql'
 import { Disqualification } from './disqualification.model'
 
 import { Eligibility } from './eligibility.model'
+import { Remark } from './remark.model'
 
 @ObjectType()
 export class DrivingLicense {
@@ -21,7 +22,7 @@ export class DrivingLicense {
   categories!: Eligibility[]
 
   @Field(() => [String])
-  remarks?: string[]
+  remarks?: Remark[]
 
   @Field(() => Disqualification, { nullable: true })
   disqualification?: Disqualification

--- a/libs/api/domains/driving-license/src/lib/graphql/models/remark.model.ts
+++ b/libs/api/domains/driving-license/src/lib/graphql/models/remark.model.ts
@@ -1,0 +1,10 @@
+import { Field, ObjectType } from '@nestjs/graphql'
+
+@ObjectType()
+export class Remark {
+  @Field()
+  code!: string
+
+  @Field()
+  description!: string
+}

--- a/libs/application/template-api-modules/src/lib/modules/shared/api/driving-license/driving-license.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/shared/api/driving-license/driving-license.service.ts
@@ -147,7 +147,13 @@ export class DrivingLicenseProviderService extends BaseTemplateApiService {
         currentLicense: fakeData.currentLicense === 'temp' ? 'B' : null,
         remarks:
           fakeData.remarks === YES
-            ? ['Gervilimur eða gervilimir/stoðtæki fyrir fætur og hendur.']
+            ? [
+                {
+                  code: '',
+                  description:
+                    'Gervilimur eða gervilimir/stoðtæki fyrir fætur og hendur.',
+                },
+              ]
             : undefined,
       }
     }

--- a/libs/application/template-api-modules/src/lib/modules/shared/api/driving-license/types.ts
+++ b/libs/application/template-api-modules/src/lib/modules/shared/api/driving-license/types.ts
@@ -29,9 +29,14 @@ export type DrivingLicenseCategory = {
   nr?: string | null
 }
 
+export interface Remark {
+  code: string
+  description: string
+}
+
 export type DrivingLicense = {
   currentLicense: string | null
-  remarks?: string[]
+  remarks?: Remark[]
   categories?: DrivingLicenseCategory[]
   id?: number
   birthCountry?: string | null

--- a/libs/application/templates/driving-license/src/fields/HealthRemarks.tsx
+++ b/libs/application/templates/driving-license/src/fields/HealthRemarks.tsx
@@ -5,14 +5,14 @@ import { FieldBaseProps } from '@island.is/application/types'
 import { m } from '../lib/messages'
 import { useLocale } from '@island.is/localization'
 import { useFormContext } from 'react-hook-form'
-import { YES, NO } from '../lib/constants'
-import { DrivingLicense } from '../lib/types'
+import { YES, NO, codesRequiringHealthCertificate } from '../lib/constants'
+import { DrivingLicense, Remark } from '../lib/types'
 
 const HealthRemarks: FC<React.PropsWithChildren<FieldBaseProps>> = ({
   application,
 }) => {
   const { formatMessage } = useLocale()
-  const remarks: string[] =
+  const remarks: Remark[] =
     getValueViaPath<DrivingLicense>(
       application.externalData,
       'currentLicense.data',
@@ -21,7 +21,12 @@ const HealthRemarks: FC<React.PropsWithChildren<FieldBaseProps>> = ({
   const { setValue } = useFormContext()
 
   useEffect(() => {
-    setValue('hasHealthRemarks', remarks?.length > 0 ? YES : NO)
+    setValue(
+      'hasHealthRemarks',
+      remarks.some((r) => codesRequiringHealthCertificate.includes(r.code))
+        ? YES
+        : NO,
+    )
   }, [remarks, setValue])
 
   return (
@@ -32,7 +37,7 @@ const HealthRemarks: FC<React.PropsWithChildren<FieldBaseProps>> = ({
         message={
           formatText(m.healthRemarksDescription, application, formatMessage) +
             ' ' +
-            remarks?.join(', ') || ''
+            remarks?.map((r) => r.description).join(', ') || ''
         }
       />
     </Box>

--- a/libs/application/templates/driving-license/src/lib/constants.ts
+++ b/libs/application/templates/driving-license/src/lib/constants.ts
@@ -9,6 +9,9 @@ export const B_FULL = 'B-full'
 export const B_TEMP = 'B-temp'
 export const BE = 'BE'
 
+export const otherLicenseCategories = ['C', 'C1', 'CE', 'D', 'D1', 'DE']
+export const codesRequiringHealthCertificate = ['400', '01.06']
+
 export type DrivingLicenseApplicationFor =
   | typeof B_FULL
   | typeof B_TEMP

--- a/libs/application/templates/driving-license/src/lib/types.ts
+++ b/libs/application/templates/driving-license/src/lib/types.ts
@@ -13,8 +13,13 @@ export type DrivingLicenseCategory = {
   validToCode: number
 }
 
+export interface Remark {
+  code: string
+  description: string
+}
+
 export type DrivingLicense = {
   currentLicense: string | null
-  remarks?: string[]
+  remarks?: Remark[]
   categories: DrivingLicenseCategory[]
 }

--- a/libs/clients/driving-license/src/lib/drivingLicenseApi.types.ts
+++ b/libs/clients/driving-license/src/lib/drivingLicenseApi.types.ts
@@ -28,13 +28,17 @@ export interface Disqualification {
   from?: Date | null
 }
 
+export interface Remark {
+  code: string
+  description: string
+}
 export interface DriversLicense {
   id: number
   name: string
   issued?: Date | null
   expires?: Date | null
   categories: DriversLicenseCategory[]
-  remarks?: string[]
+  remarks?: Remark[]
   disqualification?: Disqualification | null
   birthCountry?: string | null
   publishPlaceName?: string | null


### PR DESCRIPTION
## Made remarks more expressive. 

This way we do not have to compare full text descriptions but rather just the remark code.
Should simplify eligibility and other validation work considerably for maintenance.

### Example old remark:
```typescript
'Réttindi til farþegaflutninga í atvinnuskyni fyrir B-flokk.'
```

### Example new remark:
```typescript
{
  code: '400',
  description: 'Réttindi til farþegaflutninga í atvinnuskyni fyrir B-flokk.'
}
```

## Bugfixes
Data fetching from external data not fully expressed

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced driving license data model to include detailed remarks with codes and descriptions.
	
- **Refactor**
	- Refactored logic to accommodate the updated driving license remarks structure.

- **Bug Fixes**
	- Improved consistency and accuracy in handling driving license remarks.

- **Style**
	- Updated code to ensure compatibility with new remark data structure.

- **Documentation**
	- Updated types and constants to reflect changes in driving license remarks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->