### PR TITLE
feat(search-indexer): Move mapping logic to separate class

### DIFF
--- a/libs/cms/src/lib/search/cmsSync.module.ts
+++ b/libs/cms/src/lib/search/cmsSync.module.ts
@@ -32,6 +32,7 @@ import { ManualChapterItemSyncService } from './importers/manualChapterItem.serv
 import { CustomPageSyncService } from './importers/customPage.service'
 import { GenericListItemSyncService } from './importers/genericListItem.service'
 import { TeamListSyncService } from './importers/teamList.service'
+import { MappingService } from './mapping.service'
 
 @Module({
   imports: [
@@ -69,6 +70,7 @@ import { TeamListSyncService } from './importers/teamList.service'
     CustomPageSyncService,
     GenericListItemSyncService,
     TeamListSyncService,
+    MappingService,
   ],
   exports: [CmsSyncService],
 })

--- a/libs/cms/src/lib/search/cmsSync.service.ts
+++ b/libs/cms/src/lib/search/cmsSync.service.ts
@@ -8,34 +8,11 @@ import {
   SyncOptions,
   SyncResponse,
 } from '@island.is/content-search-indexer/types'
-import { ArticleSyncService } from './importers/article.service'
-import { SubArticleSyncService } from './importers/subArticle.service'
 import { ContentfulService } from './contentful.service'
-import { AnchorPageSyncService } from './importers/anchorPage.service'
-import { LifeEventPageSyncService } from './importers/lifeEventPage.service'
-import { ArticleCategorySyncService } from './importers/articleCategory.service'
-import { NewsSyncService } from './importers/news.service'
 import { Entry } from 'contentful'
 import { ElasticService, SearchInput } from '@island.is/content-search-toolkit'
-import { AdgerdirPageSyncService } from './importers/adgerdirPage'
-import { MenuSyncService } from './importers/menu.service'
-import { GroupedMenuSyncService } from './importers/groupedMenu.service'
 import { getElasticsearchIndex } from '@island.is/content-search-index-manager'
-import { OrganizationPageSyncService } from './importers/organizationPage.service'
-import { OrganizationSubpageSyncService } from './importers/organizationSubpage.service'
-import { FrontpageSyncService } from './importers/frontpage.service'
-import { SupportQNASyncService } from './importers/supportQNA.service'
-import { LinkSyncService } from './importers/link.service'
-import { ProjectPageSyncService } from './importers/projectPage.service'
-import { EnhancedAssetSyncService } from './importers/enhancedAsset.service'
-import { VacancySyncService } from './importers/vacancy.service'
-import { ServiceWebPageSyncService } from './importers/serviceWebPage.service'
-import { EventSyncService } from './importers/event.service'
-import { ManualSyncService } from './importers/manual.service'
-import { ManualChapterItemSyncService } from './importers/manualChapterItem.service'
-import { CustomPageSyncService } from './importers/customPage.service'
-import { GenericListItemSyncService } from './importers/genericListItem.service'
-import { TeamListSyncService } from './importers/teamList.service'
+import { MappingService } from './mapping.service'
 
 export interface PostSyncOptions {
   folderHash: string
@@ -56,62 +33,11 @@ export interface CmsSyncProvider<T, ProcessOutput = any> {
 
 @Injectable()
 export class CmsSyncService implements ContentSearchImporter<PostSyncOptions> {
-  private contentSyncProviders: CmsSyncProvider<any>[]
   constructor(
-    private readonly newsSyncService: NewsSyncService,
-    private readonly articleCategorySyncService: ArticleCategorySyncService,
-    private readonly articleSyncService: ArticleSyncService,
-    private readonly subArticleSyncService: SubArticleSyncService,
-    private readonly anchorPageSyncService: AnchorPageSyncService,
-    private readonly lifeEventPageSyncService: LifeEventPageSyncService,
-    private readonly adgerdirPageSyncService: AdgerdirPageSyncService,
     private readonly contentfulService: ContentfulService,
-    private readonly menuSyncService: MenuSyncService,
-    private readonly groupedMenuSyncService: GroupedMenuSyncService,
-    private readonly organizationPageSyncService: OrganizationPageSyncService,
-    private readonly organizationSubpageSyncService: OrganizationSubpageSyncService,
-    private readonly projectPageSyncService: ProjectPageSyncService,
-    private readonly frontpageSyncService: FrontpageSyncService,
-    private readonly supportQNASyncService: SupportQNASyncService,
-    private readonly linkSyncService: LinkSyncService,
-    private readonly enhancedAssetService: EnhancedAssetSyncService,
+    private readonly mappingService: MappingService,
     private readonly elasticService: ElasticService,
-    private readonly vacancyService: VacancySyncService,
-    private readonly serviceWebPageSyncService: ServiceWebPageSyncService,
-    private readonly eventSyncService: EventSyncService,
-    private readonly manualSyncService: ManualSyncService,
-    private readonly manualChapterItemSyncService: ManualChapterItemSyncService,
-    private readonly customPageSyncService: CustomPageSyncService,
-    private readonly genericListItemSyncService: GenericListItemSyncService,
-    private readonly teamListSyncService: TeamListSyncService,
-  ) {
-    this.contentSyncProviders = [
-      this.articleSyncService,
-      this.subArticleSyncService,
-      this.anchorPageSyncService,
-      this.lifeEventPageSyncService,
-      this.articleCategorySyncService,
-      this.newsSyncService,
-      this.adgerdirPageSyncService,
-      this.menuSyncService,
-      this.groupedMenuSyncService,
-      this.organizationPageSyncService,
-      this.organizationSubpageSyncService,
-      this.projectPageSyncService,
-      this.frontpageSyncService,
-      this.supportQNASyncService,
-      this.linkSyncService,
-      this.enhancedAssetService,
-      this.vacancyService,
-      this.serviceWebPageSyncService,
-      this.eventSyncService,
-      this.manualSyncService,
-      this.manualChapterItemSyncService,
-      this.customPageSyncService,
-      this.genericListItemSyncService,
-      this.teamListSyncService,
-    ]
-  }
+  ) {}
 
   private async getLastFolderHash(elasticIndex: string): Promise<string> {
     logger.info('Getting folder hash from index', {
@@ -228,12 +154,7 @@ export class CmsSyncService implements ContentSearchImporter<PostSyncOptions> {
     logger.info('Got sync data')
 
     // import data from all providers
-    const importableData = this.contentSyncProviders.map(
-      (contentSyncProvider) => {
-        const data = contentSyncProvider.processSyncData(items)
-        return contentSyncProvider.doMapping(data)
-      },
-    )
+    const importableData = this.mappingService.mapData(items)
 
     return {
       add: flatten(importableData),

--- a/libs/cms/src/lib/search/mapping.service.ts
+++ b/libs/cms/src/lib/search/mapping.service.ts
@@ -1,0 +1,93 @@
+import { Injectable } from '@nestjs/common'
+
+import { ArticleSyncService } from './importers/article.service'
+import { SubArticleSyncService } from './importers/subArticle.service'
+import { AnchorPageSyncService } from './importers/anchorPage.service'
+import { LifeEventPageSyncService } from './importers/lifeEventPage.service'
+import { ArticleCategorySyncService } from './importers/articleCategory.service'
+import { NewsSyncService } from './importers/news.service'
+import { AdgerdirPageSyncService } from './importers/adgerdirPage'
+import { MenuSyncService } from './importers/menu.service'
+import { GroupedMenuSyncService } from './importers/groupedMenu.service'
+import { OrganizationPageSyncService } from './importers/organizationPage.service'
+import { OrganizationSubpageSyncService } from './importers/organizationSubpage.service'
+import { FrontpageSyncService } from './importers/frontpage.service'
+import { SupportQNASyncService } from './importers/supportQNA.service'
+import { LinkSyncService } from './importers/link.service'
+import { ProjectPageSyncService } from './importers/projectPage.service'
+import { EnhancedAssetSyncService } from './importers/enhancedAsset.service'
+import { VacancySyncService } from './importers/vacancy.service'
+import { ServiceWebPageSyncService } from './importers/serviceWebPage.service'
+import { EventSyncService } from './importers/event.service'
+import { ManualSyncService } from './importers/manual.service'
+import { ManualChapterItemSyncService } from './importers/manualChapterItem.service'
+import { CustomPageSyncService } from './importers/customPage.service'
+import { GenericListItemSyncService } from './importers/genericListItem.service'
+import { TeamListSyncService } from './importers/teamList.service'
+import type { CmsSyncProvider, processSyncDataInput } from './cmsSync.service'
+
+@Injectable()
+export class MappingService {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private contentSyncProviders: CmsSyncProvider<any>[]
+  constructor(
+    private readonly newsSyncService: NewsSyncService,
+    private readonly articleCategorySyncService: ArticleCategorySyncService,
+    private readonly articleSyncService: ArticleSyncService,
+    private readonly subArticleSyncService: SubArticleSyncService,
+    private readonly anchorPageSyncService: AnchorPageSyncService,
+    private readonly lifeEventPageSyncService: LifeEventPageSyncService,
+    private readonly adgerdirPageSyncService: AdgerdirPageSyncService,
+    private readonly menuSyncService: MenuSyncService,
+    private readonly groupedMenuSyncService: GroupedMenuSyncService,
+    private readonly organizationPageSyncService: OrganizationPageSyncService,
+    private readonly organizationSubpageSyncService: OrganizationSubpageSyncService,
+    private readonly projectPageSyncService: ProjectPageSyncService,
+    private readonly frontpageSyncService: FrontpageSyncService,
+    private readonly supportQNASyncService: SupportQNASyncService,
+    private readonly linkSyncService: LinkSyncService,
+    private readonly enhancedAssetService: EnhancedAssetSyncService,
+    private readonly vacancyService: VacancySyncService,
+    private readonly serviceWebPageSyncService: ServiceWebPageSyncService,
+    private readonly eventSyncService: EventSyncService,
+    private readonly manualSyncService: ManualSyncService,
+    private readonly manualChapterItemSyncService: ManualChapterItemSyncService,
+    private readonly customPageSyncService: CustomPageSyncService,
+    private readonly genericListItemSyncService: GenericListItemSyncService,
+    private readonly teamListSyncService: TeamListSyncService,
+  ) {
+    this.contentSyncProviders = [
+      this.articleSyncService,
+      this.subArticleSyncService,
+      this.anchorPageSyncService,
+      this.lifeEventPageSyncService,
+      this.articleCategorySyncService,
+      this.newsSyncService,
+      this.adgerdirPageSyncService,
+      this.menuSyncService,
+      this.groupedMenuSyncService,
+      this.organizationPageSyncService,
+      this.organizationSubpageSyncService,
+      this.projectPageSyncService,
+      this.frontpageSyncService,
+      this.supportQNASyncService,
+      this.linkSyncService,
+      this.enhancedAssetService,
+      this.vacancyService,
+      this.serviceWebPageSyncService,
+      this.eventSyncService,
+      this.manualSyncService,
+      this.manualChapterItemSyncService,
+      this.customPageSyncService,
+      this.genericListItemSyncService,
+      this.teamListSyncService,
+    ]
+  }
+
+  mapData(entries: processSyncDataInput<unknown>) {
+    return this.contentSyncProviders.map((contentSyncProvider) => {
+      const data = contentSyncProvider.processSyncData(entries)
+      return contentSyncProvider.doMapping(data)
+    })
+  }
+}


### PR DESCRIPTION
# Move mapping logic to separate class

## What

* Now there is a MappingService class that takes care of mapping cms data into elasticsearch data.

* Instead of writing all resolved root entries from nested entries alongside other entries we now separately write them down to elasticsearch to reduce the memory load

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the `MappingService` to enhance content synchronization and mapping capabilities.
	- Updated `ContentfulService` to improve nested entries resolution with progress tracking.

- **Bug Fixes**
	- Simplified `CmsSyncService` to streamline dependency management and improve data processing.

- **Improvements**
	- Enhanced `doSync` method in `CmsSyncService` for a more centralized mapping approach.
	- Refined `resolveNestedEntries` method in `ContentfulService` for better handling of indexable entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->