### PR TITLE
chore(j-s): Add fileName to indictment pdfs in indictment case files list

### DIFF
--- a/apps/judicial-system/web/src/components/IndictmentCaseFilesList/IndictmentCaseFilesList.tsx
+++ b/apps/judicial-system/web/src/components/IndictmentCaseFilesList/IndictmentCaseFilesList.tsx
@@ -187,6 +187,7 @@ const IndictmentCaseFilesList: FC<Props> = ({
                 title={formatMessage(caseFiles.indictmentTitle)}
                 pdfType="indictment"
                 renderAs="row"
+                elementId="Ákæra"
               />
             </Box>
           </Box>


### PR DESCRIPTION
# Add fileName to indictment pdfs in indictment case files list

[Asana](https://app.asana.com/0/1199153462262248/1209508264598989)

## What

In #18066, we implemented a filename for indictment pdfs. We forgot to put the filename in the indictment case file list. This PR does that.

## Why

So that when users download the file, the suggested name is Ákæra instead of indictment

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced the PDF download button by adding an internal identifier. There are no visible changes to its functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->