### PR TITLE
chore: Monitor client scope files in charts dirty check

### DIFF
--- a/.github/workflows/config-values.yaml
+++ b/.github/workflows/config-values.yaml
@@ -10,12 +10,14 @@ on:
       - 'charts/**'
       - 'infra/**'
       - '**/infra/**'
+      - 'libs/auth/scopes/src/lib/clients/**'
   workflow_dispatch: {}
   pull_request:
     paths:
       - 'charts/**'
       - 'infra/**'
       - '**/infra/**'
+      - 'libs/auth/scopes/src/lib/clients/**'
 
 defaults:
   run:


### PR DESCRIPTION
## What

Monitor changes to client scope lists in config-values workflow.

## Why

These files are used by infra files to build value files. When users add a scope to these files, they must also regenerate charts. This workflow is meant to check that this has been done, but it doesn't work if it doesn't watch these files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated our automation triggers to monitor additional areas. This enhancement helps ensure that updates are integrated and processed more responsively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->