### PR TITLE
fix(ids-api): Filter delegated national registry scopes by delegation types.

### DIFF
--- a/apps/services/auth/ids-api/src/app/delegations/test/delegations-scopes.spec.ts
+++ b/apps/services/auth/ids-api/src/app/delegations/test/delegations-scopes.spec.ts
@@ -19,6 +19,7 @@ const domainName = faker.random.word()
 const identityResources = ['id1', 'id2']
 
 const legalGuardianScopes = ['lg1', 'lg2']
+const legalGuardianMinorScopes = ['lgm1', 'lgm2']
 const procurationHolderScopes = ['ph1', 'ph2']
 const customScopes1 = ['cu1', 'cu2']
 const customScopes2 = ['cu3', 'cu4']
@@ -26,6 +27,7 @@ const legalRepresentativeScopes = ['lr1', 'lr2']
 
 const apiScopes = [
   ...legalGuardianScopes,
+  ...legalGuardianMinorScopes,
   ...procurationHolderScopes,
   ...customScopes1,
   ...customScopes2,
@@ -43,6 +45,9 @@ const supportedDelegationTypes = (scopeName: string): AuthDelegationType[] => {
 
   if (legalGuardianScopes.includes(scopeName)) {
     result.push(AuthDelegationType.LegalGuardian)
+  }
+  if (legalGuardianMinorScopes.includes(scopeName)) {
+    result.push(AuthDelegationType.LegalGuardianMinor)
   }
   if (procurationHolderScopes.includes(scopeName)) {
     result.push(AuthDelegationType.ProcurationHolder)
@@ -107,6 +112,18 @@ const testCases: Record<string, TestCase> = {
     fromNationalId: createNationalId('person'),
     delegationType: [AuthDelegationType.LegalRepresentative],
     expected: [...legalRepresentativeScopes, ...identityResources],
+  },
+  '8': {
+    fromNationalId: createNationalId('person'),
+    delegationType: [
+      AuthDelegationType.LegalGuardian,
+      AuthDelegationType.LegalGuardianMinor,
+    ],
+    expected: [
+      ...legalGuardianScopes,
+      ...legalGuardianMinorScopes,
+      ...identityResources,
+    ],
   },
 }
 

--- a/apps/services/auth/public-api/src/app/modules/delegations/actorDelegations.controller.spec.ts
+++ b/apps/services/auth/public-api/src/app/modules/delegations/actorDelegations.controller.spec.ts
@@ -793,7 +793,10 @@ describe('ActorDelegationsController', () => {
               await clientDelegationTypeModel.destroy({
                 where: {
                   clientId: client.clientId,
-                  delegationType: AuthDelegationType.LegalGuardian,
+                  delegationType: [
+                    AuthDelegationType.LegalGuardian,
+                    AuthDelegationType.LegalGuardianMinor,
+                  ],
                 },
               })
 

--- a/libs/services/auth/testing/src/fixtures/fixture-factory.ts
+++ b/libs/services/auth/testing/src/fixtures/fixture-factory.ts
@@ -316,6 +316,7 @@ export class FixtureFactory {
       case AuthDelegationType.Custom:
         return AuthDelegationProvider.Custom
       case AuthDelegationType.LegalGuardian:
+      case AuthDelegationType.LegalGuardianMinor:
         return AuthDelegationProvider.NationalRegistry
       case AuthDelegationType.ProcurationHolder:
         return AuthDelegationProvider.CompanyRegistry


### PR DESCRIPTION
## What

Filter delegated national registry scopes by delegation types in scope check.

## Why

So we grant correct scopes to legal guardians of youths (16-18 year old).

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new scope identifiers for legal guardianship, enhancing API interactions.
	- Added support for a new delegation type, `LegalGuardianMinor`, in delegation logic.
	- Expanded the `getProvider` method to handle the `LegalGuardianMinor` delegation type.
	- Updated the delegation handling logic to consider both `LegalGuardian` and `LegalGuardianMinor`.

- **Bug Fixes**
	- Resolved duplicate import issue in the delegation scope service.

- **Tests**
	- Added new test cases to validate the behavior of the updated delegation types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->