### PR TITLE
feat(web): Add namespace for 'samgongustofa' web chat config

### DIFF
--- a/apps/web/components/ChatPanel/types.ts
+++ b/apps/web/components/ChatPanel/types.ts
@@ -24,7 +24,11 @@ export interface WatsonChatPanelProps {
   carbonTheme?: string
 
   // What key in the 'ChatPanels' UI Configuration in Contentful stores the language pack for this chat bot
-  namespaceKey?: 'default' | 'ukrainian-citizens' | 'skatturinn'
+  namespaceKey?:
+    | 'default'
+    | 'ukrainian-citizens'
+    | 'skatturinn'
+    | 'samgongustofa'
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onLoad?: (instance: any) => void

--- a/apps/web/components/Organization/Wrapper/config.ts
+++ b/apps/web/components/Organization/Wrapper/config.ts
@@ -116,7 +116,7 @@ export const watsonConfig: Record<
       serviceInstanceID: 'bc3d8312-d862-4750-b8bf-529db282050a',
       showLauncher: false,
       carbonTheme: 'g10',
-      namespaceKey: 'default',
+      namespaceKey: 'samgongustofa',
     },
   },
   is: {
@@ -127,7 +127,7 @@ export const watsonConfig: Record<
       serviceInstanceID: 'bc3d8312-d862-4750-b8bf-529db282050a',
       showLauncher: false,
       carbonTheme: 'g10',
-      namespaceKey: 'default',
+      namespaceKey: 'samgongustofa',
     },
 
     // Skatturinn - Organization

--- a/apps/web/components/ServiceWeb/config.ts
+++ b/apps/web/components/ServiceWeb/config.ts
@@ -113,7 +113,7 @@ export const watsonConfig: Record<
       serviceInstanceID: 'bc3d8312-d862-4750-b8bf-529db282050a',
       showLauncher: false,
       carbonTheme: 'g10',
-      namespaceKey: 'default',
+      namespaceKey: 'samgongustofa',
     },
   },
   en: {
@@ -147,7 +147,7 @@ export const watsonConfig: Record<
       serviceInstanceID: 'bc3d8312-d862-4750-b8bf-529db282050a',
       showLauncher: false,
       carbonTheme: 'g10',
-      namespaceKey: 'default',
+      namespaceKey: 'samgongustofa',
     },
   },
 }

--- a/apps/web/screens/Article/components/ArticleChatPanel/config.ts
+++ b/apps/web/screens/Article/components/ArticleChatPanel/config.ts
@@ -59,7 +59,7 @@ export const watsonConfig: Record<
       serviceInstanceID: 'bc3d8312-d862-4750-b8bf-529db282050a',
       showLauncher: false,
       carbonTheme: 'g10',
-      namespaceKey: 'default',
+      namespaceKey: 'samgongustofa',
       onLoad(instance) {
         setupOneScreenWatsonChatBot(
           instance,
@@ -309,7 +309,7 @@ export const watsonConfig: Record<
       serviceInstanceID: 'bc3d8312-d862-4750-b8bf-529db282050a',
       showLauncher: false,
       carbonTheme: 'g10',
-      namespaceKey: 'default',
+      namespaceKey: 'samgongustofa',
       onLoad(instance) {
         setupOneScreenWatsonChatBot(
           instance,
@@ -327,7 +327,7 @@ export const watsonConfig: Record<
       serviceInstanceID: 'bc3d8312-d862-4750-b8bf-529db282050a',
       showLauncher: false,
       carbonTheme: 'g10',
-      namespaceKey: 'default',
+      namespaceKey: 'samgongustofa',
       onLoad(instance) {
         setupOneScreenWatsonChatBot(
           instance,
@@ -345,7 +345,7 @@ export const watsonConfig: Record<
       serviceInstanceID: 'bc3d8312-d862-4750-b8bf-529db282050a',
       showLauncher: false,
       carbonTheme: 'g10',
-      namespaceKey: 'default',
+      namespaceKey: 'samgongustofa',
       onLoad(instance) {
         setupOneScreenWatsonChatBot(
           instance,

--- a/apps/web/screens/Article/components/ArticleChatPanel/config.ts
+++ b/apps/web/screens/Article/components/ArticleChatPanel/config.ts
@@ -287,7 +287,7 @@ export const watsonConfig: Record<
       serviceInstanceID: 'bc3d8312-d862-4750-b8bf-529db282050a',
       showLauncher: false,
       carbonTheme: 'g10',
-      namespaceKey: 'default',
+      namespaceKey: 'samgongustofa',
     },
   },
   is: {
@@ -298,7 +298,7 @@ export const watsonConfig: Record<
       serviceInstanceID: 'bc3d8312-d862-4750-b8bf-529db282050a',
       showLauncher: false,
       carbonTheme: 'g10',
-      namespaceKey: 'default',
+      namespaceKey: 'samgongustofa',
     },
 
     // Uppfletting í ökutækjaskrá


### PR DESCRIPTION
# Add namespace for 'samgongustofa' web chat config

## What

So we can in the CMS edit properties for the transport authority (Samgöngustofa) web chat

## Why

* This was requested by Digital Iceland

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Expanded options for the `namespaceKey` in the Watson Chat Panel to include `'samgongustofa'`.
- **Configuration Updates**
	- Updated `namespaceKey` for the `Samgöngustofa` organization in multiple configurations to reflect the new value.
	- Adjusted `namespaceKey` for the `TRANSPORT_AUTHORITY` organization to align with the new naming convention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->