### PR TITLE
fix:(auth-admin): Adds nationalId to IdentityCard for createdBy in DelegationViewModal

### DIFF
--- a/libs/portals/shared-modules/delegations/src/components/delegations/DelegationViewModal.tsx
+++ b/libs/portals/shared-modules/delegations/src/components/delegations/DelegationViewModal.tsx
@@ -138,6 +138,7 @@ export const DelegationViewModal = ({
                 <IdentityCard
                   label={formatMessage(m.createdBy)}
                   title={delegation.createdBy.name}
+                  description={formatNationalId(delegation.createdBy.nationalId)}
                 />
               )}
             </Box>

--- a/libs/portals/shared-modules/delegations/src/components/delegations/DelegationViewModal.tsx
+++ b/libs/portals/shared-modules/delegations/src/components/delegations/DelegationViewModal.tsx
@@ -138,7 +138,9 @@ export const DelegationViewModal = ({
                 <IdentityCard
                   label={formatMessage(m.createdBy)}
                   title={delegation.createdBy.name}
-                  description={formatNationalId(delegation.createdBy.nationalId)}
+                  description={formatNationalId(
+                    delegation.createdBy.nationalId,
+                  )}
                 />
               )}
             </Box>


### PR DESCRIPTION

## What

Add nationalId to IdentityCard in the DelegationViewModal

## Why

Match design

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a `description` field to the `IdentityCard` in the `DelegationViewModal` for administrative users, displaying the creator's national ID when applicable. 

This enhancement provides more context for admin users without altering existing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->