### PR TITLE
fix(j-s): Fix Empty National Id

### DIFF
--- a/apps/judicial-system/web/src/routes/Court/Indictments/Advocates/SelectDefender.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/Advocates/SelectDefender.tsx
@@ -43,16 +43,16 @@ const SelectDefender: FC<Props> = ({ defendant }) => {
         caseId,
         defendantId: defendant.id,
         defenderNationalId: defendantWaivesRightToCounsel
-          ? ''
-          : defendant.defenderNationalId,
+          ? null
+          : defendant.defenderNationalId || null,
         defenderName: defendantWaivesRightToCounsel
-          ? ''
+          ? null
           : defendant.defenderName,
         defenderEmail: defendantWaivesRightToCounsel
-          ? ''
+          ? null
           : defendant.defenderEmail,
         defenderPhoneNumber: defendantWaivesRightToCounsel
-          ? ''
+          ? null
           : defendant.defenderPhoneNumber,
         defenderChoice:
           defendantWaivesRightToCounsel === true

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/Defendant.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/Defendant.tsx
@@ -370,7 +370,6 @@ const Defendant = () => {
           router.push(`${destination}/${createdCase.id}`)
         } else {
           toast.error(formatMessage(errors.createCase))
-          return
         }
       } else {
         router.push(`${destination}/${workingCase.id}`)
@@ -416,14 +415,7 @@ const Defendant = () => {
 
   const handleCreateDefendantClick = async () => {
     if (workingCase.id) {
-      const defendantId = await createDefendant({
-        caseId: workingCase.id,
-        gender: undefined,
-        name: '',
-        address: '',
-        nationalId: null,
-        citizenship: '',
-      })
+      const defendantId = await createDefendant({ caseId: workingCase.id })
 
       createEmptyDefendant(defendantId)
     } else {
@@ -438,14 +430,7 @@ const Defendant = () => {
       ...prevWorkingCase,
       defendants: prevWorkingCase.defendants && [
         ...prevWorkingCase.defendants,
-        {
-          id: defendantId || uuid(),
-          gender: undefined,
-          name: '',
-          nationalId: null,
-          address: '',
-          citizenship: '',
-        } as TDefendant,
+        { id: defendantId || uuid() },
       ],
     }))
   }

--- a/apps/judicial-system/web/src/routes/Prosecutor/InvestigationCase/Defendant/Defendant.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/InvestigationCase/Defendant/Defendant.tsx
@@ -192,14 +192,7 @@ const Defendant = () => {
 
   const handleCreateDefendantClick = async () => {
     if (workingCase.id) {
-      const defendantId = await createDefendant({
-        caseId: workingCase.id,
-        gender: undefined,
-        name: '',
-        address: '',
-        nationalId: '',
-        citizenship: '',
-      })
+      const defendantId = await createDefendant({ caseId: workingCase.id })
 
       createEmptyDefendant(defendantId)
     } else {
@@ -214,14 +207,7 @@ const Defendant = () => {
       ...prevWorkingCase,
       defendants: prevWorkingCase.defendants && [
         ...prevWorkingCase.defendants,
-        {
-          id: defendantId || uuid(),
-          gender: undefined,
-          name: '',
-          nationalId: '',
-          address: '',
-          citizenship: '',
-        } as TDefendant,
+        { id: defendantId || uuid() },
       ],
     }))
   }


### PR DESCRIPTION
# Fix Empty National Id

[Ákærða óskar ekki eftir að sér sé skipaður verjandi böggur](https://app.asana.com/0/1199153462262248/1208894033390306/f)

## What

- The court was not able to allow defendant to wafe right to defender. This is fixed in this PR.

## Why

- Verified bug.

## Screenshots / Gifs

https://github.com/user-attachments/assets/4f1c6663-4edd-454e-9eb9-cc446fa7439f

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified the defendant creation process by reducing the number of parameters required.
	- Updated the handling of defendant properties when waiving the right to counsel to set fields to `null` instead of empty strings.

- **Bug Fixes**
	- Improved the initialization of new defendant objects to streamline state updates.

- **Documentation**
	- Clarified the functionality around creating and managing defendants within the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->