### PR TITLE
chore: Add config for `markdownlint`

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,4 @@
+line-length:
+  line_length: 500
+  heading_line_length: 80
+  code_block_line_length: 100

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,7 @@
 {
-  "recommendations": ["esbenp.prettier-vscode", "firsttris.vscode-jest-runner"]
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "firsttris.vscode-jest-runner",
+    "DavidAnson.vscode-markdownlint"
+  ]
 }


### PR DESCRIPTION
Stop those annoying "line too long" warnings in my editor. Also, suggest a plugin (and add config), so more will follow its style guide.