### PR TITLE
fix(web): Hotfix - Form, English locale with different options doesn't load email config correctly (#18015)

### DIFF
--- a/apps/web/components/Form/Form.tsx
+++ b/apps/web/components/Form/Form.tsx
@@ -639,6 +639,7 @@ export const Form = ({ form }: FormProps) => {
               files: files.map((f) => f[1]).flat(),
               recipientFormFieldDeciderValue:
                 getRecipientFormFieldDeciderValue(),
+              lang: activeLocale,
             },
           },
         }).then(() => {

--- a/libs/api/domains/communications/src/lib/communications.service.ts
+++ b/libs/api/domains/communications/src/lib/communications.service.ts
@@ -153,7 +153,7 @@ export class CommunicationsService {
   async sendFormResponse(input: GenericFormInput): Promise<boolean> {
     const form = await this.cmsContentfulService.getForm({
       id: input.id,
-      lang: 'is-IS',
+      lang: input.lang === 'en' ? 'en' : 'is-IS',
     })
     if (!form) {
       return false

--- a/libs/api/domains/communications/src/lib/dto/genericForm.input.ts
+++ b/libs/api/domains/communications/src/lib/dto/genericForm.input.ts
@@ -26,4 +26,7 @@ export class GenericFormInput {
 
   @Field({ nullable: true })
   recipientFormFieldDeciderValue?: string
+
+  @Field(() => String, { nullable: true })
+  lang?: string | null
 }


### PR DESCRIPTION


# Hotfix - Form, English locale with different options doesn't load email config correctly (#18015)
