### PR TITLE
feat(user-profile): Catching 404 error for getBankInfoFromIslykill

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/shared/api/user-profile/user-profile.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/shared/api/user-profile/user-profile.service.ts
@@ -19,7 +19,7 @@ import { Inject } from '@nestjs/common'
 import { ConfigService, ConfigType } from '@nestjs/config'
 import { getConfigValue } from '../../shared.utils'
 import { TemplateApiError } from '@island.is/nest/problem'
-import {FetchError} from "@island.is/clients/middlewares";
+import { FetchError } from '@island.is/clients/middlewares'
 
 @Injectable()
 export class UserProfileService extends BaseTemplateApiService {

--- a/libs/application/template-api-modules/src/lib/modules/shared/api/user-profile/user-profile.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/shared/api/user-profile/user-profile.service.ts
@@ -19,6 +19,7 @@ import { Inject } from '@nestjs/common'
 import { ConfigService, ConfigType } from '@nestjs/config'
 import { getConfigValue } from '../../shared.utils'
 import { TemplateApiError } from '@island.is/nest/problem'
+import {FetchError} from "@island.is/clients/middlewares";
 
 @Injectable()
 export class UserProfileService extends BaseTemplateApiService {
@@ -100,6 +101,8 @@ export class UserProfileService extends BaseTemplateApiService {
       .catch((error) => {
         if (isRunningOnEnvironment('local')) {
           return '0000-11-222222'
+        } else if (error instanceof FetchError && error.status === 404) {
+          return undefined
         }
         throw error
       })


### PR DESCRIPTION
# ...

When no kt is found for user in islykill we want to return undefined instead of 404 error. If bank info is required caller should pass params.validateBankInformation = true to force the validation.

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling in user profile service by returning `undefined` for 404 errors, improving app stability and user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->