### PR TITLE
fix(ids-api): Use name field instead of fullname.

### DIFF
--- a/apps/services/auth/ids-api/src/app/user-profile/user-profile.service.ts
+++ b/apps/services/auth/ids-api/src/app/user-profile/user-profile.service.ts
@@ -130,7 +130,7 @@ export class UserProfileService {
       }
 
       return {
-        name: individual.fulltNafn?.fulltNafn ?? individual.nafn ?? undefined,
+        name: individual.nafn ?? undefined,
         givenName: individual.fulltNafn?.eiginNafn ?? undefined,
         familyName: individual.fulltNafn?.kenniNafn ?? undefined,
         middleName: individual.fulltNafn?.milliNafn ?? undefined,


### PR DESCRIPTION
## What

Use `nafn` instead of `fulltNafn` for name in user profile.

## Why

The value in `fulltNafn` apparently has not always been up to date. Using `nafn` also aligns with my pages and other services.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified logic for retrieving user names from the national registry, enhancing the accuracy of user profile claims.
  
- **Chores**
	- Removed outdated comments related to TypeScript version requirements for cleaner code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->