### PR TITLE
fix(application-driving-license): Remove redundant health cert warning for BE license

### DIFF
--- a/libs/application/templates/driving-license/src/forms/draft/subSectionHealthDeclaration.ts
+++ b/libs/application/templates/driving-license/src/forms/draft/subSectionHealthDeclaration.ts
@@ -28,7 +28,8 @@ export const subSectionHealthDeclaration = buildSubSection({
           id: 'remarks',
           title: '',
           component: 'HealthRemarks',
-          condition: (_, externalData) => hasHealthRemarks(externalData),
+          condition: (answers, externalData) =>
+            hasHealthRemarks(externalData) && answers.applicationFor !== BE,
         }),
         buildCustomField(
           {


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logic for displaying the health remarks section based on the application type, improving user experience by ensuring relevance to the specific application context.
  
- **Bug Fixes**
	- Corrected conditions under which the health remarks section is displayed, ensuring accurate visibility based on user input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->