### PR TITLE
chore(web): Generic List - Remove result count and page number text

### DIFF
--- a/apps/web/components/GenericList/GenericList.tsx
+++ b/apps/web/components/GenericList/GenericList.tsx
@@ -25,7 +25,6 @@ import {
   Text,
 } from '@island.is/island-ui/core'
 import { theme } from '@island.is/island-ui/theme'
-import { Locale } from '@island.is/shared/types'
 import { NewsCard } from '@island.is/web/components'
 import {
   GenericListItem,
@@ -52,25 +51,6 @@ import * as styles from './GenericList.css'
 
 const DEBOUNCE_TIME_IN_MS = 300
 const ITEMS_PER_PAGE = 10
-
-const getResultsFoundText = (totalItems: number, locale: Locale) => {
-  const singular = locale === 'is' ? 'niðurstaða fannst' : 'result found'
-  const plural = locale === 'is' ? 'niðurstöður fundust' : 'results found'
-
-  if (locale !== 'is') {
-    if (totalItems === 1) {
-      return singular
-    }
-    return plural
-  }
-
-  // Handle Icelandic locale specifically
-  if (totalItems % 10 === 1 && totalItems % 100 !== 11) {
-    return singular
-  }
-
-  return plural
-}
 
 interface ItemProps {
   item: GenericListItem
@@ -332,10 +312,6 @@ export const GenericList = ({
   const noResultsFoundText =
     activeLocale === 'is' ? 'Engar niðurstöður fundust' : 'No results found'
 
-  const resultsFoundText = getResultsFoundText(totalItems, activeLocale)
-
-  const totalPages = Math.ceil(totalItems / ITEMS_PER_PAGE)
-
   const filterInputComponent = (
     <FilterInput
       name="list-search"
@@ -553,23 +529,7 @@ export const GenericList = ({
           {totalItems === 0 && !displayError && !loading && (
             <Text>{noResultsFoundText}</Text>
           )}
-          {totalItems > 0 && (
-            <Stack space={3}>
-              <Inline space={2} justifyContent="spaceBetween" alignY="center">
-                <Text>
-                  {totalItems} {resultsFoundText}
-                </Text>
-                {totalPages > 1 && (
-                  <Text>
-                    {activeLocale === 'is' ? 'Síða' : 'Page'} {page ?? 1}{' '}
-                    {activeLocale === 'is' ? 'af' : 'of'} {totalPages}
-                  </Text>
-                )}
-              </Inline>
-              {children}
-            </Stack>
-          )}
-
+          {totalItems > 0 && children}
           {totalItems > ITEMS_PER_PAGE && (
             <Pagination
               page={page ?? 1}


### PR DESCRIPTION
# Generic List - Remove result count and page number text

## Screenshots / Gifs

### Before

![Screenshot 2025-01-22 at 10 48 27](https://github.com/user-attachments/assets/f4a391f9-b22e-4225-85c3-b913dfad814e)

### After

![Screenshot 2025-01-22 at 10 49 05](https://github.com/user-attachments/assets/4b47d395-43c1-446f-8d1a-4bd68a0f8dec)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified `GenericList` component by removing results found text and pagination display logic
	- Streamlined rendering to focus on displaying children when items are present
	- Removed custom text generation for result counts in different locales

<!-- end of auto-generated comment: release notes by coderabbit.ai -->