### PR TITLE
fix(CI): Use own buildkit image for buildx

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -347,7 +347,10 @@ jobs:
         with:
           image: '${{ env.DOCKER_BASE_IMAGE_REGISTRY }}/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0'
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=${{vars.AWS_ECR_REPO_BASE}}/moby/buildkit:buildx-stable-1
       - name: Get node hash
         uses: actions/github-script@v7
         id: calculate_node_modules_hash
@@ -553,7 +556,10 @@ jobs:
         with:
           image: '${{ env.DOCKER_BASE_IMAGE_REGISTRY }}/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0'
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=${{vars.AWS_ECR_REPO_BASE}}/moby/buildkit:buildx-stable-1
 
       - name: Building Docker images
         continue-on-error: true


### PR DESCRIPTION
The [setup-buildx action](https://github.com/docker/setup-buildx-action) when pulling `moby/buildkit` is breaking our docker builds due to rate limits.