### PR TITLE
fix(web): Readspeaker href gets opened by Plausible outbound link tracking script

### DIFF
--- a/apps/web/components/Webreader/Webreader.tsx
+++ b/apps/web/components/Webreader/Webreader.tsx
@@ -117,6 +117,9 @@ const Webreader: FC<React.PropsWithChildren<WebReaderProps>> = ({
           accessKey="L"
           title={buttonTitle}
           href={href}
+          onClick={(event) => {
+            event.preventDefault() // So the Plausible outbound link tracking script doesn't open the href
+          }}
         >
           <span className="rsbtn_left rsimg rspart">
             <span className="rsbtn_text">


### PR DESCRIPTION
# Readspeaker href gets opened by Plausible outbound link tracking script

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
