### PR TITLE
fix(vehicles): Reset page nr on input input

### DIFF
--- a/libs/portals/my-pages/assets/src/screens/VehicleBulkMileage/VehicleBulkMileage.tsx
+++ b/libs/portals/my-pages/assets/src/screens/VehicleBulkMileage/VehicleBulkMileage.tsx
@@ -187,6 +187,9 @@ const VehicleBulkMileage = () => {
                     backgroundColor="blue"
                     value={search ?? ''}
                     onChange={(search) => {
+                      if (page !== 1) {
+                        setPage(1)
+                      }
                       setSearch(search)
                     }}
                     name={formatMessage(m.searchLabel)}


### PR DESCRIPTION
## What

Set page number on pagination to 1 on input change.

## Why

You do not want to search with input page 2 when searching in your initial search!

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
