### PR TITLE
fix(j-s): Add indictment file name for defenders

### DIFF
--- a/apps/judicial-system/api/src/app/modules/file/limitedAccessFile.controller.ts
+++ b/apps/judicial-system/api/src/app/modules/file/limitedAccessFile.controller.ts
@@ -149,7 +149,12 @@ export class LimitedAccessFileController {
     )
   }
 
-  @Get(['indictment', 'mergedCase/:mergedCaseId/indictment'])
+  @Get([
+    'indictment',
+    'indictment/:fileName',
+    'mergedCase/:mergedCaseId/indictment',
+    'mergedCase/:mergedCaseId/indictment/:fileName',
+  ])
   @Header('Content-Type', 'application/pdf')
   async getIndictmentPdf(
     @Param('id') id: string,


### PR DESCRIPTION
# Add indictment file name for defenders

[Asana](https://app.asana.com/1/203394141643832/project/322488613152836/task/1209508264598989)

## What

In #18147, we implemented a change so that the default filename for indictments would be "Ákæra" instead of "Indictment". We forgot to implement this for defenders. This PR fixes that.

## Why

It's a bug

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated PDF document retrieval endpoints now support an additional identifier parameter, enabling more precise access for both standalone and merged-case requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->