### PR TITLE
fix(web): Broken anchor page links in search

### DIFF
--- a/apps/web/screens/Search/Search.tsx
+++ b/apps/web/screens/Search/Search.tsx
@@ -66,7 +66,10 @@ import { useLinkResolver, usePlausible } from '@island.is/web/hooks'
 import { useI18n } from '@island.is/web/i18n'
 import { withMainLayout } from '@island.is/web/layouts/main'
 import { CustomNextError } from '@island.is/web/units/errors'
-import { AnchorPageType } from '@island.is/web/utils/anchorPage'
+import {
+  AnchorPageType,
+  extractAnchorPageLinkType,
+} from '@island.is/web/utils/anchorPage'
 import { hasProcessEntries } from '@island.is/web/utils/article'
 
 import { Screen } from '../../types'
@@ -314,11 +317,8 @@ const Search: Screen<CategoryProps> = ({
   }, [countResults.typesCount, getArticleCount, tagTitles])
 
   const getItemLink = (item: SearchEntryType) => {
-    if (
-      item.__typename === 'AnchorPage' &&
-      item.pageType === AnchorPageType.DIGITAL_ICELAND_SERVICE
-    ) {
-      return linkResolver('digitalicelandservicesdetailpage', [item.slug])
+    if (item.__typename === 'AnchorPage') {
+      return linkResolver(extractAnchorPageLinkType(item), [item.slug])
     }
 
     if (item.__typename === 'ManualChapterItem') {


### PR DESCRIPTION
# Broken anchor page links in search

## What

* Digital Iceland community pages were linking to a 404 page due to the search link resolution code not handling all anchor page types

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
