### PR TITLE
chore(docker): Ignores and Ownership

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,7 @@ node_modules/
 dist/
 scripts/ci/
 /cache*
+cache/
+.git/
+log/
+*.log

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -383,6 +383,7 @@ codemagic.yaml                                                                  
 /scripts/postinstall.js                                                                                  @island-is/devops @island-is/core
 /scripts/codegen.js                                                                                      @island-is/devops @island-is/core
 /charts/                                                                                                 @island-is/devops
+.dockerignore                                                                                            @island-is/devops
 
 
 # System tests


### PR DESCRIPTION
Ignore more stuff for faster builds. Take ownership of Docker-stuff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `.dockerignore` file to enhance the exclusion of unnecessary files during the Docker build process.
	- Revised the `.github/CODEOWNERS` file to clarify ownership assignments for project directories and files, including a new entry for `.dockerignore`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->