### PR TITLE
chore(web): News card title variant set to H3

### DIFF
--- a/apps/web/components/NewsItems/Item.tsx
+++ b/apps/web/components/NewsItems/Item.tsx
@@ -70,7 +70,7 @@ export const Item = ({
               <Text
                 color={colorVariant === 'blue' ? 'blue600' : undefined}
                 as="h3"
-                variant="h2"
+                variant="h3"
                 title={heading}
               >
                 {heading}


### PR DESCRIPTION
# News card title variant set to H3

## Screenshots / Gifs

### Before

![Screenshot 2024-12-18 at 15 35 09](https://github.com/user-attachments/assets/c9196782-4ceb-4060-a35e-3e3cd8ea14c6)

### After

![Screenshot 2024-12-18 at 15 34 51](https://github.com/user-attachments/assets/2725be13-386b-47eb-9086-a93e14fe980c)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
