### PR TITLE
fix(j-s): Display verdict view date for defenders

### DIFF
--- a/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.strings.ts
+++ b/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.strings.ts
@@ -29,7 +29,7 @@ export const strings = defineMessages({
     description: 'Notað til að birta dagsetningu þegar dómur var birtur.',
   },
   serviceNotRequired: {
-    id: 'judicial.system.core:info_card.defendant_info.service_not_required',
+    id: 'judicial.system.core:info_card.defendant_info.service_not_required_v1',
     defaultMessage: 'Birting dóms ekki þörf',
     description: 'Notað sem texti þegar birting dóms er ekki þörf',
   },

--- a/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.strings.ts
+++ b/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.strings.ts
@@ -35,7 +35,7 @@ export const strings = defineMessages({
   },
   serviceRequired: {
     id: 'judicial.system.core:info_card.defendant_info.service_required_v1',
-    defaultMessage: 'Birting skal dómfellda dóminn',
+    defaultMessage: 'Birta skal dómfellda dóminn',
     description: 'Notað sem texti þegar birting dóms er þörf',
   },
   spokesperson: {

--- a/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.strings.ts
+++ b/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.strings.ts
@@ -35,7 +35,7 @@ export const strings = defineMessages({
   },
   serviceRequired: {
     id: 'judicial.system.core:info_card.defendant_info.service_required',
-    defaultMessage: 'Birting skal dómfellda dóminn',
+    defaultMessage: 'Birta skal dómfellda dóminn',
     description: 'Notað sem texti þegar birting dóms er þörf',
   },
   spokesperson: {

--- a/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.strings.ts
+++ b/apps/judicial-system/web/src/components/InfoCard/DefendantInfo/DefendantInfo.strings.ts
@@ -29,13 +29,13 @@ export const strings = defineMessages({
     description: 'Notað til að birta dagsetningu þegar dómur var birtur.',
   },
   serviceNotRequired: {
-    id: 'judicial.system.core:info_card.defendant_info.service_not_required_v1',
+    id: 'judicial.system.core:info_card.defendant_info.service_not_required',
     defaultMessage: 'Birting dóms ekki þörf',
     description: 'Notað sem texti þegar birting dóms er ekki þörf',
   },
   serviceRequired: {
-    id: 'judicial.system.core:info_card.defendant_info.service_required',
-    defaultMessage: 'Birta skal dómfellda dóminn',
+    id: 'judicial.system.core:info_card.defendant_info.service_required_v1',
+    defaultMessage: 'Birting skal dómfellda dóminn',
     description: 'Notað sem texti þegar birting dóms er þörf',
   },
   spokesperson: {

--- a/apps/judicial-system/web/src/routes/Shared/IndictmentOverview/IndictmentOverview.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/IndictmentOverview/IndictmentOverview.tsx
@@ -152,10 +152,12 @@ const IndictmentOverview: FC = () => {
                 (user?.role === UserRole.DEFENDER ||
                   workingCase.indictmentReviewer?.id === user?.id)
               }
-              displayVerdictViewDate={isProsecutionUser(user)}
+              displayVerdictViewDate={
+                isProsecutionUser(user) || isDefenceUser(user)
+              }
             />
           ) : (
-            <InfoCardActiveIndictment />
+            <InfoCardActiveIndictment displayVerdictViewDate />
           )}
         </Box>
         {(hasLawsBroken || hasMergeCases) && (

--- a/apps/judicial-system/web/src/routes/Shared/IndictmentOverview/IndictmentOverview.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/IndictmentOverview/IndictmentOverview.tsx
@@ -152,9 +152,7 @@ const IndictmentOverview: FC = () => {
                 (user?.role === UserRole.DEFENDER ||
                   workingCase.indictmentReviewer?.id === user?.id)
               }
-              displayVerdictViewDate={
-                isProsecutionUser(user) || isDefenceUser(user)
-              }
+              displayVerdictViewDate
             />
           ) : (
             <InfoCardActiveIndictment displayVerdictViewDate />


### PR DESCRIPTION
# Display verdict view date for defenders

[Asana](https://app.asana.com/0/1199153462262248/1208595674703393/f)

## What

This PR addresses issues from https://github.com/island-is/island.is/pull/16709. 

1. Fixes typo -- `Birting skal dómfellda dóminn` ➡️ `Birta skal dómfellda dóminn`
2. Display verdict view date for defenders in their info cards. 

## Why

These are bugs

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
