### PR TITLE
chore(codeowners): modify ownership of health directorate clients

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -195,7 +195,8 @@ codemagic.yaml                                                                  
 /libs/portals/admin/regulations-admin/                                                                   @island-is/hugsmidjan
 /libs/portals/admin/document-provider/                                                                   @island-is/hugsmidjan @island-is/core
 /libs/clients/icelandic-health-insurance/rights-portal/                                                  @island-is/hugsmidjan
-/libs/clients/health-directorate                                                                         @island-is/hugsmidjan @island-is/origo
+/libs/clients/health-directorate                                                                         @island-is/hugsmidjan
+/libs/clients/health-directorate/src/lib/clients/occupational-license                                    @island-is/hugsmidjan @island-is/origo
 /libs/clients/mms/grade                                                                                  @island-is/hugsmidjan
 /libs/portals/admin/air-discount-scheme                                                                  @island-is/hugsmidjan
 /libs/application/templates/official-journal-of-iceland/                                                 @island-is/hugsmidjan


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Narrowed Hugsmiðjan-Origo shared ownership of health directorate clients to only occupational-licenses. Left Hugmsiðjan as sole owner of other health-directorate clients.

## Why

To clarify ownership

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
