### PR TITLE
fix(contentful-apps): Translation namespace fallback in case we have an undefined defaultMessage

### DIFF
--- a/apps/contentful-apps/components/translation-namespace/index.tsx
+++ b/apps/contentful-apps/components/translation-namespace/index.tsx
@@ -129,10 +129,10 @@ export const App = () => {
 
               {values[item].markdown ? (
                 <div>
-                  <Markdown>{values[item].defaultMessage}</Markdown>
+                  <Markdown>{values[item].defaultMessage ?? ''}</Markdown>
                 </div>
               ) : (
-                <p>{values[item].defaultMessage}</p>
+                <p>{values[item].defaultMessage ?? ''}</p>
               )}
             </TableCell>
           </TableRow>


### PR DESCRIPTION
# Translation namespace fallback in case we have an undefined defaultMessage

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of undefined default messages in translation namespace component
	- Prevented potential rendering errors by adding fallback to empty string when default message is not defined

<!-- end of auto-generated comment: release notes by coderabbit.ai -->