### PR TITLE
chore(my-pages): Slugify document names

### DIFF
--- a/apps/download-service/src/app/modules/documents/document.controller.ts
+++ b/apps/download-service/src/app/modules/documents/document.controller.ts
@@ -1,4 +1,5 @@
 import type { User } from '@island.is/auth-nest-tools'
+import slugify from '@sindresorhus/slugify'
 import {
   CurrentUser,
   IdsUserGuard,
@@ -60,12 +61,17 @@ export class DocumentController {
 
     const buffer = Buffer.from(rawDocumentDTO.content, 'base64')
 
-    res.header('Content-length', buffer.length.toString())
+    const slugFileName = slugify(rawDocumentDTO.fileName ?? 'postholf-skjal', {
+      customReplacements: [
+        ['Þ', 'th'],
+        ['ö', 'o'],
+      ],
+    })
     res.header(
       'Content-Disposition',
-      `${action === 'download' ? 'attachment' : 'inline'}; filename=${
-        rawDocumentDTO.fileName
-      }.pdf`,
+      `${
+        action === 'download' ? 'attachment' : 'inline'
+      }; filename=${slugFileName}.pdf`,
     )
     res.header('Pragma', 'no-cache')
     res.header('Cache-Control', 'no-cache')


### PR DESCRIPTION
## What

Slugify document names
`"Þetta er nafnið sem hér verður.pdf" = "thetta-er-nafnid-sem-her-verdur.pdf"`

## Why

File names can be of all shapes and sizes. And all kinds of peculiar characters.
We need to unify the pdf names.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved filename generation for document downloads using the `slugify` library
  - Enhanced URL-friendly filename formatting with custom character replacements

- **Bug Fixes**
  - Removed unnecessary `Content-length` header from document downloads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->