### PR TITLE
feat(web): Organization Parent Subpage List Component

### DIFF
--- a/apps/web/components/Organization/Slice/OrganizationParentSubpageListSlice/OrganizationParentSubpageList.css.ts
+++ b/apps/web/components/Organization/Slice/OrganizationParentSubpageListSlice/OrganizationParentSubpageList.css.ts
@@ -1,0 +1,17 @@
+import { style } from '@vanilla-extract/css'
+
+import { themeUtils } from '@island.is/island-ui/theme'
+
+export const itemContainer = style({
+  display: 'grid',
+  gap: '24px',
+  gridTemplateColumns: '1fr',
+  ...themeUtils.responsiveStyle({
+    lg: {
+      gridTemplateColumns: '1fr 1fr',
+    },
+    xl: {
+      gridTemplateColumns: '1fr 1fr 1fr',
+    },
+  }),
+})

--- a/apps/web/components/Organization/Slice/OrganizationParentSubpageListSlice/OrganizationParentSubpageList.css.ts
+++ b/apps/web/components/Organization/Slice/OrganizationParentSubpageListSlice/OrganizationParentSubpageList.css.ts
@@ -2,12 +2,26 @@ import { style } from '@vanilla-extract/css'
 
 import { themeUtils } from '@island.is/island-ui/theme'
 
-export const itemContainer = style({
+export const serviceCardContainer = style({
   display: 'grid',
   gap: '24px',
   gridTemplateColumns: '1fr',
   ...themeUtils.responsiveStyle({
     lg: {
+      gridTemplateColumns: '1fr 1fr',
+    },
+    xl: {
+      gridTemplateColumns: '1fr 1fr 1fr',
+    },
+  }),
+})
+
+export const profileCardContainer = style({
+  display: 'grid',
+  gap: '24px',
+  gridTemplateColumns: '1fr',
+  ...themeUtils.responsiveStyle({
+    sm: {
       gridTemplateColumns: '1fr 1fr',
     },
     xl: {

--- a/apps/web/components/Organization/Slice/OrganizationParentSubpageListSlice/OrganizationParentSubpageListSlice.tsx
+++ b/apps/web/components/Organization/Slice/OrganizationParentSubpageListSlice/OrganizationParentSubpageListSlice.tsx
@@ -30,6 +30,7 @@ export const OrganizationParentSubpageListSlice = ({
         <Box className={styles.serviceCardContainer}>
           {slice.pageLinks.map((page) => (
             <IconTitleCard
+              key={page.id}
               heading={page.label}
               href={page.href}
               imgSrc={page.thumbnailImageHref ?? ''}

--- a/apps/web/components/Organization/Slice/OrganizationParentSubpageListSlice/OrganizationParentSubpageListSlice.tsx
+++ b/apps/web/components/Organization/Slice/OrganizationParentSubpageListSlice/OrganizationParentSubpageListSlice.tsx
@@ -1,0 +1,30 @@
+import { Box, Stack, Text } from '@island.is/island-ui/core'
+import { IconTitleCard } from '@island.is/web/components'
+import { OrganizationParentSubpageList } from '@island.is/web/graphql/schema'
+
+import * as styles from './OrganizationParentSubpageList.css'
+
+interface OrganizationParentSubpageListSliceProps {
+  slice: OrganizationParentSubpageList
+}
+
+// TODO: add variant
+export const OrganizationParentSubpageListSlice = ({
+  slice,
+}: OrganizationParentSubpageListSliceProps) => {
+  return (
+    <Stack space={3}>
+      {slice.title && <Text variant="h3">{slice.title}</Text>}
+      <Box className={styles.itemContainer}>
+        {slice.pageLinks.map((page) => (
+          <IconTitleCard
+            heading={page.label}
+            href={page.href}
+            imgSrc={page.thumbnailImageHref ?? ''}
+            alt=""
+          />
+        ))}
+      </Box>
+    </Stack>
+  )
+}

--- a/apps/web/components/Organization/Slice/OrganizationParentSubpageListSlice/OrganizationParentSubpageListSlice.tsx
+++ b/apps/web/components/Organization/Slice/OrganizationParentSubpageListSlice/OrganizationParentSubpageListSlice.tsx
@@ -1,6 +1,16 @@
-import { Box, Stack, Text } from '@island.is/island-ui/core'
+import {
+  Box,
+  LinkV2,
+  ProfileCard,
+  Stack,
+  Text,
+} from '@island.is/island-ui/core'
 import { IconTitleCard } from '@island.is/web/components'
-import { OrganizationParentSubpageList } from '@island.is/web/graphql/schema'
+import {
+  OrganizationParentSubpageList,
+  OrganizationParentSubpageListVariant,
+} from '@island.is/web/graphql/schema'
+import { useI18n } from '@island.is/web/i18n'
 
 import * as styles from './OrganizationParentSubpageList.css'
 
@@ -8,23 +18,49 @@ interface OrganizationParentSubpageListSliceProps {
   slice: OrganizationParentSubpageList
 }
 
-// TODO: add variant
 export const OrganizationParentSubpageListSlice = ({
   slice,
 }: OrganizationParentSubpageListSliceProps) => {
+  const { activeLocale } = useI18n()
   return (
     <Stack space={3}>
       {slice.title && <Text variant="h3">{slice.title}</Text>}
-      <Box className={styles.itemContainer}>
-        {slice.pageLinks.map((page) => (
-          <IconTitleCard
-            heading={page.label}
-            href={page.href}
-            imgSrc={page.thumbnailImageHref ?? ''}
-            alt=""
-          />
-        ))}
-      </Box>
+      {slice.pageLinkVariant ===
+        OrganizationParentSubpageListVariant.ServiceCard && (
+        <Box className={styles.serviceCardContainer}>
+          {slice.pageLinks.map((page) => (
+            <IconTitleCard
+              heading={page.label}
+              href={page.href}
+              imgSrc={page.thumbnailImageHref ?? ''}
+              alt=""
+            />
+          ))}
+        </Box>
+      )}
+      {slice.pageLinkVariant ===
+        OrganizationParentSubpageListVariant.ProfileCardWithTitleAbove && (
+        <Box
+          className={styles.profileCardContainer}
+          marginLeft={[0, 0, 0, 0, 6]}
+        >
+          {slice.pageLinks.map((page) => (
+            <LinkV2 key={page.id} href={page.href}>
+              <ProfileCard
+                heightFull={true}
+                variant="title-above"
+                size="small"
+                title={page.label}
+                link={{
+                  text: activeLocale === 'is' ? 'Sjá nánar' : 'See more',
+                  url: page.href,
+                }}
+                image={page.thumbnailImageHref ?? ''}
+              />
+            </LinkV2>
+          ))}
+        </Box>
+      )}
     </Stack>
   )
 }

--- a/apps/web/components/Organization/Slice/OrganizationParentSubpageListSlice/OrganizationParentSubpageListSlice.tsx
+++ b/apps/web/components/Organization/Slice/OrganizationParentSubpageListSlice/OrganizationParentSubpageListSlice.tsx
@@ -55,6 +55,7 @@ export const OrganizationParentSubpageListSlice = ({
                   text: activeLocale === 'is' ? 'Sjá nánar' : 'See more',
                   url: page.href,
                 }}
+                description={page.pageLinkIntro}
                 image={page.thumbnailImageHref ?? ''}
               />
             </LinkV2>

--- a/apps/web/components/Organization/Slice/SliceMachine.tsx
+++ b/apps/web/components/Organization/Slice/SliceMachine.tsx
@@ -22,6 +22,7 @@ import {
 import { webRenderConnectedComponent } from '@island.is/web/utils/richText'
 
 import { FeaturedSupportQNAs } from '../../FeaturedSupportQNAs'
+import { OrganizationParentSubpageListSlice } from './OrganizationParentSubpageListSlice/OrganizationParentSubpageListSlice'
 
 const DistrictsSlice = dynamic(() =>
   import('@island.is/web/components').then((mod) => mod.DistrictsSlice),
@@ -227,6 +228,8 @@ export const renderSlice = (
     }
     case 'FeaturedLinks':
       return <FeaturedLinksSlice slice={slice} />
+    case 'OrganizationParentSubpageList':
+      return <OrganizationParentSubpageListSlice slice={slice} />
     default:
       return <RichText body={[slice]} />
   }

--- a/apps/web/screens/Organization/SubPage.tsx
+++ b/apps/web/screens/Organization/SubPage.tsx
@@ -396,7 +396,10 @@ const renderSlices = (
       return <SliceTableOfContents slices={slices} sliceExtraText={extraText} />
     default:
       return slices.map((slice, index) => {
-        if (slice.__typename === 'AnchorPageListSlice') {
+        if (
+          slice.__typename === 'AnchorPageListSlice' ||
+          slice.__typename === 'OrganizationParentSubpageList'
+        ) {
           return (
             <SliceMachine
               key={slice.id}

--- a/apps/web/screens/queries/fragments.ts
+++ b/apps/web/screens/queries/fragments.ts
@@ -1020,7 +1020,7 @@ export const slices = gql`
     pageLinkVariant
     pageLinks {
       id
-      intro
+      pageLinkIntro
       label
       href
       thumbnailImageHref

--- a/apps/web/screens/queries/fragments.ts
+++ b/apps/web/screens/queries/fragments.ts
@@ -1017,7 +1017,10 @@ export const slices = gql`
     __typename
     id
     title
+    pageLinkVariant
     pageLinks {
+      id
+      intro
       label
       href
       thumbnailImageHref

--- a/apps/web/screens/queries/fragments.ts
+++ b/apps/web/screens/queries/fragments.ts
@@ -1013,6 +1013,21 @@ export const slices = gql`
     }
   }
 
+  fragment OrganizationParentSubpageListFields on OrganizationParentSubpageList {
+    __typename
+    id
+    title
+    pageLinks {
+      label
+      href
+      thumbnailImageHref
+    }
+    seeMoreLink {
+      text
+      url
+    }
+  }
+
   fragment BaseSlices on Slice {
     ...TimelineFields
     ...StoryFields
@@ -1060,6 +1075,7 @@ export const slices = gql`
     ...LatestGenericListItemsFields
     ...FeaturedLinksFields
     ...GrantCardsListFields
+    ...OrganizationParentSubpageListFields
   }
 
   fragment AllSlices on Slice {

--- a/apps/web/utils/richText.tsx
+++ b/apps/web/utils/richText.tsx
@@ -72,6 +72,7 @@ import {
   GrantCardsList as GrantCardsListSchema,
   MultipleStatistics as MultipleStatisticsSchema,
   OneColumnText,
+  OrganizationParentSubpageList,
   OverviewLinks as OverviewLinksSliceSchema,
   PowerBiSlice as PowerBiSliceSchema,
   SectionWithImage as SectionWithImageSchema,
@@ -98,6 +99,7 @@ import FeaturedEvents from '../components/FeaturedEvents/FeaturedEvents'
 import FeaturedSupportQNAs from '../components/FeaturedSupportQNAs/FeaturedSupportQNAs'
 import { GrantCardsList } from '../components/GrantCardsList'
 import { EmbedSlice } from '../components/Organization/Slice/EmbedSlice/EmbedSlice'
+import { OrganizationParentSubpageListSlice } from '../components/Organization/Slice/OrganizationParentSubpageListSlice/OrganizationParentSubpageListSlice'
 
 interface TranslationNamespaceProviderProps {
   messages: IntlConfig['messages']
@@ -312,6 +314,9 @@ const defaultRenderComponent = {
   },
   GrantCardsList: (slice: GrantCardsListSchema) => (
     <GrantCardsList slice={slice} />
+  ),
+  OrganizationParentSubpageList: (slice: OrganizationParentSubpageList) => (
+    <OrganizationParentSubpageListSlice slice={slice} />
   ),
 }
 

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -3376,6 +3376,9 @@ export interface IOrganizationParentSubpageFields {
 
   /** Image */
   image?: Asset | undefined
+
+  /** Thumbnail Image */
+  thumbnailImage?: Asset | undefined
 }
 
 /** Navigation page for content that belongs in multiple organization subpages */
@@ -3391,6 +3394,43 @@ export interface IOrganizationParentSubpage
     contentType: {
       sys: {
         id: 'organizationParentSubpage'
+        linkType: 'ContentType'
+        type: 'Link'
+      }
+    }
+  }
+}
+
+export interface IOrganizationParentSubpageListFields {
+  /** Internal Title */
+  internalTitle?: string | undefined
+
+  /** Displayed Title */
+  displayedTitle?: string | undefined
+
+  /** Variant */
+  variant?: 'Service Card' | 'Profile Card - Title Above' | undefined
+
+  /** Page List */
+  pageList?: IOrganizationParentSubpage[] | undefined
+
+  /** See More Link */
+  seeMoreLink?: ILink | undefined
+}
+
+/** List of organization parent subpages */
+
+export interface IOrganizationParentSubpageList
+  extends Entry<IOrganizationParentSubpageListFields> {
+  sys: {
+    id: string
+    type: string
+    createdAt: string
+    updatedAt: string
+    locale: string
+    contentType: {
+      sys: {
+        id: 'organizationParentSubpageList'
         linkType: 'ContentType'
         type: 'Link'
       }
@@ -5462,6 +5502,7 @@ export type CONTENT_TYPE =
   | 'organization'
   | 'organizationPage'
   | 'organizationParentSubpage'
+  | 'organizationParentSubpageList'
   | 'organizationSubpage'
   | 'organizationTag'
   | 'overviewLinks'

--- a/libs/cms/src/lib/models/organizationParentSubpageList.model.ts
+++ b/libs/cms/src/lib/models/organizationParentSubpageList.model.ts
@@ -16,6 +16,9 @@ registerEnumType(Variant, {
 
 @ObjectType('OrganizationParentSubpageListPageLink')
 class PageLink {
+  @Field(() => ID)
+  id!: string
+
   @Field()
   label!: string
 
@@ -24,6 +27,9 @@ class PageLink {
 
   @Field(() => String, { nullable: true })
   thumbnailImageHref?: string | null
+
+  @Field()
+  intro!: string
 }
 
 @ObjectType()
@@ -35,7 +41,7 @@ export class OrganizationParentSubpageList {
   title!: string
 
   @CacheField(() => Variant)
-  variant!: Variant
+  pageLinkVariant!: Variant
 
   @CacheField(() => [PageLink])
   pageLinks!: PageLink[]
@@ -52,7 +58,7 @@ export const mapOrganizationParentSubpageList = ({
     typename: 'OrganizationParentSubpageList',
     id: sys.id,
     title: fields.displayedTitle ?? '',
-    variant:
+    pageLinkVariant:
       fields.variant === 'Profile Card - Title Above'
         ? Variant.ProfileCardWithTitleAbove
         : Variant.ServiceCard,
@@ -64,11 +70,13 @@ export const mapOrganizationParentSubpageList = ({
           Boolean(page?.fields?.title),
       )
       .map((page) => ({
+        id: page.sys.id,
         label: page.fields.title ?? '',
         href: `/${getOrganizationPageUrlPrefix(sys.locale)}/${
           page.fields.organizationPage.fields.slug
         }/${page.fields.slug}`,
         thumbnailImageHref: page.fields.thumbnailImage?.fields?.file?.url,
+        intro: page.fields.pages?.[0]?.fields?.intro ?? '',
       })),
     seeMoreLink: fields.seeMoreLink ? mapLink(fields.seeMoreLink) : null,
   }

--- a/libs/cms/src/lib/models/organizationParentSubpageList.model.ts
+++ b/libs/cms/src/lib/models/organizationParentSubpageList.model.ts
@@ -29,7 +29,7 @@ class PageLink {
   thumbnailImageHref?: string | null
 
   @Field()
-  intro!: string
+  pageLinkIntro!: string
 }
 
 @ObjectType()
@@ -76,7 +76,7 @@ export const mapOrganizationParentSubpageList = ({
           page.fields.organizationPage.fields.slug
         }/${page.fields.slug}`,
         thumbnailImageHref: page.fields.thumbnailImage?.fields?.file?.url,
-        intro: page.fields.pages?.[0]?.fields?.intro ?? '',
+        pageLinkIntro: page.fields.pages?.[0]?.fields?.intro ?? '',
       })),
     seeMoreLink: fields.seeMoreLink ? mapLink(fields.seeMoreLink) : null,
   }

--- a/libs/cms/src/lib/models/organizationParentSubpageList.model.ts
+++ b/libs/cms/src/lib/models/organizationParentSubpageList.model.ts
@@ -1,0 +1,75 @@
+import { CacheField } from '@island.is/nest/graphql'
+import { Field, ID, ObjectType, registerEnumType } from '@nestjs/graphql'
+import type { SystemMetadata } from '@island.is/shared/types'
+import { getOrganizationPageUrlPrefix } from '@island.is/shared/utils'
+import type { IOrganizationParentSubpageList } from '../generated/contentfulTypes'
+import { Link, mapLink } from './link.model'
+
+enum Variant {
+  ServiceCard = 'ServiceCard',
+  ProfileCardWithTitleAbove = 'ProfileCardWithTitleAbove',
+}
+
+registerEnumType(Variant, {
+  name: 'OrganizationParentSubpageListVariant',
+})
+
+@ObjectType('OrganizationParentSubpageListPageLink')
+class PageLink {
+  @Field()
+  label!: string
+
+  @Field()
+  href!: string
+
+  @Field(() => String, { nullable: true })
+  thumbnailImageHref?: string | null
+}
+
+@ObjectType()
+export class OrganizationParentSubpageList {
+  @Field(() => ID)
+  id!: string
+
+  @Field()
+  title!: string
+
+  @CacheField(() => Variant)
+  variant!: Variant
+
+  @CacheField(() => [PageLink])
+  pageLinks!: PageLink[]
+
+  @CacheField(() => Link, { nullable: true })
+  seeMoreLink?: Link | null
+}
+
+export const mapOrganizationParentSubpageList = ({
+  sys,
+  fields,
+}: IOrganizationParentSubpageList): SystemMetadata<OrganizationParentSubpageList> => {
+  return {
+    typename: 'OrganizationParentSubpageList',
+    id: sys.id,
+    title: fields.displayedTitle ?? '',
+    variant:
+      fields.variant === 'Profile Card - Title Above'
+        ? Variant.ProfileCardWithTitleAbove
+        : Variant.ServiceCard,
+    pageLinks: (fields.pageList ?? [])
+      .filter(
+        (page) =>
+          Boolean(page?.fields?.organizationPage?.fields?.slug) &&
+          Boolean(page?.fields?.slug) &&
+          Boolean(page?.fields?.title),
+      )
+      .map((page) => ({
+        label: page.fields.title ?? '',
+        href: `/${getOrganizationPageUrlPrefix(sys.locale)}/${
+          page.fields.organizationPage.fields.slug
+        }/${page.fields.slug}`,
+        thumbnailImageHref: page.fields.thumbnailImage?.fields?.file?.url,
+      })),
+    seeMoreLink: fields.seeMoreLink ? mapLink(fields.seeMoreLink) : null,
+  }
+}

--- a/libs/cms/src/lib/unions/slice.union.ts
+++ b/libs/cms/src/lib/unions/slice.union.ts
@@ -50,6 +50,7 @@ import {
   ILatestGenericListItems,
   IFeaturedLinks,
   IGrantCardsList,
+  IOrganizationParentSubpageList,
 } from '../generated/contentfulTypes'
 import { Image, mapImage } from '../models/image.model'
 import { Asset, mapAsset } from '../models/asset.model'
@@ -152,6 +153,10 @@ import {
   GrantCardsList,
   mapGrantCardsList,
 } from '../models/grantCardsList.model'
+import {
+  OrganizationParentSubpageList,
+  mapOrganizationParentSubpageList,
+} from '../models/organizationParentSubpageList.model'
 
 export type SliceTypes =
   | ITimeline
@@ -201,6 +206,7 @@ export type SliceTypes =
   | IGrantCardsList
   | ILatestGenericListItems
   | IFeaturedLinks
+  | IOrganizationParentSubpageList
 
 export const SliceUnion = createUnionType({
   name: 'Slice',
@@ -255,6 +261,7 @@ export const SliceUnion = createUnionType({
     LatestGenericListItems,
     FeaturedLinks,
     GrantCardsList,
+    OrganizationParentSubpageList,
   ],
   resolveType: (document) => document.typename, // typename is appended to request on indexing
 })
@@ -356,6 +363,10 @@ export const mapSliceUnion = (slice: SliceTypes): typeof SliceUnion => {
       return mapFeaturedLinks(slice as IFeaturedLinks)
     case 'grantCardsList':
       return mapGrantCardsList(slice as IGrantCardsList)
+    case 'organizationParentSubpageList':
+      return mapOrganizationParentSubpageList(
+        slice as IOrganizationParentSubpageList,
+      )
     default:
       throw new ApolloError(`Can not convert to slice: ${contentType}`)
   }


### PR DESCRIPTION
# Organization Parent Subpage List Component

We are replacing the anchor page list component that is used on the digital iceland organization page, now they'll use organization parent subpages instead and therefore we need a new list component both because digital iceland is the only organization allowed to use it for now and because it's simpler than changing how the anchor page list component works.

## Screenshots / Gifs

![Screenshot 2025-02-10 at 14 01 14](https://github.com/user-attachments/assets/baa44b8d-16a4-4d0c-89a8-cb1f947ffd69)

![Screenshot 2025-02-10 at 14 01 53](https://github.com/user-attachments/assets/eef412f7-4ab7-4cd0-8f8e-32ae28e39816)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new organizational content slice for displaying subpages, supporting multiple card variants with localized titles and descriptions.
	- Enhanced content mapping and rich text rendering to support the new slice type.
- **Style**
	- Implemented responsive grid layouts with dynamic column adjustments for improved display across various screen sizes.
- **Bug Fixes**
	- Improved handling of new slice types in rendering logic to ensure proper display and functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->