### PR TITLE
chore(ci): `codegen` in Dockerfile

### DIFF
--- a/scripts/ci/Dockerfile
+++ b/scripts/ci/Dockerfile
@@ -39,6 +39,12 @@ FROM deps AS src
 
 COPY . .
 
+ARG NX_TASKS_RUNNER=ci
+RUN --mount=type=secret,id=nx_cloud_access_token \
+  NX_TASKS_RUNNER="${NX_TASKS_RUNNER}" NX_CLOUD_ACCESS_TOKEN="$(cat /run/secrets/nx_cloud_access_token)" \
+  yarn codegen
+
+
 # ------------------------------------------------
 # Build stage (app-specific args start here)
 # ------------------------------------------------


### PR DESCRIPTION
Without `codegen` the build will fail. Currently we do `codegen` on the runner, and copying generated files with `COPY . .`.

Running `codegen` when the files are present/copied already, should add minimal extra time.