### PR TITLE
fix(infra): Optional annotations

### DIFF
--- a/infra/src/dsl/types/input-types.ts
+++ b/infra/src/dsl/types/input-types.ts
@@ -139,11 +139,9 @@ export interface Ingress {
   }
   paths: string[]
   public?: boolean
-  extraAnnotations?: Partial<
-    {
-      [env in OpsEnv]: { [annotation: string]: string | null }
-    }
-  >
+  extraAnnotations?: Partial<{
+    [env in OpsEnv]: { [annotation: string]: string | null }
+  }>
 }
 
 export interface IngressForEnv {

--- a/infra/src/dsl/types/input-types.ts
+++ b/infra/src/dsl/types/input-types.ts
@@ -139,9 +139,11 @@ export interface Ingress {
   }
   paths: string[]
   public?: boolean
-  extraAnnotations?: {
-    [env in OpsEnv]: { [annotation: string]: string | null }
-  }
+  extraAnnotations?: Partial<
+    {
+      [env in OpsEnv]: { [annotation: string]: string | null }
+    }
+  >
 }
 
 export interface IngressForEnv {


### PR DESCRIPTION
Fix type check failures when not all environments are specified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced test coverage for ingress configurations, focusing on handling annotations.
	- Added test cases for ingress configurations with no annotations and empty annotations.

- **Improvements**
	- Updated the `extraAnnotations` property in the `Ingress` interface to allow optional annotations for each environment, increasing flexibility in configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->