### PR TITLE
fix(service-portal-vehicles): Spacing for cta when tag is visible

### DIFF
--- a/libs/service-portal/core/src/components/ActionCard/ActionCard.tsx
+++ b/libs/service-portal/core/src/components/ActionCard/ActionCard.tsx
@@ -248,7 +248,7 @@ export const ActionCard: React.FC<React.PropsWithChildren<ActionCardProps>> = ({
     return (
       !!hasCTA && (
         <Box
-          paddingTop={tag.label ? 'gutter' : 0}
+          paddingTop={tag.label || secondaryTag?.label ? 'gutter' : 0}
           display="flex"
           justifyContent={['flexStart', 'flexEnd']}
           alignItems="center"


### PR DESCRIPTION
## What

Fix Spacing for cta when tag is visible

## Why

A tag can either be secondary or primary. Secondary can be visible when primary is not visible.

## Screenshots / Gifs

Current 😞 
![Screenshot 2024-08-13 at 13 54 06](https://github.com/user-attachments/assets/3462aeb9-b857-4d74-9866-fb6e6068b5dd)

This PR 🥳 
![Screenshot 2024-08-13 at 13 53 53](https://github.com/user-attachments/assets/d3b17191-eb74-4395-b542-59b944528f90)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `ActionCard` component to adjust padding based on the presence of multiple tags for improved layout flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->