### PR TITLE
fix(web): Project Subpage title is not present in head tag

### DIFF
--- a/apps/web/screens/Project/Project.tsx
+++ b/apps/web/screens/Project/Project.tsx
@@ -279,7 +279,7 @@ const ProjectPage: Screen<PageProps> = ({
   return (
     <>
       <HeadWithSocialSharing
-        title={`${projectPage?.title} | Ísland.is`}
+        title={`${subpage?.title ?? projectPage?.title} | Ísland.is`}
         description={projectPage?.featuredDescription || projectPage?.intro}
         imageUrl={projectPage?.featuredImage?.url}
         imageContentType={projectPage?.featuredImage?.contentType}


### PR DESCRIPTION
# Project Subpage title is not present in head tag

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the project page title display to reflect a contextual header based on the viewed section. When a subpage title is available, it is used to create a more descriptive and relevant header; otherwise, the default project title is shown. This improvement enhances clarity and provides a better user experience with dynamically tailored page headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->