### PR TITLE
feat(parental-leave): Add periods and applicationRights onExit

### DIFF
--- a/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.ts
+++ b/libs/application/templates/parental-leave/src/lib/ParentalLeaveTemplate.ts
@@ -1019,6 +1019,20 @@ const ParentalLeaveTemplate: ApplicationTemplate<
             pendingAction: employerApprovalStatePendingAction,
           },
           lifecycle: pruneAfterDays(970),
+          onExit: [
+            defineTemplateApi({
+              action: ApiModuleActions.setVMSTPeriods,
+              triggerEvent: DefaultEvents.EDIT,
+              externalDataId: 'VMSTPeriods',
+              throwOnError: false,
+            }),
+            defineTemplateApi({
+              action: ApiModuleActions.setApplicationRights,
+              triggerEvent: DefaultEvents.EDIT,
+              externalDataId: 'VMSTApplicationRights',
+              throwOnError: false,
+            }),
+          ],
           onEntry: defineTemplateApi({
             action: ApiModuleActions.assignEmployer,
             throwOnError: true,
@@ -1070,6 +1084,20 @@ const ParentalLeaveTemplate: ApplicationTemplate<
             ],
           },
           lifecycle: pruneAfterDays(970),
+          onExit: [
+            defineTemplateApi({
+              action: ApiModuleActions.setVMSTPeriods,
+              triggerEvent: DefaultEvents.EDIT,
+              externalDataId: 'VMSTPeriods',
+              throwOnError: false,
+            }),
+            defineTemplateApi({
+              action: ApiModuleActions.setApplicationRights,
+              triggerEvent: DefaultEvents.EDIT,
+              externalDataId: 'VMSTApplicationRights',
+              throwOnError: false,
+            }),
+          ],
           roles: [
             {
               id: Roles.ASSIGNEE,
@@ -1155,6 +1183,20 @@ const ParentalLeaveTemplate: ApplicationTemplate<
             ],
           },
           lifecycle: pruneAfterDays(970),
+          onExit: [
+            defineTemplateApi({
+              action: ApiModuleActions.setVMSTPeriods,
+              triggerEvent: DefaultEvents.EDIT,
+              externalDataId: 'VMSTPeriods',
+              throwOnError: false,
+            }),
+            defineTemplateApi({
+              action: ApiModuleActions.setApplicationRights,
+              triggerEvent: DefaultEvents.EDIT,
+              externalDataId: 'VMSTApplicationRights',
+              throwOnError: false,
+            }),
+          ],
           onEntry: defineTemplateApi({
             action: ApiModuleActions.notifyApplicantOfRejectionFromEmployer,
             throwOnError: true,


### PR DESCRIPTION
# setVMSTPeriods and setApplicationRights onExit

## What

We were missing setVMSTPeriods and setApplicationRights onExit in three states that transition to addPeriodsAndEmployers 

## Why

So we fetch new periods and rights from VMSTwhen applications go into state ddPeriodsAndEmployers

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the parental leave application flow to ensure that updated period calculations and access rights are accurately refreshed when moving between key steps, providing a more consistent and reliable user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->