### PR TITLE
fix(ids-admin): Add missing return type for OpenApi

### DIFF
--- a/apps/services/auth/ids-api/src/app/confirm-identity/confirm-identity.controller.ts
+++ b/apps/services/auth/ids-api/src/app/confirm-identity/confirm-identity.controller.ts
@@ -60,6 +60,7 @@ export class ConfirmIdentityController {
   @Documentation({
     response: {
       status: 200,
+      type: IdentityConfirmationDTO,
     },
     request: {
       params: {


### PR DESCRIPTION
## What

GET `/confirm-identity/id` was missing return type for open api docs 

## Why

So it can be generated for ids

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Enhanced API documentation for identity confirmation responses by clarifying the expected response format for successful requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->