### PR TITLE
feat(native-app): add more info on passkey screen

### DIFF
--- a/apps/native/app/src/messages/en.ts
+++ b/apps/native/app/src/messages/en.ts
@@ -595,7 +595,7 @@ export const en: TranslatedMessages = {
     'Do you want to create a passkey to sign in automatically with the app?',
   'passkeys.settings':
     'In settings it is always possible to delete or add a passkey',
-  'passkeys.furtherInformation': 'Further information about passkeys',
+  'passkeys.furtherInformation': 'More about passkeys',
   'passkeys.createButton': 'Create a passkey',
   'passkeys.skipButton': 'Skip',
   'passkeys.errorRegistering': 'Error',

--- a/apps/native/app/src/messages/en.ts
+++ b/apps/native/app/src/messages/en.ts
@@ -593,6 +593,9 @@ export const en: TranslatedMessages = {
     'You are opening Island.is in a browser. Do you want to create a passkey to sign in automatically with the app?',
   'passkeys.headingSubtitle':
     'Do you want to create a passkey to sign in automatically with the app?',
+  'passkeys.settings':
+    'In settings it is always possible to delete or add a passkey',
+  'passkeys.furtherInformation': 'Further information about passkeys',
   'passkeys.createButton': 'Create a passkey',
   'passkeys.skipButton': 'Skip',
   'passkeys.errorRegistering': 'Error',

--- a/apps/native/app/src/messages/is.ts
+++ b/apps/native/app/src/messages/is.ts
@@ -593,6 +593,9 @@ export const is = {
     'Þú ert að fara að opna Ísland.is í vafra. Viltu búa til aðgangslykil til að skrá þig inn sjálfkrafa með appinu?',
   'passkeys.headingSubtitle':
     'Viltu búa til aðgangslykil til að skrá þig inn sjálfkrafa með appinu?',
+  'passkeys.settings':
+    'Undir stillingum er alltaf hægt að eyða eða búa til aðgangslykil',
+  'passkeys.furtherInformation': 'Nánar um aðgangslykla',
   'passkeys.createButton': 'Búa til aðgangslykil',
   'passkeys.skipButton': 'Sleppa',
   'passkeys.errorRegistering': 'Villa',

--- a/apps/native/app/src/screens/passkey/passkey.tsx
+++ b/apps/native/app/src/screens/passkey/passkey.tsx
@@ -1,4 +1,4 @@
-import { Button, Typography, NavigationBarSheet } from '@ui'
+import { Button, Typography, NavigationBarSheet, LinkText } from '@ui'
 import React, { useEffect, useState } from 'react'
 import { useIntl, FormattedMessage } from 'react-intl'
 import {
@@ -7,6 +7,8 @@ import {
   SafeAreaView,
   ActivityIndicator,
   Alert,
+  TouchableOpacity,
+  useWindowDimensions,
 } from 'react-native'
 import styled, { useTheme } from 'styled-components/native'
 import {
@@ -15,6 +17,7 @@ import {
 } from 'react-native-navigation'
 import { createNavigationOptionHooks } from '../../hooks/create-navigation-option-hooks'
 import logo from '../../assets/logo/logo-64w.png'
+import externalLink from '../../assets/icons/external-link.png'
 import illustrationSrc from '../../assets/illustrations/digital-services-m1-dots.png'
 import { openNativeBrowser } from '../../lib/rn-island'
 import { preferencesStore } from '../../stores/preferences-store'
@@ -24,16 +27,19 @@ import { authStore } from '../../stores/auth-store'
 import { useBrowser } from '../../lib/use-browser'
 import { addPasskeyAsLoginHint } from '../../lib/passkeys/helpers'
 
-const Text = styled.View`
+const Text = styled.View<{ isSmallDevice: boolean }>`
   margin-horizontal: ${({ theme }) => theme.spacing[7]}px;
   text-align: center;
-  margin-bottom: ${({ theme }) => theme.spacing[5]}px;
-  margin-top: ${({ theme }) => theme.spacing[5]}px;
+  margin-bottom: ${({ theme }) => theme.spacing[2]}px;
+  margin-top: ${({ theme, isSmallDevice }) =>
+    isSmallDevice ? theme.spacing[2] : theme.spacing[3]}px;
 `
 
-const Host = styled.View`
+const Host = styled.View<{ isSmallDevice: boolean }>`
   justify-content: center;
   align-items: center;
+  margin-top: ${({ theme, isSmallDevice }) =>
+    isSmallDevice ? -theme.spacing[3] : 0}px;
   flex: 1;
 `
 
@@ -45,6 +51,17 @@ const ButtonWrapper = styled.View`
 const Title = styled(Typography)`
   padding-horizontal: ${({ theme }) => theme.spacing[2]}px;
   margin-bottom: ${({ theme }) => theme.spacing[2]}px;
+`
+const SettingsMessage = styled(Typography)<{ isSmallDevice: boolean }>`
+  margin-top: ${({ theme, isSmallDevice }) =>
+    isSmallDevice ? theme.spacing[1] : theme.spacing[2]}px;
+  max-width: 265px;
+  text-align: center;
+`
+
+const LinkWrapper = styled.View<{ isSmallDevice: boolean }>`
+  margin-bottom: ${({ theme, isSmallDevice }) =>
+    isSmallDevice ? theme.spacing[2] : theme.spacing[3]}px;
 `
 
 const LoadingOverlay = styled.View`
@@ -79,6 +96,8 @@ export const PasskeyScreen: NavigationFunctionComponent<{
   const intl = useIntl()
   const theme = useTheme()
   const { openBrowser } = useBrowser()
+  const { height } = useWindowDimensions()
+  const isSmallDevice = height < 800
   const [isLoading, setIsLoading] = useState(false)
 
   const { registerPasskey } = useRegisterPasskey()
@@ -99,13 +118,13 @@ export const PasskeyScreen: NavigationFunctionComponent<{
         style={{ marginHorizontal: 16 }}
       />
       <SafeAreaView style={{ flex: 1 }}>
-        <Host>
+        <Host isSmallDevice={isSmallDevice}>
           <Image
             source={logo}
             resizeMode="contain"
             style={{ width: 45, height: 45 }}
           />
-          <Text>
+          <Text isSmallDevice={isSmallDevice}>
             <Title variant={'heading2'} textAlign="center">
               <FormattedMessage
                 id="passkeys.headingTitle"
@@ -127,11 +146,30 @@ export const PasskeyScreen: NavigationFunctionComponent<{
               />
             </Typography>
           </Text>
+          <LinkWrapper isSmallDevice={isSmallDevice}>
+            <TouchableOpacity
+              style={{ flexWrap: 'wrap' }}
+              onPress={() =>
+                openBrowser('https://island.is/adgangslyklar', componentId)
+              }
+            >
+              <LinkText>
+                <FormattedMessage id="passkeys.furtherInformation" />{' '}
+                <Image source={externalLink} />
+              </LinkText>
+            </TouchableOpacity>
+          </LinkWrapper>
           <Image
             source={illustrationSrc}
-            style={{ width: 210, height: 240 }}
+            style={{
+              width: isSmallDevice ? 120 : 174,
+              height: isSmallDevice ? 140 : 204,
+            }}
             resizeMode="contain"
           />
+          <SettingsMessage variant="body3" isSmallDevice={isSmallDevice}>
+            <FormattedMessage id="passkeys.settings" />
+          </SettingsMessage>
         </Host>
         <ButtonWrapper>
           <Button

--- a/apps/native/app/src/screens/passkey/passkey.tsx
+++ b/apps/native/app/src/screens/passkey/passkey.tsx
@@ -99,7 +99,6 @@ export const PasskeyScreen: NavigationFunctionComponent<{
   const { height } = useWindowDimensions()
   const isSmallDevice = height < 800
   const [isLoading, setIsLoading] = useState(false)
-
   const { registerPasskey } = useRegisterPasskey()
   const { authenticatePasskey } = useAuthenticatePasskey()
 
@@ -159,14 +158,16 @@ export const PasskeyScreen: NavigationFunctionComponent<{
               </LinkText>
             </TouchableOpacity>
           </LinkWrapper>
-          <Image
-            source={illustrationSrc}
-            style={{
-              width: isSmallDevice ? 120 : 174,
-              height: isSmallDevice ? 140 : 204,
-            }}
-            resizeMode="contain"
-          />
+          {height > 650 && (
+            <Image
+              source={illustrationSrc}
+              style={{
+                width: isSmallDevice ? 120 : 174,
+                height: isSmallDevice ? 140 : 204,
+              }}
+              resizeMode="contain"
+            />
+          )}
           <SettingsMessage variant="body3" isSmallDevice={isSmallDevice}>
             <FormattedMessage id="passkeys.settings" />
           </SettingsMessage>


### PR DESCRIPTION
## What

Add link to island.is with more info about passkeys and a small clause at the bottom that this can always be changed in settings.
Also adjusted the screen more for smaller screen sizes. If height of the screen is less than 800px then I make the image smaller and have less margin between elements to be sure that everything is in view. If this is an extra extra small screen (height < 650 px) then we skip the image.

## Screenshots / Gifs
On iPhone 16 (393x852) and iPhone SE (375x667):
<div><img height = "770" src="https://github.com/user-attachments/assets/73bb158e-1968-44fc-bafe-97948b92a986">
<img height = "770" src="https://github.com/user-attachments/assets/56694ad5-bdc9-48c5-acd3-6108fb913fa5"></div>


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
