### PR TITLE
feat(native-app): update nav bar right buttons

### DIFF
--- a/apps/native/app/src/screens/applications/applications.tsx
+++ b/apps/native/app/src/screens/applications/applications.tsx
@@ -20,11 +20,9 @@ import {
   useListSearchQuery,
 } from '../../graphql/types/schema'
 import { createNavigationOptionHooks } from '../../hooks/create-navigation-option-hooks'
-import { useActiveTabItemPress } from '../../hooks/use-active-tab-item-press'
 import { useConnectivityIndicator } from '../../hooks/use-connectivity-indicator'
 import { useBrowser } from '../../lib/useBrowser'
 import { getApplicationOverviewUrl } from '../../utils/applications-utils'
-import { getRightButtons } from '../../utils/get-main-root'
 import { testIDs } from '../../utils/test-ids'
 import { ApplicationsModule } from '../home/applications-module'
 
@@ -42,7 +40,6 @@ const { useNavigationOptions, getNavigationOptions } =
         searchBar: {
           visible: false,
         },
-        rightButtons: initialized ? getRightButtons({ theme } as any) : [],
       },
       bottomTab: {
         iconColor: theme.color.blue400,
@@ -98,7 +95,6 @@ export const ApplicationsScreen: NavigationFunctionComponent = ({
 
   useConnectivityIndicator({
     componentId,
-    rightButtons: getRightButtons(),
     refetching,
     queryResult: [applicationsRes, res],
   })
@@ -138,13 +134,6 @@ export const ApplicationsScreen: NavigationFunctionComponent = ({
     },
     [],
   )
-
-  useActiveTabItemPress(3, () => {
-    flatListRef.current?.scrollToOffset({
-      offset: -150,
-      animated: true,
-    })
-  })
 
   const keyExtractor = useCallback((item: ListItem) => item.id, [])
 

--- a/apps/native/app/src/screens/home/home.tsx
+++ b/apps/native/app/src/screens/home/home.tsx
@@ -48,7 +48,9 @@ const { useNavigationOptions, getNavigationOptions } =
   createNavigationOptionHooks(
     (theme, intl, initialized) => ({
       topBar: {
-        rightButtons: initialized ? getRightButtons({ theme } as any) : [],
+        rightButtons: initialized
+          ? getRightButtons({ screen: 'Home', theme: theme as any })
+          : [],
       },
       bottomTab: {
         ...({
@@ -110,7 +112,7 @@ export const MainHomeScreen: NavigationFunctionComponent = ({
 
   useConnectivityIndicator({
     componentId,
-    rightButtons: getRightButtons(),
+    rightButtons: getRightButtons({ screen: 'Home' }),
     queryResult: applicationsRes,
     refetching,
   })

--- a/apps/native/app/src/screens/inbox/inbox.tsx
+++ b/apps/native/app/src/screens/inbox/inbox.tsx
@@ -45,7 +45,6 @@ import { toggleAction } from '../../lib/post-mail-action'
 import { useOrganizationsStore } from '../../stores/organizations-store'
 import { useUiStore } from '../../stores/ui-store'
 import { ComponentRegistry } from '../../utils/component-registry'
-import { getRightButtons } from '../../utils/get-main-root'
 import { testIDs } from '../../utils/test-ids'
 
 type ListItem =
@@ -61,7 +60,6 @@ const { useNavigationOptions, getNavigationOptions } =
         title: {
           text: intl.formatMessage({ id: 'inbox.screenTitle' }),
         },
-        rightButtons: initialized ? getRightButtons({ theme } as any) : [],
       },
       bottomTab: {
         iconColor: theme.color.blue400,
@@ -297,7 +295,6 @@ export const InboxScreen: NavigationFunctionComponent<{
 
   useConnectivityIndicator({
     componentId,
-    rightButtons: getRightButtons(),
     queryResult: res,
     refetching: res.refetching,
   })

--- a/apps/native/app/src/screens/more/more.tsx
+++ b/apps/native/app/src/screens/more/more.tsx
@@ -16,8 +16,8 @@ import { useConnectivityIndicator } from '../../hooks/use-connectivity-indicator
 import { navigateTo } from '../../lib/deep-linking'
 import { formatNationalId } from '../../lib/format-national-id'
 import { useAuthStore } from '../../stores/auth-store'
-import { getRightButtons } from '../../utils/get-main-root'
 import { testIDs } from '../../utils/test-ids'
+import { getRightButtons } from '../../utils/get-main-root'
 
 const Row = styled.View`
   margin-top: ${({ theme }) => theme.spacing[2]}px;
@@ -34,7 +34,9 @@ const { useNavigationOptions, getNavigationOptions } =
         title: {
           text: intl.formatMessage({ id: 'profile.screenTitle' }),
         },
-        rightButtons: initialized ? getRightButtons({ theme } as any) : [],
+        rightButtons: initialized
+          ? getRightButtons({ screen: 'More', theme: theme as any })
+          : [],
       },
       bottomTab: {
         iconColor: theme.color.blue400,
@@ -71,7 +73,10 @@ export const MoreScreen: NavigationFunctionComponent = ({ componentId }) => {
   const showAirDiscount = useFeatureFlag('isAirDiscountEnabled', false)
 
   useNavigationOptions(componentId)
-  useConnectivityIndicator({ componentId, rightButtons: getRightButtons() })
+  useConnectivityIndicator({
+    componentId,
+    rightButtons: getRightButtons({ screen: 'More' }),
+  })
 
   return (
     <>

--- a/apps/native/app/src/screens/wallet/wallet.tsx
+++ b/apps/native/app/src/screens/wallet/wallet.tsx
@@ -54,15 +54,9 @@ const { useNavigationOptions, getNavigationOptions } =
         title: {
           text: intl.formatMessage({ id: 'wallet.screenTitle' }),
         },
-        rightButtons: initialized ? getRightButtons({ theme } as any) : [],
-        leftButtons: [
-          {
-            id: ButtonRegistry.ScanLicenseButton,
-            testID: testIDs.TOPBAR_SCAN_LICENSE_BUTTON,
-            icon: require('../../assets/icons/navbar-scan.png'),
-            color: theme.color.blue400,
-          },
-        ],
+        rightButtons: initialized
+          ? getRightButtons({ screen: 'Wallet', theme: theme as any })
+          : [],
       },
       bottomTab: {
         iconColor: theme.color.blue400,
@@ -133,16 +127,9 @@ export const WalletScreen: NavigationFunctionComponent = ({ componentId }) => {
 
   useConnectivityIndicator({
     componentId,
-    rightButtons: getRightButtons(),
+    rightButtons: getRightButtons({ screen: 'Wallet' }),
     queryResult: [res, resPassport],
     refetching,
-  })
-
-  useActiveTabItemPress(1, () => {
-    flatListRef.current?.scrollToOffset({
-      offset: -150,
-      animated: true,
-    })
   })
 
   // Filter licenses

--- a/apps/native/app/src/utils/get-main-root.ts
+++ b/apps/native/app/src/utils/get-main-root.ts
@@ -10,10 +10,19 @@ import {
 import { getThemeWithPreferences } from './get-theme-with-preferences'
 import { testIDs } from './test-ids'
 
+type Screen = 'Inbox' | 'Wallet' | 'Home' | 'Applications' | 'More'
+
+type RightButtonProps = {
+  unseenCount?: number
+  theme?: ReturnType<typeof getThemeWithPreferences>
+  screen?: Screen
+}
+
 export const getRightButtons = ({
   unseenCount = notificationsStore.getState().unseenCount,
   theme = getThemeWithPreferences(preferencesStore.getState()),
-} = {}): OptionsTopBarButton[] => {
+  screen,
+}: RightButtonProps = {}): OptionsTopBarButton[] => {
   const iconBackground = {
     color: 'transparent',
     cornerRadius: 8,
@@ -21,25 +30,42 @@ export const getRightButtons = ({
     height: theme.spacing[4],
   }
 
-  return [
-    {
-      accessibilityLabel: 'Settings',
-      id: ButtonRegistry.SettingsButton,
-      testID: testIDs.TOPBAR_SETTINGS_BUTTON,
-      icon: require('../assets/icons/settings.png'),
-      iconBackground,
-    },
-    {
-      accessibilityLabel: 'Notifications',
-      id: ButtonRegistry.NotificationsButton,
-      testID: testIDs.TOPBAR_NOTIFICATIONS_BUTTON,
-      icon:
-        unseenCount > 0
-          ? require('../assets/icons/topbar-notifications-bell.png')
-          : require('../assets/icons/topbar-notifications.png'),
-      iconBackground,
-    },
-  ]
+  switch (screen) {
+    case 'Home':
+      return [
+        {
+          accessibilityLabel: 'Notifications',
+          id: ButtonRegistry.NotificationsButton,
+          testID: testIDs.TOPBAR_NOTIFICATIONS_BUTTON,
+          icon:
+            unseenCount > 0
+              ? require('../assets/icons/topbar-notifications-bell.png')
+              : require('../assets/icons/topbar-notifications.png'),
+          iconBackground,
+        },
+      ]
+    case 'Wallet':
+      return [
+        {
+          id: ButtonRegistry.ScanLicenseButton,
+          testID: testIDs.TOPBAR_SCAN_LICENSE_BUTTON,
+          icon: require('../assets/icons/navbar-scan.png'),
+          color: theme.color.blue400,
+        },
+      ]
+    case 'More':
+      return [
+        {
+          accessibilityLabel: 'Settings',
+          id: ButtonRegistry.SettingsButton,
+          testID: testIDs.TOPBAR_SETTINGS_BUTTON,
+          icon: require('../assets/icons/settings.png'),
+          iconBackground,
+        },
+      ]
+    default:
+      return []
+  }
 }
 
 /**


### PR DESCRIPTION
## What

Updating nav bar buttons. Only show notification bell on home screen and settings icon on more screen. Move scan icon on wallet screen to be on the right side instead of left.

## Why

Simplify nav bar buttons and create space for screen specific buttons when needed. 

## Screenshots / Gifs

https://github.com/island-is/island.is/assets/19665778/abc3acf9-81d8-425a-880b-b2f0286568e5



## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
