### PR TITLE
feat: Configure universal links for the test app HOTFIX

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -109,6 +109,7 @@ libs/clients/rsk/relationships/                                                 
 /libs/service-portal/sessions                                                                            @island-is/aranja
 /apps/native/app/                                                                                        @island-is/aranja-app
 codemagic.yaml                                                                                           @island-is/aranja-app
+/apps/web/public/.well-known/                                                                            @island-is/aranja-app
 
 /apps/judicial-system/                                                                                   @island-is/kolibri-justice-league
 /libs/judicial-system/                                                                                   @island-is/kolibri-justice-league

--- a/apps/web/public/.well-known/apple-app-site-association
+++ b/apps/web/public/.well-known/apple-app-site-association
@@ -1,5 +1,23 @@
 {
-  "applinks": {},
+  "applinks": {
+    "details": [
+      {
+        "appIDs": [
+          "J3WWZR9JLF.is.island.app.dev"
+        ],
+        "components": [
+          { "/": "/minarsidur/postholf" },
+          { "/": "/minarsidur/postholf/*" },
+          { "/": "/minarsidur/skirteini" },
+          { "/": "/minarsidur/eignir/fasteignir" },
+          { "/": "/minarsidur/eignir/fasteignir/*" },
+          { "/": "/minarsidur/eignir/okutaeki/min-okutaeki" },
+          { "/": "/minarsidur/eignir/okutaeki/min-okutaeki/*" },
+          { "/": "/minarsidur/loftbru" }
+        ]
+      }
+    ]
+  },
   "webcredentials": {
     "apps": [
       "J3WWZR9JLF.is.island.app",


### PR DESCRIPTION
This allows us to deep link specific URLs with the island.is app.