### PR TITLE
chore(j-s): Set current user as prosecutor in new indictments

### DIFF
--- a/apps/judicial-system/api/src/app/modules/case/dto/createCase.input.ts
+++ b/apps/judicial-system/api/src/app/modules/case/dto/createCase.input.ts
@@ -7,7 +7,7 @@ import {
 } from 'class-validator'
 import { GraphQLJSONObject } from 'graphql-type-json'
 
-import { Field, InputType } from '@nestjs/graphql'
+import { Field, ID, InputType } from '@nestjs/graphql'
 
 import type {
   CrimeSceneMap,
@@ -75,4 +75,9 @@ export class CreateCaseInput {
   @IsOptional()
   @Field(() => GraphQLJSONObject, { nullable: true })
   readonly crimeScenes?: CrimeSceneMap
+
+  @Allow()
+  @IsOptional()
+  @Field(() => ID, { nullable: true })
+  readonly prosecutorId?: string
 }

--- a/apps/judicial-system/backend/src/app/modules/case/case.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/case.service.ts
@@ -1756,8 +1756,11 @@ export class CaseService {
             ...caseToCreate,
             origin: CaseOrigin.RVG,
             creatingProsecutorId: user.id,
-            prosecutorId:
-              user.role === UserRole.PROSECUTOR ? user.id : undefined,
+            prosecutorId: isIndictmentCase(caseToCreate.type)
+              ? caseToCreate.prosecutorId
+              : user.role === UserRole.PROSECUTOR
+              ? user.id
+              : undefined,
             courtId: isRequestCase(caseToCreate.type)
               ? user.institution?.defaultCourtId
               : undefined,

--- a/apps/judicial-system/backend/src/app/modules/case/dto/createCase.dto.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/dto/createCase.dto.ts
@@ -7,6 +7,7 @@ import {
   IsObject,
   IsOptional,
   IsString,
+  IsUUID,
   MaxLength,
   MinLength,
 } from 'class-validator'
@@ -90,4 +91,9 @@ export class CreateCaseDto {
   @IsObject()
   @ApiPropertyOptional({ type: Object })
   readonly crimeScenes?: CrimeSceneMap
+
+  @IsOptional()
+  @IsUUID()
+  @ApiPropertyOptional({ type: String })
+  readonly prosecutorId?: string
 }

--- a/apps/judicial-system/backend/src/app/modules/case/test/caseController/create.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/test/caseController/create.spec.ts
@@ -68,6 +68,7 @@ describe('CaseController - Create', () => {
         then.result = await caseController.create(user, {
           ...createProperties,
           type,
+          prosecutorId: userId,
         } as unknown as CreateCaseDto)
       } catch (error) {
         then.error = error as Error

--- a/apps/judicial-system/web/src/components/ProsecutorSelection/ProsecutorSelection.tsx
+++ b/apps/judicial-system/web/src/components/ProsecutorSelection/ProsecutorSelection.tsx
@@ -18,17 +18,20 @@ interface Props {
 
 const ProsecutorSelection: FC<Props> = ({ onChange }) => {
   const { formatMessage } = useIntl()
-  const { workingCase } = useContext(FormContext)
+  const { workingCase, setWorkingCase } = useContext(FormContext)
   const { user: currentUser } = useContext(UserContext)
 
   const selectedProsecutor = useMemo(() => {
-    return workingCase.prosecutor
-      ? {
-          label: workingCase.prosecutor.name ?? '',
-          value: workingCase.prosecutor.id,
-        }
-      : undefined
-  }, [workingCase.prosecutor])
+    const label = workingCase.prosecutor
+      ? workingCase.prosecutor.name ?? ''
+      : currentUser?.name ?? ''
+
+    const value = workingCase.prosecutor
+      ? workingCase.prosecutor.id
+      : currentUser?.id
+
+    return { label, value }
+  }, [currentUser?.id, currentUser?.name, workingCase.prosecutor])
 
   const { data, loading } = useProsecutorSelectionUsersQuery({
     fetchPolicy: 'no-cache',
@@ -73,7 +76,18 @@ const ProsecutorSelection: FC<Props> = ({ onChange }) => {
       options={eligibleProsecutors}
       onChange={(value) => {
         const id = value?.value
+
         if (id && typeof id === 'string') {
+          if (!workingCase.id) {
+            const prosecutor = data?.users?.find((p) => p.id === id)
+
+            setWorkingCase((prevWorkingCase) => ({
+              ...prevWorkingCase,
+              prosecutor,
+            }))
+          } else {
+            onChange(id)
+          }
           onChange(id)
         }
       }}

--- a/apps/judicial-system/web/src/routes/Court/Indictments/Summary/Summary.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/Summary/Summary.tsx
@@ -1,7 +1,6 @@
 import { FC, useCallback, useContext, useState } from 'react'
 import { useIntl } from 'react-intl'
 import router from 'next/router'
-import { format } from 'path'
 
 import { Accordion, Box, Text } from '@island.is/island-ui/core'
 import * as constants from '@island.is/judicial-system/consts'

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/Defendant.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Defendant/Defendant.tsx
@@ -119,8 +119,6 @@ const Defendant = () => {
   const { updateIndictmentCount, deleteIndictmentCount } = useIndictmentCounts()
 
   const [policeCases, setPoliceCases] = useState<PoliceCase[]>([])
-  const [isProsecutorSelected, setIsProsecutorSelected] =
-    useState<boolean>(false)
 
   useEffect(() => {
     setPoliceCases(getPoliceCases(workingCase))
@@ -456,16 +454,7 @@ const Defendant = () => {
     }))
   }
 
-  /**
-   * This condition can be a little hard to read. The point is that if the
-   * case exists, i.e. if `workingCase.id` is truthy, then the user has
-   * selected a prosecutor. If the case does not exist, i.e. if
-   * `workingCase.id` is falsy, then the user has not selected a prosecutor
-   * and must do so before proceeding.
-   */
-  const stepIsValid =
-    isDefendantStepValidIndictments(workingCase) &&
-    Boolean(workingCase.id || isProsecutorSelected)
+  const stepIsValid = isDefendantStepValidIndictments(workingCase)
 
   return (
     <PageLayout
@@ -480,11 +469,9 @@ const Defendant = () => {
       />
       <FormContentContainer>
         <PageTitle>{formatMessage(defendant.heading)}</PageTitle>
-        <ProsecutorSection
-          handleChange={
-            workingCase.id ? undefined : () => setIsProsecutorSelected(true)
-          }
-        />
+        <Box component="section" marginBottom={5}>
+          <ProsecutorSection />
+        </Box>
         <Box component="section" marginBottom={5}>
           <SectionHeading
             title={formatMessage(defendant.policeCaseNumbersHeading)}

--- a/apps/judicial-system/web/src/routes/Prosecutor/components/ProsecutorSection/ProsecutorSection.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/components/ProsecutorSection/ProsecutorSection.tsx
@@ -1,6 +1,5 @@
 import { FC, useContext } from 'react'
 
-import { Box } from '@island.is/island-ui/core'
 import { isIndictmentCase } from '@island.is/judicial-system/types'
 import {
   FormContext,
@@ -10,12 +9,7 @@ import { useCase } from '@island.is/judicial-system-web/src/utils/hooks'
 
 import ProsecutorSectionHeading from './ProsecutorSectionHeading'
 
-interface Props {
-  handleChange?: () => void
-}
-
-const ProsecutorSection: FC<Props> = (props) => {
-  const { handleChange } = props
+const ProsecutorSection: FC = () => {
   const { workingCase, setWorkingCase } = useContext(FormContext)
   const { updateCase } = useCase()
 
@@ -39,12 +33,12 @@ const ProsecutorSection: FC<Props> = (props) => {
   }
 
   return (
-    <Box component="section" marginBottom={5}>
+    <>
       <ProsecutorSectionHeading
         isIndictment={isIndictmentCase(workingCase.type)}
       />
-      <ProsecutorSelection onChange={handleChange ?? handleProsecutorChange} />
-    </Box>
+      <ProsecutorSelection onChange={handleProsecutorChange} />
+    </>
   )
 }
 

--- a/apps/judicial-system/web/src/utils/hooks/useCase/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useCase/index.ts
@@ -192,6 +192,7 @@ const useCase = () => {
                   requestSharedWithDefender: theCase.requestSharedWithDefender,
                   leadInvestigator: theCase.leadInvestigator,
                   crimeScenes: theCase.crimeScenes,
+                  prosecutorId: theCase.prosecutor?.id,
                 },
               },
             })

--- a/apps/system-e2e/src/tests/judicial-system/regression/indictment-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/indictment-tests.spec.ts
@@ -34,9 +34,6 @@ test.describe.serial('Indictment tests', () => {
     await page.getByTestId('policeCaseNumber0').click()
     await page.getByTestId('policeCaseNumber0').fill(policeCaseNumber)
 
-    await page.locator('#prosecutor').click()
-    await page.getByRole('option', { name: 'Test Sækjandi' }).click()
-
     await page.getByText('Sakarefni *Veldu sakarefni').click()
     await page.getByRole('option', { name: 'Umferðarlagabrot' }).click()
     await page.getByPlaceholder('Sláðu inn vettvang').click()


### PR DESCRIPTION
See #18005

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Case creation now supports an optional prosecutor identifier, allowing users to associate a case with a specific legal representative.

- **Refactor**
  - Enhanced the prosecutor selection flow by automatically defaulting to the current user's details when a prosecutor isn’t explicitly chosen.
  - Optimized the assignment logic for indictment cases, resulting in a smoother and more intuitive case creation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->