### PR TITLE
fix(web): Parent subpage sidebar navigation highlighting - Add extra depth if not icelandic locale

### DIFF
--- a/apps/web/screens/Organization/ParentSubpage.tsx
+++ b/apps/web/screens/Organization/ParentSubpage.tsx
@@ -73,7 +73,11 @@ const OrganizationParentSubpage: Screen<
       ]}
       navigationData={{
         title: n('navigationTitle', 'Efnisyfirlit'),
-        items: getSubpageNavList(organizationPage, router, 3),
+        items: getSubpageNavList(
+          organizationPage,
+          router,
+          activeLocale === 'is' ? 3 : 4,
+        ),
       }}
       mainContent={
         <Box paddingTop={4}>


### PR DESCRIPTION
# Parent subpage sidebar navigation highlighting - Add extra depth if not icelandic locale

## Screenshots / Gifs

### Before

Active page link does not get highlighted

![Screenshot 2025-02-14 at 14 08 54](https://github.com/user-attachments/assets/c84718da-a45f-490c-a298-c0cf1587760e)


### After

![Screenshot 2025-02-14 at 14 06 59](https://github.com/user-attachments/assets/4f86d49e-0004-442d-95de-5cc4602ed9c2)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The organization page navigation now dynamically adjusts its menu items based on the active locale, providing a more tailored and intuitive browsing experience for users in different language settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->