### PR TITLE
feat(new button in form): Add possibility to render ServicePortal button in form footer

### DIFF
--- a/libs/application/core/src/lib/messages.ts
+++ b/libs/application/core/src/lib/messages.ts
@@ -11,6 +11,11 @@ export const coreMessages = defineMessages({
     defaultMessage: 'Til baka',
     description: 'Back',
   },
+  buttonServicePortal: {
+    id: 'application.system:button.buttonServicePortal',
+    defaultMessage: 'Til baka á mínar síður',
+    description: 'Service portal',
+  },
   buttonSubmit: {
     id: 'application.system:button.submit',
     defaultMessage: 'Senda',

--- a/libs/application/types/src/lib/Form.ts
+++ b/libs/application/types/src/lib/Form.ts
@@ -82,6 +82,7 @@ export interface Form {
   logo?: FormComponent
   mode?: FormModes
   renderLastScreenBackButton?: boolean
+  renderLastScreenServicePortalButton?: boolean
   renderLastScreenButton?: boolean
   title: StaticText
   type: FormItemTypes.FORM

--- a/libs/application/ui-shell/src/components/Screen.tsx
+++ b/libs/application/ui-shell/src/components/Screen.tsx
@@ -74,6 +74,7 @@ type ScreenProps = {
   screen: FormScreen
   renderLastScreenButton?: boolean
   renderLastScreenBackButton?: boolean
+  renderLastScreenServicePortalButton?: boolean
   goToScreen: (id: string) => void
   setUpdateForbidden: (value: boolean) => void
   canGoBack: boolean
@@ -106,6 +107,7 @@ const Screen: FC<React.PropsWithChildren<ScreenProps>> = ({
   currentDraftScreen,
   renderLastScreenButton,
   renderLastScreenBackButton,
+  renderLastScreenServicePortalButton,
   screen,
   sections,
   canGoBack,
@@ -414,6 +416,9 @@ const Screen: FC<React.PropsWithChildren<ScreenProps>> = ({
           application={application}
           renderLastScreenButton={renderLastScreenButton}
           renderLastScreenBackButton={renderLastScreenBackButton}
+          renderLastScreenServicePortalButton={
+            renderLastScreenServicePortalButton
+          }
           activeScreenIndex={activeScreenIndex}
           numberOfScreens={numberOfScreens}
           mode={mode}

--- a/libs/application/ui-shell/src/components/ScreenFooter.tsx
+++ b/libs/application/ui-shell/src/components/ScreenFooter.tsx
@@ -25,6 +25,7 @@ interface FooterProps {
   renderLastScreenButton?: boolean
   shouldLastScreenButtonSubmit?: boolean
   renderLastScreenBackButton?: boolean
+  renderLastScreenServicePortalButton?: boolean
   submitButtonDisabled?: boolean
   nextButtonText?: FormText
   canGoBack: boolean
@@ -67,6 +68,7 @@ export const ScreenFooter: FC<React.PropsWithChildren<FooterProps>> = ({
   submitField,
   renderLastScreenButton,
   renderLastScreenBackButton,
+  renderLastScreenServicePortalButton,
   submitButtonDisabled,
   nextButtonText,
   canGoBack,
@@ -76,6 +78,10 @@ export const ScreenFooter: FC<React.PropsWithChildren<FooterProps>> = ({
   const hasSubmitField = submitField !== undefined
   const isLastScreen = activeScreenIndex === numberOfScreens - 1
   const showGoBack = canGoBack && (!isLastScreen || renderLastScreenBackButton)
+  const showOpenServicePortal =
+    !showGoBack && renderLastScreenServicePortalButton
+
+  const servicePortalUrl = `/minarsidur/umsoknir#${application.id}`
 
   if (
     (isLastScreen && !renderLastScreenButton) ||
@@ -190,6 +196,19 @@ export const ScreenFooter: FC<React.PropsWithChildren<FooterProps>> = ({
                 {formatMessage(coreMessages.buttonBack)}
               </Button>
             )}
+
+            {showOpenServicePortal && (
+              <Button
+                variant="ghost"
+                data-testid="step-back"
+                onClick={() => {
+                  window.open(servicePortalUrl, '_self')
+                }}
+                disabled={!canProceed || loading}
+              >
+                {formatMessage(coreMessages.buttonServicePortal)}
+              </Button>
+            )}
           </Box>
           <Box display={['inlineFlex', 'none']} padding={2} paddingLeft="none">
             {showGoBack && (
@@ -199,6 +218,19 @@ export const ScreenFooter: FC<React.PropsWithChildren<FooterProps>> = ({
                 variant="ghost"
                 icon="arrowBack"
                 onClick={goBack}
+                disabled={!canProceed || loading}
+              />
+            )}
+
+            {showOpenServicePortal && (
+              <Button
+                circle
+                data-testid="step-back"
+                variant="ghost"
+                icon="arrowBack"
+                onClick={() => {
+                  window.open(servicePortalUrl, '_self')
+                }}
                 disabled={!canProceed || loading}
               />
             )}

--- a/libs/application/ui-shell/src/lib/FormShell.tsx
+++ b/libs/application/ui-shell/src/lib/FormShell.tsx
@@ -65,6 +65,7 @@ export const FormShell: FC<
     mode = FormModes.DRAFT,
     renderLastScreenButton,
     renderLastScreenBackButton,
+    renderLastScreenServicePortalButton,
   } = state.form
   const showProgressTag = mode !== FormModes.DRAFT
   const currentScreen = screens[activeScreen]
@@ -150,6 +151,9 @@ export const FormShell: FC<
                   numberOfScreens={screens.length}
                   renderLastScreenButton={renderLastScreenButton}
                   renderLastScreenBackButton={renderLastScreenBackButton}
+                  renderLastScreenServicePortalButton={
+                    renderLastScreenServicePortalButton
+                  }
                   currentDraftScreen={getDraftSectionCurrentScreen()}
                   totalDraftScreens={getDraftSectionTotalScreens()}
                   screen={currentScreen}


### PR DESCRIPTION
## What

In the application SecondarySchool, we have an overview page after application has been submitted to MMS. We need to add a back button on that screen, but since there is no steps to go back to, it should just open minar-sidur. If using the built in buildMessageWithLinkButtonField to display button for minar-sidur, then the page looks weird with both "Breyta umsókn" and this blue box

## Screenshots / Gifs

Before (using buildMessageWithLinkButtonField):

![image](https://github.com/user-attachments/assets/bc04c956-a489-4ce3-b07a-ee3c19064dc7)


After (using renderLastScreenServicePortalButton on form):

![image](https://github.com/user-attachments/assets/0709dbc5-6ce5-4736-b1ee-a01aeff445d3)



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added a service portal button option for the last screen of forms
  - Introduced new configuration to conditionally render a "Back to My Pages" button

- **Improvements**
  - Enhanced form navigation with a new optional service portal button
  - Increased flexibility in screen footer rendering

The update provides users with an additional navigation option, allowing them to easily return to their personal service portal from the last screen of forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->