### PR TITLE
fix(native-app): if organ donation errors and there is no data, only show error message

### DIFF
--- a/apps/native/app/src/screens/health/health-overview.tsx
+++ b/apps/native/app/src/screens/health/health-overview.tsx
@@ -550,36 +550,37 @@ export const HealthOverviewScreen: NavigationFunctionComponent = ({
               }
             />
           )}
-          {isOrganDonationEnabled && (
-            <InputRow background>
-              <Input
-                label={intl.formatMessage({
-                  id: isOrganDonorWithLimitations
-                    ? 'health.organDonation.isDonorWithLimitations'
-                    : isOrganDonor
-                    ? 'health.organDonation.isDonor'
-                    : 'health.organDonation.isNotDonor',
-                })}
-                value={`${intl.formatMessage(
-                  {
+          {isOrganDonationEnabled &&
+            (organDonationRes.loading || organDonationRes.data) && (
+              <InputRow background>
+                <Input
+                  label={intl.formatMessage({
                     id: isOrganDonorWithLimitations
-                      ? 'health.organDonation.isDonorWithLimitationsDescription'
+                      ? 'health.organDonation.isDonorWithLimitations'
                       : isOrganDonor
-                      ? 'health.organDonation.isDonorDescription'
-                      : 'health.organDonation.isNotDonorDescription',
-                  },
-                  {
-                    limitations: isOrganDonorWithLimitations
-                      ? organLimitations?.join(', ')
-                      : '',
-                  },
-                )}`}
-                loading={organDonationRes.loading && !organDonationRes.data}
-                error={organDonationRes.error && !organDonationRes.data}
-                noBorder
-              />
-            </InputRow>
-          )}
+                      ? 'health.organDonation.isDonor'
+                      : 'health.organDonation.isNotDonor',
+                  })}
+                  value={`${intl.formatMessage(
+                    {
+                      id: isOrganDonorWithLimitations
+                        ? 'health.organDonation.isDonorWithLimitationsDescription'
+                        : isOrganDonor
+                        ? 'health.organDonation.isDonorDescription'
+                        : 'health.organDonation.isNotDonorDescription',
+                    },
+                    {
+                      limitations: isOrganDonorWithLimitations
+                        ? organLimitations?.join(', ')
+                        : '',
+                    },
+                  )}`}
+                  loading={organDonationRes.loading && !organDonationRes.data}
+                  error={organDonationRes.error && !organDonationRes.data}
+                  noBorder
+                />
+              </InputRow>
+            )}
           {isOrganDonationEnabled &&
             organDonationRes.error &&
             !organDonationRes.data &&


### PR DESCRIPTION
## What

When organ donation service is down we were accidentally showing half of the data (defaulting to user not being an organ donor even if we know nothing about it) along with an error message, when we should only be showing the error message if we don't have any data. 

## Screenshots / Gifs
Before:
<img height = "800" src="https://github.com/user-attachments/assets/444fe506-3c3b-4e31-a619-c052a0c8c603">
After:
<img height = "800" src="https://github.com/user-attachments/assets/8f51c347-8fba-4dfe-b841-dc8ad2ee1137">


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
