### PR TITLE
fix(j-s): select all when only invalid files are in list

### DIFF
--- a/apps/judicial-system/web/src/components/SelectableList/SelectableList.tsx
+++ b/apps/judicial-system/web/src/components/SelectableList/SelectableList.tsx
@@ -103,6 +103,7 @@ const SelectableList: FC<Props> = (props) => {
     setIsHandlingCTA(false)
   }
 
+  const validSelectableItems = selectableItems.filter((item) => !item.invalid)
   return (
     <>
       <Box
@@ -118,9 +119,8 @@ const SelectableList: FC<Props> = (props) => {
             name="select-all"
             label={formatMessage(strings.selectAllLabel)}
             checked={
-              selectableItems.length > 0 &&
-              // check if all valid selectable items are checked
-              selectableItems
+              validSelectableItems.length > 0 &&
+              validSelectableItems
                 .filter((item) => !item.invalid)
                 .every((item) => item.checked)
             }
@@ -132,7 +132,7 @@ const SelectableList: FC<Props> = (props) => {
                 })),
               )
             }
-            disabled={isHandlingCTA || selectableItems.length === 0}
+            disabled={isHandlingCTA || validSelectableItems.length === 0}
             strong
           />
         </Box>

--- a/apps/judicial-system/web/src/components/SelectableList/SelectableList.tsx
+++ b/apps/judicial-system/web/src/components/SelectableList/SelectableList.tsx
@@ -121,7 +121,6 @@ const SelectableList: FC<Props> = (props) => {
             checked={
               validSelectableItems.length > 0 &&
               validSelectableItems
-                .filter((item) => !item.invalid)
                 .every((item) => item.checked)
             }
             onChange={(evt) =>

--- a/apps/judicial-system/web/src/components/SelectableList/SelectableList.tsx
+++ b/apps/judicial-system/web/src/components/SelectableList/SelectableList.tsx
@@ -120,8 +120,7 @@ const SelectableList: FC<Props> = (props) => {
             label={formatMessage(strings.selectAllLabel)}
             checked={
               validSelectableItems.length > 0 &&
-              validSelectableItems
-                .every((item) => item.checked)
+              validSelectableItems.every((item) => item.checked)
             }
             onChange={(evt) =>
               setSelectableItems((selectableItems) =>


### PR DESCRIPTION
# [Asana task](https://app.asana.com/0/1199153462262248/1209167991158191)

## What
- Fixing a bug when only invalid files are present in the police case files checklist

## Why
- Not expected behaviour to have "select all" enabled when only invalid file items are in the list

## Screenshots / Gifs
Full functionality tested locally on dev data
https://github.com/user-attachments/assets/a929309d-26f6-4215-8cb9-b7382d906fe7


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved logic in the `SelectableList` component by introducing a `validSelectableItems` variable
  - Simplified checkbox selection and disabled state handling
  - Enhanced code clarity and efficiency by centralizing valid item management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->