### PR TITLE
fix(j-s): Don't run useDebounce on render

### DIFF
--- a/apps/judicial-system/web/src/utils/hooks/useDeb/index.tsx
+++ b/apps/judicial-system/web/src/utils/hooks/useDeb/index.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react'
 import { useDebounce } from 'react-use'
 
 import { TempCase as Case } from '@island.is/judicial-system-web/src/types'
@@ -7,6 +8,7 @@ import useCase from '../useCase'
 const useDeb = (workingCase: Case, keys: (keyof Case)[] | keyof Case) => {
   const { updateCase } = useCase()
   const newKeys = Array.isArray(keys) ? keys : [keys]
+  const initialRender = useRef(true)
 
   const update = newKeys.reduce((acc, key) => {
     if (workingCase[key] === null) {
@@ -18,13 +20,17 @@ const useDeb = (workingCase: Case, keys: (keyof Case)[] | keyof Case) => {
 
   useDebounce(
     () => {
-      if (Object.entries(update).length === 0) {
-        return
+      if (!initialRender.current) {
+        if (Object.entries(update).length === 0) {
+          return
+        }
+
+        updateCase(workingCase.id, {
+          ...update,
+        })
       }
 
-      updateCase(workingCase.id, {
-        ...update,
-      })
+      initialRender.current = false
     },
     4000,
     [...newKeys.map((key) => workingCase[key])],


### PR DESCRIPTION
# Don't run useDebounce on render

[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1209533971680997)

## What

We are running useDebounce on render and saving fields that already exist. This PR fixes that and makes it so that the useDeb hook doesn't run on render.

## Screenshots / Gifs

### Before

https://github.com/user-attachments/assets/21a36569-38cb-4196-841d-c1469af86caf

### After

https://github.com/user-attachments/assets/4544c2d3-0253-4f75-bb4e-554b75638c66


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the debounce behavior to prevent triggering updates on the initial render, ensuring updates only occur on subsequent valid changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->