### PR TITLE
fix(web): Stepper - If step type is "information" then allow pressing the continue button

### DIFF
--- a/apps/web/components/Stepper/Stepper/Stepper.tsx
+++ b/apps/web/components/Stepper/Stepper/Stepper.tsx
@@ -305,7 +305,10 @@ const Stepper = ({
     <Box marginTop={3}>
       <Button
         onClick={() => {
-          if (selectedOption === null) {
+          if (
+            selectedOption === null &&
+            currentStepType !== STEP_TYPES.INFORMATION
+          ) {
             setHasClickedContinueWithoutSelecting(true)
             return
           }


### PR DESCRIPTION
# Stepper - If step type is "information" then allow pressing the continue button

* Information step types are basically questions with only one answer that the user can select "Continue"
* This PR allows the user to press continue to see the next step

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced validation for the `ContinueButton` to ensure users make selections before proceeding, except on informational steps.
  
- **Bug Fixes**
	- Improved logic for handling selected options, preventing unintended transitions in the stepper.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->