### PR TITLE
feat(web): Latest generic list items - Item count is now editable in the CMS

### DIFF
--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -2127,6 +2127,9 @@ export interface ILatestGenericListItemsFields {
 
   /** See more link text */
   seeMoreLinkText?: string | undefined
+
+  /** Item Count */
+  itemCount?: number | undefined
 }
 
 export interface ILatestGenericListItems

--- a/libs/cms/src/lib/models/latestGenericListItems.model.ts
+++ b/libs/cms/src/lib/models/latestGenericListItems.model.ts
@@ -80,7 +80,7 @@ export const mapLatestGenericListItems = ({
             ? 'is'
             : (sys.locale as ElasticsearchIndexLocale),
         page: 1,
-        size: 2,
+        size: fields.itemCount ?? 2,
       }
     : null,
 })


### PR DESCRIPTION
# Latest generic list items - Item count is now editable in the CMS

## What

* Previously only 2 items were fetched, now we can edit how many are shown (in Contentful)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility in item response size, now dynamically derived from input data.
  
- **Bug Fixes**
	- Clarified handling of `itemResponse` field to indicate it can be null, improving data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->