### PR TITLE
fix(service-portal): action card tag if no heading

### DIFF
--- a/libs/service-portal/core/src/components/ActionCard/ActionCard.tsx
+++ b/libs/service-portal/core/src/components/ActionCard/ActionCard.tsx
@@ -339,13 +339,13 @@ export const ActionCard: React.FC<React.PropsWithChildren<ActionCardProps>> = ({
         {/* Checking image type so the image is placed correctly */}
         {image?.type !== 'logo' && renderImage()}
         <Box flexDirection="row" width="full">
-          {heading && (
-            <Box
-              display="flex"
-              flexDirection="row"
-              justifyContent="spaceBetween"
-              alignItems={['flexStart', 'flexStart', 'flexEnd']}
-            >
+          <Box
+            display="flex"
+            flexDirection="row"
+            justifyContent="spaceBetween"
+            alignItems={['flexStart', 'flexStart', 'flexEnd']}
+          >
+            {heading && (
               <Box
                 display="flex"
                 flexDirection="row"
@@ -365,17 +365,20 @@ export const ActionCard: React.FC<React.PropsWithChildren<ActionCardProps>> = ({
                   {heading}
                 </Text>
               </Box>
-              <Hidden above="xs">
-                {secondaryTag && (
-                  <Box marginRight="smallGutter">
-                    {!date && !eyebrow && renderTag(secondaryTag)}
-                  </Box>
-                )}
-                <Box>{!date && !eyebrow && renderTag(tag)}</Box>
-              </Hidden>
-            </Box>
-          )}
-          {text && <Text paddingTop={heading ? 1 : 0}>{text}</Text>}
+            )}
+            {!heading && text && (
+              <Text paddingTop={heading ? 1 : 0}>{text}</Text>
+            )}
+            <Hidden above="xs">
+              {secondaryTag && (
+                <Box marginRight="smallGutter">
+                  {!date && !eyebrow && renderTag(secondaryTag)}
+                </Box>
+              )}
+              <Box>{!date && !eyebrow && renderTag(tag)}</Box>
+            </Hidden>
+          </Box>
+          {heading && text && <Text paddingTop={heading ? 1 : 0}>{text}</Text>}
           {subText && <Text>{subText}</Text>}
         </Box>
         <Box


### PR DESCRIPTION
## What

* Display tags on very small screen sizes if heading is missing

## Why

Wasn't displaying tags on mobile

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the display logic for headings and text within the ActionCard component to ensure proper conditional rendering based on their presence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->