### PR TITLE
feat(web): Add default header for landlaeknir organization

### DIFF
--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.css.ts
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.css.ts
@@ -33,3 +33,15 @@ export const sakHeaderGridContainer = style({
     },
   }),
 })
+
+export const landlaeknirHeaderGridContainer = style({
+  display: 'grid',
+  maxWidth: '1342px',
+  margin: '0 auto',
+  ...themeUtils.responsiveStyle({
+    lg: {
+      gridTemplateRows: '315px',
+      gridTemplateColumns: '60fr 40fr',
+    },
+  }),
+})

--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -331,7 +331,16 @@ export const OrganizationHeader: React.FC<
         />
       )
     case 'landlaeknir':
-      return (
+      return n('usingDefaultHeader', false) ? (
+        <DefaultHeader
+          {...defaultProps}
+          image={n(
+            'landlaeknirHeaderImage',
+            'https://images.ctfassets.net/8k0h54kbe6bj/2p6UWMBdVkVHBAjsnX20bY/c04b402332dbae96c198db7b8640f20b/Header_illustration_1.svg',
+          )}
+          className={styles.landlaeknirHeaderGridContainer}
+        />
+      ) : (
         <LandlaeknirHeader
           organizationPage={organizationPage}
           logoAltText={logoAltText}


### PR DESCRIPTION
# Add default header for landlaeknir organization

## What

Make it possible to use default header for Landlæknir organization via config.

## Why

A design that was approved by Digital Iceland

## Screenshots / Gifs

### Before
![image](https://github.com/user-attachments/assets/a3bdb26c-4841-4eef-b1ee-301a8dd8ec3f)

### After
![image](https://github.com/user-attachments/assets/c3f4f591-3d5b-4201-bbaf-af6dd7887f23)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new grid layout for the "landlaeknir" header, enhancing the visual structure.
	- Added conditional rendering in the `OrganizationHeader` component, allowing for dynamic display based on the `usingDefaultHeader` flag. 

These updates improve the overall user experience by providing a more organized layout and flexible header options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->