### PR TITLE
feat(native-app): support type: 'Table' in field render

### DIFF
--- a/apps/native/app/src/screens/wallet-pass/components/field-render.tsx
+++ b/apps/native/app/src/screens/wallet-pass/components/field-render.tsx
@@ -67,6 +67,31 @@ export const FieldRender = ({
                 </FieldGroup>
               )
 
+            case 'Table':
+              if (label) {
+                return (
+                  <View key={key} style={{ marginTop: 24, paddingBottom: 4 }}>
+                    <FieldLabel>{label}</FieldLabel>
+                    {FieldRender({
+                      data: fields as GenericLicenseDataField[],
+                      level: 2,
+                      licenseType: licenseType,
+                    })}
+                  </View>
+                )
+              }
+              return (
+                <FieldGroup key={key}>
+                  <View>
+                    {FieldRender({
+                      data: fields as GenericLicenseDataField[],
+                      level: 2,
+                      licenseType: licenseType,
+                    })}
+                  </View>
+                </FieldGroup>
+              )
+
             case 'Category':
               return (
                 <FieldCard


### PR DESCRIPTION
## What

Support type 'Table' in Field render. 
## Why
The service portal is using this for firearm licenses. To keep everything in sync the app supports that as well now. Máni from Hugsmiðjan is creating a rule on the backend that if the user-agent is version that is older than 1.4.8 then he will send the type: 'Group' for firearm licenses to be backwards compatible, otherwise he just sends type: 'Table'

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
