### PR TITLE
fix(contentful-apps): Add missing variable in check for pie chart type

### DIFF
--- a/apps/contentful-apps/pages/fields/chart-component-source-data-key-field.tsx
+++ b/apps/contentful-apps/pages/fields/chart-component-source-data-key-field.tsx
@@ -179,7 +179,8 @@ const ChartComponentSourceDataKeyField = () => {
     }))
   }
 
-  const disableMoreThanOneItemOnPieChart = manualData?.categoryItems?.length > 0
+  const disableMoreThanOneItemOnPieChart =
+    typeIsPieChart && manualData?.categoryItems?.length > 0
 
   return (
     <>


### PR DESCRIPTION
# Add missing variable in check for pie chart type

## What

Added missing variable in check for pie chart

## Why

So user can not add more than one item per component for pie-chart

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved logic for disabling the button for adding items in pie charts, ensuring it only applies when the chart type is a pie chart and category items are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->