### PR TITLE
fix(signature-collection): refetch is owner 16.10

### DIFF
--- a/libs/service-portal/signature-collection/src/lib/messages.ts
+++ b/libs/service-portal/signature-collection/src/lib/messages.ts
@@ -190,9 +190,20 @@ export const m = defineMessages({
     defaultMessage: 'Þú ert að fara að hætta við söfnun meðmæla. Ertu viss?',
     description: '',
   },
+  cancelCollectionModalMessageLastList: {
+    id: 'sp.signatureCollection:cancelCollectionModalMessageLastList',
+    defaultMessage:
+      'Þú ert að fara að hætta við söfnun meðmæla í þessu kjördæmi. Þau meðmæli sem þú hefur nú þegar safnað munu eyðast. Athugaðu að með því að hætta við síðustu söfnun framboðsins verður framboðinu einnig eytt. Ertu viss um að þú viljir hætta við söfnun og eyða framboði?',
+    description: '',
+  },
   cancelCollectionModalConfirmButton: {
     id: 'sp.signatureCollection:modalConfirmButton',
     defaultMessage: 'Já, hætta við',
+    description: '',
+  },
+  cancelCollectionModalConfirmButtonLastList: {
+    id: 'sp.signatureCollection:cancelCollectionModalConfirmButtonLastList',
+    defaultMessage: 'Já, hætta við söfnun of eyða framboði',
     description: '',
   },
   cancelCollectionModalCancelButton: {

--- a/libs/service-portal/signature-collection/src/screens/Parliamentary/OwnerView/index.tsx
+++ b/libs/service-portal/signature-collection/src/screens/Parliamentary/OwnerView/index.tsx
@@ -33,10 +33,12 @@ import { formatNationalId } from '@island.is/portals/core'
 import SignedList from '../../shared/SignedList'
 
 const OwnerView = ({
+  refetchIsOwner,
   currentCollection,
   // list holder is an individual who owns a list or has a delegation of type Procuration Holder
   isListHolder,
 }: {
+  refetchIsOwner: () => void
   currentCollection: SignatureCollection
   isListHolder: boolean
 }) => {
@@ -54,6 +56,7 @@ const OwnerView = ({
       onCompleted: () => {
         toast.success(formatMessage(m.cancelCollectionModalToastSuccess))
         refetchListsForOwner()
+        refetchIsOwner()
       },
       onError: () => {
         toast.error(formatMessage(m.cancelCollectionModalToastError))
@@ -145,9 +148,13 @@ const OwnerView = ({
                               ' - ' +
                               list.area?.name
                             }
-                            description={formatMessage(
-                              m.cancelCollectionModalMessage,
-                            )}
+                            description={
+                              listsForOwner.length === 1
+                                ? formatMessage(
+                                    m.cancelCollectionModalMessageLastList,
+                                  )
+                                : formatMessage(m.cancelCollectionModalMessage)
+                            }
                             ariaLabel="delete"
                             disclosureElement={
                               <Tag outlined variant="red">
@@ -164,7 +171,9 @@ const OwnerView = ({
                               onCancelCollection(list.id)
                             }}
                             buttonTextConfirm={formatMessage(
-                              m.cancelCollectionModalConfirmButton,
+                              listsForOwner.length === 1
+                                ? m.cancelCollectionModalConfirmButtonLastList
+                                : m.cancelCollectionModalConfirmButton,
                             )}
                             buttonPropsConfirm={{
                               variant: 'primary',

--- a/libs/service-portal/signature-collection/src/screens/Parliamentary/OwnerView/index.tsx
+++ b/libs/service-portal/signature-collection/src/screens/Parliamentary/OwnerView/index.tsx
@@ -78,10 +78,13 @@ const OwnerView = ({
   return (
     <Stack space={8}>
       <Box marginTop={5}>
-        <Box marginBottom={8}>
-          <SignedList currentCollection={currentCollection} />
-        </Box>
-        <Box display="flex" justifyContent="spaceBetween" alignItems="baseline">
+        <SignedList currentCollection={currentCollection} />
+        <Box
+          display="flex"
+          justifyContent="spaceBetween"
+          alignItems="baseline"
+          marginTop={5}
+        >
           <Text variant="h4">
             {formatMessage(m.myListsDescription) + ' '}
             <Tooltip

--- a/libs/service-portal/signature-collection/src/screens/Parliamentary/OwnerView/index.tsx
+++ b/libs/service-portal/signature-collection/src/screens/Parliamentary/OwnerView/index.tsx
@@ -83,7 +83,7 @@ const OwnerView = ({
           display="flex"
           justifyContent="spaceBetween"
           alignItems="baseline"
-          marginTop={5}
+          marginTop={[5, 10]}
         >
           <Text variant="h4">
             {formatMessage(m.myListsDescription) + ' '}

--- a/libs/service-portal/signature-collection/src/screens/Parliamentary/index.tsx
+++ b/libs/service-portal/signature-collection/src/screens/Parliamentary/index.tsx
@@ -16,7 +16,7 @@ const SignatureListsParliamentary = () => {
   useNamespaces('sp.signatureCollection')
   const { formatMessage } = useLocale()
 
-  const { isOwner, loadingIsOwner } = useIsOwner()
+  const { isOwner, loadingIsOwner, refetchIsOwner } = useIsOwner()
   const userInfo = useUserInfo()
   const { currentCollection, loadingCurrentCollection } =
     useGetCurrentCollection()
@@ -34,6 +34,7 @@ const SignatureListsParliamentary = () => {
           {!currentCollection?.isPresidential ? (
             isOwner.success ? (
               <OwnerView
+                refetchIsOwner={refetchIsOwner}
                 currentCollection={currentCollection}
                 isListHolder={
                   !userInfo?.profile?.delegationType ||

--- a/libs/service-portal/signature-collection/src/screens/shared/SignedList/index.tsx
+++ b/libs/service-portal/signature-collection/src/screens/shared/SignedList/index.tsx
@@ -62,11 +62,6 @@ const SignedList = ({
 
   return (
     <Box>
-      {loadingSignedLists && (
-        <Box marginTop={10}>
-          <SingleListSkeleton />
-        </Box>
-      )}
       {!loadingSignedLists && !!signedLists?.length && (
         <Box marginTop={[5, 7]}>
           <Text marginBottom={2} variant="h4">

--- a/libs/service-portal/signature-collection/src/screens/shared/SignedList/index.tsx
+++ b/libs/service-portal/signature-collection/src/screens/shared/SignedList/index.tsx
@@ -12,7 +12,6 @@ import {
   SignatureCollectionSignedList,
   SignatureCollectionSuccess,
 } from '@island.is/api/schema'
-import { SingleListSkeleton } from '../../../skeletons'
 
 const SignedList = ({
   currentCollection,


### PR DESCRIPTION
## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added detailed cancellation messages for endorsement collections, improving user clarity.
	- Introduced a confirmation button label for canceling the last collection.

- **Enhancements**
	- Updated the `OwnerView` component to refresh owner status after cancellation.
	- Improved messaging in the `DialogPrompt` based on the number of lists.

- **Refactor**
	- Simplified rendering logic in the `SignedList` component by removing the loading skeleton.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->