### PR TITLE
fix(parental-leave): Parental leave slider now gets correct value in onChangeEnd function

### DIFF
--- a/libs/application/ui-components/src/components/Slider/Slider.tsx
+++ b/libs/application/ui-components/src/components/Slider/Slider.tsx
@@ -109,10 +109,19 @@ const Slider = ({
 
   const convertDeltaToIndex = (delta: number) => {
     const currentX = x + delta
-
-    dragX.current = Math.max(min * sizePerCell, Math.min(size.width, currentX))
-
-    return roundByNum(dragX.current / sizePerCell, step)
+    const roundedMin = toFixedNumber(min, 1, 10)
+    dragX.current = Math.max(0, Math.min(size.width, currentX))
+    // Get value to display in slider.
+    // Get max if more or equal to max, get min if less or equal to min and then show rest with only one decimal point.
+    const index =
+      dragX.current / sizePerCell + min >= max
+        ? max
+        : dragX.current / sizePerCell + min <= min
+        ? min
+        : roundByNum(dragX.current / sizePerCell, step) === 0
+        ? min
+        : roundByNum(dragX.current / sizePerCell, step) + roundedMin
+    return index
   }
 
   useEffect(() => {
@@ -146,19 +155,7 @@ const Slider = ({
 
   const dragBind = useDrag({
     onDragMove(deltaX: number) {
-      const currentX = x + deltaX
-      const roundedMin = toFixedNumber(min, 1, 10)
-      dragX.current = Math.max(0, Math.min(size.width, currentX))
-      // Get value to display in slider.
-      // Get max if more or equal to max, get min if less or equal to min and then show rest with only one decimal point.
-      const index =
-        dragX.current / sizePerCell + min >= max
-          ? max
-          : dragX.current / sizePerCell + min <= min
-          ? min
-          : roundByNum(dragX.current / sizePerCell, step) === 0
-          ? min
-          : roundByNum(dragX.current / sizePerCell, step) + roundedMin
+      const index = convertDeltaToIndex(deltaX)
 
       if (onChange && index !== indexRef.current) {
         onChange(index)
@@ -183,7 +180,6 @@ const Slider = ({
       dragX.current = undefined
       if (onChangeEnd) {
         const index = convertDeltaToIndex(deltaX)
-
         onChangeEnd?.(index)
       }
       setIsDragging(false)


### PR DESCRIPTION
# Parental leave slider fix
The slider was not passing the correct value for onChangeEnd

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the slider functionality to ensure it correctly respects minimum and maximum bounds during drag movements.
	- Enhanced handling of index calculations to prevent exceeding defined limits.

- **Refactor**
	- Streamlined the logic for calculating the slider index, improving code readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->