### PR TITLE
fix(inheritance-report): expandable texts

### DIFF
--- a/libs/application/templates/inheritance-report/src/forms/done.ts
+++ b/libs/application/templates/inheritance-report/src/forms/done.ts
@@ -17,7 +17,14 @@ export const done: Form = buildForm({
         answers.applicationFor === PREPAID_INHERITANCE
           ? m.doneTitlePrepaidEFS
           : m.doneTitleEFS,
-      expandableHeader: m.nextSteps,
+      expandableHeader: ({ answers }) =>
+        answers.applicationFor === PREPAID_INHERITANCE
+          ? m.expandableHeaderPrepaid
+          : m.expandableHeaderEFS,
+      expandableIntro: ({ answers }) =>
+        answers.applicationFor === PREPAID_INHERITANCE
+          ? m.expandableIntroPrepaid
+          : m.expandableIntroEFS,
       expandableDescription: ({ answers }) =>
         answers.applicationFor === PREPAID_INHERITANCE
           ? m.doneDescriptionPrepaidEFS

--- a/libs/application/templates/inheritance-report/src/lib/messages.ts
+++ b/libs/application/templates/inheritance-report/src/lib/messages.ts
@@ -669,7 +669,7 @@ export const m = defineMessages({
     description: '',
   },
   stocksDescriptionPrePaid: {
-    id: 'ir.application:stocksDescriptionPrePaid',
+    id: 'ir.application:stocksDescriptionPrePaid#markdown',
     defaultMessage:
       'Upplýsingar um nafnverð hlutabréfa má finna í síðasta skattframtali. Upplýsingar um gengi hlutabréfa er hægt að fá hjá bönkum, félaginu sjálfu eða miða við síðasta ársreikning félagsins sem sækja má á heimasíðu Skattsins, www.skatturinn.is/fyrirtaekjaskra',
     description: '',

--- a/libs/application/templates/inheritance-report/src/lib/messages.ts
+++ b/libs/application/templates/inheritance-report/src/lib/messages.ts
@@ -1713,15 +1713,30 @@ export const m = defineMessages({
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed sit amet urna nec nunc ultricies ultricies.',
     description: '',
   },
-  nextSteps: {
-    id: 'ir.application:nextSteps',
-    defaultMessage: 'Næstu skref',
-    description: '',
-  },
   errorRelation: {
     id: 'ir.application:error.errorRelation',
     defaultMessage: 'Tengsl virðast ekki vera rétt',
     description: 'Relation is invalid',
+  },
+  expandableHeaderEFS: {
+    id: 'ir.application:expandableHeaderEFS',
+    defaultMessage: 'Næstu skref',
+    description: '',
+  },
+  expandableHeaderPrepaid: {
+    id: 'ir.application:expandableHeaderPrepaid',
+    defaultMessage: 'Næstu skref',
+    description: '',
+  },
+  expandableIntroEFS: {
+    id: 'ir.application:expandableIntroEFS',
+    defaultMessage: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+    description: '',
+  },
+  expandableIntroPrepaid: {
+    id: 'ir.application:expandableIntroPrepaid',
+    defaultMessage: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+    description: '',
   },
 
   // Tax Free Limit

--- a/libs/application/types/src/lib/Fields.ts
+++ b/libs/application/types/src/lib/Fields.ts
@@ -441,7 +441,7 @@ export interface MessageWithLinkButtonField extends BaseField {
 export interface ExpandableDescriptionField extends BaseField {
   readonly type: FieldTypes.EXPANDABLE_DESCRIPTION
   component: FieldComponents.EXPANDABLE_DESCRIPTION
-  introText?: StaticText
+  introText?: FormText
   description: FormText
   startExpanded?: boolean
 }

--- a/libs/application/ui-forms/src/lib/formConclusionSection/formConclusionSection.ts
+++ b/libs/application/ui-forms/src/lib/formConclusionSection/formConclusionSection.ts
@@ -19,7 +19,7 @@ type Props = Partial<{
   secondButtonLabel: StaticText
   secondButtonMessage: StaticText
   expandableHeader: FormText
-  expandableIntro: StaticText
+  expandableIntro: FormText
   expandableDescription: FormText
   conclusionLinkS3FileKey: FormText
   conclusionLink: string


### PR DESCRIPTION
## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the `done` form to dynamically display headers and introductory content based on application type (prepaid inheritance or EFS).
	- Introduced new contextual messaging for headers and intros related to EFS and prepaid applications.

- **Bug Fixes**
	- Updated data types for `introText` and `expandableIntro` to improve compatibility and functionality within the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->