### PR TITLE
fix(secondary school): Allow different text in formConclusionSection depending on answer

### DIFF
--- a/libs/application/templates/secondary-school/src/forms/secondarySchoolForm/conclusionSection/index.ts
+++ b/libs/application/templates/secondary-school/src/forms/secondarySchoolForm/conclusionSection/index.ts
@@ -1,10 +1,30 @@
+import { getValueViaPath } from '@island.is/application/core'
 import { conclusion } from '../../../lib/messages'
 import { buildFormConclusionSection } from '@island.is/application/ui-forms'
+import { ApplicationType } from '../../../utils'
 
 export const conclusionSection = buildFormConclusionSection({
   alertTitle: conclusion.general.alertTitle,
-  alertMessage: conclusion.general.alertMessageFreshman,
+  alertMessage: (application) => {
+    const isFreshman =
+      getValueViaPath<ApplicationType>(
+        application.answers,
+        'applicationType.value',
+      ) === ApplicationType.FRESHMAN
+    return isFreshman
+      ? conclusion.general.alertMessageFreshman
+      : conclusion.general.alertMessageGeneral
+  },
   expandableHeader: conclusion.general.accordionTitle,
   expandableIntro: '',
-  expandableDescription: conclusion.general.accordionTextFreshman,
+  expandableDescription: (application) => {
+    const isFreshman =
+      getValueViaPath<ApplicationType>(
+        application.answers,
+        'applicationType.value',
+      ) === ApplicationType.FRESHMAN
+    return isFreshman
+      ? conclusion.general.accordionTextFreshman
+      : conclusion.general.accordionTextGeneral
+  },
 })

--- a/libs/application/types/src/lib/Fields.ts
+++ b/libs/application/types/src/lib/Fields.ts
@@ -519,7 +519,7 @@ export interface ExpandableDescriptionField extends BaseField {
   readonly type: FieldTypes.EXPANDABLE_DESCRIPTION
   component: FieldComponents.EXPANDABLE_DESCRIPTION
   introText?: FormText
-  description: FormText
+  description: FormTextWithLocale
   startExpanded?: boolean
 }
 
@@ -527,7 +527,7 @@ export interface AlertMessageField extends BaseField {
   readonly type: FieldTypes.ALERT_MESSAGE
   component: FieldComponents.ALERT_MESSAGE
   alertType?: 'default' | 'warning' | 'error' | 'info' | 'success'
-  message?: FormText
+  message?: FormTextWithLocale
   links?: AlertMessageLink[]
 }
 

--- a/libs/application/ui-fields/src/lib/AlertMessageFormField/AlertMessageFormField.tsx
+++ b/libs/application/ui-fields/src/lib/AlertMessageFormField/AlertMessageFormField.tsx
@@ -34,7 +34,12 @@ export const AlertMessageFormField: FC<React.PropsWithChildren<Props>> = ({
               {field.message != null ? (
                 <Text variant="small">
                   <Markdown>
-                    {formatText(field.message, application, formatMessage)}
+                    {formatTextWithLocale(
+                      field.message,
+                      application,
+                      locale as Locale,
+                      formatMessage,
+                    )}
                   </Markdown>
                 </Text>
               ) : null}

--- a/libs/application/ui-fields/src/lib/ExpandableDescriptionFormField/ExpandableDescriptionFormField.tsx
+++ b/libs/application/ui-fields/src/lib/ExpandableDescriptionFormField/ExpandableDescriptionFormField.tsx
@@ -40,7 +40,12 @@ export const ExpandableDescriptionFormField: FC<
         )}
         <BulletList space="gutter" type="ul">
           <Markdown>
-            {formatText(field.description, application, formatMessage)}
+            {formatTextWithLocale(
+              field.description,
+              application,
+              locale as Locale,
+              formatMessage,
+            )}
           </Markdown>
         </BulletList>
       </AccordionCard>

--- a/libs/application/ui-forms/src/lib/formConclusionSection/formConclusionSection.ts
+++ b/libs/application/ui-forms/src/lib/formConclusionSection/formConclusionSection.ts
@@ -7,12 +7,17 @@ import {
   buildSection,
   coreMessages,
 } from '@island.is/application/core'
-import { Condition, FormText, StaticText } from '@island.is/application/types'
+import {
+  Condition,
+  FormText,
+  FormTextWithLocale,
+  StaticText,
+} from '@island.is/application/types'
 import { conclusion } from './messages'
 
 type Props = Partial<{
   alertTitle: FormText
-  alertMessage: FormText
+  alertMessage: FormTextWithLocale
   alertType: 'success' | 'warning' | 'error' | 'info'
   multiFieldTitle: StaticText
   secondButtonLink: StaticText
@@ -21,7 +26,7 @@ type Props = Partial<{
   accordion?: boolean
   expandableHeader: FormText
   expandableIntro: FormText
-  expandableDescription: FormText
+  expandableDescription: FormTextWithLocale
   conclusionLinkS3FileKey: FormText
   conclusionLink: string
   conclusionLinkLabel: StaticText


### PR DESCRIPTION
## What

In the application secondary school, we need to display different text in formConclusion depending on an answer (whether applicant is freshman or not)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
