### PR TITLE
fix(j-s): Enable send to prison admin if service not required

### DIFF
--- a/apps/judicial-system/web/src/components/BlueBoxWithIcon/BlueBoxWithDate.tsx
+++ b/apps/judicial-system/web/src/components/BlueBoxWithIcon/BlueBoxWithDate.tsx
@@ -348,7 +348,7 @@ const BlueBoxWithDate: FC<Props> = (props) => {
             size="small"
             disabled={
               !workingCase.indictmentReviewDecision ||
-              (!isFine && !defendant.verdictViewDate)
+              (!isFine && !defendant.verdictViewDate && serviceRequired)
             }
           >
             {formatMessage(strings.sendToPrisonAdmin)}


### PR DESCRIPTION
[Ríksak - ekki er hægt að senda til fullnustu ef ekki þurfti að birta dóminn](https://app.asana.com/0/1199153462262248/1208848575466391)

## What

Allow indictment to be sent to prison admin if it doesn't require servicing

## Why

Because it should be allowed

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
