### PR TITLE
chore(j-s): Hide the resend indictment button

### DIFF
--- a/apps/judicial-system/web/src/routes/Court/Indictments/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/Overview/Overview.tsx
@@ -141,10 +141,15 @@ const IndictmentOverview = () => {
             )
           }
           nextButtonText={formatMessage(core.continue)}
-          actionButtonText={formatMessage(strings.returnIndictmentButtonText)}
-          actionButtonColorScheme={'destructive'}
-          actionButtonIsDisabled={!caseHasBeenReceivedByCourt}
-          onActionButtonClick={() => setModalVisible('RETURN_INDICTMENT')}
+          /* 
+            The return indictment feature has been removed for the time being but
+            we want to hold on to the functionality for now, since we are likely
+            to change this feature in the future.
+          */
+          // actionButtonText={formatMessage(strings.returnIndictmentButtonText)}
+          // actionButtonColorScheme={'destructive'}
+          // actionButtonIsDisabled={!caseHasBeenReceivedByCourt}
+          // onActionButtonClick={() => setModalVisible('RETURN_INDICTMENT')}
         />
       </FormContentContainer>
       {modalVisible === 'RETURN_INDICTMENT' && (


### PR DESCRIPTION
# Hide the resend indictment button

[Asana](https://app.asana.com/0/1199153462262248/1208258864572717/f)

## What

Hide the resend indictment button

## Why

This feature is no longer wanted. We do however plan on repurposing it later on so we decided to hold on to the functionality.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Removed the option to return an indictment from the Indictment Overview interface. 

- **Impact**
	- This change modifies the user interface and limits the available actions for users interacting with the indictment overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->