### PR TITLE
fix(native-app): fix lock screen android bug

### DIFF
--- a/apps/native/app/src/screens/home/applications-module.tsx
+++ b/apps/native/app/src/screens/home/applications-module.tsx
@@ -18,6 +18,7 @@ import { Application } from '../../graphql/types/schema'
 import { navigateTo } from '../../lib/deep-linking'
 import { useBrowser } from '../../lib/useBrowser'
 import { getApplicationUrl } from '../../utils/applications-utils'
+import { useTheme } from 'styled-components'
 
 interface ApplicationsModuleProps {
   applications: Application[]
@@ -36,6 +37,7 @@ export const ApplicationsModule = React.memo(
     hideSeeAllButton = false,
   }: ApplicationsModuleProps) => {
     const intl = useIntl()
+    const theme = useTheme()
     const count = applications.length
     const { openBrowser } = useBrowser()
 
@@ -75,7 +77,12 @@ export const ApplicationsModule = React.memo(
     ))
 
     return (
-      <SafeAreaView style={{ marginHorizontal: 16 }}>
+      <SafeAreaView
+        style={{
+          marginHorizontal: theme.spacing[2],
+          marginBottom: theme.spacing[2],
+        }}
+      >
         <TouchableOpacity onPress={() => navigateTo(`/applications`)}>
           <Heading
             button={

--- a/apps/native/app/src/utils/lifecycle/setup-event-handlers.ts
+++ b/apps/native/app/src/utils/lifecycle/setup-event-handlers.ts
@@ -95,7 +95,19 @@ export function setupEventHandlers() {
 
       if (status === 'background' || status === 'inactive') {
         // Add a small delay for those accidental backgrounds in iOS
-        backgroundAppLockTimeout = setTimeout(() => {
+        if (isIos) {
+          backgroundAppLockTimeout = setTimeout(() => {
+            const { lockScreenComponentId, lockScreenActivatedAt } =
+              authStore.getState()
+
+            if (!lockScreenComponentId && !lockScreenActivatedAt) {
+              showAppLockOverlay({ status })
+            } else if (lockScreenComponentId) {
+              Navigation.updateProps(lockScreenComponentId, { status })
+            }
+          }, 100)
+        } else {
+          // set timeout does not work properly on android when app is in background
           const { lockScreenComponentId, lockScreenActivatedAt } =
             authStore.getState()
 
@@ -104,7 +116,7 @@ export function setupEventHandlers() {
           } else if (lockScreenComponentId) {
             Navigation.updateProps(lockScreenComponentId, { status })
           }
-        }, 100)
+        }
       }
 
       if (status === 'active') {


### PR DESCRIPTION
## What

Android lock screen is not being triggered when app is in background/inactive. That is because setTimeout doesn't work in android when the app is in background - found a few issues talking about this so it seems to be happening for other people too. Since I am going on a summer vacation this will be the fix for now and we can look at it in more detail in August :) 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dynamic theme-based styling to the ApplicationsModule component.
  
- **Bug Fixes**
  - Improved handling of background status for iOS devices, ensuring proper behavior for app locking and overlays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->