### PR TITLE
fix(web): Global footer - Do not wrap privacy policy title below icon

### DIFF
--- a/libs/island-ui/core/src/lib/Footer/Footer.css.ts
+++ b/libs/island-ui/core/src/lib/Footer/Footer.css.ts
@@ -8,3 +8,7 @@ export const withDecorator = style({
     },
   },
 })
+
+export const iconPaddingTop = style({
+  paddingTop: '3px',
+})

--- a/libs/island-ui/core/src/lib/Footer/Footer.tsx
+++ b/libs/island-ui/core/src/lib/Footer/Footer.tsx
@@ -126,19 +126,28 @@ export const Footer = ({
                 </Box>
                 <div>
                   <Stack space={1}>
-                    <Inline space={1} alignY="center">
-                      <Icon
-                        icon="informationCircle"
-                        size="small"
-                        color="blue400"
-                        type="outline"
-                      />
+                    <Box
+                      display="flex"
+                      rowGap={1}
+                      columnGap={1}
+                      flexWrap="nowrap"
+                      justifyContent="flexStart"
+                    >
+                      <Box className={styles.iconPaddingTop}>
+                        <Icon
+                          icon="informationCircle"
+                          size="small"
+                          color="blue400"
+                          type="outline"
+                        />
+                      </Box>
+
                       <Text variant="h5" color="blue600" fontWeight="light">
                         <Link href={privacyPolicyLink.href}>
                           {privacyPolicyLink.title}
                         </Link>
                       </Text>
-                    </Inline>
+                    </Box>
                     <Inline space={1} alignY="center">
                       <Icon
                         type="outline"


### PR DESCRIPTION
# Global footer - Do not wrap privacy policy title below icon

## Screenshots / Gifs

### Before

![image](https://github.com/user-attachments/assets/24b12f2e-c30c-4391-9f85-b4b77a66abc5)


### After

![Screenshot 2025-02-20 at 10 43 56](https://github.com/user-attachments/assets/0a696cec-1c31-4b7d-beb3-d62e5277879e)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
