### PR TITLE
fix(native-app): change border radius circle to be full

### DIFF
--- a/apps/native/app/src/ui/utils/theme.ts
+++ b/apps/native/app/src/ui/utils/theme.ts
@@ -82,7 +82,7 @@ export const theme = {
       standard: '4px',
       large: '8px',
       extraLarge: '16px',
-      circle: '100px',
+      full: '100px',
     },
     width: {
       standard: 1,


### PR DESCRIPTION
## What

Changes in #17042 broke the app since the app has its own theme (not using the same theme as other projects in the monorepo).
I changed the `borderRadius.circle` to be `borderRadius.full`. 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the border radius terminology for circular elements from `circle` to `full` in the theme settings. 

This change enhances clarity in design specifications while maintaining all other theme properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->