### PR TITLE
chore: Make QA codeowners of testing/e2e lib

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -386,10 +386,10 @@ codemagic.yaml                                                                  
 /charts/                                                                                                 @island-is/devops
 .dockerignore                                                                                            @island-is/devops
 
-
-# System tests
-# Catch-all
+# QA
 /apps/system-e2e/                                                                                        @island-is/qa
+/libs/testing/e2e                                                                                        @island-is/qa        
+
 # Islandis
 /apps/system-e2e/src/tests/islandis/admin-portal/                                                        @island-is/aranja
 /apps/system-e2e/src/tests/islandis/application-system/                                                  @island-is/norda-applications


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated ownership assignments for project directories, including new ownership for the `/libs/testing/e2e` directory.
	- Changed section header from `# System tests` to `# QA` for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->