### PR TITLE
feat(web): Add boost chat panel for 'Vinnumálastofnun'

### DIFF
--- a/apps/web/components/ChatPanel/BoostChatPanel/config.ts
+++ b/apps/web/components/ChatPanel/BoostChatPanel/config.ts
@@ -1,13 +1,14 @@
 import { theme } from '@island.is/island-ui/theme'
+
 import { BoostChatPanelConfig } from './types'
 
 export const boostChatPanelEndpoints = {
-  // Sýslumenn organization
-  // https://app.contentful.com/spaces/8k0h54kbe6bj/entries/kENblMMMvZ3DlyXw1dwxQ
-  kENblMMMvZ3DlyXw1dwxQ: {
-    id: 'syslumenn',
-    conversationKey: 'syslumenn',
-    url: 'https://syslumenn.boost.ai/chatPanel/chatPanel.js',
+  // Vinnumálastofnun organization
+  //https://app.contentful.com/spaces/8k0h54kbe6bj/entries/co6SSvHZjUpEICpTlJT1B
+  co6SSvHZjUpEICpTlJT1B: {
+    id: '313vinnumalastofnun',
+    conversationKey: '313vinnumalastofnun',
+    url: 'https://313vinnumalastofnun.boost.ai/chatPanel/chatPanel.js',
   },
 }
 

--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -31,6 +31,8 @@ import {
 } from '@island.is/island-ui/core'
 import { theme } from '@island.is/island-ui/theme'
 import {
+  BoostChatPanel,
+  boostChatPanelEndpoints,
   DefaultHeaderProps,
   Footer as WebFooter,
   HeadWithSocialSharing,
@@ -957,6 +959,20 @@ export const OrganizationChatPanel = ({
     )
   }
 
+  const organizationIdWithBoost = organizationIds.find((id) => {
+    return id in boostChatPanelEndpoints
+  })
+
+  if (organizationIdWithBoost) {
+    return (
+      <BoostChatPanel
+        endpoint={
+          organizationIdWithBoost as keyof typeof boostChatPanelEndpoints
+        }
+      />
+    )
+  }
+
   return null
 }
 
@@ -1087,8 +1103,7 @@ export const OrganizationWrapper: React.FC<
   const router = useRouter()
   const { width } = useWindowSize()
   const [isMobile, setIsMobile] = useState<boolean | undefined>()
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore make web strict
+
   usePlausiblePageview(organizationPage.organization?.trackingDomain)
 
   useEffect(() => {
@@ -1113,6 +1128,18 @@ export const OrganizationWrapper: React.FC<
   const SidebarContainer = stickySidebar ? Sticky : Box
 
   const sidebarCards = organizationPage.sidebarCards ?? []
+
+  const namespace = useMemo(() => {
+    try {
+      return JSON.parse(
+        organizationPage.organization?.namespace?.fields || '{}',
+      )
+    } catch {
+      return {}
+    }
+  }, [organizationPage.organization?.namespace?.fields])
+
+  const n = useNamespace(namespace)
 
   return (
     <>
@@ -1382,11 +1409,13 @@ export const OrganizationWrapper: React.FC<
           />
         </Box>
       )}
-      <OrganizationChatPanel
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore make web strict
-        organizationIds={[organizationPage?.organization?.id]}
-      />
+      {n('enableOrganizationChatPanelForOrgPages', true) && (
+        <OrganizationChatPanel
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore make web strict
+          organizationIds={[organizationPage?.organization?.id]}
+        />
+      )}
     </>
   )
 }

--- a/apps/web/hooks/usePlausiblePageview.ts
+++ b/apps/web/hooks/usePlausiblePageview.ts
@@ -6,7 +6,7 @@ const { publicRuntimeConfig = {} } = getConfig() ?? {}
 
 let newestVisitedUrl = ''
 
-export const usePlausiblePageview = (domain?: string) => {
+export const usePlausiblePageview = (domain?: string | null) => {
   const router = useRouter()
 
   useEffect(() => {


### PR DESCRIPTION
# Add boost chat panel for 'Vinnumálastofnun'

## What

* Boost AI chat panel added to Vinnumálastofnun organization page
* Just in case we've got a "config flag" so we can remove the chat if needed

## Screenshots / Gifs

![Screenshot 2024-11-28 at 13 08 53](https://github.com/user-attachments/assets/97ac91d6-922f-4b7c-b5b5-4dcebd03bc32)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new chat panel for the "Vinnumálastofnun" organization, replacing the previous "Sýslumenn" configuration.
  - Enhanced the `OrganizationWrapper` component to conditionally render the new chat panel based on organization IDs.

- **Improvements**
  - Improved error handling for JSON parsing in the chat panel logic.
  - Enhanced type safety for the `domain` parameter in the pageview tracking hook.

These updates enhance user experience by providing new chat functionalities and improving the reliability of existing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->