### PR TITLE
feat(native-app): Update nav bar buttons

### DIFF
--- a/apps/native/app/src/screens/applications/applications.tsx
+++ b/apps/native/app/src/screens/applications/applications.tsx
@@ -43,7 +43,6 @@ const { useNavigationOptions, getNavigationOptions } =
         searchBar: {
           visible: false,
         },
-        rightButtons: initialized ? getRightButtons({ theme } as any) : [],
       },
       bottomTab: {
         iconColor: theme.color.blue400,
@@ -100,7 +99,6 @@ export const ApplicationsScreen: NavigationFunctionComponent = ({
 
   useConnectivityIndicator({
     componentId,
-    rightButtons: getRightButtons(),
     refetching,
     queryResult: [applicationsRes, res],
   })

--- a/apps/native/app/src/screens/applications/applications.tsx
+++ b/apps/native/app/src/screens/applications/applications.tsx
@@ -25,7 +25,6 @@ import { useConnectivityIndicator } from '../../hooks/use-connectivity-indicator
 import { useBrowser } from '../../lib/use-browser'
 import { getApplicationOverviewUrl } from '../../utils/applications-utils'
 import { testIDs } from '../../utils/test-ids'
-import { getRightButtons } from '../../utils/get-main-root'
 import { ApplicationsModule } from '../home/applications-module'
 import { isIos } from '../../utils/devices'
 

--- a/apps/native/app/src/screens/document-detail/document-detail.tsx
+++ b/apps/native/app/src/screens/document-detail/document-detail.tsx
@@ -45,7 +45,6 @@ const PdfWrapper = styled.View`
   flex: 1;
   background-color: ${dynamicColor('background')};
 `
-
 const regexForBr = /<br \/>*\\?>/g
 
 // Styles for html documents
@@ -84,7 +83,7 @@ const useHtmlStyles = () => {
     <meta name="viewport" content="width=device-width">`
 }
 
-function getRightButtons({
+function getRightButtonsForDocumentDetail({
   archived,
   bookmarked,
 }: {
@@ -143,7 +142,7 @@ const { useNavigationOptions, getNavigationOptions } =
       },
       topBar: {
         noBorder: true,
-        rightButtons: getRightButtons(),
+        rightButtons: getRightButtonsForDocumentDetail(),
       },
     },
   )
@@ -251,7 +250,7 @@ export const DocumentDetailScreen: NavigationFunctionComponent<{
 
   useConnectivityIndicator({
     componentId,
-    rightButtons: getRightButtons({
+    rightButtons: getRightButtonsForDocumentDetail({
       archived: doc.data?.archived ?? false,
       bookmarked: doc.data?.bookmarked ?? false,
     }),

--- a/apps/native/app/src/screens/home/home.tsx
+++ b/apps/native/app/src/screens/home/home.tsx
@@ -50,7 +50,7 @@ const { useNavigationOptions, getNavigationOptions } =
     (theme, intl, initialized) => ({
       topBar: {
         rightButtons: initialized
-          ? getRightButtons({ screen: 'Home', theme: theme as any })
+          ? getRightButtons({ icons: ['notifications'], theme: theme as any })
           : [],
       },
       bottomTab: {
@@ -110,7 +110,7 @@ export const MainHomeScreen: NavigationFunctionComponent = ({
 
   useConnectivityIndicator({
     componentId,
-    rightButtons: getRightButtons({ screen: 'Home' }),
+    rightButtons: getRightButtons({ icons: ['notifications'] }),
     queryResult: applicationsRes,
     refetching,
   })

--- a/apps/native/app/src/screens/home/home.tsx
+++ b/apps/native/app/src/screens/home/home.tsx
@@ -49,7 +49,9 @@ const { useNavigationOptions, getNavigationOptions } =
   createNavigationOptionHooks(
     (theme, intl, initialized) => ({
       topBar: {
-        rightButtons: initialized ? getRightButtons({ theme } as any) : [],
+        rightButtons: initialized
+          ? getRightButtons({ screen: 'Home', theme: theme as any })
+          : [],
       },
       bottomTab: {
         ...({
@@ -108,7 +110,7 @@ export const MainHomeScreen: NavigationFunctionComponent = ({
 
   useConnectivityIndicator({
     componentId,
-    rightButtons: getRightButtons(),
+    rightButtons: getRightButtons({ screen: 'Home' }),
     queryResult: applicationsRes,
     refetching,
   })

--- a/apps/native/app/src/screens/inbox/inbox.tsx
+++ b/apps/native/app/src/screens/inbox/inbox.tsx
@@ -42,7 +42,6 @@ import { navigateTo } from '../../lib/deep-linking'
 import { useOrganizationsStore } from '../../stores/organizations-store'
 import { useUiStore } from '../../stores/ui-store'
 import { ComponentRegistry } from '../../utils/component-registry'
-import { getRightButtons } from '../../utils/get-main-root'
 import { testIDs } from '../../utils/test-ids'
 import { isAndroid } from '../../utils/devices'
 import { useApolloClient } from '@apollo/client'
@@ -82,7 +81,6 @@ const { useNavigationOptions, getNavigationOptions } =
         title: {
           text: intl.formatMessage({ id: 'inbox.screenTitle' }),
         },
-        rightButtons: initialized ? getRightButtons({ theme } as any) : [],
       },
       bottomTab: {
         iconColor: theme.color.blue400,
@@ -243,7 +241,6 @@ export const InboxScreen: NavigationFunctionComponent<{
 
   useConnectivityIndicator({
     componentId,
-    rightButtons: getRightButtons(),
     queryResult: res,
     refetching: refetching || markAllAsReadLoading,
   })

--- a/apps/native/app/src/screens/more/more.tsx
+++ b/apps/native/app/src/screens/more/more.tsx
@@ -1,5 +1,5 @@
 import { FamilyMemberCard, ListButton } from '@ui'
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { useIntl } from 'react-intl'
 import {
   Image,
@@ -7,10 +7,7 @@ import {
   ScrollView,
   TouchableHighlight,
 } from 'react-native'
-import {
-  Navigation,
-  NavigationFunctionComponent,
-} from 'react-native-navigation'
+import { NavigationFunctionComponent } from 'react-native-navigation'
 import { useNavigationComponentDidAppear } from 'react-native-navigation-hooks'
 import styled, { useTheme } from 'styled-components/native'
 import assetsIcon from '../../assets/icons/assets.png'

--- a/apps/native/app/src/screens/more/more.tsx
+++ b/apps/native/app/src/screens/more/more.tsx
@@ -42,7 +42,7 @@ const { useNavigationOptions, getNavigationOptions } =
           text: intl.formatMessage({ id: 'profile.screenTitle' }),
         },
         rightButtons: initialized
-          ? getRightButtons({ screen: 'More', theme: theme as any })
+          ? getRightButtons({ icons: ['settings'], theme: theme as any })
           : [],
       },
       bottomTab: {
@@ -84,7 +84,7 @@ export const MoreScreen: NavigationFunctionComponent = ({ componentId }) => {
 
   useConnectivityIndicator({
     componentId,
-    rightButtons: getRightButtons({ screen: 'More' }),
+    rightButtons: getRightButtons({ icons: ['settings'] }),
   })
 
   useNavigationComponentDidAppear(() => {

--- a/apps/native/app/src/screens/more/more.tsx
+++ b/apps/native/app/src/screens/more/more.tsx
@@ -1,5 +1,5 @@
 import { FamilyMemberCard, ListButton } from '@ui'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useIntl } from 'react-intl'
 import {
   Image,
@@ -44,7 +44,9 @@ const { useNavigationOptions, getNavigationOptions } =
         title: {
           text: intl.formatMessage({ id: 'profile.screenTitle' }),
         },
-        rightButtons: initialized ? getRightButtons({ theme } as any) : [],
+        rightButtons: initialized
+          ? getRightButtons({ screen: 'More', theme: theme as any })
+          : [],
       },
       bottomTab: {
         iconColor: theme.color.blue400,
@@ -85,7 +87,7 @@ export const MoreScreen: NavigationFunctionComponent = ({ componentId }) => {
 
   useConnectivityIndicator({
     componentId,
-    rightButtons: getRightButtons(),
+    rightButtons: getRightButtons({ screen: 'More' }),
   })
 
   useNavigationComponentDidAppear(() => {

--- a/apps/native/app/src/screens/wallet/wallet.tsx
+++ b/apps/native/app/src/screens/wallet/wallet.tsx
@@ -54,7 +54,10 @@ const { useNavigationOptions, getNavigationOptions } =
           text: intl.formatMessage({ id: 'wallet.screenTitle' }),
         },
         rightButtons: initialized
-          ? getRightButtons({ screen: 'Wallet', theme: theme as any })
+          ? getRightButtons({
+              icons: ['licenseScan'],
+              theme: theme as any,
+            })
           : [],
       },
       bottomTab: {
@@ -127,7 +130,7 @@ export const WalletScreen: NavigationFunctionComponent = ({ componentId }) => {
 
   useConnectivityIndicator({
     componentId,
-    rightButtons: getRightButtons({ screen: 'Wallet' }),
+    rightButtons: getRightButtons({ icons: ['licenseScan'] }),
     queryResult: [res, resPassport],
     refetching,
   })

--- a/apps/native/app/src/screens/wallet/wallet.tsx
+++ b/apps/native/app/src/screens/wallet/wallet.tsx
@@ -33,7 +33,6 @@ import { getRightButtons } from '../../utils/get-main-root'
 import { isDefined } from '../../utils/is-defined'
 import { testIDs } from '../../utils/test-ids'
 import { WalletItem } from './components/wallet-item'
-import { ButtonRegistry } from '../../utils/component-registry'
 
 type FlatListItem =
   | GenericUserLicense

--- a/apps/native/app/src/screens/wallet/wallet.tsx
+++ b/apps/native/app/src/screens/wallet/wallet.tsx
@@ -54,15 +54,9 @@ const { useNavigationOptions, getNavigationOptions } =
         title: {
           text: intl.formatMessage({ id: 'wallet.screenTitle' }),
         },
-        rightButtons: initialized ? getRightButtons({ theme } as any) : [],
-        leftButtons: [
-          {
-            id: ButtonRegistry.ScanLicenseButton,
-            testID: testIDs.TOPBAR_SCAN_LICENSE_BUTTON,
-            icon: require('../../assets/icons/navbar-scan.png'),
-            color: theme.color.blue400,
-          },
-        ],
+        rightButtons: initialized
+          ? getRightButtons({ screen: 'Wallet', theme: theme as any })
+          : [],
       },
       bottomTab: {
         iconColor: theme.color.blue400,
@@ -134,7 +128,7 @@ export const WalletScreen: NavigationFunctionComponent = ({ componentId }) => {
 
   useConnectivityIndicator({
     componentId,
-    rightButtons: getRightButtons(),
+    rightButtons: getRightButtons({ screen: 'Wallet' }),
     queryResult: [res, resPassport],
     refetching,
   })

--- a/apps/native/app/src/stores/notifications-store.ts
+++ b/apps/native/app/src/stores/notifications-store.ts
@@ -117,7 +117,7 @@ export const notificationsStore = create<NotificationsStore>(
 
         Navigation.mergeOptions(ComponentRegistry.HomeScreen, {
           topBar: {
-            rightButtons: getRightButtons({ unseenCount }),
+            rightButtons: getRightButtons({ unseenCount, screen: 'Home' }),
           },
         })
       },

--- a/apps/native/app/src/stores/notifications-store.ts
+++ b/apps/native/app/src/stores/notifications-store.ts
@@ -117,7 +117,10 @@ export const notificationsStore = create<NotificationsStore>(
 
         Navigation.mergeOptions(ComponentRegistry.HomeScreen, {
           topBar: {
-            rightButtons: getRightButtons({ unseenCount, screen: 'Home' }),
+            rightButtons: getRightButtons({
+              unseenCount,
+              icons: ['notifications'],
+            }),
           },
         })
       },

--- a/apps/native/app/src/stores/notifications-store.ts
+++ b/apps/native/app/src/stores/notifications-store.ts
@@ -46,14 +46,6 @@ interface NotificationsActions {
 
 type NotificationsStore = NotificationsState & NotificationsActions
 
-const rightButtonScreens = [
-  ComponentRegistry.HomeScreen,
-  ComponentRegistry.InboxScreen,
-  ComponentRegistry.WalletScreen,
-  ComponentRegistry.ApplicationsScreen,
-  ComponentRegistry.MoreScreen,
-]
-
 const initialState: NotificationsState = {
   unseenCount: 0,
   pushToken: undefined,
@@ -123,12 +115,10 @@ export const notificationsStore = create<NotificationsStore>(
       updateNavigationUnseenCount(unseenCount: number) {
         set({ unseenCount })
 
-        rightButtonScreens.forEach((componentId) => {
-          Navigation.mergeOptions(componentId, {
-            topBar: {
-              rightButtons: getRightButtons({ unseenCount }),
-            },
-          })
+        Navigation.mergeOptions(ComponentRegistry.HomeScreen, {
+          topBar: {
+            rightButtons: getRightButtons({ unseenCount }),
+          },
         })
       },
       async checkUnseen() {

--- a/apps/native/app/src/utils/get-main-root.ts
+++ b/apps/native/app/src/utils/get-main-root.ts
@@ -10,61 +10,64 @@ import {
 import { getThemeWithPreferences } from './get-theme-with-preferences'
 import { testIDs } from './test-ids'
 
-type Screen = 'Inbox' | 'Wallet' | 'Home' | 'Applications' | 'More'
+type Icons = 'notifications' | 'settings' | 'licenseScan'
 
 type RightButtonProps = {
   unseenCount?: number
   theme?: ReturnType<typeof getThemeWithPreferences>
-  screen?: Screen
+  icons?: Icons[]
 }
 
 export const getRightButtons = ({
   unseenCount = notificationsStore.getState().unseenCount,
   theme = getThemeWithPreferences(preferencesStore.getState()),
-  screen,
+  icons,
 }: RightButtonProps = {}): OptionsTopBarButton[] => {
+  if (!icons) {
+    return []
+  }
+
   const iconBackground = {
     color: 'transparent',
     cornerRadius: 4,
     width: theme.spacing[4],
     height: theme.spacing[4],
   }
-  switch (screen) {
-    case 'Home':
-      return [
-        {
-          accessibilityLabel: 'Notifications',
-          id: ButtonRegistry.NotificationsButton,
-          testID: testIDs.TOPBAR_NOTIFICATIONS_BUTTON,
-          icon:
-            unseenCount > 0
-              ? require('../assets/icons/topbar-notifications-bell.png')
-              : require('../assets/icons/topbar-notifications.png'),
-          iconBackground,
-        },
-      ]
-    case 'Wallet':
-      return [
-        {
-          id: ButtonRegistry.ScanLicenseButton,
-          testID: testIDs.TOPBAR_SCAN_LICENSE_BUTTON,
-          icon: require('../assets/icons/navbar-scan.png'),
-          color: theme.color.blue400,
-        },
-      ]
-    case 'More':
-      return [
-        {
-          accessibilityLabel: 'Settings',
-          id: ButtonRegistry.SettingsButton,
-          testID: testIDs.TOPBAR_SETTINGS_BUTTON,
-          icon: require('../assets/icons/settings.png'),
-          iconBackground,
-        },
-      ]
-    default:
-      return []
-  }
+
+  const rightButtons: OptionsTopBarButton[] = []
+
+  // Note: the first icon in the array will be displayed in top right corner
+  icons.forEach((icon) => {
+    if (icon === 'notifications') {
+      rightButtons.push({
+        accessibilityLabel: 'Notifications',
+        id: ButtonRegistry.NotificationsButton,
+        testID: testIDs.TOPBAR_NOTIFICATIONS_BUTTON,
+        icon:
+          unseenCount > 0
+            ? require('../assets/icons/topbar-notifications-bell.png')
+            : require('../assets/icons/topbar-notifications.png'),
+        iconBackground,
+      })
+    } else if (icon === 'settings') {
+      rightButtons.push({
+        accessibilityLabel: 'Settings',
+        id: ButtonRegistry.SettingsButton,
+        testID: testIDs.TOPBAR_SETTINGS_BUTTON,
+        icon: require('../assets/icons/settings.png'),
+        iconBackground,
+      })
+    } else if (icon === 'licenseScan') {
+      rightButtons.push({
+        id: ButtonRegistry.ScanLicenseButton,
+        testID: testIDs.TOPBAR_SCAN_LICENSE_BUTTON,
+        icon: require('../assets/icons/navbar-scan.png'),
+        color: theme.color.blue400,
+        iconBackground,
+      })
+    }
+  })
+  return rightButtons
 }
 
 /**

--- a/apps/native/app/src/utils/get-main-root.ts
+++ b/apps/native/app/src/utils/get-main-root.ts
@@ -10,14 +10,18 @@ import {
 import { getThemeWithPreferences } from './get-theme-with-preferences'
 import { testIDs } from './test-ids'
 
+type Screen = 'Inbox' | 'Wallet' | 'Home' | 'Applications' | 'More'
+
 type RightButtonProps = {
   unseenCount?: number
   theme?: ReturnType<typeof getThemeWithPreferences>
+  screen?: Screen
 }
 
 export const getRightButtons = ({
   unseenCount = notificationsStore.getState().unseenCount,
   theme = getThemeWithPreferences(preferencesStore.getState()),
+  screen,
 }: RightButtonProps = {}): OptionsTopBarButton[] => {
   const iconBackground = {
     color: 'transparent',
@@ -25,26 +29,42 @@ export const getRightButtons = ({
     width: theme.spacing[4],
     height: theme.spacing[4],
   }
-
-  return [
-    {
-      accessibilityLabel: 'Settings',
-      id: ButtonRegistry.SettingsButton,
-      testID: testIDs.TOPBAR_SETTINGS_BUTTON,
-      icon: require('../assets/icons/settings.png'),
-      iconBackground,
-    },
-    {
-      accessibilityLabel: 'Notifications',
-      id: ButtonRegistry.NotificationsButton,
-      testID: testIDs.TOPBAR_NOTIFICATIONS_BUTTON,
-      icon:
-        unseenCount > 0
-          ? require('../assets/icons/topbar-notifications-bell.png')
-          : require('../assets/icons/topbar-notifications.png'),
-      iconBackground,
-    },
-  ]
+  switch (screen) {
+    case 'Home':
+      return [
+        {
+          accessibilityLabel: 'Notifications',
+          id: ButtonRegistry.NotificationsButton,
+          testID: testIDs.TOPBAR_NOTIFICATIONS_BUTTON,
+          icon:
+            unseenCount > 0
+              ? require('../assets/icons/topbar-notifications-bell.png')
+              : require('../assets/icons/topbar-notifications.png'),
+          iconBackground,
+        },
+      ]
+    case 'Wallet':
+      return [
+        {
+          id: ButtonRegistry.ScanLicenseButton,
+          testID: testIDs.TOPBAR_SCAN_LICENSE_BUTTON,
+          icon: require('../assets/icons/navbar-scan.png'),
+          color: theme.color.blue400,
+        },
+      ]
+    case 'More':
+      return [
+        {
+          accessibilityLabel: 'Settings',
+          id: ButtonRegistry.SettingsButton,
+          testID: testIDs.TOPBAR_SETTINGS_BUTTON,
+          icon: require('../assets/icons/settings.png'),
+          iconBackground,
+        },
+      ]
+    default:
+      return []
+  }
 }
 
 /**


### PR DESCRIPTION
## What

Stop showing notification bell and settings icon on all screens. 
Now we have notification bell only on the home screen and settings icon only on the more screen. Also moved the license scan icon to be on the right on the wallet screen.

## Screenshots / Gifs
<div><img height = "800" src="https://github.com/user-attachments/assets/9f384c0e-8d24-4d3d-96a8-fff3ec537899">
<img height = "800" src="https://github.com/user-attachments/assets/8d1002cd-f76b-4b75-aca4-f57ad87c4aeb"><img height = "800" src="https://github.com/user-attachments/assets/46c047da-4fb5-41e2-a552-3db4b2486ca0"></div>
## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced navigation options with context-specific right buttons across multiple screens (Home, Wallet, More).
	- Improved clarity in button rendering logic by incorporating relevant icons.

- **Bug Fixes**
	- Streamlined button configuration, removing unnecessary references and improving navigation consistency.

- **Chores**
	- Removed unused imports and optimized navigation setup for better performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->