### PR TITLE
fix: add missing ns grant to api for bff

### DIFF
--- a/apps/api/infra/api.ts
+++ b/apps/api/infra/api.ts
@@ -478,6 +478,6 @@ export const serviceSetup = (services: {
       'consultation-portal',
       'portals-admin',
       'service-portal',
-      'portals-my-pages'
+      'portals-my-pages',
     )
 }

--- a/apps/api/infra/api.ts
+++ b/apps/api/infra/api.ts
@@ -478,5 +478,6 @@ export const serviceSetup = (services: {
       'consultation-portal',
       'portals-admin',
       'service-portal',
+      'portals-my-pages'
     )
 }

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -423,6 +423,7 @@ api:
     - 'consultation-portal'
     - 'portals-admin'
     - 'service-portal'
+    - 'portals-my-pages'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -411,6 +411,7 @@ api:
     - 'consultation-portal'
     - 'portals-admin'
     - 'service-portal'
+    - 'portals-my-pages'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -423,6 +423,7 @@ api:
     - 'consultation-portal'
     - 'portals-admin'
     - 'service-portal'
+    - 'portals-my-pages'
   grantNamespacesEnabled: true
   healthCheck:
     liveness:

--- a/charts/services/api/values.dev.yaml
+++ b/charts/services/api/values.dev.yaml
@@ -172,6 +172,7 @@ grantNamespaces:
   - 'consultation-portal'
   - 'portals-admin'
   - 'service-portal'
+  - 'portals-my-pages'
 grantNamespacesEnabled: true
 healthCheck:
   liveness:

--- a/charts/services/api/values.prod.yaml
+++ b/charts/services/api/values.prod.yaml
@@ -172,6 +172,7 @@ grantNamespaces:
   - 'consultation-portal'
   - 'portals-admin'
   - 'service-portal'
+  - 'portals-my-pages'
 grantNamespacesEnabled: true
 healthCheck:
   liveness:

--- a/charts/services/api/values.staging.yaml
+++ b/charts/services/api/values.staging.yaml
@@ -172,6 +172,7 @@ grantNamespaces:
   - 'consultation-portal'
   - 'portals-admin'
   - 'service-portal'
+  - 'portals-my-pages'
 grantNamespacesEnabled: true
 healthCheck:
   liveness:


### PR DESCRIPTION
# Fix bff api
API needs a grant to allow bff communications for the service portal