### PR TITLE
fix(web): Service web subpages - Encode uri before setting header when redirecting

### DIFF
--- a/apps/web/screens/ServiceWeb/SubPage/SubPage.tsx
+++ b/apps/web/screens/ServiceWeb/SubPage/SubPage.tsx
@@ -432,16 +432,18 @@ SubPage.getProps = async ({ apolloClient, locale, query, res }) => {
   const categorySlug = slugs[1]
   const questionSlug = slugs[2] ?? undefined
 
-  if (single(query.q)) {
+  const q = single(query.q)
+
+  if (q) {
     if (res) {
       res.writeHead(302, {
-        Location: linkResolver(
-          'supportqna',
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore make web strict
-          [organizationSlug, categorySlug, single(query.q)],
-          locale as Locale,
-        ).href,
+        Location: encodeURI(
+          linkResolver(
+            'supportqna',
+            [organizationSlug, categorySlug, q],
+            locale as Locale,
+          ).href,
+        ),
       })
       res.end()
     }


### PR DESCRIPTION
#  Service web subpages - Encode uri before setting header when redirecting

## What

* We were seeing a lot of "Invalid character in header content ["Location"]" errorsso a fix for that is to simply encode the uri

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced code clarity and readability by refining the logic in the `SubPage` component.
	- Improved robustness of URL handling by ensuring proper encoding of the `Location` header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->