### PR TITLE
fix(web): Use || instead of ?? for JSON.parse fallback

### DIFF
--- a/apps/web/components/Organization/OrganizationIslandFooter/OrganizationIslandFooter.tsx
+++ b/apps/web/components/Organization/OrganizationIslandFooter/OrganizationIslandFooter.tsx
@@ -26,7 +26,7 @@ export const OrganizationIslandFooter = () => {
   })
 
   const namespace = useMemo(
-    () => JSON.parse(data?.getNamespace?.fields ?? '{}'),
+    () => JSON.parse(data?.getNamespace?.fields || '{}'),
     [data?.getNamespace?.fields],
   )
 

--- a/apps/web/components/Organization/Wrapper/Themes/FiskistofaTheme/FiskistofaHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/FiskistofaTheme/FiskistofaHeader.tsx
@@ -40,7 +40,7 @@ const FiskistofaHeader: React.FC<React.PropsWithChildren<HeaderProps>> = ({
 }) => {
   const { linkResolver } = useLinkResolver()
   const namespace = useMemo(
-    () => JSON.parse(organizationPage.organization?.namespace?.fields ?? '{}'),
+    () => JSON.parse(organizationPage.organization?.namespace?.fields || '{}'),
     [organizationPage.organization?.namespace?.fields],
   )
   const n = useNamespace(namespace)

--- a/apps/web/components/Organization/Wrapper/Themes/FjarsyslaRikisinsTheme/FjarsyslaRikisinsHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/FjarsyslaRikisinsTheme/FjarsyslaRikisinsHeader.tsx
@@ -30,7 +30,7 @@ const FjarsyslaRikisinsHeader = ({
 }: HeaderProps) => {
   const { linkResolver } = useLinkResolver()
   const namespace = useMemo(
-    () => JSON.parse(organizationPage.organization?.namespace?.fields ?? '{}'),
+    () => JSON.parse(organizationPage.organization?.namespace?.fields || '{}'),
     [organizationPage.organization?.namespace?.fields],
   )
   const n = useNamespace(namespace)

--- a/apps/web/components/Organization/Wrapper/Themes/GevTheme/GevHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/GevTheme/GevHeader.tsx
@@ -39,7 +39,7 @@ const GevHeader: React.FC<React.PropsWithChildren<HeaderProps>> = ({
 }) => {
   const { linkResolver } = useLinkResolver()
   const namespace = useMemo(
-    () => JSON.parse(organizationPage.organization?.namespace?.fields ?? '{}'),
+    () => JSON.parse(organizationPage.organization?.namespace?.fields || '{}'),
     [organizationPage.organization?.namespace?.fields],
   )
   const n = useNamespace(namespace)

--- a/apps/web/components/Organization/Wrapper/Themes/HeilbrigdisstofnunAusturlandsTheme/HeilbrigdisstofnunAusturlandsHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/HeilbrigdisstofnunAusturlandsTheme/HeilbrigdisstofnunAusturlandsHeader.tsx
@@ -50,7 +50,7 @@ const HeilbrigdisstofnunAusturlandsHeader: React.FC<
   const { linkResolver } = useLinkResolver()
 
   const namespace = useMemo(
-    () => JSON.parse(organizationPage.organization?.namespace?.fields ?? '{}'),
+    () => JSON.parse(organizationPage.organization?.namespace?.fields || '{}'),
     [organizationPage.organization?.namespace?.fields],
   )
 

--- a/apps/web/components/Organization/Wrapper/Themes/HeilbrigdisstofnunNordurlandsTheme/HeilbrigdisstofnunNordurlandsHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/HeilbrigdisstofnunNordurlandsTheme/HeilbrigdisstofnunNordurlandsHeader.tsx
@@ -31,7 +31,7 @@ const HeilbrigdisstofnunNordurlandsHeader: React.FC<
 > = ({ organizationPage, logoAltText }) => {
   const { linkResolver } = useLinkResolver()
   const namespace = useMemo(
-    () => JSON.parse(organizationPage.organization?.namespace?.fields ?? '{}'),
+    () => JSON.parse(organizationPage.organization?.namespace?.fields || '{}'),
     [organizationPage.organization?.namespace?.fields],
   )
   const n = useNamespace(namespace)

--- a/apps/web/components/Organization/Wrapper/Themes/HeilbrigdisstofnunSudurlandsTheme/HeilbrigdisstofnunSudurlandsHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/HeilbrigdisstofnunSudurlandsTheme/HeilbrigdisstofnunSudurlandsHeader.tsx
@@ -42,7 +42,7 @@ const HeilbrigdisstofnunSudurlandsHeader: React.FC<
   const { linkResolver } = useLinkResolver()
 
   const namespace = useMemo(
-    () => JSON.parse(organizationPage.organization?.namespace?.fields ?? '{}'),
+    () => JSON.parse(organizationPage.organization?.namespace?.fields || '{}'),
     [organizationPage.organization?.namespace?.fields],
   )
 

--- a/apps/web/components/Organization/Wrapper/Themes/HmsTheme/HmsHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/HmsTheme/HmsHeader.tsx
@@ -38,7 +38,7 @@ const HmsHeader: React.FC<HeaderProps> = ({
 }) => {
   const { linkResolver } = useLinkResolver()
   const namespace = useMemo(
-    () => JSON.parse(organizationPage.organization?.namespace?.fields ?? '{}'),
+    () => JSON.parse(organizationPage.organization?.namespace?.fields || '{}'),
     [organizationPage.organization?.namespace?.fields],
   )
   const n = useNamespace(namespace)

--- a/apps/web/components/Organization/Wrapper/Themes/HveTheme/HveHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/HveTheme/HveHeader.tsx
@@ -39,7 +39,7 @@ const HveHeader: React.FC<React.PropsWithChildren<HeaderProps>> = ({
 }) => {
   const { linkResolver } = useLinkResolver()
   const namespace = useMemo(
-    () => JSON.parse(organizationPage.organization?.namespace?.fields ?? '{}'),
+    () => JSON.parse(organizationPage.organization?.namespace?.fields || '{}'),
     [organizationPage.organization?.namespace?.fields],
   )
   const n = useNamespace(namespace)

--- a/apps/web/components/Organization/Wrapper/Themes/IcelandicNaturalDisasterInsuranceTheme/IcelandicNaturalDisasterInsuranceHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/IcelandicNaturalDisasterInsuranceTheme/IcelandicNaturalDisasterInsuranceHeader.tsx
@@ -70,7 +70,7 @@ const IcelandicNaturalDisasterInsuranceHeader: React.FC<HeaderProps> = ({
 }) => {
   const { linkResolver } = useLinkResolver()
   const namespace = useMemo(
-    () => JSON.parse(organizationPage.organization?.namespace?.fields ?? '{}'),
+    () => JSON.parse(organizationPage.organization?.namespace?.fields || '{}'),
     [organizationPage.organization?.namespace?.fields],
   )
   const n = useNamespace(namespace)

--- a/apps/web/components/Organization/Wrapper/Themes/IcelandicRadiationSafetyAuthority/IcelandicRadiationSafetyAuthorityHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/IcelandicRadiationSafetyAuthority/IcelandicRadiationSafetyAuthorityHeader.tsx
@@ -38,7 +38,7 @@ const IcelandicNaturalDisasterInsuranceHeader: React.FC<HeaderProps> = ({
 }) => {
   const { linkResolver } = useLinkResolver()
   const namespace = useMemo(
-    () => JSON.parse(organizationPage.organization?.namespace?.fields ?? '{}'),
+    () => JSON.parse(organizationPage.organization?.namespace?.fields || '{}'),
     [organizationPage.organization?.namespace?.fields],
   )
   const n = useNamespace(namespace)

--- a/apps/web/components/Organization/Wrapper/Themes/LandkjorstjornTheme/LandskjorstjornHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/LandkjorstjornTheme/LandskjorstjornHeader.tsx
@@ -36,7 +36,7 @@ const LandskjorstjornHeader: React.FC<React.PropsWithChildren<HeaderProps>> = ({
 }) => {
   const { linkResolver } = useLinkResolver()
   const namespace = useMemo(
-    () => JSON.parse(organizationPage.organization?.namespace?.fields ?? '{}'),
+    () => JSON.parse(organizationPage.organization?.namespace?.fields || '{}'),
     [organizationPage.organization?.namespace?.fields],
   )
   const n = useNamespace(namespace)

--- a/apps/web/components/Organization/Wrapper/Themes/LandlaeknirTheme/LandlaeknirHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/LandlaeknirTheme/LandlaeknirHeader.tsx
@@ -52,7 +52,7 @@ const LandlaeknirHeader: React.FC<React.PropsWithChildren<HeaderProps>> = ({
 }) => {
   const { linkResolver } = useLinkResolver()
   const namespace = useMemo(
-    () => JSON.parse(organizationPage.organization?.namespace?.fields ?? '{}'),
+    () => JSON.parse(organizationPage.organization?.namespace?.fields || '{}'),
     [organizationPage.organization?.namespace?.fields],
   )
   const n = useNamespace(namespace)

--- a/apps/web/components/Organization/Wrapper/Themes/RikislogmadurTheme/RikislogmadurHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/RikislogmadurTheme/RikislogmadurHeader.tsx
@@ -33,7 +33,7 @@ const RikislogmadurHeader = ({
 }: HeaderProps) => {
   const { linkResolver } = useLinkResolver()
   const namespace = useMemo(
-    () => JSON.parse(organizationPage.organization?.namespace?.fields ?? '{}'),
+    () => JSON.parse(organizationPage.organization?.namespace?.fields || '{}'),
     [organizationPage.organization?.namespace?.fields],
   )
   const n = useNamespace(namespace)

--- a/apps/web/components/Organization/Wrapper/Themes/RikissaksoknariTheme/RikissaksoknariHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/RikissaksoknariTheme/RikissaksoknariHeader.tsx
@@ -33,7 +33,7 @@ const RikissaksoknariHeader = ({
 }: HeaderProps) => {
   const { linkResolver } = useLinkResolver()
   const namespace = useMemo(
-    () => JSON.parse(organizationPage.organization?.namespace?.fields ?? '{}'),
+    () => JSON.parse(organizationPage.organization?.namespace?.fields || '{}'),
     [organizationPage.organization?.namespace?.fields],
   )
   const n = useNamespace(namespace)

--- a/apps/web/components/Organization/Wrapper/Themes/SAkTheme/SAkHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/SAkTheme/SAkHeader.tsx
@@ -19,7 +19,7 @@ const SAkHeader: React.FC<React.PropsWithChildren<HeaderProps>> = ({
 }) => {
   const { linkResolver } = useLinkResolver()
   const namespace = useMemo(
-    () => JSON.parse(organizationPage.organization?.namespace?.fields ?? '{}'),
+    () => JSON.parse(organizationPage.organization?.namespace?.fields || '{}'),
     [organizationPage.organization?.namespace?.fields],
   )
   const n = useNamespace(namespace)

--- a/apps/web/components/Organization/Wrapper/Themes/SHHTheme/ShhHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/SHHTheme/ShhHeader.tsx
@@ -41,7 +41,7 @@ const ShhHeader: React.FC<React.PropsWithChildren<HeaderProps>> = ({
   const { linkResolver } = useLinkResolver()
 
   const namespace = useMemo(
-    () => JSON.parse(organizationPage.organization?.namespace?.fields ?? '{}'),
+    () => JSON.parse(organizationPage.organization?.namespace?.fields || '{}'),
     [organizationPage.organization?.namespace?.fields],
   )
 

--- a/apps/web/components/Organization/Wrapper/Themes/SyslumennTheme/SyslumennHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/SyslumennTheme/SyslumennHeader.tsx
@@ -42,7 +42,7 @@ const SyslumennHeader: React.FC<React.PropsWithChildren<HeaderProps>> = ({
 }) => {
   const { linkResolver } = useLinkResolver()
   const namespace = useMemo(
-    () => JSON.parse(organizationPage.organization?.namespace?.fields ?? '{}'),
+    () => JSON.parse(organizationPage.organization?.namespace?.fields || '{}'),
     [organizationPage.organization?.namespace?.fields],
   )
   const n = useNamespace(namespace)

--- a/apps/web/components/Organization/Wrapper/Themes/TransportAuthorityTheme/TransportAuthorityHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/TransportAuthorityTheme/TransportAuthorityHeader.tsx
@@ -41,7 +41,7 @@ const TransportAuthorityHeader: React.FC<HeaderProps> = ({
 }) => {
   const { linkResolver } = useLinkResolver()
   const namespace = useMemo(
-    () => JSON.parse(organizationPage.organization?.namespace?.fields ?? '{}'),
+    () => JSON.parse(organizationPage.organization?.namespace?.fields || '{}'),
     [organizationPage.organization?.namespace?.fields],
   )
   const n = useNamespace(namespace)

--- a/apps/web/components/Organization/Wrapper/Themes/UtlendingastofnunTheme/UtlendingastofnunHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/UtlendingastofnunTheme/UtlendingastofnunHeader.tsx
@@ -35,7 +35,7 @@ const UtlendingastofnunHeader: React.FC<
 > = ({ organizationPage, logoAltText }) => {
   const { linkResolver } = useLinkResolver()
   const namespace = useMemo(
-    () => JSON.parse(organizationPage.organization?.namespace?.fields ?? '{}'),
+    () => JSON.parse(organizationPage.organization?.namespace?.fields || '{}'),
     [organizationPage.organization?.namespace?.fields],
   )
   const n = useNamespace(namespace)

--- a/apps/web/components/Organization/Wrapper/Themes/VinnueftirlitidTheme/VinnueftirlitidHeader.tsx
+++ b/apps/web/components/Organization/Wrapper/Themes/VinnueftirlitidTheme/VinnueftirlitidHeader.tsx
@@ -19,7 +19,7 @@ const VinnueftilitidHeader: React.FC<React.PropsWithChildren<HeaderProps>> = ({
 }) => {
   const { linkResolver } = useLinkResolver()
   const namespace = useMemo(
-    () => JSON.parse(organizationPage.organization?.namespace?.fields ?? '{}'),
+    () => JSON.parse(organizationPage.organization?.namespace?.fields || '{}'),
     [organizationPage.organization?.namespace?.fields],
   )
   const n = useNamespace(namespace)

--- a/apps/web/components/Project/Header/DirectorateOfHealthDashboardHeader.tsx
+++ b/apps/web/components/Project/Header/DirectorateOfHealthDashboardHeader.tsx
@@ -18,7 +18,7 @@ export const DirectorateOfHealthDashboardHeader: React.FC<
   React.PropsWithChildren<DirectorateOfHealthDashboardHeaderProps>
 > = ({ projectPage }) => {
   const namespace = useMemo(() => {
-    return JSON.parse(projectPage?.namespace?.fields ?? '{}')
+    return JSON.parse(projectPage?.namespace?.fields || '{}')
   }, [projectPage?.namespace?.fields])
   const { activeLocale } = useI18n()
 

--- a/apps/web/components/Project/Header/FiskistofaDashboardHeader.tsx
+++ b/apps/web/components/Project/Header/FiskistofaDashboardHeader.tsx
@@ -13,7 +13,7 @@ export const FiskistofaDashboardHeader: React.FC<
   React.PropsWithChildren<FiskistofaDashboardHeaderProps>
 > = ({ projectPage }) => {
   const namespace = useMemo(() => {
-    return JSON.parse(projectPage?.namespace?.fields ?? '{}')
+    return JSON.parse(projectPage?.namespace?.fields || '{}')
   }, [projectPage?.namespace?.fields])
 
   const n = useNamespace(namespace)

--- a/apps/web/components/SignLanguageButton/SignLanguageButton.tsx
+++ b/apps/web/components/SignLanguageButton/SignLanguageButton.tsx
@@ -44,7 +44,7 @@ export const SignLanguageButton = ({
   )
 
   const namespace = useMemo(
-    () => JSON.parse(data?.getNamespace?.fields ?? '{}'),
+    () => JSON.parse(data?.getNamespace?.fields || '{}'),
     [data?.getNamespace?.fields],
   )
 

--- a/apps/web/screens/Article/Article.tsx
+++ b/apps/web/screens/Article/Article.tsx
@@ -850,7 +850,7 @@ ArticleScreen.getProps = async ({ apolloClient, query, locale }) => {
       })
       .then((content) => {
         // map data here to reduce data processing in component
-        return JSON.parse(content?.data?.getNamespace?.fields ?? '{}')
+        return JSON.parse(content?.data?.getNamespace?.fields || '{}')
       }),
   ])
 

--- a/apps/web/screens/Category/Categories/Categories.tsx
+++ b/apps/web/screens/Category/Categories/Categories.tsx
@@ -58,7 +58,7 @@ Categories.getProps = async ({ apolloClient, locale }) => {
           },
         },
       })
-      .then((res) => JSON.parse(res?.data?.getNamespace?.fields ?? '{}')),
+      .then((res) => JSON.parse(res?.data?.getNamespace?.fields || '{}')),
   ])
 
   return {

--- a/apps/web/screens/Home/Home.tsx
+++ b/apps/web/screens/Home/Home.tsx
@@ -39,7 +39,7 @@ interface HomeProps {
 }
 
 const Home: Screen<HomeProps> = ({ categories, news, page, locale }) => {
-  const namespace = JSON.parse(page?.namespace?.fields ?? '{}')
+  const namespace = JSON.parse(page?.namespace?.fields || '{}')
   const { activeLocale } = useI18n()
   const { globalNamespace } = useContext(GlobalContext)
   const n = useNamespace(namespace)

--- a/apps/web/screens/Organization/PublishedMaterial/PublishedMaterial.tsx
+++ b/apps/web/screens/Organization/PublishedMaterial/PublishedMaterial.tsx
@@ -527,7 +527,7 @@ PublishedMaterial.getProps = async ({ apolloClient, locale, query }) => {
       })
       .then((variables) => {
         // map data here to reduce data processing in component
-        return JSON.parse(variables?.data?.getNamespace?.fields ?? '{}')
+        return JSON.parse(variables?.data?.getNamespace?.fields || '{}')
       }),
   ])
 

--- a/apps/web/screens/ServiceWeb/Forms/Forms.tsx
+++ b/apps/web/screens/ServiceWeb/Forms/Forms.tsx
@@ -96,7 +96,7 @@ const ServiceWebFormsPage: Screen<ServiceWebFormsPageProps> = ({
   useLocalLinkTypeResolver()
 
   const organizationNamespace = useMemo(
-    () => JSON.parse(organization?.namespace?.fields ?? '{}'),
+    () => JSON.parse(organization?.namespace?.fields || '{}'),
     [organization?.namespace],
   )
   const o = useNamespace(organizationNamespace)
@@ -434,7 +434,7 @@ ServiceWebFormsPage.getProps = async ({ apolloClient, locale, query }) => {
       })
       .then(
         (variables) =>
-          JSON.parse(variables?.data?.getNamespace?.fields ?? '{}')?.entities ??
+          JSON.parse(variables?.data?.getNamespace?.fields || '{}')?.entities ??
           [],
       ),
     apolloClient
@@ -448,7 +448,7 @@ ServiceWebFormsPage.getProps = async ({ apolloClient, locale, query }) => {
         },
       })
       .then((variables) =>
-        JSON.parse(variables?.data?.getNamespace?.fields ?? '{}'),
+        JSON.parse(variables?.data?.getNamespace?.fields || '{}'),
       ),
     apolloClient.query<Query, QueryGetServiceWebPageArgs>({
       query: GET_SERVICE_WEB_PAGE_QUERY,

--- a/apps/web/screens/ServiceWeb/Search/ServiceSearch.tsx
+++ b/apps/web/screens/ServiceWeb/Search/ServiceSearch.tsx
@@ -83,7 +83,7 @@ const ServiceSearch: Screen<ServiceSearchProps> = ({
   })
   const { linkResolver } = useLinkResolver()
   const organizationNamespace = useMemo(
-    () => JSON.parse(organization?.namespace?.fields ?? '{}'),
+    () => JSON.parse(organization?.namespace?.fields || '{}'),
     [organization?.namespace?.fields],
   )
   const o = useNamespace(organizationNamespace)
@@ -431,7 +431,7 @@ ServiceSearch.getProps = async ({ apolloClient, locale, query }) => {
       })
       .then((variables) => {
         // map data here to reduce data processing in component
-        return JSON.parse(variables?.data?.getNamespace?.fields ?? '{}')
+        return JSON.parse(variables?.data?.getNamespace?.fields || '{}')
       }),
     apolloClient.query<Query, QueryGetServiceWebPageArgs>({
       query: GET_SERVICE_WEB_PAGE_QUERY,


### PR DESCRIPTION
# Use || instead of ?? for JSON.parse fallback

## What

* The CMS can return an empty string, this means that the JSON.parse call will throw an error
* By using || instead of ?? we prevent the JSON.parse call from throwing an error in case there is an empty string

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the handling of `fields` properties across multiple components to ensure they default to an empty object if falsy, improving reliability and preventing potential errors.
  
- **Refactor**
	- Adjusted variable initialization methods for consistency across various themes and components, enhancing code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->