### PR TITLE
chore(documents): Allow SVG in HTML sanitation

### DIFF
--- a/libs/clients/documents-v2/src/lib/dto/document.dto.ts
+++ b/libs/clients/documents-v2/src/lib/dto/document.dto.ts
@@ -1,5 +1,6 @@
 import { DocumentDTO, MessageAction } from '../..'
 import sanitizeHtml from 'sanitize-html'
+import { svgAttr, svgTags } from '../../utils/htmlConfig'
 
 const customDocument = {
   senderName: 'Ríkisskattstjóri',
@@ -61,10 +62,14 @@ export const mapToDocument = (
     fileType = 'html'
 
     const html = sanitizeHtml(document.htmlContent, {
-      allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
+      allowedTags: sanitizeHtml.defaults.allowedTags.concat([
+        'img',
+        ...svgTags,
+      ]),
       allowedAttributes: {
         ...sanitizeHtml.defaults.allowedAttributes,
         '*': ['style'],
+        ...svgAttr,
       },
       allowedSchemes: sanitizeHtml.defaults.allowedSchemes.concat([
         'data',

--- a/libs/clients/documents-v2/src/utils/htmlConfig.ts
+++ b/libs/clients/documents-v2/src/utils/htmlConfig.ts
@@ -1,0 +1,58 @@
+// Allowed HTML tags and attributes for SVG.
+
+export const svgTags = [
+  'svg',
+  'g',
+  'path',
+  'circle',
+  'rect',
+  'line',
+  'polyline',
+  'polygon',
+  'ellipse',
+  'text',
+  'tspan',
+  'defs',
+  'use',
+  'symbol',
+  'clipPath',
+  'mask',
+  'filter',
+  'foreignObject',
+]
+
+const svgAttributes = [
+  'width',
+  'height',
+  'x',
+  'y',
+  'viewBox',
+  'fill',
+  'stroke',
+  'stroke-width',
+  'opacity',
+  'transform',
+  'd',
+  'cx',
+  'cy',
+  'r',
+  'rx',
+  'ry',
+  'points',
+  'xlink:href',
+]
+
+export const svgAttr = {
+  svg: svgAttributes,
+  g: svgAttributes,
+  path: svgAttributes,
+  circle: svgAttributes,
+  rect: svgAttributes,
+  line: svgAttributes,
+  polyline: svgAttributes,
+  polygon: svgAttributes,
+  ellipse: svgAttributes,
+  text: svgAttributes,
+  tspan: svgAttributes,
+  use: ['xlink:href'],
+}


### PR DESCRIPTION
## What

Allow SVG in HTML sanitation

## Why

Organizations that send to the inbox, should be allowed to send HTML including SVG.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
