### PR TITLE
fix(j-s): Add case info also to reception and assignment component

### DIFF
--- a/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.tsx
+++ b/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.tsx
@@ -84,7 +84,9 @@ const Defendants: FC<Props> = ({ workingCase }) => {
 
 const Prosecutor: FC<Props> = ({ workingCase }) => {
   const { formatMessage } = useIntl()
-  if (!workingCase.prosecutorsOffice?.name) return null
+  if (!workingCase.prosecutorsOffice?.name) {
+    return null
+  }
 
   return (
     <Entry

--- a/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.tsx
+++ b/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.tsx
@@ -84,8 +84,8 @@ const Defendants: FC<Props> = ({ workingCase }) => {
 
 const Prosecutor: FC<Props> = ({ workingCase }) => {
   const { formatMessage } = useIntl()
-  if (!workingCase.prosecutorsOffice?.name) return null;
-  
+  if (!workingCase.prosecutorsOffice?.name) return null
+
   return (
     <Entry
       label={formatMessage(core.prosecutor)}
@@ -114,9 +114,13 @@ export const ProsecutorCaseInfo: FC<Props & { hideCourt?: boolean }> = ({
   )
 }
 
-export const ProsecutorAndDefendantsEntries: FC<Props> = ({ workingCase }: { workingCase: Case; }) => (
+export const ProsecutorAndDefendantsEntries: FC<Props> = ({
+  workingCase,
+}: {
+  workingCase: Case
+}) => (
   <>
-    <Prosecutor workingCase={workingCase}/>
+    <Prosecutor workingCase={workingCase} />
     <Defendants workingCase={workingCase} />
   </>
 )
@@ -145,7 +149,7 @@ export const CourtCaseInfo: FC<Props> = ({ workingCase }) => {
           </Text>
         </Box>
       ) : (
-        <ProsecutorAndDefendantsEntries workingCase={workingCase}/>
+        <ProsecutorAndDefendantsEntries workingCase={workingCase} />
       )}
     </Box>
   )

--- a/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.tsx
+++ b/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.tsx
@@ -65,7 +65,7 @@ interface Props {
   workingCase: Case
 }
 
-export const Defendants: FC<Props> = ({ workingCase }) => {
+const Defendants: FC<Props> = ({ workingCase }) => {
   const { defendants, type } = workingCase
   const { formatMessage } = useIntl()
 
@@ -82,12 +82,14 @@ export const Defendants: FC<Props> = ({ workingCase }) => {
   )
 }
 
-export const Prosecutor: FC<Props> = ({ workingCase }) => {
+const Prosecutor: FC<Props> = ({ workingCase }) => {
   const { formatMessage } = useIntl()
+  if (!workingCase.prosecutorsOffice?.name) return null;
+  
   return (
     <Entry
       label={formatMessage(core.prosecutor)}
-      value={workingCase.prosecutorsOffice?.name ?? ''}
+      value={workingCase.prosecutorsOffice.name}
     />
   )
 }
@@ -111,6 +113,13 @@ export const ProsecutorCaseInfo: FC<Props & { hideCourt?: boolean }> = ({
     </Box>
   )
 }
+
+export const ProsecutorAndDefendantsEntries: FC<Props> = ({ workingCase }: { workingCase: Case; }) => (
+  <>
+    <Prosecutor workingCase={workingCase}/>
+    <Defendants workingCase={workingCase} />
+  </>
+)
 
 export const CourtCaseInfo: FC<Props> = ({ workingCase }) => {
   const { formatMessage } = useIntl()
@@ -136,15 +145,7 @@ export const CourtCaseInfo: FC<Props> = ({ workingCase }) => {
           </Text>
         </Box>
       ) : (
-        <>
-          {workingCase.prosecutorsOffice?.name && (
-            <Entry
-              label={formatMessage(core.prosecutor)}
-              value={workingCase.prosecutorsOffice.name}
-            />
-          )}
-          <Defendants workingCase={workingCase} />
-        </>
+        <ProsecutorAndDefendantsEntries workingCase={workingCase}/>
       )}
     </Box>
   )

--- a/apps/judicial-system/web/src/routes/Court/Indictments/Summary/Summary.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/Summary/Summary.tsx
@@ -21,10 +21,7 @@ import {
   SectionHeading,
   UserContext,
 } from '@island.is/judicial-system-web/src/components'
-import {
-  Defendants,
-  Prosecutor,
-} from '@island.is/judicial-system-web/src/components/CaseInfo/CaseInfo'
+import { ProsecutorAndDefendantsEntries } from '@island.is/judicial-system-web/src/components/CaseInfo/CaseInfo'
 import {
   CaseFile,
   CaseFileCategory,
@@ -129,8 +126,7 @@ const Summary: FC = () => {
           </Text>
         </Box>
         <Box component="section" marginBottom={2}>
-          <Prosecutor workingCase={workingCase} />
-          <Defendants workingCase={workingCase} />
+          <ProsecutorAndDefendantsEntries workingCase={workingCase} />
         </Box>
         <Box component="section" marginBottom={6}>
           <InfoCardClosedIndictment />

--- a/apps/judicial-system/web/src/routes/Court/components/ReceptionAndAssignment/ReceptionAndAssignment.tsx
+++ b/apps/judicial-system/web/src/routes/Court/components/ReceptionAndAssignment/ReceptionAndAssignment.tsx
@@ -11,6 +11,7 @@ import {
 } from '@island.is/judicial-system/types'
 import { titles } from '@island.is/judicial-system-web/messages'
 import {
+  CourtCaseInfo,
   FormContentContainer,
   FormContext,
   FormFooter,
@@ -112,6 +113,7 @@ const ReceptionAndAssignment = () => {
             </Box>
           )}
         <PageTitle>{formatMessage(strings.title)}</PageTitle>
+        <CourtCaseInfo workingCase={workingCase} />
         <Box component="section" marginBottom={6}>
           <CourtCaseNumber />
         </Box>

--- a/apps/judicial-system/web/src/routes/Shared/Cases/PrisonCases.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/Cases/PrisonCases.tsx
@@ -2,7 +2,7 @@ import { FC, useContext, useMemo } from 'react'
 import { useIntl } from 'react-intl'
 import partition from 'lodash/partition'
 
-import { AlertMessage, Box, Tag, Text } from '@island.is/island-ui/core'
+import { AlertMessage, Box, Text } from '@island.is/island-ui/core'
 import {
   capitalize,
   districtCourtAbbreviation,


### PR DESCRIPTION
## What
- [Asana task](https://app.asana.com/0/1199153462262248/1208824627882909)
- Adding missing headers to reception and judge assignments overview

## Why
- To have helpful information visible and consistent to the registrar/judge 

## Screenshots / Gifs
![Screenshot 2024-12-27 at 16 48 31](https://github.com/user-attachments/assets/faefb8df-a9fc-43c4-b772-50fdd6d02068)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new component, `ProsecutorAndDefendantsEntries`, to streamline the display of prosecutor and defendant information.
	- Added `CourtCaseInfo` component to enhance the `ReceptionAndAssignment` functionality.

- **Bug Fixes**
	- Improved error handling in the `Prosecutor` component with null checks.

- **Refactor**
	- Refactored `Defendants` and `Prosecutor` components to local scope for better encapsulation.
	- Simplified rendering structure in the `Summary` component by consolidating components. 

- **Chores**
	- Removed unused `Tag` component from `PrisonCases.tsx`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->