### PR TITLE
fix(my-pages): revert using isMobile hook

### DIFF
--- a/apps/portals/my-pages/src/components/Header/Header.tsx
+++ b/apps/portals/my-pages/src/components/Header/Header.tsx
@@ -9,7 +9,7 @@ import {
   Hidden,
   Logo,
 } from '@island.is/island-ui/core'
-import { helperStyles } from '@island.is/island-ui/theme'
+import { helperStyles, theme } from '@island.is/island-ui/theme'
 import { useLocale } from '@island.is/localization'
 import { PortalPageLoader } from '@island.is/portals/core'
 import { SERVICE_PORTAL_HEADER_HEIGHT_SM } from '@island.is/portals/my-pages/constants'
@@ -17,7 +17,6 @@ import {
   LinkResolver,
   ServicePortalPaths,
   m,
-  useIsMobile,
   useScrollPosition,
 } from '@island.is/portals/my-pages/core'
 import { DocumentsPaths } from '@island.is/portals/my-pages/documents'
@@ -26,6 +25,7 @@ import { UserLanguageSwitcher, UserMenu } from '@island.is/shared/components'
 import cn from 'classnames'
 import { useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
+import { useWindowSize } from 'react-use'
 import NotificationButton from '../Notifications/NotificationButton'
 import Sidemenu from '../Sidemenu/Sidemenu'
 import * as styles from './Header.css'
@@ -38,7 +38,8 @@ export const Header = ({ position }: Props) => {
   const { formatMessage } = useLocale()
   const [menuOpen, setMenuOpen] = useState<MenuTypes>()
   const ref = useRef<HTMLButtonElement>(null)
-  const isMobile = useIsMobile()
+  const { width } = useWindowSize()
+  const isMobile = width < theme.breakpoints.md
 
   const user = useUserInfo()
 

--- a/apps/portals/my-pages/src/components/Sidemenu/Sidemenu.css.ts
+++ b/apps/portals/my-pages/src/components/Sidemenu/Sidemenu.css.ts
@@ -6,7 +6,6 @@ import {
   styleVariants,
 } from '@vanilla-extract/css'
 import { StyleWithSelectors } from '@vanilla-extract/css/dist/declarations/src/types'
-import { createGlobalTheme } from '@vanilla-extract/css'
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const wrapperAnimation = keyframes({
@@ -209,12 +208,4 @@ export const itemText = style({
 export const overviewIcon = style({
   height: 40,
   width: 40,
-})
-
-const sidemenuOpen = createGlobalTheme(':root', {
-  sidemenuOpen: 'false',
-})
-
-globalStyle(`html[data-sidemenu-open="true"]`, {
-  overflow: 'hidden',
 })

--- a/apps/portals/my-pages/src/components/Sidemenu/Sidemenu.tsx
+++ b/apps/portals/my-pages/src/components/Sidemenu/Sidemenu.tsx
@@ -1,4 +1,3 @@
-import React, { ReactElement, useEffect } from 'react'
 import {
   Box,
   GridContainer,
@@ -7,19 +6,20 @@ import {
   ModalBase,
   Text,
 } from '@island.is/island-ui/core'
+import { theme } from '@island.is/island-ui/theme'
+import { useLocale, useNamespaces } from '@island.is/localization'
 import {
+  m,
   ServicePortalPaths,
   useDynamicRoutesWithNavigation,
-  useIsMobile,
 } from '@island.is/portals/my-pages/core'
-import * as styles from './Sidemenu.css'
 import { sharedMessages } from '@island.is/shared/translations'
-import { useLocale, useNamespaces } from '@island.is/localization'
-import { MAIN_NAVIGATION } from '../../lib/masterNavigation'
 import cn from 'classnames'
+import { ReactElement } from 'react'
+import { useWindowSize } from 'react-use'
+import { MAIN_NAVIGATION } from '../../lib/masterNavigation'
+import * as styles from './Sidemenu.css'
 import SidemenuItem from './SidemenuItem'
-import { m } from '@island.is/portals/my-pages/core'
-
 interface Props {
   setSideMenuOpen: (status: boolean) => void
   sideMenuOpen: boolean
@@ -33,21 +33,8 @@ const Sidemenu = ({
   useNamespaces(['service.portal'])
   const navigation = useDynamicRoutesWithNavigation(MAIN_NAVIGATION)
   const { formatMessage } = useLocale()
-
-  const isMobile = useIsMobile()
-
-  // In your component logic, you can toggle the attribute on the HTML element
-  useEffect(() => {
-    if (sideMenuOpen) {
-      document.documentElement.setAttribute('data-sidemenu-open', 'true')
-    } else {
-      document.documentElement.setAttribute('data-sidemenu-open', 'false')
-    }
-
-    return () => {
-      document.documentElement.removeAttribute('data-sidemenu-open')
-    }
-  }, [sideMenuOpen])
+  const { width } = useWindowSize()
+  const isMobile = width < theme.breakpoints.md
 
   const onClose = () => {
     setSideMenuOpen(false)


### PR DESCRIPTION
# My pages - Mobile hook

## What

Mobile hook is not reliable, revert using it and use window width like before

... and cleanup other unused code 🧹 

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated mobile detection across header and side menu to use dynamic viewport width, ensuring improved responsiveness.
	- Simplified component logic for determining mobile views.

- **Style**
	- Removed styling that previously restricted page scrolling when the sidebar menu was open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->