### PR TITLE
fix(contentful-apps): Add external source data key on initializing value field

### DIFF
--- a/apps/contentful-apps/pages/fields/chart-component-source-data-key-field.tsx
+++ b/apps/contentful-apps/pages/fields/chart-component-source-data-key-field.tsx
@@ -78,6 +78,7 @@ const ChartComponentSourceDataKeyField = () => {
     sdk.entry.fields.values.getValue() || {
       typeOfSource: SourceDataKeyValues.ExternalSourceKey,
       typeOfManualDataKey: ManualDataKeyValues.Date,
+      externalSourceDataKey: sdk.entry.fields.sourceDataKey.getValue(),
       dateItems: [],
       categoryItems: [],
     },


### PR DESCRIPTION
# Add external source data key on initializing value field

## Why

So value of source data key does not get lost when initializing value field for first time.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new property, `externalSourceDataKey`, enhancing the data handling capabilities of the chart component.
	- Updated rendering logic to conditionally display input for `externalSourceDataKey` based on user selection.
- **Bug Fixes**
	- Improved state management to ensure accurate representation of `manualData` based on user input changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->