### PR TITLE
fix(native-app): fix normal document loading

### DIFF
--- a/apps/native/app/src/screens/document-detail/document-detail.tsx
+++ b/apps/native/app/src/screens/document-detail/document-detail.tsx
@@ -252,7 +252,6 @@ export const DocumentDetailScreen: NavigationFunctionComponent<{
     } finally {
       markDocumentAsRead()
       setRefetching(false)
-      setLoaded(true)
     }
   }
 
@@ -487,17 +486,13 @@ export const DocumentDetailScreen: NavigationFunctionComponent<{
               />
             ) : hasPdf ? (
               <PdfWrapper>
-                {visible && accessToken && loaded && (
+                {visible && accessToken && (
                   <PdfViewer
                     url={`data:application/pdf;base64,${Document.content?.value}`}
                     body={`documentId=${Document.id}&__accessToken=${accessToken}`}
                     onLoaded={(filePath: any) => {
                       setPdfUrl(filePath)
-                      // Make sure to not set document as loaded until actions have been fetched
-                      // To prevent top of first page not being shown
-                      if (shouldIncludeDocument) {
-                        setLoaded(true)
-                      }
+                      setLoaded(true)
                     }}
                     onError={() => {
                       setLoaded(true)


### PR DESCRIPTION

## What

Reverting fix for not scrolling subpoena documents a little bit down when loading

## Why

It broke loading of other documents. 
## Screenshots / Gifs

After this fix (loading already confirmed subpoena, normal document and unconfirmed subpoena):

https://github.com/user-attachments/assets/f96d0ed8-394f-4744-9412-28076833dc0d


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced document loading process for PDF files in the Document Detail Screen.
  
- **Bug Fixes**
	- Improved error handling during PDF loading, ensuring the loading state is managed correctly even when errors occur.

- **Style**
	- Minor styling adjustments and removal of unnecessary comments for a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->