### PR TITLE
fix(island-ui): Only set SelectController placeholder for undefined or null values

### DIFF
--- a/libs/shared/form-fields/src/lib/SelectController/SelectController.tsx
+++ b/libs/shared/form-fields/src/lib/SelectController/SelectController.tsx
@@ -57,7 +57,7 @@ export const SelectController = <Value, IsMulti extends boolean = false>({
   }
 
   const getValue = (value: Value | Value[]) => {
-    if (value === undefined || value === null) {
+    if (value === null) {
       return null
     }
 

--- a/libs/shared/form-fields/src/lib/SelectController/SelectController.tsx
+++ b/libs/shared/form-fields/src/lib/SelectController/SelectController.tsx
@@ -57,7 +57,7 @@ export const SelectController = <Value, IsMulti extends boolean = false>({
   }
 
   const getValue = (value: Value | Value[]) => {
-    if (!value) {
+    if (value === undefined || value === null) {
       return null
     }
 


### PR DESCRIPTION
We should only use the placeholder for undefined or null. Since this can affect falsy values and have unwanted results

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced clarity in value validation for the SelectController component, ensuring better handling of null values.
	- Improved onChange functionality to clear errors before processing new selections.

- **Bug Fixes**
	- Strengthened robustness of the component's value checks while maintaining existing multi-value selection functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->