### PR TITLE
chore(island-ui): Change max height of the menu in Select

### DIFF
--- a/libs/island-ui/core/src/lib/Select/Select.css.ts
+++ b/libs/island-ui/core/src/lib/Select/Select.css.ts
@@ -172,6 +172,7 @@ globalStyle(
 
 globalStyle(`${wrapper}  .island-select__menu-list`, {
   padding: 0,
+  maxHeight: '336px',
 })
 
 export const icon = style({


### PR DESCRIPTION
# Change max height of the menu in Select

[Asana](https://app.asana.com/0/1199153462262248/1209262604613147)

## What

When there are more than four options in a Select component, the menu becomes scrollable. The fifth option is not visible so users might not know that there are more options in the menu to select from. This PR overwrites the max height on the menu in Select components so that if there are more than 4 options users see the fifth option and know that there are more options.

### Before

<img width="783" alt="Screenshot 2025-02-19 at 15 21 09" src="https://github.com/user-attachments/assets/b25a714e-95ad-476f-9ebe-e920da6278c1" />

### After

<img width="812" alt="Screenshot 2025-02-19 at 15 22 02" src="https://github.com/user-attachments/assets/b2114664-3f34-481e-9489-6b5ae19208a6" />

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the dropdown menu's appearance by limiting its maximum height to 336px. This adjustment streamlines the display of options, ensuring a cleaner interface and improved usability when scrolling through longer lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->