### PR TITLE
fix(auth-nest-tools): Client claims prefix is defaulted to `client_` with single underscore

### DIFF
--- a/libs/auth-nest-tools/src/lib/jwt.payload.ts
+++ b/libs/auth-nest-tools/src/lib/jwt.payload.ts
@@ -21,5 +21,5 @@ export interface JwtPayload {
     scope?: string | string[]
   }
   audkenni_sim_number?: string
-  client__delegation_provider?: AuthDelegationProvider
+  client_delegation_provider?: AuthDelegationProvider
 }

--- a/libs/auth-nest-tools/src/lib/jwt.strategy.ts
+++ b/libs/auth-nest-tools/src/lib/jwt.strategy.ts
@@ -61,7 +61,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       ip: String(request.headers['x-forwarded-for'] ?? request.ip),
       userAgent: request.headers['user-agent'],
       audkenniSimNumber: payload.audkenni_sim_number,
-      delegationProvider: payload.client__delegation_provider,
+      delegationProvider: payload.client_delegation_provider,
     }
   }
 }


### PR DESCRIPTION
## What

Fix expected client claim prefix in auth-nest-tools when parsing the `delegation_provider` claim.

## Why

To match the default and expected value of client claim

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the naming convention for the delegation provider property to enhance consistency and clarity.

- **Bug Fixes**
	- Addressed potential compatibility issues arising from the previous naming convention of the delegation provider property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->