### PR TITLE
chore(ids-api): Try fix flaky tests

### DIFF
--- a/apps/services/auth/ids-api/src/app/delegations/delegations-personal-representative.controller.spec.ts
+++ b/apps/services/auth/ids-api/src/app/delegations/delegations-personal-representative.controller.spec.ts
@@ -75,6 +75,7 @@ describe('Personal Representative DelegationsController', () => {
         let prTypeModel: typeof PersonalRepresentativeType
         let prDelegationTypeModel: typeof PersonalRepresentativeDelegationTypeModel
         let delegationTypeModel: typeof DelegationTypeModel
+        let nationalRegistryV3FeatureService: NationalRegistryV3FeatureService
         let nationalRegistryApi: NationalRegistryClientService
         let nationalRegistryV3Api: NationalRegistryV3ClientService
         let delegationProviderModel: typeof DelegationProviderModel
@@ -154,15 +155,12 @@ describe('Personal Representative DelegationsController', () => {
             getModelToken(DelegationProviderModel),
           )
           clientModel = app.get<typeof Client>(getModelToken(Client))
+          nationalRegistryV3FeatureService = app.get(
+            NationalRegistryV3FeatureService,
+          )
           nationalRegistryApi = app.get(NationalRegistryClientService)
           nationalRegistryV3Api = app.get(NationalRegistryV3ClientService)
           delegationIndexService = app.get(DelegationsIndexService)
-          const nationalRegistryV3FeatureService = app.get(
-            NationalRegistryV3FeatureService,
-          )
-          jest
-            .spyOn(nationalRegistryV3FeatureService, 'getValue')
-            .mockImplementation(async () => featureFlag)
           factory = new FixtureFactory(app)
         }, setupHookTimeout)
 
@@ -405,6 +403,10 @@ describe('Personal Representative DelegationsController', () => {
                   ),
                 ]
 
+                jest
+                  .spyOn(nationalRegistryV3FeatureService, 'getValue')
+                  .mockImplementation(async () => featureFlag)
+
                 nationalRegistryApiSpy = jest
                   .spyOn(nationalRegistryApi, 'getIndividual')
                   .mockImplementation(async (id) => {
@@ -463,7 +465,7 @@ describe('Personal Representative DelegationsController', () => {
               })
 
               afterAll(async () => {
-                jest.clearAllMocks()
+                jest.resetAllMocks()
                 await prRightsModel.destroy({
                   where: {},
                   cascade: true,

--- a/apps/services/auth/ids-api/src/app/delegations/delegations-personal-representative.controller.spec.ts
+++ b/apps/services/auth/ids-api/src/app/delegations/delegations-personal-representative.controller.spec.ts
@@ -36,16 +36,13 @@ import {
 } from '@island.is/shared/types'
 import {
   createCurrentUser,
+  createNationalId,
   createNationalRegistryUser,
 } from '@island.is/testing/fixtures'
 import { TestApp } from '@island.is/testing/nest'
 
 import { defaultScopes, setupWithAuth } from '../../../test/setup'
-import {
-  getFakeName,
-  getFakeNationalId,
-  NameIdTuple,
-} from '../../../test/stubs/genericStubs'
+import { getFakeName, NameIdTuple } from '../../../test/stubs/genericStubs'
 import {
   delegationTypes,
   getPersonalRepresentativeRelationship,
@@ -54,6 +51,8 @@ import {
   getScopePermission,
   personalRepresentativeType,
 } from '../../../test/stubs/personalRepresentativeStubs'
+
+const getFakeNationalId = () => createNationalId('person')
 
 const setupHookTimeout = 10000
 

--- a/apps/services/auth/ids-api/src/app/delegations/delegations-personal-representative.controller.spec.ts
+++ b/apps/services/auth/ids-api/src/app/delegations/delegations-personal-representative.controller.spec.ts
@@ -55,6 +55,8 @@ import {
   personalRepresentativeType,
 } from '../../../test/stubs/personalRepresentativeStubs'
 
+const setupHookTimeout = 10000
+
 describe('Personal Representative DelegationsController', () => {
   describe.each([false, true])(
     'national registry v3 featureflag: %s',
@@ -162,7 +164,7 @@ describe('Personal Representative DelegationsController', () => {
             .spyOn(nationalRegistryV3FeatureService, 'getValue')
             .mockImplementation(async () => featureFlag)
           factory = new FixtureFactory(app)
-        })
+        }, setupHookTimeout)
 
         const createDelegationTypeAndProvider = async (rightCode: string[]) => {
           const newDelegationProvider = await delegationProviderModel.create({


### PR DESCRIPTION
## What

Increase timeout for beforeAll hook. Reset mocks. Ensure only person national ids.

## Why

Try to prevent flakyness in tests.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Enhanced the test suite for the Personal Representative Delegations Controller.
	- Introduced a new function to generate national IDs for improved test scenarios.
	- Updated mock implementations and adjusted test lifecycle for better clarity and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->