### PR TITLE
fix(native-app): don't show see all button for finished applications if they 3 or less

### DIFF
--- a/apps/native/app/src/screens/applications/components/applications-preview.tsx
+++ b/apps/native/app/src/screens/applications/components/applications-preview.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { useIntl } from 'react-intl'
 import { TouchableOpacity, View } from 'react-native'
 import { useTheme } from 'styled-components'
@@ -130,17 +131,13 @@ export const ApplicationsPreview = ({
     <>
       {applications.length > 0 ? (
         <TouchableOpacity
-          disabled={
-            (slider && !applications.length) ||
-            (!slider && applications.length <= numberOfItems)
-          }
+          disabled={applications.length <= numberOfItems}
           onPress={() => navigateTo(`${headingTitleNavigationLink}`)}
           style={{ marginHorizontal: theme.spacing[2] }}
         >
           <Heading
             button={
-              (slider && applications.length) ||
-              (!slider && applications.length > numberOfItems) ? (
+              applications.length > numberOfItems ? (
                 <TouchableOpacity
                   onPress={() => navigateTo(`${headingTitleNavigationLink}`)}
                   style={{


### PR DESCRIPTION
## What

Currently we are always showing the 'See all' button for completed applications. Strange if you only have one completed application to be able to open up a whole new screen with that one application. 
Removing the see all button if completed applications are fewer than 4.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the conditions for enabling interactive elements and displaying controls based on the available items, resulting in a more straightforward and predictable user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->