### PR TITLE
fix(search-indexer): Stop refreshing index immediately

### DIFF
--- a/libs/content-search-indexer/src/lib/indexing.service.ts
+++ b/libs/content-search-indexer/src/lib/indexing.service.ts
@@ -61,8 +61,6 @@ export class IndexingService {
       let nextPageToken: string | undefined = undefined
       let postSyncOptions: SyncResponse['postSyncOptions']
 
-      const isIncrementalUpdate = syncType === 'fromLast'
-
       // Fetch initial page specifically in case importing is skipped (no need to wait for a new sync token if we don't need it)
       {
         const importerResponse = await importer.doSync({
@@ -83,11 +81,7 @@ export class IndexingService {
           postSyncOptions: importerResponsePostSyncOptions,
           ...elasticData
         } = importerResponse
-        await this.elasticService.bulk(
-          elasticIndex,
-          elasticData,
-          isIncrementalUpdate,
-        )
+        await this.elasticService.bulk(elasticIndex, elasticData)
 
         nextPageToken = importerResponseNextPageToken
         postSyncOptions = importerResponsePostSyncOptions
@@ -115,11 +109,7 @@ export class IndexingService {
               postSyncOptions: importerResponsePostSyncOptions,
               ...elasticData
             } = importerResponse
-            await this.elasticService.bulk(
-              elasticIndex,
-              elasticData,
-              isIncrementalUpdate,
-            )
+            await this.elasticService.bulk(elasticIndex, elasticData)
 
             nextPageToken = importerResponseNextPageToken
             postSyncOptions = importerResponsePostSyncOptions

--- a/libs/content-search-toolkit/src/services/elastic.service.ts
+++ b/libs/content-search-toolkit/src/services/elastic.service.ts
@@ -68,7 +68,7 @@ export class ElasticService {
   }
 
   // this can partially succeed
-  async bulk(index: string, documents: SyncRequest, refresh = false) {
+  async bulk(index: string, documents: SyncRequest) {
     logger.info('Processing documents', {
       index,
       added: documents.add.length,
@@ -106,14 +106,10 @@ export class ElasticService {
       return false
     }
 
-    await this.bulkRequest(index, requests, refresh)
+    await this.bulkRequest(index, requests)
   }
 
-  async bulkRequest(
-    index: string,
-    requests: Record<string, unknown>[],
-    refresh = false,
-  ) {
+  async bulkRequest(index: string, requests: Record<string, unknown>[]) {
     const chunkSize = 14
     let delay = INITIAL_DELAY
     let retries = MAX_RETRY_COUNT
@@ -129,7 +125,6 @@ export class ElasticService {
           const response = await client.bulk({
             index: index,
             body: requestChunk,
-            refresh: refresh ? 'true' : undefined,
           })
 
           // not all errors are thrown log if the response has any errors


### PR DESCRIPTION
# Stop refreshing index immediately

## What

* After we've stopped relying so much on Elasticsearch to be up to date due to content previews we no longer need to make sure the index get immediately updated

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined bulk request handling by simplifying method signatures, enhancing ease of use.
  
- **Bug Fixes**
	- Improved error handling in synchronization status retrieval, ensuring clearer logging and default status return.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->