### PR TITLE
feat(web): Temporary event licenses - Add bold text showing that the permit is temporary

### DIFF
--- a/apps/web/components/connected/syslumenn/CardLists/TemporaryEventLicencesList/TemporaryEventLicencesList.tsx
+++ b/apps/web/components/connected/syslumenn/CardLists/TemporaryEventLicencesList/TemporaryEventLicencesList.tsx
@@ -300,6 +300,16 @@ const TemporaryEventLicencesList: FC<
             {filteredTemporaryEventLicences
               .slice(0, showCount)
               .map((temporaryEventLicence, index) => {
+                const periodRepresentation = getValidPeriodRepresentation(
+                  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                  // @ts-ignore make web strict
+                  temporaryEventLicence.validFrom,
+                  temporaryEventLicence.validTo,
+                  DATE_FORMAT,
+                  format,
+                  formatMessage(t.validPeriodUntil),
+                  formatMessage(t.validPeriodIndefinite),
+                )
                 return (
                   <Box
                     key={`temporary-event-licence-${index}`}
@@ -340,16 +350,13 @@ const TemporaryEventLicencesList: FC<
 
                       <Text>
                         {formatMessage(t.validPeriodLabel)}:{' '}
-                        {getValidPeriodRepresentation(
-                          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                          // @ts-ignore make web strict
-                          temporaryEventLicence.validFrom,
-                          temporaryEventLicence.validTo,
-                          DATE_FORMAT,
-                          format,
-                          formatMessage(t.validPeriodUntil),
-                          formatMessage(t.validPeriodIndefinite),
-                        )}
+                        {periodRepresentation}{' '}
+                        {temporaryEventLicence.validTo ? (
+                          <div>
+                            -{' '}
+                            <strong>{formatMessage(t.temporaryPermit)}</strong>
+                          </div>
+                        ) : null}
                       </Text>
 
                       <Text>

--- a/apps/web/components/connected/syslumenn/CardLists/TemporaryEventLicencesList/translation.strings.ts
+++ b/apps/web/components/connected/syslumenn/CardLists/TemporaryEventLicencesList/translation.strings.ts
@@ -6,6 +6,11 @@ export const translation = defineMessages({
     defaultMessage: "d. MMMM yyyy 'kl.' HH:mm",
     description: 'Hvernig dagsetningin birtist',
   },
+  temporaryPermit: {
+    id: 'web.syslumenn.temporaryEventLicencesList:temporaryPermit',
+    defaultMessage: 'Bráðabirgðaleyfi',
+    description: 'Bráðabirgðaleyfi',
+  },
   csvHeaderLicenceType: {
     id: 'web.syslumenn.temporaryEventLicencesList:csvHeaderLicenceType',
     defaultMessage: 'Tegund',


### PR DESCRIPTION
# Temporary event licenses - Add bold text showing that the permit is temporary

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved the display of temporary event licences. Users will now see a dedicated temporary permit notice when applicable.
- **Localization**
	- Enhanced language support with new translatable text for temporary permits, ensuring a more consistent localized experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->