### PR TITLE
ci(codegen): use nx cache

### DIFF
--- a/.github/actions/get-cache/action.yml
+++ b/.github/actions/get-cache/action.yml
@@ -48,3 +48,9 @@ runs:
         cd scripts/ci/cache
         npx yarn install --immutable
         node cache-action.mjs
+
+    # NOTE: Will restore NX cloud cache or generate new cache
+    - name: Codegen
+      id: codegen
+      shell: bash
+      run: yarn codegen

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -56,7 +56,7 @@ jobs:
   #       uses: ./.github/actions/get-cache
   #       with:
   #         github-token: ${{ secrets.GITHUB_TOKEN }}
-  #         enable-cache: 'node_modules,cypress,generated-files'
+  #         enable-cache: 'node_modules,cypress'
 
   #     - name: Derive appropriate SHAs
   #       uses: nrwl/nx-set-shas@v4
@@ -100,7 +100,7 @@ jobs:
   #       with:
   #         github-token: ${{ secrets.GITHUB_TOKEN }}
   #         keys: ${{ needs.prepare.outputs.CACHE_KEYS }}
-  #         enable-cache: 'node_modules,cypress,generated-files'
+  #         enable-cache: 'node_modules,cypress'
 
   #     - uses: ./.github/actions/unit-test
   #       with:
@@ -142,7 +142,7 @@ jobs:
   #       with:
   #         github-token: ${{ secrets.GITHUB_TOKEN }}
   #         keys: ${{ needs.prepare.outputs.CACHE_KEYS }}
-  #         enable-cache: 'node_modules,cypress,generated-files'
+  #         enable-cache: 'node_modules,cypress'
 
   #     - name: Running e2e tests
   #       run: ./scripts/ci/40_e2e.sh "${AFFECTED_PROJECT}"
@@ -171,7 +171,7 @@ jobs:
   #       with:
   #         github-token: ${{ secrets.GITHUB_TOKEN }}
   #         keys: ${{ needs.prepare.outputs.CACHE_KEYS }}
-  #         enable-cache: 'node_modules,generated-files'
+  #         enable-cache: 'node_modules'
 
   #     - name: Building
   #       run: ./scripts/ci/run-in-parallel-native.sh build

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -118,7 +118,7 @@ jobs:
         uses: ./.github/actions/get-cache
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          enable-cache: 'node_modules,cypress,generated-files'
+          enable-cache: 'node_modules,cypress'
 
       - name: License audit Node modules
         run: ./scripts/ci/20_license-audit.sh
@@ -222,7 +222,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           keys: ${{ needs.prepare.outputs.CACHE_KEYS }}
-          enable-cache: 'node_modules,cypress,generated-files'
+          enable-cache: 'node_modules,cypress'
 
       - name: Run unit tests
         uses: ./.github/actions/unit-test
@@ -266,7 +266,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           keys: ${{ needs.prepare.outputs.CACHE_KEYS }}
-          enable-cache: 'node_modules,cypress,generated-files'
+          enable-cache: 'node_modules,cypress'
 
       - name: Running e2e tests
         run: ./scripts/ci/40_e2e.sh "${AFFECTED_PROJECT}"
@@ -291,7 +291,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           keys: ${{ needs.prepare.outputs.CACHE_KEYS }}
-          enable-cache: 'node_modules,generated-files'
+          enable-cache: 'node_modules'
 
       - name: Linting workspace
         run: ./scripts/ci/20_lint-workspace.sh
@@ -373,7 +373,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           keys: ${{ needs.prepare.outputs.CACHE_KEYS }}
-          enable-cache: 'node_modules,generated-files'
+          enable-cache: 'node_modules'
       - name: Linting
         run: ./scripts/ci/run-in-parallel-native.sh lint
 
@@ -402,7 +402,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           keys: ${{ needs.prepare.outputs.CACHE_KEYS }}
-          enable-cache: 'node_modules,generated-files'
+          enable-cache: 'node_modules'
 
       - name: Building
         run: ./scripts/ci/run-in-parallel-native.sh build

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -316,7 +316,7 @@ jobs:
         uses: ./.github/actions/get-cache
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          enable-cache: 'node_modules,generated-files'
+          enable-cache: 'node_modules'
 
       - name: Set Test Everything true
         run: |
@@ -481,7 +481,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           keys: ${{ needs.prepare.outputs.CACHE_KEYS }}
-          enable-cache: 'node_modules,cypress,generated-files'
+          enable-cache: 'node_modules,cypress'
 
       - name: Run unit tests
         uses: ./.github/actions/unit-test
@@ -538,7 +538,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           keys: ${{ needs.prepare.outputs.CACHE_KEYS }}
-          enable-cache: 'node_modules,generated-files'
+          enable-cache: 'node_modules'
 
       - name: Cache for dependencies Docker layer
         if: steps.gather.outcome == 'success'

--- a/infra/src/dsl/dsl.ts
+++ b/infra/src/dsl/dsl.ts
@@ -1,6 +1,6 @@
 import { merge } from 'lodash'
 import { CodeOwners } from '../../../libs/shared/constants/src/lib/codeOwners'
-import {
+import type {
   Context,
   EnvironmentVariables,
   ExtraValues,
@@ -572,4 +572,4 @@ export const service = <Service extends string>(
 
 export const json = (value: unknown): string => JSON.stringify(value)
 
-export { CodeOwners, Context }
+export type { CodeOwners, Context }

--- a/infra/src/dsl/dsl.ts
+++ b/infra/src/dsl/dsl.ts
@@ -572,4 +572,5 @@ export const service = <Service extends string>(
 
 export const json = (value: unknown): string => JSON.stringify(value)
 
-export type { CodeOwners, Context }
+export { CodeOwners }
+export type { Context }

--- a/nx.json
+++ b/nx.json
@@ -30,8 +30,6 @@
           "codegen/frontend-client",
           "generateDevIndexHTML"
         ],
-        "cacheDirectory": ".cache/nx",
-        "parallel": 1,
         "nxCloudId": "64e4eb6a54304f090734e8df"
       }
     },

--- a/scripts/codegen.js
+++ b/scripts/codegen.js
@@ -24,7 +24,8 @@ const fileExists = async (path) =>
 
 const main = async () => {
   const schemaExists = await fileExists(SCHEMA_PATH)
-  const maxParallel = process.env.NX_MAX_PARALLEL ?? '6'
+  const nxMaxParallel = process.env.NX_MAX_PARALLEL ?? '2'
+  const nxParallel = process.env.NX_PARALLEL ?? '2'
 
   if (!schemaExists) {
     await promisify(writeFile)(SCHEMA_PATH, 'export default () => {}')
@@ -35,7 +36,7 @@ const main = async () => {
 
     try {
       await exec(
-        `nx run-many --target=${target} --all --parallel --maxParallel=${maxParallel} $NX_OPTIONS`,
+        `nx run-many --target=${target} --all --parallel=${nxParallel} --maxParallel=${nxMaxParallel} $NX_OPTIONS`,
         {
           env: skipCache
             ? { ...process.env, NX_OPTIONS: '--skip-nx-cache' }


### PR DESCRIPTION
# Codegen
`codegen` is a cacheable task in NX, let's use that instead of actions cache.

- Remove codegen from actions cache
- Run `yarn codegen` in the `get-cache` action for non-redundant code.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflows to simplify caching strategy
	- Removed `generated-files` from cache configurations
	- Added a new Codegen step in GitHub Actions to support code generation
	- Adjusted code generation script to reduce parallel execution from 6 to 2 processes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->