### PR TITLE
feat(income-plan): Only allow one income plan in draft

### DIFF
--- a/libs/application/templates/social-insurance-administration/income-plan/src/lib/IncomePlanTemplate.ts
+++ b/libs/application/templates/social-insurance-administration/income-plan/src/lib/IncomePlanTemplate.ts
@@ -61,6 +61,7 @@ const IncomePlanTemplate: ApplicationTemplate<
   featureFlag: Features.IncomePlanEnabled,
   translationNamespaces: ApplicationConfigurations.IncomePlan.translation,
   dataSchema,
+  allowMultipleApplicationsInDraft: false,
   newApplicationButtonLabel: historyMessages.newIncomePlanButtonLabel,
   applicationText: historyMessages.incomePlanPageTitle,
   stateMachineConfig: {


### PR DESCRIPTION
# ...

[TS-910](https://dit-iceland.atlassian.net/browse/TS-910)

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a restriction on creating multiple draft applications for the income plan feature, enhancing workflow clarity.
  
- **Bug Fixes**
	- Addressed potential confusion by enforcing a single draft application limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->