### PR TITLE
feat(web): Latest Generic List Items content type - Don't allow clicking on cards if there isn't a 'see more page'

### DIFF
--- a/apps/web/components/GenericList/LatestGenericListItems/LatestGenericListItems.tsx
+++ b/apps/web/components/GenericList/LatestGenericListItems/LatestGenericListItems.tsx
@@ -19,8 +19,6 @@ export const LatestGenericListItems = ({
     return null
   }
 
-  const itemsAreClickable = slice.genericList?.itemType === 'Clickable'
-
   // Only allow organization subpage links as is
   let seeMoreLinkHref = ''
   if (
@@ -33,6 +31,11 @@ export const LatestGenericListItems = ({
       slice.seeMorePage.slug,
     ]).href
   }
+
+  const itemsAreClickable =
+    slice.genericList?.itemType === 'Clickable' &&
+    slice.seeMoreLinkText &&
+    seeMoreLinkHref
 
   return (
     <Stack space={6}>


### PR DESCRIPTION
# Latest Generic List Items content type - Don't allow clicking on cards if there isn't a 'see more page'

## Why

* Otherwise in most cases the user would click and reach a 404 page (which isn't helpful)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced item clickability logic in the list, ensuring items are only clickable when all necessary conditions are met (item type, link text, and href are defined).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->