### PR TITLE
fix: Enable corepack in `infra/`

### DIFF
--- a/.github/workflows/config-values.yaml
+++ b/.github/workflows/config-values.yaml
@@ -94,6 +94,7 @@ jobs:
       - name: Commit any changes to charts
         if: ${{ github.event_name == 'pull_request' }}
         run: |
+          (cd infra && corepack enable)
           yarn --cwd infra charts
           ./infra/scripts/ci/git-check-dirty.sh "charts/" "charts" "dirtybot"
 


### PR DESCRIPTION
Fix breaking workflow in e.g. https://github.com/island-is/island.is/pull/14819

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow configurations to ensure environment setup commands are executed before running yarn and git-check-dirty script for committing changes to charts on pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->