### PR TITLE
feat(income-plan): Add disabled to TableRepeaterItem

### DIFF
--- a/libs/application/templates/social-insurance-administration/income-plan/src/forms/IncomePlanForm.ts
+++ b/libs/application/templates/social-insurance-administration/income-plan/src/forms/IncomePlanForm.ts
@@ -266,7 +266,7 @@ export const IncomePlanForm: Form = buildForm({
                   width: 'half',
                   type: 'number',
                   currency: true,
-                  readonly: (_, activeField) => {
+                  disabled: (_, activeField) => {
                     return activeField?.income === RatioType.MONTHLY
                   },
                   updateValueObj: {

--- a/libs/application/types/src/lib/Fields.ts
+++ b/libs/application/types/src/lib/Fields.ts
@@ -94,6 +94,12 @@ export type TableRepeaterItem = {
         application: Application,
         activeField?: Record<string, string>,
       ) => boolean)
+  disabled?:
+    | boolean
+    | ((
+        application: Application,
+        activeField?: Record<string, string>,
+      ) => boolean)
   updateValueObj?: {
     valueModifier: (activeField?: Record<string, string>) => unknown
     watchValues:

--- a/libs/application/ui-fields/src/lib/TableRepeaterFormField/TableRepeaterItem.tsx
+++ b/libs/application/ui-fields/src/lib/TableRepeaterFormField/TableRepeaterItem.tsx
@@ -54,6 +54,7 @@ export const Item = ({
     width = 'full',
     condition,
     readonly = false,
+    disabled = false,
     updateValueObj,
     defaultValue,
     ...props
@@ -148,6 +149,13 @@ export const Item = ({
     Readonly = readonly
   }
 
+  let Disabled: boolean | undefined
+  if (typeof disabled === 'function') {
+    Disabled = disabled(application, activeValues)
+  } else {
+    Disabled = disabled
+  }
+
   let DefaultValue: any
   if (component === 'input') {
     DefaultValue = getDefaultValue(item, application, activeValues)
@@ -194,6 +202,7 @@ export const Item = ({
         error={getFieldError(itemId)}
         control={control}
         readOnly={Readonly}
+        disabled={Disabled}
         backgroundColor={backgroundColor}
         onChange={() => {
           if (error) {


### PR DESCRIPTION
## What

Added `disabled` to `TableRepeaterItem` and changed `incomePerYear` `readonly` to `disabled`

## Screenshots / Gifs
Input field "Tekjur á ári" is disabled
![image](https://github.com/user-attachments/assets/e08bf4a1-0c3f-4f37-bdd9-e6c91dec1146)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `disabled` property for form fields, enhancing control over user interaction.
	- Added flexibility to the `TableRepeaterItem` type, allowing conditional disabling of items based on application state.

- **Bug Fixes**
	- Improved user experience by ensuring non-interactive fields are clearly disabled rather than just read-only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->