### PR TITLE
fix(web): /rss.xml link should be an anchor tag

### DIFF
--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -31,6 +31,7 @@ import {
   Text,
 } from '@island.is/island-ui/core'
 import { theme } from '@island.is/island-ui/theme'
+import { shouldLinkBeAnAnchorTag } from '@island.is/shared/utils'
 import {
   BoostChatPanel,
   boostChatPanelEndpoints,
@@ -1228,12 +1229,12 @@ export const OrganizationWrapper: React.FC<
                   title={navigationData.title}
                   activeItemTitle={activeNavigationItemTitle}
                   renderLink={(link, item) => {
-                    return item?.href ? (
+                    return !item?.href || shouldLinkBeAnAnchorTag(item.href) ? (
+                      link
+                    ) : (
                       <NextLink href={item?.href} legacyBehavior>
                         {link}
                       </NextLink>
-                    ) : (
-                      link
                     )
                   }}
                 />

--- a/libs/shared/utils/src/lib/shouldLinkBeAnAnchorTag.ts
+++ b/libs/shared/utils/src/lib/shouldLinkBeAnAnchorTag.ts
@@ -4,4 +4,5 @@ import { ProjectBasePath } from '@island.is/shared/constants'
  * then the link should be an anchor tag instead of a nextlink for example
  * */
 export const shouldLinkBeAnAnchorTag = (path: string) =>
-  Object.values(ProjectBasePath).some((basePath) => path.includes(basePath))
+  Object.values(ProjectBasePath).some((basePath) => path.includes(basePath)) ||
+  path.startsWith('/rss.xml')


### PR DESCRIPTION
# /rss.xml link should be an anchor tag

## What

NextLink with href="/rss.xml" doesn't load page properly during cilent side routing.
One solution is to make sure the link gets rendered as an "a" tag

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
