### PR TITLE
fix(native-app): open correct browser when authenticating using passkeys

### DIFF
--- a/apps/native/app/src/screens/passkey/passkey.tsx
+++ b/apps/native/app/src/screens/passkey/passkey.tsx
@@ -177,7 +177,7 @@ export const PasskeyScreen: NavigationFunctionComponent<{
                       authenticationResponse,
                     )
                     if (urlWithLoginHint) {
-                      openNativeBrowser(urlWithLoginHint)
+                      openNativeBrowser(urlWithLoginHint, parentComponentId)
                     }
                   }
                   setIsLoading(false)
@@ -200,7 +200,9 @@ export const PasskeyScreen: NavigationFunctionComponent<{
 
                 // If authenticate fails we fail silently - close the modal and open the browser
                 Navigation.dismissModal(componentId)
-                url && openNativeBrowser(url, parentComponentId)
+                if (url) {
+                  openNativeBrowser(url, parentComponentId)
+                }
               }
             }}
             style={{ marginBottom: theme.spacing[1] }}


### PR DESCRIPTION
## What

When authenticating with passkeys, make sure to open up the in app browser instead of opening the real browser. 
Was broken in one place since I forgot to send in componentId.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
