### PR TITLE
chore(search-indexer-service): Change prod url

### DIFF
--- a/apps/services/search-indexer/infra/search-indexer-service.ts
+++ b/apps/services/search-indexer/infra/search-indexer-service.ts
@@ -117,7 +117,7 @@ export const serviceSetup = (): ServiceBuilder<'search-indexer-service'> =>
         host: {
           dev: 'search-indexer-service',
           staging: 'search-indexer-service',
-          prod: 'search-indexer-service.devland.is',
+          prod: 'search-indexer-service',
         },
         paths: ['/'],
         extraAnnotations: {

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -1862,7 +1862,7 @@ search-indexer-service:
         kubernetes.io/ingress.class: 'nginx-external-alb'
         nginx.ingress.kubernetes.io/service-upstream: 'true'
       hosts:
-        - host: 'search-indexer-service.devland.is'
+        - host: 'search-indexer-service.island.is'
           paths:
             - '/'
   initContainer:


### PR DESCRIPTION
#  Change prod url

## What

* Due to recent change by devops the prod url could no longer be called, I was told that changing the prod url would be better so here I'm doing just that

Slack discussion: https://islandis.slack.com/archives/C019LNRM6LE/p1730371957246189
https://islandis.slack.com/archives/C04R5PKH8TZ/p1730370825455869


I'll be responsible for changing the webhook url in the cms when the next release goes out


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Simplified production host URL for the search indexer service, aligning it with development and staging environments.
	- Updated ingress host for improved external access to the search indexer service.

- **Improvements**
	- Adjusted health check paths and readiness criteria for better service monitoring.
	- Increased resource limits for the search indexer service to enhance performance.
	- Updated environment variables for improved service communication.
	- Set consistent pod disruption budgets to minimize service disruption during updates.

- **Bug Fixes**
	- No bug fixes were made in this release.

- **Documentation**
	- No documentation updates were included in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->