### PR TITLE
fix: Add namespace grants for services that need it, but don't have it

### DIFF
--- a/apps/api/infra/api.ts
+++ b/apps/api/infra/api.ts
@@ -99,12 +99,10 @@ export const serviceSetup = (services: {
         prod: 'https://innskra.island.is/api',
       },
       ELASTIC_NODE: {
-        dev:
-          'https://vpc-search-njkekqydiegezhr4vqpkfnw5la.eu-west-1.es.amazonaws.com',
+        dev: 'https://vpc-search-njkekqydiegezhr4vqpkfnw5la.eu-west-1.es.amazonaws.com',
         staging:
           'https://vpc-search-q6hdtjcdlhkffyxvrnmzfwphuq.eu-west-1.es.amazonaws.com/',
-        prod:
-          'https://vpc-search-mw4w5c2m2g5edjrtvwbpzhkw24.eu-west-1.es.amazonaws.com/',
+        prod: 'https://vpc-search-mw4w5c2m2g5edjrtvwbpzhkw24.eu-west-1.es.amazonaws.com/',
       },
 
       CONTENTFUL_HOST: {
@@ -163,8 +161,7 @@ export const serviceSetup = (services: {
       XROAD_FINANCES_TIMEOUT: '20000',
       XROAD_CHARGE_FJS_V2_TIMEOUT: '20000',
       AUTH_DELEGATION_API_URL: {
-        dev:
-          'http://web-services-auth-delegation-api.identity-server-delegation.svc.cluster.local',
+        dev: 'http://web-services-auth-delegation-api.identity-server-delegation.svc.cluster.local',
         staging:
           'http://web-services-auth-delegation-api.identity-server-delegation.svc.cluster.local',
         prod: 'https://auth-delegation-api.internal.innskra.island.is',

--- a/apps/api/infra/api.ts
+++ b/apps/api/infra/api.ts
@@ -99,10 +99,12 @@ export const serviceSetup = (services: {
         prod: 'https://innskra.island.is/api',
       },
       ELASTIC_NODE: {
-        dev: 'https://vpc-search-njkekqydiegezhr4vqpkfnw5la.eu-west-1.es.amazonaws.com',
+        dev:
+          'https://vpc-search-njkekqydiegezhr4vqpkfnw5la.eu-west-1.es.amazonaws.com',
         staging:
           'https://vpc-search-q6hdtjcdlhkffyxvrnmzfwphuq.eu-west-1.es.amazonaws.com/',
-        prod: 'https://vpc-search-mw4w5c2m2g5edjrtvwbpzhkw24.eu-west-1.es.amazonaws.com/',
+        prod:
+          'https://vpc-search-mw4w5c2m2g5edjrtvwbpzhkw24.eu-west-1.es.amazonaws.com/',
       },
 
       CONTENTFUL_HOST: {
@@ -161,7 +163,8 @@ export const serviceSetup = (services: {
       XROAD_FINANCES_TIMEOUT: '20000',
       XROAD_CHARGE_FJS_V2_TIMEOUT: '20000',
       AUTH_DELEGATION_API_URL: {
-        dev: 'http://web-services-auth-delegation-api.identity-server-delegation.svc.cluster.local',
+        dev:
+          'http://web-services-auth-delegation-api.identity-server-delegation.svc.cluster.local',
         staging:
           'http://web-services-auth-delegation-api.identity-server-delegation.svc.cluster.local',
         prod: 'https://auth-delegation-api.internal.innskra.island.is',
@@ -469,6 +472,6 @@ export const serviceSetup = (services: {
       'api-catalogue',
       'application-system',
       'consultation-portal',
-      'services-bff-portals-admin',
+      'portals-admin',
     )
 }

--- a/apps/auth-admin-web/infra/auth-admin-web.ts
+++ b/apps/auth-admin-web/infra/auth-admin-web.ts
@@ -8,8 +8,8 @@ const extraAnnotations = {
     'client_header_buffer_size 16k; large_client_header_buffers 4 16k;',
 }
 
-export const serviceSetup = (): ServiceBuilder<'auth-admin-web'> => {
-  return service('auth-admin-web')
+export const serviceSetup = (): ServiceBuilder<'auth-admin-web'> =>
+  service('auth-admin-web')
     .namespace('identity-server-admin')
     .image('auth-admin-web')
     .env({
@@ -74,4 +74,3 @@ export const serviceSetup = (): ServiceBuilder<'auth-admin-web'> => {
       staging: { progressDeadlineSeconds: 1200 },
       prod: { progressDeadlineSeconds: 1200 },
     })
-}

--- a/apps/auth-admin-web/infra/auth-admin-web.ts
+++ b/apps/auth-admin-web/infra/auth-admin-web.ts
@@ -74,5 +74,4 @@ export const serviceSetup = (): ServiceBuilder<'auth-admin-web'> => {
       staging: { progressDeadlineSeconds: 1200 },
       prod: { progressDeadlineSeconds: 1200 },
     })
-    .grantNamespaces('nginx-ingress-external')
 }

--- a/apps/auth-admin-web/infra/auth-admin-web.ts
+++ b/apps/auth-admin-web/infra/auth-admin-web.ts
@@ -74,5 +74,5 @@ export const serviceSetup = (): ServiceBuilder<'auth-admin-web'> => {
       staging: { progressDeadlineSeconds: 1200 },
       prod: { progressDeadlineSeconds: 1200 },
     })
-    .grantNamespaces('portals-admin', 'nginx-ingress-external')
+    .grantNamespaces('nginx-ingress-external')
 }

--- a/apps/auth-admin-web/infra/auth-admin-web.ts
+++ b/apps/auth-admin-web/infra/auth-admin-web.ts
@@ -74,4 +74,5 @@ export const serviceSetup = (): ServiceBuilder<'auth-admin-web'> => {
       staging: { progressDeadlineSeconds: 1200 },
       prod: { progressDeadlineSeconds: 1200 },
     })
+    .grantNamespaces('portals-admin', 'nginx-ingress-external')
 }

--- a/apps/portals/admin/infra/portals-admin.ts
+++ b/apps/portals/admin/infra/portals-admin.ts
@@ -53,3 +53,4 @@ export const serviceSetup = (): ServiceBuilder<'portals-admin'> =>
         paths: ['/stjornbord'],
       },
     })
+    .grantNamespaces('nginx-ingress-internal')

--- a/apps/portals/admin/infra/portals-admin.ts
+++ b/apps/portals/admin/infra/portals-admin.ts
@@ -53,4 +53,4 @@ export const serviceSetup = (): ServiceBuilder<'portals-admin'> =>
         paths: ['/stjornbord'],
       },
     })
-    .grantNamespaces('nginx-ingress-internal')
+    .grantNamespaces('nginx-ingress-external')

--- a/apps/portals/admin/infra/portals-admin.ts
+++ b/apps/portals/admin/infra/portals-admin.ts
@@ -53,4 +53,4 @@ export const serviceSetup = (): ServiceBuilder<'portals-admin'> =>
         paths: ['/stjornbord'],
       },
     })
-    .grantNamespaces('nginx-ingress-external')
+    .grantNamespaces('nginx-ingress-external', 'identity-server')

--- a/apps/services/auth/ids-api/infra/identity-server.ts
+++ b/apps/services/auth/ids-api/infra/identity-server.ts
@@ -192,5 +192,9 @@ export const serviceSetup = (services: {
         },
       },
     })
-    .grantNamespaces('nginx-ingress-external', 'portals-admin')
+    .grantNamespaces(
+      'nginx-ingress-external',
+      'portals-admin',
+      'user-notification',
+    )
 }

--- a/apps/services/auth/ids-api/infra/identity-server.ts
+++ b/apps/services/auth/ids-api/infra/identity-server.ts
@@ -192,4 +192,5 @@ export const serviceSetup = (services: {
         },
       },
     })
+    .grantNamespaces('nginx-ingress-external', 'portals-admin')
 }

--- a/apps/services/auth/ids-api/infra/identity-server.ts
+++ b/apps/services/auth/ids-api/infra/identity-server.ts
@@ -192,5 +192,9 @@ export const serviceSetup = (services: {
         },
       },
     })
-    .grantNamespaces('nginx-ingress-external', 'user-notification')
+    .grantNamespaces(
+      'nginx-ingress-external',
+      'user-notification',
+      'portals-admin',
+    )
 }

--- a/apps/services/auth/ids-api/infra/ids-api.ts
+++ b/apps/services/auth/ids-api/infra/ids-api.ts
@@ -122,7 +122,11 @@ export const serviceSetup = (): ServiceBuilder<'services-auth-ids-api'> => {
       min: 2,
       max: 15,
     })
-    .grantNamespaces('user-notification')
+    .grantNamespaces(
+      'nginx-ingress-external',
+      'portals-admin',
+      'user-notification',
+    )
 }
 
 const cleanupId = 'services-auth-ids-api-cleanup'
@@ -158,3 +162,8 @@ export const cleanupSetup = (): ServiceBuilder<typeof cleanupId> =>
       staging: schedule,
       prod: schedule,
     })
+    .grantNamespaces(
+      'nginx-ingress-external',
+      'portals-admin',
+      'user-notification',
+    )

--- a/apps/services/auth/ids-api/infra/ids-api.ts
+++ b/apps/services/auth/ids-api/infra/ids-api.ts
@@ -158,4 +158,3 @@ export const cleanupSetup = (): ServiceBuilder<typeof cleanupId> =>
       staging: schedule,
       prod: schedule,
     })
-    .grantNamespaces('nginx-ingress-external', 'user-notification')

--- a/charts/identity-server/values.dev.yaml
+++ b/charts/identity-server/values.dev.yaml
@@ -15,9 +15,8 @@ auth-admin-web:
     NODE_OPTIONS: '--max-old-space-size=230 -r dd-trace/init'
     SERVERSIDE_FEATURES_ON: ''
   grantNamespaces:
+    - 'portals-admin'
     - 'nginx-ingress-external'
-    - 'nginx-ingress-internal'
-    - 'islandis'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:
@@ -758,9 +757,8 @@ services-auth-public-api:
     XROAD_TLS_BASE_PATH: 'https://securityserver.dev01.devland.is'
     XROAD_TLS_BASE_PATH_WITH_ENV: 'https://securityserver.dev01.devland.is/r1/IS-DEV'
   grantNamespaces:
+    - 'portals-admin'
     - 'nginx-ingress-external'
-    - 'nginx-ingress-internal'
-    - 'islandis'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:

--- a/charts/identity-server/values.dev.yaml
+++ b/charts/identity-server/values.dev.yaml
@@ -126,6 +126,7 @@ identity-server:
   grantNamespaces:
     - 'nginx-ingress-external'
     - 'user-notification'
+    - 'portals-admin'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:
@@ -540,6 +541,7 @@ services-auth-ids-api-cleanup:
   grantNamespaces:
     - 'nginx-ingress-external'
     - 'user-notification'
+    - 'portals-admin'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:

--- a/charts/identity-server/values.dev.yaml
+++ b/charts/identity-server/values.dev.yaml
@@ -126,6 +126,7 @@ identity-server:
   grantNamespaces:
     - 'nginx-ingress-external'
     - 'portals-admin'
+    - 'user-notification'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:
@@ -434,6 +435,8 @@ services-auth-ids-api:
     XROAD_TLS_BASE_PATH: 'https://securityserver.dev01.devland.is'
     XROAD_TLS_BASE_PATH_WITH_ENV: 'https://securityserver.dev01.devland.is/r1/IS-DEV'
   grantNamespaces:
+    - 'nginx-ingress-external'
+    - 'portals-admin'
     - 'user-notification'
   grantNamespacesEnabled: true
   healthCheck:
@@ -539,6 +542,7 @@ services-auth-ids-api-cleanup:
   grantNamespaces:
     - 'nginx-ingress-external'
     - 'portals-admin'
+    - 'user-notification'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:

--- a/charts/identity-server/values.dev.yaml
+++ b/charts/identity-server/values.dev.yaml
@@ -16,6 +16,8 @@ auth-admin-web:
     SERVERSIDE_FEATURES_ON: ''
   grantNamespaces:
     - 'nginx-ingress-external'
+    - 'nginx-ingress-internal'
+    - 'islandis'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:
@@ -759,6 +761,8 @@ services-auth-public-api:
     XROAD_TLS_BASE_PATH_WITH_ENV: 'https://securityserver.dev01.devland.is/r1/IS-DEV'
   grantNamespaces:
     - 'nginx-ingress-external'
+    - 'nginx-ingress-internal'
+    - 'islandis'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:

--- a/charts/identity-server/values.dev.yaml
+++ b/charts/identity-server/values.dev.yaml
@@ -15,7 +15,6 @@ auth-admin-web:
     NODE_OPTIONS: '--max-old-space-size=230 -r dd-trace/init'
     SERVERSIDE_FEATURES_ON: ''
   grantNamespaces:
-    - 'portals-admin'
     - 'nginx-ingress-external'
   grantNamespacesEnabled: true
   healthCheck:
@@ -123,7 +122,8 @@ identity-server:
   files:
     - 'ids-signing.pfx'
   grantNamespaces:
-    - 'user-notification'
+    - 'nginx-ingress-external'
+    - 'portals-admin'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:
@@ -535,7 +535,8 @@ services-auth-ids-api-cleanup:
     NODE_OPTIONS: '--max-old-space-size=921 -r dd-trace/init'
     SERVERSIDE_FEATURES_ON: ''
   grantNamespaces:
-    - 'user-notification'
+    - 'nginx-ingress-external'
+    - 'portals-admin'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:
@@ -757,7 +758,6 @@ services-auth-public-api:
     XROAD_TLS_BASE_PATH: 'https://securityserver.dev01.devland.is'
     XROAD_TLS_BASE_PATH_WITH_ENV: 'https://securityserver.dev01.devland.is/r1/IS-DEV'
   grantNamespaces:
-    - 'portals-admin'
     - 'nginx-ingress-external'
   grantNamespacesEnabled: true
   healthCheck:

--- a/charts/identity-server/values.prod.yaml
+++ b/charts/identity-server/values.prod.yaml
@@ -15,9 +15,8 @@ auth-admin-web:
     NODE_OPTIONS: '--max-old-space-size=230 -r dd-trace/init'
     SERVERSIDE_FEATURES_ON: 'driving-license-use-v1-endpoint-for-v2-comms'
   grantNamespaces:
+    - 'portals-admin'
     - 'nginx-ingress-external'
-    - 'nginx-ingress-internal'
-    - 'islandis'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:
@@ -755,9 +754,8 @@ services-auth-public-api:
     XROAD_TLS_BASE_PATH: 'https://securityserver.island.is'
     XROAD_TLS_BASE_PATH_WITH_ENV: 'https://securityserver.island.is/r1/IS'
   grantNamespaces:
+    - 'portals-admin'
     - 'nginx-ingress-external'
-    - 'nginx-ingress-internal'
-    - 'islandis'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:

--- a/charts/identity-server/values.prod.yaml
+++ b/charts/identity-server/values.prod.yaml
@@ -124,6 +124,7 @@ identity-server:
   grantNamespaces:
     - 'nginx-ingress-external'
     - 'portals-admin'
+    - 'user-notification'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:
@@ -431,6 +432,8 @@ services-auth-ids-api:
     XROAD_TLS_BASE_PATH: 'https://securityserver.island.is'
     XROAD_TLS_BASE_PATH_WITH_ENV: 'https://securityserver.island.is/r1/IS'
   grantNamespaces:
+    - 'nginx-ingress-external'
+    - 'portals-admin'
     - 'user-notification'
   grantNamespacesEnabled: true
   healthCheck:
@@ -536,6 +539,7 @@ services-auth-ids-api-cleanup:
   grantNamespaces:
     - 'nginx-ingress-external'
     - 'portals-admin'
+    - 'user-notification'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:

--- a/charts/identity-server/values.prod.yaml
+++ b/charts/identity-server/values.prod.yaml
@@ -124,6 +124,7 @@ identity-server:
   grantNamespaces:
     - 'nginx-ingress-external'
     - 'user-notification'
+    - 'portals-admin'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:
@@ -537,6 +538,7 @@ services-auth-ids-api-cleanup:
   grantNamespaces:
     - 'nginx-ingress-external'
     - 'user-notification'
+    - 'portals-admin'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:

--- a/charts/identity-server/values.prod.yaml
+++ b/charts/identity-server/values.prod.yaml
@@ -16,6 +16,8 @@ auth-admin-web:
     SERVERSIDE_FEATURES_ON: 'driving-license-use-v1-endpoint-for-v2-comms'
   grantNamespaces:
     - 'nginx-ingress-external'
+    - 'nginx-ingress-internal'
+    - 'islandis'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:
@@ -756,6 +758,8 @@ services-auth-public-api:
     XROAD_TLS_BASE_PATH_WITH_ENV: 'https://securityserver.island.is/r1/IS'
   grantNamespaces:
     - 'nginx-ingress-external'
+    - 'nginx-ingress-internal'
+    - 'islandis'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:

--- a/charts/identity-server/values.prod.yaml
+++ b/charts/identity-server/values.prod.yaml
@@ -15,7 +15,6 @@ auth-admin-web:
     NODE_OPTIONS: '--max-old-space-size=230 -r dd-trace/init'
     SERVERSIDE_FEATURES_ON: 'driving-license-use-v1-endpoint-for-v2-comms'
   grantNamespaces:
-    - 'portals-admin'
     - 'nginx-ingress-external'
   grantNamespacesEnabled: true
   healthCheck:
@@ -121,7 +120,8 @@ identity-server:
   files:
     - 'ids-signing.pfx'
   grantNamespaces:
-    - 'user-notification'
+    - 'nginx-ingress-external'
+    - 'portals-admin'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:
@@ -532,7 +532,8 @@ services-auth-ids-api-cleanup:
     NODE_OPTIONS: '--max-old-space-size=921 -r dd-trace/init'
     SERVERSIDE_FEATURES_ON: 'driving-license-use-v1-endpoint-for-v2-comms'
   grantNamespaces:
-    - 'user-notification'
+    - 'nginx-ingress-external'
+    - 'portals-admin'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:
@@ -754,7 +755,6 @@ services-auth-public-api:
     XROAD_TLS_BASE_PATH: 'https://securityserver.island.is'
     XROAD_TLS_BASE_PATH_WITH_ENV: 'https://securityserver.island.is/r1/IS'
   grantNamespaces:
-    - 'portals-admin'
     - 'nginx-ingress-external'
   grantNamespacesEnabled: true
   healthCheck:

--- a/charts/identity-server/values.staging.yaml
+++ b/charts/identity-server/values.staging.yaml
@@ -15,7 +15,6 @@ auth-admin-web:
     NODE_OPTIONS: '--max-old-space-size=230 -r dd-trace/init'
     SERVERSIDE_FEATURES_ON: ''
   grantNamespaces:
-    - 'portals-admin'
     - 'nginx-ingress-external'
   grantNamespacesEnabled: true
   healthCheck:
@@ -123,7 +122,8 @@ identity-server:
   files:
     - 'ids-signing.pfx'
   grantNamespaces:
-    - 'user-notification'
+    - 'nginx-ingress-external'
+    - 'portals-admin'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:
@@ -535,7 +535,8 @@ services-auth-ids-api-cleanup:
     NODE_OPTIONS: '--max-old-space-size=921 -r dd-trace/init'
     SERVERSIDE_FEATURES_ON: ''
   grantNamespaces:
-    - 'user-notification'
+    - 'nginx-ingress-external'
+    - 'portals-admin'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:
@@ -757,7 +758,6 @@ services-auth-public-api:
     XROAD_TLS_BASE_PATH: 'https://securityserver.staging01.devland.is'
     XROAD_TLS_BASE_PATH_WITH_ENV: 'https://securityserver.staging01.devland.is/r1/IS-TEST'
   grantNamespaces:
-    - 'portals-admin'
     - 'nginx-ingress-external'
   grantNamespacesEnabled: true
   healthCheck:

--- a/charts/identity-server/values.staging.yaml
+++ b/charts/identity-server/values.staging.yaml
@@ -15,9 +15,8 @@ auth-admin-web:
     NODE_OPTIONS: '--max-old-space-size=230 -r dd-trace/init'
     SERVERSIDE_FEATURES_ON: ''
   grantNamespaces:
+    - 'portals-admin'
     - 'nginx-ingress-external'
-    - 'nginx-ingress-internal'
-    - 'islandis'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:
@@ -758,9 +757,8 @@ services-auth-public-api:
     XROAD_TLS_BASE_PATH: 'https://securityserver.staging01.devland.is'
     XROAD_TLS_BASE_PATH_WITH_ENV: 'https://securityserver.staging01.devland.is/r1/IS-TEST'
   grantNamespaces:
+    - 'portals-admin'
     - 'nginx-ingress-external'
-    - 'nginx-ingress-internal'
-    - 'islandis'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:

--- a/charts/identity-server/values.staging.yaml
+++ b/charts/identity-server/values.staging.yaml
@@ -126,6 +126,7 @@ identity-server:
   grantNamespaces:
     - 'nginx-ingress-external'
     - 'portals-admin'
+    - 'user-notification'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:
@@ -434,6 +435,8 @@ services-auth-ids-api:
     XROAD_TLS_BASE_PATH: 'https://securityserver.staging01.devland.is'
     XROAD_TLS_BASE_PATH_WITH_ENV: 'https://securityserver.staging01.devland.is/r1/IS-TEST'
   grantNamespaces:
+    - 'nginx-ingress-external'
+    - 'portals-admin'
     - 'user-notification'
   grantNamespacesEnabled: true
   healthCheck:
@@ -539,6 +542,7 @@ services-auth-ids-api-cleanup:
   grantNamespaces:
     - 'nginx-ingress-external'
     - 'portals-admin'
+    - 'user-notification'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:

--- a/charts/identity-server/values.staging.yaml
+++ b/charts/identity-server/values.staging.yaml
@@ -126,6 +126,7 @@ identity-server:
   grantNamespaces:
     - 'nginx-ingress-external'
     - 'user-notification'
+    - 'portals-admin'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:
@@ -540,6 +541,7 @@ services-auth-ids-api-cleanup:
   grantNamespaces:
     - 'nginx-ingress-external'
     - 'user-notification'
+    - 'portals-admin'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:

--- a/charts/identity-server/values.staging.yaml
+++ b/charts/identity-server/values.staging.yaml
@@ -16,6 +16,8 @@ auth-admin-web:
     SERVERSIDE_FEATURES_ON: ''
   grantNamespaces:
     - 'nginx-ingress-external'
+    - 'nginx-ingress-internal'
+    - 'islandis'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:
@@ -759,6 +761,8 @@ services-auth-public-api:
     XROAD_TLS_BASE_PATH_WITH_ENV: 'https://securityserver.staging01.devland.is/r1/IS-TEST'
   grantNamespaces:
     - 'nginx-ingress-external'
+    - 'nginx-ingress-internal'
+    - 'islandis'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -1804,6 +1804,7 @@ portals-admin:
     SI_PUBLIC_IDENTITY_SERVER_ISSUER_URL: 'https://identity-server.dev01.devland.is'
   grantNamespaces:
     - 'nginx-ingress-external'
+    - 'identity-server'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -1803,7 +1803,7 @@ portals-admin:
     SI_PUBLIC_ENVIRONMENT: 'dev'
     SI_PUBLIC_IDENTITY_SERVER_ISSUER_URL: 'https://identity-server.dev01.devland.is'
   grantNamespaces:
-    - 'identity-server'
+    - 'nginx-ingress-internal'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -1803,7 +1803,7 @@ portals-admin:
     SI_PUBLIC_ENVIRONMENT: 'dev'
     SI_PUBLIC_IDENTITY_SERVER_ISSUER_URL: 'https://identity-server.dev01.devland.is'
   grantNamespaces:
-    - 'nginx-ingress-internal'
+    - 'nginx-ingress-external'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -418,7 +418,7 @@ api:
     - 'api-catalogue'
     - 'application-system'
     - 'consultation-portal'
-    - 'services-bff-portals-admin'
+    - 'portals-admin'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -406,7 +406,7 @@ api:
     - 'api-catalogue'
     - 'application-system'
     - 'consultation-portal'
-    - 'services-bff-portals-admin'
+    - 'portals-admin'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -1668,7 +1668,7 @@ portals-admin:
     SI_PUBLIC_ENVIRONMENT: 'prod'
     SI_PUBLIC_IDENTITY_SERVER_ISSUER_URL: 'https://innskra.island.is'
   grantNamespaces:
-    - 'nginx-ingress-internal'
+    - 'nginx-ingress-external'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -1669,6 +1669,7 @@ portals-admin:
     SI_PUBLIC_IDENTITY_SERVER_ISSUER_URL: 'https://innskra.island.is'
   grantNamespaces:
     - 'nginx-ingress-external'
+    - 'identity-server'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -1668,7 +1668,7 @@ portals-admin:
     SI_PUBLIC_ENVIRONMENT: 'prod'
     SI_PUBLIC_IDENTITY_SERVER_ISSUER_URL: 'https://innskra.island.is'
   grantNamespaces:
-    - 'identity-server'
+    - 'nginx-ingress-internal'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -1541,7 +1541,7 @@ portals-admin:
     SI_PUBLIC_ENVIRONMENT: 'staging'
     SI_PUBLIC_IDENTITY_SERVER_ISSUER_URL: 'https://identity-server.staging01.devland.is'
   grantNamespaces:
-    - 'identity-server'
+    - 'nginx-ingress-internal'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -1542,6 +1542,7 @@ portals-admin:
     SI_PUBLIC_IDENTITY_SERVER_ISSUER_URL: 'https://identity-server.staging01.devland.is'
   grantNamespaces:
     - 'nginx-ingress-external'
+    - 'identity-server'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -418,7 +418,7 @@ api:
     - 'api-catalogue'
     - 'application-system'
     - 'consultation-portal'
-    - 'services-bff-portals-admin'
+    - 'portals-admin'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -1541,7 +1541,7 @@ portals-admin:
     SI_PUBLIC_ENVIRONMENT: 'staging'
     SI_PUBLIC_IDENTITY_SERVER_ISSUER_URL: 'https://identity-server.staging01.devland.is'
   grantNamespaces:
-    - 'nginx-ingress-internal'
+    - 'nginx-ingress-external'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:


### PR DESCRIPTION

- `nginx-ingress-external` (ALB) -> `identity-server`

Fix for recent `504` incident on `dev`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced service configurations with the addition of `nginx-ingress-external` namespace across multiple services, improving access control.
  - Introduced new readiness health check paths for better service monitoring.
  
- **Bug Fixes**
  - Adjusted Horizontal Pod Autoscaler settings for improved scaling behavior based on updated metrics.
  
- **Documentation**
  - Updated configuration files to reflect changes in resource limits, replica counts, and health check paths, ensuring clarity in deployment strategies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->