### PR TITLE
fix(documents): Don't force lowercase attribute names (hotfix)

### DIFF
--- a/libs/clients/documents-v2/src/lib/dto/document.dto.ts
+++ b/libs/clients/documents-v2/src/lib/dto/document.dto.ts
@@ -62,6 +62,9 @@ export const mapToDocument = (
     fileType = 'html'
 
     const html = sanitizeHtml(document.htmlContent, {
+      parser: {
+        lowerCaseAttributeNames: false,
+      },
       allowedTags: sanitizeHtml.defaults.allowedTags.concat([
         'img',
         ...svgTags,

--- a/libs/clients/documents-v2/src/utils/htmlConfig.ts
+++ b/libs/clients/documents-v2/src/utils/htmlConfig.ts
@@ -39,7 +39,8 @@ const svgAttributes = [
   'rx',
   'ry',
   'points',
-  'xlink:href',
+  'href',
+  'xlink:href', // Legacy href for SVGs
 ]
 
 export const svgAttr = {
@@ -54,5 +55,5 @@ export const svgAttr = {
   ellipse: svgAttributes,
   text: svgAttributes,
   tspan: svgAttributes,
-  use: ['xlink:href'],
+  use: ['xlink:href', 'href'],
 }


### PR DESCRIPTION
#17645