### PR TITLE
fix(contentful-entry-tagger): Fix prod url

### DIFF
--- a/apps/services/contentful-entry-tagger/infra/contentful-entry-tagger-service.ts
+++ b/apps/services/contentful-entry-tagger/infra/contentful-entry-tagger-service.ts
@@ -17,7 +17,7 @@ export const serviceSetup =
           host: {
             dev: 'contentful-entry-tagger-service',
             staging: 'contentful-entry-tagger-service',
-            prod: 'contentful-entry-tagger-service.devland.is',
+            prod: 'contentful-entry-tagger-service',
           },
           paths: ['/'],
         },


### PR DESCRIPTION
# Fix prod url

Since devland.is is out we need to change the prod url