### PR TITLE
feat(native-app): vehicle fetching on home screen should be cache-first

### DIFF
--- a/apps/native/app/src/screens/home/home.tsx
+++ b/apps/native/app/src/screens/home/home.tsx
@@ -181,6 +181,7 @@ export const MainHomeScreen: NavigationFunctionComponent = ({
         pageSize: 15,
       },
     },
+    fetchPolicy: 'cache-first',
     skip: !vehiclesWidgetEnabled,
   })
 

--- a/apps/native/app/src/screens/vehicles/vehicles.tsx
+++ b/apps/native/app/src/screens/vehicles/vehicles.tsx
@@ -61,7 +61,7 @@ const Empty = () => (
 
 const input = {
   page: 1,
-  pageSize: 10,
+  pageSize: 15,
 }
 
 export const VehiclesScreen: NavigationFunctionComponent = ({


### PR DESCRIPTION
## What
Vehicle fetching on home screen should be cache-first.

## Why
When releasing barcodes we could get a lot of more traffic to the app and we don't want to overload samgöngustofa with requests if not necessary.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved speed and responsiveness in the vehicle display. This update optimizes data retrieval by prioritizing local cached information, leading to faster load times and smoother interactions when viewing vehicle details. Users should experience a more efficient and responsive interface overall.
  - Increased the number of vehicle items displayed per page from 10 to 15, allowing users to view more vehicles at once.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->