### PR TITLE
fix(web): Fix watermark on redocly

### DIFF
--- a/apps/web/components/OpenApiDocumentation/OpenApiDocumentation.tsx
+++ b/apps/web/components/OpenApiDocumentation/OpenApiDocumentation.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
+
 import { OpenApi } from '@island.is/api-catalogue/types'
 import { Box } from '@island.is/island-ui/core'
+
 import RedocStandalone from './RedocStandalone'
 
 export interface OpenApiDocumentationProps {
@@ -9,7 +11,8 @@ export interface OpenApiDocumentationProps {
 
 export const OpenApiDocumentation = ({ spec }: OpenApiDocumentationProps) => {
   return (
-    <Box width="full" background="white">
+    // Use transform that has no effect(similar to null) to keep Redocly watermark inside element
+    <Box width="full" background="white" style={{ transform: 'scale(1)' }}>
       <RedocStandalone
         spec={spec}
         options={{


### PR DESCRIPTION
# Fix watermark on redocly

## What

Keep watermark element inside open API documentation

## Screenshots / Gifs

### Before
![image](https://github.com/user-attachments/assets/774b3665-6c43-4c24-9e96-f1842a2631bf)


### After
![image](https://github.com/user-attachments/assets/0c26c4a7-b599-4cdf-a095-90de54dce17d)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced code readability with added comments in the OpenApiDocumentation component.
	- Modified the Box component to ensure proper display of the Redocly watermark without visual changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->