### PR TITLE
chore(j-s): Give registrars and judge assistants access to service status

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/police/police.controller.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/police.controller.ts
@@ -22,7 +22,9 @@ import {
 import type { User } from '@island.is/judicial-system/types'
 
 import {
+  districtCourtAssistantRule,
   districtCourtJudgeRule,
+  districtCourtRegistrarRule,
   prosecutorRepresentativeRule,
   prosecutorRule,
 } from '../../guards'
@@ -78,6 +80,8 @@ export class PoliceController {
     prosecutorRule,
     prosecutorRepresentativeRule,
     districtCourtJudgeRule,
+    districtCourtAssistantRule,
+    districtCourtRegistrarRule,
   )
   @Get('subpoenaStatus/:subpoenaId')
   @ApiOkResponse({


### PR DESCRIPTION
# Give registrars and judge assistants access to service status

[Asana](https://app.asana.com/0/1199153462262248/1208639438532865/f)

## What

Give registrars and judge assistants access to service status

## Why

They need to be able to see the status of the service.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new role-based access control for the subpoena status endpoint, allowing district court assistants and registrars to access this functionality.
  
- **Bug Fixes**
	- No bug fixes were reported. 

- **Documentation**
	- Updated access control rules documentation to reflect new roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->