### PR TITLE
chore(tests): Use tags instead of projects Playwright

### DIFF
--- a/libs/testing/e2e/README.md
+++ b/libs/testing/e2e/README.md
@@ -58,7 +58,7 @@ yarn e2e <app-name>
    yarn e2e <app-name> --skip-nx-cache
   ```
 
-- **Run with Specific Tag**: Run only the tests tagged with a specific tag:
+- **Run with a Specific Tag**: Run only the tests tagged with a specific tag:
 
   ```bash
    yarn e2e <app-name> --grep @fast

--- a/libs/testing/e2e/README.md
+++ b/libs/testing/e2e/README.md
@@ -58,12 +58,10 @@ yarn e2e <app-name>
    yarn e2e <app-name> --skip-nx-cache
   ```
 
-- **Run a Specific Project**: Run only the tests defined under a specific project in your Playwright config:
+- **Run with Specific Tag**: Run only the tests tagged with a specific tag:
 
   ```bash
-  yarn e2e <app-name> -- --project=smoke
-  yarn e2e <app-name> -- --project=acceptance
-  yarn e2e <app-name> -- --project=everything
+   yarn e2e <app-name> --grep @fast
   ```
 
 - **View the Test Report**: After running tests, use this command to view the generated report:
@@ -100,14 +98,12 @@ You should therefore aim to write test for:
 
 ### 🏗️ Test structure
 
-Test cases are written in spec files. Tests that do not modify anything (e.g., _create_ an application, _change_ the user’s name, etc.) and verify basic functionality are called **smoke tests**. Tests that are more detailed and/or make any changes at all, are called **acceptance tests**. Test cases are put into folders by what app they are testing, smoke/acceptance test, and each file tests some aspect of an app. Here is an example of the folder layout for testing the search engine and front-page of the `web` project (within the system-e2e app):
+Test cases are written in spec files. Tests are tagged based on their execution time or other criteria. For example, you can use tags like `@fast` for quick tests and `@slow` for longer-running tests. Here is an example of the folder layout for testing the search engine and front-page of the `web` project:
 
 ```shell
 web/                      (app name)
-├── smoke/                (test type)
-│   └── home-page.spec.ts (feature name, kebab-case)
-└── acceptance/
-    └── search.spec.ts
+├── home-page.spec.ts     (feature name, kebab-case)
+└── search.spec.ts
 ```
 
 ### 🗃️ Spec files
@@ -132,7 +128,7 @@ test.describe('Overview part of banking app', () => {
     // Basic state reset, e.g. clear inbox
   })
 
-  test('should get paid', () => {
+  test('should get paid @slow', () => {
     // Make user get money using page.selector, page.click, etc.
     // Verify money is present
   })

--- a/libs/testing/e2e/README.md
+++ b/libs/testing/e2e/README.md
@@ -68,7 +68,7 @@ yarn e2e <app-name>
     yarn e2e <app-name> --grep-invert @fast
 
     # Run tests tagged with either @fast or @slow
-    npx playwright test --grep "@fast|@slow"
+    yarn e2e <app-name> --grep "@fast|@slow"
   ```
 
 - **View the Test Report**: After running tests, use this command to view the generated report:

--- a/libs/testing/e2e/README.md
+++ b/libs/testing/e2e/README.md
@@ -58,10 +58,17 @@ yarn e2e <app-name>
    yarn e2e <app-name> --skip-nx-cache
   ```
 
-- **Run with a Specific Tag**: Run only the tests tagged with a specific tag:
+- **Run Tests with Tags**: Use tags to include or exclude specific tests.
 
   ```bash
-   yarn e2e <app-name> --grep @fast
+    # Run only tests tagged with @fast
+    yarn e2e <app-name> --grep @fast
+
+    # Exclude tests tagged with @fast
+    yarn e2e <app-name> --grep-invert @fast
+
+    # Run tests tagged with either @fast or @slow
+    npx playwright test --grep "@fast|@slow"
   ```
 
 - **View the Test Report**: After running tests, use this command to view the generated report:
@@ -81,6 +88,8 @@ yarn e2e <app-name>
   ```bash
   yarn e2e <app-name> --debug
   ```
+
+For more details on Playwright commands and flags, refer to the [official documentation](https://playwright.dev/docs/test-cli)
 
 ## ✍️ Writing Tests
 

--- a/libs/testing/e2e/README.md
+++ b/libs/testing/e2e/README.md
@@ -128,7 +128,7 @@ test.describe('Overview part of banking app', () => {
     // Basic state reset, e.g. clear inbox
   })
 
-  test('should get paid @slow', () => {
+  test('should get paid', { tag: '@slow' }, () => {
     // Make user get money using page.selector, page.click, etc.
     // Verify money is present
   })

--- a/libs/testing/e2e/src/lib/config/playwright-config.ts
+++ b/libs/testing/e2e/src/lib/config/playwright-config.ts
@@ -25,7 +25,7 @@ export const createPlaywrightConfig = ({
   webServerUrl,
   port,
   command,
-  cwd = '../../../',
+  cwd,
   timeoutMs = 5 * 60 * 1000,
 }: PlaywrightConfigParams) =>
   defineConfig({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Improved clarity and updated usage instructions for the E2E Testing Library.
	- Revised test execution commands to use tags for filtering tests, promoting a more flexible approach.
	- Simplified test case organization structure and provided enhanced guidance on writing tests, including the use of `test.step`.

- **Chores**
	- Made the `cwd` parameter in the Playwright configuration a required parameter to streamline configuration setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->