### PR TITLE
Revert "feat(endorsement-lists): Revert endorsementCounter.

### DIFF
--- a/apps/services/endorsements/api/src/app/modules/endorsementList/endorsementList.model.ts
+++ b/apps/services/endorsements/api/src/app/modules/endorsementList/endorsementList.model.ts
@@ -97,9 +97,6 @@ export class EndorsementList extends Model {
   endorsements?: Endorsement[]
 
   @ApiProperty()
-  endorsementCounter?: number
-
-  @ApiProperty()
   @Column({
     type: DataType.JSONB,
     allowNull: false,

--- a/apps/services/endorsements/api/src/app/modules/endorsementList/endorsementList.service.ts
+++ b/apps/services/endorsements/api/src/app/modules/endorsementList/endorsementList.service.ts
@@ -5,7 +5,7 @@ import {
   BadRequestException,
 } from '@nestjs/common'
 import { InjectModel } from '@nestjs/sequelize'
-import { Op, Sequelize } from 'sequelize'
+import { Op } from 'sequelize'
 import type { Logger } from '@island.is/logging'
 import { LOGGER_PROVIDER } from '@island.is/logging'
 import { EndorsementList } from './endorsementList.model'
@@ -76,28 +76,8 @@ export class EndorsementListService {
       after: query.after,
       before: query.before,
       primaryKeyField: 'counter',
-      orderOption: [
-        ['endorsementCounter', 'DESC'],
-        ['counter', 'DESC'],
-      ],
+      orderOption: [['counter', 'DESC']],
       where: where,
-      attributes: {
-        include: [
-          [
-            Sequelize.fn('COUNT', Sequelize.col('endorsements.id')),
-            'endorsementCounter',
-          ],
-        ],
-      },
-      include: [
-        {
-          model: Endorsement,
-          required: false, // Required false for left outer join so that counts come for 0 as well
-          duplicating: false,
-          attributes: [],
-        },
-      ],
-      group: ['EndorsementList.id'],
     })
   }
 

--- a/libs/api/domains/endorsement-system/src/lib/models/endorsementList.model.ts
+++ b/libs/api/domains/endorsement-system/src/lib/models/endorsementList.model.ts
@@ -39,7 +39,4 @@ export class EndorsementList {
 
   @Field({ nullable: true })
   owner?: string
-
-  @Field({ nullable: true })
-  endorsementCounter?: number
 }

--- a/libs/nest/pagination/src/lib/paginate.ts
+++ b/libs/nest/pagination/src/lib/paginate.ts
@@ -179,26 +179,8 @@ export async function paginate<T = any>({
 
   const [instances, totalCount, cursorCount] = await Promise.all([
     Model.findAll(paginationQueryOptions),
-    Model.count(totalCountQueryOptions).then(
-      // If the query does relation aggregations, then the count will be an array.
-      // Since we are only interested in the list length, not related elements, we
-      // can just take the length of the array.
-
-      (count: Array<unknown> | number) => {
-        if (Array.isArray(count)) {
-          return count.length
-        }
-        return count
-      },
-    ),
-    Model.count(cursorCountQueryOptions).then(
-      (count: Array<unknown> | number) => {
-        if (Array.isArray(count)) {
-          return count.length
-        }
-        return count
-      },
-    ),
+    Model.count(totalCountQueryOptions),
+    Model.count(cursorCountQueryOptions),
   ])
 
   if (before) {

--- a/libs/service-portal/petitions/src/screens/Petitions/index.tsx
+++ b/libs/service-portal/petitions/src/screens/Petitions/index.tsx
@@ -125,6 +125,7 @@ const Petitions = () => {
                       </Stack>
                     </Box>
                   )}
+
                   {openSignedLists && openSignedLists.length > 0 && (
                     <Box marginTop={6}>
                       <Text variant="h4" marginBottom={2}>

--- a/libs/shared/connected/src/lib/generalPetition/GeneralPetitionLists/useGetPetitionLists.ts
+++ b/libs/shared/connected/src/lib/generalPetition/GeneralPetitionLists/useGetPetitionLists.ts
@@ -20,7 +20,6 @@ const GetGeneralPetitionLists = gql`
         description
         closedDate
         openedDate
-        endorsementCounter
         adminLock
         meta
         owner


### PR DESCRIPTION
```sql
select
	"EndorsementList"."id",
	count("EndorsementList"."id") as "count"
from
	"endorsement_list" as "EndorsementList"
left outer join "endorsement" as "endorsements" on
	"EndorsementList"."id" = "endorsements"."endorsement_list_id"
where
	(("EndorsementList"."endorsementCounter" < 0
		or ("EndorsementList"."endorsementCounter" = 0
			and "EndorsementList"."counter" < 25))
	and ("EndorsementList"."tags" = array['generalPetition']::VARCHAR(255)[]
		and "EndorsementList"."opened_date" < '2024-08-21 17:00:13.913 +00:00'
		and "EndorsementList"."closed_date" > '2024-08-21 17:00:13.913 +00:00'
		and "EndorsementList"."admin_lock" = false))
group by
	"EndorsementList"."id";
```

An example of what is generated by the ORM.
We can see that this is problematic since the pagination library is written to assume that the endorsementCounter is already a property on the table.

This will instead have to be refactored on a later date with less generalization.
For example, another issue is that the `fn.count` on the sql statement returns a column of the type `BigInt` which is cast into a string.

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
