### PR TITLE
fix(service-portal-documents): Make input bigger + add label

### DIFF
--- a/libs/service-portal/core/src/components/Filter/Filter.css.ts
+++ b/libs/service-portal/core/src/components/Filter/Filter.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css'
+import { globalStyle, style } from '@vanilla-extract/css'
 
 export const dialogDisclosure = style({
   width: '100%',
@@ -14,4 +14,10 @@ export const popoverContainer = style({
   maxWidth: 360,
   width: '100%',
   overflowY: 'auto',
+})
+
+export const lgBtn = style({})
+
+globalStyle(`${lgBtn} span`, {
+  height: '100%',
 })

--- a/libs/service-portal/core/src/components/Filter/Filter.tsx
+++ b/libs/service-portal/core/src/components/Filter/Filter.tsx
@@ -48,6 +48,8 @@ export interface FilterProps {
   popoverFlip?: boolean
 
   additionalFilters?: ReactNode
+
+  largeButton?: boolean
 }
 
 /**
@@ -79,6 +81,7 @@ export const Filter: FC<React.PropsWithChildren<FilterProps>> = ({
   children,
   popoverFlip = true,
   fullWidthInput = false,
+  largeButton = false,
   additionalFilters,
 }) => {
   const dialog = useDialogState()
@@ -124,6 +127,7 @@ export const Filter: FC<React.PropsWithChildren<FilterProps>> = ({
                   borderRadius="large"
                   tabIndex={-1}
                   marginLeft={fullWidthInput ? 2 : undefined}
+                  className={largeButton ? styles.lgBtn : undefined}
                   {...popover}
                 >
                   <Button

--- a/libs/service-portal/documents/src/components/DocumentFilter/DocumentsFilterV2.tsx
+++ b/libs/service-portal/documents/src/components/DocumentFilter/DocumentsFilterV2.tsx
@@ -94,11 +94,13 @@ const DocumentsFilter = ({
         labelOpen={formatMessage(m.openFilter)}
         labelClose={formatMessage(m.closeFilter)}
         fullWidthInput
+        largeButton
         filterInput={
           <Input
             placeholder={formatMessage(m.searchPlaceholder)}
             name="rafraen-skjol-input"
-            size="xs"
+            size="sm"
+            label={formatMessage(messages.documentSearchLabel)}
             onChange={debounceChange}
             backgroundColor="blue"
             icon={{ name: 'search' }}

--- a/libs/service-portal/documents/src/utils/messages.ts
+++ b/libs/service-portal/documents/src/utils/messages.ts
@@ -112,4 +112,8 @@ export const messages = defineMessages({
     id: 'sp.documents:success-unarchive-message',
     defaultMessage: 'Skjal tekið úr geymslu',
   },
+  documentSearchLabel: {
+    id: 'sp.documents:search-label',
+    defaultMessage: 'Leita',
+  },
 })


### PR DESCRIPTION
## What

Make input bigger + add label

## Why

Add label and improve accessibility

## Screenshots / Gifs

<img width="602" alt="Screenshot 2024-08-12 at 13 19 45" src="https://github.com/user-attachments/assets/235c11ee-528d-4bc3-ac37-307a0e78568b">

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new optional `largeButton` property in the `Filter` component, enhancing its styling flexibility.
  - Added a localized `label` prop to the `DocumentsFilter`, improving accessibility.
  - Implemented a new message for document search, enhancing internationalization.

- **Style Enhancements**
  - Updated the `lgBtn` class to unify button styling across components.
  - Increased input field size for better usability in the `DocumentsFilter`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->