### PR TITLE
chore(tests): Make Jest ignore E2E test files

### DIFF
--- a/jest.preset.js
+++ b/jest.preset.js
@@ -6,6 +6,7 @@ const customResolver = path.join(__dirname, 'jest.resolver.js')
 module.exports = {
   ...nxPresetRest,
   testMatch: ['**/+(*.)+(spec|test).+(ts|js)?(x)'],
+  testPathIgnorePatterns: ['<rootDir>/apps/.*/e2e'],
   resolver: customResolver,
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageReporters: ['json'],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Jest configuration to exclude end-to-end tests from test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->