### PR TITLE
fix(search-indexer): Limit what fields are indexed for "Latest Generic List Items" model

### DIFF
--- a/libs/cms/src/lib/models/latestGenericListItems.model.ts
+++ b/libs/cms/src/lib/models/latestGenericListItems.model.ts
@@ -44,13 +44,18 @@ const mapSeeMorePage = (seeMorePage: IOrganizationSubpage | undefined) => {
   return mapOrganizationSubpage({
     ...seeMorePage,
     fields: {
-      ...seeMorePage.fields,
+      title: seeMorePage.fields?.title,
+      slug: seeMorePage.fields?.slug,
       organizationPage: {
-        ...seeMorePage.fields.organizationPage,
+        ...seeMorePage.fields?.organizationPage,
         fields: {
-          ...seeMorePage.fields.organizationPage?.fields,
-          slices: [],
-          bottomSlices: [],
+          title: seeMorePage.fields?.organizationPage?.fields?.title,
+          slug: seeMorePage.fields?.organizationPage?.fields?.slug,
+          featuredImage:
+            seeMorePage.fields?.organizationPage?.fields?.featuredImage,
+          organization:
+            seeMorePage.fields?.organizationPage?.fields?.organization,
+          theme: seeMorePage.fields?.organizationPage?.fields?.theme,
         },
       },
     },


### PR DESCRIPTION
# Limit what fields are indexed for "Latest Generic List Items" model

## What



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
