### PR TITLE
fix(react-spa-bff): Change user compare util func

### DIFF
--- a/libs/react-spa/bff/src/lib/BffPoller.tsx
+++ b/libs/react-spa/bff/src/lib/BffPoller.tsx
@@ -7,7 +7,7 @@ import {
   useBffBroadcaster,
   useUserInfo,
 } from './bff.hooks'
-import { isNewSession } from './bff.utils'
+import { isNewUser } from './bff.utils'
 
 type BffPollerProps = {
   children: ReactNode
@@ -78,8 +78,8 @@ export const BffPoller = ({
       // If user polling fails, likely due to 401, then sign in.
       signIn()
     } else if (newUser) {
-      // If session has changed (e.g. delegation switch), then notifiy tabs/windows/iframes and execute the callback.
-      if (isNewSession(newUser, userInfo)) {
+      // If user has changed (e.g. delegation switch), then notifiy tabs/windows/iframes and execute the callback.
+      if (isNewUser(newUser, userInfo)) {
         // Note! The tab, window, or iframe that sends this message will not receive it.
         // This is because the BroadcastChannel API does not broadcast messages to the sender.
         // Therefore we need to manually handle the new session in the current tab/window, by calling the newSessionCb().

--- a/libs/react-spa/bff/src/lib/BffProvider.tsx
+++ b/libs/react-spa/bff/src/lib/BffProvider.tsx
@@ -8,7 +8,7 @@ import { BffSessionExpiredModal } from './BffSessionExpiredModal'
 import { ErrorScreen } from './ErrorScreen'
 import { BffBroadcastEvents, useBffBroadcaster } from './bff.hooks'
 import { ActionType, LoggedInState, initialState, reducer } from './bff.state'
-import { createBffUrlGenerator, isNewSession } from './bff.utils'
+import { createBffUrlGenerator, isNewUser } from './bff.utils'
 
 const BFF_SERVER_UNAVAILABLE = 'BFF_SERVER_UNAVAILABLE'
 
@@ -45,7 +45,7 @@ export const BffProvider = ({
     if (
       isLoggedIn &&
       event.data.type === BffBroadcastEvents.NEW_SESSION &&
-      isNewSession(state.userInfo, event.data.userInfo)
+      isNewUser(state.userInfo, event.data.userInfo)
     ) {
       setSessionExpiredScreen(true)
     } else if (event.data.type === BffBroadcastEvents.LOGOUT) {

--- a/libs/react-spa/bff/src/lib/bff.utils.ts
+++ b/libs/react-spa/bff/src/lib/bff.utils.ts
@@ -38,11 +38,8 @@ export const createQueryStr = (params: Record<string, string>) => {
 }
 
 /**
- *  This method checks if the user has a new session
+ *  Checks if the user is a new user compared to the old user, by comparing the nationalId's
  */
-export const isNewSession = (oldUser: BffUser, newUser: BffUser) => {
-  const oldSid = oldUser.profile.sid
-  const newSid = newUser.profile.sid
-
-  return oldSid && newSid && oldSid !== newSid
+export const isNewUser = (oldUser: BffUser, newUser: BffUser) => {
+  return oldUser.profile.nationalId !== newUser.profile.nationalId
 }


### PR DESCRIPTION
# Change user switch to compare nationalId instead of sid

## What

Change user switch to compare nationalId instead of sid when notifying other windows/tabs.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated user session handling to differentiate between new users and session changes.

- **Bug Fixes**
	- Improved session validity checks to enhance user experience during authentication.

- **Documentation**
	- Updated comments to reflect the new logic for user identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->