### PR TITLE
fix(ui-fields): message color for message with link

### DIFF
--- a/libs/application/core/src/lib/fieldBuilders.ts
+++ b/libs/application/core/src/lib/fieldBuilders.ts
@@ -598,13 +598,14 @@ export const buildPaymentPendingField = (data: {
 export const buildMessageWithLinkButtonField = (
   data: Omit<MessageWithLinkButtonField, 'type' | 'component' | 'children'>,
 ): MessageWithLinkButtonField => {
-  const { id, url, message, buttonTitle } = data
+  const { id, url, message, messageColor, buttonTitle } = data
   return {
     ...extractCommonFields(data),
     children: undefined,
     id,
     url,
     message,
+    messageColor,
     buttonTitle,
     type: FieldTypes.MESSAGE_WITH_LINK_BUTTON_FIELD,
     component: FieldComponents.MESSAGE_WITH_LINK_BUTTON_FIELD,

--- a/libs/application/types/src/lib/Fields.ts
+++ b/libs/application/types/src/lib/Fields.ts
@@ -549,6 +549,7 @@ export interface MessageWithLinkButtonField extends BaseField {
   url: string
   buttonTitle: FormText
   message: FormText
+  messageColor?: Colors
 }
 
 export interface ExpandableDescriptionField extends BaseField {

--- a/libs/application/ui-fields/src/lib/MessageWithLinkButtonFormField/MessageWithLinkButtonFormField.tsx
+++ b/libs/application/ui-fields/src/lib/MessageWithLinkButtonFormField/MessageWithLinkButtonFormField.tsx
@@ -36,7 +36,7 @@ export const MessageWithLinkButtonFormField: FC<
         marginY={2}
       >
         <Box paddingRight={[0, 0, 4]} style={{ overflowWrap: 'anywhere' }}>
-          <Text variant="small">
+          <Text variant="small" color={field.messageColor}>
             {formatText(field.message, application, formatMessage)}
           </Text>
         </Box>


### PR DESCRIPTION

![Screenshot 2025-03-04 at 11 13 59](https://github.com/user-attachments/assets/36fc921a-12b9-4a23-84f3-ce71b529274e)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
