### PR TITLE
feat(j-s): Allow defendant to make a verdict appeal decision

### DIFF
--- a/apps/judicial-system/api/src/app/modules/defendant/dto/updateDefendant.input.ts
+++ b/apps/judicial-system/api/src/app/modules/defendant/dto/updateDefendant.input.ts
@@ -9,6 +9,7 @@ import {
   PunishmentType,
   ServiceRequirement,
   SubpoenaType,
+  VerdictAppealDecision,
 } from '@island.is/judicial-system/types'
 
 @InputType()
@@ -85,6 +86,11 @@ export class UpdateDefendantInput {
   @IsOptional()
   @Field(() => String, { nullable: true })
   readonly verdictViewDate?: string
+
+  @Allow()
+  @IsOptional()
+  @Field(() => VerdictAppealDecision, { nullable: true })
+  readonly verdictAppealDecision?: VerdictAppealDecision
 
   @Allow()
   @IsOptional()

--- a/apps/judicial-system/api/src/app/modules/defendant/models/defendant.model.ts
+++ b/apps/judicial-system/api/src/app/modules/defendant/models/defendant.model.ts
@@ -7,6 +7,7 @@ import {
   PunishmentType,
   ServiceRequirement,
   SubpoenaType,
+  VerdictAppealDecision,
 } from '@island.is/judicial-system/types'
 
 import { Subpoena } from '../../subpoena'
@@ -17,6 +18,7 @@ registerEnumType(ServiceRequirement, { name: 'ServiceRequirement' })
 registerEnumType(DefenderChoice, { name: 'DefenderChoice' })
 registerEnumType(SubpoenaType, { name: 'SubpoenaType' })
 registerEnumType(PunishmentType, { name: 'PunishmentType' })
+registerEnumType(VerdictAppealDecision, { name: 'VerdictAppealDecision' })
 
 @ObjectType()
 export class Defendant {
@@ -73,6 +75,9 @@ export class Defendant {
 
   @Field(() => String, { nullable: true })
   readonly verdictAppealDeadline?: string
+
+  @Field(() => VerdictAppealDecision, { nullable: true })
+  readonly verdictAppealDecision?: VerdictAppealDecision
 
   @Field(() => String, { nullable: true })
   readonly verdictAppealDate?: string

--- a/apps/judicial-system/backend/migrations/20250310135651-update-defendant.js
+++ b/apps/judicial-system/backend/migrations/20250310135651-update-defendant.js
@@ -1,0 +1,26 @@
+'use strict'
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction((t) =>
+      Promise.all([
+        queryInterface.addColumn(
+          'defendant',
+          'verdict_appeal_decision',
+          {
+            type: Sequelize.STRING,
+            allowNull: true,
+          },
+          { transaction: t },
+        ),
+      ]),
+    )
+  },
+  async down(queryInterface) {
+    return queryInterface.sequelize.transaction((t) =>
+      queryInterface.removeColumn('defendant', 'verdict_appeal_decision', {
+        transaction: t,
+      }),
+    )
+  },
+}

--- a/apps/judicial-system/backend/src/app/modules/defendant/dto/updateDefendant.dto.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/dto/updateDefendant.dto.ts
@@ -18,6 +18,7 @@ import {
   PunishmentType,
   ServiceRequirement,
   SubpoenaType,
+  VerdictAppealDecision,
 } from '@island.is/judicial-system/types'
 
 import { nationalIdTransformer } from '../../../transformers'
@@ -105,6 +106,11 @@ export class UpdateDefendantDto {
   @IsDate()
   @ApiPropertyOptional({ type: Date })
   readonly verdictViewDate?: Date | null
+
+  @IsOptional()
+  @IsEnum(VerdictAppealDecision)
+  @ApiPropertyOptional({ enum: VerdictAppealDecision })
+  readonly verdictAppealDecision?: VerdictAppealDecision
 
   @IsOptional()
   @Type(() => Date)

--- a/apps/judicial-system/backend/src/app/modules/defendant/models/defendant.model.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/models/defendant.model.ts
@@ -20,6 +20,7 @@ import {
   PunishmentType,
   ServiceRequirement,
   SubpoenaType,
+  VerdictAppealDecision,
 } from '@island.is/judicial-system/types'
 
 import { Case } from '../../case/models/case.model'
@@ -157,6 +158,14 @@ export class Defendant extends Model {
   @Column({ type: DataType.DATE, allowNull: true })
   @ApiPropertyOptional({ type: Date })
   verdictViewDate?: Date
+
+  @Column({
+    type: DataType.ENUM,
+    allowNull: true,
+    values: Object.values(VerdictAppealDecision),
+  })
+  @ApiPropertyOptional({ enum: VerdictAppealDecision })
+  verdictAppealDecision?: VerdictAppealDecision
 
   @Column({ type: DataType.DATE, allowNull: true })
   @ApiPropertyOptional({ type: Date })

--- a/apps/judicial-system/web/src/components/FormProvider/case.graphql
+++ b/apps/judicial-system/web/src/components/FormProvider/case.graphql
@@ -30,6 +30,7 @@ query Case($input: CaseQueryInput!) {
       serviceRequirement
       verdictViewDate
       verdictAppealDeadline
+      verdictAppealDecision
       verdictAppealDate
       isVerdictAppealDeadlineExpired
       subpoenaType

--- a/libs/judicial-system/types/src/index.ts
+++ b/libs/judicial-system/types/src/index.ts
@@ -8,6 +8,7 @@ export {
   ServiceRequirement,
   ServiceStatus,
   PunishmentType,
+  VerdictAppealDecision,
   isSuccessfulServiceStatus,
   isFailedServiceStatus,
 } from './lib/defendant'

--- a/libs/judicial-system/types/src/lib/defendant.ts
+++ b/libs/judicial-system/types/src/lib/defendant.ts
@@ -44,6 +44,14 @@ export enum PunishmentType {
   SIGNED_FINE_INVITATION = 'SIGNED_FINE_INVITATION',
 }
 
+// We could possibly also have an APPEAL option here if we want,
+// but we can also see from the verdict appeal date if the verdict
+// has been appealed
+export enum VerdictAppealDecision {
+  ACCEPT = 'ACCEPT', // Una
+  POSTPONE = 'POSTPONE', // Taka áfrýjunarfrest
+}
+
 export const successfulServiceStatus: string[] = [
   ServiceStatus.ELECTRONICALLY,
   ServiceStatus.DEFENDER,


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1209626676964097)

## What

Add new field to the defendant table to register a defendants verdict appeal decision. There are two possible options as is, either accept (una) or postpone (taka áfrýjunarfrest). The enum is in line with the current naming conventions of the choices available to defendants in investigation and restriction cases (except for the fact that we have two additional options there that are not applicable to indictment cases for now).

## Why

Defendants need to make this decision when a verdict has been made and we need to know what their decision was in order to display the correct inputs for users that proceed to edit and complete processing indictment cases post verdict.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Defendant records now support an optional verdict appeal decision, allowing users to capture decisions such as ACCEPT or POSTPONE.
  - The enhanced functionality updates how verdict appeal information is entered and retrieved across the system's interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->