### PR TITLE
feat(web): Organization parent subpage - Bottom slices

### DIFF
--- a/apps/web/screens/Organization/ParentSubpage.tsx
+++ b/apps/web/screens/Organization/ParentSubpage.tsx
@@ -21,7 +21,11 @@ import {
   getProps,
   StandaloneParentSubpageProps,
 } from './Standalone/ParentSubpage'
-import { getSubpageNavList, SubPageContent } from './SubPage'
+import {
+  getSubpageNavList,
+  SubPageBottomSlices,
+  SubPageContent,
+} from './SubPage'
 
 type OrganizationParentSubpageScreenContext = ScreenContext & {
   organizationPage?: Query['getOrganizationPage']
@@ -70,50 +74,60 @@ const OrganizationParentSubpage: Screen<
         title: n('navigationTitle', 'Efnisyfirlit'),
         items: getSubpageNavList(organizationPage, router, 3),
       }}
-    >
-      <Box paddingTop={4}>
-        <GridContainer>
-          <GridRow>
-            <GridColumn span={['9/9', '9/9', '7/9']} offset={['0', '0', '1/9']}>
-              <Stack space={3}>
-                {parentSubpage.childLinks.length > 1 && (
-                  <Stack space={4}>
-                    <Text variant="h1" as="h1">
-                      {parentSubpage.title}
-                    </Text>
-                    <TableOfContents
-                      headings={tableOfContentHeadings}
-                      onClick={(headingId) => {
-                        const href = tableOfContentHeadings.find(
-                          (heading) => heading.headingId === headingId,
-                        )?.href
-                        if (href) {
-                          router.push(href)
+      mainContent={
+        <Box paddingTop={4}>
+          <GridContainer>
+            <GridRow>
+              <GridColumn
+                span={['9/9', '9/9', '7/9']}
+                offset={['0', '0', '1/9']}
+              >
+                <Stack space={3}>
+                  {parentSubpage.childLinks.length > 1 && (
+                    <Stack space={4}>
+                      <Text variant="h1" as="h1">
+                        {parentSubpage.title}
+                      </Text>
+                      <TableOfContents
+                        headings={tableOfContentHeadings}
+                        onClick={(headingId) => {
+                          const href = tableOfContentHeadings.find(
+                            (heading) => heading.headingId === headingId,
+                          )?.href
+                          if (href) {
+                            router.push(href)
+                          }
+                        }}
+                        tableOfContentsTitle={
+                          namespace?.['OrganizationTableOfContentsTitle'] ??
+                          activeLocale === 'is'
+                            ? 'Efnisyfirlit'
+                            : 'Table of contents'
                         }
-                      }}
-                      tableOfContentsTitle={
-                        namespace?.['OrganizationTableOfContentsTitle'] ??
-                        activeLocale === 'is'
-                          ? 'Efnisyfirlit'
-                          : 'Table of contents'
-                      }
-                      selectedHeadingId={selectedHeadingId}
-                    />
-                  </Stack>
-                )}
-              </Stack>
-            </GridColumn>
-          </GridRow>
-        </GridContainer>
-        <SubPageContent
-          namespace={namespace}
-          organizationPage={organizationPage}
-          subpage={subpage}
-          subpageTitleVariant={
-            parentSubpage.childLinks.length > 1 ? 'h2' : 'h1'
-          }
-        />
-      </Box>
+                        selectedHeadingId={selectedHeadingId}
+                      />
+                    </Stack>
+                  )}
+                </Stack>
+              </GridColumn>
+            </GridRow>
+          </GridContainer>
+          <SubPageContent
+            namespace={namespace}
+            organizationPage={organizationPage}
+            subpage={subpage}
+            subpageTitleVariant={
+              parentSubpage.childLinks.length > 1 ? 'h2' : 'h1'
+            }
+          />
+        </Box>
+      }
+    >
+      <SubPageBottomSlices
+        namespace={namespace}
+        organizationPage={organizationPage}
+        subpage={subpage}
+      />
     </OrganizationWrapper>
   )
 }

--- a/apps/web/screens/Organization/SubPage.tsx
+++ b/apps/web/screens/Organization/SubPage.tsx
@@ -258,6 +258,50 @@ export const getSubpageNavList = (
   return items
 }
 
+export const SubPageBottomSlices = ({
+  organizationPage,
+  subpage,
+  namespace,
+}: Pick<SubPageProps, 'organizationPage' | 'subpage' | 'namespace'>) => {
+  return (
+    !!organizationPage && (
+      <Stack
+        space={
+          subpage?.bottomSlices && subpage.bottomSlices.length > 0
+            ? SLICE_SPACING
+            : 0
+        }
+      >
+        {subpage?.bottomSlices?.map((slice) => {
+          if (
+            (organizationPage.slug === 'stafraent-island' ||
+              organizationPage.slug === 'digital-iceland') &&
+            slice.__typename === 'LatestNewsSlice'
+          ) {
+            return (
+              <Box paddingTop={[5, 5, 8]} paddingBottom={[2, 2, 5]}>
+                <DigitalIcelandLatestNewsSlice
+                  slice={slice}
+                  slug={organizationPage.slug}
+                />
+              </Box>
+            )
+          }
+          return (
+            <SliceMachine
+              key={slice.id}
+              slice={slice}
+              namespace={namespace}
+              slug={organizationPage.slug}
+              fullWidth={true}
+            />
+          )
+        })}
+      </Stack>
+    )
+  )
+}
+
 type SubPageScreenContext = ScreenContext & {
   organizationPage?: Query['getOrganizationPage']
 }
@@ -343,41 +387,11 @@ const SubPage: Screen<SubPageProps, SubPageScreenContext> = ({
         )
       }
     >
-      {!!organizationPage && (
-        <Stack
-          space={
-            subpage?.bottomSlices && subpage.bottomSlices.length > 0
-              ? SLICE_SPACING
-              : 0
-          }
-        >
-          {subpage?.bottomSlices?.map((slice) => {
-            if (
-              (organizationPage.slug === 'stafraent-island' ||
-                organizationPage.slug === 'digital-iceland') &&
-              slice.__typename === 'LatestNewsSlice'
-            ) {
-              return (
-                <Box paddingTop={[5, 5, 8]} paddingBottom={[2, 2, 5]}>
-                  <DigitalIcelandLatestNewsSlice
-                    slice={slice}
-                    slug={organizationPage.slug}
-                  />
-                </Box>
-              )
-            }
-            return (
-              <SliceMachine
-                key={slice.id}
-                slice={slice}
-                namespace={namespace}
-                slug={organizationPage.slug}
-                fullWidth={true}
-              />
-            )
-          })}
-        </Stack>
-      )}
+      <SubPageBottomSlices
+        namespace={namespace}
+        organizationPage={organizationPage}
+        subpage={subpage}
+      />
     </OrganizationWrapper>
   )
 }


### PR DESCRIPTION
# Organization parent subpage - Bottom slices

* Move parent subpage into "mainContent" field on OrganizationWrapper
* Render bottom slices of selected organization subpage at the bottom

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated bottom content area for subpages that dynamically presents additional slices.

- **Refactor**
  - Reorganized the organization page layout to separate primary content from supplementary sections, ensuring a clearer structure while preserving existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->