### PR TITLE
fix(my-pages): User Info Line UI 

### DIFF
--- a/libs/portals/my-pages/core/src/components/InfoLine/InfoLine.tsx
+++ b/libs/portals/my-pages/core/src/components/InfoLine/InfoLine.tsx
@@ -65,9 +65,11 @@ export const InfoLine = ({
   loading,
   button,
   tooltip,
-  labelColumnSpan = ['1/1', '5/12', '5/12'],
-  valueColumnSpan = ['1/1', '5/12', '5/12'],
-  buttonColumnSpan = ['1/1', '2/12'],
+  labelColumnSpan = ['1/1', '1/1', '1/1', '5/12'],
+  valueColumnSpan = button
+    ? ['1/1', '6/12', '6/12', '5/12']
+    : ['1/1', '1/1', '1/1', '7/12'],
+  buttonColumnSpan = ['1/1', '6/12', '6/12', '2/12'],
   paddingY = 2,
   paddingBottom,
   warning,
@@ -115,7 +117,7 @@ export const InfoLine = ({
               </Text>
             </Box>
           </GridColumn>
-          <GridColumn order={[3, 2]} span={valueColumnSpan}>
+          <GridColumn order={2} span={valueColumnSpan}>
             <Box
               display="flex"
               alignItems="center"
@@ -141,8 +143,8 @@ export const InfoLine = ({
               )}
             </Box>
           </GridColumn>
-          <GridColumn order={4} span={buttonColumnSpan}>
-            {button && (
+          {button && (
+            <GridColumn order={3} span={buttonColumnSpan}>
               <Box
                 display="flex"
                 justifyContent={['flexStart', 'flexEnd']}
@@ -179,8 +181,8 @@ export const InfoLine = ({
                   </>
                 )}
               </Box>
-            )}
-          </GridColumn>
+            </GridColumn>
+          )}
         </GridRow>
       </Box>
       {divider && <Divider />}

--- a/libs/portals/my-pages/health/src/screens/HealthCenter/HealthCenter.tsx
+++ b/libs/portals/my-pages/health/src/screens/HealthCenter/HealthCenter.tsx
@@ -1,7 +1,6 @@
 import {
   AlertMessage,
   Box,
-  Divider,
   SkeletonLoader,
   Stack,
 } from '@island.is/island-ui/core'
@@ -9,9 +8,10 @@ import { useLocale, useNamespaces } from '@island.is/localization'
 import {
   CardLoader,
   EmptyState,
+  InfoLine,
+  InfoLineStack,
   IntroWrapper,
   SJUKRATRYGGINGAR_SLUG,
-  UserInfoLine,
 } from '@island.is/portals/my-pages/core'
 import { Problem } from '@island.is/react-spa/shared'
 import subYears from 'date-fns/subYears'
@@ -93,42 +93,40 @@ const HealthCenter = () => {
 
       {healthCenterData?.current && (
         <Box width="full" marginTop={[1, 1, 4]}>
-          <Stack space={2}>
-            <UserInfoLine
-              title={formatMessage(messages.myRegistration)}
+          <InfoLineStack
+            space={2}
+            label={formatMessage(messages.myRegistration)}
+          >
+            <InfoLine
               label={formatMessage(messages.healthCenterTitle)}
               content={
                 healthCenterData.current.healthCenterName ??
                 formatMessage(messages.healthCenterNoHealthCenterRegistered)
               }
-              editLink={
+              button={
                 canRegister
                   ? {
-                      url: HealthPaths.HealthCenterRegistration,
-                      title: hm.changeRegistration,
+                      type: 'link',
+                      to: HealthPaths.HealthCenterRegistration,
+                      label: hm.changeRegistration,
                     }
                   : undefined
               }
             />
-            <Divider />
-            <UserInfoLine
+            <InfoLine
               label={formatMessage(messages.personalDoctor)}
               content={
                 healthCenterData.current.doctor ??
                 formatMessage(messages.healthCenterNoDoctor)
               }
             />
-            <Divider />
             {neighborhoodCenter && (
-              <>
-                <UserInfoLine
-                  label={formatMessage(messages.neighborhoodHealthCenter)}
-                  content={neighborhoodCenter}
-                />
-                <Divider />
-              </>
+              <InfoLine
+                label={formatMessage(messages.neighborhoodHealthCenter)}
+                content={neighborhoodCenter}
+              />
             )}
-          </Stack>
+          </InfoLineStack>
         </Box>
       )}
 


### PR DESCRIPTION
# User Info Line UI 

Replace UserInfoLine with InfoLine and InfoLineStack

Change responsiveness for info line 

Ticket: https://www.notion.so/Table-Big-Table-highlight-1265a76701d680cbb9e8fab0b0cc1341?pvs=4

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced layout responsiveness for information display in the Health Center screen
  - Improved component structure for user information presentation

- **Improvements**
  - Replaced `UserInfoLine` with more flexible `InfoLine` component
  - Simplified layout by removing unnecessary dividers
  - Updated navigation and link handling for user information sections

- **Component Updates**
  - Introduced new `InfoLine` and `InfoLineStack` components
  - Refined column span properties for better screen adaptation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->