### PR TITLE
feat(web): Organization pages - Show parent subpage even though standalone theme is not set

### DIFF
--- a/apps/web/pages/s/[...slugs]/index.tsx
+++ b/apps/web/pages/s/[...slugs]/index.tsx
@@ -262,12 +262,16 @@ Component.getProps = async (context) => {
       }
     }
 
-    if (isStandaloneTheme) {
+    try {
       return {
         page: {
           type: PageType.STANDALONE_PARENT_SUBPAGE,
           props: await StandaloneParentSubpage.getProps(modifiedContext),
         },
+      }
+    } catch (error) {
+      if (!(error instanceof CustomNextError)) {
+        throw error
       }
     }
 


### PR DESCRIPTION
# Organization pages - Show parent subpage even though standalone theme is not set

## What

Skip the standalone theme check and instead default to fetching props for parent subpage (if there is a customnexterror then we fallback to organization subpages)

## Why

So that content editors can continue working on parent subpages even though the theme isn't finalized

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for the `StandaloneParentSubpage` to manage specific errors more effectively.
	- Enhanced robustness of the property retrieval process, ensuring better stability during asynchronous operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->