### PR TITLE
fix(auth): Fix ids-api service startup due to lru cache dependency issue through path-scurry

### DIFF
--- a/apps/services/auth/ids-api/esbuild.json
+++ b/apps/services/auth/ids-api/esbuild.json
@@ -54,6 +54,7 @@
     "url-parse-lax",
     "safer-buffer",
     "ioredis",
+    "path-scurry",
     "@mikro-orm/core"
   ],
   "keepNames": true


### PR DESCRIPTION
Same as was needed in [notification-service](https://github.com/island-is/island.is/pull/13395).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced our internal module integration to improve the build process. This update aims to boost overall stability and performance, contributing to a more reliable experience for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->