### PR TITLE
fix(api): Health Directorate - Prescription 

### DIFF
--- a/libs/api/domains/health-directorate/src/lib/health-directorate.service.ts
+++ b/libs/api/domains/health-directorate/src/lib/health-directorate.service.ts
@@ -240,7 +240,7 @@ export class HealthDirectorateService {
                   name: item.productName,
                   strength: item.productStrength,
                   amount: item.dispensedAmountDisplay,
-                  numberOfPackages: item.numberOfPackages,
+                  numberOfPackages: item.numberOfPackages?.toString(),
                 }
               }),
             }

--- a/libs/api/domains/health-directorate/src/lib/models/dispensations.model.ts
+++ b/libs/api/domains/health-directorate/src/lib/models/dispensations.model.ts
@@ -20,8 +20,8 @@ export class DispensedItem {
   @Field({ nullable: true })
   amount?: string
 
-  @Field(() => Int, { nullable: true })
-  numberOfPackages?: number
+  @Field({ nullable: true })
+  numberOfPackages?: string
 
   @Field({ nullable: true })
   quantity?: string


### PR DESCRIPTION
# Health Directorate - Prescriptions

* Dispensation item was typed as int but returns float. 
* Changed to string to prevent further number issues

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
