### PR TITLE
refactor(react-spa-bff): Replace useBff with useAuth in components

### DIFF
--- a/apps/portals/my-pages/src/components/Loaders/AuthOverlay/AuthOverlay.tsx
+++ b/apps/portals/my-pages/src/components/Loaders/AuthOverlay/AuthOverlay.tsx
@@ -2,11 +2,11 @@ import { Text } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
 import { m } from '@island.is/portals/my-pages/core'
 
-import { useBff } from '@island.is/react-spa/bff'
+import { useAuth } from '@island.is/react-spa/bff'
 import * as styles from './AuthOverlay.css'
 
 const AuthOverlay = () => {
-  const { authState } = useBff()
+  const { authState } = useAuth()
   const { formatMessage } = useLocale()
 
   if (authState === 'switching')

--- a/libs/application/ui-shell/src/components/DelegationsScreen.tsx
+++ b/libs/application/ui-shell/src/components/DelegationsScreen.tsx
@@ -16,7 +16,7 @@ import {
   Text,
 } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
-import { useBff } from '@island.is/react-spa/bff'
+import { useAuth } from '@island.is/react-spa/bff'
 import { useFeatureFlagClient } from '@island.is/react/feature-flags'
 import * as kennitala from 'kennitala'
 import { format as formatKennitala } from 'kennitala'
@@ -50,7 +50,7 @@ export const DelegationsScreen = ({
   })
   const { formatMessage } = useLocale()
   const type = getTypeFromSlug(slug)
-  const { switchUser, userInfo: user } = useBff()
+  const { switchUser, userInfo: user } = useAuth()
   const featureFlagClient: FeatureFlagClient = useFeatureFlagClient()
   const navigate = useNavigate()
 

--- a/libs/react-spa/bff/src/lib/BffPoller.tsx
+++ b/libs/react-spa/bff/src/lib/BffPoller.tsx
@@ -3,7 +3,7 @@ import { BffUser } from '@island.is/shared/types'
 import { ReactNode, useCallback, useEffect, useMemo } from 'react'
 import {
   BffBroadcastEvents,
-  useBff,
+  useAuth,
   useBffBroadcaster,
   useUserInfo,
 } from './bff.hooks'
@@ -43,7 +43,7 @@ export const BffPoller = ({
   newSessionCb,
   pollIntervalMS = 10000,
 }: BffPollerProps) => {
-  const { signIn, bffUrlGenerator } = useBff()
+  const { signIn, bffUrlGenerator } = useAuth()
   const userInfo = useUserInfo()
   const { postMessage } = useBffBroadcaster()
 

--- a/libs/react-spa/bff/src/lib/bff.hooks.ts
+++ b/libs/react-spa/bff/src/lib/bff.hooks.ts
@@ -8,11 +8,11 @@ import { BffContext, BffContextType } from './BffContext'
 /**
  * This hook is used to get the BFF authentication context.
  */
-export const useBff = () => {
+export const useAuth = () => {
   const bffContext = useContext(BffContext)
 
   if (!bffContext) {
-    throw new Error('useBff must be used within a BffProvider')
+    throw new Error('use must be used within a BffProvider')
   }
 
   return bffContext
@@ -24,7 +24,7 @@ export const useBff = () => {
 export const useDynamicBffHook = <Key extends keyof BffContextType>(
   returnField: Key,
 ): NonNullable<BffContextType[Key]> => {
-  const bffContext = useBff()
+  const bffContext = useAuth()
 
   if (!isDefined(bffContext[returnField])) {
     throw new Error(`The field ${returnField} does not exist in the BffContext`)

--- a/libs/shared/components/src/auth/UserMenu/UserDelegations.tsx
+++ b/libs/shared/components/src/auth/UserMenu/UserDelegations.tsx
@@ -1,6 +1,6 @@
 import { Box, Stack } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
-import { useBff, useUserInfo } from '@island.is/react-spa/bff'
+import { useAuth, useUserInfo } from '@island.is/react-spa/bff'
 import { userMessages } from '@island.is/shared/translations'
 import { UserDropdownItem } from './UserDropdownItem'
 import { UserTopicCard } from './UserTopicCard'
@@ -16,7 +16,7 @@ export const UserDelegations = ({
 }: UserDelegationsProps) => {
   const user = useUserInfo()
   const { formatMessage } = useLocale()
-  const { switchUser } = useBff()
+  const { switchUser } = useAuth()
   const actor = user.profile.actor
 
   return (

--- a/libs/shared/components/src/auth/UserMenu/UserMenu.tsx
+++ b/libs/shared/components/src/auth/UserMenu/UserMenu.tsx
@@ -1,5 +1,5 @@
 import { Box, Hidden } from '@island.is/island-ui/core'
-import { useBff } from '@island.is/react-spa/bff'
+import { useAuth } from '@island.is/react-spa/bff'
 import { useEffect, useState } from 'react'
 import { UserButton } from './UserButton'
 import { UserDropdown } from './UserDropdown'
@@ -29,7 +29,7 @@ export const UserMenu = ({
   const [dropdownState, setDropdownState] = useState<'closed' | 'open'>(
     'closed',
   )
-  const { signOut, switchUser, userInfo: user } = useBff()
+  const { signOut, switchUser, userInfo: user } = useAuth()
 
   const handleClick = () => {
     setDropdownState(dropdownState === 'open' ? 'closed' : 'open')


### PR DESCRIPTION
# Replace useBff with useAuth

## What

Update components to use the new useAuth hook instead of  useBff for authentication context. This change improves  consistency across the codebase and aligns with recent  refactoring efforts to streamline authentication handling.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
