### PR TITLE
fix(services-bff): Fix bff proxy download service aws cognito

### DIFF
--- a/apps/services/bff/infra/admin-portal.infra.ts
+++ b/apps/services/bff/infra/admin-portal.infra.ts
@@ -55,6 +55,7 @@ export const serviceSetup = (
         },
         extraAnnotations: {
           dev: {
+            'nginx.ingress.kubernetes.io/enable-global-auth': 'false',
             'nginx.ingress.kubernetes.io/proxy-buffering': 'on',
             'nginx.ingress.kubernetes.io/proxy-buffer-size': '8k',
           },

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -2329,6 +2329,7 @@ services-bff-portals-admin:
     primary-alb:
       annotations:
         kubernetes.io/ingress.class: 'nginx-external-alb'
+        nginx.ingress.kubernetes.io/enable-global-auth: 'false'
         nginx.ingress.kubernetes.io/proxy-buffer-size: '8k'
         nginx.ingress.kubernetes.io/proxy-buffering: 'on'
         nginx.ingress.kubernetes.io/service-upstream: 'true'


### PR DESCRIPTION
# Fix bff proxy download service aws cognito

## What

Since the introduction of our bff server we need to be able to download from the download service through the bff proxy. Currently we are blocked by aws cognito


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated ingress configurations to disable global authentication for development and staging environments.
  
- **Bug Fixes**
  - Ensured consistent health check configurations across multiple services for improved reliability.

- **Chores**
  - Minor adjustments made to environment variables, resource limits, and requests for better resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->