### PR TITLE
chore(auth-api-ids): Duplicating Ríkiskaup Gangaskilagátt delegations to FJS Rammasamningar

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -344,7 +344,7 @@ codemagic.yaml                                                                  
 /apps/services/sessions/                                                                                  @island-is/fuglar @island-is/aranja
 /apps/auth-admin-web/                                                                                     @island-is/fuglar @island-is/aranja
 /libs/auth-api-lib/                                                                                       @island-is/fuglar @island-is/aranja
-/libs/auth-api-lib/seeders/                                                                               @island-is/fuglar @island-is/aranja @island-is/origo-auth
+/libs/auth-api-lib/seeders/                                                                               @island-is/fuglar @island-is/aranja
 /libs/auth-nest-tools/                                                                                    @island-is/fuglar @island-is/aranja
 /libs/application/templates/european-health-insurance-card/                                               @island-is/fuglar
 /libs/application/template-api-modules/src/lib/modules/templates/european-health-insurance-card/          @island-is/fuglar

--- a/libs/auth-api-lib/migrations/20241121135100-migrate-rikiskaup-to-fjs.js
+++ b/libs/auth-api-lib/migrations/20241121135100-migrate-rikiskaup-to-fjs.js
@@ -1,0 +1,76 @@
+'use strict'
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.query(`
+        BEGIN;
+
+        -- If delegator has granted a delegation to the delegatee for FJS AND Rikiskaup we change the delegetion_id reference for all 
+        -- delegation_scopes in domain rikiskaup
+        UPDATE delegation_scope
+        SET delegation_id = fjs_entry.id
+        FROM delegation rikiskaup_entry
+        JOIN delegation fjs_entry
+            ON rikiskaup_entry.to_national_id = fjs_entry.to_national_id
+            AND rikiskaup_entry.from_national_id = fjs_entry.from_national_id
+            AND fjs_entry.domain_name = '@fjs.is'
+        WHERE delegation_scope.delegation_id = rikiskaup_entry.id
+            AND rikiskaup_entry.domain_name = '@rikiskaup.is'
+            AND EXISTS (
+            SELECT 1
+            FROM delegation d
+            WHERE d.domain_name = '@fjs.is'
+                AND d.to_national_id = rikiskaup_entry.to_national_id
+                AND d.from_national_id = rikiskaup_entry.from_national_id
+        );
+
+        -- This leaves us with rows in delegation that have same to_national_id and from_national_id and domain=@rikiskaup.is as another row  
+        -- with domain=@fjs.is. We need to delete those entries before the next step to avoid breaking uniqueness constraint
+        DELETE FROM delegation
+        WHERE domain_name = '@rikiskaup.is'
+            AND EXISTS (
+            SELECT 1
+            FROM delegation d
+            WHERE d.domain_name = '@fjs.is'
+                AND d.to_national_id = delegation.to_national_id
+                AND d.from_national_id = delegation.from_national_id
+            );
+
+        -- Move remaining delegations from domain Rikiskaup to FJS
+            UPDATE delegation
+            SET domain_name='@fjs.is'
+            WHERE domain_name='@rikiskaup.is'
+            
+        -- Optional 
+        -- Delete all delegations with no scope grant in domain Rikiskaup
+            DELETE FROM delegation
+            WHERE id IN (
+                SELECT d.id
+                FROM delegation d
+                LEFT JOIN scope s ON d.id = s.delegation_id
+                WHERE s.delegation_id IS NULL
+                AND d.domain_name = '@rikiskaup.is'
+            );
+
+        -- Next we update scope ID for all delegation scopes
+            UPDATE delegation_scope t
+            SET scope_name='TODO'
+            WHERE t.scope_name='@rikiskaup.is/gagnaskilagatt';
+    
+        -- Optional 
+        -- Remove Rikiskaup from the IDS
+            -- disable Rikiskaup clients
+            -- disable Rikiskaup scopes
+            -- delete? Rikiskaup domain
+            -- deactivate Rikiskaup api scope user
+            -- delete Rikiskaup api scope user delegation grants
+
+        COMMIT;
+    `)
+  },
+
+  down: () => {
+    // it's impossible to know which delegations were granted by users before or after the migration
+    // thus it's impossible to revert the migration
+  },
+}

--- a/libs/auth-api-lib/seeders/local/004-island.is.client.js
+++ b/libs/auth-api-lib/seeders/local/004-island.is.client.js
@@ -10,7 +10,7 @@ const api_resource = {
 
 const api_resources = [api_resource]
 
-const api_scope = {
+const api_scope_applications_read = {
   enabled: true,
   name: '@island.is/applications:read',
   display_name: 'Read applications',
@@ -27,12 +27,29 @@ const api_scope = {
   domain_name: '@island.is',
 }
 
-const api_scopes = [api_scope]
+const api_scope_documents = {
+  enabled: true,
+  name: '@island.is/documents',
+  display_name: 'Documents',
+  description: null,
+  show_in_discovery_document: false,
+  required: false,
+  emphasize: false,
+  grant_to_legal_guardians: true,
+  grant_to_procuring_holders: true,
+  allow_explicit_delegation_grant: true,
+  also_for_delegated_user: false,
+  automatic_delegation_grant: false,
+  is_access_controlled: false,
+  domain_name: '@island.is',
+}
+
+const api_scopes = [api_scope_applications_read, api_scope_documents]
 
 const api_resource_scopes = [
   {
     api_resource_name: api_resource.name,
-    scope_name: api_scope.name,
+    scope_name: api_scope_applications_read.name,
   },
 ]
 
@@ -94,7 +111,11 @@ const client_allowed_scopes = [
   },
   {
     client_id: client.client_id,
-    scope_name: api_scope.name,
+    scope_name: api_scope_applications_read.name,
+  },
+  {
+    client_id: client.client_id,
+    scope_name: api_scope_documents.name,
   },
 ]
 
@@ -193,7 +214,7 @@ module.exports = {
       throw err
     }
 
-    transaction.commit()
+    await transaction.commit()
   },
 
   down: async (queryInterface, Sequelize) => {


### PR DESCRIPTION
## What

An SQL script to migrate delegations between from @rikiskaup.is to @fjs.is.

The client and scope has been created manually using the IAS self-service.

This PR adds a migration script to duplicate the delegations. Then we will do a followup PR to remove the Rikiskaup delegations completely. But this is done in steps via two different PRs to allow for no downtime while FJS updates their environment variables to change the client id, secret and scope.


## Why

Ríkiskaup is merging into Fjársýslan so all Ríkiskaup related data in the IDS will be moved to Fjársýslan.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced refined API access with separate scopes for reading applications and accessing documents, enhancing permission granularity.

- **Chores**
  - Streamlined backend data migration for delegation management to simplify data handling and improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->