### PR TITLE
fix(documents): Sort by publication v1 and v2 by default

### DIFF
--- a/libs/api/domains/documents/src/lib/documentV2.service.ts
+++ b/libs/api/domains/documents/src/lib/documentV2.service.ts
@@ -245,8 +245,6 @@ export class DocumentServiceV2 {
       mutableCategoryIds.filter((c) => !hiddenCategoryIds.includes(c))
     }
 
-    console.log('restOfInput', restOfInput)
-
     const documents = await this.documentService.getDocumentList({
       ...restOfInput,
       categoryId: mutableCategoryIds.join(),

--- a/libs/api/domains/documents/src/lib/documentV2.service.ts
+++ b/libs/api/domains/documents/src/lib/documentV2.service.ts
@@ -245,6 +245,8 @@ export class DocumentServiceV2 {
       mutableCategoryIds.filter((c) => !hiddenCategoryIds.includes(c))
     }
 
+    console.log('restOfInput', restOfInput)
+
     const documents = await this.documentService.getDocumentList({
       ...restOfInput,
       categoryId: mutableCategoryIds.join(),

--- a/libs/api/domains/documents/src/lib/dto/getDocumentListInput.ts
+++ b/libs/api/domains/documents/src/lib/dto/getDocumentListInput.ts
@@ -21,7 +21,7 @@ export class GetDocumentListInput {
   typeId?: string
 
   @Field({ nullable: true })
-  sortBy?: 'Date' | 'Category' | 'Type' | 'Subject' | 'Sender'
+  sortBy?: 'Date' | 'Category' | 'Type' | 'Subject' | 'Sender' | 'Publication'
 
   @Field({ nullable: true })
   order?: 'Ascending' | 'Descending'

--- a/libs/api/domains/documents/src/lib/models/v2/documents.input.ts
+++ b/libs/api/domains/documents/src/lib/models/v2/documents.input.ts
@@ -17,7 +17,8 @@ import {
 } from 'class-validator'
 
 export enum DocumentPageSort {
-  Date = 'Date',
+  Date = 'Date', // Date is document date
+  Publication = 'Publication', // Publication is document publication date (default)
   Category = 'Category',
   Type = 'Type',
   Sender = 'Sender',
@@ -79,7 +80,10 @@ export class DocumentsInput {
   @IsBoolean()
   readonly opened?: boolean
 
-  @Field(() => DocumentPageSort, { nullable: true, defaultValue: 'Date' })
+  @Field(() => DocumentPageSort, {
+    nullable: true,
+    defaultValue: 'Publication',
+  })
   @IsOptional()
   @IsEnum(DocumentPageSort)
   readonly sortBy?: DocumentPageSort

--- a/libs/clients/documents-v2/src/lib/dto/listDocuments.input.ts
+++ b/libs/clients/documents-v2/src/lib/dto/listDocuments.input.ts
@@ -8,7 +8,7 @@ export type ListDocumentsInputDto = {
   typeId?: string
   subjectContains?: string
   archived?: boolean
-  sortBy?: 'Date' | 'Category' | 'Type' | 'Sender' | 'Subject'
+  sortBy?: 'Date' | 'Category' | 'Type' | 'Sender' | 'Subject' | 'Publication'
   order?: 'Ascending' | 'Descending'
   opened?: boolean
   page?: number

--- a/libs/clients/documents/src/lib/documentClient.ts
+++ b/libs/clients/documents/src/lib/documentClient.ts
@@ -133,7 +133,7 @@ export class DocumentClient {
     type ExcludesFalse = <T>(x: T | null | undefined | false | '') => x is T
 
     const inputs = [
-      sortBy ? `sortBy=${sortBy}` : 'sortBy=Date', // first in array to skip &
+      sortBy ? `sortBy=${sortBy}` : 'sortBy=Publication', // first in array to skip &
       order ? `orderBy=${order}` : 'order=Descending',
       page ? `page=${page}` : 'page=1',
       pageSize ? `pageSize=${pageSize}` : 'pageSize=15',

--- a/libs/clients/documents/src/lib/models/DocumentInput.ts
+++ b/libs/clients/documents/src/lib/models/DocumentInput.ts
@@ -5,7 +5,7 @@ export type GetDocumentListInput = {
   categoryId?: string
   subjectContains?: string
   typeId?: string
-  sortBy?: 'Date' | 'Category' | 'Type' | 'Subject' | 'Sender'
+  sortBy?: 'Date' | 'Category' | 'Type' | 'Subject' | 'Sender' | 'Publication'
   order?: 'Ascending' | 'Descending'
   opened?: boolean
   archived?: boolean


### PR DESCRIPTION
## What

Sort by publication in documents v1 and v2 by default

## Why

After client config update in october, `Publication` has been added. UI already sorts by publication, so the service should sort by publication by default.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
