### PR TITLE
fix(secondary school): Change into buildPhoneField so that zod validation does not fail

### DIFF
--- a/libs/application/templates/secondary-school/src/forms/secondarySchoolForm/userInformationSection/personalSubSection.ts
+++ b/libs/application/templates/secondary-school/src/forms/secondarySchoolForm/userInformationSection/personalSubSection.ts
@@ -3,6 +3,7 @@ import {
   buildDescriptionField,
   buildHiddenInput,
   buildMultiField,
+  buildPhoneField,
   buildRadioField,
   buildSubSection,
   buildTextField,
@@ -64,12 +65,10 @@ export const personalSubSection = buildSubSection({
             return userProfile?.email
           },
         }),
-        buildTextField({
+        buildPhoneField({
           id: 'applicant.phoneNumber',
           title: userInformation.applicant.phone,
           width: 'half',
-          variant: 'tel',
-          format: '###-####',
           condition: (_1, _2, user) => {
             return !checkIsActor(user)
           },


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the phone number input on the secondary school application form to automatically use your registered mobile phone number for a more streamlined and accurate experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->