### PR TITLE
fix(application-system): adding aosh. prefix to translationsNamespace for contentful

### DIFF
--- a/libs/application/types/src/lib/ApplicationTypes.ts
+++ b/libs/application/types/src/lib/ApplicationTypes.ts
@@ -360,7 +360,7 @@ export const ApplicationConfigurations = {
   },
   [ApplicationTypes.STREET_REGISTRATION]: {
     slug: 'gotuskraning-taekis',
-    translation: 'sr.application',
+    translation: 'aosh.sr.application',
   },
   [ApplicationTypes.NEW_PRIMARY_SCHOOL]: {
     slug: 'nyr-grunnskoli',


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the translation reference for the STREET_REGISTRATION entry, enhancing the clarity and structure of translation keys used within the application.
  
- **Bug Fixes**
	- Adjusted the translation retrieval process to accommodate the updated translation key, ensuring accurate display of information in the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->