### PR TITLE
feat(web): Organization - alert banner field

### DIFF
--- a/apps/web/screens/Article/Article.tsx
+++ b/apps/web/screens/Article/Article.tsx
@@ -878,6 +878,7 @@ ArticleScreen.getProps = async ({ apolloClient, query, locale }) => {
     stepOptionsFromNamespace,
     stepperNamespace,
     ...getThemeConfig(article),
+    customAlertBanner: article.organization?.[0]?.alertBanner,
   }
 }
 

--- a/apps/web/screens/ServiceWeb/Home/Home.tsx
+++ b/apps/web/screens/ServiceWeb/Home/Home.tsx
@@ -439,6 +439,7 @@ Home.getProps = async ({ apolloClient, locale, query }) => {
       : [],
     serviceWebPage: getServiceWebPage,
     locale: locale as Locale,
+    customAlertBanner: organization?.data?.getOrganization?.alertBanner,
   }
 }
 

--- a/apps/web/screens/queries/Article.ts
+++ b/apps/web/screens/queries/Article.ts
@@ -61,6 +61,19 @@ export const GET_ARTICLE_QUERY = gql`
         hasALandingPage
         trackingDomain
         footerConfig
+        alertBanner {
+          showAlertBanner
+          bannerVariant
+          title
+          description
+          linkTitle
+          link {
+            slug
+            type
+          }
+          isDismissable
+          dismissedForDays
+        }
         logo {
           url
           width

--- a/apps/web/screens/queries/ServiceWeb.ts
+++ b/apps/web/screens/queries/ServiceWeb.ts
@@ -214,6 +214,19 @@ export const GET_SERVICE_WEB_ORGANIZATION = gql`
         width
         height
       }
+      alertBanner {
+        showAlertBanner
+        bannerVariant
+        title
+        description
+        linkTitle
+        link {
+          slug
+          type
+        }
+        isDismissable
+        dismissedForDays
+      }
       footerConfig
       footerItems {
         title

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -2915,6 +2915,9 @@ export interface IOrganizationFields {
 
   /** Kennitala */
   kennitala?: string | undefined
+
+  /** Alert Banner */
+  alertBanner?: IAlertBanner | undefined
 }
 
 export interface IOrganization extends Entry<IOrganizationFields> {

--- a/libs/cms/src/lib/models/organization.model.ts
+++ b/libs/cms/src/lib/models/organization.model.ts
@@ -7,6 +7,7 @@ import { OrganizationTag, mapOrganizationTag } from './organizationTag.model'
 import { FooterItem, mapFooterItem } from './footerItem.model'
 import { mapNamespace, Namespace } from './namespace.model'
 import { GenericTag, mapGenericTag } from './genericTag.model'
+import { AlertBanner, mapAlertBanner } from './alertBanner.model'
 
 @ObjectType()
 export class Organization {
@@ -75,6 +76,9 @@ export class Organization {
 
   @Field({ nullable: true })
   referenceIdentifier?: string
+
+  @CacheField(() => AlertBanner, { nullable: true })
+  alertBanner?: AlertBanner | null
 }
 
 export const mapOrganization = ({
@@ -109,5 +113,6 @@ export const mapOrganization = ({
     hasALandingPage: fields.hasALandingPage ?? true,
     trackingDomain: fields.trackingDomain ?? '',
     referenceIdentifier: fields.referenceIdentifier,
+    alertBanner: fields.alertBanner ? mapAlertBanner(fields.alertBanner) : null,
   }
 }


### PR DESCRIPTION
# Organization - alert banner field

## What

* Add alert banner field to organization content type, meaning that all articles that belong to an organization will display a banner if provided

## Why

* This was requested by Digital Iceland

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `customAlertBanner` property in the `ArticleScreen` and `Home` components to display organization-specific alert banners.
	- Enhanced GraphQL queries to include detailed alert banner information for organizations.

- **Bug Fixes**
	- Improved data structure in queries to ensure accurate retrieval of alert banner details.

- **Documentation**
	- Updated method signatures and query structures to reflect the addition of the `alertBanner` field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->