### PR TITLE
chore(ci): Use dynamic node version

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,7 +55,6 @@ env:
   # Regsitry to for build images and cache
   IMAGE_REGISTRY: ${{ vars.IMAGE_REGISTRY || 'localhost' }}
   AWS_ECR_REPO_BASE: ${{ vars.AWS_ECR_REPO_BASE || 'docker.io' }}
-  NODE_IMAGE_VERSION: 20
 
 jobs:
   prepare:
@@ -73,7 +72,7 @@ jobs:
       - name: Build arg prep
         id: build-args
         run: |
-          node_image_version="$NODE_IMAGE_VERSION"
+          node_image_version="$(./scripts/ci/get-node-version.mjs)"
           echo node-image-version="$node_image_version" >>"$GITHUB_OUTPUT"
           yarn info --json @playwright/test | jq -r '.children.Version | "playwright-image-tag=v\(.)-focal"' >>"$GITHUB_OUTPUT"
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -46,7 +46,6 @@ env:
   MAX_JOBS: '2'
   NX_PARALLEL: '2'
   NX_MAX_PARALLEL: '4'
-  NODE_IMAGE_VERSION: 20
 
 jobs:
   pre-checks:
@@ -267,7 +266,7 @@ jobs:
         continue-on-error: false
         run: |
           set -euo pipefail
-          export NODE_IMAGE_VERSION="$NODE_IMAGE_VERSION"
+          export NODE_IMAGE_VERSION="$(./scripts/ci/get-node-version.mjs)"
           echo "NODE_IMAGE_VERSION: '${NODE_IMAGE_VERSION}'"
           echo NODE_IMAGE_VERSION="${NODE_IMAGE_VERSION}" >> "$GITHUB_OUTPUT"
           echo NODE_IMAGE_VERSION="${NODE_IMAGE_VERSION}" >> "$GITHUB_ENV"

--- a/scripts/ci/10_prepare-docker-deps.sh
+++ b/scripts/ci/10_prepare-docker-deps.sh
@@ -8,7 +8,7 @@ source "$DIR"/_common.sh
 
 mkdir -p "$PROJECT_ROOT"/cache
 
-NODE_IMAGE_VERSION=${NODE_IMAGE_VERSION:-20}
+NODE_IMAGE_VERSION=${NODE_IMAGE_VERSION:-$(./scripts/ci/get-node-version.mjs)}
 
 docker buildx create --driver docker-container --use || true
 

--- a/scripts/ci/cache/__config.mjs
+++ b/scripts/ci/cache/__config.mjs
@@ -114,6 +114,7 @@ export const caches = [
       const files = [
         'scripts/ci/10_prepare-docker-deps.sh',
         'scripts/ci/Dockerfile',
+        'scripts/ci/get-node-version.mjs',
         'scripts/ci/_common.mjs',
       ].map((file) => resolve(ROOT, file))
       const filesHash = getFilesHash(files)

--- a/scripts/ci/get-node-version.mjs
+++ b/scripts/ci/get-node-version.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+import { getPackageJSON } from './_common.mjs'
+
+const DOCKERHUB_BASE_URL =
+  'https://hub.docker.com/v2/repositories/library/node/tags?page_size=100'
+
+const nodeVersion = await getPackageVersion()
+// TODO: make better
+// const version = await getVersion(nodeVersion)
+const version = '20-alpine3.20'
+
+if (!version) {
+  console.error(`Failed getting docker image for ${nodeVersion}`)
+  process.exit(1)
+}
+process.stdout.write(version)
+
+async function getVersion(
+  version,
+  withAlpine = true,
+  architecture = 'amd64',
+  url = null,
+) {
+  try {
+    const baseURL = url ?? DOCKERHUB_BASE_URL
+    const response = await fetch(baseURL)
+    const data = await response.json()
+
+    const filteredTags = data.results.filter((tag) => {
+      const isVersionMatch = tag.name.startsWith(version)
+      const isAlpine = withAlpine ? tag.name.includes('alpine') : true
+      const isArchitectureMatch = tag.images.some(
+        (image) => image.architecture === architecture,
+      )
+      return isVersionMatch && isAlpine && isArchitectureMatch
+    })
+
+    const latestTag = filteredTags.sort((a, b) =>
+      b.last_updated.localeCompare(a.last_updated),
+    )[0]
+
+    if (latestTag) {
+      return latestTag.name
+    }
+    const nextUrl = data.next
+    if (!nextUrl) {
+      return null
+    }
+    return getVersion(version, withAlpine, architecture, nextUrl)
+  } catch (error) {
+    console.error('Failed to fetch the Docker tags', error)
+  }
+}
+
+async function getPackageVersion() {
+  const content = await getPackageJSON()
+  const version = content.engines?.node
+  if (!version) {
+    throw new Error(`Cannot find node version`)
+  }
+  return version
+}

--- a/scripts/ci/get-node-version.mjs
+++ b/scripts/ci/get-node-version.mjs
@@ -1,56 +1,13 @@
 #!/usr/bin/env node
 import { getPackageJSON } from './_common.mjs'
 
-const DOCKERHUB_BASE_URL =
-  'https://hub.docker.com/v2/repositories/library/node/tags?page_size=100'
-
-const nodeVersion = await getPackageVersion()
-// TODO: make better
-// const version = await getVersion(nodeVersion)
-const version = '20-alpine3.20'
+const version = await getPackageVersion()
 
 if (!version) {
   console.error(`Failed getting docker image for ${nodeVersion}`)
   process.exit(1)
 }
 process.stdout.write(version)
-
-async function getVersion(
-  version,
-  withAlpine = true,
-  architecture = 'amd64',
-  url = null,
-) {
-  try {
-    const baseURL = url ?? DOCKERHUB_BASE_URL
-    const response = await fetch(baseURL)
-    const data = await response.json()
-
-    const filteredTags = data.results.filter((tag) => {
-      const isVersionMatch = tag.name.startsWith(version)
-      const isAlpine = withAlpine ? tag.name.includes('alpine') : true
-      const isArchitectureMatch = tag.images.some(
-        (image) => image.architecture === architecture,
-      )
-      return isVersionMatch && isAlpine && isArchitectureMatch
-    })
-
-    const latestTag = filteredTags.sort((a, b) =>
-      b.last_updated.localeCompare(a.last_updated),
-    )[0]
-
-    if (latestTag) {
-      return latestTag.name
-    }
-    const nextUrl = data.next
-    if (!nextUrl) {
-      return null
-    }
-    return getVersion(version, withAlpine, architecture, nextUrl)
-  } catch (error) {
-    console.error('Failed to fetch the Docker tags', error)
-  }
-}
 
 async function getPackageVersion() {
   const content = await getPackageJSON()

--- a/scripts/ci/get-node-version.mjs
+++ b/scripts/ci/get-node-version.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 import { getPackageJSON } from './_common.mjs'
 
-const version = await getPackageVersion()
+const onlyMajor = true
+const version = await getPackageVersion({ onlyMajor })
 
 if (!version) {
   console.error(`Failed getting docker image for ${nodeVersion}`)
@@ -9,11 +10,14 @@ if (!version) {
 }
 process.stdout.write(version)
 
-async function getPackageVersion() {
+async function getPackageVersion({ onlyMajor = false } = {}) {
   const content = await getPackageJSON()
   const version = content.engines?.node
   if (!version) {
     throw new Error(`Cannot find node version`)
   }
   return version
+    .split('.')
+    .slice(0, onlyMajor ? 1 : 3)
+    .join('.')
 }


### PR DESCRIPTION
- Re-add removed version script
- Use only the major node version
- Use script instead of static (hardcoded) versions