### PR TITLE
fix(web): Generic List - Reset page number when filters are changed

### DIFF
--- a/apps/web/components/GenericList/GenericList.tsx
+++ b/apps/web/components/GenericList/GenericList.tsx
@@ -311,6 +311,7 @@ export const GenericList = ({
               key={value}
               active={true}
               onClick={() => {
+                setPage(null)
                 setParameters((prevParameters) => {
                   const updatedParameters = {
                     ...prevParameters,
@@ -465,6 +466,7 @@ export const GenericList = ({
                             if (!category) {
                               return
                             }
+                            setPage(null)
                             setParameters((prevParameters) => ({
                               ...prevParameters,
                               [category]: (


### PR DESCRIPTION
# Generic List - Reset page number when filters are changed

## What

* Clicking on filters (when there is only one or fewer filter categories) does not reset the page number

## Screenshots / Gifs

This will fix this issue:

https://github.com/user-attachments/assets/8cd17d7b-ec55-4fd6-b11c-8e2063b3ad55

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
