### PR TITLE
fix(j-s): Prison admin indictment notifications

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/defendant/defendant.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/defendant.service.ts
@@ -85,7 +85,7 @@ export class DefendantService {
 
     const message = {
       type: MessageType.DEFENDANT_NOTIFICATION,
-      caseId: caseId,
+      caseId,
       elementId: defendant.id,
       body: {
         type: messageType,

--- a/apps/judicial-system/backend/src/app/modules/defendant/defendant.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/defendant.service.ts
@@ -76,6 +76,7 @@ export class DefendantService {
 
   private getMessagesForIndictmentToPrisonAdminChanges(
     defendant: Defendant,
+    caseId: string,
   ): Message {
     const messageType =
       defendant.isSentToPrisonAdmin === true
@@ -84,7 +85,7 @@ export class DefendantService {
 
     const message = {
       type: MessageType.DEFENDANT_NOTIFICATION,
-      caseId: defendant.caseId,
+      caseId: caseId,
       elementId: defendant.id,
       body: {
         type: messageType,
@@ -196,7 +197,10 @@ export class DefendantService {
       updatedDefendant.isSentToPrisonAdmin !== oldDefendant.isSentToPrisonAdmin
     ) {
       messages.push(
-        this.getMessagesForIndictmentToPrisonAdminChanges(updatedDefendant),
+        this.getMessagesForIndictmentToPrisonAdminChanges(
+          updatedDefendant,
+          theCase.id,
+        ),
       )
     }
 

--- a/apps/judicial-system/backend/src/app/modules/defendant/models/defendant.model.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/models/defendant.model.ts
@@ -81,7 +81,7 @@ export class Defendant extends Model {
   @ApiProperty({ type: String })
   caseId!: string
 
-  @BelongsTo(() => Case, 'case_id')
+  @BelongsTo(() => Case, 'caseId')
   @ApiPropertyOptional({ type: () => Case })
   case?: Case
 


### PR DESCRIPTION
Notifications weren't getting sent due to a bug in the defendant model that returned an undefined value for defendant.caseId

[Senda tilkynningu til FMST - fullnusta](https://app.asana.com/0/1199153462262248/1208708538371121)

## What

Fix indictment sent and withdrawn from prison admin notifications

## Why

Because they weren't sending

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced message handling for defendants in court cases by allowing direct use of `caseId` for message creation.
	- Improved clarity in method signatures related to indictment case updates.

- **Bug Fixes**
	- Updated foreign key reference for the `case` property in the `Defendant` model to ensure consistency with naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->