### PR TITLE
feat(web): Operating licenses, Add bold text showing that the permit is temporary

### DIFF
--- a/apps/web/screens/Organization/Syslumenn/OperatingLicenses.tsx
+++ b/apps/web/screens/Organization/Syslumenn/OperatingLicenses.tsx
@@ -490,7 +490,18 @@ const OperatingLicenses: Screen<OperatingLicensesProps> = ({
               </Text>
               <Text paddingBottom={2}>
                 {n('operatingLicensesValidPeriod', 'Gildistími')}:{' '}
-                {getLicenseValidPeriod(operatingLicense)}
+                {getLicenseValidPeriod(operatingLicense)}{' '}
+                {operatingLicense.validTo ? (
+                  <span>
+                    -{' '}
+                    <strong>
+                      {n(
+                        'operatingLicensesTemporaryPermit',
+                        'Bráðabirgðaleyfi',
+                      )}
+                    </strong>
+                  </span>
+                ) : null}
               </Text>
 
               <Text paddingBottom={0}>


### PR DESCRIPTION
# Operating licenses, Add bold text showing that the permit is temporary

![Screenshot 2025-02-18 at 15 57 27](https://github.com/user-attachments/assets/29b73518-6b0c-413e-86cd-8b1d68d8dca7)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the operating licenses display by adding a clear indicator for temporary permits. The validity period information now shows an extra label when a license is temporary, enabling users to easily recognize and distinguish these permits. This user-friendly enhancement streamlines the process of verifying license durations and improves overall clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->