### PR TITLE
fix(web): Wrap FormProvider around InputController usage on web

### DIFF
--- a/apps/web/components/connected/HousingBenefitCalculator/HousingBenefitCalculator/HousingBenefitCalculator.tsx
+++ b/apps/web/components/connected/HousingBenefitCalculator/HousingBenefitCalculator/HousingBenefitCalculator.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react'
-import { Controller, useForm } from 'react-hook-form'
+import { Controller, FormProvider, useForm } from 'react-hook-form'
 import { useIntl } from 'react-intl'
 import { useLazyQuery } from '@apollo/client'
 
@@ -48,6 +48,7 @@ const HousingBenefitCalculator = ({ slice }: HousingBenefitCalculatorProps) => {
   const updateInputState = (key: keyof InputState, value: string | number) => {
     setInputState((prevState) => ({ ...prevState, [key]: value }))
   }
+  const methods = useForm()
 
   const { control, getValues } = useForm()
 
@@ -133,7 +134,7 @@ const HousingBenefitCalculator = ({ slice }: HousingBenefitCalculatorProps) => {
   }, [])
 
   return (
-    <Box>
+    <FormProvider {...methods}>
       <Box
         background="blue100"
         paddingY={[3, 3, 5]}
@@ -317,7 +318,7 @@ const HousingBenefitCalculator = ({ slice }: HousingBenefitCalculatorProps) => {
           message={formatMessage(translationStrings.errorOccurredMessage)}
         />
       )}
-    </Box>
+    </FormProvider>
   )
 }
 

--- a/apps/web/components/connected/HousingBenefitCalculator/SpecificHousingBenefitSupportCalculator/SpecificHousingBenefitSupportCalculator.tsx
+++ b/apps/web/components/connected/HousingBenefitCalculator/SpecificHousingBenefitSupportCalculator/SpecificHousingBenefitSupportCalculator.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react'
-import { Controller, useForm } from 'react-hook-form'
+import { Controller, FormProvider, useForm } from 'react-hook-form'
 import { useIntl } from 'react-intl'
 import { useLazyQuery } from '@apollo/client'
 
@@ -14,11 +14,9 @@ import {
 } from '@island.is/island-ui/core'
 import { InputController } from '@island.is/shared/form-fields'
 import {
-  ConnectedComponent,
   GetSpecificHousingBenefitSupportCalculationQuery,
   GetSpecificHousingBenefitSupportCalculationQueryVariables,
 } from '@island.is/web/graphql/schema'
-import { useNamespace } from '@island.is/web/hooks'
 import { GET_SPECIFIC_HOUSING_BENEFIT_SUPPORT_CALCULATION } from '@island.is/web/screens/queries/HousingBenefitCalculator'
 import { formatCurrency } from '@island.is/web/utils/currency'
 
@@ -42,6 +40,7 @@ const SpecificHousingBenefitSupportCalculator = () => {
   const updateInputState = (key: keyof InputState, value: string | number) => {
     setInputState((prevState) => ({ ...prevState, [key]: value }))
   }
+  const methods = useForm()
 
   const { control, getValues } = useForm()
 
@@ -105,7 +104,7 @@ const SpecificHousingBenefitSupportCalculator = () => {
   }, [])
 
   return (
-    <Box>
+    <FormProvider {...methods}>
       <Box
         background="blue100"
         paddingY={[3, 3, 5]}
@@ -226,7 +225,7 @@ const SpecificHousingBenefitSupportCalculator = () => {
           message={formatMessage(translationStrings.errorOccurredMessage)}
         />
       )}
-    </Box>
+    </FormProvider>
   )
 }
 

--- a/apps/web/components/connected/UmbodsmadurSkuldara/UmsCostOfLivingCalculator.tsx
+++ b/apps/web/components/connected/UmbodsmadurSkuldara/UmsCostOfLivingCalculator.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react'
-import { Control, Controller, useForm } from 'react-hook-form'
+import { Control, Controller, FormProvider, useForm } from 'react-hook-form'
 import { useIntl } from 'react-intl'
 import { PropsValue } from 'react-select'
 import { useQuery } from '@apollo/client/react'
@@ -265,7 +265,7 @@ const UmsCostOfLivingCalculator = () => {
   }
 
   return (
-    <Box>
+    <FormProvider {...methods}>
       <Box
         background="blue100"
         paddingY={[3, 3, 6]}
@@ -416,7 +416,7 @@ const UmsCostOfLivingCalculator = () => {
           </Stack>
         )}
       </Box>
-    </Box>
+    </FormProvider>
   )
 }
 


### PR DESCRIPTION
# Wrap FormProvider around InputController usage on web

## What

InputController changes are now causing errors on the web due to it now relying on the form context (which isn't always provided)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced form management in multiple components using React Hook Form's `FormProvider`
	- Improved context handling for form state and validation across nested components
	- Simplified form handling by centralizing form methods and state

- **Technical Improvement**
	- Updated form management approach in Housing Benefit Calculator and Cost of Living Calculator
	- Streamlined form context sharing between parent and child components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->