### PR TITLE
hotfix(auth-admin): SuperAdmin block PersonalRepresentative changes in IDS

### DIFF
--- a/libs/auth-api-lib/src/lib/resources/admin/admin-scope.service.ts
+++ b/libs/auth-api-lib/src/lib/resources/admin/admin-scope.service.ts
@@ -387,7 +387,25 @@ export class AdminScopeService {
   ): Promise<boolean> {
     const isSuperUser = user.scope.includes(AdminPortalScope.idsAdminSuperUser)
 
+    // Check if none SuperUser is trying to update PersonalRepresentative fields
+    const allDelegationTypes = [
+      ...(input.addedDelegationTypes ?? []),
+      ...(input.removedDelegationTypes ?? []),
+    ]
+
+    const isPersonalRepresentativeUpdate = allDelegationTypes.some(
+      (delegationType) =>
+        delegationType.startsWith(
+          `${AuthDelegationType.PersonalRepresentative}:`,
+        ),
+    )
+
+    if (isPersonalRepresentativeUpdate && !isSuperUser) {
+      return false
+    }
+
     const updatedFields = Object.keys(input)
+
     const superUserUpdatedFields = updatedFields.filter((field) =>
       superUserScopeFields.includes(field),
     )

--- a/libs/portals/admin/ids-admin/src/screens/Client/components/Delegation.tsx
+++ b/libs/portals/admin/ids-admin/src/screens/Client/components/Delegation.tsx
@@ -1,5 +1,8 @@
+import React from 'react'
 import { useLocale } from '@island.is/localization'
 import { Checkbox, Hidden, Stack, Text } from '@island.is/island-ui/core'
+import { AuthAdminEnvironment } from '@island.is/api/schema'
+import { AuthDelegationProvider } from '@island.is/shared/types'
 
 import { m } from '../../../lib/messages'
 import { useEnvironmentState } from '../../../hooks/useEnvironmentState'
@@ -8,10 +11,7 @@ import { useSuperAdmin } from '../../../hooks/useSuperAdmin'
 import { checkEnvironmentsSync } from '../../../utils/checkEnvironmentsSync'
 import { useClient } from '../ClientContext'
 import { FormCard } from '../../../components/FormCard/FormCard'
-
-import React from 'react'
 import { useDelegationProviders } from '../../../context/DelegationProviders/DelegationProvidersContext'
-import { AuthAdminEnvironment } from '@island.is/api/schema'
 import { getDelegationProviderTranslations } from '../../../utils/getDelegationProviderTranslations'
 
 interface DelegationProps {
@@ -32,6 +32,7 @@ const Delegation = ({
   const { formatMessage } = useLocale()
   const { client } = useClient()
   const { getDelegationProviders } = useDelegationProviders()
+  const { isSuperAdmin } = useSuperAdmin()
 
   const delegationProviders = getDelegationProviders(selectedEnvironment)
 
@@ -128,7 +129,10 @@ const Delegation = ({
     >
       <Stack space={4}>
         {providers.map((provider) =>
-          !provider ? null : (
+          !provider ||
+          (!isSuperAdmin &&
+            provider.id ===
+              AuthDelegationProvider.PersonalRepresentativeRegistry) ? null : (
             <Stack space={2} key={provider.id}>
               <div>
                 <Text variant="h5" as="h4" paddingBottom={1}>

--- a/libs/portals/admin/ids-admin/src/screens/Permission/components/PermissionDelegations.tsx
+++ b/libs/portals/admin/ids-admin/src/screens/Permission/components/PermissionDelegations.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { useLocale } from '@island.is/localization'
 import { Checkbox, Hidden, Stack, Text } from '@island.is/island-ui/core'
+import { AuthDelegationProvider } from '@island.is/shared/types'
 
 import { usePermission } from '../PermissionContext'
 import { FormCard } from '../../../components/FormCard/FormCard'
@@ -11,12 +12,14 @@ import { useEnvironmentState } from '../../../hooks/useEnvironmentState'
 import { checkEnvironmentsSync } from '../../../utils/checkEnvironmentsSync'
 import { useDelegationProviders } from '../../../context/DelegationProviders/DelegationProvidersContext'
 import { getDelegationProviderTranslations } from '../../../utils/getDelegationProviderTranslations'
+import { useSuperAdmin } from '../../../hooks/useSuperAdmin'
 
 const FIELD_PREFIX = 'field-'
 
 export const PermissionDelegations = () => {
   const { formatMessage } = useLocale()
   const { selectedPermission, permission } = usePermission()
+  const { isSuperAdmin } = useSuperAdmin()
   const {
     isAccessControlled,
     grantToAuthenticatedUser,
@@ -113,7 +116,10 @@ export const PermissionDelegations = () => {
     >
       <Stack space={4}>
         {providers.map((provider) =>
-          !provider ? null : (
+          !provider ||
+          (!isSuperAdmin &&
+            provider.id ===
+              AuthDelegationProvider.PersonalRepresentativeRegistry) ? null : (
             <Stack space={2} key={provider.id}>
               <div>
                 <Text variant="h5" as="h4" paddingBottom={1}>


### PR DESCRIPTION
## What

Only allow Super admins to make changes to PersonalRepresentative changes in the new IDS

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
