### PR TITLE
feat(native-app): add third party error template and use in health overview

### DIFF
--- a/apps/native/app/src/messages/en.ts
+++ b/apps/native/app/src/messages/en.ts
@@ -594,6 +594,9 @@ export const en: TranslatedMessages = {
   'problem.offline.title': 'No internet connection',
   'problem.offline.message':
     'An error occurred while communicating with the service provider',
+  'problem.thirdParty.title': 'No connection',
+  'problem.thirdParty.message':
+    'An error occurred while communicating with the service provider',
 
   // passkeys
   'passkeys.headingTitle': 'Sign in with Island.is app',

--- a/apps/native/app/src/messages/is.ts
+++ b/apps/native/app/src/messages/is.ts
@@ -595,6 +595,8 @@ export const is = {
     'Ef þú telur þig eiga gögn sem ættu að birtast hér, vinsamlegast hafðu samband við þjónustuaðila.',
   'problem.offline.title': 'Samband næst ekki',
   'problem.offline.message': 'Villa kom upp í samskiptum við þjónustuaðila',
+  'problem.thirdParty.title': 'Samband næst ekki',
+  'problem.thirdParty.message': 'Villa kom upp í samskiptum við þjónustuaðila',
 
   // passkeys
   'passkeys.headingTitle': 'Innskrá með Ísland.is appinu',

--- a/apps/native/app/src/stores/organizations-store.ts
+++ b/apps/native/app/src/stores/organizations-store.ts
@@ -30,6 +30,7 @@ interface Organization {
 interface OrganizationsStore extends State {
   organizations: Organization[]
   getOrganizationLogoUrl(forName: string, size?: number): ImageSourcePropType
+  getOrganizationNameBySlug(slug: string): string
   actions: any
 }
 
@@ -71,6 +72,10 @@ export const organizationsStore = create<OrganizationsStore>(
           'https://images.ctfassets.net/8k0h54kbe6bj/6XhCz5Ss17OVLxpXNVDxAO/d3d6716bdb9ecdc5041e6baf68b92ba6/coat_of_arms.svg'
         const uri = `${url}?w=${size}&h=${size}&fit=pad&fm=png`
         return { uri }
+      },
+      getOrganizationNameBySlug(slug: string) {
+        const org = get().organizations.find((o) => o.slug === slug)
+        return org?.title ?? ''
       },
       actions: {
         updateOriganizations: async () => {

--- a/apps/native/app/src/ui/lib/problem/problem-template.tsx
+++ b/apps/native/app/src/ui/lib/problem/problem-template.tsx
@@ -10,6 +10,7 @@ export type ProblemTemplateBaseProps = {
   title: string
   message: string | ReactNode
   withContainer?: boolean
+  size?: 'small' | 'large'
 }
 
 interface WithIconProps extends ProblemTemplateBaseProps {
@@ -68,6 +69,7 @@ const getColorsByVariant = (
 const Host = styled.View<{
   borderColor: Colors
   noContainer?: boolean
+  size: 'small' | 'large'
 }>`
   border-color: ${({ borderColor, theme }) => theme.color[borderColor]};
   border-width: 1px;
@@ -76,11 +78,12 @@ const Host = styled.View<{
   justify-content: center;
   align-items: center;
   flex: 1;
-  row-gap: ${({ theme }) => theme.spacing[3]}px;
+  row-gap: ${({ theme, size }) =>
+    size === 'small' ? theme.spacing[2] : theme.spacing[3]}px;
 
   padding: ${({ theme }) => theme.spacing[2]}px;
   ${({ noContainer, theme }) => noContainer && `margin: ${theme.spacing[2]}px;`}
-  min-height: 280px;
+  min-height: ${({ size }) => (size === 'large' ? '280' : '142')}px;
 `
 
 const Tag = styled(View)<{
@@ -114,12 +117,13 @@ export const ProblemTemplate = ({
   showIcon,
   tag,
   withContainer,
+  size = 'large',
 }: ProblemTemplateProps) => {
   const { borderColor, tagColor, tagBackgroundColor } =
     getColorsByVariant(variant)
 
   return (
-    <Host borderColor={borderColor} noContainer={withContainer}>
+    <Host borderColor={borderColor} noContainer={withContainer} size={size}>
       {tag && (
         <Tag backgroundColor={tagBackgroundColor}>
           <TagText variant="eyebrow" color={tagColor}>
@@ -129,10 +133,18 @@ export const ProblemTemplate = ({
       )}
       {showIcon && <Icon source={getIcon(variant)} />}
       <Content>
-        <Typography variant="heading3" textAlign="center">
+        <Typography
+          variant={size === 'small' ? 'heading5' : 'heading3'}
+          textAlign="center"
+        >
           {title}
         </Typography>
-        <Typography textAlign="center">{message}</Typography>
+        <Typography
+          variant={size === 'small' ? 'body3' : 'body'}
+          textAlign="center"
+        >
+          {message}
+        </Typography>
       </Content>
     </Host>
   )

--- a/apps/native/app/src/ui/lib/problem/problem.tsx
+++ b/apps/native/app/src/ui/lib/problem/problem.tsx
@@ -1,7 +1,10 @@
 import { useEffect } from 'react'
+
 import { useTranslate } from '../../../hooks/use-translate'
 import { useOfflineStore } from '../../../stores/offline-store'
 import { ProblemTemplate, ProblemTemplateBaseProps } from './problem-template'
+import { getOrganizationSlugFromError } from '../../../utils/get-organization-slug-from-error'
+import { ThirdPartyServiceError } from './third-party-service-error'
 
 enum ProblemTypes {
   error = 'error',
@@ -20,7 +23,7 @@ type ProblemBaseProps = {
   title?: string
   message?: string
   logError?: boolean
-} & Pick<ProblemTemplateBaseProps, 'withContainer'>
+} & Pick<ProblemTemplateBaseProps, 'withContainer' | 'size'>
 
 interface ErrorProps extends ProblemBaseProps {
   type?: 'error'
@@ -61,6 +64,7 @@ export const Problem = ({
   logError = false,
   withContainer,
   showIcon,
+  size = 'large',
 }: ProblemProps) => {
   const t = useTranslate()
   const { isConnected } = useOfflineStore()
@@ -73,6 +77,7 @@ export const Problem = ({
     message: message ?? t('problem.error.message'),
     tag: tag ?? t('problem.error.tag'),
     variant: 'error',
+    size: size ?? 'large',
   } as const
 
   useEffect(() => {
@@ -90,6 +95,7 @@ export const Problem = ({
         variant="warning"
         title={title ?? t('problem.offline.title')}
         message={message ?? t('problem.offline.message')}
+        size={size}
       />
     )
   }
@@ -99,6 +105,18 @@ export const Problem = ({
 
   switch (type) {
     case ProblemTypes.error:
+      if (error) {
+        const organizationSlug = getOrganizationSlugFromError(error)
+
+        if (organizationSlug) {
+          return (
+            <ThirdPartyServiceError
+              organizationSlug={organizationSlug}
+              size={size}
+            />
+          )
+        }
+      }
       return <ProblemTemplate {...fallbackProps} />
 
     case ProblemTypes.noData:
@@ -109,6 +127,7 @@ export const Problem = ({
           variant="info"
           title={title ?? t('problem.noData.title')}
           message={message ?? t('problem.noData.message')}
+          size={size}
         />
       )
 

--- a/apps/native/app/src/ui/lib/problem/third-party-service-error.tsx
+++ b/apps/native/app/src/ui/lib/problem/third-party-service-error.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { useIntl } from 'react-intl'
+
+import { ProblemTemplate } from './problem-template'
+import { useOrganizationsStore } from '../../../stores/organizations-store'
+
+type ThirdPartyServiceErrorProps = {
+  organizationSlug: string
+  size: 'small' | 'large'
+}
+
+export const ThirdPartyServiceError = ({
+  organizationSlug,
+  size,
+}: ThirdPartyServiceErrorProps) => {
+  const intl = useIntl()
+
+  const { getOrganizationNameBySlug } = useOrganizationsStore()
+  const organizationName = getOrganizationNameBySlug(organizationSlug)
+
+  return (
+    <ProblemTemplate
+      variant="warning"
+      {...(organizationName ? { tag: organizationName } : { showIcon: true })}
+      title={intl.formatMessage({ id: 'problem.thirdParty.title' })}
+      message={intl.formatMessage({ id: 'problem.thirdParty.message' })}
+      size={size}
+    />
+  )
+}

--- a/apps/native/app/src/utils/get-organization-slug-from-error.ts
+++ b/apps/native/app/src/utils/get-organization-slug-from-error.ts
@@ -1,0 +1,36 @@
+import { ApolloError } from '@apollo/client'
+
+type PartialProblem = {
+  organizationSlug?: string
+}
+
+type CustomExtension = {
+  code: string
+  problem?: PartialProblem
+  exception?: {
+    problem?: PartialProblem
+  }
+}
+
+/**
+ * Extracts the organization slug from the Apollo error, if it exists.
+ */
+export function getOrganizationSlugFromError(error: ApolloError | unknown) {
+  const graphQLErrors = (error as ApolloError)?.graphQLErrors
+
+  if (graphQLErrors) {
+    for (const graphQLError of graphQLErrors) {
+      const extensions = graphQLError.extensions as CustomExtension
+
+      const organizationSlug =
+        extensions?.problem?.organizationSlug ??
+        extensions?.exception?.problem?.organizationSlug
+
+      if (organizationSlug) {
+        return organizationSlug
+      }
+    }
+  }
+
+  return undefined
+}


### PR DESCRIPTION
## What

Modify Problem component in app to support Third Party Error, so we show the name of the organization that should provide the information that is erroring.

Using that new error component in health-overview section
## Why

Error states for inputs are currently loading state which is not good - this is better. Will rewrite errors for inputs soon.

## Screenshots / Gifs

![Simulator Screenshot - iPhone 16 - 2024-11-14 at 10 23 35](https://github.com/user-attachments/assets/f817ec4c-e8d0-4eae-b551-c12ce1eb79f1)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
