### PR TITLE
chore(ci): (almost) No `always()`

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -54,13 +54,13 @@ runs:
         # force-cache-save: ${{ inputs.force-cache-save }}
 
     - name: Give cache server a bit of time to recover
-      if: always() && inputs.retry > 0 && steps.cache_try_number_one.outputs.success != 'true'
+      if: ${{ !cancelled() && inputs.retry > 0 && steps.cache_try_number_one.outputs.success != 'true' }}
       shell: bash
       run: sleep 10
 
     - name: Cache try number two
       id: cache_try_number_two
-      if: always() && inputs.retry > 0 && steps.cache_try_number_one.outputs.success != 'true'
+      if: ${{ !cancelled() && inputs.retry > 0 && steps.cache_try_number_one.outputs.success != 'true' }}
       uses: island-is/cache@v0.3
       with:
         path: ${{ inputs.path }}
@@ -68,13 +68,13 @@ runs:
         # force-cache-save: ${{ inputs.force-cache-save }}
 
     - name: Give cache server a bit of time to recover
-      if: always() && inputs.retry > 1 && steps.cache_try_number_one.outputs.success != 'true' && steps.cache_try_number_two.outputs.success != 'true'
+      if: ${{ !cancelled() && inputs.retry > 1 && steps.cache_try_number_one.outputs.success != 'true' && steps.cache_try_number_two.outputs.success != 'true' }}
       shell: bash
       run: sleep 10
 
     - name: Cache try number three
       id: cache_try_number_three
-      if: always() && inputs.retry > 1 && steps.cache_try_number_one.outputs.success != 'true' && steps.cache_try_number_two.outputs.success != 'true'
+      if: ${{ !cancelled() && inputs.retry > 1 && steps.cache_try_number_one.outputs.success != 'true' && steps.cache_try_number_two.outputs.success != 'true' }}
       uses: island-is/cache@v0.3
       with:
         path: ${{ inputs.path }}
@@ -83,7 +83,7 @@ runs:
 
     - name: Gather outputs
       id: computed_outputs
-      if: always()
+      if: ${{ always() }} # We want to always report status, even when cancelled
       shell: bash
       run: |
         if [[ "${{ steps.cache_try_number_one.outputs.success }}" == "true" ]] || \

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -399,7 +399,7 @@ jobs:
     runs-on: ec2-runners
     container:
       image: public.ecr.aws/m3u4c4h9/island-is/actions-runner-public:latest
-    if: always()
+    if: ${{ !cancelled() }}
     needs:
       - prepare
       - linting-workspace

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -644,7 +644,7 @@ jobs:
     container:
       image: public.ecr.aws/m3u4c4h9/island-is/actions-runner-public:latest
     timeout-minutes: 5
-    if: always() && needs.pre-checks.result == 'success' && needs.prepare.result != 'skipped'
+    if: ${{ !cancelled() && needs.pre-checks.result == 'success' && needs.prepare.result != 'skipped' }}
     needs:
       - pre-checks
       - docker-build
@@ -674,7 +674,7 @@ jobs:
     runs-on: ec2-runners
     container:
       image: public.ecr.aws/m3u4c4h9/island-is/actions-runner-public:latest
-    if: always() && needs.retag-unaffected.result == 'success' && needs.helm-docker-build.result != 'failure'
+    if: ${{ !cancelled() && needs.retag-unaffected.result == 'success' && needs.helm-docker-build.result != 'failure' }}
     needs:
       - retag-unaffected
       - pre-checks
@@ -730,7 +730,7 @@ jobs:
     runs-on: ec2-runners
     container:
       image: public.ecr.aws/m3u4c4h9/island-is/actions-runner-public:latest
-    if: always()
+    if: ${{ !cancelled() }}
     needs:
       - pre-checks
       - retag-unaffected


### PR DESCRIPTION
Using `always()` causes hanging jobs and unnecessary waits for jobs to run after a cancel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the GitHub Actions workflow by adding conditions to prevent the execution of jobs and cache attempts if the workflow is cancelled.

- **Bug Fixes**
	- Modified job execution logic to ensure jobs only run when the workflow has not been cancelled, improving overall control flow and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->