### PR TITLE
fix(services-bff): Add missing exp check on the user endpoint

### DIFF
--- a/apps/services/bff/src/app/modules/user/user.service.ts
+++ b/apps/services/bff/src/app/modules/user/user.service.ts
@@ -5,6 +5,7 @@ import { BffUser } from '@island.is/shared/types'
 import { SESSION_COOKIE_NAME } from '../../constants/cookies'
 
 import { ErrorService } from '../../services/error.service'
+import { hasTimestampExpiredInMS } from '../../utils/has-timestamp-expired-in-ms'
 import { CachedTokenResponse } from '../auth/auth.types'
 import { TokenRefreshService } from '../auth/token-refresh.service'
 import { CacheService } from '../cache/cache.service'
@@ -58,7 +59,11 @@ export class UserService {
           false,
         )
 
-      if (cachedTokenResponse && refresh) {
+      if (
+        cachedTokenResponse &&
+        hasTimestampExpiredInMS(cachedTokenResponse.accessTokenExp) &&
+        refresh
+      ) {
         cachedTokenResponse = await this.tokenRefreshService.refreshToken({
           sid,
           encryptedRefreshToken: cachedTokenResponse.encryptedRefreshToken,


### PR DESCRIPTION
# Fix for missing expiration check on the user endpoint

## What

Add a utility function to check if the access token has expired  before attempting to refresh it. This change improves the  efficiency of the token refresh process by ensuring that  refresh operations are only triggered when necessary.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
