### PR TITLE
fix(new-primary-school): Tag shown in the language overview page instead of value

### DIFF
--- a/libs/application/templates/new-primary-school/src/fields/Review/review-groups/Languages.tsx
+++ b/libs/application/templates/new-primary-school/src/fields/Review/review-groups/Languages.tsx
@@ -83,7 +83,7 @@ export const Languages = ({
                       label={formatMessage(
                         newPrimarySchoolMessages.differentNeeds
                           .languageSelectionTitle,
-                        { no: `${index + 1}` },
+                        { index: `${index + 1}` },
                       )}
                       value={getLanguageByCode(code)?.name}
                     />


### PR DESCRIPTION
[TS-990](https://dit-iceland.atlassian.net/browse/TS-990)

<img width="1118" alt="image" src="https://github.com/user-attachments/assets/b1039154-e018-42d6-91f4-f1dc5766c3c5" />

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Revised the formatting for language selection to ensure a more intuitive display of language order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->