### PR TITLE
fix(web): Manual chapter - Accordion scroll bugfix

### DIFF
--- a/apps/web/screens/Manual/ManualChapter.tsx
+++ b/apps/web/screens/Manual/ManualChapter.tsx
@@ -75,7 +75,7 @@ const ManualChapter: ManualScreen = ({ manual, manualChapter, namespace }) => {
   const { activeLocale } = useI18n()
 
   const [selectedItemId, setSelectedItemId] = useQueryState('selectedItemId')
-  const [expandedItemIds, setExpandedItemsIds] = useState(
+  const [expandedItemIds, setExpandedItemIds] = useState(
     selectedItemId ? [selectedItemId] : [],
   )
   const initialScrollHasHappened = useRef(false)
@@ -184,10 +184,10 @@ const ManualChapter: ManualScreen = ({ manual, manualChapter, namespace }) => {
                 onToggle={(expanded) => {
                   initialScrollHasHappened.current = true
                   if (expanded) {
-                    setExpandedItemsIds((prev) => prev.concat(item.id))
+                    setExpandedItemIds((prev) => prev.concat(item.id))
                     setSelectedItemId(item.id)
                   } else {
-                    setExpandedItemsIds((prev) => {
+                    setExpandedItemIds((prev) => {
                       const updatedExpandedItemIds = prev.filter(
                         (id) => id !== item.id,
                       )

--- a/apps/web/screens/Manual/ManualChapter.tsx
+++ b/apps/web/screens/Manual/ManualChapter.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useQueryState } from 'next-usequerystate'
 import { BLOCKS } from '@contentful/rich-text-types'
 
@@ -75,6 +75,9 @@ const ManualChapter: ManualScreen = ({ manual, manualChapter, namespace }) => {
   const { activeLocale } = useI18n()
 
   const [selectedItemId, setSelectedItemId] = useQueryState('selectedItemId')
+  const [expandedItemIds, setExpandedItemsIds] = useState(
+    selectedItemId ? [selectedItemId] : [],
+  )
   const initialScrollHasHappened = useRef(false)
 
   useLocalLinkTypeResolver()
@@ -174,13 +177,29 @@ const ManualChapter: ManualScreen = ({ manual, manualChapter, namespace }) => {
                 key={item.id}
                 id={item.id}
                 label={item.title}
-                expanded={item.id === selectedItemId}
+                expanded={
+                  expandedItemIds.includes(item.id) ||
+                  item.id === selectedItemId
+                }
                 onToggle={(expanded) => {
                   initialScrollHasHappened.current = true
                   if (expanded) {
+                    setExpandedItemsIds((prev) => prev.concat(item.id))
                     setSelectedItemId(item.id)
-                  } else if (selectedItemId === item.id) {
-                    setSelectedItemId(null)
+                  } else {
+                    setExpandedItemsIds((prev) => {
+                      const updatedExpandedItemIds = prev.filter(
+                        (id) => id !== item.id,
+                      )
+                      if (selectedItemId === item.id) {
+                        setSelectedItemId(
+                          updatedExpandedItemIds[
+                            updatedExpandedItemIds.length - 1
+                          ] ?? null,
+                        )
+                      }
+                      return updatedExpandedItemIds
+                    })
                   }
                 }}
               >


### PR DESCRIPTION
# Manual chapter - Accordion scroll bugfix

## What

* Keep accordion items open instead of closing them when another opens

## Why

* To prevent the page from scrolling out of view

## Screenshots / Gifs

### Before

https://github.com/user-attachments/assets/0bcde6ed-af29-4093-b5ec-9accb9ea52e1


### After

https://github.com/user-attachments/assets/19a188c9-4aa0-41f3-aff2-b6398afb462e

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced accordion component functionality to allow multiple items to be expanded simultaneously.
  - Improved state management for selected and expanded items within the accordion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->