### PR TITLE
ci(native): install distutils

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -40,6 +40,11 @@ definitions:
         else
           echo "No previous commit detected. Continuing."
         fi
+    - &pip_install
+      name: Install distutils with pip
+      script: |
+        pip3 install --upgrade setuptools
+        python3 -c "import distutils; print(distutils.__file__)"
     - &set_android_location
       name: Prepare Android configuration
       script: |
@@ -129,6 +134,7 @@ workflows:
         APP_STORE_APPLE_ID: 1569828682
     scripts:
       - *check_changes
+      - *pip_install
       - *npm_install
       - *codegen
       - *cocoapods
@@ -163,6 +169,7 @@ workflows:
         APP_STORE_APPLE_ID: 1570427360
     scripts:
       - *check_changes
+      - *pip_install
       - *npm_install
       - *codegen
       - *cocoapods
@@ -203,6 +210,7 @@ workflows:
     scripts:
       - *check_changes
       - *set_android_location
+      - *pip_install
       - *npm_install
       - *codegen
       - *build_android
@@ -233,6 +241,7 @@ workflows:
     scripts:
       - *check_changes
       - *set_android_location
+      - *pip_install
       - *npm_install
       - *codegen
       - *build_android


### PR DESCRIPTION
Install missing `distutils` for the codemagic runner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced the automated build process by adding a step to ensure all required dependencies are installed across iOS and Android workflows, supporting smoother and more reliable deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->