### PR TITLE
fix(j-s): Add prosecutor to state when creating a new indictment

### DIFF
--- a/apps/judicial-system/web/src/components/ProsecutorSelection/ProsecutorSelection.tsx
+++ b/apps/judicial-system/web/src/components/ProsecutorSelection/ProsecutorSelection.tsx
@@ -1,5 +1,6 @@
-import { FC, useContext, useMemo } from 'react'
+import { FC, useCallback, useContext, useEffect, useMemo } from 'react'
 import { useIntl } from 'react-intl'
+import { SingleValue } from 'react-select'
 
 import { Option, Select } from '@island.is/island-ui/core'
 import { isIndictmentCase } from '@island.is/judicial-system/types'
@@ -63,6 +64,36 @@ const ProsecutorSelection: FC<Props> = ({ onChange }) => {
     workingCase.prosecutorsOffice?.id,
   ])
 
+  const setProsecutorState = useCallback(
+    (prosecutorId: string) => {
+      const prosecutor = data?.users?.find((p) => p.id === prosecutorId)
+
+      setWorkingCase((prevWorkingCase) => ({
+        ...prevWorkingCase,
+        prosecutor,
+      }))
+    },
+    [data?.users, setWorkingCase],
+  )
+
+  const handleChange = (value: SingleValue<Option<string | undefined>>) => {
+    const id = value?.value
+
+    if (id && typeof id === 'string') {
+      if (!workingCase.id) {
+        setProsecutorState(id)
+      } else {
+        onChange(id)
+      }
+    }
+  }
+
+  useEffect(() => {
+    if (!workingCase.id && !workingCase.prosecutor && currentUser) {
+      setProsecutorState(currentUser.id)
+    }
+  }, [currentUser, setProsecutorState, workingCase.id, workingCase.prosecutor])
+
   return (
     <Select
       name="prosecutor"
@@ -74,22 +105,7 @@ const ProsecutorSelection: FC<Props> = ({ onChange }) => {
       })}
       value={selectedProsecutor}
       options={eligibleProsecutors}
-      onChange={(value) => {
-        const id = value?.value
-
-        if (id && typeof id === 'string') {
-          if (!workingCase.id) {
-            const prosecutor = data?.users?.find((p) => p.id === id)
-
-            setWorkingCase((prevWorkingCase) => ({
-              ...prevWorkingCase,
-              prosecutor,
-            }))
-          } else {
-            onChange(id)
-          }
-        }
-      }}
+      onChange={handleChange}
       isDisabled={loading}
       required
     />


### PR DESCRIPTION
# Add prosecutor to state when creating a new indictment

[Asana](https://app.asana.com/0/1199153462262248/1209442847517229)

## What

In a previous PR, we moved the prosecutor selection to the defendant screen. In that PR, we auto-selected prosecutor with the current user when users create new indictments. In doing so, we forgot to update the state with the new prosecutor, causing issues for various users.

This PR fixes that. In this PR, we check if the user is creating an indictment and if there is a prosecutor set in state. If not, we add the current user to state.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced prosecutor selection behavior that automatically assigns a default prosecutor when none is selected, ensuring a smoother workflow.
- **Refactor**
	- Streamlined the handling of prosecutor changes for improved consistency and clarity in the selection process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->