### PR TITLE
fix(service-portal): Add error toast to overveiw

### DIFF
--- a/libs/service-portal/documents/src/components/DocumentLine/DocumentLineV2.tsx
+++ b/libs/service-portal/documents/src/components/DocumentLine/DocumentLineV2.tsx
@@ -3,7 +3,7 @@ import format from 'date-fns/format'
 import { FC, useEffect, useRef, useState } from 'react'
 
 import { DocumentV2, DocumentV2Content } from '@island.is/api/schema'
-import { Box, Text, LoadingDots, Icon } from '@island.is/island-ui/core'
+import { Box, Text, LoadingDots, Icon, toast } from '@island.is/island-ui/core'
 import { dateFormat } from '@island.is/shared/constants'
 import { m } from '@island.is/service-portal/core'
 import * as styles from './DocumentLine.css'
@@ -135,11 +135,14 @@ export const DocumentLine: FC<Props> = ({
         }
       },
       onError: () => {
-        setDocumentDisplayError(
-          formatMessage(messages.documentFetchError, {
-            senderName: documentLine.sender?.name ?? '',
-          }),
-        )
+        const errorMessage = formatMessage(messages.documentFetchError, {
+          senderName: documentLine.sender?.name ?? '',
+        })
+        if (asFrame) {
+          toast.error(errorMessage, { toastId: 'overview-doc-error' })
+        } else {
+          setDocumentDisplayError(errorMessage)
+        }
       },
     })
 

--- a/libs/service-portal/documents/src/components/OverviewDisplay/OverviewDocumentDisplayV2.tsx
+++ b/libs/service-portal/documents/src/components/OverviewDisplay/OverviewDocumentDisplayV2.tsx
@@ -21,6 +21,8 @@ export interface Props {
 export const DocumentDisplay: FC<Props> = (props) => {
   const { width } = useWindowSize()
 
+  console.log(' doc display')
+
   const isDesktop = width > theme.breakpoints.lg
 
   if (props.error?.message) {

--- a/libs/service-portal/documents/src/components/OverviewDisplay/OverviewDocumentDisplayV2.tsx
+++ b/libs/service-portal/documents/src/components/OverviewDisplay/OverviewDocumentDisplayV2.tsx
@@ -21,8 +21,6 @@ export interface Props {
 export const DocumentDisplay: FC<Props> = (props) => {
   const { width } = useWindowSize()
 
-  console.log(' doc display')
-
   const isDesktop = width > theme.breakpoints.lg
 
   if (props.error?.message) {


### PR DESCRIPTION
## What

Add error toast to overveiw

## Why

No error message when docs fail on overview

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
