### PR TITLE
fix(web): NewsList - Filter out frontpage news tags

### DIFF
--- a/apps/web/components/NewsItems/NewsItems.tsx
+++ b/apps/web/components/NewsItems/NewsItems.tsx
@@ -10,7 +10,7 @@ import {
   Text,
 } from '@island.is/island-ui/core'
 import { GridItems } from '@island.is/web/components'
-import { FRONTPAGE_NEWS_TAG_ID } from '@island.is/web/constants'
+import { FRONTPAGE_NEWS_TAG_SLUG } from '@island.is/web/constants'
 import { GetNewsQuery } from '@island.is/web/graphql/schema'
 import { LinkType, useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
 
@@ -125,7 +125,7 @@ export const NewsItems = ({
                 // @ts-ignore make web strict
                 image={image}
                 tags={genericTags
-                  .filter((tag) => tag.slug !== FRONTPAGE_NEWS_TAG_ID)
+                  .filter((tag) => tag.slug !== FRONTPAGE_NEWS_TAG_SLUG)
                   .map(({ slug, title, __typename: tn }) => {
                     return {
                       label: title,

--- a/apps/web/components/NewsList/NewsList.tsx
+++ b/apps/web/components/NewsList/NewsList.tsx
@@ -222,7 +222,7 @@ export const NewsList = ({
                 }
                 imageSrc={newsItem.image?.url ?? ''}
                 tags={newsItem.genericTags
-                  .filter((tag) => tag.id !== FRONTPAGE_NEWS_TAG_ID)
+                  .filter((tag) => tag.slug !== FRONTPAGE_NEWS_TAG_ID)
                   .map((tag) => tag.title)}
                 title={newsItem.title}
                 description={newsItem.intro}

--- a/apps/web/components/NewsList/NewsList.tsx
+++ b/apps/web/components/NewsList/NewsList.tsx
@@ -19,7 +19,7 @@ import {
   NewsCard,
   Webreader,
 } from '@island.is/web/components'
-import { FRONTPAGE_NEWS_TAG_ID } from '@island.is/web/constants'
+import { FRONTPAGE_NEWS_TAG_SLUG } from '@island.is/web/constants'
 import { GenericTag, GetNewsQuery } from '@island.is/web/graphql/schema'
 import { LinkType, useLinkResolver, useNamespace } from '@island.is/web/hooks'
 
@@ -222,7 +222,7 @@ export const NewsList = ({
                 }
                 imageSrc={newsItem.image?.url ?? ''}
                 tags={newsItem.genericTags
-                  .filter((tag) => tag.slug !== FRONTPAGE_NEWS_TAG_ID)
+                  .filter((tag) => tag.slug !== FRONTPAGE_NEWS_TAG_SLUG)
                   .map((tag) => tag.title)}
                 title={newsItem.title}
                 description={newsItem.intro}

--- a/apps/web/components/Organization/Slice/LatestNewsSlice/DigitalIcelandLatestNewsSlice/DigitalIcelandLatestNewsSlice.tsx
+++ b/apps/web/components/Organization/Slice/LatestNewsSlice/DigitalIcelandLatestNewsSlice/DigitalIcelandLatestNewsSlice.tsx
@@ -10,7 +10,7 @@ import {
   Text,
 } from '@island.is/island-ui/core'
 import { DigitalIcelandNewsCard } from '@island.is/web/components'
-import { FRONTPAGE_NEWS_TAG_ID } from '@island.is/web/constants'
+import { FRONTPAGE_NEWS_TAG_SLUG } from '@island.is/web/constants'
 import { LatestNewsSlice as LatestNewsSliceSchema } from '@island.is/web/graphql/schema'
 import { useLinkResolver } from '@island.is/web/hooks'
 
@@ -75,7 +75,7 @@ export const DigitalIcelandLatestNewsSlice: React.FC<
                 description={news.intro}
                 imageSrc={news.image?.url ?? ''}
                 tags={news.genericTags
-                  .filter((tag) => tag.slug !== FRONTPAGE_NEWS_TAG_ID)
+                  .filter((tag) => tag.slug !== FRONTPAGE_NEWS_TAG_SLUG)
                   .map((tag) => tag.title)}
                 title={news.title}
               />

--- a/apps/web/constants/index.ts
+++ b/apps/web/constants/index.ts
@@ -6,7 +6,7 @@ export const SLICE_SPACING: ResponsiveSpace = 7
 export const PROJECT_STORIES_TAG_ID = '9yqOTwQYzgyej5kItFTtd'
 export const ADGERDIR_INDIVIDUALS_TAG_ID = '4kLt3eRht5yJoakIHWsusb'
 export const ADGERDIR_COMPANIES_TAG_ID = '4ZWcwoW2IiB2AhtzQpzdIW'
-export const FRONTPAGE_NEWS_TAG_ID = 'forsidufrettir'
+export const FRONTPAGE_NEWS_TAG_SLUG = 'forsidufrettir'
 export const PLAUSIBLE_SCRIPT_SRC =
   'https://plausible.io/js/script.outbound-links.js'
 export const DIGITAL_ICELAND_PLAUSIBLE_TRACKING_DOMAIN =

--- a/apps/web/pages/api/rss/index.ts
+++ b/apps/web/pages/api/rss/index.ts
@@ -6,7 +6,7 @@ import { parseAsString, parseAsStringEnum } from 'next-usequerystate'
 
 import { defaultLanguage } from '@island.is/shared/constants'
 import type { Locale } from '@island.is/shared/types'
-import { FRONTPAGE_NEWS_TAG_ID } from '@island.is/web/constants'
+import { FRONTPAGE_NEWS_TAG_SLUG } from '@island.is/web/constants'
 import initApollo from '@island.is/web/graphql/client'
 import {
   ContentLanguage,
@@ -50,7 +50,7 @@ const extractTagsFromQuery = (query: NextApiRequest['query']) => {
   }
 
   // If nothing is defined in query we'll show frontpage news
-  return [FRONTPAGE_NEWS_TAG_ID]
+  return [FRONTPAGE_NEWS_TAG_SLUG]
 }
 
 const generateItemString = (item: Item) => {

--- a/apps/web/screens/Home/Home.tsx
+++ b/apps/web/screens/Home/Home.tsx
@@ -9,7 +9,7 @@ import {
   SearchSection,
   WatsonChatPanel,
 } from '@island.is/web/components'
-import { FRONTPAGE_NEWS_TAG_ID } from '@island.is/web/constants'
+import { FRONTPAGE_NEWS_TAG_SLUG } from '@island.is/web/constants'
 import { GlobalContext } from '@island.is/web/context'
 import {
   ContentLanguage,
@@ -156,7 +156,7 @@ Home.getProps = async ({ apolloClient, locale }) => {
         input: {
           size: 3,
           lang: locale as ContentLanguage,
-          tags: [FRONTPAGE_NEWS_TAG_ID],
+          tags: [FRONTPAGE_NEWS_TAG_SLUG],
         },
       },
     }),
@@ -177,7 +177,7 @@ Home.getProps = async ({ apolloClient, locale }) => {
         ...item,
         genericTags:
           item?.genericTags?.filter(
-            (tag) => tag.slug !== FRONTPAGE_NEWS_TAG_ID,
+            (tag) => tag.slug !== FRONTPAGE_NEWS_TAG_SLUG,
           ) ?? [],
       })) ?? [],
     categories: getArticleCategories,

--- a/apps/web/screens/News.tsx
+++ b/apps/web/screens/News.tsx
@@ -25,7 +25,7 @@ import {
   NewsCard,
   Webreader,
 } from '@island.is/web/components'
-import { FRONTPAGE_NEWS_TAG_ID } from '@island.is/web/constants'
+import { FRONTPAGE_NEWS_TAG_SLUG } from '@island.is/web/constants'
 import { useNamespace } from '@island.is/web/hooks'
 import { useDateUtils } from '@island.is/web/i18n/useDateUtils'
 import { withMainLayout } from '@island.is/web/layouts/main'
@@ -412,7 +412,7 @@ NewsListNew.getProps = async ({ apolloClient, locale, query }) => {
   const year = getIntParam(query.y, { minValue: 1000, maxValue: 9999 })
   const month = year && getIntParam(query.m, { minValue: 1, maxValue: 12 })
   const selectedPage = getIntParam(query.page, { minValue: 1 }) ?? 1
-  const tag = (query.tag as string) ?? FRONTPAGE_NEWS_TAG_ID
+  const tag = (query.tag as string) ?? FRONTPAGE_NEWS_TAG_SLUG
   const [
     {
       data: { getNewsDates: newsDatesList },
@@ -492,7 +492,7 @@ NewsListNew.getProps = async ({ apolloClient, locale, query }) => {
   }
 
   const filterOutFrontpageTag = (tag: GenericTag) =>
-    tag?.slug !== FRONTPAGE_NEWS_TAG_ID
+    tag?.slug !== FRONTPAGE_NEWS_TAG_SLUG
 
   return {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment


### PR DESCRIPTION
# NewsList - Filter out frontpage news tags

Wrong field was being used in the filter function, we should be comparing slugs, not id's

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the tag filtering criteria on news cards to ensure that only the intended tags are displayed. This update improves the accuracy of tag presentation for news items.
	- Updated tag identifiers across various components to enhance consistency in tag filtering logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->