### PR TITLE
feat(web): Pension calculator translations for 2025 comparison

### DIFF
--- a/apps/web/screens/Organization/SocialInsuranceAdministration/translationStrings.ts
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/translationStrings.ts
@@ -920,6 +920,27 @@ export const translationStrings = defineMessages({
     defaultMessage: 'Aldursviðbót',
     description: 'Niðurstöðuskjár, Aldursviðbót 2025',
   },
+  'REIKNH.ORORKA_ALDURSV_HUPPBOT_2025': {
+    id: 'web.pensionCalculator:REIKNH.ORORKA_ALDURSV_HUPPBOT_2025',
+    defaultMessage: 'Örorkulífeyrir, aldursviðbót og heimilisuppbót',
+    description:
+      'Niðurstöðuskjár, Örorkulífeyrir, aldursviðbót og heimilisuppbót 2025',
+  },
+  'REIKNH.ORORKA_HUPPBOT_2025': {
+    id: 'web.pensionCalculator:REIKNH.ORORKA_HUPPBOT_2025',
+    defaultMessage: 'Örorkulífeyrir og heimilisuppbót',
+    description: 'Niðurstöðuskjár, Örorkulífeyrir og heimilisuppbót 2025',
+  },
+  'REIKNH.ORORKA_ALDURSV_2025': {
+    id: 'web.pensionCalculator:REIKNH.ORORKA_ALDURSV_2025',
+    defaultMessage: 'Örorkulífeyrir og aldursviðbót',
+    description: 'Niðurstöðuskjár, Örorkulífeyrir og aldursviðbót 2025',
+  },
+  'REIKNH.ORORKA_2025': {
+    id: 'web.pensionCalculator:REIKNH.ORORKA_2025',
+    defaultMessage: 'Örorkulífeyrir',
+    description: 'Niðurstöðuskjár, Örorkulífeyrir 2025',
+  },
   highlighedResultItemHeadingForTotalAfterTaxFromTR: {
     id: 'web.pensionCalculator:REIKNH.highlighedResultItemHeadingForTotalAfterTaxFromTR',
     defaultMessage: 'Þar af greiðslur frá TR',


### PR DESCRIPTION
# Pension calculator translations for 2025 comparison

## What

* Translation strings needed for 2025 comparison view

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new translation strings to enhance localization for the pension calculator application, including labels for various benefits related to disability and age supplements for 2025.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->