### PR TITLE
feat(j-s): Add punishment type tag column in prison cases overview table

### DIFF
--- a/apps/judicial-system/api/src/app/modules/case-list/models/caseList.model.ts
+++ b/apps/judicial-system/api/src/app/modules/case-list/models/caseList.model.ts
@@ -11,6 +11,7 @@ import {
   CourtSessionType,
   IndictmentCaseReviewDecision,
   IndictmentDecision,
+  PunishmentType,
 } from '@island.is/judicial-system/types'
 
 import { Defendant } from '../../defendant'
@@ -142,4 +143,10 @@ export class CaseListEntry {
 
   @Field(() => String, { nullable: true })
   readonly indictmentCompletedDate?: string
+
+  // TEMP: Use with caution! This key will never be populated. 
+  // It was added to bypass table component type checks for a required custom sort key
+  // until we have a resolution on how to handle multiple defendants in the case list
+  @Field(() => PunishmentType, { nullable: true })
+  readonly defendantsPunishmentType?: PunishmentType
 }

--- a/apps/judicial-system/web/messages/Core/tables.ts
+++ b/apps/judicial-system/web/messages/Core/tables.ts
@@ -113,6 +113,11 @@ export const tables = defineMessages({
     defaultMessage: 'Dómstóll',
     description: 'Notaður sem titill fyrir dómstóll dálk í lista yfir mál.',
   },
+  punishmentType: {
+    id: 'judicial.system.core:tables.punishmentType',
+    defaultMessage: 'Refsitegund',
+    description: 'Notaður sem titill fyrir refsitegund dálk í lista yfir mál.',
+  },
   sentencingDate: {
     id: 'judicial.system.core:tables.sentencing_date',
     defaultMessage: 'Dómsuppkvaðning',

--- a/apps/judicial-system/web/src/components/Table/Table.tsx
+++ b/apps/judicial-system/web/src/components/Table/Table.tsx
@@ -180,6 +180,8 @@ const Table: FC<TableProps> = (props) => {
     switch (column) {
       case 'defendants':
         return entry.defendants?.[0]?.name ?? ''
+      case 'defendantsPunishmentType':
+        return entry.defendants?.[0]?.punishmentType ?? ''
       case 'courtCaseNumber':
         return courtAbbreviation
           ? `${courtAbbreviation}: ${entry.courtCaseNumber}`

--- a/apps/judicial-system/web/src/components/Tags/CaseTag.strings.ts
+++ b/apps/judicial-system/web/src/components/Tags/CaseTag.strings.ts
@@ -97,4 +97,29 @@ export const strings = defineMessages({
     defaultMessage: 'Afturkallað',
     description: 'Notað fyrir "Afturkallað" tagg',
   },
+  punishmentTypeImprisonment: {
+    id: 'judicial.system.core:case_tag.punishment_type_imprisonment',
+    defaultMessage: 'Óskb.',
+    description: 'Notað fyrir "Óskilorðsbundið" tagg',
+  },
+  punishmentTypeProbation: {
+    id: 'judicial.system.core:case_tag.punishment_type_probation',
+    defaultMessage: 'Skb.',
+    description: 'Notað fyrir "Skilorðsbundið" tagg',
+  },
+  punishmentTypeFine: {
+    id: 'judicial.system.core:case_tag.punishment_type_fine',
+    defaultMessage: 'Sekt',
+    description: 'Notað fyrir "Sekt" tagg',
+  },
+  punishmentTypeIndictmentRulingDecisionFine: {
+    id: 'judicial.system.core:case_tag.punishment_type_indictment_ruling_decision_fine',
+    defaultMessage: 'VL',
+    description: 'Notað fyrir "Viðurlagaákvörðun" tagg',
+  },
+  punishmentTypeSignedFineInvitation: {
+    id: 'judicial.system.core:case_tag.punishment_type_signed_fine_invitation',
+    defaultMessage: 'ÁS',
+    description: 'Notað fyrir "Áritað sektarboð" tagg',
+  },
 })

--- a/apps/judicial-system/web/src/components/Tags/utils.ts
+++ b/apps/judicial-system/web/src/components/Tags/utils.ts
@@ -2,6 +2,7 @@ import { TagVariant } from '@island.is/island-ui/core'
 import {
   isDistrictCourtUser,
   isPublicProsecutorUser,
+  PunishmentType,
 } from '@island.is/judicial-system/types'
 
 import {
@@ -117,5 +118,36 @@ export const getIndictmentRulingDecisionTag = (
       return { color: 'rose', text: strings.indictmentWithdrawal }
     default:
       return { color: 'darkerBlue', text: strings.complete }
+  }
+}
+
+export const getPunishmentTypeTag = (
+  punishmentType?: PunishmentType | null,
+): {
+  color: TagVariant
+  text: { id: string; defaultMessage: string; description: string }
+} | null => {
+  if (!punishmentType) return null
+
+  const getPunishmentTypeLabel = (punishmentType?: PunishmentType | null) => {
+    switch (punishmentType) {
+      case PunishmentType.IMPRISONMENT:
+        return strings.punishmentTypeImprisonment
+      case PunishmentType.PROBATION:
+        return strings.punishmentTypeProbation
+      case PunishmentType.FINE:
+        return strings.punishmentTypeFine
+      case PunishmentType.INDICTMENT_RULING_DECISION_FINE:
+        return strings.punishmentTypeIndictmentRulingDecisionFine
+      case PunishmentType.SIGNED_FINE_INVITATION:
+        return strings.punishmentTypeSignedFineInvitation
+      default:
+        return strings.unknown 
+    }
+  }
+
+  return {
+    color: 'red' as TagVariant,
+    text: getPunishmentTypeLabel(punishmentType),
   }
 }

--- a/apps/judicial-system/web/src/routes/Shared/Cases/PrisonCases.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/Cases/PrisonCases.tsx
@@ -14,6 +14,7 @@ import {
   titles,
 } from '@island.is/judicial-system-web/messages'
 import {
+  CaseTag,
   Logo,
   PageHeader,
   SectionHeading,
@@ -31,12 +32,14 @@ import {
   getDurationDate,
 } from '@island.is/judicial-system-web/src/components/Table'
 import Table from '@island.is/judicial-system-web/src/components/Table/Table'
+import { getPunishmentTypeTag } from '@island.is/judicial-system-web/src/components/Tags/utils'
 import {
   CaseListEntry,
   CaseState,
   CaseType,
   InstitutionType,
 } from '@island.is/judicial-system-web/src/graphql/schema'
+import { isNonEmptyArray } from '@island.is/judicial-system-web/src/utils/arrayHelpers'
 
 import { usePrisonCasesQuery } from './prisonCases.generated'
 import { cases as m } from './Cases.strings'
@@ -182,6 +185,10 @@ export const PrisonCases: FC = () => {
               title: formatMessage(tables.court),
             },
             {
+              title: formatMessage(tables.punishmentType),
+              sortable: { isSortable: true, key: 'defendants' },
+            },
+            {
               title: capitalize(formatMessage(tables.sentencingDate)),
             },
             { title: formatMessage(tables.state) },
@@ -210,6 +217,20 @@ export const PrisonCases: FC = () => {
             },
             {
               cell: (row) => <ColumnCaseType type={row.type} />,
+            },
+            {
+              cell: (row) => {
+                const punishmentType = isNonEmptyArray(row.defendants)
+                  ? row.defendants[0].punishmentType
+                  : undefined
+                const punishmentTypeTag = getPunishmentTypeTag(punishmentType)
+                return punishmentTypeTag ? (
+                  <CaseTag
+                    color={punishmentTypeTag.color}
+                    text={formatMessage(punishmentTypeTag.text)}
+                  />
+                ) : null
+              },
             },
             {
               cell: (row) => (

--- a/apps/judicial-system/web/src/routes/Shared/Cases/PrisonCases.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/Cases/PrisonCases.tsx
@@ -186,7 +186,7 @@ export const PrisonCases: FC = () => {
             },
             {
               title: formatMessage(tables.punishmentType),
-              sortable: { isSortable: true, key: 'defendants' },
+              sortable: { isSortable: true, key: 'defendantsPunishmentType' },
             },
             {
               title: capitalize(formatMessage(tables.sentencingDate)),

--- a/apps/judicial-system/web/src/routes/Shared/Cases/cases.graphql
+++ b/apps/judicial-system/web/src/routes/Shared/Cases/cases.graphql
@@ -28,6 +28,7 @@ query Cases {
       defenderChoice
       verdictViewDate
       isSentToPrisonAdmin
+      punishmentType
     }
     courtDate
     isValidToDateInThePast

--- a/apps/judicial-system/web/src/routes/Shared/Cases/cases.graphql
+++ b/apps/judicial-system/web/src/routes/Shared/Cases/cases.graphql
@@ -30,6 +30,7 @@ query Cases {
       isSentToPrisonAdmin
       punishmentType
     }
+    defendantsPunishmentType
     courtDate
     isValidToDateInThePast
     initialRulingDate

--- a/apps/judicial-system/web/src/routes/Shared/Cases/prisonCases.graphql
+++ b/apps/judicial-system/web/src/routes/Shared/Cases/prisonCases.graphql
@@ -26,6 +26,7 @@ query PrisonCases {
       name
       noNationalId
       defenderChoice
+      punishmentType
     }
     courtDate
     isValidToDateInThePast

--- a/apps/judicial-system/web/src/utils/arrayHelpers.spec.ts
+++ b/apps/judicial-system/web/src/utils/arrayHelpers.spec.ts
@@ -1,0 +1,45 @@
+import { isEmptyArray, isNonEmptyArray, isPresentArray } from './arrayHelpers'
+
+describe('arrayHelpers', () => {
+  describe('isPresentArray', () => {
+    const testCases = [
+      { input: undefined, expected: false },
+      { input: null, expected: false },
+      { input: [], expected: true },
+      { input: [1], expected: true },
+    ]
+    testCases.forEach(({ input, expected }) => {
+      it(`should return ${expected} for input ${input}`, () => {
+        expect(isPresentArray(input)).toBe(expected)
+      })
+    })
+  })
+
+  describe('isEmptyArray', () => {
+    const testCases = [
+      { input: undefined, expected: false },
+      { input: null, expected: false },
+      { input: [], expected: true },
+      { input: [1], expected: true },
+    ]
+    testCases.forEach(({ input, expected }) => {
+      it(`should return ${expected} for input ${input}`, () => {
+        expect(isEmptyArray(input)).toBe(expected)
+      })
+    })
+  })
+
+  describe('isEmptyArray', () => {
+    const testCases = [
+      { input: undefined, expected: false },
+      { input: null, expected: false },
+      { input: [], expected: false },
+      { input: [1], expected: true },
+    ]
+    testCases.forEach(({ input, expected }) => {
+      it(`should return ${expected} for input ${input}`, () => {
+        expect(isNonEmptyArray(input)).toBe(expected)
+      })
+    })
+  })
+})

--- a/apps/judicial-system/web/src/utils/arrayHelpers.ts
+++ b/apps/judicial-system/web/src/utils/arrayHelpers.ts
@@ -1,0 +1,8 @@
+export const isPresentArray = <T>(arr: T[] | undefined | null): arr is T[] =>
+  arr !== undefined && Array.isArray(arr)
+
+export const isEmptyArray = <T>(arr: T[] | undefined | null): arr is T[] =>
+  isPresentArray(arr) && arr?.length === 0
+
+export const isNonEmptyArray = <T>(arr: T[] | undefined | null): arr is T[] =>
+  isPresentArray(arr) && arr.length > 0


### PR DESCRIPTION
## What
- [Asana task](https://app.asana.com/0/1199153462262248/1208902010654181)
- Render punishment type tag in the prison case table overview representing the added punishment type per case
- Add a sorting functionality for the punishment type
    - Note: Due to the current defendants data structure, we by default sort by the punishment type of the first defendant

## Why
- To give a better overview of the case list by enabling prison admin to group prison cases according to punishment type 

## Screenshots / Gifs
https://github.com/user-attachments/assets/43b67956-ebf2-4ba4-b231-69a8f2362171


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
