### PR TITLE
fix(application-plc): Stop double candidacies in dataprovider

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/signature-collection/parliamentary-list-creation/parliamentary-list-creation.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/signature-collection/parliamentary-list-creation/parliamentary-list-creation.service.ts
@@ -53,6 +53,17 @@ export class ParliamentaryListCreationService extends BaseTemplateApiService {
         405,
       )
     }
+    const contactNationalId = isCompany(auth.nationalId)
+      ? auth.actor?.nationalId ?? auth.nationalId
+      : auth.nationalId
+
+    if (
+      currentCollection.candidates.some(
+        (c) => c.nationalId.replace('-', '') === contactNationalId,
+      )
+    ) {
+      throw new TemplateApiError(errorMessages.alreadyCandidate, 412)
+    }
 
     return currentCollection
   }

--- a/libs/application/templates/signature-collection/parliamentary-list-creation/src/lib/errors.ts
+++ b/libs/application/templates/signature-collection/parliamentary-list-creation/src/lib/errors.ts
@@ -26,6 +26,18 @@ export const errorMessages = {
       description: '',
     },
   }),
+  alreadyCandidate: defineMessages({
+    title: {
+      id: 'plc.application:error.alreadyCandidate.title',
+      defaultMessage: 'Ekki hægt að tvískrá meðmælasöfnun',
+      description: '',
+    },
+    summary: {
+      id: 'plc.application:error.alreadyCandidate.summary',
+      defaultMessage: 'Þú ert nú þegar með framboð',
+      description: '',
+    },
+  }),
   citizenship: defineMessages({
     title: {
       id: 'plc.application:error.citizenship.title',


### PR DESCRIPTION
## Simple video showing what it does
I create a candidacy for 7789, then reload the application and try again.
Prestó
[Screencast from 2024-09-16 15-30-49.webm](https://github.com/user-attachments/assets/fc10d35a-8826-47db-be58-34009435e1bd)


## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Implemented a check to prevent duplicate candidates from being added based on national ID.
	- Added a new error message for users attempting to register as candidates when they are already registered.

- **Bug Fixes**
	- Enhanced error handling to provide clearer feedback for duplicate candidacy attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->