### PR TITLE
feat(web): Add default header for GEV organization

### DIFF
--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -421,7 +421,15 @@ export const OrganizationHeader: React.FC<
         />
       )
     case 'gev':
-      return (
+      return n('usingDefaultHeader', false) ? (
+        <DefaultHeader
+          {...defaultProps}
+          image={n(
+            'gevHeaderImage',
+            'https://images.ctfassets.net/8k0h54kbe6bj/13E4vIA69gDNF87pkHwJgc/c2175b5ce58e50c93ddef5ea26854740/figura.png',
+          )}
+        />
+      ) : (
         <GevHeader
           organizationPage={organizationPage}
           logoAltText={logoAltText}


### PR DESCRIPTION
# Add default header for GEV organization

## What

Make it possible to use default header for Gæða- og eftirlitsstofnun velferðarmála organization via config.

## Why

A design that was approved by Digital Iceland

## Screenshots / Gifs

### Before
![image](https://github.com/user-attachments/assets/3e58dd9b-49dc-4c16-86a6-4c401b225f31)

### After
![image](https://github.com/user-attachments/assets/6f91990e-403e-4920-9c8c-6cbb43dc706a)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced conditional rendering in the OrganizationHeader for organizations of type 'gev', allowing for a DefaultHeader or GevHeader based on specific conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->