### PR TITLE
fix(financial-aid): use bankNumber and ledger

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/financial-aid/financial-aid.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/financial-aid/financial-aid.service.ts
@@ -201,8 +201,8 @@ export class FinancialAidService extends BaseTemplateApiService {
       usePersonalTaxCredit: Boolean(
         answersSchema.personalTaxCredit.type === ApproveOptions.Yes,
       ),
-      bankNumber: answersSchema.bankInfo.accountNumber,
-      ledger: answersSchema.bankInfo.accountNumber,
+      bankNumber: answersSchema.bankInfo.bankNumber,
+      ledger: answersSchema.bankInfo.ledger,
       accountNumber: answersSchema.bankInfo.accountNumber,
       employment: answersSchema.employment.type,
       employmentCustom: answersSchema.employment.custom,


### PR DESCRIPTION
## What

Use bankNumber and ledger when sending bank info

## Why

bank info was returning as accountNumber-acountNumber-acountNumber but should be bankNumber-ledger-accountNumer

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
