### PR TITLE
fix(j-s): Fix subpoena pdf

### DIFF
--- a/apps/judicial-system/api/src/app/modules/file/file.controller.ts
+++ b/apps/judicial-system/api/src/app/modules/file/file.controller.ts
@@ -196,7 +196,7 @@ export class FileController {
       } for defendant ${defendantId} of case ${id} as a pdf document`,
     )
 
-    const subpoenaIdInjection = subpoenaId ? `/${subpoenaId}` : ''
+    const subpoenaIdInjection = subpoenaId ? `/${subpoenaId}/pdf` : ''
     const queryInjection = arraignmentDate
       ? `?arraignmentDate=${arraignmentDate}&location=${location}&subpoenaType=${subpoenaType}`
       : ''

--- a/apps/judicial-system/backend/src/app/modules/subpoena/subpoena.controller.ts
+++ b/apps/judicial-system/backend/src/app/modules/subpoena/subpoena.controller.ts
@@ -105,7 +105,7 @@ export class SubpoenaController {
     districtCourtRegistrarRule,
     districtCourtAssistantRule,
   )
-  @Get(['', ':subpoenaId'])
+  @Get(['', ':subpoenaId/pdf'])
   @UseGuards(SubpoenaExistsOptionalGuard)
   @Header('Content-Type', 'application/pdf')
   @ApiOkResponse({


### PR DESCRIPTION
## What

Fix retrieval of subpoena pdf

## Why

Because it wasn't working

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the API endpoint for fetching subpoena PDFs to include `/pdf` in the URL structure, enhancing clarity in document retrieval.
  
- **Bug Fixes**
	- Ensured that the endpoint correctly handles the construction of the URL when a subpoena ID is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->