### PR TITLE
fix(web): Hotfix - pension calculator result preview only for current year (#16751)

### DIFF
--- a/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculatorResults.tsx
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculatorResults.tsx
@@ -606,6 +606,14 @@ const PensionCalculatorResults: CustomScreen<PensionCalculatorResultsProps> = ({
   )
 }
 
+const isSameYear = (
+  date1: string | null | undefined,
+  date2: string | null | undefined,
+) => {
+  if (!date1 || !date2) return false
+  return new Date(date1).getFullYear() === new Date(date2).getFullYear()
+}
+
 PensionCalculatorResults.getProps = async ({
   apolloClient,
   locale,
@@ -614,6 +622,7 @@ PensionCalculatorResults.getProps = async ({
 }) => {
   const calculationInput = convertQueryParametersToCalculationInput(query)
   const slug = extractSlug(locale, customPageData)
+  const dateOfCalculationsOptions = getDateOfCalculationsOptions(customPageData)
   const [
     {
       data: { getOrganizationPage },
@@ -654,14 +663,17 @@ PensionCalculatorResults.getProps = async ({
     }),
     calculationInput.typeOfBasePension ===
       SocialInsurancePensionCalculationBasePensionType.Disability &&
-    is2025PreviewActive(customPageData)
+    is2025PreviewActive(customPageData) &&
+    isSameYear(
+      dateOfCalculationsOptions?.[0]?.value,
+      calculationInput.dateOfCalculations,
+    )
       ? apolloClient.query<Query, QueryGetPensionCalculationArgs>({
           query: GET_PENSION_CALCULATION,
           variables: {
             input: {
               ...calculationInput,
-              startYear: 2025,
-              startMonth: 9,
+              dateOfCalculations: new Date(2025, 8, 1).toISOString(),
               typeOfBasePension:
                 SocialInsurancePensionCalculationBasePensionType.NewSystem,
             },
@@ -700,7 +712,7 @@ PensionCalculatorResults.getProps = async ({
     calculation: getPensionCalculation,
     calculation2025: getPensionCalculation2025,
     calculationInput,
-    dateOfCalculationsOptions: getDateOfCalculationsOptions(customPageData),
+    dateOfCalculationsOptions,
     queryParamString: queryParams.toString(),
     ...getThemeConfig(
       getOrganizationPage?.theme,


### PR DESCRIPTION
# Hotfix - pension calculator result preview only for current year (#16751)