### PR TITLE
fix(native-app): use replace instead of replaceAll

### DIFF
--- a/apps/native/app/src/screens/document-detail/document-detail.tsx
+++ b/apps/native/app/src/screens/document-detail/document-detail.tsx
@@ -45,7 +45,7 @@ const PdfWrapper = styled.View`
   flex: 1;
   background-color: ${dynamicColor('background')};
 `
-const regexForBr = /<br \/>*\\?>/g
+const regexForBr = /<br\s*\/>/gi
 
 // Styles for html documents
 const useHtmlStyles = () => {

--- a/apps/native/app/src/screens/document-detail/document-detail.tsx
+++ b/apps/native/app/src/screens/document-detail/document-detail.tsx
@@ -377,7 +377,7 @@ export const DocumentDetailScreen: NavigationFunctionComponent<{
                   html: Document.content?.value
                     ? // Removing all <br /> tags to fix a bug in react-native that renders <br /> with too much vertical space
                       // https://github.com/facebook/react-native/issues/32062
-                      `${htmlStyles}${Document.content?.value.replaceAll(
+                      `${htmlStyles}${Document.content?.value.replace(
                         regexForBr,
                         '',
                       )}`

--- a/apps/native/app/src/screens/vehicles/components/vehicle-item.tsx
+++ b/apps/native/app/src/screens/vehicles/components/vehicle-item.tsx
@@ -15,7 +15,7 @@ type VehicleListItem = NonNullable<
 >[0]
 
 const Cell = styled(TouchableHighlight)`
-  margin-bottom: ${({ theme }) => theme.spacing[2]};
+  margin-bottom: ${({ theme }) => theme.spacing[2]}px;
   border-radius: ${({ theme }) => theme.border.radius.extraLarge};
 `
 


### PR DESCRIPTION
replaceAll is not supported on all android devices. replace is and it does the same, using that instead. Tested on both ios and android.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of line breaks in the Document Detail screen to address excessive vertical spacing caused by `<br />` tags.
  
- **Style**
	- Enhanced clarity in the Vehicle Item component by explicitly defining the `margin-bottom` property in pixels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->