### PR TITLE
fix(web): Youtube id extraction from url

### DIFF
--- a/libs/shared/utils/src/lib/videoEmbed.ts
+++ b/libs/shared/utils/src/lib/videoEmbed.ts
@@ -34,7 +34,14 @@ export const getVideoEmbedProperties = (
     if (match) {
       let id = match[7]
       if (id.startsWith('/')) id = id.slice(1)
-      if (id.length === 11) youtubeId = id
+      if (id.length === 11) {
+        youtubeId = id
+      } else {
+        const v = item.searchParams.get('v')
+        if (v && v.length == 11) {
+          youtubeId = v
+        }
+      }
     }
 
     if (youtubeId) {


### PR DESCRIPTION
# Youtube id extraction from url

## What

Id from url couldn't be extracted from the following url: https://www.youtube.com/watch?v=lHtAy38Ay8Y&feature=youtu.be

To handle that case I added a fallback that checks for the v parameter of the url

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
