### PR TITLE
fix(web): Stop displaying short title for organization vacancies

### DIFF
--- a/libs/api/domains/icelandic-government-institution-vacancies/src/lib/icelandic-government-institution-vacancies.resolver.ts
+++ b/libs/api/domains/icelandic-government-institution-vacancies/src/lib/icelandic-government-institution-vacancies.resolver.ts
@@ -103,7 +103,7 @@ export class IcelandicGovernmentInstitutionVacanciesResolver {
       if (organization?.referenceIdentifier) {
         organizationMap.set(organization.referenceIdentifier, {
           logoUrl: organization.logo?.url,
-          title: organization.shortTitle || organization.title,
+          title: organization.title,
         })
       }
     }


### PR DESCRIPTION
# Stop displaying short title for organization vacancies

## What

* Few people know what "DMR" and "FVA" means, we'd rather display the entire title

## Screenshots / Gifs

![Screenshot 2024-11-11 at 14 02 12](https://github.com/user-attachments/assets/590a28c3-e7c8-4efd-a8b1-86803e7f9bc0)

![Screenshot 2024-11-11 at 14 02 30](https://github.com/user-attachments/assets/7bbb559f-0f05-455e-a7c3-c90f48089dbb)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of organization titles in vacancy listings.
- **Bug Fixes**
	- Enhanced error logging for fetch errors in vacancy retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->