### PR TITLE
fix(service-portal): Applications sorting fix

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -228,6 +228,7 @@ codemagic.yaml                                                                  
 /libs/application/template-api-modules/src/lib/modules/templates/data-protection-complaint/              @island-is/norda
 /libs/shared/form-fields/                                                                                @island-is/norda @island-is/island-ui
 
+/libs/service-portal/applications/                                                                       @island-is/norda-applications
 /libs/portals/admin/application-system/                                                                  @island-is/norda-applications
 /libs/api/domains/application/                                                                           @island-is/norda-applications
 /libs/api/domains/payment/                                                                               @island-is/norda-applications

--- a/libs/service-portal/applications/src/shared/utils/index.ts
+++ b/libs/service-portal/applications/src/shared/utils/index.ts
@@ -23,8 +23,8 @@ export const sortApplicationsStatus = (
 
   applications.forEach((application) => {
     if (
-      application.state === 'draft' ||
-      application.state === 'prerequisites'
+      application.status === ApplicationStatus.DRAFT ||
+      application.status === ApplicationStatus.NOT_STARTED
     ) {
       incomplete.push(application)
     } else if (application.status === ApplicationStatus.IN_PROGRESS) {


### PR DESCRIPTION
# Applications sorting fix

Attach a link to issue if relevant

## What

Use `status` instead of `state` to sort applications

## Why

`state` is dynamic and can be any value, so it is not certain that the states `draft` and `prerequisites` exist (even though they are present on most templates).
`status` however is static, and if an application has status `draft` or `not_started`, we know that it is incomplete.

## Screenshots / Gifs

![image](https://github.com/user-attachments/assets/666ca5ee-4580-41bf-8b87-c042891ef0c1)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the logic for identifying incomplete applications, enhancing accuracy in application status management.
- **Chores**
	- Updated ownership structure for the service portal applications, designating the `@island-is/norda-applications` team for code review responsibilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->