### PR TITLE
fix(web): Overview Links - Set max height on image for mobile screen

### DIFF
--- a/apps/web/components/Organization/Slice/OverviewLinks/OverviewLinks.css.ts
+++ b/apps/web/components/Organization/Slice/OverviewLinks/OverviewLinks.css.ts
@@ -1,0 +1,14 @@
+import { style } from '@vanilla-extract/css'
+
+import { themeUtils } from '@island.is/island-ui/theme'
+
+export const image = style({
+  ...themeUtils.responsiveStyle({
+    xs: {
+      maxHeight: '150px',
+    },
+    sm: {
+      maxHeight: 'unset',
+    },
+  }),
+})

--- a/apps/web/components/Organization/Slice/OverviewLinks/OverviewLinks.tsx
+++ b/apps/web/components/Organization/Slice/OverviewLinks/OverviewLinks.tsx
@@ -8,6 +8,7 @@ import {
   GridColumn,
   GridContainer,
   GridRow,
+  Hyphen,
   Link,
   Stack,
   Text,
@@ -21,6 +22,8 @@ import {
 } from '@island.is/web/graphql/schema'
 import { LinkType, useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
 import { webRichText } from '@island.is/web/utils/richText'
+
+import * as styles from './OverviewLinks.css'
 
 interface SliceProps {
   slice: OverviewLinks
@@ -37,7 +40,7 @@ const IntroLinkImageComponent = ({
 }: IntroLinkImageComponentProps) => {
   const { linkResolver } = useLinkResolver()
   return (
-    <GridRow direction={leftImage ? 'row' : 'rowReverse'}>
+    <GridRow direction={leftImage ? 'row' : 'rowReverse'} rowGap={1}>
       {image?.url && (
         <GridColumn span={['8/8', '3/8', '4/8', '3/8']}>
           <Box
@@ -46,7 +49,11 @@ const IntroLinkImageComponent = ({
             paddingLeft={leftImage ? undefined : [0, 0, 0, 0, 6]}
             paddingRight={leftImage ? [10, 0, 0, 0, 6] : [10, 0]}
           >
-            <img src={`${image.url}?w=774&fm=webp&q=80`} alt="" />
+            <img
+              className={styles.image}
+              src={`${image.url}?w=774&fm=webp&q=80`}
+              alt=""
+            />
           </Box>
         </GridColumn>
       )}
@@ -64,7 +71,7 @@ const IntroLinkImageComponent = ({
               marginBottom={2}
               id={'sliceTitle-' + slice.id}
             >
-              {title}
+              {!leftImage ? <Hyphen>{title}</Hyphen> : title}
             </Text>
             {Boolean(intro) && (
               <Box marginBottom={4}>


### PR DESCRIPTION
# Overview Links - Set max height on image for mobile screen

* max-height set to 150px for mobile screens
* Add a bit of spacing between image and title
* Make title wrap if the image is not on the left

## Screenshots / Gifs

### Before

![Screenshot 2025-01-21 at 10 22 07](https://github.com/user-attachments/assets/52a72c87-8cf4-4c96-aa2a-6ed152e8132c)

### After

![Screenshot 2025-01-21 at 10 22 39](https://github.com/user-attachments/assets/99adc939-04ae-4759-ac52-d9e4886f9b94)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Added responsive image styling with max height adjustments for different screen sizes
  - Enhanced layout control with row gap in grid component

- **New Features**
  - Introduced conditional title wrapping with Hyphen component based on image position

- **Improvements**
  - Updated image rendering with new CSS module styles

<!-- end of auto-generated comment: release notes by coderabbit.ai -->