### PR TITLE
fix(j-s): Use latest subpoena on Mínar síður

### DIFF
--- a/apps/judicial-system/digital-mailbox-api/src/app/modules/cases/models/internal/internalCase.response.ts
+++ b/apps/judicial-system/digital-mailbox-api/src/app/modules/cases/models/internal/internalCase.response.ts
@@ -47,6 +47,7 @@ interface DateLog {
 
 interface Subpoena {
   id: string
+  created: Date
   subpoenaId: string
   serviceStatus?: ServiceStatus
 }

--- a/apps/judicial-system/digital-mailbox-api/src/app/modules/cases/models/subpoena.response.ts
+++ b/apps/judicial-system/digital-mailbox-api/src/app/modules/cases/models/subpoena.response.ts
@@ -120,9 +120,14 @@ export class SubpoenaResponse {
       defendantInfo?.requestedDefenderChoice === DefenderChoice.WAIVE
     const hasDefender = defendantInfo?.requestedDefenderNationalId !== null
     const subpoenas = defendantInfo?.subpoenas ?? []
+
+    const latestSubpoena = subpoenas.sort(
+      (a, b) => new Date(b.created).getTime() - new Date(a.created).getTime(),
+    )[0]
+
     const hasBeenServed =
       subpoenas.length > 0 &&
-      isSuccessfulServiceStatus(subpoenas[0].serviceStatus)
+      isSuccessfulServiceStatus(latestSubpoena.serviceStatus)
     const canChangeDefenseChoice = !waivedRight && !hasDefender
 
     const subpoenaDateLog = internalCase.dateLogs?.find(


### PR DESCRIPTION
# Use latest subpoena on Mínar síður

[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1209519762987523)

## What

There is an issue with subpoenas on mínar síður. The issue is that if a defendant has multiple subpoenas on their name, they cannot select a defender on mínar síður unless all subpoenas have been opened. This was because the order of the subpoenas would get mixed up on their way to mínar síður. We order the subpoenas in decending order and then select the first subpoena. The order on mínar síður was in ascending order, meaning that you'd have to open all pervious subpoenas in order to select a defender.

The fix is to stop relying on the order of the subpoenas and simply select the newest subpoena manually instead.

## Why

This is a bug

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a timestamp for tracking when subpoenas are created.
	- Enhanced the logic to always reflect the most recent service status across multiple records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->