### PR TITLE
fix(cms): Latest Generic List Items - Mark seeMorePage field as nullable

### DIFF
--- a/libs/cms/src/lib/models/latestGenericListItems.model.ts
+++ b/libs/cms/src/lib/models/latestGenericListItems.model.ts
@@ -23,7 +23,7 @@ export class LatestGenericListItems {
   @CacheField(() => GenericList, { nullable: true })
   genericList?: GenericList | null
 
-  @CacheField(() => PageUnion)
+  @CacheField(() => PageUnion, { nullable: true })
   seeMorePage?: typeof PageUnion | null
 
   @Field()


### PR DESCRIPTION
# Latest Generic List Items - Mark seeMorePage field as nullable

## What

I forgot to mark the field as nullable so now the field is required in the CMS (when it really shouldn't be)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `seeMorePage` property to allow explicit null values, improving flexibility in data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->