### PR TITLE
fix(web): Action Card - Wrap button below text on some screen sizes

### DIFF
--- a/libs/island-ui/core/src/lib/ActionCard/ActionCard.tsx
+++ b/libs/island-ui/core/src/lib/ActionCard/ActionCard.tsx
@@ -297,9 +297,10 @@ export const ActionCard: React.FC<React.PropsWithChildren<ActionCardProps>> = ({
 
       <Box
         // The left content box
-        alignItems={['stretch', 'center']}
+        alignItems={['stretch', 'center', 'stretch', 'center']}
         display="flex"
-        flexDirection={['column', 'row']}
+        flexDirection={['column', 'row', 'column', 'row']}
+        rowGap={3}
       >
         {renderAvatar()}
 


### PR DESCRIPTION
# Action Card - Wrap button below text on some screen sizes

## Screenshots / Gifs



### Before

https://github.com/user-attachments/assets/e0df9ec8-9e6d-4641-b8d6-2c74c28936fd



### After


https://github.com/user-attachments/assets/d137fa4e-9882-4cd9-adeb-93cadacef55a



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
