### PR TITLE
fix(web): DefaultHeader - Stop using useEffect for mobile width check

### DIFF
--- a/apps/web/components/DefaultHeader/DefaultHeader.tsx
+++ b/apps/web/components/DefaultHeader/DefaultHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import cn from 'classnames'
 
 import {
@@ -66,11 +66,7 @@ export const DefaultHeader: React.FC<
   const logoProvided = !!logo
   const LinkWrapper = logoHref ? Link : Box
 
-  const [isMobile, setIsMobile] = useState(false)
-
-  useEffect(() => {
-    setIsMobile(width < theme.breakpoints.lg)
-  }, [width])
+  const isMobile = width < theme.breakpoints.lg
 
   return (
     <>


### PR DESCRIPTION
# DefaultHeader - Stop using useEffect for mobile width check

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified mobile detection logic in the header component
  - Removed unnecessary state management for viewport size
  - Improved component performance by directly computing mobile state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->