### PR TITLE
fix(auth-admin): Allow delegation-admin into domains controller

### DIFF
--- a/apps/services/auth/delegation-api/src/app/domains/domains.controller.ts
+++ b/apps/services/auth/delegation-api/src/app/domains/domains.controller.ts
@@ -15,7 +15,7 @@ import {
   ScopesGuard,
   User,
 } from '@island.is/auth-nest-tools'
-import { delegationScopes } from '@island.is/auth/scopes'
+import { AdminPortalScope, delegationScopes } from '@island.is/auth/scopes'
 import { Audit } from '@island.is/nest/audit'
 import { Documentation } from '@island.is/nest/swagger'
 
@@ -92,6 +92,10 @@ export class DomainsController {
   @Audit<DomainDTO[]>({
     resources: (domains) => domains.map((domain) => domain.name),
   })
+  @Scopes(
+    AdminPortalScope.delegationSystemAdmin,
+    AdminPortalScope.delegationSystem,
+  )
   findAll(
     @CurrentUser() user: User,
     @Query('lang') language?: string,


### PR DESCRIPTION
## What

When fetching delegations for delegation lookups, those who did not have `@admin.island.is/delegations` scope could not look it up since that was required to get the domain name for the delegation.

## Why

So all users with delegation system access can lookup delegations.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
