### PR TITLE
fix(native-app): Settings icon should always appear in nav bar on more page

### DIFF
--- a/apps/native/app/src/screens/more/more.tsx
+++ b/apps/native/app/src/screens/more/more.tsx
@@ -7,7 +7,10 @@ import {
   ScrollView,
   TouchableHighlight,
 } from 'react-native'
-import { NavigationFunctionComponent } from 'react-native-navigation'
+import {
+  Navigation,
+  NavigationFunctionComponent,
+} from 'react-native-navigation'
 import { useNavigationComponentDidAppear } from 'react-native-navigation-hooks'
 import styled, { useTheme } from 'styled-components/native'
 import assetsIcon from '../../assets/icons/assets.png'
@@ -74,6 +77,7 @@ const { useNavigationOptions, getNavigationOptions } =
   )
 
 export const MoreScreen: NavigationFunctionComponent = ({ componentId }) => {
+  useNavigationOptions(componentId)
   const authStore = useAuthStore()
   const intl = useIntl()
   const theme = useTheme()
@@ -81,13 +85,19 @@ export const MoreScreen: NavigationFunctionComponent = ({ componentId }) => {
   const showFinances = useFeatureFlag('isFinancesEnabled', false)
   const showAirDiscount = useFeatureFlag('isAirDiscountEnabled', false)
 
-  useNavigationOptions(componentId)
   useConnectivityIndicator({
     componentId,
     rightButtons: getRightButtons({ screen: 'More' }),
   })
+
   useNavigationComponentDidAppear(() => {
     setHiddenContent(false)
+    // This is needed to make sure we show the settings icon on a cold boot
+    Navigation.mergeOptions(componentId, {
+      topBar: {
+        rightButtons: getRightButtons({ screen: 'More' }),
+      },
+    })
   }, componentId)
 
   // Fix for a bug in react-native-navigation where the large title is not visible on iOS with bottom tabs https://github.com/wix/react-native-navigation/issues/6717

--- a/apps/native/app/src/utils/get-main-root.ts
+++ b/apps/native/app/src/utils/get-main-root.ts
@@ -51,6 +51,7 @@ export const getRightButtons = ({
           testID: testIDs.TOPBAR_SCAN_LICENSE_BUTTON,
           icon: require('../assets/icons/navbar-scan.png'),
           color: theme.color.blue400,
+          iconBackground,
         },
       ]
     case 'More':


### PR DESCRIPTION
## What

After I merged #15478 I noticed that on cold boot I did not see the settings icon on more page. 
After some investigation it was because the more screen did not have any query to fetch and in return update navigation options inside the useConnectivityIndicator hook.

I'm not sure why `createNavigationOptionHooks` is not setting the buttons correctly though 🤔  I will try to look into that if I have time, otherwise I will do it after summer vacation.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new top bar button management system in the "More" screen, enhancing navigation options.
- **Improvements**
  - Updated button configurations to include an `iconBackground` parameter, providing more customization options for navigation buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->