### PR TITLE
fix(search-indexer): Latest Generic List Items - Prevent infinite loop when mapping organization subpage reference

### DIFF
--- a/libs/cms/src/lib/models/latestGenericListItems.model.ts
+++ b/libs/cms/src/lib/models/latestGenericListItems.model.ts
@@ -1,12 +1,16 @@
 import { Field, ID, ObjectType } from '@nestjs/graphql'
 import { SystemMetadata } from '@island.is/shared/types'
 import { CacheField } from '@island.is/nest/graphql'
-import { ILatestGenericListItems } from '../generated/contentfulTypes'
+import {
+  ILatestGenericListItems,
+  IOrganizationSubpage,
+} from '../generated/contentfulTypes'
 import { GenericList, mapGenericList } from './genericList.model'
 import { mapPageUnion, PageUnion } from '../unions/page.union'
 import { GetGenericListItemsInput } from '../dto/getGenericListItems.input'
 import { GenericListItemResponse } from './genericListItemResponse.model'
 import { ElasticsearchIndexLocale } from '@island.is/content-search-index-manager'
+import { mapOrganizationSubpage } from './organizationSubpage.model'
 
 @ObjectType()
 export class LatestGenericListItems {
@@ -29,6 +33,30 @@ export class LatestGenericListItems {
   itemResponse?: GetGenericListItemsInput | null // This field is populated by resolver
 }
 
+const mapSeeMorePage = (seeMorePage: IOrganizationSubpage | undefined) => {
+  if (!seeMorePage) {
+    return null
+  }
+  if (seeMorePage.sys.contentType.sys.id !== 'organizationSubpage') {
+    return mapPageUnion(seeMorePage)
+  }
+
+  return mapOrganizationSubpage({
+    ...seeMorePage,
+    fields: {
+      ...seeMorePage.fields,
+      organizationPage: {
+        ...seeMorePage.fields.organizationPage,
+        fields: {
+          ...seeMorePage.fields.organizationPage?.fields,
+          slices: [],
+          bottomSlices: [],
+        },
+      },
+    },
+  })
+}
+
 export const mapLatestGenericListItems = ({
   fields,
   sys,
@@ -37,7 +65,7 @@ export const mapLatestGenericListItems = ({
   id: sys.id,
   title: fields.title ?? '',
   genericList: fields.genericList ? mapGenericList(fields.genericList) : null,
-  seeMorePage: fields.seeMorePage ? mapPageUnion(fields.seeMorePage) : null,
+  seeMorePage: mapSeeMorePage(fields.seeMorePage),
   seeMoreLinkText: fields.seeMoreLinkText ?? '',
   itemResponse: fields.genericList?.sys.id
     ? {


### PR DESCRIPTION
# Latest Generic List Items - Prevent infinite loop when mapping organization subpage reference

## What

Infinite loop occurs during mapping since org subpage references an org page
Organization Page -> Latest Generic List items -> Organization Subpage -> Organization Page -> ...

So when calling mapOrganizationPage() we'll end up calling the same mapOrganizationPage() a few levels deeper, resulting in an infinite loop

We simply remove all possible reference fields to prevent this from occuring

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of the "see more" page functionality, allowing for more specific processing based on content type.
	- Introduced a new function to improve the initialization of nested fields within organization pages.

- **Bug Fixes**
	- Improved logic for mapping the "see more" page, ensuring accurate content type processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->