### PR TITLE
feat(income-plan): Update updateValueObj in incomeType

### DIFF
--- a/libs/application/templates/social-insurance-administration/income-plan/src/forms/IncomePlanForm.ts
+++ b/libs/application/templates/social-insurance-administration/income-plan/src/forms/IncomePlanForm.ts
@@ -113,7 +113,18 @@ export const IncomePlanForm: Form = buildForm({
                   width: 'half',
                   isSearchable: true,
                   updateValueObj: {
-                    valueModifier: (_) => '',
+                    valueModifier: (application, activeField) => {
+                      const options = getTypesOptions(
+                        application.externalData,
+                        activeField?.incomeCategory,
+                      )
+
+                      return (
+                        options.find(
+                          (option) => option.value === activeField?.incomeType,
+                        )?.value ?? ''
+                      )
+                    },
                     watchValues: 'incomeCategory',
                   },
                   options: (application, activeField) => {
@@ -129,7 +140,7 @@ export const IncomePlanForm: Form = buildForm({
                   placeholder: incomePlanFormMessage.incomePlan.selectCurrency,
                   isSearchable: true,
                   updateValueObj: {
-                    valueModifier: (activeField) => {
+                    valueModifier: (_, activeField) => {
                       const defaultCurrency =
                         activeField?.incomeType === FOREIGN_BASIC_PENSION ||
                         activeField?.incomeType === FOREIGN_PENSION ||
@@ -186,7 +197,7 @@ export const IncomePlanForm: Form = buildForm({
                   displayInTable: false,
                   currency: true,
                   updateValueObj: {
-                    valueModifier: (activeField) => {
+                    valueModifier: (_, activeField) => {
                       const unevenAndEmploymentIncome =
                         activeField?.unevenIncomePerYear?.[0] !== YES ||
                         (activeField?.incomeCategory !== INCOME &&
@@ -227,7 +238,7 @@ export const IncomePlanForm: Form = buildForm({
                   displayInTable: false,
                   currency: true,
                   updateValueObj: {
-                    valueModifier: (activeField) => {
+                    valueModifier: (_, activeField) => {
                       const unevenAndEmploymentIncome =
                         activeField?.unevenIncomePerYear?.[0] !== YES ||
                         (activeField?.incomeCategory !== INCOME &&
@@ -270,7 +281,7 @@ export const IncomePlanForm: Form = buildForm({
                     return activeField?.income === RatioType.MONTHLY
                   },
                   updateValueObj: {
-                    valueModifier: (activeField) => {
+                    valueModifier: (_, activeField) => {
                       if (
                         activeField?.income === RatioType.MONTHLY &&
                         activeField?.incomeCategory === INCOME &&

--- a/libs/application/types/src/lib/Fields.ts
+++ b/libs/application/types/src/lib/Fields.ts
@@ -95,7 +95,10 @@ export type TableRepeaterItem = {
         activeField?: Record<string, string>,
       ) => boolean)
   updateValueObj?: {
-    valueModifier: (activeField?: Record<string, string>) => unknown
+    valueModifier: (
+      application: Application,
+      activeField?: Record<string, string>,
+    ) => unknown
     watchValues:
       | string
       | string[]

--- a/libs/application/ui-fields/src/lib/TableRepeaterFormField/TableRepeaterItem.tsx
+++ b/libs/application/ui-fields/src/lib/TableRepeaterFormField/TableRepeaterItem.tsx
@@ -98,7 +98,10 @@ export const Item = ({
           ? !watchedValues.every((value) => value === undefined)
           : true)
       ) {
-        const finalValue = updateValueObj.valueModifier(activeValues)
+        const finalValue = updateValueObj.valueModifier(
+          application,
+          activeValues,
+        )
         setValue(id, finalValue)
       }
     }


### PR DESCRIPTION
[[TS-913] Update updateValueObj in incomeType](https://dit-iceland.atlassian.net/jira/software/c/projects/TS/boards/82?issueParent=60310&selectedIssue=TS-913)

## What

Added `application` to `valueModifier` in `TableRepeaterItem` and updated `updateValueObj` in `incomeType`.

## Why

`incomeType` is unset ('') when a row in income-plan table is edited. Should only be unset if `incomeCategory` is changed (`incomeType` does not match `incomeCategory`)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced income type selection functionality with improved value handling.
	- Updated value modifier functions to utilize application context for better logic processing.

- **Bug Fixes**
	- Standardized parameter handling across various value modifier functions.

- **Documentation**
	- Updated function signatures to reflect new parameters and capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->