### PR TITLE
feat(web): Add default header for sak organization

### DIFF
--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.css.ts
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.css.ts
@@ -1,5 +1,7 @@
 import { style } from '@vanilla-extract/css'
 
+import { themeUtils } from '@island.is/island-ui/theme'
+
 export const menuStyle = style({
   position: 'relative',
   zIndex: 20,
@@ -18,4 +20,16 @@ export const digitalIcelandHeaderTitle = style({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ['-webkit-text-fill-color' as any]: 'transparent',
   textShadow: '0px 0px #00000000',
+})
+
+export const sakHeaderGridContainer = style({
+  display: 'grid',
+  maxWidth: '1342px',
+  margin: '0 auto',
+  ...themeUtils.responsiveStyle({
+    lg: {
+      gridTemplateRows: '315px',
+      gridTemplateColumns: '52fr 48fr',
+    },
+  }),
 })

--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -374,7 +374,17 @@ export const OrganizationHeader: React.FC<
         />
       )
     case 'sak':
-      return (
+      return n('usingDefaultHeader', false) ? (
+        <DefaultHeader
+          {...defaultProps}
+          className={styles.sakHeaderGridContainer}
+          image={n(
+            `sakHeaderBgImage`,
+            'https://images.ctfassets.net/8k0h54kbe6bj/4SjqwRBZRMWVWG0y73sXxq/cf8d0d16704cfea124362eca03afdb41/sak-header-trans_2x.png',
+          )}
+          titleSectionPaddingLeft={isSubpage ? 0 : 10}
+        />
+      ) : (
         <SAkHeader
           organizationPage={organizationPage}
           logoAltText={logoAltText}


### PR DESCRIPTION
# Add default header for sak organization

## What

Make it possible to use default header for SAK organization via config.

## Why

A design that was approved by Digital Iceland

## Screenshots / Gifs

### Before
![image](https://github.com/user-attachments/assets/c39a0583-3642-478b-a5a8-d91e01968658)

### After
![image](https://github.com/user-attachments/assets/cd17aaef-d0a4-4cc4-bf2d-0eca7f315ae9)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a responsive grid layout for the organization header, enhancing visual structure on large screens.
	- Added conditional rendering for the `OrganizationHeader`, allowing for dynamic display of either a default or specific header based on user settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->