### PR TITLE
fix(ids-api): Fix guards for Confirm-Identity controller

### DIFF
--- a/apps/services/auth/ids-api/src/app/confirm-identity/confirm-identity.controller.ts
+++ b/apps/services/auth/ids-api/src/app/confirm-identity/confirm-identity.controller.ts
@@ -15,6 +15,7 @@ import {
 import { ApiTags } from '@nestjs/swagger'
 import {
   CurrentUser,
+  IdsAuthGuard,
   IdsUserGuard,
   Scopes,
   ScopesGuard,
@@ -23,7 +24,7 @@ import type { User } from '@island.is/auth-nest-tools'
 
 const namespace = '@island.is/auth/confirm-identity'
 
-@UseGuards(IdsUserGuard, ScopesGuard)
+@UseGuards(ScopesGuard)
 @Scopes('@identityserver.api/authentication')
 @ApiTags('confirm-identity')
 @Controller({
@@ -37,6 +38,7 @@ export class ConfirmIdentityController {
   ) {}
 
   @Post(':id')
+  @UseGuards(IdsUserGuard)
   @Documentation({
     response: {
       status: 200,
@@ -57,6 +59,7 @@ export class ConfirmIdentityController {
   }
 
   @Get(':id')
+  @UseGuards(IdsAuthGuard)
   @Documentation({
     response: {
       status: 200,


### PR DESCRIPTION
## What

Set IdsAuthGuard to GET method, and IdsUserGuard for the POST method

## Why

Because we need the user info in the POST route and not the GET route

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the security of identity verification processes by updating how authentication checks are applied. Specific routes now have tailored security measures to ensure robust and targeted access control, improving the overall user experience during identity confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->