### PR TITLE
fix(web): og:image urls that contain a non ascii character fail to show up on social media as a preview image

### DIFF
--- a/apps/web/components/HeadWithSocialSharing/HeadWithSocialSharing.tsx
+++ b/apps/web/components/HeadWithSocialSharing/HeadWithSocialSharing.tsx
@@ -30,6 +30,10 @@ export const HeadWithSocialSharing: FC<
     : false
   const isUsableImage = !isSvg && usableContentTypes.includes(imageContentType)
 
+  const encodedImageUrl = !imageUrl
+    ? ''
+    : encodeURI(`${imageUrl.startsWith('//') ? 'https:' : ''}${imageUrl}`)
+
   return (
     <Head>
       {title.length > 0 ? (
@@ -59,14 +63,10 @@ export const HeadWithSocialSharing: FC<
 
       {isUsableImage && imageUrl && imageUrl.length > 0 ? (
         <>
-          <meta
-            property="og:image"
-            content={`${imageUrl.startsWith('//') ? 'https:' : ''}${imageUrl}`}
-            key="ogImage"
-          />
+          <meta property="og:image" content={encodedImageUrl} key="ogImage" />
           <meta
             property="twitter:image"
-            content={`${imageUrl.startsWith('//') ? 'https:' : ''}${imageUrl}`}
+            content={encodedImageUrl}
             key="twitterImage"
           />
           <meta


### PR DESCRIPTION
# og:image urls that contain a non ascii character fail to show up on social media as a preview image

<img width="462" alt="Screenshot 2025-02-19 at 13 57 05" src="https://github.com/user-attachments/assets/92eb1e09-fc19-4937-a453-cabf52acdc29" />

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced social sharing functionality by ensuring preview images display correctly. Image URLs are now safely processed before being used in meta tags, leading to more reliable and consistent social media previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->