### PR TITLE
feat(regulations-admin): ministry basic + bugfixes

### DIFF
--- a/apps/download-service/src/app/modules/regulation-documents/regulation-documents.controller.ts
+++ b/apps/download-service/src/app/modules/regulation-documents/regulation-documents.controller.ts
@@ -76,6 +76,7 @@ export class RegulationDocumentsController {
       comments: draftRegulation.comments,
       name: draftRegulation.name,
       publishedDate: draftRegulation.idealPublishDate,
+      ministry: draftRegulation.ministry,
     }
 
     const documentResponse =

--- a/libs/portals/admin/regulations-admin/src/components/EditBasics.tsx
+++ b/libs/portals/admin/regulations-admin/src/components/EditBasics.tsx
@@ -128,8 +128,6 @@ export const EditBasics = () => {
     setHasUpdated(true)
   }
 
-  console.log('draft.ministry.error', draft.ministry.error)
-  console.log('draft.ministry.showError', draft.ministry.showError)
   return (
     <>
       <Box marginBottom={3}>

--- a/libs/portals/admin/regulations-admin/src/components/EditBasics.tsx
+++ b/libs/portals/admin/regulations-admin/src/components/EditBasics.tsx
@@ -11,7 +11,7 @@ import {
   Select,
 } from '@island.is/island-ui/core'
 import { EditorInput } from './EditorInput'
-import { editorMsgs as msg, errorMsgs, m, editorMsgs } from '../lib/messages'
+import { editorMsgs as msg, errorMsgs, m } from '../lib/messages'
 import { useLocale } from '@island.is/localization'
 import { Appendixes } from './Appendixes'
 import { MagicTextarea } from './MagicTextarea'
@@ -253,17 +253,17 @@ export const EditBasics = () => {
                         }
                       : undefined
                   }
-                  placeholder={t(editorMsgs.selectMinistry)}
+                  placeholder={t(msg.selectMinistry)}
                   options={[
                     {
-                      label: t(editorMsgs.selectMinistry),
-                      value: undefined,
+                      label: t(msg.selectMinistry),
+                      value: '',
                     },
                     ...ministries.map((ministry) => ({
                       value: ministry.name,
                       label: ministry.name,
                     })),
-                  ]}
+                  ].filter((item) => item.label)}
                   required={false}
                   onChange={(option) => actions.setMinistry(option?.value)}
                   backgroundColor="white"

--- a/libs/portals/admin/regulations-admin/src/components/EditBasics.tsx
+++ b/libs/portals/admin/regulations-admin/src/components/EditBasics.tsx
@@ -8,9 +8,10 @@ import {
   Button,
   AlertMessage,
   AlertBanner,
+  Select,
 } from '@island.is/island-ui/core'
 import { EditorInput } from './EditorInput'
-import { editorMsgs as msg, errorMsgs } from '../lib/messages'
+import { editorMsgs as msg, errorMsgs, m } from '../lib/messages'
 import { useLocale } from '@island.is/localization'
 import { Appendixes } from './Appendixes'
 import { MagicTextarea } from './MagicTextarea'
@@ -32,7 +33,7 @@ const updateText =
 
 export const EditBasics = () => {
   const t = useLocale().formatMessage
-  const { draft, actions } = useDraftingState()
+  const { draft, actions, ministries } = useDraftingState()
   const [editorKey, setEditorKey] = useState('initial')
   const [titleError, setTitleError] = useState<string | undefined>(undefined)
   const [hasUpdated, setHasUpdated] = useState<boolean>(false)
@@ -127,6 +128,8 @@ export const EditBasics = () => {
     setHasUpdated(true)
   }
 
+  console.log('draft.ministry.error', draft.ministry.error)
+  console.log('draft.ministry.showError', draft.ministry.showError)
   return (
     <>
       <Box marginBottom={3}>
@@ -162,13 +165,15 @@ export const EditBasics = () => {
             label={t(msg.text)}
             startExpanded={startTextExpanded}
           >
-            <Box marginBottom={3}>
-              <AlertBanner
-                description={t(msg.diffPrecisionWarning)}
-                variant="info"
-                dismissable
-              />
-            </Box>
+            {draft.type.value === RegulationDraftTypes.amending ? (
+              <Box marginBottom={3}>
+                <AlertBanner
+                  description={t(msg.diffPrecisionWarning)}
+                  variant="info"
+                  dismissable
+                />
+              </Box>
+            ) : undefined}
             <Box marginBottom={3}>
               <EditorInput
                 key={editorKey} // Force re-render of TinyMCE
@@ -224,7 +229,7 @@ export const EditBasics = () => {
               <Divider />
               {' '}
             </Box>
-            {draft.signedDocumentUrl.value && (
+            {draft.signedDocumentUrl.value ? (
               <Box marginBottom={[4, 4, 6]}>
                 <EditorInput
                   label={t(msg.signatureText)}
@@ -234,6 +239,35 @@ export const EditBasics = () => {
                   readOnly
                 />
               </Box>
+            ) : (
+              <Select
+                size="sm"
+                label={t(m.regulationAdminMinistries)}
+                name="setMinistry"
+                isSearchable
+                value={
+                  draft.ministry.value
+                    ? {
+                        value: draft.ministry.value,
+                        label: draft.ministry.value,
+                      }
+                    : undefined
+                }
+                placeholder={t(m.regulationAdminMinistries)}
+                options={ministries.map((ministry) => ({
+                  value: ministry.name,
+                  label: ministry.name,
+                }))}
+                required={false}
+                onChange={(option) => actions.setMinistry(option?.value)}
+                backgroundColor="white"
+                hasError={
+                  draft.ministry.showError &&
+                  !!draft.ministry.error &&
+                  t(draft.ministry.error) !== t(errorMsgs.fieldRequired)
+                }
+                errorMessage={draft.ministry.error && t(draft.ministry.error)}
+              />
             )}
           </AccordionItem>
         </Accordion>

--- a/libs/portals/admin/regulations-admin/src/components/EditBasics.tsx
+++ b/libs/portals/admin/regulations-admin/src/components/EditBasics.tsx
@@ -267,12 +267,6 @@ export const EditBasics = () => {
                   required={false}
                   onChange={(option) => actions.setMinistry(option?.value)}
                   backgroundColor="white"
-                  hasError={
-                    draft.ministry.showError &&
-                    !!draft.ministry.error &&
-                    !!draft.ministry.value
-                  }
-                  errorMessage={draft.ministry.error && t(draft.ministry.error)}
                 />
               )
             )}

--- a/libs/portals/admin/regulations-admin/src/components/EditBasics.tsx
+++ b/libs/portals/admin/regulations-admin/src/components/EditBasics.tsx
@@ -11,7 +11,7 @@ import {
   Select,
 } from '@island.is/island-ui/core'
 import { EditorInput } from './EditorInput'
-import { editorMsgs as msg, errorMsgs, m } from '../lib/messages'
+import { editorMsgs as msg, errorMsgs, m, editorMsgs } from '../lib/messages'
 import { useLocale } from '@island.is/localization'
 import { Appendixes } from './Appendixes'
 import { MagicTextarea } from './MagicTextarea'
@@ -238,34 +238,43 @@ export const EditBasics = () => {
                 />
               </Box>
             ) : (
-              <Select
-                size="sm"
-                label={t(m.regulationAdminMinistries)}
-                name="setMinistry"
-                isSearchable
-                value={
-                  draft.ministry.value
-                    ? {
-                        value: draft.ministry.value,
-                        label: draft.ministry.value,
-                      }
-                    : undefined
-                }
-                placeholder={t(m.regulationAdminMinistries)}
-                options={ministries.map((ministry) => ({
-                  value: ministry.name,
-                  label: ministry.name,
-                }))}
-                required={false}
-                onChange={(option) => actions.setMinistry(option?.value)}
-                backgroundColor="white"
-                hasError={
-                  draft.ministry.showError &&
-                  !!draft.ministry.error &&
-                  t(draft.ministry.error) !== t(errorMsgs.fieldRequired)
-                }
-                errorMessage={draft.ministry.error && t(draft.ministry.error)}
-              />
+              ministries.length > 0 &&
+              !draft.signatureText.value && (
+                <Select
+                  size="sm"
+                  label={t(m.regulationAdminMinistries)}
+                  name="setMinistry"
+                  isSearchable
+                  value={
+                    draft.ministry.value
+                      ? {
+                          value: draft.ministry.value,
+                          label: draft.ministry.value,
+                        }
+                      : undefined
+                  }
+                  placeholder={t(editorMsgs.selectMinistry)}
+                  options={[
+                    {
+                      label: t(editorMsgs.selectMinistry),
+                      value: undefined,
+                    },
+                    ...ministries.map((ministry) => ({
+                      value: ministry.name,
+                      label: ministry.name,
+                    })),
+                  ]}
+                  required={false}
+                  onChange={(option) => actions.setMinistry(option?.value)}
+                  backgroundColor="white"
+                  hasError={
+                    draft.ministry.showError &&
+                    !!draft.ministry.error &&
+                    !!draft.ministry.value
+                  }
+                  errorMessage={draft.ministry.error && t(draft.ministry.error)}
+                />
+              )
             )}
           </AccordionItem>
         </Accordion>

--- a/libs/portals/admin/regulations-admin/src/components/EditSignature.tsx
+++ b/libs/portals/admin/regulations-admin/src/components/EditSignature.tsx
@@ -159,7 +159,7 @@ export const EditSignature = () => {
               draftId={draft.id}
               value={
                 draft.signatureText.value ||
-                getDefaultSignatureText(formatDateFns)
+                getDefaultSignatureText(formatDateFns, draft.ministry.value)
               }
               onChange={(text) => updateState('signatureText', text)}
               required={!!draft.signatureText.required}

--- a/libs/portals/admin/regulations-admin/src/components/impacts/EditCancellation.tsx
+++ b/libs/portals/admin/regulations-admin/src/components/impacts/EditCancellation.tsx
@@ -142,7 +142,11 @@ export const EditCancellation = (props: EditCancellationProp) => {
             <ImpactModalTitle
               impact={activeCancellation}
               name={activeCancellation.name}
-              title={activeCancellation.regTitle}
+              title={
+                activeCancellation.name === 'self'
+                  ? 'stofnreglugerð'
+                  : activeCancellation.regTitle
+              }
               type={'cancel'}
               minDate={minDate}
               tag={

--- a/libs/portals/admin/regulations-admin/src/components/impacts/EditChange.tsx
+++ b/libs/portals/admin/regulations-admin/src/components/impacts/EditChange.tsx
@@ -414,7 +414,11 @@ export const EditChange = (props: EditChangeProp) => {
           >
             <ImpactModalTitle
               type="edit"
-              title={activeChange.regTitle}
+              title={
+                activeChange.name === 'self'
+                  ? 'stofnreglugerð'
+                  : activeChange.regTitle
+              }
               name={activeChange.name}
               impact={activeChange}
               minDate={readOnly ? activeChange.date.value : minDate}

--- a/libs/portals/admin/regulations-admin/src/lib/messages.ts
+++ b/libs/portals/admin/regulations-admin/src/lib/messages.ts
@@ -350,6 +350,10 @@ export const editorMsgs = defineMessages({
     defaultMessage:
       'Vakin er athygli á því að kerfið útbýr tillögu að breytingareglugerð sem starfsmaður þarf að rýna gaumgæfilega áður en haldið er áfram. Ekki er öruggt að inngangsliðir og efnisákvæði færist réttilega inn í breytingareglugerðina.',
   },
+  selectMinistry: {
+    id: 'ap.regulations-admin:select-ministry',
+    defaultMessage: 'Veldu ráðuneyti',
+  },
 })
 
 export const impactMsgs = defineMessages({

--- a/libs/portals/admin/regulations-admin/src/state/actionHandlers.ts
+++ b/libs/portals/admin/regulations-admin/src/state/actionHandlers.ts
@@ -136,11 +136,7 @@ export const actionHandlers: {
   },
 
   SET_MINISTRY: (state, { value }) => {
-    if (value) {
-      updateFieldValue(state.draft.ministry, value)
-    } else {
-      updateFieldValue(state.draft.ministry, undefined)
-    }
+    updateFieldValue(state.draft.ministry, value ?? undefined)
   },
 
   SET_IMPACT: (state, { impactId }) => {

--- a/libs/portals/admin/regulations-admin/src/state/actionHandlers.ts
+++ b/libs/portals/admin/regulations-admin/src/state/actionHandlers.ts
@@ -136,7 +136,7 @@ export const actionHandlers: {
   },
 
   SET_MINISTRY: (state, { value }) => {
-    updateFieldValue(state.draft.ministry, value ?? undefined)
+    updateFieldValue(state.draft.ministry, value || undefined)
   },
 
   SET_IMPACT: (state, { impactId }) => {

--- a/libs/portals/admin/regulations-admin/src/state/actionHandlers.ts
+++ b/libs/portals/admin/regulations-admin/src/state/actionHandlers.ts
@@ -135,6 +135,14 @@ export const actionHandlers: {
     }
   },
 
+  SET_MINISTRY: (state, { value }) => {
+    if (value) {
+      updateFieldValue(state.draft.ministry, value)
+    } else {
+      updateFieldValue(state.draft.ministry, undefined)
+    }
+  },
+
   SET_IMPACT: (state, { impactId }) => {
     if (impactId) {
       Object.entries(state.draft.impacts).forEach(([key, impacts]) => {

--- a/libs/portals/admin/regulations-admin/src/state/types.ts
+++ b/libs/portals/admin/regulations-admin/src/state/types.ts
@@ -215,6 +215,10 @@ export type Action =
       action?: 'add' | 'delete'
       value: LawChapterSlug
     }
+  | {
+      type: 'SET_MINISTRY'
+      value?: PlainText
+    }
   | ({
       type: 'UPDATE_PROP'
     } & FieldNameValuePair)

--- a/libs/portals/admin/regulations-admin/src/state/useDraftingState.ts
+++ b/libs/portals/admin/regulations-admin/src/state/useDraftingState.ts
@@ -7,7 +7,7 @@ import {
   ReactNode,
 } from 'react'
 import { useMutation, gql } from '@apollo/client'
-import { LawChapterSlug, toISODate } from '@island.is/regulations'
+import { LawChapterSlug, PlainText, toISODate } from '@island.is/regulations'
 import { useNavigate } from 'react-router-dom'
 import { RegulationDraftTypes, Step, StepNames } from '../types'
 import { useLocale } from '@island.is/localization'
@@ -250,6 +250,10 @@ const useMakeDraftingState = (inputs: StateInputs) => {
 
       addAppendix: () => {
         dispatch({ type: 'APPENDIX_ADD' })
+      },
+
+      setMinistry: (value?: PlainText) => {
+        dispatch({ type: 'SET_MINISTRY', value })
       },
 
       updateLawChapterProp: (

--- a/libs/regulations/src/lib/types-admin.ts
+++ b/libs/regulations/src/lib/types-admin.ts
@@ -205,6 +205,7 @@ export type RegulationPdfInput = {
   comments: HTMLText
   name?: RegName
   publishedDate?: ISODate
+  ministry?: string
 }
 
 /** API response from regulation API */


### PR DESCRIPTION
## What

Add ministry selection to basic screen + minor bugfixes

## Why

bugfixing
ministry required earlier in steps

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new property, `ministry`, in regulation document responses for enhanced context.
	- Added a `Select` component for ministry selection in the regulation editing interface.
	- Implemented dynamic title changes in the `ImpactModalTitle` based on specific conditions.
	- Added a localization message prompting users to select a ministry.

- **Improvements**
	- Enhanced state management with a new action handler for setting the ministry.
	- Expanded functionality in the drafting state management to include ministry updates.
	- Improved data structure to accommodate ministry designations in regulation PDF inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->