### PR TITLE
fix(old-age-pension): Change banner to warning and add link to income plan in pendingAction

### DIFF
--- a/libs/application/templates/social-insurance-administration/old-age-pension/src/lib/OldAgePensionTemplate.ts
+++ b/libs/application/templates/social-insurance-administration/old-age-pension/src/lib/OldAgePensionTemplate.ts
@@ -162,8 +162,8 @@ const OldAgePensionTemplate: ApplicationTemplate<
             },
             pendingAction: {
               title: coreSIAStatesMessages.tryggingastofnunSubmittedTitle,
-              content: coreSIAStatesMessages.tryggingastofnunSubmittedContent,
-              displayStatus: 'info',
+              content: statesMessages.oldAgePensionSubmittedContent,
+              displayStatus: 'warning',
             },
             historyLogs: [
               {

--- a/libs/application/templates/social-insurance-administration/old-age-pension/src/lib/messages.ts
+++ b/libs/application/templates/social-insurance-administration/old-age-pension/src/lib/messages.ts
@@ -516,4 +516,11 @@ export const statesMessages = defineMessages({
     defaultMessage: 'Umsókn vegna ellilífeyris hefur verið samþykkt',
     description: 'The application for old-age pension has been approved',
   },
+  oldAgePensionSubmittedContent: {
+    id: 'oap.application:oldAgePensionSubmittedContent#markdown',
+    defaultMessage:
+      'Umsókn þín er í bið eftir yfirferð. Hægt er að breyta umsókn þar til hún er tekin til yfirferðar. Athugið að ef ekki er búið að skila inn tekjuáætlun þarf að gera það hér.',
+    description:
+      'Your application is awaiting review. It is possible to edit the application until it is under review. Please note that if you have not submitted an income plan, you must do so here.',
+  },
 })


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced messaging for the old-age pension application process, providing clearer updates on application status.
	- New message descriptor added to inform users that their application is awaiting review and can be edited until then.

- **Bug Fixes**
	- Updated content for pending actions in the application states to reflect more accurate descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->