### PR TITLE
chore(j-s): implement offense hooks

### DIFF
--- a/apps/judicial-system/api/src/app/modules/indictment-count/dto/createOffense.input.ts
+++ b/apps/judicial-system/api/src/app/modules/indictment-count/dto/createOffense.input.ts
@@ -1,6 +1,8 @@
-import { Allow } from 'class-validator'
+import { Allow, IsEnum } from 'class-validator'
 
 import { Field, ID, InputType } from '@nestjs/graphql'
+
+import { IndictmentCountOffense } from '@island.is/judicial-system/types'
 
 @InputType()
 export class CreateOffenseInput {
@@ -11,4 +13,9 @@ export class CreateOffenseInput {
   @Allow()
   @Field(() => ID)
   readonly indictmentCountId!: string
+
+  @Allow()
+  @IsEnum(IndictmentCountOffense)
+  @Field(() => IndictmentCountOffense)
+  readonly offense!: IndictmentCountOffense
 }

--- a/apps/judicial-system/api/src/app/modules/indictment-count/dto/updateOffense.input.ts
+++ b/apps/judicial-system/api/src/app/modules/indictment-count/dto/updateOffense.input.ts
@@ -1,10 +1,9 @@
-import { Allow, IsEnum, IsOptional } from 'class-validator'
+import { Allow, IsOptional } from 'class-validator'
 import { GraphQLJSONObject } from 'graphql-type-json'
 
 import { Field, ID, InputType } from '@nestjs/graphql'
 
 import type { SubstanceMap } from '@island.is/judicial-system/types'
-import { IndictmentCountOffense } from '@island.is/judicial-system/types'
 
 @InputType()
 export class UpdateOffenseInput {
@@ -19,11 +18,6 @@ export class UpdateOffenseInput {
   @Allow()
   @Field(() => ID)
   readonly indictmentCountId!: string
-
-  @Allow()
-  @IsEnum(IndictmentCountOffense)
-  @Field(() => IndictmentCountOffense)
-  readonly offense!: IndictmentCountOffense
 
   @Allow()
   @IsOptional()

--- a/apps/judicial-system/api/src/app/modules/indictment-count/models/offense.model.ts
+++ b/apps/judicial-system/api/src/app/modules/indictment-count/models/offense.model.ts
@@ -21,8 +21,8 @@ export class Offense {
   @Field(() => ID, { nullable: true })
   readonly indictmentCountId?: string
 
-  @Field(() => IndictmentCountOffense, { nullable: true })
-  readonly offense?: IndictmentCountOffense
+  @Field(() => IndictmentCountOffense, { nullable: false })
+  readonly offense!: IndictmentCountOffense
 
   @Field(() => GraphQLJSONObject, { nullable: true })
   readonly substances?: SubstanceMap

--- a/apps/judicial-system/backend/src/app/modules/indictment-count/dto/updateOffense.dto.ts
+++ b/apps/judicial-system/backend/src/app/modules/indictment-count/dto/updateOffense.dto.ts
@@ -1,17 +1,10 @@
-import { IsEnum, IsObject, IsOptional } from 'class-validator'
+import { IsObject, IsOptional } from 'class-validator'
 
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
+import { ApiPropertyOptional } from '@nestjs/swagger'
 
-import {
-  IndictmentCountOffense,
-  type SubstanceMap,
-} from '@island.is/judicial-system/types'
+import { type SubstanceMap } from '@island.is/judicial-system/types'
 
 export class UpdateOffenseDto {
-  @IsEnum(IndictmentCountOffense)
-  @ApiProperty({ enum: IndictmentCountOffense })
-  readonly offense!: IndictmentCountOffense
-
   @IsOptional()
   @IsObject()
   @ApiPropertyOptional({ type: Object })

--- a/apps/judicial-system/web/src/components/FormProvider/case.graphql
+++ b/apps/judicial-system/web/src/components/FormProvider/case.graphql
@@ -213,6 +213,14 @@ query Case($input: CaseQueryInput!) {
       created
       modified
       vehicleRegistrationNumber
+      offenses {
+        id
+        indictmentCountId
+        created
+        modified
+        offense
+        substances
+      }
       deprecatedOffenses
       substances
       lawsBroken

--- a/apps/judicial-system/web/src/components/FormProvider/limitedAccessCase.graphql
+++ b/apps/judicial-system/web/src/components/FormProvider/limitedAccessCase.graphql
@@ -203,6 +203,14 @@ query LimitedAccessCase($input: CaseQueryInput!) {
       created
       modified
       vehicleRegistrationNumber
+      offenses {
+        id
+        indictmentCountId
+        created
+        modified
+        offense
+        substances
+      }
       deprecatedOffenses
       substances
       lawsBroken

--- a/apps/judicial-system/web/src/utils/hooks/useOffenses/createOffense.graphql
+++ b/apps/judicial-system/web/src/utils/hooks/useOffenses/createOffense.graphql
@@ -1,0 +1,10 @@
+mutation CreateOffense($input: CreateOffenseInput!) {
+  createOffense(input: $input) {
+    id
+    created
+    modified
+    indictmentCountId
+    offense
+    substances
+  }
+}

--- a/apps/judicial-system/web/src/utils/hooks/useOffenses/deleteOffense.graphql
+++ b/apps/judicial-system/web/src/utils/hooks/useOffenses/deleteOffense.graphql
@@ -1,0 +1,5 @@
+mutation DeleteOffense($input: DeleteOffenseInput!) {
+  deleteOffense(input: $input) {
+    deleted
+  }
+}

--- a/apps/judicial-system/web/src/utils/hooks/useOffenses/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useOffenses/index.ts
@@ -1,0 +1,118 @@
+import { useCallback } from 'react'
+import { useIntl } from 'react-intl'
+
+import { toast } from '@island.is/island-ui/core'
+import {
+  IndictmentCountOffense,
+  SubstanceMap,
+} from '@island.is/judicial-system/types'
+import { errors } from '@island.is/judicial-system-web/messages'
+import { UpdateOffenseInput } from '@island.is/judicial-system-web/src/graphql/schema'
+
+import { useCreateOffenseMutation } from './createOffense.generated'
+import { useDeleteOffenseMutation } from './deleteOffense.generated'
+import { useUpdateOffenseMutation } from './updateOffense.generated'
+
+export interface UpdateOffense
+  extends Omit<
+    UpdateOffenseInput,
+    'caseId' | 'indictmentCountId' | 'offenseId' | 'substances'
+  > {
+  substances?: SubstanceMap | null
+}
+
+const useOffenses = () => {
+  const { formatMessage } = useIntl()
+
+  const [createOffenseMutation] = useCreateOffenseMutation()
+  const [updateOffenseMutation] = useUpdateOffenseMutation()
+  const [deleteOffenseMutation] = useDeleteOffenseMutation()
+
+  const createOffense = useCallback(
+    async (
+      caseId: string,
+      indictmentCountId: string,
+      offense: IndictmentCountOffense,
+    ) => {
+      try {
+        const { data } = await createOffenseMutation({
+          variables: {
+            input: {
+              caseId,
+              indictmentCountId,
+              offense,
+            },
+          },
+        })
+
+        if (!data) {
+          toast.error(formatMessage(errors.createOffense))
+        }
+
+        return data?.createOffense
+      } catch (e) {
+        toast.error(formatMessage(errors.createOffense))
+      }
+    },
+    [createOffenseMutation, formatMessage],
+  )
+
+  const deleteOffense = useCallback(
+    async (caseId: string, indictmentCountId: string, offenseId: string) => {
+      try {
+        const { data } = await deleteOffenseMutation({
+          variables: {
+            input: {
+              caseId,
+              indictmentCountId,
+              offenseId,
+            },
+          },
+        })
+
+        return data?.deleteOffense?.deleted
+      } catch (e) {
+        toast.error(formatMessage(errors.deleteOffense))
+      }
+    },
+    [deleteOffenseMutation, formatMessage],
+  )
+
+  const updateOffense = useCallback(
+    async (
+      caseId: string,
+      indictmentCountId: string,
+      offenseId: string,
+      update: UpdateOffense,
+    ) => {
+      try {
+        const { data } = await updateOffenseMutation({
+          variables: {
+            input: {
+              caseId,
+              indictmentCountId,
+              offenseId,
+              ...update,
+            },
+          },
+        })
+
+        if (!data) {
+          toast.error(formatMessage(errors.updateOffense))
+        }
+        return data?.updateOffense
+      } catch (e) {
+        toast.error(formatMessage(errors.updateOffense))
+      }
+    },
+    [updateOffenseMutation, formatMessage],
+  )
+
+  return {
+    updateOffense,
+    createOffense,
+    deleteOffense,
+  }
+}
+
+export default useOffenses

--- a/apps/judicial-system/web/src/utils/hooks/useOffenses/updateOffense.graphql
+++ b/apps/judicial-system/web/src/utils/hooks/useOffenses/updateOffense.graphql
@@ -1,0 +1,10 @@
+mutation UpdateOffense($input: UpdateOffenseInput!) {
+  updateOffense(input: $input) {
+    id
+    created
+    modified
+    indictmentCountId
+    offense
+    substances
+  }
+}


### PR DESCRIPTION
# Part 1: Útfæra client lógík fyrir nýja offense endapunkta

## What
- Implementing hooks to call offense endpoints

## Why
- This is part of new offense data structure. We Cannot maintain offenses in the current data structure in indictment_count.
For more details see technical docs [here](https://www.notion.so/hellokolibri/Technical-backlog-WIP-16123303f8e68039a5e1fc314d56819a?p=18a23303f8e680408a64e9e2f82a0dc3&pm=s).

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
