### PR TITLE
fix(search-indexer): Reduce how much we write and read from elasticsearch

### DIFF
--- a/libs/cms/src/lib/search/contentful.service.ts
+++ b/libs/cms/src/lib/search/contentful.service.ts
@@ -475,7 +475,7 @@ export class ContentfulService {
     let idsChunk = idsCopy.splice(-MAX_REQUEST_COUNT, MAX_REQUEST_COUNT)
 
     while (idsChunk.length > 0) {
-      const size = 1000
+      const size = 100
       let page = 1
 
       const items: string[] = []

--- a/libs/content-search-toolkit/src/services/elastic.service.ts
+++ b/libs/content-search-toolkit/src/services/elastic.service.ts
@@ -112,10 +112,10 @@ export class ElasticService {
     refresh = false,
   ) {
     try {
-      // elasticsearch does not like big requests (above 5mb) so we limit the size to X entries just in case
       const client = await this.getClient()
 
-      let requestChunk = getValidBulkRequestChunk(requests)
+      // elasticsearch does not like big requests (above 5mb) so we limit the size to X entries just in case
+      let requestChunk = getValidBulkRequestChunk(requests, 10)
 
       while (requestChunk.length) {
         // wait for request b4 continuing


### PR DESCRIPTION
# Reduce how much we write and read from elasticsearch

Attach a link to issue if relevant

## What

Datadog logs indicate that we are writing too much and reading too much from elasticsearch

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of large requests in the search functionality, ensuring better performance and reliability.

- **Bug Fixes**
	- Adjusted processing limits to enhance efficiency and prevent issues related to large data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->