### PR TITLE
feat(web): Language Toggler - Pass query params props

### DIFF
--- a/apps/web/components/Header/Header.tsx
+++ b/apps/web/components/Header/Header.tsx
@@ -120,6 +120,7 @@ export const Header: FC<React.PropsWithChildren<HeaderProps>> = ({
                         buttonColorScheme={buttonColorScheme}
                         onMenuOpen={webMenuButtonClicked}
                         organizationSearchFilter={organizationSearchFilter}
+                        languageToggleQueryParams={languageToggleQueryParams}
                       />
                     </Box>
                   </Box>

--- a/apps/web/components/Menu/Menu.tsx
+++ b/apps/web/components/Menu/Menu.tsx
@@ -11,6 +11,7 @@ import {
 import { SearchInput } from '@island.is/web/components'
 import { LinkResolverResponse } from '@island.is/web/hooks/useLinkResolver'
 import { useI18n } from '@island.is/web/i18n'
+import type { LayoutProps } from '@island.is/web/layouts/main'
 
 import { LanguageToggler } from '../LanguageToggler'
 
@@ -29,6 +30,7 @@ interface Props {
   buttonColorScheme?: ButtonTypes['colorScheme']
   onMenuOpen?: () => void
   organizationSearchFilter?: string
+  languageToggleQueryParams?: LayoutProps['languageToggleQueryParams']
 }
 
 const minarsidurLink = '/minarsidur/'
@@ -41,6 +43,7 @@ export const Menu = ({
   buttonColorScheme = 'default',
   onMenuOpen,
   organizationSearchFilter,
+  languageToggleQueryParams,
 }: Props) => {
   const searchInput = useRef<HTMLInputElement>()
   const { activeLocale, t } = useI18n()
@@ -133,6 +136,7 @@ export const Menu = ({
           dialogId={
             isMobile ? 'menu-language-toggle-mobile' : 'menu-language-toggle'
           }
+          queryParams={languageToggleQueryParams}
         />
       )}
       renderSearch={(input, closeModal) => (


### PR DESCRIPTION
# Language Toggler - Pass query params props

## What

* We want the language toggler to be able to set query params

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new optional property for the `Menu` component to enhance language toggling functionality.
	- Updated the `Header` component to support the new language toggle feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->