### PR TITLE
chore(j-s): Sanitise input before using in SQL queries

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/case/case.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/case.service.ts
@@ -1696,13 +1696,16 @@ export class CaseService {
     ]
 
     if (defendant.noNationalId) {
+      const defendantName = defendant.name ?? ''
+      const defendantNationalId = defendant.nationalId ?? ''
+
       whereClause.push({
         id: {
           [Op.in]: Sequelize.literal(`
             (SELECT case_id
               FROM defendant
-              WHERE national_id = '${defendant.nationalId}'
-              AND name = '${defendant.name}'
+              WHERE national_id = ${this.sequelize.escape(defendantNationalId)}
+              AND name = ${this.sequelize.escape(defendantName)}
           )`),
         },
       })


### PR DESCRIPTION
# Sanitise input before using in SQL queries

[Asana](https://app.asana.com/0/1199153462262248/1209412022978053)

## What

This PR fixes a bug when we are fetching connected cases for defendants in RVG. When we are fetching connected cases, we are querying by name in a `literal` sequalize query. If the name had a special character, f.x. an `'`, there would be an error causing a crash of the application. 

This has now been fixed by escaping the name and national id before querying. 

## Why

This is a bug and a SQL injection threat.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
