### PR TITLE
fix(services-bff): Fix refresh token condition

### DIFF
--- a/apps/services/bff/src/app/modules/user/user.service.ts
+++ b/apps/services/bff/src/app/modules/user/user.service.ts
@@ -55,7 +55,7 @@ export class UserService {
         cachedTokenResponse.accessTokenExp,
       )
 
-      if (accessTokenHasExpired && !refresh) {
+      if (accessTokenHasExpired && refresh) {
         // Get new token data with refresh token
         const tokenResponse = await this.idsService.refreshToken(
           cachedTokenResponse.encryptedRefreshToken,


### PR DESCRIPTION
# Fix refresh token condition


## Why

Wrong condition 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the logic for refreshing access tokens to enhance control over token expiration scenarios. The system will now only refresh the token if it has expired and the refresh parameter is set to true.
  
- **Improvements**
	- Maintained robust error handling and logging for user retrieval processes, ensuring consistent feedback during operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->