### PR TITLE
fix(signature-collection): Not stop paper signatures when already signed

### DIFF
--- a/libs/api/domains/signature-collection/src/lib/signatureCollection.service.ts
+++ b/libs/api/domains/signature-collection/src/lib/signatureCollection.service.ts
@@ -148,8 +148,17 @@ export class SignatureCollectionService {
     user: User,
     input: SignatureCollectionCanSignFromPaperInput,
   ): Promise<boolean> {
-    const signee = await this.signee(user, input.signeeNationalId)
+    const signee = await this.signatureCollectionClientService.getSignee(
+      user,
+      input.signeeNationalId,
+    )
     const list = await this.list(input.listId, user)
-    return signee.canSign && list.area.id === signee.area?.id
+    // Current signatures should not prevent paper signatures
+    const canSign =
+      signee.canSign ||
+      (signee.canSignInfo?.length === 1 &&
+        signee.canSignInfo[0] === ReasonKey.AlreadySigned)
+
+    return canSign && list.area.id === signee.area?.id
   }
 }


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced eligibility criteria for signing from paper, allowing for more flexibility in signature approvals.

- **Bug Fixes**
	- Resolved issues with the previous signing logic to ensure that existing signatures do not block new paper signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->