### PR TITLE
fix(search-indexer-service): use correct prod domain

### DIFF
--- a/apps/services/search-indexer/infra/search-indexer-service.ts
+++ b/apps/services/search-indexer/infra/search-indexer-service.ts
@@ -8,10 +8,12 @@ import {
 const envs = {
   APPLICATION_URL: 'http://search-indexer-service',
   ELASTIC_NODE: {
-    dev: 'https://vpc-search-njkekqydiegezhr4vqpkfnw5la.eu-west-1.es.amazonaws.com',
+    dev:
+      'https://vpc-search-njkekqydiegezhr4vqpkfnw5la.eu-west-1.es.amazonaws.com',
     staging:
       'https://vpc-search-q6hdtjcdlhkffyxvrnmzfwphuq.eu-west-1.es.amazonaws.com',
-    prod: 'https://vpc-search-mw4w5c2m2g5edjrtvwbpzhkw24.eu-west-1.es.amazonaws.com',
+    prod:
+      'https://vpc-search-mw4w5c2m2g5edjrtvwbpzhkw24.eu-west-1.es.amazonaws.com',
   },
   ELASTIC_INDEX: 'island-is',
   CONTENTFUL_SPACE: '8k0h54kbe6bj',
@@ -123,7 +125,7 @@ export const serviceSetup = (): ServiceBuilder<'search-indexer-service'> =>
         host: {
           dev: 'search-indexer-service',
           staging: 'search-indexer-service',
-          prod: 'search-indexer-service.devland.is',
+          prod: 'search-indexer-service',
         },
         paths: ['/'],
         extraAnnotations: {

--- a/charts/islandis-services/search-indexer-service/values.prod.yaml
+++ b/charts/islandis-services/search-indexer-service/values.prod.yaml
@@ -59,7 +59,7 @@ ingress:
       kubernetes.io/ingress.class: 'nginx-external-alb'
       nginx.ingress.kubernetes.io/service-upstream: 'true'
     hosts:
-      - host: 'search-indexer-service.devland.is'
+      - host: 'search-indexer-service.island.is'
         paths:
           - '/'
 initContainer:

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -1883,7 +1883,7 @@ search-indexer-service:
         kubernetes.io/ingress.class: 'nginx-external-alb'
         nginx.ingress.kubernetes.io/service-upstream: 'true'
       hosts:
-        - host: 'search-indexer-service.devland.is'
+        - host: 'search-indexer-service.island.is'
           paths:
             - '/'
   initContainer:


### PR DESCRIPTION
The prod url has been using `.devland.is` from the start but should use `.island.is` to unclutter infra code complexities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the production service endpoint to streamline environment settings.
- **Style**
	- Enhanced the formatting of environment URLs for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->