### PR TITLE
fix(web): Form - English locale with different options doesn't load email config correctly

### DIFF
--- a/apps/web/components/Form/Form.tsx
+++ b/apps/web/components/Form/Form.tsx
@@ -639,6 +639,7 @@ export const Form = ({ form }: FormProps) => {
               files: files.map((f) => f[1]).flat(),
               recipientFormFieldDeciderValue:
                 getRecipientFormFieldDeciderValue(),
+              lang: activeLocale,
             },
           },
         }).then(() => {

--- a/libs/api/domains/communications/src/lib/communications.service.ts
+++ b/libs/api/domains/communications/src/lib/communications.service.ts
@@ -153,7 +153,7 @@ export class CommunicationsService {
   async sendFormResponse(input: GenericFormInput): Promise<boolean> {
     const form = await this.cmsContentfulService.getForm({
       id: input.id,
-      lang: 'is-IS',
+      lang: input.lang === 'en' ? 'en' : 'is-IS',
     })
     if (!form) {
       return false

--- a/libs/api/domains/communications/src/lib/dto/genericForm.input.ts
+++ b/libs/api/domains/communications/src/lib/dto/genericForm.input.ts
@@ -26,4 +26,7 @@ export class GenericFormInput {
 
   @Field({ nullable: true })
   recipientFormFieldDeciderValue?: string
+
+  @Field(() => String, { nullable: true })
+  lang?: string | null
 }


### PR DESCRIPTION
# Form - English locale with different options doesn't load email config correctly

If a form field has a different text between locales then the email never gets sent since there is no match in the email config.
The email config is currently only fetching the Icelandic form but now we are also fetching the english locale which'll address the issue.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Form submissions now automatically include current language information for improved localized processing.
  - Communication services dynamically adjust language settings based on user input.
  - User input options have been enhanced to support an optional language preference, ensuring a better tailored experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->