### PR TITLE
feat(app-sys): markdown labels for checkboxes and radio

### DIFF
--- a/libs/application/ui-fields/src/lib/CheckboxFormField/CheckboxFormField.tsx
+++ b/libs/application/ui-fields/src/lib/CheckboxFormField/CheckboxFormField.tsx
@@ -17,6 +17,7 @@ import { useLocale } from '@island.is/localization'
 
 import { getDefaultValue } from '../../getDefaultValue'
 import { Locale } from '@island.is/shared/types'
+import { Markdown } from '@island.is/shared/components'
 
 interface Props extends FieldBaseProps {
   field: CheckboxField
@@ -96,7 +97,11 @@ export const CheckboxFormField = ({
           options={finalOptions?.map(
             ({ label, subLabel, rightContent, tooltip, ...o }) => ({
               ...o,
-              label: HtmlParser(formatText(label, application, formatMessage)),
+              label: (
+                <Markdown>
+                  {formatText(label, application, formatMessage)}
+                </Markdown>
+              ),
               rightContent,
               subLabel:
                 subLabel &&

--- a/libs/application/ui-fields/src/lib/RadioFormField/RadioFormField.tsx
+++ b/libs/application/ui-fields/src/lib/RadioFormField/RadioFormField.tsx
@@ -17,6 +17,7 @@ import {
 
 import { getDefaultValue } from '../../getDefaultValue'
 import { Locale } from '@island.is/shared/types'
+import { Markdown } from '@island.is/shared/components'
 
 interface Props extends FieldBaseProps {
   field: RadioField
@@ -105,7 +106,11 @@ export const RadioFormField: FC<React.PropsWithChildren<Props>> = ({
           }
           options={finalOptions.map(({ label, subLabel, tooltip, ...o }) => ({
             ...o,
-            label: HtmlParser(formatText(label, application, formatMessage)),
+            label: (
+              <Markdown>
+                {formatText(label, application, formatMessage)}
+              </Markdown>
+            ),
             subLabel:
               subLabel &&
               HtmlParser(formatText(subLabel, application, formatMessage)),


### PR DESCRIPTION
## What

Ability to have markdown from messages as a label in checkboxes and radio buttons

## Why

Wasn't possible but should be

## Screenshots / Gifs

![Screenshot 2025-01-15 at 12 55 38](https://github.com/user-attachments/assets/83089791-dc54-4ba0-bfbe-41375c93af82)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated form field components to use Markdown rendering for labels
  - Improved text formatting in checkbox and radio form fields

- **Refactor**
  - Replaced HTML parsing with Markdown component for better text rendering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->