### PR TITLE
fix(j-s): Contentful Keys

### DIFF
--- a/apps/judicial-system/web/src/components/Inputs/InputAdvocate.strings.ts
+++ b/apps/judicial-system/web/src/components/Inputs/InputAdvocate.strings.ts
@@ -2,22 +2,22 @@ import { defineMessages } from 'react-intl'
 
 export const nameLabelStrings = defineMessages({
   defender: {
-    id: 'judicial.system.core:lawyer_input.defender',
+    id: 'judicial.system.core:input_advocate.name_label.defender',
     defaultMessage: 'Nafn verjanda',
     description: 'Notaður sem titill á nafni fyrir verjanda.',
   },
   spokesperson: {
-    id: 'judicial.system.core:lawyer_input.spokesperson',
+    id: 'judicial.system.core:input_advocate.name_label.spokesperson',
     defaultMessage: 'Nafn talsmanns',
     description: 'Notaður sem titill á nafni fyrir talsmann.',
   },
   lawyer: {
-    id: 'judicial.system.core:lawyer_input.lawyer',
+    id: 'judicial.system.core:input_advocate.name_label.lawyer',
     defaultMessage: 'Nafn lögmanns',
     description: 'Notaður sem titill á nafni fyrir lögmann.',
   },
   legalRightsProtector: {
-    id: 'judicial.system.core:lawyer_input.legal_rights_protector',
+    id: 'judicial.system.core:input_advocate.name_label.legal_rights_protector',
     defaultMessage: 'Nafn réttargæslumanns',
     description: 'Notaður sem titill á nafni fyrir réttargæslumann.',
   },
@@ -25,22 +25,22 @@ export const nameLabelStrings = defineMessages({
 
 export const emailLabelStrings = defineMessages({
   defender: {
-    id: 'judicial.system.core:lawyer_input.defender',
+    id: 'judicial.system.core:input_advocate.email_label.defender',
     defaultMessage: 'Netfang verjanda',
     description: 'Notaður sem titill á netfangi fyrir verjanda.',
   },
   spokesperson: {
-    id: 'judicial.system.core:lawyer_input.spokesperson',
+    id: 'judicial.system.core:input_advocate.email_label.spokesperson',
     defaultMessage: 'Netfang talsmanns',
     description: 'Notaður sem titill á netfangi fyrir talsmann.',
   },
   lawyer: {
-    id: 'judicial.system.core:lawyer_input.lawyer',
+    id: 'judicial.system.core:input_advocate.email_label.lawyer',
     defaultMessage: 'Netfang lögmanns',
     description: 'Notaður sem titill á netfangi fyrir lögmann.',
   },
   legalRightsProtector: {
-    id: 'judicial.system.core:lawyer_input.legal_rights_protector',
+    id: 'judicial.system.core:input_advocate.email_label.legal_rights_protector',
     defaultMessage: 'Netfang réttargæslumanns',
     description: 'Notaður sem titill á netfangi fyrir réttargæslumann.',
   },
@@ -48,22 +48,22 @@ export const emailLabelStrings = defineMessages({
 
 export const phoneNumberLabelStrings = defineMessages({
   defender: {
-    id: 'judicial.system.core:lawyer_input.defender',
+    id: 'judicial.system.core:input_advocate.phone_number_label.defender',
     defaultMessage: 'Símanúmer verjanda',
     description: 'Notaður sem titill á símanúmeri fyrir verjanda.',
   },
   spokesperson: {
-    id: 'judicial.system.core:lawyer_input.spokesperson',
+    id: 'judicial.system.core:input_advocate.phone_number_label.spokesperson',
     defaultMessage: 'Símanúmer talsmanns',
     description: 'Notaður sem titill á símanúmeri fyrir talsmann.',
   },
   lawyer: {
-    id: 'judicial.system.core:lawyer_input.lawyer',
+    id: 'judicial.system.core:input_advocate.phone_number_label.lawyer',
     defaultMessage: 'Símanúmer lögmanns',
     description: 'Notaður sem titill á símanúmeri fyrir lögmann.',
   },
   legalRightsProtector: {
-    id: 'judicial.system.core:lawyer_input.legal_rights_protector',
+    id: 'judicial.system.core:input_advocate.phone_number_label.legal_rights_protector',
     defaultMessage: 'Símanúmer réttargæslumanns',
     description: 'Notaður sem titill á símanúmeri fyrir réttargæslumann.',
   },
@@ -71,17 +71,17 @@ export const phoneNumberLabelStrings = defineMessages({
 
 export const placeholderStrings = defineMessages({
   namePlaceholder: {
-    id: 'judicial.system.core:lawyer_input.name_placeholder',
+    id: 'judicial.system.core:input_advocate.name_placeholder',
     defaultMessage: 'Fullt nafn',
     description: 'Notaður sem hálpartexti fyrir nafn.',
   },
   emailPlaceholder: {
-    id: 'judicial.system.core:lawyer_input.email_placeholder',
+    id: 'judicial.system.core:input_advocate.email_placeholder',
     defaultMessage: 'Netfang',
     description: 'Notaður sem hálpartexti fyrir netfang.',
   },
   phoneNumberPlaceholder: {
-    id: 'judicial.system.core:lawyer_input.phone_number_placeholder',
+    id: 'judicial.system.core:input_advocate.phone_number_placeholder',
     defaultMessage: 'Símanúmer',
     description: 'Notaður sem hálpartexti fyrir símanúmer.',
   },


### PR DESCRIPTION
# Fix Contentful Keys

[Rewrite advocate input](https://app.asana.com/0/1199153462262248/1209108787511068/f)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated translation string identifiers for advocate input components
	- Renamed translation keys from `lawyer_input` prefix to `input_advocate`
	- Improved consistency in translation key naming conventions for name, email, phone number, and placeholder strings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->