### PR TITLE
feat(web): Add default header for fjarsysla rikisins

### DIFF
--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -387,7 +387,9 @@ export const OrganizationHeader: React.FC<
     case 'landing_page':
       return null
     case 'fjarsysla-rikisins':
-      return (
+      return n('usingDefaultHeader', false) ? (
+        <DefaultHeader {...defaultProps} />
+      ) : (
         <FjarsyslaRikisinsHeader
           organizationPage={organizationPage}
           logoAltText={logoAltText}


### PR DESCRIPTION
# Add default header for fjarsysla rikisins organization

## What

Make it possible to use default header for Fjársýsla ríkisins organization via config.

## Why

A design that was approved by Digital Iceland

## Screenshots / Gifs

### Before
![image](https://github.com/user-attachments/assets/06d12684-dd23-48bb-8ffb-dc4aa60aec39)

### After
![image](https://github.com/user-attachments/assets/0db96b49-d850-4296-b694-2ded456af68c)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced conditional rendering for the `OrganizationHeader` component, allowing for dynamic display of headers based on specific conditions.
- **Bug Fixes**
	- Enhanced rendering logic to ensure the correct header is displayed for the organization `'fjarsysla-rikisins'`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->