### PR TITLE
fix(signature-colletion): allow manager on paper upload

### DIFF
--- a/libs/api/domains/signature-collection/src/lib/guards/userAccess.guard.ts
+++ b/libs/api/domains/signature-collection/src/lib/guards/userAccess.guard.ts
@@ -28,6 +28,7 @@ export class UserAccessGuard implements CanActivate {
   private determineUserDelegationContext(
     user: Express.User & User,
   ): UserDelegationContext {
+    console.log('user', user)
     // If actor found on user, then user is delegated
     if (user.actor?.nationalId) {
       // If delegation is from person to person
@@ -56,7 +57,10 @@ export class UserAccessGuard implements CanActivate {
     const restrictGuarantors = m.getMetadataIfExists<boolean>(
       RESTRICT_GUARANTOR_KEY,
     )
-
+    console.log('isOwnerRestriction', isOwnerRestriction)
+    console.log('bypassAuth', bypassAuth)
+    console.log('allowDelegation', allowDelegation)
+    console.log('restrictGuarantors', restrictGuarantors)
     if (bypassAuth) {
       return true
     }
@@ -71,7 +75,7 @@ export class UserAccessGuard implements CanActivate {
       UserDelegationContext.PersonDelegatedToCompany,
       UserDelegationContext.PersonDelegatedToPerson,
     ].includes(delegationContext)
-
+    console.log('delegationContext', delegationContext)
     if (isDelegatedUser && !allowDelegation) {
       return false
     }
@@ -83,17 +87,19 @@ export class UserAccessGuard implements CanActivate {
     // IsOwner needs signee
     const signee = await this.signatureCollectionService.signee(user)
     request.body = { ...request.body, signee }
-
+    console.log('signee', signee)
     const { candidate } = signee
 
     if (isOwnerRestriction) {
       if (signee.isOwner && candidate) {
         // Check if user is an actor for owner and if so check if registered collector, if not actor will be added as collector
         if (isDelegatedUser && allowDelegation) {
+          console.log('calling is collector')
           const isCollector = await this.signatureCollectionService.isCollector(
             candidate.id,
             user,
           )
+          console.log('is collector', isCollector)
           return isCollector
         }
       }

--- a/libs/api/domains/signature-collection/src/lib/guards/userAccess.guard.ts
+++ b/libs/api/domains/signature-collection/src/lib/guards/userAccess.guard.ts
@@ -57,10 +57,7 @@ export class UserAccessGuard implements CanActivate {
     const restrictGuarantors = m.getMetadataIfExists<boolean>(
       RESTRICT_GUARANTOR_KEY,
     )
-    console.log('isOwnerRestriction', isOwnerRestriction)
-    console.log('bypassAuth', bypassAuth)
-    console.log('allowDelegation', allowDelegation)
-    console.log('restrictGuarantors', restrictGuarantors)
+
     if (bypassAuth) {
       return true
     }
@@ -87,19 +84,17 @@ export class UserAccessGuard implements CanActivate {
     // IsOwner needs signee
     const signee = await this.signatureCollectionService.signee(user)
     request.body = { ...request.body, signee }
-    console.log('signee', signee)
+
     const { candidate } = signee
 
     if (isOwnerRestriction) {
       if (signee.isOwner && candidate) {
         // Check if user is an actor for owner and if so check if registered collector, if not actor will be added as collector
         if (isDelegatedUser && allowDelegation) {
-          console.log('calling is collector')
           const isCollector = await this.signatureCollectionService.isCollector(
             candidate.id,
             user,
           )
-          console.log('is collector', isCollector)
           return isCollector
         }
       }

--- a/libs/api/domains/signature-collection/src/lib/guards/userAccess.guard.ts
+++ b/libs/api/domains/signature-collection/src/lib/guards/userAccess.guard.ts
@@ -28,7 +28,6 @@ export class UserAccessGuard implements CanActivate {
   private determineUserDelegationContext(
     user: Express.User & User,
   ): UserDelegationContext {
-    console.log('user', user)
     // If actor found on user, then user is delegated
     if (user.actor?.nationalId) {
       // If delegation is from person to person
@@ -72,7 +71,7 @@ export class UserAccessGuard implements CanActivate {
       UserDelegationContext.PersonDelegatedToCompany,
       UserDelegationContext.PersonDelegatedToPerson,
     ].includes(delegationContext)
-    console.log('delegationContext', delegationContext)
+
     if (isDelegatedUser && !allowDelegation) {
       return false
     }

--- a/libs/api/domains/signature-collection/src/lib/signatureCollection.resolver.ts
+++ b/libs/api/domains/signature-collection/src/lib/signatureCollection.resolver.ts
@@ -21,11 +21,7 @@ import {
   SignatureCollectionListIdInput,
   SignatureCollectionUploadPaperSignatureInput,
 } from './dto'
-import {
-  AllowManager,
-  CurrentSignee,
-  IsOwner,
-} from './decorators'
+import { AllowManager, CurrentSignee, IsOwner } from './decorators'
 import {
   SignatureCollection,
   SignatureCollectionCollector,

--- a/libs/api/domains/signature-collection/src/lib/signatureCollection.resolver.ts
+++ b/libs/api/domains/signature-collection/src/lib/signatureCollection.resolver.ts
@@ -22,7 +22,6 @@ import {
   SignatureCollectionUploadPaperSignatureInput,
 } from './dto'
 import {
-  AllowDelegation,
   AllowManager,
   CurrentSignee,
   IsOwner,
@@ -185,6 +184,7 @@ export class SignatureCollectionResolver {
 
   @Scopes(ApiScope.signatureCollection)
   @IsOwner()
+  @AllowManager()
   @Mutation(() => SignatureCollectionSuccess)
   @Audit()
   async signatureCollectionUploadPaperSignature(


### PR DESCRIPTION


## What

Allow manager to upload paper signatures

## Why

It is their right

## Screenshots / Gifs



## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced access control for uploading paper signatures with the addition of the `@AllowManager()` decorator.
  
- **Bug Fixes**
	- Removed unnecessary import statements to streamline the code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->