### PR TITLE
feat(cms): Be able to query organization by national id

### DIFF
--- a/libs/cms/src/lib/cms.contentful.service.ts
+++ b/libs/cms/src/lib/cms.contentful.service.ts
@@ -349,9 +349,9 @@ export class CmsContentfulService {
   }
 
   private async getOrganizationBy(
-    lang: string,
     fieldName: string,
     fieldValue: string,
+    lang: string,
   ): Promise<Organization | null> {
     if (!fieldValue) {
       return null
@@ -377,28 +377,28 @@ export class CmsContentfulService {
     slug: string,
     lang: string,
   ): Promise<Organization | null> {
-    return this.getOrganizationBy(lang, 'slug', slug)
+    return this.getOrganizationBy('slug', slug, lang)
   }
 
   async getOrganizationByTitle(
     title: string,
     lang: string,
   ): Promise<Organization | null> {
-    return this.getOrganizationBy(lang, 'title[match]', title)
+    return this.getOrganizationBy('title[match]', title, lang)
   }
 
   async getOrganizationByReferenceId(
     referenceId: string,
     lang: string,
   ): Promise<Organization | null> {
-    return this.getOrganizationBy(lang, 'referenceIdentifier', referenceId)
+    return this.getOrganizationBy('referenceIdentifier', referenceId, lang)
   }
 
   async getOrganizationByNationalId(
     nationalId: string,
     lang: string,
   ): Promise<Organization | null> {
-    return this.getOrganizationBy(lang, 'kennitala', nationalId)
+    return this.getOrganizationBy('kennitala', nationalId, lang)
   }
 
   async getOrganizationPage(

--- a/libs/cms/src/lib/cms.contentful.service.ts
+++ b/libs/cms/src/lib/cms.contentful.service.ts
@@ -348,18 +348,19 @@ export class CmsContentfulService {
     )
   }
 
-  async getOrganization(
-    slug: string,
+  private async getOrganizationBy(
     lang: string,
+    fieldName: string,
+    fieldValue: string,
   ): Promise<Organization | null> {
-    if (!slug) {
+    if (!fieldValue) {
       return null
     }
 
     const params = {
       ['content_type']: 'organization',
       include: 10,
-      'fields.slug': slug,
+      [`fields.${fieldName}`]: fieldValue,
       limit: 1,
     }
 
@@ -372,42 +373,32 @@ export class CmsContentfulService {
     )
   }
 
+  async getOrganization(
+    slug: string,
+    lang: string,
+  ): Promise<Organization | null> {
+    return this.getOrganizationBy(lang, 'slug', slug)
+  }
+
   async getOrganizationByTitle(
     title: string,
     lang: string,
-  ): Promise<Organization> {
-    const params = {
-      ['content_type']: 'organization',
-      include: 10,
-      'fields.title[match]': title,
-    }
-
-    const result = await this.contentfulRepository
-      .getLocalizedEntries<types.IOrganizationFields>(lang, params)
-      .catch(errorHandler('getOrganization'))
-
-    return (
-      (result.items as types.IOrganization[]).map(mapOrganization)[0] ?? null
-    )
+  ): Promise<Organization | null> {
+    return this.getOrganizationBy(lang, 'title[match]', title)
   }
 
   async getOrganizationByReferenceId(
     referenceId: string,
     lang: string,
-  ): Promise<Organization> {
-    const params = {
-      ['content_type']: 'organization',
-      include: 10,
-      'fields.referenceIdentifier': referenceId,
-    }
+  ): Promise<Organization | null> {
+    return this.getOrganizationBy(lang, 'referenceIdentifier', referenceId)
+  }
 
-    const result = await this.contentfulRepository
-      .getLocalizedEntries<types.IOrganizationFields>(lang, params)
-      .catch(errorHandler('getOrganization'))
-
-    return (
-      (result.items as types.IOrganization[]).map(mapOrganization)[0] ?? null
-    )
+  async getOrganizationByNationalId(
+    nationalId: string,
+    lang: string,
+  ): Promise<Organization | null> {
+    return this.getOrganizationBy(lang, 'kennitala', nationalId)
   }
 
   async getOrganizationPage(

--- a/libs/cms/src/lib/cms.contentful.service.ts
+++ b/libs/cms/src/lib/cms.contentful.service.ts
@@ -352,8 +352,9 @@ export class CmsContentfulService {
     fieldName: string,
     fieldValue: string,
     lang: string,
+    requireFieldValue = false,
   ): Promise<Organization | null> {
-    if (!fieldValue) {
+    if (requireFieldValue && !fieldValue) {
       return null
     }
 
@@ -377,7 +378,7 @@ export class CmsContentfulService {
     slug: string,
     lang: string,
   ): Promise<Organization | null> {
-    return this.getOrganizationBy('slug', slug, lang)
+    return this.getOrganizationBy('slug', slug, lang, true)
   }
 
   async getOrganizationByTitle(
@@ -398,7 +399,7 @@ export class CmsContentfulService {
     nationalId: string,
     lang: string,
   ): Promise<Organization | null> {
-    return this.getOrganizationBy('kennitala', nationalId, lang)
+    return this.getOrganizationBy('kennitala', nationalId, lang, true)
   }
 
   async getOrganizationPage(


### PR DESCRIPTION
## What

- Refactor getOrganization and getOrganizationByX to use a utility function
- Add getOrganizationByNationalId

## Why

To be able to query organizations by national id

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to retrieve organizations by national ID.
	- Enhanced flexibility in organization retrieval with a new querying method.
- **Bug Fixes**
	- Improved error handling across organization retrieval methods for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->