### PR TITLE
fix(web): Organization parent subpage table of contents, use links instead of buttons

### DIFF
--- a/apps/web/screens/Organization/ParentSubpage.css.ts
+++ b/apps/web/screens/Organization/ParentSubpage.css.ts
@@ -1,0 +1,5 @@
+import { style } from '@vanilla-extract/css'
+
+export const fitContentWidth = style({
+  width: 'fit-content',
+})

--- a/apps/web/screens/Organization/ParentSubpage.tsx
+++ b/apps/web/screens/Organization/ParentSubpage.tsx
@@ -5,8 +5,8 @@ import {
   GridColumn,
   GridContainer,
   GridRow,
+  LinkV2,
   Stack,
-  TableOfContents,
   Text,
 } from '@island.is/island-ui/core'
 import { getThemeConfig, OrganizationWrapper } from '@island.is/web/components'
@@ -26,6 +26,7 @@ import {
   SubPageBottomSlices,
   SubPageContent,
 } from './SubPage'
+import * as styles from './ParentSubpage.css'
 
 type OrganizationParentSubpageScreenContext = ScreenContext & {
   organizationPage?: Query['getOrganizationPage']
@@ -88,24 +89,50 @@ const OrganizationParentSubpage: Screen<
                       <Text variant="h1" as="h1">
                         {parentSubpage.title}
                       </Text>
-                      <TableOfContents
-                        headings={tableOfContentHeadings}
-                        onClick={(headingId) => {
-                          const href = tableOfContentHeadings.find(
-                            (heading) => heading.headingId === headingId,
-                          )?.href
-                          if (href) {
-                            router.push(href)
-                          }
-                        }}
-                        tableOfContentsTitle={
-                          namespace?.['OrganizationTableOfContentsTitle'] ??
-                          activeLocale === 'is'
-                            ? 'Efnisyfirlit'
-                            : 'Table of contents'
-                        }
-                        selectedHeadingId={selectedHeadingId}
-                      />
+                      <Box
+                        paddingX={4}
+                        paddingY={2}
+                        borderLeftWidth="standard"
+                        borderColor="blue200"
+                      >
+                        <Stack space={1}>
+                          <Text variant="h5" as="h2">
+                            {namespace?.['OrganizationTableOfContentsTitle'] ??
+                            activeLocale === 'is'
+                              ? 'Efnisyfirlit'
+                              : 'Table of contents'}
+                          </Text>
+                          <Stack space={1}>
+                            {tableOfContentHeadings.map(
+                              ({ headingTitle, headingId, href }) => (
+                                <Box
+                                  key={headingId}
+                                  className={styles.fitContentWidth}
+                                >
+                                  <LinkV2 href={href}>
+                                    <Text
+                                      fontWeight={
+                                        headingId === selectedHeadingId
+                                          ? 'semiBold'
+                                          : 'regular'
+                                      }
+                                      variant="small"
+                                      color={
+                                        selectedHeadingId &&
+                                        headingId === selectedHeadingId
+                                          ? 'blue400'
+                                          : 'blue600'
+                                      }
+                                    >
+                                      {headingTitle}
+                                    </Text>
+                                  </LinkV2>
+                                </Box>
+                              ),
+                            )}
+                          </Stack>
+                        </Stack>
+                      </Box>
                     </Stack>
                   )}
                 </Stack>

--- a/apps/web/screens/Organization/ParentSubpage.tsx
+++ b/apps/web/screens/Organization/ParentSubpage.tsx
@@ -105,29 +105,28 @@ const OrganizationParentSubpage: Screen<
                           <Stack space={1}>
                             {tableOfContentHeadings.map(
                               ({ headingTitle, headingId, href }) => (
-                                <Box
+                                <LinkV2
                                   key={headingId}
+                                  href={href}
                                   className={styles.fitContentWidth}
                                 >
-                                  <LinkV2 href={href}>
-                                    <Text
-                                      fontWeight={
-                                        headingId === selectedHeadingId
-                                          ? 'semiBold'
-                                          : 'regular'
-                                      }
-                                      variant="small"
-                                      color={
-                                        selectedHeadingId &&
-                                        headingId === selectedHeadingId
-                                          ? 'blue400'
-                                          : 'blue600'
-                                      }
-                                    >
-                                      {headingTitle}
-                                    </Text>
-                                  </LinkV2>
-                                </Box>
+                                  <Text
+                                    fontWeight={
+                                      headingId === selectedHeadingId
+                                        ? 'semiBold'
+                                        : 'regular'
+                                    }
+                                    variant="small"
+                                    color={
+                                      selectedHeadingId &&
+                                      headingId === selectedHeadingId
+                                        ? 'blue400'
+                                        : 'blue600'
+                                    }
+                                  >
+                                    {headingTitle}
+                                  </Text>
+                                </LinkV2>
                               ),
                             )}
                           </Stack>


### PR DESCRIPTION
# Organization parent subpage table of contents, use links instead of buttons

## Screenshots / Gifs

Same look, now these are "a" tags instead of being buttons with onClick handlers

![Screenshot 2025-02-10 at 15 52 47](https://github.com/user-attachments/assets/d8b17b43-96c5-4040-8c21-f331641085e0)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Introduced a new styling option that enables elements to automatically adjust their width based on their content, ensuring a more responsive layout.
- **Refactor**
  - Redesigned the table of contents section with simplified navigation and updated visual cues for selected headings, resulting in a more streamlined user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->