### PR TITLE
feat(web): Team List - Move frontend logic to the backend

### DIFF
--- a/apps/web/components/Organization/Slice/TeamListSlice/TeamListSlice.tsx
+++ b/apps/web/components/Organization/Slice/TeamListSlice/TeamListSlice.tsx
@@ -1,9 +1,8 @@
-import { useMemo, useState } from 'react'
+import { useState } from 'react'
 import flatten from 'lodash/flatten'
 import { useLazyQuery } from '@apollo/client'
 
 import { TeamList, type TeamListProps } from '@island.is/island-ui/contentful'
-import { sortAlpha } from '@island.is/shared/utils'
 import { GenericList } from '@island.is/web/components'
 import {
   type GenericTag,
@@ -67,43 +66,7 @@ export const TeamMemberListWrapper = ({
 
   const totalItems = itemsResponse?.total ?? 0
 
-  const items = useMemo(
-    () =>
-      (itemsResponse?.items ?? []).map((item) => {
-        const tagGroups: { groupLabel: string; tagLabels: string[] }[] = []
-        for (const tag of item.filterTags ?? []) {
-          if (!tag.genericTagGroup?.title || !tag.title) {
-            continue
-          }
-          const index = tagGroups.findIndex(
-            (group) => group.groupLabel === tag.genericTagGroup?.title,
-          )
-          if (index >= 0) {
-            tagGroups[index].tagLabels.push(tag.title)
-          } else {
-            tagGroups.push({
-              groupLabel: tag.genericTagGroup.title,
-              tagLabels: [tag.title],
-            })
-          }
-
-          // Add a colon to the end of group labels if it doesn't have one
-          for (const group of tagGroups) {
-            if (!group.groupLabel.endsWith(':')) {
-              group.groupLabel += ':'
-            }
-          }
-        }
-
-        tagGroups.sort(sortAlpha('groupLabel'))
-
-        return {
-          ...(item as TeamListProps['teamMembers'][number]),
-          tagGroups,
-        }
-      }),
-    [itemsResponse],
-  )
+  const items = itemsResponse?.items ?? []
 
   return (
     <GenericList
@@ -132,7 +95,7 @@ export const TeamMemberListWrapper = ({
       tagQueryId={tagQueryId}
     >
       <TeamList
-        teamMembers={items}
+        teamMembers={items as TeamListProps['teamMembers']}
         variant="accordion"
         prefixes={{
           email: activeLocale === 'is' ? 'Netfang:' : 'Email:',

--- a/apps/web/screens/queries/TeamList.ts
+++ b/apps/web/screens/queries/TeamList.ts
@@ -16,15 +16,9 @@ export const GET_TEAM_MEMBERS_QUERY = gql`
         title
         email
         phone
-        filterTags {
-          id
-          title
-          slug
-          genericTagGroup {
-            id
-            title
-            slug
-          }
+        tagGroups {
+          groupLabel
+          tagLabels
         }
         image {
           ...ImageFields

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -4369,6 +4369,9 @@ export interface ITeamListFields {
   /** Filter Tags */
   filterTags?: IGenericTag[] | undefined
 
+  /** Filter groups */
+  filterGroups?: IGenericTagGroup[] | undefined
+
   /** Variant */
   variant?: 'card' | 'accordion' | undefined
 }

--- a/libs/cms/src/lib/models/teamList.model.ts
+++ b/libs/cms/src/lib/models/teamList.model.ts
@@ -3,7 +3,7 @@ import { CacheField } from '@island.is/nest/graphql'
 import { ITeamList } from '../generated/contentfulTypes'
 import { SystemMetadata } from '@island.is/shared/types'
 import { TeamMember, mapTeamMember } from './teamMember.model'
-import { GenericTag, mapGenericTag } from './genericTag.model'
+import { GenericTag } from './genericTag.model'
 
 @ObjectType()
 export class TeamList {
@@ -23,10 +23,42 @@ export class TeamList {
 export const mapTeamList = ({
   fields,
   sys,
-}: ITeamList): SystemMetadata<TeamList> => ({
-  typename: 'TeamList',
-  id: sys.id,
-  teamMembers: (fields.teamMembers ?? []).map(mapTeamMember),
-  variant: fields.variant === 'accordion' ? 'accordion' : 'card',
-  filterTags: fields.filterTags ? fields.filterTags.map(mapGenericTag) : [],
-})
+}: ITeamList): SystemMetadata<TeamList> => {
+  const teamMembers = (fields.teamMembers ?? []).map(mapTeamMember)
+
+  const filterTags: GenericTag[] = []
+
+  for (const teamMember of teamMembers) {
+    for (const tag of teamMember.filterTags ?? []) {
+      const tagBelongsToAFilterGroup = fields.filterGroups?.some(
+        (group) => group?.sys?.id === tag?.genericTagGroup?.id,
+      )
+      if (tag?.genericTagGroup?.id && tagBelongsToAFilterGroup) {
+        const tagHasAlreadyBeenAdded = filterTags.some((t) => t.id === tag.id)
+        if (!tagHasAlreadyBeenAdded) {
+          filterTags.push(tag)
+        }
+      }
+    }
+
+    // Reorder the team member tag groups so they are in the same order as the team list filter groups
+    const tagGroups = []
+    for (const filterGroup of fields.filterGroups ?? []) {
+      const group = teamMember.tagGroups?.find(
+        (g) => g.groupId === filterGroup.sys.id,
+      )
+      if (group) {
+        tagGroups.push(group)
+      }
+    }
+    teamMember.tagGroups = tagGroups
+  }
+
+  return {
+    typename: 'TeamList',
+    id: sys.id,
+    teamMembers,
+    variant: fields.variant === 'accordion' ? 'accordion' : 'card',
+    filterTags,
+  }
+}

--- a/libs/cms/src/lib/models/teamMember.model.ts
+++ b/libs/cms/src/lib/models/teamMember.model.ts
@@ -1,4 +1,4 @@
-import { Field, ObjectType } from '@nestjs/graphql'
+import { Field, ObjectType, ID } from '@nestjs/graphql'
 import { CacheField } from '@island.is/nest/graphql'
 import { ITeamMember } from '../generated/contentfulTypes'
 import { Image, mapImage } from './image.model'
@@ -6,7 +6,22 @@ import { GenericTag, mapGenericTag } from './genericTag.model'
 import { SliceUnion, mapDocument } from '../unions/slice.union'
 
 @ObjectType()
+export class TeamMemberTagGroup {
+  @Field()
+  groupId!: string
+
+  @Field()
+  groupLabel!: string
+
+  @Field(() => [String])
+  tagLabels!: string[]
+}
+
+@ObjectType()
 export class TeamMember {
+  @Field(() => ID)
+  id?: string
+
   @Field()
   name!: string
 
@@ -30,15 +45,57 @@ export class TeamMember {
 
   @CacheField(() => [SliceUnion], { nullable: true })
   intro?: Array<typeof SliceUnion> = []
+
+  @CacheField(() => [TeamMemberTagGroup], { nullable: true })
+  tagGroups?: TeamMemberTagGroup[]
+
+  @Field({ nullable: true })
+  createdAt?: string
 }
 
-export const mapTeamMember = ({ fields, sys }: ITeamMember): TeamMember => ({
-  name: fields.name ?? '',
-  title: fields.title ?? '',
-  image: mapImage(fields.mynd),
-  imageOnSelect: fields.imageOnSelect ? mapImage(fields.imageOnSelect) : null,
-  filterTags: fields.filterTags ? fields.filterTags.map(mapGenericTag) : [],
-  intro: fields.intro ? mapDocument(fields.intro, `${sys.id}:intro`) : [],
-  email: fields.email,
-  phone: fields.phone,
-})
+export const mapTeamMember = ({ fields, sys }: ITeamMember): TeamMember => {
+  const tagGroups: TeamMemberTagGroup[] = []
+
+  const filterTags = fields.filterTags
+    ? fields.filterTags.map(mapGenericTag)
+    : []
+
+  for (const tag of filterTags) {
+    if (!tag.genericTagGroup?.title || !tag.title) {
+      continue
+    }
+    const index = tagGroups.findIndex(
+      (group) => group.groupLabel === tag.genericTagGroup?.title,
+    )
+    if (index >= 0) {
+      tagGroups[index].tagLabels.push(tag.title)
+    } else {
+      tagGroups.push({
+        groupLabel: tag.genericTagGroup.title,
+        tagLabels: [tag.title],
+        groupId: tag.genericTagGroup.id,
+      })
+    }
+
+    // Add a colon to the end of group labels if it doesn't have one
+    for (const group of tagGroups) {
+      if (!group.groupLabel.endsWith(':')) {
+        group.groupLabel += ':'
+      }
+    }
+  }
+
+  return {
+    id: sys.id,
+    name: fields.name ?? '',
+    title: fields.title ?? '',
+    image: mapImage(fields.mynd),
+    imageOnSelect: fields.imageOnSelect ? mapImage(fields.imageOnSelect) : null,
+    filterTags,
+    intro: fields.intro ? mapDocument(fields.intro, `${sys.id}:intro`) : [],
+    email: fields.email,
+    phone: fields.phone,
+    tagGroups,
+    createdAt: sys.createdAt,
+  }
+}

--- a/libs/cms/src/lib/search/importers/teamList.service.ts
+++ b/libs/cms/src/lib/search/importers/teamList.service.ts
@@ -35,7 +35,13 @@ export class TeamListSyncService implements CmsSyncProvider<ITeamList> {
               ...member,
               typename: 'webTeamMember',
             }),
-            tags: [{ key: teamListEntry.sys.id, type: 'referencedBy' }],
+            tags: [
+              { key: teamListEntry.sys.id, type: 'referencedBy' },
+              ...(member.filterTags ?? []).map((tag) => ({
+                key: tag.slug,
+                type: 'genericTag',
+              })),
+            ],
             dateCreated: member.createdAt ?? '',
             dateUpdated: new Date().getTime().toString(),
           })

--- a/libs/island-ui/contentful/src/lib/TeamList/TeamList.tsx
+++ b/libs/island-ui/contentful/src/lib/TeamList/TeamList.tsx
@@ -144,8 +144,8 @@ const TeamMemberAccordionList = ({
 }: Pick<TeamListProps, 'teamMembers' | 'prefixes'>) => {
   return (
     <Accordion singleExpand={false}>
-      {teamMembers.map((member) => {
-        const id = `${member.name}-${member.title}`
+      {teamMembers.map((member, index) => {
+        const id = `${member.name}-${member.title}-${index}`
         return (
           <AccordionItem
             key={id}


### PR DESCRIPTION
# Team List - Move frontend logic to the backend

## What

* Extract team member tag data into a new graphql field called "tagGroups" instead of doing so in the frontend

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new optional property for filtering team members by tag groups.
	- Added a structured representation for team member tags, enhancing organization and clarity.
	- Improved uniqueness of team member identifiers in the display list.

- **Bug Fixes**
	- Enhanced logic for processing team members and their associated tags, ensuring unique tags are included.

- **Refactor**
	- Streamlined the logic for processing team members, simplifying data retrieval and enhancing performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->