### PR TITLE
fix(j-s): Hide ruling if case completed without ruling

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/case/limitedAccessCase.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/limitedAccessCase.service.ts
@@ -578,7 +578,7 @@ export class LimitedAccessCaseService {
   }
 
   async getAllFilesZip(theCase: Case, user: TUser): Promise<Buffer> {
-    const allowedCseFileCategories = getDefenceUserCaseFileCategories(
+    const allowedCaseFileCategories = getDefenceUserCaseFileCategories(
       user.nationalId,
       theCase.type,
       theCase.defendants,
@@ -590,7 +590,7 @@ export class LimitedAccessCaseService {
         (file) =>
           file.key &&
           file.category &&
-          allowedCseFileCategories.includes(file.category),
+          allowedCaseFileCategories.includes(file.category),
       ) ?? []
 
     const promises: Promise<void>[] = []
@@ -614,12 +614,16 @@ export class LimitedAccessCaseService {
           'Þingbók.pdf',
           filesToZip,
         ),
-        this.tryAddGeneratedPdfToFilesToZip(
-          this.pdfService.getRulingPdf(theCase),
-          'Úrskurður.pdf',
-          filesToZip,
-        ),
       )
+      if (!theCase.isCompletedWithoutRuling) {
+        promises.push(
+          this.tryAddGeneratedPdfToFilesToZip(
+            this.pdfService.getRulingPdf(theCase),
+            'Úrskurður.pdf',
+            filesToZip,
+          ),
+        )
+      }
     }
 
     if (

--- a/apps/judicial-system/web/src/routes/Defender/CaseOverview.strings.ts
+++ b/apps/judicial-system/web/src/routes/Defender/CaseOverview.strings.ts
@@ -26,6 +26,12 @@ export const strings = defineMessages({
     description:
       'Texti sem birtist ef úrskurður er ekki undirritaður á yfirlitsskjá verjanda',
   },
+  noRuling: {
+    id: 'judicial.system.core:defender_case_overview.no_ruling',
+    defaultMessage: 'Máli lokið án úrskurðar',
+    description:
+      'Texti sem birtist ef enginn úrskurður er skráður á yfirlitsskjá verjanda',
+  },
   confirmAppealAfterDeadlineModalTitle: {
     id: 'judicial.system.core:defender_case_overview.confirm_appeal_after_deadline_modal_title',
     defaultMessage: 'Kærufrestur er liðinn',

--- a/apps/judicial-system/web/src/routes/Defender/CaseOverview.tsx
+++ b/apps/judicial-system/web/src/routes/Defender/CaseOverview.tsx
@@ -245,12 +245,15 @@ export const CaseOverview = () => {
                       caseId={workingCase.id}
                       title={formatMessage(core.pdfButtonRuling)}
                       pdfType="ruling"
+                      disabled={workingCase.isCompletedWithoutRuling || false}
                     >
                       {workingCase.rulingSignatureDate ? (
                         <SignedDocument
                           signatory={workingCase.judge?.name}
                           signingDate={workingCase.rulingSignatureDate}
                         />
+                      ) : workingCase.isCompletedWithoutRuling ? (
+                        <Text>{formatMessage(strings.noRuling)}</Text>
                       ) : (
                         <Text>{formatMessage(strings.unsignedRuling)}</Text>
                       )}


### PR DESCRIPTION
[Asana](https://app.asana.com/0/1199153462262248/1209412018641625)

## What

Disable ruling button for defenders if the case was completed without a ruling.
Don't include the ruling PDF in the downloadable folder of all files

## Why

If there is no ruling with the case we don't want to generate it as it's not going to be accurate and is not applicable. 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated document processing logic so that the ruling PDF is now added only when appropriate, ensuring correct document handling.

- **New Features**
  - Enhanced the case overview screen with conditional actions for the ruling button. A new localized message now appears to clearly indicate when a case is closed without a ruling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->