### PR TITLE
fix(web): Add safe fallback operator to namespace conversion for service webs

### DIFF
--- a/apps/web/components/ServiceWeb/Wrapper/Wrapper.tsx
+++ b/apps/web/components/ServiceWeb/Wrapper/Wrapper.tsx
@@ -84,7 +84,7 @@ export const Wrapper: FC<React.PropsWithChildren<WrapperProps>> = ({
   }, [options])
 
   const namespace = useMemo(
-    () => JSON.parse(organization?.namespace?.fields ?? '{}'),
+    () => JSON.parse(organization?.namespace?.fields || '{}'),
     [],
   )
 


### PR DESCRIPTION
# Add safe fallback operator to namespace conversion for service webs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of the `namespace` variable initialization to ensure more robust fallback behavior, addressing potential issues with undefined or falsy values.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->