### PR TITLE
ci: Group some log lines for more compact action logs

### DIFF
--- a/.github/actions/get-cache/action.yml
+++ b/.github/actions/get-cache/action.yml
@@ -46,5 +46,7 @@ runs:
         echo "COREPACK_HOME=$COREPACK_HOME" >> $GITHUB_ENV
         echo "CYPRESS_CACHE_FOLDER=$CYPRESS_CACHE_FOLDER" >> $GITHUB_ENV
         cd scripts/ci/cache
+        echo "::group::yarn install"
         npx yarn install --immutable
+        echo "::endgroup::"
         node cache-action.mjs

--- a/scripts/ci/cache/_generated_files.mjs
+++ b/scripts/ci/cache/_generated_files.mjs
@@ -43,13 +43,14 @@ export async function getGeneratedFilesHash() {
       ignore: ignorePatterns,
     })
   ).sort()
-  console.log(`Files to hash:`)
+  console.log('::group::Files to hash:')
   for (const _file of files) {
     console.log(_file)
     const file = resolve(ROOT, _file)
     const content = await readFile(file, 'utf8')
     hash.update(content)
   }
+  console.log('::endgroup::')
 
   const finalHash = hash.digest('hex')
   return finalHash


### PR DESCRIPTION
`Files to hash` is very long, and takes time and effort to scroll. Use grouping to remove needless scrolling and rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated automated processes by grouping log outputs for dependency installation and file handling. This improvement enhances the clarity of logs and makes troubleshooting more straightforward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->