### PR TITLE
fix(j-s): Edit Count

### DIFF
--- a/apps/judicial-system/web/src/components/EditableCaseFile/EditableCaseFile.tsx
+++ b/apps/judicial-system/web/src/components/EditableCaseFile/EditableCaseFile.tsx
@@ -178,7 +178,10 @@ const EditableCaseFile: FC<Props> = (props) => {
                   </button>
                   <Box marginLeft={1}>
                     <button
-                      onClick={() => onDelete(caseFile as TUploadFile)}
+                      onClick={() => {
+                        onDelete(caseFile as TUploadFile)
+                        onStopEditing()
+                      }}
                       className={cn(styles.editCaseFileButton, {
                         [styles.background.primary]:
                           caseFile.status !== 'error',


### PR DESCRIPTION
# Edit Count

[Tryggja virkni hnapps þegar skrám er eytt](https://app.asana.com/0/1199153462262248/1208259727040517/f)

## What

- Fixes the counting of files being edited when an edited file is deleted.

## Why

- Verified bug.

## Screenshots / Gifs

https://github.com/user-attachments/assets/48ad4f44-17b8-4fc0-97e9-427b0e2856f5

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the button functionality in the Editable Case File component to ensure that editing mode stops automatically when a case file is deleted, improving user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->