### PR TITLE
fix: use accounts table instead of star_clients

### DIFF
--- a/libs/clients/financial-statements-inao/src/lib/financialStatementsInaoClient.service.ts
+++ b/libs/clients/financial-statements-inao/src/lib/financialStatementsInaoClient.service.ts
@@ -84,11 +84,11 @@ export class FinancialStatementsInaoClientService {
   }
 
   async getUserClientType(nationalId: string): Promise<ClientType | null> {
-    const select = '$select=star_nationalid, star_name, star_type'
-    const filter = `$filter=star_nationalid eq '${encodeURIComponent(
+    const select = '$select=accountnumber,name,star_type'
+    const filter = `$filter=accountnumber eq '${encodeURIComponent(
       nationalId,
     )}'`
-    const url = `${this.basePath}/star_clients?${select}&${filter}`
+    const url = `${this.basePath}/accounts?${select}&${filter}`
     const data = await this.getData(url)
 
     if (!data || !data.value) return null
@@ -112,11 +112,11 @@ export class FinancialStatementsInaoClientService {
   }
 
   async getClientIdByNationalId(nationalId: string): Promise<string | null> {
-    const select = '$select=star_nationalid, star_name, star_type'
-    const filter = `$filter=star_nationalid eq '${encodeURIComponent(
+    const select = '$select=accountnumber,name,star_type'
+    const filter = `$filter=accountnumber eq '${encodeURIComponent(
       nationalId,
     )}'`
-    const url = `${this.basePath}/star_clients?${select}&${filter}`
+    const url = `${this.basePath}/accounts?${select}&${filter}`
     const data = await this.getData(url)
 
     if (!data || !data.value) return null
@@ -133,14 +133,12 @@ export class FinancialStatementsInaoClientService {
   }
 
   async createClient(client: Client, clientType: ClientTypes) {
-    const url = `${this.basePath}/star_clients`
+    const url = `${this.basePath}/accounts`
 
     const body = {
-      star_nationalid: client.nationalId,
+      accountnumber: client.nationalId,
       star_type: clientType,
-      star_name: client.name,
-      star_phone: client.phone,
-      star_email: client.email,
+      name: client.name,
     }
 
     await this.fetch(url, {


### PR DESCRIPTION
## What

Use a different table to look up political parties and cemeteries

## Why

Wrong table was being used

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined client data operations by updating how account information is retrieved and created.
  - Enhanced consistency with the new integration endpoints, ensuring improved and reliable client data management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->