### PR TITLE
revert: "chore(infra): Improve `.dockerignore` (#17048)"

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,31 +1,8 @@
-# vi: ft=gitignore
-
-# Known ignores
-/.github/
-/.git/
-/scripts/ci/
-/.env.*
-/.envrc*
-
-# Cache and packages
-**/node_modules/
-**/cache/
+node_modules/
+dist/
+scripts/ci/
 /cache*
-
-# Logs and temporaries
-**/log/
-**/*.log
-**/tmp/
-**/temp/
-
-# Outputs
-**/dist/
-**/out/
-
-# Docker-stuff
-**/Dockerfile
-**/Dockerfile.*
-**/Containerfile
-**/Containerfile.*
-**/*-compose.yaml
-**/*-compose.yml
+cache/
+.git/
+log/
+*.log


### PR DESCRIPTION
This reverts commit ede53ec81c26abb87c4b0352912652dc694e9ec0.

This is breaking docker builds due to our GtiHub cache project being ignored
