### PR TITLE
fix(native-app): more heap for codemagic builds

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -17,7 +17,7 @@ definitions:
   shared_envs: &shared_envs
     XCODE_WORKSPACE: 'IslandApp.xcworkspace'
     CM_CLONE_DEPTH: 200
-    NODE_OPTIONS: '--max_old_space_size=8192'
+    NODE_OPTIONS: '--max-old-space-size=8192'
   scripts:
     - &check_changes
       name: Check changes since last build

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -17,6 +17,7 @@ definitions:
   shared_envs: &shared_envs
     XCODE_WORKSPACE: 'IslandApp.xcworkspace'
     CM_CLONE_DEPTH: 200
+    NODE_OPTIONS: '--max_old_space_size=8192'
   scripts:
     - &check_changes
       name: Check changes since last build


### PR DESCRIPTION
Codemagic builds are failing due to running out of heap memory. Testing to add a env variable to increase the size to see if it fixes the problem.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new environment variable to enhance memory management during builds, allowing for better performance in memory-intensive applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->