### PR TITLE
fix(j-s): Disable ServiceRequirement rather then hiding it when sent to public prosecutor

### DIFF
--- a/apps/judicial-system/web/src/routes/Court/Indictments/Completed/Completed.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/Completed/Completed.tsx
@@ -147,139 +147,139 @@ const Completed: FC = () => {
         <Box marginBottom={5} component="section">
           <IndictmentCaseFilesList workingCase={workingCase} />
         </Box>
-        {!sentToPublicProsecutor && (
-          <>
-            {isRulingOrFine && (
-              <Box marginBottom={5} component="section">
-                <SectionHeading
-                  title={formatMessage(strings.criminalRecordUpdateTitle)}
-                />
-                <InputFileUpload
-                  fileList={uploadFiles.filter(
-                    (file) =>
-                      file.category === CaseFileCategory.CRIMINAL_RECORD_UPDATE,
-                  )}
-                  accept="application/pdf"
-                  header={formatMessage(core.uploadBoxTitle)}
-                  buttonLabel={formatMessage(core.uploadBoxButtonLabel)}
-                  description={formatMessage(core.uploadBoxDescription, {
-                    fileEndings: '.pdf',
-                  })}
-                  onChange={(files) =>
-                    handleCriminalRecordUpdateUpload(
-                      files,
-                      CaseFileCategory.CRIMINAL_RECORD_UPDATE,
-                    )
-                  }
-                  onRemove={(file) => handleRemoveFile(file)}
-                />
-              </Box>
-            )}
-            {workingCase.indictmentRulingDecision ===
-              CaseIndictmentRulingDecision.RULING && (
-              <Box marginBottom={10}>
-                <SectionHeading
-                  title={formatMessage(strings.serviceRequirementTitle)}
-                />
-                {workingCase.defendants?.map((defendant, index) => (
-                  <Box
-                    key={defendant.id}
-                    component="section"
-                    marginBottom={
-                      workingCase.defendants &&
-                      workingCase.defendants.length - 1 === index
-                        ? 10
-                        : 3
-                    }
-                  >
-                    <BlueBox>
-                      <SectionHeading
-                        title={defendant.name || ''}
-                        marginBottom={2}
-                        heading="h4"
-                        required
-                      />
-                      <Box marginBottom={2}>
-                        <RadioButton
-                          id={`defendant-${defendant.id}-service-requirement-not-applicable`}
-                          name={`defendant-${defendant.id}-service-requirement`}
-                          checked={
-                            defendant.serviceRequirement ===
-                            ServiceRequirement.NOT_APPLICABLE
-                          }
-                          onChange={() => {
-                            setAndSendDefendantToServer(
-                              {
-                                defendantId: defendant.id,
-                                caseId: workingCase.id,
-                                serviceRequirement:
-                                  ServiceRequirement.NOT_APPLICABLE,
-                              },
-                              setWorkingCase,
-                            )
-                          }}
-                          large
-                          backgroundColor="white"
-                          label={formatMessage(
-                            strings.serviceRequirementNotApplicable,
-                          )}
-                        />
-                      </Box>
-                      <Box marginBottom={2}>
-                        <RadioButton
-                          id={`defendant-${defendant.id}-service-requirement-required`}
-                          name={`defendant-${defendant.id}-service-requirement`}
-                          checked={
-                            defendant.serviceRequirement ===
-                            ServiceRequirement.REQUIRED
-                          }
-                          onChange={() => {
-                            setAndSendDefendantToServer(
-                              {
-                                defendantId: defendant.id,
-                                caseId: workingCase.id,
-                                serviceRequirement: ServiceRequirement.REQUIRED,
-                              },
-                              setWorkingCase,
-                            )
-                          }}
-                          large
-                          backgroundColor="white"
-                          label={formatMessage(
-                            strings.serviceRequirementRequired,
-                          )}
-                        />
-                      </Box>
-                      <RadioButton
-                        id={`defendant-${defendant.id}-service-requirement-not-required`}
-                        name={`defendant-${defendant.id}-service-requirement`}
-                        checked={
-                          defendant.serviceRequirement ===
-                          ServiceRequirement.NOT_REQUIRED
-                        }
-                        onChange={() => {
-                          setAndSendDefendantToServer(
-                            {
-                              defendantId: defendant.id,
-                              caseId: workingCase.id,
-                              serviceRequirement:
-                                ServiceRequirement.NOT_REQUIRED,
-                            },
-                            setWorkingCase,
-                          )
-                        }}
-                        large
-                        backgroundColor="white"
-                        label={formatMessage(
-                          strings.serviceRequirementNotRequired,
-                        )}
-                      />
-                    </BlueBox>
+        {!sentToPublicProsecutor && isRulingOrFine && (
+          <Box marginBottom={5} component="section">
+            <SectionHeading
+              title={formatMessage(strings.criminalRecordUpdateTitle)}
+            />
+            <InputFileUpload
+              fileList={uploadFiles.filter(
+                (file) =>
+                  file.category === CaseFileCategory.CRIMINAL_RECORD_UPDATE,
+              )}
+              accept="application/pdf"
+              header={formatMessage(core.uploadBoxTitle)}
+              buttonLabel={formatMessage(core.uploadBoxButtonLabel)}
+              description={formatMessage(core.uploadBoxDescription, {
+                fileEndings: '.pdf',
+              })}
+              onChange={(files) =>
+                handleCriminalRecordUpdateUpload(
+                  files,
+                  CaseFileCategory.CRIMINAL_RECORD_UPDATE,
+                )
+              }
+              onRemove={(file) => handleRemoveFile(file)}
+            />
+          </Box>
+        )}
+        {workingCase.indictmentRulingDecision ===
+          CaseIndictmentRulingDecision.RULING && (
+          <Box marginBottom={10}>
+            <SectionHeading
+              title={formatMessage(strings.serviceRequirementTitle)}
+            />
+            {workingCase.defendants?.map((defendant, index) => (
+              <Box
+                key={defendant.id}
+                component="section"
+                marginBottom={
+                  workingCase.defendants &&
+                  workingCase.defendants.length - 1 === index
+                    ? 10
+                    : 3
+                }
+              >
+                <BlueBox>
+                  <SectionHeading
+                    title={defendant.name || ''}
+                    marginBottom={2}
+                    heading="h4"
+                    required
+                  />
+                  <Box marginBottom={2}>
+                    <RadioButton
+                      id={`defendant-${defendant.id}-service-requirement-not-applicable`}
+                      name={`defendant-${defendant.id}-service-requirement`}
+                      checked={
+                        defendant.serviceRequirement ===
+                        ServiceRequirement.NOT_APPLICABLE
+                      }
+                      disabled={
+                        !!defendant.serviceRequirement && sentToPublicProsecutor
+                      }
+                      onChange={() => {
+                        setAndSendDefendantToServer(
+                          {
+                            defendantId: defendant.id,
+                            caseId: workingCase.id,
+                            serviceRequirement:
+                              ServiceRequirement.NOT_APPLICABLE,
+                          },
+                          setWorkingCase,
+                        )
+                      }}
+                      large
+                      backgroundColor="white"
+                      label={formatMessage(
+                        strings.serviceRequirementNotApplicable,
+                      )}
+                    />
                   </Box>
-                ))}
+                  <Box marginBottom={2}>
+                    <RadioButton
+                      id={`defendant-${defendant.id}-service-requirement-required`}
+                      name={`defendant-${defendant.id}-service-requirement`}
+                      checked={
+                        defendant.serviceRequirement ===
+                        ServiceRequirement.REQUIRED
+                      }
+                      disabled={
+                        !!defendant.serviceRequirement && sentToPublicProsecutor
+                      }
+                      onChange={() => {
+                        setAndSendDefendantToServer(
+                          {
+                            defendantId: defendant.id,
+                            caseId: workingCase.id,
+                            serviceRequirement: ServiceRequirement.REQUIRED,
+                          },
+                          setWorkingCase,
+                        )
+                      }}
+                      large
+                      backgroundColor="white"
+                      label={formatMessage(strings.serviceRequirementRequired)}
+                    />
+                  </Box>
+                  <RadioButton
+                    id={`defendant-${defendant.id}-service-requirement-not-required`}
+                    name={`defendant-${defendant.id}-service-requirement`}
+                    checked={
+                      defendant.serviceRequirement ===
+                      ServiceRequirement.NOT_REQUIRED
+                    }
+                    disabled={
+                      !!defendant.serviceRequirement && sentToPublicProsecutor
+                    }
+                    onChange={() => {
+                      setAndSendDefendantToServer(
+                        {
+                          defendantId: defendant.id,
+                          caseId: workingCase.id,
+                          serviceRequirement: ServiceRequirement.NOT_REQUIRED,
+                        },
+                        setWorkingCase,
+                      )
+                    }}
+                    large
+                    backgroundColor="white"
+                    label={formatMessage(strings.serviceRequirementNotRequired)}
+                  />
+                </BlueBox>
               </Box>
-            )}
-          </>
+            ))}
+          </Box>
         )}
       </FormContentContainer>
       <FormContentContainer isFooter>


### PR DESCRIPTION
# Disable ServiceRequirement rather then hiding it when sent to public prosecutor

[Asana](https://app.asana.com/0/1199153462262248/1208084487748778/f)

## What

Today, when a case is sent to public prosecutor, we hide the ServiceRequirement section from court users. We should rather disable the section so that court users can see what ServiceRequirement was selected.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved UI logic for handling defendants, enhancing clarity and user experience.
	- Added a disabled state to radio buttons based on the public prosecutor status, preventing modifications to service requirements after submission.
  
- **Bug Fixes**
	- Consolidated conditional checks for rendering components related to defendants for more efficient UI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->