### PR TITLE
feat(old-age-pension): remove early retirement file upload, change button link and some text

### DIFF
--- a/libs/application/templates/social-insurance-administration/core/src/lib/messages.ts
+++ b/libs/application/templates/social-insurance-administration/core/src/lib/messages.ts
@@ -43,8 +43,7 @@ export const socialInsuranceAdministrationMessage: MessageDir = {
     },
     checkboxProvider: {
       id: 'sia.application:prerequisites.checkbox.provider',
-      defaultMessage:
-        'Ég samþykki gagnaöflun í umsóknarferlinu',
+      defaultMessage: 'Ég samþykki gagnaöflun í umsóknarferlinu',
       description:
         'I agree to the collection of data as a part of the application process',
     },

--- a/libs/application/templates/social-insurance-administration/core/src/lib/messages.ts
+++ b/libs/application/templates/social-insurance-administration/core/src/lib/messages.ts
@@ -44,9 +44,9 @@ export const socialInsuranceAdministrationMessage: MessageDir = {
     checkboxProvider: {
       id: 'sia.application:prerequisites.checkbox.provider',
       defaultMessage:
-        'Ég skil að ofangreindra upplýsinga verður aflað í umsóknarferlinu',
+        'Ég samþykki gagnaöflun í umsóknarferlinu',
       description:
-        'I understand that the above information will be collected during the application process',
+        'I agree to the collection of data as a part of the application process',
     },
     skraInformationTitle: {
       id: 'sia.application:prerequisites.national.registry.title',
@@ -126,9 +126,9 @@ export const socialInsuranceAdministrationMessage: MessageDir = {
     infoSubSectionDescription: {
       id: 'sia.application:applicant.info.sub.section.description#markdown',
       defaultMessage:
-        'Vinsamlegast farið yfir netfang og símanúmer til að tryggja að þær upplýsingar séu réttar. Netfangi er breytt með því að fara inn á Mínar síður á Ísland.is. Athugið að ef að aðrar upplýsingar eru ekki réttar þarf að breyta þeim í þjóðskrá.',
+        'Vinsamlegast farið yfir netfang og símanúmer til að tryggja að þær upplýsingar séu réttar. Netfangi er breytt hér. Athugið að ef að aðrar upplýsingar eru ekki réttar þarft þú að breyta þeim í Þjóðskrá.',
       description:
-        'Please review the email address and phone number to ensure that the information is correct. Email address can be changed by logging into My pages at Ísland.is. Note that if the following information is not correct, it must be changed at Registers Iceland.',
+        'Please review the email address and phone number to ensure that the information is correct. Email address can be changed here. Note that if any other information is not correct, you must have it changed at Registers Iceland.',
     },
     applicantEmail: {
       id: 'sia.application:info.applicant.email',

--- a/libs/application/templates/social-insurance-administration/income-plan/src/forms/IncomePlanForm.ts
+++ b/libs/application/templates/social-insurance-administration/income-plan/src/forms/IncomePlanForm.ts
@@ -701,7 +701,7 @@ export const IncomePlanForm: Form = buildForm({
       expandableIntro: '',
       bottomButtonMessage:
         incomePlanFormMessage.conclusionScreen.bottomButtonMessage,
-      bottomButtonLink: '/minarsidur/framfaersla/tekjuaaetlun',
+      bottomButtonLink: '/minarsidur/umsoknir',
     }),
   ],
 })

--- a/libs/application/templates/social-insurance-administration/old-age-pension/src/forms/OldAgePensionForm.ts
+++ b/libs/application/templates/social-insurance-administration/old-age-pension/src/forms/OldAgePensionForm.ts
@@ -629,28 +629,6 @@ export const OldAgePensionForm: Form = buildForm({
       title: socialInsuranceAdministrationMessage.fileUpload.title,
       children: [
         buildSubSection({
-          condition: (answers, externalData) => {
-            const earlyRetirement = isEarlyRetirement(answers, externalData)
-            return earlyRetirement
-          },
-          id: 'fileUpload.earlyRetirement.section',
-          title: oldAgePensionFormMessage.fileUpload.earlyRetirementTitle,
-          children: [
-            buildFileUploadField({
-              id: 'fileUpload.earlyRetirement',
-              title: oldAgePensionFormMessage.fileUpload.earlyRetirementTitle,
-              description:
-                oldAgePensionFormMessage.fileUpload.earlyRetirementDescription,
-              introduction:
-                oldAgePensionFormMessage.fileUpload.earlyRetirementDescription,
-              ...fileUploadSharedProps,
-              condition: (answers, externalData) => {
-                return isEarlyRetirement(answers, externalData)
-              },
-            }),
-          ],
-        }),
-        buildSubSection({
           id: 'fileUpload.pension.section',
           title: oldAgePensionFormMessage.fileUpload.pensionFileTitle,
           children: [

--- a/libs/application/templates/social-insurance-administration/old-age-pension/src/lib/messages.ts
+++ b/libs/application/templates/social-insurance-administration/old-age-pension/src/lib/messages.ts
@@ -295,18 +295,6 @@ export const oldAgePensionFormMessage: MessageDir = {
   }),
 
   fileUpload: defineMessages({
-    earlyRetirementTitle: {
-      id: 'oap.application:fileUpload.earlyRetirement.title',
-      defaultMessage: 'Fylgiskjöl vegna snemmtöku',
-      description: 'Early retirement attachment',
-    },
-    earlyRetirementDescription: {
-      id: 'oap.application:fileUpload.earlyRetirement.description',
-      defaultMessage:
-        'Hér getur þú skilað yfirliti úr lífeyrisgátt sem þú hefur áunnið þér réttindi í. Athugaðu að skjalið þarf að vera á .pdf formi.',
-      description:
-        'Here you can submit an overview from the pension portal in which you have earned rights. Note that the document must be in .pdf format.',
-    },
     pensionFileTitle: {
       id: 'oap.application:fileUpload.pensionFile.title',
       defaultMessage: 'Fylgiskjöl lífeyrissjóða',


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **User Interface Updates**
  - Updated consent and data collection messaging for improved clarity.
  - Refined contact information update instructions.

- **Navigation Changes**
  - Modified form conclusion section link to redirect users to a different application page.

- **Form Modifications**
  - Removed early retirement file upload section from Old Age Pension application.
  - Deleted related early retirement message descriptors.

These updates aim to enhance user experience and streamline the application process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->