### PR TITLE
fix(j-s): Fix formatting for lawyers in info cards

### DIFF
--- a/apps/judicial-system/web/src/components/InfoCard/CivilClaimantInfo/CivilClaimantInfo.tsx
+++ b/apps/judicial-system/web/src/components/InfoCard/CivilClaimantInfo/CivilClaimantInfo.tsx
@@ -47,9 +47,14 @@ export const CivilClaimantInfo: FC<CivilClaimantInfoProps> = (props) => {
           )}
         </>
       ) : (
-        <Text>{`${formatMessage(strings.lawyer)}: ${formatMessage(
-          strings.noLawyer,
-        )}`}</Text>
+        <>
+          <Text
+            as="span"
+            whiteSpace="pre"
+            fontWeight="semiBold"
+          >{`${formatMessage(strings.lawyer)}: `}</Text>
+          <Text as="span">{`${formatMessage(strings.noLawyer)}`}</Text>
+        </>
       )}
     </>
   )


### PR DESCRIPTION
# Fix formatting for lawyers in info cards

[Asana](https://app.asana.com/0/1199153462262248/1209330913054507)

## What

When a spokesperson for a claimant is registered, the label in info cards are not bold like other labels. This PR fixes that.

## Why

This is a UI bug.

## Screenshots / Gifs

### Before

<img width="461" alt="Screenshot 2025-02-07 at 11 43 01" src="https://github.com/user-attachments/assets/262153ec-ca49-401d-8b88-8c4e806dbb18" />

### After

<img width="512" alt="Screenshot 2025-02-07 at 11 42 32" src="https://github.com/user-attachments/assets/9a835a48-b3d1-4e00-9e6f-e2893ab95aec" />


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Improved the display of lawyer representation information by separating the label and the associated message. The lawyer label now appears with enhanced emphasis, providing better readability when no legal representative is assigned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->