### PR TITLE
fix(shared): Change type generics for sortAlpha utility function

### DIFF
--- a/apps/web/components/OfficialJournalOfIceland/OJOIUtils.ts
+++ b/apps/web/components/OfficialJournalOfIceland/OJOIUtils.ts
@@ -76,9 +76,7 @@ export const mapEntityToOptions = (
 }
 
 export const sortCategories = (cats: EntityOption[]) => {
-  return cats.sort((a, b) => {
-    return sortAlpha('title')(a, b)
-  })
+  return cats.sort(sortAlpha('label'))
 }
 
 export const formatDate = (date?: string, df = 'dd.MM.yyyy') => {

--- a/libs/shared/utils/src/lib/sortAlpha.ts
+++ b/libs/shared/utils/src/lib/sortAlpha.ts
@@ -10,9 +10,8 @@ const isStringOrNumber = (key: unknown) =>
   ['number', 'string'].includes(typeof key)
 
 export const sortAlpha =
-  <Item, Key extends keyof Item>(_key?: Key) =>
-  (a: Item, b: Item) => {
-    const key = _key ?? ('title' as keyof Item)
+  <Item>(key: keyof Partial<Item>) =>
+  (a: Partial<Item>, b: Partial<Item>) => {
     if (
       !a[key] ||
       !b[key] ||

--- a/libs/shared/utils/src/lib/sortAlpha.ts
+++ b/libs/shared/utils/src/lib/sortAlpha.ts
@@ -10,10 +10,10 @@ const isStringOrNumber = (key: unknown) =>
   ['number', 'string'].includes(typeof key)
 
 export const sortAlpha =
-  <T, K extends keyof T>(key?: K) =>
-  (a: T, b: T) => {
+  <Item, Key extends keyof Item>(_key?: Key) =>
+  (a: Item, b: Item) => {
+    const key = _key ?? ('title' as keyof Item)
     if (
-      !key ||
       !a[key] ||
       !b[key] ||
       !isStringOrNumber(a[key]) ||

--- a/libs/shared/utils/src/lib/sortAlpha.ts
+++ b/libs/shared/utils/src/lib/sortAlpha.ts
@@ -1,7 +1,3 @@
-type Item = {
-  [key: string]: unknown
-}
-
 const order =
   '0123456789aAáÁbBcCdDðÐeEéÉfFgGhHiIíÍjJkKlLmMnNoOóÓpPqQrRsStTuUúÚvVwWxXyYýÝzZþÞæÆöÖ'
 
@@ -14,9 +10,10 @@ const isStringOrNumber = (key: unknown) =>
   ['number', 'string'].includes(typeof key)
 
 export const sortAlpha =
-  <T extends Item>(key = 'title') =>
+  <T, K extends keyof T>(key?: K) =>
   (a: T, b: T) => {
     if (
+      !key ||
       !a[key] ||
       !b[key] ||
       !isStringOrNumber(a[key]) ||


### PR DESCRIPTION
# Change type generics for sortAlpha utility function

## What

* The previous types for the function were both not restricting enough and in some cases didn't work nicely if we were using classes or interfaces for the items passed in (see screenshot below)

## Screenshots


Previous error (which we don't see anymore)

![image](https://github.com/user-attachments/assets/4819465a-9243-49d5-802d-012bf5855e52)

Now we even get autocorrect when typing in the key

![Screenshot 2025-01-17 at 16 03 08](https://github.com/user-attachments/assets/c46cecd7-a52d-43fd-96c7-cdf55ab4a5ce)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated the `sortAlpha` utility function to improve type flexibility.
	- Enhanced function to work with partial objects during sorting.
	- Generalized type parameters to support more dynamic sorting scenarios.
	- Simplified the sorting logic in the `sortCategories` function by directly using `sortAlpha` with the property 'label'.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->