### PR TITLE
feat(contentful-apps): Refactor list search functionality into a reusable component

### DIFF
--- a/apps/contentful-apps/components/EntryListSearch.tsx
+++ b/apps/contentful-apps/components/EntryListSearch.tsx
@@ -1,0 +1,155 @@
+import { useRef, useState } from 'react'
+import { useDebounce } from 'react-use'
+import {
+  CollectionProp,
+  EntryProps,
+  KeyValueMap,
+  QueryOptions,
+} from 'contentful-management'
+import {
+  Box,
+  EntryCard,
+  Pagination,
+  Spinner,
+  Stack,
+  Text,
+  TextInput,
+} from '@contentful/f36-components'
+import { useCMA, useSDK } from '@contentful/react-apps-toolkit'
+
+import { DEFAULT_LOCALE } from '../constants'
+
+const SEARCH_DEBOUNCE_TIME_IN_MS = 300
+
+interface EntryListSearchProps {
+  contentTypeId: string
+  contentTypeLabel: string
+  contentTypeTitleField: string
+  itemsPerPage?: number
+  onEntryClick?: (entry: EntryProps) => void
+  query?: QueryOptions
+}
+
+export const EntryListSearch = ({
+  itemsPerPage = 4,
+  contentTypeId,
+  contentTypeLabel,
+  contentTypeTitleField,
+  onEntryClick,
+  query,
+}: EntryListSearchProps) => {
+  const sdk = useSDK()
+  const cma = useCMA()
+
+  const searchValueRef = useRef('')
+  const [searchValue, setSearchValue] = useState('')
+  const [listItemResponse, setListItemResponse] =
+    useState<CollectionProp<EntryProps<KeyValueMap>>>()
+  const [loading, setLoading] = useState(false)
+  const [page, setPage] = useState(0)
+  const pageRef = useRef(0)
+  const [counter, setCounter] = useState(0)
+
+  const skip = itemsPerPage * page
+
+  useDebounce(
+    async () => {
+      setLoading(true)
+      try {
+        const response = await cma.entry.getMany({
+          query: {
+            content_type: contentTypeId,
+            limit: itemsPerPage,
+            skip,
+            [`fields.${contentTypeTitleField}[match]`]: searchValue,
+            'sys.archivedAt[exists]': false,
+            ...query,
+          },
+        })
+        if (
+          searchValueRef.current === searchValue &&
+          pageRef.current === page
+        ) {
+          setListItemResponse(response)
+        }
+      } finally {
+        setLoading(false)
+      }
+    },
+    SEARCH_DEBOUNCE_TIME_IN_MS,
+    [page, searchValue, counter],
+  )
+
+  return (
+    <Box style={{ display: 'flex', flexFlow: 'column nowrap', gap: '24px' }}>
+      <TextInput
+        placeholder="Search for an entry"
+        value={searchValue}
+        onChange={(ev) => {
+          searchValueRef.current = ev.target.value
+          setSearchValue(ev.target.value)
+          setPage(0)
+          pageRef.current = 0
+        }}
+      />
+
+      <Box
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          visibility: loading ? 'visible' : 'hidden',
+        }}
+      >
+        <Spinner />
+      </Box>
+
+      {listItemResponse?.items?.length > 0 && (
+        <>
+          <Box style={{ minHeight: '440px' }}>
+            <Stack flexDirection="column" spacing="spacingL">
+              {listItemResponse.items.map((item) => (
+                <EntryCard
+                  key={item.sys.id}
+                  contentType={contentTypeLabel}
+                  title={
+                    item.fields[contentTypeTitleField]?.[DEFAULT_LOCALE] ||
+                    'Untitled'
+                  }
+                  onClick={() => {
+                    if (onEntryClick) {
+                      onEntryClick(item)
+                      return
+                    }
+
+                    sdk.navigator
+                      .openEntry(item.sys.id, {
+                        slideIn: { waitForClose: true },
+                      })
+                      .then(() => {
+                        setCounter((c) => c + 1)
+                      })
+                  }}
+                />
+              ))}
+            </Stack>
+          </Box>
+          <Pagination
+            activePage={page}
+            itemsPerPage={itemsPerPage}
+            totalItems={listItemResponse.total}
+            onPageChange={(newPage) => {
+              pageRef.current = newPage
+              setPage(newPage)
+            }}
+          />
+        </>
+      )}
+
+      {listItemResponse?.items?.length === 0 && (
+        <Box style={{ display: 'flex', justifyContent: 'center' }}>
+          <Text>No entry was found</Text>
+        </Box>
+      )}
+    </Box>
+  )
+}

--- a/apps/contentful-apps/components/editors/lists/GenericListEditor/GenericListEditor.tsx
+++ b/apps/contentful-apps/components/editors/lists/GenericListEditor/GenericListEditor.tsx
@@ -140,6 +140,9 @@ export const GenericListEditor = () => {
         contentTypeId={LIST_ITEM_CONTENT_TYPE_ID}
         contentTypeLabel="List Item"
         contentTypeTitleField="internalTitle"
+        query={{
+          'fields.genericList.sys.id': sdk.ids.entry,
+        }}
       />
     </Box>
   )

--- a/apps/contentful-apps/components/editors/lists/GenericListEditor/GenericListEditor.tsx
+++ b/apps/contentful-apps/components/editors/lists/GenericListEditor/GenericListEditor.tsx
@@ -1,27 +1,14 @@
-import { useMemo, useRef, useState } from 'react'
-import { useDebounce } from 'react-use'
-import { CollectionProp, EntryProps, KeyValueMap } from 'contentful-management'
+import { useMemo, useState } from 'react'
 import dynamic from 'next/dynamic'
 import { EditorExtensionSDK } from '@contentful/app-sdk'
-import {
-  Box,
-  Button,
-  EntryCard,
-  FormControl,
-  Pagination,
-  Spinner,
-  Stack,
-  Text,
-  TextInput,
-} from '@contentful/f36-components'
+import { Box, Button, FormControl } from '@contentful/f36-components'
 import { PlusIcon } from '@contentful/f36-icons'
 import { useCMA, useSDK } from '@contentful/react-apps-toolkit'
 
+import { EntryListSearch } from '../../../../components/EntryListSearch'
 import { mapLocalesToFieldApis } from '../../utils'
 
-const SEARCH_DEBOUNCE_TIME_IN_MS = 300
 const LIST_ITEM_CONTENT_TYPE_ID = 'genericListItem'
-const LIST_ITEMS_PER_PAGE = 4
 
 const createLocaleToFieldMapping = (sdk: EditorExtensionSDK) => {
   return {
@@ -58,50 +45,10 @@ export const GenericListEditor = () => {
   const sdk = useSDK<EditorExtensionSDK>()
   const cma = useCMA()
 
-  const searchValueRef = useRef('')
-  const [searchValue, setSearchValue] = useState('')
-  const [listItemResponse, setListItemResponse] =
-    useState<CollectionProp<EntryProps<KeyValueMap>>>()
-  const [loading, setLoading] = useState(false)
-  const [page, setPage] = useState(0)
-  const pageRef = useRef(0)
-
   /** Counter that's simply used to refresh the list when an item gets created */
-  const [counter, setCounter] = useState(0)
-
-  const skip = LIST_ITEMS_PER_PAGE * page
+  const [_, setCounter] = useState(0)
 
   const defaultLocale = sdk.locales.default
-
-  useDebounce(
-    async () => {
-      setLoading(true)
-      try {
-        const response = await cma.entry.getMany({
-          environmentId: sdk.ids.environment,
-          spaceId: sdk.ids.space,
-          query: {
-            content_type: LIST_ITEM_CONTENT_TYPE_ID,
-            limit: LIST_ITEMS_PER_PAGE,
-            skip,
-            'fields.internalTitle[match]': searchValue,
-            'fields.genericList.sys.id': sdk.entry.getSys().id,
-            'sys.archivedAt[exists]': false,
-          },
-        })
-        if (
-          searchValueRef.current === searchValue &&
-          pageRef.current === page
-        ) {
-          setListItemResponse(response)
-        }
-      } finally {
-        setLoading(false)
-      }
-    },
-    SEARCH_DEBOUNCE_TIME_IN_MS,
-    [page, searchValue, counter],
-  )
 
   const createListItem = async () => {
     const cardIntro = {}
@@ -189,70 +136,11 @@ export const GenericListEditor = () => {
           <Button startIcon={<PlusIcon />}>Add item</Button>
         </Box>
       </Box>
-      <Box style={{ display: 'flex', flexFlow: 'column nowrap', gap: '24px' }}>
-        <TextInput
-          placeholder="Search for a list item"
-          value={searchValue}
-          onChange={(ev) => {
-            searchValueRef.current = ev.target.value
-            setSearchValue(ev.target.value)
-            setPage(0)
-            pageRef.current = 0
-          }}
-        />
-
-        <Box
-          style={{
-            display: 'flex',
-            justifyContent: 'center',
-            visibility: loading ? 'visible' : 'hidden',
-          }}
-        >
-          <Spinner />
-        </Box>
-
-        {listItemResponse?.items?.length > 0 && (
-          <>
-            <Box style={{ minHeight: '440px' }}>
-              <Stack flexDirection="column" spacing="spacingL">
-                {listItemResponse.items.map((item) => (
-                  <EntryCard
-                    key={item.sys.id}
-                    contentType="List Item"
-                    title={
-                      item.fields.internalTitle?.[defaultLocale] ?? 'Untitled'
-                    }
-                    onClick={() => {
-                      sdk.navigator
-                        .openEntry(item.sys.id, {
-                          slideIn: { waitForClose: true },
-                        })
-                        .then(() => {
-                          setCounter((c) => c + 1)
-                        })
-                    }}
-                  />
-                ))}
-              </Stack>
-            </Box>
-            <Pagination
-              activePage={page}
-              itemsPerPage={LIST_ITEMS_PER_PAGE}
-              totalItems={listItemResponse.total}
-              onPageChange={(newPage) => {
-                pageRef.current = newPage
-                setPage(newPage)
-              }}
-            />
-          </>
-        )}
-
-        {listItemResponse?.items?.length === 0 && (
-          <Box style={{ display: 'flex', justifyContent: 'center' }}>
-            <Text>No item was found</Text>
-          </Box>
-        )}
-      </Box>
+      <EntryListSearch
+        contentTypeId={LIST_ITEM_CONTENT_TYPE_ID}
+        contentTypeLabel="List Item"
+        contentTypeTitleField="internalTitle"
+      />
     </Box>
   )
 }

--- a/apps/contentful-apps/pages/fields/generic-tag-group-items-field.tsx
+++ b/apps/contentful-apps/pages/fields/generic-tag-group-items-field.tsx
@@ -1,36 +1,16 @@
-import { useEffect, useRef, useState } from 'react'
-import { useDebounce } from 'react-use'
+import { useEffect, useState } from 'react'
 import type { FieldExtensionSDK } from '@contentful/app-sdk'
-import {
-  Box,
-  Button,
-  EntryCard,
-  Pagination,
-  Spinner,
-  Stack,
-  Text,
-  TextInput,
-} from '@contentful/f36-components'
+import { Box, Button } from '@contentful/f36-components'
 import { PlusIcon } from '@contentful/f36-icons'
 import { useCMA, useSDK } from '@contentful/react-apps-toolkit'
 
-const LIST_ITEMS_PER_PAGE = 4
-const SEARCH_DEBOUNCE_TIME_IN_MS = 300
+import { EntryListSearch } from '../../components/EntryListSearch'
 
 const GenericTagGroupItemsField = () => {
-  const [page, setPage] = useState(0)
-  const pageRef = useRef(0)
-  const [searchValue, setSearchValue] = useState('')
-  const searchValueRef = useRef('')
-  const [listItemResponse, setListItemResponse] = useState(null)
-  const [isLoading, setIsLoading] = useState(false)
-
-  const [counter, setCounter] = useState(0)
+  const [_, setCounter] = useState(0)
 
   const sdk = useSDK<FieldExtensionSDK>()
   const cma = useCMA()
-
-  const skip = LIST_ITEMS_PER_PAGE * page
 
   const createGenericTag = async () => {
     const tag = await cma.entry.create(
@@ -62,35 +42,6 @@ const GenericTagGroupItemsField = () => {
       })
   }
 
-  useDebounce(
-    async () => {
-      setIsLoading(true)
-      try {
-        const response = await cma.entry.getMany({
-          query: {
-            content_type: 'genericTag',
-            limit: LIST_ITEMS_PER_PAGE,
-            skip,
-            'fields.internalTitle[match]': searchValue,
-            'fields.genericTagGroup.sys.id': sdk.entry.getSys().id,
-            'sys.archivedAt[exists]': false,
-          },
-        })
-
-        if (
-          searchValueRef.current === searchValue &&
-          pageRef.current === page
-        ) {
-          setListItemResponse(response)
-        }
-      } finally {
-        setIsLoading(false)
-      }
-    },
-    SEARCH_DEBOUNCE_TIME_IN_MS,
-    [page, searchValue, counter],
-  )
-
   useEffect(() => {
     sdk.window.startAutoResizer()
     return () => {
@@ -108,71 +59,11 @@ const GenericTagGroupItemsField = () => {
           <Button startIcon={<PlusIcon />}>Create tag</Button>
         </Box>
       </Box>
-      <Box style={{ display: 'flex', flexFlow: 'column nowrap', gap: '24px' }}>
-        <TextInput
-          placeholder="Search for a generic tag"
-          value={searchValue}
-          onChange={(ev) => {
-            searchValueRef.current = ev.target.value
-            setSearchValue(ev.target.value)
-            setPage(0)
-            pageRef.current = 0
-          }}
-        />
-
-        <Box
-          style={{
-            display: 'flex',
-            justifyContent: 'center',
-            visibility: isLoading ? 'visible' : 'hidden',
-          }}
-        >
-          <Spinner />
-        </Box>
-
-        {listItemResponse?.items?.length > 0 && (
-          <>
-            <Box style={{ minHeight: '440px' }}>
-              <Stack flexDirection="column" spacing="spacingL">
-                {listItemResponse.items.map((item) => (
-                  <EntryCard
-                    key={item.sys.id}
-                    contentType="Generic Tag"
-                    title={
-                      item.fields.internalTitle?.[sdk.locales.default] ??
-                      'Untitled'
-                    }
-                    onClick={() => {
-                      sdk.navigator
-                        .openEntry(item.sys.id, {
-                          slideIn: { waitForClose: true },
-                        })
-                        .then(() => {
-                          setCounter((c) => c + 1)
-                        })
-                    }}
-                  />
-                ))}
-              </Stack>
-            </Box>
-            <Pagination
-              activePage={page}
-              itemsPerPage={LIST_ITEMS_PER_PAGE}
-              totalItems={listItemResponse.total}
-              onPageChange={(newPage) => {
-                pageRef.current = newPage
-                setPage(newPage)
-              }}
-            />
-          </>
-        )}
-
-        {listItemResponse?.items?.length === 0 && (
-          <Box style={{ display: 'flex', justifyContent: 'center' }}>
-            <Text>No item was found</Text>
-          </Box>
-        )}
-      </Box>
+      <EntryListSearch
+        contentTypeId="genericTag"
+        contentTypeLabel="Generic Tag"
+        contentTypeTitleField="title"
+      />
     </div>
   )
 }

--- a/apps/contentful-apps/pages/fields/generic-tag-group-items-field.tsx
+++ b/apps/contentful-apps/pages/fields/generic-tag-group-items-field.tsx
@@ -63,6 +63,9 @@ const GenericTagGroupItemsField = () => {
         contentTypeId="genericTag"
         contentTypeLabel="Generic Tag"
         contentTypeTitleField="title"
+        query={{
+          'fields.genericTagGroup.sys.id': sdk.ids.entry,
+        }}
       />
     </div>
   )


### PR DESCRIPTION
# Refactor list search functionality into a reusable component

## What

Instead of writing the same code we'd rather like a reusable component

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `EntryListSearch` component for enhanced searching and displaying of entries from Contentful.
	- Improved user experience with responsive search input and pagination.

- **Bug Fixes**
	- Streamlined search functionality by removing unnecessary state management and debounce logic.

- **Refactor**
	- Updated `GenericListEditor` and `GenericTagGroupItemsField` components to utilize the new `EntryListSearch` component, simplifying their structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->