### PR TITLE
fix(ui-core): Render button string children in span (hotfix)

### DIFF
--- a/libs/island-ui/core/src/lib/Button/Button.tsx
+++ b/libs/island-ui/core/src/lib/Button/Button.tsx
@@ -101,7 +101,11 @@ export const Button = forwardRef<
             {preTextIcon && (
               <ButtonIcon icon={preTextIcon} type={preTextIconType} preText />
             )}
-            {children}
+            {typeof children === 'string' && variant !== 'text' ? (
+              <span>{children}</span>
+            ) : (
+              children
+            )}
             {icon && <ButtonIcon icon={icon} type={iconType} />}
           </>
         )}


### PR DESCRIPTION
# ...

Render button children in span

## What

Hotfix #16515

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
