### PR TITLE
fix(web): Pension Calculator - Different max month pension delay if year <= 1951

### DIFF
--- a/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculator.tsx
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculator.tsx
@@ -133,8 +133,11 @@ const PensionCalculator: CustomScreen<PensionCalculatorProps> = ({
   const currencyInputMaxLength =
     customPageData?.configJson?.currencyInputMaxLength ?? 14
 
-  const maxMonthPensionDelay =
-    customPageData?.configJson?.maxMonthPensionDelay ?? 156
+  const maxMonthPensionDelayIfBornAfter1951 =
+    customPageData?.configJson?.maxMonthPensionDelayIfBornAfter1951 ?? 156
+
+  const maxMonthPensionDelayIfBorn1951OrEarlier =
+    customPageData?.configJson?.maxMonthPensionDelayIfBorn1951OrEarlier ?? 60
 
   const [loadingResultPage, setLoadingResultPage] = useState(false)
   const [hasLivedAbroad, setHasLivedAbroad] = useState(
@@ -386,6 +389,12 @@ const PensionCalculator: CustomScreen<PensionCalculatorProps> = ({
       const minYear = add(defaultPensionDate, {
         months: -maxMonthPensionHurry,
       }).getFullYear()
+
+      const maxMonthPensionDelay =
+        typeof birthYear === 'number' && birthYear < 1952
+          ? maxMonthPensionDelayIfBorn1951OrEarlier
+          : maxMonthPensionDelayIfBornAfter1951
+
       const maxYear = add(defaultPensionDate, {
         months: maxMonthPensionDelay,
       }).getFullYear()
@@ -399,7 +408,13 @@ const PensionCalculator: CustomScreen<PensionCalculatorProps> = ({
     }
 
     return options
-  }, [defaultPensionDate, maxMonthPensionDelay, maxMonthPensionHurry])
+  }, [
+    birthYear,
+    defaultPensionDate,
+    maxMonthPensionDelayIfBorn1951OrEarlier,
+    maxMonthPensionDelayIfBornAfter1951,
+    maxMonthPensionHurry,
+  ])
 
   const title = `${formatMessage(translationStrings.mainTitle)} ${
     dateOfCalculationsOptions.find((o) => o.value === dateOfCalculations)


### PR DESCRIPTION
# Pension Calculator - Different max month pension delay if year <= 1951

## Why

* This change was requested by the social insurance administration

## Screenshots / Gifs

### Before

If birthyear <= 1951 then user can select up to a 156 month delay

![Screenshot 2024-09-18 at 11 21 55](https://github.com/user-attachments/assets/1b5d2e0c-a024-458c-ae78-45834e6c6138)

### After 

If birthyear <= 1951 then user can no longer select an option more than 60 months in advance

![Screenshot 2024-09-18 at 11 22 47](https://github.com/user-attachments/assets/1ec516c8-e43d-4b2a-bad9-ce285908602f)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced pension delay calculations based on the individual's birth year, allowing for more accurate pension outcomes.
  
- **Bug Fixes**
	- Updated logic to ensure correct pension delay calculations when the birth year changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->