### PR TITLE
fix: move GestureHandlerRootView to only wrap license scanner

### DIFF
--- a/apps/native/app/src/screens/license-scanner/license-scanner.tsx
+++ b/apps/native/app/src/screens/license-scanner/license-scanner.tsx
@@ -10,7 +10,11 @@ import Reanimated, {
   useAnimatedProps,
   useSharedValue,
 } from 'react-native-reanimated'
-import { Gesture, GestureDetector } from 'react-native-gesture-handler'
+import {
+  Gesture,
+  GestureDetector,
+  GestureHandlerRootView,
+} from 'react-native-gesture-handler'
 import {
   Navigation,
   NavigationFunctionComponent,
@@ -315,28 +319,30 @@ export const LicenseScannerScreen: NavigationFunctionComponent = ({
   }
 
   return (
-    <View style={{ flex: 1, backgroundColor: '#000' }}>
-      {hasPermission && device && (
-        <GestureDetector gesture={gesture}>
-          <ReanimatedCamera
-            style={StyleSheet.absoluteFill}
-            device={device}
-            isActive={active}
-            torch={torch ? 'on' : 'off'}
-            codeScanner={codeScanner}
-            animatedProps={animatedZoom}
-          />
-        </GestureDetector>
-      )}
-      {renderBubble()}
-      <BottomRight>
-        <TouchableOpacity onPress={onFlashlightPress}>
-          <FlashLight>
-            <FlashImg source={flashligth} resizeMode="contain" />
-          </FlashLight>
-        </TouchableOpacity>
-      </BottomRight>
-    </View>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <View style={{ flex: 1, backgroundColor: '#000' }}>
+        {hasPermission && device && (
+          <GestureDetector gesture={gesture}>
+            <ReanimatedCamera
+              style={StyleSheet.absoluteFill}
+              device={device}
+              isActive={active}
+              torch={torch ? 'on' : 'off'}
+              codeScanner={codeScanner}
+              animatedProps={animatedZoom}
+            />
+          </GestureDetector>
+        )}
+        {renderBubble()}
+        <BottomRight>
+          <TouchableOpacity onPress={onFlashlightPress}>
+            <FlashLight>
+              <FlashImg source={flashligth} resizeMode="contain" />
+            </FlashLight>
+          </TouchableOpacity>
+        </BottomRight>
+      </View>
+    </GestureHandlerRootView>
   )
 }
 

--- a/apps/native/app/src/utils/register-component.tsx
+++ b/apps/native/app/src/utils/register-component.tsx
@@ -1,5 +1,4 @@
 import { ApolloProvider } from '@apollo/client'
-import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import {
   Navigation,
   NavigationFunctionComponent,
@@ -26,11 +25,9 @@ export function registerComponent<Props>(
             <NavigationProvider value={{ componentId: props.componentId }}>
               <FeatureFlagProvider>
                 <ApolloProvider client={client}>
-                  <GestureHandlerRootView style={{ flex: 1 }}>
-                    <OfflineHoc>
-                      <Component {...props} />
-                    </OfflineHoc>
-                  </GestureHandlerRootView>
+                  <OfflineHoc>
+                    <Component {...props} />
+                  </OfflineHoc>
                 </ApolloProvider>
               </FeatureFlagProvider>
             </NavigationProvider>


### PR DESCRIPTION
## What

There is a bug in [react-native-gesture-handler](https://github.com/software-mansion/react-native-gesture-handler/issues/514) that if we are wrapping `<GestureHandlerRootView>` and then showing an overlay with `react-native-navigation` then no touches outside the overlay are being registered until the overlay is closed.
We need this wrapper for `license-scanner` component to work on android so I moved it to only wrap that component instead of every component in the app. 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced gesture handling capabilities in the License Scanner, improving user interaction.

- **Refactor**
  - Simplified component structure by removing unnecessary wrappers, streamlining the rendering process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->