### PR TITLE
fix(j-s): hide review date field when review date is falsy

### DIFF
--- a/apps/judicial-system/web/src/components/InfoCard/InfoCardClosedIndictment.tsx
+++ b/apps/judicial-system/web/src/components/InfoCard/InfoCardClosedIndictment.tsx
@@ -80,7 +80,7 @@ const InfoCardClosedIndictment: FC<Props> = (props) => {
                   ...(workingCase.indictmentReviewDecision
                     ? [indictmentReviewDecision]
                     : []),
-                  ...(indictmentReviewedDate
+                  ...(reviewedDate
                     ? [indictmentReviewedDate(reviewedDate)]
                     : []),
                 ],

--- a/apps/judicial-system/web/src/components/InfoCard/useInfoCardItems.tsx
+++ b/apps/judicial-system/web/src/components/InfoCard/useInfoCardItems.tsx
@@ -289,7 +289,7 @@ const useInfoCardItems = () => {
     ],
   }
 
-  const indictmentReviewedDate = (date?: string | null): Item => ({
+  const indictmentReviewedDate = (date: string): Item => ({
     id: 'indictment-reviewed-date-item',
     title: formatMessage(strings.indictmentReviewedDateTitle),
     values: [formatDate(date, 'PP')],


### PR DESCRIPTION
## What
- [Asana task](https://app.asana.com/0/1199153462262248/1208837484868039)
- Removing rendering an empty date field when prosecutor is reviewing a case

## Why
- Don't want to render labels with `undefined` value

## Screenshots / Gifs
- First time a prosecutor is reviewing
![Screenshot 2024-12-30 at 13 35 09](https://github.com/user-attachments/assets/9e610f8c-c62b-4200-a586-e658d9933d35)
- After review we see the date 👍 
![Screenshot 2024-12-30 at 13 35 32](https://github.com/user-attachments/assets/fbc7e057-f750-480e-8b8d-f1838a2e66b4)

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
