### PR TITLE
fix(contentful-apps): Hotfix - Translation namespace app - trim whitespace when considering if a node is empty

### DIFF
--- a/apps/contentful-apps/components/translation-namespace/utils/deserialize.ts
+++ b/apps/contentful-apps/components/translation-namespace/utils/deserialize.ts
@@ -161,7 +161,7 @@ export const deserialize = (
 
 export const unifyAndDeserialize = (markdown?: string): Node[] => {
   // We start by checking if the markdown is undefined
-  if (!markdown) {
+  if (!markdown?.trim()) {
     return EMPTY_STATE
   }
 


### PR DESCRIPTION
# Hotfix - Translation namespace app - trim whitespace when considering if a node is empty

Cherrypicked from PR: https://github.com/island-is/island.is/pull/15618