### PR TITLE
fix(web): Parent subpage list slice - Set different margin depending on where the slice is

### DIFF
--- a/apps/web/components/Organization/Slice/OrganizationParentSubpageListSlice/OrganizationParentSubpageListSlice.tsx
+++ b/apps/web/components/Organization/Slice/OrganizationParentSubpageListSlice/OrganizationParentSubpageListSlice.tsx
@@ -1,3 +1,5 @@
+import { useRouter } from 'next/router'
+
 import {
   Box,
   Button,
@@ -11,6 +13,7 @@ import {
   OrganizationParentSubpageList,
   OrganizationParentSubpageListVariant,
 } from '@island.is/web/graphql/schema'
+import { pathIsRoute } from '@island.is/web/hooks'
 import { useI18n } from '@island.is/web/i18n'
 
 import * as styles from './OrganizationParentSubpageList.css'
@@ -23,61 +26,67 @@ export const OrganizationParentSubpageListSlice = ({
   slice,
 }: OrganizationParentSubpageListSliceProps) => {
   const { activeLocale } = useI18n()
+  const router = useRouter()
+  const isFrontpage = pathIsRoute(
+    router.asPath,
+    'organizationpage',
+    activeLocale,
+  )
+
   return (
-    <Stack space={4}>
-      {slice.title && <Text variant="h3">{slice.title}</Text>}
-      {slice.pageLinkVariant ===
-        OrganizationParentSubpageListVariant.ServiceCard && (
-        <Box className={styles.serviceCardContainer}>
-          {slice.pageLinks.map((page) => (
-            <IconTitleCard
-              key={page.id}
-              heading={page.label}
-              href={page.href}
-              imgSrc={page.tinyThumbnailImageHref ?? ''}
-              alt=""
-            />
-          ))}
-        </Box>
-      )}
-      {slice.pageLinkVariant ===
-        OrganizationParentSubpageListVariant.ProfileCardWithTitleAbove && (
-        <Box
-          className={styles.profileCardContainer}
-          marginLeft={[0, 0, 0, 0, 6]}
-        >
-          {slice.pageLinks.map((page) => (
-            <LinkV2 key={page.id} href={page.href}>
-              <ProfileCard
-                heightFull={true}
-                variant="title-above"
-                size="small"
-                title={page.label}
-                link={{
-                  text: activeLocale === 'is' ? 'Sjá nánar' : 'See more',
-                  url: page.href,
-                }}
-                description={page.pageLinkIntro}
-                image={page.thumbnailImageHref ?? ''}
+    <Box marginLeft={!isFrontpage ? [0, 0, 0, 0, 6] : undefined}>
+      <Stack space={4}>
+        {slice.title && <Text variant="h3">{slice.title}</Text>}
+        {slice.pageLinkVariant ===
+          OrganizationParentSubpageListVariant.ServiceCard && (
+          <Box className={styles.serviceCardContainer}>
+            {slice.pageLinks.map((page) => (
+              <IconTitleCard
+                key={page.id}
+                heading={page.label}
+                href={page.href}
+                imgSrc={page.tinyThumbnailImageHref ?? ''}
+                alt=""
               />
+            ))}
+          </Box>
+        )}
+        {slice.pageLinkVariant ===
+          OrganizationParentSubpageListVariant.ProfileCardWithTitleAbove && (
+          <Box className={styles.profileCardContainer}>
+            {slice.pageLinks.map((page) => (
+              <LinkV2 key={page.id} href={page.href}>
+                <ProfileCard
+                  heightFull={true}
+                  variant="title-above"
+                  size="small"
+                  title={page.label}
+                  link={{
+                    text: activeLocale === 'is' ? 'Sjá nánar' : 'See more',
+                    url: page.href,
+                  }}
+                  description={page.pageLinkIntro}
+                  image={page.thumbnailImageHref ?? ''}
+                />
+              </LinkV2>
+            ))}
+          </Box>
+        )}
+        {!!slice.seeMoreLink?.text && !!slice.seeMoreLink?.url && (
+          <Box display="flex" justifyContent="flexEnd">
+            <LinkV2 href={slice.seeMoreLink.url}>
+              <Button
+                variant="text"
+                as="span"
+                unfocusable={true}
+                icon="arrowForward"
+              >
+                {slice.seeMoreLink.text}
+              </Button>
             </LinkV2>
-          ))}
-        </Box>
-      )}
-      {!!slice.seeMoreLink?.text && !!slice.seeMoreLink?.url && (
-        <Box display="flex" justifyContent="flexEnd">
-          <LinkV2 href={slice.seeMoreLink.url}>
-            <Button
-              variant="text"
-              as="span"
-              unfocusable={true}
-              icon="arrowForward"
-            >
-              {slice.seeMoreLink.text}
-            </Button>
-          </LinkV2>
-        </Box>
-      )}
-    </Stack>
+          </Box>
+        )}
+      </Stack>
+    </Box>
   )
 }


### PR DESCRIPTION
# Parent subpage list slice - Set different margin depending on where the slice is

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the organization subpage component to adjust its layout dynamically based on the current page, delivering a more responsive visual experience.
  
- **Refactor**
  - Streamlined the component's structure to better accommodate routing context, ensuring consistent display of key elements while adapting spacing appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->