### PR TITLE
feat(web): Display logos in login button if there is a different top item

### DIFF
--- a/apps/web/components/Header/LoginButton.css.ts
+++ b/apps/web/components/Header/LoginButton.css.ts
@@ -1,0 +1,5 @@
+import { style } from '@vanilla-extract/css'
+
+export const dropdownMenu = style({
+  width: 193,
+})

--- a/apps/web/components/Header/LoginButton.tsx
+++ b/apps/web/components/Header/LoginButton.tsx
@@ -1,16 +1,21 @@
 import React, { MouseEvent } from 'react'
+import { useWindowSize } from 'react-use'
+import cn from 'classnames'
 import { useRouter } from 'next/router'
 
 import {
   Button,
   ButtonTypes,
   DropdownMenu,
-  Hidden,
   Inline,
+  Logo,
 } from '@island.is/island-ui/core'
+import { theme } from '@island.is/island-ui/theme'
 import { webLoginButtonSelect } from '@island.is/plausible'
 import { useI18n } from '@island.is/web/i18n'
 import { LayoutProps } from '@island.is/web/layouts/main'
+
+import * as styles from './LoginButton.css'
 
 const minarsidurLink = '/minarsidur/'
 const minarsidurDelegationsLink = '/minarsidur/login?prompt=select_account'
@@ -21,6 +26,7 @@ export function LoginButton(props: {
 }) {
   const { t } = useI18n()
   const router = useRouter()
+  const { width } = useWindowSize()
 
   function trackAndNavigate(
     buttonType: 'Dropdown - Individuals' | 'Dropdown - Companies' | string,
@@ -49,12 +55,38 @@ export function LoginButton(props: {
   const items = [
     {
       href: minarsidurLink,
-      title: t.loginIndividuals,
+      title: (
+        <Inline alignY="center" space={1} flexWrap="nowrap">
+          {props.topItem && (
+            <Logo
+              width={17}
+              height={17}
+              iconOnly={true}
+              id="minar-sidur-individuals"
+              solid={false}
+            />
+          )}
+          {t.loginIndividuals}
+        </Inline>
+      ),
       onClick: trackAndNavigate.bind(null, 'Dropdown - Individuals'),
     },
     {
       href: minarsidurDelegationsLink,
-      title: t.loginDelegations,
+      title: (
+        <Inline alignY="center" space={1} flexWrap="nowrap">
+          {props.topItem && (
+            <Logo
+              width={17}
+              height={17}
+              iconOnly={true}
+              id="minar-sidur-companies"
+              solid={false}
+            />
+          )}
+          {t.loginDelegations}
+        </Inline>
+      ),
       onClick: trackAndNavigate.bind(null, 'Dropdown - Companies'),
     },
   ]
@@ -79,42 +111,26 @@ export function LoginButton(props: {
     })
   }
 
+  const isMobile = width < theme.breakpoints.md
+
   return (
-    <>
-      <Hidden above={'md'}>
-        <DropdownMenu
-          fixed
-          disclosure={
-            <Button
-              colorScheme={props.colorScheme}
-              variant="utility"
-              icon="person"
-              title={t.login}
-            />
-          }
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore make web strict
-          items={items}
-        />
-      </Hidden>
-      <Hidden below={'lg'}>
-        <DropdownMenu
-          fixed
-          disclosure={
-            <Button
-              colorScheme={props.colorScheme}
-              variant="utility"
-              icon="person"
-            >
-              {t.login}
-            </Button>
-          }
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore make web strict
-          items={items}
-          openOnHover
-        />
-      </Hidden>
-    </>
+    <DropdownMenu
+      fixed
+      menuClassName={cn({ [styles.dropdownMenu]: Boolean(props.topItem) })}
+      disclosure={
+        <Button
+          colorScheme={props.colorScheme}
+          variant="utility"
+          icon="person"
+          title={isMobile ? t.login : undefined}
+        >
+          {!isMobile && t.login}
+        </Button>
+      }
+      openOnHover={!isMobile}
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore make web strict
+      items={items}
+    />
   )
 }


### PR DESCRIPTION
# Display logos in login button if there is a different top item

## Why

To make it more clear to the user that the "Individual" and "Company" sign in options don't relate to the organization above

## Screenshots / Gifs

### Before

![Screenshot 2024-12-09 at 10 26 05](https://github.com/user-attachments/assets/12415a39-9d32-4b45-b466-cbfc3ff74049)

### After

![Screenshot 2024-12-09 at 10 25 40](https://github.com/user-attachments/assets/88dc74e7-c394-4c31-9d14-146d319cb8e1)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
