### PR TITLE
feat(signature-collection): Allow candidacy to update signature page number

### DIFF
--- a/libs/api/domains/signature-collection/src/lib/signatureCollection.resolver.ts
+++ b/libs/api/domains/signature-collection/src/lib/signatureCollection.resolver.ts
@@ -32,6 +32,7 @@ import {
   SignatureCollectionSignee,
 } from './models'
 import { SignatureCollectionListSummary } from './models/areaSummaryReport.model'
+import { SignatureCollectionSignatureUpdateInput } from './dto/signatureUpdate.input'
 
 @UseGuards(IdsUserGuard, ScopesGuard, UserAccessGuard)
 @Resolver()
@@ -219,5 +220,20 @@ export class SignatureCollectionResolver {
     @Args('input') input: SignatureCollectionListIdInput,
   ): Promise<SignatureCollectionListSummary> {
     return this.signatureCollectionService.listOverview(user, input.listId)
+  }
+
+  @Scopes(ApiScope.signatureCollection)
+  @IsOwner()
+  @AllowManager()
+  @Mutation(() => SignatureCollectionSuccess)
+  @Audit()
+  async signatureCollectionUpdatePaperSignaturePageNumber(
+    @CurrentUser() user: User,
+    @Args('input') input: SignatureCollectionSignatureUpdateInput,
+  ): Promise<SignatureCollectionSuccess> {
+    return this.signatureCollectionService.updateSignaturePageNumber(
+      user,
+      input,
+    )
   }
 }

--- a/libs/api/domains/signature-collection/src/lib/signatureCollection.service.ts
+++ b/libs/api/domains/signature-collection/src/lib/signatureCollection.service.ts
@@ -19,6 +19,7 @@ import { SignatureCollectionUploadPaperSignatureInput } from './dto/uploadPaperS
 import { SignatureCollectionCanSignFromPaperInput } from './dto/canSignFromPaper.input'
 import { SignatureCollectionCollector } from './models/collector.model'
 import { SignatureCollectionListSummary } from './models/areaSummaryReport.model'
+import { SignatureCollectionSignatureUpdateInput } from './dto/signatureUpdate.input'
 
 @Injectable()
 export class SignatureCollectionService {
@@ -196,6 +197,17 @@ export class SignatureCollectionService {
     return await this.signatureCollectionClientService.getListOverview(
       user,
       listId,
+    )
+  }
+
+  async updateSignaturePageNumber(
+    user: User,
+    input: SignatureCollectionSignatureUpdateInput,
+  ): Promise<SignatureCollectionSuccess> {
+    return await this.signatureCollectionClientService.updateSignaturePageNumber(
+      user,
+      input.signatureId,
+      input.pageNumber,
     )
   }
 }

--- a/libs/clients/signature-collection/src/lib/signature-collection-admin.service.ts
+++ b/libs/clients/signature-collection/src/lib/signature-collection-admin.service.ts
@@ -360,9 +360,9 @@ export class SignatureCollectionAdminClientService {
   ): Promise<Success> {
     try {
       const res = await this.getApiWithAuth(
-        this.signatureApi,
+        this.adminApi,
         auth,
-      ).medmaeliIDUpdateBlsPatch({
+      ).adminMedmaeliIDUpdateBlsPatch({
         iD: parseInt(signatureId),
         blsNr: pageNumber,
       })

--- a/libs/clients/signature-collection/src/lib/signature-collection.service.ts
+++ b/libs/clients/signature-collection/src/lib/signature-collection.service.ts
@@ -573,4 +573,23 @@ export class SignatureCollectionClientService {
 
     return mapListSummary(summary)
   }
+
+  async updateSignaturePageNumber(
+    auth: Auth,
+    signatureId: string,
+    pageNumber: number,
+  ): Promise<Success> {
+    try {
+      const res = await this.getApiWithAuth(
+        this.signatureApi,
+        auth,
+      ).medmaeliIDUpdateBlsPatch({
+        iD: parseInt(signatureId),
+        blsNr: pageNumber,
+      })
+      return { success: res.bladsidaNr === pageNumber }
+    } catch {
+      return { success: false }
+    }
+  }
 }

--- a/libs/portals/admin/signature-collection/src/lib/messages.ts
+++ b/libs/portals/admin/signature-collection/src/lib/messages.ts
@@ -710,7 +710,7 @@ export const m = defineMessages({
     description: '',
   },
   editPaperNumberError: {
-    id: 'admin-portal.signature-collection:editPaperNumberSuccess',
+    id: 'admin-portal.signature-collection:editPaperNumberError',
     defaultMessage: 'Ekki tókst að breyta blaðsíðunúmeri',
     description: '',
   },

--- a/libs/portals/admin/signature-collection/src/shared-components/signees/editPage/index.tsx
+++ b/libs/portals/admin/signature-collection/src/shared-components/signees/editPage/index.tsx
@@ -75,7 +75,9 @@ const EditPage = ({
                   label={formatMessage(m.paperNumber)}
                   value={newPage}
                   size="sm"
-                  onChange={(e) => setNewPage(Number(e.target.value))}
+                  onChange={(e) =>
+                    setNewPage(Number(e.target.value.replace(/\D/g, '')))
+                  }
                   backgroundColor="blue"
                 />
                 <Input

--- a/libs/service-portal/signature-collection/src/hooks/graphql/mutations.ts
+++ b/libs/service-portal/signature-collection/src/hooks/graphql/mutations.ts
@@ -39,3 +39,12 @@ export const uploadPaperSignature = gql`
     }
   }
 `
+export const updatePaperSignaturePageNumber = gql`
+  mutation SignatureCollectionUpdatePaperSignaturePageNumber(
+    $input: SignatureCollectionSignatureUpdateInput!
+  ) {
+    signatureCollectionUpdatePaperSignaturePageNumber(input: $input) {
+      success
+    }
+  }
+`

--- a/libs/service-portal/signature-collection/src/lib/messages.ts
+++ b/libs/service-portal/signature-collection/src/lib/messages.ts
@@ -361,6 +361,26 @@ export const m = defineMessages({
     defaultMessage: 'Ekki tókst að skrá meðmæli',
     description: '',
   },
+  editPaperNumber: {
+    id: 'sp.signature-collection:editPaperNumber',
+    defaultMessage: 'Breyta blaðsíðunúmeri',
+    description: '',
+  },
+  editPaperNumberSuccess: {
+    id: 'sp.signature-collection:editPaperNumberSuccess',
+    defaultMessage: 'Tókst að breyta blaðsíðunúmeri',
+    description: '',
+  },
+  editPaperNumberError: {
+    id: 'sp.signature-collection:editPaperNumberSuccess',
+    defaultMessage: 'Ekki tókst að breyta blaðsíðunúmeri',
+    description: '',
+  },
+  saveEditPaperNumber: {
+    id: 'sp.signature-collection:saveEditPaperNumber',
+    defaultMessage: 'Uppfæra blaðsíðunúmer',
+    description: '',
+  },
 
   /* Parliamentary */
   parliamentaryElectionsTitle: {

--- a/libs/service-portal/signature-collection/src/lib/messages.ts
+++ b/libs/service-portal/signature-collection/src/lib/messages.ts
@@ -372,7 +372,7 @@ export const m = defineMessages({
     description: '',
   },
   editPaperNumberError: {
-    id: 'sp.signatureCollection:editPaperNumberSuccess',
+    id: 'sp.signatureCollection:editPaperNumberError',
     defaultMessage: 'Ekki tókst að breyta blaðsíðunúmeri',
     description: '',
   },

--- a/libs/service-portal/signature-collection/src/lib/messages.ts
+++ b/libs/service-portal/signature-collection/src/lib/messages.ts
@@ -362,22 +362,22 @@ export const m = defineMessages({
     description: '',
   },
   editPaperNumber: {
-    id: 'sp.signature-collection:editPaperNumber',
+    id: 'sp.signatureCollection:editPaperNumber',
     defaultMessage: 'Breyta blaðsíðunúmeri',
     description: '',
   },
   editPaperNumberSuccess: {
-    id: 'sp.signature-collection:editPaperNumberSuccess',
+    id: 'sp.signatureCollection:editPaperNumberSuccess',
     defaultMessage: 'Tókst að breyta blaðsíðunúmeri',
     description: '',
   },
   editPaperNumberError: {
-    id: 'sp.signature-collection:editPaperNumberSuccess',
+    id: 'sp.signatureCollection:editPaperNumberSuccess',
     defaultMessage: 'Ekki tókst að breyta blaðsíðunúmeri',
     description: '',
   },
   saveEditPaperNumber: {
-    id: 'sp.signature-collection:saveEditPaperNumber',
+    id: 'sp.signatureCollection:saveEditPaperNumber',
     defaultMessage: 'Uppfæra blaðsíðunúmer',
     description: '',
   },

--- a/libs/service-portal/signature-collection/src/screens/Parliamentary/OwnerView/ViewList/Signees/EditPage/index.tsx
+++ b/libs/service-portal/signature-collection/src/screens/Parliamentary/OwnerView/ViewList/Signees/EditPage/index.tsx
@@ -1,0 +1,116 @@
+import {
+  Icon,
+  Box,
+  Button,
+  Input,
+  Stack,
+  GridColumn,
+  GridRow,
+} from '@island.is/island-ui/core'
+import { useLocale } from '@island.is/localization'
+import { Modal } from '@island.is/react/components'
+import { useState } from 'react'
+import { toast } from 'react-toastify'
+import { m } from '../../../../../../lib/messages'
+import { useMutation } from '@apollo/client'
+import { updatePaperSignaturePageNumber } from '../../../../../../hooks/graphql/mutations'
+
+const EditPage = ({
+  page,
+  name,
+  nationalId,
+  signatureId,
+  refetchSignees,
+}: {
+  page: number
+  name: string
+  nationalId: string
+  signatureId: string
+  refetchSignees: () => void
+}) => {
+  const { formatMessage } = useLocale()
+  const [newPage, setNewPage] = useState(page)
+  const [modalIsOpen, setModalIsOpen] = useState(false)
+
+  const [updatePage, { loading }] = useMutation(
+    updatePaperSignaturePageNumber,
+    {
+      variables: {
+        input: {
+          pageNumber: newPage,
+          signatureId: signatureId,
+        },
+      },
+      onCompleted: () => {
+        toast.success(formatMessage(m.editPaperNumberSuccess))
+        refetchSignees()
+        setModalIsOpen(false)
+      },
+      onError: () => {
+        toast.error(formatMessage(m.editPaperNumberError))
+      },
+    },
+  )
+
+  return (
+    <Box>
+      <Box marginLeft={1} onClick={() => setModalIsOpen(true)} cursor="pointer">
+        <Icon icon="pencil" type="outline" color="blue400" />
+      </Box>
+      <Modal
+        id="editPageModal"
+        isVisible={modalIsOpen}
+        title={formatMessage(m.editPaperNumber)}
+        onClose={() => {
+          setNewPage(page)
+          setModalIsOpen(false)
+        }}
+        hideOnClickOutside={false}
+        closeButtonLabel={''}
+        label={''}
+      >
+        <Box marginY={3}>
+          <GridRow>
+            <GridColumn span="10/12" offset="1/12">
+              <Stack space={3}>
+                <Input
+                  name="page"
+                  label={formatMessage(m.paperNumber)}
+                  value={newPage}
+                  size="sm"
+                  onChange={(e) => setNewPage(Number(e.target.value))}
+                  backgroundColor="blue"
+                />
+                <Input
+                  name="name"
+                  label={formatMessage(m.signeeName)}
+                  value={name}
+                  size="sm"
+                  readOnly
+                />
+                <Input
+                  name="nationalId"
+                  label={formatMessage(m.signeeNationalId)}
+                  value={nationalId}
+                  size="sm"
+                  readOnly
+                />
+              </Stack>
+            </GridColumn>
+          </GridRow>
+          <Box display="flex" justifyContent="center" marginTop={7}>
+            <Button
+              colorScheme="default"
+              onClick={() => updatePage()}
+              loading={loading}
+            >
+              {formatMessage(m.saveEditPaperNumber)}
+            </Button>
+          </Box>
+        </Box>
+      </Modal>
+    </Box>
+  )
+}
+
+export default EditPage

--- a/libs/service-portal/signature-collection/src/screens/Parliamentary/OwnerView/ViewList/Signees/EditPage/index.tsx
+++ b/libs/service-portal/signature-collection/src/screens/Parliamentary/OwnerView/ViewList/Signees/EditPage/index.tsx
@@ -78,7 +78,9 @@ const EditPage = ({
                   label={formatMessage(m.paperNumber)}
                   value={newPage}
                   size="sm"
-                  onChange={(e) => setNewPage(Number(e.target.value))}
+                  onChange={(e) =>
+                    setNewPage(Number(e.target.value.replace(/\D/g, '')))
+                  }
                   backgroundColor="blue"
                 />
                 <Input

--- a/libs/service-portal/signature-collection/src/screens/Parliamentary/OwnerView/ViewList/Signees/index.tsx
+++ b/libs/service-portal/signature-collection/src/screens/Parliamentary/OwnerView/ViewList/Signees/index.tsx
@@ -18,6 +18,7 @@ import { SignatureCollectionSignature as Signature } from '@island.is/api/schema
 import { PaperSignees } from './PaperSignees'
 import sortBy from 'lodash/sortBy'
 import PdfReport from '../PdfReport'
+import EditPage from './EditPage'
 
 const Signees = () => {
   useNamespaces('sp.signatureCollection')
@@ -113,6 +114,15 @@ const Signees = () => {
                                   color="blue400"
                                 />
                               </Box>
+                              <EditPage
+                                page={s.pageNumber ?? 0}
+                                name={s.signee.name}
+                                nationalId={formatNationalId(
+                                  s.signee.nationalId,
+                                )}
+                                signatureId={s.id}
+                                refetchSignees={refetchListSignees}
+                              />
                             </Box>
                           )}
                         </T.Data>


### PR DESCRIPTION
## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new mutation to update the page number of paper signatures.
	- Added a new input type for signature updates.
	- Implemented a new React component for editing signature page numbers within a modal interface.
	- Expanded messaging for editing paper numbers, including success and error notifications.

- **Bug Fixes**
	- Enhanced error handling for deletion processes to provide clearer feedback.
	- Improved input handling for the page number to ensure only valid numeric characters are processed.

- **Chores**
	- Updated API endpoint for the signature page number update operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->