### PR TITLE
feat(user-notification): Add getNotificationStatus endpoint

### DIFF
--- a/apps/services/user-notification/src/app/modules/notifications/notifications.controller.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/notifications.controller.ts
@@ -134,7 +134,7 @@ export class NotificationsController {
     lastUpdated: string
   }> {
     this.logger.info(`Fetching status for notification: ${notificationId}`)
-    
+
     return {
       id: notificationId,
       status: 'DELIVERED',

--- a/apps/services/user-notification/src/app/modules/notifications/notifications.controller.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/notifications.controller.ts
@@ -108,6 +108,41 @@ export class NotificationsController {
     return this.notificationsService.findMany(nationalId, query)
   }
 
+  @UseGuards(IdsUserGuard, ScopesGuard)
+  @Scopes(AdminPortalScope.serviceDesk)
+  @Get('/status/:notificationId')
+  @Version('1')
+  @Documentation({
+    summary: 'Get status information for a specific notification',
+    response: { status: HttpStatus.OK },
+    request: {
+      params: {
+        notificationId: {
+          type: 'string',
+          description: 'ID of the notification',
+          example: 'notif-123-456',
+        },
+      },
+    },
+  })
+  async getNotificationStatus(
+    @Param('notificationId') notificationId: string,
+  ): Promise<{
+    id: string
+    status: string
+    createdAt: string
+    lastUpdated: string
+  }> {
+    this.logger.info(`Fetching status for notification: ${notificationId}`)
+    
+    return {
+      id: notificationId,
+      status: 'DELIVERED',
+      createdAt: '2024-12-10T10:00:00Z',
+      lastUpdated: '2024-12-10T10:15:00Z',
+    }
+  }
+
   @Documentation({
     summary: 'Creates a new notification and adds to queue',
     includeNoContentResponse: true,

--- a/infra/src/uber-charts/islandis.ts
+++ b/infra/src/uber-charts/islandis.ts
@@ -269,9 +269,10 @@ export const FeatureDeploymentServices: ServiceBuilder<any>[] = []
 
 // Services that are included in some environment above but should be excluded from feature deployments
 export const ExcludedFeatureDeploymentServices: ServiceBuilder<any>[] = [
-  userNotificationService,
-  userNotificationWorkerService,
-  userNotificationCleanupWorkerService,
+  // FIXME BEFORE APPROVEING THIS PR !!!!!!!!!!!!!!!! MERGE AND DIE
+  //userNotificationService,
+  //userNotificationWorkerService,
+  //userNotificationCleanupWorkerService,
   contentfulEntryTagger,
   searchIndexer,
   contentfulApps,


### PR DESCRIPTION
Adds a new endpoint to fetch notification status with dummy data

# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a method to retrieve the status of a specific notification by its ID.
  
- **Chores**
	- Temporarily excluded certain user notification services from deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->