### PR TITLE
fix(regulations-admin): Group gildistaka last

### DIFF
--- a/libs/portals/admin/regulations-admin/src/utils/formatAmendingRegulation.ts
+++ b/libs/portals/admin/regulations-admin/src/utils/formatAmendingRegulation.ts
@@ -16,6 +16,19 @@ const removeRegPrefix = (title: string) => {
   return title
 }
 
+const moveMatchingStringsToEnd = (arr: Array<string>) => {
+  const isGildisTaka = (str: string) => {
+    return /(öðlast|tekur).*gildi|sett.*með.*(?:heimild|stoð)/.test(
+      (str || '').toLowerCase(),
+    )
+  }
+
+  const matchingStrings = arr.filter((str) => isGildisTaka(str))
+  const nonMatchingStrings = arr.filter((str) => !isGildisTaka(str))
+
+  return [...nonMatchingStrings, ...matchingStrings]
+}
+
 const removeRegNamePrefix = (name: string) => {
   if (/^0+/.test(name)) {
     return name.replace(/^0+/, '')
@@ -325,7 +338,9 @@ export const formatAmendingBodyWithArticlePrefix = (
 
   const additions = flatten(impactAdditionArray)
 
-  const prependString = additions.map(
+  const returnArray = moveMatchingStringsToEnd(additions)
+
+  const prependString = returnArray.map(
     (item, i) =>
       `<h3 class="article__title">${i + 1}. gr.</h3>${item}` as HTMLText,
   )

--- a/libs/portals/admin/regulations-admin/src/utils/getDeletionOrAddition.ts
+++ b/libs/portals/admin/regulations-admin/src/utils/getDeletionOrAddition.ts
@@ -155,7 +155,7 @@ export const getDeletionOrAddition = (
 
       // Remove gr number if there is some more text within the title
       const modContent = modifiedTextContent ?? ''
-      const match = modContent.match(/^\d+\.\s*gr\.$/)
+      const match = modContent.match(/^\d+\.\s*gr\.\s*(<br\s*\/?>)?$/)
       if (match) {
         // If the string matches the pattern for "{num}. gr.", return it as is
         newText = modContent


### PR DESCRIPTION
## What

* Group gildistaka last in change regulation
* Minor bugfix of empty paragraphs with `<br />` should be treated as empty.

## Why

All effect paragraphs should be grouped and placed last in change regulation.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new utility function for rearranging strings based on specific criteria, enhancing string manipulation capabilities.
  
- **Bug Fixes**
  - Updated the pattern matching logic to allow for optional HTML line breaks in string processing, improving the flexibility of input recognition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->