### PR TITLE
fix(documents): Don't force lowercase attribute names

### DIFF
--- a/libs/clients/documents-v2/src/lib/dto/document.dto.ts
+++ b/libs/clients/documents-v2/src/lib/dto/document.dto.ts
@@ -62,6 +62,9 @@ export const mapToDocument = (
     fileType = 'html'
 
     const html = sanitizeHtml(document.htmlContent, {
+      parser: {
+        lowerCaseAttributeNames: false,
+      },
       allowedTags: sanitizeHtml.defaults.allowedTags.concat([
         'img',
         ...svgTags,

--- a/libs/clients/documents-v2/src/utils/htmlConfig.ts
+++ b/libs/clients/documents-v2/src/utils/htmlConfig.ts
@@ -39,7 +39,8 @@ const svgAttributes = [
   'rx',
   'ry',
   'points',
-  'xlink:href',
+  'href',
+  'xlink:href', // Legacy href for SVGs
 ]
 
 export const svgAttr = {
@@ -54,5 +55,5 @@ export const svgAttr = {
   ellipse: svgAttributes,
   text: svgAttributes,
   tspan: svgAttributes,
-  use: ['xlink:href'],
+  use: ['xlink:href', 'href'],
 }


### PR DESCRIPTION
## What

Don't force lowercase attribute names

## Why

For using attributes like `viewBox`
[It's fine](https://github.com/apostrophecms/sanitize-html?tab=readme-ov-file#htmlparser2-options)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced SVG attribute support by adding both `href` and `xlink:href` for legacy compatibility
  - Improved HTML sanitization to preserve original attribute casing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->