### PR TITLE
fix(web): Api catalogue, footer appearing at the top of the page

### DIFF
--- a/apps/web/screens/Organization/StafraentIsland/ApiCatalogue.tsx
+++ b/apps/web/screens/Organization/StafraentIsland/ApiCatalogue.tsx
@@ -25,6 +25,7 @@ import {
 import { theme } from '@island.is/island-ui/theme'
 import {
   ApiCatalogueFilter,
+  getThemeConfig,
   OrganizationWrapper,
   ServiceList,
   Webreader,
@@ -231,56 +232,62 @@ const ApiCatalogue: Screen<HomestayProps> = ({
   )
 
   return (
-    <>
-      <OrganizationWrapper
-        pageTitle={subpage?.title ?? ''}
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore make web strict
-        organizationPage={organizationPage}
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore make web strict
-        pageFeaturedImage={subpage?.featuredImage}
-        showReadSpeaker={false}
-        breadcrumbItems={[
-          {
-            title: 'Ísland.is',
-            href: linkResolver('homepage').href,
-          },
-          {
-            title: organizationPage?.title ?? '',
-            href: linkResolver('organizationpage', [
-              organizationPage?.slug ?? '',
-            ]).href,
-          },
-        ]}
-        navigationData={{
-          title: nn('navigationTitle', 'Efnisyfirlit'),
-          items: navList,
-        }}
-        showSecondaryMenu={false}
-      >
-        <Box paddingBottom={0}>
-          <Text variant="h1" as="h2">
-            {subpage?.title}
-          </Text>
-          <Webreader
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore make web strict
-            readId={null}
-            readClass="rs_read"
-          />
+    <OrganizationWrapper
+      pageTitle={subpage?.title ?? ''}
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore make web strict
+      organizationPage={organizationPage}
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore make web strict
+      pageFeaturedImage={subpage?.featuredImage}
+      showReadSpeaker={false}
+      breadcrumbItems={[
+        {
+          title: 'Ísland.is',
+          href: linkResolver('homepage').href,
+        },
+        {
+          title: organizationPage?.title ?? '',
+          href: linkResolver('organizationpage', [organizationPage?.slug ?? ''])
+            .href,
+        },
+      ]}
+      navigationData={{
+        title: nn('navigationTitle', 'Efnisyfirlit'),
+        items: navList,
+      }}
+      showSecondaryMenu={false}
+      mainContent={
+        <Box>
+          <Box paddingBottom={0}>
+            <Text variant="h1" as="h2">
+              {subpage?.title}
+            </Text>
+            <Webreader
+              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+              // @ts-ignore make web strict
+              readId={null}
+              readClass="rs_read"
+            />
+          </Box>
+          {webRichText(subpage?.description as SliceType[], {
+            renderNode: {
+              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+              // @ts-ignore make web strict
+              [INLINES.HYPERLINK]: (node, children: ReactNode) => (
+                <ArrowLink href={node.data.uri}>{children}</ArrowLink>
+              ),
+            },
+          })}
         </Box>
-        {webRichText(subpage?.description as SliceType[], {
-          renderNode: {
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore make web strict
-            [INLINES.HYPERLINK]: (node, children: ReactNode) => (
-              <ArrowLink href={node.data.uri}>{children}</ArrowLink>
-            ),
-          },
-        })}
-      </OrganizationWrapper>
-      <Box background="blue100" display="inlineBlock" width="full">
+      }
+    >
+      <Box
+        background="blue100"
+        display="inlineBlock"
+        width="full"
+        paddingBottom={3}
+      >
         <ColorSchemeContext.Provider value={{ colorScheme: 'blue' }}>
           <GridContainer id="service-list">
             <Box marginY={[3, 3, 6]}>
@@ -360,7 +367,8 @@ const ApiCatalogue: Screen<HomestayProps> = ({
           </GridContainer>
         </ColorSchemeContext.Provider>
       </Box>
-    </>
+      <Box paddingBottom={4} />
+    </OrganizationWrapper>
   )
 }
 
@@ -456,6 +464,10 @@ ApiCatalogue.getProps = async ({ apolloClient, locale }) => {
     filterContent,
     navigationLinks,
     showSearchInHeader: false,
+    ...getThemeConfig(
+      getOrganizationPage?.theme,
+      getOrganizationPage?.organization,
+    ),
   }
 }
 

--- a/apps/web/screens/Organization/StafraentIsland/ApiDetails.tsx
+++ b/apps/web/screens/Organization/StafraentIsland/ApiDetails.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router'
 
 import { Box, NavigationItem, Text } from '@island.is/island-ui/core'
 import {
+  getThemeConfig,
   OpenApiView,
   OrganizationWrapper,
   ServiceInformation,
@@ -107,38 +108,36 @@ const ServiceDetails: Screen<ServiceDetailsProps> = ({
   )
 
   return (
-    <>
-      <OrganizationWrapper
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore make web strict
-        pageTitle={service.title ?? ''}
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore make web strict
-        organizationPage={organizationPage}
-        showReadSpeaker={false}
-        breadcrumbItems={[
-          {
-            title: 'Ísland.is',
-            href: linkResolver('homepage').href,
-          },
-          {
-            title: organizationPage?.title ?? '',
-            href: linkResolver('organizationpage', [
-              organizationPage?.slug ?? '',
-            ]).href,
-          },
-          {
-            title: n('linkServicesText'),
-            href: linkResolver('apicataloguepage').href,
-          },
-        ]}
-        navigationData={{
-          title: n('navigationTitle', 'Efnisyfirlit'),
-          items: navList,
-        }}
-        showSecondaryMenu={false}
-      >
-        {!service ? (
+    <OrganizationWrapper
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore make web strict
+      pageTitle={service.title ?? ''}
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore make web strict
+      organizationPage={organizationPage}
+      showReadSpeaker={false}
+      breadcrumbItems={[
+        {
+          title: 'Ísland.is',
+          href: linkResolver('homepage').href,
+        },
+        {
+          title: organizationPage?.title ?? '',
+          href: linkResolver('organizationpage', [organizationPage?.slug ?? ''])
+            .href,
+        },
+        {
+          title: n('linkServicesText'),
+          href: linkResolver('apicataloguepage').href,
+        },
+      ]}
+      navigationData={{
+        title: n('navigationTitle', 'Efnisyfirlit'),
+        items: navList,
+      }}
+      showSecondaryMenu={false}
+      mainContent={
+        !service ? (
           <Box>
             <Text variant="h3" as="h3">
               {nfc('serviceNotFound')}
@@ -152,29 +151,32 @@ const ServiceDetails: Screen<ServiceDetailsProps> = ({
               setApiContent(selectedServiceDetail)
             }
           />
-        )}
-      </OrganizationWrapper>
-      <SubpageLayout
-        main={null}
-        details={
-          <SubpageDetailsContent
-            header={
-              <Text variant="h4" color="blue600">
-                {noa('title')}
-              </Text>
-            }
-            content={
-              selectedGetOpenApiInput && (
-                <OpenApiView
-                  strings={openApiContent}
-                  openApiInput={selectedGetOpenApiInput}
-                />
-              )
-            }
-          />
-        }
-      />
-    </>
+        )
+      }
+    >
+      <Box paddingBottom={3}>
+        <SubpageLayout
+          main={null}
+          details={
+            <SubpageDetailsContent
+              header={
+                <Text variant="h4" color="blue600">
+                  {noa('title')}
+                </Text>
+              }
+              content={
+                selectedGetOpenApiInput && (
+                  <OpenApiView
+                    strings={openApiContent}
+                    openApiInput={selectedGetOpenApiInput}
+                  />
+                )
+              }
+            />
+          }
+        />
+      </Box>
+    </OrganizationWrapper>
   )
 }
 
@@ -267,6 +269,10 @@ ServiceDetails.getProps = async ({ apolloClient, locale, query }) => {
     filterContent: filterContent,
     openApiContent: openApiContent,
     service: service,
+    ...getThemeConfig(
+      getOrganizationPage?.theme,
+      getOrganizationPage?.organization,
+    ),
   }
 }
 


### PR DESCRIPTION
# Api catalogue, footer appearing at the top of the page

## What

After a recent change for most Digital Iceland pages we noticed that custom programmed pages (like the API catalogue page) were a bit strange, the footer for example appeared at the top of the page.

## Screenshots / Gifs

### Before


https://github.com/user-attachments/assets/6b4a21f4-cb2b-40a6-ad32-397620afadd0

### After

This is running locally, I don't have Elasticsearch populated so that's why there are no cards displayed

https://github.com/user-attachments/assets/daa9a252-d380-441d-80ef-b68d9c2a8ba4



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced dynamic theming support now adapts page styling to match your organization’s specific visual preferences.
- **Refactor**
	- Streamlined content structure on organization pages for a clearer layout and improved presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->