### PR TITLE
fix(web): Explicitly pass down elastic index

### DIFF
--- a/libs/content-search-indexer/src/lib/indexing.service.ts
+++ b/libs/content-search-indexer/src/lib/indexing.service.ts
@@ -72,6 +72,7 @@ export class IndexingService {
           while (initialFetch || nextPageToken) {
             const importerResponse = await importer.doSync({
               ...options,
+              elasticIndex,
               nextPageToken,
               folderHash: postSyncOptions?.folderHash,
             })


### PR DESCRIPTION
# Explicitly pass down elastic index to importer

It's clearer to pass it down than have to rely on the importer checking if it was passed down and if not fetch it himself

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
