### PR TITLE
feat(web): Change and improve teammember list search

### DIFF
--- a/libs/cms/src/lib/cms.elasticsearch.service.ts
+++ b/libs/cms/src/lib/cms.elasticsearch.service.ts
@@ -665,8 +665,6 @@ export class CmsElasticsearchService {
       },
     })
 
-    console.log('must: ', must)
-
     const size = input.size ?? 10
 
     let sort: sortRule[] = []

--- a/libs/cms/src/lib/cms.elasticsearch.service.ts
+++ b/libs/cms/src/lib/cms.elasticsearch.service.ts
@@ -477,9 +477,7 @@ export class CmsElasticsearchService {
     })
   }
 
-  private async getListItems<
-    ListItemType extends 'webGenericListItem' | 'webTeamMember',
-  >(input: {
+  private async getListItems<ListItemType extends 'webGenericListItem'>(input: {
     listId: string
     lang: ElasticsearchIndexLocale
     page?: number
@@ -488,12 +486,8 @@ export class CmsElasticsearchService {
     tags?: string[]
     tagGroups?: Record<string, string[]>
     type: ListItemType
-    orderBy?: GetGenericListItemsInputOrderBy | GetTeamMembersInputOrderBy
-  }): Promise<
-    ListItemType extends 'webGenericListItem'
-      ? Omit<GenericListItemResponse, 'input'>
-      : Omit<TeamMemberResponse, 'input'>
-  > {
+    orderBy?: GetGenericListItemsInputOrderBy
+  }): Promise<Omit<GenericListItemResponse, 'input'>> {
     let must: Record<string, unknown>[] = [
       {
         term: {
@@ -611,17 +605,176 @@ export class CmsElasticsearchService {
     }
   }
 
+  private async getTeamListItems<ListItemType extends 'webTeamMember'>(input: {
+    listId: string
+    lang: ElasticsearchIndexLocale
+    page?: number
+    size?: number
+    queryString?: string
+    tags?: string[]
+    tagGroups?: Record<string, string[]>
+    type: ListItemType
+    orderBy?: GetTeamMembersInputOrderBy
+  }): Promise<Omit<TeamMemberResponse, 'input'>> {
+    let must: Record<string, unknown>[] = [
+      {
+        term: {
+          type: {
+            value: input.type,
+          },
+        },
+      },
+      {
+        nested: {
+          path: 'tags',
+          query: {
+            bool: {
+              must: [
+                {
+                  term: {
+                    'tags.key': input.listId,
+                  },
+                },
+                {
+                  term: {
+                    'tags.type': 'referencedBy',
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    ]
+
+    let queryString = input.queryString
+      ? input.queryString.trim().toLowerCase()
+      : ''
+
+    if (input.lang === 'is') {
+      queryString = queryString.replace('`', '')
+      queryString = queryString.replace('´', '')
+    }
+
+    must.push({
+      simple_query_string: {
+        query: queryString + '*',
+        fields: ['title^100'],
+        analyze_wildcard: true,
+        default_operator: 'and',
+      },
+    })
+
+    console.log('must: ', must)
+
+    const size = input.size ?? 10
+
+    let sort: sortRule[] = []
+
+    if (!input.orderBy) {
+      sort = [
+        { _score: { order: SortDirection.DESC } },
+        {
+          [SortField.RELEASE_DATE]: {
+            order: SortDirection.DESC,
+          },
+        },
+        { 'title.sort': { order: SortDirection.ASC } },
+        { dateCreated: { order: SortDirection.DESC } },
+      ]
+    }
+
+    if (input.orderBy === GetTeamMembersInputOrderBy.Name) {
+      sort = [
+        { _score: { order: SortDirection.DESC } },
+        { 'title.sort': { order: SortDirection.ASC } },
+        {
+          [SortField.RELEASE_DATE]: {
+            order: SortDirection.DESC,
+          },
+        },
+        { dateCreated: { order: SortDirection.DESC } },
+      ]
+    }
+
+    if (input.orderBy === GetTeamMembersInputOrderBy.Manual) {
+      sort = [
+        { _score: { order: SortDirection.DESC } },
+        { dateCreated: { order: SortDirection.DESC } },
+        { 'title.sort': { order: SortDirection.ASC } },
+        {
+          [SortField.RELEASE_DATE]: {
+            order: SortDirection.DESC,
+          },
+        },
+      ]
+    }
+
+    if (input.tags && input.tags.length > 0 && input.tagGroups) {
+      must = must.concat(
+        generateGenericTagGroupQueries(input.tags, input.tagGroups),
+      )
+    }
+
+    const response: ApiResponse<SearchResponse<MappedData>> =
+      await this.elasticService.findByQuery(getElasticsearchIndex(input.lang), {
+        query: {
+          bool: {
+            must,
+            should: [
+              {
+                wildcard: {
+                  'title.keyword': {
+                    value: queryString + '*',
+                    boost: 50,
+                  },
+                },
+              },
+              {
+                prefix: {
+                  'title.keyword': {
+                    value: queryString,
+                    boost: 100,
+                  },
+                },
+              },
+              {
+                match_phrase: {
+                  title: {
+                    query: queryString,
+                    boost: 5,
+                  },
+                },
+              },
+            ],
+            minimum_should_match: 0,
+          },
+        },
+        sort,
+        track_scores: true,
+        size,
+        from: ((input.page ?? 1) - 1) * size,
+      })
+
+    return {
+      items: response.body.hits.hits
+        .map((item) => JSON.parse(item._source.response ?? 'null'))
+        .filter(Boolean),
+      total: response.body.hits.total.value,
+    }
+  }
+
   async getTeamMembers(
     input: GetTeamMembersInput,
   ): Promise<TeamMemberResponse> {
-    const response = await this.getListItems({
+    const response = await this.getTeamListItems({
       ...input,
       type: 'webTeamMember',
       listId: input.teamListId,
       orderBy:
         input.orderBy === GetTeamMembersInputOrderBy.Manual
-          ? GetGenericListItemsInputOrderBy.DATE
-          : GetGenericListItemsInputOrderBy.TITLE,
+          ? GetTeamMembersInputOrderBy.Manual
+          : GetTeamMembersInputOrderBy.Name,
     })
 
     return {

--- a/libs/cms/src/lib/search/importers/teamList.service.ts
+++ b/libs/cms/src/lib/search/importers/teamList.service.ts
@@ -46,7 +46,7 @@ export class TeamListSyncService implements CmsSyncProvider<ITeamList> {
           const content = contentSection.join(' ')
           teamMembers.push({
             _id: member.id,
-            title: member.name,
+            title: member.name.toLowerCase(),
             content,
             contentWordCount: content?.split(/\s+/).length,
             type: 'webTeamMember',

--- a/libs/content-search-toolkit/src/types/shared.ts
+++ b/libs/content-search-toolkit/src/types/shared.ts
@@ -29,6 +29,7 @@ export type sortableFields =
   | 'title.sort'
   | 'popularityScore'
   | 'releaseDate'
+  | '_score'
 
 export type sortRule = {
   [key in sortableFields]?: {


### PR DESCRIPTION
# Change and improve teammember list search

## What

- Make separated search function for team member list items
- Improve search boost for title to use score in query
- Only search in title field

## Why

To make the team member list search more accurate

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a dedicated method for retrieving team member items, enhancing search capabilities.
	- Added a new sorting option based on item scores for improved relevance in search results.
- **Refactor**
	- Simplified the retrieval of generic list items for clearer functionality.
	- Standardized team member title formatting to lowercase for consistent display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->