### PR TITLE
fix(web): Organization header - Remove namespace check for whether the subpage header should be smaller

### DIFF
--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -214,7 +214,7 @@ export const getThemeConfig = (
 
 export const OrganizationHeader: React.FC<
   React.PropsWithChildren<HeaderProps>
-> = ({ organizationPage, isSubpage }) => {
+> = ({ organizationPage, isSubpage = false }) => {
   const { linkResolver } = useLinkResolver()
   const namespace = useMemo(
     () => JSON.parse(organizationPage?.organization?.namespace?.fields || '{}'),
@@ -264,7 +264,7 @@ export const OrganizationHeader: React.FC<
     titleSectionPaddingLeft: organizationPage.themeProperties
       .titleSectionPaddingLeft as ResponsiveSpace,
     mobileBackground: organizationPage.themeProperties.mobileBackgroundColor,
-    isSubpage: isSubpage && n('smallerSubpageHeader', false),
+    isSubpage,
   }
 
   switch (organizationPage.theme) {
@@ -273,7 +273,7 @@ export const OrganizationHeader: React.FC<
         <SyslumennDefaultHeader
           organizationPage={organizationPage}
           logoAltText={logoAltText}
-          isSubpage={(isSubpage && n('smallerSubpageHeader', false)) ?? false}
+          isSubpage={isSubpage}
         />
       ) : (
         <SyslumennHeader
@@ -286,7 +286,7 @@ export const OrganizationHeader: React.FC<
         <SjukratryggingarDefaultHeader
           organizationPage={organizationPage}
           logoAltText={logoAltText}
-          isSubpage={(isSubpage && n('smallerSubpageHeader', false)) ?? false}
+          isSubpage={isSubpage}
         />
       ) : (
         <SjukratryggingarHeader
@@ -370,7 +370,7 @@ export const OrganizationHeader: React.FC<
         <FiskistofaDefaultHeader
           organizationPage={organizationPage}
           logoAltText={logoAltText}
-          isSubpage={(isSubpage && n('smallerSubpageHeader', false)) ?? false}
+          isSubpage={isSubpage}
         />
       ) : (
         <FiskistofaHeader


### PR DESCRIPTION
# Organization header - Remove namespace check for whether the subpage header should be smaller

## What

* Remove unneeded namespace check for deciding if the subpage header should be smaller

## Why

* We want this to be the new default (that subpage headers are smaller)

## Screenshots / Gifs

### Frontpage header

![Screenshot 2025-01-22 at 12 39 49](https://github.com/user-attachments/assets/6f7d45d2-9feb-46b9-be2e-6dd574dae58d)

### Subpage header

![Screenshot 2025-01-22 at 12 40 13](https://github.com/user-attachments/assets/ab27060d-5810-4d58-837a-97130540292b)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified prop handling in the `OrganizationHeader` component
	- Updated default behavior for `isSubpage` prop
	- Streamlined component logic for better code clarity

The changes improve the component's prop management, making the code more straightforward and easier to understand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->