### PR TITLE
fix(island-ui): Polyfill for PDF viewer

### DIFF
--- a/jest.preset.js
+++ b/jest.preset.js
@@ -24,6 +24,7 @@ module.exports = {
     // PDF viewer external css can be excluded from tests, otherwise will cause an error.
     '^react-pdf/dist/Page/(.*)$': 'jest-transform-stub',
   },
+  transformIgnorePatterns: ['<rootDir>/node_modules/(?!pdfjs-dist)'],
   /* TODO: Update to latest Jest snapshotFormat
    * By default Nx has kept the older style of Jest Snapshot formats
    * to prevent breaking of any existing tests with snapshots.

--- a/libs/island-ui/core/src/lib/PdfViewer/PdfViewer.tsx
+++ b/libs/island-ui/core/src/lib/PdfViewer/PdfViewer.tsx
@@ -10,7 +10,7 @@ import * as styles from './PdfViewer.css'
 import cn from 'classnames'
 
 pdfjs.GlobalWorkerOptions.workerSrc = new URL(
-  'pdfjs-dist/build/pdf.worker.min.mjs',
+  'pdfjs-dist/legacy/build/pdf.worker.min.mjs',
   import.meta.url,
 ).toString()
 

--- a/libs/island-ui/core/src/lib/PdfViewer/PdfViewer.tsx
+++ b/libs/island-ui/core/src/lib/PdfViewer/PdfViewer.tsx
@@ -8,11 +8,7 @@ import 'react-pdf/dist/Page/TextLayer.css'
 import 'react-pdf/dist/Page/AnnotationLayer.css'
 import * as styles from './PdfViewer.css'
 import cn from 'classnames'
-
-pdfjs.GlobalWorkerOptions.workerSrc = new URL(
-  'pdfjs-dist/legacy/build/pdf.worker.min.mjs',
-  import.meta.url,
-).toString()
+import 'pdfjs-dist/build/pdf.worker.min.mjs'
 
 const pdfError = 'Villa kom upp við að birta skjal, reyndu aftur síðar.'
 

--- a/libs/island-ui/core/src/lib/PdfViewer/PdfViewer.tsx
+++ b/libs/island-ui/core/src/lib/PdfViewer/PdfViewer.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState, ReactNode } from 'react'
+import React, { FC, useState, ReactNode } from 'react'
 import { Box } from '../Box/Box'
 import { Document, Page, Outline, pdfjs } from 'react-pdf'
 import { Pagination } from '../Pagination/Pagination'

--- a/libs/island-ui/core/src/lib/PdfViewer/PdfViewer.tsx
+++ b/libs/island-ui/core/src/lib/PdfViewer/PdfViewer.tsx
@@ -8,7 +8,11 @@ import 'react-pdf/dist/Page/TextLayer.css'
 import 'react-pdf/dist/Page/AnnotationLayer.css'
 import * as styles from './PdfViewer.css'
 import cn from 'classnames'
-import 'pdfjs-dist/build/pdf.worker.min.mjs'
+
+pdfjs.GlobalWorkerOptions.workerSrc = new URL(
+  'pdfjs-dist/legacy/build/pdf.worker.min.mjs',
+  import.meta.url,
+).toString()
 
 const pdfError = 'Villa kom upp við að birta skjal, reyndu aftur síðar.'
 

--- a/libs/island-ui/core/src/lib/PdfViewer/PdfViewer.tsx
+++ b/libs/island-ui/core/src/lib/PdfViewer/PdfViewer.tsx
@@ -45,8 +45,7 @@ export const PdfViewer: FC<React.PropsWithChildren<PdfViewerProps>> = ({
   useEffect(() => {
     import('react-pdf')
       .then((pdf) => {
-        pdf.pdfjs.GlobalWorkerOptions.workerSrc =
-          'https://unpkg.com/pdfjs-dist@4.4.168/legacy/build/pdf.worker.min.mjs'
+        pdf.pdfjs.GlobalWorkerOptions.workerSrc = `https://unpkg.com/pdfjs-dist@${pdf.pdfjs.version}/legacy/build/pdf.worker.min.mjs`
         setPdfLib(pdf)
       })
       .catch((e) => {

--- a/libs/island-ui/core/src/lib/PdfViewer/PdfViewer.tsx
+++ b/libs/island-ui/core/src/lib/PdfViewer/PdfViewer.tsx
@@ -9,10 +9,17 @@ import 'react-pdf/dist/Page/AnnotationLayer.css'
 import * as styles from './PdfViewer.css'
 import cn from 'classnames'
 
-pdfjs.GlobalWorkerOptions.workerSrc = new URL(
-  'pdfjs-dist/legacy/build/pdf.worker.min.mjs',
-  import.meta.url,
-).toString()
+if (typeof window !== 'undefined') {
+  // @ts-expect-error - dynamic import
+  import('pdfjs-dist/legacy/build/pdf.worker.min.mjs')
+    .then((workerSrc) => {
+      pdfjs.GlobalWorkerOptions.workerSrc = workerSrc
+    })
+    .catch(() => {
+      pdfjs.GlobalWorkerOptions.workerSrc =
+        'pdfjs-dist/legacy/build/pdf.worker.min.mjs' // Fallback if dynamic import fails
+    })
+}
 
 const pdfError = 'Villa kom upp við að birta skjal, reyndu aftur síðar.'
 

--- a/libs/island-ui/core/src/lib/PdfViewer/PdfViewer.tsx
+++ b/libs/island-ui/core/src/lib/PdfViewer/PdfViewer.tsx
@@ -11,19 +11,6 @@ import cn from 'classnames'
 
 const pdfError = 'Villa kom upp við að birta skjal, reyndu aftur síðar.'
 
-// @ts-expect-error This does not exist outside of polyfill.
-if (!Promise.withResolvers) {
-  // @ts-expect-error Need to polyfill withResolvers.
-  Promise.withResolvers = function () {
-    let resolve, reject
-    const promise = new Promise((res, rej) => {
-      resolve = res
-      reject = rej
-    })
-    return { promise, resolve, reject }
-  }
-}
-
 export interface PdfViewerProps {
   file: string
   showAllPages?: boolean
@@ -58,7 +45,8 @@ export const PdfViewer: FC<React.PropsWithChildren<PdfViewerProps>> = ({
   useEffect(() => {
     import('react-pdf')
       .then((pdf) => {
-        pdf.pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdf.pdfjs.version}/pdf.worker.min.mjs`
+        pdf.pdfjs.GlobalWorkerOptions.workerSrc =
+          'https://unpkg.com/pdfjs-dist@4.4.168/legacy/build/pdf.worker.min.mjs'
         setPdfLib(pdf)
       })
       .catch((e) => {

--- a/libs/island-ui/core/src/lib/PdfViewer/PdfViewer.tsx
+++ b/libs/island-ui/core/src/lib/PdfViewer/PdfViewer.tsx
@@ -11,6 +11,19 @@ import cn from 'classnames'
 
 const pdfError = 'Villa kom upp við að birta skjal, reyndu aftur síðar.'
 
+// @ts-expect-error This does not exist outside of polyfill.
+if (!Promise.withResolvers) {
+  // @ts-expect-error Need to polyfill withResolvers.
+  Promise.withResolvers = function () {
+    let resolve, reject
+    const promise = new Promise((res, rej) => {
+      resolve = res
+      reject = rej
+    })
+    return { promise, resolve, reject }
+  }
+}
+
 export interface PdfViewerProps {
   file: string
   showAllPages?: boolean
@@ -45,20 +58,6 @@ export const PdfViewer: FC<React.PropsWithChildren<PdfViewerProps>> = ({
   useEffect(() => {
     import('react-pdf')
       .then((pdf) => {
-        // @ts-expect-error This does not exist outside of polyfill.
-        if (typeof Promise.withResolvers === 'undefined') {
-          if (window)
-            // @ts-expect-error Need to polyfill withResolvers.
-            window.Promise.withResolvers = function () {
-              let resolve, reject
-              const promise = new Promise((res, rej) => {
-                resolve = res
-                reject = rej
-              })
-              return { promise, resolve, reject }
-            }
-        }
-
         pdf.pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdf.pdfjs.version}/pdf.worker.min.mjs`
         setPdfLib(pdf)
       })

--- a/libs/island-ui/core/src/lib/PdfViewer/PdfViewer.tsx
+++ b/libs/island-ui/core/src/lib/PdfViewer/PdfViewer.tsx
@@ -45,6 +45,20 @@ export const PdfViewer: FC<React.PropsWithChildren<PdfViewerProps>> = ({
   useEffect(() => {
     import('react-pdf')
       .then((pdf) => {
+        // @ts-expect-error This does not exist outside of polyfill.
+        if (typeof Promise.withResolvers === 'undefined') {
+          if (window)
+            // @ts-expect-error Need to polyfill withResolvers.
+            window.Promise.withResolvers = function () {
+              let resolve, reject
+              const promise = new Promise((res, rej) => {
+                resolve = res
+                reject = rej
+              })
+              return { promise, resolve, reject }
+            }
+        }
+
         pdf.pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdf.pdfjs.version}/pdf.worker.min.mjs`
         setPdfLib(pdf)
       })

--- a/libs/shared/types/src/lib/pdfjs-dist.d.ts
+++ b/libs/shared/types/src/lib/pdfjs-dist.d.ts
@@ -1,0 +1,5 @@
+declare module 'pdfjs-dist/legacy/build/pdf.worker.min.mjs' {
+  const workerSrc: string
+
+  export default workerSrc
+}

--- a/package.json
+++ b/package.json
@@ -126,7 +126,6 @@
     "@types/react-csv": "1.1.1",
     "@types/react-input-mask": "3.0.0",
     "@types/react-modal": "3.13.1",
-    "@types/react-pdf": "5.0.9",
     "@types/react-table": "7.0.24",
     "@vanilla-extract/babel-plugin": "1.1.6",
     "@vanilla-extract/css": "1.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20845,16 +20845,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-pdf@npm:5.0.9":
-  version: 5.0.9
-  resolution: "@types/react-pdf@npm:5.0.9"
-  dependencies:
-    "@types/react": "*"
-    pdfjs-dist: ^2.10.377
-  checksum: 5247dd76dc20beb504f13756d576d4036dab19416de648553f6405b44d4cf8467be3d50063f98cc07eed39b37d07bc834756a3f275b8bc7f635226fd59ae17c7
-  languageName: node
-  linkType: hard
-
 "@types/react-table@npm:7.0.24":
   version: 7.0.24
   resolution: "@types/react-table@npm:7.0.24"
@@ -37358,7 +37348,6 @@ __metadata:
     "@types/react-infinite-scroller": ^1.2.3
     "@types/react-input-mask": 3.0.0
     "@types/react-modal": 3.13.1
-    "@types/react-pdf": 5.0.9
     "@types/react-table": 7.0.24
     "@types/request": 2.48.5
     "@types/resolve": ^1.20.2
@@ -45293,15 +45282,6 @@ __metadata:
     path2d:
       optional: true
   checksum: 96ff90da5b1aca99cfe3c706434f2215ee5405ccd680f1f40c9b97760c39a6d7865911f67a3130301f845c924ebda110da4fa90fd613c999438df408c347505c
-  languageName: node
-  linkType: hard
-
-"pdfjs-dist@npm:^2.10.377":
-  version: 2.10.377
-  resolution: "pdfjs-dist@npm:2.10.377"
-  peerDependencies:
-    worker-loader: ^3.0.7
-  checksum: 5a4c14777676e15aeca9a627cc1f368821071ae040154983edf21f1040cb89acd9b0168b43b64ac10d66f86094dcb48b33513b9810b6d422446c599fb172d5a4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

Polyfill for pdf-viewer ✨ 
Remove types package, no longer needed. It depends on an older version of pdfjs-dist, which causes an error.
We need the new version to depend on legacy for browser support.

## Why

Proper browser support.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the PdfViewer component for improved clarity and efficiency.
	- Streamlined rendering logic for displaying PDF documents.

- **Bug Fixes**
	- Adjusted error handling for the Document component.

- **Chores**
	- Updated dependencies in package.json to ensure compatibility and resolve potential issues.
	- Modified jest.preset.js for better handling of specific modules during testing.
	- Introduced a new module declaration for PDF.js worker to facilitate TypeScript usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->