### PR TITLE
feat(j-s): Send civil claim to RLS

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/case/pdf.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/pdf.service.ts
@@ -204,16 +204,17 @@ export class PdfService {
 
   async getCivilClaimPdf(
     theCase: Case,
-    fileId?: string,
-    fileName?: string,
+    fileKey?: string,
   ): Promise<Buffer | undefined> {
-    const existingPdf = await this.tryGetPdfFromS3(
-      theCase,
-      `${theCase.id}/${fileId}/${fileName}`,
-    )
+    if (!fileKey) {
+      this.logger.error('No key provided')
+      return
+    }
+
+    const existingPdf = await this.tryGetPdfFromS3(theCase, fileKey)
 
     if (existingPdf === undefined) {
-      this.logger.error(`Civil claim with id ${fileId} not found`)
+      this.logger.error(`Civil claim with id ${fileKey} not found`)
     }
 
     return existingPdf

--- a/apps/judicial-system/backend/src/app/modules/case/pdf.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/pdf.service.ts
@@ -202,6 +202,23 @@ export class PdfService {
       })
   }
 
+  async getCivilClaimPdf(
+    theCase: Case,
+    fileId?: string,
+    fileName?: string,
+  ): Promise<Buffer | undefined> {
+    const existingPdf = await this.tryGetPdfFromS3(
+      theCase,
+      `${theCase.id}/${fileId}/${fileName}`,
+    )
+
+    if (existingPdf === undefined) {
+      this.logger.error(`Civil claim with id ${fileId} not found`)
+    }
+
+    return existingPdf
+  }
+
   async getIndictmentPdf(theCase: Case): Promise<Buffer> {
     let confirmation: Confirmation | undefined = undefined
 

--- a/apps/judicial-system/backend/src/app/modules/case/pdf.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/pdf.service.ts
@@ -202,24 +202,6 @@ export class PdfService {
       })
   }
 
-  async getCivilClaimPdf(
-    theCase: Case,
-    fileKey?: string,
-  ): Promise<Buffer | undefined> {
-    if (!fileKey) {
-      this.logger.error('No key provided')
-      return
-    }
-
-    const existingPdf = await this.tryGetPdfFromS3(theCase, fileKey)
-
-    if (existingPdf === undefined) {
-      this.logger.error(`Civil claim with id ${fileKey} not found`)
-    }
-
-    return existingPdf
-  }
-
   async getIndictmentPdf(theCase: Case): Promise<Buffer> {
     let confirmation: Confirmation | undefined = undefined
 

--- a/apps/judicial-system/backend/src/app/modules/police/police.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/police.service.ts
@@ -618,6 +618,7 @@ export class PoliceService {
     subpoena: string,
     indictment: string,
     user: User,
+    civilClaim?: string,
   ): Promise<CreateSubpoenaResponse> {
     const { courtCaseNumber, dateLogs, prosecutor, policeCaseNumbers, court } =
       workingCase
@@ -645,7 +646,11 @@ export class PoliceService {
           agent: this.agent,
           body: JSON.stringify({
             documentName: documentName,
-            documentsBase64: [subpoena, indictment],
+            documentsBase64: [
+              subpoena,
+              indictment,
+              ...(civilClaim ? [civilClaim] : []),
+            ],
             courtRegistrationDate: arraignmentInfo?.date,
             prosecutorSsn: prosecutor?.nationalId,
             prosecutedSsn: normalizedNationalId,

--- a/apps/judicial-system/backend/src/app/modules/police/police.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/police.service.ts
@@ -632,6 +632,7 @@ export class PoliceService {
     const arraignmentInfo = dateLogs?.find(
       (dateLog) => dateLog.dateType === 'ARRAIGNMENT_DATE',
     )
+
     try {
       const res = await this.fetchPoliceCaseApi(
         `${this.xRoadPath}/CreateSubpoena`,

--- a/apps/judicial-system/backend/src/app/modules/subpoena/subpoena.module.ts
+++ b/apps/judicial-system/backend/src/app/modules/subpoena/subpoena.module.ts
@@ -8,6 +8,7 @@ import { CourtModule } from '../court/court.module'
 import { DefendantModule } from '../defendant/defendant.module'
 import { Defendant } from '../defendant/models/defendant.model'
 import { EventModule } from '../event/event.module'
+import { FileModule } from '../file/file.module'
 import { PoliceModule } from '../police/police.module'
 import { Subpoena } from './models/subpoena.model'
 import { InternalSubpoenaController } from './internalSubpoena.controller'
@@ -22,6 +23,7 @@ import { SubpoenaService } from './subpoena.service'
     forwardRef(() => MessageModule),
     forwardRef(() => EventModule),
     forwardRef(() => DefendantModule),
+    forwardRef(() => FileModule),
     CourtModule,
     SequelizeModule.forFeature([Subpoena, Defendant]),
   ],

--- a/apps/judicial-system/backend/src/app/modules/subpoena/subpoena.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/subpoena/subpoena.service.ts
@@ -308,8 +308,7 @@ export class SubpoenaService {
 
       const civilClaimPdf = await this.pdfService.getCivilClaimPdf(
         theCase,
-        civilClaim?.id,
-        civilClaim?.name,
+        civilClaim?.key,
       )
 
       const createdSubpoena = await this.policeService.createSubpoena(

--- a/apps/judicial-system/backend/src/app/modules/subpoena/subpoena.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/subpoena/subpoena.service.ts
@@ -20,6 +20,7 @@ import {
   MessageType,
 } from '@island.is/judicial-system/message'
 import {
+  CaseFileCategory,
   isFailedServiceStatus,
   isSuccessfulServiceStatus,
   ServiceStatus,
@@ -294,13 +295,22 @@ export class SubpoenaService {
     user: TUser,
   ): Promise<DeliverResponse> {
     try {
+      const civilClaim = theCase.caseFiles?.find(
+        (caseFile) => caseFile.category === CaseFileCategory.CIVIL_CLAIM,
+      )
+
+      const indictmentPdf = await this.pdfService.getIndictmentPdf(theCase)
       const subpoenaPdf = await this.pdfService.getSubpoenaPdf(
         theCase,
         defendant,
         subpoena,
       )
 
-      const indictmentPdf = await this.pdfService.getIndictmentPdf(theCase)
+      const civilClaimPdf = await this.pdfService.getCivilClaimPdf(
+        theCase,
+        civilClaim?.id,
+        civilClaim?.name,
+      )
 
       const createdSubpoena = await this.policeService.createSubpoena(
         theCase,
@@ -308,6 +318,9 @@ export class SubpoenaService {
         Base64.btoa(subpoenaPdf.toString('binary')),
         Base64.btoa(indictmentPdf.toString('binary')),
         user,
+        civilClaimPdf
+          ? Base64.btoa(civilClaimPdf.toString('binary'))
+          : undefined,
       )
 
       if (!createdSubpoena) {

--- a/apps/judicial-system/backend/src/app/modules/subpoena/test/createTestingSubpoenaModule.ts
+++ b/apps/judicial-system/backend/src/app/modules/subpoena/test/createTestingSubpoenaModule.ts
@@ -16,6 +16,7 @@ import { CaseService, PdfService } from '../../case'
 import { CourtService } from '../../court'
 import { Defendant, DefendantService } from '../../defendant'
 import { EventService } from '../../event'
+import { FileService } from '../../file'
 import { PoliceService } from '../../police'
 import { UserService } from '../../user'
 import { InternalSubpoenaController } from '../internalSubpoena.controller'
@@ -32,6 +33,7 @@ jest.mock('../../police/police.service')
 jest.mock('../../event/event.service')
 jest.mock('../../defendant/defendant.service')
 jest.mock('../../court/court.service')
+jest.mock('../../file/file.service')
 
 export const createTestingSubpoenaModule = async () => {
   const subpoenaModule = await Test.createTestingModule({
@@ -47,6 +49,7 @@ export const createTestingSubpoenaModule = async () => {
       UserService,
       CaseService,
       PdfService,
+      FileService,
       PoliceService,
       EventService,
       DefendantService,
@@ -90,6 +93,8 @@ export const createTestingSubpoenaModule = async () => {
 
   const pdfService = subpoenaModule.get<PdfService>(PdfService)
 
+  const fileService = subpoenaModule.get<FileService>(FileService)
+
   const policeService = subpoenaModule.get<PoliceService>(PoliceService)
 
   const courtService = subpoenaModule.get<CourtService>(CourtService)
@@ -116,6 +121,7 @@ export const createTestingSubpoenaModule = async () => {
   return {
     userService,
     pdfService,
+    fileService,
     policeService,
     courtService,
     subpoenaModel,


### PR DESCRIPTION
# Send civil claim to RLS

[Asana](https://app.asana.com/0/1199153462262248/1208536692205568/f)

## What

Send civil claim to RSL when creating a subpoena.

## Why

The civil claim should be displayed to the defendant on island.is. This PR implements that.

## Screenshots / Gifs

https://github.com/user-attachments/assets/fac30c85-5004-430f-8f1b-08f0b9c5badc

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced subpoena creation process to optionally include civil claim documents.
	- Added support for retrieving and attaching civil claim PDFs during subpoena delivery.

- **Refactor**
	- Updated service methods to handle new optional civil claim parameter.
	- Improved module dependencies to support new file handling functionality.
	- Expanded testing capabilities by integrating file-related functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->