### PR TITLE
fix(j-s): Fine Sent to Prison Admin Tag

### DIFF
--- a/apps/judicial-system/web/src/routes/PublicProsecutor/Tables/CasesReviewed.tsx
+++ b/apps/judicial-system/web/src/routes/PublicProsecutor/Tables/CasesReviewed.tsx
@@ -63,11 +63,13 @@ const CasesReviewed: FC<Props> = ({ loading, cases }) => {
         row.defendants.some((defendant) => defendant.isSentToPrisonAdmin),
     )
 
-    if (row.indictmentRulingDecision === CaseIndictmentRulingDecision.FINE) {
-      return null
-    } else if (someDefendantIsSentToPrisonAdmin) {
+    if (someDefendantIsSentToPrisonAdmin) {
       variant = 'red'
       message = strings.tagVerdictViewSentToPrisonAdmin
+    } else if (
+      row.indictmentRulingDecision === CaseIndictmentRulingDecision.FINE
+    ) {
+      return null
     } else if (!row.indictmentVerdictViewedByAll) {
       variant = 'red'
       message = strings.tagVerdictUnviewed


### PR DESCRIPTION
# Fine Sent to Prison Admin Tag

[Viðurlagaákvörðun - sést ekki staðan Til fullnustu á málalistanum.](https://app.asana.com/0/1199153462262248/1209150155925142/f)

## What

- Displays the tag "Til fullnustu" when a fine has been sent to the prison admin.

## Why

- Verified bug.

## Screenshots / Gifs

<img width="1471" alt="image" src="https://github.com/user-attachments/assets/76d009c9-54d8-4822-9372-74e69879e7d6" />

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated verdict view tag generation logic to improve case ruling display
  - Refined conditions for rendering verdict tags, particularly for cases involving prison administration and fines

The changes modify how case verdicts are visually represented, ensuring more accurate and context-specific tag rendering for reviewed cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->