### PR TITLE
fix(web): RSS feed - Event dates should show single digit for date if it can

### DIFF
--- a/apps/web/pages/api/rss/index.ts
+++ b/apps/web/pages/api/rss/index.ts
@@ -180,7 +180,7 @@ export default async function handler(
       .map((item) => {
         const formattedStartDate = format(
           new Date(item.startDate),
-          'dd. MMMM yyyy',
+          'd. MMMM yyyy',
           {
             locale: localeMap[locale],
           },


### PR DESCRIPTION
# RSS feed - Event dates should show single digit for date if it can

## What

Let's say an event date is the 9th of May.
Then the date in the rss will say "09. May" instead of just "9. May", we want to show just the single digit, hence this PR

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated date formatting for events in the API response to display single-digit days without a leading zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->