### PR TITLE
feat(app-sys): add tab title option

### DIFF
--- a/libs/application/types/src/lib/Form.ts
+++ b/libs/application/types/src/lib/Form.ts
@@ -110,11 +110,13 @@ export interface Section extends FormItem {
   type: FormItemTypes.SECTION
   children: SectionChildren[]
   draftPageNumber?: number
+  tabTitle?: string
 }
 
 export interface SubSection extends FormItem {
   type: FormItemTypes.SUB_SECTION
   children: FormLeaf[]
+  tabTitle?: string
 }
 
 export interface Repeater extends FormItem {

--- a/libs/application/types/src/lib/Form.ts
+++ b/libs/application/types/src/lib/Form.ts
@@ -110,13 +110,13 @@ export interface Section extends FormItem {
   type: FormItemTypes.SECTION
   children: SectionChildren[]
   draftPageNumber?: number
-  tabTitle?: string
+  tabTitle?: FormTextWithLocale
 }
 
 export interface SubSection extends FormItem {
   type: FormItemTypes.SUB_SECTION
   children: FormLeaf[]
-  tabTitle?: string
+  tabTitle?: FormTextWithLocale
 }
 
 export interface Repeater extends FormItem {

--- a/libs/application/ui-shell/src/hooks/useApplicationTitle.ts
+++ b/libs/application/ui-shell/src/hooks/useApplicationTitle.ts
@@ -32,8 +32,10 @@ export const getApplicationTitle = (
   const titleParts = [`${formName} | Ísland.is`]
 
   if (activeSection) {
+    const tabTitle = activeSection.tabTitle
+    const title = activeSection.title
     const sectionTitle = formatTextWithLocale(
-      activeSection.title,
+      tabTitle || title,
       state.application,
       locale as Locale,
       formatMessage,


### PR DESCRIPTION
## What

Option to set the title in the tab for sections and subsections

## Why

It is possible to have an empty stepper and since the title for the tab is derived from there, this option is needed

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced localization support by adding a new optional property, `tabTitle`, to the `Section` and `SubSection` interfaces.
	- Updated logic for determining the application section title to prioritize `tabTitle` over the existing title property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->