### PR TITLE
fix(email-service): Add anchor tag around copy

### DIFF
--- a/libs/email-service/src/tools/design/copy.hbs
+++ b/libs/email-service/src/tools/design/copy.hbs
@@ -1,5 +1,5 @@
 {{#> center}}
   <div class="copy size-{{ternary small 'small' 'normal'}} style-{{ternary style style 'normal'}}">
-    <p class="text-{{ternary align align 'center'}}">{{{copy}}}</p>
+    <a class="text-{{ternary align align 'center'}}">{{{copy}}}</a>
   </div>
 {{/center}}


### PR DESCRIPTION
## What

Add anchor tag around copy in emails, did this for heading, to prevent Outlook from creating a link around text that looks like a url, that works, then I noticed we also have island.is in the copy so adding this around copy as well 

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the email content design by replacing a plain text block with a link element, enhancing semantic structure while preserving existing styling and alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->