### PR TITLE
chore(license-service): Disable cache when not prod

### DIFF
--- a/libs/services/license/src/lib/licenseCache.provider.ts
+++ b/libs/services/license/src/lib/licenseCache.provider.ts
@@ -9,12 +9,17 @@ export const LICENSE_SERVICE_CACHE_MANAGER_PROVIDER =
 export const LicenseCacheProvider: FactoryProvider = {
   provide: LICENSE_SERVICE_CACHE_MANAGER_PROVIDER,
   scope: LazyDuringDevScope,
-  useFactory: (licenseServiceConfig: ConfigType<typeof LicenseConfig>) =>
-    createRedisCacheManager({
+  useFactory: (licenseServiceConfig: ConfigType<typeof LicenseConfig>) => {
+    console.log(process.env.NODE_ENV)
+    if (process.env.NODE_ENV !== 'production') {
+      return undefined
+    }
+    return createRedisCacheManager({
       name: 'license_service_cache_manager',
       nodes: licenseServiceConfig.redis.nodes,
       ssl: licenseServiceConfig.redis.ssl,
       ttl: licenseServiceConfig.redis.cacheTtl,
-    }),
+    })
+  },
   inject: [LicenseConfig.KEY],
 }


### PR DESCRIPTION
## What

* Only use caching for the barcode service on prod

## Why

* Extreme log noise on dev

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
