### PR TITLE
feat(web): Add search input to organization standalone theme mobile frontpage

### DIFF
--- a/apps/web/layouts/organization/standalone/components/Header.tsx
+++ b/apps/web/layouts/organization/standalone/components/Header.tsx
@@ -2,8 +2,17 @@ import { useEffect, useState } from 'react'
 import { useWindowSize } from 'react-use'
 import cn from 'classnames'
 
-import { ResponsiveSpace, Text, TextProps } from '@island.is/island-ui/core'
+import {
+  Box,
+  Hidden,
+  ResponsiveSpace,
+  Stack,
+  Text,
+  TextProps,
+} from '@island.is/island-ui/core'
 import { theme } from '@island.is/island-ui/theme'
+import { SearchInput } from '@island.is/web/components'
+import { useI18n } from '@island.is/web/i18n'
 
 import * as styles from './Header.css'
 
@@ -21,6 +30,7 @@ export interface HeaderProps {
   imageObjectPosition?: 'left' | 'center' | 'right'
   className?: string
   isFrontpage?: boolean
+  organizationSlug?: string
 }
 
 export const Header: React.FC<React.PropsWithChildren<HeaderProps>> = ({
@@ -36,8 +46,10 @@ export const Header: React.FC<React.PropsWithChildren<HeaderProps>> = ({
   imageObjectPosition = 'center',
   className,
   isFrontpage = false,
+  organizationSlug,
 }) => {
   const { width } = useWindowSize()
+  const { activeLocale } = useI18n()
   const imageProvided = !!image
 
   const [isMobile, setIsMobile] = useState(false)
@@ -46,50 +58,64 @@ export const Header: React.FC<React.PropsWithChildren<HeaderProps>> = ({
     setIsMobile(width < theme.breakpoints.lg)
   }, [width])
   return (
-    <div
-      className={cn({ [styles.gridContainerWidth]: !fullWidth })}
-      style={{
-        background: isMobile ? mobileBackground || background : background,
-      }}
-    >
+    <Stack space={2}>
       <div
-        className={cn(
-          {
-            [styles.gridContainer]: !className,
-            [styles.gridContainerSubpage]: !isFrontpage,
-          },
-          className,
-        )}
+        className={cn({ [styles.gridContainerWidth]: !fullWidth })}
+        style={{
+          background: isMobile ? mobileBackground || background : background,
+        }}
       >
         <div
-          className={cn({
-            [styles.textContainerNoTitle]: isFrontpage && !underTitle,
-            [styles.textContainer]: isFrontpage && underTitle,
-            [styles.textContainerSubpage]: !isFrontpage,
-          })}
+          className={cn(
+            {
+              [styles.gridContainer]: !className,
+              [styles.gridContainerSubpage]: !isFrontpage,
+            },
+            className,
+          )}
         >
-          {underTitle && isFrontpage && (
-            <div className={cn(styles.textInnerContainer)}>
-              <Text variant="h1" as="h1" color={titleColor}>
-                {underTitle}
-              </Text>
-            </div>
+          <div
+            className={cn({
+              [styles.textContainerNoTitle]: isFrontpage && !underTitle,
+              [styles.textContainer]: isFrontpage && underTitle,
+              [styles.textContainerSubpage]: !isFrontpage,
+            })}
+          >
+            {underTitle && isFrontpage && (
+              <div className={cn(styles.textInnerContainer)}>
+                <Text variant="h1" as="h1" color={titleColor}>
+                  {underTitle}
+                </Text>
+              </div>
+            )}
+          </div>
+          {imageProvided && isFrontpage && (
+            <img
+              style={{
+                padding: imagePadding,
+                objectFit: imageObjectFit,
+                objectPosition: imageObjectPosition,
+                height: imageIsFullHeight ? '100%' : undefined,
+              }}
+              className={styles.headerImage}
+              src={image}
+              alt=""
+            />
           )}
         </div>
-        {imageProvided && isFrontpage && (
-          <img
-            style={{
-              padding: imagePadding,
-              objectFit: imageObjectFit,
-              objectPosition: imageObjectPosition,
-              height: imageIsFullHeight ? '100%' : undefined,
-            }}
-            className={styles.headerImage}
-            src={image}
-            alt=""
-          />
-        )}
       </div>
-    </div>
+      {isFrontpage && (
+        <Hidden above="md">
+          <Box marginX={3}>
+            <SearchInput
+              size="medium"
+              activeLocale={activeLocale}
+              placeholder={activeLocale === 'is' ? 'Leit' : 'Search'}
+              organization={organizationSlug}
+            />
+          </Box>
+        </Hidden>
+      )}
+    </Stack>
   )
 }

--- a/apps/web/layouts/organization/standalone/standalone.tsx
+++ b/apps/web/layouts/organization/standalone/standalone.tsx
@@ -67,7 +67,7 @@ export const StandaloneLayout = ({
     mobileBackground: organizationPage?.themeProperties.mobileBackgroundColor,
     isFrontpage: isFrontpage,
     underTitle: bannerTitle,
-    organizationSlug: organizationPage?.organization?.slug ?? ''
+    organizationSlug: organizationPage?.organization?.slug ?? '',
   }
 
   const { activeLocale } = useI18n()

--- a/apps/web/layouts/organization/standalone/standalone.tsx
+++ b/apps/web/layouts/organization/standalone/standalone.tsx
@@ -67,6 +67,7 @@ export const StandaloneLayout = ({
     mobileBackground: organizationPage?.themeProperties.mobileBackgroundColor,
     isFrontpage: isFrontpage,
     underTitle: bannerTitle,
+    organizationSlug: organizationPage?.organization?.slug ?? ''
   }
 
   const { activeLocale } = useI18n()


### PR DESCRIPTION
# Add search input to organization standalone theme mobile frontpage

## Screenshots / Gifs

### Before
![image](https://github.com/user-attachments/assets/1f25bf13-226c-42a6-b341-671bb1dcd90e)


### After
![image](https://github.com/user-attachments/assets/df30c0a2-de2f-4215-9337-f74bed4b2432)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced header with conditional search input visibility based on the front page.
	- Added support for organization-specific configurations with the new `organizationSlug` property.

- **Bug Fixes**
	- Improved layout structure for better visual consistency in the header component.

- **Documentation**
	- Updated interface declarations to reflect the addition of the `organizationSlug` property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->