### PR TITLE
feat(web): Generic List - Display filter tags if only one tag group is present

### DIFF
--- a/apps/web/components/GenericList/GenericList.tsx
+++ b/apps/web/components/GenericList/GenericList.tsx
@@ -292,12 +292,53 @@ export const GenericList = ({
 
   const selectedFilters = extractFilterTags(filterCategories)
 
+  const selectedFiltersComponent = (
+    <Box className={styles.filterTagsContainer}>
+      <Inline space={1} alignY="top">
+        {selectedFilters.length > 0 && (
+          <Text>{activeLocale === 'is' ? 'Síað eftir:' : 'Filtered by:'}</Text>
+        )}
+        <Inline space={1}>
+          {selectedFilters.map(({ value, label, category }) => (
+            <FilterTag
+              key={value}
+              active={true}
+              onClick={() => {
+                setParameters((prevParameters) => {
+                  const updatedParameters = {
+                    ...prevParameters,
+                    [category]: (prevParameters?.[category] ?? []).filter(
+                      (prevValue) => prevValue !== value,
+                    ),
+                  }
+
+                  // Make sure we clear out the query params from the url when there is nothing selected
+                  if (
+                    Object.values(updatedParameters).every(
+                      (s) => !s || s.length === 0,
+                    )
+                  ) {
+                    return null
+                  }
+
+                  return updatedParameters
+                })
+              }}
+            >
+              {label}
+            </FilterTag>
+          ))}
+        </Inline>
+      </Inline>
+    </Box>
+  )
+
   return (
     <Box paddingBottom={3}>
       <GridContainer>
-        <Stack space={5}>
+        <Stack space={4}>
           <Box ref={ref}>
-            {filterCategories.length > 0 && (
+            {filterCategories.length > 1 && (
               <Stack space={4}>
                 <Stack space={3}>
                   {isMobile && filterInputComponent}
@@ -386,49 +427,52 @@ export const GenericList = ({
                     />
                   </Filter>
                 </Stack>
+                {selectedFiltersComponent}
+              </Stack>
+            )}
 
-                <Box className={styles.filterTagsContainer}>
-                  <Inline space={1} alignY="top">
-                    {selectedFilters.length > 0 && (
-                      <Text>
-                        {activeLocale === 'is' ? 'Síað eftir:' : 'Filtered by:'}
-                      </Text>
-                    )}
-                    <Inline space={1}>
-                      {selectedFilters.map(({ value, label, category }) => (
-                        <FilterTag
-                          key={value}
+            {filterCategories.length <= 1 && (
+              <Stack space={4}>
+                <Stack space={3}>
+                  {filterInputComponent}
+                  {selectedFilters.length > 0 && selectedFiltersComponent}
+                </Stack>
+                <Inline space={1}>
+                  {filterTags
+                    ?.filter((tag) => {
+                      const isActive = Boolean(
+                        selectedFilters.find(
+                          (filter) => filter.value === tag.slug,
+                        ),
+                      )
+                      return !isActive
+                    })
+                    .map((tag) => {
+                      const category = tag.genericTagGroup?.slug
+                      const value = tag.slug
+                      const label = tag.title
+                      return (
+                        <Tag
+                          key={tag.id}
                           onClick={() => {
-                            setParameters((prevParameters) => {
-                              const updatedParameters = {
-                                ...prevParameters,
-                                [category]: (
-                                  prevParameters?.[category] ?? []
-                                ).filter((prevValue) => prevValue !== value),
-                              }
-
-                              // Make sure we clear out the query params from the url when there is nothing selected
-                              if (
-                                Object.values(updatedParameters).every(
-                                  (s) => !s || s.length === 0,
-                                )
-                              ) {
-                                return null
-                              }
-
-                              return updatedParameters
-                            })
+                            if (!category) {
+                              return
+                            }
+                            setParameters((prevParameters) => ({
+                              ...prevParameters,
+                              [category]: (
+                                prevParameters?.[category] ?? []
+                              ).concat(value),
+                            }))
                           }}
                         >
                           {label}
-                        </FilterTag>
-                      ))}
-                    </Inline>
-                  </Inline>
-                </Box>
+                        </Tag>
+                      )
+                    })}
+                </Inline>
               </Stack>
             )}
-            {filterCategories.length === 0 && filterInputComponent}
           </Box>
           {displayError && (
             <AlertMessage


### PR DESCRIPTION
# Generic List - Display filter tags if only one tag group is present

## What

* Design change

Now the "selected filters" section has active tags (meaning that now we have the dark blue color on the tag)

## Why

* No need to have a dropdown if there is only one tag group

## Screenshots / Gifs


### Before

![Screenshot 2024-09-23 at 13 24 42](https://github.com/user-attachments/assets/ea07ad59-417c-4ece-acde-90d9bf730f37)

![Screenshot 2024-09-23 at 13 24 54](https://github.com/user-attachments/assets/65bf9e40-3315-4deb-bc74-290329dad793)


### After

![Screenshot 2024-09-23 at 13 24 11](https://github.com/user-attachments/assets/7058d75e-cae1-4d3d-b4c8-991efe6733d7)

![Screenshot 2024-09-23 at 13 25 09](https://github.com/user-attachments/assets/b224087d-3423-4629-ace5-fc4988a38bd5)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `selectedFiltersComponent` to display currently selected filters in the `GenericList`.
	- Enhanced filter management with improved logic for adding and removing filters.
	- Replaced the `FilterTag` component with a new `Tag` component for better filter display.

- **Bug Fixes**
	- Adjusted rendering conditions to ensure accurate display of selected filters based on filter categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->