### PR TITLE
fix(j-s): Verdict Appeal Deadline

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/subpoenaPdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/subpoenaPdf.ts
@@ -7,12 +7,7 @@ import {
   formatDOB,
   lowercase,
 } from '@island.is/judicial-system/formatters'
-import {
-  DateType,
-  DistrictCourtLocation,
-  DistrictCourts,
-  SubpoenaType,
-} from '@island.is/judicial-system/types'
+import { DateType, SubpoenaType } from '@island.is/judicial-system/types'
 
 import { subpoena as strings } from '../messages'
 import { Case } from '../modules/case'
@@ -26,6 +21,28 @@ import {
   addNormalText,
   setTitle,
 } from './pdfHelpers'
+
+type DistrictCourts =
+  | 'Héraðsdómur Reykjavíkur'
+  | 'Héraðsdómur Reykjaness'
+  | 'Héraðsdómur Vesturlands'
+  | 'Héraðsdómur Vestfjarða'
+  | 'Héraðsdómur Norðurlands vestra'
+  | 'Héraðsdómur Norðurlands eystra'
+  | 'Héraðsdómur Austurlands'
+  | 'Héraðsdómur Suðurlands'
+
+// TODO: Move to databas
+const DistrictCourtLocation: Record<DistrictCourts, string> = {
+  'Héraðsdómur Reykjavíkur': 'Dómhúsið við Lækjartorg, Reykjavík',
+  'Héraðsdómur Reykjaness': 'Fjarðargata 9, Hafnarfirði',
+  'Héraðsdómur Vesturlands': 'Bjarnarbraut 8, Borgarnesi',
+  'Héraðsdómur Vestfjarða': 'Hafnarstræti 9, Ísafirði',
+  'Héraðsdómur Norðurlands vestra': 'Skagfirðingabraut 21, Sauðárkróki',
+  'Héraðsdómur Norðurlands eystra': 'Hafnarstræti 107, 4. hæð, Akureyri',
+  'Héraðsdómur Austurlands': 'Lyngás 15, Egilsstöðum',
+  'Héraðsdómur Suðurlands': 'Austurvegur 4, Selfossi',
+}
 
 export const createSubpoena = (
   theCase: Case,

--- a/apps/judicial-system/backend/src/app/modules/case/filters/case.filter.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/filters/case.filter.ts
@@ -186,8 +186,8 @@ const canPrisonSystemUserAccessCase = (
   // Check case type access
   if (user.institution?.type === InstitutionType.PRISON_ADMIN) {
     if (isIndictmentCase(theCase.type)) {
-      const verdictViewDates = theCase.defendants?.map((defendant) =>
-        defendant.verdictViewDate?.toISOString(),
+      const verdictViewDates = theCase.defendants?.map(
+        (defendant) => defendant.verdictViewDate,
       )
 
       const indictmentVerdictAppealDeadline =

--- a/apps/judicial-system/backend/src/app/modules/defendant/defendant.controller.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/defendant.controller.ts
@@ -27,6 +27,7 @@ import {
 } from '@island.is/judicial-system/auth'
 import {
   indictmentCases,
+  ServiceRequirement,
   SubpoenaType,
   type User,
 } from '@island.is/judicial-system/types'
@@ -107,6 +108,17 @@ export class DefendantController {
     @Body() defendantToUpdate: UpdateDefendantDto,
   ): Promise<Defendant> {
     this.logger.debug(`Updating defendant ${defendantId} of case ${caseId}`)
+
+    // If the defendant was present at the court hearing,
+    // then set the verdict view date to the case ruling date
+    if (
+      defendantToUpdate.serviceRequirement === ServiceRequirement.NOT_APPLICABLE
+    ) {
+      defendantToUpdate = {
+        ...defendantToUpdate,
+        verdictViewDate: theCase.rulingDate,
+      }
+    }
 
     return this.defendantService.update(
       theCase,

--- a/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.spec.ts
+++ b/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.spec.ts
@@ -55,7 +55,7 @@ describe('DefendantInfo', () => {
       expect(dataSections.message.id).toStrictEqual(
         'judicial.system.core:info_card.defendant_info.appeal_expiration_date',
       )
-      expect(dataSections.data).toStrictEqual('05.08.2024')
+      expect(dataSections.date).toStrictEqual('05.08.2024')
     })
 
     test('should return the correct string if appeal expiration date is in the past', () => {
@@ -67,7 +67,7 @@ describe('DefendantInfo', () => {
       expect(dataSections.message.id).toStrictEqual(
         'judicial.system.core:info_card.defendant_info.appeal_date_expired',
       )
-      expect(dataSections.data).toStrictEqual('07.07.2024')
+      expect(dataSections.date).toStrictEqual('07.07.2024')
     })
   })
 })

--- a/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.strings.ts
+++ b/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.strings.ts
@@ -19,12 +19,7 @@ export const strings = defineMessages({
       'Notaður til að láta vita að áfrýjunarfrestur dómfellda er ekki hafinn.',
   },
   serviceRequirementNotRequired: {
-    id: 'judicial.system.core:info_card.defendant_info.service_requirement_not_required',
-    defaultMessage: 'Dómfelldi var viðstaddur dómþing',
-    description: 'Notað til að láta vita birting dóms er ekki nauðsynleg.',
-  },
-  serviceRequirementNotApplicable: {
-    id: 'judicial.system.core:info_card.defendant_info.service_requirement_not_applicable',
+    id: 'judicial.system.core:info_card.defendant_info.service_requirement_not_required_v1',
     defaultMessage: 'Birting dóms ekki þörf',
     description: 'Notað til að láta vita birting dóms er ekki nauðsynleg.',
   },

--- a/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.tsx
+++ b/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.tsx
@@ -37,31 +37,27 @@ interface DefendantInfoProps {
 }
 
 export const getAppealExpirationInfo = (
-  viewDate?: string | null,
+  viewAppealDeadline?: string | null,
   serviceRequirement?: ServiceRequirement | null,
 ) => {
-  if (!viewDate) {
-    return { message: strings.appealDateNotBegun, data: null }
-  }
-
   if (serviceRequirement === ServiceRequirement.NOT_REQUIRED) {
     return { message: strings.serviceRequirementNotRequired, data: null }
   }
 
-  if (serviceRequirement === ServiceRequirement.NOT_APPLICABLE) {
-    return { message: strings.serviceRequirementNotApplicable, data: null }
+  if (!viewAppealDeadline) {
+    return { message: strings.appealDateNotBegun, date: null }
   }
 
+  // TODO: Move to the server as today may not be accurate in the client
   const today = new Date()
-  const expiryDate = new Date(viewDate)
-  expiryDate.setDate(expiryDate.getDate() + 28)
+  const expiryDate = new Date(viewAppealDeadline)
 
   const message =
     today < expiryDate
       ? strings.appealExpirationDate
       : strings.appealDateExpired
 
-  return { message, data: formatDate(expiryDate) }
+  return { message, date: formatDate(expiryDate) }
 }
 
 export const DefendantInfo: FC<DefendantInfoProps> = (props) => {
@@ -75,7 +71,7 @@ export const DefendantInfo: FC<DefendantInfoProps> = (props) => {
   const { formatMessage } = useIntl()
 
   const appealExpirationInfo = getAppealExpirationInfo(
-    defendant.verdictViewDate,
+    defendant.verdictAppealDeadline,
     defendant.serviceRequirement,
   )
 
@@ -123,7 +119,7 @@ export const DefendantInfo: FC<DefendantInfoProps> = (props) => {
           <Box>
             <Text as="span">
               {formatMessage(appealExpirationInfo.message, {
-                appealExpirationDate: appealExpirationInfo.data,
+                appealExpirationDate: appealExpirationInfo.date,
               })}
             </Text>
           </Box>

--- a/apps/judicial-system/web/src/routes/Court/Indictments/Completed/Completed.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/Completed/Completed.tsx
@@ -57,7 +57,7 @@ const Completed: FC = () => {
 
   const handleNextButtonClick = useCallback(async () => {
     const allSucceeded = await handleUpload(
-      uploadFiles.filter((file) => !file.key),
+      uploadFiles.filter((file) => file.percent === 0),
       updateUploadFile,
     )
     if (!allSucceeded) {
@@ -93,8 +93,8 @@ const Completed: FC = () => {
   )
 
   const handleCriminalRecordUpdateUpload = useCallback(
-    (files: File[], type: CaseFileCategory) => {
-      addUploadFiles(files, type, 'done')
+    (files: File[]) => {
+      addUploadFiles(files, CaseFileCategory.CRIMINAL_RECORD_UPDATE, 'done')
     },
     [addUploadFiles],
   )
@@ -165,13 +165,8 @@ const Completed: FC = () => {
                   description={formatMessage(core.uploadBoxDescription, {
                     fileEndings: '.pdf',
                   })}
-                  onChange={(files) =>
-                    handleCriminalRecordUpdateUpload(
-                      files,
-                      CaseFileCategory.CRIMINAL_RECORD_UPDATE,
-                    )
-                  }
-                  onRemove={(file) => handleRemoveFile(file)}
+                  onChange={handleCriminalRecordUpdateUpload}
+                  onRemove={handleRemoveFile}
                 />
               </Box>
             )}

--- a/apps/judicial-system/web/src/routes/Court/Indictments/ReturnIndictmentCaseModal/ReturnIndictmentCaseModal.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/ReturnIndictmentCaseModal/ReturnIndictmentCaseModal.tsx
@@ -54,6 +54,8 @@ const ReturnIndictmentModal: FC<Props> = ({
       return
     }
 
+    // TODO: Generally, we cannot trust the client date so we should let the server handle this instead.
+    //       There is already precedent for adding eplanatory strings on the server side when transitioning cases.
     const now = new Date()
     const prependedReturnedExplanation = `${formatMessage(
       strings.prependedReturnedExplanation,

--- a/apps/judicial-system/web/src/routes/PublicProsecutor/Indictments/Overview/Overview.spec.ts
+++ b/apps/judicial-system/web/src/routes/PublicProsecutor/Indictments/Overview/Overview.spec.ts
@@ -4,7 +4,7 @@ import { isDefendantInfoActionButtonDisabled } from './Overview'
 
 describe('Overview', () => {
   describe('isDefendantInfoActionButtonDisabled', () => {
-    test('should return true if defendant vervidictViewDate is not null', () => {
+    test('should return true if defendant service requirement is REQUIRED and defendant vervidictViewDate is not null', () => {
       const verdictViewDate = '2024-07-08'
       const serviceRequirement = ServiceRequirement.REQUIRED
 
@@ -17,8 +17,21 @@ describe('Overview', () => {
       expect(res).toEqual(true)
     })
 
-    test('should return true if defendant service requirement is NOT_APPLICABLE', () => {
+    test('should return true if defendant service requirement is REQUIRED and defendant vervidictViewDate is null', () => {
       const verdictViewDate = null
+      const serviceRequirement = ServiceRequirement.REQUIRED
+
+      const res = isDefendantInfoActionButtonDisabled({
+        id: 'id',
+        verdictViewDate,
+        serviceRequirement,
+      })
+
+      expect(res).toEqual(false)
+    })
+
+    test('should return true if defendant service requirement is NOT_APPLICABLE and defendant vervidictViewDate is not null', () => {
+      const verdictViewDate = '2024-07-09'
       const serviceRequirement = ServiceRequirement.NOT_APPLICABLE
 
       const res = isDefendantInfoActionButtonDisabled({
@@ -28,6 +41,19 @@ describe('Overview', () => {
       })
 
       expect(res).toEqual(true)
+    })
+
+    test('should return true if defendant service requirement is NOT_APPLICABLE and defendant vervidictViewDate is null', () => {
+      const verdictViewDate = null
+      const serviceRequirement = ServiceRequirement.NOT_APPLICABLE
+
+      const res = isDefendantInfoActionButtonDisabled({
+        id: 'id',
+        verdictViewDate,
+        serviceRequirement,
+      })
+
+      expect(res).toEqual(false)
     })
 
     test('should return true if defendant service requirement is NOT_REQUIRED', () => {

--- a/apps/judicial-system/web/src/routes/PublicProsecutor/Indictments/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/PublicProsecutor/Indictments/Overview/Overview.tsx
@@ -39,15 +39,10 @@ import { strings } from './Overview.strings'
 type VisibleModal = 'REVIEWER_ASSIGNED' | 'DEFENDANT_VIEWS_VERDICT'
 
 export const isDefendantInfoActionButtonDisabled = (defendant: Defendant) => {
-  switch (defendant.serviceRequirement) {
-    case ServiceRequirement.NOT_APPLICABLE:
-    case ServiceRequirement.NOT_REQUIRED:
-      return true
-    case ServiceRequirement.REQUIRED:
-      return defendant.verdictViewDate !== null
-    default:
-      return false
-  }
+  return (
+    defendant.serviceRequirement === ServiceRequirement.NOT_REQUIRED ||
+    Boolean(defendant.verdictViewDate)
+  )
 }
 
 export const Overview = () => {
@@ -89,7 +84,7 @@ export const Overview = () => {
     const updatedDefendant = {
       caseId: workingCase.id,
       defendantId: selectedDefendant.id,
-      verdictViewDate: formatDateForServer(new Date()),
+      verdictViewDate: formatDateForServer(new Date()), // TODO: Let the server override this date as we cannot trust the client date
     }
 
     setAndSendDefendantToServer(updatedDefendant, setWorkingCase)
@@ -143,20 +138,15 @@ export const Overview = () => {
         <CourtCaseInfo workingCase={workingCase} />
         <Box component="section" marginBottom={5}>
           <InfoCardClosedIndictment
-            defendantInfoActionButton={
-              isCompletedCase(workingCase.state) &&
-              workingCase.indictmentReviewer !== null
-                ? {
-                    text: fm(strings.displayVerdict),
-                    onClick: (defendant) => {
-                      setSelectedDefendant(defendant)
-                      setModalVisible('DEFENDANT_VIEWS_VERDICT')
-                    },
-                    icon: 'mailOpen',
-                    isDisabled: isDefendantInfoActionButtonDisabled,
-                  }
-                : undefined
-            }
+            defendantInfoActionButton={{
+              text: fm(strings.displayVerdict),
+              onClick: (defendant) => {
+                setSelectedDefendant(defendant)
+                setModalVisible('DEFENDANT_VIEWS_VERDICT')
+              },
+              icon: 'mailOpen',
+              isDisabled: isDefendantInfoActionButtonDisabled,
+            }}
             displayAppealExpirationInfo={true}
           />
         </Box>

--- a/apps/judicial-system/web/src/routes/PublicProsecutor/Tables/CasesReviewed.tsx
+++ b/apps/judicial-system/web/src/routes/PublicProsecutor/Tables/CasesReviewed.tsx
@@ -41,7 +41,7 @@ const CasesReviewed: FC<Props> = ({ loading, cases }) => {
   }
 
   const getVerdictViewTag = (row: CaseListEntry) => {
-    const today = new Date()
+    const today = new Date() // TODO: Let the server determine if the deadline has passed
     const deadline = new Date(row.indictmentVerdictAppealDeadline ?? '')
     const variant = !row.indictmentVerdictViewedByAll
       ? 'red'

--- a/apps/judicial-system/web/src/routes/Shared/AppealToCourtOfAppeals/AppealCaseFiles.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/AppealToCourtOfAppeals/AppealCaseFiles.tsx
@@ -84,7 +84,7 @@ const AppealFiles = () => {
 
   const handleNextButtonClick = useCallback(async () => {
     const allSucceeded = await handleUpload(
-      uploadFiles.filter((file) => !file.key),
+      uploadFiles.filter((file) => file.percent === 0),
       updateUploadFile,
     )
 
@@ -111,8 +111,8 @@ const AppealFiles = () => {
     }
   }
 
-  const handleChange = (files: File[], type: CaseFileCategory) => {
-    addUploadFiles(files, type, 'done')
+  const handleChange = (files: File[]) => {
+    addUploadFiles(files, appealCaseFilesType, 'done')
   }
 
   return (
@@ -181,10 +181,8 @@ const AppealFiles = () => {
               fileEndings: '.pdf',
             })}
             buttonLabel={formatMessage(core.uploadBoxButtonLabel)}
-            onChange={(files) => {
-              handleChange(files, appealCaseFilesType)
-            }}
-            onRemove={(file) => handleRemoveFile(file)}
+            onChange={handleChange}
+            onRemove={handleRemoveFile}
             hideIcons={!allFilesDoneOrError}
             disabled={!allFilesDoneOrError}
           />

--- a/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/SignedVerdictOverview.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/SignedVerdictOverview.tsx
@@ -388,6 +388,7 @@ export const SignedVerdictOverview: FC = () => {
           ),
         })
 
+        // TODO: Pass the real insitution into shareCaseWithAnotherInstitution, no nned for faking values here.
         setWorkingCase((prevWorkingCase) => ({
           ...prevWorkingCase,
           sharedWithProsecutorsOffice: {

--- a/apps/judicial-system/web/src/routes/Shared/Statement/Statement.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/Statement/Statement.tsx
@@ -86,7 +86,7 @@ const Statement = () => {
     const updated = await updateCase(
       workingCase.id,
       isDefenceUser(user)
-        ? { defendantStatementDate: new Date().toISOString() }
+        ? { defendantStatementDate: new Date().toISOString() } // TODO: Let the server override this date. It is already overriding prosecutorStatementDate.
         : { prosecutorStatementDate: new Date().toISOString() },
     )
 

--- a/apps/judicial-system/web/src/utils/stepHelper.ts
+++ b/apps/judicial-system/web/src/utils/stepHelper.ts
@@ -77,7 +77,7 @@ export const createCaseResentExplanation = (
   workingCase: Case,
   explanation?: string,
 ) => {
-  const now = new Date()
+  const now = new Date() // TODO: Find a way to set this message server side as we cannot trust the client date.
 
   return `${
     workingCase.caseResentExplanation

--- a/libs/judicial-system/types/src/index.ts
+++ b/libs/judicial-system/types/src/index.ts
@@ -1,6 +1,12 @@
 export { Feature } from './lib/feature'
 
-export { Gender, DefenderChoice, SubpoenaType } from './lib/defendant'
+export {
+  Gender,
+  DefenderChoice,
+  SubpoenaType,
+  DefendantPlea,
+  ServiceRequirement,
+} from './lib/defendant'
 export { InstitutionType } from './lib/institution'
 export { NotificationType } from './lib/notification'
 export type { Institution } from './lib/institution'
@@ -48,8 +54,6 @@ export {
   CaseAppealRulingDecision,
   CaseIndictmentRulingDecision,
   RequestSharedWithDefender,
-  DefendantPlea,
-  ServiceRequirement,
   SessionArrangements,
   indictmentCases,
   restrictionCases,
@@ -72,7 +76,6 @@ export {
   isRequestCaseState,
   isIndictmentCaseTransition,
   isRequestCaseTransition,
-  DistrictCourtLocation,
   CourtSessionType,
   courtSessionTypeNames,
 } from './lib/case'
@@ -82,7 +85,6 @@ export { getIndictmentVerdictAppealDeadline } from './lib/indictmentCase'
 export type {
   CrimeScene,
   CrimeSceneMap,
-  DistrictCourts,
   IndictmentSubtypeMap,
 } from './lib/case'
 

--- a/libs/judicial-system/types/src/lib/case.ts
+++ b/libs/judicial-system/types/src/lib/case.ts
@@ -262,18 +262,6 @@ export enum RequestSharedWithDefender {
   NOT_SHARED = 'NOT_SHARED',
 }
 
-export enum DefendantPlea {
-  GUILTY = 'GUILTY',
-  NOT_GUILTY = 'NOT_GUILTY',
-  NO_PLEA = 'NO_PLEA',
-}
-
-export enum ServiceRequirement {
-  REQUIRED = 'REQUIRED',
-  NOT_REQUIRED = 'NOT_REQUIRED',
-  NOT_APPLICABLE = 'NOT_APPLICABLE',
-}
-
 export enum CourtSessionType {
   MAIN_HEARING = 'MAIN_HEARING',
   OTHER = 'OTHER',
@@ -443,25 +431,4 @@ export const isRequestCaseTransition = (
   return Object.values(RequestCaseTransition).includes(
     transition as RequestCaseTransition,
   )
-}
-
-export type DistrictCourts =
-  | 'Héraðsdómur Reykjavíkur'
-  | 'Héraðsdómur Reykjaness'
-  | 'Héraðsdómur Vesturlands'
-  | 'Héraðsdómur Vestfjarða'
-  | 'Héraðsdómur Norðurlands vestra'
-  | 'Héraðsdómur Norðurlands eystra'
-  | 'Héraðsdómur Austurlands'
-  | 'Héraðsdómur Suðurlands'
-
-export const DistrictCourtLocation: Record<DistrictCourts, string> = {
-  'Héraðsdómur Reykjavíkur': 'Dómhúsið við Lækjartorg, Reykjavík',
-  'Héraðsdómur Reykjaness': 'Fjarðargata 9, Hafnarfirði',
-  'Héraðsdómur Vesturlands': 'Bjarnarbraut 8, Borgarnesi',
-  'Héraðsdómur Vestfjarða': 'Hafnarstræti 9, Ísafirði',
-  'Héraðsdómur Norðurlands vestra': 'Skagfirðingabraut 21, Sauðárkróki',
-  'Héraðsdómur Norðurlands eystra': 'Hafnarstræti 107, 4. hæð, Akureyri',
-  'Héraðsdómur Austurlands': 'Lyngás 15, Egilsstöðum',
-  'Héraðsdómur Suðurlands': 'Austurvegur 4, Selfossi',
 }

--- a/libs/judicial-system/types/src/lib/defendant.ts
+++ b/libs/judicial-system/types/src/lib/defendant.ts
@@ -15,3 +15,15 @@ export enum SubpoenaType {
   ABSENCE = 'ABSENCE',
   ARREST = 'ARREST',
 }
+
+export enum DefendantPlea {
+  GUILTY = 'GUILTY',
+  NOT_GUILTY = 'NOT_GUILTY',
+  NO_PLEA = 'NO_PLEA',
+}
+
+export enum ServiceRequirement {
+  REQUIRED = 'REQUIRED',
+  NOT_REQUIRED = 'NOT_REQUIRED',
+  NOT_APPLICABLE = 'NOT_APPLICABLE',
+}

--- a/libs/judicial-system/types/src/lib/indictmentCase.spec.ts
+++ b/libs/judicial-system/types/src/lib/indictmentCase.spec.ts
@@ -9,10 +9,10 @@ describe('getIndictmentVerdictAppealDeadline', () => {
   it('should return undefined if any dates are undefined', () => {
     const result1 = getIndictmentVerdictAppealDeadline([
       undefined,
-      '2024-06-10T00:00:00Z',
+      new Date('2024-06-10T00:00:00Z'),
     ])
     const result2 = getIndictmentVerdictAppealDeadline([
-      '2024-06-10T00:00:00Z',
+      new Date('2024-06-10T00:00:00Z'),
       undefined,
     ])
     expect(result1).toBeUndefined()
@@ -21,22 +21,20 @@ describe('getIndictmentVerdictAppealDeadline', () => {
 
   it('should return the correct deadline', () => {
     const dates = [
-      '2024-06-01T00:00:00Z',
-      '2024-06-01T00:00:00Z',
-      '2024-06-01T00:00:00Z',
+      new Date('2024-06-01T00:00:00Z'),
+      new Date('2024-06-01T00:00:00Z'),
+      new Date('2024-06-01T00:00:00Z'),
     ]
     const result = getIndictmentVerdictAppealDeadline(dates)
-    const expectedDeadline = new Date('2024-06-01T00:00:00Z')
-    expectedDeadline.setDate(expectedDeadline.getDate() + 28)
+    const expectedDeadline = new Date('2024-06-29T00:00:00Z')
 
     expect(result).toStrictEqual(expectedDeadline)
   })
 
   it('should handle a single valid date', () => {
-    const dates = ['2024-07-15T00:00:00Z']
+    const dates = [new Date('2024-07-15T00:00:00Z')]
     const result = getIndictmentVerdictAppealDeadline(dates)
-    const expectedDeadline = new Date('2024-07-15T00:00:00Z')
-    expectedDeadline.setDate(expectedDeadline.getDate() + 28)
+    const expectedDeadline = new Date('2024-08-12T00:00:00Z')
 
     expect(result).toStrictEqual(expectedDeadline)
   })

--- a/libs/judicial-system/types/src/lib/indictmentCase.ts
+++ b/libs/judicial-system/types/src/lib/indictmentCase.ts
@@ -1,26 +1,20 @@
+const MILLISECONDS_TO_EXPIRY = 28 * 24 * 60 * 60 * 1000
+
 export const getIndictmentVerdictAppealDeadline = (
-  verdictViewDates?: (string | undefined)[],
+  verdictViewDates?: (Date | undefined)[],
 ): Date | undefined => {
   if (
-    !verdictViewDates?.length ||
-    !verdictViewDates.every((date) => date != null)
+    !verdictViewDates ||
+    verdictViewDates.length === 0 ||
+    verdictViewDates.some((date) => !date)
   ) {
     return undefined
   }
 
-  const viewDates = verdictViewDates.map((date) => new Date(date as string))
-
-  if (viewDates.length === 0) {
-    return undefined
-  }
-
-  const newestViewDate = viewDates.reduce(
-    (newest, current) => (current > newest ? current : newest),
+  const newestViewDate = verdictViewDates.reduce(
+    (newest: Date, current) => (current && current > newest ? current : newest),
     new Date(0),
   )
 
-  const expiryDate = new Date(newestViewDate.getTime())
-  expiryDate.setDate(newestViewDate.getDate() + 28)
-
-  return expiryDate
+  return new Date(newestViewDate.getTime() + MILLISECONDS_TO_EXPIRY)
 }


### PR DESCRIPTION
# Verdict Appeal Deadline

[Ríksak - Dómfelldi var viðstaddur dómsuppkvaðningu, áfrýjunarfrestur á að koma fram](https://app.asana.com/0/1199153462262248/1207998287689929/f)
[Ríksak - "Dómur birtur" á að vera alltaf í boði hjá skrifstofu ríksak](Ríksak - "Dómur birtur" á að vera alltaf í boði hjá skrifstofu ríksak)

## What

- Fixes the display of verdict appeal deadline text on info card for verdicts (dómur) when the defendant was present during sentencing and when it showing the verdict to the defendant is not required.
- There is still some uncertainty about the verdict appeal deadline text for fines (viðurlagaákvörðun) and that will be addressed in a subsequent PR.
- Allwas shows a button for setting the defendant verdict view date to the public prosecutor's office staff. The button is disabled if the date has already been set or if showing the verdict to the defendant is not required. Previously, the button was not shown until a prosecutor had been assigned to review the verdict.
- This PR includes some refactoring and simplifications as well as some comments about suggested future improvements.

## Why

- Verified bugs.

## Screenshots / Gifs

<img width="653" alt="image" src="https://github.com/user-attachments/assets/1e90917b-de5b-4ec1-8e6f-d25364bd283c">

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
