### PR TITLE
fix(web): Organization Parent Subpage - Table of contents links are 100% width

### DIFF
--- a/apps/web/screens/Organization/ParentSubpage.tsx
+++ b/apps/web/screens/Organization/ParentSubpage.tsx
@@ -105,28 +105,29 @@ const OrganizationParentSubpage: Screen<
                           <Stack space={1}>
                             {tableOfContentHeadings.map(
                               ({ headingTitle, headingId, href }) => (
-                                <LinkV2
+                                <Box
                                   key={headingId}
-                                  href={href}
                                   className={styles.fitContentWidth}
                                 >
-                                  <Text
-                                    fontWeight={
-                                      headingId === selectedHeadingId
-                                        ? 'semiBold'
-                                        : 'regular'
-                                    }
-                                    variant="small"
-                                    color={
-                                      selectedHeadingId &&
-                                      headingId === selectedHeadingId
-                                        ? 'blue400'
-                                        : 'blue600'
-                                    }
-                                  >
-                                    {headingTitle}
-                                  </Text>
-                                </LinkV2>
+                                  <LinkV2 href={href}>
+                                    <Text
+                                      fontWeight={
+                                        headingId === selectedHeadingId
+                                          ? 'semiBold'
+                                          : 'regular'
+                                      }
+                                      variant="small"
+                                      color={
+                                        selectedHeadingId &&
+                                        headingId === selectedHeadingId
+                                          ? 'blue400'
+                                          : 'blue600'
+                                      }
+                                    >
+                                      {headingTitle}
+                                    </Text>
+                                  </LinkV2>
+                                </Box>
                               ),
                             )}
                           </Stack>


### PR DESCRIPTION
# Organization Parent Subpage - Table of contents links are 100% width

## Before

![Screenshot 2025-02-11 at 12 51 08](https://github.com/user-attachments/assets/ea83d3e1-d697-48b8-9234-94d27758b3b3)


## After

![Screenshot 2025-02-11 at 12 50 48](https://github.com/user-attachments/assets/9d300864-4cbb-4828-9f99-08bf72311c70)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the hierarchical structure for displaying heading titles on the Organization page, maintaining a consistent visual appearance while enhancing internal layout organization with no change to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->