### PR TITLE
fix(occupational-licenses): Remove date of birth for health directorate licenses

### DIFF
--- a/libs/api/domains/occupational-licenses-v2/src/lib/occupationalLicensesV2.service.ts
+++ b/libs/api/domains/occupational-licenses-v2/src/lib/occupationalLicensesV2.service.ts
@@ -268,7 +268,6 @@ export class OccupationalLicensesV2Service {
       permit: data.practice,
       licenseHolderName: data.licenseHolderName,
       licenseHolderNationalId: data.licenseHolderNationalId,
-      dateOfBirth: info(data.licenseHolderNationalId).birthday,
       validFrom: data.validFrom,
       title: `${data.profession} - ${data.practice}`,
       status,

--- a/libs/service-portal/occupational-licenses/src/screens/v2/OccupationalLicensesDetail/OccupationalLicensesDetail.tsx
+++ b/libs/service-portal/occupational-licenses/src/screens/v2/OccupationalLicensesDetail/OccupationalLicensesDetail.tsx
@@ -140,7 +140,7 @@ const OccupationalLicenseDetail = () => {
               content={license?.licenseNumber ?? ''}
             />
           )}
-          {(license?.dateOfBirth || loading) && (
+          {license?.dateOfBirth && (
             <UserInfoLine
               loading={loading}
               label={formatMessage(om.dateOfBirth)}


### PR DESCRIPTION
## What

* Remove date of birth for health directorate occupational licenses

## Why

* Unnecessary

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the rendering logic for the `UserInfoLine` component to only display when the date of birth is available, removing the loading state dependency.

- **Impact**
	- The removal of the date of birth extraction may affect features relying on this information, potentially altering the user experience regarding license holder details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->