### PR TITLE
fix(Consultation-portal): KAM-2800 user cannot deregister from "all" cases

### DIFF
--- a/apps/consultation-portal/screens/Subscriptions/components/SubscriptionTable/SubscriptionTable.tsx
+++ b/apps/consultation-portal/screens/Subscriptions/components/SubscriptionTable/SubscriptionTable.tsx
@@ -1,10 +1,5 @@
 import React from 'react'
-import {
-  Stack,
-  Table as T,
-  Text,
-  useBreakpoint,
-} from '@island.is/island-ui/core'
+import { Stack, Table as T, Text } from '@island.is/island-ui/core'
 import { mapIsToEn, sortLocale } from '../../../../utils/helpers'
 import { SubscriptionArray } from '../../../../types/interfaces'
 import { Area } from '../../../../types/enums'
@@ -37,7 +32,6 @@ const SubscriptionTable = ({
   searchValue,
   isMySubscriptions,
 }: Props) => {
-  const { md: mdBreakpoint } = useBreakpoint()
   const { Table, Body } = T
   const loc = localization.subscriptionTable
   const mappedCurrentTab = mapIsToEn[currentTab]

--- a/apps/consultation-portal/screens/Subscriptions/components/SubscriptionTable/SubscriptionTable.tsx
+++ b/apps/consultation-portal/screens/Subscriptions/components/SubscriptionTable/SubscriptionTable.tsx
@@ -54,8 +54,13 @@ const SubscriptionTable = ({
     data: thisData,
   })
 
-  if (
+  const hasNoItemsToShow =
     dataToRender.length === 0 &&
+    dontShowNew !== false &&
+    dontShowChanges !== false
+
+  if (
+    hasNoItemsToShow &&
     !subscribedToAllNewObj.checked &&
     !subscribedToAllChangesObj.checked
   ) {


### PR DESCRIPTION
# ...

Attach a link to issue if relevant
https://veflausnir.atlassian.net/browse/KAM-2800

## What
* Show the "all" cases option under "Mínar áskriftir" when applicable

## Why

The user cannot deregister from "all" cases

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced readability and maintainability of the SubscriptionTable component.
	- Streamlined logic for displaying messages when no subscriptions are found.
	- Maintained core functionality for rendering subscription items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->