### PR TITLE
feat(web): Pension Calculator - Display icon to left of title for 2025 preview

### DIFF
--- a/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculator.css.ts
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculator.css.ts
@@ -46,3 +46,7 @@ export const yearSelectContainer = style({
     md: { width: '204px' },
   }),
 })
+
+export const noWrap = style({
+  flexWrap: 'nowrap',
+})

--- a/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculator.tsx
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculator.tsx
@@ -50,6 +50,7 @@ import {
   GET_ORGANIZATION_PAGE_QUERY,
   GET_ORGANIZATION_QUERY,
 } from '../../queries'
+import { PensionCalculatorTitle } from './PensionCalculatorTitle'
 import { PensionCalculatorWrapper } from './PensionCalculatorWrapper'
 import { translationStrings } from './translationStrings'
 import {
@@ -554,16 +555,12 @@ const PensionCalculator: CustomScreen<PensionCalculatorProps> = ({
             >
               <Box paddingY={5}>
                 <Stack space={3}>
-                  {isNewSystemActive && (
-                    <Text variant={titleVariant} as="h1">
-                      {title} <div>{titlePostfix}</div>
-                    </Text>
-                  )}
-                  {!isNewSystemActive && (
-                    <Text variant={titleVariant} as="h1">
-                      {title} {titlePostfix}
-                    </Text>
-                  )}
+                  <PensionCalculatorTitle
+                    isNewSystemActive={isNewSystemActive}
+                    title={title}
+                    titlePostfix={titlePostfix}
+                    titleVariant={titleVariant}
+                  />
                   <Text>{formatMessage(translationStrings.isTurnedOff)}</Text>
                 </Stack>
               </Box>
@@ -584,16 +581,12 @@ const PensionCalculator: CustomScreen<PensionCalculatorProps> = ({
                     <Stack space={3}>
                       <Stack space={3}>
                         <Box paddingTop={6}>
-                          {isNewSystemActive && (
-                            <Text variant={titleVariant} as="h1">
-                              {title} <div>{titlePostfix}</div>
-                            </Text>
-                          )}
-                          {!isNewSystemActive && (
-                            <Text variant={titleVariant} as="h1">
-                              {title} {titlePostfix}
-                            </Text>
-                          )}
+                          <PensionCalculatorTitle
+                            isNewSystemActive={isNewSystemActive}
+                            title={title}
+                            titlePostfix={titlePostfix}
+                            titleVariant={titleVariant}
+                          />
                         </Box>
                       </Stack>
                       <Box

--- a/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculatorResults.tsx
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculatorResults.tsx
@@ -51,6 +51,7 @@ import {
   GET_ORGANIZATION_QUERY,
 } from '../../queries'
 import { GET_PENSION_CALCULATION } from '../../queries/PensionCalculator'
+import { PensionCalculatorTitle } from './PensionCalculatorTitle'
 import { PensionCalculatorWrapper } from './PensionCalculatorWrapper'
 import { translationStrings } from './translationStrings'
 import {
@@ -361,16 +362,12 @@ const PensionCalculatorResults: CustomScreen<PensionCalculatorResultsProps> = ({
                 >
                   <Box paddingY={5}>
                     <Stack space={3}>
-                      {isNewSystemActive && (
-                        <Text variant={titleVariant} as="h1">
-                          {title} <div>{titlePostfix}</div>
-                        </Text>
-                      )}
-                      {!isNewSystemActive && (
-                        <Text variant={titleVariant} as="h1">
-                          {title} {titlePostfix}
-                        </Text>
-                      )}
+                      <PensionCalculatorTitle
+                        isNewSystemActive={isNewSystemActive}
+                        title={title}
+                        titlePostfix={titlePostfix}
+                        titleVariant={titleVariant}
+                      />
                       <Text>
                         {formatMessage(translationStrings.isTurnedOff)}
                       </Text>
@@ -391,16 +388,12 @@ const PensionCalculatorResults: CustomScreen<PensionCalculatorResultsProps> = ({
                   <Box paddingY={6}>
                     <Stack space={5}>
                       <Stack space={2}>
-                        {isNewSystemActive && (
-                          <Text variant={titleVariant} as="h1">
-                            {title} <div>{titlePostfix}</div>
-                          </Text>
-                        )}
-                        {!isNewSystemActive && (
-                          <Text variant={titleVariant} as="h1">
-                            {title} {titlePostfix}
-                          </Text>
-                        )}
+                        <PensionCalculatorTitle
+                          isNewSystemActive={isNewSystemActive}
+                          title={title}
+                          titlePostfix={titlePostfix}
+                          titleVariant={titleVariant}
+                        />
                         <Box className={styles.textMaxWidth}>
                           <Text>
                             {formatMessage(

--- a/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculatorTitle.tsx
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculatorTitle.tsx
@@ -1,0 +1,45 @@
+import { useIntl } from 'react-intl'
+
+import { GridColumn, GridRow, Text } from '@island.is/island-ui/core'
+
+import { translationStrings } from './translationStrings'
+import * as styles from './PensionCalculator.css'
+
+interface PensionCalculatorTitleProps {
+  isNewSystemActive: boolean
+  title: string
+  titlePostfix: string
+  titleVariant: 'h1' | 'h2'
+}
+
+export const PensionCalculatorTitle = ({
+  isNewSystemActive,
+  title,
+  titlePostfix,
+  titleVariant,
+}: PensionCalculatorTitleProps) => {
+  const { formatMessage } = useIntl()
+  if (isNewSystemActive)
+    return (
+      <GridRow rowGap={3} className={styles.noWrap}>
+        <GridColumn hiddenBelow="lg">
+          <img
+            width={84}
+            height={70}
+            src={formatMessage(translationStrings.after1stSeptember2025IconUrl)}
+            alt=""
+          />
+        </GridColumn>
+        <GridColumn>
+          <Text variant={titleVariant} as="h1">
+            {title} <div>{titlePostfix}</div>
+          </Text>
+        </GridColumn>
+      </GridRow>
+    )
+  return (
+    <Text variant={titleVariant} as="h1">
+      {title} {titlePostfix}
+    </Text>
+  )
+}

--- a/apps/web/screens/Organization/SocialInsuranceAdministration/translationStrings.ts
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/translationStrings.ts
@@ -625,6 +625,13 @@ export const translationStrings = defineMessages({
     defaultMessage: 'Eftir 1. september 2025',
     description: 'Eftir 1. september 2025',
   },
+  after1stSeptember2025IconUrl: {
+    id: 'web.pensionCalculator:after1stSeptember2025IconUrl',
+    defaultMessage:
+      'https://images.ctfassets.net/8k0h54kbe6bj/5RIwKVet87Nm4ycltkzjnX/9c594855a9b2f90dde63766ee87a09ca/58dd40fbf365769d984be22a9b64bc29.png',
+    description:
+      'Mynd vinstra megin við titil "Reiknivél örorku- og endurhæfingargreiðslna eftir 1. september 2025"',
+  },
   after1stSeptember2025Calculate: {
     id: 'web.pensionCalculator:after1stSeptember2025Calculate',
     defaultMessage: 'Reikna',


### PR DESCRIPTION
# Pension Calculator - Display icon to left of title for 2025 preview

## Why

* This was requested by TR (https://tr.is)

## Screenshots / Gifs

![Screenshot 2024-12-16 at 13 50 33](https://github.com/user-attachments/assets/9e0a464e-611b-48b6-a494-8cfb37e8d514)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `PensionCalculatorTitle` component for improved title rendering.
	- Added a new CSS class `noWrap` to enhance layout styling.
	- Expanded localization with a new message for an image URL related to pension calculations.

- **Bug Fixes**
	- Refactored title rendering logic to improve modularity and readability in the `PensionCalculatorResults` component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->