### PR TITLE
fix(native-app): spacing bug when opening license from home screen

### DIFF
--- a/apps/native/app/src/screens/wallet/components/wallet-item.tsx
+++ b/apps/native/app/src/screens/wallet/components/wallet-item.tsx
@@ -28,13 +28,11 @@ export const WalletItem = React.memo(
     item: GenericUserLicense | IdentityDocumentModel
     style?: ViewStyle
   }) => {
-    let cardHeight = 140
+    let cardHeight = 96
     const type = item.__typename
 
     // Passport card
     if (type === 'IdentityDocumentModel') {
-      const isInvalid = item?.status?.toLowerCase() === 'invalid'
-
       return (
         <Container
           style={style}


### PR DESCRIPTION
* When opening licenses from the home screen there was some extra margin that was not when opening from the licenses screen.
* Also removed unused isInvalid variable.
## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - The wallet screen now features a more compact and streamlined card design, offering a visually balanced display.
  - The updated card layout ensures a consistent presentation across wallet items and maintains full tap interactivity.
  - These improvements significantly enhance usability and deliver a polished, reliable experience when managing and reviewing wallet content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->