### PR TITLE
chore(j-s): Strip National Id Hyphen

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/case/dto/createCase.dto.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/dto/createCase.dto.ts
@@ -1,3 +1,4 @@
+import { Transform } from 'class-transformer'
 import {
   ArrayMinSize,
   IsArray,
@@ -7,6 +8,7 @@ import {
   IsOptional,
   IsString,
   MaxLength,
+  MinLength,
 } from 'class-validator'
 
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
@@ -20,6 +22,8 @@ import {
   RequestSharedWithDefender,
 } from '@island.is/judicial-system/types'
 
+import { nationalIdTransformer } from '../../../transformers'
+
 export class CreateCaseDto {
   @IsNotEmpty()
   @IsEnum(CaseType)
@@ -32,40 +36,42 @@ export class CreateCaseDto {
   readonly indictmentSubtypes?: IndictmentSubtypeMap
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly description?: string
 
   @IsNotEmpty()
   @IsArray()
   @ArrayMinSize(1)
-  @MaxLength(255, { each: true })
   @IsString({ each: true })
+  @MaxLength(255)
   @ApiProperty({ type: String, isArray: true })
   readonly policeCaseNumbers!: string[]
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly defenderName?: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MinLength(10)
+  @MaxLength(10)
+  @Transform(nationalIdTransformer)
   @ApiPropertyOptional({ type: String })
   readonly defenderNationalId?: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly defenderEmail?: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly defenderPhoneNumber?: string
 
@@ -75,8 +81,8 @@ export class CreateCaseDto {
   readonly requestSharedWithDefender?: RequestSharedWithDefender
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly leadInvestigator?: string
 

--- a/apps/judicial-system/backend/src/app/modules/case/dto/internalCases.dto.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/dto/internalCases.dto.ts
@@ -1,10 +1,16 @@
-import { IsNotEmpty, IsString } from 'class-validator'
+import { Transform } from 'class-transformer'
+import { IsNotEmpty, IsString, MaxLength, MinLength } from 'class-validator'
 
 import { ApiProperty } from '@nestjs/swagger'
+
+import { nationalIdTransformer } from '../../../transformers'
 
 export class InternalCasesDto {
   @IsNotEmpty()
   @IsString()
+  @MinLength(10)
+  @MaxLength(10)
+  @Transform(nationalIdTransformer)
   @ApiProperty({ type: String })
   readonly nationalId!: string
 }

--- a/apps/judicial-system/backend/src/app/modules/case/dto/internalCreateCase.dto.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/dto/internalCreateCase.dto.ts
@@ -1,3 +1,4 @@
+import { Transform } from 'class-transformer'
 import {
   ArrayMinSize,
   IsArray,
@@ -6,11 +7,15 @@ import {
   IsNotEmpty,
   IsOptional,
   IsString,
+  MaxLength,
+  MinLength,
 } from 'class-validator'
 
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
 
 import { CaseType, Gender } from '@island.is/judicial-system/types'
+
+import { nationalIdTransformer } from '../../../transformers'
 
 export class InternalCreateCaseDto {
   @IsNotEmpty()
@@ -27,11 +32,17 @@ export class InternalCreateCaseDto {
 
   @IsNotEmpty()
   @IsString()
+  @MinLength(10)
+  @MaxLength(10)
+  @Transform(nationalIdTransformer)
   @ApiProperty({ type: String })
   readonly prosecutorNationalId!: string
 
   @IsNotEmpty()
   @IsString()
+  @MinLength(10)
+  @MaxLength(10)
+  @Transform(nationalIdTransformer)
   @ApiProperty({ type: String })
   readonly accusedNationalId!: string
 

--- a/apps/judicial-system/backend/src/app/modules/case/dto/updateCase.dto.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/dto/updateCase.dto.ts
@@ -1,4 +1,4 @@
-import { Type } from 'class-transformer'
+import { Transform, Type } from 'class-transformer'
 import {
   ArrayMinSize,
   IsArray,
@@ -10,6 +10,7 @@ import {
   IsString,
   IsUUID,
   MaxLength,
+  MinLength,
   ValidateNested,
 } from 'class-validator'
 
@@ -36,6 +37,8 @@ import {
   UserRole,
 } from '@island.is/judicial-system/types'
 
+import { nationalIdTransformer } from '../../../transformers'
+
 class UpdateDateLog {
   @IsOptional()
   @Type(() => Date)
@@ -44,8 +47,8 @@ class UpdateDateLog {
   readonly date?: Date
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly location?: string
 }
@@ -62,40 +65,42 @@ export class UpdateCaseDto {
   readonly indictmentSubtypes?: IndictmentSubtypeMap
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly description?: string
 
   @IsOptional()
   @IsArray()
   @ArrayMinSize(1)
-  @MaxLength(255, { each: true })
   @IsString({ each: true })
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String, isArray: true })
   readonly policeCaseNumbers?: string[]
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly defenderName?: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MinLength(10)
+  @MaxLength(10)
+  @Transform(nationalIdTransformer)
   @ApiPropertyOptional({ type: String })
   readonly defenderNationalId?: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly defenderEmail?: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly defenderPhoneNumber?: string
 
@@ -115,8 +120,8 @@ export class UpdateCaseDto {
   readonly courtId?: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly leadInvestigator?: string
 
@@ -133,8 +138,8 @@ export class UpdateCaseDto {
   readonly requestedCourtDate?: Date
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly translator?: string
 
@@ -217,8 +222,8 @@ export class UpdateCaseDto {
   readonly sharedWithProsecutorsOfficeId?: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly courtCaseNumber?: string
 
@@ -240,8 +245,8 @@ export class UpdateCaseDto {
   readonly courtDate?: UpdateDateLog
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly courtLocation?: string
 
@@ -419,8 +424,8 @@ export class UpdateCaseDto {
   readonly defendantStatementDate?: Date
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly appealCaseNumber?: string
 

--- a/apps/judicial-system/backend/src/app/modules/defendant/dto/createDefendant.dto.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/dto/createDefendant.dto.ts
@@ -1,14 +1,18 @@
+import { Transform } from 'class-transformer'
 import {
   IsBoolean,
   IsEnum,
   IsOptional,
   IsString,
   MaxLength,
+  MinLength,
 } from 'class-validator'
 
 import { ApiPropertyOptional } from '@nestjs/swagger'
 
 import { DefenderChoice, Gender } from '@island.is/judicial-system/types'
+
+import { nationalIdTransformer } from '../../../transformers'
 
 export class CreateDefendantDto {
   @IsOptional()
@@ -17,14 +21,16 @@ export class CreateDefendantDto {
   readonly noNationalId?: boolean
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MinLength(10)
+  @MaxLength(10)
+  @Transform(nationalIdTransformer)
   @ApiPropertyOptional({ type: String })
   readonly nationalId?: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly name?: string
 
@@ -34,38 +40,40 @@ export class CreateDefendantDto {
   readonly gender?: Gender
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly address?: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly citizenship?: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly defenderName?: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MinLength(10)
+  @MaxLength(10)
+  @Transform(nationalIdTransformer)
   @ApiPropertyOptional({ type: String })
   readonly defenderNationalId?: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly defenderEmail?: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly defenderPhoneNumber?: string
 

--- a/apps/judicial-system/backend/src/app/modules/defendant/dto/internalUpdateDefendant.dto.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/dto/internalUpdateDefendant.dto.ts
@@ -1,8 +1,17 @@
-import { IsEnum, IsOptional, IsString } from 'class-validator'
+import { Transform } from 'class-transformer'
+import {
+  IsEnum,
+  IsOptional,
+  IsString,
+  MaxLength,
+  MinLength,
+} from 'class-validator'
 
 import { ApiPropertyOptional } from '@nestjs/swagger'
 
 import { DefenderChoice } from '@island.is/judicial-system/types'
+
+import { nationalIdTransformer } from '../../../transformers'
 
 export class InternalUpdateDefendantDto {
   @IsOptional()
@@ -12,6 +21,9 @@ export class InternalUpdateDefendantDto {
 
   @IsOptional()
   @IsString()
+  @MinLength(10)
+  @MaxLength(10)
+  @Transform(nationalIdTransformer)
   @ApiPropertyOptional({ type: String })
   readonly defenderNationalId?: string
 
@@ -37,6 +49,9 @@ export class InternalUpdateDefendantDto {
 
   @IsOptional()
   @IsString()
+  @MinLength(10)
+  @MaxLength(10)
+  @Transform(nationalIdTransformer)
   @ApiPropertyOptional({ type: String })
   readonly requestedDefenderNationalId?: string
 

--- a/apps/judicial-system/backend/src/app/modules/defendant/dto/updateCivilClaimant.dto.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/dto/updateCivilClaimant.dto.ts
@@ -1,6 +1,15 @@
-import { IsBoolean, IsOptional, IsString, MaxLength } from 'class-validator'
+import { Transform } from 'class-transformer'
+import {
+  IsBoolean,
+  IsOptional,
+  IsString,
+  MaxLength,
+  MinLength,
+} from 'class-validator'
 
 import { ApiPropertyOptional } from '@nestjs/swagger'
+
+import { nationalIdTransformer } from '../../../transformers'
 
 export class UpdateCivilClaimantDto {
   @IsOptional()
@@ -9,16 +18,18 @@ export class UpdateCivilClaimantDto {
   readonly noNationalId?: boolean
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
-  @ApiPropertyOptional({ type: String })
-  readonly name?: string
-
-  @IsOptional()
-  @MaxLength(255)
-  @IsString()
+  @MinLength(10)
+  @MaxLength(10)
+  @Transform(nationalIdTransformer)
   @ApiPropertyOptional({ type: String })
   readonly nationalId?: string
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  @ApiPropertyOptional({ type: String })
+  readonly name?: string
 
   @IsOptional()
   @IsBoolean()
@@ -31,26 +42,28 @@ export class UpdateCivilClaimantDto {
   readonly spokespersonIsLawyer?: boolean
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MinLength(10)
+  @MaxLength(10)
+  @Transform(nationalIdTransformer)
   @ApiPropertyOptional({ type: String })
   readonly spokespersonNationalId?: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly spokespersonName?: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly spokespersonEmail?: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly spokespersonPhoneNumber?: string
 

--- a/apps/judicial-system/backend/src/app/modules/defendant/dto/updateDefendant.dto.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/dto/updateDefendant.dto.ts
@@ -1,4 +1,4 @@
-import { Type } from 'class-transformer'
+import { Transform, Type } from 'class-transformer'
 import {
   IsBoolean,
   IsDate,
@@ -6,6 +6,7 @@ import {
   IsOptional,
   IsString,
   MaxLength,
+  MinLength,
 } from 'class-validator'
 
 import { ApiPropertyOptional } from '@nestjs/swagger'
@@ -18,6 +19,8 @@ import {
   SubpoenaType,
 } from '@island.is/judicial-system/types'
 
+import { nationalIdTransformer } from '../../../transformers'
+
 export class UpdateDefendantDto {
   @IsOptional()
   @IsBoolean()
@@ -25,14 +28,16 @@ export class UpdateDefendantDto {
   readonly noNationalId?: boolean
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MinLength(10)
+  @MaxLength(10)
+  @Transform(nationalIdTransformer)
   @ApiPropertyOptional({ type: String })
   readonly nationalId?: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly name?: string
 
@@ -42,38 +47,40 @@ export class UpdateDefendantDto {
   readonly gender?: Gender
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly address?: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly citizenship?: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly defenderName?: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MinLength(10)
+  @MaxLength(10)
+  @Transform(nationalIdTransformer)
   @ApiPropertyOptional({ type: String })
   readonly defenderNationalId?: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly defenderEmail?: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly defenderPhoneNumber?: string
 
@@ -115,14 +122,16 @@ export class UpdateDefendantDto {
   readonly requestedDefenderChoice?: DefenderChoice
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MinLength(10)
+  @MaxLength(10)
+  @Transform(nationalIdTransformer)
   @ApiPropertyOptional({ type: String })
   readonly requestedDefenderNationalId?: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly requestedDefenderName?: string
 

--- a/apps/judicial-system/backend/src/app/modules/file/dto/createFile.dto.ts
+++ b/apps/judicial-system/backend/src/app/modules/file/dto/createFile.dto.ts
@@ -15,8 +15,8 @@ import { CaseFileCategory } from '@island.is/judicial-system/types'
 
 export class CreateFileDto {
   @IsNotEmpty()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiProperty({ type: String })
   readonly type!: string
 
@@ -26,8 +26,8 @@ export class CreateFileDto {
   readonly category?: CaseFileCategory
 
   @IsNotEmpty()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiProperty({ type: String })
   readonly key!: string
 
@@ -37,8 +37,8 @@ export class CreateFileDto {
   readonly size!: number
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly policeCaseNumber?: string
 
@@ -59,14 +59,14 @@ export class CreateFileDto {
   readonly displayDate?: Date
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly policeFileId?: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly userGeneratedFilename?: string
 }

--- a/apps/judicial-system/backend/src/app/modules/file/dto/createPresignedPost.dto.ts
+++ b/apps/judicial-system/backend/src/app/modules/file/dto/createPresignedPost.dto.ts
@@ -4,14 +4,14 @@ import { ApiProperty } from '@nestjs/swagger'
 
 export class CreatePresignedPostDto {
   @IsNotEmpty()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiProperty({ type: String })
   readonly fileName!: string
 
   @IsNotEmpty()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiProperty({ type: String })
   readonly type!: string
 }

--- a/apps/judicial-system/backend/src/app/modules/file/dto/updateFile.dto.ts
+++ b/apps/judicial-system/backend/src/app/modules/file/dto/updateFile.dto.ts
@@ -22,8 +22,8 @@ export class UpdateFileDto {
   readonly id!: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly userGeneratedFilename?: string
 

--- a/apps/judicial-system/backend/src/app/modules/indictment-count/dto/updateIndictmentCount.dto.ts
+++ b/apps/judicial-system/backend/src/app/modules/indictment-count/dto/updateIndictmentCount.dto.ts
@@ -14,14 +14,14 @@ import { IndictmentCountOffense } from '@island.is/judicial-system/types'
 
 export class UpdateIndictmentCountDto {
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly policeCaseNumber?: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly vehicleRegistrationNumber?: string
 

--- a/apps/judicial-system/backend/src/app/modules/subpoena/dto/updateSubpoena.dto.ts
+++ b/apps/judicial-system/backend/src/app/modules/subpoena/dto/updateSubpoena.dto.ts
@@ -1,8 +1,17 @@
-import { IsEnum, IsOptional, IsString, MaxLength } from 'class-validator'
+import { Transform } from 'class-transformer'
+import {
+  IsEnum,
+  IsOptional,
+  IsString,
+  MaxLength,
+  MinLength,
+} from 'class-validator'
 
 import { ApiPropertyOptional } from '@nestjs/swagger'
 
 import { DefenderChoice, ServiceStatus } from '@island.is/judicial-system/types'
+
+import { nationalIdTransformer } from '../../../transformers'
 
 export class UpdateSubpoenaDto {
   @IsOptional()
@@ -11,8 +20,8 @@ export class UpdateSubpoenaDto {
   readonly serviceStatus?: ServiceStatus
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly servedBy?: string
 
@@ -32,26 +41,28 @@ export class UpdateSubpoenaDto {
   readonly defenderChoice?: DefenderChoice
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MinLength(10)
+  @MaxLength(10)
+  @Transform(nationalIdTransformer)
   @ApiPropertyOptional({ type: String })
   readonly defenderNationalId?: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly defenderName?: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly defenderEmail?: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly defenderPhoneNumber?: string
 
@@ -61,14 +72,16 @@ export class UpdateSubpoenaDto {
   readonly requestedDefenderChoice?: DefenderChoice
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MinLength(10)
+  @MaxLength(10)
+  @Transform(nationalIdTransformer)
   @ApiPropertyOptional({ type: String })
   readonly requestedDefenderNationalId?: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly requestedDefenderName?: string
 }

--- a/apps/judicial-system/backend/src/app/modules/user/dto/createUser.dto.ts
+++ b/apps/judicial-system/backend/src/app/modules/user/dto/createUser.dto.ts
@@ -1,3 +1,4 @@
+import { Transform } from 'class-transformer'
 import {
   IsBoolean,
   IsEnum,
@@ -5,40 +6,45 @@ import {
   IsString,
   IsUUID,
   MaxLength,
+  MinLength,
 } from 'class-validator'
 
 import { ApiProperty } from '@nestjs/swagger'
 
 import { UserRole } from '@island.is/judicial-system/types'
 
+import { nationalIdTransformer } from '../../../transformers'
+
 export class CreateUserDto {
   @IsNotEmpty()
-  @MaxLength(255)
   @IsString()
+  @MinLength(10)
+  @MaxLength(10)
+  @Transform(nationalIdTransformer)
   @ApiProperty({ type: String })
   readonly nationalId!: string
 
   @IsNotEmpty()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiProperty({ type: String })
   readonly name!: string
 
   @IsNotEmpty()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiProperty({ type: String })
   readonly title!: string
 
   @IsNotEmpty()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiProperty({ type: String })
   readonly mobileNumber!: string
 
   @IsNotEmpty()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiProperty({ type: String })
   readonly email!: string
 

--- a/apps/judicial-system/backend/src/app/modules/user/dto/updateUser.dto.ts
+++ b/apps/judicial-system/backend/src/app/modules/user/dto/updateUser.dto.ts
@@ -13,26 +13,26 @@ import { UserRole } from '@island.is/judicial-system/types'
 
 export class UpdateUserDto {
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly name?: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly title?: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly mobileNumber?: string
 
   @IsOptional()
-  @MaxLength(255)
   @IsString()
+  @MaxLength(255)
   @ApiPropertyOptional({ type: String })
   readonly email?: string
 

--- a/apps/judicial-system/backend/src/app/transformers/index.ts
+++ b/apps/judicial-system/backend/src/app/transformers/index.ts
@@ -1,0 +1,1 @@
+export { nationalIdTransformer } from './nationalId.transformer'

--- a/apps/judicial-system/backend/src/app/transformers/nationalId.transformer.ts
+++ b/apps/judicial-system/backend/src/app/transformers/nationalId.transformer.ts
@@ -1,0 +1,8 @@
+interface Value {
+  value?: string
+}
+
+type NationalIdTransformer = ({ value }: Value) => string | undefined
+
+export const nationalIdTransformer: NationalIdTransformer = ({ value }) =>
+  value?.replace(/-/g, '')


### PR DESCRIPTION
# Strip National Id Hyphen

[Hætta að geyma kennitölur með bandstriki í gagnagrunni](https://app.asana.com/0/1199153462262248/1207463927816269/f)

## What

- Strips hyphens from national ids before saving to the database.
- Removes hyphens from national ids already in the database.

## Why

- Data consistency.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
