### PR TITLE
chore(web): Parental Leave Calculator - Reverse year order

### DIFF
--- a/apps/web/components/connected/ParentalLeaveCalculator/ParentalLeaveCalculator.tsx
+++ b/apps/web/components/connected/ParentalLeaveCalculator/ParentalLeaveCalculator.tsx
@@ -121,7 +121,7 @@ const FormScreen = ({ slice, changeScreen }: ScreenProps) => {
 
   const yearOptions = useMemo<Option<number>[]>(() => {
     const keys = Object.keys(slice.configJson?.yearConfig || {}).map(Number)
-    keys.sort()
+    keys.sort().reverse()
     return keys.map((key) => ({
       label: String(key),
       value: key,


### PR DESCRIPTION
# Parental Leave Calculator - Reverse year order


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the year selection in the Parental Leave Calculator to display years in descending order, prioritizing more recent years for user convenience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->