### PR TITLE
feat(ci): `set-cache-url` action

### DIFF
--- a/.github/actions/get-cache/action.yml
+++ b/.github/actions/get-cache/action.yml
@@ -20,18 +20,11 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - name: Adding required env vars
-      # Skip when running locally
-      if: ${{ !github.event.localrun }}
-      uses: actions/github-script@v7
-      env:
-        cache-url: ${{ inputs.cache-url }}
-        github-token: ${{ inputs.GITHUB_TOKEN }}
+    - uses: ./.github/actions/set-cache-url
       with:
-        script: |
-          core.exportVariable('ACTIONS_CACHE_URL', process.env['cache-url'])
-          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env['ACTIONS_RUNTIME_TOKEN'])
-          core.exportVariable('ACTIONS_RUNTIME_URL', process.env['ACTIONS_RUNTIME_URL'])
+        github-token: ${{ inputs.github-token }}
+        cache-url: ${{ inputs.cache-url }}
+
     - name: Get cache
       id: prepare
       shell: bash

--- a/.github/actions/set-cache-url/action.yml
+++ b/.github/actions/set-cache-url/action.yml
@@ -1,0 +1,24 @@
+name: 'Set GHA cache url'
+description: 'Set your custom cache URL'
+inputs:
+  github-token:
+    description: 'GitHub token (omit to skip setting URL)'
+    required: false
+  cache-url:
+    description: 'Cache URL'
+    default: 'https://cache.dev01.devland.is/'
+runs:
+  using: 'composite'
+  steps:
+    - name: Adding required env vars
+      # Skip when running locally
+      if: ${{ !!inputs.github-token && !github.event.localrun }}
+      uses: actions/github-script@v7
+      env:
+        cache-url: ${{ inputs.cache-url }}
+        github-token: ${{ inputs.GITHUB_TOKEN }}
+      with:
+        script: |
+          core.exportVariable('ACTIONS_CACHE_URL', process.env['cache-url'])
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env['ACTIONS_RUNTIME_TOKEN'])
+          core.exportVariable('ACTIONS_RUNTIME_URL', process.env['ACTIONS_RUNTIME_URL'])


### PR DESCRIPTION
Create a new action to set the cache URL.

This is useful to set the cache url to a self-hosted cache, which subsequent actions will use when they use the standard https://github.com/actions/cache. This means that when using actions like `actions/setup-node` which uses the `actions/cache` action for caching, it will transparently use the self-hosted cache set with `set-cache-url`.