### PR TITLE
fix(shared): InputController relies on FormContext being provided

### DIFF
--- a/libs/shared/form-fields/src/lib/InputController/InputController.tsx
+++ b/libs/shared/form-fields/src/lib/InputController/InputController.tsx
@@ -99,7 +99,7 @@ export const InputController = forwardRef(
       step,
       clearOnChange,
     } = props
-    const { setValue } = useFormContext()
+    const formContext = useFormContext()
 
     const renderChildInput = (c: ChildParams & TestSupport) => {
       const { value, onChange, ...props } = c
@@ -133,8 +133,8 @@ export const InputController = forwardRef(
               if (onInputChange) {
                 onInputChange(e)
               }
-              if (clearOnChange) {
-                clearInputsOnChange(clearOnChange, setValue)
+              if (clearOnChange && formContext?.setValue) {
+                clearInputsOnChange(clearOnChange, formContext.setValue)
               }
             }}
             onValueChange={({ value }) => {
@@ -176,8 +176,8 @@ export const InputController = forwardRef(
               if (onInputChange) {
                 onInputChange(e)
               }
-              if (clearOnChange) {
-                clearInputsOnChange(clearOnChange, setValue)
+              if (clearOnChange && formContext?.setValue) {
+                clearInputsOnChange(clearOnChange, formContext.setValue)
               }
             }}
             onValueChange={({ value }) => {
@@ -219,8 +219,8 @@ export const InputController = forwardRef(
               if (onInputChange) {
                 onInputChange(e)
               }
-              if (clearOnChange) {
-                clearInputsOnChange(clearOnChange, setValue)
+              if (clearOnChange && formContext?.setValue) {
+                clearInputsOnChange(clearOnChange, formContext.setValue)
               }
             }}
             onValueChange={({ value }) => {
@@ -261,8 +261,8 @@ export const InputController = forwardRef(
               if (onInputChange) {
                 onInputChange(e)
               }
-              if (clearOnChange) {
-                clearInputsOnChange(clearOnChange, setValue)
+              if (clearOnChange && formContext?.setValue) {
+                clearInputsOnChange(clearOnChange, formContext.setValue)
               }
             }}
             rows={rows}


### PR DESCRIPTION
# InputController relies on FormContext being provided

## What

This is causing issues in numerous places since the FormProvider isn't always wrapped around the InputController.

## Why

Instead of having to manually wrap FormProvider around InputControllers in numerous places in the codebase I suggest we instead make it so that the InputController functions even though the FormContext isn't provided (like it used to do).

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated form context handling in input controller
	- Improved error prevention by adding conditional context checks
	- Enhanced robustness of form value setting mechanism

<!-- end of auto-generated comment: release notes by coderabbit.ai -->