### PR TITLE
fix(web): Add clear on faq and accordion in generic list item view

### DIFF
--- a/apps/web/screens/GenericList/GenericListItem.css.ts
+++ b/apps/web/screens/GenericList/GenericListItem.css.ts
@@ -11,3 +11,10 @@ export const floatedImage = style({
     },
   }),
 })
+export const clearBoth = style({
+  ...themeUtils.responsiveStyle({
+    sm: {
+      clear: 'both',
+    },
+  }),
+})

--- a/apps/web/screens/GenericList/GenericListItem.tsx
+++ b/apps/web/screens/GenericList/GenericListItem.tsx
@@ -1,6 +1,6 @@
 import cn from 'classnames'
 
-import { Image } from '@island.is/island-ui/contentful'
+import { FaqList, FaqListProps, Image } from '@island.is/island-ui/contentful'
 import {
   Box,
   GridContainer,
@@ -9,8 +9,13 @@ import {
   Tag,
   Text,
 } from '@island.is/island-ui/core'
-import { HeadWithSocialSharing, Webreader } from '@island.is/web/components'
+import {
+  AccordionSlice,
+  HeadWithSocialSharing,
+  Webreader,
+} from '@island.is/web/components'
 import type {
+  AccordionSlice as AccordionSliceSchema,
   GenericListItem,
   Query,
   QueryGetGenericListItemBySlugArgs,
@@ -87,7 +92,22 @@ const GenericListItemPage: Screen<GenericListItemPageProps> = ({
               />
             </Box>
           )}
-          <Text as="div">{webRichText(item.content ?? [])}</Text>
+          <Text as="div">
+            {webRichText(item.content ?? [], {
+              renderComponent: {
+                FaqList: (slice: FaqListProps) => (
+                  <Box style={{ clear: 'both' }}>
+                    <FaqList {...slice} />
+                  </Box>
+                ),
+                AccordionSlice: (slice: AccordionSliceSchema) => (
+                  <Box style={{ clear: 'both' }}>
+                    <AccordionSlice slice={slice} />
+                  </Box>
+                ),
+              },
+            })}
+          </Text>
         </Stack>
       </Box>
     </GridContainer>

--- a/apps/web/screens/GenericList/GenericListItem.tsx
+++ b/apps/web/screens/GenericList/GenericListItem.tsx
@@ -96,12 +96,12 @@ const GenericListItemPage: Screen<GenericListItemPageProps> = ({
             {webRichText(item.content ?? [], {
               renderComponent: {
                 FaqList: (slice: FaqListProps) => (
-                  <Box style={{ clear: 'both' }}>
+                  <Box className={styles.clearBoth}>
                     <FaqList {...slice} />
                   </Box>
                 ),
                 AccordionSlice: (slice: AccordionSliceSchema) => (
-                  <Box style={{ clear: 'both' }}>
+                  <Box className={styles.clearBoth}>
                     <AccordionSlice slice={slice} />
                   </Box>
                 ),


### PR DESCRIPTION
# Add clear on faq and accordion in generic list item view

## What

- Return faqlist and accordion in rich text with clearfix

## Why

- Fix that accordions in faq list and accordions content types does not goes over image when image is floated right.

## Screenshots / Gifs

### Before

#### Faq list
![image](https://github.com/user-attachments/assets/4119fb41-0d13-4d87-8d8e-c6bbebf96d5e)

#### Accordion
![image](https://github.com/user-attachments/assets/9be68b78-40e5-4f65-9085-42bc68ac3042)

### After
#### Faq list
![image](https://github.com/user-attachments/assets/0e4db713-1198-400e-b08d-b499e823b395)

#### Accordion
![image](https://github.com/user-attachments/assets/0637a514-0894-4197-9e09-9ee160f7926c)



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced content rendering now supports the dynamic display of interactive FAQ lists and expandable sections for a more engaging reading experience.
- **Style**
  - Introduced responsive styling improvements to maintain consistent layout adjustments across various screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->