### PR TITLE
feat(application-ol): Remove/Replace criminal record service

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/operating-license/operatingLicense.module.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/operating-license/operatingLicense.module.ts
@@ -2,7 +2,6 @@ import { Module } from '@nestjs/common'
 import { OperatingLicenseService } from './operatingLicense.service'
 import { SharedTemplateAPIModule } from '../../shared'
 import { SyslumennClientModule } from '@island.is/clients/syslumenn'
-import { CriminalRecordModule } from '@island.is/api/domains/criminal-record'
 import { FinanceClientModule } from '@island.is/clients/finance'
 import { JudicialAdministrationClientModule } from '@island.is/clients/judicial-administration'
 import { AwsModule } from '@island.is/nest/aws'
@@ -11,7 +10,6 @@ import { AwsModule } from '@island.is/nest/aws'
   imports: [
     SyslumennClientModule,
     SharedTemplateAPIModule,
-    CriminalRecordModule,
     FinanceClientModule,
     JudicialAdministrationClientModule,
     AwsModule,

--- a/libs/application/template-api-modules/src/lib/modules/templates/operating-license/operatingLicense.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/operating-license/operatingLicense.service.ts
@@ -1,7 +1,11 @@
 import { Injectable } from '@nestjs/common'
 import { SharedTemplateApiService } from '../../shared'
 import { TemplateApiModuleActionProps } from '../../../types'
-import { coreErrorMessages, getValueViaPath, YES } from '@island.is/application/core'
+import {
+  coreErrorMessages,
+  getValueViaPath,
+  YES,
+} from '@island.is/application/core'
 import {
   SyslumennService,
   Person,
@@ -13,25 +17,21 @@ import {
   File,
   ApplicationAttachments,
   AttachmentPaths,
-  CriminalRecord,
   DebtLessCertificateResult,
 } from './types/attachments'
 import {
   ApplicationTypes,
   ApplicationWithAttachments,
-  InstitutionNationalIds,
 } from '@island.is/application/types'
 import { Info, BankruptcyHistoryResult } from './types/application'
 import { getExtraData } from './utils'
 import { BaseTemplateApiService } from '../../base-template-api.service'
-import { CriminalRecordService } from '@island.is/api/domains/criminal-record'
 import { TemplateApiError } from '@island.is/nest/problem'
 import { FinanceClientService } from '@island.is/clients/finance'
 import { OperatingLicenseFakeData } from '@island.is/application/templates/operating-license/types'
 import { JudicialAdministrationService } from '@island.is/clients/judicial-administration'
 import { BANNED_BANKRUPTCY_STATUSES } from './constants'
 import { error } from '@island.is/application/templates/operating-license'
-import { isPerson } from 'kennitala'
 import { User } from '@island.is/auth-nest-tools'
 import { S3Service } from '@island.is/nest/aws'
 
@@ -40,7 +40,6 @@ export class OperatingLicenseService extends BaseTemplateApiService {
   constructor(
     private readonly sharedTemplateAPIService: SharedTemplateApiService,
     private readonly syslumennService: SyslumennService,
-    private readonly criminalRecordService: CriminalRecordService,
     private readonly financeService: FinanceClientService,
     private readonly judicialAdministrationService: JudicialAdministrationService,
     private readonly s3Service: S3Service,
@@ -69,17 +68,14 @@ export class OperatingLicenseService extends BaseTemplateApiService {
             statusCode: 404,
           })
     }
-    try {
-      const applicantSsn =
-        application.applicantActors.length > 0
-          ? application.applicantActors[0]
-          : application.applicant
-      const hasCriminalRecord =
-        await this.criminalRecordService.validateCriminalRecord(applicantSsn)
-      if (hasCriminalRecord) {
-        return { success: true }
-      }
+    const applicantSsn =
+      application.applicantActors.length > 0
+        ? application.applicantActors[0]
+        : application.applicant
 
+    // The criminalRecord endpoint is a void endpoint that only fails
+    // if there is no criminal record available.
+    this.syslumennService.checkCriminalRecord(applicantSsn).catch((e) => {
       throw new TemplateApiError(
         {
           title: error.dataCollectionCriminalRecordTitle,
@@ -87,15 +83,8 @@ export class OperatingLicenseService extends BaseTemplateApiService {
         },
         400,
       )
-    } catch (e) {
-      throw new TemplateApiError(
-        {
-          title: error.dataCollectionCriminalRecordTitle,
-          summary: coreErrorMessages.errorDataProvider,
-        },
-        400,
-      )
-    }
+    })
+    return { success: true }
   }
 
   async getDebtLessCertificate(auth: User): Promise<DebtLessCertificateResult> {
@@ -248,27 +237,6 @@ export class OperatingLicenseService extends BaseTemplateApiService {
     }
   }
 
-  async getCriminalRecord(nationalId: string): Promise<CriminalRecord> {
-    const document = await this.criminalRecordService.getCriminalRecord(
-      nationalId,
-    )
-
-    // Call sýslumaður to get the document sealed before handing it over to the user
-    const sealedDocumentResponse = await this.syslumennService.sealDocument(
-      document.contentBase64,
-    )
-
-    if (!sealedDocumentResponse?.skjal) {
-      throw new Error('Eitthvað fór úrskeiðis.')
-    }
-
-    const sealedDocument: CriminalRecord = {
-      contentBase64: sealedDocumentResponse.skjal,
-    }
-
-    return sealedDocument
-  }
-
   private async getAttachments(
     application: ApplicationWithAttachments,
     auth: User,
@@ -276,28 +244,6 @@ export class OperatingLicenseService extends BaseTemplateApiService {
     const attachments: Attachment[] = []
 
     const dateStr = new Date(Date.now()).toISOString().substring(0, 10)
-
-    let criminalRecordSSN = application.applicant
-
-    if (!isPerson(application.applicant)) {
-      // Go through actors until a person is found
-      // if no person then an error is thrown in the next step
-      application.applicantActors.every((actor) => {
-        if (isPerson(actor)) {
-          criminalRecordSSN = actor
-          return false
-        }
-        return true
-      })
-    }
-
-    const criminalRecord = await this.getCriminalRecord(criminalRecordSSN)
-    if (criminalRecord.contentBase64) {
-      attachments.push({
-        name: `sakavottord_${application.applicant}_${dateStr}.pdf`,
-        content: criminalRecord.contentBase64,
-      })
-    }
 
     const debtLess = await this.getDebtLessCertificate(auth)
     if (debtLess.certificate?.document) {

--- a/libs/application/template-api-modules/src/lib/modules/templates/operating-license/operatingLicense.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/operating-license/operatingLicense.service.ts
@@ -75,7 +75,7 @@ export class OperatingLicenseService extends BaseTemplateApiService {
 
     // The criminalRecord endpoint is a void endpoint that only fails
     // if there is no criminal record available.
-    this.syslumennService.checkCriminalRecord(applicantSsn).catch((e) => {
+    await this.syslumennService.checkCriminalRecord(applicantSsn).catch((e) => {
       throw new TemplateApiError(
         {
           title: error.dataCollectionCriminalRecordTitle,


### PR DESCRIPTION
The Criminal Record service has been deprecated.
We are now using the District Commissioner's endpoint for checking whether a criminal record is available.

Futhermore, DC will henceforth link the criminal records to their operating license cases on their end, so we also removed the attachment feature for the criminal record.

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the operating license processing workflow by updating the verification steps for applicant records.
  - Optimized attachment handling by removing redundant validation steps for a more efficient process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->