### PR TITLE
feat(web): Events, toggle for showing past events

### DIFF
--- a/apps/web/screens/queries/Organization.tsx
+++ b/apps/web/screens/queries/Organization.tsx
@@ -128,6 +128,7 @@ export const GET_ORGANIZATION_PAGE_QUERY = gql`
       title
       description
       canBeFoundInSearchResults
+      showPastEventsOption
       topLevelNavigation {
         links {
           label

--- a/libs/cms/src/lib/cms.elasticsearch.service.ts
+++ b/libs/cms/src/lib/cms.elasticsearch.service.ts
@@ -167,7 +167,7 @@ export class CmsElasticsearchService {
 
   async getEvents(
     index: string,
-    { size, page, order, organization }: GetEventsInput,
+    { size, page, order, organization, includePastEvents }: GetEventsInput,
   ) {
     const tagList: {
       key: string
@@ -193,9 +193,13 @@ export class CmsElasticsearchService {
       ...tagQuery,
       page,
       size,
-      releaseDate: {
-        from: 'now',
-      },
+      ...(!includePastEvents
+        ? {
+            releaseDate: {
+              from: 'now',
+            },
+          }
+        : {}),
     }
 
     const eventsResponse = await this.elasticService.getDocumentsByMetaData(

--- a/libs/cms/src/lib/dto/getEvents.input.ts
+++ b/libs/cms/src/lib/dto/getEvents.input.ts
@@ -27,4 +27,8 @@ export class GetEventsInput {
   @Field(() => String, { nullable: true })
   @IsOptional()
   organization?: string
+
+  @Field(() => Boolean, { nullable: true })
+  @IsOptional()
+  includePastEvents?: boolean
 }

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -3330,6 +3330,9 @@ export interface IOrganizationPageFields {
 
   /** Can be found in search results */
   canBeFoundInSearchResults?: boolean | undefined
+
+  /** Show past events option */
+  showPastEventsOption?: boolean | undefined
 }
 
 export interface IOrganizationPage extends Entry<IOrganizationPageFields> {

--- a/libs/cms/src/lib/models/organizationPage.model.ts
+++ b/libs/cms/src/lib/models/organizationPage.model.ts
@@ -89,6 +89,9 @@ export class OrganizationPage {
 
   @Field(() => Boolean, { nullable: true })
   canBeFoundInSearchResults?: boolean
+
+  @Field(() => Boolean, { nullable: true })
+  showPastEventsOption?: boolean
 }
 
 export const mapOrganizationPage = ({
@@ -150,5 +153,6 @@ export const mapOrganizationPage = ({
       : undefined,
     topLevelNavigation,
     canBeFoundInSearchResults: fields.canBeFoundInSearchResults ?? true,
+    showPastEventsOption: fields.showPastEventsOption ?? false,
   }
 }


### PR DESCRIPTION
# Events, toggle for showing past events

## What

* Boolean field in CMS that chooses whether the toggle option is shown on the web
* If toggled then we show all events (in descending order)

## Why

* Previously there was no way to see all events (only upcoming events)

## Screenshots / Gifs

### Before

![Screenshot 2025-01-23 at 13 03 31](https://github.com/user-attachments/assets/d952c5f5-49d6-4f2f-8d11-c7e8765840bd)

### After

![Screenshot 2025-01-23 at 13 04 07](https://github.com/user-attachments/assets/29bfa82c-6e1b-41d8-b77a-60f63dbf311a)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added option to toggle visibility of past events in organization event lists
  - Introduced a switch to filter events based on their past/future status

- **Improvements**
  - Enhanced event listing functionality with more flexible filtering
  - Updated server and client-side logic to support past event display preferences

- **Technical Updates**
  - Expanded GraphQL query to include past events configuration option
  - Modified event retrieval methods to support dynamic event filtering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->