### PR TITLE
chore(j-s): Show user role in service certificate

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/serviceCertificatePdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/serviceCertificatePdf.ts
@@ -42,7 +42,6 @@ const getSubpoenaType = (subpoenaType?: SubpoenaType): string => {
 }
 
 const getRole = (userRole?: UserRole) => {
-  console.log(userRole)
   switch (userRole) {
     case UserRole.DISTRICT_COURT_ASSISTANT: {
       return 'Aðstoðarmaður dómara'

--- a/apps/judicial-system/backend/src/app/formatters/serviceCertificatePdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/serviceCertificatePdf.ts
@@ -9,7 +9,11 @@ import {
   getWordByGender,
   Word,
 } from '@island.is/judicial-system/formatters'
-import { ServiceStatus, SubpoenaType } from '@island.is/judicial-system/types'
+import {
+  ServiceStatus,
+  SubpoenaType,
+  UserRole,
+} from '@island.is/judicial-system/types'
 
 import { serviceCertificate as strings } from '../messages'
 import { Case } from '../modules/case'
@@ -34,6 +38,18 @@ const getSubpoenaType = (subpoenaType?: SubpoenaType): string => {
     default:
       // Should never happen
       return 'Ekki skráð'
+  }
+}
+
+const getRole = (userRole?: UserRole) => {
+  console.log(userRole)
+  switch (userRole) {
+    case UserRole.DISTRICT_COURT_ASSISTANT: {
+      return 'Aðstoðarmaður dómara'
+    }
+    default: {
+      return 'Dómari'
+    }
   }
 }
 
@@ -132,7 +148,7 @@ export const createServiceCertificate = (
     'Times-Roman',
   )
 
-  addNormalText(doc, 'Dómari: ', 'Times-Bold', true)
+  addNormalText(doc, `${getRole(theCase.judge?.role)}: `, 'Times-Bold', true)
   addNormalText(
     doc,
     theCase.judge ? theCase.judge.name : 'Ekki skráður',


### PR DESCRIPTION
# Show user role in service certificate

[Asana](https://app.asana.com/0/1199153462262248/1208626990151887/f)

## What

If the judge in an indictment is an assistant to the judge, that is reflected in the service certificate pdf

## Why

For correctness

## Screenshots / Gifs

<img width="360" alt="Screenshot 2024-10-28 at 14 44 16" src="https://github.com/user-attachments/assets/d77ad070-1107-4890-8069-a64ddb95e403">

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced PDF document generation with dynamic user role determination for judges.
	- Improved logic for displaying the judge's title based on their role.
  
- **Bug Fixes**
	- Removed hardcoded strings for judge titles, ensuring accurate representation of roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->