### PR TITLE
fix(application-estate): Selection bugfix

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/estate/estate.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/estate/estate.service.ts
@@ -73,7 +73,10 @@ export class EstateTemplateService extends BaseTemplateApiService {
     }
 
     const applicationAnswers = application.answers as unknown as EstateSchema
-    const estateData = applicationData.find((estate) => estate.caseNumber)
+    const selectedCaseNumber = applicationAnswers.estateInfoSelection
+    const estateData = applicationData.find(
+      (estate) => estate.caseNumber === selectedCaseNumber,
+    )
     if (
       !estateData?.caseNumber?.length ||
       estateData?.caseNumber.length === 0

--- a/libs/application/template-api-modules/src/lib/modules/templates/estate/utils/fakeData.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/estate/utils/fakeData.ts
@@ -91,7 +91,7 @@ export const getFakeEstateInfo = (
         nationalId: '0101304929',
       },
     ],
-    caseNumber: `2020-00012${nationalIdOfDeceased.slice(-1)}`,
+    caseNumber: `2020-00012${nationalIdOfDeceased.slice(-4)}`,
     dateOfDeath: new Date(Date.now() - 1000 * 3600 * 24 * 100),
     nameOfDeceased,
     nationalIdOfDeceased,


### PR DESCRIPTION
Selection was accidentally being ignored and instead the first estate found with a casenumber where `Boolean(caseNumber) => true` was selected.

* Fixed minor issue with testData as well.

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
