### PR TITLE
fix(j-s): Default Subpoena Date

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/subpoenaPdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/subpoenaPdf.ts
@@ -52,17 +52,15 @@ export const createSubpoena = (
   setTitle(doc, formatMessage(strings.title))
   addNormalText(doc, `${theCase.court?.name}`, 'Times-Bold', true)
 
-  if (dateLog) {
-    addNormalRightAlignedText(
-      doc,
-      `${formatDate(new Date(dateLog.created), 'PPP')}`,
-      'Times-Roman',
-    )
-  }
+  addNormalRightAlignedText(
+    doc,
+    `${formatDate(new Date(dateLog?.created ?? new Date()), 'PPP')}`,
+    'Times-Roman',
+  )
 
-  arraignmentDate = arraignmentDate || dateLog?.date
-  location = location || dateLog?.location
-  subpoenaType = subpoenaType || defendant.subpoenaType
+  arraignmentDate = arraignmentDate ?? dateLog?.date
+  location = location ?? dateLog?.location
+  subpoenaType = subpoenaType ?? defendant.subpoenaType
 
   if (theCase.court?.name) {
     addNormalText(

--- a/apps/judicial-system/backend/src/app/modules/case/test/caseController/getConnectedCases.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/test/caseController/getConnectedCases.spec.ts
@@ -1,7 +1,5 @@
 import { uuid } from 'uuidv4'
 
-import { User } from '@island.is/judicial-system/types'
-
 import { createTestingCaseModule } from '../createTestingCaseModule'
 
 import { Case } from '../../models/case.model'
@@ -14,7 +12,6 @@ interface Then {
 type GivenWhenThen = (caseId: string, theCase: Case) => Promise<Then>
 
 describe('CaseController - Get connected cases', () => {
-  const user = { id: uuid() } as User
   let mockCaseModel: typeof Case
   let givenWhenThen: GivenWhenThen
 

--- a/apps/judicial-system/backend/src/app/modules/defendant/defendant.controller.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/defendant.controller.ts
@@ -165,7 +165,7 @@ export class DefendantController {
     @Query('subpoenaType') subpoenaType?: SubpoenaType,
   ): Promise<void> {
     this.logger.debug(
-      `Getting the subpoena for defendant ${defendantId} og case ${caseId} as a pdf document`,
+      `Getting the subpoena for defendant ${defendantId} of case ${caseId} as a pdf document`,
     )
 
     const pdf = await this.pdfService.getSubpoenaPdf(

--- a/apps/judicial-system/digital-mailbox-api/src/app/modules/cases/dto/subpoena.dto.ts
+++ b/apps/judicial-system/digital-mailbox-api/src/app/modules/cases/dto/subpoena.dto.ts
@@ -1,10 +1,4 @@
-import {
-  IsBoolean,
-  IsEnum,
-  IsNotEmpty,
-  IsOptional,
-  IsString,
-} from 'class-validator'
+import { IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator'
 
 import { ApiProperty } from '@nestjs/swagger'
 


### PR DESCRIPTION
# Default Subpoena Date

[Fyrirkall PDF, ný lína fyrir heimilisfangs dóms](https://app.asana.com/0/1199153462262248/1207998287689921/f)

## What

- Uses today as the subpoena creation date if an arraignment date has not been stored in the database.

## Why

- Verified bug.

## Screenshots / Gifs

<img width="1561" alt="image" src="https://github.com/user-attachments/assets/beca54a2-5175-4a4e-9e64-92b6d542cd35">

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
