### PR TITLE
fix(driving-license): allow continuing without quality photo

### DIFF
--- a/libs/application/templates/driving-license/src/fields/EligibilitySummary/useEligibility.ts
+++ b/libs/application/templates/driving-license/src/fields/EligibilitySummary/useEligibility.ts
@@ -203,7 +203,6 @@ export const useEligibility = (
         isEligible: loading
           ? undefined
           : (data.drivingLicenseApplicationEligibility?.isEligible ?? false) &&
-            hasQualityPhoto &&
             !hasExtendedLicense &&
             !hasAnyInvalidRemarks,
         requirements,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced eligibility criteria for the `B_FULL_RENEWAL_65` driving license application, now excluding quality photo requirements.
	- Introduced conditional requirements based on the applicant's extended license status.

- **Bug Fixes**
	- Improved error handling for eligibility queries, ensuring consistent logging and error management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->