### PR TITLE
fix(vedbokarvottord): Stop logging 404 errors when searching for property

### DIFF
--- a/libs/application/templates/mortgage-certificate/src/fields/SelectProperty/PropertyTypeSearchField/index.tsx
+++ b/libs/application/templates/mortgage-certificate/src/fields/SelectProperty/PropertyTypeSearchField/index.tsx
@@ -56,11 +56,14 @@ export const PropertyTypeSearchField: FC<
       setFoundProperties(resProperty)
       if (resProperty?.propertyNumber) {
         setShowSearchError(false)
+        setShowApiError(false)
       } else {
         setShowSearchError(true)
+        setShowApiError(false)
       }
     },
     onError() {
+      setShowSearchError(false)
       setShowApiError(true)
       setFoundProperties(undefined)
     },

--- a/libs/application/templates/mortgage-certificate/src/fields/SelectProperty/PropertyTypeSearchField/index.tsx
+++ b/libs/application/templates/mortgage-certificate/src/fields/SelectProperty/PropertyTypeSearchField/index.tsx
@@ -50,8 +50,11 @@ export const PropertyTypeSearchField: FC<
 
   const [runQuery, { loading }] = useLazyQuery(searchPropertiesQuery, {
     onCompleted(result) {
-      setFoundProperties(result.searchForAllProperties)
-      if (foundProperties?.propertyNumber) {
+      const resProperty = result.searchForAllProperties as
+        | ManyPropertyDetail
+        | undefined
+      setFoundProperties(resProperty)
+      if (resProperty?.propertyNumber) {
         setShowSearchError(false)
       } else {
         setShowSearchError(true)

--- a/libs/application/templates/mortgage-certificate/src/fields/SelectProperty/PropertyTypeSearchField/index.tsx
+++ b/libs/application/templates/mortgage-certificate/src/fields/SelectProperty/PropertyTypeSearchField/index.tsx
@@ -40,6 +40,7 @@ export const PropertyTypeSearchField: FC<
 }) => {
   const { formatMessage } = useLocale()
   const [showSearchError, setShowSearchError] = useState<boolean>(false)
+  const [showApiError, setShowApiError] = useState<boolean>(false)
   const [searchStr, setSearchStr] = useState(
     getValueViaPath(application.answers, `${field.id}.searchStr`, '') as string,
   )
@@ -49,17 +50,23 @@ export const PropertyTypeSearchField: FC<
 
   const [runQuery, { loading }] = useLazyQuery(searchPropertiesQuery, {
     onCompleted(result) {
-      setShowSearchError(false)
       setFoundProperties(result.searchForAllProperties)
+      if (foundProperties?.propertyNumber) {
+        setShowSearchError(false)
+      } else {
+        setShowSearchError(true)
+      }
     },
     onError() {
-      setShowSearchError(true)
+      setShowApiError(true)
       setFoundProperties(undefined)
     },
   })
 
   useEffect(() => {
     if (searchStr.length) {
+      setShowSearchError(false)
+      setShowApiError(false)
       runQuery({
         variables: {
           input: {
@@ -105,6 +112,13 @@ export const PropertyTypeSearchField: FC<
         <AlertMessage
           type="warning"
           message={formatMessage(propertySearch.labels.propertyNotFound)}
+        />
+      </Box>
+
+      <Box paddingTop={3} hidden={loading || !showApiError}>
+        <AlertMessage
+          type="warning"
+          message={formatMessage(propertySearch.labels.propertyApiError)}
         />
       </Box>
     </Box>

--- a/libs/application/templates/mortgage-certificate/src/lib/messages/propertySearch.ts
+++ b/libs/application/templates/mortgage-certificate/src/lib/messages/propertySearch.ts
@@ -47,6 +47,12 @@ export const propertySearch = {
       defaultMessage: 'Eign með þessu númeri fannst ekki.',
       description: 'Property not found alert message',
     },
+    propertyApiError: {
+      id: 'mc.application:propertySearch.labels.propertyApiError',
+      defaultMessage:
+        'Ekki tókst að sækja upplýsingar, vinsamlegast reynið aftur síðar.',
+      description: 'Error connection to API alert message',
+    },
     propertyNumber: {
       id: 'mc.application:propertySearch.labels.propertyNumber',
       defaultMessage: 'Fastanúmer',

--- a/libs/clients/syslumenn/src/lib/syslumennClient.service.ts
+++ b/libs/clients/syslumenn/src/lib/syslumennClient.service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from '@nestjs/common'
 import startOfDay from 'date-fns/startOfDay'
 
 import { AuthHeaderMiddleware } from '@island.is/auth-nest-tools'
-import { createEnhancedFetch } from '@island.is/clients/middlewares'
+import { createEnhancedFetch, handle404 } from '@island.is/clients/middlewares'
 
 import {
   Configuration,
@@ -516,18 +516,14 @@ export class SyslumennService {
               : VedbondTegundAndlags.NUMBER_0, // 0 = Real estate
         },
       })
-      .catch(() => {
-        throw new Error(
-          `Failed to get all properties for property number: ${propertyNumber}`,
-        )
-      })
+      .catch(handle404)
 
     return {
-      propertyNumber: res.fastanum ?? undefined, // Removes nulls with ?? undefined
-      propertyType: res.tegundEignar ?? undefined,
-      realEstate: res.fasteign ? res.fasteign.map(mapRealEstateResponse) : [],
-      vehicle: res.okutaeki ? mapVehicleResponse(res.okutaeki) : undefined,
-      ship: res.skip ? mapShipResponse(res.skip) : undefined,
+      propertyNumber: res?.fastanum ?? undefined,
+      propertyType: res?.tegundEignar ?? undefined,
+      realEstate: res?.fasteign ? res.fasteign.map(mapRealEstateResponse) : [],
+      vehicle: res?.okutaeki ? mapVehicleResponse(res.okutaeki) : undefined,
+      ship: res?.skip ? mapShipResponse(res.skip) : undefined,
     }
   }
 


### PR DESCRIPTION
## What

Stop logging error when we get 404 from API when searching for property, only log if actual error from API.

## Why

To not overload Datadog with these error logs, that are not "real" errors we need to look into

![image](https://github.com/user-attachments/assets/6fe11458-f78f-4cb9-987e-282112e50321)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for property search, distinguishing between API errors and search-related errors.
	- Added user-friendly messages for API connection errors.

- **Bug Fixes**
	- Improved robustness of property details retrieval by implementing structured error handling for 404 errors.

These updates provide clearer feedback to users during property searches and improve overall functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->