### PR TITLE
fix(parental-leave): Correct endDate for month slider

### DIFF
--- a/libs/application/templates/parental-leave/src/lib/parentalLeaveUtils.ts
+++ b/libs/application/templates/parental-leave/src/lib/parentalLeaveUtils.ts
@@ -1449,8 +1449,9 @@ export const calculateEndDateForPeriodWithStartAndLength = (
       endDate = addDays(endDate, -1)
     }
   } else {
-    // startDate is 16 and months with 31 days
-    if (start.getDate() === 16 && daysInMonth === 31) {
+    // startDate is 16 or 17 and months with 31 days
+    const startDay = start.getDate()
+    if ((startDay === 16 || startDay === 17) && daysInMonth === 31) {
       endDate = addDays(endDate, 1)
     }
   }


### PR DESCRIPTION
https://github.com/island-is/island.is/pull/16756

When the start day is 17 and end month has 31 days it was giving wrong endDate

Co-authored-by: hfhelgason <hfhelgason@deloitte.is>
Co-authored-by: Ylfa <55542991+ylfahfa@users.noreply.github.com>
Co-authored-by: kodiakhq[bot] <49736102+kodiakhq[bot]@users.noreply.github.com>

# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
