### PR TITLE
fix(application-system): Use s3Uri to get attachment bucket

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/shared/services/attachment-s3.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/shared/services/attachment-s3.service.ts
@@ -79,7 +79,7 @@ export class AttachmentS3Service {
     fileName: string,
   ): Promise<string | undefined> {
     try {
-      return this.awsService.getFileBase64({ fileName })
+      return this.awsService.getFileBase64({ s3Uri: fileName })
     } catch (error) {
       logger.error(error)
       return undefined

--- a/libs/application/template-api-modules/src/lib/modules/templates/estate/estate.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/estate/estate.service.ts
@@ -241,7 +241,7 @@ export class EstateTemplateService extends BaseTemplateApiService {
             attachmentAnswerData[index]?.key
           ]
           const content =
-            (await this.awsService.getFileBase64({ fileName })) ?? ''
+            (await this.awsService.getFileBase64({ s3Uri: fileName })) ?? ''
           attachments.push({ name, content })
         }
       }

--- a/libs/application/template-api-modules/src/lib/modules/templates/p-sign-submission/p-sign-submission.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/p-sign-submission/p-sign-submission.service.ts
@@ -206,6 +206,6 @@ export class PSignSubmissionService extends BaseTemplateApiService {
       }
     )[attachmentKey]
 
-    return (await this.awsService.getFileBase64({ fileName })) ?? ''
+    return (await this.awsService.getFileBase64({ s3Uri: fileName })) ?? ''
   }
 }


### PR DESCRIPTION
# Use s3Uri to get attachment bucket

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated file retrieval process to utilize S3 URIs instead of file names, enhancing the accuracy and flexibility of file access within the application.

- **Bug Fixes**
	- Improved error handling during file retrieval, ensuring a more reliable user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->