### PR TITLE
fix(j-s): remove verify request completition

### DIFF
--- a/apps/system-e2e/src/tests/judicial-system/regression/custody-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/custody-tests.spec.ts
@@ -332,7 +332,6 @@ test.describe.serial('Custody tests', () => {
     await page.locator('input[id=reqValidToDate]').fill(extendedCustodyEndDate)
     await page.keyboard.press('Escape')
     await page.locator('input[id=reqValidToDate-time]').fill('16:00')
-    await verifyRequestCompletion(page, '/api/graphql', 'UpdateCase')
     await Promise.all([
       page.getByTestId('continueButton').click(),
       verifyRequestCompletion(page, '/api/graphql', 'Case'),


### PR DESCRIPTION
# [Fix custody specs e2e tests](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1209582900535991)

## What
- Due to a change in the `useDebounce` logic made [here](https://github.com/island-is/island.is/pull/18183/files), we are not sending an update requests as before. 
- Thus we need to remove a step in the custody e2e tests to wait for requests completion after filling out couple of fields in _domkrofur-og-lagagrundvollur_ page for R-cases

## Why
- This was causing the our e2e tests to fail


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Streamlined internal regression tests for custody operations by optimizing verification steps. This update improves our testing workflow and does not affect the public functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->