### PR TITLE
feat(web): Add custom top login button item to VMST "My Pages" page

### DIFF
--- a/apps/web/screens/Organization/DirectorateOfLabour/MyPages.tsx
+++ b/apps/web/screens/Organization/DirectorateOfLabour/MyPages.tsx
@@ -26,6 +26,7 @@ import { useNamespace } from '@island.is/web/hooks'
 import { useI18n } from '@island.is/web/i18n'
 import { withMainLayout } from '@island.is/web/layouts/main'
 import { CustomNextError } from '@island.is/web/units/errors'
+import { extractNamespaceFromOrganization } from '@island.is/web/utils/extractNamespaceFromOrganization'
 import { getOrganizationSidebarNavigationItems } from '@island.is/web/utils/organization'
 import { webRichText } from '@island.is/web/utils/richText'
 
@@ -159,9 +160,14 @@ MyPages.getProps = async ({ apolloClient, locale }) => {
     throw new CustomNextError(404, 'Organization page not found')
   }
 
+  const organizationNamespace = extractNamespaceFromOrganization(
+    getOrganizationPage.organization,
+  )
+
   return {
     organizationPage: getOrganizationPage,
     namespace,
+    customTopLoginButtonItem: organizationNamespace?.customTopLoginButtonItem,
   }
 }
 


### PR DESCRIPTION
# Add custom top login button item to VMST "My Pages" page

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced organization page data retrieval with additional namespace-specific information
	- Added conditional top login button configuration based on organization details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->