### PR TITLE
fix(web): Vehicle search - Add new field and display it in frontend

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -170,7 +170,7 @@ codemagic.yaml                                                                  
 /libs/clients/national-registry/v3/                                                                      @island-is/hugsmidjan
 /libs/clients/district-commissioners-licenses/                                                           @island-is/hugsmidjan
 /libs/clients/regulations/                                                                               @island-is/hugsmidjan
-/libs/clients/vehicles/                                                                                  @island-is/hugsmidjan
+/libs/clients/vehicles/                                                                                  @island-is/hugsmidjan @island-is/stefna
 /libs/clients/vehicles-mileage/                                                                          @island-is/hugsmidjan
 /libs/clients/user-notification/                                                                         @island-is/hugsmidjan
 /libs/clients/passports/                                                                                 @island-is/hugsmidjan

--- a/apps/web/components/connected/vehicles/PublicVehicleSearch.tsx
+++ b/apps/web/components/connected/vehicles/PublicVehicleSearch.tsx
@@ -228,7 +228,7 @@ const PublicVehicleSearch = ({ slice }: PublicVehicleSearchProps) => {
                 <Table.Row>
                   <Table.Data>
                     <Text fontWeight="semiBold">
-                      {n('newRegDate', 'Fyrst skráð:')}
+                      {n('firstRegDate', 'Fyrst skráð:')}
                     </Text>
                   </Table.Data>
                   <Table.Data>

--- a/apps/web/components/connected/vehicles/PublicVehicleSearch.tsx
+++ b/apps/web/components/connected/vehicles/PublicVehicleSearch.tsx
@@ -101,8 +101,8 @@ const PublicVehicleSearch = ({ slice }: PublicVehicleSearchProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router?.isReady, router?.query?.vq])
 
-  const formattedRegistrationDate = vehicleInformation?.newRegDate
-    ? format(new Date(vehicleInformation.newRegDate), 'do MMMM yyyy')
+  const formattedRegistrationDate = vehicleInformation?.firstRegDate
+    ? format(new Date(vehicleInformation.firstRegDate), 'do MMMM yyyy')
     : ''
   const formattedNextVehicleMainInspectionDate =
     vehicleInformation?.nextVehicleMainInspection

--- a/apps/web/screens/queries/PublicVehicleSearch.ts
+++ b/apps/web/screens/queries/PublicVehicleSearch.ts
@@ -10,6 +10,7 @@ export const PUBLIC_VEHICLE_SEARCH_QUERY = gql`
       vehicleCommercialName
       color
       newRegDate
+      firstRegDate
       vehicleStatus
       nextVehicleMainInspection
       co2

--- a/libs/api/domains/vehicles/src/models/getPublicVehicleSearch.model.ts
+++ b/libs/api/domains/vehicles/src/models/getPublicVehicleSearch.model.ts
@@ -23,6 +23,9 @@ export class VehiclesPublicVehicleSearch {
   @Field(() => Date, { nullable: true })
   newRegDate?: Date | null
 
+  @Field(() => Date, { nullable: true })
+  firstRegDate?: Date | null
+
   @Field(() => String, { nullable: true })
   vehicleStatus?: string | null
 

--- a/libs/clients/vehicles/src/clientConfig.json
+++ b/libs/clients/vehicles/src/clientConfig.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "SamgÃ¶ngustofa",
-    "description": "Leitar eftir Ã¶kutÃ¦kjum Ãºt frÃ¡ fastanÃºmeri, skrï¿½ningarnÃºmeri eÃ°a verksmiÃ°junÃºmeri - Release-38 : 20240605.1",
+    "description": "Leitar eftir Ã¶kutÃ¦kjum Ãºt frÃ¡ fastanÃºmeri, skrï¿½ningarnÃºmeri eÃ°a verksmiÃ°junÃºmeri - Release-41 : 20240708.1",
     "contact": {
       "name": "Samgongustofa",
       "url": "https://www.samgongustofa.is/",
@@ -2965,6 +2965,11 @@
             "nullable": true
           },
           "newRegDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "firstRegDate": {
             "type": "string",
             "format": "date-time",
             "nullable": true


### PR DESCRIPTION
# Vehicle search - Add new field and display it in frontend

## What

* Now firstRegDate field is displayed instead of the newRegDate field for vehicles

## Why

* This was requested by Samgöngustofa

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced vehicle search results by including the first registration date of vehicles.
	- Updated vehicle API documentation to reflect new functionalities and versioning.

- **Bug Fixes**
	- Corrected the source of the registration date for improved accuracy in vehicle history representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->