### PR TITLE
feat(fetch): Log `name` in fetch failure body

### DIFF
--- a/libs/clients/middlewares/src/lib/withAutoAuth.ts
+++ b/libs/clients/middlewares/src/lib/withAutoAuth.ts
@@ -154,7 +154,7 @@ export const withAutoAuth = ({
     if (options.mode === 'tokenExchange' && !auth) {
       const message = `Fetch failure (${name}): Could not perform token exchange. Auth object was missing.`
       logger.error({
-        name,
+        fetch: { name },
         url: request.url,
         message,
       })

--- a/libs/clients/middlewares/src/lib/withAutoAuth.ts
+++ b/libs/clients/middlewares/src/lib/withAutoAuth.ts
@@ -154,6 +154,7 @@ export const withAutoAuth = ({
     if (options.mode === 'tokenExchange' && !auth) {
       const message = `Fetch failure (${name}): Could not perform token exchange. Auth object was missing.`
       logger.error({
+        name,
         url: request.url,
         message,
       })

--- a/libs/clients/middlewares/src/lib/withErrorLog.ts
+++ b/libs/clients/middlewares/src/lib/withErrorLog.ts
@@ -33,6 +33,7 @@ export function withErrorLog({
         stack: error.stack,
         url: request.url,
         message: `Fetch failure (${name}): ${error.message}`,
+        name,
         body,
         cacheStatus,
         // Do not log large response objects.

--- a/libs/clients/middlewares/src/lib/withErrorLog.ts
+++ b/libs/clients/middlewares/src/lib/withErrorLog.ts
@@ -33,7 +33,7 @@ export function withErrorLog({
         stack: error.stack,
         url: request.url,
         message: `Fetch failure (${name}): ${error.message}`,
-        name,
+        fetch: { name },
         body,
         cacheStatus,
         // Do not log large response objects.


### PR DESCRIPTION
It's hard to trace _which_ component failed. With this change, we can finally filter by failed component in Datadog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced error logging capabilities to include additional context for better traceability and debugging during authentication failures.
	- Improved error reporting with more detailed context in the logged errors, aiding in troubleshooting and analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->