### PR TITLE
fix(web): Organization Parent Subpage List - Image urls now start with https

### DIFF
--- a/libs/cms/src/lib/models/organizationParentSubpageList.model.ts
+++ b/libs/cms/src/lib/models/organizationParentSubpageList.model.ts
@@ -72,17 +72,28 @@ export const mapOrganizationParentSubpageList = ({
           Boolean(page?.fields?.slug) &&
           Boolean(page?.fields?.title),
       )
-      .map((page) => ({
-        id: page.sys.id,
-        label: page.fields.title ?? '',
-        href: `/${getOrganizationPageUrlPrefix(sys.locale)}/${
-          page.fields.organizationPage.fields.slug
-        }/${page.fields.slug}`,
-        thumbnailImageHref: page.fields.thumbnailImage?.fields?.file?.url,
-        tinyThumbnailImageHref:
-          page.fields.tinyThumbnailImage?.fields?.file?.url,
-        pageLinkIntro: page.fields.pages?.[0]?.fields?.intro ?? '',
-      })),
+      .map((page) => {
+        let thumbnailImageHref =
+          page.fields.thumbnailImage?.fields?.file?.url ?? ''
+        if (thumbnailImageHref.startsWith('//')) {
+          thumbnailImageHref = `https:${thumbnailImageHref}`
+        }
+        let tinyThumbnailImageHref =
+          page.fields.tinyThumbnailImage?.fields?.file?.url ?? ''
+        if (tinyThumbnailImageHref.startsWith('//')) {
+          tinyThumbnailImageHref = `https:${tinyThumbnailImageHref}`
+        }
+        return {
+          id: page.sys.id,
+          label: page.fields.title ?? '',
+          href: `/${getOrganizationPageUrlPrefix(sys.locale)}/${
+            page.fields.organizationPage.fields.slug
+          }/${page.fields.slug}`,
+          thumbnailImageHref,
+          tinyThumbnailImageHref,
+          pageLinkIntro: page.fields.pages?.[0]?.fields?.intro ?? '',
+        }
+      }),
     seeMoreLink: fields.seeMoreLink ? mapLink(fields.seeMoreLink) : null,
   }
 }


### PR DESCRIPTION
# Organization Parent Subpage List - Image urls now start with https

## Screenshots / Gifs

### Before

![Screenshot 2025-02-11 at 12 33 17](https://github.com/user-attachments/assets/aee53c87-e15a-4fef-a955-2d768eb82f0c)


### After

![Screenshot 2025-02-11 at 12 33 26](https://github.com/user-attachments/assets/c10c48ea-88cf-43f5-a80e-12a523aa08b9)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved image URL handling to ensure thumbnails load securely by auto-prepending "https:" when needed.
- **Refactor**
	- Streamlined the mapping process for clearer, more robust processing of media URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->