### PR TITLE
fix(web): Generic List Items - Handle urls of depth 4

### DIFF
--- a/apps/web/pages/s/[...slugs]/index.tsx
+++ b/apps/web/pages/s/[...slugs]/index.tsx
@@ -401,7 +401,9 @@ Component.getProps = async (context) => {
         throw error
       }
     }
+  }
 
+  if (slugs.length === 4) {
     return {
       page: {
         type: PageType.GENERIC_LIST_ITEM,

--- a/apps/web/screens/GenericList/GenericListItem.tsx
+++ b/apps/web/screens/GenericList/GenericListItem.tsx
@@ -115,8 +115,9 @@ const GenericListItemPage: Screen<GenericListItemPageProps> = ({
 }
 
 GenericListItemPage.getProps = async ({ apolloClient, query, locale }) => {
+  const querySlugs = (query.slugs ?? []) as string[]
   const slug =
-    (query.slugs as string[])?.[2] ?? (query.genericListItemSlug as string)
+    querySlugs[querySlugs.length - 1] ?? (query.genericListItemSlug as string)
 
   if (!slug) {
     throw new CustomNextError(


### PR DESCRIPTION
# Generic List Items - Handle urls of depth 4

Handle urls of depth 4 (org page, parent subpage, org subpage, generic list item)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new routing behavior that renders a generic list item page when exactly four URL segments are provided.
  
- **Bug Fixes**
	- Improved the URL parameter processing by always using the most recent segment for content retrieval, ensuring more reliable page navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->