### PR TITLE
fix(auth-api-lib): Migration bff admin portal back_channel_logout_uri

### DIFF
--- a/libs/auth-api-lib/migrations/20241104143212-add_back_channel_logout_uri_to_client_bff-stjornbord.js
+++ b/libs/auth-api-lib/migrations/20241104143212-add_back_channel_logout_uri_to_client_bff-stjornbord.js
@@ -1,0 +1,27 @@
+'use strict'
+
+const BFF_ADMIN_PORTAL_CLIENT_ID = '@admin.island.is/bff-stjornbord'
+
+module.exports = {
+  async up(queryInterface) {
+    /**
+     * Add altering commands here.
+     */
+    return queryInterface.sequelize.query(`
+      UPDATE "client"
+      SET back_channel_logout_uri = 'https://island.is/stjornbord/bff/callbacks/logout'
+      WHERE client_id = '${BFF_ADMIN_PORTAL_CLIENT_ID}';
+    `)
+  },
+
+  async down(queryInterface) {
+    /**
+     * Add reverting commands here.
+     */
+    return queryInterface.sequelize.query(`
+      UPDATE "client"
+      SET back_channel_logout_uri = NULL
+      WHERE client_id = '${BFF_ADMIN_PORTAL_CLIENT_ID}';
+    `)
+  },
+}


### PR DESCRIPTION
# IDS db migration

## What

Migration to update bff admin portal client back_channel_logout_uri

## Why

This cant be done in the ids admin

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Implemented a database migration to update the logout URI for the client `@admin.island.is/bff-stjornbord`.

- **Bug Fixes**
	- Added the ability to revert the logout URI change if necessary, ensuring database integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->