### PR TITLE
feat(web): Pension Calculator - Tax calculation translation

### DIFF
--- a/apps/web/screens/Organization/SocialInsuranceAdministration/translationStrings.ts
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/translationStrings.ts
@@ -622,6 +622,11 @@ export const translationStrings = defineMessages({
     defaultMessage: 'Samtals frá TR fyrir skatt',
     description: 'Niðurstöðuskjár, Samtals frá TR fyrir skatt',
   },
+  'REIKNH.FRADRSKATTUR': {
+    id: 'web.pensionCalculator:REIKNH.FRADRSKATTUR',
+    defaultMessage: 'Frádreginn skattur af öðrum greiðslum',
+    description: 'Niðurstöðuskjár, Frádreginn skattur af öðrum greiðslum',
+  },
   'REIKNH.FRADRSKATTURTR1': {
     id: 'web.pensionCalculator:REIKNH.FRADRSKATTURTR1',
     defaultMessage: 'Frádreginn skattur TR (1. og 2. skattþrep)',


### PR DESCRIPTION
# Pension Calculator - Tax calculation translation

## What

* Missing translation key added

## Why

* So we don't see "REIKNH.FRADRSKATTUR" on the web

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new translation for Icelandic-speaking users in the pension calculator feature, enhancing clarity on deducted taxes from other payments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->