### PR TITLE
fix(regulations-admin): Update gildistaka regex

### DIFF
--- a/libs/portals/admin/regulations-admin/src/utils/formatAmendingUtils.ts
+++ b/libs/portals/admin/regulations-admin/src/utils/formatAmendingUtils.ts
@@ -71,7 +71,7 @@ export const removeRegPrefix = (title: string) => {
 }
 
 export const isGildisTaka = (str: string) => {
-  return /(öðlast|tekur).*gildi|sett.*með.*(?:heimild|stoð)/.test(
+  return /\b(öðlast|tekur)\b.*\bgildi\b|\bsett\b.*\bmeð\b.*\b(?:heimild|stoð)\b/.test(
     (str || '').toLowerCase(),
   )
 }


### PR DESCRIPTION
## What

Update gildistaka regex

## Why

it's too loose. 😞
It will match paragraphs like:
_"Það má selja apótekurum flygildi hvenær sem er"._

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the precision of keyword matching in the regulations admin portal, ensuring specific terms are recognized as whole words.
  
- **Chores**
	- No changes to exported or public entities were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->