### PR TITLE
hotfix(bff):bff reverse user refresh param

### DIFF
--- a/libs/react-spa/bff/src/lib/BffPoller.tsx
+++ b/libs/react-spa/bff/src/lib/BffPoller.tsx
@@ -48,10 +48,7 @@ export const BffPoller = ({
   const { postMessage } = useBffBroadcaster()
   const bffBaseUrl = bffUrlGenerator()
 
-  const url = useMemo(
-    () => bffUrlGenerator('/user', { refresh: 'true' }),
-    [bffUrlGenerator],
-  )
+  const url = useMemo(() => bffUrlGenerator('/user'), [bffUrlGenerator])
 
   const fetchUser = useCallback(async () => {
     const res = await fetch(url, {

--- a/libs/react-spa/bff/src/lib/BffPoller.tsx
+++ b/libs/react-spa/bff/src/lib/BffPoller.tsx
@@ -48,7 +48,13 @@ export const BffPoller = ({
   const { postMessage } = useBffBroadcaster()
   const bffBaseUrl = bffUrlGenerator()
 
-  const url = useMemo(() => bffUrlGenerator('/user'), [bffUrlGenerator])
+  const url = useMemo(
+    () =>
+      bffUrlGenerator('/user', {
+        refresh: 'false',
+      }),
+    [bffUrlGenerator],
+  )
 
   const fetchUser = useCallback(async () => {
     const res = await fetch(url, {

--- a/libs/react-spa/bff/src/lib/BffProvider.tsx
+++ b/libs/react-spa/bff/src/lib/BffProvider.tsx
@@ -124,14 +124,14 @@ export const BffProvider = ({
     return params
   }, [applicationBasePath, oldLoginPath])
 
-  const checkLogin = async (noRefresh = false) => {
+  const checkLogin = async () => {
     dispatch({
       type: ActionType.SIGNIN_START,
     })
 
     try {
       const url = bffUrlGenerator('/user', {
-        refresh: noRefresh.toString(),
+        refresh: 'true',
       })
 
       const res = await fetch(url, {


### PR DESCRIPTION
- The BFF token refresh rotation was reversed during polling and on initial load.

- Since bff user endpoint needs to be specific about the refresh param we pass it along with the poller request.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
