### PR TITLE
feat(react-spa): New modal when user switches from child to self

### DIFF
--- a/libs/react-spa/bff/src/lib/BffNewUserSameSessionModal.tsx
+++ b/libs/react-spa/bff/src/lib/BffNewUserSameSessionModal.tsx
@@ -1,25 +1,18 @@
 import { BffProblemTemplateModal } from './BffProblemTemplateModal'
 
-type BffSessionExpiredModalProps = {
-  /**
-   * Reload callback
-   */
-  onReload(): void
-}
-
 /**
  * This screen is unfortunately not translated because at this point we don't have a user locale.
  */
-export const BffNewUserSameSessionModal = ({
-  onReload,
-}: BffSessionExpiredModalProps) => (
+export const BffNewUserSameSessionModal = () => (
   <BffProblemTemplateModal
     title="Nýr notandi"
     action={{
       prefixText: 'Þú hefur skipt um notanda. Viltu',
       text: 'endurhlaða',
       postfixText: 'síðunni?',
-      onClick: onReload,
+      onClick: () => {
+        window.location.reload()
+      },
     }}
   />
 )

--- a/libs/react-spa/bff/src/lib/BffNewUserSameSessionModal.tsx
+++ b/libs/react-spa/bff/src/lib/BffNewUserSameSessionModal.tsx
@@ -2,24 +2,24 @@ import { BffProblemTemplateModal } from './BffProblemTemplateModal'
 
 type BffSessionExpiredModalProps = {
   /**
-   * Login callback
+   * Reload callback
    */
-  onLogin(): void
+  onReload(): void
 }
 
 /**
  * This screen is unfortunately not translated because at this point we don't have a user locale.
  */
-export const BffSessionExpiredModal = ({
-  onLogin,
+export const BffNewUserSameSessionModal = ({
+  onReload,
 }: BffSessionExpiredModalProps) => (
   <BffProblemTemplateModal
-    title="Innskráning útrunnin"
+    title="Nýr notandi"
     action={{
-      prefixText: 'Þú hefur skráð þig inn í öðru umboði. Viltu',
-      text: 'skrá þig',
-      postfixText: 'aftur inn?',
-      onClick: onLogin,
+      prefixText: 'Þú hefur skipt um notanda. Viltu',
+      text: 'endurhlaða',
+      postfixText: 'síðunni?',
+      onClick: onReload,
     }}
   />
 )

--- a/libs/react-spa/bff/src/lib/BffProblemTemplateModal.tsx
+++ b/libs/react-spa/bff/src/lib/BffProblemTemplateModal.tsx
@@ -1,0 +1,43 @@
+import { Box, Button, ProblemTemplate } from '@island.is/island-ui/core'
+import { fullScreen } from './ErrorScreen.css'
+
+export type BffProblemTemplateModalProps = {
+  title: string
+  action: {
+    prefixText: string
+    text: string
+    postfixText: string
+    onClick(): void
+  }
+}
+
+/**
+ * Reusable warning screen for BFF
+ */
+export const BffProblemTemplateModal = ({
+  title,
+  action: { prefixText, text, postfixText, onClick },
+}: BffProblemTemplateModalProps) => (
+  <Box
+    display="flex"
+    justifyContent="center"
+    alignItems="center"
+    padding={[0, 6]}
+    className={fullScreen}
+  >
+    <ProblemTemplate
+      variant="warning"
+      expand
+      title={title}
+      message={
+        <>
+          {prefixText}{' '}
+          <Button variant="text" onClick={onClick}>
+            {text}
+          </Button>{' '}
+          {postfixText}
+        </>
+      }
+    />
+  </Box>
+)

--- a/libs/react-spa/bff/src/lib/BffProvider.tsx
+++ b/libs/react-spa/bff/src/lib/BffProvider.tsx
@@ -226,13 +226,7 @@ export const BffProvider = ({
     }
 
     if (showNewUserScreen) {
-      return (
-        <BffNewUserSameSessionModal
-          onReload={() => {
-            window.location.reload()
-          }}
-        />
-      )
+      return <BffNewUserSameSessionModal />
     }
 
     if (isLoggedIn) {

--- a/libs/react-spa/bff/src/lib/bff.utils.ts
+++ b/libs/react-spa/bff/src/lib/bff.utils.ts
@@ -37,12 +37,27 @@ export const createQueryStr = (params: Record<string, string>) => {
   return new URLSearchParams(params).toString()
 }
 
+type UserCheckFn = (oldUser: BffUser, newUser: BffUser) => boolean
+
 /**
  *  This method checks if the user has a new session
  */
-export const isNewSession = (oldUser: BffUser, newUser: BffUser) => {
+export const isNewSession: UserCheckFn = (oldUser, newUser) => {
   const oldSid = oldUser.profile.sid
   const newSid = newUser.profile.sid
 
-  return oldSid && newSid && oldSid !== newSid
+  return !!(oldSid && newSid && oldSid !== newSid)
+}
+
+/**
+ * Checks if the user is a new user with the same session
+ */
+export const isNewUserWithSameSession: UserCheckFn = (oldUser, newUser) => {
+  const isSameSession = !isNewSession(oldUser, newUser)
+
+  if (isSameSession) {
+    return oldUser.profile.nationalId !== newUser.profile.nationalId
+  }
+
+  return false
 }


### PR DESCRIPTION
# New BFF modal for user switch

## What

New modal when user switches from child to self. This is more relevant when mínarsíður makes the bff transition.

## Why

When switching from child to user the other tabs where not detecting it.
I added a new modal telling the user that new user switch had happened.

## Screenshots / Gifs

<img width="1636" alt="image" src="https://github.com/user-attachments/assets/f61550c2-4f45-4e4b-a23f-ca5e0f1a3f2a">


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new modal for new users in the same session, enhancing user experience.
	- Added a reusable warning modal for improved session management.
- **Bug Fixes**
	- Updated session expired modal to streamline the login prompt presentation.
- **Refactor**
	- Enhanced user session checking capabilities with new utility functions for better type safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->