### PR TITLE
feat(income-plan): Remove edit function after submission

### DIFF
--- a/libs/application/templates/social-insurance-administration/income-plan/src/fields/Review/index.tsx
+++ b/libs/application/templates/social-insurance-administration/income-plan/src/fields/Review/index.tsx
@@ -126,21 +126,6 @@ export const Review: FC<ReviewScreenProps> = ({
             </Box>
           </Box>
           <Box display="flex" columnGap={2} alignItems="center">
-            {state === `${States.TRYGGINGASTOFNUN_SUBMITTED}` && (
-              <Button
-                colorScheme="default"
-                iconType="filled"
-                size="small"
-                type="button"
-                variant="text"
-                icon="pencil"
-                loading={loadingSubmit}
-                disabled={loadingSubmit}
-                onClick={() => handleSubmit('EDIT')}
-              >
-                {formatMessage(incomePlanFormMessage.confirm.buttonEdit)}
-              </Button>
-            )}
             <Button
               variant="utility"
               icon="print"

--- a/libs/application/templates/social-insurance-administration/income-plan/src/lib/IncomePlanTemplate.ts
+++ b/libs/application/templates/social-insurance-administration/income-plan/src/lib/IncomePlanTemplate.ts
@@ -202,13 +202,6 @@ const IncomePlanTemplate: ApplicationTemplate<
                 import('../forms/InReview').then((val) =>
                   Promise.resolve(val.InReview),
                 ),
-              actions: [
-                {
-                  event: DefaultEvents.EDIT,
-                  name: incomePlanFormMessage.confirm.buttonEdit,
-                  type: 'primary',
-                },
-              ],
               read: 'all',
               write: 'all',
             },
@@ -223,7 +216,6 @@ const IncomePlanTemplate: ApplicationTemplate<
           ],
         },
         on: {
-          [DefaultEvents.EDIT]: { target: States.DRAFT },
           INREVIEW: {
             target: States.TRYGGINGASTOFNUN_IN_REVIEW,
           },

--- a/libs/application/templates/social-insurance-administration/income-plan/src/lib/messages.ts
+++ b/libs/application/templates/social-insurance-administration/income-plan/src/lib/messages.ts
@@ -270,11 +270,6 @@ export const incomePlanFormMessage: MessageDir = {
         'Vinsamlegast farðu yfir tekjuáætlunina áður en þú sendir hana inn.',
       description: 'Please review the application before submitting.',
     },
-    buttonEdit: {
-      id: 'ip.application:button.edit',
-      defaultMessage: 'Breyta tekjuáætlun',
-      description: 'Edit application',
-    },
   }),
 
   conclusionScreen: defineMessages({
@@ -337,9 +332,9 @@ export const statesMessages = defineMessages({
   tryggingastofnunSubmittedContent: {
     id: 'ip.application:tryggingastofnunSubmittedContent',
     defaultMessage:
-      'Tekjuáætlunin þín er í bið eftir yfirferð. Hægt er að breyta tekjuáætlun þar til hún er komin í yfirferð.',
+      'Tekjuáætlunin þín er í bið eftir yfirferð.',
     description:
-      'Your income plan is awaiting review. It is possible to edit the income plan until it is under review.',
+      'Your income plan is awaiting review.',
   },
   incomePlanEdited: {
     id: 'ip.application:incomePlanEdited',

--- a/libs/application/templates/social-insurance-administration/income-plan/src/lib/messages.ts
+++ b/libs/application/templates/social-insurance-administration/income-plan/src/lib/messages.ts
@@ -331,10 +331,8 @@ export const statesMessages = defineMessages({
   },
   tryggingastofnunSubmittedContent: {
     id: 'ip.application:tryggingastofnunSubmittedContent',
-    defaultMessage:
-      'Tekjuáætlunin þín er í bið eftir yfirferð.',
-    description:
-      'Your income plan is awaiting review.',
+    defaultMessage: 'Tekjuáætlunin þín er í bið eftir yfirferð.',
+    description: 'Your income plan is awaiting review.',
   },
   incomePlanEdited: {
     id: 'ip.application:incomePlanEdited',


### PR DESCRIPTION
# Remove edit functionality

## What

Don't allow applicant to edit application after submission

## Why

To simplify the process

## Screenshots / Gifs

Remove this button and edit functionality
<img width="1012" alt="Screenshot 2024-12-16 at 10 56 13" src="https://github.com/user-attachments/assets/71ec8dee-82e3-4747-978f-23a7e617de38" />

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
