### PR TITLE
fix(my-pages): Use different id type in health directorate occupational licenses

### DIFF
--- a/libs/api/domains/occupational-licenses-v2/src/lib/occupationalLicensesV2.service.ts
+++ b/libs/api/domains/occupational-licenses-v2/src/lib/occupationalLicensesV2.service.ts
@@ -166,7 +166,7 @@ export class OccupationalLicensesV2Service {
       return null
     }
 
-    const license = licenses.find((l) => l.licenseNumber === id)
+    const license = licenses.find((l) => l.id.toString() === id)
 
     if (!license) {
       return null
@@ -259,7 +259,7 @@ export class OccupationalLicensesV2Service {
     const organization: OrganizationSlugType = 'landlaeknir'
 
     return {
-      licenseId: addLicenseTypePrefix(data.licenseNumber, 'Health'),
+      licenseId: addLicenseTypePrefix(data.id.toString(), 'Health'),
       licenseNumber: data.licenseNumber,
       type: LicenseType.HEALTH_DIRECTORATE,
       legalEntityId: data.legalEntityId,


### PR DESCRIPTION
## What

* Use id instead of number for id'ing health directorate licenses

## Why
* Some licenses have "extra" licenses that share a number, but each license has a unique id.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the license retrieval process to use a consistent and standardized identifier.
  - Adjusted the mapping of license details to align with this unified identifier approach, ensuring consistent handling across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->