### PR TITLE
fix(j-s): Show sentToPrisonAdmin in FINE cases

### DIFF
--- a/apps/judicial-system/web/src/components/BlueBoxWithIcon/BlueBoxWithDate.tsx
+++ b/apps/judicial-system/web/src/components/BlueBoxWithIcon/BlueBoxWithDate.tsx
@@ -190,14 +190,14 @@ const BlueBoxWithDate: FC<Props> = (props) => {
           }),
         )
       }
+    }
 
-      if (defendant.sentToPrisonAdminDate && defendant.isSentToPrisonAdmin) {
-        texts.push(
-          formatMessage(strings.sendToPrisonAdminDate, {
-            date: formatDate(defendant.sentToPrisonAdminDate),
-          }),
-        )
-      }
+    if (defendant.sentToPrisonAdminDate && defendant.isSentToPrisonAdmin) {
+      texts.push(
+        formatMessage(strings.sendToPrisonAdminDate, {
+          date: formatDate(defendant.sentToPrisonAdminDate),
+        }),
+      )
     }
 
     return texts


### PR DESCRIPTION
# Show sentToPrisonAdmin in FINE cases

[Asana](https://app.asana.com/0/1199153462262248/1209150155925140/f)

## What

In FINE cases that have been sent to prison admin, we should show the sent to prison admin date in the BlueBoxWithDate component. Currently we are only doing so in non fine cases.

## Screenshots / Gifs

<img width="771" alt="Screenshot 2025-01-16 at 15 23 46" src="https://github.com/user-attachments/assets/48c7ee74-19a5-4f5b-bf94-5177d4b63512" />

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
