### PR TITLE
fix(user-notification): Args null variant fix

### DIFF
--- a/apps/services/user-notification/src/app/modules/notifications/notifications.service.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/notifications.service.ts
@@ -120,12 +120,14 @@ export class NotificationsService {
   }
 
   async getTemplates(locale?: Locale): Promise<HnippTemplate[]> {
-    locale = mapToLocale(locale as Locale)
-    const queryVariables = {
-      locale: mapToContentfulLocale(locale),
-    }
-    const res = await this.cmsService.fetchData(GetTemplates, queryVariables)
-    return res.hnippTemplateCollection.items
+    locale = mapToLocale(locale as Locale);
+    const queryVariables = { locale: mapToContentfulLocale(locale) };
+    const res = await this.cmsService.fetchData(GetTemplates, queryVariables);
+    
+    return res.hnippTemplateCollection.items.map((template: HnippTemplate) => ({
+      ...template,
+      args: template.args || [], // Ensure args is an array
+    }));
   }
 
   async getTemplate(
@@ -143,9 +145,10 @@ export class NotificationsService {
     )
     const items = res.hnippTemplateCollection.items
     if (items.length > 0) {
-      return items[0]
+      const template = items[0];
+      return { ...template, args: template.args || [] }; // Ensure args is an array
     } else {
-      throw new NotFoundException(`Template not found for ID: ${templateId}`)
+      throw new NotFoundException(`Template not found for ID: ${templateId}`);
     }
   }
   /**
@@ -169,6 +172,7 @@ export class NotificationsService {
 
   validateArgCounts(args: ArgumentDto[], template: HnippTemplate): boolean {
     return args.length == template.args.length
+    // return (args ? args.length : 0) === (template.args ? template.args.length : 0); ... superforgiving
   }
 
   /**


### PR DESCRIPTION
contentful sends null instead of empty arrays for empty lists - this is to ensure declared value of dto for 0 argument templates

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
