### PR TITLE
fix(web): DefaultHeader component - Show mobile background on subpages

### DIFF
--- a/apps/web/components/DefaultHeader/DefaultHeader.tsx
+++ b/apps/web/components/DefaultHeader/DefaultHeader.tsx
@@ -102,7 +102,8 @@ export const DefaultHeader: React.FC<
       <div
         className={cn({ [styles.gridContainerWidth]: !fullWidth })}
         style={{
-          background: isMobile ? mobileBackground || background : background,
+          background:
+            isMobile || isSubpage ? mobileBackground || background : background,
         }}
       >
         <div


### PR DESCRIPTION
# DefaultHeader component - Show mobile background on subpages

## What

* On subpages the headers' height decreases, meaning that sometimes if there is a background image it'll be cut off.
* To address this we'd like to use the mobile background on subpages (if it is present)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The header now adapts its background style to use a mobile-friendly version when viewing subpages as well as on mobile devices, enhancing visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->