### PR TITLE
fix(web): Life events - Links lead to a 404 page on other than Icelandic locales

### DIFF
--- a/apps/web/screens/LifeEvents/LifeEvents.tsx
+++ b/apps/web/screens/LifeEvents/LifeEvents.tsx
@@ -1,28 +1,30 @@
 import Head from 'next/head'
-import {
-  Text,
-  GridContainer,
-  GridRow,
-  GridColumn,
-  Breadcrumbs,
-} from '@island.is/island-ui/core'
-import {
-  LinkType,
-  linkResolver,
-  useNamespaceStrict as useNamespace,
-} from '@island.is/web/hooks'
-import { withMainLayout } from '@island.is/web/layouts/main'
-import {
-  type QueryGetNamespaceArgs,
-  type GetNamespaceQuery,
-  type GetLifeEventsForOverviewQuery,
-} from '@island.is/web/graphql/schema'
-import type { Screen } from '../../types'
-import { CardWithFeaturedItems, GridItems } from '@island.is/web/components'
+
 import {
   ContentLanguage,
   QueryGetLifeEventsForOverviewArgs,
 } from '@island.is/api/schema'
+import {
+  Breadcrumbs,
+  GridColumn,
+  GridContainer,
+  GridRow,
+  Text,
+} from '@island.is/island-ui/core'
+import { CardWithFeaturedItems, GridItems } from '@island.is/web/components'
+import {
+  type GetLifeEventsForOverviewQuery,
+  type GetNamespaceQuery,
+  type QueryGetNamespaceArgs,
+} from '@island.is/web/graphql/schema'
+import {
+  LinkType,
+  useLinkResolver,
+  useNamespaceStrict as useNamespace,
+} from '@island.is/web/hooks'
+import { withMainLayout } from '@island.is/web/layouts/main'
+
+import type { Screen } from '../../types'
 import {
   GET_LIFE_EVENTS_FOR_OVERVIEW_QUERY,
   GET_NAMESPACE_QUERY,
@@ -37,6 +39,7 @@ interface Props {
 
 const LifeEvents: Screen<Props> = ({ lifeEvents, namespace }) => {
   const n = useNamespace(namespace)
+  const { linkResolver } = useLinkResolver()
   return (
     <>
       <Head>


### PR DESCRIPTION
# Life events - Links lead to a 404 page on other than Icelandic locales

## What

* Links on https://island.is/en/life-events are broken

## Why

### Before

https://github.com/user-attachments/assets/d78adcc6-ea60-4e2e-8ae0-4c0103b65f28


### After


https://github.com/user-attachments/assets/5f1d8da6-27c8-4ceb-871a-537afe30a3a4



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
