### PR TITLE
feat(web): Global search alias for 'Vinnumálastofnun'

### DIFF
--- a/libs/content-search-toolkit/src/queries/search.ts
+++ b/libs/content-search-toolkit/src/queries/search.ts
@@ -35,6 +35,8 @@ export const searchQuery = (
   // Handle aliases since the search engine has not been configured to support organization aliases
   if (queryString.trim().toLowerCase() === 'tr') {
     queryString = 'Tryggingastofnun'
+  } else if (queryString.trim().toLowerCase() === 'vmst') {
+    queryString = 'Vinnumálastofnun'
   }
 
   // * wildcard support for internal clients - eg. used by island.is app


### PR DESCRIPTION
# Global search alias for 'Vinnumálastofnun'

## What

Similar to what we did for 'TR', now users can search 'VMST' and that'll lead to the same results as typing 'Vinnumálastofnun'


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
