### PR TITLE
feat(j-s): add the earliest LOKE nr to an police institution email

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/notification/notification.config.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/notification.config.ts
@@ -31,10 +31,9 @@ export const notificationModuleConfig = defineConfig({
         'COURT_OF_APPEALS_ASSISTANT_EMAILS',
         '',
       ),
-      policeInstitutionEmails: env.requiredJSON(
-        'POLICE_INSTITUTIONS_EMAILS',
-        {},
-      ) as {
+      policeInstitutionEmails: env.requiredJSON('POLICE_INSTITUTIONS_EMAILS', {
+        '53581d7b-0591-45e5-9cbe-c96b2f82da85': 'ben10@omnitrix.is',
+      }) as {
         [key: string]: string
       },
     },

--- a/apps/judicial-system/backend/src/app/modules/notification/notification.config.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/notification.config.ts
@@ -31,9 +31,10 @@ export const notificationModuleConfig = defineConfig({
         'COURT_OF_APPEALS_ASSISTANT_EMAILS',
         '',
       ),
-      policeInstitutionEmails: env.requiredJSON('POLICE_INSTITUTIONS_EMAILS', {
-        '53581d7b-0591-45e5-9cbe-c96b2f82da85': 'ben10@omnitrix.is',
-      }) as {
+      policeInstitutionEmails: env.requiredJSON(
+        'POLICE_INSTITUTIONS_EMAILS',
+        {},
+      ) as {
         [key: string]: string
       },
     },

--- a/apps/judicial-system/backend/src/app/modules/notification/services/indictmentCaseNotification/indictmentCaseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/indictmentCaseNotification/indictmentCaseNotification.service.ts
@@ -105,8 +105,10 @@ export class IndictmentCaseNotificationService extends BaseNotificationService {
       strings.indictmentCompletedWithRuling.body,
       {
         courtCaseNumber: theCase.courtCaseNumber,
-        policeCaseNumber: theCase.policeCaseNumbers[0],
-
+        policeCaseNumber:
+          theCase.policeCaseNumbers.length > 0
+            ? theCase.policeCaseNumbers[0]
+            : '',
         courtName: applyDativeCaseToCourtName(theCase.court?.name || ''),
         serviceRequirement:
           theCase.defendants && theCase.defendants[0].serviceRequirement,

--- a/apps/judicial-system/backend/src/app/modules/notification/services/indictmentCaseNotification/indictmentCaseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/indictmentCaseNotification/indictmentCaseNotification.service.ts
@@ -105,6 +105,8 @@ export class IndictmentCaseNotificationService extends BaseNotificationService {
       strings.indictmentCompletedWithRuling.body,
       {
         courtCaseNumber: theCase.courtCaseNumber,
+        policeCaseNumber: theCase.policeCaseNumbers[0],
+
         courtName: applyDativeCaseToCourtName(theCase.court?.name || ''),
         serviceRequirement:
           theCase.defendants && theCase.defendants[0].serviceRequirement,

--- a/apps/judicial-system/backend/src/app/modules/notification/services/indictmentCaseNotification/indictmentCaseNotification.strings.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/indictmentCaseNotification/indictmentCaseNotification.strings.ts
@@ -9,9 +9,9 @@ export const strings = {
         'Notað sem titill í tilkynningu um stöðu birtingar dóms í lokinni ákæru',
     },
     body: {
-      id: 'judicial.system.backend:indictment_case_notifications.verdict_service.body',
+      id: 'judicial.system.backend:indictment_case_notifications.verdict_service.body_v2',
       defaultMessage:
-        'Máli {courtCaseNumber} hjá {courtName} hefur verið lokið.\n\nNiðurstaða: Dómur\n\n{serviceRequirement, select, REQUIRED {Birta skal dómfellda dóminn} NOT_REQUIRED {Birting dóms ekki þörf} NOT_APPLICABLE {Dómfelldi var viðstaddur dómsuppkvaðningu} other {}}\n\n{caseOrigin, select, LOKE {Dómur er aðgengilegur í LÖKE.} other {}}',
+        'Máli {courtCaseNumber} hjá {courtName} hefur verið lokið.\n\nNiðurstaða: Dómur\n\n{serviceRequirement, select, REQUIRED {Birta skal dómfellda dóminn} NOT_REQUIRED {Birting dóms ekki þörf} NOT_APPLICABLE {Dómfelldi var viðstaddur dómsuppkvaðningu} other {}}\n\n{caseOrigin, select, LOKE {Dómur er aðgengilegur í LÖKE ({policeCaseNumber}).} other {}}',
       description:
         'Notað sem body í tilkynningu um stöðu birtingar dóms í lokinni ákæru',
     },

--- a/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/indictmentCaseNotification/sendIndictmentVerdictInfoNotification.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/test/internalNotificationController/indictmentCaseNotification/sendIndictmentVerdictInfoNotification.spec.ts
@@ -38,6 +38,7 @@ describe('IndictmentCaseService', () => {
   const prosecutorsOfficeEmail = prosecutorsOffice.email
   const prosecutorInstitutionId = uuid()
   const courtCaseNumber = uuid()
+  const policeCaseNumbers = [uuid()]
   let theCase = {
     id: caseId,
     court: { name: courtName },
@@ -53,8 +54,8 @@ describe('IndictmentCaseService', () => {
     prosecutor: {
       institution: { name: prosecutorsOfficeName, id: prosecutorInstitutionId },
     },
-
     courtCaseNumber,
+    policeCaseNumbers,
   } as Case
 
   let mockEmailService: EmailService


### PR DESCRIPTION
# [Add LOKE number to verdict emails to police institution emails recipients](https://app.asana.com/0/1199153462262248/1209425985827492)

## What
- Add the latest LOKE number when sending the verdict results to police instituion

## Why
- Because it was missing and hard to look for it in LÖKE only via the case number

## Screenshots / Gifs
![Screenshot 2025-02-24 at 15 20 25](https://github.com/user-attachments/assets/a16f743e-70fa-42cf-b96f-1a51fd1d993a)

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced verdict notifications to include a police case number when available.
	- Updated the notification message text to incorporate additional contextual information about the case.
	- Improved test coverage by including multiple police case numbers in the notification tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->