### PR TITLE
fix(ojoi): Update form context

### DIFF
--- a/libs/application/templates/official-journal-of-iceland/src/components/signatures/AddCommitteeMember.tsx
+++ b/libs/application/templates/official-journal-of-iceland/src/components/signatures/AddCommitteeMember.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../lib/constants'
 import { getCommitteeAnswers, getEmptyMember } from '../../lib/utils'
 import set from 'lodash/set'
+import { useFormContext } from 'react-hook-form'
 
 type Props = {
   applicationId: string
@@ -19,6 +20,8 @@ export const AddCommitteeMember = ({ applicationId }: Props) => {
   const { updateApplication, application, isLoading } = useApplication({
     applicationId,
   })
+
+  const { setValue } = useFormContext()
 
   const onAddCommitteeMember = () => {
     const { signature, currentAnswers } = getCommitteeAnswers(
@@ -36,6 +39,8 @@ export const AddCommitteeMember = ({ applicationId }: Props) => {
         InputFields.signature.committee,
         withExtraMember,
       )
+
+      setValue(InputFields.signature.committee, withExtraMember)
 
       updateApplication(updatedAnswers)
     }

--- a/libs/application/templates/official-journal-of-iceland/src/components/signatures/AddRegularMember.tsx
+++ b/libs/application/templates/official-journal-of-iceland/src/components/signatures/AddRegularMember.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../lib/constants'
 import { getEmptyMember, getRegularAnswers } from '../../lib/utils'
 import set from 'lodash/set'
+import { useFormContext } from 'react-hook-form'
 
 type Props = {
   applicationId: string
@@ -20,6 +21,8 @@ export const AddRegularMember = ({ applicationId, signatureIndex }: Props) => {
   const { updateApplication, application, isLoading } = useApplication({
     applicationId,
   })
+
+  const { setValue } = useFormContext()
 
   const onAddMember = () => {
     const { signature, currentAnswers } = getRegularAnswers(
@@ -46,6 +49,8 @@ export const AddRegularMember = ({ applicationId, signatureIndex }: Props) => {
           InputFields.signature.regular,
           updatedRegularSignature,
         )
+
+        setValue(InputFields.signature.regular, updatedRegularSignature)
 
         updateApplication(updatedAnswers)
       }

--- a/libs/application/templates/official-journal-of-iceland/src/components/signatures/AddRegularSignature.tsx
+++ b/libs/application/templates/official-journal-of-iceland/src/components/signatures/AddRegularSignature.tsx
@@ -15,6 +15,7 @@ import {
   MAXIMUM_REGULAR_SIGNATURE_COUNT,
   ONE,
 } from '../../lib/constants'
+import { useFormContext } from 'react-hook-form'
 
 type Props = {
   applicationId: string
@@ -25,6 +26,8 @@ export const AddRegularSignature = ({ applicationId }: Props) => {
   const { updateApplication, application, isLoading } = useApplication({
     applicationId,
   })
+
+  const { setValue } = useFormContext()
 
   const onAddInstitution = () => {
     const { signature, currentAnswers } = getRegularAnswers(
@@ -37,11 +40,15 @@ export const AddRegularSignature = ({ applicationId }: Props) => {
         DEFAULT_REGULAR_SIGNATURE_MEMBER_COUNT,
       )?.pop()
 
+      const updatedSignature = [...signature, newSignature]
+
       const updatedAnswers = set(
         currentAnswers,
         InputFields.signature.regular,
-        [...signature, newSignature],
+        updatedSignature,
       )
+
+      setValue(InputFields.signature.regular, updatedSignature)
 
       updateApplication(updatedAnswers)
     }

--- a/libs/application/templates/official-journal-of-iceland/src/components/signatures/Chairman.tsx
+++ b/libs/application/templates/official-journal-of-iceland/src/components/signatures/Chairman.tsx
@@ -13,6 +13,7 @@ import { SignatureMember } from './Member'
 import set from 'lodash/set'
 import * as styles from './Signatures.css'
 import * as z from 'zod'
+import { useFormContext } from 'react-hook-form'
 
 type Props = {
   applicationId: string
@@ -26,6 +27,8 @@ export const Chairman = ({ applicationId, member }: Props) => {
   const { application, debouncedOnUpdateApplicationHandler } = useApplication({
     applicationId,
   })
+
+  const { setValue } = useFormContext()
 
   const handleChairmanChange = (value: string, key: keyof MemberProperties) => {
     const { signature, currentAnswers } = getCommitteeAnswers(
@@ -56,6 +59,8 @@ export const Chairman = ({ applicationId, member }: Props) => {
         InputFields.signature.committee,
         updatedCommitteeSignature,
       )
+
+      setValue(InputFields.signature.committee, updatedCommitteeSignature)
 
       return updatedSignatures
     }

--- a/libs/application/templates/official-journal-of-iceland/src/components/signatures/CommitteeMember.tsx
+++ b/libs/application/templates/official-journal-of-iceland/src/components/signatures/CommitteeMember.tsx
@@ -14,6 +14,7 @@ import { memberItemSchema } from '../../lib/dataSchema'
 import { SignatureMember } from './Member'
 import * as z from 'zod'
 import { RemoveCommitteeMember } from './RemoveComitteeMember'
+import { useFormContext } from 'react-hook-form'
 
 type Props = {
   applicationId: string
@@ -32,6 +33,8 @@ export const CommitteeMember = ({
   const { debouncedOnUpdateApplicationHandler, application } = useApplication({
     applicationId,
   })
+
+  const { setValue } = useFormContext()
 
   const handleMemberChange = (
     value: string,
@@ -76,6 +79,8 @@ export const CommitteeMember = ({
         InputFields.signature.committee,
         updatedCommitteeSignature,
       )
+
+      setValue(InputFields.signature.committee, updatedCommitteeSignature)
 
       return updatedSignatures
     }

--- a/libs/application/templates/official-journal-of-iceland/src/components/signatures/Institution.tsx
+++ b/libs/application/templates/official-journal-of-iceland/src/components/signatures/Institution.tsx
@@ -27,6 +27,7 @@ import {
 import { z } from 'zod'
 import { signatureInstitutionSchema } from '../../lib/dataSchema'
 import { RemoveRegularSignature } from './RemoveRegularSignature'
+import { useFormContext } from 'react-hook-form'
 type Props = {
   applicationId: string
   type: SignatureType
@@ -48,6 +49,8 @@ export const InstitutionSignature = ({
   } = useApplication({
     applicationId,
   })
+
+  const { setValue } = useFormContext()
 
   const handleInstitutionChange = (
     value: string,
@@ -88,6 +91,8 @@ export const InstitutionSignature = ({
         updatedRegularSignature,
       )
 
+      setValue(InputFields.signature[type], updatedRegularSignature)
+
       return updatedSignatures
     }
 
@@ -113,6 +118,8 @@ export const InstitutionSignature = ({
           [key]: value,
         },
       )
+
+      setValue(InputFields.signature[type], updatedCommitteeSignature)
 
       return updatedCommitteeSignature
     }

--- a/libs/application/templates/official-journal-of-iceland/src/components/signatures/RegularMember.tsx
+++ b/libs/application/templates/official-journal-of-iceland/src/components/signatures/RegularMember.tsx
@@ -15,6 +15,7 @@ import { memberItemSchema } from '../../lib/dataSchema'
 import { SignatureMember } from './Member'
 import * as z from 'zod'
 import { RemoveRegularMember } from './RemoveRegularMember'
+import { useFormContext } from 'react-hook-form'
 
 type Props = {
   applicationId: string
@@ -35,6 +36,8 @@ export const RegularMember = ({
   const { debouncedOnUpdateApplicationHandler, application } = useApplication({
     applicationId,
   })
+
+  const { setValue } = useFormContext()
 
   const handleMemberChange = (
     value: string,
@@ -83,6 +86,8 @@ export const RegularMember = ({
         InputFields.signature.regular,
         updatedRegularSignature,
       )
+
+      setValue(InputFields.signature.regular, updatedRegularSignature)
 
       return updatedSignatures
     }

--- a/libs/application/templates/official-journal-of-iceland/src/components/signatures/RemoveComitteeMember.tsx
+++ b/libs/application/templates/official-journal-of-iceland/src/components/signatures/RemoveComitteeMember.tsx
@@ -5,6 +5,7 @@ import { MINIMUM_COMMITTEE_SIGNATURE_MEMBER_COUNT } from '../../lib/constants'
 import set from 'lodash/set'
 import * as styles from './Signatures.css'
 import { getCommitteeAnswers, isCommitteeSignature } from '../../lib/utils'
+import { useFormContext } from 'react-hook-form'
 
 type Props = {
   applicationId: string
@@ -18,6 +19,8 @@ export const RemoveCommitteeMember = ({
   const { updateApplication, application, isLoading } = useApplication({
     applicationId,
   })
+
+  const { setValue } = useFormContext()
 
   const onRemoveMember = () => {
     const { currentAnswers, signature } = getCommitteeAnswers(
@@ -35,6 +38,8 @@ export const RemoveCommitteeMember = ({
         InputFields.signature.committee,
         updatedCommitteeSignature,
       )
+
+      setValue(InputFields.signature.committee, updatedCommitteeSignature)
 
       updateApplication(updatedAnswers)
     }

--- a/libs/application/templates/official-journal-of-iceland/src/components/signatures/RemoveRegularMember.tsx
+++ b/libs/application/templates/official-journal-of-iceland/src/components/signatures/RemoveRegularMember.tsx
@@ -5,6 +5,7 @@ import { MINIMUM_REGULAR_SIGNATURE_MEMBER_COUNT } from '../../lib/constants'
 import set from 'lodash/set'
 import * as styles from './Signatures.css'
 import { getRegularAnswers } from '../../lib/utils'
+import { useFormContext } from 'react-hook-form'
 
 type Props = {
   applicationId: string
@@ -20,6 +21,8 @@ export const RemoveRegularMember = ({
   const { updateApplication, application, isLoading } = useApplication({
     applicationId,
   })
+
+  const { setValue } = useFormContext()
 
   const onRemoveMember = () => {
     const { currentAnswers, signature } = getRegularAnswers(application.answers)
@@ -44,6 +47,8 @@ export const RemoveRegularMember = ({
           InputFields.signature.regular,
           updatedRegularSignature,
         )
+
+        setValue(InputFields.signature.regular, updatedRegularSignature)
 
         updateApplication(updatedAnswers)
       }

--- a/libs/application/templates/official-journal-of-iceland/src/components/signatures/RemoveRegularSignature.tsx
+++ b/libs/application/templates/official-journal-of-iceland/src/components/signatures/RemoveRegularSignature.tsx
@@ -4,6 +4,7 @@ import { getValueViaPath } from '@island.is/application/core'
 import { InputFields } from '../../lib/types'
 import { isRegularSignature } from '../../lib/utils'
 import set from 'lodash/set'
+import { useFormContext } from 'react-hook-form'
 
 type Props = {
   applicationId: string
@@ -17,6 +18,8 @@ export const RemoveRegularSignature = ({
   const { updateApplication, application } = useApplication({
     applicationId,
   })
+
+  const { setValue } = useFormContext()
 
   const onRemove = () => {
     const currentAnswers = structuredClone(application.answers)
@@ -35,6 +38,8 @@ export const RemoveRegularSignature = ({
         InputFields.signature.regular,
         updatedRegularSignature,
       )
+
+      setValue(InputFields.signature.regular, updatedRegularSignature)
 
       updateApplication(updatedSignatures)
     }

--- a/libs/application/templates/official-journal-of-iceland/src/screens/RequirementsScreen.tsx
+++ b/libs/application/templates/official-journal-of-iceland/src/screens/RequirementsScreen.tsx
@@ -14,7 +14,7 @@ import {
   DEFAULT_COMMITTEE_SIGNATURE_MEMBER_COUNT,
   DEFAULT_REGULAR_SIGNATURE_COUNT,
   DEFAULT_REGULAR_SIGNATURE_MEMBER_COUNT,
-  OJOI_INPUT_HEIGHT as OJOI_INPUT_HEIGHT,
+  OJOI_INPUT_HEIGHT,
   SignatureTypes,
 } from '../lib/constants'
 import { useApplication } from '../hooks/useUpdateApplication'


### PR DESCRIPTION
## What

Saving the updated signature values in the react-hook-form context.

## Why

So that when the application-system updates the application between state changes that it uses the correct values.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced form management for adding and removing committee and regular members, ensuring signatures are updated dynamically.
	- Improved integration of form state management using `react-hook-form` across multiple components.

- **Bug Fixes**
	- Fixed issues with form state not reflecting changes after adding or removing members.

- **Documentation**
	- Updated import statements for clarity and consistency across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->