### PR TITLE
fix(my-pages-notifications): Change logger from error to info

### DIFF
--- a/libs/api/domains/notifications/src/lib/notifications.resolver.ts
+++ b/libs/api/domains/notifications/src/lib/notifications.resolver.ts
@@ -51,7 +51,7 @@ export class NotificationsResolver {
         this.service.getNotification(id, locale, user),
       )
     } catch (e) {
-      this.logger.error('failed to get notification by id', {
+      this.logger.info('failed to get notification by id', {
         id,
         locale,
         category: LOG_CATEGORY,
@@ -83,7 +83,7 @@ export class NotificationsResolver {
     try {
       result = await this.service.markAllNotificationsAsSeen(user)
     } catch (e) {
-      this.logger.error('failed to mark all notifications as seen', {
+      this.logger.info('failed to mark all notifications as seen', {
         category: LOG_CATEGORY,
         error: e,
       })
@@ -104,7 +104,7 @@ export class NotificationsResolver {
     try {
       result = await this.service.markAllNotificationsAsRead(user)
     } catch (e) {
-      this.logger.error('failed to mark all notifications as read', {
+      this.logger.info('failed to mark all notifications as read', {
         category: LOG_CATEGORY,
         error: e,
       })
@@ -138,7 +138,7 @@ export class NotificationsResolver {
         this.service.markNotificationAsRead(id, locale, user),
       )
     } catch (e) {
-      this.logger.error('failed to mark notification as read', {
+      this.logger.info('failed to mark notification as read', {
         id,
         locale,
         category: LOG_CATEGORY,

--- a/libs/api/domains/notifications/src/lib/notificationsList.resolver.ts
+++ b/libs/api/domains/notifications/src/lib/notificationsList.resolver.ts
@@ -57,7 +57,7 @@ export class NotificationsListResolver {
     try {
       notifications = await this.service.getNotifications(locale, user, input)
     } catch (e) {
-      this.logger.error('failed to get notifications', {
+      this.logger.info('failed to get notifications', {
         locale,
         category: LOG_CATEGORY,
         error: e,


### PR DESCRIPTION
## What

Change error logging for error to info

## Why

Prevent double error reporting. The error bubbles and is reported. Additional info should be logged as info.

## Screenshots / Gifs
<img width="1772" alt="Screenshot 2024-04-19 at 09 52 50" src="https://github.com/island-is/island.is/assets/24840451/de82a03b-e900-4a48-b811-5b18db58ce2f">


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Logging Updates**
	- Modified error logging levels from error to info in notification-related methods
	- Updated logging for notification retrieval and processing to use info-level messages
	- No changes to core functionality or method behaviors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->