### PR TITLE
fix(cms): getOrganizations endpoint - Lower include depth to 4

### DIFF
--- a/libs/cms/src/lib/cms.contentful.service.ts
+++ b/libs/cms/src/lib/cms.contentful.service.ts
@@ -153,7 +153,7 @@ export class CmsContentfulService {
 
     const params = {
       ['content_type']: 'organization',
-      include: 10,
+      include: 4,
       limit: 1000,
       ...organizationTitles,
       ...organizationReferenceIdentifiers,


### PR DESCRIPTION
# getOrganizations endpoint - Lower include depth to 4

## What

* Contentful response max size limit was reached when calling this endpoint, the depth used to be 10 but there is no need to have it that high of a number so lowering it to 4 will help with lowering the response size from contentful


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Adjusted content retrieval settings to optimize the depth of related entries fetched from the Contentful API, enhancing data relevance and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->