### PR TITLE
fix(web): Change asset link extension tag

### DIFF
--- a/libs/island-ui/contentful/src/lib/AssetLink/AssetLink.tsx
+++ b/libs/island-ui/contentful/src/lib/AssetLink/AssetLink.tsx
@@ -11,14 +11,19 @@ export const AssetLink: FC<React.PropsWithChildren<AssetLinkProps>> = ({
   url,
   children,
 }) => {
+  let extension: string
   const parts = url.split('.')
-  const extension = parts[parts.length - 1].toUpperCase()
+  extension = parts[parts.length - 1].toUpperCase()
+
+  if (url.includes('videos.ctfassets') && extension.length >= 10) {
+    extension = 'VIDEO'
+  }
 
   const secureUrl = `${url.startsWith('//') ? 'https:' : ''}${url}`
 
   return (
     <FocusableBox href={secureUrl} border="standard" borderRadius="large">
-      <LinkCard background="white" tag={extension}>
+      <LinkCard background="white" tag={extension.length < 10 ? extension : ''}>
         {title || children}
       </LinkCard>
     </FocusableBox>


### PR DESCRIPTION
# Change asset link extension tag

## What

- Handle asset link extension tag when it is video and does not have dot extension in url
- Do not render extension tag if it is to long

## Why

- Because if file has no dot extension in the end then the tag text was far too long and had affect the site style

## Screenshots / Gifs

### Before
![image](https://github.com/user-attachments/assets/7a8b6699-a9b7-47f3-9e2a-8a5d64a39da2)

### After
![image](https://github.com/user-attachments/assets/0b1e80df-9476-48b7-9ed2-178396ed3b90)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
