### PR TITLE
chore(docker-compose): Use docker binary instead of standalone

### DIFF
--- a/apps/air-discount-scheme/Makefile
+++ b/apps/air-discount-scheme/Makefile
@@ -5,7 +5,7 @@ ARGS=$(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
 $(eval $(ARGS):;@:)
 
 docker:
-	docker-compose -f ./backend/docker-compose.yml up
+	docker compose -f ./backend/docker-compose.yml up
 
 backend:
 	./${CWD}scripts/_wait-for.sh localhost:5432  # postgresql

--- a/apps/air-discount-scheme/README.md
+++ b/apps/air-discount-scheme/README.md
@@ -72,10 +72,10 @@ yarn get-secrets air-discount-scheme-backend
 yarn get-secrets air-discount-scheme-web
 ```
 
-2. Start the resources with docker-compose and migrate/seed the database:
+2. Start the resources with docker compose and migrate/seed the database:
 
 ```bash
-docker-compose -f apps/air-discount-scheme/backend/docker-compose.yml up
+docker compose -f apps/air-discount-scheme/backend/docker-compose.yml up
 ```
 
 ```bash
@@ -104,7 +104,7 @@ yarn start air-discount-scheme-backend
 
 6. Check Contentful and AWS
 
-Login here https://island-is.awsapps.com/start#/ (Contact devops if you need access)
+Login here <https://island-is.awsapps.com/start#/> (Contact devops if you need access)
 Copy env variables as instructed [here](https://docs.devland.is/technical-overview/devops/dockerizing#troubleshooting) (image arrows 1,2,3)
 Paste env variables into terminal
 Run `./scripts/run-es-proxy.sh` from island.is root

--- a/apps/air-discount-scheme/backend/project.json
+++ b/apps/air-discount-scheme/backend/project.json
@@ -64,7 +64,7 @@
     "dev-services": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "docker-compose up -d",
+        "command": "docker compose up -d",
         "cwd": "apps/air-discount-scheme/backend"
       }
     },

--- a/apps/api/project.json
+++ b/apps/api/project.json
@@ -74,7 +74,7 @@
     "dev-services": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "docker-compose up -d",
+        "command": "docker compose up -d",
         "cwd": "apps/api"
       }
     },

--- a/apps/application-system/api/project.json
+++ b/apps/application-system/api/project.json
@@ -124,7 +124,7 @@
     "dev-services": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "docker-compose up -d",
+        "command": "docker compose up -d",
         "cwd": "apps/application-system/api"
       }
     },

--- a/apps/financial-aid/backend/project.json
+++ b/apps/financial-aid/backend/project.json
@@ -61,7 +61,7 @@
     "dev-services": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "docker-compose up -d",
+        "command": "docker compose up -d",
         "cwd": "apps/financial-aid/backend"
       }
     },

--- a/apps/icelandic-names-registry/backend/project.json
+++ b/apps/icelandic-names-registry/backend/project.json
@@ -71,7 +71,7 @@
     "dev-services": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "docker-compose up -d",
+        "command": "docker compose up -d",
         "cwd": "apps/icelandic-names-registry/backend"
       }
     },

--- a/apps/judicial-system/backend/project.json
+++ b/apps/judicial-system/backend/project.json
@@ -63,7 +63,7 @@
     "dev-services": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "docker-compose up -d",
+        "command": "docker compose up -d",
         "cwd": "apps/judicial-system/backend"
       }
     },

--- a/apps/judicial-system/message-handler/project.json
+++ b/apps/judicial-system/message-handler/project.json
@@ -50,7 +50,7 @@
     "dev-services": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "docker-compose up -d",
+        "command": "docker compose up -d",
         "cwd": "apps/judicial-system/message-handler"
       }
     },

--- a/apps/reference-backend/README.md
+++ b/apps/reference-backend/README.md
@@ -15,7 +15,7 @@ This project is used as reference for future backend project.
 If your service or app needs external services like Postgres, ActiveMQ, etc. you can provision those using:
 
 ```bash
-docker-compose
+docker compose
 ```
 
 Your local dev setup should be in a file named `docker-compose.yml`. If you are using those services as part of an integration or end-to-end tests you need to add them to the ci scripts.

--- a/apps/reference-backend/project.json
+++ b/apps/reference-backend/project.json
@@ -63,7 +63,7 @@
     "dev-services": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "docker-compose up -d",
+        "command": "docker compose up -d",
         "cwd": "apps/reference-backend"
       }
     },

--- a/apps/services/auth/ids-api/project.json
+++ b/apps/services/auth/ids-api/project.json
@@ -99,7 +99,7 @@
     "dev-services": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "docker-compose up -d",
+        "command": "docker compose up -d",
         "cwd": "apps/services/auth/ids-api"
       }
     },

--- a/apps/services/documents/project.json
+++ b/apps/services/documents/project.json
@@ -61,7 +61,7 @@
     "dev-services": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "docker-compose up -d",
+        "command": "docker compose up -d",
         "cwd": "apps/services/documents"
       }
     },

--- a/apps/services/endorsements/api/project.json
+++ b/apps/services/endorsements/api/project.json
@@ -64,7 +64,7 @@
     "dev-services": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "docker-compose up -d --build",
+        "command": "docker compose up -d --build",
         "cwd": "apps/services/endorsements/api"
       }
     },

--- a/apps/services/regulations-admin-backend/project.json
+++ b/apps/services/regulations-admin-backend/project.json
@@ -66,7 +66,7 @@
     "dev-services": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "docker-compose up -d",
+        "command": "docker compose up -d",
         "cwd": "apps/services/regulations-admin-backend"
       }
     },

--- a/apps/services/search-indexer/dev-services/README.md
+++ b/apps/services/search-indexer/dev-services/README.md
@@ -2,7 +2,7 @@
 
 ### Dependencies
 
-You must have `docker` and `docker-compose` installed and running on you machine.  
+You must have `docker` and `docker compose` installed and running on you machine.  
 **Docker must be given 4gb+ of ram**
 
 ### Start the server

--- a/apps/services/search-indexer/project.json
+++ b/apps/services/search-indexer/project.json
@@ -46,7 +46,7 @@
     "dev-services": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "docker-compose -f docker-compose.yml up -d --build",
+        "command": "docker compose -f docker-compose.yml up -d --build",
         "cwd": "apps/services/search-indexer/dev-services"
       }
     },

--- a/apps/services/sessions/project.json
+++ b/apps/services/sessions/project.json
@@ -86,7 +86,7 @@
     "dev-services": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "docker-compose up -d",
+        "command": "docker compose up -d",
         "cwd": "apps/services/sessions"
       }
     },

--- a/apps/services/university-gateway/project.json
+++ b/apps/services/university-gateway/project.json
@@ -66,7 +66,7 @@
     "dev-services": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "docker-compose up -d",
+        "command": "docker compose up -d",
         "cwd": "apps/services/university-gateway"
       }
     },

--- a/apps/services/user-notification/project.json
+++ b/apps/services/user-notification/project.json
@@ -90,7 +90,7 @@
     "dev-services": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "docker-compose up -d --build",
+        "command": "docker compose up -d --build",
         "cwd": "apps/services/user-notification"
       }
     },

--- a/apps/services/user-profile/project.json
+++ b/apps/services/user-profile/project.json
@@ -67,7 +67,7 @@
     "dev-services": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "docker-compose up -d",
+        "command": "docker compose up -d",
         "cwd": "apps/services/user-profile"
       }
     },

--- a/apps/skilavottord/README.md
+++ b/apps/skilavottord/README.md
@@ -68,7 +68,7 @@ cd apps/skilavottord/ws
 and run
 
 ```bash
-docker-compose up
+docker compose up
 ```
 
 Then run migrations and seed the database:

--- a/infra/src/dsl/README.md
+++ b/infra/src/dsl/README.md
@@ -4,7 +4,7 @@
 
 In order to ensure the most effortless and error-free way to connect our code to the execution environment we created a Domain-Specific Language(DSL) to support an expressive way for developers to define the services' expected configuration. The DSL is written intentionally such that it enforces conventions and principles we have.
 
-Additionally, we have started experimenting with using the DSL to generate _bash_ commands for running locally services. The DSL is abstract enough that is not tied to any one specific execution environment and leaves our options open to generating pretty much any deployment environments we might want to explore in the future - docker-compose, raw k8s manifests, etc.
+Additionally, we have started experimenting with using the DSL to generate _bash_ commands for running locally services. The DSL is abstract enough that is not tied to any one specific execution environment and leaves our options open to generating pretty much any deployment environments we might want to explore in the future - docker compose, raw k8s manifests, etc.
 
 ## A few key abstractions
 

--- a/libs/api-catalogue/elastic/README.md
+++ b/libs/api-catalogue/elastic/README.md
@@ -9,7 +9,7 @@ Run `ng test api-catalogue-elastic` to execute the unit tests via [Jest](https:/
 Local development uses a docker container for elasticsearch.
 The `elastic.yml` sets up a docker container named `es01` and needs to be running.
 
-For the initial setup the command: `docker-compose -f .\libs\api-catalogue\elastic\elastic.yml up` initiates the container which can then be managed through Docker.
+For the initial setup the command: `docker compose -f .\libs\api-catalogue\elastic\elastic.yml up` initiates the container which can then be managed through Docker.
 
 After the `es01` is running it can be initialized with data from `initialData.json` using curl command:
 `curl -H 'Content-Type: application/x-ndjson' -XPOST localhost:9200/_bulk --data-binary '@./libs/api-catalogue/elastic/initialData.txt'`

--- a/libs/application/templates/parental-leave/README.md
+++ b/libs/application/templates/parental-leave/README.md
@@ -160,7 +160,7 @@ Once you have everything running you can navigate to [http://localhost:4200/umso
 
 By setting up the application-system you'll have created a local postgres database on a docker image, if you haven't already you should setup a tool to interact with your database. For example [pgAdmin](https://www.pgadmin.org/download/).
 
-You’ll find the relevant connection information in [the docker-compose file](../../../../apps/application-system/api/docker-compose.base.yml).
+You’ll find the relevant connection information in [the docker compose file](../../../../apps/application-system/api/docker compose.base.yml).
 
 ## Investigating errors
 

--- a/libs/portals/admin/regulations-admin/README.md
+++ b/libs/portals/admin/regulations-admin/README.md
@@ -7,7 +7,7 @@ This library was generated with [Nx](https://nx.dev).
 Get fresh AWS credentials, and then open six (6) terminal windows.
 
 1. `sh scripts/run-es-proxy.sh`
-2. `docker-compose -f apps/services/regulations-admin-backend/docker-compose.yml up`  
+2. `docker compose -f apps/services/regulations-admin-backend/docker-compose.yml up`  
    (for setup see [the README.md](../../../services/../../apps/services/regulations-admin-backend/Readme.md))
 3. `yarn start regulations-admin-backend`
 4. `yarn start api`


### PR DESCRIPTION
`docker` now ships with a `compose` command, which replaces the need for a standalone `docker-compose`. This is compatible with `podman` as well.