### PR TITLE
chore(web): Prevent 500 error in case of failure when fetching PowerBi embed props

### DIFF
--- a/libs/cms/src/lib/powerbi.service.ts
+++ b/libs/cms/src/lib/powerbi.service.ts
@@ -58,7 +58,7 @@ export class PowerBiService {
         embedUrl: report.embedUrl,
       }
     } catch (error) {
-      this.logger.error(error)
+      this.logger.error('Failed to fetch PowerBi embed props', error)
       return null
     }
   }


### PR DESCRIPTION
# Prevent 500 error in case of failure when fetching PowerBi embed props

## What

* Client secret expired and the backend throws an error that gets forwared to the frontend
* I added a try catch block and still log the error in case it happens because I don't think it's correct to cause a 500 error on the web when a single PowerBi report can't be embedded

## Screenshots / Gifs

### Before

![Screenshot 2024-11-05 at 13 26 00](https://github.com/user-attachments/assets/d735d108-c94c-4076-a0a9-f6063f74da28)


### After
![Screenshot 2024-11-05 at 13 25 32](https://github.com/user-attachments/assets/1f06c553-65bd-42d2-b8da-b8c5e080a3e5)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling in the Power BI service for improved reliability.
  
- **Bug Fixes**
	- Implemented logging for errors occurring during the retrieval of embed properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->