### PR TITLE
chore(ci): Fewer test timouts/cancellations

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -220,7 +220,7 @@ jobs:
     runs-on: ec2-runners
     container:
       image: public.ecr.aws/m3u4c4h9/island-is/actions-runner-public:latest
-    timeout-minutes: 35
+    timeout-minutes: 45
     env:
       AFFECTED_PROJECT: ${{ matrix.projects }}
       CYPRESS_PROJECT_ID: 4q7jz8

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -178,7 +178,7 @@ jobs:
     runs-on: ec2-runners
     container:
       image: public.ecr.aws/m3u4c4h9/island-is/actions-runner-public:latest
-    timeout-minutes: 35
+    timeout-minutes: 45
     env:
       AFFECTED_PROJECTS: ${{ matrix.projects }}
       MAX_JOBS: 1


### PR DESCRIPTION
The timeout includes waiting for runners, which means that tests on the edge of hitting the timeout frequently do, even though the test itself is within limits (barely).

Increasing timeout to accommodate for long tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Increased timeout settings for `tests` and `e2e` jobs in the GitHub Actions workflow to enhance job execution reliability.
	- Made minor adjustments for clarity in the workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->