### PR TITLE
feat(web): Allow ChartNumberBox to be embedded as a 'slice'

### DIFF
--- a/apps/web/components/Organization/Slice/SliceMachine.tsx
+++ b/apps/web/components/Organization/Slice/SliceMachine.tsx
@@ -94,6 +94,10 @@ const PowerBiSlice = dynamic(() =>
   import('@island.is/web/components').then((mod) => mod.PowerBiSlice),
 )
 
+const ChartNumberBox = dynamic(() =>
+  import('@island.is/web/components').then((mod) => mod.ChartNumberBox),
+)
+
 interface SliceMachineProps {
   slice: Slice
   namespace?: Record<string, string>
@@ -192,6 +196,8 @@ const renderSlice = (
           filterTags={(slice as GenericListSchema).filterTags}
         />
       )
+    case 'ChartNumberBox':
+      return <ChartNumberBox slice={slice} />
     default:
       return <RichText body={[slice]} />
   }


### PR DESCRIPTION
# Allow ChartNumberBox to be embedded as a 'slice' in the CMS

## Why

* This was requested by 'Geislavarnir Ríkisins'
* So the chart number box component can be used on an organization frontpage 

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new `ChartNumberBox` component, enhancing the rendering capabilities of the `PowerBiSlice` component for improved visualization.
	- Enabled conditional rendering of the `ChartNumberBox` based on the slice type, allowing for more dynamic content display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->