### PR TITLE
feat(web): Level 2 navigation for parent subpages should be visible despite theme

### DIFF
--- a/apps/web/pages/s/[...slugs]/index.tsx
+++ b/apps/web/pages/s/[...slugs]/index.tsx
@@ -320,12 +320,16 @@ Component.getProps = async (context) => {
       }
     }
 
-    if (isStandaloneTheme) {
+    try {
       return {
         page: {
           type: PageType.STANDALONE_PARENT_SUBPAGE,
           props: await StandaloneParentSubpage.getProps(modifiedContext),
         },
+      }
+    } catch (error) {
+      if (!(error instanceof CustomNextError)) {
+        throw error
       }
     }
 


### PR DESCRIPTION
# Level 2 navigation for parent subpages should be visible despite theme

## What

Follow up PR after https://github.com/island-is/island.is/pull/17096

The previous PR didn't handle "level 2" navigation, here we are adding the same logic for those pages.

It no longer matters if the theme is set to standalone or not


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling for the StandaloneParentSubpage to improve robustness and ensure proper error propagation.
  
These changes aim to provide a smoother user experience by addressing potential issues that may arise during page property retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->