### PR TITLE
fix(react-spa-bff): Enhance broadcaster with subpath handling

### DIFF
--- a/libs/react-spa/bff/src/lib/BffPoller.tsx
+++ b/libs/react-spa/bff/src/lib/BffPoller.tsx
@@ -86,12 +86,21 @@ export const BffPoller = ({
         postMessage({
           type: BffBroadcastEvents.NEW_SESSION,
           userInfo: newUser,
+          bffBasePath: bffUrlGenerator(),
         })
 
         newSessionCb()
       }
     }
-  }, [newUser, error, userInfo, signIn, postMessage, newSessionCb])
+  }, [
+    newUser,
+    error,
+    userInfo,
+    signIn,
+    postMessage,
+    newSessionCb,
+    bffUrlGenerator,
+  ])
 
   return children
 }

--- a/libs/react-spa/bff/src/lib/BffPoller.tsx
+++ b/libs/react-spa/bff/src/lib/BffPoller.tsx
@@ -93,7 +93,7 @@ export const BffPoller = ({
         newSessionCb()
       }
     }
-  }, [newUser, error, userInfo, signIn, postMessage, newSessionCb, bffBasePath])
+  }, [newUser, error, userInfo, signIn, postMessage, newSessionCb, bffBaseUrl])
 
   return children
 }

--- a/libs/react-spa/bff/src/lib/BffPoller.tsx
+++ b/libs/react-spa/bff/src/lib/BffPoller.tsx
@@ -86,21 +86,13 @@ export const BffPoller = ({
         postMessage({
           type: BffBroadcastEvents.NEW_SESSION,
           userInfo: newUser,
-          bffBasePath: bffUrlGenerator(),
+          bffBasePath,
         })
 
         newSessionCb()
       }
     }
-  }, [
-    newUser,
-    error,
-    userInfo,
-    signIn,
-    postMessage,
-    newSessionCb,
-    bffUrlGenerator,
-  ])
+  }, [newUser, error, userInfo, signIn, postMessage, newSessionCb, bffBasePath])
 
   return children
 }

--- a/libs/react-spa/bff/src/lib/BffPoller.tsx
+++ b/libs/react-spa/bff/src/lib/BffPoller.tsx
@@ -46,6 +46,7 @@ export const BffPoller = ({
   const { signIn, bffUrlGenerator } = useAuth()
   const userInfo = useUserInfo()
   const { postMessage } = useBffBroadcaster()
+  const bffBasePath = bffUrlGenerator()
 
   const url = useMemo(
     () => bffUrlGenerator('/user', { refresh: 'true' }),

--- a/libs/react-spa/bff/src/lib/BffPoller.tsx
+++ b/libs/react-spa/bff/src/lib/BffPoller.tsx
@@ -46,7 +46,7 @@ export const BffPoller = ({
   const { signIn, bffUrlGenerator } = useAuth()
   const userInfo = useUserInfo()
   const { postMessage } = useBffBroadcaster()
-  const bffBasePath = bffUrlGenerator()
+  const bffBaseUrl = bffUrlGenerator()
 
   const url = useMemo(
     () => bffUrlGenerator('/user', { refresh: 'true' }),
@@ -87,7 +87,7 @@ export const BffPoller = ({
         postMessage({
           type: BffBroadcastEvents.NEW_SESSION,
           userInfo: newUser,
-          bffBasePath,
+          bffBaseUrl,
         })
 
         newSessionCb()

--- a/libs/react-spa/bff/src/lib/BffProvider.tsx
+++ b/libs/react-spa/bff/src/lib/BffProvider.tsx
@@ -278,7 +278,6 @@ export const BffProvider = ({
         signOut,
         switchUser,
         bffUrlGenerator,
-        applicationBasePath,
       }}
     >
       {renderContent()}

--- a/libs/react-spa/bff/src/lib/BffProvider.tsx
+++ b/libs/react-spa/bff/src/lib/BffProvider.tsx
@@ -43,11 +43,19 @@ export const BffProvider = ({
     authState === 'logging-out'
   const isLoggedIn = authState === 'logged-in'
   const oldLoginPath = `${applicationBasePath}/login`
+  const bffBasePath = bffUrlGenerator()
 
   const { postMessage } = useBffBroadcaster((event) => {
-    // Only act if bff base url matches
-    // Reason: Broadcaster broadcasts to all tabs/windows/iframes on the same origin no matter the subpath, so we need to handle this manually.
-    if (event.data.bffBasePath === bffUrlGenerator()) {
+    /**
+     * Filter broadcast events by matching BFF base path
+     *
+     * Since the Broadcaster sends messages to all tabs/windows/iframes
+     * sharing the same origin (domain), we need to explicitly check if
+     * the message belongs to our specific BFF instance by comparing base paths.
+     * This prevents handling events meant for other applications/contexts
+     * running on the same domain.
+     */
+    if (event.data.bffBasePath === bffBasePath) {
       if (
         isLoggedIn &&
         event.data.type === BffBroadcastEvents.NEW_SESSION &&
@@ -75,10 +83,10 @@ export const BffProvider = ({
       postMessage({
         type: BffBroadcastEvents.NEW_SESSION,
         userInfo: state.userInfo,
-        bffBasePath: bffUrlGenerator(),
+        bffBasePath,
       })
     }
-  }, [postMessage, state.userInfo, isLoggedIn, bffUrlGenerator])
+  }, [postMessage, state.userInfo, isLoggedIn, bffBasePath])
 
   /**
    * Builds authentication query parameters for login redirection:
@@ -180,13 +188,13 @@ export const BffProvider = ({
     // Broadcast to all tabs/windows/iframes that the user is logging out
     postMessage({
       type: BffBroadcastEvents.LOGOUT,
-      bffBasePath: bffUrlGenerator(),
+      bffBasePath,
     })
 
     window.location.href = bffUrlGenerator('/logout', {
       sid: state.userInfo.profile.sid,
     })
-  }, [bffUrlGenerator, postMessage, state.userInfo])
+  }, [bffUrlGenerator, postMessage, state.userInfo, bffBasePath])
 
   const switchUser = useCallback(
     (nationalId?: string) => {

--- a/libs/react-spa/bff/src/lib/BffProvider.tsx
+++ b/libs/react-spa/bff/src/lib/BffProvider.tsx
@@ -43,19 +43,19 @@ export const BffProvider = ({
     authState === 'logging-out'
   const isLoggedIn = authState === 'logged-in'
   const oldLoginPath = `${applicationBasePath}/login`
-  const bffBasePath = bffUrlGenerator()
+  const bffBaseUrl = bffUrlGenerator()
 
   const { postMessage } = useBffBroadcaster((event) => {
     /**
-     * Filter broadcast events by matching BFF base path
+     * Filter broadcast events by matching BFF base url
      *
      * Since the Broadcaster sends messages to all tabs/windows/iframes
      * sharing the same origin (domain), we need to explicitly check if
-     * the message belongs to our specific BFF instance by comparing base paths.
+     * the message belongs to our specific BFF instance by comparing base urls.
      * This prevents handling events meant for other applications/contexts
      * running on the same domain.
      */
-    if (event.data.bffBasePath === bffBasePath) {
+    if (event.data.bffBaseUrl === bffBaseUrl) {
       if (
         isLoggedIn &&
         event.data.type === BffBroadcastEvents.NEW_SESSION &&
@@ -83,10 +83,10 @@ export const BffProvider = ({
       postMessage({
         type: BffBroadcastEvents.NEW_SESSION,
         userInfo: state.userInfo,
-        bffBasePath,
+        bffBaseUrl,
       })
     }
-  }, [postMessage, state.userInfo, isLoggedIn, bffBasePath])
+  }, [postMessage, state.userInfo, isLoggedIn, bffBaseUrl])
 
   /**
    * Builds authentication query parameters for login redirection:
@@ -188,13 +188,13 @@ export const BffProvider = ({
     // Broadcast to all tabs/windows/iframes that the user is logging out
     postMessage({
       type: BffBroadcastEvents.LOGOUT,
-      bffBasePath,
+      bffBaseUrl,
     })
 
     window.location.href = bffUrlGenerator('/logout', {
       sid: state.userInfo.profile.sid,
     })
-  }, [bffUrlGenerator, postMessage, state.userInfo, bffBasePath])
+  }, [bffUrlGenerator, postMessage, state.userInfo, bffBaseUrl])
 
   const switchUser = useCallback(
     (nationalId?: string) => {

--- a/libs/react-spa/bff/src/lib/BffProvider.tsx
+++ b/libs/react-spa/bff/src/lib/BffProvider.tsx
@@ -45,9 +45,9 @@ export const BffProvider = ({
   const oldLoginPath = `${applicationBasePath}/login`
 
   const { postMessage } = useBffBroadcaster((event) => {
-    // Only act if subpath matches application base path.
+    // Only act if bff base url matches
     // Reason: Broadcaster broadcasts to all tabs/windows/iframes on the same origin no matter the subpath, so we need to handle this manually.
-    if (event.data.subpath === applicationBasePath) {
+    if (event.data.bffBasePath === bffUrlGenerator()) {
       if (
         isLoggedIn &&
         event.data.type === BffBroadcastEvents.NEW_SESSION &&
@@ -75,10 +75,10 @@ export const BffProvider = ({
       postMessage({
         type: BffBroadcastEvents.NEW_SESSION,
         userInfo: state.userInfo,
-        subpath: applicationBasePath,
+        bffBasePath: bffUrlGenerator(),
       })
     }
-  }, [postMessage, state.userInfo, isLoggedIn, applicationBasePath])
+  }, [postMessage, state.userInfo, isLoggedIn, bffUrlGenerator])
 
   /**
    * Builds authentication query parameters for login redirection:
@@ -180,6 +180,7 @@ export const BffProvider = ({
     // Broadcast to all tabs/windows/iframes that the user is logging out
     postMessage({
       type: BffBroadcastEvents.LOGOUT,
+      bffBasePath: bffUrlGenerator(),
     })
 
     window.location.href = bffUrlGenerator('/logout', {
@@ -277,6 +278,7 @@ export const BffProvider = ({
         signOut,
         switchUser,
         bffUrlGenerator,
+        applicationBasePath,
       }}
     >
       {renderContent()}

--- a/libs/react-spa/bff/src/lib/bff.hooks.ts
+++ b/libs/react-spa/bff/src/lib/bff.hooks.ts
@@ -64,12 +64,12 @@ export enum BffBroadcastEvents {
 type NewSessionEvent = {
   type: BffBroadcastEvents.NEW_SESSION
   userInfo: BffUser
-  bffBasePath: string
+  bffBaseUrl: string
 }
 
 type LogoutEvent = {
   type: BffBroadcastEvents.LOGOUT
-  bffBasePath: string
+  bffBaseUrl: string
 }
 
 export type BffBroadcastEvent = NewSessionEvent | LogoutEvent

--- a/libs/react-spa/bff/src/lib/bff.hooks.ts
+++ b/libs/react-spa/bff/src/lib/bff.hooks.ts
@@ -64,10 +64,12 @@ export enum BffBroadcastEvents {
 type NewSessionEvent = {
   type: BffBroadcastEvents.NEW_SESSION
   userInfo: BffUser
+  subpath: string
 }
 
 type LogoutEvent = {
   type: BffBroadcastEvents.LOGOUT
+  subpath: string
 }
 
 export type BffBroadcastEvent = NewSessionEvent | LogoutEvent

--- a/libs/react-spa/bff/src/lib/bff.hooks.ts
+++ b/libs/react-spa/bff/src/lib/bff.hooks.ts
@@ -64,12 +64,12 @@ export enum BffBroadcastEvents {
 type NewSessionEvent = {
   type: BffBroadcastEvents.NEW_SESSION
   userInfo: BffUser
-  subpath: string
+  bffBasePath: string
 }
 
 type LogoutEvent = {
   type: BffBroadcastEvents.LOGOUT
-  subpath: string
+  bffBasePath: string
 }
 
 export type BffBroadcastEvent = NewSessionEvent | LogoutEvent


### PR DESCRIPTION
#  Enhance broadcaster with bffBasePath handling

## What

Add subpath to NewSessionEvent and LogoutEvent types.  Update BffProvider to include applicationBasePath in  postMessage dependencies. Modify event handling to  only act on events matching the current subpath, 
ensuring proper session management across multiple  tabs/windows/iframes.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced event handling for session management with additional context for subpaths in session and logout events.
	- Improved message broadcasting to include base path information when a new session starts.
- **Bug Fixes**
	- Improved responsiveness of the component to changes in application base path, ensuring accurate session management across different contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->