### PR TITLE
fix(j-s): Spokesperson Placeholders

### DIFF
--- a/apps/judicial-system/web/src/components/DefenderInfo/DefenderInfo.tsx
+++ b/apps/judicial-system/web/src/components/DefenderInfo/DefenderInfo.tsx
@@ -1,5 +1,5 @@
 import { Dispatch, FC, SetStateAction, useContext, useState } from 'react'
-import { MessageDescriptor, useIntl } from 'react-intl'
+import { useIntl } from 'react-intl'
 
 import { Box, RadioButton, Text, Tooltip } from '@island.is/island-ui/core'
 import {
@@ -119,7 +119,13 @@ const DefenderInfo: FC<Props> = ({ workingCase, setWorkingCase }) => {
       {defenderNotFound && <DefenderNotFound />}
       <BlueBox>
         <InputAdvocate
-          advocateType="defender"
+          advocateType={
+            !isProsecutionUser(user) &&
+            workingCase.sessionArrangements ===
+              SessionArrangements.ALL_PRESENT_SPOKESPERSON
+              ? 'spokesperson'
+              : 'defender'
+          }
           name={workingCase.defenderName}
           email={workingCase.defenderEmail}
           phoneNumber={workingCase.defenderPhoneNumber}

--- a/apps/judicial-system/web/src/components/Table/PastCasesTable/PastCasesTable.tsx
+++ b/apps/judicial-system/web/src/components/Table/PastCasesTable/PastCasesTable.tsx
@@ -1,7 +1,7 @@
 import { FC, useContext, useMemo } from 'react'
 import { useIntl } from 'react-intl'
 
-import { Box, Text } from '@island.is/island-ui/core'
+import { Text } from '@island.is/island-ui/core'
 import { capitalize } from '@island.is/judicial-system/formatters'
 import {
   isDistrictCourtUser,

--- a/apps/judicial-system/web/src/routes/Court/components/ReceptionAndAssignment/ReceptionAndAssignment.tsx
+++ b/apps/judicial-system/web/src/routes/Court/components/ReceptionAndAssignment/ReceptionAndAssignment.tsx
@@ -11,7 +11,6 @@ import {
 } from '@island.is/judicial-system/types'
 import { titles } from '@island.is/judicial-system-web/messages'
 import {
-  CourtCaseInfo,
   FormContentContainer,
   FormContext,
   FormFooter,


### PR DESCRIPTION
# Spokesperson Placeholders

[Label fyrir talsmann}(https://app.asana.com/0/1199153462262248/1209152827462334/f)

## What

- Fixes spokesperson placeholders.
- Note that in the proseution flow, the defendant representative is always called a defender (verjandi) and that was not changed.

## Why

- Verified bug.

## Screenshots / Gifs

<img width="792" alt="image" src="https://github.com/user-attachments/assets/a4f04380-3f65-48e0-a6fc-80f959ac41eb" />

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated advocate type selection logic in the `DefenderInfo` component based on user role and session arrangements
  - Removed unused `Box` component from `PastCasesTable`
  - Removed unused `CourtCaseInfo` import from `ReceptionAndAssignment` component

- **Code Cleanup**
  - Removed unnecessary `MessageDescriptor` import

These changes appear to be minor optimizations and code cleanup across different components of the judicial system web application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->