### PR TITLE
fix(native-app): make sure applications are not undefined when showing empty state in module on home screen

### DIFF
--- a/apps/native/app/src/screens/home/applications-module.tsx
+++ b/apps/native/app/src/screens/home/applications-module.tsx
@@ -36,7 +36,10 @@ const validateApplicationsInitialData = ({
     return true
   }
   // Only show widget initially if there are applications
-  if (data?.applicationApplications?.length !== 0) {
+  if (
+    data?.applicationApplications?.length &&
+    data?.applicationApplications?.length !== 0
+  ) {
     return true
   }
   return false


### PR DESCRIPTION
## What

I noticed that suddenly for users that don't have any applications I was seeing the empty state for applications module on the home screen without the title for that module. Turns out that sometimes the response from the server is `undefined` (seems to have changed since this is a new issue) and we were currently only checking for the length of the data, not if it was present.

## Why

Specify why you need to achieve this

## Screenshots / Gifs
Before and after:

<div><img height = "800" src="https://github.com/user-attachments/assets/af22d0cc-6d86-4d54-bf40-d7007f8b6143">
<img height = "800" src="https://github.com/user-attachments/assets/1429afb1-cb04-421f-8a21-0256dc13dd66"></div>

## Checklist:


- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation logic for application data loading to ensure more accurate handling of application lists
  - Enhanced check to prevent false positives when determining application presence

The changes refine how the application data is processed, providing a more robust method for detecting when applications are actually available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->