### PR TITLE
feat(web): Organization Parent Subpage - Tiny thumbnail image field

### DIFF
--- a/apps/web/components/Organization/Slice/OrganizationParentSubpageListSlice/OrganizationParentSubpageListSlice.tsx
+++ b/apps/web/components/Organization/Slice/OrganizationParentSubpageListSlice/OrganizationParentSubpageListSlice.tsx
@@ -33,7 +33,7 @@ export const OrganizationParentSubpageListSlice = ({
               key={page.id}
               heading={page.label}
               href={page.href}
-              imgSrc={page.thumbnailImageHref ?? ''}
+              imgSrc={page.tinyThumbnailImageHref ?? ''}
               alt=""
             />
           ))}

--- a/apps/web/screens/queries/fragments.ts
+++ b/apps/web/screens/queries/fragments.ts
@@ -1024,6 +1024,7 @@ export const slices = gql`
       label
       href
       thumbnailImageHref
+      tinyThumbnailImageHref
     }
     seeMoreLink {
       text

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -3379,6 +3379,9 @@ export interface IOrganizationParentSubpageFields {
 
   /** Thumbnail Image */
   thumbnailImage?: Asset | undefined
+
+  /** Tiny Thumbnail Image */
+  tinyThumbnailImage?: Asset | undefined
 }
 
 /** Navigation page for content that belongs in multiple organization subpages */

--- a/libs/cms/src/lib/models/organizationParentSubpageList.model.ts
+++ b/libs/cms/src/lib/models/organizationParentSubpageList.model.ts
@@ -28,6 +28,9 @@ class PageLink {
   @Field(() => String, { nullable: true })
   thumbnailImageHref?: string | null
 
+  @Field(() => String, { nullable: true })
+  tinyThumbnailImageHref?: string | null
+
   @Field()
   pageLinkIntro!: string
 }
@@ -76,6 +79,8 @@ export const mapOrganizationParentSubpageList = ({
           page.fields.organizationPage.fields.slug
         }/${page.fields.slug}`,
         thumbnailImageHref: page.fields.thumbnailImage?.fields?.file?.url,
+        tinyThumbnailImageHref:
+          page.fields.tinyThumbnailImage?.fields?.file?.url,
         pageLinkIntro: page.fields.pages?.[0]?.fields?.intro ?? '',
       })),
     seeMoreLink: fields.seeMoreLink ? mapLink(fields.seeMoreLink) : null,


### PR DESCRIPTION
# Organization Parent Subpage - Tiny thumbnail image field

We need a specific field for tiny thumbnails (image width: 40px)

![Screenshot 2025-02-11 at 10 19 14](https://github.com/user-attachments/assets/92191431-2311-4c19-b294-a452a7f42768)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the visual display in service and profile sections by switching to a compact thumbnail option for images, providing a cleaner and more optimized viewing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->