### PR TITLE
fix(web): Digital Iceland latest news - Filter out frontpage news tags

### DIFF
--- a/apps/web/components/Organization/Slice/LatestNewsSlice/DigitalIcelandLatestNewsSlice/DigitalIcelandLatestNewsSlice.tsx
+++ b/apps/web/components/Organization/Slice/LatestNewsSlice/DigitalIcelandLatestNewsSlice/DigitalIcelandLatestNewsSlice.tsx
@@ -12,12 +12,12 @@ import {
   Text,
 } from '@island.is/island-ui/core'
 import { BackgroundImage } from '@island.is/web/components'
+import { FRONTPAGE_NEWS_TAG_ID } from '@island.is/web/constants'
 import { LatestNewsSlice as LatestNewsSliceSchema } from '@island.is/web/graphql/schema'
 import { useLinkResolver } from '@island.is/web/hooks'
 import { shortenText } from '@island.is/web/screens/IcelandicGovernmentInstitutionVacancies/IcelandicGovernmentInstitutionVacanciesList'
 
 import * as styles from './DigitalIcelandLatestNewsSlice.css'
-import { FRONTPAGE_NEWS_TAG_ID } from '@island.is/web/constants'
 
 interface ItemProps {
   imageSrc: string

--- a/apps/web/components/Organization/Slice/LatestNewsSlice/DigitalIcelandLatestNewsSlice/DigitalIcelandLatestNewsSlice.tsx
+++ b/apps/web/components/Organization/Slice/LatestNewsSlice/DigitalIcelandLatestNewsSlice/DigitalIcelandLatestNewsSlice.tsx
@@ -17,6 +17,7 @@ import { useLinkResolver } from '@island.is/web/hooks'
 import { shortenText } from '@island.is/web/screens/IcelandicGovernmentInstitutionVacancies/IcelandicGovernmentInstitutionVacanciesList'
 
 import * as styles from './DigitalIcelandLatestNewsSlice.css'
+import { FRONTPAGE_NEWS_TAG_ID } from '@island.is/web/constants'
 
 interface ItemProps {
   imageSrc: string
@@ -132,7 +133,9 @@ export const DigitalIcelandLatestNewsSlice: React.FC<
                 date={news.date}
                 description={news.intro}
                 imageSrc={news.image?.url ?? ''}
-                tags={news.genericTags.map((tag) => tag.title)}
+                tags={news.genericTags
+                  .filter((tag) => tag.slug !== FRONTPAGE_NEWS_TAG_ID)
+                  .map((tag) => tag.title)}
                 title={news.title}
               />
             ))}


### PR DESCRIPTION
# Digital Iceland latest news - Filter out frontpage news tags

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Refined the news section display by filtering out a tag associated with the front page, ensuring that only relevant tags appear alongside news items for a cleaner viewing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->