### PR TITLE
fix(template-api-modules): user-profile.service throwing 500 instead of 400 errors 

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/shared/api/user-profile/user-profile.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/shared/api/user-profile/user-profile.service.ts
@@ -21,8 +21,11 @@ import { getConfigValue } from '../../shared.utils'
 import { TemplateApiError } from '@island.is/nest/problem'
 import { FetchError } from '@island.is/clients/middlewares'
 import { parsePhoneNumberFromString } from 'libphonenumber-js'
+import { CodeOwner } from '@island.is/nest/core'
+import { CodeOwners } from '@island.is/shared/constants'
 
 @Injectable()
+@CodeOwner(CodeOwners.NordaApplications)
 export class UserProfileService extends BaseTemplateApiService {
   constructor(
     private readonly userProfileApi: V2MeApi,
@@ -92,7 +95,7 @@ export class UserProfileService extends BaseTemplateApiService {
             },
           },
         },
-        500,
+        400,
       )
     } else if (emailIsInvalid) {
       throw new TemplateApiError(
@@ -103,7 +106,7 @@ export class UserProfileService extends BaseTemplateApiService {
             values: { link: this.getIDSLink(application, { email: true }) },
           },
         },
-        500,
+        400,
       )
     } else if (phoneIsInvalid) {
       if (!mobilePhoneNumber || !this.isValidPhoneNumber(mobilePhoneNumber))
@@ -115,7 +118,7 @@ export class UserProfileService extends BaseTemplateApiService {
               values: { link: this.getIDSLink(application, { phone: true }) },
             },
           },
-          500,
+          400,
         )
     }
 


### PR DESCRIPTION
# Correcting status of some errors thrown

Attach a link to issue if relevant

## What

Make user-profile.service throw 400s instead of 500s

## Why

Because we dont need to be throwing 500s for something that is caused by user error, should be 400 bad request.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

This release improves user profile validation feedback by ensuring that errors are communicated accurately when email or phone inputs are invalid.

- **Bug Fixes**
  - Adjusted error responses in user profile validations to return client error notifications (HTTP 400) instead of server errors, providing clearer guidance when submissions require correction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->