### PR TITLE
fix(applications-admin-portal): Remove procurer name from application

### DIFF
--- a/libs/portals/admin/application-system/src/components/ApplicationDetails/ApplicationDetails.tsx
+++ b/libs/portals/admin/application-system/src/components/ApplicationDetails/ApplicationDetails.tsx
@@ -102,9 +102,6 @@ export const ApplicationDetails = ({
             <Box padding={4} background="purple100" borderRadius="large">
               <GridRow rowGap={3}>
                 <GridColumn span={['2/2', '2/2', '1/2']}>
-                  <ValueLine title={formatMessage(m.name)}>{actor}</ValueLine>
-                </GridColumn>
-                <GridColumn span={['2/2', '2/2', '1/2']}>
                   <ValueLine title={formatMessage(m.nationalId)}>
                     {actor}
                   </ValueLine>


### PR DESCRIPTION
# Remove procurer name from application

Attach a link to issue if relevant

## What

Remove procurer name from application.
We don't have information about his name, only the nationalId.

## Why

Specify why you need to achieve this

## Screenshots / Gifs

![image](https://github.com/user-attachments/assets/40ae552d-63a5-4f75-8e36-3d991c10eda4)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
