### PR TITLE
chore(web): My pages dropdown button feature is back and can now be turned on/off

### DIFF
--- a/apps/web/components/Header/Header.tsx
+++ b/apps/web/components/Header/Header.tsx
@@ -34,6 +34,7 @@ interface HeaderProps {
   organizationSearchFilter?: string
   searchPlaceholder?: string
   customTopLoginButtonItem?: LayoutProps['customTopLoginButtonItem']
+  loginButtonType?: 'dropdown' | 'link'
 }
 
 const marginLeft = [1, 1, 1, 2] as ResponsiveSpace
@@ -46,6 +47,7 @@ export const Header: FC<React.PropsWithChildren<HeaderProps>> = ({
   organizationSearchFilter,
   searchPlaceholder,
   customTopLoginButtonItem,
+  loginButtonType = 'dropdown',
   children,
 }) => {
   const { activeLocale, t } = useI18n()
@@ -109,6 +111,7 @@ export const Header: FC<React.PropsWithChildren<HeaderProps>> = ({
                       <LoginButton
                         colorScheme={buttonColorScheme}
                         topItem={customTopLoginButtonItem}
+                        type={loginButtonType}
                       />
                     </Box>
 

--- a/apps/web/components/Header/Header.tsx
+++ b/apps/web/components/Header/Header.tsx
@@ -33,6 +33,7 @@ interface HeaderProps {
   megaMenuData
   organizationSearchFilter?: string
   searchPlaceholder?: string
+  customTopLoginButtonItem?: LayoutProps['customTopLoginButtonItem']
 }
 
 const marginLeft = [1, 1, 1, 2] as ResponsiveSpace
@@ -44,6 +45,7 @@ export const Header: FC<React.PropsWithChildren<HeaderProps>> = ({
   languageToggleQueryParams,
   organizationSearchFilter,
   searchPlaceholder,
+  customTopLoginButtonItem,
   children,
 }) => {
   const { activeLocale, t } = useI18n()
@@ -104,7 +106,10 @@ export const Header: FC<React.PropsWithChildren<HeaderProps>> = ({
                     )}
 
                     <Box marginLeft={marginLeft}>
-                      <LoginButton colorScheme={buttonColorScheme} />
+                      <LoginButton
+                        colorScheme={buttonColorScheme}
+                        topItem={customTopLoginButtonItem}
+                      />
                     </Box>
 
                     <Box

--- a/apps/web/components/Header/LoginButton.tsx
+++ b/apps/web/components/Header/LoginButton.tsx
@@ -1,6 +1,5 @@
 import React, { MouseEvent } from 'react'
 import { useWindowSize } from 'react-use'
-import cn from 'classnames'
 import { useRouter } from 'next/router'
 
 import {
@@ -12,16 +11,20 @@ import {
 } from '@island.is/island-ui/core'
 import { theme } from '@island.is/island-ui/theme'
 import { webLoginButtonSelect } from '@island.is/plausible'
+import { ProjectBasePath } from '@island.is/shared/constants'
 import { useI18n } from '@island.is/web/i18n'
 import { LayoutProps } from '@island.is/web/layouts/main'
 
 const minarsidurLink = '/minarsidur/'
 const minarsidurDelegationsLink = '/bff/login?prompt=select_account'
 
-export function LoginButton(props: {
+interface Props {
   colorScheme: ButtonTypes['colorScheme']
   topItem?: LayoutProps['customTopLoginButtonItem']
-}) {
+  type?: 'dropdown' | 'link'
+}
+
+function LoginButtonDropdown(props: Props) {
   const { t } = useI18n()
   const router = useRouter()
   const { width } = useWindowSize()
@@ -130,4 +133,29 @@ export function LoginButton(props: {
       items={items}
     />
   )
+}
+
+const LoginButtonLink = (props: Props) => {
+  const { t } = useI18n()
+  const { width } = useWindowSize()
+  const isMobile = width < theme.breakpoints.md
+
+  return (
+    <a href={ProjectBasePath.ServicePortal} tabIndex={-1}>
+      <Button
+        colorScheme={props.colorScheme}
+        variant="utility"
+        icon="person"
+        title={isMobile ? t.login : undefined}
+        as="span"
+      >
+        {!isMobile && t.login}
+      </Button>
+    </a>
+  )
+}
+
+export const LoginButton = (props: Props) => {
+  if (props.type === 'link') return <LoginButtonLink {...props} />
+  return <LoginButtonDropdown {...props} />
 }

--- a/apps/web/components/Header/LoginButton.tsx
+++ b/apps/web/components/Header/LoginButton.tsx
@@ -1,30 +1,133 @@
-import React from 'react'
+import React, { MouseEvent } from 'react'
 import { useWindowSize } from 'react-use'
+import cn from 'classnames'
+import { useRouter } from 'next/router'
 
-import { Button, ButtonTypes } from '@island.is/island-ui/core'
+import {
+  Button,
+  ButtonTypes,
+  DropdownMenu,
+  Inline,
+  Logo,
+} from '@island.is/island-ui/core'
 import { theme } from '@island.is/island-ui/theme'
-import { ProjectBasePath } from '@island.is/shared/constants'
+import { webLoginButtonSelect } from '@island.is/plausible'
 import { useI18n } from '@island.is/web/i18n'
+import { LayoutProps } from '@island.is/web/layouts/main'
 
-export const LoginButton = (props: {
+const minarsidurLink = '/minarsidur/'
+const minarsidurDelegationsLink = '/bff/login?prompt=select_account'
+
+export function LoginButton(props: {
   colorScheme: ButtonTypes['colorScheme']
-}) => {
+  topItem?: LayoutProps['customTopLoginButtonItem']
+}) {
   const { t } = useI18n()
+  const router = useRouter()
   const { width } = useWindowSize()
+
+  function trackAndNavigate(
+    buttonType: 'Dropdown - Individuals' | 'Dropdown - Companies' | string,
+    event: MouseEvent<HTMLAnchorElement>,
+  ) {
+    event.preventDefault()
+    const href = event.currentTarget.href
+
+    // If the plausible script is not loaded (For example in case of adBlocker) the user will be navigated directly to /minarsidur.
+    if (window?.plausible) {
+      // In case the script is there, but the event is not firing (different adBlock settings) then the user is navigated without Plausible callback.
+      const id = window.setTimeout(() => {
+        window.location.assign(href)
+      }, 500)
+
+      // The plausible custom event.
+      webLoginButtonSelect(buttonType, () => {
+        window.clearTimeout(id)
+        window.location.assign(href)
+      })
+    } else {
+      window.location.assign(href)
+    }
+  }
+
+  const items = [
+    {
+      href: minarsidurLink,
+      title: (
+        <Inline alignY="center" space={1} flexWrap="nowrap">
+          {props.topItem && (
+            <Logo
+              width={17}
+              height={17}
+              iconOnly={true}
+              id="minar-sidur-individuals"
+              solid={false}
+            />
+          )}
+          {t.loginIndividuals}
+        </Inline>
+      ),
+      onClick: trackAndNavigate.bind(null, 'Dropdown - Individuals'),
+    },
+    {
+      href: minarsidurDelegationsLink,
+      title: (
+        <Inline alignY="center" space={1} flexWrap="nowrap">
+          {props.topItem && (
+            <Logo
+              width={17}
+              height={17}
+              iconOnly={true}
+              id="minar-sidur-companies"
+              solid={false}
+            />
+          )}
+          {t.loginDelegations}
+        </Inline>
+      ),
+      onClick: trackAndNavigate.bind(null, 'Dropdown - Companies'),
+    },
+  ]
+
+  if (
+    props.topItem &&
+    !props.topItem.blacklistedPathnames?.includes(
+      new URL(router.asPath, 'https://island.is').pathname,
+    )
+  ) {
+    items.unshift({
+      href: props.topItem.href,
+      title: (
+        <Inline alignY="center" space={1} flexWrap="nowrap">
+          {props.topItem.imgSrc && (
+            <img width={17} height={17} src={props.topItem.imgSrc} alt="" />
+          )}
+          {props.topItem.label}
+        </Inline>
+      ),
+      onClick: trackAndNavigate.bind(null, props.topItem.buttonType),
+    })
+  }
 
   const isMobile = width < theme.breakpoints.md
 
   return (
-    <a href={ProjectBasePath.ServicePortal} tabIndex={-1}>
-      <Button
-        colorScheme={props.colorScheme}
-        variant="utility"
-        icon="person"
-        title={isMobile ? t.login : undefined}
-        as="span"
-      >
-        {!isMobile && t.login}
-      </Button>
-    </a>
+    <DropdownMenu
+      fixed
+      disclosure={
+        <Button
+          colorScheme={props.colorScheme}
+          variant="utility"
+          icon="person"
+          title={isMobile ? t.login : undefined}
+        >
+          {!isMobile && t.login}
+        </Button>
+      }
+      openOnHover={!isMobile}
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore make web strict
+      items={items}
+    />
   )
 }

--- a/apps/web/hooks/useLinkResolver/useLinkResolver.ts
+++ b/apps/web/hooks/useLinkResolver/useLinkResolver.ts
@@ -107,6 +107,10 @@ export const routesTemplate = {
     is: '/s/tryggingastofnun/reiknivel',
     en: '/en/o/social-insurance-administration/calculator',
   },
+  directorateoflabourmypages: {
+    is: '/s/vinnumalastofnun/minar-sidur',
+    en: '/en/o/directorate-of-labour/my-pages',
+  },
   digitalicelandservices: {
     is: '/s/stafraent-island/thjonustur',
     en: '/en/o/digital-iceland/island-services',

--- a/apps/web/layouts/main.tsx
+++ b/apps/web/layouts/main.tsx
@@ -116,6 +116,7 @@ export interface LayoutProps {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-expect-error make web strict
   megaMenuData
+  customTopLoginButtonItem: LayoutComponentProps['customTopLoginButtonItem']
   children?: React.ReactNode
 }
 
@@ -158,6 +159,7 @@ const Layout: Screen<LayoutProps> = ({
   respOrigin,
   children,
   megaMenuData,
+  customTopLoginButtonItem,
 }) => {
   const { activeLocale, t } = useI18n()
   const { linkResolver } = useLinkResolver()
@@ -411,6 +413,7 @@ const Layout: Screen<LayoutProps> = ({
                       )
                     : undefined
                 }
+                customTopLoginButtonItem={customTopLoginButtonItem}
               />
             </ColorSchemeContext.Provider>
           )}
@@ -693,6 +696,13 @@ interface LayoutComponentProps {
   article?: GetSingleArticleQuery['getSingleArticle']
   customAlertBanner?: GetAlertBannerQuery['getAlertBanner']
   languageToggleQueryParams?: LayoutProps['languageToggleQueryParams']
+  customTopLoginButtonItem?: {
+    href: string
+    imgSrc: string
+    label: string
+    buttonType: string
+    blacklistedPathnames?: string[]
+  }
 }
 
 export const withMainLayout = <T, C extends ScreenContext>(
@@ -738,6 +748,9 @@ export const withMainLayout = <T, C extends ScreenContext>(
     const languageToggleQueryParams =
       layoutComponentProps?.languageToggleQueryParams
 
+    const customTopLoginButtonItem =
+      layoutComponentProps?.customTopLoginButtonItem
+
     return {
       layoutProps: {
         ...layoutProps,
@@ -747,6 +760,7 @@ export const withMainLayout = <T, C extends ScreenContext>(
         articleAlertBannerContent,
         customAlertBannerContent,
         languageToggleQueryParams,
+        customTopLoginButtonItem,
       },
       componentProps,
     }

--- a/apps/web/layouts/main.tsx
+++ b/apps/web/layouts/main.tsx
@@ -414,6 +414,7 @@ const Layout: Screen<LayoutProps> = ({
                     : undefined
                 }
                 customTopLoginButtonItem={customTopLoginButtonItem}
+                loginButtonType={n('minarsidurLoginButtonType', 'dropdown')}
               />
             </ColorSchemeContext.Provider>
           )}

--- a/apps/web/pages/en/o/directorate-of-labour/my-pages/index.ts
+++ b/apps/web/pages/en/o/directorate-of-labour/my-pages/index.ts
@@ -1,0 +1,12 @@
+import withApollo from '@island.is/web/graphql/withApollo'
+import { withLocale } from '@island.is/web/i18n'
+import MyPages from '@island.is/web/screens/Organization/DirectorateOfLabour/MyPages'
+import { getServerSidePropsWrapper } from '@island.is/web/utils/getServerSidePropsWrapper'
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore make web strict
+const Screen = withApollo(withLocale('en')(MyPages))
+
+export default Screen
+
+export const getServerSideProps = getServerSidePropsWrapper(Screen)

--- a/apps/web/pages/s/vinnumalastofnun/minar-sidur/index.ts
+++ b/apps/web/pages/s/vinnumalastofnun/minar-sidur/index.ts
@@ -1,0 +1,12 @@
+import withApollo from '@island.is/web/graphql/withApollo'
+import { withLocale } from '@island.is/web/i18n'
+import MyPages from '@island.is/web/screens/Organization/DirectorateOfLabour/MyPages'
+import { getServerSidePropsWrapper } from '@island.is/web/utils/getServerSidePropsWrapper'
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore make web strict
+const Screen = withApollo(withLocale('is')(MyPages))
+
+export default Screen
+
+export const getServerSideProps = getServerSidePropsWrapper(Screen)

--- a/apps/web/screens/Article/Article.tsx
+++ b/apps/web/screens/Article/Article.tsx
@@ -932,6 +932,7 @@ ArticleScreen.getProps = async ({ apolloClient, query, locale }) => {
     namespace,
     stepOptionsFromNamespace,
     stepperNamespace,
+    customTopLoginButtonItem: organizationNamespace?.customTopLoginButtonItem,
     organizationNamespace,
     ...getThemeConfig(article),
   }

--- a/apps/web/screens/Organization/DirectorateOfLabour/MyPages.strings.ts
+++ b/apps/web/screens/Organization/DirectorateOfLabour/MyPages.strings.ts
@@ -1,0 +1,58 @@
+import { defineMessages } from 'react-intl'
+
+export const m = defineMessages({
+  mainTitle: {
+    id: 'web.directorateOfLabour.myPages:mainTitle',
+    defaultMessage: 'Mínar síður Vinnumálastofnunar',
+    description: 'Mínar síður Vinnumálastofnunar',
+  },
+  individualsLabel: {
+    id: 'web.directorateOfLabour.myPages:individualsLabel',
+    defaultMessage: 'Einstaklingar',
+    description: 'Einstaklingar',
+  },
+  individualsDescription: {
+    id: 'web.directorateOfLabour.myPages:individualsDescription',
+    defaultMessage: 'Mínar síður fyrir einstaklinga.',
+    description: 'Mínar síður fyrir einstaklinga.',
+  },
+  individualsHref: {
+    id: 'web.directorateOfLabour.myPages:individualsHref',
+    defaultMessage: 'https://vinnumalastofnun.is/islandisatvinnuleitandi',
+    description: 'https://vinnumalastofnun.is/islandisatvinnuleitandi',
+  },
+  individualsImageSrc: {
+    id: 'web.directorateOfLabour.myPages:individualsImageSrc',
+    defaultMessage:
+      'https://images.ctfassets.net/8k0h54kbe6bj/74YI1HhTZ5ufC1qSsr2TEF/315ca87541dd256c196d6394a6ecf50b/Vinnumalastofnun-Logo.svg',
+    description:
+      'https://images.ctfassets.net/8k0h54kbe6bj/74YI1HhTZ5ufC1qSsr2TEF/315ca87541dd256c196d6394a6ecf50b/Vinnumalastofnun-Logo.svg',
+  },
+  companyLabel: {
+    id: 'web.directorateOfLabour.myPages:companyLabel',
+    defaultMessage: 'Fyrirtæki',
+    description: 'Fyrirtæki',
+  },
+  companyDescription: {
+    id: 'web.directorateOfLabour.myPages:companyDescription',
+    defaultMessage: 'Mínar síður fyrir atvinnurekendur og fyrirtæki.',
+    description: 'Mínar síður fyrir atvinnurekendur og fyrirtæki.',
+  },
+  companyHref: {
+    id: 'web.directorateOfLabour.myPages:companyHref',
+    defaultMessage: 'https://vinnumalastofnun.is/islandisatvinnurekandi',
+    description: 'https://vinnumalastofnun.is/islandisatvinnurekandi',
+  },
+  companyImageSrc: {
+    id: 'web.directorateOfLabour.myPages:companyImageSrc',
+    defaultMessage:
+      'https://images.ctfassets.net/8k0h54kbe6bj/74YI1HhTZ5ufC1qSsr2TEF/315ca87541dd256c196d6394a6ecf50b/Vinnumalastofnun-Logo.svg',
+    description:
+      'https://images.ctfassets.net/8k0h54kbe6bj/74YI1HhTZ5ufC1qSsr2TEF/315ca87541dd256c196d6394a6ecf50b/Vinnumalastofnun-Logo.svg',
+  },
+  loginLabel: {
+    id: 'web.directorateOfLabour.myPages:loginLabel',
+    defaultMessage: 'Innskráning',
+    description: 'Innskráning',
+  },
+})

--- a/apps/web/screens/Organization/DirectorateOfLabour/MyPages.tsx
+++ b/apps/web/screens/Organization/DirectorateOfLabour/MyPages.tsx
@@ -168,6 +168,10 @@ MyPages.getProps = async ({ apolloClient, locale }) => {
     getOrganizationPage.organization,
   )
 
+  if (organizationNamespace?.myPagesJumpPageIsDisabled) {
+    throw new CustomNextError(404, 'VMST my pages link page has been disabled')
+  }
+
   return {
     organizationPage: getOrganizationPage,
     namespace,

--- a/apps/web/screens/Organization/DirectorateOfLabour/MyPages.tsx
+++ b/apps/web/screens/Organization/DirectorateOfLabour/MyPages.tsx
@@ -1,0 +1,186 @@
+import { useIntl } from 'react-intl'
+import { useRouter } from 'next/router'
+
+import {
+  Box,
+  CategoryCard,
+  GridColumn,
+  GridRow,
+  Stack,
+  Text,
+} from '@island.is/island-ui/core'
+import {
+  OrganizationFooter,
+  OrganizationWrapper,
+} from '@island.is/web/components'
+import {
+  ContentLanguage,
+  CustomPageUniqueIdentifier,
+  GetNamespaceQuery,
+  OrganizationPage,
+  Query,
+  QueryGetNamespaceArgs,
+  QueryGetOrganizationPageArgs,
+} from '@island.is/web/graphql/schema'
+import { useNamespace } from '@island.is/web/hooks'
+import { useI18n } from '@island.is/web/i18n'
+import { withMainLayout } from '@island.is/web/layouts/main'
+import { CustomNextError } from '@island.is/web/units/errors'
+import { extractNamespaceFromOrganization } from '@island.is/web/utils/extractNamespaceFromOrganization'
+import { getOrganizationSidebarNavigationItems } from '@island.is/web/utils/organization'
+import { webRichText } from '@island.is/web/utils/richText'
+
+import {
+  CustomScreen,
+  withCustomPageWrapper,
+} from '../../CustomPage/CustomPageWrapper'
+import { GET_NAMESPACE_QUERY, GET_ORGANIZATION_PAGE_QUERY } from '../../queries'
+import { m } from './MyPages.strings'
+
+interface MyPagesProps {
+  organizationPage: OrganizationPage
+  namespace: Record<string, string>
+}
+
+const MyPages: CustomScreen<MyPagesProps> = ({
+  organizationPage,
+  namespace,
+  customPageData,
+}) => {
+  const n = useNamespace(namespace)
+  const router = useRouter()
+  const baseRouterPath = router.asPath.split('?')[0].split('#')[0]
+  const { activeLocale } = useI18n()
+  const { formatMessage } = useIntl()
+
+  return (
+    <OrganizationWrapper
+      navigationData={{
+        title: n(
+          'navigationTitle',
+          activeLocale === 'is' ? 'Efnisyfirlit' : 'Menu',
+        ),
+        items: getOrganizationSidebarNavigationItems(
+          organizationPage,
+          baseRouterPath,
+        ),
+      }}
+      organizationPage={organizationPage}
+      pageTitle={formatMessage(m.mainTitle)}
+      minimal
+      mainContent={
+        <Box paddingBottom={8} paddingTop={[1, 1, 2]}>
+          <Stack space={5}>
+            <Text variant="h1" as="h1">
+              {formatMessage(m.mainTitle)}
+            </Text>
+            <GridRow
+              rowGap={5}
+              direction={[
+                'columnReverse',
+                'columnReverse',
+                'columnReverse',
+                'row',
+              ]}
+            >
+              <GridColumn span={['1/1', '1/1', '1/1', '4/7', '6/12']}>
+                <Stack space={1}>
+                  {webRichText(
+                    customPageData?.content ?? [],
+                    undefined,
+                    activeLocale,
+                  )}
+                </Stack>
+              </GridColumn>
+              <GridColumn span={['1/1', '1/1', '1/1', '3/7', '6/12']}>
+                <Stack space={3}>
+                  <CategoryCard
+                    heading={formatMessage(m.individualsLabel)}
+                    text={formatMessage(m.individualsDescription)}
+                    href={formatMessage(m.individualsHref)}
+                    src={formatMessage(m.individualsImageSrc)}
+                    alt=""
+                    autoStack={true}
+                  />
+                  <CategoryCard
+                    heading={formatMessage(m.companyLabel)}
+                    text={formatMessage(m.companyDescription)}
+                    href={formatMessage(m.companyHref)}
+                    src={formatMessage(m.companyImageSrc)}
+                    alt=""
+                    autoStack={true}
+                  />
+                </Stack>
+              </GridColumn>
+            </GridRow>
+          </Stack>
+        </Box>
+      }
+    >
+      {organizationPage.organization && (
+        <OrganizationFooter organizations={[organizationPage.organization]} />
+      )}
+    </OrganizationWrapper>
+  )
+}
+
+MyPages.getProps = async ({ apolloClient, locale }) => {
+  const organizationSlug =
+    locale === 'en' ? 'directorate-of-labour' : 'vinnumalastofnun'
+
+  const [
+    {
+      data: { getOrganizationPage },
+    },
+    namespace,
+  ] = await Promise.all([
+    apolloClient.query<Query, QueryGetOrganizationPageArgs>({
+      query: GET_ORGANIZATION_PAGE_QUERY,
+      variables: {
+        input: {
+          slug: organizationSlug,
+          lang: locale as ContentLanguage,
+        },
+      },
+    }),
+    apolloClient
+      .query<GetNamespaceQuery, QueryGetNamespaceArgs>({
+        query: GET_NAMESPACE_QUERY,
+        variables: {
+          input: {
+            namespace: 'OrganizationPages',
+            lang: locale as ContentLanguage,
+          },
+        },
+      })
+      .then((res) =>
+        res.data.getNamespace?.fields
+          ? JSON.parse(res.data.getNamespace.fields)
+          : {},
+      ),
+  ])
+
+  if (!getOrganizationPage) {
+    throw new CustomNextError(404, 'Organization page not found')
+  }
+
+  const organizationNamespace = extractNamespaceFromOrganization(
+    getOrganizationPage.organization,
+  )
+
+  return {
+    organizationPage: getOrganizationPage,
+    namespace,
+    customTopLoginButtonItem: organizationNamespace?.customTopLoginButtonItem,
+  }
+}
+
+export default withMainLayout(
+  withCustomPageWrapper(
+    CustomPageUniqueIdentifier.DirectorateOfLabourMyPages,
+    MyPages,
+  ),
+  {
+    footerVersion: 'organization',
+  },
+)

--- a/apps/web/screens/Organization/Home/Home.tsx
+++ b/apps/web/screens/Organization/Home/Home.tsx
@@ -344,6 +344,7 @@ Home.getProps = async ({ apolloClient, locale, query, organizationPage }) => {
     organization: getOrganization,
     namespace,
     showSearchInHeader: false,
+    customTopLoginButtonItem: organizationNamespace?.customTopLoginButtonItem,
     ...getThemeConfig(
       getOrganizationPage?.theme ?? 'landing_page',
       getOrganization ?? getOrganizationPage?.organization,

--- a/apps/web/screens/Organization/OrganizationEvents/OrganizationEventArticle.tsx
+++ b/apps/web/screens/Organization/OrganizationEvents/OrganizationEventArticle.tsx
@@ -365,6 +365,7 @@ OrganizationEventArticle.getProps = async ({
     event,
     namespace,
     locale: locale as Locale,
+    customTopLoginButtonItem: organizationNamespace?.customTopLoginButtonItem,
     ...getThemeConfig(organizationPage?.theme, organizationPage?.organization),
   }
 }

--- a/apps/web/screens/Organization/OrganizationEvents/OrganizationEventList.tsx
+++ b/apps/web/screens/Organization/OrganizationEvents/OrganizationEventList.tsx
@@ -288,6 +288,7 @@ OrganizationEventList.getProps = async ({ apolloClient, query, locale }) => {
     eventList: eventsResponse?.data?.getEvents,
     namespace,
     selectedPage,
+    customTopLoginButtonItem: organizationNamespace?.customTopLoginButtonItem,
     ...getThemeConfig(organizationPage?.theme, organizationPage?.organization),
   }
 }

--- a/apps/web/screens/Organization/OrganizationNews/OrganizationNewsArticle.tsx
+++ b/apps/web/screens/Organization/OrganizationNews/OrganizationNewsArticle.tsx
@@ -241,6 +241,7 @@ OrganizationNewsArticle.getProps = async ({
     newsItem,
     namespace,
     locale: locale as Locale,
+    customTopLoginButtonItem: organizationNamespace?.customTopLoginButtonItem,
     ...getThemeConfig(organizationPage?.theme, organizationPage?.organization),
   }
 }

--- a/apps/web/screens/Organization/OrganizationNews/OrganizationNewsList.tsx
+++ b/apps/web/screens/Organization/OrganizationNews/OrganizationNewsList.tsx
@@ -387,6 +387,7 @@ OrganizationNewsList.getProps = async ({ apolloClient, query, locale }) => {
     namespace,
     locale: locale as Locale,
     languageToggleQueryParams,
+    customTopLoginButtonItem: organizationNamespace?.customTopLoginButtonItem,
     ...getThemeConfig(organizationPage?.theme, organizationPage?.organization),
   }
 }

--- a/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculator.tsx
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculator.tsx
@@ -1421,6 +1421,7 @@ PensionCalculator.getProps = async ({
     organizationPage: getOrganizationPage,
     organization: getOrganization,
     defaultValues,
+    customTopLoginButtonItem: organizationNamespace?.customTopLoginButtonItem,
     dateOfCalculationsOptions,
     ...getThemeConfig(
       getOrganizationPage?.theme,

--- a/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculatorResults.tsx
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculatorResults.tsx
@@ -40,6 +40,7 @@ import { useLinkResolver } from '@island.is/web/hooks'
 import { withMainLayout } from '@island.is/web/layouts/main'
 import { CustomNextError } from '@island.is/web/units/errors'
 import { formatCurrency } from '@island.is/web/utils/currency'
+import { extractNamespaceFromOrganization } from '@island.is/web/utils/extractNamespaceFromOrganization'
 
 import {
   CustomScreen,
@@ -740,6 +741,9 @@ PensionCalculatorResults.getProps = async ({
   const queryParams = convertToQueryParams(calculationInput)
   const queryParamsObject = Object.fromEntries(queryParams)
 
+  const organizationNamespace =
+    extractNamespaceFromOrganization(getOrganization)
+
   return {
     organizationPage: getOrganizationPage,
     organization: getOrganization,
@@ -748,6 +752,7 @@ PensionCalculatorResults.getProps = async ({
     calculationInput,
     dateOfCalculationsOptions,
     queryParamString: queryParams.toString(),
+    customTopLoginButtonItem: organizationNamespace?.customTopLoginButtonItem,
     ...getThemeConfig(
       getOrganizationPage?.theme,
       getOrganizationPage?.organization,

--- a/apps/web/screens/Organization/SubPage.tsx
+++ b/apps/web/screens/Organization/SubPage.tsx
@@ -527,6 +527,7 @@ SubPage.getProps = async ({
     namespace,
     showSearchInHeader: false,
     locale: locale as Locale,
+    customTopLoginButtonItem: organizationNamespace?.customTopLoginButtonItem,
     ...getThemeConfig(
       getOrganizationPage?.theme,
       getOrganizationPage?.organization,


### PR DESCRIPTION
# My pages dropdown button feature is back and can now be turned on/off

Reverted https://github.com/island-is/island.is/pull/18068 which was changing the my pages button from being a dropdown to being a link, now we are doing exactly that in this PR but have a way to toggle it on and off.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the login button with a customizable dropdown for dynamic login options.
	- Launched a new localized "My Pages" section for the Directorate of Labour, available in both English and Icelandic.
	- Expanded key organization pages to support the new customizable login feature.

- **Refactor**
	- Streamlined component interactions and routing to seamlessly integrate the enhanced login experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->