### PR TITLE
feat(web): Add default header for fiskistofa organization

### DIFF
--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -59,7 +59,10 @@ import { getBackgroundStyle } from '@island.is/web/utils/organization'
 
 import { LatestNewsCardConnectedComponent } from '../LatestNewsCardConnectedComponent'
 import { DigitalIcelandHeader } from './Themes/DigitalIcelandTheme'
-import { FiskistofaHeader } from './Themes/FiskistofaTheme'
+import {
+  FiskistofaDefaultHeader,
+  FiskistofaHeader,
+} from './Themes/FiskistofaTheme'
 import { FiskistofaFooter } from './Themes/FiskistofaTheme'
 import {
   FjarsyslaRikisinsFooter,
@@ -328,7 +331,13 @@ export const OrganizationHeader: React.FC<
         />
       )
     case 'fiskistofa':
-      return (
+      return n('usingDefaultHeader', false) ? (
+        <FiskistofaDefaultHeader
+          organizationPage={organizationPage}
+          logoAltText={logoAltText}
+          isSubpage={(isSubpage && n('smallerSubpageHeader', false)) ?? false}
+        />
+      ) : (
         <FiskistofaHeader
           organizationPage={organizationPage}
           logoAltText={logoAltText}

--- a/apps/web/components/Organization/Wrapper/Themes/FiskistofaTheme/FiskistofaDefaultHeader.css.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/FiskistofaTheme/FiskistofaDefaultHeader.css.ts
@@ -1,0 +1,6 @@
+import { style } from '@vanilla-extract/css'
+
+export const gridContainerWidth = style({
+  maxWidth: '1342px',
+  margin: '0 auto',
+})

--- a/apps/web/components/Organization/Wrapper/Themes/FiskistofaTheme/FiskistofaDefaultHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/FiskistofaTheme/FiskistofaDefaultHeader.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+
+import { ResponsiveSpace } from '@island.is/island-ui/core'
+import { theme } from '@island.is/island-ui/theme'
+import { DefaultHeader } from '@island.is/web/components'
+import { OrganizationPage } from '@island.is/web/graphql/schema'
+import { useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
+import { useWindowSize } from '@island.is/web/hooks/useViewport'
+
+import * as styles from './FiskistofaDefaultHeader.css'
+
+interface HeaderProps {
+  organizationPage: OrganizationPage
+  logoAltText: string
+  isSubpage: boolean
+}
+
+const FiskistofaDefaultHeader: React.FC<
+  React.PropsWithChildren<HeaderProps>
+> = ({ organizationPage, logoAltText, isSubpage }) => {
+  const { linkResolver } = useLinkResolver()
+
+  const { width } = useWindowSize()
+
+  const themeProp = organizationPage.themeProperties
+
+  return (
+    <div
+      style={{
+        background:
+          (width > theme.breakpoints.lg && !isSubpage
+            ? themeProp.backgroundColor
+            : 'no-repeat 52% 30% ,linear-gradient(180deg, #E6F2FB 21.56%, #90D9E3 239.74%)') ??
+          '',
+      }}
+      className={styles.gridContainerWidth}
+    >
+      <DefaultHeader
+        title={organizationPage.title}
+        titleColor="dark400"
+        imagePadding={themeProp.imagePadding ?? '0'}
+        fullWidth={themeProp.fullWidth ?? false}
+        imageIsFullHeight={themeProp.imageIsFullHeight ?? false}
+        imageObjectFit={
+          themeProp?.imageObjectFit === 'cover' ? 'cover' : 'contain'
+        }
+        logo={organizationPage.organization?.logo?.url}
+        logoHref={
+          linkResolver('organizationpage', [organizationPage.slug]).href
+        }
+        logoAltText={logoAltText}
+        titleSectionPaddingLeft={
+          organizationPage.themeProperties
+            .titleSectionPaddingLeft as ResponsiveSpace
+        }
+        isSubpage={isSubpage}
+        mobileBackground={
+          organizationPage.themeProperties.mobileBackgroundColor
+        }
+      />
+    </div>
+  )
+}
+
+export default FiskistofaDefaultHeader

--- a/apps/web/components/Organization/Wrapper/Themes/FiskistofaTheme/index.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/FiskistofaTheme/index.ts
@@ -1,5 +1,6 @@
 import dynamic from 'next/dynamic'
 
+import DefaultHeader from './FiskistofaDefaultHeader'
 import Header from './FiskistofaHeader'
 
 export const FiskistofaFooter = dynamic(() => import('./FiskistofaFooter'), {
@@ -7,3 +8,4 @@ export const FiskistofaFooter = dynamic(() => import('./FiskistofaFooter'), {
 })
 
 export const FiskistofaHeader = Header
+export const FiskistofaDefaultHeader = DefaultHeader


### PR DESCRIPTION
# Add default header for fiskistofa organization

## What

Make it possible to use default header for syslumenn organization via config.

## Why

A design that was approved by Digital Iceland

## Screenshots / Gifs

### Before
![image](https://github.com/user-attachments/assets/1731a24c-1730-4c8d-8c88-d238dedd6d39)

### After
![image](https://github.com/user-attachments/assets/ae01aca5-8d10-49f5-acd6-1ee1285e398b)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a conditional rendering mechanism for the organization header, allowing for a default header display based on specific conditions.
	- Added a customizable `FiskistofaDefaultHeader` component that adapts to different contexts and screen sizes.
- **Style**
	- Implemented new styles for the Fiskistofa theme's grid container, ensuring consistent width and alignment.
- **Documentation**
	- Updated exports to include the new `FiskistofaDefaultHeader` component for enhanced module functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->