### PR TITLE
chore(clients-syslumenn): Update client config

### DIFF
--- a/libs/clients/syslumenn/project.json
+++ b/libs/clients/syslumenn/project.json
@@ -19,7 +19,7 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "curl https://api.syslumenn.is/staging/swagger/v1/swagger.json -H 'Accept: application/json' | jq '.paths[][].tags = [\"Syslumenn\"]' > src/clientConfig.json"
+          "curl https://api.syslumenn.is/staging/swagger/v1/swagger.json -H 'Accept: application/json' | jq '.paths[][].tags = [\"Syslumenn\"]' | jq '(.. | objects | select(has(\"application/json\")) | .[\"application/json\"].schema) |= if has(\"items\") and .items == {} then .items = {\"type\": \"object\"} else . end' | jq '(.components[][] | select(has(\"additionalProperties\")) | select(.additionalProperties|objects) | .additionalProperties) |= if has(\"nullable\") and .nullable == true then (.type = \"object\") else . end' | jq '(.components[][] | objects | select(has(\"properties\")) | .properties | .[]) |= if has(\"items\") and .items == {} then .items = {\"type\": \"object\"} else . end' > src/clientConfig.json"
         ],
         "parallel": false,
         "cwd": "libs/clients/syslumenn"

--- a/libs/clients/syslumenn/src/clientConfig.json
+++ b/libs/clients/syslumenn/src/clientConfig.json
@@ -3474,7 +3474,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": {}
+                  "items": {
+                    "type": "object"
+                  }
                 }
               }
             }
@@ -4123,7 +4125,8 @@
       "ProblemDetails": {
         "type": "object",
         "additionalProperties": {
-          "nullable": true
+          "nullable": true,
+          "type": "object"
         },
         "properties": {
           "type": {
@@ -7688,7 +7691,9 @@
           "crew": {
             "type": "array",
             "nullable": true,
-            "items": {}
+            "items": {
+              "type": "object"
+            }
           },
           "owners": {
             "type": "array",
@@ -7700,7 +7705,9 @@
           "passengerPermits": {
             "type": "array",
             "nullable": true,
-            "items": {}
+            "items": {
+              "type": "object"
+            }
           },
           "insurances": {
             "type": "array",

--- a/libs/clients/syslumenn/src/clientConfig.json
+++ b/libs/clients/syslumenn/src/clientConfig.json
@@ -1,140 +1,169 @@
 {
   "x-generator": "NSwag v13.19.0.0 (NJsonSchema v10.9.0.0 (Newtonsoft.Json v13.0.0.0))",
-  "swagger": "2.0",
+  "openapi": "3.0.0",
   "info": {
     "title": "Þjónustugátt starfskerfa sýslumanna",
     "description": "Rafrænn aðgengi að gögnum og aðgerðum starfskerfis sýslumanna",
     "version": "v1"
   },
-  "host": "api.syslumenn.is",
-  "basePath": "/staging",
-  "schemes": ["https"],
-  "produces": ["text/plain", "application/json", "text/json"],
+  "servers": [
+    {
+      "url": "https://api.syslumenn.is/staging"
+    }
+  ],
   "paths": {
     "/v1/Innskraning": {
       "post": {
-        "tags": ["Syslumenn"],
-        "operationId": "Innskraning_Post",
-        "consumes": ["application/json", "text/json", "application/*+json"],
-        "parameters": [
-          {
-            "name": "notandi",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/ApiNotandi"
-            },
-            "x-nullable": false
-          }
+        "tags": [
+          "Syslumenn"
         ],
+        "operationId": "Innskraning_Post",
+        "requestBody": {
+          "x-name": "notandi",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiNotandi"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/InnskraningSvarSkeyti"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InnskraningSvarSkeyti"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/v1/Postnumer": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "Postnumer_GetPostnumerAll",
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Postnumer"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Postnumer"
+                  }
+                }
               }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/v1/Postnumer/{id}": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "Postnumer_GetPostnumer",
         "parameters": [
           {
-            "type": "integer",
             "name": "id",
             "in": "path",
             "required": true,
-            "format": "int32",
-            "x-nullable": false
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 1
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/Postnumer"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Postnumer"
+                }
+              }
             }
           },
           "404": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "default": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/SkraSveinsbref": {
       "post": {
-        "tags": ["Syslumenn"],
-        "operationId": "SkraSveinsbref_CreateSveinsbref",
-        "consumes": ["application/json", "text/json", "application/*+json"],
-        "parameters": [
-          {
-            "name": "sveinsbrefList",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/SkraSveinsbrefModel"
-              }
-            },
-            "x-nullable": false
-          }
+        "tags": [
+          "Syslumenn"
         ],
+        "operationId": "SkraSveinsbref_CreateSveinsbref",
+        "requestBody": {
+          "x-name": "sveinsbrefList",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/SkraSveinsbrefModel"
+                }
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/NyskraAdfaraBeidniSvar"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NyskraAdfaraBeidniSvar"
+                }
+              }
             }
           },
           "401": {
@@ -143,32 +172,39 @@
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/Sveinsbref/{audkenni}": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "Sveinsbref_Get",
         "parameters": [
           {
-            "type": "string",
             "name": "audkenni",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/SveinsbrefModel"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SveinsbrefModel"
+                  }
+                }
               }
             }
           },
@@ -181,283 +217,360 @@
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/v1/AdfarabeidnirHeimildaflokkur": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "AdfarabeidnirHeimildaflokkur_GetAdfarabeidnirHeimildaflokkurAll",
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/AdfarabeidnirHeimildaflokkur"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AdfarabeidnirHeimildaflokkur"
+                  }
+                }
               }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/v1/AdfarabeidnirHeimildaflokkur/{id}": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "AdfarabeidnirHeimildaflokkur_GetAdfarabeidnirHeimildaflokkur",
         "parameters": [
           {
-            "type": "integer",
             "name": "id",
             "in": "path",
             "required": true,
-            "format": "int32",
-            "x-nullable": false
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 1
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/AdfarabeidnirHeimildaflokkur"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdfarabeidnirHeimildaflokkur"
+                }
+              }
             }
           },
           "404": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "default": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/v1/Embaetti": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "Embaetti_GetEmbaettiAll",
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Embaetti"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Embaetti"
+                  }
+                }
               }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/v1/Embaetti/{id}": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "Embaetti_GetEmbaetti",
         "parameters": [
           {
-            "type": "integer",
             "name": "id",
             "in": "path",
             "required": true,
-            "format": "int32",
-            "x-nullable": false
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 1
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/Embaetti"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Embaetti"
+                }
+              }
             }
           },
           "404": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "default": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/v1/EmbaettiOgStarfsstodvar": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "EmbaettiOgStarfsstodvar_GetEmbaetti",
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/EmbaettiOgStarfsstodvar"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EmbaettiOgStarfsstodvar"
+                  }
+                }
               }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/Okutaeki/{fastanumer}/{audkenni}": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "Okutaeki_Get",
         "parameters": [
           {
-            "type": "string",
             "name": "fastanumer",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
           },
           {
-            "type": "string",
             "name": "audkenni",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 2
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/Okutaeki"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Okutaeki"
+                }
+              }
             }
           },
           "404": {
-            "x-nullable": false,
             "description": "Not found",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "400": {
-            "x-nullable": false,
             "description": "Bad request",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/Uppbod/{audkenni}": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "Uppbod_Get",
         "parameters": [
           {
-            "type": "string",
             "name": "audkenni",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Uppbod"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Uppbod"
+                  }
+                }
               }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "default": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/v1/IdngreinarMeistara": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "IdngreinarMeistara_Get",
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -467,1836 +580,2339 @@
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/Logradamadur/{audkenni}": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "Logradamadur_Get",
         "parameters": [
           {
-            "type": "string",
             "name": "audkenni",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
           },
           {
-            "type": "string",
             "name": "kennitala",
             "in": "query",
-            "x-nullable": true
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 2
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/LogradamadurSvar"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LogradamadurSvar"
+                  }
+                }
               }
             }
           },
           "500": {
-            "x-nullable": false,
             "description": "Internal server error",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/Logmannalisti": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "Logmannalisti_Get",
         "parameters": [
           {
-            "type": "string",
             "name": "audkenni",
             "in": "query",
-            "x-nullable": true
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 1
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Logmenn"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Logmenn"
+                  }
+                }
               }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/Afengisleyfi/{audkenni}": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "Afengisleyfi_Get",
         "parameters": [
           {
-            "type": "string",
             "name": "audkenni",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Afengisleyfi"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Afengisleyfi"
+                  }
+                }
               }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "default": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/Meistaraleyfi/{audkenni}": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "Meistaraleyfi_Get",
         "parameters": [
           {
-            "type": "string",
             "name": "audkenni",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Meistaraleyfi"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Meistaraleyfi"
+                  }
+                }
               }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "default": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/Starfsrettindi/api/Starfsrettindi/{audkenni}": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "Starfsrettindi_Get",
         "parameters": [
           {
-            "type": "string",
             "name": "audkenni",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/StarfsrettindiModel"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/StarfsrettindiModel"
+                  }
+                }
               }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "default": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/Taekifaerisleyfi/{audkenni}": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "Taekifaerisleyfi_Get",
         "parameters": [
           {
-            "type": "string",
             "name": "audkenni",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Taekifaerisleyfi"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Taekifaerisleyfi"
+                  }
+                }
               }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "default": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/VirkLeyfi/{audkenni}": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "VirkLeyfi_Get",
         "parameters": [
           {
-            "type": "string",
             "name": "audkenni",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
           },
           {
-            "type": "string",
             "name": "SearchBy",
             "in": "query",
-            "x-nullable": true
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 2
           },
           {
-            "type": "integer",
             "name": "PageNumber",
             "in": "query",
-            "format": "int32",
-            "x-nullable": false
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 3
           },
           {
-            "type": "integer",
             "name": "PageSize",
             "in": "query",
-            "format": "int32",
-            "x-nullable": false
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 4
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/VirkLeyfi"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/VirkLeyfi"
+                  }
+                }
               }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "default": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/VirkLeyfiCsv/{audkenni}": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "VirkLeyfiCsv_Get",
         "parameters": [
           {
-            "type": "string",
             "name": "audkenni",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "type": "string"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "default": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/VirkLeyfiMedFastanumerum/{audkenni}": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "VirkLeyfiMedFastanumerum_Get",
         "parameters": [
           {
-            "type": "string",
             "name": "audkenni",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
           },
           {
-            "type": "string",
             "name": "SearchBy",
             "in": "query",
-            "x-nullable": true
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 2
           },
           {
-            "type": "integer",
             "name": "PageNumber",
             "in": "query",
-            "format": "int32",
-            "x-nullable": false
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 3
           },
           {
-            "type": "integer",
             "name": "PageSize",
             "in": "query",
-            "format": "int32",
-            "x-nullable": false
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 4
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/VirkLeyfiMedfastanumer"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/VirkLeyfiMedfastanumer"
+                  }
+                }
               }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "default": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/v1/Heimagistingar/{audkenni}": {
       "put": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "Heimagistingar_Put",
-        "consumes": ["application/json", "text/json", "application/*+json"],
         "parameters": [
           {
-            "name": "payload",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/UppfaeraHeimagistingarModel"
-            },
-            "x-nullable": false
-          },
-          {
-            "type": "string",
             "name": "audkenni",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 2
           }
         ],
+        "requestBody": {
+          "x-name": "payload",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UppfaeraHeimagistingarModel"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
         "responses": {
           "200": {
             "description": ""
           },
           "401": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "default": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       },
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "Heimagistingar_Get",
         "parameters": [
           {
-            "type": "string",
             "name": "audkenni",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/HeimagistingarModel"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/HeimagistingarModel"
+                  }
+                }
               }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "default": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/v1/VirkarHeimagistingar/{audkenni}": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "VirkarHeimagistingar_Get",
         "parameters": [
           {
-            "type": "string",
             "name": "audkenni",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/VirkarHeimagistingar"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/VirkarHeimagistingar"
+                  }
+                }
               }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "default": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/v1/VirkarHeimagistingar/{audkenni}/{ar}": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "VirkarHeimagistingar_Get2",
         "parameters": [
           {
-            "type": "string",
             "name": "audkenni",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
           },
           {
-            "type": "string",
             "name": "ar",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 2
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/VirkarHeimagistingar"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/VirkarHeimagistingar"
+                  }
+                }
               }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "default": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/v1/ArangurslausFraDags": {
       "post": {
-        "tags": ["Syslumenn"],
-        "operationId": "ArangurslausFraDags_Post",
-        "consumes": ["application/json", "text/json", "application/*+json"],
-        "parameters": [
-          {
-            "name": "skilabod",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/AranuslausFyrirspurn"
-            },
-            "x-nullable": false
-          }
+        "tags": [
+          "Syslumenn"
         ],
+        "operationId": "ArangurslausFraDags_Post",
+        "requestBody": {
+          "x-name": "skilabod",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AranuslausFyrirspurn"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/AranuslausSvar"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AranuslausSvar"
+                }
+              }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/v1/NyskraAdfaraBeidni": {
       "post": {
-        "tags": ["Syslumenn"],
-        "operationId": "NyskraAdfaraBeidni_Post",
-        "consumes": ["application/json", "text/json", "application/*+json"],
-        "parameters": [
-          {
-            "name": "skilabod",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/NyskraAdfaraBeidniSkeyti"
-            },
-            "x-nullable": false
-          }
+        "tags": [
+          "Syslumenn"
         ],
+        "operationId": "NyskraAdfaraBeidni_Post",
+        "requestBody": {
+          "x-name": "skilabod",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NyskraAdfaraBeidniSkeyti"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/NyskraAdfaraBeidniSvar"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NyskraAdfaraBeidniSvar"
+                }
+              }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/v1/Fullnustusvid/Naudungarsala/UppbodFaFasteignir": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "UppbodFaFasteignir_Get",
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/UppbodFasteignir"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/UppbodFasteignir"
+                  }
+                }
               }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/v1/AfturkallaAdfarabeidni": {
       "post": {
-        "tags": ["Syslumenn"],
-        "operationId": "AfturkallaAdfarabeidni_Post",
-        "consumes": ["application/json", "text/json", "application/*+json"],
-        "parameters": [
-          {
-            "name": "skilabod",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/AdfarabeidniSkeyti"
-            },
-            "x-nullable": false
-          }
+        "tags": [
+          "Syslumenn"
         ],
+        "operationId": "AfturkallaAdfarabeidni_Post",
+        "requestBody": {
+          "x-name": "skilabod",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdfarabeidniSkeyti"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/NyskraAdfaraBeidniSvar"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NyskraAdfaraBeidniSvar"
+                }
+              }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/v1/ArangurslausFraTilDags": {
       "post": {
-        "tags": ["Syslumenn"],
-        "operationId": "ArangurslausFraTilDags_Post",
-        "consumes": ["application/json", "text/json", "application/*+json"],
-        "parameters": [
-          {
-            "name": "skilabod",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/AranuslausFratilFyrirspurn"
-            },
-            "x-nullable": false
-          }
+        "tags": [
+          "Syslumenn"
         ],
+        "operationId": "ArangurslausFraTilDags_Post",
+        "requestBody": {
+          "x-name": "skilabod",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AranuslausFratilFyrirspurn"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/AranuslausFraTilSvar"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AranuslausFraTilSvar"
+                }
+              }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/KannaKonnunarvottord/{audkenni}": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "KannaKonnunarvottord_Get",
         "parameters": [
           {
-            "type": "string",
             "name": "audkenni",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
           },
           {
-            "type": "string",
             "name": "kennitala",
             "in": "query",
-            "x-nullable": true
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 2
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/KonnunarvottordSvar"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KonnunarvottordSvar"
+                }
+              }
             }
           },
           "500": {
-            "x-nullable": false,
             "description": "Internal server error",
-            "schema": {
-              "$ref": "#/definitions/KonnunarvottordSvar"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KonnunarvottordSvar"
+                }
+              }
             }
           },
           "400": {
-            "x-nullable": false,
             "description": "Bad request",
-            "schema": {
-              "$ref": "#/definitions/KonnunarvottordSvar"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KonnunarvottordSvar"
+                }
+              }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/KonnunarvottordSvar"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KonnunarvottordSvar"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/v1/Danarbu/BankaupplysingarDanarbus": {
       "post": {
-        "tags": ["Syslumenn"],
-        "operationId": "BankaupplysingarDanarbus_Post",
-        "consumes": ["application/json", "text/json", "application/*+json"],
-        "parameters": [
-          {
-            "name": "skeyti",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/BankaupplysingarDanarbusSkeyti"
-            },
-            "x-nullable": false
-          }
+        "tags": [
+          "Syslumenn"
         ],
+        "operationId": "BankaupplysingarDanarbus_Post",
+        "requestBody": {
+          "x-name": "skeyti",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BankaupplysingarDanarbusSkeyti"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/BankaupplysingarDanarbusSkeyti"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BankaupplysingarDanarbusSkeyti"
+                }
+              }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/DanarbuAlgengTengsl/{audkenni}": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "DanarbuAlgengTengsl_Get",
         "parameters": [
           {
-            "type": "string",
             "name": "audkenni",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/AlgengTengsl"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AlgengTengsl"
+                  }
+                }
               }
             }
           },
           "404": {
-            "x-nullable": false,
             "description": "Not found",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "400": {
-            "x-nullable": false,
             "description": "Bad request",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/DanarbuAlgengTengslUmsaekjanda/{audkenni}": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "DanarbuAlgengTengslUmsaekjanda_Get",
         "parameters": [
           {
-            "type": "string",
             "name": "audkenni",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/AlgengUmsaekjandaTengsl"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AlgengUmsaekjandaTengsl"
+                  }
+                }
               }
             }
           },
           "404": {
-            "x-nullable": false,
             "description": "Not found",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "400": {
-            "x-nullable": false,
             "description": "Bad request",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/{audkenni}": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "Erfdafjarskattur_Get",
         "parameters": [
           {
-            "type": "string",
             "name": "malsnumer",
             "in": "query",
-            "x-nullable": true
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 1
           },
           {
-            "type": "string",
             "name": "audkenni",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 2
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/ErfdafjarskatturSvar"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErfdafjarskatturSvar"
+                }
+              }
             }
           },
           "404": {
-            "x-nullable": false,
             "description": "Not found",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "400": {
-            "x-nullable": false,
             "description": "Bad request",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/SkiptaUmSkraningaradilaDanarbus": {
       "post": {
-        "tags": ["Syslumenn"],
-        "operationId": "SkiptaUmSkraningaradilaDanarbus_Post",
-        "consumes": ["application/json", "text/json", "application/*+json"],
-        "parameters": [
-          {
-            "name": "payload",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/SkiptaUmSkraningaradili"
-            },
-            "x-nullable": false
-          }
+        "tags": [
+          "Syslumenn"
         ],
+        "operationId": "SkiptaUmSkraningaradilaDanarbus_Post",
+        "requestBody": {
+          "x-name": "payload",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SkiptaUmSkraningaradili"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/SkiptaUmSkraningaradiliSkeyti"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkiptaUmSkraningaradiliSkeyti"
+                }
+              }
             }
           },
           "404": {
-            "x-nullable": false,
             "description": "Not found",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "400": {
-            "x-nullable": false,
             "description": "Bad request",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/SkraningaradiliDanarbus/{kennitala}/{audkenni}": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "SkraningaradiliDanarbus_Get",
         "parameters": [
           {
-            "type": "string",
             "name": "kennitala",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
           },
           {
-            "type": "string",
             "name": "audkenni",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 2
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/SkraningaradiliDanarbusSkeyti"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SkraningaradiliDanarbusSkeyti"
+                  }
+                }
               }
             }
           },
           "404": {
-            "x-nullable": false,
             "description": "Not found",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "400": {
-            "x-nullable": false,
             "description": "Bad request",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/UpplysingarRadstofunDanarbus": {
       "post": {
-        "tags": ["Syslumenn"],
-        "operationId": "UpplysingarRadstofunDanarbus_Post",
-        "consumes": ["application/json", "text/json", "application/*+json"],
-        "parameters": [
-          {
-            "name": "fyrirspurn",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/Fyrirspurn"
-            },
-            "x-nullable": false
-          }
+        "tags": [
+          "Syslumenn"
         ],
+        "operationId": "UpplysingarRadstofunDanarbus_Post",
+        "requestBody": {
+          "x-name": "fyrirspurn",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Fyrirspurn"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/UpplysingarUrDanarbuiRadstofunSkeyti"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpplysingarUrDanarbuiRadstofunSkeyti"
+                }
+              }
             }
           },
           "404": {
-            "x-nullable": false,
             "description": "Not found",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "400": {
-            "x-nullable": false,
             "description": "Bad request",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/v1/Danarbu/UpplysingarUrDanarbui": {
       "post": {
-        "tags": ["Syslumenn"],
-        "operationId": "UpplysingarUrDanarbui_Post",
-        "consumes": ["application/json", "text/json", "application/*+json"],
-        "parameters": [
-          {
-            "name": "fyrirspurn",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/Fyrirspurn"
-            },
-            "x-nullable": false
-          }
+        "tags": [
+          "Syslumenn"
         ],
+        "operationId": "UpplysingarUrDanarbui_Post",
+        "requestBody": {
+          "x-name": "fyrirspurn",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Fyrirspurn"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/UpplysingarUrDanarbuiSkeyti"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpplysingarUrDanarbuiSkeyti"
+                }
+              }
             }
           },
           "404": {
-            "x-nullable": false,
             "description": "Not found",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "400": {
-            "x-nullable": false,
             "description": "Bad request",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/v1/Danarbu/UpplysingarUrDanarbuiErfdafjarskatt": {
       "post": {
-        "tags": ["Syslumenn"],
-        "operationId": "UpplysingarUrDanarbuiErfdafjarskatt_Post",
-        "consumes": ["application/json", "text/json", "application/*+json"],
-        "parameters": [
-          {
-            "name": "fyrirspurn",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/Fyrirspurn"
-            },
-            "x-nullable": false
-          }
+        "tags": [
+          "Syslumenn"
         ],
+        "operationId": "UpplysingarUrDanarbuiErfdafjarskatt_Post",
+        "requestBody": {
+          "x-name": "fyrirspurn",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Fyrirspurn"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/UpplysingarUrDanarbuiSkeytiErfdafjarskatt"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpplysingarUrDanarbuiSkeytiErfdafjarskatt"
+                }
+              }
             }
           },
           "404": {
-            "x-nullable": false,
             "description": "Not found",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "400": {
-            "x-nullable": false,
             "description": "Bad request",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/v1/Danarbu/YfirlitUmFramvinduSkipta": {
       "post": {
-        "tags": ["Syslumenn"],
-        "operationId": "YfirlitUmFramvinduSkipta_Post",
-        "consumes": ["application/json", "text/json", "application/*+json"],
-        "parameters": [
-          {
-            "name": "fyrirspurn",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/Fyrirspurn"
-            },
-            "x-nullable": false
-          }
+        "tags": [
+          "Syslumenn"
         ],
+        "operationId": "YfirlitUmFramvinduSkipta_Post",
+        "requestBody": {
+          "x-name": "fyrirspurn",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Fyrirspurn"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
         "responses": {
           "200": {
             "description": ""
           },
           "401": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "default": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/Fasteignasalar": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "Fasteignasalar_Get",
         "parameters": [
           {
-            "type": "string",
             "name": "audkenni",
             "in": "query",
-            "x-nullable": true
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 1
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Fasteignasalar"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Fasteignasalar"
+                  }
+                }
               }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/AlmennFyrirspurn/{audkenni}/{eining}/{adgerd}": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "AlmennFyrirspurn_Get",
         "parameters": [
           {
-            "type": "string",
             "name": "audkenni",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
           },
           {
-            "type": "string",
             "name": "eining",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 2
           },
           {
-            "type": "string",
             "name": "adgerd",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 3
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "type": "string"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "default": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/EinstaklingaSkra/{audkenni}/{kennitala}": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "EinstaklingaSkra_Get",
         "parameters": [
           {
-            "type": "string",
             "name": "audkenni",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
           },
           {
-            "type": "string",
             "name": "kennitala",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 2
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/ThjoldskraEnstaklingar"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThjoldskraEnstaklingar"
+                }
+              }
             }
           },
           "404": {
-            "x-nullable": false,
             "description": "Not found",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "400": {
-            "x-nullable": false,
             "description": "Bad request",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/ErfdarskraJaNei/{kennitala}/{audkenni}": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "ErfdarskraJaNei_Get",
         "parameters": [
           {
-            "type": "string",
             "name": "kennitala",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
           },
           {
-            "type": "string",
             "name": "audkenni",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 2
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/ErfdarskraSkeyti"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErfdarskraSkeyti"
+                }
+              }
             }
           },
           "404": {
-            "x-nullable": false,
             "description": "Not found",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "400": {
-            "x-nullable": false,
             "description": "Bad request",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/FaVottordUpplysingar/{audkenni}/{kennitala}": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "FaVottordUpplysingar_Get",
         "parameters": [
           {
-            "type": "string",
             "name": "audkenni",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
           },
           {
-            "type": "string",
             "name": "kennitala",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 2
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/VottordSkeyti"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VottordSkeyti"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/InnsiglaSkjol": {
       "post": {
-        "tags": ["Syslumenn"],
-        "operationId": "InnsiglaSkjol_Post",
-        "consumes": ["application/json", "text/json", "application/*+json"],
-        "parameters": [
-          {
-            "name": "skeyti",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/InnsiglaSkjolSkeyti"
-            },
-            "x-nullable": false
-          }
+        "tags": [
+          "Syslumenn"
         ],
+        "operationId": "InnsiglaSkjol_Post",
+        "requestBody": {
+          "x-name": "skeyti",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InnsiglaSkjolSkeyti"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/InnsigludSkjol"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InnsigludSkjol"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/Innsiglun": {
       "post": {
-        "tags": ["Syslumenn"],
-        "operationId": "Innsiglun_Post",
-        "consumes": ["application/json", "text/json", "application/*+json"],
-        "parameters": [
-          {
-            "name": "skeyti",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/InnsiglaSkeyti"
-            },
-            "x-nullable": false
-          }
+        "tags": [
+          "Syslumenn"
         ],
+        "operationId": "Innsiglun_Post",
+        "requestBody": {
+          "x-name": "skeyti",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InnsiglaSkeyti"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/SvarSkeyti"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SvarSkeyti"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/KannaRafraenSkilriki/{simi}/{kennitala}/{audkenni}": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "KannaRafraenSkilriki_Get",
         "parameters": [
           {
-            "type": "string",
             "name": "simi",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
           },
           {
-            "type": "string",
             "name": "kennitala",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 2
           },
           {
-            "type": "string",
             "name": "audkenni",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 3
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/KannaRafraenSkilrikiSimiKennitala"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KannaRafraenSkilrikiSimiKennitala"
+                }
+              }
             }
           },
           "404": {
-            "x-nullable": false,
             "description": "Not found",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "400": {
-            "x-nullable": false,
             "description": "Bad request",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/KannaRafraenSkilriki/{kennitala}/{audkenni}": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "KannaRafraenSkilriki_Get2",
         "parameters": [
           {
-            "type": "string",
             "name": "kennitala",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
           },
           {
-            "type": "string",
             "name": "audkenni",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 2
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/KannaRafraenSkilrikiKennitala"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KannaRafraenSkilrikiKennitala"
+                }
+              }
             }
           },
           "404": {
-            "x-nullable": false,
             "description": "Not found",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "400": {
-            "x-nullable": false,
             "description": "Bad request",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/KannaSakavottord/{audkenni}/{kennitala}": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "KannaSakavottord_Get",
         "parameters": [
           {
-            "type": "string",
             "name": "audkenni",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
           },
           {
-            "type": "string",
             "name": "kennitala",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 2
           }
         ],
         "responses": {
@@ -2304,4207 +2920,5231 @@
             "description": ""
           },
           "401": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "default": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/KaupmaliJaNei/{kennitala}/{audkenni}": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "KaupmaliJaNei_Get",
         "parameters": [
           {
-            "type": "string",
             "name": "kennitala",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
           },
           {
-            "type": "string",
             "name": "audkenni",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 2
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/KaupmaliSkeyti"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KaupmaliSkeyti"
+                }
+              }
             }
           },
           "404": {
-            "x-nullable": false,
             "description": "Not found",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "400": {
-            "x-nullable": false,
             "description": "Bad request",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/LeitaAdKennitoluIThjodskra": {
       "post": {
-        "tags": ["Syslumenn"],
-        "operationId": "LeitaAdKennitoluIThjodskra_Post",
-        "consumes": ["application/json", "text/json", "application/*+json"],
-        "parameters": [
-          {
-            "name": "skeyti",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/ThjodskraSkeyti"
-            },
-            "x-nullable": false
-          }
+        "tags": [
+          "Syslumenn"
         ],
+        "operationId": "LeitaAdKennitoluIThjodskra_Post",
+        "requestBody": {
+          "x-name": "skeyti",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ThjodskraSkeyti"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ThjodskraSvarSkeyti"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThjodskraSvarSkeyti"
+                }
+              }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/Logadilaskra/{kennitalaEdaNafnEdaHeimlisfang}/{audkenni}": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "Logadilaskra_Get",
         "parameters": [
           {
-            "type": "string",
             "name": "kennitalaEdaNafnEdaHeimlisfang",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
           },
           {
-            "type": "string",
             "name": "audkenni",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 2
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/ThjodskraLogadilar"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThjodskraLogadilar"
+                }
+              }
             }
           },
           "404": {
-            "x-nullable": false,
             "description": "Not found",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "400": {
-            "x-nullable": false,
             "description": "Bad request",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/v1/Almennt/MottakaRafraentSkjal": {
       "post": {
-        "tags": ["Syslumenn"],
-        "operationId": "MottakaRafraentSkjal_Post",
-        "consumes": ["application/json", "text/json", "application/*+json"],
-        "parameters": [
-          {
-            "name": "payload",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/WebhookEventPayload"
-            },
-            "x-nullable": false
-          }
+        "tags": [
+          "Syslumenn"
         ],
+        "operationId": "MottakaRafraentSkjal_Post",
+        "requestBody": {
+          "x-name": "payload",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WebhookEventPayload"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
         "responses": {
           "200": {
             "description": ""
           },
           "401": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "default": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/v1/Almennt/MottakaSkjalaUrUndirritun": {
       "post": {
-        "tags": ["Syslumenn"],
-        "operationId": "MottakaSkjalaUrUndirritun_Post",
-        "consumes": ["application/json", "text/json", "application/*+json"],
-        "parameters": [
-          {
-            "name": "payload",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/WebhookEventPayload"
-            },
-            "x-nullable": false
-          }
+        "tags": [
+          "Syslumenn"
         ],
+        "operationId": "MottakaSkjalaUrUndirritun_Post",
+        "requestBody": {
+          "x-name": "payload",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WebhookEventPayload"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
         "responses": {
           "200": {
             "description": ""
           },
           "401": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "default": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/v1/Ping": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "Ping_Get",
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
               }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       },
       "post": {
-        "tags": ["Syslumenn"],
-        "operationId": "Ping_Post",
-        "consumes": ["application/json", "text/json", "application/*+json"],
-        "parameters": [
-          {
-            "name": "skilabod",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/Skilabod"
-            },
-            "x-nullable": false
-          }
+        "tags": [
+          "Syslumenn"
         ],
+        "operationId": "Ping_Post",
+        "requestBody": {
+          "x-name": "skilabod",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Skilabod"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
         "responses": {
           "200": {
             "description": ""
           },
           "401": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "default": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/RettindiFyrirIslandIs/RettindiFyrirIslandIs": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "RettindiFyrirIslandIs_Get",
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/LeyfiListi"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LeyfiListi"
+                }
+              }
             }
           },
           "404": {
-            "x-nullable": false,
             "description": "Not found",
-            "schema": {
-              "$ref": "#/definitions/LeyfiListi"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LeyfiListi"
+                }
+              }
             }
           },
           "400": {
-            "x-nullable": false,
             "description": "Bad request",
-            "schema": {
-              "$ref": "#/definitions/LeyfiListi"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LeyfiListi"
+                }
+              }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/LeyfiListi"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LeyfiListi"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/RettindiFyrirIslandIs/RettindiFyrirIslandIs/{audkenni}": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "RettindiFyrirIslandIs_GetStakt",
         "parameters": [
           {
-            "type": "string",
             "name": "audkenni",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
           },
           {
-            "type": "string",
             "name": "locale",
             "in": "query",
-            "x-nullable": true
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 2
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/LeyfiStakt"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LeyfiStakt"
+                }
+              }
             }
           },
           "404": {
-            "x-nullable": false,
             "description": "Not found",
-            "schema": {
-              "$ref": "#/definitions/LeyfiStakt"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LeyfiStakt"
+                }
+              }
             }
           },
           "400": {
-            "x-nullable": false,
             "description": "Bad request",
-            "schema": {
-              "$ref": "#/definitions/LeyfiStakt"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LeyfiStakt"
+                }
+              }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/LeyfiStakt"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LeyfiStakt"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/SamkynjaTolfraedi/{audkenni}": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "SamkynjaTolfraedi_Get",
         "parameters": [
           {
-            "type": "string",
             "name": "audkenni",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "type": "array",
-              "items": {}
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {}
+                }
+              }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "default": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/v1/SkraMottakaGogn": {
       "post": {
-        "tags": ["Syslumenn"],
-        "operationId": "SkraMottakaGogn_Post",
-        "consumes": ["application/json", "text/json", "application/*+json"],
-        "parameters": [
-          {
-            "name": "payload",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/SyslSkeyti"
-            },
-            "x-nullable": false
-          }
+        "tags": [
+          "Syslumenn"
         ],
+        "operationId": "SkraMottakaGogn_Post",
+        "requestBody": {
+          "x-name": "payload",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SyslSkeyti"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/Skilabod"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Skilabod"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/StadaUndirritunarSkjals": {
       "post": {
-        "tags": ["Syslumenn"],
-        "operationId": "StadaUndirritunarSkjals_Post",
-        "consumes": ["application/json", "text/json", "application/*+json"],
-        "parameters": [
-          {
-            "name": "payload",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/StadaUndirritunarSkjalsSkeyti"
-            },
-            "x-nullable": false
-          }
+        "tags": [
+          "Syslumenn"
         ],
+        "operationId": "StadaUndirritunarSkjals_Post",
+        "requestBody": {
+          "x-name": "payload",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StadaUndirritunarSkjalsSkeyti"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/StadaUndirritunarSkjalsSvarSkeyti"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StadaUndirritunarSkjalsSvarSkeyti"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/StaediskortaMal/GetStaediskort": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "StaediskortaMal_GetStaediskort",
         "parameters": [
           {
-            "type": "string",
             "name": "kennitala",
             "in": "query",
-            "x-nullable": true
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 1
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/StaediskortamalSvarSkeyti"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StaediskortamalSvarSkeyti"
+                }
+              }
             }
           },
           "404": {
-            "x-nullable": false,
             "description": "NotFound",
-            "schema": {
-              "$ref": "#/definitions/StaediskortamalSvarSkeyti"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StaediskortamalSvarSkeyti"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/StaediskortaMal/GetStaediskortToken": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "StaediskortaMal_GetStaediskortToken",
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/Staediskortamal"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Staediskortamal"
+                }
+              }
             }
           },
           "404": {
-            "x-nullable": false,
             "description": "NotFound",
-            "schema": {
-              "$ref": "#/definitions/Staediskortamal"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Staediskortamal"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/StofnaskjalOgSendaTilUndirritunar": {
       "post": {
-        "tags": ["Syslumenn"],
-        "operationId": "StofnaskjalOgSendaTilUndirritunar_Post",
-        "consumes": ["application/json", "text/json", "application/*+json"],
-        "parameters": [
-          {
-            "name": "payload",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/StofnaskjalOgSendaTilUndirritunarSkeyti"
-            },
-            "x-nullable": false
-          }
+        "tags": [
+          "Syslumenn"
         ],
+        "operationId": "StofnaskjalOgSendaTilUndirritunar_Post",
+        "requestBody": {
+          "x-name": "payload",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StofnaskjalOgSendaTilUndirritunarSkeyti"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/StofnaskjalOgSendaTilUndirritunarSvarSkeyti"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StofnaskjalOgSendaTilUndirritunarSvarSkeyti"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/v1/SyslMottakaGogn": {
       "post": {
-        "tags": ["Syslumenn"],
-        "operationId": "SyslMottakaGogn_Post",
-        "consumes": ["application/json", "text/json", "application/*+json"],
-        "parameters": [
-          {
-            "name": "payload",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/SyslSkeyti"
-            },
-            "x-nullable": false
-          }
+        "tags": [
+          "Syslumenn"
         ],
+        "operationId": "SyslMottakaGogn_Post",
+        "requestBody": {
+          "x-name": "payload",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SyslSkeyti"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/Skilabod"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Skilabod"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/v1/SyslMottakaVilluprofaGogn": {
       "post": {
-        "tags": ["Syslumenn"],
-        "operationId": "SyslMottakaVilluprofaGogn_Post",
-        "consumes": ["application/json", "text/json", "application/*+json"],
-        "parameters": [
-          {
-            "name": "payload",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/SyslSkeyti"
-            },
-            "x-nullable": false
-          }
+        "tags": [
+          "Syslumenn"
         ],
+        "operationId": "SyslMottakaVilluprofaGogn_Post",
+        "requestBody": {
+          "x-name": "payload",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SyslSkeyti"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/Skilabod"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Skilabod"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/SyslSaekjaSkra": {
       "post": {
-        "tags": ["Syslumenn"],
-        "operationId": "SyslSaekjaSkra_Post",
-        "consumes": ["application/json", "text/json", "application/*+json"],
-        "parameters": [
-          {
-            "name": "payload",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/SyslSekjaSkra"
-            },
-            "x-nullable": false
-          }
+        "tags": [
+          "Syslumenn"
         ],
+        "operationId": "SyslSaekjaSkra_Post",
+        "requestBody": {
+          "x-name": "payload",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SyslSekjaSkra"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
         "responses": {
           "200": {
             "description": ""
           },
           "401": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "default": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/Vedbokarvottord2": {
       "post": {
-        "tags": ["Syslumenn"],
-        "operationId": "Vedbokarvottord2_Post",
-        "consumes": ["application/json", "text/json", "application/*+json"],
-        "parameters": [
-          {
-            "name": "skilabod",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/VedbandayfirlitMargirSkeyti"
-            },
-            "x-nullable": false
-          }
+        "tags": [
+          "Syslumenn"
         ],
+        "operationId": "Vedbokarvottord2_Post",
+        "requestBody": {
+          "x-name": "skilabod",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VedbandayfirlitMargirSkeyti"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/VedbandayfirlitMargirSvarSkeyti"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VedbandayfirlitMargirSvarSkeyti"
+                }
+              }
             }
           },
           "404": {
-            "x-nullable": false,
             "description": "NotFound",
-            "schema": {
-              "$ref": "#/definitions/VedbandayfirlitMargirSvarSkeyti"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VedbandayfirlitMargirSvarSkeyti"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/Vedbokarvottord": {
       "post": {
-        "tags": ["Syslumenn"],
-        "operationId": "Vedbokarvottord_Post",
-        "consumes": ["application/json", "text/json", "application/*+json"],
-        "parameters": [
-          {
-            "name": "skilabod",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/VedbandayfirlitSkeyti"
-            },
-            "x-nullable": false
-          }
+        "tags": [
+          "Syslumenn"
         ],
+        "operationId": "Vedbokarvottord_Post",
+        "requestBody": {
+          "x-name": "skilabod",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VedbandayfirlitSkeyti"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/VedbandayfirlitSvarSkeyti"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VedbandayfirlitSvarSkeyti"
+                }
+              }
             }
           },
           "404": {
-            "x-nullable": false,
             "description": "NotFound",
-            "schema": {
-              "$ref": "#/definitions/VedbandayfirlitSvarSkeyti"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VedbandayfirlitSvarSkeyti"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/VedbokavottordRegluverki": {
       "post": {
-        "tags": ["Syslumenn"],
-        "operationId": "VedbokavottordRegluverki_Post",
-        "consumes": ["application/json", "text/json", "application/*+json"],
-        "parameters": [
-          {
-            "name": "skilabod",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/VedbandayfirlitSkeyti"
-            },
-            "x-nullable": false
-          }
+        "tags": [
+          "Syslumenn"
         ],
+        "operationId": "VedbokavottordRegluverki_Post",
+        "requestBody": {
+          "x-name": "skilabod",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VedbandayfirlitSkeyti"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/VedbandayfirlitRegluverkGeneralSvar"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VedbandayfirlitRegluverkGeneralSvar"
+                }
+              }
             }
           },
           "404": {
-            "x-nullable": false,
             "description": "NotFound",
-            "schema": {
-              "$ref": "#/definitions/VedbandayfirlitRegluverkGeneralSvar"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VedbandayfirlitRegluverkGeneralSvar"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/api/Verdbrefamidlarar/{audkenni}": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "Verdbrefamidlarar_Get",
         "parameters": [
           {
-            "type": "string",
             "name": "audkenni",
             "in": "path",
             "required": true,
-            "x-nullable": false
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
           }
         ],
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Verdbrefamidlari"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Verdbrefamidlari"
+                  }
+                }
               }
             }
           },
           "401": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
           "default": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "$ref": "#/definitions/ProblemDetails"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     },
     "/Version": {
       "get": {
-        "tags": ["Syslumenn"],
+        "tags": [
+          "Syslumenn"
+        ],
         "operationId": "Version_Get",
         "responses": {
           "200": {
-            "x-nullable": false,
             "description": "",
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
               }
             }
           }
         },
         "security": [
           {
-            "JWT Token": []
+            "JWTToken": []
           }
         ]
       }
     }
   },
-  "definitions": {
-    "InnskraningSvarSkeyti": {
-      "type": "object",
-      "properties": {
-        "skilabod": {
-          "type": "string"
-        },
-        "audkenni": {
-          "type": "string"
-        },
-        "accessToken": {
-          "type": "string"
-        }
-      }
-    },
-    "ApiNotandi": {
-      "type": "object",
-      "properties": {
-        "notandi": {
-          "type": "string",
-          "minLength": 4
-        },
-        "lykilord": {
-          "type": "string",
-          "minLength": 9
-        }
-      }
-    },
-    "Postnumer": {
-      "type": "object",
-      "required": ["oid"],
-      "properties": {
-        "oid": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "numer": {
-          "type": "string"
-        },
-        "heiti": {
-          "type": "string"
-        },
-        "stadur": {
-          "type": "string"
-        },
-        "optimisticLockField": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "gcrecord": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "ProblemDetails": {
-      "type": "object",
-      "additionalProperties": {},
-      "properties": {
-        "type": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "status": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "detail": {
-          "type": "string"
-        },
-        "instance": {
-          "type": "string"
-        }
-      }
-    },
-    "NyskraAdfaraBeidniSvar": {
-      "type": "object",
-      "properties": {
-        "audkenniSvars": {
-          "type": "string"
-        },
-        "malsnumer": {
-          "type": "string"
-        },
-        "texti": {
-          "type": "string"
-        }
-      }
-    },
-    "SkraSveinsbrefModel": {
-      "type": "object",
-      "required": ["stadidFallid"],
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "kennitala": {
-          "type": "string"
-        },
-        "idngrein": {
-          "type": "string"
-        },
-        "profstadur": {
-          "type": "string"
-        },
-        "dagSveinsprof": {
-          "type": "string"
-        },
-        "burtfaraskyrteiniFra": {
-          "type": "string"
-        },
-        "dagsBurtfaraskyrteini": {
-          "type": "string"
-        },
-        "dagsAfhendingarSveinsbref": {
-          "type": "string"
-        },
-        "stadidFallid": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "SveinsbrefModel": {
-      "type": "object",
-      "properties": {
-        "nafn": {
-          "type": "string"
-        },
-        "kennitala": {
-          "type": "string"
-        },
-        "idngrein": {
-          "type": "string"
-        },
-        "gildirFra": {
-          "type": "string",
-          "format": "date-time"
-        }
-      }
-    },
-    "AdfarabeidnirHeimildaflokkur": {
-      "type": "object",
-      "required": ["numer"],
-      "properties": {
-        "numer": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "heiti": {
-          "type": "string"
-        }
-      }
-    },
-    "Embaetti": {
-      "type": "object",
-      "required": ["numer"],
-      "properties": {
-        "numer": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "heiti": {
-          "type": "string"
-        },
-        "kennitala": {
-          "type": "string"
-        }
-      }
-    },
-    "EmbaettiOgStarfsstodvar": {
-      "type": "object",
-      "properties": {
-        "kennitala": {
-          "type": "string"
-        },
-        "nafn": {
-          "type": "string"
-        },
-        "stadur": {
-          "type": "string"
-        },
-        "adsetur": {
-          "type": "string"
-        },
-        "starfsstodID": {
-          "type": "string"
-        }
-      }
-    },
-    "Okutaeki": {
-      "type": "object",
-      "required": ["skraningardagur", "skraningardagurEiganda"],
-      "properties": {
-        "numerOkutaekis": {
-          "type": "string"
-        },
-        "fastanumerOkutaekis": {
-          "type": "string"
-        },
-        "framleidandi": {
-          "type": "string"
-        },
-        "framleidandaGerd": {
-          "type": "string"
-        },
-        "litur": {
-          "type": "string"
-        },
-        "skraning": {
-          "type": "string"
-        },
-        "nafnEiganda": {
-          "type": "string"
-        },
-        "kennitalaEiganda": {
-          "type": "string"
-        },
-        "heimilisfangEiganda": {
-          "type": "string"
-        },
-        "skraningardagur": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "skraningardagurEiganda": {
-          "type": "string",
-          "format": "date-time"
-        }
-      }
-    },
-    "Uppbod": {
-      "type": "object",
-      "properties": {
-        "embaetti": {
-          "type": "string"
-        },
-        "starfsstod": {
-          "type": "string"
-        },
-        "tegund": {
-          "type": "string"
-        },
-        "andlag": {
-          "type": "string"
-        },
-        "dagsetning": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "klukkan": {
-          "type": "string"
-        },
-        "fastanumer": {
-          "type": "string"
-        },
-        "andlagHeiti": {
-          "type": "string"
-        },
-        "gerdarbeidendur": {
-          "type": "string"
-        },
-        "gerdartholar": {
-          "type": "string"
-        },
-        "lausafjarmunir": {
-          "type": "string"
-        },
-        "auglysingatexti": {
-          "type": "string"
-        },
-        "uppbodStadur": {
-          "type": "string"
-        }
-      }
-    },
-    "LogradamadurSvar": {
-      "type": "object",
-      "properties": {
-        "kennitala": {
-          "type": "string"
-        },
-        "gildirTil": {
-          "type": "string",
-          "format": "date-time"
-        }
-      }
-    },
-    "Logmenn": {
-      "type": "object",
-      "properties": {
-        "nafn": {
-          "type": "string"
-        },
-        "tegundRettinda": {
-          "type": "string"
-        }
-      }
-    },
-    "Afengisleyfi": {
-      "type": "object",
-      "properties": {
-        "tegund": {
-          "type": "string"
-        },
-        "tegundLeyfis": {
-          "type": "string"
-        },
-        "leyfisnumer": {
-          "type": "string"
-        },
-        "utgefidAf": {
-          "type": "string"
-        },
-        "skraningarAr": {
-          "type": "string"
-        },
-        "gildirFra": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "gildirTil": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "leyfishafi": {
-          "type": "string"
-        },
-        "abyrgdarmadur": {
-          "type": "string"
-        },
-        "embaetti": {
-          "type": "string"
-        },
-        "starfsstodEmbaettis": {
-          "type": "string"
-        }
-      }
-    },
-    "Meistaraleyfi": {
-      "type": "object",
-      "properties": {
-        "nafn": {
-          "type": "string"
-        },
-        "kennitala": {
-          "type": "string"
-        },
-        "idngrein": {
-          "type": "string"
-        },
-        "gildirFra": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "embaetti": {
-          "type": "string"
-        }
-      }
-    },
-    "StarfsrettindiModel": {
-      "type": "object",
-      "properties": {
-        "nafn": {
-          "type": "string"
-        },
-        "kennitala": {
-          "type": "string"
-        },
-        "starfsrettindi": {
-          "type": "string"
-        }
-      }
-    },
-    "Taekifaerisleyfi": {
-      "type": "object",
-      "required": [
-        "gildirFra",
-        "gildirTil",
-        "hamarksfjoldi",
-        "aaetladurFjoldi"
-      ],
-      "properties": {
-        "malategund": {
-          "type": "string"
-        },
-        "tegund": {
-          "type": "string"
-        },
-        "tegundLeyfis": {
-          "type": "string"
-        },
-        "leyfisnumer": {
-          "type": "string"
-        },
-        "utgefidAf": {
-          "type": "string"
-        },
-        "skraningarAr": {
-          "type": "string"
-        },
-        "gildirFra": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "gildirTil": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "leyfishafi": {
-          "type": "string"
-        },
-        "abyrgdarmadur": {
-          "type": "string"
-        },
-        "hamarksfjoldi": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "aaetladurFjoldi": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "stadur": {
-          "type": "string"
-        }
-      }
-    },
-    "VirkLeyfi": {
-      "type": "object",
-      "required": ["rowNum"],
-      "properties": {
-        "rowNum": {
-          "type": "integer",
-          "format": "int64"
-        },
-        "utgefidAf": {
-          "type": "string"
-        },
-        "leyfisnumer": {
-          "type": "string"
-        },
-        "stadur": {
-          "type": "string"
-        },
-        "kallast": {
-          "type": "string"
-        },
-        "gata": {
-          "type": "string"
-        },
-        "postnumer": {
-          "type": "string"
-        },
-        "tegund": {
-          "type": "string"
-        },
-        "tegund2": {
-          "type": "string"
-        },
-        "tegundVeitingastadar": {
-          "type": "string"
-        },
-        "gildirFra": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "gildirTil": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "leyfishafi": {
-          "type": "string"
-        },
-        "abyrgdarmadur": {
-          "type": "string"
-        },
-        "flokkur": {
-          "type": "string"
-        },
-        "leyfi_Til_Utiveitinga": {
-          "type": "string"
-        },
-        "afgr_Afgengis_Virkirdagar": {
-          "type": "string"
-        },
-        "afgr_Afgengis_Adfaranott_Fridaga": {
-          "type": "string"
-        },
-        "afgr_Afgengis_Virkirdagar_Utiveitingar": {
-          "type": "string"
-        },
-        "afgr_Afgengis_Adfaranott_Fridaga_Utiveitingar": {
-          "type": "string"
-        },
-        "hamarksfjoldiGesta": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "fjoldiGestaIVeitingum": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "VirkLeyfiMedfastanumer": {
-      "type": "object",
-      "required": ["rowNum"],
-      "properties": {
-        "rowNum": {
-          "type": "integer",
-          "format": "int64"
-        },
-        "utgefidAf": {
-          "type": "string"
-        },
-        "leyfisnumer": {
-          "type": "string"
-        },
-        "stadur": {
-          "type": "string"
-        },
-        "kallast": {
-          "type": "string"
-        },
-        "gata": {
-          "type": "string"
-        },
-        "postnumer": {
-          "type": "string"
-        },
-        "tegund": {
-          "type": "string"
-        },
-        "tegund2": {
-          "type": "string"
-        },
-        "tegundVeitingastadar": {
-          "type": "string"
-        },
-        "gildirFra": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "gildirTil": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "leyfishafi": {
-          "type": "string"
-        },
-        "abyrgdarmadur": {
-          "type": "string"
-        },
-        "flokkur": {
-          "type": "string"
-        },
-        "leyfi_Til_Utiveitinga": {
-          "type": "string"
-        },
-        "afgr_Afgengis_Virkirdagar": {
-          "type": "string"
-        },
-        "afgr_Afgengis_Adfaranott_Fridaga": {
-          "type": "string"
-        },
-        "afgr_Afgengis_Virkirdagar_Utiveitingar": {
-          "type": "string"
-        },
-        "afgr_Afgengis_Adfaranott_Fridaga_Utiveitingar": {
-          "type": "string"
-        },
-        "hamarksfjoldiGesta": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "fjoldiGestaIVeitingum": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "fastanumerFasteigna": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/VirkLeyfiFastanumerListi"
-          }
-        }
-      }
-    },
-    "VirkLeyfiFastanumerListi": {
-      "type": "object",
-      "properties": {
-        "fastaNumer": {
-          "type": "string"
-        },
-        "hamarksfjoldiGestaIGistingu": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "hamarksfjoldiGestaIVeitingum": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "UppfaeraHeimagistingarModel": {
-      "type": "object",
-      "properties": {
-        "leyfi": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/UppfaeraHeimagistingDetail"
-          }
-        }
-      }
-    },
-    "UppfaeraHeimagistingDetail": {
-      "type": "object",
-      "properties": {
-        "tegund": {
-          "type": "string"
-        },
-        "numer": {
-          "type": "string"
-        },
-        "markadsefniSlod": {
-          "type": "string"
-        },
-        "fannst": {
-          "type": "boolean"
-        }
-      }
-    },
-    "HeimagistingarModel": {
-      "type": "object",
-      "properties": {
-        "leyfi": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/HeimagistingDetail"
-          }
-        }
-      }
-    },
-    "HeimagistingDetail": {
-      "type": "object",
-      "properties": {
-        "tegund": {
-          "type": "string"
-        },
-        "numerLeyfist": {
-          "type": "string"
-        },
-        "virkt": {
-          "type": "boolean"
-        },
-        "utgefid": {
-          "type": "string"
-        }
-      }
-    },
-    "VirkarHeimagistingar": {
-      "type": "object",
-      "properties": {
-        "skraningarnumer": {
-          "type": "string"
-        },
-        "heitiHeimagistingar": {
-          "type": "string"
-        },
-        "heimilisfang": {
-          "type": "string"
-        },
-        "abyrgdarmadur": {
-          "type": "string"
-        },
-        "umsoknarAr": {
-          "type": "string"
-        },
-        "sveitarfelag": {
-          "type": "string"
-        },
-        "gestafjoldi": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "fjoldiHerbergja": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "fastanumer": {
-          "type": "string"
-        },
-        "ibudanumer": {
-          "type": "string"
-        },
-        "postnumer": {
-          "type": "string"
-        }
-      }
-    },
-    "AranuslausSvar": {
-      "type": "object",
-      "required": ["fraDags"],
-      "properties": {
-        "fraDags": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "audkenniSvars": {
-          "type": "string"
-        },
-        "aranguslausFjarnam": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/AranguslausFjarnamMal"
-          }
-        }
-      }
-    },
-    "AranguslausFjarnamMal": {
-      "type": "object",
-      "required": ["dags"],
-      "properties": {
-        "malsnumer": {
-          "type": "string"
-        },
-        "dags": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "kennitala": {
-          "type": "string"
-        },
-        "nafn": {
-          "type": "string"
-        },
-        "upphaedKrofu": {
-          "type": "number",
-          "format": "decimal"
-        },
-        "kennitalaUmbodsmanns": {
-          "type": "string"
-        },
-        "kennitalaGerdarbeidanda": {
-          "type": "string"
-        },
-        "kennitalaEmbaettis": {
-          "type": "string"
-        }
-      }
-    },
-    "AranuslausFyrirspurn": {
-      "type": "object",
-      "required": ["fraDags"],
-      "properties": {
-        "fraDags": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "audkenni": {
-          "type": "string"
-        }
-      }
-    },
-    "NyskraAdfaraBeidniSkeyti": {
-      "type": "object",
-      "properties": {
-        "beidni": {
-          "$ref": "#/definitions/AdfaraBeidni"
-        },
-        "audkenni": {
-          "type": "string"
-        }
-      }
-    },
-    "AdfaraBeidni": {
-      "type": "object",
-      "required": [
-        "bendaNumer",
-        "dags",
-        "dagsBunka",
-        "upphaedKrofu",
-        "dagsetningLoksAðdararfrests",
-        "fallidFraForgangi"
-      ],
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "embaetti": {
-          "type": "string"
-        },
-        "bendaNumer": {
-          "type": "integer",
-          "format": "int64"
-        },
-        "adilar": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/AdfaraAdili"
-          }
-        },
-        "gerdarbeidandi": {
-          "$ref": "#/definitions/AdfaraAdili"
-        },
-        "umbodsmadur": {
-          "$ref": "#/definitions/AdfaraAdili"
-        },
-        "dags": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "dagsBunka": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "flokkur": {
-          "type": "string"
-        },
-        "upphaedKrofu": {
-          "type": "number",
-          "format": "decimal"
-        },
-        "malsnumerGerdarbeidanda": {
-          "type": "string"
-        },
-        "krofulysing": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/AdfaraKrofulysing"
-          }
-        },
-        "fylgiskjol": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/AdfaraFylgiskjol"
-          }
-        },
-        "dagsetningLoksAðdararfrests": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "fallidFraForgangi": {
-          "type": "boolean"
-        },
-        "fyrirsvarsmadur": {
-          "$ref": "#/definitions/Fyrirsvarsmadur"
-        }
-      }
-    },
-    "AdfaraAdili": {
-      "type": "object",
-      "required": ["notarKyn", "kyn"],
-      "properties": {
-        "kennitala": {
-          "type": "string"
-        },
-        "nafn": {
-          "type": "string"
-        },
-        "heimili": {
-          "type": "string"
-        },
-        "postfang": {
-          "type": "string"
-        },
-        "simi": {
-          "type": "string"
-        },
-        "notarKyn": {
-          "type": "boolean"
-        },
-        "kyn": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "AdfaraKrofulysing": {
-      "type": "object",
-      "required": ["upphaed"],
-      "properties": {
-        "lysing": {
-          "type": "string"
-        },
-        "upphaed": {
-          "type": "number",
-          "format": "decimal"
-        }
-      }
-    },
-    "AdfaraFylgiskjol": {
-      "type": "object",
-      "properties": {
-        "numer": {
-          "type": "string"
-        },
-        "heiti": {
-          "type": "string"
-        }
-      }
-    },
-    "Fyrirsvarsmadur": {
-      "type": "object",
-      "properties": {
-        "nafn": {
-          "type": "string"
-        },
-        "heimilisfang": {
-          "type": "string"
-        },
-        "kennitala": {
-          "type": "string"
-        },
-        "postnumerStadur": {
-          "type": "string"
-        }
-      }
-    },
-    "UppbodFasteignir": {
-      "type": "object",
-      "required": ["dagsUppbods"],
-      "properties": {
-        "lysing": {
-          "type": "string"
-        },
-        "eigendur": {
-          "type": "string"
-        },
-        "gerdarbeidendur": {
-          "type": "string"
-        },
-        "dagsUppbods": {
-          "type": "string",
-          "format": "date-time"
-        }
-      }
-    },
-    "AdfarabeidniSkeyti": {
-      "type": "object",
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "malsnumer": {
-          "type": "string"
-        },
-        "kennitalaVinnsluadila": {
-          "type": "string"
-        }
-      }
-    },
-    "AranuslausFraTilSvar": {
-      "type": "object",
-      "required": ["fraDags", "tilDags"],
-      "properties": {
-        "fraDags": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "tilDags": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "audkenniSvars": {
-          "type": "string"
-        },
-        "aranguslausFjarnam": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/AranguslausFjarnamMal"
-          }
-        }
-      }
-    },
-    "AranuslausFratilFyrirspurn": {
-      "type": "object",
-      "required": ["fraDags", "tilDags"],
-      "properties": {
-        "fraDags": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "tilDags": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "audkenni": {
-          "type": "string"
-        }
-      }
-    },
-    "KonnunarvottordSvar": {
-      "type": "object",
-      "properties": {
-        "stada": {
-          "type": "string"
-        },
-        "skyring": {
-          "type": "string"
-        },
-        "simi": {
-          "type": "string"
-        },
-        "netfang": {
-          "type": "string"
-        }
-      }
-    },
-    "BankaupplysingarDanarbusSkeyti": {
-      "type": "object",
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "stadaVidskiptamanns": {
-          "$ref": "#/definitions/Stadavidskiptamanns"
-        }
-      }
-    },
-    "Stadavidskiptamanns": {
-      "type": "object",
-      "required": ["keyrsluDags", "dagsetningYfirlits"],
-      "properties": {
-        "kennitala": {
-          "type": "string"
-        },
-        "keyrsluDags": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "dagsetningYfirlits": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "abyrgdVegna3jaAdila": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/AbyrgdVegna3jaAdila"
-          }
-        },
-        "geymsluholf": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Geymsluholf"
-          }
-        },
-        "hlutabref": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Hlutabref"
-          }
-        },
-        "innheimtuSkuldabref": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/InnheimtuSkuldabref"
-          }
-        },
-        "innstaedurIBonkumOgSparisjodum": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/InnistaedaIBonkumOgSparisjodum"
-          }
-        },
-        "sjodir": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Sjodir"
-          }
-        },
-        "skjol": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Skjol"
-          }
-        },
-        "skuldabref": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Skuldabref"
-          }
-        },
-        "stadaKreditkorta": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/StadaKreditkorta"
-          }
-        },
-        "tryggingarbref": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Tryggingarbref"
-          }
-        },
-        "utlan": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Utlan"
-          }
-        }
-      }
-    },
-    "AbyrgdVegna3jaAdila": {
-      "type": "object",
-      "required": ["tegund", "stadaISK"],
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "tegund": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "stadaISK": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "mynt": {
-          "type": "string"
-        }
-      }
-    },
-    "Geymsluholf": {
-      "type": "object",
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "stadsetning": {
-          "type": "string"
-        }
-      }
-    },
-    "Hlutabref": {
-      "type": "object",
-      "required": ["stadaISK", "erSkradAMarkad"],
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "heiti": {
-          "type": "string"
-        },
-        "stadaISK": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "erSkradAMarkad": {
-          "type": "boolean"
-        }
-      }
-    },
-    "InnheimtuSkuldabref": {
-      "type": "object",
-      "required": ["stadaIsk"],
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "utgefandi": {
-          "type": "string"
-        },
-        "stadaIsk": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "InnistaedaIBonkumOgSparisjodum": {
-      "type": "object",
-      "required": ["stadaISK", "afallnirVextirISK", "stadaSamtalsISK"],
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "stadaISK": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "afallnirVextirISK": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "stadaSamtalsISK": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "mynt": {
-          "type": "string"
-        }
-      }
-    },
-    "Sjodir": {
-      "type": "object",
-      "required": ["stadaISK"],
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "stadaISK": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "Skjol": {
-      "type": "object",
-      "properties": {
-        "nafn": {
-          "type": "string"
-        },
-        "lysing": {
-          "type": "string"
-        },
-        "tegund": {
-          "type": "string"
-        },
-        "fileDataBase64": {
-          "type": "string"
-        }
-      }
-    },
-    "Skuldabref": {
-      "type": "object",
-      "required": ["stadaIsk"],
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "utgefandi": {
-          "type": "string"
-        },
-        "stadaIsk": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "StadaKreditkorta": {
-      "type": "object",
-      "required": ["inneignISK", "skuldISK"],
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "inneignISK": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "skuldISK": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "Tryggingarbref": {
-      "type": "object",
-      "required": ["stadaISK"],
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "heiti": {
-          "type": "string"
-        },
-        "vedAndlag": {
-          "type": "string"
-        },
-        "stadaISK": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "Utlan": {
-      "type": "object",
-      "required": ["stadaISK"],
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "heiti": {
-          "type": "string"
-        },
-        "stadaISK": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "mynt": {
-          "type": "string"
-        }
-      }
-    },
-    "AlgengTengsl": {
-      "type": "object",
-      "required": ["oid", "virk"],
-      "properties": {
-        "oid": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "heiti": {
-          "type": "string"
-        },
-        "virk": {
-          "type": "boolean"
-        }
-      }
-    },
-    "AlgengUmsaekjandaTengsl": {
-      "type": "object",
-      "required": ["oid"],
-      "properties": {
-        "oid": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "heiti": {
-          "type": "string"
-        }
-      }
-    },
-    "ErfdafjarskatturSvar": {
-      "type": "object",
-      "required": ["gildirFra", "erfdafjarskattur", "skattfrelsismorkUpphaed"],
-      "properties": {
-        "gildirFra": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "erfdafjarskattur": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "skattfrelsismorkUpphaed": {
-          "type": "number",
-          "format": "double"
-        }
-      }
-    },
-    "SkiptaUmSkraningaradiliSkeyti": {
-      "type": "object",
-      "properties": {
-        "stada": {
-          "type": "string"
-        }
-      }
-    },
-    "SkiptaUmSkraningaradili": {
-      "type": "object",
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "kennitalaFra": {
-          "type": "string"
-        },
-        "kennitalaTil": {
-          "type": "string"
-        },
-        "malsnumer": {
-          "type": "string"
-        }
-      }
-    },
-    "SkraningaradiliDanarbusSkeyti": {
-      "type": "object",
-      "required": [
-        "danardagur",
-        "kaupmaili",
-        "erfdaskraIVorsluSyslumanns",
-        "vitneskjaUmAdraErfdaskra",
-        "bankareikningarVerdbrefEdaHlutabref",
-        "eiginRekstur",
-        "buseturetturVegnaKaupleiguIbuda",
-        "eignirErlendis"
-      ],
-      "properties": {
-        "adilarDanarbus": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/AdiliDanarbus"
-          }
-        },
-        "eignir": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/EignirDanarbus"
-          }
-        },
-        "kennitalaSkreningaradila": {
-          "type": "string"
-        },
-        "simiSkraningaradila": {
-          "type": "string"
-        },
-        "tolvuposturSkreningaradila": {
-          "type": "string"
-        },
-        "kennitalaLatins": {
-          "type": "string"
-        },
-        "nafnLatins": {
-          "type": "string"
-        },
-        "danardagur": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "malsnumer": {
-          "type": "string"
-        },
-        "embaetti": {
-          "type": "string"
-        },
-        "kaupmaili": {
-          "type": "boolean"
-        },
-        "erfdaskraIVorsluSyslumanns": {
-          "type": "boolean"
-        },
-        "vitneskjaUmAdraErfdaskra": {
-          "type": "boolean"
-        },
-        "bankareikningarVerdbrefEdaHlutabref": {
-          "type": "boolean"
-        },
-        "eiginRekstur": {
-          "type": "boolean"
-        },
-        "buseturetturVegnaKaupleiguIbuda": {
-          "type": "boolean"
-        },
-        "eignirErlendis": {
-          "type": "boolean"
-        },
-        "vidbotarupplysingar": {
-          "type": "string"
-        }
-      }
-    },
-    "AdiliDanarbus": {
-      "type": "object",
-      "properties": {
-        "kennitala": {
-          "type": "string"
-        },
-        "nafn": {
-          "type": "string"
-        },
-        "tegundTengsla": {
-          "type": "string"
-        }
-      }
-    },
-    "EignirDanarbus": {
-      "type": "object",
-      "required": ["tegundAngalgs", "eignarhlutfall"],
-      "properties": {
-        "tegundAngalgs": {
-          "$ref": "#/definitions/TegundAndlags"
-        },
-        "fastanumer": {
-          "type": "string"
-        },
-        "lysing": {
-          "type": "string"
-        },
-        "eignarhlutfall": {
-          "type": "number",
-          "format": "float"
-        },
-        "verdmaeti": {
-          "type": "string"
-        },
-        "upphaed": {
-          "type": "string"
-        },
-        "gengiVextir": {
-          "type": "string"
-        }
-      }
-    },
-    "TegundAndlags": {
-      "type": "integer",
-      "description": "0 = Fasteign\n1 = Okutaeki\n2 = Skip\n3 = Lausafe\n4 = Loftfar\n5 = Oskrad\n6 = AdrarEignir\n7 = Hlutabref\n8 = InnistaedaIBanka\n9 = PeningarOgBankaholf\n10 = Skotvopn\n11 = VerdbrefOgKrofur\n12 = Utfarakostnadur\n13 = OpinberGjold\n14 = AdrarSkuldir\n15 = EignirIAtvinnurekstri\n16 = SkuldirIAtvinnurekstri\n17 = Fasteignagjold\n18 = Tryggingastofnun\n19 = Lan\n20 = Kreditkort\n21 = Yfirdrattur",
-      "x-enumNames": [
-        "Fasteign",
-        "Okutaeki",
-        "Skip",
-        "Lausafe",
-        "Loftfar",
-        "Oskrad",
-        "AdrarEignir",
-        "Hlutabref",
-        "InnistaedaIBanka",
-        "PeningarOgBankaholf",
-        "Skotvopn",
-        "VerdbrefOgKrofur",
-        "Utfarakostnadur",
-        "OpinberGjold",
-        "AdrarSkuldir",
-        "EignirIAtvinnurekstri",
-        "SkuldirIAtvinnurekstri",
-        "Fasteignagjold",
-        "Tryggingastofnun",
-        "Lan",
-        "Kreditkort",
-        "Yfirdrattur"
-      ],
-      "enum": [
-        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
-        20, 21
-      ]
-    },
-    "UpplysingarUrDanarbuiRadstofunSkeyti": {
-      "type": "object",
-      "properties": {
-        "mogulegSkipti": {
-          "type": "object",
-          "x-dictionaryKey": {
-            "$ref": "#/definitions/DanarbuSkipti"
+  "components": {
+    "schemas": {
+      "InnskraningSvarSkeyti": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "skilabod": {
+            "type": "string",
+            "nullable": true
           },
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "audkenni": {
-          "type": "string"
-        },
-        "yfirlit": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/DanarbuUpplRadstofun"
-          }
-        },
-        "texti": {
-          "type": "string"
-        }
-      }
-    },
-    "DanarbuSkipti": {
-      "type": "integer",
-      "description": "0 = OpinberSkipti\n1 = EignalaustDanarbu\n2 = SetaiOskiptuBui\n3 = Einkaskipti",
-      "x-enumNames": [
-        "OpinberSkipti",
-        "EignalaustDanarbu",
-        "SetaiOskiptuBui",
-        "Einkaskipti"
-      ],
-      "enum": [0, 1, 2, 3]
-    },
-    "DanarbuUpplRadstofun": {
-      "type": "object",
-      "required": ["kaupmali", "erfdakraVitneskja"],
-      "properties": {
-        "malsnumer": {
-          "type": "string"
-        },
-        "kennitala": {
-          "type": "string"
-        },
-        "nafn": {
-          "type": "string"
-        },
-        "danardagur": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "logheimili": {
-          "type": "string"
-        },
-        "erfingar": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Erfingar"
-          }
-        },
-        "erfdaskra": {
-          "type": "string"
-        },
-        "kaupmali": {
-          "type": "boolean"
-        },
-        "erfdakraVitneskja": {
-          "type": "boolean"
-        },
-        "eignir": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/EignirDanarbus"
-          }
-        },
-        "mogulegSkipti": {
-          "type": "object",
-          "x-dictionaryKey": {
-            "$ref": "#/definitions/DanarbuSkipti2"
+          "audkenni": {
+            "type": "string",
+            "nullable": true
           },
-          "additionalProperties": {
-            "type": "string"
+          "accessToken": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "ApiNotandi": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "notandi": {
+            "type": "string",
+            "minLength": 4,
+            "nullable": true
+          },
+          "lykilord": {
+            "type": "string",
+            "minLength": 9,
+            "nullable": true
+          }
+        }
+      },
+      "Postnumer": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "oid": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "numer": {
+            "type": "string",
+            "nullable": true
+          },
+          "heiti": {
+            "type": "string",
+            "nullable": true
+          },
+          "stadur": {
+            "type": "string",
+            "nullable": true
+          },
+          "optimisticLockField": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "gcrecord": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "additionalProperties": {
+          "nullable": true
+        },
+        "properties": {
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "detail": {
+            "type": "string",
+            "nullable": true
+          },
+          "instance": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "NyskraAdfaraBeidniSvar": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenniSvars": {
+            "type": "string",
+            "nullable": true
+          },
+          "malsnumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "texti": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "SkraSveinsbrefModel": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          },
+          "idngrein": {
+            "type": "string",
+            "nullable": true
+          },
+          "profstadur": {
+            "type": "string",
+            "nullable": true
+          },
+          "dagSveinsprof": {
+            "type": "string",
+            "nullable": true
+          },
+          "burtfaraskyrteiniFra": {
+            "type": "string",
+            "nullable": true
+          },
+          "dagsBurtfaraskyrteini": {
+            "type": "string",
+            "nullable": true
+          },
+          "dagsAfhendingarSveinsbref": {
+            "type": "string",
+            "nullable": true
+          },
+          "stadidFallid": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "SveinsbrefModel": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "nafn": {
+            "type": "string",
+            "nullable": true
+          },
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          },
+          "idngrein": {
+            "type": "string",
+            "nullable": true
+          },
+          "gildirFra": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        }
+      },
+      "AdfarabeidnirHeimildaflokkur": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "numer": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "heiti": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "Embaetti": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "numer": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "heiti": {
+            "type": "string",
+            "nullable": true
+          },
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "EmbaettiOgStarfsstodvar": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          },
+          "nafn": {
+            "type": "string",
+            "nullable": true
+          },
+          "stadur": {
+            "type": "string",
+            "nullable": true
+          },
+          "adsetur": {
+            "type": "string",
+            "nullable": true
+          },
+          "starfsstodID": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "Okutaeki": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "numerOkutaekis": {
+            "type": "string",
+            "nullable": true
+          },
+          "fastanumerOkutaekis": {
+            "type": "string",
+            "nullable": true
+          },
+          "framleidandi": {
+            "type": "string",
+            "nullable": true
+          },
+          "framleidandaGerd": {
+            "type": "string",
+            "nullable": true
+          },
+          "litur": {
+            "type": "string",
+            "nullable": true
+          },
+          "skraning": {
+            "type": "string",
+            "nullable": true
+          },
+          "nafnEiganda": {
+            "type": "string",
+            "nullable": true
+          },
+          "kennitalaEiganda": {
+            "type": "string",
+            "nullable": true
+          },
+          "heimilisfangEiganda": {
+            "type": "string",
+            "nullable": true
+          },
+          "skraningardagur": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "skraningardagurEiganda": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "Uppbod": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "embaetti": {
+            "type": "string",
+            "nullable": true
+          },
+          "starfsstod": {
+            "type": "string",
+            "nullable": true
+          },
+          "tegund": {
+            "type": "string",
+            "nullable": true
+          },
+          "andlag": {
+            "type": "string",
+            "nullable": true
+          },
+          "dagsetning": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "klukkan": {
+            "type": "string",
+            "nullable": true
+          },
+          "fastanumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "andlagHeiti": {
+            "type": "string",
+            "nullable": true
+          },
+          "gerdarbeidendur": {
+            "type": "string",
+            "nullable": true
+          },
+          "gerdartholar": {
+            "type": "string",
+            "nullable": true
+          },
+          "lausafjarmunir": {
+            "type": "string",
+            "nullable": true
+          },
+          "auglysingatexti": {
+            "type": "string",
+            "nullable": true
+          },
+          "uppbodStadur": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "LogradamadurSvar": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          },
+          "gildirTil": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        }
+      },
+      "Logmenn": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "nafn": {
+            "type": "string",
+            "nullable": true
+          },
+          "tegundRettinda": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "Afengisleyfi": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "tegund": {
+            "type": "string",
+            "nullable": true
+          },
+          "tegundLeyfis": {
+            "type": "string",
+            "nullable": true
+          },
+          "leyfisnumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "utgefidAf": {
+            "type": "string",
+            "nullable": true
+          },
+          "skraningarAr": {
+            "type": "string",
+            "nullable": true
+          },
+          "gildirFra": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "gildirTil": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "leyfishafi": {
+            "type": "string",
+            "nullable": true
+          },
+          "abyrgdarmadur": {
+            "type": "string",
+            "nullable": true
+          },
+          "embaetti": {
+            "type": "string",
+            "nullable": true
+          },
+          "starfsstodEmbaettis": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "Meistaraleyfi": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "nafn": {
+            "type": "string",
+            "nullable": true
+          },
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          },
+          "idngrein": {
+            "type": "string",
+            "nullable": true
+          },
+          "gildirFra": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "embaetti": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "StarfsrettindiModel": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "nafn": {
+            "type": "string",
+            "nullable": true
+          },
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          },
+          "starfsrettindi": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "Taekifaerisleyfi": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "malategund": {
+            "type": "string",
+            "nullable": true
+          },
+          "tegund": {
+            "type": "string",
+            "nullable": true
+          },
+          "tegundLeyfis": {
+            "type": "string",
+            "nullable": true
+          },
+          "leyfisnumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "utgefidAf": {
+            "type": "string",
+            "nullable": true
+          },
+          "skraningarAr": {
+            "type": "string",
+            "nullable": true
+          },
+          "gildirFra": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "gildirTil": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "leyfishafi": {
+            "type": "string",
+            "nullable": true
+          },
+          "abyrgdarmadur": {
+            "type": "string",
+            "nullable": true
+          },
+          "hamarksfjoldi": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "aaetladurFjoldi": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "stadur": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "VirkLeyfi": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "rowNum": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "utgefidAf": {
+            "type": "string",
+            "nullable": true
+          },
+          "leyfisnumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "stadur": {
+            "type": "string",
+            "nullable": true
+          },
+          "kallast": {
+            "type": "string",
+            "nullable": true
+          },
+          "gata": {
+            "type": "string",
+            "nullable": true
+          },
+          "postnumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "tegund": {
+            "type": "string",
+            "nullable": true
+          },
+          "tegund2": {
+            "type": "string",
+            "nullable": true
+          },
+          "tegundVeitingastadar": {
+            "type": "string",
+            "nullable": true
+          },
+          "gildirFra": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "gildirTil": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "leyfishafi": {
+            "type": "string",
+            "nullable": true
+          },
+          "abyrgdarmadur": {
+            "type": "string",
+            "nullable": true
+          },
+          "flokkur": {
+            "type": "string",
+            "nullable": true
+          },
+          "leyfi_Til_Utiveitinga": {
+            "type": "string",
+            "nullable": true
+          },
+          "afgr_Afgengis_Virkirdagar": {
+            "type": "string",
+            "nullable": true
+          },
+          "afgr_Afgengis_Adfaranott_Fridaga": {
+            "type": "string",
+            "nullable": true
+          },
+          "afgr_Afgengis_Virkirdagar_Utiveitingar": {
+            "type": "string",
+            "nullable": true
+          },
+          "afgr_Afgengis_Adfaranott_Fridaga_Utiveitingar": {
+            "type": "string",
+            "nullable": true
+          },
+          "hamarksfjoldiGesta": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "fjoldiGestaIVeitingum": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        }
+      },
+      "VirkLeyfiMedfastanumer": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "rowNum": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "utgefidAf": {
+            "type": "string",
+            "nullable": true
+          },
+          "leyfisnumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "stadur": {
+            "type": "string",
+            "nullable": true
+          },
+          "kallast": {
+            "type": "string",
+            "nullable": true
+          },
+          "gata": {
+            "type": "string",
+            "nullable": true
+          },
+          "postnumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "tegund": {
+            "type": "string",
+            "nullable": true
+          },
+          "tegund2": {
+            "type": "string",
+            "nullable": true
+          },
+          "tegundVeitingastadar": {
+            "type": "string",
+            "nullable": true
+          },
+          "gildirFra": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "gildirTil": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "leyfishafi": {
+            "type": "string",
+            "nullable": true
+          },
+          "abyrgdarmadur": {
+            "type": "string",
+            "nullable": true
+          },
+          "flokkur": {
+            "type": "string",
+            "nullable": true
+          },
+          "leyfi_Til_Utiveitinga": {
+            "type": "string",
+            "nullable": true
+          },
+          "afgr_Afgengis_Virkirdagar": {
+            "type": "string",
+            "nullable": true
+          },
+          "afgr_Afgengis_Adfaranott_Fridaga": {
+            "type": "string",
+            "nullable": true
+          },
+          "afgr_Afgengis_Virkirdagar_Utiveitingar": {
+            "type": "string",
+            "nullable": true
+          },
+          "afgr_Afgengis_Adfaranott_Fridaga_Utiveitingar": {
+            "type": "string",
+            "nullable": true
+          },
+          "hamarksfjoldiGesta": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "fjoldiGestaIVeitingum": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "fastanumerFasteigna": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/VirkLeyfiFastanumerListi"
+            }
+          }
+        }
+      },
+      "VirkLeyfiFastanumerListi": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "fastaNumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "hamarksfjoldiGestaIGistingu": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "hamarksfjoldiGestaIVeitingum": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        }
+      },
+      "UppfaeraHeimagistingarModel": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "leyfi": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/UppfaeraHeimagistingDetail"
+            }
+          }
+        }
+      },
+      "UppfaeraHeimagistingDetail": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "tegund": {
+            "type": "string",
+            "nullable": true
+          },
+          "numer": {
+            "type": "string",
+            "nullable": true
+          },
+          "markadsefniSlod": {
+            "type": "string",
+            "nullable": true
+          },
+          "fannst": {
+            "type": "boolean",
+            "nullable": true
+          }
+        }
+      },
+      "HeimagistingarModel": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "leyfi": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/HeimagistingDetail"
+            }
+          }
+        }
+      },
+      "HeimagistingDetail": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "tegund": {
+            "type": "string",
+            "nullable": true
+          },
+          "numerLeyfist": {
+            "type": "string",
+            "nullable": true
+          },
+          "virkt": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "utgefid": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "VirkarHeimagistingar": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "skraningarnumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "heitiHeimagistingar": {
+            "type": "string",
+            "nullable": true
+          },
+          "heimilisfang": {
+            "type": "string",
+            "nullable": true
+          },
+          "abyrgdarmadur": {
+            "type": "string",
+            "nullable": true
+          },
+          "umsoknarAr": {
+            "type": "string",
+            "nullable": true
+          },
+          "sveitarfelag": {
+            "type": "string",
+            "nullable": true
+          },
+          "gestafjoldi": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "fjoldiHerbergja": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "fastanumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "ibudanumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "postnumer": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "AranuslausSvar": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "fraDags": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "audkenniSvars": {
+            "type": "string",
+            "nullable": true
+          },
+          "aranguslausFjarnam": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/AranguslausFjarnamMal"
+            }
+          }
+        }
+      },
+      "AranguslausFjarnamMal": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "malsnumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "dags": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          },
+          "nafn": {
+            "type": "string",
+            "nullable": true
+          },
+          "upphaedKrofu": {
+            "type": "number",
+            "format": "decimal",
+            "nullable": true
+          },
+          "kennitalaUmbodsmanns": {
+            "type": "string",
+            "nullable": true
+          },
+          "kennitalaGerdarbeidanda": {
+            "type": "string",
+            "nullable": true
+          },
+          "kennitalaEmbaettis": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "AranuslausFyrirspurn": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "fraDags": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "NyskraAdfaraBeidniSkeyti": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "beidni": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AdfaraBeidni"
+              }
+            ]
+          },
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "AdfaraBeidni": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "embaetti": {
+            "type": "string",
+            "nullable": true
+          },
+          "bendaNumer": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "adilar": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/AdfaraAdili"
+            }
+          },
+          "gerdarbeidandi": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AdfaraAdili"
+              }
+            ]
+          },
+          "umbodsmadur": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AdfaraAdili"
+              }
+            ]
+          },
+          "dags": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "dagsBunka": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "flokkur": {
+            "type": "string",
+            "nullable": true
+          },
+          "upphaedKrofu": {
+            "type": "number",
+            "format": "decimal"
+          },
+          "malsnumerGerdarbeidanda": {
+            "type": "string",
+            "nullable": true
+          },
+          "krofulysing": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/AdfaraKrofulysing"
+            }
+          },
+          "fylgiskjol": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/AdfaraFylgiskjol"
+            }
+          },
+          "dagsetningLoksAðdararfrests": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "fallidFraForgangi": {
+            "type": "boolean"
+          },
+          "fyrirsvarsmadur": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Fyrirsvarsmadur"
+              }
+            ]
+          }
+        }
+      },
+      "AdfaraAdili": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          },
+          "nafn": {
+            "type": "string",
+            "nullable": true
+          },
+          "heimili": {
+            "type": "string",
+            "nullable": true
+          },
+          "postfang": {
+            "type": "string",
+            "nullable": true
+          },
+          "simi": {
+            "type": "string",
+            "nullable": true
+          },
+          "notarKyn": {
+            "type": "boolean"
+          },
+          "kyn": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "AdfaraKrofulysing": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "lysing": {
+            "type": "string",
+            "nullable": true
+          },
+          "upphaed": {
+            "type": "number",
+            "format": "decimal"
+          }
+        }
+      },
+      "AdfaraFylgiskjol": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "numer": {
+            "type": "string",
+            "nullable": true
+          },
+          "heiti": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "Fyrirsvarsmadur": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "nafn": {
+            "type": "string",
+            "nullable": true
+          },
+          "heimilisfang": {
+            "type": "string",
+            "nullable": true
+          },
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          },
+          "postnumerStadur": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "UppbodFasteignir": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "lysing": {
+            "type": "string",
+            "nullable": true
+          },
+          "eigendur": {
+            "type": "string",
+            "nullable": true
+          },
+          "gerdarbeidendur": {
+            "type": "string",
+            "nullable": true
+          },
+          "dagsUppbods": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "AdfarabeidniSkeyti": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "malsnumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "kennitalaVinnsluadila": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "AranuslausFraTilSvar": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "fraDags": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "tilDags": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "audkenniSvars": {
+            "type": "string",
+            "nullable": true
+          },
+          "aranguslausFjarnam": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/AranguslausFjarnamMal"
+            }
+          }
+        }
+      },
+      "AranuslausFratilFyrirspurn": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "fraDags": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "tilDags": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "KonnunarvottordSvar": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "stada": {
+            "type": "string",
+            "nullable": true
+          },
+          "skyring": {
+            "type": "string",
+            "nullable": true
+          },
+          "simi": {
+            "type": "string",
+            "nullable": true
+          },
+          "netfang": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "BankaupplysingarDanarbusSkeyti": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "stadaVidskiptamanns": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Stadavidskiptamanns"
+              }
+            ]
+          }
+        }
+      },
+      "Stadavidskiptamanns": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          },
+          "keyrsluDags": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "dagsetningYfirlits": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "abyrgdVegna3jaAdila": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/AbyrgdVegna3jaAdila"
+            }
+          },
+          "geymsluholf": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/Geymsluholf"
+            }
+          },
+          "hlutabref": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/Hlutabref"
+            }
+          },
+          "innheimtuSkuldabref": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/InnheimtuSkuldabref"
+            }
+          },
+          "innstaedurIBonkumOgSparisjodum": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/InnistaedaIBonkumOgSparisjodum"
+            }
+          },
+          "sjodir": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/Sjodir"
+            }
+          },
+          "skjol": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/Skjol"
+            }
+          },
+          "skuldabref": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/Skuldabref"
+            }
+          },
+          "stadaKreditkorta": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/StadaKreditkorta"
+            }
+          },
+          "tryggingarbref": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/Tryggingarbref"
+            }
+          },
+          "utlan": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/Utlan"
+            }
+          }
+        }
+      },
+      "AbyrgdVegna3jaAdila": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "tegund": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "stadaISK": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "mynt": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "Geymsluholf": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "stadsetning": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "Hlutabref": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "heiti": {
+            "type": "string",
+            "nullable": true
+          },
+          "stadaISK": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "erSkradAMarkad": {
+            "type": "boolean"
+          }
+        }
+      },
+      "InnheimtuSkuldabref": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "utgefandi": {
+            "type": "string",
+            "nullable": true
+          },
+          "stadaIsk": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "InnistaedaIBonkumOgSparisjodum": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "stadaISK": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "afallnirVextirISK": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "stadaSamtalsISK": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "mynt": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "Sjodir": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "stadaISK": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "Skjol": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "nafn": {
+            "type": "string",
+            "nullable": true
+          },
+          "lysing": {
+            "type": "string",
+            "nullable": true
+          },
+          "tegund": {
+            "type": "string",
+            "nullable": true
+          },
+          "fileDataBase64": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "Skuldabref": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "utgefandi": {
+            "type": "string",
+            "nullable": true
+          },
+          "stadaIsk": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "StadaKreditkorta": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "inneignISK": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "skuldISK": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "Tryggingarbref": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "heiti": {
+            "type": "string",
+            "nullable": true
+          },
+          "vedAndlag": {
+            "type": "string",
+            "nullable": true
+          },
+          "stadaISK": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "Utlan": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "heiti": {
+            "type": "string",
+            "nullable": true
+          },
+          "stadaISK": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "mynt": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "AlgengTengsl": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "oid": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "heiti": {
+            "type": "string",
+            "nullable": true
+          },
+          "virk": {
+            "type": "boolean"
+          }
+        }
+      },
+      "AlgengUmsaekjandaTengsl": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "oid": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "heiti": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "ErfdafjarskatturSvar": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "gildirFra": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "erfdafjarskattur": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "skattfrelsismorkUpphaed": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "SkiptaUmSkraningaradiliSkeyti": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "stada": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "SkiptaUmSkraningaradili": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "kennitalaFra": {
+            "type": "string",
+            "nullable": true
+          },
+          "kennitalaTil": {
+            "type": "string",
+            "nullable": true
+          },
+          "malsnumer": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "SkraningaradiliDanarbusSkeyti": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "adilarDanarbus": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/AdiliDanarbus"
+            }
+          },
+          "eignir": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/EignirDanarbus"
+            }
+          },
+          "kennitalaSkreningaradila": {
+            "type": "string",
+            "nullable": true
+          },
+          "simiSkraningaradila": {
+            "type": "string",
+            "nullable": true
+          },
+          "tolvuposturSkreningaradila": {
+            "type": "string",
+            "nullable": true
+          },
+          "kennitalaLatins": {
+            "type": "string",
+            "nullable": true
+          },
+          "nafnLatins": {
+            "type": "string",
+            "nullable": true
+          },
+          "danardagur": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "malsnumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "embaetti": {
+            "type": "string",
+            "nullable": true
+          },
+          "kaupmaili": {
+            "type": "boolean"
+          },
+          "erfdaskraIVorsluSyslumanns": {
+            "type": "boolean"
+          },
+          "vitneskjaUmAdraErfdaskra": {
+            "type": "boolean"
+          },
+          "bankareikningarVerdbrefEdaHlutabref": {
+            "type": "boolean"
+          },
+          "eiginRekstur": {
+            "type": "boolean"
+          },
+          "buseturetturVegnaKaupleiguIbuda": {
+            "type": "boolean"
+          },
+          "eignirErlendis": {
+            "type": "boolean"
+          },
+          "vidbotarupplysingar": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "AdiliDanarbus": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          },
+          "nafn": {
+            "type": "string",
+            "nullable": true
+          },
+          "tegundTengsla": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "EignirDanarbus": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "tegundAngalgs": {
+            "$ref": "#/components/schemas/TegundAndlags"
+          },
+          "fastanumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "lysing": {
+            "type": "string",
+            "nullable": true
+          },
+          "eignarhlutfall": {
+            "type": "number",
+            "format": "float"
+          },
+          "verdmaeti": {
+            "type": "string",
+            "nullable": true
+          },
+          "upphaed": {
+            "type": "string",
+            "nullable": true
+          },
+          "gengiVextir": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "TegundAndlags": {
+        "type": "integer",
+        "description": "0 = Fasteign\n1 = Okutaeki\n2 = Skip\n3 = Lausafe\n4 = Loftfar\n5 = Oskrad\n6 = AdrarEignir\n7 = Hlutabref\n8 = InnistaedaIBanka\n9 = PeningarOgBankaholf\n10 = Skotvopn\n11 = VerdbrefOgKrofur\n12 = Utfarakostnadur\n13 = OpinberGjold\n14 = AdrarSkuldir\n15 = EignirIAtvinnurekstri\n16 = SkuldirIAtvinnurekstri\n17 = Fasteignagjold\n18 = Tryggingastofnun\n19 = Lan\n20 = Kreditkort\n21 = Yfirdrattur",
+        "x-enumNames": [
+          "Fasteign",
+          "Okutaeki",
+          "Skip",
+          "Lausafe",
+          "Loftfar",
+          "Oskrad",
+          "AdrarEignir",
+          "Hlutabref",
+          "InnistaedaIBanka",
+          "PeningarOgBankaholf",
+          "Skotvopn",
+          "VerdbrefOgKrofur",
+          "Utfarakostnadur",
+          "OpinberGjold",
+          "AdrarSkuldir",
+          "EignirIAtvinnurekstri",
+          "SkuldirIAtvinnurekstri",
+          "Fasteignagjold",
+          "Tryggingastofnun",
+          "Lan",
+          "Kreditkort",
+          "Yfirdrattur"
+        ],
+        "enum": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+          17,
+          18,
+          19,
+          20,
+          21
+        ]
+      },
+      "UpplysingarUrDanarbuiRadstofunSkeyti": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "mogulegSkipti": {
+            "type": "object",
+            "nullable": true,
+            "x-dictionaryKey": {
+              "$ref": "#/components/schemas/DanarbuSkipti"
+            },
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "yfirlit": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/DanarbuUpplRadstofun"
+            }
+          },
+          "texti": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "DanarbuSkipti": {
+        "type": "integer",
+        "description": "0 = OpinberSkipti\n1 = EignalaustDanarbu\n2 = SetaiOskiptuBui\n3 = Einkaskipti",
+        "x-enumNames": [
+          "OpinberSkipti",
+          "EignalaustDanarbu",
+          "SetaiOskiptuBui",
+          "Einkaskipti"
+        ],
+        "enum": [
+          0,
+          1,
+          2,
+          3
+        ]
+      },
+      "DanarbuUpplRadstofun": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "malsnumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          },
+          "nafn": {
+            "type": "string",
+            "nullable": true
+          },
+          "danardagur": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "logheimili": {
+            "type": "string",
+            "nullable": true
+          },
+          "erfingar": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/Erfingar"
+            }
+          },
+          "erfdaskra": {
+            "type": "string",
+            "nullable": true
+          },
+          "kaupmali": {
+            "type": "boolean"
+          },
+          "erfdakraVitneskja": {
+            "type": "boolean"
+          },
+          "eignir": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/EignirDanarbus"
+            }
+          },
+          "mogulegSkipti": {
+            "type": "object",
+            "nullable": true,
+            "x-dictionaryKey": {
+              "$ref": "#/components/schemas/DanarbuSkipti2"
+            },
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "Erfingar": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          },
+          "nafn": {
+            "type": "string",
+            "nullable": true
+          },
+          "heimilisfang": {
+            "type": "string",
+            "nullable": true
+          },
+          "tengsl": {
+            "type": "string",
+            "nullable": true
+          },
+          "simi": {
+            "type": "string",
+            "nullable": true
+          },
+          "netfang": {
+            "type": "string",
+            "nullable": true
+          },
+          "malsvari": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Malsvari"
+              }
+            ]
+          },
+          "arfshlutfall": {
+            "type": "number",
+            "format": "decimal",
+            "nullable": true
+          }
+        }
+      },
+      "Malsvari": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          },
+          "nafn": {
+            "type": "string",
+            "nullable": true
+          },
+          "heimilisfang": {
+            "type": "string",
+            "nullable": true
+          },
+          "simi": {
+            "type": "string",
+            "nullable": true
+          },
+          "netfang": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "DanarbuSkipti2": {
+        "type": "integer",
+        "description": "0 = OpinberSkipti\n1 = EignalaustDanarbu\n2 = SetaiOskiptuBui\n3 = Einkaskipti",
+        "x-enumNames": [
+          "OpinberSkipti",
+          "EignalaustDanarbu",
+          "SetaiOskiptuBui",
+          "Einkaskipti"
+        ],
+        "enum": [
+          0,
+          1,
+          2,
+          3
+        ]
+      },
+      "Fyrirspurn": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "UpplysingarUrDanarbuiSkeyti": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "yfirlit": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/DanarbuUppl"
+            }
+          },
+          "texti": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "DanarbuUppl": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "malsnumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          },
+          "nafn": {
+            "type": "string",
+            "nullable": true
+          },
+          "danardagur": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "logheimili": {
+            "type": "string",
+            "nullable": true
+          },
+          "erfingar": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/Erfingar"
+            }
+          },
+          "erfdaskra": {
+            "type": "string",
+            "nullable": true
+          },
+          "kaupmali": {
+            "type": "boolean"
+          },
+          "erfdakraVitneskja": {
+            "type": "boolean"
+          },
+          "eignir": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/EignirDanarbus"
+            }
+          }
+        }
+      },
+      "UpplysingarUrDanarbuiSkeytiErfdafjarskatt": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "yfirlit": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/DanarbuUpplErfdafjarskatt"
+            }
+          },
+          "texti": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "DanarbuUpplErfdafjarskatt": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "malsnumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          },
+          "nafn": {
+            "type": "string",
+            "nullable": true
+          },
+          "danardagur": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "logheimili": {
+            "type": "string",
+            "nullable": true
+          },
+          "erfingar": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/Erfingar"
+            }
+          },
+          "erfdaskra": {
+            "type": "string",
+            "nullable": true
+          },
+          "kaupmali": {
+            "type": "boolean"
+          },
+          "erfdakraVitneskja": {
+            "type": "boolean"
+          },
+          "eignir": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/EignirDanarbusErfdafjarskatt"
+            }
+          }
+        }
+      },
+      "EignirDanarbusErfdafjarskatt": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "tegundAngalgs": {
+            "$ref": "#/components/schemas/TegundAndlags"
+          },
+          "fastanumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "lysing": {
+            "type": "string",
+            "nullable": true
+          },
+          "eignarhlutfall": {
+            "type": "number",
+            "format": "float"
+          },
+          "fasteignamat": {
+            "type": "string",
+            "nullable": true
+          },
+          "upphaed": {
+            "type": "string",
+            "nullable": true
+          },
+          "gengiVextir": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "Fasteignasalar": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "nafn": {
+            "type": "string",
+            "nullable": true
+          },
+          "starfsstod": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "ThjoldskraEnstaklingar": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "stada": {
+            "type": "string",
+            "nullable": true
+          },
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          },
+          "nafn": {
+            "type": "string",
+            "nullable": true
+          },
+          "faedD": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "faedingarstadur": {
+            "type": "string",
+            "nullable": true
+          },
+          "hjuskaparstada": {
+            "type": "string",
+            "nullable": true
+          },
+          "hjuskaparkodi": {
+            "type": "string",
+            "nullable": true
+          },
+          "kyn": {
+            "type": "string",
+            "nullable": true
+          },
+          "kynKodi": {
+            "type": "string",
+            "nullable": true
+          },
+          "rikisfang": {
+            "type": "string",
+            "nullable": true
+          },
+          "fjolskNr": {
+            "type": "string",
+            "nullable": true
+          },
+          "maki": {
+            "type": "string",
+            "nullable": true
+          },
+          "loghHusk": {
+            "type": "string",
+            "nullable": true
+          },
+          "heimili": {
+            "type": "string",
+            "nullable": true
+          },
+          "postNr": {
+            "type": "string",
+            "nullable": true
+          },
+          "postaritun": {
+            "type": "string",
+            "nullable": true
+          },
+          "sveitarfelag": {
+            "type": "string",
+            "nullable": true
+          },
+          "adsetur": {
+            "type": "string",
+            "nullable": true
+          },
+          "aldur": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "eiginnafn": {
+            "type": "string",
+            "nullable": true
+          },
+          "millinafn": {
+            "type": "string",
+            "nullable": true
+          },
+          "kenninafn": {
+            "type": "string",
+            "nullable": true
+          },
+          "birtingarnafn": {
+            "type": "string",
+            "nullable": true
+          },
+          "nafnStadfest": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "svfNr": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "ErfdarskraSkeyti": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "stada": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "VottordSkeyti": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          },
+          "gildisTimi": {
+            "type": "string",
+            "nullable": true
+          },
+          "utgafudagur": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "InnsigludSkjol": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "skilabod": {
+            "type": "string",
+            "nullable": true
+          },
+          "skjol": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "InnsiglaSkjolSkeyti": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "skyring": {
+            "type": "string",
+            "nullable": true
+          },
+          "skjol": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "SvarSkeyti": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "skilabod": {
+            "type": "string",
+            "nullable": true
+          },
+          "skjal": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "InnsiglaSkeyti": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "skyring": {
+            "type": "string",
+            "nullable": true
+          },
+          "skjal": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "KannaRafraenSkilrikiSimiKennitala": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "stada": {
+            "type": "string",
+            "nullable": true
+          },
+          "skilabod": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "KannaRafraenSkilrikiKennitala": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          },
+          "dagsetning": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "gildSkilriki": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ActiveCertsModel"
+              }
+            ]
+          }
+        }
+      },
+      "ActiveCertsModel": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "simi": {
+            "type": "boolean"
+          },
+          "app": {
+            "type": "boolean"
+          },
+          "kort": {
+            "type": "boolean"
+          }
+        }
+      },
+      "KaupmaliSkeyti": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "stada": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "ThjodskraSvarSkeyti": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "stada": {
+            "type": "string",
+            "nullable": true
+          },
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          },
+          "nafn": {
+            "type": "string",
+            "nullable": true
+          },
+          "loghHusk": {
+            "type": "string",
+            "nullable": true
+          },
+          "heimili": {
+            "type": "string",
+            "nullable": true
+          },
+          "postaritun": {
+            "type": "string",
+            "nullable": true
+          },
+          "sveitarfelag": {
+            "type": "string",
+            "nullable": true
+          },
+          "svfNr": {
+            "type": "string",
+            "nullable": true
+          },
+          "kynkodi": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "ThjodskraSkeyti": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "ThjodskraLogadilar": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          },
+          "nafn": {
+            "type": "string",
+            "nullable": true
+          },
+          "heimili": {
+            "type": "string",
+            "nullable": true
+          },
+          "postnumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "svfNr": {
+            "type": "string",
+            "nullable": true
+          },
+          "postfang": {
+            "type": "string",
+            "nullable": true
+          },
+          "postnumerPostfang": {
+            "type": "string",
+            "nullable": true
+          },
+          "svfNrPostfang": {
+            "type": "string",
+            "nullable": true
+          },
+          "atvinnugreinarnumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "starfsemi": {
+            "type": "string",
+            "nullable": true
+          },
+          "flokkur": {
+            "type": "string",
+            "nullable": true
+          },
+          "kennitalaforradanda": {
+            "type": "string",
+            "nullable": true
+          },
+          "erBrottfellt": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "dagsBrottfellt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "dagsGjaldthrot": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "kennitalaModurfelags": {
+            "type": "string",
+            "nullable": true
+          },
+          "vsk": {
+            "type": "string",
+            "nullable": true
+          },
+          "bannmerking": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "WebhookEventPayload": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "guid"
+          },
+          "eventData": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/SignedDocumentEventData"
+              }
+            ]
+          },
+          "eventSignature": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/EventSignature"
+              }
+            ]
+          }
+        }
+      },
+      "SignedDocumentEventData": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "flowKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "flowName": {
+            "type": "string",
+            "nullable": true
+          },
+          "signees": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/Signee"
+            }
+          },
+          "signedDocument": {
+            "type": "string",
+            "nullable": true
+          },
+          "attachments": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/SigningAttachment"
+            }
+          },
+          "eventType": {
+            "$ref": "#/components/schemas/EventType"
+          },
+          "meta": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "Signee": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "ssn": {
+            "type": "string",
+            "nullable": true
+          },
+          "phoneNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "nullable": true
+          },
+          "address": {
+            "type": "string",
+            "nullable": true
+          },
+          "postalCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "city": {
+            "type": "string",
+            "nullable": true
+          },
+          "key": {
+            "type": "string",
+            "nullable": true
+          },
+          "signed": {
+            "type": "boolean"
+          },
+          "processKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "communicationDeliveryType": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "SigningAttachment": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "fileName": {
+            "type": "string",
+            "nullable": true
+          },
+          "fileContent": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "EventType": {
+        "type": "integer",
+        "description": "0 = AllSigned",
+        "x-enumNames": [
+          "AllSigned"
+        ],
+        "enum": [
+          0
+        ]
+      },
+      "EventSignature": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "timeStamp": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "guid": {
+            "type": "string",
+            "format": "guid"
+          },
+          "signature": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "Skilabod": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "skilabod": {
+            "type": "string",
+            "nullable": true
+          },
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "malsnumer": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "LeyfiListi": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "leyfi": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/Leyfi"
+            }
+          },
+          "villur": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Villur"
+              }
+            ]
+          }
+        }
+      },
+      "Leyfi": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "titill": {
+            "type": "string",
+            "nullable": true
+          },
+          "utgafudagur": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "utgefandi": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Utgefandi"
+              }
+            ]
+          },
+          "stada": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Stada"
+              }
+            ]
+          }
+        }
+      },
+      "Utgefandi": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "titill": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "Stada": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "titill": {
+            "type": "string",
+            "nullable": true
+          },
+          "kodi": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "Villur": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "kodi": {
+            "type": "string",
+            "nullable": true
+          },
+          "skilabod": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "LeyfiStakt": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "nafn": {
+            "type": "string",
+            "nullable": true
+          },
+          "leyfi": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Leyfi"
+              }
+            ]
+          },
+          "svid": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/Svid"
+            }
+          },
+          "textar": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Textar"
+              }
+            ]
+          },
+          "adgerdir": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/Adgerd"
+            }
+          },
+          "skrar": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/Skra"
+            }
+          },
+          "villur": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Villur"
+              }
+            ]
+          }
+        }
+      },
+      "Svid": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "heiti": {
+            "type": "string",
+            "nullable": true
+          },
+          "gildi": {
+            "type": "string",
+            "nullable": true
+          },
+          "tegund": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "Textar": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "haus": {
+            "type": "string",
+            "nullable": true
+          },
+          "fotur": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "Adgerd": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "tegund": {
+            "type": "string",
+            "nullable": true
+          },
+          "titill": {
+            "type": "string",
+            "nullable": true
+          },
+          "slod": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "Skra": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "tegund": {
+            "type": "string",
+            "nullable": true
+          },
+          "skraarnafn": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "SyslSkeyti": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "gognSkeytis": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/SyslGagnaSkeyti"
+              }
+            ]
+          }
+        }
+      },
+      "SyslGagnaSkeyti": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "skeytaHeiti": {
+            "type": "string",
+            "nullable": true
+          },
+          "adilar": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/Adili"
+            }
+          },
+          "attachments": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/VidhengiSkra"
+            }
+          },
+          "gagnaMengi": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "Adili": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "nafn": {
+            "type": "string",
+            "nullable": true
+          },
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          },
+          "simi": {
+            "type": "string",
+            "nullable": true
+          },
+          "tolvupostur": {
+            "type": "string",
+            "nullable": true
+          },
+          "heimilisfang": {
+            "type": "string",
+            "nullable": true
+          },
+          "postaritun": {
+            "type": "string",
+            "nullable": true
+          },
+          "sveitafelag": {
+            "type": "string",
+            "nullable": true
+          },
+          "undirritad": {
+            "type": "boolean"
+          },
+          "tegund": {
+            "$ref": "#/components/schemas/AdiliTegund"
+          }
+        }
+      },
+      "AdiliTegund": {
+        "type": "integer",
+        "description": "0 = Malshefjandi\n1 = Gagnadili\n2 = Barn",
+        "x-enumNames": [
+          "Malshefjandi",
+          "Gagnadili",
+          "Barn"
+        ],
+        "enum": [
+          0,
+          1,
+          2
+        ]
+      },
+      "VidhengiSkra": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "nafnSkraar": {
+            "type": "string",
+            "nullable": true
+          },
+          "innihaldSkraar": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "StadaUndirritunarSkjalsSvarSkeyti": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "skilabod": {
+            "type": "string",
+            "nullable": true
+          },
+          "stadaUndirritunar": {
+            "$ref": "#/components/schemas/StadaUndirritunar"
+          }
+        }
+      },
+      "StadaUndirritunar": {
+        "type": "integer",
+        "description": "0 = EkkiUndirritad\n1 = Hafnad\n2 = Undirritad\n3 = EkkiUndirritadVilla\n4 = EkkiUndirritadUtrunnid",
+        "x-enumNames": [
+          "EkkiUndirritad",
+          "Hafnad",
+          "Undirritad",
+          "EkkiUndirritadVilla",
+          "EkkiUndirritadUtrunnid"
+        ],
+        "enum": [
+          0,
+          1,
+          2,
+          3,
+          4
+        ]
+      },
+      "StadaUndirritunarSkjalsSkeyti": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "malsnumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "skjalasnid": {
+            "type": "string",
+            "nullable": true
+          },
+          "kennitalaUndirritanda": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "StaediskortamalSvarSkeyti": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "skilabod": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "Staediskortamal": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "malsnumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          },
+          "nafn": {
+            "type": "string",
+            "nullable": true
+          },
+          "tegundMalsadila": {
+            "type": "string",
+            "nullable": true
+          },
+          "undirtegund": {
+            "type": "string",
+            "nullable": true
+          },
+          "tegund": {
+            "type": "string",
+            "nullable": true
+          },
+          "stada": {
+            "type": "string",
+            "nullable": true
+          },
+          "malalok": {
+            "type": "string",
+            "nullable": true
+          },
+          "mottekidDagsetning": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "malalokDagsetning": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "gildistimi": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "utgafudagur": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "utgefandi": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "StofnaskjalOgSendaTilUndirritunarSvarSkeyti": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "skilabod": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "StofnaskjalOgSendaTilUndirritunarSkeyti": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "malsnumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "kennitalaMalsadila": {
+            "type": "string",
+            "nullable": true
+          },
+          "skjalasnid": {
+            "type": "string",
+            "nullable": true
+          },
+          "gildirTil": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "smsTexti": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "SyslSekjaSkra": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "malsnumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          },
+          "skraarnafn": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "VedbandayfirlitMargirSvarSkeyti": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "skilabodOgSkra": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/SkilaSkeyti"
+            }
+          }
+        }
+      },
+      "SkilaSkeyti": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "fastanumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "skilabod": {
+            "type": "string",
+            "nullable": true
+          },
+          "vedbandayfirlitPDFSkra": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "VedbandayfirlitMargirSkeyti": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "eignir": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/Eign"
+            }
+          }
+        }
+      },
+      "Eign": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "fastanumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "tegundAndlags": {
+            "$ref": "#/components/schemas/VedbondTegundAndlags"
+          }
+        }
+      },
+      "VedbondTegundAndlags": {
+        "type": "integer",
+        "description": "0 = Fasteign\n1 = Okutaeki\n2 = Skip\n3 = Lausafe\n4 = Loftfar\n5 = Oskrad",
+        "x-enumNames": [
+          "Fasteign",
+          "Okutaeki",
+          "Skip",
+          "Lausafe",
+          "Loftfar",
+          "Oskrad"
+        ],
+        "enum": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5
+        ]
+      },
+      "VedbandayfirlitSvarSkeyti": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "skilabod": {
+            "type": "string",
+            "nullable": true
+          },
+          "vedbandayfirlitPDFSkra": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "VedbandayfirlitSkeyti": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "audkenni": {
+            "type": "string",
+            "nullable": true
+          },
+          "fastanumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "tegundAndlags": {
+            "$ref": "#/components/schemas/VedbondTegundAndlags"
+          }
+        }
+      },
+      "VedbandayfirlitRegluverkGeneralSvar": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "fastanum": {
+            "type": "string",
+            "nullable": true
+          },
+          "tegundEignar": {
+            "type": "string",
+            "nullable": true
+          },
+          "fasteign": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/VedbandayfirlitReguverkiSvarSkeyti"
+            }
+          },
+          "okutaeki": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Okutaeki"
+              }
+            ]
+          },
+          "skip": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Skip"
+              }
+            ]
+          }
+        }
+      },
+      "VedbandayfirlitReguverkiSvarSkeyti": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "fastnum": {
+            "type": "string",
+            "nullable": true
+          },
+          "landNr": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "heiti": {
+            "type": "string",
+            "nullable": true
+          },
+          "svfn": {
+            "type": "string",
+            "nullable": true
+          },
+          "svetiarfelag": {
+            "type": "string",
+            "nullable": true
+          },
+          "notkun": {
+            "type": "string",
+            "nullable": true
+          },
+          "eining": {
+            "type": "string",
+            "nullable": true
+          },
+          "byggd": {
+            "type": "string",
+            "nullable": true
+          },
+          "embaetti": {
+            "type": "string",
+            "nullable": true
+          },
+          "embaettiNumer": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "Skip": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "shipRegistrationNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "isOpen": {
+            "type": "boolean"
+          },
+          "usageType": {
+            "type": "string",
+            "nullable": true
+          },
+          "operationArea": {
+            "type": "string",
+            "nullable": true
+          },
+          "imoNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "nullable": true
+          },
+          "isLegallyStaffed": {
+            "type": "boolean"
+          },
+          "initialRegistrationDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "constructionYear": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "seaworhiness": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Seaworhiness"
+              }
+            ]
+          },
+          "identification": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Identification"
+              }
+            ]
+          },
+          "mainMeasurements": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Mainmeasurements"
+              }
+            ]
+          },
+          "crew": {
+            "type": "array",
+            "nullable": true,
+            "items": {}
+          },
+          "owners": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/Owner"
+            }
+          },
+          "passengerPermits": {
+            "type": "array",
+            "nullable": true,
+            "items": {}
+          },
+          "insurances": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/Insurance"
+            }
+          },
+          "engines": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/Engine"
+            }
+          },
+          "fishery": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Fishery"
+              }
+            ]
+          },
+          "constructionPlace": {
+            "type": "string",
+            "nullable": true
+          },
+          "constructionStation": {
+            "type": "string",
+            "nullable": true
+          },
+          "constructionCountry": {
+            "type": "string",
+            "nullable": true
+          },
+          "constructionNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "identificationRegistrationDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "changeDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "hullMaterial": {
+            "type": "string",
+            "nullable": true
+          },
+          "classificationSociety": {
+            "type": "string",
+            "nullable": true
+          },
+          "propellerCount": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "auxiliaryEnginePowerKiloWatts": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "acOrDc": {
+            "type": "string",
+            "nullable": true
+          },
+          "previousNameOfShip": {
+            "type": "string",
+            "nullable": true
+          },
+          "powerIndicator": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "otherInfo": {
+            "type": "string",
+            "nullable": true
+          },
+          "maxPropellerDiameter": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "powerKW": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "voltage": {
+            "type": "string",
+            "nullable": true
+          },
+          "comments": {
+            "type": "string",
+            "nullable": true
+          },
+          "legallyStaffed": {
+            "type": "boolean"
+          },
+          "open": {
+            "type": "boolean"
+          }
+        }
+      },
+      "Seaworhiness": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "isValid": {
+            "type": "boolean"
+          },
+          "validFrom": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "validTo": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "extendedValidTo": {
+            "type": "string",
+            "nullable": true
+          },
+          "valid": {
+            "type": "boolean"
+          }
+        }
+      },
+      "Identification": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "homeHarbor": {
+            "type": "string",
+            "nullable": true
+          },
+          "regionName": {
+            "type": "string",
+            "nullable": true
+          },
+          "regionAcronym": {
+            "type": "string",
+            "nullable": true
+          },
+          "regionNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "callSign": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "Mainmeasurements": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "length": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "mostLength": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "width": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "depth": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "draft": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "bruttoGrt": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "bruttoWeightTons": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "nettoWeightTons": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          }
+        }
+      },
+      "Owner": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "percentage": {
+            "type": "string",
+            "nullable": true
+          },
+          "nationalIdentificationNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "registrationDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "lastUpdated": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "documentTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "address": {
+            "type": "string",
+            "nullable": true
+          },
+          "postalCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "foreign": {
+            "type": "boolean"
+          },
+          "isForeign": {
+            "type": "boolean"
+          }
+        }
+      },
+      "Insurance": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "insuranceRegistrationNumber": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "validFrom": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "validTo": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "numberOfInsured": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "comment": {
+            "type": "string",
+            "nullable": true
+          },
+          "amountISK": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "insuranceType": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Insurancetype"
+              }
+            ]
+          },
+          "insuranceCompany": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Insurancecompany"
+              }
+            ]
+          }
+        }
+      },
+      "Insurancetype": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "insuranceTypeRegistrationNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "code": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "Insurancecompany": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "insuranceCompanyRegistrationNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "nationalIdentificationNumber": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "Engine": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "manufacturingNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "power": {
+            "type": "number",
+            "format": "float"
+          },
+          "year": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "usage": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Usage"
+              }
+            ]
+          },
+          "manufacturer": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Manufacturer"
+              }
+            ]
+          }
+        }
+      },
+      "Usage": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "Manufacturer": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "code": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "Fishery": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "identityNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "address": {
+            "type": "string",
+            "nullable": true
+          },
+          "postalCode": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "Verdbrefamidlari": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "nafn": {
+            "type": "string",
+            "nullable": true
+          },
+          "kennitala": {
+            "type": "string",
+            "nullable": true
           }
         }
       }
     },
-    "Erfingar": {
-      "type": "object",
-      "properties": {
-        "kennitala": {
-          "type": "string"
-        },
-        "nafn": {
-          "type": "string"
-        },
-        "heimilisfang": {
-          "type": "string"
-        },
-        "tengsl": {
-          "type": "string"
-        },
-        "simi": {
-          "type": "string"
-        },
-        "netfang": {
-          "type": "string"
-        },
-        "malsvari": {
-          "$ref": "#/definitions/Malsvari"
-        },
-        "arfshlutfall": {
-          "type": "number",
-          "format": "decimal"
-        }
+    "securitySchemes": {
+      "Bearer": {
+        "type": "apiKey",
+        "description": "Copy this into the value field: Bearer {token}",
+        "name": "Authorization",
+        "in": "header"
+      },
+      "JWTToken": {
+        "type": "apiKey",
+        "description": "Copy this into the value field: Bearer {token}",
+        "name": "Authorization",
+        "in": "header"
       }
-    },
-    "Malsvari": {
-      "type": "object",
-      "properties": {
-        "kennitala": {
-          "type": "string"
-        },
-        "nafn": {
-          "type": "string"
-        },
-        "heimilisfang": {
-          "type": "string"
-        },
-        "simi": {
-          "type": "string"
-        },
-        "netfang": {
-          "type": "string"
-        }
-      }
-    },
-    "DanarbuSkipti2": {
-      "type": "integer",
-      "description": "0 = OpinberSkipti\n1 = EignalaustDanarbu\n2 = SetaiOskiptuBui\n3 = Einkaskipti",
-      "x-enumNames": [
-        "OpinberSkipti",
-        "EignalaustDanarbu",
-        "SetaiOskiptuBui",
-        "Einkaskipti"
-      ],
-      "enum": [0, 1, 2, 3]
-    },
-    "Fyrirspurn": {
-      "type": "object",
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "kennitala": {
-          "type": "string"
-        }
-      }
-    },
-    "UpplysingarUrDanarbuiSkeyti": {
-      "type": "object",
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "yfirlit": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/DanarbuUppl"
-          }
-        },
-        "texti": {
-          "type": "string"
-        }
-      }
-    },
-    "DanarbuUppl": {
-      "type": "object",
-      "required": ["kaupmali", "erfdakraVitneskja"],
-      "properties": {
-        "malsnumer": {
-          "type": "string"
-        },
-        "kennitala": {
-          "type": "string"
-        },
-        "nafn": {
-          "type": "string"
-        },
-        "danardagur": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "logheimili": {
-          "type": "string"
-        },
-        "erfingar": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Erfingar"
-          }
-        },
-        "erfdaskra": {
-          "type": "string"
-        },
-        "kaupmali": {
-          "type": "boolean"
-        },
-        "erfdakraVitneskja": {
-          "type": "boolean"
-        },
-        "eignir": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/EignirDanarbus"
-          }
-        }
-      }
-    },
-    "UpplysingarUrDanarbuiSkeytiErfdafjarskatt": {
-      "type": "object",
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "yfirlit": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/DanarbuUpplErfdafjarskatt"
-          }
-        },
-        "texti": {
-          "type": "string"
-        }
-      }
-    },
-    "DanarbuUpplErfdafjarskatt": {
-      "type": "object",
-      "required": ["kaupmali", "erfdakraVitneskja"],
-      "properties": {
-        "malsnumer": {
-          "type": "string"
-        },
-        "kennitala": {
-          "type": "string"
-        },
-        "nafn": {
-          "type": "string"
-        },
-        "danardagur": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "logheimili": {
-          "type": "string"
-        },
-        "erfingar": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Erfingar"
-          }
-        },
-        "erfdaskra": {
-          "type": "string"
-        },
-        "kaupmali": {
-          "type": "boolean"
-        },
-        "erfdakraVitneskja": {
-          "type": "boolean"
-        },
-        "eignir": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/EignirDanarbusErfdafjarskatt"
-          }
-        }
-      }
-    },
-    "EignirDanarbusErfdafjarskatt": {
-      "type": "object",
-      "required": ["tegundAngalgs", "eignarhlutfall"],
-      "properties": {
-        "tegundAngalgs": {
-          "$ref": "#/definitions/TegundAndlags"
-        },
-        "fastanumer": {
-          "type": "string"
-        },
-        "lysing": {
-          "type": "string"
-        },
-        "eignarhlutfall": {
-          "type": "number",
-          "format": "float"
-        },
-        "fasteignamat": {
-          "type": "string"
-        },
-        "upphaed": {
-          "type": "string"
-        },
-        "gengiVextir": {
-          "type": "string"
-        }
-      }
-    },
-    "Fasteignasalar": {
-      "type": "object",
-      "properties": {
-        "nafn": {
-          "type": "string"
-        },
-        "starfsstod": {
-          "type": "string"
-        }
-      }
-    },
-    "ThjoldskraEnstaklingar": {
-      "type": "object",
-      "required": ["faedD"],
-      "properties": {
-        "stada": {
-          "type": "string"
-        },
-        "kennitala": {
-          "type": "string"
-        },
-        "nafn": {
-          "type": "string"
-        },
-        "faedD": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "faedingarstadur": {
-          "type": "string"
-        },
-        "hjuskaparstada": {
-          "type": "string"
-        },
-        "hjuskaparkodi": {
-          "type": "string"
-        },
-        "kyn": {
-          "type": "string"
-        },
-        "kynKodi": {
-          "type": "string"
-        },
-        "rikisfang": {
-          "type": "string"
-        },
-        "fjolskNr": {
-          "type": "string"
-        },
-        "maki": {
-          "type": "string"
-        },
-        "loghHusk": {
-          "type": "string"
-        },
-        "heimili": {
-          "type": "string"
-        },
-        "postNr": {
-          "type": "string"
-        },
-        "postaritun": {
-          "type": "string"
-        },
-        "sveitarfelag": {
-          "type": "string"
-        },
-        "adsetur": {
-          "type": "string"
-        },
-        "aldur": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "eiginnafn": {
-          "type": "string"
-        },
-        "millinafn": {
-          "type": "string"
-        },
-        "kenninafn": {
-          "type": "string"
-        },
-        "birtingarnafn": {
-          "type": "string"
-        },
-        "nafnStadfest": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "svfNr": {
-          "type": "string"
-        }
-      }
-    },
-    "ErfdarskraSkeyti": {
-      "type": "object",
-      "properties": {
-        "stada": {
-          "type": "string"
-        }
-      }
-    },
-    "VottordSkeyti": {
-      "type": "object",
-      "properties": {
-        "kennitala": {
-          "type": "string"
-        },
-        "gildisTimi": {
-          "type": "string"
-        },
-        "utgafudagur": {
-          "type": "string"
-        }
-      }
-    },
-    "InnsigludSkjol": {
-      "type": "object",
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "skilabod": {
-          "type": "string"
-        },
-        "skjol": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "InnsiglaSkjolSkeyti": {
-      "type": "object",
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "skyring": {
-          "type": "string"
-        },
-        "skjol": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "SvarSkeyti": {
-      "type": "object",
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "skilabod": {
-          "type": "string"
-        },
-        "skjal": {
-          "type": "string"
-        }
-      }
-    },
-    "InnsiglaSkeyti": {
-      "type": "object",
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "skyring": {
-          "type": "string"
-        },
-        "skjal": {
-          "type": "string"
-        }
-      }
-    },
-    "KannaRafraenSkilrikiSimiKennitala": {
-      "type": "object",
-      "properties": {
-        "stada": {
-          "type": "string"
-        },
-        "skilabod": {
-          "type": "string"
-        }
-      }
-    },
-    "KannaRafraenSkilrikiKennitala": {
-      "type": "object",
-      "required": ["dagsetning"],
-      "properties": {
-        "kennitala": {
-          "type": "string"
-        },
-        "dagsetning": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "gildSkilriki": {
-          "$ref": "#/definitions/ActiveCertsModel"
-        }
-      }
-    },
-    "ActiveCertsModel": {
-      "type": "object",
-      "required": ["simi", "app", "kort"],
-      "properties": {
-        "simi": {
-          "type": "boolean"
-        },
-        "app": {
-          "type": "boolean"
-        },
-        "kort": {
-          "type": "boolean"
-        }
-      }
-    },
-    "KaupmaliSkeyti": {
-      "type": "object",
-      "properties": {
-        "stada": {
-          "type": "string"
-        }
-      }
-    },
-    "ThjodskraSvarSkeyti": {
-      "type": "object",
-      "required": ["kynkodi"],
-      "properties": {
-        "stada": {
-          "type": "string"
-        },
-        "kennitala": {
-          "type": "string"
-        },
-        "nafn": {
-          "type": "string"
-        },
-        "loghHusk": {
-          "type": "string"
-        },
-        "heimili": {
-          "type": "string"
-        },
-        "postaritun": {
-          "type": "string"
-        },
-        "sveitarfelag": {
-          "type": "string"
-        },
-        "svfNr": {
-          "type": "string"
-        },
-        "kynkodi": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "ThjodskraSkeyti": {
-      "type": "object",
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "kennitala": {
-          "type": "string"
-        }
-      }
-    },
-    "ThjodskraLogadilar": {
-      "type": "object",
-      "required": ["erBrottfellt", "bannmerking"],
-      "properties": {
-        "kennitala": {
-          "type": "string"
-        },
-        "nafn": {
-          "type": "string"
-        },
-        "heimili": {
-          "type": "string"
-        },
-        "postnumer": {
-          "type": "string"
-        },
-        "svfNr": {
-          "type": "string"
-        },
-        "postfang": {
-          "type": "string"
-        },
-        "postnumerPostfang": {
-          "type": "string"
-        },
-        "svfNrPostfang": {
-          "type": "string"
-        },
-        "atvinnugreinarnumer": {
-          "type": "string"
-        },
-        "starfsemi": {
-          "type": "string"
-        },
-        "flokkur": {
-          "type": "string"
-        },
-        "kennitalaforradanda": {
-          "type": "string"
-        },
-        "erBrottfellt": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "dagsBrottfellt": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "dagsGjaldthrot": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "kennitalaModurfelags": {
-          "type": "string"
-        },
-        "vsk": {
-          "type": "string"
-        },
-        "bannmerking": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "WebhookEventPayload": {
-      "type": "object",
-      "required": ["id"],
-      "properties": {
-        "id": {
-          "type": "string",
-          "format": "guid"
-        },
-        "eventData": {
-          "$ref": "#/definitions/SignedDocumentEventData"
-        },
-        "eventSignature": {
-          "$ref": "#/definitions/EventSignature"
-        }
-      }
-    },
-    "SignedDocumentEventData": {
-      "type": "object",
-      "required": ["eventType"],
-      "properties": {
-        "flowKey": {
-          "type": "string"
-        },
-        "flowName": {
-          "type": "string"
-        },
-        "signees": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Signee"
-          }
-        },
-        "signedDocument": {
-          "type": "string"
-        },
-        "attachments": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/SigningAttachment"
-          }
-        },
-        "eventType": {
-          "$ref": "#/definitions/EventType"
-        },
-        "meta": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "Signee": {
-      "type": "object",
-      "required": ["signed", "communicationDeliveryType"],
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "ssn": {
-          "type": "string"
-        },
-        "phoneNumber": {
-          "type": "string"
-        },
-        "email": {
-          "type": "string"
-        },
-        "address": {
-          "type": "string"
-        },
-        "postalCode": {
-          "type": "string"
-        },
-        "city": {
-          "type": "string"
-        },
-        "key": {
-          "type": "string"
-        },
-        "signed": {
-          "type": "boolean"
-        },
-        "processKey": {
-          "type": "string"
-        },
-        "communicationDeliveryType": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "SigningAttachment": {
-      "type": "object",
-      "properties": {
-        "fileName": {
-          "type": "string"
-        },
-        "fileContent": {
-          "type": "string"
-        }
-      }
-    },
-    "EventType": {
-      "type": "integer",
-      "description": "0 = AllSigned",
-      "x-enumNames": ["AllSigned"],
-      "enum": [0]
-    },
-    "EventSignature": {
-      "type": "object",
-      "required": ["timeStamp", "guid"],
-      "properties": {
-        "timeStamp": {
-          "type": "integer",
-          "format": "int64"
-        },
-        "guid": {
-          "type": "string",
-          "format": "guid"
-        },
-        "signature": {
-          "type": "string"
-        }
-      }
-    },
-    "Skilabod": {
-      "type": "object",
-      "properties": {
-        "skilabod": {
-          "type": "string"
-        },
-        "audkenni": {
-          "type": "string"
-        },
-        "malsnumer": {
-          "type": "string"
-        }
-      }
-    },
-    "LeyfiListi": {
-      "type": "object",
-      "properties": {
-        "leyfi": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Leyfi"
-          }
-        },
-        "villur": {
-          "$ref": "#/definitions/Villur"
-        }
-      }
-    },
-    "Leyfi": {
-      "type": "object",
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "titill": {
-          "type": "string"
-        },
-        "utgafudagur": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "utgefandi": {
-          "$ref": "#/definitions/Utgefandi"
-        },
-        "stada": {
-          "$ref": "#/definitions/Stada"
-        }
-      }
-    },
-    "Utgefandi": {
-      "type": "object",
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "titill": {
-          "type": "string"
-        }
-      }
-    },
-    "Stada": {
-      "type": "object",
-      "properties": {
-        "titill": {
-          "type": "string"
-        },
-        "kodi": {
-          "type": "string"
-        }
-      }
-    },
-    "Villur": {
-      "type": "object",
-      "properties": {
-        "kodi": {
-          "type": "string"
-        },
-        "skilabod": {
-          "type": "string"
-        }
-      }
-    },
-    "LeyfiStakt": {
-      "type": "object",
-      "properties": {
-        "nafn": {
-          "type": "string"
-        },
-        "leyfi": {
-          "$ref": "#/definitions/Leyfi"
-        },
-        "svid": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Svid"
-          }
-        },
-        "textar": {
-          "$ref": "#/definitions/Textar"
-        },
-        "adgerdir": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Adgerd"
-          }
-        },
-        "skrar": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Skra"
-          }
-        },
-        "villur": {
-          "$ref": "#/definitions/Villur"
-        }
-      }
-    },
-    "Svid": {
-      "type": "object",
-      "properties": {
-        "heiti": {
-          "type": "string"
-        },
-        "gildi": {
-          "type": "string"
-        },
-        "tegund": {
-          "type": "string"
-        }
-      }
-    },
-    "Textar": {
-      "type": "object",
-      "properties": {
-        "haus": {
-          "type": "string"
-        },
-        "fotur": {
-          "type": "string"
-        }
-      }
-    },
-    "Adgerd": {
-      "type": "object",
-      "properties": {
-        "tegund": {
-          "type": "string"
-        },
-        "titill": {
-          "type": "string"
-        },
-        "slod": {
-          "type": "string"
-        }
-      }
-    },
-    "Skra": {
-      "type": "object",
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "tegund": {
-          "type": "string"
-        },
-        "skraarnafn": {
-          "type": "string"
-        }
-      }
-    },
-    "SyslSkeyti": {
-      "type": "object",
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "gognSkeytis": {
-          "$ref": "#/definitions/SyslGagnaSkeyti"
-        }
-      }
-    },
-    "SyslGagnaSkeyti": {
-      "type": "object",
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "skeytaHeiti": {
-          "type": "string"
-        },
-        "adilar": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Adili"
-          }
-        },
-        "attachments": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/VidhengiSkra"
-          }
-        },
-        "gagnaMengi": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "Adili": {
-      "type": "object",
-      "required": ["undirritad", "tegund"],
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "nafn": {
-          "type": "string"
-        },
-        "kennitala": {
-          "type": "string"
-        },
-        "simi": {
-          "type": "string"
-        },
-        "tolvupostur": {
-          "type": "string"
-        },
-        "heimilisfang": {
-          "type": "string"
-        },
-        "postaritun": {
-          "type": "string"
-        },
-        "sveitafelag": {
-          "type": "string"
-        },
-        "undirritad": {
-          "type": "boolean"
-        },
-        "tegund": {
-          "$ref": "#/definitions/AdiliTegund"
-        }
-      }
-    },
-    "AdiliTegund": {
-      "type": "integer",
-      "description": "0 = Malshefjandi\n1 = Gagnadili\n2 = Barn",
-      "x-enumNames": ["Malshefjandi", "Gagnadili", "Barn"],
-      "enum": [0, 1, 2]
-    },
-    "VidhengiSkra": {
-      "type": "object",
-      "properties": {
-        "nafnSkraar": {
-          "type": "string"
-        },
-        "innihaldSkraar": {
-          "type": "string"
-        }
-      }
-    },
-    "StadaUndirritunarSkjalsSvarSkeyti": {
-      "type": "object",
-      "required": ["stadaUndirritunar"],
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "skilabod": {
-          "type": "string"
-        },
-        "stadaUndirritunar": {
-          "$ref": "#/definitions/StadaUndirritunar"
-        }
-      }
-    },
-    "StadaUndirritunar": {
-      "type": "integer",
-      "description": "0 = EkkiUndirritad\n1 = Hafnad\n2 = Undirritad\n3 = EkkiUndirritadVilla\n4 = EkkiUndirritadUtrunnid",
-      "x-enumNames": [
-        "EkkiUndirritad",
-        "Hafnad",
-        "Undirritad",
-        "EkkiUndirritadVilla",
-        "EkkiUndirritadUtrunnid"
-      ],
-      "enum": [0, 1, 2, 3, 4]
-    },
-    "StadaUndirritunarSkjalsSkeyti": {
-      "type": "object",
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "malsnumer": {
-          "type": "string"
-        },
-        "skjalasnid": {
-          "type": "string"
-        },
-        "kennitalaUndirritanda": {
-          "type": "string"
-        }
-      }
-    },
-    "StaediskortamalSvarSkeyti": {
-      "type": "object",
-      "properties": {
-        "skilabod": {
-          "type": "string"
-        }
-      }
-    },
-    "Staediskortamal": {
-      "type": "object",
-      "properties": {
-        "malsnumer": {
-          "type": "string"
-        },
-        "kennitala": {
-          "type": "string"
-        },
-        "nafn": {
-          "type": "string"
-        },
-        "tegundMalsadila": {
-          "type": "string"
-        },
-        "undirtegund": {
-          "type": "string"
-        },
-        "tegund": {
-          "type": "string"
-        },
-        "stada": {
-          "type": "string"
-        },
-        "malalok": {
-          "type": "string"
-        },
-        "mottekidDagsetning": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "malalokDagsetning": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "gildistimi": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "utgafudagur": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "utgefandi": {
-          "type": "string"
-        }
-      }
-    },
-    "StofnaskjalOgSendaTilUndirritunarSvarSkeyti": {
-      "type": "object",
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "skilabod": {
-          "type": "string"
-        }
-      }
-    },
-    "StofnaskjalOgSendaTilUndirritunarSkeyti": {
-      "type": "object",
-      "required": ["gildirTil"],
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "malsnumer": {
-          "type": "string"
-        },
-        "kennitalaMalsadila": {
-          "type": "string"
-        },
-        "skjalasnid": {
-          "type": "string"
-        },
-        "gildirTil": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "smsTexti": {
-          "type": "string"
-        }
-      }
-    },
-    "SyslSekjaSkra": {
-      "type": "object",
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "malsnumer": {
-          "type": "string"
-        },
-        "kennitala": {
-          "type": "string"
-        },
-        "skraarnafn": {
-          "type": "string"
-        }
-      }
-    },
-    "VedbandayfirlitMargirSvarSkeyti": {
-      "type": "object",
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "skilabodOgSkra": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/SkilaSkeyti"
-          }
-        }
-      }
-    },
-    "SkilaSkeyti": {
-      "type": "object",
-      "properties": {
-        "fastanumer": {
-          "type": "string"
-        },
-        "skilabod": {
-          "type": "string"
-        },
-        "vedbandayfirlitPDFSkra": {
-          "type": "string"
-        }
-      }
-    },
-    "VedbandayfirlitMargirSkeyti": {
-      "type": "object",
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "eignir": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Eign"
-          }
-        }
-      }
-    },
-    "Eign": {
-      "type": "object",
-      "required": ["tegundAndlags"],
-      "properties": {
-        "fastanumer": {
-          "type": "string"
-        },
-        "tegundAndlags": {
-          "$ref": "#/definitions/VedbondTegundAndlags"
-        }
-      }
-    },
-    "VedbondTegundAndlags": {
-      "type": "integer",
-      "description": "0 = Fasteign\n1 = Okutaeki\n2 = Skip\n3 = Lausafe\n4 = Loftfar\n5 = Oskrad",
-      "x-enumNames": [
-        "Fasteign",
-        "Okutaeki",
-        "Skip",
-        "Lausafe",
-        "Loftfar",
-        "Oskrad"
-      ],
-      "enum": [0, 1, 2, 3, 4, 5]
-    },
-    "VedbandayfirlitSvarSkeyti": {
-      "type": "object",
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "skilabod": {
-          "type": "string"
-        },
-        "vedbandayfirlitPDFSkra": {
-          "type": "string"
-        }
-      }
-    },
-    "VedbandayfirlitSkeyti": {
-      "type": "object",
-      "required": ["tegundAndlags"],
-      "properties": {
-        "audkenni": {
-          "type": "string"
-        },
-        "fastanumer": {
-          "type": "string"
-        },
-        "tegundAndlags": {
-          "$ref": "#/definitions/VedbondTegundAndlags"
-        }
-      }
-    },
-    "VedbandayfirlitRegluverkGeneralSvar": {
-      "type": "object",
-      "properties": {
-        "fastanum": {
-          "type": "string"
-        },
-        "tegundEignar": {
-          "type": "string"
-        },
-        "fasteign": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/VedbandayfirlitReguverkiSvarSkeyti"
-          }
-        },
-        "okutaeki": {
-          "$ref": "#/definitions/Okutaeki"
-        },
-        "skip": {
-          "$ref": "#/definitions/Skip"
-        }
-      }
-    },
-    "VedbandayfirlitReguverkiSvarSkeyti": {
-      "type": "object",
-      "required": ["landNr"],
-      "properties": {
-        "fastnum": {
-          "type": "string"
-        },
-        "landNr": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "heiti": {
-          "type": "string"
-        },
-        "svfn": {
-          "type": "string"
-        },
-        "svetiarfelag": {
-          "type": "string"
-        },
-        "notkun": {
-          "type": "string"
-        },
-        "eining": {
-          "type": "string"
-        },
-        "byggd": {
-          "type": "string"
-        },
-        "embaetti": {
-          "type": "string"
-        },
-        "embaettiNumer": {
-          "type": "string"
-        }
-      }
-    },
-    "Skip": {
-      "type": "object",
-      "required": [
-        "shipRegistrationNumber",
-        "isOpen",
-        "isLegallyStaffed",
-        "initialRegistrationDate",
-        "constructionYear",
-        "identificationRegistrationDate",
-        "changeDate",
-        "legallyStaffed",
-        "open"
-      ],
-      "properties": {
-        "shipRegistrationNumber": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "name": {
-          "type": "string"
-        },
-        "isOpen": {
-          "type": "boolean"
-        },
-        "usageType": {
-          "type": "string"
-        },
-        "operationArea": {
-          "type": "string"
-        },
-        "imoNumber": {
-          "type": "string"
-        },
-        "status": {
-          "type": "string"
-        },
-        "isLegallyStaffed": {
-          "type": "boolean"
-        },
-        "initialRegistrationDate": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "constructionYear": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "seaworhiness": {
-          "$ref": "#/definitions/Seaworhiness"
-        },
-        "identification": {
-          "$ref": "#/definitions/Identification"
-        },
-        "mainMeasurements": {
-          "$ref": "#/definitions/Mainmeasurements"
-        },
-        "crew": {
-          "type": "array",
-          "items": {}
-        },
-        "owners": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Owner"
-          }
-        },
-        "passengerPermits": {
-          "type": "array",
-          "items": {}
-        },
-        "insurances": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Insurance"
-          }
-        },
-        "engines": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Engine"
-          }
-        },
-        "fishery": {
-          "$ref": "#/definitions/Fishery"
-        },
-        "constructionPlace": {
-          "type": "string"
-        },
-        "constructionStation": {
-          "type": "string"
-        },
-        "constructionCountry": {
-          "type": "string"
-        },
-        "constructionNumber": {
-          "type": "string"
-        },
-        "identificationRegistrationDate": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "changeDate": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "hullMaterial": {
-          "type": "string"
-        },
-        "classificationSociety": {
-          "type": "string"
-        },
-        "propellerCount": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "auxiliaryEnginePowerKiloWatts": {
-          "type": "number",
-          "format": "float"
-        },
-        "acOrDc": {
-          "type": "string"
-        },
-        "previousNameOfShip": {
-          "type": "string"
-        },
-        "powerIndicator": {
-          "type": "number",
-          "format": "float"
-        },
-        "otherInfo": {
-          "type": "string"
-        },
-        "maxPropellerDiameter": {
-          "type": "number",
-          "format": "float"
-        },
-        "powerKW": {
-          "type": "number",
-          "format": "float"
-        },
-        "voltage": {
-          "type": "string"
-        },
-        "comments": {
-          "type": "string"
-        },
-        "legallyStaffed": {
-          "type": "boolean"
-        },
-        "open": {
-          "type": "boolean"
-        }
-      }
-    },
-    "Seaworhiness": {
-      "type": "object",
-      "required": ["isValid", "validFrom", "validTo", "valid"],
-      "properties": {
-        "isValid": {
-          "type": "boolean"
-        },
-        "validFrom": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "validTo": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "extendedValidTo": {
-          "type": "string"
-        },
-        "valid": {
-          "type": "boolean"
-        }
-      }
-    },
-    "Identification": {
-      "type": "object",
-      "properties": {
-        "homeHarbor": {
-          "type": "string"
-        },
-        "regionName": {
-          "type": "string"
-        },
-        "regionAcronym": {
-          "type": "string"
-        },
-        "regionNumber": {
-          "type": "string"
-        },
-        "callSign": {
-          "type": "string"
-        }
-      }
-    },
-    "Mainmeasurements": {
-      "type": "object",
-      "properties": {
-        "length": {
-          "type": "number",
-          "format": "float"
-        },
-        "mostLength": {
-          "type": "number",
-          "format": "float"
-        },
-        "width": {
-          "type": "number",
-          "format": "float"
-        },
-        "depth": {
-          "type": "number",
-          "format": "float"
-        },
-        "draft": {
-          "type": "number",
-          "format": "float"
-        },
-        "bruttoGrt": {
-          "type": "number",
-          "format": "float"
-        },
-        "bruttoWeightTons": {
-          "type": "number",
-          "format": "float"
-        },
-        "nettoWeightTons": {
-          "type": "number",
-          "format": "float"
-        }
-      }
-    },
-    "Owner": {
-      "type": "object",
-      "required": ["registrationDate", "lastUpdated", "foreign", "isForeign"],
-      "properties": {
-        "percentage": {
-          "type": "string"
-        },
-        "nationalIdentificationNumber": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "registrationDate": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "lastUpdated": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "documentTitle": {
-          "type": "string"
-        },
-        "address": {
-          "type": "string"
-        },
-        "postalCode": {
-          "type": "string"
-        },
-        "foreign": {
-          "type": "boolean"
-        },
-        "isForeign": {
-          "type": "boolean"
-        }
-      }
-    },
-    "Insurance": {
-      "type": "object",
-      "required": ["validFrom", "validTo", "enabled"],
-      "properties": {
-        "insuranceRegistrationNumber": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "validFrom": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "validTo": {
-          "type": "string",
-          "format": "date-time"
-        },
-        "enabled": {
-          "type": "boolean"
-        },
-        "numberOfInsured": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "comment": {
-          "type": "string"
-        },
-        "amountISK": {
-          "type": "number",
-          "format": "float"
-        },
-        "insuranceType": {
-          "$ref": "#/definitions/Insurancetype"
-        },
-        "insuranceCompany": {
-          "$ref": "#/definitions/Insurancecompany"
-        }
-      }
-    },
-    "Insurancetype": {
-      "type": "object",
-      "required": ["insuranceTypeRegistrationNumber"],
-      "properties": {
-        "insuranceTypeRegistrationNumber": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "name": {
-          "type": "string"
-        },
-        "code": {
-          "type": "string"
-        }
-      }
-    },
-    "Insurancecompany": {
-      "type": "object",
-      "required": ["insuranceCompanyRegistrationNumber"],
-      "properties": {
-        "insuranceCompanyRegistrationNumber": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "name": {
-          "type": "string"
-        },
-        "nationalIdentificationNumber": {
-          "type": "string"
-        }
-      }
-    },
-    "Engine": {
-      "type": "object",
-      "required": ["power", "year"],
-      "properties": {
-        "manufacturingNumber": {
-          "type": "string"
-        },
-        "power": {
-          "type": "number",
-          "format": "float"
-        },
-        "year": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "usage": {
-          "$ref": "#/definitions/Usage"
-        },
-        "manufacturer": {
-          "$ref": "#/definitions/Manufacturer"
-        }
-      }
-    },
-    "Usage": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        }
-      }
-    },
-    "Manufacturer": {
-      "type": "object",
-      "properties": {
-        "code": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        }
-      }
-    },
-    "Fishery": {
-      "type": "object",
-      "properties": {
-        "identityNumber": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "address": {
-          "type": "string"
-        },
-        "postalCode": {
-          "type": "string"
-        }
-      }
-    },
-    "Verdbrefamidlari": {
-      "type": "object",
-      "properties": {
-        "nafn": {
-          "type": "string"
-        },
-        "kennitala": {
-          "type": "string"
-        }
-      }
-    }
-  },
-  "securityDefinitions": {
-    "Bearer": {
-      "type": "apiKey",
-      "description": "Copy this into the value field: Bearer {token}",
-      "name": "Authorization",
-      "in": "header"
-    },
-    "JWT Token": {
-      "type": "apiKey",
-      "description": "Copy this into the value field: Bearer {token}",
-      "name": "Authorization",
-      "in": "header"
     }
   },
   "security": [
@@ -6512,7 +8152,7 @@
       "Bearer": []
     },
     {
-      "JWT Token": []
+      "JWTToken": []
     }
   ]
 }

--- a/libs/clients/syslumenn/src/lib/syslumennClient.service.ts
+++ b/libs/clients/syslumenn/src/lib/syslumennClient.service.ts
@@ -107,7 +107,7 @@ export class SyslumennService {
     }
 
     const { audkenni, accessToken } = await api.innskraningPost({
-      notandi: config,
+      apiNotandi: config,
     })
     if (audkenni && accessToken) {
       return {
@@ -255,7 +255,7 @@ export class SyslumennService {
     const { id, api } = await this.createApi()
     const explanation = 'Rafrænt undirritað vottorð'
     return await api.innsiglaSkjolPost({
-      skeyti: {
+      innsiglaSkjolSkeyti: {
         audkenni: id,
         skyring: explanation,
         skjol: documents,
@@ -267,7 +267,7 @@ export class SyslumennService {
     const { id, api } = await this.createApi()
     const explanation = 'Rafrænt undirritað vottorð'
     return await api.innsiglunPost({
-      skeyti: {
+      innsiglaSkeyti: {
         audkenni: id,
         skyring: explanation,
         skjal: document,
@@ -365,7 +365,7 @@ export class SyslumennService {
     const { id, api } = await this.createApi()
     const response = await api
       .vedbokavottordRegluverkiPost({
-        skilabod: {
+        vedbandayfirlitSkeyti: {
           audkenni: id,
           fastanumer: cleanPropertyNumber(assetId),
           tegundAndlags: assetType as number,
@@ -411,7 +411,7 @@ export class SyslumennService {
     const { id, api } = await this.createApi()
 
     const res = await api.vedbokarvottord2Post({
-      skilabod: {
+      vedbandayfirlitMargirSkeyti: {
         audkenni: id,
         eignir: properties.map(({ propertyNumber, propertyType }) => {
           return {
@@ -432,8 +432,8 @@ export class SyslumennService {
         const contentBase64 = resultItem.vedbandayfirlitPDFSkra || ''
         return {
           contentBase64: contentBase64,
-          apiMessage: resultItem.skilabod,
-          propertyNumber: resultItem.fastanumer,
+          apiMessage: resultItem.skilabod ?? undefined,
+          propertyNumber: resultItem.fastanumer ?? undefined,
         }
       }) ?? []
 
@@ -465,7 +465,7 @@ export class SyslumennService {
 
     const res = await api
       .vedbokavottordRegluverkiPost({
-        skilabod: {
+        vedbandayfirlitSkeyti: {
           audkenni: id,
           fastanumer: cleanPropertyNumber(propertyNumber),
           tegundAndlags: VedbondTegundAndlags.NUMBER_0, // 0 = Real estate
@@ -487,7 +487,7 @@ export class SyslumennService {
       unitsOfUse: {
         unitsOfUse: [
           {
-            explanation: fasteign?.notkun,
+            explanation: fasteign?.notkun ?? undefined,
           },
         ],
       },
@@ -502,7 +502,7 @@ export class SyslumennService {
 
     const res = await api
       .vedbokavottordRegluverkiPost({
-        skilabod: {
+        vedbandayfirlitSkeyti: {
           audkenni: id,
           fastanumer:
             propertyType === '0'
@@ -523,8 +523,8 @@ export class SyslumennService {
       })
 
     return {
-      propertyNumber: res.fastanum,
-      propertyType: res.tegundEignar,
+      propertyNumber: res.fastanum ?? undefined, // Removes nulls with ?? undefined
+      propertyType: res.tegundEignar ?? undefined,
       realEstate: res.fasteign ? res.fasteign.map(mapRealEstateResponse) : [],
       vehicle: res.okutaeki ? mapVehicleResponse(res.okutaeki) : undefined,
       ship: res.skip ? mapShipResponse(res.skip) : undefined,
@@ -562,7 +562,7 @@ export class SyslumennService {
   async getRegistryPerson(nationalId: string): Promise<RegistryPerson> {
     const { id, api } = await this.createApi()
     const res = await api.leitaAdKennitoluIThjodskraPost({
-      skeyti: {
+      thjodskraSkeyti: {
         audkenni: id,
         kennitala: nationalId,
       },
@@ -603,7 +603,7 @@ export class SyslumennService {
   ): Promise<unknown> {
     const { id, api } = await this.createApi()
     const res = await api.skiptaUmSkraningaradilaDanarbusPost({
-      payload: {
+      skiptaUmSkraningaradili: {
         audkenni: id,
         kennitalaFra: currentRegistrantNationalId,
         kennitalaTil: newRegistrantNationalId,

--- a/libs/clients/syslumenn/src/lib/syslumennClient.utils.ts
+++ b/libs/clients/syslumenn/src/lib/syslumennClient.utils.ts
@@ -111,16 +111,16 @@ export const mapVehicleResponse = (response: Okutaeki): VehicleDetail => {
     manufacturer: response.framleidandi ?? '',
     manufacturerType: response.framleidandaGerd ?? '',
     color: response.litur ?? '',
-    dateOfRegistration: response.skraningardagur,
+    dateOfRegistration: response.skraningardagur ?? new Date(),
   }
 }
 
 export const mapShipResponse = (response: Skip): ShipDetail => {
   return {
-    shipRegistrationNumber: response.shipRegistrationNumber.toString(),
+    shipRegistrationNumber: response.shipRegistrationNumber?.toString() ?? '',
     usageType: response.usageType ?? '',
     name: response.name ?? '',
-    initialRegistrationDate: response.initialRegistrationDate,
+    initialRegistrationDate: response.initialRegistrationDate ?? new Date(),
     mainMeasurements: {
       length: response.mainMeasurements?.length?.toString() ?? '',
       bruttoWeightTons:
@@ -147,9 +147,9 @@ export const mapCertificateInfo = (
   response: VottordSkeyti,
 ): CertificateInfoResponse => {
   return {
-    nationalId: response.kennitala,
-    expirationDate: response.gildisTimi,
-    releaseDate: response.utgafudagur,
+    nationalId: response.kennitala ?? undefined,
+    expirationDate: response.gildisTimi ?? undefined,
+    releaseDate: response.utgafudagur ?? undefined,
   }
 }
 export const mapDataUploadResponse = (
@@ -157,9 +157,9 @@ export const mapDataUploadResponse = (
 ): DataUploadResponse => {
   return {
     success: response.skilabod === UPLOAD_DATA_SUCCESS,
-    message: response.skilabod,
-    id: response.audkenni,
-    caseNumber: response.malsnumer,
+    message: response.skilabod ?? undefined,
+    id: response.audkenni ?? undefined,
+    caseNumber: response.malsnumer ?? undefined,
   }
 }
 
@@ -171,8 +171,8 @@ export const mapHomestay = (homestay: VirkarHeimagistingar): Homestay => {
     manager: homestay.abyrgdarmadur ?? '',
     year: homestay.umsoknarAr ? parseInt(homestay.umsoknarAr) : undefined,
     city: homestay.sveitarfelag ?? '',
-    guests: homestay.gestafjoldi,
-    rooms: homestay.fjoldiHerbergja,
+    guests: homestay.gestafjoldi ?? undefined,
+    rooms: homestay.fjoldiHerbergja ?? undefined,
     propertyId: homestay.fastanumer ?? '',
     apartmentId: homestay.ibudanumer ?? '',
   }
@@ -213,29 +213,30 @@ export const mapOperatingLicense = (
   operatingLicense: VirkLeyfi,
 ): OperatingLicense => ({
   id: operatingLicense.rowNum,
-  issuedBy: operatingLicense.utgefidAf,
-  licenseNumber: operatingLicense.leyfisnumer,
-  location: operatingLicense.stadur,
-  name: operatingLicense.kallast,
-  street: operatingLicense.gata,
-  postalCode: operatingLicense.postnumer,
-  type: operatingLicense.tegund,
-  type2: operatingLicense.tegund2,
-  restaurantType: operatingLicense.tegundVeitingastadar,
-  validFrom: operatingLicense.gildirFra,
-  validTo: operatingLicense.gildirTil,
-  licenseHolder: operatingLicense.leyfishafi,
-  licenseResponsible: operatingLicense.abyrgdarmadur,
-  category: operatingLicense.flokkur,
-  outdoorLicense: operatingLicense.leyfiTilUtiveitinga,
-  alcoholWeekdayLicense: operatingLicense.afgrAfgengisVirkirdagar,
-  alcoholWeekendLicense: operatingLicense.afgrAfgengisAdfaranottFridaga,
+  issuedBy: operatingLicense.utgefidAf ?? undefined,
+  licenseNumber: operatingLicense.leyfisnumer ?? undefined,
+  location: operatingLicense.stadur ?? undefined,
+  name: operatingLicense.kallast ?? undefined,
+  street: operatingLicense.gata ?? undefined,
+  postalCode: operatingLicense.postnumer ?? undefined,
+  type: operatingLicense.tegund ?? undefined,
+  type2: operatingLicense.tegund2 ?? undefined,
+  restaurantType: operatingLicense.tegundVeitingastadar ?? undefined,
+  validFrom: operatingLicense.gildirFra ?? undefined,
+  validTo: operatingLicense.gildirTil ?? undefined,
+  licenseHolder: operatingLicense.leyfishafi ?? undefined,
+  licenseResponsible: operatingLicense.abyrgdarmadur ?? undefined,
+  category: operatingLicense.flokkur ?? undefined,
+  outdoorLicense: operatingLicense.leyfiTilUtiveitinga ?? undefined,
+  alcoholWeekdayLicense: operatingLicense.afgrAfgengisVirkirdagar ?? undefined,
+  alcoholWeekendLicense:
+    operatingLicense.afgrAfgengisAdfaranottFridaga ?? undefined,
   alcoholWeekdayOutdoorLicense:
-    operatingLicense.afgrAfgengisVirkirdagarUtiveitingar,
+    operatingLicense.afgrAfgengisVirkirdagarUtiveitingar ?? undefined,
   alcoholWeekendOutdoorLicense:
-    operatingLicense.afgrAfgengisAdfaranottFridagaUtiveitingar,
-  maximumNumberOfGuests: operatingLicense.hamarksfjoldiGesta,
-  numberOfDiningGuests: operatingLicense.fjoldiGestaIVeitingum,
+    operatingLicense.afgrAfgengisAdfaranottFridagaUtiveitingar ?? undefined,
+  maximumNumberOfGuests: operatingLicense.hamarksfjoldiGesta ?? undefined,
+  numberOfDiningGuests: operatingLicense.fjoldiGestaIVeitingum ?? undefined,
 })
 
 export const mapPaginationInfo = (
@@ -321,7 +322,7 @@ export function constructUploadDataObject(
   uploadDataId?: string,
 ): SyslMottakaGognPostRequest {
   return {
-    payload: {
+    syslSkeyti: {
       audkenni: id,
       gognSkeytis: {
         audkenni: uploadDataId || uuid(),
@@ -387,10 +388,10 @@ export const mapAssetName = (
 
 export const mapVehicle = (response: Okutaeki): VehicleRegistration => {
   return {
-    licensePlate: response.numerOkutaekis,
-    modelName: response.framleidandaGerd,
-    manufacturer: response.framleidandi,
-    color: response.litur,
+    licensePlate: response.numerOkutaekis ?? undefined,
+    modelName: response.framleidandaGerd ?? undefined,
+    manufacturer: response.framleidandi ?? undefined,
+    color: response.litur ?? undefined,
   }
 }
 
@@ -479,7 +480,7 @@ export const mapEstateRegistrant = (
     marriageSettlement: syslaData.kaupmaili ?? false,
     office: syslaData.embaetti ?? '',
     caseNumber: syslaData.malsnumer ?? '',
-    dateOfDeath: syslaData.danardagur ?? '',
+    dateOfDeath: syslaData.danardagur ?? new Date(), // Todo: suitable backup for date
     nameOfDeceased: syslaData.nafnLatins ?? '',
     nationalIdOfDeceased: syslaData.kennitalaLatins ?? '',
     ownBusinessManagement: syslaData.eiginRekstur ?? false,
@@ -535,7 +536,7 @@ export const mapEstateInfo = (syslaData: DanarbuUpplRadstofun): EstateInfo => {
       : new Date(),
     districtCommissionerHasWill: Boolean(syslaData?.erfdaskra),
     knowledgeOfOtherWills: syslaData.erfdakraVitneskja ? 'Yes' : 'No',
-    marriageSettlement: syslaData.kaupmali,
+    marriageSettlement: syslaData.kaupmali ?? false,
     nameOfDeceased: syslaData?.nafn ?? '',
     nationalIdOfDeceased: syslaData?.kennitala ?? '',
     availableSettlements: mapAvailableSettlements(syslaData.mogulegSkipti),
@@ -544,11 +545,11 @@ export const mapEstateInfo = (syslaData: DanarbuUpplRadstofun): EstateInfo => {
 
 export const mapMasterLicence = (licence: Meistaraleyfi): MasterLicence => {
   return {
-    name: licence.nafn,
-    dateOfPublication: licence.gildirFra,
-    profession: licence.idngrein,
-    office: licence.embaetti,
-    nationalId: licence.kennitala,
+    name: licence.nafn ?? undefined,
+    dateOfPublication: licence.gildirFra ?? undefined,
+    profession: licence.idngrein ?? undefined,
+    office: licence.embaetti ?? undefined,
+    nationalId: licence.kennitala ?? undefined,
   }
 }
 
@@ -556,10 +557,10 @@ export const mapJourneymanLicence = (
   licence: SveinsbrefModel,
 ): JourneymanLicence => {
   return {
-    name: licence.nafn,
-    dateOfPublication: licence.gildirFra,
-    profession: licence.idngrein,
-    nationalId: licence.kennitala,
+    name: licence.nafn ?? undefined,
+    dateOfPublication: licence.gildirFra ?? undefined,
+    profession: licence.idngrein ?? undefined,
+    nationalId: licence.kennitala ?? undefined,
   }
 }
 
@@ -567,9 +568,9 @@ export const mapProfessionRight = (
   professionRight: StarfsrettindiModel,
 ): ProfessionRight => {
   return {
-    name: professionRight.nafn,
-    profession: professionRight.starfsrettindi,
-    nationalId: professionRight.kennitala,
+    name: professionRight.nafn ?? undefined,
+    profession: professionRight.starfsrettindi ?? undefined,
+    nationalId: professionRight.kennitala ?? undefined,
   }
 }
 
@@ -589,9 +590,9 @@ export const mapInheritanceTax = (
   inheritance: ErfdafjarskatturSvar,
 ): InheritanceTax => {
   return {
-    inheritanceTax: inheritance.erfdafjarskattur,
-    taxExemptionLimit: inheritance.skattfrelsismorkUpphaed,
-    validFrom: inheritance.gildirFra,
+    inheritanceTax: inheritance.erfdafjarskattur ?? 0,
+    taxExemptionLimit: inheritance.skattfrelsismorkUpphaed ?? 0,
+    validFrom: inheritance.gildirFra ?? new Date(), // TODO: Figure out a suitable fallback for date
   }
 }
 
@@ -609,7 +610,7 @@ const mapInheritanceReportAsset = (
   return {
     description: lysing ?? '',
     assetNumber: fastanumer ?? '',
-    share: parseShare(eignarhlutfall) ?? 100,
+    share: parseShare(eignarhlutfall ?? 100),
     propertyValuation: fasteignamat ?? '',
     amount: upphaed ?? '',
     exchangeRateOrInterest: gengiVextir ?? '',
@@ -624,10 +625,10 @@ const mapInheritanceReportHeirs = (
     nationalId: heir.kennitala ?? '',
     relation: heir.tengsl ?? 'Annað',
     advocate: heir.malsvari ? mapAdvocate(heir.malsvari) : undefined,
-    email: heir.netfang,
-    phone: heir.simi,
-    relationWithApplicant: heir.tengsl,
-    address: heir.heimilisfang,
+    email: heir.netfang ?? undefined,
+    phone: heir.simi ?? undefined,
+    relationWithApplicant: heir.tengsl ?? undefined,
+    address: heir.heimilisfang ?? undefined,
   }))
 }
 
@@ -756,14 +757,14 @@ export const mapEstateToInheritanceReportInfo = (
   estate: DanarbuUpplErfdafjarskatt,
 ): InheritanceReportInfo => {
   return {
-    caseNumber: estate.malsnumer,
-    dateOfDeath: estate.danardagur,
-    will: estate.erfdaskra,
+    caseNumber: estate.malsnumer ?? undefined,
+    dateOfDeath: estate.danardagur ?? undefined,
+    will: estate.erfdaskra ?? undefined,
     knowledgeOfOtherWill: estate.erfdakraVitneskja,
     settlement: estate.kaupmali,
-    nameOfDeceased: estate.nafn,
-    nationalId: estate.kennitala,
-    addressOfDeceased: estate.logheimili,
+    nameOfDeceased: estate.nafn ?? undefined,
+    nationalId: estate.kennitala ?? undefined,
+    addressOfDeceased: estate.logheimili ?? undefined,
     heirs: mapInheritanceReportHeirs(estate.erfingar ?? []),
     ...mapInheritanceReportAssets(estate.eignir),
   }


### PR DESCRIPTION
# Warning
Please be advised that our openapi generation client is probably in need of updating. We can avoid some problems if we transform the client config heavily, as can be seen in the undesiredly long command for the update-openapi-document directive.

I yet again refer to the issue raised here: https://github.com/island-is/island.is/issues/11858 although I think an update is not being planned.

I would greatly appreciate if anyone knows if there is a simpler solution than transforming incoming client configs to this extent just to avoid config errors.

In this case we are avoiding "AnyType" models not being generated since responses have now been wrapped in "application/json" blocks, triggering the JSON serializer/deserializer which has an issue with items being empty.

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
