### PR TITLE
feat(web): Organization parent subpage

### DIFF
--- a/apps/web/pages/s/[...slugs]/index.tsx
+++ b/apps/web/pages/s/[...slugs]/index.tsx
@@ -166,7 +166,6 @@ Component.getProps = async (context) => {
 
   const STANDALONE_THEME = 'standalone'
 
-  // Frontpage
   if (slugs.length === 1) {
     if (organizationPage.theme === STANDALONE_THEME) {
       return {

--- a/apps/web/pages/s/[...slugs]/index.tsx
+++ b/apps/web/pages/s/[...slugs]/index.tsx
@@ -31,6 +31,9 @@ import PublishedMaterial, {
 import StandaloneHome, {
   type StandaloneHomeProps,
 } from '@island.is/web/screens/Organization/Standalone/Home'
+import StandaloneParentSubpage, {
+  StandaloneParentSubpageProps,
+} from '@island.is/web/screens/Organization/Standalone/ParentSubpage'
 import SubPage, {
   type SubPageProps,
 } from '@island.is/web/screens/Organization/SubPage'
@@ -42,6 +45,7 @@ import { getServerSidePropsWrapper } from '@island.is/web/utils/getServerSidePro
 enum PageType {
   FRONTPAGE = 'frontpage',
   STANDALONE_FRONTPAGE = 'standalone-frontpage',
+  STANDALONE_PARENT_SUBPAGE = 'standalone-parent-subpage',
   SUBPAGE = 'subpage',
   ALL_NEWS = 'news',
   PUBLISHED_MATERIAL = 'published-material',
@@ -55,6 +59,9 @@ enum PageType {
 const pageMap: Record<PageType, FC<any>> = {
   [PageType.FRONTPAGE]: (props) => <Home {...props} />,
   [PageType.STANDALONE_FRONTPAGE]: (props) => <StandaloneHome {...props} />,
+  [PageType.STANDALONE_PARENT_SUBPAGE]: (props) => (
+    <StandaloneParentSubpage {...props} />
+  ),
   [PageType.SUBPAGE]: (props) => <SubPage {...props} />,
   [PageType.ALL_NEWS]: (props) => <OrganizationNewsList {...props} />,
   [PageType.PUBLISHED_MATERIAL]: (props) => <PublishedMaterial {...props} />,
@@ -78,6 +85,10 @@ interface Props {
     | {
         type: PageType.STANDALONE_FRONTPAGE
         props: StandaloneHomeProps
+      }
+    | {
+        type: PageType.STANDALONE_PARENT_SUBPAGE
+        props: StandaloneParentSubpageProps
       }
     | {
         type: PageType.SUBPAGE
@@ -135,32 +146,32 @@ Component.getProps = async (context) => {
   const slugs = context.query.slugs as string[]
   const locale = context.locale || 'is'
 
+  const {
+    data: { getOrganizationPage: organizationPage },
+  } = await context.apolloClient.query<Query, QueryGetOrganizationPageArgs>({
+    query: GET_ORGANIZATION_PAGE_QUERY,
+    variables: {
+      input: {
+        slug: slugs[0],
+        lang: locale,
+      },
+    },
+  })
+
+  if (!organizationPage) {
+    throw new CustomNextError(404, 'Organization page was not found')
+  }
+
+  const modifiedContext = { ...context, organizationPage }
+  // TODO: make use of organizationPage field in other screens
+
   // Frontpage
   if (slugs.length === 1) {
-    const {
-      data: { getOrganizationPage: organizationPage },
-    } = await context.apolloClient.query<Query, QueryGetOrganizationPageArgs>({
-      query: GET_ORGANIZATION_PAGE_QUERY,
-      variables: {
-        input: {
-          slug: slugs[0],
-          lang: locale,
-        },
-      },
-    })
-
-    if (!organizationPage) {
-      throw new CustomNextError(404)
-    }
-
     if (organizationPage.theme === 'standalone') {
       return {
         page: {
           type: PageType.STANDALONE_FRONTPAGE,
-          props: await StandaloneHome.getProps({
-            ...context,
-            organizationPage,
-          }),
+          props: await StandaloneHome.getProps(modifiedContext),
         },
       }
     }
@@ -168,7 +179,7 @@ Component.getProps = async (context) => {
     return {
       page: {
         type: PageType.FRONTPAGE,
-        props: await Home.getProps({ ...context, organizationPage }),
+        props: await Home.getProps(modifiedContext),
       },
     }
   }
@@ -179,7 +190,7 @@ Component.getProps = async (context) => {
         return {
           page: {
             type: PageType.ALL_NEWS,
-            props: await OrganizationNewsList.getProps(context),
+            props: await OrganizationNewsList.getProps(modifiedContext),
           },
         }
       }
@@ -187,7 +198,7 @@ Component.getProps = async (context) => {
         return {
           page: {
             type: PageType.ALL_EVENTS,
-            props: await OrganizationEventList.getProps(context),
+            props: await OrganizationEventList.getProps(modifiedContext),
           },
         }
       }
@@ -195,7 +206,7 @@ Component.getProps = async (context) => {
         return {
           page: {
             type: PageType.PUBLISHED_MATERIAL,
-            props: await PublishedMaterial.getProps(context),
+            props: await PublishedMaterial.getProps(modifiedContext),
           },
         }
       }
@@ -204,7 +215,7 @@ Component.getProps = async (context) => {
         return {
           page: {
             type: PageType.ALL_NEWS,
-            props: await OrganizationNewsList.getProps(context),
+            props: await OrganizationNewsList.getProps(modifiedContext),
           },
         }
       }
@@ -212,7 +223,7 @@ Component.getProps = async (context) => {
         return {
           page: {
             type: PageType.ALL_EVENTS,
-            props: await OrganizationEventList.getProps(context),
+            props: await OrganizationEventList.getProps(modifiedContext),
           },
         }
       }
@@ -220,18 +231,25 @@ Component.getProps = async (context) => {
         return {
           page: {
             type: PageType.PUBLISHED_MATERIAL,
-            props: await PublishedMaterial.getProps(context),
+            props: await PublishedMaterial.getProps(modifiedContext),
           },
         }
       }
     }
 
-    // Subpage
-    const props = await SubPage.getProps(context)
+    if (organizationPage.theme === 'standalone') {
+      return {
+        page: {
+          type: PageType.STANDALONE_PARENT_SUBPAGE,
+          props: await StandaloneParentSubpage.getProps(modifiedContext),
+        },
+      }
+    }
+
     return {
       page: {
         type: PageType.SUBPAGE,
-        props,
+        props: await SubPage.getProps(modifiedContext),
       },
     }
   }
@@ -242,7 +260,7 @@ Component.getProps = async (context) => {
         return {
           page: {
             type: PageType.NEWS_DETAILS,
-            props: await OrganizationNewsArticle.getProps(context),
+            props: await OrganizationNewsArticle.getProps(modifiedContext),
           },
         }
       }
@@ -250,7 +268,7 @@ Component.getProps = async (context) => {
         return {
           page: {
             type: PageType.EVENT_DETAILS,
-            props: await OrganizationEventArticle.getProps(context),
+            props: await OrganizationEventArticle.getProps(modifiedContext),
           },
         }
       }
@@ -259,7 +277,7 @@ Component.getProps = async (context) => {
         return {
           page: {
             type: PageType.NEWS_DETAILS,
-            props: await OrganizationNewsArticle.getProps(context),
+            props: await OrganizationNewsArticle.getProps(modifiedContext),
           },
         }
       }
@@ -267,16 +285,27 @@ Component.getProps = async (context) => {
         return {
           page: {
             type: PageType.EVENT_DETAILS,
-            props: await OrganizationEventArticle.getProps(context),
+            props: await OrganizationEventArticle.getProps(modifiedContext),
           },
         }
+      }
+    }
+
+    if (organizationPage.theme !== 'standalone') {
+      return {
+        page: {
+          type: PageType.STANDALONE_PARENT_SUBPAGE,
+          props: await StandaloneParentSubpage.getProps(modifiedContext),
+        },
       }
     }
 
     return {
       page: {
         type: PageType.GENERIC_LIST_ITEM,
-        props: await OrganizationSubPageGenericListItem.getProps(context),
+        props: await OrganizationSubPageGenericListItem.getProps(
+          modifiedContext,
+        ),
       },
     }
   }

--- a/apps/web/pages/s/[...slugs]/index.tsx
+++ b/apps/web/pages/s/[...slugs]/index.tsx
@@ -163,11 +163,12 @@ Component.getProps = async (context) => {
   }
 
   const modifiedContext = { ...context, organizationPage }
-  // TODO: make use of organizationPage field in other screens
+
+  const STANDALONE_THEME = 'standalone'
 
   // Frontpage
   if (slugs.length === 1) {
-    if (organizationPage.theme === 'standalone') {
+    if (organizationPage.theme === STANDALONE_THEME) {
       return {
         page: {
           type: PageType.STANDALONE_FRONTPAGE,
@@ -237,7 +238,7 @@ Component.getProps = async (context) => {
       }
     }
 
-    if (organizationPage.theme === 'standalone') {
+    if (organizationPage.theme === STANDALONE_THEME) {
       return {
         page: {
           type: PageType.STANDALONE_PARENT_SUBPAGE,
@@ -291,7 +292,7 @@ Component.getProps = async (context) => {
       }
     }
 
-    if (organizationPage.theme !== 'standalone') {
+    if (organizationPage.theme === STANDALONE_THEME) {
       return {
         page: {
           type: PageType.STANDALONE_PARENT_SUBPAGE,

--- a/apps/web/screens/GenericList/OrganizationSubPageGenericListItem.tsx
+++ b/apps/web/screens/GenericList/OrganizationSubPageGenericListItem.tsx
@@ -1,10 +1,11 @@
 import { useMemo } from 'react'
 import { useRouter } from 'next/router'
 
+import { Query } from '@island.is/web/graphql/schema'
 import { useLinkResolver } from '@island.is/web/hooks'
 import { useI18n } from '@island.is/web/i18n'
-import { type LayoutProps, withMainLayout } from '@island.is/web/layouts/main'
-import { Screen } from '@island.is/web/types'
+import { type LayoutProps } from '@island.is/web/layouts/main'
+import { Screen, ScreenContext } from '@island.is/web/types'
 
 import SubPage, { type SubPageProps } from '../Organization/SubPage'
 import GenericListItemPage, {
@@ -19,8 +20,13 @@ export interface OrganizationSubPageGenericListItemProps {
   genericListItemProps: GenericListItemPageProps
 }
 
+type OrganizationSubPageGenericListItemScreenContext = ScreenContext & {
+  organizationPage?: Query['getOrganizationPage']
+}
+
 const OrganizationSubPageGenericListItem: Screen<
-  OrganizationSubPageGenericListItemProps
+  OrganizationSubPageGenericListItemProps,
+  OrganizationSubPageGenericListItemScreenContext
 > = (props) => {
   const { organizationPage, subpage } = props.parentProps.componentProps
   const router = useRouter()

--- a/apps/web/screens/Organization/OrganizationNews/OrganizationNewsArticle.tsx
+++ b/apps/web/screens/Organization/OrganizationNews/OrganizationNewsArticle.tsx
@@ -175,17 +175,15 @@ OrganizationNewsArticle.getProps = async ({
 
   const organizationPage = !_organizationPage
     ? (
-        await Promise.resolve(
-          apolloClient.query<Query, QueryGetOrganizationPageArgs>({
-            query: GET_ORGANIZATION_PAGE_QUERY,
-            variables: {
-              input: {
-                slug: organizationPageSlug,
-                lang: locale as Locale,
-              },
+        await apolloClient.query<Query, QueryGetOrganizationPageArgs>({
+          query: GET_ORGANIZATION_PAGE_QUERY,
+          variables: {
+            input: {
+              slug: organizationPageSlug,
+              lang: locale as Locale,
             },
-          }),
-        )
+          },
+        })
       ).data?.getOrganizationPage
     : _organizationPage
 

--- a/apps/web/screens/Organization/Standalone/ParentSubpage.tsx
+++ b/apps/web/screens/Organization/Standalone/ParentSubpage.tsx
@@ -1,0 +1,269 @@
+import { useMemo } from 'react'
+import { useRouter } from 'next/router'
+
+import {
+  Breadcrumbs,
+  GridColumn,
+  GridContainer,
+  GridRow,
+  Stack,
+  TableOfContents,
+  Text,
+} from '@island.is/island-ui/core'
+import {
+  ContentLanguage,
+  OrganizationPage,
+  OrganizationParentSubpage,
+  OrganizationSubpage,
+  Query,
+  QueryGetNamespaceArgs,
+  QueryGetOrganizationPageArgs,
+  QueryGetOrganizationParentSubpageArgs,
+  QueryGetOrganizationSubpageArgs,
+} from '@island.is/web/graphql/schema'
+import { useLinkResolver, useNamespace } from '@island.is/web/hooks'
+import { useI18n } from '@island.is/web/i18n'
+import { StandaloneLayout } from '@island.is/web/layouts/organization/standalone'
+import type { Screen, ScreenContext } from '@island.is/web/types'
+import { CustomNextError } from '@island.is/web/units/errors'
+
+import {
+  GET_NAMESPACE_QUERY,
+  GET_ORGANIZATION_PAGE_QUERY,
+  GET_ORGANIZATION_PARENT_SUBPAGE_QUERY,
+  GET_ORGANIZATION_SUBPAGE_QUERY,
+} from '../../queries'
+import { SubPageContent } from '../SubPage'
+
+type StandaloneParentSubpageScreenContext = ScreenContext & {
+  organizationPage?: Query['getOrganizationPage']
+}
+
+export interface StandaloneParentSubpageProps {
+  organizationPage: OrganizationPage
+  subpage: OrganizationSubpage
+  tableOfContentHeadings: {
+    headingId: string
+    headingTitle: string
+    label: string
+    href: string
+  }[]
+  selectedHeadingId: string
+  parentSubpage: OrganizationParentSubpage
+  namespace: Record<string, string>
+}
+
+const StandaloneParentSubpage: Screen<
+  StandaloneParentSubpageProps,
+  StandaloneParentSubpageScreenContext
+> = ({
+  organizationPage,
+  parentSubpage,
+  selectedHeadingId,
+  subpage,
+  tableOfContentHeadings,
+  namespace,
+}) => {
+  const organizationNamespace = useMemo(() => {
+    return JSON.parse(organizationPage.organization?.namespace?.fields || '{}')
+  }, [organizationPage.organization?.namespace?.fields])
+
+  const n = useNamespace(organizationNamespace)
+
+  const router = useRouter()
+  const { activeLocale } = useI18n()
+  const { linkResolver } = useLinkResolver()
+
+  return (
+    <StandaloneLayout
+      organizationPage={organizationPage}
+      bannerTitle={n('bannerTitle', '')}
+    >
+      <GridContainer>
+        <GridRow>
+          <GridColumn span={['9/9', '9/9', '7/9']} offset={['0', '0', '1/9']}>
+            <Stack space={4}>
+              <Breadcrumbs
+                items={[
+                  {
+                    title: organizationPage.title,
+                    href: linkResolver('organizationpage', [
+                      organizationPage.slug,
+                    ]).href,
+                  },
+                ]}
+              />
+              <Text variant="h1" as="h1">
+                {parentSubpage.title}
+              </Text>
+              <TableOfContents
+                headings={tableOfContentHeadings}
+                onClick={(headingId) => {
+                  const href = tableOfContentHeadings.find(
+                    (heading) => heading.headingId === headingId,
+                  )?.href
+                  if (href) {
+                    router.push(href)
+                  }
+                }}
+                tableOfContentsTitle={
+                  namespace?.['standaloneTableOfContentsTitle'] ??
+                  activeLocale === 'is'
+                    ? 'Efnisyfirlit'
+                    : 'Table of contents'
+                }
+                selectedHeadingId={selectedHeadingId}
+              />
+            </Stack>
+          </GridColumn>
+        </GridRow>
+        <SubPageContent
+          namespace={namespace}
+          organizationPage={organizationPage}
+          subpage={subpage}
+          subpageTitleVariant="h2"
+        />
+      </GridContainer>
+    </StandaloneLayout>
+  )
+}
+
+StandaloneParentSubpage.getProps = async ({
+  apolloClient,
+  locale,
+  query,
+  organizationPage,
+}) => {
+  const [organizationPageSlug, parentSubpageSlug, subpageSlug] = (query.slugs ??
+    []) as string[]
+
+  const [
+    {
+      data: { getOrganizationPage },
+    },
+    {
+      data: { getOrganizationParentSubpage },
+    },
+    namespace,
+  ] = await Promise.all([
+    !organizationPage
+      ? apolloClient.query<Query, QueryGetOrganizationPageArgs>({
+          query: GET_ORGANIZATION_PAGE_QUERY,
+          variables: {
+            input: {
+              slug: organizationPageSlug,
+              lang: locale as ContentLanguage,
+            },
+          },
+        })
+      : {
+          data: { getOrganizationPage: organizationPage },
+        },
+    apolloClient.query<Query, QueryGetOrganizationParentSubpageArgs>({
+      query: GET_ORGANIZATION_PARENT_SUBPAGE_QUERY,
+      variables: {
+        input: {
+          organizationPageSlug: organizationPageSlug as string,
+          slug: parentSubpageSlug as string,
+          lang: locale as ContentLanguage,
+        },
+      },
+    }),
+    apolloClient
+      .query<Query, QueryGetNamespaceArgs>({
+        query: GET_NAMESPACE_QUERY,
+        variables: {
+          input: {
+            namespace: 'OrganizationPages',
+            lang: locale,
+          },
+        },
+      })
+      .then((variables) =>
+        variables.data.getNamespace?.fields
+          ? JSON.parse(variables.data.getNamespace.fields)
+          : {},
+      ),
+  ])
+
+  if (!getOrganizationPage) {
+    throw new CustomNextError(404, 'Organization page not found')
+  }
+
+  if (!getOrganizationParentSubpage) {
+    throw new CustomNextError(404, 'Organization parent subpage was not found')
+  }
+
+  let selectedIndex = 0
+
+  if (subpageSlug) {
+    const index = getOrganizationParentSubpage.childLinks.findIndex(
+      (link) => link.href.split('/').pop() === subpageSlug,
+    )
+    if (index > 0) {
+      selectedIndex = index
+    }
+  }
+
+  let subpage = (
+    await apolloClient.query<Query, QueryGetOrganizationSubpageArgs>({
+      query: GET_ORGANIZATION_SUBPAGE_QUERY,
+      variables: {
+        input: {
+          organizationSlug: organizationPageSlug,
+          slug: getOrganizationParentSubpage.childLinks[selectedIndex].href
+            .split('/')
+            .pop() as string,
+          lang: locale as ContentLanguage,
+        },
+      },
+    })
+  ).data.getOrganizationSubpage
+
+  // Try getting the first subpage in case others can't be found
+  if (!subpage && selectedIndex > 0) {
+    selectedIndex = 0
+    subpage = (
+      await apolloClient.query<Query, QueryGetOrganizationSubpageArgs>({
+        query: GET_ORGANIZATION_SUBPAGE_QUERY,
+        variables: {
+          input: {
+            organizationSlug: organizationPageSlug,
+            slug: getOrganizationParentSubpage.childLinks[selectedIndex].href
+              .split('/')
+              .pop() as string,
+            lang: locale as ContentLanguage,
+          },
+        },
+      })
+    ).data.getOrganizationSubpage
+  }
+
+  if (!subpage) {
+    throw new CustomNextError(
+      404,
+      'Subpage belonging to an organization parent subpage was not found',
+    )
+  }
+
+  const tableOfContentHeadings = getOrganizationParentSubpage.childLinks.map(
+    (link) => ({
+      headingId: link.href,
+      headingTitle: link.label,
+      label: link.label,
+      href: link.href,
+    }),
+  )
+  const selectedHeadingId = tableOfContentHeadings[selectedIndex].headingId
+
+  return {
+    organizationPage: getOrganizationPage,
+    parentSubpage: getOrganizationParentSubpage,
+    subpage,
+    tableOfContentHeadings,
+    selectedHeadingId,
+    namespace,
+  }
+}
+
+export default StandaloneParentSubpage

--- a/apps/web/screens/queries/Organization.tsx
+++ b/apps/web/screens/queries/Organization.tsx
@@ -416,3 +416,17 @@ export const EMAIL_SIGNUP_MUTATION = gql`
     }
   }
 `
+
+export const GET_ORGANIZATION_PARENT_SUBPAGE_QUERY = gql`
+  query GetOrganizationParentSubpageQuery(
+    $input: GetOrganizationParentSubpageInput!
+  ) {
+    getOrganizationParentSubpage(input: $input) {
+      title
+      childLinks {
+        label
+        href
+      }
+    }
+  }
+`

--- a/libs/cms/src/lib/cms.contentful.service.ts
+++ b/libs/cms/src/lib/cms.contentful.service.ts
@@ -1162,16 +1162,17 @@ export class CmsContentfulService {
       limit: 1,
     }
 
-    const response =
-      await this.contentfulRepository.getLocalizedEntries<types.IOrganizationParentSubpageFields>(
+    const response = await this.contentfulRepository
+      .getLocalizedEntries<types.IOrganizationParentSubpageFields>(
         input.lang,
         params,
       )
+      .catch(errorHandler('getOrganizationParentSubpage'))
 
     return (
-      (response?.items as types.IOrganizationParentSubpage[])?.map(
+      (response?.items as types.IOrganizationParentSubpage[]).map(
         mapOrganizationParentSubpage,
-      )?.[0] ?? null
+      )[0] ?? null
     )
   }
 }

--- a/libs/cms/src/lib/cms.contentful.service.ts
+++ b/libs/cms/src/lib/cms.contentful.service.ts
@@ -83,10 +83,11 @@ import { LifeEventPage, mapLifeEventPage } from './models/lifeEventPage.model'
 import { GetGenericTagBySlugInput } from './dto/getGenericTagBySlug.input'
 import { GetGenericTagsInTagGroupsInput } from './dto/getGenericTagsInTagGroups.input'
 import { Grant, mapGrant } from './models/grant.model'
-import { GrantList } from './models/grantList.model'
 import { mapManual } from './models/manual.model'
 import { mapServiceWebPage } from './models/serviceWebPage.model'
 import { mapEvent } from './models/event.model'
+import { GetOrganizationParentSubpageInput } from './dto/getOrganizationParentSubpage.input'
+import { mapOrganizationParentSubpage } from './models/organizationParentSubpage.model'
 
 const errorHandler = (name: string) => {
   return (error: Error) => {
@@ -1150,5 +1151,27 @@ export class CmsContentfulService {
       .catch(errorHandler('getGenericTag'))
 
     return (result.items as types.IGenericTag[]).map(mapGenericTag)
+  }
+
+  async getOrganizationParentSubpage(input: GetOrganizationParentSubpageInput) {
+    const params = {
+      content_type: 'organizationParentSubpage',
+      'fields.slug': input.slug,
+      'fields.organizationPage.sys.contentType.sys.id': 'organizationPage',
+      'fields.organizationPage.fields.slug': input.organizationPageSlug,
+      limit: 1,
+    }
+
+    const response =
+      await this.contentfulRepository.getLocalizedEntries<types.IOrganizationParentSubpageFields>(
+        input.lang,
+        params,
+      )
+
+    return (
+      (response?.items as types.IOrganizationParentSubpage[])?.map(
+        mapOrganizationParentSubpage,
+      )?.[0] ?? null
+    )
   }
 }

--- a/libs/cms/src/lib/cms.contentful.service.ts
+++ b/libs/cms/src/lib/cms.contentful.service.ts
@@ -1170,7 +1170,7 @@ export class CmsContentfulService {
       .catch(errorHandler('getOrganizationParentSubpage'))
 
     return (
-      (response?.items as types.IOrganizationParentSubpage[]).map(
+      (response.items as types.IOrganizationParentSubpage[]).map(
         mapOrganizationParentSubpage,
       )[0] ?? null
     )

--- a/libs/cms/src/lib/cms.resolver.ts
+++ b/libs/cms/src/lib/cms.resolver.ts
@@ -126,6 +126,8 @@ import { Grant } from './models/grant.model'
 import { GetGrantsInput } from './dto/getGrants.input'
 import { GetSingleGrantInput } from './dto/getSingleGrant.input'
 import { GrantList } from './models/grantList.model'
+import { OrganizationParentSubpage } from './models/organizationParentSubpage.model'
+import { GetOrganizationParentSubpageInput } from './dto/getOrganizationParentSubpage.input'
 
 const defaultCache: CacheControlOptions = { maxAge: CACHE_CONTROL_MAX_AGE }
 
@@ -706,6 +708,14 @@ export class CmsResolver {
     @Args('input') input: GetTeamMembersInput,
   ): Promise<TeamMemberResponse> {
     return this.cmsElasticsearchService.getTeamMembers(input)
+  }
+
+  @CacheControl(defaultCache)
+  @Query(() => OrganizationParentSubpage, { nullable: true })
+  getOrganizationParentSubpage(
+    @Args('input') input: GetOrganizationParentSubpageInput,
+  ): Promise<OrganizationParentSubpage | null> {
+    return this.cmsContentfulService.getOrganizationParentSubpage(input)
   }
 }
 

--- a/libs/cms/src/lib/dto/getOrganizationParentSubpage.input.ts
+++ b/libs/cms/src/lib/dto/getOrganizationParentSubpage.input.ts
@@ -1,0 +1,18 @@
+import { Field, InputType } from '@nestjs/graphql'
+import { IsString } from 'class-validator'
+import { ElasticsearchIndexLocale } from '@island.is/content-search-index-manager'
+
+@InputType()
+export class GetOrganizationParentSubpageInput {
+  @Field()
+  @IsString()
+  slug!: string
+
+  @Field()
+  @IsString()
+  organizationPageSlug!: string
+
+  @Field(() => String)
+  @IsString()
+  lang: ElasticsearchIndexLocale = 'is'
+}

--- a/libs/cms/src/lib/models/organizationParentSubpage.model.ts
+++ b/libs/cms/src/lib/models/organizationParentSubpage.model.ts
@@ -1,0 +1,47 @@
+import { CacheField } from '@island.is/nest/graphql'
+import { Field, ID, ObjectType } from '@nestjs/graphql'
+import { IOrganizationParentSubpage } from '../generated/contentfulTypes'
+import { getOrganizationPageUrlPrefix } from '@island.is/shared/utils'
+import { Image, mapImage } from './image.model'
+
+@ObjectType()
+class OrganizationSubpageLink {
+  @Field()
+  label!: string
+
+  @Field()
+  href!: string
+}
+
+@ObjectType()
+export class OrganizationParentSubpage {
+  @Field(() => ID)
+  id!: string
+
+  @Field()
+  title!: string
+
+  @CacheField(() => [OrganizationSubpageLink])
+  childLinks!: OrganizationSubpageLink[]
+
+  @CacheField(() => Image, { nullable: true })
+  image?: Image | null
+}
+
+export const mapOrganizationParentSubpage = ({
+  sys,
+  fields,
+}: IOrganizationParentSubpage): OrganizationParentSubpage => {
+  return {
+    id: sys.id,
+    title: fields.title,
+    childLinks:
+      fields.pages?.map((page) => ({
+        label: page.fields.title,
+        href: `/${getOrganizationPageUrlPrefix(sys.locale)}/${
+          page.fields.organizationPage.fields.slug
+        }/${fields.slug}/${page.fields.slug}`,
+      })) ?? [],
+    image: fields.image ? mapImage(fields.image) : null,
+  }
+}

--- a/libs/cms/src/lib/models/organizationParentSubpage.model.ts
+++ b/libs/cms/src/lib/models/organizationParentSubpage.model.ts
@@ -2,7 +2,6 @@ import { CacheField } from '@island.is/nest/graphql'
 import { Field, ID, ObjectType } from '@nestjs/graphql'
 import { IOrganizationParentSubpage } from '../generated/contentfulTypes'
 import { getOrganizationPageUrlPrefix } from '@island.is/shared/utils'
-import { Image, mapImage } from './image.model'
 
 @ObjectType()
 class OrganizationSubpageLink {
@@ -23,9 +22,6 @@ export class OrganizationParentSubpage {
 
   @CacheField(() => [OrganizationSubpageLink])
   childLinks!: OrganizationSubpageLink[]
-
-  @CacheField(() => Image, { nullable: true })
-  image?: Image | null
 }
 
 export const mapOrganizationParentSubpage = ({
@@ -42,6 +38,5 @@ export const mapOrganizationParentSubpage = ({
           page.fields.organizationPage.fields.slug
         }/${fields.slug}/${page.fields.slug}`,
       })) ?? [],
-    image: fields.image ? mapImage(fields.image) : null,
   }
 }

--- a/libs/cms/src/lib/models/organizationParentSubpage.model.ts
+++ b/libs/cms/src/lib/models/organizationParentSubpage.model.ts
@@ -32,11 +32,17 @@ export const mapOrganizationParentSubpage = ({
     id: sys.id,
     title: fields.title,
     childLinks:
-      fields.pages?.map((page) => ({
-        label: page.fields.title,
-        href: `/${getOrganizationPageUrlPrefix(sys.locale)}/${
-          page.fields.organizationPage.fields.slug
-        }/${fields.slug}/${page.fields.slug}`,
-      })) ?? [],
+      fields.pages
+        ?.filter(
+          (page) =>
+            Boolean(page.fields.organizationPage?.fields?.slug) &&
+            Boolean(page.fields.slug),
+        )
+        .map((page) => ({
+          label: page.fields.title,
+          href: `/${getOrganizationPageUrlPrefix(sys.locale)}/${
+            page.fields.organizationPage.fields.slug
+          }/${fields.slug}/${page.fields.slug}`,
+        })) ?? [],
   }
 }


### PR DESCRIPTION
# Organization parent subpage

## What

* Organization pages that have the theme "standalone" can have a so called "parent subpage"

1. A parent subpage contains a list of subpages
2. A parent subpage fits within the "standalone" layout

## Why

* One of many changes needed for new design that "Landspítalinn" will utilize

## Screenshots / Gifs


https://github.com/user-attachments/assets/a2f27046-bac9-4614-8c18-b52a5cf3c4cd




## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new standalone parent subpage component for organizations, enhancing navigation and content display.
	- Added a new GraphQL query for fetching organization parent subpage details.
	- Enhanced existing components to support dynamic rendering based on organization page data.

- **Bug Fixes**
	- Improved error handling for missing organization pages and events, providing clearer messages.

- **Documentation**
	- Updated type definitions and props for better clarity and type safety across various components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->