### PR TITLE
fix: make form-system env var optional

### DIFF
--- a/libs/clients/form-system/src/lib/FormSystemClient.config.ts
+++ b/libs/clients/form-system/src/lib/FormSystemClient.config.ts
@@ -10,7 +10,7 @@ export const FormSystemClientConfig = defineConfig({
   schema,
   load(env) {
     return {
-      basePath: env.required(
+      basePath: env.optional(
         'FORM_SYSTEM_API_BASE_PATH',
         'https://profun.island.is/umsoknarkerfi',
       ),


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The `basePath` property in the form system configuration is now optional, allowing for greater flexibility in environment variable settings.

- **Bug Fixes**
	- Default value provided for `basePath` if the environment variable is not set, improving application resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->