### PR TITLE
fix(api): Add missing content type header for Campaign Monitor email signup

### DIFF
--- a/libs/api/domains/email-signup/src/lib/services/campaignMonitor/campaignMonitor.service.ts
+++ b/libs/api/domains/email-signup/src/lib/services/campaignMonitor/campaignMonitor.service.ts
@@ -35,7 +35,12 @@ export class CampaignMonitorSignupService {
     const obj = Object.fromEntries(map)
 
     return axios
-      .post(url, obj, { headers: { Authorization: authHeader } })
+      .post(url, obj, {
+        headers: {
+          Authorization: authHeader,
+          'Content-Type': 'application/json',
+        },
+      })
       .then((response) => {
         return {
           subscribed: response?.data?.result === 'error' ? false : true,


### PR DESCRIPTION
# Add missing content type header for Campaign Monitor email signup
