### PR TITLE
feat(web): Profession rights list - Display national id field in table view

### DIFF
--- a/apps/web/components/connected/syslumenn/TableLists/ProfessionRights/ProfessionRights.tsx
+++ b/apps/web/components/connected/syslumenn/TableLists/ProfessionRights/ProfessionRights.tsx
@@ -33,7 +33,7 @@ import { GET_PROFESSION_RIGHTS_QUERY } from './queries'
 
 const DEFAULT_PAGE_SIZE = 20
 const DEFAULT_TABLE_MIN_HEIGHT = '800px'
-const SEARCH_KEYS: (keyof ProfessionRight)[] = ['name']
+const SEARCH_KEYS: (keyof ProfessionRight)[] = ['name', 'nationalId']
 
 interface ProfessionRightsProps {
   slice: ConnectedComponent
@@ -110,12 +110,14 @@ const ProfessionRights = ({ slice }: ProfessionRightsProps) => {
         const headerRow = [
           n('csvHeaderName', 'Nafn') as string,
           n('csvHeaderProfession', 'Starf') as string,
+          n('csvHeaderNationalId', 'Kennitala'),
         ]
         const dataRows = []
         for (const item of list) {
           dataRows.push([
             item.name ?? '', // Nafn
             item.profession ?? '', // Starf
+            item.nationalId ?? '',
           ])
         }
         return resolve(prepareCsvString(headerRow, dataRows))
@@ -259,6 +261,9 @@ const ProfessionRights = ({ slice }: ProfessionRightsProps) => {
                 <T.Row>
                   <T.HeadData>{n('name', 'Nafn')}</T.HeadData>
                   <T.HeadData>{n('profession', 'Starf')}</T.HeadData>
+                  <T.HeadData align="right">
+                    {n('nationalId', 'Kennitala')}
+                  </T.HeadData>
                 </T.Row>
               </T.Head>
               <T.Body>
@@ -276,6 +281,13 @@ const ProfessionRights = ({ slice }: ProfessionRightsProps) => {
                         <T.Data>
                           <Box>
                             <Text variant="small">{item.profession}</Text>
+                          </Box>
+                        </T.Data>
+                        <T.Data>
+                          <Box>
+                            <Text variant="small" textAlign="right">
+                              {item.nationalId}
+                            </Text>
                           </Box>
                         </T.Data>
                       </T.Row>

--- a/apps/web/components/connected/syslumenn/TableLists/ProfessionRights/ProfessionRights.tsx
+++ b/apps/web/components/connected/syslumenn/TableLists/ProfessionRights/ProfessionRights.tsx
@@ -17,11 +17,7 @@ import {
 } from '@island.is/island-ui/core'
 import { sortAlpha } from '@island.is/shared/utils'
 import { SyslumennListCsvExport } from '@island.is/web/components'
-import type {
-  ConnectedComponent,
-  ProfessionRight,
-  Query,
-} from '@island.is/web/graphql/schema'
+import type { ConnectedComponent, Query } from '@island.is/web/graphql/schema'
 import { useNamespace } from '@island.is/web/hooks'
 
 import {
@@ -33,7 +29,7 @@ import { GET_PROFESSION_RIGHTS_QUERY } from './queries'
 
 const DEFAULT_PAGE_SIZE = 20
 const DEFAULT_TABLE_MIN_HEIGHT = '800px'
-const SEARCH_KEYS: (keyof ProfessionRight)[] = ['name', 'nationalId']
+const SEARCH_KEYS = ['name', 'nationalId']
 
 interface ProfessionRightsProps {
   slice: ConnectedComponent
@@ -140,7 +136,8 @@ const ProfessionRights = ({ slice }: ProfessionRightsProps) => {
         : item.profession === filterProfession?.value,
     ),
     searchTerms,
-    SEARCH_KEYS,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    SEARCH_KEYS as any,
   )
 
   const pageSize = slice?.configJson?.pageSize ?? DEFAULT_PAGE_SIZE

--- a/apps/web/components/connected/syslumenn/TableLists/ProfessionRights/queries.ts
+++ b/apps/web/components/connected/syslumenn/TableLists/ProfessionRights/queries.ts
@@ -6,6 +6,7 @@ export const GET_PROFESSION_RIGHTS_QUERY = gql`
       list {
         name
         profession
+        nationalId
       }
     }
   }

--- a/libs/api/domains/syslumenn/src/lib/models/professionRights.ts
+++ b/libs/api/domains/syslumenn/src/lib/models/professionRights.ts
@@ -8,6 +8,9 @@ class ProfessionRight {
 
   @Field({ nullable: true })
   profession?: string
+
+  @Field({ nullable: true })
+  nationalId?: string
 }
 
 @ObjectType()

--- a/libs/clients/syslumenn/src/lib/syslumennClient.types.ts
+++ b/libs/clients/syslumenn/src/lib/syslumennClient.types.ts
@@ -404,6 +404,7 @@ export interface JourneymanLicence {
 export interface ProfessionRight {
   name?: string
   profession?: string
+  nationalId?: string
 }
 
 export interface VehicleRegistration {

--- a/libs/clients/syslumenn/src/lib/syslumennClient.utils.ts
+++ b/libs/clients/syslumenn/src/lib/syslumennClient.utils.ts
@@ -567,6 +567,7 @@ export const mapProfessionRight = (
   return {
     name: professionRight.nafn,
     profession: professionRight.starfsrettindi,
+    nationalId: professionRight.kennitala,
   }
 }
 


### PR DESCRIPTION
# Profession rights list - Display national id field in table view

## What

* OpenAPI schema now lists a national id field for profession rights response
* This PR maps that field and displays it in the frontend

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
