### PR TITLE
fix(parental-leave): Change text in employer email

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/emailGenerators/assignEmployerEmail.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/emailGenerators/assignEmployerEmail.ts
@@ -92,7 +92,7 @@ export const generateAssignEmployerApplicationEmail: AssignEmployerEmail = (
         {
           component: 'Copy',
           context: {
-            copy: `Athugið: Ef upp kemur 404 villa hefur umsækjandi breytt umsókninni og sent nýja, þér ætti að hafa borist nýr póstur.`,
+            copy: `Athugið: Ef upp kemur villa við að tengjast umsókn þá hefur umsækjandinn að öllum líkindum tekið umsóknina aftur til breytinga. Þér mun berast nýr póstur þegar umsækjandi hefur lokið við breytingarnar og sent umsóknina aftur til samþykkis.`,
             small: true,
           },
         },

--- a/libs/application/template-api-modules/src/lib/modules/templates/reference-template/emailGenerators/assignEmail.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/reference-template/emailGenerators/assignEmail.ts
@@ -64,7 +64,7 @@ export const generateAssignApplicationEmail: AssignmentEmailTemplateGenerator =
           {
             component: 'Copy',
             context: {
-              copy: `Athugið: Ef upp kemur 404 villa hefur umsækjandi breytt umsókninni og sent nýja, þér ætti að hafa borist nýr póstur.`,
+              copy: `Athugið: Ef upp kemur villa við að tengjast umsókn þá hefur umsækjandinn að öllum líkindum tekið umsóknina aftur til breytinga. Þér mun berast nýr póstur þegar umsækjandi hefur lokið við breytingarnar og sent umsóknina aftur til samþykkis.`,
               small: true,
             },
           },

--- a/libs/application/template-api-modules/src/lib/modules/templates/reference-template/emailGenerators/assignEmail.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/reference-template/emailGenerators/assignEmail.ts
@@ -64,7 +64,7 @@ export const generateAssignApplicationEmail: AssignmentEmailTemplateGenerator =
           {
             component: 'Copy',
             context: {
-              copy: `Athugið: Ef upp kemur villa við að tengjast umsókn þá hefur umsækjandinn að öllum líkindum tekið umsóknina aftur til breytinga. Þér mun berast nýr póstur þegar umsækjandi hefur lokið við breytingarnar og sent umsóknina aftur til samþykkis.`,
+              copy: `Athugið: Ef upp kemur 404 villa hefur umsækjandi breytt umsókninni og sent nýja, þér ætti að hafa borist nýr póstur.`,
               small: true,
             },
           },


### PR DESCRIPTION
# Change "attention" error text

## What

Change text to make it more informative

## Why

To reduce the amount of employers that contact FOS with questions

## Screenshots / Gifs

Before:
<img width="608" alt="Screenshot 2025-02-12 at 11 29 16" src="https://github.com/user-attachments/assets/4823ed6b-ea2a-432c-8ba9-3b4c62b0736c" />

After:
<img width="676" alt="Screenshot 2025-02-12 at 20 39 41" src="https://github.com/user-attachments/assets/ca113e6b-c72b-4be7-a2bf-351f788bae9c" />

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Revised email notifications to enhance clarity. The updated messages now inform recipients that if an application is withdrawn for revisions, a new notification will follow upon resubmission, replacing the previous error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->