### PR TITLE
feat(web): Add allow decimals prop to axis on chart

### DIFF
--- a/apps/web/components/Charts/v2/utils/chart.tsx
+++ b/apps/web/components/Charts/v2/utils/chart.tsx
@@ -108,6 +108,9 @@ export const getCartesianGridComponents = ({
       type={slice.flipAxis ? 'number' : 'category'}
       height={customStyleConfig.xAxis?.height ?? DEFAULT_XAXIS_HEIGHT}
       tick={customStyleConfig.xAxis?.tick ?? undefined}
+      allowDecimals={
+        slice.reduceAndRoundValue === true && slice.flipAxis ? false : true
+      }
     />,
     <YAxis
       axisLine={{ stroke: theme.color.blue200 }}
@@ -126,6 +129,9 @@ export const getCartesianGridComponents = ({
       domain={customStyleConfig.yAxis?.domain ?? [0, 'auto']}
       tick={customStyleConfig.yAxis?.tick ?? undefined}
       ticks={customStyleConfig.yAxis?.ticks ?? undefined}
+      allowDecimals={
+        slice.reduceAndRoundValue === true && !slice.flipAxis ? false : true
+      }
     >
       {slice.yAxisLabel && (
         <Label


### PR DESCRIPTION
# Add allow decimals prop to axis on chart

## What

Added allowDecimals prop to Y and X axis dependend on reduceAndRoundValue field on chart content type in contentful.

## Why

To get right values in Yaxis and not the same rounded values like in screenshot below.

## Screenshots / Gifs

### Before
![image](https://github.com/user-attachments/assets/489235d0-bd04-41ff-ad86-663624d6e137)

### After
![image](https://github.com/user-attachments/assets/d6218e6d-f5f5-4245-8046-709a909fbf9e)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced chart components with new `allowDecimals` property for both XAxis and YAxis, improving control over decimal display based on chart configuration.
  
- **Bug Fixes**
	- Improved conditional rendering logic for decimal allowances, ensuring accurate representation of chart data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->