### PR TITLE
fix(native-app): revert: update nav bar right buttons

### DIFF
--- a/apps/native/app/src/screens/applications/applications.tsx
+++ b/apps/native/app/src/screens/applications/applications.tsx
@@ -25,6 +25,7 @@ import { useConnectivityIndicator } from '../../hooks/use-connectivity-indicator
 import { useBrowser } from '../../lib/useBrowser'
 import { getApplicationOverviewUrl } from '../../utils/applications-utils'
 import { testIDs } from '../../utils/test-ids'
+import { getRightButtons } from '../../utils/get-main-root'
 import { ApplicationsModule } from '../home/applications-module'
 import { isIos } from '../../utils/devices'
 
@@ -42,6 +43,7 @@ const { useNavigationOptions, getNavigationOptions } =
         searchBar: {
           visible: false,
         },
+        rightButtons: initialized ? getRightButtons({ theme } as any) : [],
       },
       bottomTab: {
         iconColor: theme.color.blue400,
@@ -98,6 +100,7 @@ export const ApplicationsScreen: NavigationFunctionComponent = ({
 
   useConnectivityIndicator({
     componentId,
+    rightButtons: getRightButtons(),
     refetching,
     queryResult: [applicationsRes, res],
   })

--- a/apps/native/app/src/screens/home/home.tsx
+++ b/apps/native/app/src/screens/home/home.tsx
@@ -47,9 +47,7 @@ const { useNavigationOptions, getNavigationOptions } =
   createNavigationOptionHooks(
     (theme, intl, initialized) => ({
       topBar: {
-        rightButtons: initialized
-          ? getRightButtons({ screen: 'Home', theme: theme as any })
-          : [],
+        rightButtons: initialized ? getRightButtons({ theme } as any) : [],
       },
       bottomTab: {
         ...({
@@ -107,7 +105,7 @@ export const MainHomeScreen: NavigationFunctionComponent = ({
 
   useConnectivityIndicator({
     componentId,
-    rightButtons: getRightButtons({ screen: 'Home' }),
+    rightButtons: getRightButtons(),
     queryResult: applicationsRes,
     refetching,
   })

--- a/apps/native/app/src/screens/inbox/inbox.tsx
+++ b/apps/native/app/src/screens/inbox/inbox.tsx
@@ -42,6 +42,7 @@ import { navigateTo } from '../../lib/deep-linking'
 import { useOrganizationsStore } from '../../stores/organizations-store'
 import { useUiStore } from '../../stores/ui-store'
 import { ComponentRegistry } from '../../utils/component-registry'
+import { getRightButtons } from '../../utils/get-main-root'
 import { testIDs } from '../../utils/test-ids'
 import { isAndroid } from '../../utils/devices'
 import { useApolloClient } from '@apollo/client'
@@ -80,6 +81,7 @@ const { useNavigationOptions, getNavigationOptions } =
         title: {
           text: intl.formatMessage({ id: 'inbox.screenTitle' }),
         },
+        rightButtons: initialized ? getRightButtons({ theme } as any) : [],
       },
       bottomTab: {
         iconColor: theme.color.blue400,
@@ -240,6 +242,7 @@ export const InboxScreen: NavigationFunctionComponent<{
 
   useConnectivityIndicator({
     componentId,
+    rightButtons: getRightButtons(),
     queryResult: res,
     refetching: refetching || markAllAsReadLoading,
   })

--- a/apps/native/app/src/screens/more/more.tsx
+++ b/apps/native/app/src/screens/more/more.tsx
@@ -44,9 +44,7 @@ const { useNavigationOptions, getNavigationOptions } =
         title: {
           text: intl.formatMessage({ id: 'profile.screenTitle' }),
         },
-        rightButtons: initialized
-          ? getRightButtons({ screen: 'More', theme: theme as any })
-          : [],
+        rightButtons: initialized ? getRightButtons({ theme } as any) : [],
       },
       bottomTab: {
         iconColor: theme.color.blue400,
@@ -87,17 +85,11 @@ export const MoreScreen: NavigationFunctionComponent = ({ componentId }) => {
 
   useConnectivityIndicator({
     componentId,
-    rightButtons: getRightButtons({ screen: 'More' }),
+    rightButtons: getRightButtons(),
   })
 
   useNavigationComponentDidAppear(() => {
     setHiddenContent(false)
-    // This is needed to make sure we show the settings icon on a cold boot
-    Navigation.mergeOptions(componentId, {
-      topBar: {
-        rightButtons: getRightButtons({ screen: 'More' }),
-      },
-    })
   }, componentId)
 
   // Fix for a bug in react-native-navigation where the large title is not visible on iOS with bottom tabs https://github.com/wix/react-native-navigation/issues/6717

--- a/apps/native/app/src/screens/wallet/wallet.tsx
+++ b/apps/native/app/src/screens/wallet/wallet.tsx
@@ -33,6 +33,7 @@ import { getRightButtons } from '../../utils/get-main-root'
 import { isDefined } from '../../utils/is-defined'
 import { testIDs } from '../../utils/test-ids'
 import { WalletItem } from './components/wallet-item'
+import { ButtonRegistry } from '../../utils/component-registry'
 
 type FlatListItem =
   | GenericUserLicense
@@ -53,9 +54,15 @@ const { useNavigationOptions, getNavigationOptions } =
         title: {
           text: intl.formatMessage({ id: 'wallet.screenTitle' }),
         },
-        rightButtons: initialized
-          ? getRightButtons({ screen: 'Wallet', theme: theme as any })
-          : [],
+        rightButtons: initialized ? getRightButtons({ theme } as any) : [],
+        leftButtons: [
+          {
+            id: ButtonRegistry.ScanLicenseButton,
+            testID: testIDs.TOPBAR_SCAN_LICENSE_BUTTON,
+            icon: require('../../assets/icons/navbar-scan.png'),
+            color: theme.color.blue400,
+          },
+        ],
       },
       bottomTab: {
         iconColor: theme.color.blue400,
@@ -127,7 +134,7 @@ export const WalletScreen: NavigationFunctionComponent = ({ componentId }) => {
 
   useConnectivityIndicator({
     componentId,
-    rightButtons: getRightButtons({ screen: 'Wallet' }),
+    rightButtons: getRightButtons(),
     queryResult: [res, resPassport],
     refetching,
   })

--- a/apps/native/app/src/utils/get-main-root.ts
+++ b/apps/native/app/src/utils/get-main-root.ts
@@ -10,18 +10,14 @@ import {
 import { getThemeWithPreferences } from './get-theme-with-preferences'
 import { testIDs } from './test-ids'
 
-type Screen = 'Inbox' | 'Wallet' | 'Home' | 'Applications' | 'More'
-
 type RightButtonProps = {
   unseenCount?: number
   theme?: ReturnType<typeof getThemeWithPreferences>
-  screen?: Screen
 }
 
 export const getRightButtons = ({
   unseenCount = notificationsStore.getState().unseenCount,
   theme = getThemeWithPreferences(preferencesStore.getState()),
-  screen,
 }: RightButtonProps = {}): OptionsTopBarButton[] => {
   const iconBackground = {
     color: 'transparent',
@@ -30,43 +26,25 @@ export const getRightButtons = ({
     height: theme.spacing[4],
   }
 
-  switch (screen) {
-    case 'Home':
-      return [
-        {
-          accessibilityLabel: 'Notifications',
-          id: ButtonRegistry.NotificationsButton,
-          testID: testIDs.TOPBAR_NOTIFICATIONS_BUTTON,
-          icon:
-            unseenCount > 0
-              ? require('../assets/icons/topbar-notifications-bell.png')
-              : require('../assets/icons/topbar-notifications.png'),
-          iconBackground,
-        },
-      ]
-    case 'Wallet':
-      return [
-        {
-          id: ButtonRegistry.ScanLicenseButton,
-          testID: testIDs.TOPBAR_SCAN_LICENSE_BUTTON,
-          icon: require('../assets/icons/navbar-scan.png'),
-          color: theme.color.blue400,
-          iconBackground,
-        },
-      ]
-    case 'More':
-      return [
-        {
-          accessibilityLabel: 'Settings',
-          id: ButtonRegistry.SettingsButton,
-          testID: testIDs.TOPBAR_SETTINGS_BUTTON,
-          icon: require('../assets/icons/settings.png'),
-          iconBackground,
-        },
-      ]
-    default:
-      return []
-  }
+  return [
+    {
+      accessibilityLabel: 'Settings',
+      id: ButtonRegistry.SettingsButton,
+      testID: testIDs.TOPBAR_SETTINGS_BUTTON,
+      icon: require('../assets/icons/settings.png'),
+      iconBackground,
+    },
+    {
+      accessibilityLabel: 'Notifications',
+      id: ButtonRegistry.NotificationsButton,
+      testID: testIDs.TOPBAR_NOTIFICATIONS_BUTTON,
+      icon:
+        unseenCount > 0
+          ? require('../assets/icons/topbar-notifications-bell.png')
+          : require('../assets/icons/topbar-notifications.png'),
+      iconBackground,
+    },
+  ]
 }
 
 /**


### PR DESCRIPTION
## What

Revert changes of navigation bar icons. Not too confident about it and I've noticed it is a bit buggy if there is no data since it is relying on `useConnectivityIndicator` to run to show the icons. Reverting for now and will finish after vacation.

## Why

Too risky to release just before summer vacation.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified and unified the initialization logic for navigation buttons across multiple screens for a more consistent user experience.
  - Removed conditional checks and streamlined right button configuration, ensuring a standard set of buttons for 'Settings' and 'Notifications'.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->