### PR TITLE
chore(j-s): Rollback subpoena entry if we get an error while creating it

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/subpoena/subpoena.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/subpoena/subpoena.service.ts
@@ -128,11 +128,6 @@ export class SubpoenaService {
           user,
         )
 
-        if (!createdSubpoena) {
-          this.logger.error('Failed to create subpoena file for police')
-          return { delivered: false }
-        }
-
         await this.subpoenaModel.update(
           { subpoenaId: createdSubpoena.subpoenaId },
           { where: { id: subpoena.id }, transaction },
@@ -141,7 +136,10 @@ export class SubpoenaService {
 
       return { delivered: true }
     } catch (error) {
-      this.logger.error('Error delivering subpoena to police', error)
+      this.logger.error(
+        'Error while attempting to deliver subpoena to police',
+        error,
+      )
       return { delivered: false }
     }
   }

--- a/apps/judicial-system/backend/src/app/modules/subpoena/subpoena.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/subpoena/subpoena.service.ts
@@ -35,7 +35,7 @@ export class SubpoenaService {
     defendant: Defendant,
     transaction: Transaction,
   ): Promise<Subpoena> {
-    return await this.subpoenaModel.create(
+    return this.subpoenaModel.create(
       {
         defendantId: defendant.id,
         caseId: defendant.caseId,


### PR DESCRIPTION
## What

Handle police creation errors by rolling back a transaction so we don't flood the db with failed subpoenas

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced subpoena creation process to support database transactions, improving data integrity during operations.
  
- **Bug Fixes**
	- Improved atomicity of subpoena creation and updates, ensuring all operations succeed or fail together.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->