### PR TITLE
fix(web): Hotfix - Readspeaker href gets opened by Plausible outbound link tracking script (#17981)

### DIFF
--- a/apps/web/components/Webreader/Webreader.tsx
+++ b/apps/web/components/Webreader/Webreader.tsx
@@ -117,6 +117,9 @@ const Webreader: FC<React.PropsWithChildren<WebReaderProps>> = ({
           accessKey="L"
           title={buttonTitle}
           href={href}
+          onClick={(event) => {
+            event.preventDefault() // So the Plausible outbound link tracking script doesn't open the href
+          }}
         >
           <span className="rsbtn_left rsimg rspart">
             <span className="rsbtn_text">


### PR DESCRIPTION

# Hotfix - Readspeaker href gets opened by Plausible outbound link tracking script (#17981)
