### PR TITLE
chore(j-s): Add indictment sent to court date to info cards

### DIFF
--- a/apps/judicial-system/web/src/components/InfoCard/InfoCardClosedIndictment.tsx
+++ b/apps/judicial-system/web/src/components/InfoCard/InfoCardClosedIndictment.tsx
@@ -28,6 +28,7 @@ const InfoCardClosedIndictment: FC<Props> = (props) => {
     indictmentReviewer,
     indictmentReviewDecision,
     indictmentReviewedDate,
+    indictmentCreated,
     civilClaimants,
   } = useInfoCardItems()
 
@@ -61,6 +62,7 @@ const InfoCardClosedIndictment: FC<Props> = (props) => {
         {
           id: 'case-info-section',
           items: [
+            indictmentCreated,
             policeCaseNumbers,
             courtCaseNumber,
             prosecutorsOffice,


### PR DESCRIPTION
# Add indictment sent to court date to info cards

[Asana](https://app.asana.com/0/1199153462262248/1209262613205633)

## What

This PR adds the date an indictment was sent to court to the following info cards

Summary — Court
Overview — FMST
Overview — Public prosecutor's office
Completed indictment overview — Defenders
Completed indictment overview — Prosecutors

## Why

For clarity

## Screenshots / Gifs

<img width="750" alt="Screenshot 2025-02-19 at 10 45 36" src="https://github.com/user-attachments/assets/41cceb75-24c3-4cd8-b560-f637bbeff8f2" />


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the case information display by incorporating additional details in the closed indictment section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->