### PR TITLE
fix(search-indexer): Development Dockerfile changes due to mirror.centos.org being down

### DIFF
--- a/apps/services/search-indexer/dev-services/elasticsearch/Dockerfile
+++ b/apps/services/search-indexer/dev-services/elasticsearch/Dockerfile
@@ -4,6 +4,9 @@ FROM $DOCKER_IMAGE_REGISTRY/elasticsearch/elasticsearch:7.9.2
 # adding ICO for unicode support
 RUN bin/elasticsearch-plugin install analysis-icu
 
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 RUN yum -y install unzip wget
 
 # get dictionaries


### PR DESCRIPTION
# Development Dockerfile changes due to mirror.centos.org being down

## What

Running Elasticsearch locally for the public web no longer works due to mirror.centos.org being down

Here's a relevant thread:
https://stackoverflow.com/questions/78692851/could-not-retrieve-mirrorlist-http-mirrorlist-centos-org-release-7arch-x86-6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Docker configuration for the Elasticsearch service to enhance reliability in package access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->