### PR TITLE
feat(eb): Add default header for sjukratryggingar organization

### DIFF
--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -97,6 +97,7 @@ import { RikissaksoknariHeader } from './Themes/RikissaksoknariTheme'
 import { SAkFooter, SAkHeader } from './Themes/SAkTheme'
 import { ShhFooter, ShhHeader } from './Themes/SHHTheme'
 import {
+  SjukratryggingarDefaultHeader,
   SjukratryggingarFooter,
   SjukratryggingarHeader,
 } from './Themes/SjukratryggingarTheme'
@@ -284,7 +285,13 @@ export const OrganizationHeader: React.FC<
         />
       )
     case 'sjukratryggingar':
-      return (
+      return n('usingDefaultHeader', false) ? (
+        <SjukratryggingarDefaultHeader
+          organizationPage={organizationPage}
+          logoAltText={logoAltText}
+          isSubpage={(isSubpage && n('smallerSubpageHeader', false)) ?? false}
+        />
+      ) : (
         <SjukratryggingarHeader
           organizationPage={organizationPage}
           logoAltText={logoAltText}

--- a/apps/web/components/Organization/Wrapper/Themes/SjukratryggingarTheme/SjukratryggingarDefaultHeader.css.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/SjukratryggingarTheme/SjukratryggingarDefaultHeader.css.ts
@@ -1,0 +1,6 @@
+import { style } from '@vanilla-extract/css'
+
+export const gridContainerWidth = style({
+  maxWidth: '1342px',
+  margin: '0 auto',
+})

--- a/apps/web/components/Organization/Wrapper/Themes/SjukratryggingarTheme/SjukratryggingarDefaultHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/SjukratryggingarTheme/SjukratryggingarDefaultHeader.tsx
@@ -1,0 +1,68 @@
+import React from 'react'
+
+import { ResponsiveSpace } from '@island.is/island-ui/core'
+import { theme } from '@island.is/island-ui/theme'
+import { DefaultHeader } from '@island.is/web/components'
+import { OrganizationPage } from '@island.is/web/graphql/schema'
+import { useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
+import { useWindowSize } from '@island.is/web/hooks/useViewport'
+
+import * as styles from './SjukratryggingarDefaultHeader.css'
+
+interface HeaderProps {
+  organizationPage: OrganizationPage
+  logoAltText: string
+  isSubpage: boolean
+}
+
+const SjukratryggingarDefaultHeader: React.FC<
+  React.PropsWithChildren<HeaderProps>
+> = ({ organizationPage, logoAltText, isSubpage }) => {
+  const { linkResolver } = useLinkResolver()
+
+  const { width } = useWindowSize()
+
+  const themeProp = organizationPage.themeProperties
+
+  return (
+    <div
+      style={{
+        background:
+          width <= theme.breakpoints.sm
+            ? '#40c5e5'
+            : (width > theme.breakpoints.lg && !isSubpage
+                ? themeProp.backgroundColor
+                : `linear-gradient(184.95deg, #40c5e5 8.38%, rgba(64, 197, 227, 0.1) 39.64%, rgba(244, 247, 247, 0) 49.64%),
+               linear-gradient(273.41deg, #f4f7f7 -9.24%, #40c5e5 66.78%, #a4def1 105.51%)`) ??
+              '',
+      }}
+      className={styles.gridContainerWidth}
+    >
+      <DefaultHeader
+        title={organizationPage.title}
+        titleColor="dark400"
+        imagePadding={themeProp.imagePadding ?? '0'}
+        fullWidth={themeProp.fullWidth ?? false}
+        imageIsFullHeight={themeProp.imageIsFullHeight ?? false}
+        imageObjectFit={
+          themeProp?.imageObjectFit === 'cover' ? 'cover' : 'contain'
+        }
+        logo={organizationPage.organization?.logo?.url}
+        logoHref={
+          linkResolver('organizationpage', [organizationPage.slug]).href
+        }
+        logoAltText={logoAltText}
+        titleSectionPaddingLeft={
+          organizationPage.themeProperties
+            .titleSectionPaddingLeft as ResponsiveSpace
+        }
+        isSubpage={isSubpage}
+        mobileBackground={
+          organizationPage.themeProperties.mobileBackgroundColor
+        }
+      />
+    </div>
+  )
+}
+
+export default SjukratryggingarDefaultHeader

--- a/apps/web/components/Organization/Wrapper/Themes/SjukratryggingarTheme/index.ts
+++ b/apps/web/components/Organization/Wrapper/Themes/SjukratryggingarTheme/index.ts
@@ -1,7 +1,9 @@
 import dynamic from 'next/dynamic'
 
+import DefaultHeader from './SjukratryggingarDefaultHeader'
 import Header from './SjukratryggingarHeader'
 
+export const SjukratryggingarDefaultHeader = DefaultHeader
 export const SjukratryggingarHeader = Header
 
 export const SjukratryggingarFooter = dynamic(


### PR DESCRIPTION
# Add default header for sjukratryggingar organization

## What

Make it possible to use default header for sjukratryggingar organization via config.

## Why

A design that was approved by Digital Iceland

## Screenshots / Gifs
### Before
![image](https://github.com/user-attachments/assets/1f839fb2-4e93-4afa-b7f8-a2ee1522e8aa)

### After
![image](https://github.com/user-attachments/assets/cc9ef91a-71e2-4f30-b4f7-8c1c7f02cc47)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new customizable header, `SjukratryggingarDefaultHeader`, for organization pages tailored to the Sjukratryggingar theme.
	- Conditional rendering logic allows for dynamic display of headers based on specific conditions.
	- Enhanced layout capabilities with a new grid container style for better responsiveness.

- **Bug Fixes**
	- Improved responsiveness of the header based on viewport size and organization theme properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->