### PR TITLE
fix(infra): Corrected the version of the docker.io/grokzen/redis-cluster 

### DIFF
--- a/apps/air-discount-scheme/backend/docker-compose.yml
+++ b/apps/air-discount-scheme/backend/docker-compose.yml
@@ -15,7 +15,7 @@ services:
 
   redis-cluster:
     container_name: ads_redis_cluster
-    image: docker.io/grokzen/redis-cluster:7.0
+    image: docker.io/grokzen/redis-cluster:7.0.0
     privileged: true
     environment:
       - IP=0.0.0.0

--- a/apps/api/docker-compose.yml
+++ b/apps/api/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.3'
 services:
   redis_cluster:
     container_name: api_redis_cluster
-    image: docker.io/grokzen/redis-cluster:7.0
+    image: docker.io/grokzen/redis-cluster:7.0.0
     networks:
       - local
     privileged: true

--- a/apps/application-system/api/docker-compose.yml
+++ b/apps/application-system/api/docker-compose.yml
@@ -15,7 +15,7 @@ services:
 
   redis_cluster:
     container_name: redis_cluster
-    image: docker.io/grokzen/redis-cluster:7.0
+    image: docker.io/grokzen/redis-cluster:7.0.0
     networks:
       - local
     privileged: true

--- a/apps/github-actions-cache/docker-compose.yml
+++ b/apps/github-actions-cache/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.3'
 services:
   redis-cluster:
     container_name: gha_cache_redis_cluster
-    image: docker.io/grokzen/redis-cluster:7.0
+    image: docker.io/grokzen/redis-cluster:7.0.0
     privileged: true
     environment:
       - IP=0.0.0.0

--- a/apps/services/sessions/docker-compose.yml
+++ b/apps/services/sessions/docker-compose.yml
@@ -17,7 +17,7 @@ services:
 
   redis_cluster:
     container_name: redis_cluster
-    image: docker.io/grokzen/redis-cluster:7.0
+    image: docker.io/grokzen/redis-cluster:7.0.0
     networks:
       - local
     privileged: true

--- a/apps/services/user-notification/docker-compose.yml
+++ b/apps/services/user-notification/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - 5432:5432
   redis_cluster:
     container_name: redis_cluster
-    image: docker.io/grokzen/redis-cluster:7.0
+    image: docker.io/grokzen/redis-cluster:7.0.0
     networks:
       - local
     privileged: true


### PR DESCRIPTION
 ## What

Added patch version to the version number of the image to fix 404 on docker hub when pulling the image.

## Why

To be able to build docker images and container locally when developing

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the Redis cluster image version across multiple services to improve stability and ensure compatibility with new features and bug fixes.

- **Bug Fixes**
	- Transitioned to a specific image version of the Redis cluster, potentially addressing previous issues with performance and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->