### PR TITLE
fix(web): Load image with 800px width when embedded in rich text

### DIFF
--- a/apps/web/utils/richText.tsx
+++ b/apps/web/utils/richText.tsx
@@ -4,6 +4,8 @@ import { IntlConfig, IntlProvider } from 'react-intl'
 import {
   FaqList,
   type FaqListProps,
+  Image,
+  type ImageProps,
   renderConnectedComponent,
   richText,
   SectionWithImage,
@@ -279,6 +281,11 @@ const defaultRenderComponent = {
       variant={slice.variant as 'accordion' | 'card'}
     />
   ),
+  Image: (slice: ImageProps) => {
+    const thumbnailUrl = slice?.url ? slice.url + '?w=50' : ''
+    const url = slice?.url ? slice.url + '?w=800' : ''
+    return <Image {...slice} thumbnail={thumbnailUrl} url={url} />
+  },
 }
 
 export const webRichText = (


### PR DESCRIPTION
# Load image with 800px width when embedded in rich text

To save bandwidth (look at before and after below)

## Screenshots / Gifs

### Before

![Screenshot 2024-10-10 at 13 59 20](https://github.com/user-attachments/assets/79fc4c8a-05c0-4ffc-8f01-3088c1c6bb9b)

### After

![Screenshot 2024-10-10 at 13 59 55](https://github.com/user-attachments/assets/a06b76d1-0e0d-4b6c-b3f3-cf083575aef9)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an `Image` component for enhanced rendering of image slices within the rich text utility.
  - Improved handling of thumbnail and full-size image URLs based on provided properties.

These updates enhance the overall functionality and user experience by allowing for better integration of images in the content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->