### PR TITLE
fix(email-service): update style since copy is now anchor tag

### DIFF
--- a/libs/email-service/src/tools/design/styles.hbs
+++ b/libs/email-service/src/tools/design/styles.hbs
@@ -115,7 +115,7 @@
     }
   }
 
-  .copy p {
+  .copy > a {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
 
@@ -126,26 +126,26 @@
     color: #00003c;
   }
 
-  .copy.style-bold p {
+  .copy.style-bold > a {
     font-weight: 600;
   }
 
-  .copy.style-italic p {
+  .copy.style-italic > a {
     font-style: italic;
   }
 
-  .copy.size-small p {
+  .copy.size-small > a {
     font-size: 18px;
     line-height: 28px;
   }
 
   @media only screen and (max-width: 620px) {
-    .copy p {
+    .copy > a {
       font-size: 18px !important;
       line-height: 26px !important;
     }
 
-    .copy.size-small p {
+    .copy.size-small > a {
       font-size: 16px !important;
       line-height: 24px !important;
     }


### PR DESCRIPTION
After [updating the tag around copy](https://github.com/island-is/island.is/pull/17911) to anchor the style needs some tweaking

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined email styling by updating text elements to ensure a consistent and modern visual presentation.
  - Enhanced responsive behavior to deliver a cohesive experience across various devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->