### PR TITLE
chore(j-s): Only show indictment review info to certain users

### DIFF
--- a/apps/judicial-system/web/src/components/InfoCard/InfoCardClosedIndictment.tsx
+++ b/apps/judicial-system/web/src/components/InfoCard/InfoCardClosedIndictment.tsx
@@ -1,7 +1,13 @@
 import { FC, useContext } from 'react'
 
+import {
+  isPrisonAdminUser,
+  isPublicProsecutorUser,
+} from '@island.is/judicial-system/types'
+
 import { EventType } from '../../graphql/schema'
 import { FormContext } from '../FormProvider/FormProvider'
+import { UserContext } from '../UserProvider/UserProvider'
 import InfoCard from './InfoCard'
 import useInfoCardItems from './useInfoCardItems'
 
@@ -13,6 +19,7 @@ export interface Props {
 
 const InfoCardClosedIndictment: FC<Props> = (props) => {
   const { workingCase } = useContext(FormContext)
+  const { user } = useContext(UserContext)
 
   const {
     showItem,
@@ -74,7 +81,8 @@ const InfoCardClosedIndictment: FC<Props> = (props) => {
           ],
           columns: 2,
         },
-        ...(workingCase.indictmentReviewer?.name
+        ...(workingCase.indictmentReviewer?.name &&
+        (isPublicProsecutorUser(user) || isPrisonAdminUser(user))
           ? [
               {
                 id: 'additional-data-section',


### PR DESCRIPTION
# Only show indictment review info to certain users

[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1209441421691300)

## What

This PR hides the indictment review info (what prosecutor at the prosecutors office reviewed the indictment, when, and what decision they made) from every user except users at the public prosecutor's office and prison admin users. 

## Why

This info is only relevant to those users.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced how detailed case information is displayed by ensuring that additional data is now visible only to users with the appropriate roles (e.g., public prosecutor and prison administrator). This update refines the user experience by conditionally showing sensitive information to authorized personnel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->