### PR TITLE
fix(application-ir): Underflow rounding protection

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/inheritance-report/inheritance-report.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/inheritance-report/inheritance-report.service.ts
@@ -51,7 +51,7 @@ export class InheritanceReportService extends BaseTemplateApiService {
     const [relationOptions, inheritanceReportInfos] = await Promise.all([
       this.syslumennService.getEstateRelations(),
       // Get estate info from syslumenn or fakedata depending on application.applicant
-      application.applicant.startsWith('110130') &&
+      application.applicant.startsWith('010130') &&
       application.applicant.endsWith('2399')
         ? [
             getFakeData('2022-14-14', 'Gervimaður Útlönd', '0101307789'),

--- a/libs/application/templates/inheritance-report/src/fields/HeirsRepeater/index.tsx
+++ b/libs/application/templates/inheritance-report/src/fields/HeirsRepeater/index.tsx
@@ -169,7 +169,11 @@ export const HeirsRepeater: FC<
 
       return current?.enabled ? acc + (isNaN(val) ? 0 : val) : acc
     }, 0)
-    total = parseFloat(total.toFixed(6))
+    if (isEqualWithTolerance(total, 100)) {
+      total = 100
+    } else {
+      total = parseFloat(total.toFixed(6))
+    }
 
     const addTotal = id.replace('data', 'total')
 

--- a/libs/application/templates/inheritance-report/src/lib/utils/integerSplit.ts
+++ b/libs/application/templates/inheritance-report/src/lib/utils/integerSplit.ts
@@ -59,6 +59,8 @@ export const integerPercentageSplit = (
 
 // Returns true if an array sums to a target number,
 // includes a tolerance to account for floating point errors
+// Example:
+//   isEqualWithTolerance(99.999999, 100, 1e-6) === true
 export const isEqualWithTolerance = (
   number: number,
   target: number,


### PR DESCRIPTION
```js
> 0.1 + 0.2 + 0.4 + 0.2 + 0.1
1.0000000000000002
```

```js
> 0.3 + 0.6 + 0.1
0.9999999999999999
```

Incorrectly assumed overflows are always positive.
Gotta stay vigilant from both sides instead of dropping overflow digits.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

This release enhances data accuracy and numerical precision in inheritance reports, ensuring consistent estate details and share breakdowns.

- **Bug Fixes**
  - Updated applicant identification checks to ensure reliable retrieval of estate data.
  - Refined percentage calculations so that totals very close to 100 are displayed as exactly 100%.

- **New Features**
  - Added a tolerance-based numeric comparison tool to boost calculation precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->