### PR TITLE
fix(web): Prevent Organizationpage.menuLinks field from containing null primary links

### DIFF
--- a/libs/cms/src/lib/models/organizationPage.model.ts
+++ b/libs/cms/src/lib/models/organizationPage.model.ts
@@ -128,7 +128,9 @@ export const mapOrganizationPage = ({
       .map(safelyMapSliceUnion)
       .filter(Boolean),
     secondaryNewsTags: (fields.secondaryNewsTags ?? []).map(mapGenericTag),
-    menuLinks: (fields.menuLinks ?? []).map(mapLinkGroup),
+    menuLinks: (fields.menuLinks ?? [])
+      .map(mapLinkGroup)
+      .filter((linkGroup) => Boolean(linkGroup?.primaryLink)),
     secondaryMenu: fields.secondaryMenu
       ? mapLinkGroup(fields.secondaryMenu)
       : null,


### PR DESCRIPTION
# Prevent Organizationpage.menuLinks field from containing null primary links

## What

* If a page that is referenced in a menu link is archived then we see an empty div on the web
* To prevent this I suggest we filter out any null values

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved menu link filtering to ensure only valid link groups are displayed
  - Removed empty or incomplete menu link groups from the organization page navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->