### PR TITLE
fix(app-sys): deep items can now be deleted

### DIFF
--- a/libs/application/ui-fields/src/lib/FieldsRepeaterFormField/FieldsRepeaterFormField.tsx
+++ b/libs/application/ui-fields/src/lib/FieldsRepeaterFormField/FieldsRepeaterFormField.tsx
@@ -93,17 +93,19 @@ export const FieldsRepeaterFormField = ({
   }
 
   const handleRemoveItem = () => {
+    const items = getValueViaPath<Array<unknown>>(answers, id)
+
     if (numberOfItems > (numberOfItemsInAnswers || 0)) {
       setNumberOfItems(numberOfItems - 1)
     } else if (numberOfItems === numberOfItemsInAnswers) {
-      setValue(id, answers[id].slice(0, -1))
+      setValue(id, items?.slice(0, -1))
       setNumberOfItems(numberOfItems - 1)
     } else if (
       numberOfItemsInAnswers &&
       numberOfItems < numberOfItemsInAnswers
     ) {
       const difference = numberOfItems - numberOfItemsInAnswers
-      setValue(id, answers[id].slice(0, difference))
+      setValue(id, items?.slice(0, difference))
       setNumberOfItems(numberOfItems)
     }
 


### PR DESCRIPTION
## What

If fields repeater had a deep id like 'foo.bar', items could not be deleted

## Why

Was a bug, needed to be fixed

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the removal process for items in repeating form fields to ensure the form stays in sync and updates reliably when items are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->