### PR TITLE
fix(web): Temporary event licences - Prevent 0 from being displayed

### DIFF
--- a/apps/web/components/connected/syslumenn/CardLists/TemporaryEventLicencesList/TemporaryEventLicencesList.tsx
+++ b/apps/web/components/connected/syslumenn/CardLists/TemporaryEventLicencesList/TemporaryEventLicencesList.tsx
@@ -358,14 +358,16 @@ const TemporaryEventLicencesList: FC<
                           formatMessage(t.licenseResponsibleNotRegistered)}
                       </Text>
 
-                      {temporaryEventLicence.estimatedNumberOfGuests && (
+                      {Boolean(
+                        temporaryEventLicence.estimatedNumberOfGuests,
+                      ) && (
                         <Text>
                           {formatMessage(t.licenseEstimatedNumberOfGuests)}:{' '}
                           {temporaryEventLicence.estimatedNumberOfGuests}
                         </Text>
                       )}
 
-                      {temporaryEventLicence.maximumNumberOfGuests && (
+                      {Boolean(temporaryEventLicence.maximumNumberOfGuests) && (
                         <Text>
                           {formatMessage(t.licenseMaximumNumberOfGuests)}:{' '}
                           {temporaryEventLicence.maximumNumberOfGuests}


### PR DESCRIPTION
# Temporary event licences - Prevent 0 from being displayed

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the conditional rendering of guest-related information in the Temporary Event Licences List for better clarity and reliability. 

These changes enhance the user experience by ensuring accurate display of guest information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->