### PR TITLE
feat(web): Add default header for natturuhamfaratryggingar islands

### DIFF
--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -430,7 +430,6 @@ export const OrganizationHeader: React.FC<
         <DefaultHeader
           {...defaultProps}
           image="https://images.ctfassets.net/8k0h54kbe6bj/eXqcbclteE88H5iQ6J3lo/bbc1d0c9d3abee93d34ec0aa718c833b/Group__1_.svg"
-          imageObjectPosition="left"
         />
       ) : (
         <IcelandicNaturalDisasterInsuranceHeader

--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -429,7 +429,10 @@ export const OrganizationHeader: React.FC<
       return n('usingDefaultHeader', false) ? (
         <DefaultHeader
           {...defaultProps}
-          image="https://images.ctfassets.net/8k0h54kbe6bj/eXqcbclteE88H5iQ6J3lo/bbc1d0c9d3abee93d34ec0aa718c833b/Group__1_.svg"
+          image={n(
+            'icelandicNaturalDisasterInsuranceHeaderImage',
+            'https://images.ctfassets.net/8k0h54kbe6bj/eXqcbclteE88H5iQ6J3lo/bbc1d0c9d3abee93d34ec0aa718c833b/Group__1_.svg',
+          )}
         />
       ) : (
         <IcelandicNaturalDisasterInsuranceHeader

--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -426,7 +426,13 @@ export const OrganizationHeader: React.FC<
         />
       )
     case 'nti':
-      return (
+      return n('usingDefaultHeader', false) ? (
+        <DefaultHeader
+          {...defaultProps}
+          image="https://images.ctfassets.net/8k0h54kbe6bj/eXqcbclteE88H5iQ6J3lo/bbc1d0c9d3abee93d34ec0aa718c833b/Group__1_.svg"
+          imageObjectPosition="left"
+        />
+      ) : (
         <IcelandicNaturalDisasterInsuranceHeader
           organizationPage={organizationPage}
           logoAltText={logoAltText}


### PR DESCRIPTION
# Add default header for natturuhamfaratryggingar islands

## What

Make it possible to use default header for Náttúruhamfaratryggingar íslands organization via config.

## Why

A design that was approved by Digital Iceland

## Screenshots / Gifs

### Before
![image](https://github.com/user-attachments/assets/0afa07ca-b7d7-4fc7-a3a7-5a2b80b7bc58)

### After
![image](https://github.com/user-attachments/assets/65ad11fe-a2e0-4a80-983b-191483b30a5e)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced dynamic header rendering in the Organization component, allowing for a DefaultHeader or IcelandicNaturalDisasterInsuranceHeader based on specific conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->