### PR TITLE
chore(j-s): adjust client logic to new offense data structure per indictment count

### DIFF
--- a/apps/judicial-system/api/infra/judicial-system-api.ts
+++ b/apps/judicial-system/api/infra/judicial-system-api.ts
@@ -46,9 +46,9 @@ export const serviceSetup = (services: {
         prod: 'master',
       },
       HIDDEN_FEATURES: {
-        dev: '',
-        staging: '',
-        prod: '',
+        dev: 'OFFENSE_ENDPOINTS',
+        staging: 'OFFENSE_ENDPOINTS',
+        prod: 'OFFENSE_ENDPOINTS',
       },
     })
     .secrets({

--- a/apps/judicial-system/api/src/app/modules/indictment-count/dto/createOffense.input.ts
+++ b/apps/judicial-system/api/src/app/modules/indictment-count/dto/createOffense.input.ts
@@ -1,6 +1,8 @@
-import { Allow } from 'class-validator'
+import { Allow, IsEnum } from 'class-validator'
 
 import { Field, ID, InputType } from '@nestjs/graphql'
+
+import { IndictmentCountOffense } from '@island.is/judicial-system/types'
 
 @InputType()
 export class CreateOffenseInput {
@@ -11,4 +13,9 @@ export class CreateOffenseInput {
   @Allow()
   @Field(() => ID)
   readonly indictmentCountId!: string
+
+  @Allow()
+  @IsEnum(IndictmentCountOffense)
+  @Field(() => IndictmentCountOffense)
+  readonly offense!: IndictmentCountOffense
 }

--- a/apps/judicial-system/api/src/app/modules/indictment-count/dto/updateOffense.input.ts
+++ b/apps/judicial-system/api/src/app/modules/indictment-count/dto/updateOffense.input.ts
@@ -1,10 +1,9 @@
-import { Allow, IsEnum, IsOptional } from 'class-validator'
+import { Allow, IsOptional } from 'class-validator'
 import { GraphQLJSONObject } from 'graphql-type-json'
 
 import { Field, ID, InputType } from '@nestjs/graphql'
 
 import type { SubstanceMap } from '@island.is/judicial-system/types'
-import { IndictmentCountOffense } from '@island.is/judicial-system/types'
 
 @InputType()
 export class UpdateOffenseInput {
@@ -19,11 +18,6 @@ export class UpdateOffenseInput {
   @Allow()
   @Field(() => ID)
   readonly indictmentCountId!: string
-
-  @Allow()
-  @IsEnum(IndictmentCountOffense)
-  @Field(() => IndictmentCountOffense)
-  readonly offense!: IndictmentCountOffense
 
   @Allow()
   @IsOptional()

--- a/apps/judicial-system/api/src/app/modules/indictment-count/models/offense.model.ts
+++ b/apps/judicial-system/api/src/app/modules/indictment-count/models/offense.model.ts
@@ -21,8 +21,8 @@ export class Offense {
   @Field(() => ID, { nullable: true })
   readonly indictmentCountId?: string
 
-  @Field(() => IndictmentCountOffense, { nullable: true })
-  readonly offense?: IndictmentCountOffense
+  @Field(() => IndictmentCountOffense, { nullable: false })
+  readonly offense!: IndictmentCountOffense
 
   @Field(() => GraphQLJSONObject, { nullable: true })
   readonly substances?: SubstanceMap

--- a/apps/judicial-system/backend/src/app/modules/indictment-count/dto/updateOffense.dto.ts
+++ b/apps/judicial-system/backend/src/app/modules/indictment-count/dto/updateOffense.dto.ts
@@ -1,17 +1,10 @@
-import { IsEnum, IsObject, IsOptional } from 'class-validator'
+import { IsObject, IsOptional } from 'class-validator'
 
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
+import { ApiPropertyOptional } from '@nestjs/swagger'
 
-import {
-  IndictmentCountOffense,
-  type SubstanceMap,
-} from '@island.is/judicial-system/types'
+import { type SubstanceMap } from '@island.is/judicial-system/types'
 
 export class UpdateOffenseDto {
-  @IsEnum(IndictmentCountOffense)
-  @ApiProperty({ enum: IndictmentCountOffense })
-  readonly offense!: IndictmentCountOffense
-
   @IsOptional()
   @IsObject()
   @ApiPropertyOptional({ type: Object })

--- a/apps/judicial-system/web/messages/Core/errors.ts
+++ b/apps/judicial-system/web/messages/Core/errors.ts
@@ -122,6 +122,22 @@ export const errors = defineMessages({
     defaultMessage: 'Upp kom villa við að eyða ákærulið',
     description: 'Notaður sem villuskilaboð þegar ekki gengur að eyða ákærulíð',
   },
+  createOffense: {
+    id: 'judicial.system.core:errors.create_offense',
+    defaultMessage: 'Upp kom villa við að stofna nýtt brot',
+    description:
+      'Notaður sem villuskilaboð þegar ekki gengur að stofna nýtt brot',
+  },
+  updateOffense: {
+    id: 'judicial.system.core:errors.update_offense',
+    defaultMessage: 'Upp kom villa við að uppfæra brot',
+    description: 'Notaður sem villuskilaboð þegar ekki gengur að uppfæra brot',
+  },
+  deleteOffense: {
+    id: 'judicial.system.core:errors.delete_offense',
+    defaultMessage: 'Upp kom villa við að eyða broti',
+    description: 'Notaður sem villuskilaboð þegar ekki gengur að eyða broti',
+  },
   getCaseToOpen: {
     id: 'judicial.system.core:errors.getCaseToOpen',
     defaultMessage: 'Upp kom villa við að sækja mál',

--- a/apps/judicial-system/web/src/components/FormProvider/case.graphql
+++ b/apps/judicial-system/web/src/components/FormProvider/case.graphql
@@ -213,6 +213,14 @@ query Case($input: CaseQueryInput!) {
       created
       modified
       vehicleRegistrationNumber
+      offenses {
+        id
+        indictmentCountId
+        created
+        modified
+        offense
+        substances
+      }
       deprecatedOffenses
       substances
       lawsBroken

--- a/apps/judicial-system/web/src/components/FormProvider/limitedAccessCase.graphql
+++ b/apps/judicial-system/web/src/components/FormProvider/limitedAccessCase.graphql
@@ -203,6 +203,14 @@ query LimitedAccessCase($input: CaseQueryInput!) {
       created
       modified
       vehicleRegistrationNumber
+      offenses {
+        id
+        indictmentCountId
+        created
+        modified
+        offense
+        substances
+      }
       deprecatedOffenses
       substances
       lawsBroken

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/Defendant.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/Defendant.tsx
@@ -38,7 +38,7 @@ import { isDefendantStepValidIndictments } from '@island.is/judicial-system-web/
 
 import { DefendantInfo } from '../../components'
 import { getIndictmentIntroductionAutofill } from '../Indictment/Indictment'
-import { getIncidentDescription } from '../Indictment/IndictmentCount'
+import { getIncidentDescription } from '../Indictment/lib/getIncidentDescription'
 import { LokeNumberList } from './LokeNumberList/LokeNumberList'
 import { PoliceCaseInfo } from './PoliceCaseInfo/PoliceCaseInfo'
 import { usePoliceCaseInfoQuery } from './policeCaseInfo.generated'

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/IndictmentCount.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/IndictmentCount.tsx
@@ -788,7 +788,7 @@ export const IndictmentCount: FC<Props> = ({
                   </InputMask>
                 </Box>
               )}
-              {/* HERE */}
+
               {indictmentCount.deprecatedOffenses
                 ?.filter(
                   (offenseType) =>
@@ -806,174 +806,170 @@ export const IndictmentCount: FC<Props> = ({
                     />
                   </Box>
                 ))}
-              <Box marginBottom={2}>
-                <SectionHeading
-                  heading="h4"
-                  title={formatMessage(strings.lawsBrokenTitle)}
-                  marginBottom={2}
-                />
-                <Select
-                  name="lawsBroken"
-                  options={lawsBrokenOptions}
-                  label={formatMessage(strings.lawsBrokenLabel)}
-                  placeholder={formatMessage(strings.lawsBrokenPlaceholder)}
-                  value={null}
-                  onChange={(selectedOption) => {
-                    const law = (selectedOption as LawsBrokenOption).law
-                    const lawsBroken = [
-                      ...(indictmentCount.lawsBroken ?? []),
-                      law,
-                    ].sort(lawsCompare)
-
-                    onChange(indictmentCount.id, {
-                      lawsBroken: lawsBroken,
-                      legalArguments: getLegalArguments(
-                        lawsBroken,
-                        formatMessage,
-                      ),
-                    })
-
-                    handleIndictmentCountChanges({
-                      lawsBroken,
-                    })
-                  }}
-                  required
-                />
-              </Box>
-              {indictmentCount.lawsBroken &&
-                indictmentCount.lawsBroken.length > 0 && (
-                  <Box marginBottom={2}>
-                    {indictmentCount.lawsBroken.map((brokenLaw) => (
-                      <Box
-                        display="inlineBlock"
-                        key={`${indictmentCount.id}-${brokenLaw}`}
-                        component="span"
-                        marginBottom={1}
-                        marginRight={1}
-                      >
-                        <Tag
-                          variant="darkerBlue"
-                          onClick={() => {
-                            const lawsBroken = (
-                              indictmentCount.lawsBroken ?? []
-                            ).filter((b) => lawsCompare(b, brokenLaw) !== 0)
-
-                            onChange(indictmentCount.id, {
-                              lawsBroken: lawsBroken,
-                              legalArguments: getLegalArguments(
-                                lawsBroken,
-                                formatMessage,
-                              ),
-                            })
-                          }}
-                          aria-label={lawTag(brokenLaw)}
-                        >
-                          <Box display="flex" alignItems="center">
-                            {lawTag(brokenLaw)}
-                            <Icon icon="close" size="small" />
-                          </Box>
-                        </Tag>
-                      </Box>
-                    ))}
-                  </Box>
-                )}
-              <Box component="section" marginBottom={3}>
-                <SectionHeading
-                  heading="h4"
-                  title={formatMessage(strings.incidentDescriptionTitle)}
-                  marginBottom={2}
-                />
-                <Box marginBottom={2}>
-                  <Input
-                    name="incidentDescription"
-                    autoComplete="off"
-                    label={formatMessage(strings.incidentDescriptionLabel)}
-                    placeholder={formatMessage(
-                      strings.incidentDescriptionPlaceholder,
-                    )}
-                    errorMessage={incidentDescriptionErrorMessage}
-                    hasError={incidentDescriptionErrorMessage !== ''}
-                    value={indictmentCount.incidentDescription ?? ''}
-                    onChange={(event) => {
-                      removeErrorMessageIfValid(
-                        ['empty'],
-                        event.target.value,
-                        incidentDescriptionErrorMessage,
-                        setIncidentDescriptionErrorMessage,
-                      )
-
-                      updateIndictmentCountState(
-                        indictmentCount.id,
-                        { incidentDescription: event.target.value },
-                        setWorkingCase,
-                      )
-                    }}
-                    onBlur={(event) => {
-                      validateAndSetErrorMessage(
-                        ['empty'],
-                        event.target.value,
-                        setIncidentDescriptionErrorMessage,
-                      )
-
-                      onChange(indictmentCount.id, {
-                        incidentDescription: event.target.value.trim(),
-                      })
-                    }}
-                    required
-                    rows={7}
-                    autoExpand={{ on: true, maxHeight: 600 }}
-                    textarea
-                  />
-                </Box>
-              </Box>
-              <Box component="section">
-                <SectionHeading
-                  heading="h4"
-                  title={formatMessage(strings.legalArgumentsTitle)}
-                  marginBottom={2}
-                />
-
-                <Input
-                  name="legalArguments"
-                  autoComplete="off"
-                  label={formatMessage(strings.legalArgumentsLabel)}
-                  placeholder={formatMessage(strings.legalArgumentsPlaceholder)}
-                  errorMessage={legalArgumentsErrorMessage}
-                  hasError={legalArgumentsErrorMessage !== ''}
-                  value={indictmentCount.legalArguments ?? ''}
-                  onChange={(event) => {
-                    removeErrorMessageIfValid(
-                      ['empty'],
-                      event.target.value,
-                      legalArgumentsErrorMessage,
-                      setLegalArgumentsErrorMessage,
-                    )
-
-                    updateIndictmentCountState(
-                      indictmentCount.id,
-                      { legalArguments: event.target.value },
-                      setWorkingCase,
-                    )
-                  }}
-                  onBlur={(event) => {
-                    validateAndSetErrorMessage(
-                      ['empty'],
-                      event.target.value,
-                      setLegalArgumentsErrorMessage,
-                    )
-
-                    onChange(indictmentCount.id, {
-                      legalArguments: event.target.value.trim(),
-                    })
-                  }}
-                  required
-                  rows={7}
-                  autoExpand={{ on: true, maxHeight: 600 }}
-                  textarea
-                />
-              </Box>
             </>
           )}
+          <Box marginBottom={2}>
+            <SectionHeading
+              heading="h4"
+              title={formatMessage(strings.lawsBrokenTitle)}
+              marginBottom={2}
+            />
+            <Select
+              name="lawsBroken"
+              options={lawsBrokenOptions}
+              label={formatMessage(strings.lawsBrokenLabel)}
+              placeholder={formatMessage(strings.lawsBrokenPlaceholder)}
+              value={null}
+              onChange={(selectedOption) => {
+                const law = (selectedOption as LawsBrokenOption).law
+                const lawsBroken = [
+                  ...(indictmentCount.lawsBroken ?? []),
+                  law,
+                ].sort(lawsCompare)
+
+                onChange(indictmentCount.id, {
+                  lawsBroken: lawsBroken,
+                  legalArguments: getLegalArguments(lawsBroken, formatMessage),
+                })
+
+                handleIndictmentCountChanges({
+                  lawsBroken,
+                })
+              }}
+              required
+            />
+          </Box>
+          {indictmentCount.lawsBroken && indictmentCount.lawsBroken.length > 0 && (
+            <Box marginBottom={2}>
+              {indictmentCount.lawsBroken.map((brokenLaw) => (
+                <Box
+                  display="inlineBlock"
+                  key={`${indictmentCount.id}-${brokenLaw}`}
+                  component="span"
+                  marginBottom={1}
+                  marginRight={1}
+                >
+                  <Tag
+                    variant="darkerBlue"
+                    onClick={() => {
+                      const lawsBroken = (
+                        indictmentCount.lawsBroken ?? []
+                      ).filter((b) => lawsCompare(b, brokenLaw) !== 0)
+
+                      onChange(indictmentCount.id, {
+                        lawsBroken: lawsBroken,
+                        legalArguments: getLegalArguments(
+                          lawsBroken,
+                          formatMessage,
+                        ),
+                      })
+                    }}
+                    aria-label={lawTag(brokenLaw)}
+                  >
+                    <Box display="flex" alignItems="center">
+                      {lawTag(brokenLaw)}
+                      <Icon icon="close" size="small" />
+                    </Box>
+                  </Tag>
+                </Box>
+              ))}
+            </Box>
+          )}
+          <Box component="section" marginBottom={3}>
+            <SectionHeading
+              heading="h4"
+              title={formatMessage(strings.incidentDescriptionTitle)}
+              marginBottom={2}
+            />
+            <Box marginBottom={2}>
+              <Input
+                name="incidentDescription"
+                autoComplete="off"
+                label={formatMessage(strings.incidentDescriptionLabel)}
+                placeholder={formatMessage(
+                  strings.incidentDescriptionPlaceholder,
+                )}
+                errorMessage={incidentDescriptionErrorMessage}
+                hasError={incidentDescriptionErrorMessage !== ''}
+                value={indictmentCount.incidentDescription ?? ''}
+                onChange={(event) => {
+                  removeErrorMessageIfValid(
+                    ['empty'],
+                    event.target.value,
+                    incidentDescriptionErrorMessage,
+                    setIncidentDescriptionErrorMessage,
+                  )
+
+                  updateIndictmentCountState(
+                    indictmentCount.id,
+                    { incidentDescription: event.target.value },
+                    setWorkingCase,
+                  )
+                }}
+                onBlur={(event) => {
+                  validateAndSetErrorMessage(
+                    ['empty'],
+                    event.target.value,
+                    setIncidentDescriptionErrorMessage,
+                  )
+
+                  onChange(indictmentCount.id, {
+                    incidentDescription: event.target.value.trim(),
+                  })
+                }}
+                required
+                rows={7}
+                autoExpand={{ on: true, maxHeight: 600 }}
+                textarea
+              />
+            </Box>
+          </Box>
+          <Box component="section">
+            <SectionHeading
+              heading="h4"
+              title={formatMessage(strings.legalArgumentsTitle)}
+              marginBottom={2}
+            />
+
+            <Input
+              name="legalArguments"
+              autoComplete="off"
+              label={formatMessage(strings.legalArgumentsLabel)}
+              placeholder={formatMessage(strings.legalArgumentsPlaceholder)}
+              errorMessage={legalArgumentsErrorMessage}
+              hasError={legalArgumentsErrorMessage !== ''}
+              value={indictmentCount.legalArguments ?? ''}
+              onChange={(event) => {
+                removeErrorMessageIfValid(
+                  ['empty'],
+                  event.target.value,
+                  legalArgumentsErrorMessage,
+                  setLegalArgumentsErrorMessage,
+                )
+
+                updateIndictmentCountState(
+                  indictmentCount.id,
+                  { legalArguments: event.target.value },
+                  setWorkingCase,
+                )
+              }}
+              onBlur={(event) => {
+                validateAndSetErrorMessage(
+                  ['empty'],
+                  event.target.value,
+                  setLegalArgumentsErrorMessage,
+                )
+
+                onChange(indictmentCount.id, {
+                  legalArguments: event.target.value.trim(),
+                })
+              }}
+              required
+              rows={7}
+              autoExpand={{ on: true, maxHeight: 600 }}
+              textarea
+            />
+          </Box>
         </>
       )}
     </BlueBox>

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/IndictmentCount.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/IndictmentCount.tsx
@@ -56,7 +56,7 @@ import {
 
 import { getIncidentDescription } from './lib/getIncidentDescription'
 import { Offenses } from './Offenses/Offenses'
-import { Substances as SubstanceChoices } from './Substances/Substances'
+import { DeprecatedSubstances as SubstanceChoices } from './Substances/DeprecatedSubstances'
 import { indictmentCount as strings } from './IndictmentCount.strings'
 import { indictmentCountEnum as enumStrings } from './IndictmentCountEnum.strings'
 import * as styles from './IndictmentCount.css'
@@ -687,7 +687,6 @@ export const IndictmentCount: FC<Props> = ({
                   </InputMask>
                 </Box>
               )}
-              {/* HERE */}
               {indictmentCount.deprecatedOffenses?.includes(
                 IndictmentCountOffense.SPEEDING,
               ) && (
@@ -789,6 +788,7 @@ export const IndictmentCount: FC<Props> = ({
                   </InputMask>
                 </Box>
               )}
+              {/* HERE */}
               {indictmentCount.deprecatedOffenses
                 ?.filter(
                   (offenseType) =>

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/IndictmentCount.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/IndictmentCount.tsx
@@ -409,7 +409,6 @@ export const IndictmentCount: FC<Props> = ({
   setWorkingCase,
 }) => {
   const { features } = useContext(FeatureContext)
-  // TODO: remove from dev, staging and prod!!!
   const isOffenseEndpointEnabled = features.includes(Feature.OFFENSE_ENDPOINTS)
 
   const { formatMessage } = useIntl()
@@ -683,7 +682,11 @@ export const IndictmentCount: FC<Props> = ({
             />
           </Box>
           {isOffenseEndpointEnabled ? (
-            <Offenses indictmentCount={indictmentCount} />
+            <Offenses
+              workingCase={workingCase}
+              indictmentCount={indictmentCount}
+              handleIndictmentCountChanges={handleIndictmentCountChanges}
+            />
           ) : (
             <>
               <Box marginBottom={2}>

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Offenses/Offenses.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Offenses/Offenses.tsx
@@ -312,7 +312,7 @@ export const Offenses = ({
           updateIndictmentCountState={updateIndictmentCountState}
         />
       )}
-      {/* DRUGS SUBSTANCE FIELDS */}
+      {/* DRUG SUBSTANCE FIELDS */}
       {getDrugsDriving(offenses).map((o) => (
         <Box key={`${indictmentCount.id}-${o.offense}-substances`}>
           <Substances offense={o} onChange={handleOffenseSubstanceUpdate} />

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Offenses/Offenses.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Offenses/Offenses.tsx
@@ -21,6 +21,7 @@ import {
 import { UpdateIndictmentCount } from '@island.is/judicial-system-web/src/utils/hooks'
 import useOffenses from '@island.is/judicial-system-web/src/utils/hooks/useOffenses'
 
+import { SpeedingOffenseFields } from './SpeedingOffenseFields'
 import { indictmentCount as strings } from '../IndictmentCount.strings'
 import { indictmentCountEnum as enumStrings } from '../IndictmentCountEnum.strings'
 
@@ -33,6 +34,9 @@ const getUpdatedOffenses = (
 ]
 const getDrunkDriving = (offenses: Offense[]) =>
   offenses.find((o) => o.offense === IndictmentCountOffense.DRUNK_DRIVING)
+
+const getSpeeding = (offenses: Offense[]) =>
+  offenses.find((o) => o.offense === IndictmentCountOffense.SPEEDING)
 
 export const Offenses = ({
   workingCase,
@@ -66,6 +70,7 @@ export const Offenses = ({
     [indictmentCount.offenses],
   )
   const drunkDrivingOffense = getDrunkDriving(offenses)
+  const speedingOffense = getSpeeding(offenses)
 
   const offensesOptions = useMemo(
     () =>
@@ -82,7 +87,7 @@ export const Offenses = ({
     selectedOffense: IndictmentCountOffense,
   ) => {
     const hasOffense = offenses?.some((o) => o.offense === selectedOffense)
-    console.log({hasOffense, offenses})
+    console.log({ hasOffense, offenses })
     if (!hasOffense) {
       const newOffense = await createOffense(
         workingCase.id,
@@ -158,6 +163,7 @@ export const Offenses = ({
 
   return (
     <>
+      {/* OFFENSE */}
       <Box marginBottom={2}>
         <SectionHeading
           heading="h4"
@@ -204,6 +210,7 @@ export const Offenses = ({
           })}
         </Box>
       )}
+      {/* ALCOHOL OFFENSE FIELDS */}
       {drunkDrivingOffense && (
         <Box marginBottom={2}>
           <SectionHeading
@@ -276,6 +283,15 @@ export const Offenses = ({
             />
           </InputMask>
         </Box>
+      )}
+      {/* SPEEDING OFFENSE FIELDS */}
+      {speedingOffense && (
+        <SpeedingOffenseFields
+          setWorkingCase={setWorkingCase}
+          indictmentCount={indictmentCount}
+          handleIndictmentCountChanges={handleIndictmentCountChanges}
+          updateIndictmentCountState={updateIndictmentCountState}
+        />
       )}
     </>
   )

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Offenses/Offenses.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Offenses/Offenses.tsx
@@ -1,0 +1,56 @@
+import { useMemo } from 'react'
+import { useIntl } from 'react-intl'
+
+import { Box, Select } from '@island.is/island-ui/core'
+import { IndictmentCountOffense } from '@island.is/judicial-system/types'
+import { SectionHeading } from '@island.is/judicial-system-web/src/components'
+import { TempIndictmentCount } from '@island.is/judicial-system-web/src/types'
+
+import { indictmentCount as strings } from '../IndictmentCount.strings'
+import { indictmentCountEnum as enumStrings } from '../IndictmentCountEnum.strings'
+
+export const Offenses = ({
+  indictmentCount,
+}: {
+  indictmentCount: TempIndictmentCount
+}) => {
+  const { formatMessage } = useIntl()
+
+  const {offenses} = indictmentCount
+  console.log({offenses})
+  // TODO
+  const offensesOptions = useMemo(
+    () =>
+      Object.values(IndictmentCountOffense).map((offense) => ({
+        value: offense,
+        label: formatMessage(enumStrings[offense]),
+        disabled: indictmentCount.deprecatedOffenses?.includes(offense),
+      })),
+    [formatMessage, indictmentCount.deprecatedOffenses],
+  )
+
+  return (
+    <Box marginBottom={2}>
+      <SectionHeading
+        heading="h4"
+        title={formatMessage(strings.incidentTitle)}
+        marginBottom={2}
+      />
+      <Select
+        name="deprecatedOffenses"
+        options={offensesOptions}
+        label={formatMessage(strings.incidentLabel)}
+        placeholder={formatMessage(strings.incidentPlaceholder)}
+        onChange={(so) => {
+          const selectedOffense = so?.value as IndictmentCountOffense
+
+          // handleIndictmentCountChanges({
+          //   deprecatedOffenses,
+          // })
+        }}
+        value={null}
+        required
+      />
+    </Box>
+  )
+}

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Offenses/Offenses.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Offenses/Offenses.tsx
@@ -1,56 +1,115 @@
 import { useMemo } from 'react'
 import { useIntl } from 'react-intl'
 
-import { Box, Select } from '@island.is/island-ui/core'
+import { Box, Icon, Select, Tag } from '@island.is/island-ui/core'
 import { IndictmentCountOffense } from '@island.is/judicial-system/types'
 import { SectionHeading } from '@island.is/judicial-system-web/src/components'
+import { Case } from '@island.is/judicial-system-web/src/graphql/schema'
 import { TempIndictmentCount } from '@island.is/judicial-system-web/src/types'
+import { isNonEmptyArray } from '@island.is/judicial-system-web/src/utils/arrayHelpers'
+import { UpdateIndictmentCount } from '@island.is/judicial-system-web/src/utils/hooks'
+import useOffenses from '@island.is/judicial-system-web/src/utils/hooks/useOffenses'
 
 import { indictmentCount as strings } from '../IndictmentCount.strings'
 import { indictmentCountEnum as enumStrings } from '../IndictmentCountEnum.strings'
 
+// TODO: it seems like we need to commit to server AND update the case state
 export const Offenses = ({
+  workingCase,
   indictmentCount,
+  handleIndictmentCountChanges,
 }: {
+  workingCase: Case
   indictmentCount: TempIndictmentCount
+  handleIndictmentCountChanges: (update: UpdateIndictmentCount) => void
 }) => {
   const { formatMessage } = useIntl()
+  const { createOffense, deleteOffense } = useOffenses()
 
-  const {offenses} = indictmentCount
-  console.log({offenses})
-  // TODO
+  const { offenses } = indictmentCount
+
   const offensesOptions = useMemo(
     () =>
       Object.values(IndictmentCountOffense).map((offense) => ({
         value: offense,
         label: formatMessage(enumStrings[offense]),
-        disabled: indictmentCount.deprecatedOffenses?.includes(offense),
+        disabled: offenses?.some((o) => o.offense === offense),
       })),
-    [formatMessage, indictmentCount.deprecatedOffenses],
+    [formatMessage, offenses],
   )
 
-  return (
-    <Box marginBottom={2}>
-      <SectionHeading
-        heading="h4"
-        title={formatMessage(strings.incidentTitle)}
-        marginBottom={2}
-      />
-      <Select
-        name="deprecatedOffenses"
-        options={offensesOptions}
-        label={formatMessage(strings.incidentLabel)}
-        placeholder={formatMessage(strings.incidentPlaceholder)}
-        onChange={(so) => {
-          const selectedOffense = so?.value as IndictmentCountOffense
 
-          // handleIndictmentCountChanges({
-          //   deprecatedOffenses,
-          // })
-        }}
-        value={null}
-        required
-      />
-    </Box>
+  return (
+    <>
+      <Box marginBottom={2}>
+        <SectionHeading
+          heading="h4"
+          title={formatMessage(strings.incidentTitle)}
+          marginBottom={2}
+        />
+        <Select
+          name="offenses"
+          options={offensesOptions}
+          label={formatMessage(strings.incidentLabel)}
+          placeholder={formatMessage(strings.incidentPlaceholder)}
+          onChange={async (so) => {
+            const selectedOffense = so?.value as IndictmentCountOffense
+            const hasOffense = offenses?.some((o) => o.offense === selectedOffense)
+            if (!hasOffense) {
+              const offense = await createOffense(
+                workingCase.id,
+                indictmentCount.id,
+                selectedOffense,
+              )
+            }
+            // TODO: do we need to update some state as well? yes
+          }}
+          value={null}
+          required
+        />
+      </Box>
+      {isNonEmptyArray(offenses) && (
+        <Box marginBottom={2}>
+          {offenses.map(({ id: offenseId, offense }) => {
+            if (!offense) {
+              return null
+            }
+            return (
+              <Box
+                display="inlineBlock"
+                key={`${indictmentCount.id}-${offenseId}-${offense}`}
+                component="span"
+                marginBottom={1}
+                marginRight={1}
+              >
+                <Tag
+                  variant="darkerBlue"
+                  onClick={async () => {
+                    await deleteOffense(
+                      workingCase.id,
+                      indictmentCount.id,
+                      offenseId,
+                    )
+
+                    // TODO: update state
+                    handleIndictmentCountChanges({
+                      ...(offense === IndictmentCountOffense.SPEEDING && {
+                        recordedSpeed: null,
+                        speedLimit: null,
+                      }),
+                    })
+                  }}
+                >
+                  <Box display="flex" alignItems="center">
+                    {formatMessage(enumStrings[offense])}
+                    <Icon icon="close" size="small" />
+                  </Box>
+                </Tag>
+              </Box>
+            )
+          })}
+        </Box>
+      )}
+    </>
   )
 }

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Offenses/Offenses.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Offenses/Offenses.tsx
@@ -21,6 +21,8 @@ import {
 import { UpdateIndictmentCount } from '@island.is/judicial-system-web/src/utils/hooks'
 import useOffenses from '@island.is/judicial-system-web/src/utils/hooks/useOffenses'
 
+import { DeprecatedSubstances as SubstanceChoices } from '../Substances/DeprecatedSubstances'
+import { Substances } from '../Substances/Substances'
 import { SpeedingOffenseFields } from './SpeedingOffenseFields'
 import { indictmentCount as strings } from '../IndictmentCount.strings'
 import { indictmentCountEnum as enumStrings } from '../IndictmentCountEnum.strings'
@@ -37,6 +39,13 @@ const getDrunkDriving = (offenses: Offense[]) =>
 
 const getSpeeding = (offenses: Offense[]) =>
   offenses.find((o) => o.offense === IndictmentCountOffense.SPEEDING)
+
+const getDrugsDriving = (offenses: Offense[]) =>
+  offenses?.filter(
+    (o) =>
+      o.offense === IndictmentCountOffense.ILLEGAL_DRUGS_DRIVING ||
+      o.offense === IndictmentCountOffense.PRESCRIPTION_DRUGS_DRIVING,
+  )
 
 export const Offenses = ({
   workingCase,
@@ -87,7 +96,6 @@ export const Offenses = ({
     selectedOffense: IndictmentCountOffense,
   ) => {
     const hasOffense = offenses?.some((o) => o.offense === selectedOffense)
-    console.log({ hasOffense, offenses })
     if (!hasOffense) {
       const newOffense = await createOffense(
         workingCase.id,
@@ -131,14 +139,14 @@ export const Offenses = ({
     })
   }
 
-  const handleAlcoholSubstanceUpdate = async (
+  const handleOffenseSubstanceUpdate = async (
     offense: Offense,
-    alcoholValue: string,
+    updatedSubstances: SubstanceMap,
   ) => {
     const offenseToBeUpdated = {
       substances: {
         ...offense.substances,
-        ALCOHOL: alcoholValue,
+        ...updatedSubstances,
       } as SubstanceMap,
     }
     const updatedOffense = await updateOffense(
@@ -159,6 +167,17 @@ export const Offenses = ({
 
       handleIndictmentCountChanges({}, updatedOffenses)
     }
+  }
+
+  const handleAlcoholSubstanceUpdate = async (
+    offense: Offense,
+    alcoholValue: string,
+  ) => {
+    const substances = {
+      ...offense.substances,
+      ALCOHOL: alcoholValue,
+    } as SubstanceMap
+    await handleOffenseSubstanceUpdate(offense, substances)
   }
 
   return (
@@ -293,6 +312,12 @@ export const Offenses = ({
           updateIndictmentCountState={updateIndictmentCountState}
         />
       )}
+      {/* DRUGS SUBSTANCE FIELDS */}
+      {getDrugsDriving(offenses).map((o) => (
+        <Box key={`${indictmentCount.id}-${o.offense}-substances`}>
+          <Substances offense={o} onChange={handleOffenseSubstanceUpdate} />
+        </Box>
+      ))}
     </>
   )
 }

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Offenses/SpeedingOffenseFields.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Offenses/SpeedingOffenseFields.tsx
@@ -1,0 +1,139 @@
+import { Dispatch, SetStateAction, useState } from 'react'
+import InputMask from 'react-input-mask'
+import { useIntl } from 'react-intl'
+
+import { Box, Input } from '@island.is/island-ui/core'
+import { SectionHeading } from '@island.is/judicial-system-web/src/components'
+import {
+  Case,
+  Offense,
+} from '@island.is/judicial-system-web/src/graphql/schema'
+import { TempIndictmentCount } from '@island.is/judicial-system-web/src/types'
+import { removeErrorMessageIfValid } from '@island.is/judicial-system-web/src/utils/formHelper'
+import { UpdateIndictmentCount } from '@island.is/judicial-system-web/src/utils/hooks'
+
+import { indictmentCount as strings } from '../IndictmentCount.strings'
+
+export const SpeedingOffenseFields = ({
+  setWorkingCase,
+  indictmentCount,
+  handleIndictmentCountChanges,
+  updateIndictmentCountState,
+}: {
+  setWorkingCase: Dispatch<SetStateAction<Case>>
+  indictmentCount: TempIndictmentCount
+  handleIndictmentCountChanges: (
+    update: UpdateIndictmentCount,
+    updatedOffenses?: Offense[],
+  ) => void
+  updateIndictmentCountState: (
+    indictmentCountId: string,
+    update: UpdateIndictmentCount,
+    setWorkingCase: Dispatch<SetStateAction<Case>>,
+    updatedOffenses?: Offense[],
+  ) => void
+}) => {
+  const { formatMessage } = useIntl()
+
+  const [recordedSpeedErrorMessage, setRecordedSpeedErrorMessage] =
+    useState<string>('')
+  const [speedLimitErrorMessage, setSpeedLimitErrorMessage] =
+    useState<string>('')
+  return (
+    <Box marginBottom={2}>
+      <SectionHeading
+        title={formatMessage(strings.speedingTitle)}
+        heading="h4"
+        marginBottom={2}
+      />
+      <Box marginBottom={1}>
+        <InputMask
+          mask={'999'}
+          maskPlaceholder={null}
+          value={indictmentCount.recordedSpeed?.toString() ?? ''}
+          onChange={(event) => {
+            const recordedSpeed = parseInt(event.target.value)
+
+            removeErrorMessageIfValid(
+              ['empty'],
+              event.target.value,
+              recordedSpeedErrorMessage,
+              setRecordedSpeedErrorMessage,
+            )
+
+            updateIndictmentCountState(
+              indictmentCount.id,
+              { recordedSpeed },
+              setWorkingCase,
+            )
+          }}
+          onBlur={(event) => {
+            const recordedSpeed = parseInt(event.target.value)
+
+            if (Number.isNaN(recordedSpeed)) {
+              setRecordedSpeedErrorMessage('Reitur má ekki vera tómur')
+              return
+            }
+
+            handleIndictmentCountChanges({
+              recordedSpeed,
+            })
+          }}
+        >
+          <Input
+            name="recordedSpeed"
+            autoComplete="off"
+            label={formatMessage(strings.recordedSpeedLabel)}
+            placeholder="0"
+            required
+            errorMessage={recordedSpeedErrorMessage}
+            hasError={recordedSpeedErrorMessage !== ''}
+          />
+        </InputMask>
+      </Box>
+      <InputMask
+        mask={'999'}
+        maskPlaceholder={null}
+        value={indictmentCount.speedLimit?.toString() ?? ''}
+        onChange={(event) => {
+          const speedLimit = parseInt(event.target.value)
+
+          removeErrorMessageIfValid(
+            ['empty'],
+            event.target.value,
+            speedLimitErrorMessage,
+            setSpeedLimitErrorMessage,
+          )
+
+          updateIndictmentCountState(
+            indictmentCount.id,
+            { speedLimit },
+            setWorkingCase,
+          )
+        }}
+        onBlur={(event) => {
+          const speedLimit = parseInt(event.target.value)
+
+          if (Number.isNaN(speedLimit)) {
+            setSpeedLimitErrorMessage('Reitur má ekki vera tómur')
+            return
+          }
+
+          handleIndictmentCountChanges({
+            speedLimit,
+          })
+        }}
+      >
+        <Input
+          name="speedLimit"
+          autoComplete="off"
+          label={formatMessage(strings.speedLimitLabel)}
+          placeholder="0"
+          required
+          errorMessage={speedLimitErrorMessage}
+          hasError={speedLimitErrorMessage !== ''}
+        />
+      </InputMask>
+    </Box>
+  )
+}

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/lib/getDeprecatedIncidentDescriptionReason.spec.ts
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/lib/getDeprecatedIncidentDescriptionReason.spec.ts
@@ -1,0 +1,120 @@
+import { IndictmentCountOffense } from '@island.is/judicial-system/types'
+import { formatMessage } from '@island.is/judicial-system-web/src/utils/testHelpers'
+
+import { getDeprecatedIncidentDescriptionReason } from './getDeprecatedIncidentDescriptionReason'
+
+describe('getDeprecatedIncidentDescriptionReason', () => {
+  test('should return a description for one offense', () => {
+    const offenses = [IndictmentCountOffense.DRIVING_WITHOUT_LICENCE]
+
+    const result = getDeprecatedIncidentDescriptionReason(
+      offenses,
+      {},
+      formatMessage,
+    )
+
+    expect(result).toBe('sviptur ökurétti')
+  })
+
+  test('should return a description for two offense', () => {
+    const offenses = [
+      IndictmentCountOffense.DRIVING_WITHOUT_LICENCE,
+      IndictmentCountOffense.DRUNK_DRIVING,
+    ]
+
+    const result = getDeprecatedIncidentDescriptionReason(
+      offenses,
+      {},
+      formatMessage,
+    )
+
+    expect(result).toBe('sviptur ökurétti og undir áhrifum áfengis')
+  })
+
+  test('should return a description with prescription drugs', () => {
+    const offenses = [
+      IndictmentCountOffense.DRUNK_DRIVING,
+      IndictmentCountOffense.PRESCRIPTION_DRUGS_DRIVING,
+    ]
+
+    const result = getDeprecatedIncidentDescriptionReason(
+      offenses,
+      {},
+      formatMessage,
+    )
+
+    expect(result).toBe(
+      'undir áhrifum áfengis og óhæfur til að stjórna henni örugglega vegna áhrifa slævandi lyfja',
+    )
+  })
+
+  test('should return a description with illegal drugs', () => {
+    const offenses = [
+      IndictmentCountOffense.DRUNK_DRIVING,
+      IndictmentCountOffense.ILLEGAL_DRUGS_DRIVING,
+    ]
+
+    const result = getDeprecatedIncidentDescriptionReason(
+      offenses,
+      {},
+      formatMessage,
+    )
+
+    expect(result).toBe(
+      'undir áhrifum áfengis og óhæfur til að stjórna henni örugglega vegna áhrifa ávana- og fíkniefna',
+    )
+  })
+
+  test('should return a description with illegal drugs as third offense', () => {
+    const offenses = [
+      IndictmentCountOffense.DRIVING_WITHOUT_LICENCE,
+      IndictmentCountOffense.DRUNK_DRIVING,
+      IndictmentCountOffense.ILLEGAL_DRUGS_DRIVING,
+    ]
+
+    const result = getDeprecatedIncidentDescriptionReason(
+      offenses,
+      {},
+      formatMessage,
+    )
+
+    expect(result).toBe(
+      'sviptur ökurétti, undir áhrifum áfengis og óhæfur til að stjórna henni örugglega vegna áhrifa ávana- og fíkniefna',
+    )
+  })
+
+  test('should return a description with illegal and prescription drugs', () => {
+    const offenses = [
+      IndictmentCountOffense.DRUNK_DRIVING,
+      IndictmentCountOffense.ILLEGAL_DRUGS_DRIVING,
+      IndictmentCountOffense.PRESCRIPTION_DRUGS_DRIVING,
+    ]
+
+    const result = getDeprecatedIncidentDescriptionReason(
+      offenses,
+      {},
+      formatMessage,
+    )
+
+    expect(result).toBe(
+      'undir áhrifum áfengis og óhæfur til að stjórna henni örugglega vegna áhrifa ávana- og fíkniefna og slævandi lyfja',
+    )
+  })
+
+  test('should return a description with only illegal and prescription drugs', () => {
+    const offenses = [
+      IndictmentCountOffense.ILLEGAL_DRUGS_DRIVING,
+      IndictmentCountOffense.PRESCRIPTION_DRUGS_DRIVING,
+    ]
+
+    const result = getDeprecatedIncidentDescriptionReason(
+      offenses,
+      {},
+      formatMessage,
+    )
+
+    expect(result).toBe(
+      'óhæfur til að stjórna henni örugglega vegna áhrifa ávana- og fíkniefna og slævandi lyfja',
+    )
+  })
+})

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/lib/getDeprecatedIncidentDescriptionReason.ts
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/lib/getDeprecatedIncidentDescriptionReason.ts
@@ -1,0 +1,90 @@
+import { IntlShape } from 'react-intl'
+
+import {
+  IndictmentCountOffense,
+  Substance,
+  SubstanceMap,
+} from '@island.is/judicial-system/types'
+
+import { getRelevantSubstances } from '../IndictmentCount'
+import { indictmentCount as strings } from '../IndictmentCount.strings'
+import { substanceEnum } from '../Substances/SubstancesEnum.strings'
+
+export const getDeprecatedIncidentDescriptionReason = (
+  deprecatedOffenses: IndictmentCountOffense[],
+  substances: SubstanceMap,
+  formatMessage: IntlShape['formatMessage'],
+) => {
+  let reason = deprecatedOffenses
+    .filter((offense) => offense !== IndictmentCountOffense.SPEEDING)
+    .reduce((acc, offense, index) => {
+      if (
+        (deprecatedOffenses.length > 1 &&
+          index === deprecatedOffenses.length - 1) ||
+        (deprecatedOffenses.length > 2 &&
+          index === deprecatedOffenses.length - 2 &&
+          offense === IndictmentCountOffense.ILLEGAL_DRUGS_DRIVING)
+      ) {
+        acc += ' og '
+      } else if (index > 0) {
+        acc += ', '
+      }
+      switch (offense) {
+        case IndictmentCountOffense.DRIVING_WITHOUT_LICENCE:
+          acc += formatMessage(
+            strings.incidentDescriptionDrivingWithoutLicenceAutofill,
+          )
+          break
+        case IndictmentCountOffense.DRUNK_DRIVING:
+          acc += formatMessage(strings.incidentDescriptionDrunkDrivingAutofill)
+          break
+        case IndictmentCountOffense.ILLEGAL_DRUGS_DRIVING:
+          acc += `${formatMessage(
+            strings.incidentDescriptionDrugsDrivingPrefixAutofill,
+          )} ${formatMessage(
+            strings.incidentDescriptionIllegalDrugsDrivingAutofill,
+          )}`
+          break
+        case IndictmentCountOffense.PRESCRIPTION_DRUGS_DRIVING:
+          acc +=
+            (deprecatedOffenses.includes(
+              IndictmentCountOffense.ILLEGAL_DRUGS_DRIVING,
+            )
+              ? ''
+              : `${formatMessage(
+                  strings.incidentDescriptionDrugsDrivingPrefixAutofill,
+                )} `) +
+            formatMessage(
+              strings.incidentDescriptionPrescriptionDrugsDrivingAutofill,
+            )
+          break
+      }
+      return acc
+    }, '')
+
+  const relevantSubstances = getRelevantSubstances(
+    deprecatedOffenses,
+    substances,
+  )
+
+  reason += relevantSubstances.reduce((acc, substance, index) => {
+    if (index === 0) {
+      acc += ` (${formatMessage(
+        strings.incidentDescriptionSubstancesPrefixAutofill,
+      )} `
+    } else if (index === relevantSubstances.length - 1) {
+      acc += ' og '
+    } else {
+      acc += ', '
+    }
+    acc += formatMessage(substanceEnum[substance[0] as Substance], {
+      amount: substance[1],
+    })
+    if (index === relevantSubstances.length - 1) {
+      acc += ')'
+    }
+    return acc
+  }, '')
+
+  return reason
+}

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/lib/getIncidentDecriptionReason.spec.ts
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/lib/getIncidentDecriptionReason.spec.ts
@@ -1,0 +1,125 @@
+import { IndictmentCountOffense } from '@island.is/judicial-system/types'
+import { Offense } from '@island.is/judicial-system-web/src/graphql/schema'
+import { formatMessage } from '@island.is/judicial-system-web/src/utils/testHelpers'
+
+import { getIncidentDescriptionReason } from './getIncidentDescriptionReason'
+
+describe('getIncidentDescriptionReason', () => {
+  test('should return a description for one offense', () => {
+    const offenses = [
+      {
+        offense: IndictmentCountOffense.DRIVING_WITHOUT_LICENCE,
+        substances: {},
+      },
+    ] as Offense[]
+
+    const result = getIncidentDescriptionReason(offenses, formatMessage)
+
+    expect(result).toBe('sviptur ökurétti')
+  })
+
+  test('should return a description for two offense', () => {
+    const offenses = [
+      {
+        offense: IndictmentCountOffense.DRIVING_WITHOUT_LICENCE,
+        substances: {},
+      },
+      { offense: IndictmentCountOffense.DRUNK_DRIVING, substances: {} },
+    ] as Offense[]
+
+    const result = getIncidentDescriptionReason(offenses, formatMessage)
+
+    expect(result).toBe('sviptur ökurétti og undir áhrifum áfengis')
+  })
+
+  test('should return a description with prescription drugs', () => {
+    const offenses = [
+      {
+        offense: IndictmentCountOffense.DRUNK_DRIVING,
+        substances: {},
+      },
+      {
+        offense: IndictmentCountOffense.PRESCRIPTION_DRUGS_DRIVING,
+        substances: {},
+      },
+    ] as Offense[]
+
+    const result = getIncidentDescriptionReason(offenses, formatMessage)
+
+    expect(result).toBe(
+      'undir áhrifum áfengis og óhæfur til að stjórna henni örugglega vegna áhrifa slævandi lyfja',
+    )
+  })
+
+  test('should return a description with illegal drugs', () => {
+    const offenses = [
+      {
+        offense: IndictmentCountOffense.DRUNK_DRIVING,
+        substances: {},
+      },
+      { offense: IndictmentCountOffense.ILLEGAL_DRUGS_DRIVING, substances: {} },
+    ] as Offense[]
+
+    const result = getIncidentDescriptionReason(offenses, formatMessage)
+
+    expect(result).toBe(
+      'undir áhrifum áfengis og óhæfur til að stjórna henni örugglega vegna áhrifa ávana- og fíkniefna',
+    )
+  })
+
+  test('should return a description with illegal drugs as third offense', () => {
+    const offenses = [
+      {
+        offense: IndictmentCountOffense.DRIVING_WITHOUT_LICENCE,
+        substances: {},
+      },
+      { offense: IndictmentCountOffense.DRUNK_DRIVING, substances: {} },
+      { offense: IndictmentCountOffense.ILLEGAL_DRUGS_DRIVING, substances: {} },
+    ] as Offense[]
+
+    const result = getIncidentDescriptionReason(offenses, formatMessage)
+
+    expect(result).toBe(
+      'sviptur ökurétti, undir áhrifum áfengis og óhæfur til að stjórna henni örugglega vegna áhrifa ávana- og fíkniefna',
+    )
+  })
+
+  test('should return a description with illegal and prescription drugs', () => {
+    const offenses = [
+      {
+        offense: IndictmentCountOffense.DRUNK_DRIVING,
+        substances: {},
+      },
+      { offense: IndictmentCountOffense.ILLEGAL_DRUGS_DRIVING, substances: {} },
+      {
+        offense: IndictmentCountOffense.PRESCRIPTION_DRUGS_DRIVING,
+        substances: {},
+      },
+    ] as Offense[]
+
+    const result = getIncidentDescriptionReason(offenses, formatMessage)
+
+    expect(result).toBe(
+      'undir áhrifum áfengis og óhæfur til að stjórna henni örugglega vegna áhrifa ávana- og fíkniefna og slævandi lyfja',
+    )
+  })
+
+  test('should return a description with only illegal and prescription drugs', () => {
+    const offenses = [
+      {
+        offense: IndictmentCountOffense.ILLEGAL_DRUGS_DRIVING,
+        substances: {},
+      },
+      {
+        offense: IndictmentCountOffense.PRESCRIPTION_DRUGS_DRIVING,
+        substances: {},
+      },
+    ] as Offense[]
+
+    const result = getIncidentDescriptionReason(offenses, formatMessage)
+
+    expect(result).toBe(
+      'óhæfur til að stjórna henni örugglega vegna áhrifa ávana- og fíkniefna og slævandi lyfja',
+    )
+  })
+})

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/lib/getIncidentDescription.spec.ts
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/lib/getIncidentDescription.spec.ts
@@ -1,133 +1,8 @@
-import { createIntl } from 'react-intl'
+import { IndictmentCountOffense } from '@island.is/judicial-system/types'
+import { IndictmentSubtype } from '@island.is/judicial-system/types'
+import { formatMessage } from '@island.is/judicial-system-web/src/utils/testHelpers'
 
-import { Substance, SubstanceMap } from '@island.is/judicial-system/types'
-import {
-  IndictmentCountOffense as offense,
-  IndictmentSubtype,
-} from '@island.is/judicial-system-web/src/graphql/schema'
-
-import { getIncidentDescription } from './lib/getIncidentDescription'
-import { getLegalArguments, getRelevantSubstances } from './IndictmentCount'
-
-const formatMessage = createIntl({
-  locale: 'is',
-  onError: jest.fn,
-}).formatMessage
-
-describe('getRelevantSubstances', () => {
-  test('should return relevant substances in the correct order for the indictment description', () => {
-    const deprecatedOffenses = [
-      offense.DRUNK_DRIVING,
-      offense.ILLEGAL_DRUGS_DRIVING,
-      offense.PRESCRIPTION_DRUGS_DRIVING,
-    ]
-    const substances: SubstanceMap = {
-      [Substance.AMPHETAMINE]: '10',
-      [Substance.MORPHINE]: '30',
-      [Substance.ETIZOLAM]: '0.5',
-      [Substance.ALCOHOL]: '1.10',
-    }
-
-    const result = getRelevantSubstances(deprecatedOffenses, substances)
-
-    expect(result).toEqual([
-      ['ALCOHOL', '1.10'],
-      ['AMPHETAMINE', '10'],
-      ['ETIZOLAM', '0.5'],
-      ['MORPHINE', '30'],
-    ])
-  })
-})
-
-describe('getLegalArguments', () => {
-  test('should format legal arguments with article 95 and one other article', () => {
-    const lawsBroken = [
-      [58, 1],
-      [95, 1],
-    ]
-
-    const result = getLegalArguments(lawsBroken, formatMessage)
-
-    expect(result).toEqual(
-      'Telst háttsemi þessi varða við 1. mgr. 58. gr., sbr. 1. mgr. 95. gr. umferðarlaga nr. 77/2019.',
-    )
-  })
-
-  test('should format legal arguments with article 95 and two other articles', () => {
-    const lawsBroken = [
-      [49, 1],
-      [49, 2],
-      [58, 1],
-      [95, 1],
-    ]
-
-    const result = getLegalArguments(lawsBroken, formatMessage)
-
-    expect(result).toEqual(
-      'Telst háttsemi þessi varða við 1., sbr. 2. mgr. 49. gr. og 1. mgr. 58. gr., sbr. 1. mgr. 95. gr. umferðarlaga nr. 77/2019.',
-    )
-  })
-
-  test('should format legal arguments without article 95 and one other article', () => {
-    const lawsBroken = [
-      [49, 1],
-      [49, 2],
-    ]
-
-    const result = getLegalArguments(lawsBroken, formatMessage)
-
-    expect(result).toEqual(
-      'Telst háttsemi þessi varða við 1., sbr. 2. mgr. 49. gr. umferðarlaga nr. 77/2019.',
-    )
-  })
-
-  test('should format legal arguments without article 95 and two other articles', () => {
-    const lawsBroken = [
-      [49, 1],
-      [49, 2],
-      [58, 1],
-    ]
-
-    const result = getLegalArguments(lawsBroken, formatMessage)
-
-    expect(result).toEqual(
-      'Telst háttsemi þessi varða við 1., sbr. 2. mgr. 49. gr. og 1. mgr. 58. gr. umferðarlaga nr. 77/2019.',
-    )
-  })
-
-  test('should format legal arguments with 95 and six other articles, not placing "sbr." after grouped articles unless it is the last one', () => {
-    const lawsBroken = [
-      [48, 1],
-      [48, 2],
-      [49, 1],
-      [49, 3],
-      [50, 1],
-      [50, 2],
-      [95, 1],
-    ]
-
-    const result = getLegalArguments(lawsBroken, formatMessage)
-
-    expect(result).toEqual(
-      'Telst háttsemi þessi varða við 1., sbr. 2. mgr. 48. gr., 1., sbr. 3. mgr. 49. gr. og 1., sbr. 2. mgr. 50. gr., sbr. 1. mgr. 95. gr. umferðarlaga nr. 77/2019.',
-    )
-  })
-
-  test('should format legal arguments with speeding', () => {
-    const lawsBroken = [
-      [37, 0],
-      [49, 1],
-      [49, 2],
-      [95, 1],
-    ]
-
-    const result = getLegalArguments(lawsBroken, formatMessage)
-
-    expect(result).toEqual(
-      'Telst háttsemi þessi varða við 37. gr. og 1., sbr. 2. mgr. 49. gr., sbr. 1. mgr. 95. gr. umferðarlaga nr. 77/2019.',
-    )
-  })
-})
+import { getIncidentDescription } from './getIncidentDescription'
 
 describe('getIncidentDescription', () => {
   test('should return an empty string if there are no deprecatedOffenses in traffic violations', () => {
@@ -156,7 +31,7 @@ describe('getIncidentDescription', () => {
     const result = getIncidentDescription(
       {
         id: 'testId',
-        deprecatedOffenses: [offense.DRUNK_DRIVING],
+        deprecatedOffenses: [IndictmentCountOffense.DRUNK_DRIVING],
         policeCaseNumber: '123-123-123',
       },
       formatMessage,
@@ -188,7 +63,7 @@ describe('getIncidentDescription', () => {
       {
         id: 'testId',
         policeCaseNumber: '123-123-123',
-        deprecatedOffenses: [offense.DRUNK_DRIVING],
+        deprecatedOffenses: [IndictmentCountOffense.DRUNK_DRIVING],
         indictmentCountSubtypes: [IndictmentSubtype.TRAFFIC_VIOLATION],
       },
       formatMessage,
@@ -211,7 +86,7 @@ describe('getIncidentDescription', () => {
       {
         id: 'testId',
         policeCaseNumber: '123-123-123',
-        deprecatedOffenses: [offense.DRUNK_DRIVING],
+        deprecatedOffenses: [IndictmentCountOffense.DRUNK_DRIVING],
         indictmentCountSubtypes: [
           IndictmentSubtype.CUSTOMS_VIOLATION,
           IndictmentSubtype.THEFT,
@@ -237,7 +112,7 @@ describe('getIncidentDescription', () => {
       {
         id: 'testId',
         policeCaseNumber: '123-123-123',
-        deprecatedOffenses: [offense.DRUNK_DRIVING],
+        deprecatedOffenses: [IndictmentCountOffense.DRUNK_DRIVING],
         indictmentCountSubtypes: [
           IndictmentSubtype.CUSTOMS_VIOLATION,
           IndictmentSubtype.TRAFFIC_VIOLATION,

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/lib/getIncidentDescription.ts
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/lib/getIncidentDescription.ts
@@ -1,0 +1,108 @@
+import { IntlShape } from 'react-intl'
+
+import {
+  formatDate,
+  indictmentSubtypes,
+} from '@island.is/judicial-system/formatters'
+import { CrimeScene, IndictmentSubtype } from '@island.is/judicial-system/types'
+import { IndictmentCountOffense } from '@island.is/judicial-system-web/src/graphql/schema'
+import { TempIndictmentCount } from '@island.is/judicial-system-web/src/types'
+import { isTrafficViolationIndictmentCount } from '@island.is/judicial-system-web/src/utils/formHelper'
+
+import { getDeprecatedIncidentDescriptionReason } from './getDeprecatedIncidentDescriptionReason'
+import { getIncidentDescriptionReason } from './getIncidentDescriptionReason'
+import { indictmentCount as strings } from '../IndictmentCount.strings'
+
+export const getIncidentDescription = (
+  indictmentCount: TempIndictmentCount,
+  formatMessage: IntlShape['formatMessage'],
+  crimeScene?: CrimeScene,
+  subtypesRecord?: Record<string, IndictmentSubtype[]>,
+  isOffenseEndpointEnabled?: boolean,
+) => {
+  const {
+    offenses,
+    deprecatedOffenses,
+    substances,
+    vehicleRegistrationNumber,
+    indictmentCountSubtypes,
+    policeCaseNumber,
+  } = indictmentCount
+
+  const incidentLocation = crimeScene?.place || '[Vettvangur]'
+  const incidentDate = crimeScene?.date
+    ? formatDate(crimeScene.date, 'PPPP')?.replace('dagur,', 'daginn') || ''
+    : '[Dagsetning]'
+
+  const vehicleRegistration =
+    vehicleRegistrationNumber || '[Skráningarnúmer ökutækis]'
+
+  const subtypes =
+    (subtypesRecord && policeCaseNumber && subtypesRecord[policeCaseNumber]) ||
+    []
+
+  if (
+    subtypes.length === 0 ||
+    (subtypes.length > 1 &&
+      (!indictmentCountSubtypes?.length ||
+        indictmentCountSubtypes.length === 0))
+  ) {
+    return ''
+  }
+
+  if (
+    isTrafficViolationIndictmentCount(policeCaseNumber, subtypesRecord) ||
+    indictmentCountSubtypes?.includes(IndictmentSubtype.TRAFFIC_VIOLATION)
+  ) {
+    if (!deprecatedOffenses || deprecatedOffenses.length === 0) {
+      return ''
+    }
+
+    const { reason, isSpeeding } = isOffenseEndpointEnabled
+      ? {
+          reason: getIncidentDescriptionReason(offenses || [], formatMessage),
+          isSpeeding: indictmentCount.offenses?.some(
+            (o) => o.offense === IndictmentCountOffense.SPEEDING,
+          ),
+        }
+      : {
+          reason: getDeprecatedIncidentDescriptionReason(
+            deprecatedOffenses,
+            substances || {},
+            formatMessage,
+          ),
+          isSpeeding: indictmentCount.deprecatedOffenses?.includes(
+            IndictmentCountOffense.SPEEDING,
+          ),
+        }
+
+    const recordedSpeed = indictmentCount.recordedSpeed ?? '[Mældur hraði]'
+    const speedLimit = indictmentCount.speedLimit ?? '[Leyfilegur hraði]'
+
+    return formatMessage(strings.incidentDescriptionAutofill, {
+      incidentDate,
+      vehicleRegistrationNumber: vehicleRegistration,
+      reason,
+      incidentLocation,
+      isSpeeding,
+      recordedSpeed,
+      speedLimit,
+    })
+  }
+
+  if (subtypes.length === 1) {
+    return formatMessage(strings.indictmentDescriptionSubtypesAutofill, {
+      subtypes: indictmentSubtypes[subtypes[0]],
+      date: incidentDate,
+    })
+  }
+
+  const allSubtypes = indictmentCountSubtypes
+    ?.map((subtype) => indictmentSubtypes[subtype])
+    .join(', ')
+
+  return formatMessage(strings.indictmentDescriptionSubtypesAutofill, {
+    subtypes: allSubtypes,
+    date: incidentDate,
+  })
+}

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/lib/getIncidentDescriptionReason.ts
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/lib/getIncidentDescriptionReason.ts
@@ -60,9 +60,9 @@ export const getIncidentDescriptionReason = (
       return acc
     }, '')
 
-  const substances = offenses.filter((o) => o.substances).flatMap(({ substances }) =>
-    Object.entries(substances as SubstanceMap),
-  )
+  const substances = offenses
+    .filter((o) => o.substances)
+    .flatMap(({ substances }) => Object.entries(substances as SubstanceMap))
   reason += substances.reduce((acc, substance, index) => {
     if (index === 0) {
       acc += ` (${formatMessage(

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/lib/getIncidentDescriptionReason.ts
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/lib/getIncidentDescriptionReason.ts
@@ -1,0 +1,86 @@
+import { IntlShape } from 'react-intl'
+
+import {
+  IndictmentCountOffense,
+  Substance,
+  SubstanceMap,
+} from '@island.is/judicial-system/types'
+import { Offense } from '@island.is/judicial-system-web/src/graphql/schema'
+
+import { indictmentCount as strings } from '../IndictmentCount.strings'
+import { substanceEnum } from '../Substances/SubstancesEnum.strings'
+
+export const getIncidentDescriptionReason = (
+  offenses: Offense[],
+  formatMessage: IntlShape['formatMessage'],
+) => {
+  let reason = offenses
+    .filter((o) => o.offense !== IndictmentCountOffense.SPEEDING)
+    .reduce((acc, o, index) => {
+      if (
+        (offenses.length > 1 && index === offenses.length - 1) ||
+        (offenses.length > 2 &&
+          index === offenses.length - 2 &&
+          o.offense === IndictmentCountOffense.ILLEGAL_DRUGS_DRIVING)
+      ) {
+        acc += ' og '
+      } else if (index > 0) {
+        acc += ', '
+      }
+      switch (o.offense) {
+        case IndictmentCountOffense.DRIVING_WITHOUT_LICENCE:
+          acc += formatMessage(
+            strings.incidentDescriptionDrivingWithoutLicenceAutofill,
+          )
+          break
+        case IndictmentCountOffense.DRUNK_DRIVING:
+          acc += formatMessage(strings.incidentDescriptionDrunkDrivingAutofill)
+          break
+        case IndictmentCountOffense.ILLEGAL_DRUGS_DRIVING:
+          acc += `${formatMessage(
+            strings.incidentDescriptionDrugsDrivingPrefixAutofill,
+          )} ${formatMessage(
+            strings.incidentDescriptionIllegalDrugsDrivingAutofill,
+          )}`
+          break
+        case IndictmentCountOffense.PRESCRIPTION_DRUGS_DRIVING:
+          acc +=
+            (offenses.some(
+              (o) => o.offense === IndictmentCountOffense.ILLEGAL_DRUGS_DRIVING,
+            )
+              ? ''
+              : `${formatMessage(
+                  strings.incidentDescriptionDrugsDrivingPrefixAutofill,
+                )} `) +
+            formatMessage(
+              strings.incidentDescriptionPrescriptionDrugsDrivingAutofill,
+            )
+          break
+      }
+      return acc
+    }, '')
+
+  const substances = offenses.filter((o) => o.substances).flatMap(({ substances }) =>
+    Object.entries(substances as SubstanceMap),
+  )
+  reason += substances.reduce((acc, substance, index) => {
+    if (index === 0) {
+      acc += ` (${formatMessage(
+        strings.incidentDescriptionSubstancesPrefixAutofill,
+      )} `
+    } else if (index === substances.length - 1) {
+      acc += ' og '
+    } else {
+      acc += ', '
+    }
+    acc += formatMessage(substanceEnum[substance[0] as Substance], {
+      amount: substance[1],
+    })
+    if (index === substances.length - 1) {
+      acc += ')'
+    }
+    return acc
+  }, '')
+
+  return reason
+}

--- a/apps/judicial-system/web/src/utils/hooks/useIndictmentCounts/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useIndictmentCounts/index.ts
@@ -4,7 +4,10 @@ import { useIntl } from 'react-intl'
 import { toast } from '@island.is/island-ui/core'
 import { SubstanceMap } from '@island.is/judicial-system/types'
 import { errors } from '@island.is/judicial-system-web/messages'
-import { UpdateIndictmentCountInput } from '@island.is/judicial-system-web/src/graphql/schema'
+import {
+  Offense,
+  UpdateIndictmentCountInput,
+} from '@island.is/judicial-system-web/src/graphql/schema'
 import { indictmentCount } from '@island.is/judicial-system-web/src/routes/Prosecutor/Indictments/Indictment/IndictmentCount.strings'
 import { TempCase as Case } from '@island.is/judicial-system-web/src/types'
 
@@ -98,11 +101,13 @@ const useIndictmentCounts = () => {
     [updateIndictmentCountMutation, formatMessage],
   )
 
+  // TODO: pass in updated offenses here? and update them on indictment counts
   const updateIndictmentCountState = useCallback(
     (
       indictmentCountId: string,
       update: UpdateIndictmentCount,
       setWorkingCase: Dispatch<SetStateAction<Case>>,
+      updatedOffenses?: Offense[],
     ) => {
       setWorkingCase((prevWorkingCase) => {
         if (!prevWorkingCase.indictmentCounts) {
@@ -119,6 +124,7 @@ const useIndictmentCounts = () => {
         newIndictmentCounts[indictmentCountIndexToUpdate] = {
           ...newIndictmentCounts[indictmentCountIndexToUpdate],
           ...update,
+          ...(updatedOffenses ? { offenses: updatedOffenses } : {}),
         }
 
         return { ...prevWorkingCase, indictmentCounts: newIndictmentCounts }

--- a/apps/judicial-system/web/src/utils/hooks/useOffenses/createOffense.graphql
+++ b/apps/judicial-system/web/src/utils/hooks/useOffenses/createOffense.graphql
@@ -1,0 +1,10 @@
+mutation CreateOffense($input: CreateOffenseInput!) {
+  createOffense(input: $input) {
+    id
+    created
+    modified
+    indictmentCountId
+    offense
+    substances
+  }
+}

--- a/apps/judicial-system/web/src/utils/hooks/useOffenses/deleteOffense.graphql
+++ b/apps/judicial-system/web/src/utils/hooks/useOffenses/deleteOffense.graphql
@@ -1,0 +1,5 @@
+mutation DeleteOffense($input: DeleteOffenseInput!) {
+  deleteOffense(input: $input) {
+    deleted
+  }
+}

--- a/apps/judicial-system/web/src/utils/hooks/useOffenses/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useOffenses/index.ts
@@ -1,0 +1,111 @@
+import { useCallback } from 'react'
+import { useIntl } from 'react-intl'
+
+import { toast } from '@island.is/island-ui/core'
+import { IndictmentCountOffense, SubstanceMap } from '@island.is/judicial-system/types'
+import { errors } from '@island.is/judicial-system-web/messages'
+import { UpdateOffenseInput } from '@island.is/judicial-system-web/src/graphql/schema'
+
+import { useCreateOffenseMutation } from './createOffense.generated'
+import { useDeleteOffenseMutation } from './deleteOffense.generated'
+import { useUpdateOffenseMutation } from './updateOffense.generated'
+
+export interface UpdateOffense
+  extends Omit<
+    UpdateOffenseInput,
+    'caseId' | 'indictmentCountId' | 'offenseId' | 'substances'
+  > {
+  substances?: SubstanceMap | null
+}
+
+const useOffenses = () => {
+  const { formatMessage } = useIntl()
+
+  const [createOffenseMutation] = useCreateOffenseMutation()
+  const [updateOffenseMutation] = useUpdateOffenseMutation()
+  const [deleteOffenseMutation] = useDeleteOffenseMutation()
+
+  const createOffense = useCallback(
+    async (caseId: string, indictmentCountId: string, offense: IndictmentCountOffense) => {
+      try {
+        const { data } = await createOffenseMutation({
+          variables: {
+            input: {
+              caseId,
+              indictmentCountId,
+              offense
+            },
+          },
+        })
+
+        if (!data) {
+          toast.error(formatMessage(errors.createOffense))
+        }
+
+        return data?.createOffense
+      } catch (e) {
+        toast.error(formatMessage(errors.createOffense))
+      }
+    },
+    [createOffenseMutation, formatMessage],
+  )
+
+  const deleteOffense = useCallback(
+    async (caseId: string, indictmentCountId: string, offenseId: string) => {
+      try {
+        const { data } = await deleteOffenseMutation({
+          variables: {
+            input: {
+              caseId,
+              indictmentCountId,
+              offenseId,
+            },
+          },
+        })
+
+        return data?.deleteOffense?.deleted
+      } catch (e) {
+        toast.error(formatMessage(errors.deleteOffense))
+      }
+    },
+    [deleteOffenseMutation, formatMessage],
+  )
+
+  const updateOffense = useCallback(
+    async (
+      caseId: string,
+      indictmentCountId: string,
+      offenseId: string,
+      update: UpdateOffense,
+    ) => {
+      try {
+        const { data } = await updateOffenseMutation({
+          variables: {
+            input: {
+              caseId,
+              indictmentCountId,
+              offenseId,
+              ...update,
+            },
+          },
+        })
+
+        if (!data) {
+          toast.error(formatMessage(errors.updateOffense))
+        }
+        return data?.updateOffense
+      } catch (e) {
+        toast.error(formatMessage(errors.updateOffense))
+      }
+    },
+    [updateOffenseMutation, formatMessage],
+  )
+
+  return {
+    updateOffense,
+    createOffense,
+    deleteOffense,
+  }
+}
+
+export default useOffenses

--- a/apps/judicial-system/web/src/utils/hooks/useOffenses/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useOffenses/index.ts
@@ -2,7 +2,10 @@ import { useCallback } from 'react'
 import { useIntl } from 'react-intl'
 
 import { toast } from '@island.is/island-ui/core'
-import { IndictmentCountOffense, SubstanceMap } from '@island.is/judicial-system/types'
+import {
+  IndictmentCountOffense,
+  SubstanceMap,
+} from '@island.is/judicial-system/types'
 import { errors } from '@island.is/judicial-system-web/messages'
 import { UpdateOffenseInput } from '@island.is/judicial-system-web/src/graphql/schema'
 
@@ -26,14 +29,18 @@ const useOffenses = () => {
   const [deleteOffenseMutation] = useDeleteOffenseMutation()
 
   const createOffense = useCallback(
-    async (caseId: string, indictmentCountId: string, offense: IndictmentCountOffense) => {
+    async (
+      caseId: string,
+      indictmentCountId: string,
+      offense: IndictmentCountOffense,
+    ) => {
       try {
         const { data } = await createOffenseMutation({
           variables: {
             input: {
               caseId,
               indictmentCountId,
-              offense
+              offense,
             },
           },
         })

--- a/apps/judicial-system/web/src/utils/hooks/useOffenses/updateOffense.graphql
+++ b/apps/judicial-system/web/src/utils/hooks/useOffenses/updateOffense.graphql
@@ -1,0 +1,10 @@
+mutation UpdateOffense($input: UpdateOffenseInput!) {
+  updateOffense(input: $input) {
+    id
+    created
+    modified
+    indictmentCountId
+    offense
+    substances
+  }
+}

--- a/charts/judicial-system-services/judicial-system-api/values.dev.yaml
+++ b/charts/judicial-system-services/judicial-system-api/values.dev.yaml
@@ -30,7 +30,7 @@ env:
   BACKEND_URL: 'http://web-judicial-system-backend'
   CONTENTFUL_ENVIRONMENT: 'test'
   CONTENTFUL_HOST: 'preview.contentful.com'
-  HIDDEN_FEATURES: ''
+  HIDDEN_FEATURES: 'OFFENSE_ENDPOINTS'
   IDENTITY_SERVER_ISSUER_URL: 'https://identity-server.dev01.devland.is'
   LOG_LEVEL: 'info'
   NODE_OPTIONS: '--max-old-space-size=460 -r dd-trace/init'

--- a/charts/judicial-system-services/judicial-system-api/values.prod.yaml
+++ b/charts/judicial-system-services/judicial-system-api/values.prod.yaml
@@ -30,7 +30,7 @@ env:
   BACKEND_URL: 'http://web-judicial-system-backend'
   CONTENTFUL_ENVIRONMENT: 'master'
   CONTENTFUL_HOST: 'cdn.contentful.com'
-  HIDDEN_FEATURES: ''
+  HIDDEN_FEATURES: 'OFFENSE_ENDPOINTS'
   IDENTITY_SERVER_ISSUER_URL: 'https://innskra.island.is'
   LOG_LEVEL: 'info'
   NODE_OPTIONS: '--max-old-space-size=460 -r dd-trace/init'

--- a/charts/judicial-system-services/judicial-system-api/values.staging.yaml
+++ b/charts/judicial-system-services/judicial-system-api/values.staging.yaml
@@ -30,7 +30,7 @@ env:
   BACKEND_URL: 'http://web-judicial-system-backend'
   CONTENTFUL_ENVIRONMENT: 'test'
   CONTENTFUL_HOST: 'cdn.contentful.com'
-  HIDDEN_FEATURES: ''
+  HIDDEN_FEATURES: 'OFFENSE_ENDPOINTS'
   IDENTITY_SERVER_ISSUER_URL: 'https://identity-server.staging01.devland.is'
   LOG_LEVEL: 'info'
   NODE_OPTIONS: '--max-old-space-size=460 -r dd-trace/init'

--- a/charts/judicial-system/values.dev.yaml
+++ b/charts/judicial-system/values.dev.yaml
@@ -30,7 +30,7 @@ judicial-system-api:
     BACKEND_URL: 'http://web-judicial-system-backend'
     CONTENTFUL_ENVIRONMENT: 'test'
     CONTENTFUL_HOST: 'preview.contentful.com'
-    HIDDEN_FEATURES: ''
+    HIDDEN_FEATURES: 'OFFENSE_ENDPOINTS'
     IDENTITY_SERVER_ISSUER_URL: 'https://identity-server.dev01.devland.is'
     LOG_LEVEL: 'info'
     NODE_OPTIONS: '--max-old-space-size=460 -r dd-trace/init'

--- a/charts/judicial-system/values.prod.yaml
+++ b/charts/judicial-system/values.prod.yaml
@@ -30,7 +30,7 @@ judicial-system-api:
     BACKEND_URL: 'http://web-judicial-system-backend'
     CONTENTFUL_ENVIRONMENT: 'master'
     CONTENTFUL_HOST: 'cdn.contentful.com'
-    HIDDEN_FEATURES: ''
+    HIDDEN_FEATURES: 'OFFENSE_ENDPOINTS'
     IDENTITY_SERVER_ISSUER_URL: 'https://innskra.island.is'
     LOG_LEVEL: 'info'
     NODE_OPTIONS: '--max-old-space-size=460 -r dd-trace/init'

--- a/charts/judicial-system/values.staging.yaml
+++ b/charts/judicial-system/values.staging.yaml
@@ -30,7 +30,7 @@ judicial-system-api:
     BACKEND_URL: 'http://web-judicial-system-backend'
     CONTENTFUL_ENVIRONMENT: 'test'
     CONTENTFUL_HOST: 'cdn.contentful.com'
-    HIDDEN_FEATURES: ''
+    HIDDEN_FEATURES: 'OFFENSE_ENDPOINTS'
     IDENTITY_SERVER_ISSUER_URL: 'https://identity-server.staging01.devland.is'
     LOG_LEVEL: 'info'
     NODE_OPTIONS: '--max-old-space-size=460 -r dd-trace/init'

--- a/libs/judicial-system/types/src/lib/feature.ts
+++ b/libs/judicial-system/types/src/lib/feature.ts
@@ -1,3 +1,4 @@
 export enum Feature {
   NONE = 'NONE', // must be at least one
+  OFFENSE_ENDPOINTS = 'OFFENSE_ENDPOINTS',
 }


### PR DESCRIPTION
# [Adjust client logic to new offense data structure per indictment count](https://app.asana.com/0/1199153462262248/1209309381527323)

## What
Adjusting the client logic for indictment counts to work with our new offense data structure

## Why
- Cannot maintain offenses in the current data structure in `indictmentCount`.
For more details see technical docs [here](https://www.notion.so/hellokolibri/Technical-backlog-WIP-16123303f8e68039a5e1fc314d56819a?p=18a23303f8e680408a64e9e2f82a0dc3&pm=s).

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
