### PR TITLE
fix(delegation-index): Merge custom delegations and combine scopes when indexing.

### DIFF
--- a/apps/services/auth/delegation-api/src/app/delegations/test/delegation-index/delegation-index-test-cases.ts
+++ b/apps/services/auth/delegation-api/src/app/delegations/test/delegation-index/delegation-index-test-cases.ts
@@ -85,4 +85,16 @@ export const indexingTestCases: Record<string, TestCase> = {
       expectedFrom: [adult1],
     },
   ),
+  customTwoDomains: new TestCase(
+    createClient({
+      clientId: clientId,
+      supportsCustomDelegation: true,
+      supportedDelegationTypes: [AuthDelegationType.Custom],
+    }),
+    {
+      fromCustom: [adult1],
+      fromCustomOtherDomain: [adult1],
+      expectedFrom: [adult1],
+    },
+  ),
 }

--- a/apps/services/auth/delegation-api/src/app/delegations/test/delegation-index/delegation-index.service.spec.ts
+++ b/apps/services/auth/delegation-api/src/app/delegations/test/delegation-index/delegation-index.service.spec.ts
@@ -26,7 +26,13 @@ import { TestApp, truncate } from '@island.is/testing/nest'
 
 import { setupWithAuth } from '../../../../../test/setup'
 import { indexingTestCases, prRight1 } from './delegation-index-test-cases'
-import { domainName, TestCase, user } from './delegations-index-types'
+import {
+  customScopes,
+  customScopesOtherDomain,
+  domainName,
+  TestCase,
+  user,
+} from './delegations-index-types'
 
 const testDate = new Date(2024, 2, 1)
 
@@ -47,7 +53,9 @@ describe('DelegationsIndexService', () => {
 
   const setup = async (testCase: TestCase) => {
     await truncate(sequelize)
-    await factory.createDomain(testCase.domain)
+    await Promise.all(
+      testCase.domains.map((domain) => factory.createDomain(domain)),
+    )
     await factory.createClient(testCase.client)
 
     await Promise.all(
@@ -56,9 +64,10 @@ describe('DelegationsIndexService', () => {
 
     // create custom delegations
     await Promise.all(
-      testCase.customDelegations.map((delegation) =>
-        factory.createCustomDelegation(delegation),
-      ),
+      [
+        ...testCase.customDelegations,
+        ...testCase.customDelegationsOtherDomain,
+      ].map((delegation) => factory.createCustomDelegation(delegation)),
     )
 
     // create personal representation delegations
@@ -76,6 +85,9 @@ describe('DelegationsIndexService', () => {
       providerSubjectId: `IS-${user.nationalId}`,
       active: true,
     })
+
+    await delegationIndexMetaModel.destroy({ where: {} })
+    await delegationIndexModel.destroy({ where: {} })
 
     // mock national registry for ward delegations
     jest
@@ -124,7 +136,9 @@ describe('DelegationsIndexService', () => {
 
   describe('indexDelegations', () => {
     describe('delegation index meta logic', () => {
-      beforeAll(async () => setup(indexingTestCases.custom))
+      beforeAll(async () => {
+        await setup(indexingTestCases.custom)
+      })
 
       beforeEach(async () => {
         jest.useFakeTimers()
@@ -195,7 +209,9 @@ describe('DelegationsIndexService', () => {
         const testCase = indexingTestCases[type]
         testCase.user = user
 
-        beforeEach(async () => setup(testCase))
+        beforeEach(async () => {
+          await setup(testCase)
+        })
 
         it('should index delegations', async () => {
           // Act
@@ -216,7 +232,9 @@ describe('DelegationsIndexService', () => {
     describe('Reindex (multiple indexing)', () => {
       const testCase = indexingTestCases.custom
 
-      beforeEach(async () => setup(testCase))
+      beforeEach(async () => {
+        await setup(testCase)
+      })
 
       it('should not duplicate delegations on reindex', async () => {
         // Act
@@ -424,7 +442,9 @@ describe('DelegationsIndexService', () => {
   describe('indexCustomDelegations', () => {
     const testCase = indexingTestCases.custom
 
-    beforeAll(async () => setup(testCase))
+    beforeAll(async () => {
+      await setup(testCase)
+    })
 
     it('should index custom delegations', async () => {
       // Arrange
@@ -451,12 +471,8 @@ describe('DelegationsIndexService', () => {
   describe('indexRepresentativeDelegations', () => {
     const testCase = indexingTestCases.personalRepresentative
 
-    beforeAll(async () => setup(testCase))
-
-    afterEach(async () => {
-      // remove all data
-      await delegationIndexMetaModel.destroy({ where: {} })
-      await delegationIndexModel.destroy({ where: {} })
+    beforeAll(async () => {
+      await setup(testCase)
     })
 
     it('should index personal representation delegations', async () => {
@@ -487,7 +503,9 @@ describe('DelegationsIndexService', () => {
   describe('SubjectId', () => {
     const testCase = indexingTestCases.singleCustomDelegation
 
-    beforeEach(async () => setup(testCase))
+    beforeEach(async () => {
+      await setup(testCase)
+    })
 
     afterEach(async () => {
       // remove all data
@@ -592,6 +610,46 @@ describe('DelegationsIndexService', () => {
 
       expect(delegations.length).toEqual(1)
       expect(delegations[0].subjectId).toBeDefined()
+    })
+  })
+
+  describe('mergeCustomDelegations', () => {
+    const testCase = indexingTestCases.customTwoDomains
+
+    beforeAll(async () => {
+      await setup(testCase)
+    })
+
+    it('should merge custom delegations', async () => {
+      // Arrange
+      const nationalId = user.nationalId
+
+      // Act
+      await delegationIndexService.indexCustomDelegations(nationalId)
+
+      // Assert
+      const delegations = await delegationModel.findAll({
+        where: {
+          toNationalId: nationalId,
+        },
+      })
+      const indexedDelegations = await delegationIndexModel.findAll({
+        where: {
+          toNationalId: nationalId,
+        },
+      })
+
+      expect(delegations.length).toEqual(2)
+      expect(indexedDelegations.length).toEqual(1)
+
+      const indexedDelegation = indexedDelegations[0]
+
+      expect(indexedDelegation.fromNationalId).toBe(testCase.expectedFrom[0])
+      expect(indexedDelegation.toNationalId).toBe(user.nationalId)
+      expect(indexedDelegation.customDelegationScopes).toHaveLength(4)
+      expect(indexedDelegation.customDelegationScopes?.sort()).toEqual(
+        [...customScopes, ...customScopesOtherDomain].sort(),
+      )
     })
   })
 })

--- a/apps/services/auth/delegation-api/src/app/delegations/test/delegation-index/delegations-index-types.ts
+++ b/apps/services/auth/delegation-api/src/app/delegations/test/delegation-index/delegations-index-types.ts
@@ -12,6 +12,7 @@ import { createCurrentUser } from '@island.is/testing/fixtures'
 
 export const clientId = '@island.is/webapp'
 export const domainName = '@island.is'
+const otherDomainName = '@other.is/webapp'
 export const user = createCurrentUser({
   nationalIdType: 'person',
   client: clientId,
@@ -20,12 +21,14 @@ export const user = createCurrentUser({
 export const legalGuardianScopes = ['lg1', 'lg2']
 export const procurationHolderScopes = ['ph1', 'ph2']
 export const customScopes = ['cu1', 'cu2']
+export const customScopesOtherDomain = ['cu-od1', 'cu-od2']
 export const representativeScopes = ['pr1', 'pr2']
 
 export interface ITestCaseOptions {
   fromChildren?: string[]
   fromCompanies?: string[]
   fromCustom?: string[]
+  fromCustomOtherDomain?: string[]
   fromRepresentative?: CreatePersonalRepresentativeDelegation[]
   scopes?: string[]
   scopeAccess?: [string, string][]
@@ -35,13 +38,16 @@ export interface ITestCaseOptions {
 
 export class TestCase {
   domainName = domainName
+  otherDomainName = otherDomainName
   user: User
   client: CreateClient
   fromChildren: string[]
   fromCompanies: string[]
   fromCustom: string[]
+  fromCustomOtherDomain: string[]
   fromRepresentative: CreatePersonalRepresentativeDelegation[]
   scopes: string[]
+  scopesOtherDomain: string[]
   scopeAccess: [string, string][]
   expectedFrom: string[]
 
@@ -51,6 +57,7 @@ export class TestCase {
     this.fromChildren = options.fromChildren ?? []
     this.fromCompanies = options.fromCompanies ?? []
     this.fromCustom = options.fromCustom ?? []
+    this.fromCustomOtherDomain = options.fromCustomOtherDomain ?? []
     this.fromRepresentative = options.fromRepresentative ?? []
     this.scopes = options.scopes ?? [
       ...legalGuardianScopes,
@@ -58,20 +65,23 @@ export class TestCase {
       ...customScopes,
       ...representativeScopes,
     ]
+    this.scopesOtherDomain = customScopesOtherDomain
     this.scopeAccess = options.scopeAccess ?? []
     this.expectedFrom = options.expectedFrom
   }
 
-  get domain(): CreateDomain {
-    return { name: this.domainName }
+  get domains(): CreateDomain[] {
+    return [{ name: this.domainName }, { name: this.otherDomainName }]
   }
 
   get apiScopes(): CreateApiScope[] {
-    return this.scopes.map((s) => ({
+    return [...this.scopes, ...this.scopesOtherDomain].map((s) => ({
       name: s,
       description: s,
       displayName: s,
-      domainName: this.domainName,
+      domainName: this.scopesOtherDomain.includes(s)
+        ? this.otherDomainName
+        : this.domainName,
       grantToLegalGuardians: legalGuardianScopes.includes(s),
       grantToProcuringHolders: procurationHolderScopes.includes(s),
       allowExplicitDelegationGrant: customScopes.includes(s),
@@ -90,6 +100,17 @@ export class TestCase {
         .map((s) => ({
           scopeName: s,
         })),
+    }))
+  }
+
+  get customDelegationsOtherDomain(): CreateCustomDelegation[] {
+    return this.fromCustomOtherDomain.map((d: string) => ({
+      domainName: this.otherDomainName,
+      toNationalId: this.user.nationalId,
+      fromNationalId: d,
+      scopes: this.scopesOtherDomain.map((s) => ({
+        scopeName: s,
+      })),
     }))
   }
 
@@ -123,7 +144,10 @@ export class TestCase {
     if (procurationHolderScopes.includes(scopeName)) {
       result.push(AuthDelegationType.ProcurationHolder)
     }
-    if (customScopes.includes(scopeName)) {
+    if (
+      customScopes.includes(scopeName) ||
+      customScopesOtherDomain.includes(scopeName)
+    ) {
       result.push(AuthDelegationType.Custom)
     }
     if (representativeScopes.includes(scopeName)) {


### PR DESCRIPTION
https://www.notion.so/Bug-Primary-key-violation-in-delegation-index-db1aa985c6184c1688ac35cdc8f850ae?pvs=4

## What

Index custom delegations for different domains as a single entry with combined scopes.

## Why

So we don´t get primary key violations when indexing.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
