### PR TITLE
chore(j-s): Add commas to indictment intro

### DIFF
--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Indictment.strings.ts
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Indictment.strings.ts
@@ -37,8 +37,8 @@ export const indictment = defineMessages({
       'Notaður sem sjálfgefinn texti í Inngangur textasvæði á ákæra skrefi í ákærum.',
   },
   indictmentIntroductionAutofillDefendant: {
-    id: 'judicial.system.core:indictments_indictment.indictment_introduction_defendant_name',
-    defaultMessage: '{defendantName}, kt. {defendantNationalId}',
+    id: 'judicial.system.core:indictments_indictment.indictment_introduction_defendant_name_v1',
+    defaultMessage: '{defendantName}, kt. {defendantNationalId},',
     description:
       'Notaður sem sjálfgefinn texti í Inngangur textasvæði á ákæra skrefi í ákærum.',
   },

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Indictment.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Indictment.tsx
@@ -76,7 +76,7 @@ export const getIndictmentIntroductionAutofill = (
                 ? formatNationalId(defendant.nationalId)
                 : 'Ekki skráð',
             },
-          )}\n          ${defendant.address}`
+          )}\n          ${defendant.address},`
         })}
     `,
       ]


### PR DESCRIPTION
# Add commas to indictment intro

[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1209426000210870)

## What

Add commas after the defendant's national id and address in the indictment intro

## Why

This was a request from our users.

## Screenshots / Gifs

<img width="626" alt="Screenshot 2025-03-07 at 10 55 02" src="https://github.com/user-attachments/assets/33bda0d7-bf51-4fbc-a761-fc25205c0e5b" />


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted punctuation in autofill texts for defendant details to ensure a consistent and clear presentation.
  - Updated versioning for defendant detail messages to maintain uniformity in the displayed information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->