### PR TITLE
feat(web): Pension Calculator - Translation strings for 2025 results

### DIFF
--- a/apps/web/screens/Organization/SocialInsuranceAdministration/translationStrings.ts
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/translationStrings.ts
@@ -905,6 +905,21 @@ export const translationStrings = defineMessages({
     defaultMessage: 'Uppbót v/reksturs bifreiðar (óskattskyld)',
     description: 'Niðurstöðuskjár, Uppbót v/reksturs bifreiðar (óskattskyld) ',
   },
+  'REIKNH.GRUNNLIFORORKA2025': {
+    id: 'web.pensionCalculator:REIKNH.GRUNNLIFORORKA2025',
+    defaultMessage: 'Örorkulífeyrir',
+    description: 'Niðurstöðuskjár, Örorkulífeyrir 2025',
+  },
+  'REIKNH.ORHEIMILISUPPB2025': {
+    id: 'web.pensionCalculator:REIKNH.ORHEIMILISUPPB2025',
+    defaultMessage: 'Heimilisuppbót',
+    description: 'Niðurstöðuskjár, Heimilisuppbót 2025',
+  },
+  'REIKNH.ORALDURSVIDBOT2025': {
+    id: 'web.pensionCalculator:REIKNH.ORALDURSVIDBOT2025',
+    defaultMessage: 'Aldursviðbót',
+    description: 'Niðurstöðuskjár, Aldursviðbót 2025',
+  },
   highlighedResultItemHeadingForTotalAfterTaxFromTR: {
     id: 'web.pensionCalculator:REIKNH.highlighedResultItemHeadingForTotalAfterTaxFromTR',
     defaultMessage: 'Þar af greiðslur frá TR',


### PR DESCRIPTION
# Pension Calculator - Translation strings for 2025 results


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new translation strings for the year 2025 to enhance localization support in the pension calculator:
		- Disability pension (Örorkulífeyrir)
		- Home supplement (Heimilisuppbót)
		- Age supplement (Aldursviðbót)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->