### PR TITLE
fix(my-pages): Sanitize sheet name

### DIFF
--- a/libs/portals/my-pages/assets/src/utils/downloadVehicleOwnedFile.ts
+++ b/libs/portals/my-pages/assets/src/utils/downloadVehicleOwnedFile.ts
@@ -1,3 +1,4 @@
+import { sanitizeSheetName } from '@island.is/portals/my-pages/core'
 import XLSX from 'xlsx'
 const locale = 'is-IS'
 
@@ -45,7 +46,7 @@ export const downloadVehicleOwnedFile = async (
     showOperatorVehicles ? header[1] : null,
     ...(showOperatorVehicles ? data[1] : [['Ekkert fannst']]),
   ]
-  const sheetName = name.substring(0, 31) // Max length for a sheet name.
+  const sheetName = sanitizeSheetName(name)
 
   const worksheet: XLSX.WorkSheet = XLSX.utils.aoa_to_sheet(sheetData)
   const workbook: XLSX.WorkBook = {

--- a/libs/portals/my-pages/core/src/utils/downloadDataFile.ts
+++ b/libs/portals/my-pages/core/src/utils/downloadDataFile.ts
@@ -31,7 +31,9 @@ export const downloadFile = async (
   } else {
     const sheetData = [header, ...data]
     const dateString = new Date().toISOString().split('T')[0]
-    const fileName = `${name.replace(/\./g, '')} - ${dateString}`
+    const fileName = sanitizeSheetName(
+      `${name.replace(/\./g, '')} - ${dateString}`,
+    )
     const sheetName = sanitizeSheetName(name)
 
     const worksheet: XLSX.WorkSheet = XLSX.utils.aoa_to_sheet(sheetData)

--- a/libs/portals/my-pages/core/src/utils/downloadDataFile.ts
+++ b/libs/portals/my-pages/core/src/utils/downloadDataFile.ts
@@ -1,5 +1,6 @@
 import CSVStringify from 'csv-stringify'
 import XLSX from 'xlsx'
+import { sanitizeSheetName } from './utils'
 
 export const downloadFile = async (
   name: string,
@@ -31,7 +32,7 @@ export const downloadFile = async (
     const sheetData = [header, ...data]
     const dateString = new Date().toISOString().split('T')[0]
     const fileName = `${name.replace(/\./g, '')} - ${dateString}`
-    const sheetName = name.substring(0, 31) // Max length for a sheet name.
+    const sheetName = sanitizeSheetName(name)
 
     const worksheet: XLSX.WorkSheet = XLSX.utils.aoa_to_sheet(sheetData)
     const workbook: XLSX.WorkBook = {

--- a/libs/portals/my-pages/core/src/utils/utils.ts
+++ b/libs/portals/my-pages/core/src/utils/utils.ts
@@ -13,6 +13,13 @@ export const getNameAbbreviation = (name: string) => {
   return initials
 }
 
+export const sanitizeSheetName = (sheetName: string) => {
+  return sheetName
+    .replace(/[:\\/?*[\]]/g, '')
+    .trim()
+    .substring(0, 31) // Max length for a sheet name.
+}
+
 export const tableStyles = {
   padding: '16px',
 }

--- a/libs/portals/my-pages/core/src/utils/utils.ts
+++ b/libs/portals/my-pages/core/src/utils/utils.ts
@@ -15,7 +15,7 @@ export const getNameAbbreviation = (name: string) => {
 
 export const sanitizeSheetName = (sheetName: string) => {
   return sheetName
-    .replace(/[:\\/?*[\]]/g, '')
+    .replace(/[:\\/?*[\]]/g, '_')
     .trim()
     .substring(0, 31) // Max length for a sheet name.
 }


### PR DESCRIPTION
## What

Sanitize sheet name for excel sheets 📜 

## Why

```
Error: Sheet name cannot contain : \ / ? * [ ]
```

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `sanitizeSheetName` function to ensure valid naming conventions for Excel sheet names.

- **Improvements**
	- Updated the `downloadVehicleOwnedFile` and `downloadFile` functions to utilize the new `sanitizeSheetName` function for generating sheet names, enhancing reliability and formatting.

These changes improve the user experience by ensuring that exported files have correctly formatted sheet names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->