### PR TITLE
fix(j-s): Sort offenses in a spesific order

### DIFF
--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/lib/getIncidentDecriptionReason.spec.ts
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/lib/getIncidentDecriptionReason.spec.ts
@@ -139,4 +139,23 @@ describe('getIncidentDescriptionReason', () => {
       'óhæfur til að stjórna henni örugglega vegna áhrifa ávana- og fíkniefna og slævandi lyfja',
     )
   })
+
+  test('should return a description with only prescription and illegal drugs, in that order', () => {
+    const offenses = [
+      {
+        offense: IndictmentCountOffense.PRESCRIPTION_DRUGS_DRIVING,
+        substances: {},
+      },
+      {
+        offense: IndictmentCountOffense.ILLEGAL_DRUGS_DRIVING,
+        substances: {},
+      },
+    ] as Offense[]
+
+    const result = getIncidentDescriptionReason(offenses, formatMessage)
+
+    expect(result).toBe(
+      'óhæfur til að stjórna henni örugglega vegna áhrifa ávana- og fíkniefna og slævandi lyfja',
+    )
+  })
 })

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/lib/getIncidentDescriptionReason.ts
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/lib/getIncidentDescriptionReason.ts
@@ -14,12 +14,19 @@ export const getIncidentDescriptionReason = (
   offenses: Offense[],
   formatMessage: IntlShape['formatMessage'],
 ) => {
+  const order = [
+    IndictmentCountOffense.DRUNK_DRIVING,
+    IndictmentCountOffense.ILLEGAL_DRUGS_DRIVING,
+    IndictmentCountOffense.PRESCRIPTION_DRUGS_DRIVING,
+  ]
+
   let reason = offenses
     .filter(
       (o) =>
         o.offense !== IndictmentCountOffense.SPEEDING &&
         o.offense !== IndictmentCountOffense.OTHER,
     )
+    .sort((a, b) => order.indexOf(a.offense) - order.indexOf(b.offense))
     .reduce((acc, o, index) => {
       if (
         (offenses.length > 1 && index === offenses.length - 1) ||


### PR DESCRIPTION
# Sort offenses in a spesific order

Asana

## What

This PR fixes a bug in generating the description in indictment counts. The bug was that if you selected prescription drugs and illegal drugs (in that order) the description would be 

`... ekið bifreiðinni AB123 slævandi lyfja og óhæfur til að stjórna henni ...`

When talking to Guðný about this, she mentioned that the description should always follow a specific order: 

drunk driving
illegal drugs
prescription drugs

I was able to fix this issue by applying this sort before generating the description.

## Why

This was a bug

## Screenshots / Gifs

<img width="802" alt="Screenshot 2025-03-05 at 10 23 44" src="https://github.com/user-attachments/assets/9d3f8bf2-ef3d-4da5-a646-463e61e99996" />

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
