### PR TITLE
chore(j-s): Allow pascal case and leading underscore in imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -311,6 +311,11 @@
           {
             "selector": "enumMember",
             "format": ["camelCase", "UPPER_CASE", "PascalCase"]
+          },
+          {
+            "selector": "import",
+            "leadingUnderscore": "allow",
+            "format": ["camelCase", "PascalCase"]
           }
         ],
         "@typescript-eslint/no-empty-interface": [


### PR DESCRIPTION
# Allow pascal case and leading underscore in imports

## What

Allows the following imports:
- `import CryptoJS from 'crypto-js'`
- `import _uniqBy from 'lodash/uniqBy'`

## Why

These imports were allowed until recently. Not sure what changed.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Adjusted ESLint rules to allow leading underscores in import statements with specific formatting requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->