### PR TITLE
fix(admin): compare lists always visible

### DIFF
--- a/libs/portals/admin/signature-collection/src/screens-parliamentary/Constituency/index.tsx
+++ b/libs/portals/admin/signature-collection/src/screens-parliamentary/Constituency/index.tsx
@@ -132,7 +132,7 @@ export const Constituency = ({
                     constituencyLists.length}
                 </Text>
                 {allowedToProcess &&
-                  collectionStatus === CollectionStatus.Processed && (
+                  collectionStatus === CollectionStatus.InInitialReview && (
                     <CreateCollection
                       collectionId={collection?.id}
                       areaId={areaId}

--- a/libs/portals/admin/signature-collection/src/screens-parliamentary/index.tsx
+++ b/libs/portals/admin/signature-collection/src/screens-parliamentary/index.tsx
@@ -223,10 +223,7 @@ const ParliamentaryRoot = ({
           </Stack>
           {allowedToProcess && (
             <Box>
-              {(collectionStatus === CollectionStatus.InInitialReview ||
-                collectionStatus === CollectionStatus.InReview) && (
-                <CompareLists collectionId={collection?.id} />
-              )}
+              <CompareLists collectionId={collection?.id} />
               {(collectionStatus === CollectionStatus.InitialActive ||
                 collectionStatus === CollectionStatus.InInitialReview) && (
                 <ActionCompleteCollectionProcessing


### PR DESCRIPTION
## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated rendering logic for the `CreateCollection` component to show it based on the collection's initial review status.
	- Simplified rendering of the `CompareLists` component, now displayed whenever processing is allowed.
  
- **Bug Fixes**
	- Improved user interface flow for the "Cancel collection" dialog prompt based on updated collection status checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->