### PR TITLE
fix(j-s): Indictment

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/indictmentPdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/indictmentPdf.ts
@@ -3,11 +3,7 @@ import PDFDocument from 'pdfkit'
 
 import { FormatMessage } from '@island.is/cms-translations'
 
-import {
-  capitalize,
-  formatDate,
-  lowercase,
-} from '@island.is/judicial-system/formatters'
+import { formatDate, lowercase } from '@island.is/judicial-system/formatters'
 
 import { nowFactory } from '../factories'
 import { indictment } from '../messages'
@@ -87,7 +83,7 @@ export const createIndictment = async (
   addGiganticHeading(doc, heading, 'Times-Roman')
   addNormalPlusText(doc, ' ')
   setLineCap(2)
-  addNormalPlusText(doc, theCase.indictmentIntroduction || '')
+  addNormalPlusText(doc, theCase.indictmentIntroduction ?? '')
 
   const hasManyCounts =
     theCase.indictmentCounts && theCase.indictmentCounts.length > 1
@@ -96,20 +92,17 @@ export const createIndictment = async (
 
     if (hasManyCounts) {
       addNormalPlusCenteredText(doc, `${roman(index + 1)}.`)
-      addNormalPlusJustifiedText(
-        doc,
-        capitalize(count.incidentDescription || ''),
-      )
+      addNormalPlusJustifiedText(doc, count.incidentDescription ?? '')
     } else {
-      addNormalPlusJustifiedText(doc, count.incidentDescription || '')
+      addNormalPlusJustifiedText(doc, count.incidentDescription ?? '')
     }
     addEmptyLines(doc)
-    addNormalPlusJustifiedText(doc, count.legalArguments || '')
-    addNormalText(doc, `M: ${count.policeCaseNumber || ''}`)
+    addNormalPlusJustifiedText(doc, count.legalArguments ?? '')
+    addNormalText(doc, `M: ${count.policeCaseNumber ?? ''}`)
   })
 
   addEmptyLines(doc, 2)
-  addNormalPlusJustifiedText(doc, theCase.demands || '')
+  addNormalPlusJustifiedText(doc, theCase.demands ?? '')
   addEmptyLines(doc, 2)
   addNormalPlusCenteredText(
     doc,


### PR DESCRIPTION
# Indictment

[Ákæra PDF - ákæruliðir stórt eða lítið F](https://app.asana.com/0/1199153462262248/1208009479047746/f)

## What

- No longer converts the start of an indictment count to upper case.

## Why

- Verified bug.

## Screenshots / Gifs

![image](https://github.com/user-attachments/assets/e4d6f210-8c9b-4c38-81b7-49b1db455423)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
