### PR TITLE
feat(web): Add default header for rettindagaesla fatlads folks organization

### DIFF
--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -532,7 +532,9 @@ export const OrganizationHeader: React.FC<
         />
       )
     case 'rettindagaesla-fatlads-folks':
-      return (
+      return n('usingDefaultHeader', false) ? (
+        <DefaultHeader {...defaultProps} />
+      ) : (
         <RettindagaeslaFatladsFolksHeader
           organizationPage={organizationPage}
           logoAltText={logoAltText}


### PR DESCRIPTION
# Add default header for rettindagaesla fatlads folks organization

## What

Make it possible to use default header for Réttindagæsla fatlaðs fólks organization via config.

## Why

A design that was approved by Digital Iceland

## Screenshots / Gifs

### Before
![image](https://github.com/user-attachments/assets/80055c3c-626e-4e7a-a32f-125eb4b3b7e5)

### After
![image](https://github.com/user-attachments/assets/4661aa43-1e30-4c2e-8562-7c4534a1ec3a)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced conditional rendering for the `OrganizationHeader` component, enhancing user experience based on specific conditions.
- **Bug Fixes**
	- Improved header rendering logic to ensure the correct header is displayed for the organization page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->