### PR TITLE
chore(ids-api): Add secrets for dd rum applicationid and clienttoken.

### DIFF
--- a/apps/services/auth/ids-api/infra/identity-server.ts
+++ b/apps/services/auth/ids-api/infra/identity-server.ts
@@ -108,6 +108,8 @@ export const serviceSetup = (services: {
         '/k8s/identity-server/redaction/USER_IDENTIFIERS_KEY_ID',
       Redaction__UserIdentifiers__Key:
         '/k8s/identity-server/redaction/USER_IDENTIFIERS_KEY',
+      Datadog__RUM__ApplicationId: '/k8s/ids/DD_RUM_APPLICATION_ID',
+      Datadog__RUM__ClientToken: '/k8s/ids/DD_RUM_CLIENT_TOKEN',
     })
     .ingress({
       primary: {

--- a/charts/identity-server/values.dev.yaml
+++ b/charts/identity-server/values.dev.yaml
@@ -191,6 +191,8 @@ identity-server:
     AudkenniSettings__ClientSecret: '/k8s/identity-server/AudkenniClientSecret'
     CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
     ContentfulSettings__AccessToken: '/k8s/identity-server/CONTENTFUL_ACCESS_TOKEN'
+    Datadog__RUM__ApplicationId: '/k8s/ids/DD_RUM_APPLICATION_ID'
+    Datadog__RUM__ClientToken: '/k8s/ids/DD_RUM_CLIENT_TOKEN'
     FeatureFlags__ConfigCatSdkKey: '/k8s/configcat/CONFIGCAT_SDK_KEY'
     IdentityServer__FakePersons: '/k8s/identity-server/FakePersons'
     IdentityServer__LicenseKey: '/k8s/identity-server/LicenseKey'

--- a/charts/identity-server/values.prod.yaml
+++ b/charts/identity-server/values.prod.yaml
@@ -188,6 +188,8 @@ identity-server:
     AudkenniSettings__ClientSecret: '/k8s/identity-server/AudkenniClientSecret'
     CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
     ContentfulSettings__AccessToken: '/k8s/identity-server/CONTENTFUL_ACCESS_TOKEN'
+    Datadog__RUM__ApplicationId: '/k8s/ids/DD_RUM_APPLICATION_ID'
+    Datadog__RUM__ClientToken: '/k8s/ids/DD_RUM_CLIENT_TOKEN'
     FeatureFlags__ConfigCatSdkKey: '/k8s/configcat/CONFIGCAT_SDK_KEY'
     IdentityServer__FakePersons: '/k8s/identity-server/FakePersons'
     IdentityServer__LicenseKey: '/k8s/identity-server/LicenseKey'

--- a/charts/identity-server/values.staging.yaml
+++ b/charts/identity-server/values.staging.yaml
@@ -191,6 +191,8 @@ identity-server:
     AudkenniSettings__ClientSecret: '/k8s/identity-server/AudkenniClientSecret'
     CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
     ContentfulSettings__AccessToken: '/k8s/identity-server/CONTENTFUL_ACCESS_TOKEN'
+    Datadog__RUM__ApplicationId: '/k8s/ids/DD_RUM_APPLICATION_ID'
+    Datadog__RUM__ClientToken: '/k8s/ids/DD_RUM_CLIENT_TOKEN'
     FeatureFlags__ConfigCatSdkKey: '/k8s/configcat/CONFIGCAT_SDK_KEY'
     IdentityServer__FakePersons: '/k8s/identity-server/FakePersons'
     IdentityServer__LicenseKey: '/k8s/identity-server/LicenseKey'

--- a/charts/services/identity-server/values.dev.yaml
+++ b/charts/services/identity-server/values.dev.yaml
@@ -121,6 +121,8 @@ secrets:
   AudkenniSettings__ClientSecret: '/k8s/identity-server/AudkenniClientSecret'
   CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
   ContentfulSettings__AccessToken: '/k8s/identity-server/CONTENTFUL_ACCESS_TOKEN'
+  Datadog__RUM__ApplicationId: '/k8s/ids/DD_RUM_APPLICATION_ID'
+  Datadog__RUM__ClientToken: '/k8s/ids/DD_RUM_CLIENT_TOKEN'
   FeatureFlags__ConfigCatSdkKey: '/k8s/configcat/CONFIGCAT_SDK_KEY'
   IdentityServer__FakePersons: '/k8s/identity-server/FakePersons'
   IdentityServer__LicenseKey: '/k8s/identity-server/LicenseKey'

--- a/charts/services/identity-server/values.prod.yaml
+++ b/charts/services/identity-server/values.prod.yaml
@@ -120,6 +120,8 @@ secrets:
   AudkenniSettings__ClientSecret: '/k8s/identity-server/AudkenniClientSecret'
   CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
   ContentfulSettings__AccessToken: '/k8s/identity-server/CONTENTFUL_ACCESS_TOKEN'
+  Datadog__RUM__ApplicationId: '/k8s/ids/DD_RUM_APPLICATION_ID'
+  Datadog__RUM__ClientToken: '/k8s/ids/DD_RUM_CLIENT_TOKEN'
   FeatureFlags__ConfigCatSdkKey: '/k8s/configcat/CONFIGCAT_SDK_KEY'
   IdentityServer__FakePersons: '/k8s/identity-server/FakePersons'
   IdentityServer__LicenseKey: '/k8s/identity-server/LicenseKey'

--- a/charts/services/identity-server/values.staging.yaml
+++ b/charts/services/identity-server/values.staging.yaml
@@ -121,6 +121,8 @@ secrets:
   AudkenniSettings__ClientSecret: '/k8s/identity-server/AudkenniClientSecret'
   CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
   ContentfulSettings__AccessToken: '/k8s/identity-server/CONTENTFUL_ACCESS_TOKEN'
+  Datadog__RUM__ApplicationId: '/k8s/ids/DD_RUM_APPLICATION_ID'
+  Datadog__RUM__ClientToken: '/k8s/ids/DD_RUM_CLIENT_TOKEN'
   FeatureFlags__ConfigCatSdkKey: '/k8s/configcat/CONFIGCAT_SDK_KEY'
   IdentityServer__FakePersons: '/k8s/identity-server/FakePersons'
   IdentityServer__LicenseKey: '/k8s/identity-server/LicenseKey'


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added Datadog Real User Monitoring (RUM) configuration for the identity server
	- Integrated application ID and client token secrets across development, staging, and production environments

- **Configuration**
	- Updated environment-specific configuration files to support Datadog RUM monitoring
	- Added secret management for RUM tracking identifiers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->