### PR TITLE
fix(infra): Static Docker builds

### DIFF
--- a/scripts/ci/Dockerfile
+++ b/scripts/ci/Dockerfile
@@ -88,7 +88,7 @@ LABEL branch=${GIT_BRANCH}
 LABEL commit=${GIT_COMMIT_SHA}
 ENTRYPOINT [ "node", "main.js" ]
 
-FROM ${DOCKER_REGISTRY}/library/nginx:1.21-alpine AS output-static
+FROM ${DOCKER_REGISTRY%/docker}/nginx/nginx:1.21-alpine AS output-static
 ARG APP
 ARG APP_DIST_HOME
 ENV APP=${APP}

--- a/scripts/ci/Dockerfile
+++ b/scripts/ci/Dockerfile
@@ -88,7 +88,7 @@ LABEL branch=${GIT_BRANCH}
 LABEL commit=${GIT_COMMIT_SHA}
 ENTRYPOINT [ "node", "main.js" ]
 
-FROM ${DOCKER_REGISTRY}/nginx/nginx:1.21-alpine AS output-static
+FROM ${DOCKER_REGISTRY}/nginx:1.21-alpine AS output-static
 ARG APP
 ARG APP_DIST_HOME
 ENV APP=${APP}

--- a/scripts/ci/Dockerfile
+++ b/scripts/ci/Dockerfile
@@ -88,7 +88,7 @@ LABEL branch=${GIT_BRANCH}
 LABEL commit=${GIT_COMMIT_SHA}
 ENTRYPOINT [ "node", "main.js" ]
 
-FROM ${DOCKER_REGISTRY}/nginx:1.21-alpine AS output-static
+FROM ${DOCKER_REGISTRY}/library/nginx:1.21-alpine AS output-static
 ARG APP
 ARG APP_DIST_HOME
 ENV APP=${APP}

--- a/scripts/ci/Dockerfile
+++ b/scripts/ci/Dockerfile
@@ -88,7 +88,7 @@ LABEL branch=${GIT_BRANCH}
 LABEL commit=${GIT_COMMIT_SHA}
 ENTRYPOINT [ "node", "main.js" ]
 
-FROM ${DOCKER_REGISTRY%/docker}/nginx/nginx:1.21-alpine AS output-static
+FROM ${DOCKER_REGISTRY}/library/nginx:1.21-alpine AS output-static
 ARG APP
 ARG APP_DIST_HOME
 ENV APP=${APP}


### PR DESCRIPTION
Building `output-static` will fail, since `/docker/nginx/nginx` doesn't exist.

Fixed here :smile: 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
	- Updated the Dockerfile to enhance the build process and manage dependencies.
	- Changed the base image for the static output stage.
	- Added installation of `zip` and `awscli` in the Playwright output stage.
	- Introduced a new output-native stage as a placeholder for future implementation.
	- Refined multiple stages to include environment variables for better traceability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->