### PR TITLE
fix(services-auth-admin-api): Fix delegation settings

### DIFF
--- a/apps/services/auth/admin-api/src/app/v2/scopes/test/me-scopes.spec.ts
+++ b/apps/services/auth/admin-api/src/app/v2/scopes/test/me-scopes.spec.ts
@@ -10,7 +10,8 @@ import {
   SequelizeConfigService,
   TranslatedValueDto,
   ApiScopeDelegationType,
-  AdminPatchScopeDto, ApiScope,
+  AdminPatchScopeDto,
+  ApiScope,
 } from '@island.is/auth-api-lib'
 import { FixtureFactory } from '@island.is/services/auth/testing'
 import {
@@ -895,9 +896,7 @@ describe('MeScopesController', () => {
       const sutScope = await fixtureFactory.createApiScope({
         domainName: TENANT_ID,
         allowExplicitDelegationGrant: true,
-        supportedDelegationTypes: [
-          AuthDelegationType.Custom,
-        ],
+        supportedDelegationTypes: [AuthDelegationType.Custom],
       })
 
       // Act - Update partially delegation setting
@@ -908,23 +907,25 @@ describe('MeScopesController', () => {
           )}`,
         )
         .send({
-          addedDelegationTypes: [
-            AuthDelegationType.ProcurationHolder,
-          ],
+          addedDelegationTypes: [AuthDelegationType.ProcurationHolder],
         })
 
       // Assert that we only updated requested delegation setting fields
       expect(response.status).toEqual(200)
       expect(response.body).toMatchObject({
         ...sutScope.toDTO(),
-        displayName: [{
-          locale: 'is',
-          value: sutScope.displayName,
-        }],
-        description: [{
-          locale: 'is',
-          value: sutScope.description,
-        }],
+        displayName: [
+          {
+            locale: 'is',
+            value: sutScope.displayName,
+          },
+        ],
+        description: [
+          {
+            locale: 'is',
+            value: sutScope.description,
+          },
+        ],
         grantToProcuringHolders: true,
         supportedDelegationTypes: expect.arrayContaining([
           AuthDelegationType.Custom,

--- a/apps/services/auth/admin-api/src/app/v2/scopes/test/me-scopes.spec.ts
+++ b/apps/services/auth/admin-api/src/app/v2/scopes/test/me-scopes.spec.ts
@@ -10,7 +10,7 @@ import {
   SequelizeConfigService,
   TranslatedValueDto,
   ApiScopeDelegationType,
-  AdminPatchScopeDto,
+  AdminPatchScopeDto, ApiScope,
 } from '@island.is/auth-api-lib'
 import { FixtureFactory } from '@island.is/services/auth/testing'
 import {
@@ -763,6 +763,7 @@ describe('MeScopesController', () => {
     let app: TestApp
     let server: request.SuperTest<request.Test>
     let apiScopeDelegationTypeModel: typeof ApiScopeDelegationType
+    let fixtureFactory: FixtureFactory
 
     beforeAll(async () => {
       app = await setupApp({
@@ -772,6 +773,7 @@ describe('MeScopesController', () => {
         dbType: 'postgres',
       })
       server = request(app.getHttpServer())
+      fixtureFactory = new FixtureFactory(app)
 
       apiScopeDelegationTypeModel = await app.get(
         getModelToken(ApiScopeDelegationType),
@@ -885,6 +887,59 @@ describe('MeScopesController', () => {
           supportedDelegationTypes: [],
         },
       })
+    })
+
+    it('should only update requested delegation setting fields', async () => {
+      // Arrange
+      // Create new subject under testing test data to control initial state of delegation settings.
+      const sutScope = await fixtureFactory.createApiScope({
+        domainName: TENANT_ID,
+        allowExplicitDelegationGrant: true,
+        supportedDelegationTypes: [
+          AuthDelegationType.Custom,
+        ],
+      })
+
+      // Act - Update partially delegation setting
+      const response = await server
+        .patch(
+          `/v2/me/tenants/${TENANT_ID}/scopes/${encodeURIComponent(
+            sutScope.name,
+          )}`,
+        )
+        .send({
+          addedDelegationTypes: [
+            AuthDelegationType.ProcurationHolder,
+          ],
+        })
+
+      // Assert that we only updated requested delegation setting fields
+      expect(response.status).toEqual(200)
+      expect(response.body).toMatchObject({
+        ...sutScope.toDTO(),
+        displayName: [{
+          locale: 'is',
+          value: sutScope.displayName,
+        }],
+        description: [{
+          locale: 'is',
+          value: sutScope.description,
+        }],
+        grantToProcuringHolders: true,
+        supportedDelegationTypes: expect.arrayContaining([
+          AuthDelegationType.Custom,
+          AuthDelegationType.ProcurationHolder,
+        ]),
+      } as AdminScopeDTO)
+      const apiScopeDelegationTypes = await apiScopeDelegationTypeModel.findAll(
+        {
+          where: {
+            apiScopeName: sutScope.name,
+          },
+        },
+      )
+
+      expect(apiScopeDelegationTypes).toHaveLength(2)
     })
   })
 

--- a/libs/auth-api-lib/src/lib/resources/admin/admin-scope.service.ts
+++ b/libs/auth-api-lib/src/lib/resources/admin/admin-scope.service.ts
@@ -480,10 +480,10 @@ export class AdminScopeService {
     ) {
       await this.apiScope.update(
         {
-          grantToLegalGuardians,
-          grantToPersonalRepresentatives,
-          grantToProcuringHolders,
-          allowExplicitDelegationGrant,
+          ...(grantToLegalGuardians ? {grantToLegalGuardians} : {}),
+          ...(grantToPersonalRepresentatives ? {grantToPersonalRepresentatives} : {}),
+          ...(grantToProcuringHolders ? {grantToProcuringHolders} : {}),
+          ...(allowExplicitDelegationGrant ? {allowExplicitDelegationGrant} : {}),
         },
         {
           transaction,

--- a/libs/auth-api-lib/src/lib/resources/admin/admin-scope.service.ts
+++ b/libs/auth-api-lib/src/lib/resources/admin/admin-scope.service.ts
@@ -480,10 +480,14 @@ export class AdminScopeService {
     ) {
       await this.apiScope.update(
         {
-          ...(grantToLegalGuardians ? {grantToLegalGuardians} : {}),
-          ...(grantToPersonalRepresentatives ? {grantToPersonalRepresentatives} : {}),
-          ...(grantToProcuringHolders ? {grantToProcuringHolders} : {}),
-          ...(allowExplicitDelegationGrant ? {allowExplicitDelegationGrant} : {}),
+          ...(grantToLegalGuardians ? { grantToLegalGuardians } : {}),
+          ...(grantToPersonalRepresentatives
+            ? { grantToPersonalRepresentatives }
+            : {}),
+          ...(grantToProcuringHolders ? { grantToProcuringHolders } : {}),
+          ...(allowExplicitDelegationGrant
+            ? { allowExplicitDelegationGrant }
+            : {}),
         },
         {
           transaction,


### PR DESCRIPTION
## What

When adding delegation type to scope it resetted all missing types to false.

## Why

To fix the bug caused by this reverting delegation types not in the array to false.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced test coverage for updating delegation settings in the API scope.
- **Improvements**
	- Improved data handling in the AdminScopeService by conditionally including properties in the update method, leading to cleaner updates and reduced risk of unintended data issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->