### PR TITLE
feat(web): Organization page with "standalone" theme - Level 1 sitemap

### DIFF
--- a/apps/web/components/LanguageToggler/LanguageToggler.tsx
+++ b/apps/web/components/LanguageToggler/LanguageToggler.tsx
@@ -188,8 +188,11 @@ export const LanguageToggler = ({
     <DialogPrompt
       baseId={dialogId}
       initialVisibility={true}
-      title={gn('switchToEnglishModalTitle')}
-      description={gn('switchToEnglishModalText')}
+      title={gn('switchToEnglishModalTitle', 'Translation not available')}
+      description={gn(
+        'switchToEnglishModalText',
+        'The page you are viewing does not have an English translation yet',
+      )}
       ariaLabel="Confirm switching to english"
       disclosureElement={Disclosure}
       onConfirm={() => {

--- a/apps/web/pages/s/[...slugs]/index.tsx
+++ b/apps/web/pages/s/[...slugs]/index.tsx
@@ -1,6 +1,6 @@
 import { type FC } from 'react'
 
-import {
+import type {
   Query,
   QueryGetOrganizationPageArgs,
 } from '@island.is/web/graphql/schema'
@@ -31,6 +31,9 @@ import PublishedMaterial, {
 import StandaloneHome, {
   type StandaloneHomeProps,
 } from '@island.is/web/screens/Organization/Standalone/Home'
+import StandaloneLevel1Sitemap, {
+  type StandaloneLevel1SitemapProps,
+} from '@island.is/web/screens/Organization/Standalone/Level1Sitemap'
 import StandaloneParentSubpage, {
   StandaloneParentSubpageProps,
 } from '@island.is/web/screens/Organization/Standalone/ParentSubpage'
@@ -46,6 +49,7 @@ enum PageType {
   FRONTPAGE = 'frontpage',
   STANDALONE_FRONTPAGE = 'standalone-frontpage',
   STANDALONE_PARENT_SUBPAGE = 'standalone-parent-subpage',
+  STANDALONE_LEVEL1_SITEMAP = 'standalone-level1-sitemap',
   SUBPAGE = 'subpage',
   ALL_NEWS = 'news',
   PUBLISHED_MATERIAL = 'published-material',
@@ -61,6 +65,9 @@ const pageMap: Record<PageType, FC<any>> = {
   [PageType.STANDALONE_FRONTPAGE]: (props) => <StandaloneHome {...props} />,
   [PageType.STANDALONE_PARENT_SUBPAGE]: (props) => (
     <StandaloneParentSubpage {...props} />
+  ),
+  [PageType.STANDALONE_LEVEL1_SITEMAP]: (props) => (
+    <StandaloneLevel1Sitemap {...props} />
   ),
   [PageType.SUBPAGE]: (props) => <SubPage {...props} />,
   [PageType.ALL_NEWS]: (props) => <OrganizationNewsList {...props} />,
@@ -89,6 +96,10 @@ interface Props {
     | {
         type: PageType.STANDALONE_PARENT_SUBPAGE
         props: StandaloneParentSubpageProps
+      }
+    | {
+        type: PageType.STANDALONE_LEVEL1_SITEMAP
+        props: StandaloneLevel1SitemapProps
       }
     | {
         type: PageType.SUBPAGE
@@ -164,10 +175,10 @@ Component.getProps = async (context) => {
 
   const modifiedContext = { ...context, organizationPage }
 
-  const STANDALONE_THEME = 'standalone'
+  const isStandaloneTheme = organizationPage.theme === 'standalone'
 
   if (slugs.length === 1) {
-    if (organizationPage.theme === STANDALONE_THEME) {
+    if (isStandaloneTheme) {
       return {
         page: {
           type: PageType.STANDALONE_FRONTPAGE,
@@ -237,7 +248,21 @@ Component.getProps = async (context) => {
       }
     }
 
-    if (organizationPage.theme === STANDALONE_THEME) {
+    if (
+      isStandaloneTheme &&
+      organizationPage.topLevelNavigation?.links.some(
+        (link) => slugs[1] === link.href.split('/').pop(),
+      )
+    ) {
+      return {
+        page: {
+          type: PageType.STANDALONE_LEVEL1_SITEMAP,
+          props: await StandaloneLevel1Sitemap.getProps(modifiedContext),
+        },
+      }
+    }
+
+    if (isStandaloneTheme) {
       return {
         page: {
           type: PageType.STANDALONE_PARENT_SUBPAGE,
@@ -291,7 +316,7 @@ Component.getProps = async (context) => {
       }
     }
 
-    if (organizationPage.theme === STANDALONE_THEME) {
+    if (isStandaloneTheme) {
       return {
         page: {
           type: PageType.STANDALONE_PARENT_SUBPAGE,

--- a/apps/web/screens/Organization/Standalone/Level1Sitemap.tsx
+++ b/apps/web/screens/Organization/Standalone/Level1Sitemap.tsx
@@ -1,0 +1,149 @@
+import {
+  CategoryCard,
+  GridColumn,
+  GridContainer,
+  GridRow,
+  Stack,
+} from '@island.is/island-ui/core'
+import { Text } from '@island.is/island-ui/core'
+import type { SpanType } from '@island.is/island-ui/core/types'
+import {
+  ContentLanguage,
+  OrganizationPage,
+  Query,
+  QueryGetOrganizationPageArgs,
+  QueryGetOrganizationPageStandaloneSitemapLevel1Args,
+} from '@island.is/web/graphql/schema'
+import { StandaloneLayout } from '@island.is/web/layouts/organization/standalone'
+import type { Screen, ScreenContext } from '@island.is/web/types'
+import { CustomNextError } from '@island.is/web/units/errors'
+
+import {
+  GET_ORGANIZATION_PAGE_QUERY,
+  GET_ORGANIZATION_PAGE_STANDALONE_SITEMAP_LEVEL1_QUERY,
+} from '../../queries'
+
+const GRID_COLUMN_SPAN: SpanType = ['1/1', '1/1', '1/1', '1/2', '1/3']
+
+type StandaloneLevel1SitemapScreenContext = ScreenContext & {
+  organizationPage?: Query['getOrganizationPage']
+}
+
+export interface StandaloneLevel1SitemapProps {
+  organizationPage: OrganizationPage
+  categoryTitle: string
+  items: {
+    label: string
+    href: string
+    description?: string | null
+  }[]
+}
+
+const StandaloneLevel1Sitemap: Screen<
+  StandaloneLevel1SitemapProps,
+  StandaloneLevel1SitemapScreenContext
+> = ({ organizationPage, categoryTitle, items }) => {
+  return (
+    <StandaloneLayout organizationPage={organizationPage}>
+      <GridContainer>
+        <GridRow>
+          <GridColumn span={['9/9', '9/9', '7/9']} offset={['0', '0', '1/9']}>
+            <Stack space={3}>
+              <Text variant="h1" as="h1">
+                {categoryTitle}
+              </Text>
+              <GridRow rowGap={3}>
+                {items.map(({ label, description, href }, index) => (
+                  <GridColumn span={GRID_COLUMN_SPAN} key={index}>
+                    <CategoryCard
+                      heading={label}
+                      headingAs="h2"
+                      headingVariant="h3"
+                      text={description ?? ''}
+                      href={href}
+                    />
+                  </GridColumn>
+                ))}
+              </GridRow>
+            </Stack>
+          </GridColumn>
+        </GridRow>
+      </GridContainer>
+    </StandaloneLayout>
+  )
+}
+
+StandaloneLevel1Sitemap.getProps = async ({
+  apolloClient,
+  locale,
+  query,
+  organizationPage,
+}) => {
+  const [organizationPageSlug, categorySlug] = (query.slugs ?? []) as string[]
+
+  const [
+    {
+      data: { getOrganizationPage },
+    },
+    {
+      data: { getOrganizationPageStandaloneSitemapLevel1 },
+    },
+  ] = await Promise.all([
+    !organizationPage
+      ? apolloClient.query<Query, QueryGetOrganizationPageArgs>({
+          query: GET_ORGANIZATION_PAGE_QUERY,
+          variables: {
+            input: {
+              slug: organizationPageSlug,
+              lang: locale as ContentLanguage,
+            },
+          },
+        })
+      : {
+          data: { getOrganizationPage: organizationPage },
+        },
+    apolloClient.query<
+      Query,
+      QueryGetOrganizationPageStandaloneSitemapLevel1Args
+    >({
+      query: GET_ORGANIZATION_PAGE_STANDALONE_SITEMAP_LEVEL1_QUERY,
+      variables: {
+        input: {
+          organizationPageSlug,
+          categorySlug,
+          lang: locale as ContentLanguage,
+        },
+      },
+    }),
+  ])
+
+  if (!getOrganizationPage) {
+    throw new CustomNextError(404, 'Organization page was not found')
+  }
+
+  if (!getOrganizationPageStandaloneSitemapLevel1) {
+    throw new CustomNextError(
+      404,
+      'Organization page standalone level 1 sitemap was not found',
+    )
+  }
+
+  const categoryTitle = organizationPage?.topLevelNavigation?.links.find(
+    (link) => categorySlug === link.href.split('/').pop(),
+  )?.label
+
+  if (!categoryTitle) {
+    throw new CustomNextError(
+      404,
+      'Organization page standalone level 1 category was not found',
+    )
+  }
+
+  return {
+    organizationPage: getOrganizationPage,
+    categoryTitle,
+    items: getOrganizationPageStandaloneSitemapLevel1.childLinks,
+  }
+}
+
+export default StandaloneLevel1Sitemap

--- a/apps/web/screens/Organization/Standalone/Level1Sitemap.tsx
+++ b/apps/web/screens/Organization/Standalone/Level1Sitemap.tsx
@@ -14,6 +14,7 @@ import {
   QueryGetOrganizationPageArgs,
   QueryGetOrganizationPageStandaloneSitemapLevel1Args,
 } from '@island.is/web/graphql/schema'
+import useContentfulId from '@island.is/web/hooks/useContentfulId'
 import { StandaloneLayout } from '@island.is/web/layouts/organization/standalone'
 import type { Screen, ScreenContext } from '@island.is/web/types'
 import { CustomNextError } from '@island.is/web/units/errors'
@@ -24,6 +25,11 @@ import {
 } from '../../queries'
 
 const GRID_COLUMN_SPAN: SpanType = ['1/1', '1/1', '1/1', '1/2', '1/3']
+
+const LanguageToggleSetup = (props: { ids: string[] }) => {
+  useContentfulId(...props.ids)
+  return null
+}
 
 type StandaloneLevel1SitemapScreenContext = ScreenContext & {
   organizationPage?: Query['getOrganizationPage']
@@ -50,6 +56,7 @@ const StandaloneLevel1Sitemap: Screen<
         title: `${categoryTitle} | ${organizationPage.title}`,
       }}
     >
+      <LanguageToggleSetup ids={[organizationPage.id]} />
       <GridContainer>
         <GridRow>
           <GridColumn span={['9/9', '9/9', '7/9']} offset={['0', '0', '1/9']}>

--- a/apps/web/screens/Organization/Standalone/Level1Sitemap.tsx
+++ b/apps/web/screens/Organization/Standalone/Level1Sitemap.tsx
@@ -44,7 +44,12 @@ const StandaloneLevel1Sitemap: Screen<
   StandaloneLevel1SitemapScreenContext
 > = ({ organizationPage, categoryTitle, items }) => {
   return (
-    <StandaloneLayout organizationPage={organizationPage}>
+    <StandaloneLayout
+      organizationPage={organizationPage}
+      seo={{
+        title: `${categoryTitle} | ${organizationPage.title}`,
+      }}
+    >
       <GridContainer>
         <GridRow>
           <GridColumn span={['9/9', '9/9', '7/9']} offset={['0', '0', '1/9']}>

--- a/apps/web/screens/Organization/Standalone/ParentSubpage.tsx
+++ b/apps/web/screens/Organization/Standalone/ParentSubpage.tsx
@@ -68,7 +68,12 @@ const StandaloneParentSubpage: Screen<
   const { linkResolver } = useLinkResolver()
 
   return (
-    <StandaloneLayout organizationPage={organizationPage}>
+    <StandaloneLayout
+      organizationPage={organizationPage}
+      seo={{
+        title: `${subpage.title} | ${organizationPage.title}`,
+      }}
+    >
       <GridContainer>
         <GridRow>
           <GridColumn span={['9/9', '9/9', '7/9']} offset={['0', '0', '1/9']}>

--- a/apps/web/screens/queries/Organization.tsx
+++ b/apps/web/screens/queries/Organization.tsx
@@ -430,3 +430,17 @@ export const GET_ORGANIZATION_PARENT_SUBPAGE_QUERY = gql`
     }
   }
 `
+
+export const GET_ORGANIZATION_PAGE_STANDALONE_SITEMAP_LEVEL1_QUERY = gql`
+  query GetOrganizationPageStandaloneSitemapLevel1Query(
+    $input: GetOrganizationPageStandaloneSitemapLevel1Input!
+  ) {
+    getOrganizationPageStandaloneSitemapLevel1(input: $input) {
+      childLinks {
+        label
+        href
+        description
+      }
+    }
+  }
+`

--- a/libs/cms/src/lib/cms.contentful.service.ts
+++ b/libs/cms/src/lib/cms.contentful.service.ts
@@ -88,6 +88,10 @@ import { mapServiceWebPage } from './models/serviceWebPage.model'
 import { mapEvent } from './models/event.model'
 import { GetOrganizationParentSubpageInput } from './dto/getOrganizationParentSubpage.input'
 import { mapOrganizationParentSubpage } from './models/organizationParentSubpage.model'
+import { GetOrganizationPageStandaloneSitemapLevel1Input } from './dto/getOrganizationPageStandaloneSitemap.input'
+import { OrganizationPageStandaloneSitemap } from './models/organizationPageStandaloneSitemap.model'
+import { SitemapTree, SitemapTreeNodeType } from '@island.is/shared/types'
+import { getOrganizationPageUrlPrefix } from '@island.is/shared/utils'
 
 const errorHandler = (name: string) => {
   return (error: Error) => {
@@ -1174,5 +1178,93 @@ export class CmsContentfulService {
         mapOrganizationParentSubpage,
       )[0] ?? null
     )
+  }
+
+  async getOrganizationPageStandaloneSitemapLevel1(
+    input: GetOrganizationPageStandaloneSitemapLevel1Input,
+  ): Promise<OrganizationPageStandaloneSitemap | null> {
+    const params = {
+      content_type: 'organizationPage',
+      'fields.slug': input.organizationPageSlug,
+      select: 'fields.sitemap',
+      limit: 1,
+    }
+
+    const response = await this.contentfulRepository
+      .getLocalizedEntries<types.IOrganizationPageFields>(input.lang, params)
+      .catch(errorHandler('getOrganizationPageStandaloneSitemapLevel1'))
+
+    const tree = response.items[0].fields.sitemap?.fields.tree as SitemapTree
+
+    if (!tree) {
+      return null
+    }
+
+    const category = tree.childNodes.find(
+      (node) =>
+        node.type === SitemapTreeNodeType.CATEGORY &&
+        node.slug === input.categorySlug,
+    )
+
+    if (!category) {
+      return null
+    }
+
+    const entryNodes = new Map<string, { label: string; href: string }[]>()
+
+    const result = {
+      childLinks: category.childNodes.map((node) => {
+        if (node.type === SitemapTreeNodeType.CATEGORY) {
+          return {
+            label: node.label,
+            href: `/${getOrganizationPageUrlPrefix(input.lang)}/${
+              input.organizationPageSlug
+            }/${node.slug}`,
+            description: node.description,
+          }
+        }
+        if (node.type === SitemapTreeNodeType.URL) {
+          return {
+            label: node.label,
+            href: node.url,
+          }
+        }
+
+        // We need to fetch the label and href for all entry nodes, so we store them in a map
+        const entryNode = {
+          label: node.entryId,
+          href: node.entryId,
+        }
+        const nodeList = entryNodes.get(node.entryId) ?? []
+        nodeList.push(entryNode)
+        entryNodes.set(node.entryId, nodeList)
+        return entryNode
+      }),
+    }
+
+    const parentSubpageResponse =
+      await this.contentfulRepository.getLocalizedEntries<types.IOrganizationParentSubpageFields>(
+        input.lang,
+        {
+          content_type: 'organizationParentSubpage',
+          'sys.id[in]': Array.from(entryNodes.keys()).join(','),
+          limit: 1000,
+        },
+      )
+
+    for (const parentSubpage of parentSubpageResponse.items) {
+      const nodeList = entryNodes.get(parentSubpage.sys.id)
+      if (!nodeList) {
+        continue
+      }
+      for (const node of nodeList) {
+        node.label = parentSubpage.fields.title
+        node.href = `/${getOrganizationPageUrlPrefix(input.lang)}/${
+          input.organizationPageSlug
+        }/${parentSubpage.fields.slug}`
+      }
+    }
+
+    return result
   }
 }

--- a/libs/cms/src/lib/cms.contentful.service.ts
+++ b/libs/cms/src/lib/cms.contentful.service.ts
@@ -1276,7 +1276,7 @@ export class CmsContentfulService {
 
     // Remove entries from result that could not be resolved to their label or href
     result.childLinks = result.childLinks.filter(
-      (link) => 'entryId' in link && entryIdsToRemove.includes(link.entryId),
+      (link) => !('entryId' in link && entryIdsToRemove.includes(link.entryId)),
     )
 
     return result

--- a/libs/cms/src/lib/cms.contentful.service.ts
+++ b/libs/cms/src/lib/cms.contentful.service.ts
@@ -1250,6 +1250,7 @@ export class CmsContentfulService {
           'sys.id[in]': Array.from(entryNodes.keys()).join(','),
           limit: 1000,
         },
+        1,
       )
 
     for (const parentSubpage of parentSubpageResponse.items) {

--- a/libs/cms/src/lib/cms.contentful.service.ts
+++ b/libs/cms/src/lib/cms.contentful.service.ts
@@ -1232,8 +1232,9 @@ export class CmsContentfulService {
 
         // We need to fetch the label and href for all entry nodes, so we store them in a map
         const entryNode = {
-          label: node.entryId,
-          href: node.entryId,
+          label: '',
+          href: '',
+          entryId: node.entryId,
         }
         const nodeList = entryNodes.get(node.entryId) ?? []
         nodeList.push(entryNode)
@@ -1274,8 +1275,8 @@ export class CmsContentfulService {
     }
 
     // Remove entries from result that could not be resolved to their label or href
-    result.childLinks = result.childLinks.filter((link) =>
-      entryIdsToRemove.includes(link.label),
+    result.childLinks = result.childLinks.filter(
+      (link) => 'entryId' in link && entryIdsToRemove.includes(link.entryId),
     )
 
     return result

--- a/libs/cms/src/lib/cms.resolver.ts
+++ b/libs/cms/src/lib/cms.resolver.ts
@@ -128,6 +128,8 @@ import { GetSingleGrantInput } from './dto/getSingleGrant.input'
 import { GrantList } from './models/grantList.model'
 import { OrganizationParentSubpage } from './models/organizationParentSubpage.model'
 import { GetOrganizationParentSubpageInput } from './dto/getOrganizationParentSubpage.input'
+import { OrganizationPageStandaloneSitemap } from './models/organizationPageStandaloneSitemap.model'
+import { GetOrganizationPageStandaloneSitemapLevel1Input } from './dto/getOrganizationPageStandaloneSitemap.input'
 
 const defaultCache: CacheControlOptions = { maxAge: CACHE_CONTROL_MAX_AGE }
 
@@ -716,6 +718,16 @@ export class CmsResolver {
     @Args('input') input: GetOrganizationParentSubpageInput,
   ): Promise<OrganizationParentSubpage | null> {
     return this.cmsContentfulService.getOrganizationParentSubpage(input)
+  }
+
+  @CacheControl(defaultCache)
+  @Query(() => OrganizationPageStandaloneSitemap, { nullable: true })
+  getOrganizationPageStandaloneSitemapLevel1(
+    @Args('input') input: GetOrganizationPageStandaloneSitemapLevel1Input,
+  ): Promise<OrganizationPageStandaloneSitemap | null> {
+    return this.cmsContentfulService.getOrganizationPageStandaloneSitemapLevel1(
+      input,
+    )
   }
 }
 

--- a/libs/cms/src/lib/dto/getOrganizationPageStandaloneSitemap.input.ts
+++ b/libs/cms/src/lib/dto/getOrganizationPageStandaloneSitemap.input.ts
@@ -1,0 +1,18 @@
+import { Field, InputType } from '@nestjs/graphql'
+import { IsString } from 'class-validator'
+import { ElasticsearchIndexLocale } from '@island.is/content-search-index-manager'
+
+@InputType()
+export class GetOrganizationPageStandaloneSitemapLevel1Input {
+  @Field()
+  @IsString()
+  organizationPageSlug!: string
+
+  @Field()
+  @IsString()
+  categorySlug!: string
+
+  @Field(() => String)
+  @IsString()
+  lang: ElasticsearchIndexLocale = 'is'
+}

--- a/libs/cms/src/lib/models/organizationPageStandaloneSitemap.model.ts
+++ b/libs/cms/src/lib/models/organizationPageStandaloneSitemap.model.ts
@@ -1,0 +1,20 @@
+import { CacheField } from '@island.is/nest/graphql'
+import { Field, ObjectType } from '@nestjs/graphql'
+
+@ObjectType()
+export class OrganizationPageStandaloneSitemapLink {
+  @Field()
+  label!: string
+
+  @Field()
+  href!: string
+
+  @Field(() => String, { nullable: true })
+  description?: string | null
+}
+
+@ObjectType()
+export class OrganizationPageStandaloneSitemap {
+  @CacheField(() => [OrganizationPageStandaloneSitemapLink])
+  childLinks!: OrganizationPageStandaloneSitemapLink[]
+}


### PR DESCRIPTION
# Organization page with "standalone" theme - Level 1 sitemap

## What

* If an organization page has it's theme set to "standalone" we've got another form of navigation there.
* Level 1 is essentially one level below the top level navigation (see image below)

## Screenshots / Gifs

![Screenshot 2024-11-28 at 12 19 58](https://github.com/user-attachments/assets/9bd8435b-ab69-4874-bdc4-137526b4d079)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new page type, `STANDALONE_LEVEL1_SITEMAP`, enhancing sitemap rendering capabilities.
  - Added a `StandaloneLevel1Sitemap` component for displaying organization-level sitemaps.
  - Enhanced SEO for `StandaloneParentSubpage` with dynamic title generation.
  - New GraphQL query for fetching organization page standalone sitemap level 1 data.
  - Updated `LanguageToggler` component to provide clearer messaging regarding translation availability.

- **Bug Fixes**
  - Improved error handling for data retrieval in organization-related queries.

These updates enhance navigation, improve SEO, and expand the application's functionality related to organization pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->