### PR TITLE
fix(j-s): Send multiple civil claims to police

### DIFF
--- a/apps/judicial-system/backend/sequelize.config.js
+++ b/apps/judicial-system/backend/sequelize.config.js
@@ -2,9 +2,9 @@
 
 module.exports = {
   development: {
-    username: 'judicial_system',
-    password: 'I47H91GsTsuTvqFwRxd580LCQwF1BSpv',
-    database: 'judicial_system',
+    username: 'dev_db',
+    password: 'dev_db',
+    database: 'dev_db',
     host: 'localhost',
     dialect: 'postgres',
   },

--- a/apps/judicial-system/backend/sequelize.config.js
+++ b/apps/judicial-system/backend/sequelize.config.js
@@ -2,9 +2,9 @@
 
 module.exports = {
   development: {
-    username: 'dev_db',
-    password: 'dev_db',
-    database: 'dev_db',
+    username: 'judicial_system',
+    password: 'I47H91GsTsuTvqFwRxd580LCQwF1BSpv',
+    database: 'judicial_system',
     host: 'localhost',
     dialect: 'postgres',
   },

--- a/apps/judicial-system/backend/src/app/modules/police/police.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/police.service.ts
@@ -646,7 +646,7 @@ export class PoliceService {
           agent: this.agent,
           body: JSON.stringify({
             documentName: documentName,
-            documentsBase64: [subpoena, indictment, civilClaims],
+            documentsBase64: [subpoena, indictment, ...civilClaims],
             courtRegistrationDate: arraignmentInfo?.date,
             prosecutorSsn: prosecutor?.nationalId,
             prosecutedSsn: normalizedNationalId,

--- a/apps/judicial-system/backend/src/app/modules/police/police.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/police.service.ts
@@ -619,7 +619,7 @@ export class PoliceService {
     subpoena: string,
     indictment: string,
     user: User,
-    civilClaim?: string,
+    civilClaims: string[],
   ): Promise<CreateSubpoenaResponse> {
     const { courtCaseNumber, dateLogs, prosecutor, policeCaseNumbers, court } =
       theCase
@@ -646,11 +646,7 @@ export class PoliceService {
           agent: this.agent,
           body: JSON.stringify({
             documentName: documentName,
-            documentsBase64: [
-              subpoena,
-              indictment,
-              ...(civilClaim ? [civilClaim] : []),
-            ],
+            documentsBase64: [subpoena, indictment, civilClaims],
             courtRegistrationDate: arraignmentInfo?.date,
             prosecutorSsn: prosecutor?.nationalId,
             prosecutedSsn: normalizedNationalId,

--- a/apps/judicial-system/backend/src/app/modules/subpoena/subpoena.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/subpoena/subpoena.service.ts
@@ -301,16 +301,19 @@ export class SubpoenaService {
     user: TUser,
   ): Promise<DeliverResponse> {
     try {
-      let civilClaimPdf = undefined
-      const civilClaim = theCase.caseFiles?.find(
-        (caseFile) => caseFile.category === CaseFileCategory.CIVIL_CLAIM,
-      )
+      const civilClaimPdfs: string[] = []
+      const civilClaimFiles =
+        theCase.caseFiles?.filter(
+          (caseFile) => caseFile.category === CaseFileCategory.CIVIL_CLAIM,
+        ) ?? []
 
-      if (civilClaim) {
-        civilClaimPdf = await this.fileService.getCaseFileFromS3(
+      for (const civilClaimFile of civilClaimFiles) {
+        const civilClaimPdf = await this.fileService.getCaseFileFromS3(
           theCase,
-          civilClaim,
+          civilClaimFile,
         )
+
+        civilClaimPdfs.push(Base64.btoa(civilClaimPdf.toString('binary')))
       }
 
       const indictmentPdf = await this.pdfService.getIndictmentPdf(theCase)
@@ -326,9 +329,7 @@ export class SubpoenaService {
         Base64.btoa(subpoenaPdf.toString('binary')),
         Base64.btoa(indictmentPdf.toString('binary')),
         user,
-        civilClaimPdf
-          ? Base64.btoa(civilClaimPdf.toString('binary'))
-          : undefined,
+        civilClaimPdfs,
       )
 
       if (!createdSubpoena) {


### PR DESCRIPTION
# Send multiple civil claims to police

[Asana](https://app.asana.com/0/1199153462262248/1208536692205568)

## What

In a previous PR we implemented sending a civil claim to the police when creating a subpoena. That implementation assumed that there was only one civil claim in a case while in reality there can be multiple civil claims in a case. This PR addresses this issue and sends all civil claims in a case to the police.

## Why

This is a bug

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the subpoena submission process to support multiple civil claims, allowing you to attach and submit several claim documents in a single request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->