### PR TITLE
fix(web): When not filtering we now fetch news from cms

### DIFF
--- a/libs/cms/src/lib/cms.contentful.service.ts
+++ b/libs/cms/src/lib/cms.contentful.service.ts
@@ -537,6 +537,7 @@ export class CmsContentfulService {
 
   async getNews(input: GetCmsNewsInput): Promise<NewsList> {
     const size = input.size ?? 10
+    const page = input.page ?? 1
 
     const orderPrefix = input.order === 'asc' ? '' : '-'
 
@@ -544,7 +545,7 @@ export class CmsContentfulService {
       ['content_type']: 'news',
       include: 5,
       limit: size,
-      skip: ((input.page ?? 1) - 1) * size,
+      skip: (page - 1) * size,
       'fields.organization.sys.contentType.sys.id': 'organization',
       'fields.organization.fields.slug': input.organization,
       order: `${orderPrefix}fields.date,${orderPrefix}fields.initialPublishDate,${orderPrefix}sys.firstPublishedAt`,

--- a/libs/cms/src/lib/cms.contentful.service.ts
+++ b/libs/cms/src/lib/cms.contentful.service.ts
@@ -91,6 +91,8 @@ import {
 } from './models/organizationPageStandaloneSitemap.model'
 import { SitemapTree, SitemapTreeNodeType } from '@island.is/shared/types'
 import { getOrganizationPageUrlPrefix } from '@island.is/shared/utils'
+import { NewsList } from './models/newsList.model'
+import { GetCmsNewsInput } from './dto/getNews.input'
 
 const errorHandler = (name: string) => {
   return (error: Error) => {
@@ -518,7 +520,7 @@ export class CmsContentfulService {
     return sortBy(results, (a) => sortedIds.indexOf(a.id))
   }
 
-  async getNews(lang: string, slug: string): Promise<News | null> {
+  async getSingleNewsItem(lang: string, slug: string): Promise<News | null> {
     const params = {
       ['content_type']: 'news',
       include: 5,
@@ -531,6 +533,33 @@ export class CmsContentfulService {
       .catch(errorHandler('getNews'))
 
     return (result.items as types.INews[]).map(mapNews)[0] ?? null
+  }
+
+  async getNews(input: GetCmsNewsInput): Promise<NewsList> {
+    const size = input.size ?? 10
+
+    const orderPrefix = input.order === 'asc' ? '' : '-'
+
+    const params = {
+      ['content_type']: 'news',
+      include: 5,
+      limit: size,
+      skip: ((input.page ?? 1) - 1) * size,
+      'fields.organization.sys.contentType.sys.id': 'organization',
+      'fields.organization.fields.slug': input.organization,
+      order: `${orderPrefix}fields.date,${orderPrefix}fields.initialPublishDate,${orderPrefix}sys.firstPublishedAt`,
+      'fields.title[exists]': true,
+      'fields.slug[exists]': true,
+    }
+
+    const result = await this.contentfulRepository
+      .getLocalizedEntries<types.INewsFields>(input.lang, params)
+      .catch(errorHandler('getNews'))
+
+    return {
+      items: ((result.items as types.INews[]) ?? []).map(mapNews),
+      total: result.total,
+    }
   }
 
   async getGrant(lang: string, id: string): Promise<Grant | null> {

--- a/libs/cms/src/lib/cms.resolver.ts
+++ b/libs/cms/src/lib/cms.resolver.ts
@@ -473,6 +473,7 @@ export class CmsResolver {
   @CacheControl(defaultCache)
   @Query(() => NewsList)
   async getNews(@Args('input') input: GetNewsInput): Promise<NewsList> {
+    // When not filtering, fetch directly from CMS to avoid Elasticsearch's maximum result window size limit (10,000 items)
     if (!input.year && !input.month && !input.tags?.length) {
       return this.cmsContentfulService.getNews(input)
     }

--- a/libs/cms/src/lib/cms.resolver.ts
+++ b/libs/cms/src/lib/cms.resolver.ts
@@ -439,7 +439,7 @@ export class CmsResolver {
   getSingleNews(
     @Args('input') { lang, slug }: GetSingleNewsInput,
   ): Promise<News | null> {
-    return this.cmsContentfulService.getNews(lang, slug)
+    return this.cmsContentfulService.getSingleNewsItem(lang, slug)
   }
 
   @CacheControl(defaultCache)
@@ -473,6 +473,9 @@ export class CmsResolver {
   @CacheControl(defaultCache)
   @Query(() => NewsList)
   async getNews(@Args('input') input: GetNewsInput): Promise<NewsList> {
+    if (!input.year && !input.month && !input.tags?.length) {
+      return this.cmsContentfulService.getNews(input)
+    }
     return this.cmsElasticsearchService.getNews(
       getElasticsearchIndex(input.lang),
       input,

--- a/libs/cms/src/lib/dto/getNews.input.ts
+++ b/libs/cms/src/lib/dto/getNews.input.ts
@@ -44,3 +44,30 @@ export class GetNewsInput {
   @IsOptional()
   organization?: string
 }
+
+@InputType()
+export class GetCmsNewsInput {
+  @Field(() => String, { nullable: true })
+  @IsString()
+  @IsOptional()
+  lang: ElasticsearchIndexLocale = 'is'
+
+  @Field({ nullable: true })
+  @IsEnum(['asc', 'desc'])
+  @IsOptional()
+  order?: 'asc' | 'desc' = 'desc'
+
+  @Field(() => Int, { nullable: true })
+  @IsInt()
+  @IsOptional()
+  page?: number = 1
+
+  @Field(() => Int, { nullable: true })
+  @IsInt()
+  @IsOptional()
+  size?: number = 10
+
+  @Field(() => String, { nullable: true })
+  @IsOptional()
+  organization?: string
+}


### PR DESCRIPTION
# When not filtering we now fetch news from cms

## What

* Elasticsearch has a max result window size set to 10000 (which is too small since we've imported around 14000 news for "Lögreglan")
* So we can see all news I've opted to fetch news from the CMS rather than from Elasticsearch

## Screenshots / Gifs

### Before

![Screenshot 2025-03-03 at 10 28 45](https://github.com/user-attachments/assets/280a99a7-3620-49db-81c2-71c01b4c5f08)


### After
![Screenshot 2025-03-03 at 10 28 32](https://github.com/user-attachments/assets/723c8f84-b01c-400b-8d31-3a9186363e7b)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced news listing that allows users to view a collection of news articles with flexible pagination, ordering, and filtering options.
  
- **Refactor**
  - Updated the single news article retrieval process for improved clarity and consistency, ensuring a smoother browsing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->