### PR TITLE
fix(j-s): Ruling signatures

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/case/case.controller.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/case.controller.ts
@@ -84,7 +84,6 @@ import {
   courtOfAppealsRegistrarUpdateRule,
   districtCourtAssistantTransitionRule,
   districtCourtAssistantUpdateRule,
-  districtCourtJudgeSignRulingRule,
   districtCourtJudgeTransitionRule,
   districtCourtJudgeUpdateRule,
   districtCourtRegistrarTransitionRule,

--- a/apps/judicial-system/backend/src/app/modules/case/case.controller.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/case.controller.ts
@@ -765,7 +765,7 @@ export class CaseController {
     new CaseTypeGuard([...restrictionCases, ...investigationCases]),
     CaseWriteGuard,
   )
-  @RolesRules(districtCourtJudgeSignRulingRule)
+  @RolesRules(districtCourtJudgeRule)
   @Post('case/:caseId/ruling/signature')
   @ApiCreatedResponse({
     type: SigningServiceResponse,
@@ -777,6 +777,12 @@ export class CaseController {
     @CurrentCase() theCase: Case,
   ): Promise<SigningServiceResponse> {
     this.logger.debug(`Requesting a signature for the ruling of case ${caseId}`)
+
+    if (user.id !== theCase.judgeId) {
+      throw new ForbiddenException(
+        'A ruling must be signed by the assigned judge',
+      )
+    }
 
     return this.caseService.requestRulingSignature(theCase).catch((error) => {
       if (error instanceof DokobitError) {
@@ -802,7 +808,7 @@ export class CaseController {
     new CaseTypeGuard([...restrictionCases, ...investigationCases]),
     CaseWriteGuard,
   )
-  @RolesRules(districtCourtJudgeSignRulingRule)
+  @RolesRules(districtCourtJudgeRule)
   @Get('case/:caseId/ruling/signature')
   @ApiOkResponse({
     type: SignatureConfirmationResponse,
@@ -816,6 +822,12 @@ export class CaseController {
     @Query('documentToken') documentToken: string,
   ): Promise<SignatureConfirmationResponse> {
     this.logger.debug(`Confirming a signature for the ruling of case ${caseId}`)
+
+    if (user.id !== theCase.judgeId) {
+      throw new ForbiddenException(
+        'A ruling must be signed by the assigned judge',
+      )
+    }
 
     return this.caseService.getRulingSignatureConfirmation(
       theCase,

--- a/apps/judicial-system/backend/src/app/modules/case/guards/rolesRules.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/guards/rolesRules.ts
@@ -354,7 +354,7 @@ export const districtCourtJudgeSignRulingRule: RolesRule = {
     const theCase: Case = request.case
 
     // Deny if something is missing - shuould never happen
-    if (!user || !theCase) {
+    if (!user) {
       return false
     }
 

--- a/apps/judicial-system/backend/src/app/modules/case/guards/rolesRules.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/guards/rolesRules.ts
@@ -354,7 +354,7 @@ export const districtCourtJudgeSignRulingRule: RolesRule = {
     const theCase: Case = request.case
 
     // Deny if something is missing - shuould never happen
-    if (!user) {
+    if (!user || !theCase) {
       return false
     }
 

--- a/apps/judicial-system/backend/src/app/modules/case/test/caseController/getRulingSignatureConfirmationRolesRules.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/test/caseController/getRulingSignatureConfirmationRolesRules.spec.ts
@@ -1,6 +1,5 @@
+import { districtCourtJudgeRule } from '../../../../guards'
 import { CaseController } from '../../case.controller'
-import { districtCourtJudgeSignRulingRule } from '../../guards/rolesRules'
-
 describe('CaseController - Get ruling signature confirmation rules', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let rules: any[]
@@ -14,6 +13,6 @@ describe('CaseController - Get ruling signature confirmation rules', () => {
 
   it('should give permission to one roles', () => {
     expect(rules).toHaveLength(1)
-    expect(rules).toContain(districtCourtJudgeSignRulingRule)
+    expect(rules).toContain(districtCourtJudgeRule)
   })
 })

--- a/apps/judicial-system/backend/src/app/modules/case/test/caseController/requestRulingSignatureRolesRules.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/test/caseController/requestRulingSignatureRolesRules.spec.ts
@@ -1,6 +1,5 @@
+import { districtCourtJudgeRule } from '../../../../guards'
 import { CaseController } from '../../case.controller'
-import { districtCourtJudgeSignRulingRule } from '../../guards/rolesRules'
-
 describe('CaseController - Request ruling signature rules', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let rules: any[]
@@ -14,6 +13,6 @@ describe('CaseController - Request ruling signature rules', () => {
 
   it('should give permission to one roles', () => {
     expect(rules).toHaveLength(1)
-    expect(rules).toContain(districtCourtJudgeSignRulingRule)
+    expect(rules).toContain(districtCourtJudgeRule)
   })
 })


### PR DESCRIPTION

## What

Bugfix for roles rules change that broke ruling signatures for judges 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured rulings are signed only by the assigned judge for enhanced accuracy and authority.

- **Tests**
  - Updated test cases to reflect the new role rule for verifying the signing of rulings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->