### PR TITLE
feat(web): Organization event list - Only show past events or upcoming events, not both

### DIFF
--- a/apps/web/screens/Organization/OrganizationEvents/OrganizationEventList.tsx
+++ b/apps/web/screens/Organization/OrganizationEvents/OrganizationEventList.tsx
@@ -4,11 +4,11 @@ import { parseAsBoolean, useQueryState } from 'next-usequerystate'
 import {
   Box,
   BreadCrumbItem,
+  Button,
   LinkV2,
   Pagination,
   Stack,
   Text,
-  ToggleSwitchCheckbox,
 } from '@island.is/island-ui/core'
 import type { Locale } from '@island.is/shared/types'
 import {
@@ -41,7 +41,7 @@ import { GET_NAMESPACE_QUERY, GET_ORGANIZATION_PAGE_QUERY } from '../../queries'
 import { GET_EVENTS_QUERY } from '../../queries/Events'
 
 const PAGE_SIZE = 10
-const INCLUDE_PAST_EVENTS_KEY = 'includePastEvents'
+const ONLY_INCLUDE_PAST_EVENTS_KEY = 'onlyIncludePastEvents'
 
 export interface OrganizationEventListProps {
   organizationPage: OrganizationPage
@@ -78,22 +78,28 @@ const OrganizationEventList: Screen<OrganizationEventListProps> = ({
     },
   ]
 
-  const eventsHeading = n(
-    'eventListPageTitle',
-    activeLocale === 'is' ? 'Viðburðir' : 'Events',
-  )
-
-  const eventOverviewHref = linkResolver('organizationeventoverview', [
-    organizationPage.slug,
-  ]).href
-
-  const [includePastEvents, setIncludePastEvents] = useQueryState(
-    INCLUDE_PAST_EVENTS_KEY,
+  const [onlyIncludePastEvents] = useQueryState(
+    ONLY_INCLUDE_PAST_EVENTS_KEY,
     parseAsBoolean.withDefault(false).withOptions({
       clearOnDefault: true,
       shallow: false,
     }),
   )
+
+  const eventsHeading = n(
+    'eventListPageTitle',
+    activeLocale === 'is'
+      ? onlyIncludePastEvents && Boolean(organizationPage.showPastEventsOption)
+        ? 'Liðnir viðburðir'
+        : 'Viðburðir framundan'
+      : onlyIncludePastEvents
+      ? 'Past events'
+      : 'Upcoming events',
+  )
+
+  const eventOverviewHref = linkResolver('organizationeventoverview', [
+    organizationPage.slug,
+  ]).href
 
   return (
     <OrganizationWrapper
@@ -123,21 +129,53 @@ const OrganizationEventList: Screen<OrganizationEventListProps> = ({
             readId={undefined}
             readClass="rs_read"
           />
+
           {organizationPage.showPastEventsOption && (
             <Box display="flex" justifyContent="flexEnd">
-              <ToggleSwitchCheckbox
-                label={
-                  activeLocale === 'is' ? 'Liðnir viðburðir' : 'Past events'
-                }
-                checked={includePastEvents}
-                onChange={setIncludePastEvents}
-              />
+              <LinkV2
+                href={{
+                  pathname: eventOverviewHref,
+                  query: {
+                    ...(!onlyIncludePastEvents
+                      ? { [ONLY_INCLUDE_PAST_EVENTS_KEY]: true }
+                      : {}),
+                  },
+                }}
+              >
+                <Button
+                  variant="ghost"
+                  as="span"
+                  unfocusable={true}
+                  icon="arrowForward"
+                  size="small"
+                  key={String(onlyIncludePastEvents)}
+                >
+                  {onlyIncludePastEvents
+                    ? activeLocale === 'is'
+                      ? 'Sjá viðburði framundan'
+                      : 'See upcoming events'
+                    : activeLocale === 'is'
+                    ? 'Sjá liðna viðburði'
+                    : 'See past events'}
+                </Button>
+              </LinkV2>
             </Box>
           )}
           <EventList
             namespace={namespace}
             eventList={eventList?.items}
             parentPageSlug={organizationPage.slug}
+            noEventsFoundFallback={
+              <Text variant="h4">
+                {!onlyIncludePastEvents
+                  ? activeLocale === 'is'
+                    ? 'Engir viðburðir framundan fundust'
+                    : 'No upcoming events found'
+                  : activeLocale === 'is'
+                  ? 'Engir liðnir viðburðir fundust'
+                  : 'No past events found'}
+              </Text>
+            }
           />
         </Stack>
 
@@ -150,7 +188,10 @@ const OrganizationEventList: Screen<OrganizationEventListProps> = ({
                 <LinkV2
                   href={{
                     pathname: eventOverviewHref,
-                    query: { page, includePastEvents },
+                    query: {
+                      page,
+                      [ONLY_INCLUDE_PAST_EVENTS_KEY]: onlyIncludePastEvents,
+                    },
                   }}
                 >
                   <span className={className}>{children}</span>
@@ -198,10 +239,10 @@ OrganizationEventList.getProps = async ({ apolloClient, query, locale }) => {
     )
   }
 
-  const includePastEvents =
+  const onlyIncludePastEvents =
     parseAsBoolean
       .withDefault(false)
-      .parseServerSide(query[INCLUDE_PAST_EVENTS_KEY]) &&
+      .parseServerSide(query[ONLY_INCLUDE_PAST_EVENTS_KEY]) &&
     Boolean(organizationPage.showPastEventsOption)
 
   const selectedPage = extractPageNumberQueryParameter(query)
@@ -215,8 +256,8 @@ OrganizationEventList.getProps = async ({ apolloClient, query, locale }) => {
           lang: locale as Locale,
           page: selectedPage,
           size: PAGE_SIZE,
-          order: includePastEvents ? 'desc' : 'asc',
-          includePastEvents,
+          order: onlyIncludePastEvents ? 'desc' : 'asc',
+          onlyIncludePastEvents,
         },
       },
     }),

--- a/libs/cms/src/lib/cms.elasticsearch.service.ts
+++ b/libs/cms/src/lib/cms.elasticsearch.service.ts
@@ -171,7 +171,7 @@ export class CmsElasticsearchService {
 
   async getEvents(
     index: string,
-    { size, page, order, organization, includePastEvents }: GetEventsInput,
+    { size, page, order, organization, onlyIncludePastEvents }: GetEventsInput,
   ) {
     const tagList: {
       key: string
@@ -197,13 +197,17 @@ export class CmsElasticsearchService {
       ...tagQuery,
       page,
       size,
-      ...(!includePastEvents
+      ...(!onlyIncludePastEvents
         ? {
             releaseDate: {
               from: 'now',
             },
           }
-        : {}),
+        : {
+            releaseDate: {
+              to: 'now',
+            },
+          }),
     }
 
     const eventsResponse = await this.elasticService.getDocumentsByMetaData(

--- a/libs/cms/src/lib/dto/getEvents.input.ts
+++ b/libs/cms/src/lib/dto/getEvents.input.ts
@@ -30,5 +30,5 @@ export class GetEventsInput {
 
   @Field(() => Boolean, { nullable: true })
   @IsOptional()
-  includePastEvents?: boolean
+  onlyIncludePastEvents?: boolean
 }


### PR DESCRIPTION
# Organization event list - Only show past events or upcoming events, not both

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
