### PR TITLE
chore(dsl): Remove global auth annotations

### DIFF
--- a/apps/air-discount-scheme/api/infra/api.ts
+++ b/apps/air-discount-scheme/api/infra/api.ts
@@ -23,10 +23,12 @@ export const serviceSetup = (services: {
         prod: 'https://innskra.island.is',
       },
       ELASTIC_NODE: {
-        dev: 'https://vpc-search-njkekqydiegezhr4vqpkfnw5la.eu-west-1.es.amazonaws.com',
+        dev:
+          'https://vpc-search-njkekqydiegezhr4vqpkfnw5la.eu-west-1.es.amazonaws.com',
         staging:
           'https://vpc-search-q6hdtjcdlhkffyxvrnmzfwphuq.eu-west-1.es.amazonaws.com',
-        prod: 'https://vpc-search-mw4w5c2m2g5edjrtvwbpzhkw24.eu-west-1.es.amazonaws.com',
+        prod:
+          'https://vpc-search-mw4w5c2m2g5edjrtvwbpzhkw24.eu-west-1.es.amazonaws.com',
       },
       BACKEND_URL: ref((h) => `http://${h.svc(services.adsBackend)}`),
       CONTENTFUL_HOST: {
@@ -53,9 +55,7 @@ export const serviceSetup = (services: {
         extraAnnotations: {
           dev: {},
           staging: {},
-          prod: {
-            'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
-          },
+          prod: {},
         },
         paths: ['/api/graphql'],
         public: true,

--- a/apps/air-discount-scheme/backend/infra/air-discount-scheme-backend.ts
+++ b/apps/air-discount-scheme/backend/infra/air-discount-scheme-backend.ts
@@ -36,10 +36,12 @@ export const serviceSetup = (): ServiceBuilder<'air-discount-scheme-backend'> =>
     .migrations()
     .redis({
       host: {
-        dev: 'clustercfg.general-redis-cluster-group.5fzau3.euw1.cache.amazonaws.com:6379',
+        dev:
+          'clustercfg.general-redis-cluster-group.5fzau3.euw1.cache.amazonaws.com:6379',
         staging:
           'clustercfg.general-redis-cluster-group.ab9ckb.euw1.cache.amazonaws.com:6379',
-        prod: 'clustercfg.general-redis-cluster-group.whakos.euw1.cache.amazonaws.com:6379',
+        prod:
+          'clustercfg.general-redis-cluster-group.whakos.euw1.cache.amazonaws.com:6379',
       },
     })
     .ingress({
@@ -50,15 +52,9 @@ export const serviceSetup = (): ServiceBuilder<'air-discount-scheme-backend'> =>
           prod: 'loftbru',
         },
         extraAnnotations: {
-          dev: {
-            'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
-          },
-          staging: {
-            'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
-          },
-          prod: {
-            'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
-          },
+          dev: {},
+          staging: {},
+          prod: {},
         },
         paths: ['/api/swagger', '/api/public'],
       },

--- a/apps/air-discount-scheme/web/infra/web.ts
+++ b/apps/air-discount-scheme/web/infra/web.ts
@@ -60,7 +60,6 @@ export const serviceSetup = (services: {
           prod: {
             'nginx.ingress.kubernetes.io/proxy-buffering': 'on',
             'nginx.ingress.kubernetes.io/proxy-buffer-size': '8k',
-            'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
             'nginx.ingress.kubernetes.io/configuration-snippet':
               'rewrite /$ https://island.is/loftbru; rewrite /en$ https://island.is/en/lower-airfares-for-residents-in-rural-areas;',
           },

--- a/apps/api/infra/api.ts
+++ b/apps/api/infra/api.ts
@@ -99,10 +99,12 @@ export const serviceSetup = (services: {
         prod: 'https://innskra.island.is/api',
       },
       ELASTIC_NODE: {
-        dev: 'https://vpc-search-njkekqydiegezhr4vqpkfnw5la.eu-west-1.es.amazonaws.com',
+        dev:
+          'https://vpc-search-njkekqydiegezhr4vqpkfnw5la.eu-west-1.es.amazonaws.com',
         staging:
           'https://vpc-search-q6hdtjcdlhkffyxvrnmzfwphuq.eu-west-1.es.amazonaws.com/',
-        prod: 'https://vpc-search-mw4w5c2m2g5edjrtvwbpzhkw24.eu-west-1.es.amazonaws.com/',
+        prod:
+          'https://vpc-search-mw4w5c2m2g5edjrtvwbpzhkw24.eu-west-1.es.amazonaws.com/',
       },
 
       CONTENTFUL_HOST: {
@@ -161,7 +163,8 @@ export const serviceSetup = (services: {
       XROAD_FINANCES_TIMEOUT: '20000',
       XROAD_CHARGE_FJS_V2_TIMEOUT: '20000',
       AUTH_DELEGATION_API_URL: {
-        dev: 'http://web-services-auth-delegation-api.identity-server-delegation.svc.cluster.local',
+        dev:
+          'http://web-services-auth-delegation-api.identity-server-delegation.svc.cluster.local',
         staging:
           'http://web-services-auth-delegation-api.identity-server-delegation.svc.cluster.local',
         prod: 'https://auth-delegation-api.internal.innskra.island.is',
@@ -452,9 +455,7 @@ export const serviceSetup = (services: {
         paths: ['/api'],
         extraAnnotations: {
           dev: {},
-          staging: {
-            'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
-          },
+          staging: {},
           prod: {},
         },
         public: true,

--- a/apps/application-system/form/infra/application-system-form.ts
+++ b/apps/application-system/form/infra/application-system-form.ts
@@ -50,7 +50,6 @@ export const serviceSetup = (services: {
             'nginx.ingress.kubernetes.io/proxy-buffer-size': '8k',
           },
           staging: {
-            'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
             'nginx.ingress.kubernetes.io/proxy-buffering': 'on',
             'nginx.ingress.kubernetes.io/proxy-buffer-size': '8k',
           },

--- a/apps/consultation-portal/infra/samradsgatt.ts
+++ b/apps/consultation-portal/infra/samradsgatt.ts
@@ -56,7 +56,6 @@ export const serviceSetup = (services: {
             'nginx.ingress.kubernetes.io/proxy-buffer-size': '8k',
           },
           staging: {
-            'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
             'nginx.ingress.kubernetes.io/proxy-buffering': 'on',
             'nginx.ingress.kubernetes.io/proxy-buffer-size': '8k',
           },

--- a/apps/contentful-apps/infra/contentful-apps.ts
+++ b/apps/contentful-apps/infra/contentful-apps.ts
@@ -13,9 +13,7 @@ export const serviceSetup = (): ServiceBuilder<'contentful-apps'> =>
         },
         paths: ['/'],
         extraAnnotations: {
-          dev: {
-            'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
-          },
+          dev: {},
           staging: {},
           prod: {},
         },

--- a/apps/download-service/infra/download-service.ts
+++ b/apps/download-service/infra/download-service.ts
@@ -66,9 +66,7 @@ export const serviceSetup = (services: {
         paths: ['/download'],
         extraAnnotations: {
           dev: {},
-          staging: {
-            'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
-          },
+          staging: {},
           prod: {},
         },
         public: true,

--- a/apps/github-actions-cache/infra/github-actions-cache.ts
+++ b/apps/github-actions-cache/infra/github-actions-cache.ts
@@ -20,9 +20,7 @@ export const serviceSetup = (): ServiceBuilder<'github-actions-cache'> => {
         },
         paths: ['/'],
         extraAnnotations: {
-          dev: {
-            'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
-          },
+          dev: {},
           staging: {},
           prod: {},
         },

--- a/apps/portals/admin/infra/portals-admin.ts
+++ b/apps/portals/admin/infra/portals-admin.ts
@@ -42,7 +42,6 @@ export const serviceSetup = (): ServiceBuilder<'portals-admin'> =>
             'nginx.ingress.kubernetes.io/proxy-buffer-size': '8k',
           },
           staging: {
-            'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
             'nginx.ingress.kubernetes.io/proxy-buffering': 'on',
             'nginx.ingress.kubernetes.io/proxy-buffer-size': '8k',
           },

--- a/apps/portals/my-pages/infra/portals-my-pages.ts
+++ b/apps/portals/my-pages/infra/portals-my-pages.ts
@@ -49,7 +49,6 @@ export const serviceSetup = (services: {
             'nginx.ingress.kubernetes.io/proxy-buffer-size': '8k',
           },
           staging: {
-            'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
             'nginx.ingress.kubernetes.io/proxy-buffering': 'on',
             'nginx.ingress.kubernetes.io/proxy-buffer-size': '8k',
           },

--- a/apps/services/auth/admin-api/infra/auth-admin-api.ts
+++ b/apps/services/auth/admin-api/infra/auth-admin-api.ts
@@ -96,15 +96,9 @@ export const serviceSetup = (): ServiceBuilder<'services-auth-admin-api'> => {
         paths: ['/backend'],
         public: true,
         extraAnnotations: {
-          dev: {
-            'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
-          },
-          staging: {
-            'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
-          },
-          prod: {
-            'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
-          },
+          dev: {},
+          staging: {},
+          prod: {},
         },
       },
     })

--- a/apps/services/auth/ids-api/infra/identity-server.ts
+++ b/apps/services/auth/ids-api/infra/identity-server.ts
@@ -31,10 +31,12 @@ export const serviceSetup = (services: {
         prod: 'true',
       },
       RedisSettings__Address: {
-        dev: 'clustercfg.general-redis-cluster-group.5fzau3.euw1.cache.amazonaws.com',
+        dev:
+          'clustercfg.general-redis-cluster-group.5fzau3.euw1.cache.amazonaws.com',
         staging:
           'clustercfg.general-redis-cluster-group.ab9ckb.euw1.cache.amazonaws.com',
-        prod: 'clustercfg.general-redis-cluster-group.dnugi2.euw1.cache.amazonaws.com',
+        prod:
+          'clustercfg.general-redis-cluster-group.dnugi2.euw1.cache.amazonaws.com',
       },
       RedisSettings__Port: {
         dev: '6379',
@@ -84,7 +86,8 @@ export const serviceSetup = (services: {
         prod: 'https://cdn.contentful.com',
       },
       Application__AllowedRedirectUris: {
-        dev: 'https://beta.dev01.devland.is/minarsidur,https://beta.dev01.devland.is/umsoknir,http://localhost:4200/minarsidur,http://localhost:4242/umsoknir',
+        dev:
+          'https://beta.dev01.devland.is/minarsidur,https://beta.dev01.devland.is/umsoknir,http://localhost:4200/minarsidur,http://localhost:4242/umsoknir',
         staging:
           'https://beta.staging01.devland.is/minarsidur,https://beta.staging01.devland.is/umsoknir',
         prod: 'https://island.is/minarsidur,https://island.is/umsoknir',
@@ -120,12 +123,10 @@ export const serviceSetup = (services: {
         public: true,
         extraAnnotations: {
           dev: {
-            'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
             'nginx.ingress.kubernetes.io/proxy-buffering': 'on',
             'nginx.ingress.kubernetes.io/proxy-buffer-size': '8k',
           },
           staging: {
-            'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
             'nginx.ingress.kubernetes.io/proxy-buffering': 'on',
             'nginx.ingress.kubernetes.io/proxy-buffer-size': '8k',
           },

--- a/apps/services/auth/public-api/infra/auth-public-api.ts
+++ b/apps/services/auth/public-api/infra/auth-public-api.ts
@@ -92,19 +92,16 @@ export const serviceSetup = (): ServiceBuilder<'services-auth-public-api'> => {
           dev: {
             'nginx.ingress.kubernetes.io/proxy-buffering': 'on',
             'nginx.ingress.kubernetes.io/proxy-buffer-size': '8k',
-            'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
             'nginx.ingress.kubernetes.io/rewrite-target': '/$2',
           },
           staging: {
             'nginx.ingress.kubernetes.io/proxy-buffering': 'on',
             'nginx.ingress.kubernetes.io/proxy-buffer-size': '8k',
-            'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
             'nginx.ingress.kubernetes.io/rewrite-target': '/$2',
           },
           prod: {
             'nginx.ingress.kubernetes.io/proxy-buffering': 'on',
             'nginx.ingress.kubernetes.io/proxy-buffer-size': '8k',
-            'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
             'nginx.ingress.kubernetes.io/rewrite-target': '/$2',
           },
         },

--- a/apps/services/contentful-entry-tagger/infra/contentful-entry-tagger-service.ts
+++ b/apps/services/contentful-entry-tagger/infra/contentful-entry-tagger-service.ts
@@ -1,35 +1,30 @@
 import { service, ServiceBuilder } from '../../../../infra/src/dsl/dsl'
 
-export const serviceSetup =
-  (): ServiceBuilder<'contentful-entry-tagger-service'> =>
-    service('contentful-entry-tagger-service')
-      .image('services-contentful-entry-tagger')
-      .namespace('contentful-entry-tagger')
-      .serviceAccount('contentful-entry-tagger')
-      .secrets({
-        CONTENTFUL_MANAGEMENT_ACCESS_TOKEN:
-          '/k8s/contentful-entry-tagger/CONTENTFUL_MANAGEMENT_ACCESS_TOKEN',
-        CONTENTFUL_REQUEST_TOKEN:
-          '/k8s/contentful-entry-tagger/CONTENTFUL_REQUEST_TOKEN',
-      })
-      .ingress({
-        primary: {
-          host: {
-            dev: 'contentful-entry-tagger-service',
-            staging: 'contentful-entry-tagger-service',
-            prod: 'contentful-entry-tagger-service.devland.is',
-          },
-          paths: ['/'],
-          extraAnnotations: {
-            dev: {
-              'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
-            },
-            staging: {
-              'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
-            },
-            prod: { 'nginx.ingress.kubernetes.io/enable-global-auth': 'false' },
-          },
+export const serviceSetup = (): ServiceBuilder<'contentful-entry-tagger-service'> =>
+  service('contentful-entry-tagger-service')
+    .image('services-contentful-entry-tagger')
+    .namespace('contentful-entry-tagger')
+    .serviceAccount('contentful-entry-tagger')
+    .secrets({
+      CONTENTFUL_MANAGEMENT_ACCESS_TOKEN:
+        '/k8s/contentful-entry-tagger/CONTENTFUL_MANAGEMENT_ACCESS_TOKEN',
+      CONTENTFUL_REQUEST_TOKEN:
+        '/k8s/contentful-entry-tagger/CONTENTFUL_REQUEST_TOKEN',
+    })
+    .ingress({
+      primary: {
+        host: {
+          dev: 'contentful-entry-tagger-service',
+          staging: 'contentful-entry-tagger-service',
+          prod: 'contentful-entry-tagger-service.devland.is',
         },
-      })
-      .liveness('/liveness')
-      .readiness('/readiness')
+        paths: ['/'],
+        extraAnnotations: {
+          dev: {},
+          staging: {},
+          prod: { 'nginx.ingress.kubernetes.io/enable-global-auth': 'false' },
+        },
+      },
+    })
+    .liveness('/liveness')
+    .readiness('/readiness')

--- a/apps/services/license-api/infra/license-api.ts
+++ b/apps/services/license-api/infra/license-api.ts
@@ -80,9 +80,7 @@ export const serviceSetup = (): ServiceBuilder<'license-api'> =>
         public: false,
         extraAnnotations: {
           dev: {},
-          staging: {
-            'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
-          },
+          staging: {},
           prod: {},
         },
       },

--- a/apps/services/search-indexer/infra/search-indexer-service.ts
+++ b/apps/services/search-indexer/infra/search-indexer-service.ts
@@ -3,10 +3,12 @@ import { ref, service, ServiceBuilder } from '../../../../infra/src/dsl/dsl'
 const envs = {
   APPLICATION_URL: 'http://search-indexer-service',
   ELASTIC_NODE: {
-    dev: 'https://vpc-search-njkekqydiegezhr4vqpkfnw5la.eu-west-1.es.amazonaws.com',
+    dev:
+      'https://vpc-search-njkekqydiegezhr4vqpkfnw5la.eu-west-1.es.amazonaws.com',
     staging:
       'https://vpc-search-q6hdtjcdlhkffyxvrnmzfwphuq.eu-west-1.es.amazonaws.com',
-    prod: 'https://vpc-search-mw4w5c2m2g5edjrtvwbpzhkw24.eu-west-1.es.amazonaws.com',
+    prod:
+      'https://vpc-search-mw4w5c2m2g5edjrtvwbpzhkw24.eu-west-1.es.amazonaws.com',
   },
   ELASTIC_INDEX: 'island-is',
   CONTENTFUL_SPACE: '8k0h54kbe6bj',
@@ -121,12 +123,8 @@ export const serviceSetup = (): ServiceBuilder<'search-indexer-service'> =>
         },
         paths: ['/'],
         extraAnnotations: {
-          dev: {
-            'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
-          },
-          staging: {
-            'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
-          },
+          dev: {},
+          staging: {},
           prod: { 'nginx.ingress.kubernetes.io/enable-global-auth': 'false' },
         },
       },

--- a/apps/web/infra/web.ts
+++ b/apps/web/infra/web.ts
@@ -45,7 +45,6 @@ export const serviceSetup = (services: {
           prod: {
             'nginx.ingress.kubernetes.io/proxy-buffering': 'on',
             'nginx.ingress.kubernetes.io/proxy-buffer-size': '8k',
-            'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
           },
         },
         paths: ['/'],

--- a/charts/identity-server/values.dev.yaml
+++ b/charts/identity-server/values.dev.yaml
@@ -149,7 +149,6 @@ identity-server:
     primary-alb:
       annotations:
         kubernetes.io/ingress.class: 'nginx-external-alb'
-        nginx.ingress.kubernetes.io/enable-global-auth: 'false'
         nginx.ingress.kubernetes.io/proxy-buffer-size: '8k'
         nginx.ingress.kubernetes.io/proxy-buffering: 'on'
         nginx.ingress.kubernetes.io/service-upstream: 'true'
@@ -267,7 +266,6 @@ services-auth-admin-api:
     primary-alb:
       annotations:
         kubernetes.io/ingress.class: 'nginx-external-alb'
-        nginx.ingress.kubernetes.io/enable-global-auth: 'false'
         nginx.ingress.kubernetes.io/service-upstream: 'true'
       hosts:
         - host: 'identity-server.dev01.devland.is'
@@ -782,7 +780,6 @@ services-auth-public-api:
     primary-alb:
       annotations:
         kubernetes.io/ingress.class: 'nginx-external-alb'
-        nginx.ingress.kubernetes.io/enable-global-auth: 'false'
         nginx.ingress.kubernetes.io/proxy-buffer-size: '8k'
         nginx.ingress.kubernetes.io/proxy-buffering: 'on'
         nginx.ingress.kubernetes.io/rewrite-target: '/$2'

--- a/charts/identity-server/values.prod.yaml
+++ b/charts/identity-server/values.prod.yaml
@@ -264,7 +264,6 @@ services-auth-admin-api:
     primary-alb:
       annotations:
         kubernetes.io/ingress.class: 'nginx-external-alb'
-        nginx.ingress.kubernetes.io/enable-global-auth: 'false'
         nginx.ingress.kubernetes.io/service-upstream: 'true'
       hosts:
         - host: 'innskra.island.is'
@@ -779,7 +778,6 @@ services-auth-public-api:
     primary-alb:
       annotations:
         kubernetes.io/ingress.class: 'nginx-external-alb'
-        nginx.ingress.kubernetes.io/enable-global-auth: 'false'
         nginx.ingress.kubernetes.io/proxy-buffer-size: '8k'
         nginx.ingress.kubernetes.io/proxy-buffering: 'on'
         nginx.ingress.kubernetes.io/rewrite-target: '/$2'

--- a/charts/identity-server/values.staging.yaml
+++ b/charts/identity-server/values.staging.yaml
@@ -149,7 +149,6 @@ identity-server:
     primary-alb:
       annotations:
         kubernetes.io/ingress.class: 'nginx-external-alb'
-        nginx.ingress.kubernetes.io/enable-global-auth: 'false'
         nginx.ingress.kubernetes.io/proxy-buffer-size: '8k'
         nginx.ingress.kubernetes.io/proxy-buffering: 'on'
         nginx.ingress.kubernetes.io/service-upstream: 'true'
@@ -267,7 +266,6 @@ services-auth-admin-api:
     primary-alb:
       annotations:
         kubernetes.io/ingress.class: 'nginx-external-alb'
-        nginx.ingress.kubernetes.io/enable-global-auth: 'false'
         nginx.ingress.kubernetes.io/service-upstream: 'true'
       hosts:
         - host: 'identity-server.staging01.devland.is'
@@ -782,7 +780,6 @@ services-auth-public-api:
     primary-alb:
       annotations:
         kubernetes.io/ingress.class: 'nginx-external-alb'
-        nginx.ingress.kubernetes.io/enable-global-auth: 'false'
         nginx.ingress.kubernetes.io/proxy-buffer-size: '8k'
         nginx.ingress.kubernetes.io/proxy-buffering: 'on'
         nginx.ingress.kubernetes.io/rewrite-target: '/$2'

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -130,7 +130,6 @@ air-discount-scheme-backend:
     primary-alb:
       annotations:
         kubernetes.io/ingress.class: 'nginx-external-alb'
-        nginx.ingress.kubernetes.io/enable-global-auth: 'false'
         nginx.ingress.kubernetes.io/service-upstream: 'true'
       hosts:
         - host: 'loftbru.dev01.devland.is'
@@ -1079,7 +1078,6 @@ contentful-apps:
     primary-alb:
       annotations:
         kubernetes.io/ingress.class: 'nginx-external-alb'
-        nginx.ingress.kubernetes.io/enable-global-auth: 'false'
         nginx.ingress.kubernetes.io/service-upstream: 'true'
       hosts:
         - host: 'contentful-apps.dev01.devland.is'
@@ -1143,7 +1141,6 @@ contentful-entry-tagger-service:
     primary-alb:
       annotations:
         kubernetes.io/ingress.class: 'nginx-external-alb'
-        nginx.ingress.kubernetes.io/enable-global-auth: 'false'
         nginx.ingress.kubernetes.io/service-upstream: 'true'
       hosts:
         - host: 'contentful-entry-tagger-service.dev01.devland.is'
@@ -1481,7 +1478,6 @@ github-actions-cache:
     primary-alb:
       annotations:
         kubernetes.io/ingress.class: 'nginx-external-alb'
-        nginx.ingress.kubernetes.io/enable-global-auth: 'false'
         nginx.ingress.kubernetes.io/service-upstream: 'true'
       hosts:
         - host: 'cache.dev01.devland.is'
@@ -1647,7 +1643,6 @@ island-ui-storybook:
     primary-alb:
       annotations:
         kubernetes.io/ingress.class: 'nginx-external-alb'
-        nginx.ingress.kubernetes.io/enable-global-auth: 'false'
         nginx.ingress.kubernetes.io/service-upstream: 'true'
       hosts:
         - host: 'ui.dev01.devland.is'
@@ -1991,7 +1986,6 @@ search-indexer-service:
     primary-alb:
       annotations:
         kubernetes.io/ingress.class: 'nginx-external-alb'
-        nginx.ingress.kubernetes.io/enable-global-auth: 'false'
         nginx.ingress.kubernetes.io/service-upstream: 'true'
       hosts:
         - host: 'search-indexer-service.dev01.devland.is'

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -42,7 +42,6 @@ air-discount-scheme-api:
     primary-alb:
       annotations:
         kubernetes.io/ingress.class: 'nginx-external-alb'
-        nginx.ingress.kubernetes.io/enable-global-auth: 'false'
         nginx.ingress.kubernetes.io/service-upstream: 'true'
       hosts:
         - host: 'loftbru.island.is'
@@ -128,7 +127,6 @@ air-discount-scheme-backend:
     primary-alb:
       annotations:
         kubernetes.io/ingress.class: 'nginx-external-alb'
-        nginx.ingress.kubernetes.io/enable-global-auth: 'false'
         nginx.ingress.kubernetes.io/service-upstream: 'true'
       hosts:
         - host: 'loftbru.island.is'
@@ -224,7 +222,6 @@ air-discount-scheme-web:
       annotations:
         kubernetes.io/ingress.class: 'nginx-external-alb'
         nginx.ingress.kubernetes.io/configuration-snippet: 'rewrite /$ https://island.is/loftbru; rewrite /en$ https://island.is/en/lower-airfares-for-residents-in-rural-areas;'
-        nginx.ingress.kubernetes.io/enable-global-auth: 'false'
         nginx.ingress.kubernetes.io/proxy-buffer-size: '8k'
         nginx.ingress.kubernetes.io/proxy-buffering: 'on'
         nginx.ingress.kubernetes.io/service-upstream: 'true'
@@ -3190,7 +3187,6 @@ web:
     primary-alb:
       annotations:
         kubernetes.io/ingress.class: 'nginx-external-alb'
-        nginx.ingress.kubernetes.io/enable-global-auth: 'false'
         nginx.ingress.kubernetes.io/proxy-buffer-size: '8k'
         nginx.ingress.kubernetes.io/proxy-buffering: 'on'
         nginx.ingress.kubernetes.io/service-upstream: 'true'

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -130,7 +130,6 @@ air-discount-scheme-backend:
     primary-alb:
       annotations:
         kubernetes.io/ingress.class: 'nginx-external-alb'
-        nginx.ingress.kubernetes.io/enable-global-auth: 'false'
         nginx.ingress.kubernetes.io/service-upstream: 'true'
       hosts:
         - host: 'loftbru.staging01.devland.is'
@@ -441,7 +440,6 @@ api:
     primary-alb:
       annotations:
         kubernetes.io/ingress.class: 'nginx-external-alb'
-        nginx.ingress.kubernetes.io/enable-global-auth: 'false'
         nginx.ingress.kubernetes.io/service-upstream: 'true'
       hosts:
         - host: 'beta.staging01.devland.is'
@@ -949,7 +947,6 @@ application-system-form:
     primary-alb:
       annotations:
         kubernetes.io/ingress.class: 'nginx-external-alb'
-        nginx.ingress.kubernetes.io/enable-global-auth: 'false'
         nginx.ingress.kubernetes.io/proxy-buffer-size: '8k'
         nginx.ingress.kubernetes.io/proxy-buffering: 'on'
         nginx.ingress.kubernetes.io/service-upstream: 'true'
@@ -1017,7 +1014,6 @@ consultation-portal:
     primary-alb:
       annotations:
         kubernetes.io/ingress.class: 'nginx-external-alb'
-        nginx.ingress.kubernetes.io/enable-global-auth: 'false'
         nginx.ingress.kubernetes.io/proxy-buffer-size: '8k'
         nginx.ingress.kubernetes.io/proxy-buffering: 'on'
         nginx.ingress.kubernetes.io/service-upstream: 'true'
@@ -1108,7 +1104,6 @@ download-service:
     primary-alb:
       annotations:
         kubernetes.io/ingress.class: 'nginx-external-alb'
-        nginx.ingress.kubernetes.io/enable-global-auth: 'false'
         nginx.ingress.kubernetes.io/service-upstream: 'true'
       hosts:
         - host: 'api.staging01.devland.is'
@@ -1391,7 +1386,6 @@ island-ui-storybook:
     primary-alb:
       annotations:
         kubernetes.io/ingress.class: 'nginx-external-alb'
-        nginx.ingress.kubernetes.io/enable-global-auth: 'false'
         nginx.ingress.kubernetes.io/service-upstream: 'true'
       hosts:
         - host: 'ui.staging01.devland.is'
@@ -1464,7 +1458,6 @@ license-api:
     primary-alb:
       annotations:
         kubernetes.io/ingress.class: 'nginx-internal-alb'
-        nginx.ingress.kubernetes.io/enable-global-auth: 'false'
         nginx.ingress.kubernetes.io/service-upstream: 'true'
       hosts:
         - host: 'license-api-xrd.internal.staging01.devland.is'
@@ -1568,7 +1561,6 @@ portals-admin:
     primary-alb:
       annotations:
         kubernetes.io/ingress.class: 'nginx-external-alb'
-        nginx.ingress.kubernetes.io/enable-global-auth: 'false'
         nginx.ingress.kubernetes.io/proxy-buffer-size: '8k'
         nginx.ingress.kubernetes.io/proxy-buffering: 'on'
         nginx.ingress.kubernetes.io/service-upstream: 'true'
@@ -1733,7 +1725,6 @@ search-indexer-service:
     primary-alb:
       annotations:
         kubernetes.io/ingress.class: 'nginx-external-alb'
-        nginx.ingress.kubernetes.io/enable-global-auth: 'false'
         nginx.ingress.kubernetes.io/service-upstream: 'true'
       hosts:
         - host: 'search-indexer-service.staging01.devland.is'
@@ -1866,7 +1857,6 @@ service-portal:
     primary-alb:
       annotations:
         kubernetes.io/ingress.class: 'nginx-external-alb'
-        nginx.ingress.kubernetes.io/enable-global-auth: 'false'
         nginx.ingress.kubernetes.io/proxy-buffer-size: '8k'
         nginx.ingress.kubernetes.io/proxy-buffering: 'on'
         nginx.ingress.kubernetes.io/service-upstream: 'true'

--- a/libs/island-ui/storybook/infra/storybook.ts
+++ b/libs/island-ui/storybook/infra/storybook.ts
@@ -1,38 +1,33 @@
 import { service, ServiceBuilder } from '../../../../infra/src/dsl/dsl'
 
-export const serviceSetup =
-  (services: {}): ServiceBuilder<'island-ui-storybook'> =>
-    service('island-ui-storybook')
-      .namespace('storybook')
-      .liveness('/liveness')
-      .readiness('/readiness')
-      .resources({
-        limits: {
-          cpu: '200m',
-          memory: '256Mi',
+export const serviceSetup = (services: {}): ServiceBuilder<'island-ui-storybook'> =>
+  service('island-ui-storybook')
+    .namespace('storybook')
+    .liveness('/liveness')
+    .readiness('/readiness')
+    .resources({
+      limits: {
+        cpu: '200m',
+        memory: '256Mi',
+      },
+      requests: {
+        cpu: '10m',
+        memory: '128Mi',
+      },
+    })
+    .ingress({
+      primary: {
+        extraAnnotations: {
+          dev: {},
+          staging: {},
+          prod: {},
         },
-        requests: {
-          cpu: '10m',
-          memory: '128Mi',
+        host: {
+          dev: 'ui',
+          staging: 'ui',
+          prod: 'ui.devland.is',
         },
-      })
-      .ingress({
-        primary: {
-          extraAnnotations: {
-            dev: {
-              'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
-            },
-            staging: {
-              'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
-            },
-            prod: {},
-          },
-          host: {
-            dev: 'ui',
-            staging: 'ui',
-            prod: 'ui.devland.is',
-          },
-          paths: ['/'],
-        },
-      })
-      .grantNamespaces('nginx-ingress-external')
+        paths: ['/'],
+      },
+    })
+    .grantNamespaces('nginx-ingress-external')


### PR DESCRIPTION
Don't set `enable-global-auth`, defaulting to `true`.

Only allow in IDS related services