### PR TITLE
chore(web): Forms - Make files appear where they are in the list instead of always at the bottom

### DIFF
--- a/apps/web/components/Form/Form.tsx
+++ b/apps/web/components/Form/Form.tsx
@@ -757,44 +757,12 @@ export const Form = ({ form }: FormProps) => {
             {form.questionsHeadingText}
           </Text>
           <Stack space={4}>
-            {form.fields
-              .filter((field) => field.type !== FormFieldType.FILE)
-              .map((field) => {
-                const slug = getUniqueFormFieldValue(field)
-                return (
-                  <FormField
-                    key={field.id}
-                    field={field}
-                    slug={slug}
-                    value={data[slug] ?? ''}
-                    error={errors.find((error) => error.field === slug)?.error}
-                    onChange={(key, value) => {
-                      if (field.type === FormFieldType.CHECKBOXES) {
-                        const prevFieldData = data[slug]
-                        if (prevFieldData) {
-                          const json = JSON.parse(prevFieldData)
-                          json[key] =
-                            json[key] === 'false' || !json[key]
-                              ? 'true'
-                              : 'false'
-                          onChange(slug, JSON.stringify(json))
-                        } else {
-                          onChange(slug, JSON.stringify({ [key]: 'true' }))
-                        }
-                      } else {
-                        onChange(key, value)
-                      }
-                    }}
-                  />
-                )
-              })}
-            {form.fields
-              .filter((field) => field.type === FormFieldType.FILE)
-              .map((field) => {
-                const slug = getUniqueFormFieldValue(field)
+            {form.fields.map((field) => {
+              const slug = getUniqueFormFieldValue(field)
+              if (field.type === FormFieldType.FILE) {
                 return (
                   <InputFileUpload
-                    key={slug}
+                    key={field.id}
                     header={field.title}
                     description={field.placeholder}
                     buttonLabel={n(
@@ -819,7 +787,34 @@ export const Form = ({ form }: FormProps) => {
                     }
                   />
                 )
-              })}
+              }
+
+              return (
+                <FormField
+                  key={field.id}
+                  field={field}
+                  slug={slug}
+                  value={data[slug] ?? ''}
+                  error={errors.find((error) => error.field === slug)?.error}
+                  onChange={(key, value) => {
+                    if (field.type === FormFieldType.CHECKBOXES) {
+                      const prevFieldData = data[slug]
+                      if (prevFieldData) {
+                        const json = JSON.parse(prevFieldData)
+                        json[key] =
+                          json[key] === 'false' || !json[key] ? 'true' : 'false'
+                        onChange(slug, JSON.stringify(json))
+                      } else {
+                        onChange(slug, JSON.stringify({ [key]: 'true' }))
+                      }
+                    } else {
+                      onChange(key, value)
+                    }
+                  }}
+                />
+              )
+            })}
+
             <Box display="flex" justifyContent="flexEnd">
               <Button onClick={() => onSubmit()} loading={isSubmitting}>
                 {n('formSend', activeLocale === 'is' ? 'Senda' : 'Submit')}


### PR DESCRIPTION
# Forms - Make files appear where they are in the list instead of always at the bottom

All file upload fields used to always appear at the bottom of forms

![Screenshot 2024-11-28 at 14 58 27](https://github.com/user-attachments/assets/84c9670b-0615-4e4c-ab1a-e35b909ff33c)


Now they'll appear where they are defined

https://github.com/user-attachments/assets/97bf727c-13ce-482f-ab22-80a29b0247b6


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined rendering of form fields for improved organization.
	- Unified handling of file input and other field types.

- **Bug Fixes**
	- Ensured stable identity for file upload components using `field.id`.

- **Documentation**
	- Maintained consistency in error handling and validation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->