### PR TITLE
fix(documents): Return bff link instead of direct dl service

### DIFF
--- a/apps/api/infra/api.ts
+++ b/apps/api/infra/api.ts
@@ -148,6 +148,11 @@ export const serviceSetup = (services: {
         dev: 'https://api.dev01.devland.is',
         staging: 'https://api.staging01.devland.is',
       },
+      CLIENT_BASE_URL: {
+        dev: 'https://beta.dev01.devland.is',
+        staging: 'https://beta.staging01.devland.is',
+        prod: 'https://island.is',
+      },
       ENDORSEMENT_SYSTEM_BASE_API_URL: ref(
         (h) => `http://${h.svc(services.servicesEndorsementApi)}`,
       ),

--- a/libs/api/domains/documents/src/lib/documentBuilder.ts
+++ b/libs/api/domains/documents/src/lib/documentBuilder.ts
@@ -6,6 +6,7 @@ import type { ConfigType } from '@island.is/nest/config'
 
 import { Document } from './models/v1/document.model'
 import { DocumentTypeFilter, FileType } from './types'
+import { createBffUrl } from './helpers/creatBffUrl'
 
 @Injectable()
 export class DocumentBuilder {
@@ -60,6 +61,10 @@ export class DocumentBuilder {
   }
 
   private formatDownloadServiceUrl(document: DocumentInfoDTO): string {
-    return `${this.downloadServiceConfig.baseUrl}/download/v1/electronic-documents/${document.id}`
+    const dlUrl = createBffUrl(
+      this.downloadServiceConfig.clientBasePath,
+      `${this.downloadServiceConfig.baseUrl}/download/v1/electronic-documents/${document.id}`,
+    )
+    return dlUrl
   }
 }

--- a/libs/api/domains/documents/src/lib/documentV2.service.ts
+++ b/libs/api/domains/documents/src/lib/documentV2.service.ts
@@ -27,6 +27,7 @@ import { AuthDelegationType } from '@island.is/shared/types'
 import { getBirthday } from './helpers/getBirthday'
 import differceInYears from 'date-fns/differenceInYears'
 import type { Locale } from '@island.is/shared/types'
+import { createBffUrl } from './helpers/creatBffUrl'
 
 const LOG_CATEGORY = 'documents-api-v2'
 @Injectable()
@@ -71,7 +72,10 @@ export class DocumentServiceV2 {
       publicationDate: document.date,
       id: documentId,
       name: document.fileName,
-      downloadUrl: `${this.downloadServiceConfig.baseUrl}/download/v1/electronic-documents/${documentId}`,
+      downloadUrl: createBffUrl(
+        this.downloadServiceConfig.clientBasePath,
+        `${this.downloadServiceConfig.baseUrl}/download/v1/electronic-documents/${documentId}`,
+      ),
       sender: {
         id: document.senderNationalId,
         name: document.senderName,
@@ -143,7 +147,10 @@ export class DocumentServiceV2 {
       publicationDate: document.date,
       id: documentId,
       name: document.fileName,
-      downloadUrl: `${this.downloadServiceConfig.baseUrl}/download/v1/electronic-documents/${documentId}`,
+      downloadUrl: createBffUrl(
+        this.downloadServiceConfig.clientBasePath,
+        `${this.downloadServiceConfig.baseUrl}/download/v1/electronic-documents/${documentId}`,
+      ),
       sender: {
         id: document.senderNationalId,
         name: document.senderName,
@@ -204,7 +211,10 @@ export class DocumentServiceV2 {
           return {
             ...d,
             id: d.id,
-            downloadUrl: `${this.downloadServiceConfig.baseUrl}/download/v1/electronic-documents/${d.id}`,
+            downloadUrl: createBffUrl(
+              this.downloadServiceConfig.clientBasePath,
+              `${this.downloadServiceConfig.baseUrl}/download/v1/electronic-documents/${d.id}`,
+            ),
             sender: {
               name: d.senderName,
               id: d.senderNationalId,
@@ -268,7 +278,10 @@ export class DocumentServiceV2 {
           return {
             ...d,
             id: d.id,
-            downloadUrl: `${this.downloadServiceConfig.baseUrl}/download/v1/electronic-documents/${d.id}`,
+            downloadUrl: createBffUrl(
+              this.downloadServiceConfig.clientBasePath,
+              `${this.downloadServiceConfig.baseUrl}/download/v1/electronic-documents/${d.id}`,
+            ),
             sender: {
               name: d.senderName,
               id: d.senderNationalId,
@@ -514,7 +527,10 @@ export class DocumentServiceV2 {
         return {
           ...x,
           icon: 'download',
-          data: `${this.downloadServiceConfig.baseUrl}/download/v1/electronic-documents/${id}`,
+          data: createBffUrl(
+            this.downloadServiceConfig.clientBasePath,
+            `${this.downloadServiceConfig.baseUrl}/download/v1/electronic-documents/${id}`,
+          ),
         }
       }
       if (x.type === 'url') {

--- a/libs/api/domains/documents/src/lib/helpers/creatBffUrl.ts
+++ b/libs/api/domains/documents/src/lib/helpers/creatBffUrl.ts
@@ -1,0 +1,13 @@
+export const createBffUrl = (base: string, path: string) => {
+  try {
+    const cleanPath = path.replace(/^\/+|\/+$/g, '')
+    const querystring = new URLSearchParams({ url: cleanPath }).toString()
+
+    const url = `${base}/bff/api`
+
+    const qs = querystring
+    return `${url}${qs ? `?${qs}` : ''}`
+  } catch (error) {
+    return path
+  }
+}

--- a/libs/api/domains/documents/src/lib/models/v2/document.model.ts
+++ b/libs/api/domains/documents/src/lib/models/v2/document.model.ts
@@ -57,7 +57,7 @@ export class Document {
 
   @Field({
     nullable: true,
-    description: 'URL in download service. For downloading PDFs',
+    description: 'BFF url for downloading documents',
   })
   downloadUrl?: string
 

--- a/libs/nest/config/src/lib/configurations/DownloadServiceConfig.ts
+++ b/libs/nest/config/src/lib/configurations/DownloadServiceConfig.ts
@@ -7,5 +7,6 @@ export const DownloadServiceConfig = defineConfig({
       'DOWNLOAD_SERVICE_BASE_PATH',
       'http://localhost:3377',
     ),
+    clientBasePath: env.required('CLIENT_BASE_URL', 'http://localhost:4200'),
   }),
 })

--- a/libs/portals/my-pages/core/src/utils/utils.ts
+++ b/libs/portals/my-pages/core/src/utils/utils.ts
@@ -75,3 +75,14 @@ export function getErrorViaPath(obj: RecordObject, path: string): string {
 export const ellipsis = (text: string, length: number) => {
   return text.length > length ? `${text.substring(0, length)}...` : text
 }
+
+export const formatBffPath = (path: string) => {
+  try {
+    // Remove domain. Add current domain. so it can be used with feature deployments.
+    const bffPath = path.replace(/.*\/\/[^/]*/, '')
+    const bffUrl = window.location.origin + bffPath
+    return bffUrl
+  } catch (error) {
+    return path
+  }
+}

--- a/libs/portals/my-pages/documents/src/components/DocumentActions/DocumentActionsV3.tsx
+++ b/libs/portals/my-pages/documents/src/components/DocumentActions/DocumentActionsV3.tsx
@@ -1,11 +1,10 @@
 import { AlertMessage, Box, Button } from '@island.is/island-ui/core'
 import { IconMapIcon } from '@island.is/island-ui/core/types'
-import { useBffUrlGenerator } from '@island.is/react-spa/bff'
 import { useDocumentContext } from '../../screens/Overview/DocumentContext'
+import { formatBffPath } from '@island.is/portals/my-pages/core'
 
 const DocumentActions = () => {
   const { activeDocument } = useDocumentContext()
-  const bffUrlGenerator = useBffUrlGenerator()
   const DEFAULT_ICON: IconMapIcon = 'document'
   const actions = activeDocument?.actions
   const alert = activeDocument?.alert
@@ -52,12 +51,10 @@ const DocumentActions = () => {
                   icon={(a.icon as IconMapIcon) ?? DEFAULT_ICON}
                   iconType="outline"
                   onClick={() => {
-                    window.open(
-                      bffUrlGenerator('/api', {
-                        url: a.data ?? activeDocument.downloadUrl,
-                      }),
-                      '_blank',
+                    const bffUrl = formatBffPath(
+                      a.data ?? activeDocument.downloadUrl,
                     )
+                    window.open(bffUrl, '_blank')
                   }}
                 >
                   {a.title}

--- a/libs/portals/my-pages/documents/src/utils/downloadDocumentV2.ts
+++ b/libs/portals/my-pages/documents/src/utils/downloadDocumentV2.ts
@@ -1,4 +1,4 @@
-import { createBffUrlGenerator } from '@island.is/react-spa/bff'
+import { formatBffPath } from '@island.is/portals/my-pages/core'
 import { ActiveDocumentType2 } from '../lib/types'
 
 type DownloadFileArgs = {
@@ -25,10 +25,8 @@ export const downloadFile = async ({ doc, query }: DownloadFileArgs) => {
       win?.focus()
     }, 250)
   } else if (downloadUrl) {
-    const bffUrlGenerator = createBffUrlGenerator()
-    const bffUrl = bffUrlGenerator('/api', {
-      url: query ? `${downloadUrl}?action=${query}` : downloadUrl,
-    })
+    const dlUrl = query ? `${downloadUrl}?action=${query}` : downloadUrl
+    const bffUrl = formatBffPath(dlUrl)
 
     window.open(bffUrl, '_blank')
   } else {


### PR DESCRIPTION
## What

Return a BFF formatted link instead of a direct link to DL service from document service.

Perhaps we have another way to generate/access the client base url?

```
      CLIENT_BASE_URL: {
        dev: 'https://beta.dev01.devland.is',
        staging: 'https://beta.staging01.devland.is',
        prod: 'https://island.is',
      },
```      

## Why

The document service returns a direct link to the DL service today, we are handling that in the front end where we generate a bff url from the dl service link.

The APP needs a direct link to BFF formatted url to be able to link directly to the correct url for a document.
And then we can remove our bff format from the front end.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
