### PR TITLE
feat(web): Auto open livechat if query param present

### DIFF
--- a/apps/web/components/ChatPanel/LiveChatIncChatPanel/LiveChatIncChatPanel.tsx
+++ b/apps/web/components/ChatPanel/LiveChatIncChatPanel/LiveChatIncChatPanel.tsx
@@ -38,7 +38,12 @@ export const LiveChatIncChatPanel = ({
   const n = useNamespace(namespace)
 
   useEffect(() => {
-    if (!hasButtonBeenClicked && !showLauncher) {
+    const queryParam = new URLSearchParams(window.location.search).get('wa_lid')
+    if (
+      !hasButtonBeenClicked &&
+      !showLauncher &&
+      !(queryParam && ['t10', 't11'].includes(queryParam))
+    ) {
       return () => {
         // No need for cleanup if we don't initialize widget
       }


### PR DESCRIPTION
# Auto open livechat if query param present

## What

For the IBM Watson web chat we've got a way so that it auto opens if wa_lid=t10|t11 is present in the url. Here we are adding similar functionality for livechat

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced control over the initialization of the chat widget based on specific URL query parameters.
  
- **Bug Fixes**
	- Improved logic to prevent widget initialization under certain conditions, ensuring a more streamlined user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->