### PR TITLE
feat(web): WHODAS Calculator - Add text to top of component

### DIFF
--- a/apps/web/components/connected/WHODAS/Calculator.strings.ts
+++ b/apps/web/components/connected/WHODAS/Calculator.strings.ts
@@ -2,6 +2,11 @@ import { defineMessages } from 'react-intl'
 
 export const m = {
   form: defineMessages({
+    topDescription: {
+      id: 'web.whodas.calculator:form.topDescription#markdown',
+      defaultMessage: 'Merktu við einn valkost fyrir hverja spurningu.',
+      description: 'Texti fyrir ofan spurningalista',
+    },
     previousStep: {
       id: 'web.whodas.calculator:form.previousStep',
       defaultMessage: 'Fyrra skref',
@@ -51,6 +56,12 @@ export const m = {
     },
   }),
   results: defineMessages({
+    topDescription: {
+      id: 'web.whodas.calculator:results.topDescription#markdown',
+      defaultMessage:
+        'Takk fyrir að svara spurningalistanum, Mat á færni þinni. Mat þitt á færni er stuðningur við að meta þörf þína fyrir heimaþjónustu. Ef þú hefur ekki svarað öllum spurningum getur það haft áhrif á niðurstöðuna.',
+      description: 'Texti fyrir ofan niðurstöðuskjá',
+    },
     mainHeading: {
       id: 'web.whodas.calculator:form.mainHeading',
       defaultMessage: 'Niðurstaða mats á færni',

--- a/apps/web/components/connected/WHODAS/Calculator.tsx
+++ b/apps/web/components/connected/WHODAS/Calculator.tsx
@@ -301,6 +301,7 @@ export const WHODASCalculator = ({ slice }: WHODASCalculatorProps) => {
         <Inline alignY="center" space={2}>
           {stepIndex > 0 && (
             <Button
+              key={`previous-step-${stepIndex}`}
               size="small"
               variant="ghost"
               preTextIcon="arrowBack"
@@ -312,6 +313,7 @@ export const WHODASCalculator = ({ slice }: WHODASCalculatorProps) => {
             </Button>
           )}
           <Button
+            key={`next-step-${stepIndex}`}
             size="small"
             onClick={() => {
               setStepIndex((s) => s + 1)

--- a/apps/web/components/connected/WHODAS/Calculator.tsx
+++ b/apps/web/components/connected/WHODAS/Calculator.tsx
@@ -257,62 +257,74 @@ export const WHODASCalculator = ({ slice }: WHODASCalculatorProps) => {
       totalScore += score
     }
     return (
-      <WHODASResults
-        results={results}
-        bracket={
-          totalScore <= (slice.configJson?.firstBracketBreakpoint ?? 16.9)
-            ? 1
-            : 2
-        }
-      />
+      <Stack space={8}>
+        <MarkdownText replaceNewLinesWithBreaks={false}>
+          {formatMessage(m.results.topDescription)}
+        </MarkdownText>
+        <WHODASResults
+          results={results}
+          bracket={
+            totalScore <= (slice.configJson?.firstBracketBreakpoint ?? 16.9)
+              ? 1
+              : 2
+          }
+        />
+      </Stack>
     )
   }
 
   return (
-    <Stack space={6}>
-      <Box ref={formRef}>
-        <Stack space={4}>
-          <Stack space={1}>
-            <Text>
-              {formatMessage(m.form.progress, {
-                stepIndex: stepIndex + 1,
-                stepCount: steps.length,
-              })}
-            </Text>
-            <ProgressMeter progress={(stepIndex + 1) / steps.length} />
+    <Stack space={8}>
+      <MarkdownText replaceNewLinesWithBreaks={false}>
+        {formatMessage(m.form.topDescription)}
+      </MarkdownText>
+      <Stack space={6}>
+        <Box ref={formRef}>
+          <Stack space={4}>
+            <Stack space={1}>
+              <Text>
+                {formatMessage(m.form.progress, {
+                  stepIndex: stepIndex + 1,
+                  stepCount: steps.length,
+                })}
+              </Text>
+              <ProgressMeter progress={(stepIndex + 1) / steps.length} />
+            </Stack>
+            <WHODASForm
+              step={step}
+              stepIndex={stepIndex}
+              state={state}
+              setState={setState}
+            />
           </Stack>
-          <WHODASForm
-            step={step}
-            stepIndex={stepIndex}
-            state={state}
-            setState={setState}
-          />
-        </Stack>
-      </Box>
-      <Inline alignY="center" space={2}>
-        {stepIndex > 0 && (
+        </Box>
+        <Inline alignY="center" space={2}>
+          {stepIndex > 0 && (
+            <Button
+              size="small"
+              variant="ghost"
+              preTextIcon="arrowBack"
+              onClick={() => {
+                setStepIndex((s) => s - 1)
+              }}
+            >
+              {formatMessage(m.form.previousStep)}
+            </Button>
+          )}
           <Button
             size="small"
-            variant="ghost"
-            preTextIcon="arrowBack"
             onClick={() => {
-              setStepIndex((s) => s - 1)
+              setStepIndex((s) => s + 1)
             }}
           >
-            {formatMessage(m.form.previousStep)}
+            {formatMessage(
+              stepIndex >= steps.length - 1
+                ? m.form.seeResults
+                : m.form.nextStep,
+            )}
           </Button>
-        )}
-        <Button
-          size="small"
-          onClick={() => {
-            setStepIndex((s) => s + 1)
-          }}
-        >
-          {formatMessage(
-            stepIndex >= steps.length - 1 ? m.form.seeResults : m.form.nextStep,
-          )}
-        </Button>
-      </Inline>
+        </Inline>
+      </Stack>
     </Stack>
   )
 }


### PR DESCRIPTION
# WHODAS Calculator - Add text to top of component

## Why

* We need to have different text for result screen and other views

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added localized descriptions in Icelandic for the WHODAS calculator form and results sections.
	- Introduced a new `MarkdownText` component to enhance the layout with top descriptions in both the form and results sections.

- **Bug Fixes**
	- Corrected button functionality to ensure proper navigation through steps in the WHODAS calculator.

- **Improvements**
	- Enhanced user interface with improved layout structure and additional context for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->