### PR TITLE
fix(parental-leave): User will not be able to choose endDate on child's 2nd birthday

### DIFF
--- a/libs/application/templates/parental-leave/src/fields/PeriodEndDate/PeriodEndDate.tsx
+++ b/libs/application/templates/parental-leave/src/fields/PeriodEndDate/PeriodEndDate.tsx
@@ -25,6 +25,11 @@ import { Box } from '@island.is/island-ui/core'
 
 import { parentalLeaveFormMessages } from '../../lib/messages'
 import { StartDateOptions } from '../../constants'
+import { getExpectedDateOfBirthOrAdoptionDateOrBirthDate } from '../../lib/parentalLeaveUtils'
+import parseISO from 'date-fns/parseISO'
+import { usageMaxMonths } from '../../config'
+import addMonths from 'date-fns/addMonths'
+import addDays from 'date-fns/addDays'
 
 type FieldPeriodEndDateProps = {
   field: {
@@ -50,6 +55,15 @@ export const PeriodEndDate: FC<
     `periods[${currentIndex}].firstPeriodStart`,
   ) as StartDateOptions
   const error = getErrorViaPath(errors as FieldErrors<FieldValues>, fieldId)
+  const expectedDateOfBirthOrAdoptionDateOrBirthDate =
+    getExpectedDateOfBirthOrAdoptionDateOrBirthDate(application, true)
+  const dob = expectedDateOfBirthOrAdoptionDateOrBirthDate
+    ? parseISO(expectedDateOfBirthOrAdoptionDateOrBirthDate)
+    : null
+  // Day before child becomes 2 years old
+  const maximumEndDate = dob
+    ? addDays(addMonths(dob, usageMaxMonths), -1)
+    : undefined
 
   useEffect(() => {
     if (currentIndex < 0) {
@@ -83,6 +97,7 @@ export const PeriodEndDate: FC<
           title,
           id: fieldId,
           minDate: props.minDate,
+          maxDate: maximumEndDate,
           excludeDates: props.excludeDates,
           children: undefined,
           placeholder: parentalLeaveFormMessages.endDate.placeholder,

--- a/libs/application/templates/parental-leave/src/lib/answerValidationSections/utils.ts
+++ b/libs/application/templates/parental-leave/src/lib/answerValidationSections/utils.ts
@@ -16,10 +16,7 @@ import {
   StaticText,
   StaticTextObject,
 } from '@island.is/application/types'
-import {
-  StartDateOptions,
-  MINIMUM_PERIOD_LENGTH,
-} from '../../constants'
+import { StartDateOptions, MINIMUM_PERIOD_LENGTH } from '../../constants'
 import { getExpectedDateOfBirthOrAdoptionDateOrBirthDate } from '../parentalLeaveUtils'
 import {
   minimumPeriodStartBeforeExpectedDateOfBirth,
@@ -231,7 +228,7 @@ export const validatePeriod = (
       )
     }
 
-    if (endDateValue > maximumEndDate) {
+    if (endDateValue >= maximumEndDate) {
       return buildError(
         useLength === YES ? 'endDateDuration' : 'endDate',
         errorMessages.periodsPeriodRange,


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced dynamic date calculations in the parental leave form, offering a more intuitive period end date selection based on expected arrival or adoption dates.
- **Bug Fixes**
  - Refined date validation to correctly accept an end date that matches the calculated maximum threshold, ensuring smoother form submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->