### PR TITLE
chore(j-s): Stop importing React

### DIFF
--- a/apps/judicial-system/web/src/components/AccordionItems/CaseFilesAccordionItem/CaseFilesAccordionItem.tsx
+++ b/apps/judicial-system/web/src/components/AccordionItems/CaseFilesAccordionItem/CaseFilesAccordionItem.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, FC, SetStateAction } from 'react'
+{ Dispatch, FC, SetStateAction } from 'react'
 import { useIntl } from 'react-intl'
 import { AnimatePresence } from 'framer-motion'
 

--- a/apps/judicial-system/web/src/components/AccordionItems/CommentsAccordionItem/CommentsAccordionItem.tsx
+++ b/apps/judicial-system/web/src/components/AccordionItems/CommentsAccordionItem/CommentsAccordionItem.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import { useIntl } from 'react-intl'
 
 import { AccordionItem, Box, Text } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/AccordionItems/ConnectedCaseFilesAccordionItem/ConnectedCaseFilesAccordionItem.tsx
+++ b/apps/judicial-system/web/src/components/AccordionItems/ConnectedCaseFilesAccordionItem/ConnectedCaseFilesAccordionItem.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import { useIntl } from 'react-intl'
 
 import { AccordionItem } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/AccordionItems/CourtRecordAccordionItem/CourtRecordAccordionItem.tsx
+++ b/apps/judicial-system/web/src/components/AccordionItems/CourtRecordAccordionItem/CourtRecordAccordionItem.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import { useIntl } from 'react-intl'
 import isSameDay from 'date-fns/isSameDay'
 

--- a/apps/judicial-system/web/src/components/AccordionItems/IndictmentsCaseFilesAccordionItem/IndictmentsCaseFilesAccordionItem.tsx
+++ b/apps/judicial-system/web/src/components/AccordionItems/IndictmentsCaseFilesAccordionItem/IndictmentsCaseFilesAccordionItem.tsx
@@ -1,4 +1,4 @@
-import React, { FC, PointerEvent, useEffect, useMemo, useState } from 'react'
+{ FC, PointerEvent, useEffect, useMemo, useState } from 'react'
 import InputMask from 'react-input-mask'
 import { useIntl } from 'react-intl'
 import { useMeasure } from 'react-use'

--- a/apps/judicial-system/web/src/components/AccordionItems/IndictmentsLawsBrokenAccordionItem/IndictmentsLawsBrokenAccordionItem.tsx
+++ b/apps/judicial-system/web/src/components/AccordionItems/IndictmentsLawsBrokenAccordionItem/IndictmentsLawsBrokenAccordionItem.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Accordion, AccordionItem, Text } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/AccordionItems/PoliceRequestAccordionItem/PoliceRequestAccordionItem.tsx
+++ b/apps/judicial-system/web/src/components/AccordionItems/PoliceRequestAccordionItem/PoliceRequestAccordionItem.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import { useIntl } from 'react-intl'
 
 import { AccordionItem, Box, Text } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/AccordionItems/RulingAccordionItem/RulingAccordionItem.tsx
+++ b/apps/judicial-system/web/src/components/AccordionItems/RulingAccordionItem/RulingAccordionItem.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import { useIntl } from 'react-intl'
 
 import { AccordionItem, Box, Text } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/AccordionListItem/AccordionListItem.tsx
+++ b/apps/judicial-system/web/src/components/AccordionListItem/AccordionListItem.tsx
@@ -1,4 +1,4 @@
-import React, { FC, PropsWithChildren } from 'react'
+import { FC, PropsWithChildren } from 'react'
 
 import { Box, Text } from '@island.is/island-ui/core'
 

--- a/apps/judicial-system/web/src/components/AppealCaseFilesOverview/AppealCaseFilesOverview.tsx
+++ b/apps/judicial-system/web/src/components/AppealCaseFilesOverview/AppealCaseFilesOverview.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react'
+{ useContext, useEffect, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { AnimatePresence } from 'framer-motion'
 import router from 'next/router'

--- a/apps/judicial-system/web/src/components/BigTextSmallText/BigTextSmallText.tsx
+++ b/apps/judicial-system/web/src/components/BigTextSmallText/BigTextSmallText.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 
 import { Box, Text } from '@island.is/island-ui/core'
 

--- a/apps/judicial-system/web/src/components/BlueBox/BlueBox.tsx
+++ b/apps/judicial-system/web/src/components/BlueBox/BlueBox.tsx
@@ -1,4 +1,4 @@
-import React, { FC, PropsWithChildren } from 'react'
+{ FC, PropsWithChildren } from 'react'
 import cn from 'classnames'
 
 import { TestSupport } from '@island.is/island-ui/utils'

--- a/apps/judicial-system/web/src/components/BlueBoxWithIcon/CaseScheduledCard.tsx
+++ b/apps/judicial-system/web/src/components/BlueBoxWithIcon/CaseScheduledCard.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Text } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/BlueBoxWithIcon/IndictmentCaseScheduledCard.tsx
+++ b/apps/judicial-system/web/src/components/BlueBoxWithIcon/IndictmentCaseScheduledCard.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Text } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/CaseDates/CaseDates.tsx
+++ b/apps/judicial-system/web/src/components/CaseDates/CaseDates.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Box, Button, IconMapIcon, Text } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/CaseFile/CaseFile.tsx
+++ b/apps/judicial-system/web/src/components/CaseFile/CaseFile.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import cn from 'classnames'
 
 import { IconMapIcon } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/CaseFileList/CaseFileList.tsx
+++ b/apps/judicial-system/web/src/components/CaseFileList/CaseFileList.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import { useIntl } from 'react-intl'
 import { AnimatePresence } from 'framer-motion'
 

--- a/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.tsx
+++ b/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import { FC } from 'react'
 import { IntlShape, useIntl } from 'react-intl'
 import flatMap from 'lodash/flatMap'
 

--- a/apps/judicial-system/web/src/components/CaseResentExplanation/CaseResentExplanation.tsx
+++ b/apps/judicial-system/web/src/components/CaseResentExplanation/CaseResentExplanation.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import { useIntl } from 'react-intl'
 
 import { AlertMessage } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/CaseResubmitModal/CaseResubmitModal.tsx
+++ b/apps/judicial-system/web/src/components/CaseResubmitModal/CaseResubmitModal.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react'
+import { FC, useState } from 'react'
 import { IntlShape, useIntl } from 'react-intl'
 
 import { Box, Input } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/CaseTitleInfoAndTags/CaseTitleInfoAndTags.tsx
+++ b/apps/judicial-system/web/src/components/CaseTitleInfoAndTags/CaseTitleInfoAndTags.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext } from 'react'
+import { FC, useContext } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Box, Text } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/CheckboxList/CheckboxList.tsx
+++ b/apps/judicial-system/web/src/components/CheckboxList/CheckboxList.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import { MessageDescriptor, useIntl } from 'react-intl'
 
 import {

--- a/apps/judicial-system/web/src/components/CommentsInput/CommentsInput.tsx
+++ b/apps/judicial-system/web/src/components/CommentsInput/CommentsInput.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, FC, SetStateAction } from 'react'
+{ Dispatch, FC, SetStateAction } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Box, Input, Text, Tooltip } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/Conclusion/Conclusion.tsx
+++ b/apps/judicial-system/web/src/components/Conclusion/Conclusion.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import { FC } from 'react'
 
 import { Box, Text } from '@island.is/island-ui/core'
 

--- a/apps/judicial-system/web/src/components/ConclusionDraft/ConclusionDraft.tsx
+++ b/apps/judicial-system/web/src/components/ConclusionDraft/ConclusionDraft.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Box, Text } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/ContextMenu/ContextMenu.tsx
+++ b/apps/judicial-system/web/src/components/ContextMenu/ContextMenu.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, ReactElement } from 'react'
+{ forwardRef, ReactElement } from 'react'
 import { useIntl } from 'react-intl'
 import cn from 'classnames'
 import { Menu, MenuButton, MenuItem, useMenuState } from 'reakit/Menu'

--- a/apps/judicial-system/web/src/components/ContextMenu/ContextMenuOptions/WithdrawAppealMenuOption.tsx
+++ b/apps/judicial-system/web/src/components/ContextMenu/ContextMenuOptions/WithdrawAppealMenuOption.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useContext, useState } from 'react'
+{ FC, useCallback, useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
 
 import { IconMapIcon } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/CourtArrangements/CourtArrangements.tsx
+++ b/apps/judicial-system/web/src/components/CourtArrangements/CourtArrangements.tsx
@@ -1,4 +1,4 @@
-import React, { FC, SetStateAction, useEffect, useState } from 'react'
+import { FC, SetStateAction, useEffect, useState } from 'react'
 import { useIntl } from 'react-intl'
 import compareAsc from 'date-fns/compareAsc'
 

--- a/apps/judicial-system/web/src/components/CourtDocuments/CourtDocuments.tsx
+++ b/apps/judicial-system/web/src/components/CourtDocuments/CourtDocuments.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, FC, useState } from 'react'
+{ Dispatch, FC, useState } from 'react'
 import { useIntl } from 'react-intl'
 import Select, {
   ClearIndicatorProps,

--- a/apps/judicial-system/web/src/components/DateTime/DateTime.tsx
+++ b/apps/judicial-system/web/src/components/DateTime/DateTime.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState } from 'react'
+{ FC, useEffect, useState } from 'react'
 import { useIntl } from 'react-intl'
 
 import { DatePicker, Input } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/Decision/Decision.tsx
+++ b/apps/judicial-system/web/src/components/Decision/Decision.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react'
+import { FC, useState } from 'react'
 
 import { Box, RadioButton } from '@island.is/island-ui/core'
 import {

--- a/apps/judicial-system/web/src/components/DefenderInfo/DefenderInfo.tsx
+++ b/apps/judicial-system/web/src/components/DefenderInfo/DefenderInfo.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext, useState } from 'react'
+{ FC, useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Box, RadioButton, Text, Tooltip } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/DefenderInfo/DefenderInput.tsx
+++ b/apps/judicial-system/web/src/components/DefenderInfo/DefenderInput.tsx
@@ -1,4 +1,4 @@
-import React, {
+{
   FC,
   SetStateAction,
   useCallback,

--- a/apps/judicial-system/web/src/components/FeatureProvider/FeatureProvider.tsx
+++ b/apps/judicial-system/web/src/components/FeatureProvider/FeatureProvider.tsx
@@ -1,4 +1,4 @@
-import React, {
+{
   createContext,
   FC,
   PropsWithChildren,

--- a/apps/judicial-system/web/src/components/FileNotFoundModal/FileNotFoundModal.tsx
+++ b/apps/judicial-system/web/src/components/FileNotFoundModal/FileNotFoundModal.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import { FC } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Modal } from '@island.is/judicial-system-web/src/components'

--- a/apps/judicial-system/web/src/components/FormContentContainer/FormContentContainer.tsx
+++ b/apps/judicial-system/web/src/components/FormContentContainer/FormContentContainer.tsx
@@ -1,4 +1,4 @@
-import React, { FC, PropsWithChildren } from 'react'
+import { FC, PropsWithChildren } from 'react'
 
 import { Box } from '@island.is/island-ui/core'
 

--- a/apps/judicial-system/web/src/components/FormFooter/FormFooter.tsx
+++ b/apps/judicial-system/web/src/components/FormFooter/FormFooter.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import { FC } from 'react'
 import { useIntl } from 'react-intl'
 import { useWindowSize } from 'react-use'
 import cn from 'classnames'

--- a/apps/judicial-system/web/src/components/FormProvider/FormProvider.tsx
+++ b/apps/judicial-system/web/src/components/FormProvider/FormProvider.tsx
@@ -1,4 +1,4 @@
-import React, {
+{
   createContext,
   ReactNode,
   useCallback,

--- a/apps/judicial-system/web/src/components/Header/Header.tsx
+++ b/apps/judicial-system/web/src/components/Header/Header.tsx
@@ -1,10 +1,4 @@
-import React, {
-  FC,
-  PropsWithChildren,
-  useContext,
-  useEffect,
-  useState,
-} from 'react'
+import { FC, PropsWithChildren, useContext, useEffect, useState } from 'react'
 import { useIntl } from 'react-intl'
 import getConfig from 'next/config'
 import Link from 'next/link'

--- a/apps/judicial-system/web/src/components/HideableText/HideableText.tsx
+++ b/apps/judicial-system/web/src/components/HideableText/HideableText.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 
 import { Icon, Text, Tooltip } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/IconAndText/IconAndText.tsx
+++ b/apps/judicial-system/web/src/components/IconAndText/IconAndText.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import { FC } from 'react'
 
 import { Box, Icon, IconMapIcon, Text } from '@island.is/island-ui/core'
 import { Colors } from '@island.is/island-ui/theme'

--- a/apps/judicial-system/web/src/components/IconButton/IconButton.tsx
+++ b/apps/judicial-system/web/src/components/IconButton/IconButton.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react'
+import { forwardRef } from 'react'
 import cn from 'classnames'
 import { Button } from 'reakit'
 

--- a/apps/judicial-system/web/src/components/IndictmentCaseFilesList/IndictmentCaseFilesList.tsx
+++ b/apps/judicial-system/web/src/components/IndictmentCaseFilesList/IndictmentCaseFilesList.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext } from 'react'
+import { FC, useContext } from 'react'
 import { useIntl } from 'react-intl'
 import { AnimatePresence } from 'framer-motion'
 

--- a/apps/judicial-system/web/src/components/IndictmentInfo/IndictmentInfo.tsx
+++ b/apps/judicial-system/web/src/components/IndictmentInfo/IndictmentInfo.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import { FC } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Box, Text } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/InfoBox/InfoBox.tsx
+++ b/apps/judicial-system/web/src/components/InfoBox/InfoBox.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import cn from 'classnames'
 
 import { Box, Icon, Text } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/InfoCard/InfoCardActiveIndictment.tsx
+++ b/apps/judicial-system/web/src/components/InfoCard/InfoCardActiveIndictment.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+{ useContext } from 'react'
 
 import { FormContext } from '../FormProvider/FormProvider'
 import InfoCard from './InfoCard'

--- a/apps/judicial-system/web/src/components/Logo/Logo.tsx
+++ b/apps/judicial-system/web/src/components/Logo/Logo.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext } from 'react'
+{ FC, useContext } from 'react'
 
 import { Box } from '@island.is/island-ui/core'
 import { InstitutionType } from '@island.is/judicial-system-web/src/graphql/schema'

--- a/apps/judicial-system/web/src/components/MarkdownWrapper/MarkdownWrapper.tsx
+++ b/apps/judicial-system/web/src/components/MarkdownWrapper/MarkdownWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import { ReactNode } from 'react'
 import Markdown from 'markdown-to-jsx'
 
 import {

--- a/apps/judicial-system/web/src/components/Modal/Modal.tsx
+++ b/apps/judicial-system/web/src/components/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { FC, PropsWithChildren, ReactNode } from 'react'
+import { FC, PropsWithChildren, ReactNode } from 'react'
 import ReactDOM from 'react-dom'
 import FocusLock from 'react-focus-lock'
 import { motion } from 'framer-motion'

--- a/apps/judicial-system/web/src/components/MultipleValueList/MultipleValueList.tsx
+++ b/apps/judicial-system/web/src/components/MultipleValueList/MultipleValueList.tsx
@@ -1,4 +1,4 @@
-import React, { FC, PropsWithChildren, useRef, useState } from 'react'
+{ FC, PropsWithChildren, useRef, useState } from 'react'
 import InputMask from 'react-input-mask'
 
 import { Button, Input } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/OverviewHeader/OverviewHeader.tsx
+++ b/apps/judicial-system/web/src/components/OverviewHeader/OverviewHeader.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext } from 'react'
+{ FC, useContext } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Box, Text } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/PageHeader/PageHeader.tsx
+++ b/apps/judicial-system/web/src/components/PageHeader/PageHeader.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import Head from 'next/head'
 
 interface Props {

--- a/apps/judicial-system/web/src/components/PageLayout/PageLayout.tsx
+++ b/apps/judicial-system/web/src/components/PageLayout/PageLayout.tsx
@@ -1,4 +1,4 @@
-import React, { FC, PropsWithChildren, ReactNode, useContext } from 'react'
+import { FC, PropsWithChildren, ReactNode, useContext } from 'react'
 import { useIntl } from 'react-intl'
 import cn from 'classnames'
 

--- a/apps/judicial-system/web/src/components/PageLayout/utils/index.spec.tsx
+++ b/apps/judicial-system/web/src/components/PageLayout/utils/index.spec.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import { FC } from 'react'
 import { IntlFormatters, useIntl } from 'react-intl'
 import { MockedProvider } from '@apollo/client/testing'
 import { render, screen } from '@testing-library/react'

--- a/apps/judicial-system/web/src/components/PageTitle/PageTitle.tsx
+++ b/apps/judicial-system/web/src/components/PageTitle/PageTitle.tsx
@@ -1,4 +1,4 @@
-import React, { FC, PropsWithChildren } from 'react'
+{ FC, PropsWithChildren } from 'react'
 
 import { Box, Text } from '@island.is/island-ui/core'
 

--- a/apps/judicial-system/web/src/components/ParentCaseFiles/ParentCaseFiles.tsx
+++ b/apps/judicial-system/web/src/components/ParentCaseFiles/ParentCaseFiles.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import { useIntl } from 'react-intl'
 
 import {

--- a/apps/judicial-system/web/src/components/PdfButton/PdfButton.tsx
+++ b/apps/judicial-system/web/src/components/PdfButton/PdfButton.tsx
@@ -1,4 +1,4 @@
-import React, { FC, PropsWithChildren, useContext } from 'react'
+{ FC, PropsWithChildren, useContext } from 'react'
 
 import { Box, Button, Text } from '@island.is/island-ui/core'
 import { api } from '@island.is/judicial-system-web/src/services'

--- a/apps/judicial-system/web/src/components/ProsecutorSelection/ProsecutorSelection.tsx
+++ b/apps/judicial-system/web/src/components/ProsecutorSelection/ProsecutorSelection.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext, useMemo } from 'react'
+{ FC, useContext, useMemo } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Option, Select } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/RequestAppealRulingNotToBePublishedCheckbox/RequestAppealRulingNotToBePublishedCheckbox.tsx
+++ b/apps/judicial-system/web/src/components/RequestAppealRulingNotToBePublishedCheckbox/RequestAppealRulingNotToBePublishedCheckbox.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext } from 'react'
+import { FC, useContext } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Checkbox } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/RestrictionLength/RestrictionLength.tsx
+++ b/apps/judicial-system/web/src/components/RestrictionLength/RestrictionLength.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext } from 'react'
+{ FC, useContext } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Box, Checkbox, Text } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/RestrictionTags/RestrictionTags.tsx
+++ b/apps/judicial-system/web/src/components/RestrictionTags/RestrictionTags.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 
 import { Box, Tag } from '@island.is/island-ui/core'
 import { getShortRestrictionByValue } from '@island.is/judicial-system/formatters'

--- a/apps/judicial-system/web/src/components/RulingDateLabel/RulingDateLabel.tsx
+++ b/apps/judicial-system/web/src/components/RulingDateLabel/RulingDateLabel.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Text } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/RulingInput/RulingInput.tsx
+++ b/apps/judicial-system/web/src/components/RulingInput/RulingInput.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Input } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/SectionHeading/SectionHeading.tsx
+++ b/apps/judicial-system/web/src/components/SectionHeading/SectionHeading.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import { FC } from 'react'
 
 import { Box, ResponsiveProp, Space, Text } from '@island.is/island-ui/core'
 

--- a/apps/judicial-system/web/src/components/SelectableList/SelectableList.tsx
+++ b/apps/judicial-system/web/src/components/SelectableList/SelectableList.tsx
@@ -1,4 +1,4 @@
-import React, { FC, PropsWithChildren, useEffect, useState } from 'react'
+{ FC, PropsWithChildren, useEffect, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { AnimatePresence, motion } from 'framer-motion'
 

--- a/apps/judicial-system/web/src/components/ServiceInterruptionBanner/ServiceInterruptionBanner.tsx
+++ b/apps/judicial-system/web/src/components/ServiceInterruptionBanner/ServiceInterruptionBanner.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+{ useContext } from 'react'
 import { useIntl } from 'react-intl'
 
 import { AlertBanner } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/SharedPageLayout/SharedPageLayout.tsx
+++ b/apps/judicial-system/web/src/components/SharedPageLayout/SharedPageLayout.tsx
@@ -1,4 +1,4 @@
-import React, { FC, PropsWithChildren } from 'react'
+{ FC, PropsWithChildren } from 'react'
 
 import { Box } from '@island.is/island-ui/core'
 

--- a/apps/judicial-system/web/src/components/SigningModal/SigningModal.tsx
+++ b/apps/judicial-system/web/src/components/SigningModal/SigningModal.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import { useIntl } from 'react-intl'
 import { useRouter } from 'next/router'
 import {

--- a/apps/judicial-system/web/src/components/Table/AppealCasesTable/AppealCasesTable.tsx
+++ b/apps/judicial-system/web/src/components/Table/AppealCasesTable/AppealCasesTable.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useMemo } from 'react'
+{ FC, useMemo } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Box, Text } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/Table/AppealCasesTable/MobileAppealCase.tsx
+++ b/apps/judicial-system/web/src/components/Table/AppealCasesTable/MobileAppealCase.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Box, Text } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/Table/CaseFileTable/CaseFileTable.tsx
+++ b/apps/judicial-system/web/src/components/Table/CaseFileTable/CaseFileTable.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import { FC } from 'react'
 import { useIntl } from 'react-intl'
 import cn from 'classnames'
 

--- a/apps/judicial-system/web/src/components/Table/ColumnCaseType/ColumnCaseType.tsx
+++ b/apps/judicial-system/web/src/components/Table/ColumnCaseType/ColumnCaseType.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import { FC } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Box, Text } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/Table/CourtCaseNumber/CourtCaseNumber.tsx
+++ b/apps/judicial-system/web/src/components/Table/CourtCaseNumber/CourtCaseNumber.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 
 import { Box, Text } from '@island.is/island-ui/core'
 import { displayFirstPlusRemaining } from '@island.is/judicial-system/formatters'

--- a/apps/judicial-system/web/src/components/Table/DefendantInfo/DefendantInfo.tsx
+++ b/apps/judicial-system/web/src/components/Table/DefendantInfo/DefendantInfo.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import { FC } from 'react'
 
 import { Box, Text } from '@island.is/island-ui/core'
 import { formatDOB } from '@island.is/judicial-system/formatters'

--- a/apps/judicial-system/web/src/components/Table/PastCasesTable/MobilePastCase.tsx
+++ b/apps/judicial-system/web/src/components/Table/PastCasesTable/MobilePastCase.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import { FC } from 'react'
 import { useIntl } from 'react-intl'
 import format from 'date-fns/format'
 import parseISO from 'date-fns/parseISO'

--- a/apps/judicial-system/web/src/components/Table/PastCasesTable/PastCasesTable.tsx
+++ b/apps/judicial-system/web/src/components/Table/PastCasesTable/PastCasesTable.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext, useMemo } from 'react'
+import { FC, useContext, useMemo } from 'react'
 import { useIntl } from 'react-intl'
 import cn from 'classnames'
 import { AnimatePresence } from 'framer-motion'

--- a/apps/judicial-system/web/src/components/Table/SortButton/SortButton.tsx
+++ b/apps/judicial-system/web/src/components/Table/SortButton/SortButton.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import { FC } from 'react'
 import cn from 'classnames'
 
 import { Box, Icon, Text } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/Table/Table.tsx
+++ b/apps/judicial-system/web/src/components/Table/Table.tsx
@@ -1,10 +1,4 @@
-import React, {
-  FC,
-  PropsWithChildren,
-  ReactNode,
-  useContext,
-  useMemo,
-} from 'react'
+import { FC, PropsWithChildren, ReactNode, useContext, useMemo } from 'react'
 import { useIntl } from 'react-intl'
 import { useLocalStorage } from 'react-use'
 import parseISO from 'date-fns/parseISO'

--- a/apps/judicial-system/web/src/components/Table/TableContainer/TableContainer.tsx
+++ b/apps/judicial-system/web/src/components/Table/TableContainer/TableContainer.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import { FC } from 'react'
 
 import { TableSkeleton } from '@island.is/judicial-system-web/src/components/Table'
 

--- a/apps/judicial-system/web/src/components/Table/TableHeaderText/TableHeaderText.tsx
+++ b/apps/judicial-system/web/src/components/Table/TableHeaderText/TableHeaderText.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import { FC } from 'react'
 
 import { Text } from '@island.is/island-ui/core'
 

--- a/apps/judicial-system/web/src/components/TagAppealState/TagAppealState.tsx
+++ b/apps/judicial-system/web/src/components/TagAppealState/TagAppealState.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext } from 'react'
+{ FC, useContext } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Tag, TagVariant } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/TagCaseState/TagCaseState.tsx
+++ b/apps/judicial-system/web/src/components/TagCaseState/TagCaseState.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import { FC } from 'react'
 import { IntlShape, useIntl } from 'react-intl'
 
 import { Tag, TagVariant } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/components/Tags/CaseTag.tsx
+++ b/apps/judicial-system/web/src/components/Tags/CaseTag.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 
 import { Tag, TagVariant } from '@island.is/island-ui/core'
 

--- a/apps/judicial-system/web/src/components/TimeInputField/TimeInputField.tsx
+++ b/apps/judicial-system/web/src/components/TimeInputField/TimeInputField.tsx
@@ -1,4 +1,4 @@
-import React, { FC, PropsWithChildren } from 'react'
+{ FC, PropsWithChildren } from 'react'
 import InputMask from 'react-input-mask'
 
 interface Props {

--- a/apps/judicial-system/web/src/components/UserProvider/UserProvider.tsx
+++ b/apps/judicial-system/web/src/components/UserProvider/UserProvider.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   createContext,
   FC,
   PropsWithChildren,

--- a/apps/judicial-system/web/src/components/ViewportProvider/ViewportProvider.tsx
+++ b/apps/judicial-system/web/src/components/ViewportProvider/ViewportProvider.tsx
@@ -1,4 +1,4 @@
-import React, { FC, PropsWithChildren } from 'react'
+{ FC, PropsWithChildren } from 'react'
 
 export type Rect = { width: number; height: number }
 

--- a/apps/judicial-system/web/src/routes/Admin/UserForm/UserForm.tsx
+++ b/apps/judicial-system/web/src/routes/Admin/UserForm/UserForm.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useEffect, useState } from 'react'
+{ FC, useCallback, useEffect, useState } from 'react'
 import InputMask from 'react-input-mask'
 
 import {

--- a/apps/judicial-system/web/src/routes/Admin/Users/Users.tsx
+++ b/apps/judicial-system/web/src/routes/Admin/Users/Users.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+{ useState } from 'react'
 import { useIntl } from 'react-intl'
 import cn from 'classnames'
 import { useRouter } from 'next/router'

--- a/apps/judicial-system/web/src/routes/Court/Indictments/Completed/Completed.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/Completed/Completed.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useContext, useState } from 'react'
+{ FC, useCallback, useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
 import router from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/Court/Indictments/Conclusion/Conclusion.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/Conclusion/Conclusion.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useContext, useEffect, useState } from 'react'
+{ FC, useCallback, useContext, useEffect, useState } from 'react'
 import { useIntl } from 'react-intl'
 import router from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/Court/Indictments/Conclusion/SelectConnectedCase.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/Conclusion/SelectConnectedCase.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, FC, SetStateAction } from 'react'
+{ Dispatch, FC, SetStateAction } from 'react'
 import { useIntl } from 'react-intl'
 
 import {

--- a/apps/judicial-system/web/src/routes/Court/Indictments/Defender/Defender.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/Defender/Defender.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext } from 'react'
+{ useCallback, useContext } from 'react'
 import { useIntl } from 'react-intl'
 import { useRouter } from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/Court/Indictments/Defender/SelectDefender.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/Defender/SelectDefender.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useContext, useState } from 'react'
+{ FC, useCallback, useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Box, Checkbox, Text } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/routes/Court/Indictments/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/Overview/Overview.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useState } from 'react'
+{ useCallback, useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { useRouter } from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/Court/Indictments/ReturnIndictmentCaseModal/ReturnIndictmentCaseModal.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/ReturnIndictmentCaseModal/ReturnIndictmentCaseModal.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext, useState } from 'react'
+{ FC, useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Box, Input } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/routes/Court/Indictments/Subpoena/Subpoena.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/Subpoena/Subpoena.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useContext, useState } from 'react'
+{ FC, useCallback, useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
 import router from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/Court/Indictments/Summary/Summary.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/Summary/Summary.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext, useState } from 'react'
+{ FC, useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
 import router from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/Court/InvestigationCase/Confirmation/Confirmation.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationCase/Confirmation/Confirmation.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext, useState } from 'react'
+{ FC, useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { useRouter } from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/Court/InvestigationCase/CourtRecord/CourtRecord.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationCase/CourtRecord/CourtRecord.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useContext, useState } from 'react'
+{ FC, useCallback, useContext, useState } from 'react'
 import { IntlShape, useIntl } from 'react-intl'
 import router from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/Court/InvestigationCase/HearingArrangements/HearingArrangements.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationCase/HearingArrangements/HearingArrangements.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useState } from 'react'
+{ useCallback, useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
 import router from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/Court/InvestigationCase/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationCase/Overview/Overview.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useState } from 'react'
+{ useCallback, useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
 import router from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/Court/InvestigationCase/Ruling/Ruling.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationCase/Ruling/Ruling.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useState } from 'react'
+{ useCallback, useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
 import router from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/Court/RestrictionCase/Confirmation/Confirmation.tsx
+++ b/apps/judicial-system/web/src/routes/Court/RestrictionCase/Confirmation/Confirmation.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext, useState } from 'react'
+{ FC, useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { useRouter } from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/Court/RestrictionCase/CourtRecord/CourtRecord.tsx
+++ b/apps/judicial-system/web/src/routes/Court/RestrictionCase/CourtRecord/CourtRecord.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useContext, useState } from 'react'
+{ FC, useCallback, useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { useRouter } from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/Court/RestrictionCase/HearingArrangements/HearingArrangements.tsx
+++ b/apps/judicial-system/web/src/routes/Court/RestrictionCase/HearingArrangements/HearingArrangements.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useState } from 'react'
+{ useCallback, useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
 import router from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/Court/RestrictionCase/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Court/RestrictionCase/Overview/Overview.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useState } from 'react'
+{ useCallback, useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { useRouter } from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/Court/RestrictionCase/Ruling/Ruling.tsx
+++ b/apps/judicial-system/web/src/routes/Court/RestrictionCase/Ruling/Ruling.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useState } from 'react'
+{ useCallback, useContext, useState } from 'react'
 import { IntlShape, useIntl } from 'react-intl'
 import formatISO from 'date-fns/formatISO'
 import { useRouter } from 'next/router'

--- a/apps/judicial-system/web/src/routes/Court/components/AppealSections/AppealSections.tsx
+++ b/apps/judicial-system/web/src/routes/Court/components/AppealSections/AppealSections.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react'
+{ FC, useState } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Box, Input, RadioButton, Text } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/routes/Court/components/CasesAwaitingAssignmentTable/CasesAwaitingAssignmentTable.tsx
+++ b/apps/judicial-system/web/src/routes/Court/components/CasesAwaitingAssignmentTable/CasesAwaitingAssignmentTable.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import { useIntl } from 'react-intl'
 import { AnimatePresence } from 'framer-motion'
 

--- a/apps/judicial-system/web/src/routes/Court/components/CasesInProgressTable/CasesInProgressTable.tsx
+++ b/apps/judicial-system/web/src/routes/Court/components/CasesInProgressTable/CasesInProgressTable.tsx
@@ -1,4 +1,4 @@
-import React, {
+{
   Dispatch,
   FC,
   SetStateAction,

--- a/apps/judicial-system/web/src/routes/Court/components/CourtCaseNumber/CourtCaseNumber.tsx
+++ b/apps/judicial-system/web/src/routes/Court/components/CourtCaseNumber/CourtCaseNumber.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext } from 'react'
+{ FC, useContext } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Box, Text } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/routes/Court/components/CourtCaseNumber/CourtCaseNumberInput.tsx
+++ b/apps/judicial-system/web/src/routes/Court/components/CourtCaseNumber/CourtCaseNumberInput.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, FC, SetStateAction, useState } from 'react'
+{ Dispatch, FC, SetStateAction, useState } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Box, Button, Input } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/routes/Court/components/DraftConclusionModal/DraftConclusionModal.tsx
+++ b/apps/judicial-system/web/src/routes/Court/components/DraftConclusionModal/DraftConclusionModal.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import { useIntl } from 'react-intl'
 import { AnimatePresence } from 'framer-motion'
 

--- a/apps/judicial-system/web/src/routes/Court/components/ReceptionAndAssignment/ReceptionAndAssignment.tsx
+++ b/apps/judicial-system/web/src/routes/Court/components/ReceptionAndAssignment/ReceptionAndAssignment.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext } from 'react'
+{ useCallback, useContext } from 'react'
 import { useIntl } from 'react-intl'
 import { useRouter } from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/Court/components/ReceptionAndAssignment/SelectCourtOfficials/SelectCourtOfficials.tsx
+++ b/apps/judicial-system/web/src/routes/Court/components/ReceptionAndAssignment/SelectCourtOfficials/SelectCourtOfficials.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+{ useContext } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Box, Select, Tooltip } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/routes/Court/components/SubpoenaType/SubpoenaType.tsx
+++ b/apps/judicial-system/web/src/routes/Court/components/SubpoenaType/SubpoenaType.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, FC, SetStateAction } from 'react'
+{ Dispatch, FC, SetStateAction } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Box, RadioButton, Text } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/routes/CourtOfAppeal/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/CourtOfAppeal/Overview/Overview.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+{ useContext } from 'react'
 import { useIntl } from 'react-intl'
 import { useRouter } from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/CourtOfAppeal/Result/Result.tsx
+++ b/apps/judicial-system/web/src/routes/CourtOfAppeal/Result/Result.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+{ useContext } from 'react'
 import { useIntl } from 'react-intl'
 
 import { AlertBanner, AlertMessage, Box } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/routes/CourtOfAppeal/Ruling/Ruling.tsx
+++ b/apps/judicial-system/web/src/routes/CourtOfAppeal/Ruling/Ruling.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useState } from 'react'
+{ useCallback, useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { useRouter } from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/CourtOfAppeal/Summary/Summary.tsx
+++ b/apps/judicial-system/web/src/routes/CourtOfAppeal/Summary/Summary.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext, useState } from 'react'
+{ FC, useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
 import router from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/CourtOfAppeal/WithdrawnAppealCase/WithdrawnAppealCase.tsx
+++ b/apps/judicial-system/web/src/routes/CourtOfAppeal/WithdrawnAppealCase/WithdrawnAppealCase.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+{ useContext } from 'react'
 import { useIntl } from 'react-intl'
 import { useRouter } from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/CourtOfAppeal/components/CaseFilesOverview/CaseFilesOverview.tsx
+++ b/apps/judicial-system/web/src/routes/CourtOfAppeal/components/CaseFilesOverview/CaseFilesOverview.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+{ useContext } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Box, Text } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/routes/CourtOfAppeal/components/CaseNumbers/CaseNumbers.tsx
+++ b/apps/judicial-system/web/src/routes/CourtOfAppeal/components/CaseNumbers/CaseNumbers.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext } from 'react'
+{ FC, useContext } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Box, Text } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/routes/CourtOfAppeal/components/CaseOverviewHeader/CaseOverviewHeader.tsx
+++ b/apps/judicial-system/web/src/routes/CourtOfAppeal/components/CaseOverviewHeader/CaseOverviewHeader.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext } from 'react'
+{ FC, useContext } from 'react'
 import { useIntl } from 'react-intl'
 import { useRouter } from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/Defender/CaseOverview.tsx
+++ b/apps/judicial-system/web/src/routes/Defender/CaseOverview.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react'
+{ useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { useRouter } from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/Defender/Cases/Cases.tsx
+++ b/apps/judicial-system/web/src/routes/Defender/Cases/Cases.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useMemo, useState } from 'react'
+{ FC, useEffect, useMemo, useState } from 'react'
 import { useIntl } from 'react-intl'
 import partition from 'lodash/partition'
 

--- a/apps/judicial-system/web/src/routes/Defender/Cases/components/DefenderCasesTable.tsx
+++ b/apps/judicial-system/web/src/routes/Defender/Cases/components/DefenderCasesTable.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import { useIntl } from 'react-intl'
 import cn from 'classnames'
 import { AnimatePresence } from 'framer-motion'

--- a/apps/judicial-system/web/src/routes/Defender/Cases/components/FilterCheckboxes.tsx
+++ b/apps/judicial-system/web/src/routes/Defender/Cases/components/FilterCheckboxes.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Box, Checkbox } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/routes/Prison/IndictmentOverview/IndictmentOverview.tsx
+++ b/apps/judicial-system/web/src/routes/Prison/IndictmentOverview/IndictmentOverview.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+{ useContext } from 'react'
 import { useIntl } from 'react-intl'
 import { useRouter } from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/CaseFile/CaseFile.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/CaseFile/CaseFile.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext } from 'react'
+{ useCallback, useContext } from 'react'
 import { useIntl } from 'react-intl'
 import { LayoutGroup } from 'framer-motion'
 import router from 'next/router'

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/CaseFiles/CaseFiles.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/CaseFiles/CaseFiles.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext } from 'react'
+{ useCallback, useContext } from 'react'
 import { useIntl } from 'react-intl'
 import router from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/Defendant.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/Defendant.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useState } from 'react'
+{ useCallback, useContext, useEffect, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { AnimatePresence, motion } from 'framer-motion'
 import { useRouter } from 'next/router'

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/LokeNumberList/LokeNumberList.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/LokeNumberList/LokeNumberList.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext, useEffect, useState } from 'react'
+{ FC, useContext, useEffect, useState } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Box } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/PoliceCaseInfo/PoliceCaseInfo.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/PoliceCaseInfo/PoliceCaseInfo.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext, useEffect, useMemo, useState } from 'react'
+{ FC, useContext, useEffect, useMemo, useState } from 'react'
 import InputMask from 'react-input-mask'
 import { useIntl } from 'react-intl'
 

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Indictment.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Indictment.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useState } from 'react'
+{ useCallback, useContext, useState } from 'react'
 import { IntlShape, useIntl } from 'react-intl'
 import { applyCase } from 'beygla/strict'
 import { AnimatePresence, motion } from 'framer-motion'

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/IndictmentCount.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/IndictmentCount.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useMemo, useState } from 'react'
+{ FC, useMemo, useState } from 'react'
 import InputMask from 'react-input-mask'
 import { IntlShape, useIntl } from 'react-intl'
 

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Substance/Substance.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Substance/Substance.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react'
+{ FC, useState } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Input } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Substances/Substances.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Substances/Substances.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useMemo } from 'react'
+{ FC, useMemo } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Box, Select } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Overview/DenyIndictmentCaseModal/DenyIndictmentCaseModal.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Overview/DenyIndictmentCaseModal/DenyIndictmentCaseModal.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, FC, SetStateAction, useState } from 'react'
+{ Dispatch, FC, SetStateAction, useState } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Box, Input } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Overview/Overview.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext, useState } from 'react'
+{ FC, useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { AnimatePresence } from 'framer-motion'
 import { useRouter } from 'next/router'

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/PoliceCaseFiles/PoliceCaseFilesRoute.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/PoliceCaseFiles/PoliceCaseFilesRoute.tsx
@@ -1,4 +1,4 @@
-import React, {
+{
   FC,
   memo,
   useCallback,

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Processing/Processing.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Processing/Processing.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useContext } from 'react'
+{ FC, useCallback, useContext } from 'react'
 import { useIntl } from 'react-intl'
 import { useRouter } from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/Prosecutor/InvestigationCase/Defendant/Defendant.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/InvestigationCase/Defendant/Defendant.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect } from 'react'
+{ useCallback, useContext, useEffect } from 'react'
 import { useIntl } from 'react-intl'
 import { AnimatePresence, motion } from 'framer-motion'
 import { useRouter } from 'next/router'

--- a/apps/judicial-system/web/src/routes/Prosecutor/InvestigationCase/HearingArrangements/HearingArrangements.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/InvestigationCase/HearingArrangements/HearingArrangements.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useState } from 'react'
+{ useCallback, useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { useRouter } from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/Prosecutor/InvestigationCase/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/InvestigationCase/Overview/Overview.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react'
+{ useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { AnimatePresence } from 'framer-motion'
 import { useRouter } from 'next/router'

--- a/apps/judicial-system/web/src/routes/Prosecutor/InvestigationCase/PoliceDemands/PoliceDemands.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/InvestigationCase/PoliceDemands/PoliceDemands.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useState } from 'react'
+{ useCallback, useContext, useState } from 'react'
 import { MessageDescriptor, useIntl } from 'react-intl'
 import router from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/Prosecutor/InvestigationCase/PoliceReport/PoliceReport.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/InvestigationCase/PoliceReport/PoliceReport.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useState } from 'react'
+{ useCallback, useContext, useEffect, useState } from 'react'
 import { useIntl } from 'react-intl'
 import router from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/Defendant/Defendant.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/Defendant/Defendant.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useState } from 'react'
+{ useCallback, useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { useRouter } from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/HearingArrangements/ArrestDate.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/HearingArrangements/ArrestDate.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useMemo } from 'react'
+{ FC, useCallback, useMemo } from 'react'
 
 import { Box, Text } from '@island.is/island-ui/core'
 import { DateTime } from '@island.is/judicial-system-web/src/components'

--- a/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/HearingArrangements/HearingArrangements.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/HearingArrangements/HearingArrangements.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useState } from 'react'
+{ useCallback, useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { useRouter } from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/Overview/Overview.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react'
+{ useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { AnimatePresence } from 'framer-motion'
 import { useRouter } from 'next/router'

--- a/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/PoliceDemands/PoliceDemands.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/PoliceDemands/PoliceDemands.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useState } from 'react'
+{ useCallback, useContext, useState } from 'react'
 import { IntlShape, useIntl } from 'react-intl'
 import { useRouter } from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/PoliceReport/PoliceReport.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/RestrictionCase/PoliceReport/PoliceReport.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react'
+{ useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { useRouter } from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/Prosecutor/components/CaseFiles/CaseFiles.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/components/CaseFiles/CaseFiles.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useMemo, useState } from 'react'
+{ useContext, useEffect, useMemo, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { useRouter } from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/Prosecutor/components/CasesAwaitingConfirmationTable/CasesAwaitingConfirmationTable.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/components/CasesAwaitingConfirmationTable/CasesAwaitingConfirmationTable.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import { useIntl } from 'react-intl'
 import { AnimatePresence } from 'framer-motion'
 

--- a/apps/judicial-system/web/src/routes/Prosecutor/components/DefendantInfo/DefendantInfo.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/components/DefendantInfo/DefendantInfo.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, FC, SetStateAction, useEffect, useState } from 'react'
+{ Dispatch, FC, SetStateAction, useEffect, useState } from 'react'
 import InputMask from 'react-input-mask'
 import { useIntl } from 'react-intl'
 

--- a/apps/judicial-system/web/src/routes/Prosecutor/components/PoliceCaseFiles/PoliceCaseFiles.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/components/PoliceCaseFiles/PoliceCaseFiles.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext } from 'react'
+{ FC, useContext } from 'react'
 import { useIntl } from 'react-intl'
 
 import { AlertMessage, Box } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/routes/Prosecutor/components/PoliceCaseNumbers/PoliceCaseNumbers.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/components/PoliceCaseNumbers/PoliceCaseNumbers.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useContext, useEffect, useState } from 'react'
+{ FC, useCallback, useContext, useEffect, useState } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Box, Icon, Tag, Text } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/routes/Prosecutor/components/ProsecutorSection/ProsecutorSection.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/components/ProsecutorSection/ProsecutorSection.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+{ useContext } from 'react'
 
 import { Box } from '@island.is/island-ui/core'
 import { isIndictmentCase } from '@island.is/judicial-system/types'

--- a/apps/judicial-system/web/src/routes/Prosecutor/components/ProsecutorSection/ProsecutorSectionHeading.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/components/ProsecutorSection/ProsecutorSectionHeading.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Box, Tooltip } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/routes/Prosecutor/components/ProsecutorSection/ProsecutorSectionHeightenedSecurity.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/components/ProsecutorSection/ProsecutorSectionHeightenedSecurity.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react'
+{ useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { useRouter } from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/Prosecutor/components/RequestCourtDate/RequestCourtDate.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/components/RequestCourtDate/RequestCourtDate.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Box, Text, Tooltip } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/routes/Prosecutor/components/SelectCourt/SelectCourt.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/components/SelectCourt/SelectCourt.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext } from 'react'
+{ FC, useContext } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Box, Select, Text } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/routes/PublicProsecutor/Cases/PublicProsecutorCases.tsx
+++ b/apps/judicial-system/web/src/routes/PublicProsecutor/Cases/PublicProsecutorCases.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useMemo } from 'react'
+{ FC, useMemo } from 'react'
 import { useIntl } from 'react-intl'
 
 import { AlertMessage } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/routes/PublicProsecutor/Indictments/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/PublicProsecutor/Indictments/Overview/Overview.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useMemo, useState } from 'react'
+{ useCallback, useContext, useMemo, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { useRouter } from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/PublicProsecutor/Tables/CasesAwaitingReview.tsx
+++ b/apps/judicial-system/web/src/routes/PublicProsecutor/Tables/CasesAwaitingReview.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import { useIntl } from 'react-intl'
 import { AnimatePresence } from 'framer-motion'
 

--- a/apps/judicial-system/web/src/routes/PublicProsecutor/Tables/CasesForReview.tsx
+++ b/apps/judicial-system/web/src/routes/PublicProsecutor/Tables/CasesForReview.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import { useIntl } from 'react-intl'
 import { AnimatePresence } from 'framer-motion'
 

--- a/apps/judicial-system/web/src/routes/PublicProsecutor/Tables/CasesReviewed.tsx
+++ b/apps/judicial-system/web/src/routes/PublicProsecutor/Tables/CasesReviewed.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import { useIntl } from 'react-intl'
 import { AnimatePresence } from 'framer-motion'
 

--- a/apps/judicial-system/web/src/routes/Shared/AppealToCourtOfAppeals/AppealCaseFiles.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/AppealToCourtOfAppeals/AppealCaseFiles.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useState } from 'react'
+{ useCallback, useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { useRouter } from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/Shared/AppealToCourtOfAppeals/AppealToCourtOfAppeals.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/AppealToCourtOfAppeals/AppealToCourtOfAppeals.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useState } from 'react'
+{ useCallback, useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { useRouter } from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/Shared/Cases/ActiveCases.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/Cases/ActiveCases.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import { useIntl } from 'react-intl'
 
 import { capitalize } from '@island.is/judicial-system/formatters'

--- a/apps/judicial-system/web/src/routes/Shared/Cases/AllCases.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/Cases/AllCases.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext } from 'react'
+{ FC, useContext } from 'react'
 
 import { isPublicProsecutorUser } from '@island.is/judicial-system/types'
 import { UserContext } from '@island.is/judicial-system-web/src/components'

--- a/apps/judicial-system/web/src/routes/Shared/Cases/Cases.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/Cases/Cases.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext, useEffect, useMemo, useState } from 'react'
+{ FC, useContext, useEffect, useMemo, useState } from 'react'
 import { useIntl } from 'react-intl'
 
 import { AlertMessage, Box, Select } from '@island.is/island-ui/core'

--- a/apps/judicial-system/web/src/routes/Shared/Cases/MobileCase.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/Cases/MobileCase.tsx
@@ -1,4 +1,4 @@
-import React, { FC, PropsWithChildren } from 'react'
+{ FC, PropsWithChildren } from 'react'
 import { useIntl } from 'react-intl'
 import format from 'date-fns/format'
 import parseISO from 'date-fns/parseISO'

--- a/apps/judicial-system/web/src/routes/Shared/Cases/PrisonCases.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/Cases/PrisonCases.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext, useMemo } from 'react'
+{ FC, useContext, useMemo } from 'react'
 import { useIntl } from 'react-intl'
 import partition from 'lodash/partition'
 

--- a/apps/judicial-system/web/src/routes/Shared/IndictmentOverview/IndictmentOverview.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/IndictmentOverview/IndictmentOverview.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useContext, useState } from 'react'
+{ FC, useCallback, useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { useRouter } from 'next/router'
 

--- a/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/Components/ModifyDatesModal/ModifyDatesModal.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/Components/ModifyDatesModal/ModifyDatesModal.tsx
@@ -1,4 +1,4 @@
-import React, {
+{
   Dispatch,
   FC,
   SetStateAction,

--- a/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/SignedVerdictOverview.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/SignedVerdictOverview/SignedVerdictOverview.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode, useCallback, useContext, useState } from 'react'
+{ FC, ReactNode, useCallback, useContext, useState } from 'react'
 import { IntlShape, useIntl } from 'react-intl'
 import { SingleValue } from 'react-select'
 import { AnimatePresence } from 'framer-motion'

--- a/apps/judicial-system/web/src/routes/Shared/Statement/Statement.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/Statement/Statement.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useState } from 'react'
+{ useCallback, useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { useRouter } from 'next/router'
 

--- a/apps/judicial-system/web/src/utils/hooks/useCaseList/index.tsx
+++ b/apps/judicial-system/web/src/utils/hooks/useCaseList/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useMemo, useState } from 'react'
+{ useCallback, useContext, useMemo, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { motion } from 'framer-motion'
 import { useRouter } from 'next/router'

--- a/apps/judicial-system/web/src/utils/restrictions.spec.tsx
+++ b/apps/judicial-system/web/src/utils/restrictions.spec.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+{ FC } from 'react'
 import { createIntl, IntlFormatters, useIntl } from 'react-intl'
 import { MockedProvider } from '@apollo/client/testing'
 import { getDefaultNormalizer, render, screen } from '@testing-library/react'

--- a/apps/judicial-system/web/src/utils/testHelpers.tsx
+++ b/apps/judicial-system/web/src/utils/testHelpers.tsx
@@ -1,4 +1,4 @@
-import React, { FC, PropsWithChildren, ReactNode } from 'react'
+{ FC, PropsWithChildren, ReactNode } from 'react'
 import { createIntl, IntlProvider } from 'react-intl'
 import { ApolloClient, ApolloProvider, InMemoryCache } from '@apollo/client'
 


### PR DESCRIPTION
# Stop importing React

Asana

## What

Stop importing React explicitly

## Why

Since React v17, importing React is not needed.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
