### PR TITLE
fix(admin-portal): Fix bff hooks to not use old auth hooks (#17018)

### DIFF
--- a/libs/portals/admin/delegation-admin/src/screens/CreateDelegation/CreateDelegation.tsx
+++ b/libs/portals/admin/delegation-admin/src/screens/CreateDelegation/CreateDelegation.tsx
@@ -1,54 +1,53 @@
-import React, { useEffect, useState } from 'react'
 import {
-  Box,
-  Stack,
   AlertMessage,
+  Box,
   Checkbox,
+  DatePicker,
   GridColumn,
   GridRow,
+  Icon,
   Input,
   Select,
-  DatePicker,
+  Stack,
   toast,
-  Icon,
 } from '@island.is/island-ui/core'
-import { BackButton } from '@island.is/portals/admin/core'
 import { useLocale } from '@island.is/localization'
+import { BackButton } from '@island.is/portals/admin/core'
+import React, { useEffect, useState } from 'react'
 
+import { Identity } from '@island.is/api/schema'
 import { IntroHeader, m as coreMessages } from '@island.is/portals/core'
-import { m } from '../../lib/messages'
-import { DelegationAdminPaths } from '../../lib/paths'
-import NumberFormat from 'react-number-format'
+import {
+  DelegationsFormFooter,
+  useDynamicShadow,
+} from '@island.is/portals/shared-modules/delegations'
+import { useUserInfo } from '@island.is/react-spa/bff'
+import { replaceParams } from '@island.is/react-spa/shared'
+import { AuthDelegationType } from '@island.is/shared/types'
+import { maskString, unmaskString } from '@island.is/shared/utils'
+import cn from 'classnames'
 import startOfDay from 'date-fns/startOfDay'
+import kennitala from 'kennitala'
+import debounce from 'lodash/debounce'
+import NumberFormat from 'react-number-format'
 import {
   Form,
-  redirect,
   useActionData,
   useNavigate,
   useSearchParams,
   useSubmit,
 } from 'react-router-dom'
+import { CreateDelegationConfirmModal } from '../../components/CreateDelegationConfirmModal'
+import { FORM_ERRORS } from '../../constants/errors'
+import { m } from '../../lib/messages'
+import { DelegationAdminPaths } from '../../lib/paths'
 import { CreateDelegationResult } from './CreateDelegation.action'
 import * as styles from './CreateDelegation.css'
 import { useIdentityLazyQuery } from './CreateDelegation.generated'
-import debounce from 'lodash/debounce'
-import cn from 'classnames'
-import {
-  DelegationsFormFooter,
-  useDynamicShadow,
-} from '@island.is/portals/shared-modules/delegations'
-import { CreateDelegationConfirmModal } from '../../components/CreateDelegationConfirmModal'
-import { Identity } from '@island.is/api/schema'
-import kennitala from 'kennitala'
-import { maskString, unmaskString } from '@island.is/shared/utils'
-import { useAuth } from '@island.is/auth/react'
-import { replaceParams } from '@island.is/react-spa/shared'
-import { FORM_ERRORS } from '../../constants/errors'
-import { AuthDelegationType } from '@island.is/shared/types'
 
 const CreateDelegationScreen = () => {
   const { formatMessage } = useLocale()
-  const { userInfo } = useAuth()
+  const userInfo = useUserInfo()
 
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()

--- a/libs/portals/admin/delegation-admin/src/screens/DelegationAdminDetails/DelegationAdmin.tsx
+++ b/libs/portals/admin/delegation-admin/src/screens/DelegationAdminDetails/DelegationAdmin.tsx
@@ -1,24 +1,23 @@
-import { Button, GridColumn, Box, Stack, Tabs } from '@island.is/island-ui/core'
-import { BackButton } from '@island.is/portals/admin/core'
-import { useLocale } from '@island.is/localization'
-import { useLoaderData, useNavigate } from 'react-router-dom'
-import { DelegationAdminResult } from './DelegationAdmin.loader'
-import { DelegationAdminPaths } from '../../lib/paths'
-import { formatNationalId, IntroHeader } from '@island.is/portals/core'
-import { m } from '../../lib/messages'
-import React from 'react'
-import DelegationList from '../../components/DelegationList'
 import { AuthCustomDelegation } from '@island.is/api/schema'
-import { DelegationsEmptyState } from '@island.is/portals/shared-modules/delegations'
-import { useAuth } from '@island.is/auth/react'
 import { AdminPortalScope } from '@island.is/auth/scopes'
+import { Box, Button, GridColumn, Stack, Tabs } from '@island.is/island-ui/core'
+import { useLocale } from '@island.is/localization'
+import { BackButton } from '@island.is/portals/admin/core'
+import { IntroHeader, formatNationalId } from '@island.is/portals/core'
+import { DelegationsEmptyState } from '@island.is/portals/shared-modules/delegations'
+import { useUserInfo } from '@island.is/react-spa/bff'
 import { maskString } from '@island.is/shared/utils'
+import { useLoaderData, useNavigate } from 'react-router-dom'
+import DelegationList from '../../components/DelegationList'
+import { m } from '../../lib/messages'
+import { DelegationAdminPaths } from '../../lib/paths'
+import { DelegationAdminResult } from './DelegationAdmin.loader'
 
 const DelegationAdminScreen = () => {
   const { formatMessage } = useLocale()
   const navigate = useNavigate()
   const delegationAdmin = useLoaderData() as DelegationAdminResult
-  const { userInfo } = useAuth()
+  const userInfo = useUserInfo()
 
   const hasAdminAccess = userInfo?.scopes.includes(
     AdminPortalScope.delegationSystemAdmin,

--- a/libs/portals/admin/delegation-admin/src/screens/Root.tsx
+++ b/libs/portals/admin/delegation-admin/src/screens/Root.tsx
@@ -1,20 +1,20 @@
-import { useLocale } from '@island.is/localization'
-import { IntroHeader } from '@island.is/portals/core'
-import { m } from '../lib/messages'
-import { Form, Outlet, useActionData, useNavigate } from 'react-router-dom'
+import { AdminPortalScope } from '@island.is/auth/scopes'
 import {
   AsyncSearchInput,
+  Box,
   Button,
   GridColumn,
   GridRow,
-  Box,
 } from '@island.is/island-ui/core'
-import React, { useEffect, useState } from 'react'
+import { useLocale } from '@island.is/localization'
+import { IntroHeader } from '@island.is/portals/core'
+import { useUserInfo } from '@island.is/react-spa/bff'
 import { useSubmitting } from '@island.is/react-spa/shared'
-import { GetDelegationForNationalIdResult } from './Root.action'
+import { useEffect, useState } from 'react'
+import { Form, Outlet, useActionData, useNavigate } from 'react-router-dom'
+import { m } from '../lib/messages'
 import { DelegationAdminPaths } from '../lib/paths'
-import { useAuth } from '@island.is/auth/react'
-import { AdminPortalScope } from '@island.is/auth/scopes'
+import { GetDelegationForNationalIdResult } from './Root.action'
 
 const Root = () => {
   const [focused, setFocused] = useState(false)
@@ -24,7 +24,7 @@ const Root = () => {
   const { isSubmitting, isLoading } = useSubmitting()
   const [error, setError] = useState({ hasError: false, message: '' })
   const navigate = useNavigate()
-  const { userInfo } = useAuth()
+  const userInfo = useUserInfo()
 
   const hasAdminAccess = userInfo?.scopes.includes(
     AdminPortalScope.delegationSystemAdmin,

--- a/libs/portals/shared-modules/delegations/src/components/delegations/DelegationViewModal.tsx
+++ b/libs/portals/shared-modules/delegations/src/components/delegations/DelegationViewModal.tsx
@@ -1,6 +1,5 @@
-import { useEffect } from 'react'
-import { useAuth } from '@island.is/auth/react'
 import { Box } from '@island.is/island-ui/core'
+import { useEffect } from 'react'
 
 import { useLocale } from '@island.is/localization'
 import { formatNationalId } from '@island.is/portals/core'
@@ -9,10 +8,11 @@ import { IdentityCard } from '../IdentityCard/IdentityCard'
 import { AccessListContainer } from '../access/AccessList/AccessListContainer/AccessListContainer'
 import { useAuthScopeTreeLazyQuery } from '../access/AccessList/AccessListContainer/AccessListContainer.generated'
 
-import { m } from '../../lib/messages'
-import format from 'date-fns/format'
 import { AuthDelegationScope, AuthDelegationType } from '@island.is/api/schema'
+import { useUserInfo } from '@island.is/react-spa/bff'
+import format from 'date-fns/format'
 import isValid from 'date-fns/isValid'
+import { m } from '../../lib/messages'
 
 type DelegationViewModalProps = {
   delegation?: {
@@ -45,7 +45,7 @@ export const DelegationViewModal = ({
   ...rest
 }: DelegationViewModalProps) => {
   const { formatMessage, lang } = useLocale()
-  const { userInfo } = useAuth()
+  const userInfo = useUserInfo()
   const isOutgoing = direction === 'outgoing'
   const [getAuthScopeTree, { data: scopeTreeData, loading: scopeTreeLoading }] =
     useAuthScopeTreeLazyQuery()


### PR DESCRIPTION
# Fix bff hooks to not use old auth hooks

## Why

Broke current auth logic for some screens

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
