### PR TITLE
feat(web): Add default header for HSU organization

### DIFF
--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -333,7 +333,15 @@ export const OrganizationHeader: React.FC<
         />
       )
     case 'hsu':
-      return (
+      return n('usingDefaultHeader', false) ? (
+        <DefaultHeader
+          {...defaultProps}
+          image={n(
+            'hsuHeaderImage',
+            'https://images.ctfassets.net/8k0h54kbe6bj/sSSuQeq3oIx9hOrKRvfzm/447c7e6811c3fa9e9d548ecd4b6d7985/vector-myndir-hsu.svg',
+          )}
+        />
+      ) : (
         <HeilbrigdisstofnunSudurlandsHeader
           organizationPage={organizationPage}
           logoAltText={logoAltText}


### PR DESCRIPTION
# Add default header for HSU organization

## What

Make it possible to use default header for Heilbrigðisstofnun suðurlands organization via config.

## Why

A design that was approved by Digital Iceland

## Screenshots / Gifs

### Before 
![image](https://github.com/user-attachments/assets/da26107d-5229-4651-8461-00d1f73bda27)

### After
![image](https://github.com/user-attachments/assets/274d1c95-2068-4f22-97dd-957724329a16)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced dynamic header rendering in the Organization component, allowing for a conditional display of either the DefaultHeader or HeilbrigdisstofnunSudurlandsHeader based on specific criteria. 

This enhancement improves user experience by providing context-sensitive headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->