### PR TITLE
fix(application-system): Conditional handling missing email/phone when request to be verified

### DIFF
--- a/libs/application/core/src/lib/messages.ts
+++ b/libs/application/core/src/lib/messages.ts
@@ -676,16 +676,30 @@ export const coreErrorMessages = defineMessages({
   invalidPhoneNumberDescription: {
     id: 'application.system:core.fetch.data.invalidPhoneNumberDescription#markdown',
     defaultMessage:
-      'Skráð símanúmer hjá Ísland.is er ekki gilt. Vinsamlegast skráðu það á [mínum síðum]({link}).',
+      'Þú ert ekki með skráð gilt símanúmer hjá Ísland.is. Vinsamlegast skráðu það á [hér]({link}).',
     description:
-      'You do not have a valid phone number registered at Ísland.is. Please register a phone number on mínar síður',
+      'You do not have a valid phone number registered at Ísland.is. Please register a phone number here.',
+  },
+  invalidPhoneNumberNoRegistration: {
+    id: 'application.system:core.fetch.data.invalidPhoneNumberDescription#markdown',
+    defaultMessage:
+      'Þú ert ekki með skráð gilt símanúmer hjá Ísland.is. Fyrir fyrirtæki geta prókúruhafar skráð símanúmer á mínum síðum Ísland.is.',
+    description:
+      'You do not have a valid phone number registered at Ísland.is. For companies, procuration holders can register a phone number on Ísland.is My Pages.',
   },
   noEmailFoundDescription: {
     id: 'application.system:core.fetch.data.noEmailError.description#markdown',
     defaultMessage:
       'Þú ert ekki með skráð netfang hjá Ísland.is. Vinsamlegast skráðu það [hér]({link}).',
     description:
-      'You do not have a registered email address at Ísland.is. Please register an email address here .',
+      'You do not have a registered email address at Ísland.is. Please register an email address here.',
+  },
+  noEmailNoRegistration: {
+    id: 'application.system:core.fetch.data.noEmailError.noRegistration',
+    defaultMessage:
+      'Ekkert netfang skráð hjá Ísland.is. Fyrir fyrirtæki geta prókúruhafar skráð netfang á mínum síðum Ísland.is.',
+    description:
+      'No email address registered at Ísland.is. For companies, procuration holders can register an email address on Ísland.is My Pages.',
   },
   machinesEmptyListDefault: {
     id: 'application.system:core.fetch.data.machinesEmptyListDefault',


### PR DESCRIPTION
## What

Add conditional messages depending on the user session and type of delegation with different or no registration link when email/phone is missing and it should be verified.

### Todos
[] Test
[] Extract new keys to Contentful and provide English translation
[] Update the Icelandic and English messages in Contentful of changed keys

## Why

To improve UX around missing user profile details, as we don't have the concept of actor profile fully implemented w.r.t. email and phone details. Depending on the delegation type it varies what options are available for the user.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
