### PR TITLE
fix(service-portal): Only display toast for multi archive

### DIFF
--- a/libs/service-portal/documents/src/hooks/useMailActionV2.ts
+++ b/libs/service-portal/documents/src/hooks/useMailActionV2.ts
@@ -91,7 +91,9 @@ export const useMailAction = () => {
             if (refetch) {
               refetch(fetchObject)
             }
-            toast.success(formatMessage(docMessages.successArchiveMulti))
+            if (action === 'archive') {
+              toast.success(formatMessage(docMessages.successArchiveMulti))
+            }
           } else {
             toast.error(formatMessage(m.errorTitle))
           }


### PR DESCRIPTION
## What

Only display toast for multi archive

## Why

No other multi action requires a toast

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved success notification logic to display messages only for relevant actions, enhancing user feedback accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->