### PR TITLE
fix(native-app): decrease size of vehicle card on home page

### DIFF
--- a/apps/native/app/src/screens/home/vehicles-module.tsx
+++ b/apps/native/app/src/screens/home/vehicles-module.tsx
@@ -93,14 +93,14 @@ const VehiclesModule = React.memo(
         key={vehicle.permno}
         item={vehicle}
         index={index}
-        minHeight={176}
+        minHeight={152}
         style={
           count > 1
             ? {
                 width: screenWidth - theme.spacing[2] * 3,
                 paddingHorizontal: 0,
                 paddingLeft: theme.spacing[2],
-                minHeight: 176,
+                minHeight: 152,
               }
             : {
                 width: '100%',

--- a/apps/native/app/src/ui/lib/card/vehicle-card.tsx
+++ b/apps/native/app/src/ui/lib/card/vehicle-card.tsx
@@ -64,7 +64,13 @@ export function VehicleCard({
   return (
     <Host minHeight={minHeight}>
       <Content>
-        <Title variant="heading4">{title}</Title>
+        <Title
+          variant="heading4"
+          numberOfLines={minHeight ? 1 : undefined}
+          ellipsizeMode="tail"
+        >
+          {title}
+        </Title>
         <Text>
           {color} - {number}
         </Text>


### PR DESCRIPTION
## What

Vehicle card in widget on home screen was set to have minHeight 176px to accommodate vehicles with long names that would wrap into two lines. (We want all vehicle cards in the widget to be of the same size, that is the reason we set minHeight to the size of the biggest possible card). This was causing really big cards so we decided to truncate the name on the home screen. They are not truncated on the vehicles screen, then they are dynamically sized based on content.

## Screenshots / Gifs
Before:
![Screenshot 2024-09-12 at 09 45 47](https://github.com/user-attachments/assets/12c44a40-11e6-4f89-99b4-4fee03db8de5)
After:
![Screenshot 2024-09-12 at 09 45 12](https://github.com/user-attachments/assets/8d074491-7f32-401e-82b8-efea30c6146c)



Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
