### PR TITLE
fix(native-app): share document fixes

### DIFF
--- a/apps/native/app/android/app/build.gradle
+++ b/apps/native/app/android/app/build.gradle
@@ -164,6 +164,8 @@ dependencies {
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
 
+    implementation project(':react-native-fs')
+
     if (hermesEnabled.toBoolean()) {
         implementation("com.facebook.react:hermes-android")
     } else {

--- a/apps/native/app/android/app/src/main/java/is/island/app/MainApplication.java
+++ b/apps/native/app/android/app/src/main/java/is/island/app/MainApplication.java
@@ -18,6 +18,7 @@ import com.reactnativenavigation.NavigationApplication;
 import com.reactnativenavigation.react.NavigationReactNativeHost;
 import com.microsoft.codepush.react.CodePush;
 import is.island.app.IslandPackage;
+import com.rnfs.RNFSPackage; 
 
 public class MainApplication extends NavigationApplication {
 
@@ -33,6 +34,7 @@ public class MainApplication extends NavigationApplication {
           @SuppressWarnings("UnnecessaryLocalVariable")
           List<ReactPackage> packages = new PackageList(this).getPackages();
           packages.add(new IslandPackage());
+          packages.add(new RNFSPackage());
           return packages;
         }
 

--- a/apps/native/app/android/settings.gradle
+++ b/apps/native/app/android/settings.gradle
@@ -9,5 +9,8 @@ project(':react-native-code-push').projectDir = new File(rootProject.projectDir,
 include ':app'
 includeBuild('../../../../node_modules/@react-native/gradle-plugin')
 
+include ':react-native-fs'
+project(':react-native-fs').projectDir = new File(settingsDir, '../../../../node_modules/react-native-fs/android')
+
 apply from: new File(["node", "--print", "require.resolve('expo/package.json')"].execute(null, rootDir).text.trim(), "../scripts/autolinking.gradle")
 useExpoModules()

--- a/apps/native/app/ios/Podfile
+++ b/apps/native/app/ios/Podfile
@@ -52,6 +52,7 @@ target 'IslandApp' do
   pod 'GoogleUtilities', :modular_headers => true
   pod 'FirebaseABTesting', :modular_headers => true
   pod 'FirebaseInstallations', :modular_headers => true
+  pod 'RNFS', :path => '../../../../node_modules/react-native-fs'
 
 
   use_react_native!(

--- a/apps/native/app/ios/Podfile.lock
+++ b/apps/native/app/ios/Podfile.lock
@@ -1504,6 +1504,8 @@ PODS:
     - Firebase/Performance (= 10.3.0)
     - React-Core
     - RNFBApp
+  - RNFS (2.20.0):
+    - React-Core
   - RNGestureHandler (2.17.1):
     - DoubleConversion
     - glog
@@ -1731,6 +1733,7 @@ DEPENDENCIES:
   - "RNFBApp (from `../../../../node_modules/@react-native-firebase/app`)"
   - "RNFBMessaging (from `../../../../node_modules/@react-native-firebase/messaging`)"
   - "RNFBPerf (from `../../../../node_modules/@react-native-firebase/perf`)"
+  - RNFS (from `../../../../node_modules/react-native-fs`)
   - RNGestureHandler (from `../../../../node_modules/react-native-gesture-handler`)
   - RNInAppBrowser (from `../../../../node_modules/react-native-inappbrowser-reborn`)
   - RNKeychain (from `../../../../node_modules/react-native-keychain`)
@@ -1955,6 +1958,8 @@ EXTERNAL SOURCES:
     :path: "../../../../node_modules/@react-native-firebase/messaging"
   RNFBPerf:
     :path: "../../../../node_modules/@react-native-firebase/perf"
+  RNFS:
+    :path: "../../../../node_modules/react-native-fs"
   RNGestureHandler:
     :path: "../../../../node_modules/react-native-gesture-handler"
   RNInAppBrowser:
@@ -2092,6 +2097,7 @@ SPEC CHECKSUMS:
   RNFBApp: aecfcdc0964d9bc0c5f7ba05efb50be724d8e8b3
   RNFBMessaging: a647b2db61602e9981933b5fc90f1b058e61922c
   RNFBPerf: 6fbd022fd0200d2bc48c443718a8bf6438a9a004
+  RNFS: 4ac0f0ea233904cb798630b3c077808c06931688
   RNGestureHandler: 8dbcccada4a7e702e7dec9338c251b1cf393c960
   RNInAppBrowser: e36d6935517101ccba0e875bac8ad7b0cb655364
   RNKeychain: ff836453cba46938e0e9e4c22e43d43fa2c90333
@@ -2104,6 +2110,6 @@ SPEC CHECKSUMS:
   VisionCamera: 2cffcbac033cb5e2fa344214bd7ccbf7cf065663
   Yoga: 950bbfd7e6f04790fdb51149ed51df41f329fcc8
 
-PODFILE CHECKSUM: 32baec0ab08102e57ab0047494b9222c59bf4afe
+PODFILE CHECKSUM: 5ed7285b19f5d495a556fab6450c9851c88a7436
 
 COCOAPODS: 1.15.2

--- a/apps/native/app/src/lib/passkeys/useRegisterPasskey.ts
+++ b/apps/native/app/src/lib/passkeys/useRegisterPasskey.ts
@@ -74,7 +74,7 @@ export const useRegisterPasskey = () => {
         ) {
           return false
         }
-        console.error('Error registering passkey', error)
+        console.error('Error registering passkey:', error)
         throw new Error('Register: Error registering passkey')
       }
     }

--- a/apps/native/app/src/screens/document-detail/document-detail.tsx
+++ b/apps/native/app/src/screens/document-detail/document-detail.tsx
@@ -357,8 +357,9 @@ export const DocumentDetailScreen: NavigationFunctionComponent<{
   const onShare = () =>
     shareFile({
       document: Document as DocumentV2,
+      type: hasPdf ? 'pdf' : isHtml ? 'html' : 'url',
       pdfUrl,
-      fallbackUrl: !hasPdf && !isHtml ? Document.content?.value : undefined,
+      content: !hasPdf ? Document.content?.value : undefined,
     })
 
   useConnectivityIndicator({

--- a/apps/native/app/src/screens/document-detail/document-detail.tsx
+++ b/apps/native/app/src/screens/document-detail/document-detail.tsx
@@ -354,7 +354,12 @@ export const DocumentDetailScreen: NavigationFunctionComponent<{
     Document?.content?.type.toLocaleLowerCase() === 'html' &&
     Document.content?.value !== ''
 
-  const onShare = () => shareFile({ document: Document as DocumentV2, pdfUrl })
+  const onShare = () =>
+    shareFile({
+      document: Document as DocumentV2,
+      pdfUrl,
+      fallbackUrl: !hasPdf && !isHtml ? Document.content?.value : undefined,
+    })
 
   useConnectivityIndicator({
     componentId,

--- a/apps/native/app/src/screens/document-detail/utils/share-file.tsx
+++ b/apps/native/app/src/screens/document-detail/utils/share-file.tsx
@@ -7,9 +7,14 @@ import { DocumentV2 } from '../../../graphql/types/schema'
 interface ShareFileProps {
   document: DocumentV2
   pdfUrl?: string
+  fallbackUrl?: string | null
 }
 
-export const shareFile = async ({ document, pdfUrl }: ShareFileProps) => {
+export const shareFile = async ({
+  document,
+  pdfUrl,
+  fallbackUrl,
+}: ShareFileProps) => {
   if (!document || !document.subject || !document.sender) {
     return
   }
@@ -24,7 +29,7 @@ export const shareFile = async ({ document, pdfUrl }: ShareFileProps) => {
       subject: document.subject,
       message: `${document.sender.name} \n ${document.subject}`,
       type: pdfUrl ? 'application/pdf' : undefined,
-      url: pdfUrl ? `file://${pdfUrl}` : document.downloadUrl!,
+      url: pdfUrl ? `file://${pdfUrl}` : fallbackUrl ?? document.downloadUrl!,
     })
   } catch (error) {
     // noop

--- a/apps/native/app/src/screens/document-detail/utils/share-file.tsx
+++ b/apps/native/app/src/screens/document-detail/utils/share-file.tsx
@@ -1,4 +1,5 @@
 import Share from 'react-native-share'
+import RNFS from 'react-native-fs'
 
 import { isAndroid } from '../../../utils/devices'
 import { authStore } from '../../../stores/auth-store'
@@ -6,21 +7,37 @@ import { DocumentV2 } from '../../../graphql/types/schema'
 
 interface ShareFileProps {
   document: DocumentV2
+  type: 'pdf' | 'html' | 'url'
   pdfUrl?: string
-  fallbackUrl?: string | null
+  content?: string | null
 }
 
 export const shareFile = async ({
   document,
   pdfUrl,
-  fallbackUrl,
+  type,
+  content,
 }: ShareFileProps) => {
   if (!document || !document.subject || !document.sender) {
     return
   }
+  const isHtml = type === 'html'
+  let htmlUrl: string | undefined
 
   if (isAndroid) {
     authStore.setState({ noLockScreenUntilNextAppStateActive: true })
+  }
+
+  if (isHtml) {
+    const utf8Prefix = '<meta charset="UTF-8">'
+    const formattedHtml = utf8Prefix + content
+    try {
+      const path = `${RNFS.TemporaryDirectoryPath}/${document.subject}.html`
+      await RNFS.writeFile(path, formattedHtml, 'utf8')
+      htmlUrl = path
+    } catch (error) {
+      // noop
+    }
   }
 
   try {
@@ -28,8 +45,12 @@ export const shareFile = async ({
       title: document.subject,
       subject: document.subject,
       message: `${document.sender.name} \n ${document.subject}`,
-      type: pdfUrl ? 'application/pdf' : undefined,
-      url: pdfUrl ? `file://${pdfUrl}` : fallbackUrl ?? document.downloadUrl!,
+      type: pdfUrl ? 'application/pdf' : isHtml ? 'text/html' : undefined,
+      url: pdfUrl
+        ? `file://${pdfUrl}`
+        : isHtml
+        ? `file://${htmlUrl}`
+        : content ?? document.downloadUrl!,
     })
   } catch (error) {
     // noop

--- a/apps/native/app/src/screens/document-detail/utils/share-file.tsx
+++ b/apps/native/app/src/screens/document-detail/utils/share-file.tsx
@@ -32,7 +32,8 @@ export const shareFile = async ({
     const utf8Prefix = '<meta charset="UTF-8">'
     const formattedHtml = utf8Prefix + content
     try {
-      const path = `${RNFS.TemporaryDirectoryPath}/${document.subject}.html`
+      const encodedSubject = encodeURIComponent(document.subject)
+      const path = `${RNFS.TemporaryDirectoryPath}/${encodedSubject}.html`
       await RNFS.writeFile(path, formattedHtml, 'utf8')
       htmlUrl = path
     } catch (error) {

--- a/apps/native/app/src/screens/document-detail/utils/share-file.tsx
+++ b/apps/native/app/src/screens/document-detail/utils/share-file.tsx
@@ -50,7 +50,7 @@ export const shareFile = async ({
         ? `file://${pdfUrl}`
         : isHtml
         ? `file://${htmlUrl}`
-        : content ?? document.downloadUrl!,
+        : content ?? undefined,
     })
   } catch (error) {
     // noop

--- a/apps/native/app/src/screens/document-detail/utils/share-file.tsx
+++ b/apps/native/app/src/screens/document-detail/utils/share-file.tsx
@@ -36,7 +36,8 @@ export const shareFile = async ({
       await RNFS.writeFile(path, formattedHtml, 'utf8')
       htmlUrl = path
     } catch (error) {
-      // noop
+      console.error('Failed to write html file', error)
+      return
     }
   }
 
@@ -53,6 +54,7 @@ export const shareFile = async ({
         : content ?? undefined,
     })
   } catch (error) {
-    // noop
+    console.error('Failed to share document', error)
+    return
   }
 }

--- a/package.json
+++ b/package.json
@@ -260,6 +260,7 @@
     "react-keyed-flatten-children": "1.2.0",
     "react-modal": "3.15.1",
     "react-native": "0.74.5",
+    "react-native-fs": "2.20.0",
     "react-number-format": "4.9.1",
     "react-pdf": "9.1.0",
     "react-popper": "2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -26873,7 +26873,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base-64@npm:0.1.0":
+"base-64@npm:0.1.0, base-64@npm:^0.1.0":
   version: 0.1.0
   resolution: "base-64@npm:0.1.0"
   checksum: 10/5a42938f82372ab5392cbacc85a5a78115cbbd9dbef9f7540fa47d78763a3a8bd7d598475f0d92341f66285afd377509851a9bb5c67bbecb89686e9255d5b3eb
@@ -39409,6 +39409,7 @@ __metadata:
     react-keyed-flatten-children: "npm:1.2.0"
     react-modal: "npm:3.15.1"
     react-native: "npm:0.74.5"
+    react-native-fs: "npm:2.20.0"
     react-native-svg: "npm:15.2.0"
     react-native-svg-transformer: "npm:1.3.0"
     react-native-web: "npm:^0.19.11"
@@ -49972,6 +49973,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-native-fs@npm:2.20.0":
+  version: 2.20.0
+  resolution: "react-native-fs@npm:2.20.0"
+  dependencies:
+    base-64: "npm:^0.1.0"
+    utf8: "npm:^3.0.0"
+  peerDependencies:
+    react-native: "*"
+    react-native-windows: "*"
+  peerDependenciesMeta:
+    react-native-windows:
+      optional: true
+  checksum: 10/372e59f55d5e544e87093d832896fa3d56ba9802ca140c17b4b8903afe047714e022d3b1a2ddf18d744cb7f4f973593c8083641db9ae0768688b1390078d67a2
+  languageName: node
+  linkType: hard
+
 "react-native-gesture-handler@npm:2.17.1":
   version: 2.17.1
   resolution: "react-native-gesture-handler@npm:2.17.1"
@@ -57351,6 +57368,13 @@ __metadata:
   version: 2.1.2
   resolution: "utf8@npm:2.1.2"
   checksum: 10/7b35ff1203d2e0209db7a28f6852cb64ff292a3bdc3b6a9c52ff2d69abcfeff992647e8d4dc787c4f1c9374613ad11f7e9c682df66985dfa516b8f8c69855860
+  languageName: node
+  linkType: hard
+
+"utf8@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "utf8@npm:3.0.0"
+  checksum: 10/31d19c4faacbb65b09ebc1c21c32b20bdb0919c6f6773cee5001b99bb83f8e503e7233c08fc71ebb34f7cfebd95cec3243b81d90176097aa2f286cccb4ce866e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What
When sharing documents that opened a webview or were rendered as html then we were using an old outdated downloadUrl that did not work after the bff changes. 

Now when sharing a document that opens a webview we share the correct url. When sharing a file that is of type html we create a .html file with the html code and share that. Tested it both on android device and ios device.
**note:** When sharing the html file in an email it is sometimes rendered as a text file. That is just how the email client handles it. 

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced file sharing now offers context-aware support, allowing users to seamlessly share documents as PDF, HTML, or URL.
	- Improved cross-platform file operations with the integration of an advanced file system library, ensuring smoother performance on both Android and iOS devices.
	- New dependency added for file system access, expanding functionality for file operations within the app.
- **Bug Fixes**
	- Updated error logging format for passkey registration to improve clarity in console outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->