### PR TITLE
chore(j-s): Use applyDativeCaseToCourtName everywhere

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/formatters.ts
+++ b/apps/judicial-system/backend/src/app/formatters/formatters.ts
@@ -163,14 +163,15 @@ export const formatDefenderResubmittedToCourtEmailNotification = (
   courtCaseNumber?: string,
 ): SubjectAndBody => {
   const cf = notifications.defenderResubmittedToCourt
+  const courtName = applyDativeCaseToCourtName(court || 'héraðsdómi')
   const subject = formatMessage(cf.subject, { courtCaseNumber })
   const body = formatMessage(cf.body, {
     courtCaseNumber,
-    courtName: court ? applyDativeCaseToCourtName(court) : 'héraðsdómi',
+    courtName,
   })
   const link = formatMessage(cf.link, {
     defenderHasAccessToRvg: Boolean(overviewUrl),
-    courtName: court ? applyDativeCaseToCourtName(court) : 'héraðsdómi',
+    courtName,
     linkStart: `<a href="${overviewUrl}">`,
     linkEnd: '</a>',
   })
@@ -470,7 +471,7 @@ export const formatDefenderCourtDateLinkEmailNotification = (
 
   const info = {
     defenderHasAccessToRvg: Boolean(overviewUrl),
-    courtName: court ? applyDativeCaseToCourtName(court) : 'Héraðsdómur',
+    courtName: applyDativeCaseToCourtName(court || 'Héraðsdómur'),
     linkStart: `<a href="${overviewUrl}">`,
     linkEnd: '</a>',
   }

--- a/apps/judicial-system/backend/src/app/formatters/formatters.ts
+++ b/apps/judicial-system/backend/src/app/formatters/formatters.ts
@@ -5,6 +5,7 @@ import {
   DEFENDER_ROUTE,
 } from '@island.is/judicial-system/consts'
 import {
+  applyDativeCaseToCourtName,
   enumerate,
   formatCaseType,
   formatDate,
@@ -165,11 +166,11 @@ export const formatDefenderResubmittedToCourtEmailNotification = (
   const subject = formatMessage(cf.subject, { courtCaseNumber })
   const body = formatMessage(cf.body, {
     courtCaseNumber,
-    courtName: court?.replace('dómur', 'dómi'),
+    courtName: court ? applyDativeCaseToCourtName(court) : '',
   })
   const link = formatMessage(cf.link, {
     defenderHasAccessToRvg: Boolean(overviewUrl),
-    courtName: court?.replace('dómur', 'dómi'),
+    courtName: court ? applyDativeCaseToCourtName(court) : '',
     linkStart: `<a href="${overviewUrl}">`,
     linkEnd: '</a>',
   })
@@ -466,22 +467,21 @@ export const formatDefenderCourtDateLinkEmailNotification = (
   requestSharedWithDefender?: boolean,
 ): string => {
   const cf = notifications.defenderCourtDateEmail
+
+  const info = {
+    defenderHasAccessToRvg: Boolean(overviewUrl),
+    courtName: court ? applyDativeCaseToCourtName(court) : '',
+    linkStart: `<a href="${overviewUrl}">`,
+    linkEnd: '</a>',
+  }
+
   const body = requestSharedWithDefender
     ? formatMessage(cf.linkBody, { courtCaseNumber })
     : formatMessage(cf.linkNoRequestBody, { courtName: court, courtCaseNumber })
+
   const link = requestSharedWithDefender
-    ? formatMessage(cf.link, {
-        defenderHasAccessToRvg: Boolean(overviewUrl),
-        courtName: court?.replace('dómur', 'dómi'),
-        linkStart: `<a href="${overviewUrl}">`,
-        linkEnd: '</a>',
-      })
-    : formatMessage(cf.linkNoRequest, {
-        defenderHasAccessToRvg: Boolean(overviewUrl),
-        courtName: court?.replace('dómur', 'dómi'),
-        linkStart: `<a href="${overviewUrl}">`,
-        linkEnd: '</a>',
-      })
+    ? formatMessage(cf.link, info)
+    : formatMessage(cf.linkNoRequest, info)
 
   return `${body}${link}`
 }
@@ -500,7 +500,7 @@ export const formatPrisonAdministrationRulingNotification = (
   const body = formatMessage(notifications.signedRuling.prisonAdminBody, {
     isModifyingRuling,
     courtCaseNumber: courtCaseNumber ?? '',
-    courtName: courtName?.replace('dómur', 'dómi') ?? '',
+    courtName: courtName ? applyDativeCaseToCourtName(courtName) : '',
     linkStart: `<a href="${overviewUrl}">`,
     linkEnd: `</a>`,
   })
@@ -588,8 +588,8 @@ export const formatDefenderRevokedEmailNotification = (
 ): string => {
   const cf = notifications.defenderRevokedEmail
   const courtText = formatMessage(cf.court, {
-    court: court || 'NONE',
-  }).replace('dómur', 'dómi')
+    court: court ? applyDativeCaseToCourtName(court) : 'NONE',
+  })
   const courtDateText = formatMessage(cf.courtDate, {
     courtDate: courtDate
       ? formatDate(courtDate, 'PPPPp')
@@ -733,7 +733,7 @@ export const formatDefenderReadyForCourtEmailNotification = (
 
   const link = formatMessage(notifications.defenderLink, {
     defenderHasAccessToRvg: Boolean(overviewUrl),
-    courtName: courtName.replace('dómur', 'dómi'),
+    courtName: applyDativeCaseToCourtName(courtName),
     linkStart: `<a href="${overviewUrl}">`,
     linkEnd: '</a>',
   })

--- a/apps/judicial-system/backend/src/app/formatters/formatters.ts
+++ b/apps/judicial-system/backend/src/app/formatters/formatters.ts
@@ -479,7 +479,7 @@ export const formatDefenderCourtDateLinkEmailNotification = (
   const body = requestSharedWithDefender
     ? formatMessage(cf.linkBody, { courtCaseNumber })
     : formatMessage(cf.linkNoRequestBody, {
-        courtName: applyDativeCaseToCourtName(court || 'Héraðsdómur'),
+        courtName: court,
         courtCaseNumber,
       })
 

--- a/apps/judicial-system/backend/src/app/formatters/formatters.ts
+++ b/apps/judicial-system/backend/src/app/formatters/formatters.ts
@@ -166,11 +166,11 @@ export const formatDefenderResubmittedToCourtEmailNotification = (
   const subject = formatMessage(cf.subject, { courtCaseNumber })
   const body = formatMessage(cf.body, {
     courtCaseNumber,
-    courtName: court ? applyDativeCaseToCourtName(court) : '',
+    courtName: court ? applyDativeCaseToCourtName(court) : 'héraðsdómi',
   })
   const link = formatMessage(cf.link, {
     defenderHasAccessToRvg: Boolean(overviewUrl),
-    courtName: court ? applyDativeCaseToCourtName(court) : '',
+    courtName: court ? applyDativeCaseToCourtName(court) : 'héraðsdómi',
     linkStart: `<a href="${overviewUrl}">`,
     linkEnd: '</a>',
   })
@@ -470,7 +470,7 @@ export const formatDefenderCourtDateLinkEmailNotification = (
 
   const info = {
     defenderHasAccessToRvg: Boolean(overviewUrl),
-    courtName: court ? applyDativeCaseToCourtName(court) : '',
+    courtName: court ? applyDativeCaseToCourtName(court) : 'Héraðsdómur',
     linkStart: `<a href="${overviewUrl}">`,
     linkEnd: '</a>',
   }
@@ -500,7 +500,7 @@ export const formatPrisonAdministrationRulingNotification = (
   const body = formatMessage(notifications.signedRuling.prisonAdminBody, {
     isModifyingRuling,
     courtCaseNumber: courtCaseNumber ?? '',
-    courtName: courtName ? applyDativeCaseToCourtName(courtName) : '',
+    courtName: courtName ? applyDativeCaseToCourtName(courtName) : 'héraðsdómi',
     linkStart: `<a href="${overviewUrl}">`,
     linkEnd: `</a>`,
   })

--- a/apps/judicial-system/backend/src/app/formatters/formatters.ts
+++ b/apps/judicial-system/backend/src/app/formatters/formatters.ts
@@ -501,7 +501,7 @@ export const formatPrisonAdministrationRulingNotification = (
   const body = formatMessage(notifications.signedRuling.prisonAdminBody, {
     isModifyingRuling,
     courtCaseNumber: courtCaseNumber ?? '',
-    courtName: courtName ? applyDativeCaseToCourtName(courtName) : 'héraðsdómi',
+    courtName: applyDativeCaseToCourtName(courtName || 'héraðsdómi'),
     linkStart: `<a href="${overviewUrl}">`,
     linkEnd: `</a>`,
   })

--- a/apps/judicial-system/backend/src/app/formatters/formatters.ts
+++ b/apps/judicial-system/backend/src/app/formatters/formatters.ts
@@ -471,14 +471,17 @@ export const formatDefenderCourtDateLinkEmailNotification = (
 
   const info = {
     defenderHasAccessToRvg: Boolean(overviewUrl),
-    courtName: applyDativeCaseToCourtName(court || 'Héraðsdómur'),
+    courtName: applyDativeCaseToCourtName(court || 'héraðsdómi'),
     linkStart: `<a href="${overviewUrl}">`,
     linkEnd: '</a>',
   }
 
   const body = requestSharedWithDefender
     ? formatMessage(cf.linkBody, { courtCaseNumber })
-    : formatMessage(cf.linkNoRequestBody, { courtName: court, courtCaseNumber })
+    : formatMessage(cf.linkNoRequestBody, {
+        courtName: applyDativeCaseToCourtName(court || 'Héraðsdómur'),
+        courtCaseNumber,
+      })
 
   const link = requestSharedWithDefender
     ? formatMessage(cf.link, info)

--- a/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
@@ -1404,7 +1404,7 @@ export class CaseNotificationService extends BaseNotificationService {
     const html = this.formatMessage(
       notifications.defenderRevokedEmail.indictmentBody,
       {
-        courtName: courtName?.replace('dómur', 'dómi'),
+        courtName: courtName ? applyDativeCaseToCourtName(courtName) : '',
         defenderHasAccessToRvg: Boolean(defenderNationalId),
         linkStart: `<a href="${formatDefenderRoute(
           this.config.clientUrl,
@@ -1778,7 +1778,7 @@ export class CaseNotificationService extends BaseNotificationService {
     })
     const html = this.formatMessage(notifications.caseFilesUpdated.body, {
       courtCaseNumber,
-      court: court?.replace('dómur', 'dómi'),
+      court: court ? applyDativeCaseToCourtName(court) : '',
       userHasAccessToRVG: Boolean(link),
       linkStart: `<a href="${link}">`,
       linkEnd: '</a>',
@@ -2022,7 +2022,10 @@ export class CaseNotificationService extends BaseNotificationService {
         notifications.caseAppealedToCourtOfAppeals.body,
         {
           userHasAccessToRVG: Boolean(url),
-          court: theCase.court?.name.replace('dómur', 'dómi'),
+          court:
+            theCase.court && theCase.court.name
+              ? applyDativeCaseToCourtName(theCase.court.name)
+              : '',
           courtCaseNumber: theCase.courtCaseNumber,
           linkStart: `<a href="${url}">`,
           linkEnd: '</a>',
@@ -2140,7 +2143,10 @@ export class CaseNotificationService extends BaseNotificationService {
         notifications.caseAppealReceivedByCourt.body,
         {
           userHasAccessToRVG: Boolean(url),
-          court: theCase.court?.name.replace('dómur', 'dómi'),
+          court:
+            theCase.court && theCase.court.name
+              ? applyDativeCaseToCourtName(theCase.court.name)
+              : '',
           courtCaseNumber: theCase.courtCaseNumber,
           statementDeadline: formatDate(statementDeadline, 'PPPp'),
           linkStart: `<a href="${url}">`,
@@ -2274,7 +2280,10 @@ export class CaseNotificationService extends BaseNotificationService {
         notifications.caseAppealStatement.body,
         {
           userHasAccessToRVG: Boolean(url),
-          court: theCase.court?.name.replace('dómur', 'dómi'),
+          court:
+            theCase.court && theCase.court.name
+              ? applyDativeCaseToCourtName(theCase.court.name)
+              : '',
           courtCaseNumber: theCase.courtCaseNumber,
           appealCaseNumber: theCase.appealCaseNumber ?? 'NONE',
           linkStart: `<a href="${url}">`,
@@ -2484,7 +2493,10 @@ export class CaseNotificationService extends BaseNotificationService {
         notifications.caseAppealCompleted.body,
         {
           userHasAccessToRVG: Boolean(url),
-          court: theCase.court?.name.replace('dómur', 'dómi'),
+          court:
+            theCase.court && theCase.court.name
+              ? applyDativeCaseToCourtName(theCase.court.name)
+              : '',
           courtCaseNumber: theCase.courtCaseNumber,
           appealCaseNumber: theCase.appealCaseNumber,
           appealRulingDecision: getAppealResultTextByValue(

--- a/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
@@ -875,9 +875,9 @@ export class CaseNotificationService extends BaseNotificationService {
       }),
       html: this.formatMessage(notifications.caseCompleted.prosecutorBody, {
         courtCaseNumber: theCase.courtCaseNumber,
-        courtName: theCase.court?.name
-          ? applyDativeCaseToCourtName(theCase.court.name)
-          : 'héraðsdómi',
+        courtName: applyDativeCaseToCourtName(
+          theCase.court?.name || 'héraðsdómi',
+        ),
         caseIndictmentRulingDecision:
           getHumanReadableCaseIndictmentRulingDecision(
             theCase.indictmentRulingDecision,
@@ -891,9 +891,9 @@ export class CaseNotificationService extends BaseNotificationService {
   private getRulingEmailNotificationToProsecutorProps = (theCase: Case) => {
     const sharedHtmlProps = {
       courtCaseNumber: theCase.courtCaseNumber,
-      courtName: theCase.court?.name
-        ? applyDativeCaseToCourtName(theCase.court.name)
-        : 'héraðsdómi',
+      courtName: applyDativeCaseToCourtName(
+        theCase.court?.name || 'héraðsdómi',
+      ),
       linkStart: `<a href="${this.config.clientUrl}${SIGNED_VERDICT_OVERVIEW_ROUTE}/${theCase.id}">`,
       linkEnd: '</a>',
     }
@@ -943,9 +943,9 @@ export class CaseNotificationService extends BaseNotificationService {
   ) {
     const sharedHtmlProps = {
       courtCaseNumber: theCase.courtCaseNumber,
-      courtName: theCase.court?.name
-        ? applyDativeCaseToCourtName(theCase.court.name)
-        : 'héraðsdómi',
+      courtName: applyDativeCaseToCourtName(
+        theCase.court?.name || 'héraðsdómi',
+      ),
       defenderHasAccessToRvg: Boolean(defenderNationalId),
       linkStart: `<a href="${formatDefenderRoute(
         this.config.clientUrl,
@@ -1410,9 +1410,7 @@ export class CaseNotificationService extends BaseNotificationService {
     const html = this.formatMessage(
       notifications.defenderRevokedEmail.indictmentBody,
       {
-        courtName: courtName
-          ? applyDativeCaseToCourtName(courtName)
-          : 'héraðsdómi',
+        courtName: applyDativeCaseToCourtName(courtName || 'héraðsdómi'),
         defenderHasAccessToRvg: Boolean(defenderNationalId),
         linkStart: `<a href="${formatDefenderRoute(
           this.config.clientUrl,
@@ -1786,7 +1784,7 @@ export class CaseNotificationService extends BaseNotificationService {
     })
     const html = this.formatMessage(notifications.caseFilesUpdated.body, {
       courtCaseNumber,
-      court: court ? applyDativeCaseToCourtName(court) : 'héraðsdómi',
+      court: applyDativeCaseToCourtName(court || 'héraðsdómi'),
       userHasAccessToRVG: Boolean(link),
       linkStart: `<a href="${link}">`,
       linkEnd: '</a>',
@@ -2030,9 +2028,9 @@ export class CaseNotificationService extends BaseNotificationService {
         notifications.caseAppealedToCourtOfAppeals.body,
         {
           userHasAccessToRVG: Boolean(url),
-          court: theCase.court?.name
-            ? applyDativeCaseToCourtName(theCase.court.name)
-            : 'héraðsdómi',
+          court: applyDativeCaseToCourtName(
+            theCase.court?.name || 'héraðsdómi',
+          ),
           courtCaseNumber: theCase.courtCaseNumber,
           linkStart: `<a href="${url}">`,
           linkEnd: '</a>',
@@ -2150,9 +2148,9 @@ export class CaseNotificationService extends BaseNotificationService {
         notifications.caseAppealReceivedByCourt.body,
         {
           userHasAccessToRVG: Boolean(url),
-          court: theCase.court?.name
-            ? applyDativeCaseToCourtName(theCase.court.name)
-            : 'héraðsdómi',
+          court: applyDativeCaseToCourtName(
+            theCase.court?.name || 'héraðsdómi',
+          ),
           courtCaseNumber: theCase.courtCaseNumber,
           statementDeadline: formatDate(statementDeadline, 'PPPp'),
           linkStart: `<a href="${url}">`,
@@ -2286,9 +2284,9 @@ export class CaseNotificationService extends BaseNotificationService {
         notifications.caseAppealStatement.body,
         {
           userHasAccessToRVG: Boolean(url),
-          court: theCase.court?.name
-            ? applyDativeCaseToCourtName(theCase.court.name)
-            : 'héraðsdómi',
+          court: applyDativeCaseToCourtName(
+            theCase.court?.name || 'héraðsdómi',
+          ),
           courtCaseNumber: theCase.courtCaseNumber,
           appealCaseNumber: theCase.appealCaseNumber ?? 'NONE',
           linkStart: `<a href="${url}">`,
@@ -2498,9 +2496,9 @@ export class CaseNotificationService extends BaseNotificationService {
         notifications.caseAppealCompleted.body,
         {
           userHasAccessToRVG: Boolean(url),
-          court: theCase.court?.name
-            ? applyDativeCaseToCourtName(theCase.court.name)
-            : 'héraðsdómi',
+          court: applyDativeCaseToCourtName(
+            theCase.court?.name || 'héraðsdómi',
+          ),
           courtCaseNumber: theCase.courtCaseNumber,
           appealCaseNumber: theCase.appealCaseNumber,
           appealRulingDecision: getAppealResultTextByValue(

--- a/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
@@ -875,7 +875,9 @@ export class CaseNotificationService extends BaseNotificationService {
       }),
       html: this.formatMessage(notifications.caseCompleted.prosecutorBody, {
         courtCaseNumber: theCase.courtCaseNumber,
-        courtName: applyDativeCaseToCourtName(theCase.court?.name || ''),
+        courtName: theCase.court?.name
+          ? applyDativeCaseToCourtName(theCase.court.name)
+          : 'héraðsdómi',
         caseIndictmentRulingDecision:
           getHumanReadableCaseIndictmentRulingDecision(
             theCase.indictmentRulingDecision,
@@ -889,7 +891,9 @@ export class CaseNotificationService extends BaseNotificationService {
   private getRulingEmailNotificationToProsecutorProps = (theCase: Case) => {
     const sharedHtmlProps = {
       courtCaseNumber: theCase.courtCaseNumber,
-      courtName: applyDativeCaseToCourtName(theCase.court?.name || ''),
+      courtName: theCase.court?.name
+        ? applyDativeCaseToCourtName(theCase.court.name)
+        : 'héraðsdómi',
       linkStart: `<a href="${this.config.clientUrl}${SIGNED_VERDICT_OVERVIEW_ROUTE}/${theCase.id}">`,
       linkEnd: '</a>',
     }
@@ -939,7 +943,9 @@ export class CaseNotificationService extends BaseNotificationService {
   ) {
     const sharedHtmlProps = {
       courtCaseNumber: theCase.courtCaseNumber,
-      courtName: applyDativeCaseToCourtName(theCase.court?.name || ''),
+      courtName: theCase.court?.name
+        ? applyDativeCaseToCourtName(theCase.court.name)
+        : 'héraðsdómi',
       defenderHasAccessToRvg: Boolean(defenderNationalId),
       linkStart: `<a href="${formatDefenderRoute(
         this.config.clientUrl,
@@ -1404,7 +1410,9 @@ export class CaseNotificationService extends BaseNotificationService {
     const html = this.formatMessage(
       notifications.defenderRevokedEmail.indictmentBody,
       {
-        courtName: courtName ? applyDativeCaseToCourtName(courtName) : '',
+        courtName: courtName
+          ? applyDativeCaseToCourtName(courtName)
+          : 'héraðsdómi',
         defenderHasAccessToRvg: Boolean(defenderNationalId),
         linkStart: `<a href="${formatDefenderRoute(
           this.config.clientUrl,
@@ -1778,7 +1786,7 @@ export class CaseNotificationService extends BaseNotificationService {
     })
     const html = this.formatMessage(notifications.caseFilesUpdated.body, {
       courtCaseNumber,
-      court: court ? applyDativeCaseToCourtName(court) : '',
+      court: court ? applyDativeCaseToCourtName(court) : 'héraðsdómi',
       userHasAccessToRVG: Boolean(link),
       linkStart: `<a href="${link}">`,
       linkEnd: '</a>',
@@ -2022,10 +2030,9 @@ export class CaseNotificationService extends BaseNotificationService {
         notifications.caseAppealedToCourtOfAppeals.body,
         {
           userHasAccessToRVG: Boolean(url),
-          court:
-            theCase.court && theCase.court.name
-              ? applyDativeCaseToCourtName(theCase.court.name)
-              : '',
+          court: theCase.court?.name
+            ? applyDativeCaseToCourtName(theCase.court.name)
+            : 'héraðsdómi',
           courtCaseNumber: theCase.courtCaseNumber,
           linkStart: `<a href="${url}">`,
           linkEnd: '</a>',
@@ -2143,10 +2150,9 @@ export class CaseNotificationService extends BaseNotificationService {
         notifications.caseAppealReceivedByCourt.body,
         {
           userHasAccessToRVG: Boolean(url),
-          court:
-            theCase.court && theCase.court.name
-              ? applyDativeCaseToCourtName(theCase.court.name)
-              : '',
+          court: theCase.court?.name
+            ? applyDativeCaseToCourtName(theCase.court.name)
+            : 'héraðsdómi',
           courtCaseNumber: theCase.courtCaseNumber,
           statementDeadline: formatDate(statementDeadline, 'PPPp'),
           linkStart: `<a href="${url}">`,
@@ -2280,10 +2286,9 @@ export class CaseNotificationService extends BaseNotificationService {
         notifications.caseAppealStatement.body,
         {
           userHasAccessToRVG: Boolean(url),
-          court:
-            theCase.court && theCase.court.name
-              ? applyDativeCaseToCourtName(theCase.court.name)
-              : '',
+          court: theCase.court?.name
+            ? applyDativeCaseToCourtName(theCase.court.name)
+            : 'héraðsdómi',
           courtCaseNumber: theCase.courtCaseNumber,
           appealCaseNumber: theCase.appealCaseNumber ?? 'NONE',
           linkStart: `<a href="${url}">`,
@@ -2493,10 +2498,9 @@ export class CaseNotificationService extends BaseNotificationService {
         notifications.caseAppealCompleted.body,
         {
           userHasAccessToRVG: Boolean(url),
-          court:
-            theCase.court && theCase.court.name
-              ? applyDativeCaseToCourtName(theCase.court.name)
-              : '',
+          court: theCase.court?.name
+            ? applyDativeCaseToCourtName(theCase.court.name)
+            : 'héraðsdómi',
           courtCaseNumber: theCase.courtCaseNumber,
           appealCaseNumber: theCase.appealCaseNumber,
           appealRulingDecision: getAppealResultTextByValue(

--- a/apps/judicial-system/backend/src/app/modules/notification/services/indictmentCaseNotification/indictmentCaseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/indictmentCaseNotification/indictmentCaseNotification.service.ts
@@ -148,7 +148,7 @@ export class IndictmentCaseNotificationService extends BaseNotificationService {
         courtCaseNumber: theCase.courtCaseNumber,
         courtName: courtName
           ? applyDativeCaseToCourtName(courtName)
-          : 'Ekki skráð',
+          : 'héraðsdómnum',
         linkStart: `<a href="${this.config.clientUrl}${ROUTE_HANDLER_ROUTE}/${theCase.id}">`,
         linkEnd: '</a>',
       },

--- a/apps/judicial-system/backend/src/app/modules/notification/services/indictmentCaseNotification/indictmentCaseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/indictmentCaseNotification/indictmentCaseNotification.service.ts
@@ -146,9 +146,7 @@ export class IndictmentCaseNotificationService extends BaseNotificationService {
       strings.criminalRecordFilesUploadedEmail.body,
       {
         courtCaseNumber: theCase.courtCaseNumber,
-        courtName: courtName
-          ? applyDativeCaseToCourtName(courtName)
-          : 'héraðsdómi',
+        courtName: applyDativeCaseToCourtName(courtName || 'héraðsdómi'),
         linkStart: `<a href="${this.config.clientUrl}${ROUTE_HANDLER_ROUTE}/${theCase.id}">`,
         linkEnd: '</a>',
       },

--- a/apps/judicial-system/backend/src/app/modules/notification/services/indictmentCaseNotification/indictmentCaseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/indictmentCaseNotification/indictmentCaseNotification.service.ts
@@ -148,7 +148,7 @@ export class IndictmentCaseNotificationService extends BaseNotificationService {
         courtCaseNumber: theCase.courtCaseNumber,
         courtName: courtName
           ? applyDativeCaseToCourtName(courtName)
-          : 'héraðsdómnum',
+          : 'héraðsdómi',
         linkStart: `<a href="${this.config.clientUrl}${ROUTE_HANDLER_ROUTE}/${theCase.id}">`,
         linkEnd: '</a>',
       },

--- a/apps/judicial-system/backend/src/app/modules/notification/services/indictmentCaseNotification/indictmentCaseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/indictmentCaseNotification/indictmentCaseNotification.service.ts
@@ -139,12 +139,16 @@ export class IndictmentCaseNotificationService extends BaseNotificationService {
         courtCaseNumber: theCase.courtCaseNumber,
       },
     )
+    const courtName =
+      theCase.court && theCase.court.name ? theCase.court.name : undefined
 
     const formattedBody = this.formatMessage(
       strings.criminalRecordFilesUploadedEmail.body,
       {
         courtCaseNumber: theCase.courtCaseNumber,
-        courtName: theCase.court?.name.replace('dómur', 'dómi'),
+        courtName: courtName
+          ? applyDativeCaseToCourtName(courtName)
+          : 'Ekki skráð',
         linkStart: `<a href="${this.config.clientUrl}${ROUTE_HANDLER_ROUTE}/${theCase.id}">`,
         linkEnd: '</a>',
       },

--- a/apps/judicial-system/web/src/routes/Court/InvestigationCase/CourtRecord/CourtRecord.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationCase/CourtRecord/CourtRecord.tsx
@@ -169,9 +169,9 @@ const CourtRecord: FC = () => {
       [
         {
           courtStartDate: workingCase.arraignmentDate?.date,
-          courtLocation:
-            workingCase.court?.name &&
-            `í ${applyDativeCaseToCourtName(workingCase.court.name)}`,
+          courtLocation: workingCase.court?.name
+            ? `í ${applyDativeCaseToCourtName(workingCase.court.name)}`
+            : 'í héraðsdómi',
           courtAttendees:
             autofillAttendees.length > 0
               ? autofillAttendees.join('')

--- a/apps/judicial-system/web/src/routes/Court/InvestigationCase/CourtRecord/CourtRecord.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationCase/CourtRecord/CourtRecord.tsx
@@ -12,7 +12,10 @@ import {
   Tooltip,
 } from '@island.is/island-ui/core'
 import * as constants from '@island.is/judicial-system/consts'
-import { lowercase } from '@island.is/judicial-system/formatters'
+import {
+  applyDativeCaseToCourtName,
+  lowercase,
+} from '@island.is/judicial-system/formatters'
 import {
   closedCourt,
   core,
@@ -166,13 +169,9 @@ const CourtRecord: FC = () => {
       [
         {
           courtStartDate: workingCase.arraignmentDate?.date,
-          courtLocation: workingCase.court?.name
-            ? `í ${
-                workingCase.court.name.indexOf('dómur') > -1
-                  ? workingCase.court.name.replace('dómur', 'dómi')
-                  : workingCase.court.name
-              }`
-            : undefined,
+          courtLocation:
+            workingCase.court?.name &&
+            `í ${applyDativeCaseToCourtName(workingCase.court.name)}`,
           courtAttendees:
             autofillAttendees.length > 0
               ? autofillAttendees.join('')

--- a/apps/judicial-system/web/src/routes/Court/InvestigationCase/CourtRecord/CourtRecord.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationCase/CourtRecord/CourtRecord.tsx
@@ -169,9 +169,9 @@ const CourtRecord: FC = () => {
       [
         {
           courtStartDate: workingCase.arraignmentDate?.date,
-          courtLocation: workingCase.court?.name
-            ? `í ${applyDativeCaseToCourtName(workingCase.court.name)}`
-            : 'í héraðsdómi',
+          courtLocation: `í ${applyDativeCaseToCourtName(
+            workingCase.court?.name || 'héraðsdómi',
+          )}`,
           courtAttendees:
             autofillAttendees.length > 0
               ? autofillAttendees.join('')

--- a/apps/judicial-system/web/src/routes/Court/RestrictionCase/CourtRecord/CourtRecord.tsx
+++ b/apps/judicial-system/web/src/routes/Court/RestrictionCase/CourtRecord/CourtRecord.tsx
@@ -207,9 +207,9 @@ export const CourtRecord: FC = () => {
       [
         {
           courtStartDate: workingCase.arraignmentDate?.date,
-          courtLocation: workingCase.court?.name
-            ? `í ${applyDativeCaseToCourtName(workingCase.court.name)}`
-            : 'í héraðsdómi',
+          courtLocation: `í ${applyDativeCaseToCourtName(
+            workingCase.court?.name || 'héraðsdómi',
+          )}`,
           courtAttendees:
             autofillAttendees.length > 0
               ? autofillAttendees.join('')

--- a/apps/judicial-system/web/src/routes/Court/RestrictionCase/CourtRecord/CourtRecord.tsx
+++ b/apps/judicial-system/web/src/routes/Court/RestrictionCase/CourtRecord/CourtRecord.tsx
@@ -12,7 +12,10 @@ import {
   Tooltip,
 } from '@island.is/island-ui/core'
 import * as constants from '@island.is/judicial-system/consts'
-import { lowercase } from '@island.is/judicial-system/formatters'
+import {
+  applyDativeCaseToCourtName,
+  lowercase,
+} from '@island.is/judicial-system/formatters'
 import { isAcceptingCaseDecision } from '@island.is/judicial-system/types'
 import {
   closedCourt,
@@ -206,11 +209,7 @@ export const CourtRecord: FC = () => {
           courtStartDate: workingCase.arraignmentDate?.date,
           courtLocation:
             workingCase.court?.name &&
-            `í ${
-              workingCase.court.name.indexOf('dómur') > -1
-                ? workingCase.court.name.replace('dómur', 'dómi')
-                : workingCase.court.name
-            }`,
+            `í ${applyDativeCaseToCourtName(workingCase.court.name)}`,
           courtAttendees:
             autofillAttendees.length > 0
               ? autofillAttendees.join('')

--- a/apps/judicial-system/web/src/routes/Court/RestrictionCase/CourtRecord/CourtRecord.tsx
+++ b/apps/judicial-system/web/src/routes/Court/RestrictionCase/CourtRecord/CourtRecord.tsx
@@ -207,9 +207,9 @@ export const CourtRecord: FC = () => {
       [
         {
           courtStartDate: workingCase.arraignmentDate?.date,
-          courtLocation:
-            workingCase.court?.name &&
-            `í ${applyDativeCaseToCourtName(workingCase.court.name)}`,
+          courtLocation: workingCase.court?.name
+            ? `í ${applyDativeCaseToCourtName(workingCase.court.name)}`
+            : 'í héraðsdómi',
           courtAttendees:
             autofillAttendees.length > 0
               ? autofillAttendees.join('')

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Indictment.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Indictment.tsx
@@ -6,7 +6,10 @@ import router from 'next/router'
 
 import { Box, Button, Checkbox, Input } from '@island.is/island-ui/core'
 import * as constants from '@island.is/judicial-system/consts'
-import { formatNationalId } from '@island.is/judicial-system/formatters'
+import {
+  applyDativeCaseToCourtName,
+  formatNationalId,
+} from '@island.is/judicial-system/formatters'
 import { Feature } from '@island.is/judicial-system/types'
 import { titles } from '@island.is/judicial-system-web/messages'
 import {
@@ -60,7 +63,10 @@ export const getIndictmentIntroductionAutofill = (
         prosecutorsOffice?.name?.toUpperCase(),
         `\n\n${formatMessage(strings.indictmentIntroductionAutofillAnnounces)}`,
         `\n\n${formatMessage(strings.indictmentIntroductionAutofillCourt, {
-          court: court?.name?.replace('dómur', 'dómi'),
+          court:
+            court && court.name
+              ? applyDativeCaseToCourtName(court.name)
+              : 'Ekki skráð',
         })}`,
         `\n\n${defendants.map((defendant) => {
           return `\n          ${formatMessage(

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Indictment.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Indictment.tsx
@@ -63,10 +63,7 @@ export const getIndictmentIntroductionAutofill = (
         prosecutorsOffice?.name?.toUpperCase(),
         `\n\n${formatMessage(strings.indictmentIntroductionAutofillAnnounces)}`,
         `\n\n${formatMessage(strings.indictmentIntroductionAutofillCourt, {
-          court:
-            court && court.name
-              ? applyDativeCaseToCourtName(court.name)
-              : 'héraðsdómi',
+          court: applyDativeCaseToCourtName(court?.name || 'héraðsdómi'),
         })}`,
         `\n\n${defendants.map((defendant) => {
           return `\n          ${formatMessage(

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Indictment.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Indictment.tsx
@@ -66,7 +66,7 @@ export const getIndictmentIntroductionAutofill = (
           court:
             court && court.name
               ? applyDativeCaseToCourtName(court.name)
-              : 'Ekki skráð',
+              : 'héraðsdómi',
         })}`,
         `\n\n${defendants.map((defendant) => {
           return `\n          ${formatMessage(


### PR DESCRIPTION
# Use applyDativeCaseToCourtName everywhere

[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1209139378163316)

## What

In various places in the code we apply the dative case to court names (Héraðsdómur Reykjavíkur &rarr; Héraðsdómi Reykjavíkur). A while ago, @thorhildurt wrote a function for this for a specific use case. This PR uses that function everywhere in the code for consistency.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Consolidated how court names are formatted across notifications and user interfaces.
  - Replaced varied inline manipulations with a unified approach that applies a consistent style and default value when necessary.
  - Enhances readability and reliability in communications and displays of court information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->