### PR TITLE
chore(financial-aid): update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -123,10 +123,8 @@ codemagic.yaml                                                                  
 /libs/financial-aid/                                                                                      @island-is/kolibri-robin-hood
 /libs/next-ids-auth/                                                                                      @island-is/kolibri-robin-hood
 /libs/clients/rsk/personal-tax-return                                                                     @island-is/kolibri-robin-hood
-/libs/application/templates/financial-aid/                                                                @island-is/kolibri-robin-hood
 /libs/api/domains/municipalities-financial-aid                                                            @island-is/kolibri-robin-hood
 /libs/clients/municipalities-financial-aid                                                                @island-is/kolibri-robin-hood
-/libs/application/template-api-modules/src/lib/modules/templates/financial-aid                            @island-is/kolibri-robin-hood
 
 /apps/download-service/                                                                                   @island-is/hugsmidjan
 /apps/portals/my-pages*/                                                                                  @island-is/hugsmidjan
@@ -246,6 +244,8 @@ codemagic.yaml                                                                  
 /libs/application/template-api-modules/src/lib/modules/templates/financial-statement-cemetery/            @island-is/norda
 /libs/application/template-api-modules/src/lib/modules/templates/financial-statement-individual-election/ @island-is/norda
 /libs/application/template-api-modules/src/lib/modules/templates/financial-statement-political-party/     @island-is/norda
+/libs/application/templates/financial-aid/                                                                @island-is/norda
+/libs/application/template-api-modules/src/lib/modules/templates/financial-aid                            @island-is/norda
 
 
 /libs/portals/my-pages/applications/                                                                      @island-is/norda-applications


### PR DESCRIPTION
## What

Update financial aid template codeowners to Norda

## Why

Kolibri isn't maintaining it anymore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated code ownership for financial aid templates and modules
	- Transferred responsibility from `@island-is/kolibri-robin-hood` to `@island-is/norda`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->