### PR TITLE
feat(web): Add default header for utlendingastofnun organization

### DIFF
--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -297,7 +297,9 @@ export const OrganizationHeader: React.FC<
         />
       )
     case 'utlendingastofnun':
-      return (
+      return n('usingDefaultHeader', false) ? (
+        <DefaultHeader {...defaultProps} />
+      ) : (
         <UtlendingastofnunHeader
           organizationPage={organizationPage}
           logoAltText={logoAltText}


### PR DESCRIPTION
# Add default header for utlendingastofnun organization

## What
Make it possible to use default header for Útlendingastofnun organization via config.

## Why

A design that was approved by Digital Iceland

## Screenshots / Gifs

### Before
![image](https://github.com/user-attachments/assets/4548069c-4014-470a-9510-d438fc433e3a)

### After
![image](https://github.com/user-attachments/assets/e08d9451-8b39-427e-9c95-584422dcb181)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
