### PR TITLE
feat(web): Verdicts - detail page visual changes

### DIFF
--- a/apps/web/screens/Verdicts/VerdictDetails.css.ts
+++ b/apps/web/screens/Verdicts/VerdictDetails.css.ts
@@ -16,3 +16,13 @@ export const hiddenOnScreen = style({
     },
   },
 })
+
+export const textMaxWidth = style({
+  maxWidth: '876px',
+})
+
+export const richText = style({})
+
+globalStyle(`${richText} h1:first-of-type, ${richText} h2:last-of-type`, {
+  textAlign: 'center',
+})

--- a/apps/web/screens/Verdicts/VerdictDetails.css.ts
+++ b/apps/web/screens/Verdicts/VerdictDetails.css.ts
@@ -5,3 +5,14 @@ export const pdfContainer = style({})
 globalStyle(`${pdfContainer} .react-pdf__Page`, {
   marginBottom: '32px',
 })
+
+export const hiddenOnScreen = style({
+  '@media': {
+    screen: {
+      display: 'none',
+    },
+    print: {
+      display: 'block',
+    },
+  },
+})

--- a/apps/web/screens/Verdicts/VerdictDetails.tsx
+++ b/apps/web/screens/Verdicts/VerdictDetails.tsx
@@ -327,4 +327,7 @@ VerdictDetails.getProps = async ({ apolloClient, query, customPageData }) => {
 
 export default withMainLayout(
   withCustomPageWrapper(CustomPageUniqueIdentifier.Verdicts, VerdictDetails),
+  {
+    showFooter: false,
+  },
 )

--- a/apps/web/screens/Verdicts/VerdictsList.tsx
+++ b/apps/web/screens/Verdicts/VerdictsList.tsx
@@ -16,6 +16,7 @@ import {
   Stack,
   Text,
 } from '@island.is/island-ui/core'
+import { Webreader } from '@island.is/web/components'
 import {
   CustomPageUniqueIdentifier,
   type GetVerdictCaseCategoriesQuery,
@@ -116,13 +117,14 @@ const VerdictsList: CustomScreen<VerdictsListProps> = ({ initialData }) => {
   )
 
   return (
-    <Box paddingBottom={5}>
+    <Box paddingBottom={5} className="rs_read">
       <GridContainer>
         <Stack space={3}>
           <Breadcrumbs items={[{ title: 'Ísland.is', href: '/' }]} />
           <Text variant="h1" as="h1">
             {formatMessage(m.listPage.heading)}{' '}
           </Text>
+          <Webreader readClass="rs_read" marginBottom={0} marginTop={0} />
           <Text>{formatMessage(m.listPage.description)}</Text>
           <GridRow rowGap={3}>
             {data.visibleVerdicts.map((item) => (

--- a/apps/web/screens/Verdicts/VerdictsList.tsx
+++ b/apps/web/screens/Verdicts/VerdictsList.tsx
@@ -8,11 +8,8 @@ import {
   Box,
   Breadcrumbs,
   Button,
-  Divider,
-  FocusableBox,
-  GridColumn,
   GridContainer,
-  GridRow,
+  InfoCardGrid,
   Stack,
   Text,
 } from '@island.is/island-ui/core'
@@ -116,6 +113,8 @@ const VerdictsList: CustomScreen<VerdictsListProps> = ({ initialData }) => {
     [page],
   )
 
+  const [isGridLayout, setIsGridLayout] = useState(false)
+
   return (
     <Box paddingBottom={5} className="rs_read">
       <GridContainer>
@@ -126,80 +125,51 @@ const VerdictsList: CustomScreen<VerdictsListProps> = ({ initialData }) => {
           </Text>
           <Webreader readClass="rs_read" marginBottom={0} marginTop={0} />
           <Text>{formatMessage(m.listPage.description)}</Text>
-          <GridRow rowGap={3}>
-            {data.visibleVerdicts.map((item) => (
-              <GridColumn key={item.id} span="1/1">
-                <FocusableBox
-                  height="full"
-                  href={`/domar/${item.id}`}
-                  background="white"
-                  borderRadius="large"
-                  borderColor="blue200"
-                  borderWidth="standard"
-                  paddingX={3}
-                  paddingY={2}
-                >
-                  <GridContainer>
-                    <Stack space={2}>
-                      <GridRow rowGap={3}>
-                        <GridColumn span={['7/12', '7/12', '9/12']}>
-                          <Text variant="h5" color="blue400">
-                            {item.caseNumber}
-                          </Text>
-                        </GridColumn>
-                        <GridColumn span={['5/12', '5/12', '3/12']}>
-                          {item.verdictDate && (
-                            <Text variant="medium" textAlign="right">
-                              {format(
-                                new Date(item.verdictDate),
-                                'd. MMM yyyy',
-                              )}
-                            </Text>
-                          )}
-                        </GridColumn>
-                      </GridRow>
-                      <Stack space={0}>
-                        <GridRow>
-                          <GridColumn>
-                            <Text color="blue400" variant="medium">
-                              {item.court}
-                            </Text>
-                            <Text color="blue400" variant="medium">
-                              {item.presidentJudge?.name}{' '}
-                              {item.presidentJudge?.title}
-                            </Text>
-                          </GridColumn>
-                          <GridColumn>
-                            <Text variant="small">{item.title}</Text>
-                          </GridColumn>
-                        </GridRow>
-                      </Stack>
-                      <GridRow>
-                        <GridColumn>
-                          <Text variant="small" color="dark300">
-                            {item.keywords.join('. ')}
-                          </Text>
-                        </GridColumn>
-                      </GridRow>
-                      {Boolean(item.presentings) && <Divider />}
-                      {Boolean(item.presentings) && (
-                        <GridRow>
-                          <GridColumn>
-                            <Text variant="small">
-                              <Text color="blue400" variant="medium" as="span">
-                                {formatMessage(m.listPage.presentings)}:
-                              </Text>{' '}
-                              {item.presentings}
-                            </Text>
-                          </GridColumn>
-                        </GridRow>
-                      )}
-                    </Stack>
-                  </GridContainer>
-                </FocusableBox>
-              </GridColumn>
-            ))}
-          </GridRow>
+          <Box display="flex" justifyContent="flexEnd">
+            <Button
+              variant="utility"
+              icon={isGridLayout ? 'menu' : 'gridView'}
+              iconType="filled"
+              colorScheme="white"
+              size="small"
+              onClick={() => {
+                setIsGridLayout((previousState) => !previousState)
+              }}
+            >
+              {formatMessage(
+                isGridLayout ? m.listPage.displayList : m.listPage.displayGrid,
+              )}
+            </Button>
+          </Box>
+
+          <InfoCardGrid
+            variant="detailed"
+            columns={isGridLayout ? 2 : 1}
+            cards={data.visibleVerdicts.map((verdict) => {
+              return {
+                description: verdict.title,
+                eyebrow: '',
+                id: verdict.id,
+                link: { href: `/domar/${verdict.id}`, label: '' },
+                title: verdict.caseNumber,
+                borderColor: 'blue200',
+                detailLines: [
+                  {
+                    icon: 'calendar',
+                    text: verdict.verdictDate
+                      ? format(new Date(verdict.verdictDate), 'd. MMMM yyyy')
+                      : '',
+                  },
+                  {
+                    icon: 'person',
+                    text: `${verdict.presidentJudge?.name ?? ''} ${
+                      verdict.presidentJudge?.title ?? ''
+                    }`,
+                  },
+                ],
+              }
+            })}
+          />
           {initialData.total > data.visibleVerdicts.length && (
             <Box
               key={page}

--- a/apps/web/screens/Verdicts/VerdictsList.tsx
+++ b/apps/web/screens/Verdicts/VerdictsList.tsx
@@ -121,35 +121,39 @@ const VerdictsList: CustomScreen<VerdictsListProps> = ({ initialData }) => {
   const overrideGridLayoutSetting = width < theme.breakpoints.lg
 
   return (
-    <Box paddingBottom={5} className="rs_read">
-      <GridContainer>
-        <Stack space={3}>
-          <Breadcrumbs items={[{ title: 'Ísland.is', href: '/' }]} />
-          <Text variant="h1" as="h1">
-            {formatMessage(m.listPage.heading)}{' '}
-          </Text>
-          <Webreader readClass="rs_read" marginBottom={0} marginTop={0} />
-          <Text>{formatMessage(m.listPage.description)}</Text>
-          <Hidden below="lg">
-            <Box display="flex" justifyContent="flexEnd">
-              <Button
-                variant="utility"
-                icon={isGridLayout ? 'menu' : 'gridView'}
-                iconType="filled"
-                colorScheme="white"
-                size="small"
-                onClick={() => {
-                  setIsGridLayout((previousState) => !previousState)
-                }}
-              >
-                {formatMessage(
-                  isGridLayout
-                    ? m.listPage.displayList
-                    : m.listPage.displayGrid,
-                )}
-              </Button>
-            </Box>
-          </Hidden>
+    <Box className="rs_read">
+      <Stack space={3}>
+        <GridContainer>
+          <Stack space={3}>
+            <Breadcrumbs items={[{ title: 'Ísland.is', href: '/' }]} />
+            <Text variant="h1" as="h1">
+              {formatMessage(m.listPage.heading)}{' '}
+            </Text>
+            <Webreader readClass="rs_read" marginBottom={0} marginTop={0} />
+            <Text>{formatMessage(m.listPage.description)}</Text>
+            <Hidden below="lg">
+              <Box display="flex" justifyContent="flexEnd">
+                <Button
+                  variant="utility"
+                  icon={isGridLayout ? 'menu' : 'gridView'}
+                  iconType="filled"
+                  colorScheme="white"
+                  size="small"
+                  onClick={() => {
+                    setIsGridLayout((previousState) => !previousState)
+                  }}
+                >
+                  {formatMessage(
+                    isGridLayout
+                      ? m.listPage.displayList
+                      : m.listPage.displayGrid,
+                  )}
+                </Button>
+              </Box>
+            </Hidden>
+          </Stack>
+        </GridContainer>
+        <Box background="blue100" paddingTop={[3, 3, 0]}>
           <SidebarLayout
             fullWidthContent={true}
             sidebarContent={
@@ -188,39 +192,38 @@ const VerdictsList: CustomScreen<VerdictsListProps> = ({ initialData }) => {
                 }
               })}
             />
-          </SidebarLayout>
-
-          {initialData.total > data.visibleVerdicts.length && (
-            <Box
-              key={page}
-              paddingTop={4}
-              display="flex"
-              flexDirection="column"
-              alignItems="center"
-              justifyContent="center"
-            >
-              {error && (
-                <Box paddingBottom={2}>
-                  <Text variant="medium" color="red600">
-                    {formatMessage(m.listPage.loadingMoreFailed)}
-                  </Text>
-                </Box>
-              )}
-              <Button
-                loading={loading}
-                onClick={() => {
-                  setPage((p) => p + 1)
-                }}
+            {initialData.total > data.visibleVerdicts.length && (
+              <Box
+                key={page}
+                paddingTop={4}
+                display="flex"
+                flexDirection="column"
+                alignItems="center"
+                justifyContent="center"
               >
-                {formatMessage(m.listPage.seeMoreVerdicts, {
-                  remainingVerdictCount:
-                    initialData.total - data.visibleVerdicts.length,
-                })}
-              </Button>
-            </Box>
-          )}
-        </Stack>
-      </GridContainer>
+                {error && (
+                  <Box paddingBottom={2}>
+                    <Text variant="medium" color="red600">
+                      {formatMessage(m.listPage.loadingMoreFailed)}
+                    </Text>
+                  </Box>
+                )}
+                <Button
+                  loading={loading}
+                  onClick={() => {
+                    setPage((p) => p + 1)
+                  }}
+                >
+                  {formatMessage(m.listPage.seeMoreVerdicts, {
+                    remainingVerdictCount:
+                      initialData.total - data.visibleVerdicts.length,
+                  })}
+                </Button>
+              </Box>
+            )}
+          </SidebarLayout>
+        </Box>
+      </Stack>
     </Box>
   )
 }
@@ -298,4 +301,7 @@ VerdictsList.getProps = async ({ apolloClient, query, customPageData }) => {
 
 export default withMainLayout(
   withCustomPageWrapper(CustomPageUniqueIdentifier.Verdicts, VerdictsList),
+  {
+    showFooter: false,
+  },
 )

--- a/apps/web/screens/Verdicts/translations.strings.ts
+++ b/apps/web/screens/Verdicts/translations.strings.ts
@@ -39,6 +39,11 @@ export const m = {
       defaultMessage: 'Sýna sem spjöld',
       description: 'Sýna sem spjöld',
     },
+    sidebarFilterHeading: {
+      id: 'web.verdicts:listPage.sidebarFilterHeading',
+      defaultMessage: 'Ítarleit',
+      description: 'Ítarleit',
+    },
   }),
   verdictPage: {
     heading: {

--- a/apps/web/screens/Verdicts/translations.strings.ts
+++ b/apps/web/screens/Verdicts/translations.strings.ts
@@ -46,5 +46,26 @@ export const m = {
       defaultMessage: 'Til baka',
       description: 'Texti á "Til baka" hnapp',
     },
+    caseNumberPrefix: {
+      id: 'web.verdicts:verdictPage.caseNumberPrefix',
+      defaultMessage: 'Mál nr.',
+      description: 'Texti á undan málsnúmeri fyrir HTML dóma',
+    },
+    keywords: {
+      id: 'web.verdicts:verdictPage.keywords',
+      defaultMessage: 'Lykilorð',
+      description: 'Lykilorð',
+    },
+    presentings: {
+      id: 'web.verdicts:verdictPage.presentings',
+      defaultMessage: 'Reifun',
+      description: 'Reifun',
+    },
+    htmlVerdictLogoUrl: {
+      id: 'web.verdicts:verdictPage.htmlVerdictLogoUrl',
+      defaultMessage:
+        'https://images.ctfassets.net/8k0h54kbe6bj/40DkdlOOP8LT7a49ytG0vS/71bdcf876b158e860e27b1d249043798/Frame_25613.svg',
+      description: 'Logo efst í HTML dómi',
+    },
   },
 }

--- a/apps/web/screens/Verdicts/translations.strings.ts
+++ b/apps/web/screens/Verdicts/translations.strings.ts
@@ -29,6 +29,16 @@ export const m = {
       description:
         'Texti í hnapp neðst á yfirlitssíðu til að sækja fleiri dóma',
     },
+    displayList: {
+      id: 'web.verdicts:listPage.displayList',
+      defaultMessage: 'Sýna sem lista',
+      description: 'Sýna sem lista',
+    },
+    displayGrid: {
+      id: 'web.verdicts:listPage.displayGrid',
+      defaultMessage: 'Sýna sem spjöld',
+      description: 'Sýna sem spjöld',
+    },
   }),
   verdictPage: {
     heading: {

--- a/apps/web/screens/Verdicts/translations.strings.ts
+++ b/apps/web/screens/Verdicts/translations.strings.ts
@@ -30,4 +30,21 @@ export const m = {
         'Texti í hnapp neðst á yfirlitssíðu til að sækja fleiri dóma',
     },
   }),
+  verdictPage: {
+    heading: {
+      id: 'web.verdicts:verdictPage.heading',
+      defaultMessage: 'Dómur',
+      description: 'H1 titill á síðu dóms',
+    },
+    print: {
+      id: 'web.verdicts:verdictPage.print',
+      defaultMessage: 'Prenta',
+      description: 'Texti á prenta hnapp',
+    },
+    goBack: {
+      id: 'web.verdicts:verdictPage.goBack',
+      defaultMessage: 'Til baka',
+      description: 'Texti á "Til baka" hnapp',
+    },
+  },
 }

--- a/apps/web/screens/queries/Verdicts.ts
+++ b/apps/web/screens/queries/Verdicts.ts
@@ -30,6 +30,12 @@ export const GET_VERDICT_BY_ID_QUERY = gql`
       item {
         pdfString
         richText
+        title
+        court
+        caseNumber
+        verdictDate
+        keywords
+        presentings
       }
     }
   }

--- a/libs/api/domains/verdicts/src/lib/dto/verdicts.response.ts
+++ b/libs/api/domains/verdicts/src/lib/dto/verdicts.response.ts
@@ -61,6 +61,24 @@ class VerdictByIdItem {
 
   @CacheField(() => graphqlTypeJson, { nullable: true })
   richText?: Html | null
+
+  @Field(() => String)
+  title!: string
+
+  @Field(() => String)
+  court!: string
+
+  @Field(() => String)
+  caseNumber!: string
+
+  @Field(() => Date, { nullable: true })
+  verdictDate?: Date | null
+
+  @CacheField(() => [String])
+  keywords!: string[]
+
+  @Field(() => String)
+  presentings!: string
 }
 
 @ObjectType('WebVerdictByIdResponse')

--- a/libs/clients/verdicts/src/lib/verdicts-client.service.ts
+++ b/libs/clients/verdicts/src/lib/verdicts-client.service.ts
@@ -126,6 +126,12 @@ export class VerdictsClientService {
         return {
           item: {
             pdfString: response.item.docContent,
+            title: response.item.title ?? '',
+            court: response.item.court ?? '',
+            verdictDate: response.item.verdictDate,
+            caseNumber: response.item.caseNumber ?? '',
+            keywords: response.item.keywords ?? [],
+            presentings: response.item.presentings ?? '',
           },
         }
     } else if (id.startsWith(SUPREME_COURT_ID_PREFIX)) {
@@ -139,6 +145,12 @@ export class VerdictsClientService {
               response.item.verdictHtml,
               'verdictHtml',
             ),
+            title: response.item.title ?? '',
+            court: response.item.court ?? '',
+            verdictDate: response.item.publishDate,
+            caseNumber: response.item.caseNumber ?? '',
+            keywords: response.item.keywords ?? [],
+            presentings: response.item.presentings ?? '',
           },
         }
     }


### PR DESCRIPTION
# Verdicts - detail page visual changes

* Updated visuals so they roughly match what we have in Figma
* Added a Readspeaker button
* Added a print and download pdf buttons
* Improved print styles (what the actual printed page looks like)
* Use InfoCard component on list page


<img width="695" alt="Screenshot 2025-03-10 at 15 11 02" src="https://github.com/user-attachments/assets/1a980104-d580-415a-99c6-f0060031e195" />



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Verdict details now offer dual views: a PDF mode with download support and an enhanced HTML mode displaying additional verdict information.
  - Added a toggle button to switch between grid and list layouts in the verdicts list.
  - New localized text and labels enhance the verdict page experience.

- **Style**
  - Updated styling optimizes on-screen and print displays with refined layout constraints and responsive design adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->