### PR TITLE
fix(auth-admin-api): Use master node when finding newly created scope

### DIFF
--- a/libs/auth-api-lib/src/lib/resources/admin/admin-scope.service.ts
+++ b/libs/auth-api-lib/src/lib/resources/admin/admin-scope.service.ts
@@ -221,6 +221,7 @@ export class AdminScopeService {
       include: [
         { model: ApiScopeDelegationType, as: 'supportedDelegationTypes' },
       ],
+      useMaster: true,
     })
 
     if (!apiScope) {


### PR DESCRIPTION
## What

Request to use master node when finding newly created scope

## Why

To avoid not finding it on other nodes and causing issues in the UI when creating permissions

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option, `useMaster`, to enhance data handling in the AdminScopeService.
  
- **Bug Fixes**
	- Improved the method's logic flow for better interaction with underlying data or APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->