### PR TITLE
feat(app-sys): add options to copyLink

### DIFF
--- a/libs/application/core/src/lib/fieldBuilders.ts
+++ b/libs/application/core/src/lib/fieldBuilders.ts
@@ -1125,12 +1125,14 @@ export const buildOverviewField = (
 export const buildCopyLinkField = (
   data: Omit<CopyLinkField, 'type' | 'component' | 'children'>,
 ): CopyLinkField => {
-  const { id, title, link } = data
+  const { id, title, link, buttonTitle, semiBoldLink } = data
   return {
     ...extractCommonFields(data),
     id,
     title,
     link,
+    buttonTitle,
+    semiBoldLink,
     type: FieldTypes.COPY_LINK,
     component: FieldComponents.COPY_LINK,
     children: undefined,

--- a/libs/application/core/src/lib/messages.ts
+++ b/libs/application/core/src/lib/messages.ts
@@ -299,6 +299,11 @@ export const coreMessages = defineMessages({
     defaultMessage: 'Hlekkur afritaður',
     description: 'Copy link success toast',
   },
+  copyLinkButtonTitle: {
+    id: 'application.system:copyLinkButtonTitle',
+    defaultMessage: 'Afrita tengil',
+    description: 'Copy link button title',
+  },
 })
 
 export const coreDefaultFieldMessages = defineMessages({
@@ -392,8 +397,7 @@ export const coreErrorMessages = defineMessages({
   },
   uploadMultipleNotAllowed: {
     id: 'application.system:core.error.file.uploadMultipleNotAllowed',
-    defaultMessage:
-      'Það má bara hlaða upp einni skrá',
+    defaultMessage: 'Það má bara hlaða upp einni skrá',
     description: 'Error message when multi upload is not allowed.',
   },
   fileRemove: {

--- a/libs/application/templates/reference-template/src/forms/exampleForm/noInputFieldsSection/copyLinkSubsection.ts
+++ b/libs/application/templates/reference-template/src/forms/exampleForm/noInputFieldsSection/copyLinkSubsection.ts
@@ -23,7 +23,18 @@ export const copyLinkSubsection = buildSubSection({
         buildCopyLinkField({
           id: 'copyLinkField2',
           title: 'Copy link, with your location',
-          link: document.location.origin,
+          link: (_application) => {
+            // build link based on answers or external data
+            return document.location.origin
+          },
+          marginBottom: 4,
+        }),
+        buildCopyLinkField({
+          id: 'copyLinkField2',
+          title: 'Custom button title and semibold text',
+          link: 'https://www.google.com',
+          semiBoldLink: true,
+          buttonTitle: 'Custom button title',
         }),
       ],
     }),

--- a/libs/application/templates/reference-template/src/forms/exampleForm/noInputFieldsSection/copyLinkSubsection.ts
+++ b/libs/application/templates/reference-template/src/forms/exampleForm/noInputFieldsSection/copyLinkSubsection.ts
@@ -30,7 +30,7 @@ export const copyLinkSubsection = buildSubSection({
           marginBottom: 4,
         }),
         buildCopyLinkField({
-          id: 'copyLinkField2',
+          id: 'copyLinkField3',
           title: 'Custom button title and semibold text',
           link: 'https://www.google.com',
           semiBoldLink: true,

--- a/libs/application/types/src/lib/Fields.ts
+++ b/libs/application/types/src/lib/Fields.ts
@@ -917,7 +917,9 @@ export interface CopyLinkField extends BaseField {
   readonly type: FieldTypes.COPY_LINK
   component: FieldComponents.COPY_LINK
   title: FormText
-  link: string
+  link: FormText
+  buttonTitle?: FormText
+  semiBoldLink?: boolean
 }
 
 export type Field =

--- a/libs/application/ui-components/src/components/CopyLink/CopyLink.tsx
+++ b/libs/application/ui-components/src/components/CopyLink/CopyLink.tsx
@@ -7,11 +7,13 @@ import { coreMessages, coreErrorMessages } from '@island.is/application/core'
 interface CopyLinkProps {
   linkUrl: string
   buttonTitle?: string
+  semiBoldLink?: boolean
 }
 
 const CopyLink: FC<React.PropsWithChildren<CopyLinkProps>> = ({
   linkUrl,
-  buttonTitle = 'Afrita tengil',
+  buttonTitle,
+  semiBoldLink,
 }) => {
   const { formatMessage } = useLocale()
   return (
@@ -24,7 +26,12 @@ const CopyLink: FC<React.PropsWithChildren<CopyLinkProps>> = ({
       borderRadius="large"
     >
       <Box style={{ overflowWrap: 'anywhere' }} paddingRight={4}>
-        <Text color="blue400">{linkUrl}</Text>
+        <Text
+          color="blue400"
+          fontWeight={semiBoldLink ? 'semiBold' : 'regular'}
+        >
+          {linkUrl}
+        </Text>
       </Box>
       <Box marginTop={[3, 0]}>
         <Button
@@ -33,14 +40,10 @@ const CopyLink: FC<React.PropsWithChildren<CopyLinkProps>> = ({
             const copied = copyToClipboard(linkUrl)
             if (!copied) {
               return toast.error(
-                formatMessage(
-                  coreErrorMessages.copyLinkErrorToast.defaultMessage,
-                ),
+                formatMessage(coreErrorMessages.copyLinkErrorToast),
               )
             }
-            toast.success(
-              formatMessage(coreMessages.copyLinkSuccessToast.defaultMessage),
-            )
+            toast.success(formatMessage(coreMessages.copyLinkSuccessToast))
           }}
           variant="ghost"
           nowrap
@@ -49,7 +52,7 @@ const CopyLink: FC<React.PropsWithChildren<CopyLinkProps>> = ({
           iconType="outline"
           size="small"
         >
-          {buttonTitle}
+          {buttonTitle ?? formatMessage(coreMessages.copyLinkButtonTitle)}
         </Button>
       </Box>
     </Box>

--- a/libs/application/ui-fields/src/lib/CopyLinkFormField/CopyLinkFormField.tsx
+++ b/libs/application/ui-fields/src/lib/CopyLinkFormField/CopyLinkFormField.tsx
@@ -15,7 +15,16 @@ export const CopyLinkFormField = ({
   showFieldName,
   application,
 }: Props) => {
-  const { id, link, marginTop, marginBottom, title, description } = field
+  const {
+    id,
+    link,
+    marginTop,
+    marginBottom,
+    title,
+    description,
+    semiBoldLink,
+    buttonTitle,
+  } = field
   const { formatMessage, lang: locale } = useLocale()
 
   return (
@@ -52,7 +61,24 @@ export const CopyLinkFormField = ({
         />
       )}
       <Box>
-        <Copy linkUrl={link} />
+        <Copy
+          linkUrl={formatTextWithLocale(
+            link,
+            application,
+            locale as Locale,
+            formatMessage,
+          )}
+          buttonTitle={
+            buttonTitle &&
+            formatTextWithLocale(
+              buttonTitle,
+              application,
+              locale as Locale,
+              formatMessage,
+            )
+          }
+          semiBoldLink={semiBoldLink}
+        />
       </Box>
     </Box>
   )


### PR DESCRIPTION
## What

Add the options to have semi bold text and custom text for the copy button

## Why

Requested feature

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the copy link functionality with customizable button text and styling options.
  - Enabled dynamic link generation, allowing copy links to adapt based on context.
  - Introduced new properties for improved customization in the copy link field.
  - Updated user interface messages for the copy link button to improve clarity and localization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->