### PR TITLE
feat(web): Hotfix - Organization pages, boolean in CMS that'll hide pages from search engines (#17283)

### DIFF
--- a/apps/contentful-apps/pages/fields/admin-only-boolean-field.tsx
+++ b/apps/contentful-apps/pages/fields/admin-only-boolean-field.tsx
@@ -1,0 +1,16 @@
+import { FieldExtensionSDK } from '@contentful/app-sdk'
+import { Paragraph } from '@contentful/f36-components'
+import { BooleanEditor } from '@contentful/field-editor-boolean'
+import { useSDK } from '@contentful/react-apps-toolkit'
+
+const AdminOnlyBooleanField = () => {
+  const sdk = useSDK<FieldExtensionSDK>()
+
+  if (!sdk.user.spaceMembership.admin) {
+    return <Paragraph>(Only admins can edit this field)</Paragraph>
+  }
+
+  return <BooleanEditor field={sdk.field} isInitiallyDisabled={false} />
+}
+
+export default AdminOnlyBooleanField

--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -1168,6 +1168,9 @@ export const OrganizationWrapper: React.FC<
 
   const n = useNamespace(namespace)
 
+  const indexableBySearchEngine =
+    organizationPage.canBeFoundInSearchResults ?? true
+
   return (
     <>
       <HeadWithSocialSharing
@@ -1177,7 +1180,11 @@ export const OrganizationWrapper: React.FC<
         imageContentType={pageFeaturedImage?.contentType}
         imageWidth={pageFeaturedImage?.width?.toString()}
         imageHeight={pageFeaturedImage?.height?.toString()}
-      />
+      >
+        {!indexableBySearchEngine && (
+          <meta name="robots" content="noindex, nofollow" />
+        )}
+      </HeadWithSocialSharing>
       <OrganizationHeader
         organizationPage={organizationPage}
         isSubpage={isSubpage}

--- a/apps/web/screens/queries/Organization.tsx
+++ b/apps/web/screens/queries/Organization.tsx
@@ -127,6 +127,7 @@ export const GET_ORGANIZATION_PAGE_QUERY = gql`
       slug
       title
       description
+      canBeFoundInSearchResults
       topLevelNavigation {
         links {
           label

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -3235,6 +3235,9 @@ export interface IOrganizationPageFields {
 
   /** Sitemap */
   sitemap?: ISitemap | undefined
+
+  /** Can be found in search results */
+  canBeFoundInSearchResults?: boolean | undefined
 }
 
 export interface IOrganizationPage extends Entry<IOrganizationPageFields> {

--- a/libs/cms/src/lib/models/organizationPage.model.ts
+++ b/libs/cms/src/lib/models/organizationPage.model.ts
@@ -86,6 +86,9 @@ export class OrganizationPage {
 
   @CacheField(() => OrganizationPageTopLevelNavigation, { nullable: true })
   topLevelNavigation?: OrganizationPageTopLevelNavigation | null
+
+  @Field(() => Boolean, { nullable: true })
+  canBeFoundInSearchResults?: boolean
 }
 
 export const mapOrganizationPage = ({
@@ -144,5 +147,6 @@ export const mapOrganizationPage = ({
       ? mapImage(fields.defaultHeaderImage)
       : undefined,
     topLevelNavigation,
+    canBeFoundInSearchResults: fields.canBeFoundInSearchResults ?? true,
   }
 }

--- a/libs/cms/src/lib/search/importers/organizationPage.service.ts
+++ b/libs/cms/src/lib/search/importers/organizationPage.service.ts
@@ -15,7 +15,8 @@ export class OrganizationPageSyncService
     return entries.filter(
       (entry: Entry<any>): entry is IOrganizationPage =>
         entry.sys.contentType.sys.id === 'organizationPage' &&
-        !!entry.fields.title,
+        !!entry.fields.title &&
+        (entry.fields.canBeFoundInSearchResults ?? true),
     )
   }
 

--- a/libs/cms/src/lib/search/importers/organizationSubpage.service.ts
+++ b/libs/cms/src/lib/search/importers/organizationSubpage.service.ts
@@ -24,7 +24,10 @@ export class OrganizationSubpageSyncService
         !!entry.fields.slug &&
         !!entry.fields.organizationPage?.fields?.slug &&
         // Standalone organization pages have their own search, we don't want subpages there to be found in the global search
-        entry.fields.organizationPage.fields.theme !== 'standalone',
+        entry.fields.organizationPage.fields.theme !== 'standalone' &&
+        // Subpage should not be searchable if the organization frontpage isn't searchable
+        (entry.fields.organizationPage.fields.canBeFoundInSearchResults ??
+          true),
     )
   }
 


### PR DESCRIPTION
# Hotfix - Organization pages, boolean in CMS that'll hide pages from search engines (#17283)