### PR TITLE
fix(applicaiton-system): Payment migration for definition to text from string

### DIFF
--- a/apps/application-system/api/migrations/20241022145836-payment-alter-column-definition-text.js
+++ b/apps/application-system/api/migrations/20241022145836-payment-alter-column-definition-text.js
@@ -4,14 +4,24 @@ module.exports = {
   up: async (queryInterface, Sequelize) => {
     await queryInterface.changeColumn('payment', 'definition', {
       type: Sequelize.TEXT,
-      allowNull: true, // Keep the same nullability as before
+      allowNull: true,
     })
   },
 
   down: async (queryInterface, Sequelize) => {
+    // Check for records that might be truncated
+    const records = await queryInterface.sequelize.query(
+      `SELECT id FROM payment WHERE LENGTH(CAST(definition AS TEXT)) > 255`,
+    )
+    if (records[0].length > 0) {
+      throw new Error(
+        'Cannot safely rollback: Some records exceed STRING length limit',
+      )
+    }
+
     await queryInterface.changeColumn('payment', 'definition', {
       type: Sequelize.STRING,
-      allowNull: true, // Revert to the original type and nullability
+      allowNull: true,
     })
   },
 }

--- a/apps/application-system/api/migrations/20241022145836-payment-alter-column-definition-text.js
+++ b/apps/application-system/api/migrations/20241022145836-payment-alter-column-definition-text.js
@@ -1,0 +1,17 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.changeColumn('payment', 'definition', {
+      type: Sequelize.TEXT,
+      allowNull: true, // Keep the same nullability as before
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.changeColumn('payment', 'definition', {
+      type: Sequelize.STRING,
+      allowNull: true, // Revert to the original type and nullability
+    })
+  },
+}


### PR DESCRIPTION
# Update `definition` Column Type to TEXT in Payment Table

## Description

This PR introduces a migration to update the `definition` column in the `payment` table from `STRING` to `TEXT`. This change is necessary to accommodate larger JSON schema data that exceeds the previous character limit imposed by the `STRING` type.

## What

- **Migration**: 
  - Altered the `definition` column type from `Sequelize.STRING` to `Sequelize.TEXT` in the `payment` table.
  - the `up` method to change the column type to `TEXT`.
  - the `down` method to revert the column type back to `STRING` if needed.

## Why

- **Increased Capacity**: The `TEXT` type allows for storing larger strings, which is essential for handling JSON data that can exceed the default `STRING` length limit.
- **Seamless Integration**: The change is expected to be seamless in PostgreSQL, with no significant side effects on storage or performance.

## Testing

- Ensure that the migration runs successfully in both development and production environments.
- Verify that JSON data exceeding the previous limit can now be stored without issues.

## Notes

- This change is backward-compatible with existing data, as `TEXT` can store all data types previously stored in `STRING`.
- No changes are required in the application logic, as Sequelize handles `TEXT` and `STRING` similarly in Node.js.

---

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review