### PR TITLE
chore(application-system): no-inputs example application

### DIFF
--- a/apps/judicial-system/web/src/components/IndictmentCaseFilesList/IndictmentCaseFilesList.tsx
+++ b/apps/judicial-system/web/src/components/IndictmentCaseFilesList/IndictmentCaseFilesList.tsx
@@ -170,12 +170,12 @@ const IndictmentCaseFilesList: FC<Props> = ({
   const showFiles = Object.values(filteredFiles).some((f) => f.length > 0)
 
   return (
-    showFiles && (
-      <>
-        {displayHeading && (
-          <SectionHeading title={formatMessage(strings.title)} />
-        )}
-        {displayGeneratedPDFs && (
+    <>
+      {displayHeading && (
+        <SectionHeading title={formatMessage(strings.title)} />
+      )}
+      {displayGeneratedPDFs && (
+        <>
           <Box marginBottom={5}>
             <Text variant="h4" as="h4" marginBottom={1}>
               {formatMessage(caseFiles.indictmentSection)}
@@ -191,29 +191,6 @@ const IndictmentCaseFilesList: FC<Props> = ({
               />
             </Box>
           </Box>
-        )}
-        <FileSection
-          title={formatMessage(caseFiles.criminalRecordSection)}
-          files={filteredFiles.criminalRecords}
-          onOpenFile={onOpen}
-        />
-        <FileSection
-          title={formatMessage(caseFiles.criminalRecordUpdateSection)}
-          files={filteredFiles.criminalRecordUpdate}
-          onOpenFile={onOpen}
-          shouldRender={permissions.canViewCriminalRecordUpdate}
-        />
-        <FileSection
-          title={formatMessage(caseFiles.costBreakdownSection)}
-          files={filteredFiles.costBreakdowns}
-          onOpenFile={onOpen}
-        />
-        <FileSection
-          title={formatMessage(caseFiles.otherDocumentsSection)}
-          files={filteredFiles.others}
-          onOpenFile={onOpen}
-        />
-        {displayGeneratedPDFs && (
           <Box marginBottom={5}>
             <Text variant="h4" as="h4" marginBottom={1}>
               {formatMessage(strings.caseFileTitle)}
@@ -233,103 +210,136 @@ const IndictmentCaseFilesList: FC<Props> = ({
               </Box>
             ))}
           </Box>
-        )}
-        {filteredFiles.courtRecords?.length || filteredFiles.rulings?.length ? (
-          <Box marginBottom={5}>
-            <Text variant="h4" as="h4" marginBottom={1}>
-              {formatMessage(strings.rulingAndCourtRecordsTitle)}
-            </Text>
-            {filteredFiles.courtRecords &&
-              filteredFiles.courtRecords.length > 0 && (
-                <RenderFiles
-                  caseFiles={filteredFiles.courtRecords}
-                  onOpenFile={onOpen}
-                />
-              )}
-            {permissions.canViewRulings &&
-              filteredFiles.rulings &&
-              filteredFiles.rulings.length > 0 && (
-                <RenderFiles
-                  caseFiles={filteredFiles.rulings}
-                  onOpenFile={onOpen}
-                />
-              )}
-          </Box>
-        ) : null}
-        <FileSection
-          title={formatMessage(strings.civilClaimsTitle)}
-          files={filteredFiles.civilClaims}
-          onOpenFile={onOpen}
-          shouldRender={permissions.canViewCivilClaims}
-        />
-        {showSubpoenaPdf && (
-          <Box marginBottom={5}>
-            <Text variant="h4" as="h4" marginBottom={1}>
-              {formatMessage(strings.subpoenaTitle)}
-            </Text>
-            {workingCase.defendants?.map((defendant) =>
-              defendant.subpoenas?.map((subpoena) => {
-                const subpoenaFileName = formatMessage(
-                  strings.subpoenaButtonText,
-                  {
-                    name: defendant.name,
-                    date: formatDate(subpoena.created),
-                  },
-                )
-
-                return (
-                  <Box key={`subpoena-${subpoena.id}`} marginBottom={2}>
-                    <PdfButton
-                      caseId={workingCase.id}
-                      title={subpoenaFileName}
-                      pdfType="subpoena"
-                      elementId={[defendant.id, subpoena.id, subpoenaFileName]}
-                      renderAs="row"
-                    />
-                    {!limitedAccess &&
-                      isSuccessfulServiceStatus(subpoena.serviceStatus) && (
-                        <PdfButton
-                          caseId={workingCase.id}
-                          title={formatMessage(
-                            strings.serviceCertificateButtonText,
-                            {
-                              name: defendant.name,
-                            },
-                          )}
-                          pdfType="serviceCertificate"
-                          elementId={[defendant.id, subpoena.id]}
-                          renderAs="row"
-                        />
-                      )}
-                  </Box>
-                )
-              }),
-            )}
-          </Box>
-        )}
-        <FileSection
-          title={formatMessage(strings.sentToPrisonAdmin)}
-          files={filteredFiles.sentToPrisonAdminFiles}
-          onOpenFile={onOpen}
-          shouldRender={permissions.canViewSentToPrisonAdminFiles}
-        />
-        {filteredFiles.uploadedCaseFiles &&
-          filteredFiles.uploadedCaseFiles.length > 0 && (
+          {showSubpoenaPdf && (
             <Box marginBottom={5}>
-              <Text variant="h4" as="h4" marginBottom={3}>
-                {formatMessage(strings.uploadedCaseFiles)}
+              <Text variant="h4" as="h4" marginBottom={1}>
+                {formatMessage(strings.subpoenaTitle)}
               </Text>
-              <CaseFileTable
-                caseFiles={filteredFiles.uploadedCaseFiles}
-                onOpenFile={onOpen}
-              />
+              {workingCase.defendants?.map((defendant) =>
+                defendant.subpoenas?.map((subpoena) => {
+                  const subpoenaFileName = formatMessage(
+                    strings.subpoenaButtonText,
+                    {
+                      name: defendant.name,
+                      date: formatDate(subpoena.created),
+                    },
+                  )
+
+                  return (
+                    <Box key={`subpoena-${subpoena.id}`} marginBottom={2}>
+                      <PdfButton
+                        caseId={workingCase.id}
+                        title={subpoenaFileName}
+                        pdfType="subpoena"
+                        elementId={[
+                          defendant.id,
+                          subpoena.id,
+                          subpoenaFileName,
+                        ]}
+                        renderAs="row"
+                      />
+                      {!limitedAccess &&
+                        isSuccessfulServiceStatus(subpoena.serviceStatus) && (
+                          <PdfButton
+                            caseId={workingCase.id}
+                            title={formatMessage(
+                              strings.serviceCertificateButtonText,
+                              {
+                                name: defendant.name,
+                              },
+                            )}
+                            pdfType="serviceCertificate"
+                            elementId={[defendant.id, subpoena.id]}
+                            renderAs="row"
+                          />
+                        )}
+                    </Box>
+                  )
+                }),
+              )}
             </Box>
           )}
-        <AnimatePresence>
-          {fileNotFound && <FileNotFoundModal dismiss={dismissFileNotFound} />}
-        </AnimatePresence>
-      </>
-    )
+        </>
+      )}
+      {showFiles && (
+        <>
+          <FileSection
+            title={formatMessage(caseFiles.criminalRecordSection)}
+            files={filteredFiles.criminalRecords}
+            onOpenFile={onOpen}
+          />
+          <FileSection
+            title={formatMessage(caseFiles.criminalRecordUpdateSection)}
+            files={filteredFiles.criminalRecordUpdate}
+            onOpenFile={onOpen}
+            shouldRender={permissions.canViewCriminalRecordUpdate}
+          />
+          <FileSection
+            title={formatMessage(caseFiles.costBreakdownSection)}
+            files={filteredFiles.costBreakdowns}
+            onOpenFile={onOpen}
+          />
+          <FileSection
+            title={formatMessage(caseFiles.otherDocumentsSection)}
+            files={filteredFiles.others}
+            onOpenFile={onOpen}
+          />
+
+          {filteredFiles.courtRecords?.length ||
+          filteredFiles.rulings?.length ? (
+            <Box marginBottom={5}>
+              <Text variant="h4" as="h4" marginBottom={1}>
+                {formatMessage(strings.rulingAndCourtRecordsTitle)}
+              </Text>
+              {filteredFiles.courtRecords &&
+                filteredFiles.courtRecords.length > 0 && (
+                  <RenderFiles
+                    caseFiles={filteredFiles.courtRecords}
+                    onOpenFile={onOpen}
+                  />
+                )}
+              {permissions.canViewRulings &&
+                filteredFiles.rulings &&
+                filteredFiles.rulings.length > 0 && (
+                  <RenderFiles
+                    caseFiles={filteredFiles.rulings}
+                    onOpenFile={onOpen}
+                  />
+                )}
+            </Box>
+          ) : null}
+          <FileSection
+            title={formatMessage(strings.civilClaimsTitle)}
+            files={filteredFiles.civilClaims}
+            onOpenFile={onOpen}
+            shouldRender={permissions.canViewCivilClaims}
+          />
+          <FileSection
+            title={formatMessage(strings.sentToPrisonAdmin)}
+            files={filteredFiles.sentToPrisonAdminFiles}
+            onOpenFile={onOpen}
+            shouldRender={permissions.canViewSentToPrisonAdminFiles}
+          />
+          {filteredFiles.uploadedCaseFiles &&
+            filteredFiles.uploadedCaseFiles.length > 0 && (
+              <Box marginBottom={5}>
+                <Text variant="h4" as="h4" marginBottom={3}>
+                  {formatMessage(strings.uploadedCaseFiles)}
+                </Text>
+                <CaseFileTable
+                  caseFiles={filteredFiles.uploadedCaseFiles}
+                  onOpenFile={onOpen}
+                />
+              </Box>
+            )}
+          <AnimatePresence>
+            {fileNotFound && (
+              <FileNotFoundModal dismiss={dismissFileNotFound} />
+            )}
+          </AnimatePresence>
+        </>
+      )}
+    </>
   )
 }
 

--- a/libs/application/template-api-modules/src/lib/modules/templates/examples/example-no-inputs/example-no-inputs-service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/examples/example-no-inputs/example-no-inputs-service.ts
@@ -1,0 +1,75 @@
+import { Injectable } from '@nestjs/common'
+import { SharedTemplateApiService } from '../../../shared'
+import { ApplicationTypes } from '@island.is/application/types'
+import { NotificationsService } from '../../../../notification/notifications.service'
+import { BaseTemplateApiService } from '../../../base-template-api.service'
+import { TemplateApiModuleActionProps } from '../../../../types'
+import { getValueViaPath } from '@island.is/application/core'
+import { TemplateApiError } from '@island.is/nest/problem'
+
+@Injectable()
+export class ExampleNoInputsService extends BaseTemplateApiService {
+  constructor(
+    private readonly sharedTemplateAPIService: SharedTemplateApiService,
+    private readonly notificationsService: NotificationsService,
+  ) {
+    super(ApplicationTypes.EXAMPLE_NO_INPUTS)
+  }
+
+  async getReferenceData({ application }: TemplateApiModuleActionProps) {
+    await new Promise((resolve) => setTimeout(resolve, 2000))
+
+    const applicantName = getValueViaPath<string>(
+      application.externalData,
+      'nationalRegistry.data.fullName',
+    )
+
+    return {
+      referenceData: {
+        applicantName,
+        some: 'data',
+        numbers: 123,
+      },
+    }
+  }
+
+  async getAnotherReferenceData() {
+    return {
+      anotherData: {
+        stuff: 'someDataString',
+      },
+    }
+  }
+
+  // A test action that can be used in the ReferenceApplicationTemplate to see
+  // what happens when an api action fails
+  async doStuffThatFails() {
+    await new Promise((resolve) => setTimeout(resolve, 2000))
+
+    throw new TemplateApiError(
+      {
+        title: 'This is a test error',
+        summary: 'This is the message that caused the failure',
+      },
+      500,
+    )
+  }
+
+  async createApplication() {
+    // Pretend to be doing stuff for a short while
+    await new Promise((resolve) => setTimeout(resolve, 2000))
+
+    return {
+      id: 1337,
+    }
+  }
+
+  async completeApplication() {
+    // Pretend to be doing stuff for a short while
+    await new Promise((resolve) => setTimeout(resolve, 2000))
+
+    return {
+      id: 1337,
+    }
+  }
+}

--- a/libs/application/template-api-modules/src/lib/modules/templates/examples/example-no-inputs/example-no-inputs.module.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/examples/example-no-inputs/example-no-inputs.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common'
+
+// This is a shared module that gives you access to common methods
+import { SharedTemplateAPIModule } from '../../../shared'
+
+// Here you import your module service
+import { ExampleNoInputsService } from './example-no-inputs-service'
+import { ApplicationsNotificationsModule } from '../../../../notification/notifications.module'
+@Module({
+  imports: [SharedTemplateAPIModule, ApplicationsNotificationsModule],
+  providers: [ExampleNoInputsService],
+  exports: [ExampleNoInputsService],
+})
+export class ExampleNoInputsModule {}

--- a/libs/application/template-api-modules/src/lib/modules/templates/index.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/index.ts
@@ -1,3 +1,15 @@
+import { ReferenceTemplateModule } from './reference-template/reference-template.module'
+import { ReferenceTemplateService } from './reference-template/reference-template.service'
+import { ExamplePaymentActionsModule } from './example-payment-actions/examplePaymentActions.module'
+import { ExamplePaymentActionsService } from './example-payment-actions/examplePaymentActions.service'
+import { ExampleCommonActionsModule } from './examples/example-common-actions/example-common-actions.module'
+import { ExampleCommonActionsService } from './examples/example-common-actions/example-common-actions.service'
+import { ExampleStateTransfersModule } from './examples/example-state-transfers/example-state-transfers.module'
+import { ExampleStateTransfersService } from './examples/example-state-transfers/example-state-transfers.service'
+import { ExampleInputsModule } from './examples/example-inputs/example-inputs.module'
+import { ExampleInputsService } from './examples/example-inputs/example-inputs.service'
+import { ExampleNoInputsModule } from './examples/example-no-inputs/example-no-inputs.module'
+import { ExampleNoInputsService } from './examples/example-no-inputs/example-no-inputs-service'
 import { AccidentNotificationModule } from './accident-notification/accident-notification.module'
 import { AccidentNotificationService } from './accident-notification/accident-notification.service'
 import { AnnouncementOfDeathModule } from './announcement-of-death/announcement-of-death.module'
@@ -18,8 +30,6 @@ import { DrivingSchoolConfirmationModule } from './driving-school-confirmation/d
 import { DrivingSchoolConfirmationService } from './driving-school-confirmation/driving-school-confirmation.service'
 import { EstateTemplateModule } from './estate/estate.module'
 import { EstateTemplateService } from './estate/estate.service'
-import { ExamplePaymentActionsModule } from './example-payment-actions/examplePaymentActions.module'
-import { ExamplePaymentActionsService } from './example-payment-actions/examplePaymentActions.service'
 import { FinancialAidModule } from './financial-aid/financial-aid.module'
 import { FinancialAidService } from './financial-aid/financial-aid.service'
 import { FinancialStatementCemeteryTemplateModule } from './financial-statement-cemetery/financial-statement-cemetery.module'
@@ -62,14 +72,6 @@ import { PassportModule } from './passport/passport.module'
 import { PassportService } from './passport/passport.service'
 import { PublicDebtPaymentPlanTemplateModule } from './public-debt-payment-plan/public-debt-payment-plan.module'
 import { PublicDebtPaymentPlanTemplateService } from './public-debt-payment-plan/public-debt-payment-plan.service'
-import { ReferenceTemplateModule } from './reference-template/reference-template.module'
-import { ReferenceTemplateService } from './reference-template/reference-template.service'
-import { ExampleCommonActionsModule } from './examples/example-common-actions/example-common-actions.module'
-import { ExampleCommonActionsService } from './examples/example-common-actions/example-common-actions.service'
-import { ExampleStateTransfersModule } from './examples/example-state-transfers/example-state-transfers.module'
-import { ExampleStateTransfersService } from './examples/example-state-transfers/example-state-transfers.service'
-import { ExampleInputsModule } from './examples/example-inputs/example-inputs.module'
-import { ExampleInputsService } from './examples/example-inputs/example-inputs.service'
 import { CitizenshipModule } from './directorate-of-immigration/citizenship/citizenship.module'
 import { CitizenshipService } from './directorate-of-immigration/citizenship/citizenship.service'
 import { DrivingLearnersPermitModule } from './driving-learners-permit/driving-learners-permit.module'
@@ -156,6 +158,7 @@ export const modules = [
   ExampleCommonActionsModule,
   ExampleStateTransfersModule,
   ExampleInputsModule,
+  ExampleNoInputsModule,
   ExamplePaymentActionsModule,
   GeneralFishingLicenseModule,
   DataProtectionComplaintModule,
@@ -232,6 +235,7 @@ export const services = [
   ExampleCommonActionsService,
   ExampleStateTransfersService,
   ExampleInputsService,
+  ExampleNoInputsService,
   ExamplePaymentActionsService,
   GeneralFishingLicenseService,
   DataProtectionComplaintService,

--- a/libs/application/template-loader/src/lib/templateLoaders.ts
+++ b/libs/application/template-loader/src/lib/templateLoaders.ts
@@ -9,6 +9,8 @@ const templates: Record<ApplicationTypes, () => Promise<unknown>> = {
     import('@island.is/application/templates/examples/example-common-actions'),
   [ApplicationTypes.EXAMPLE_INPUTS]: () =>
     import('@island.is/application/templates/examples/example-inputs'),
+  [ApplicationTypes.EXAMPLE_NO_INPUTS]: () =>
+    import('@island.is/application/templates/examples/example-no-inputs'),
   [ApplicationTypes.ESTATE]: () =>
     import('@island.is/application/templates/estate'),
   [ApplicationTypes.PARENTAL_LEAVE]: () =>

--- a/libs/application/templates/examples/example-no-inputs/.babelrc
+++ b/libs/application/templates/examples/example-no-inputs/.babelrc
@@ -1,0 +1,12 @@
+{
+  "presets": [
+    [
+      "@nx/react/babel",
+      {
+        "runtime": "automatic",
+        "useBuiltIns": "usage"
+      }
+    ]
+  ],
+  "plugins": []
+}

--- a/libs/application/templates/examples/example-no-inputs/.eslintrc.json
+++ b/libs/application/templates/examples/example-no-inputs/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["plugin:@nx/react", "../../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/application/templates/examples/example-no-inputs/README.md
+++ b/libs/application/templates/examples/example-no-inputs/README.md
@@ -1,0 +1,7 @@
+# application-templates-examples-example-no-inputs
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test application-templates-examples-example-no-inputs` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/application/templates/examples/example-no-inputs/jest.config.ts
+++ b/libs/application/templates/examples/example-no-inputs/jest.config.ts
@@ -1,0 +1,12 @@
+/* eslint-disable */
+export default {
+  displayName: 'application-templates-examples-example-no-inputs',
+  preset: '../../../../../jest.preset.js',
+  transform: {
+    '^(?!.*\\.(js|jsx|ts|tsx|css|json)$)': '@nx/react/plugins/jest',
+    '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nx/react/babel'] }],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory:
+    '../../../../../coverage/libs/application/templates/examples/example-no-inputs',
+}

--- a/libs/application/templates/examples/example-no-inputs/project.json
+++ b/libs/application/templates/examples/example-no-inputs/project.json
@@ -1,0 +1,25 @@
+{
+  "name": "application-templates-examples-example-no-inputs",
+  "$schema": "../../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/application/templates/examples/example-no-inputs/src",
+  "projectType": "library",
+  "tags": ["scope:application-system", "lib:application-system"],
+  "targets": {
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/application/templates/examples/example-no-inputs/jest.config.ts"
+      }
+    },
+    "extract-strings": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "yarn ts-node -P libs/localization/tsconfig.lib.json libs/localization/scripts/extract libs/application/templates/examples/example-no-inputs/src/lib/messages.ts"
+      }
+    }
+  }
+}

--- a/libs/application/templates/examples/example-no-inputs/src/dataProviders/index.ts
+++ b/libs/application/templates/examples/example-no-inputs/src/dataProviders/index.ts
@@ -1,0 +1,29 @@
+import { defineTemplateApi } from '@island.is/application/types'
+import { NationalRegistryUserApi } from '@island.is/application/types'
+import { ApiActions } from '../utils/types'
+
+export interface MyParameterType {
+  id: number
+}
+
+export const ReferenceDataApi = defineTemplateApi<MyParameterType>({
+  action: ApiActions.getReferenceData,
+  order: 2,
+  params: {
+    id: 12,
+  },
+})
+
+export const runsFirst = defineTemplateApi({
+  action: 'actionName',
+  order: 1, // runs first
+})
+
+export const EphemeralApi = defineTemplateApi({
+  action: ApiActions.getAnotherReferenceData,
+  shouldPersistToExternalData: false,
+})
+
+export const NationalRegistryApi = NationalRegistryUserApi.configure({
+  order: 1,
+})

--- a/libs/application/templates/examples/example-no-inputs/src/forms/completedForm/index.ts
+++ b/libs/application/templates/examples/example-no-inputs/src/forms/completedForm/index.ts
@@ -1,0 +1,15 @@
+import { buildForm } from '@island.is/application/core'
+import { buildFormConclusionSection } from '@island.is/application/ui-forms'
+import { FormModes } from '@island.is/application/types'
+
+export const completedForm = buildForm({
+  id: 'completedForm',
+  mode: FormModes.COMPLETED,
+  children: [
+    buildFormConclusionSection({
+      alertTitle: 'Congratulations',
+      alertMessage:
+        'You have now looked at all the fields with no inputs that the application system offers',
+    }),
+  ],
+})

--- a/libs/application/templates/examples/example-no-inputs/src/forms/mainForm/accordionSection.ts
+++ b/libs/application/templates/examples/example-no-inputs/src/forms/mainForm/accordionSection.ts
@@ -1,0 +1,34 @@
+import {
+  buildAccordionField,
+  buildMultiField,
+  buildSection,
+} from '@island.is/application/core'
+
+export const accordionSection = buildSection({
+  id: 'accordionSection',
+  title: 'Accordion',
+  children: [
+    buildMultiField({
+      id: 'accordionMultiField',
+      title: 'BuildMultiField',
+      children: [
+        buildAccordionField({
+          id: 'accordion',
+          title: 'Accordion',
+          accordionItems: [
+            {
+              itemTitle: 'Item 1',
+              itemContent:
+                'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+            },
+            {
+              itemTitle: 'Item 2',
+              itemContent:
+                'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+            },
+          ],
+        }),
+      ],
+    }),
+  ],
+})

--- a/libs/application/templates/examples/example-no-inputs/src/forms/mainForm/actionCardSection.ts
+++ b/libs/application/templates/examples/example-no-inputs/src/forms/mainForm/actionCardSection.ts
@@ -1,0 +1,71 @@
+import {
+  buildActionCardListField,
+  buildMultiField,
+  buildSection,
+} from '@island.is/application/core'
+
+export const actionCardSection = buildSection({
+  id: 'actionCardSection',
+  title: 'Action card',
+  children: [
+    buildMultiField({
+      id: 'actionCardMultiField',
+      title: 'BuildMultiField',
+      children: [
+        buildActionCardListField({
+          id: 'actionCardList',
+          title: 'Action cards with buttons',
+          items: (_application, _lang) => {
+            return [
+              {
+                eyebrow: 'Card eyebrow',
+                heading: 'Card heading, all the options',
+                headingVariant: 'h3',
+                text: 'Card text, lorem ipsum dolor sit amet dolor sit amet lorem ipsum dolor sit amet',
+                cta: {
+                  label: 'Card cta',
+                  variant: 'primary',
+                  external: true,
+                  to: 'https://www.google.com',
+                },
+                tag: {
+                  label: 'Outlined label',
+                  outlined: true,
+                  variant: 'blue',
+                },
+              },
+              {
+                heading: 'Card heading',
+                headingVariant: 'h4',
+                tag: {
+                  label: 'Not outlined label',
+                  outlined: false,
+                  variant: 'blue',
+                },
+                cta: {
+                  label: 'Card cta',
+                  variant: 'primary',
+                  external: true,
+                  to: 'https://www.google.com',
+                },
+                unavailable: {
+                  label: 'Unavailable label',
+                  message: 'Unavailable message',
+                },
+              },
+              {
+                heading: 'Card heading',
+                headingVariant: 'h4',
+                tag: {
+                  label: 'White label',
+                  outlined: true,
+                  variant: 'white',
+                },
+              },
+            ]
+          },
+        }),
+      ],
+    }),
+  ],
+})

--- a/libs/application/templates/examples/example-no-inputs/src/forms/mainForm/alertMessageSection.ts
+++ b/libs/application/templates/examples/example-no-inputs/src/forms/mainForm/alertMessageSection.ts
@@ -1,0 +1,117 @@
+import {
+  buildAlertMessageField,
+  buildDescriptionField,
+  buildMultiField,
+  buildSection,
+} from '@island.is/application/core'
+
+export const alertMessageSection = buildSection({
+  id: 'allertMessageSection',
+  title: 'Alert message',
+  children: [
+    buildMultiField({
+      id: 'alertMessageMultiField',
+      title: 'BuildAlertMessageField',
+      children: [
+        buildDescriptionField({
+          id: 'alertMessagesDescription',
+          description:
+            'Alert messages are used to display important information to the user. Choose the alertType based on the information you want the user to focus on.',
+          width: 'full',
+        }),
+        buildDescriptionField({
+          id: 'alertMessageDescription2',
+          description:
+            'In many cases an alert message is shown based on a condition, like something that was fetched from a data provider or the way a user fills in the application.',
+          width: 'full',
+        }),
+        buildAlertMessageField({
+          id: 'alertMessageDefault',
+          title: 'Default Alert message',
+          message:
+            "Rarely used, doesn't have a specific icon or grab attendion.",
+          alertType: 'default',
+          links: [
+            {
+              title: 'Alert messages',
+              url: 'https://www.google.com',
+              isExternal: true,
+            },
+            {
+              title: 'can also take in',
+              url: 'https://www.goog2le.com',
+              isExternal: true,
+            },
+            {
+              title: 'a list of links',
+              url: 'https://www.google.com',
+              isExternal: false,
+            },
+          ],
+        }),
+        buildAlertMessageField({
+          id: 'alertMessageWarning',
+          title: 'Warning Alert message',
+          message:
+            'Something that the user should be aware of but not necessarily act on.',
+          alertType: 'warning',
+        }),
+        buildAlertMessageField({
+          id: 'alertMessageError',
+          title: 'Error Alert message',
+          message:
+            'Something that the user should be aware of and act on, he should not be able to continue if this message showing.',
+          alertType: 'error',
+        }),
+        buildAlertMessageField({
+          id: 'alertMessageInfo',
+          title: 'Info Alert message',
+          message: 'Informational message that the user should be aware of.',
+          alertType: 'info',
+        }),
+        buildAlertMessageField({
+          id: 'alertMessageSuccess',
+          title: 'Success Alert message',
+          message:
+            'Something that went successfully, like application submission',
+          alertType: 'success',
+        }),
+        buildAlertMessageField({
+          id: 'alertMessageDefault2',
+          title: 'Half width Default',
+          message: 'Alert message',
+          alertType: 'default',
+          width: 'half',
+        }),
+        buildAlertMessageField({
+          id: 'alertMessageWarning2',
+          title: 'Half width Warning',
+          message: 'Alert message',
+          alertType: 'warning',
+          width: 'half',
+        }),
+        buildAlertMessageField({
+          id: 'alertMessageError2',
+          title: 'Half width Error',
+          message: 'Alert message',
+          alertType: 'error',
+          width: 'half',
+        }),
+        buildAlertMessageField({
+          id: 'alertMessageInfo2',
+          title: 'Half width Info',
+          message: 'Alert message',
+          alertType: 'info',
+          width: 'half',
+        }),
+        buildAlertMessageField({
+          id: 'alertMessageSuccess2',
+          title: 'Half width Success',
+          message: 'Alert message',
+          alertType: 'success',
+          width: 'half',
+        }),
+      ],
+    }),
+  ],
+})

--- a/libs/application/templates/examples/example-no-inputs/src/forms/mainForm/copyLinkSection.ts
+++ b/libs/application/templates/examples/example-no-inputs/src/forms/mainForm/copyLinkSection.ts
@@ -1,0 +1,42 @@
+import {
+  buildCopyLinkField,
+  buildMultiField,
+  buildSection,
+} from '@island.is/application/core'
+
+export const copyLinkSection = buildSection({
+  id: 'copyLinkSection',
+  title: 'Copy link',
+  children: [
+    buildMultiField({
+      id: 'copyLinkMultiField',
+      title: 'BuildCopyLinkField',
+      children: [
+        buildCopyLinkField({
+          id: 'copyLinkField',
+          title: 'Copy link',
+          description: 'Copy link description',
+          link: 'https://www.google.com',
+          marginTop: 2,
+          marginBottom: 4,
+        }),
+        buildCopyLinkField({
+          id: 'copyLinkField2',
+          title: 'Copy link, with your location',
+          link: (_application) => {
+            // build link based on answers or external data
+            return document.location.origin
+          },
+          marginBottom: 4,
+        }),
+        buildCopyLinkField({
+          id: 'copyLinkField3',
+          title: 'Custom button title and semibold text',
+          link: 'https://www.google.com',
+          semiBoldLink: true,
+          buttonTitle: 'Custom button title',
+        }),
+      ],
+    }),
+  ],
+})

--- a/libs/application/templates/examples/example-no-inputs/src/forms/mainForm/descriptionSection.ts
+++ b/libs/application/templates/examples/example-no-inputs/src/forms/mainForm/descriptionSection.ts
@@ -1,0 +1,81 @@
+import {
+  buildDescriptionField,
+  buildMultiField,
+  buildSection,
+} from '@island.is/application/core'
+import { m } from '../../lib/messages'
+
+export const descriptionSection = buildSection({
+  id: 'descriptionSubsection',
+  title: 'Description',
+  children: [
+    buildMultiField({
+      id: 'descriptionMultiField',
+      title: 'BuildDescriptionField',
+      children: [
+        buildDescriptionField({
+          id: 'description1',
+          description: m.descriptionFieldDescription,
+          marginBottom: [2],
+        }),
+        buildDescriptionField({
+          id: 'description2',
+          description: m.descriptionFieldDescription2,
+          marginBottom: [2],
+        }),
+
+        buildDescriptionField({
+          id: 'description3',
+          title: 'Default title size ',
+          description: 'Description inserted as a regular string',
+          marginBottom: [2],
+          tooltip: 'Tooltip text',
+          titleTooltip: 'Title tooltip text',
+        }),
+        buildDescriptionField({
+          id: 'description4',
+          title: 'h1 title size',
+          titleVariant: 'h1',
+          description: m.regularTextExample,
+          marginBottom: [2],
+        }),
+        buildDescriptionField({
+          id: 'description5',
+          title: 'h2 title size (same as default)',
+          titleVariant: 'h2',
+          description: m.markdownHeadingExample,
+          marginBottom: [2],
+        }),
+        buildDescriptionField({
+          id: 'description6',
+          title: 'h3 title size',
+          titleVariant: 'h3',
+          description: m.markdownBulletListExample,
+          marginBottom: [2],
+        }),
+        buildDescriptionField({
+          id: 'description7',
+          title: 'h4 title size',
+          titleVariant: 'h4',
+          description: m.markdownNumberedListExample,
+          marginBottom: [2],
+        }),
+        buildDescriptionField({
+          id: 'description8',
+          title: 'h5 title size',
+          titleVariant: 'h5',
+          description: {
+            ...m.markdownMiscExample,
+            values: { value1: 'MY VALUE' },
+          },
+          marginBottom: [2],
+        }),
+        buildDescriptionField({
+          id: 'description9',
+          description: m.markdownCodeExample,
+          marginBottom: [2],
+        }),
+      ],
+    }),
+  ],
+})

--- a/libs/application/templates/examples/example-no-inputs/src/forms/mainForm/dividerSection.ts
+++ b/libs/application/templates/examples/example-no-inputs/src/forms/mainForm/dividerSection.ts
@@ -1,0 +1,40 @@
+import {
+  buildDividerField,
+  buildMultiField,
+  buildSection,
+  buildTitleField,
+} from '@island.is/application/core'
+
+export const dividerSection = buildSection({
+  id: 'dividerSection',
+  title: 'Divider',
+  children: [
+    buildMultiField({
+      id: 'dividerMultiField',
+      title: 'BuildDividerField',
+      children: [
+        buildTitleField({
+          title: 'Below this is a divider line:',
+          marginTop: 0,
+          marginBottom: 0,
+        }),
+        buildDividerField({}),
+        buildTitleField({
+          title: 'Below this is a divider with no line, only margin:',
+          marginTop: 0,
+          marginBottom: 0,
+        }),
+        buildDividerField({
+          useDividerLine: false,
+          marginTop: 7,
+          marginBottom: 7,
+        }),
+        buildTitleField({
+          title: 'Look at all that space:',
+          marginTop: 0,
+          marginBottom: 0,
+        }),
+      ],
+    }),
+  ],
+})

--- a/libs/application/templates/examples/example-no-inputs/src/forms/mainForm/index.ts
+++ b/libs/application/templates/examples/example-no-inputs/src/forms/mainForm/index.ts
@@ -1,0 +1,27 @@
+import { buildForm } from '@island.is/application/core'
+import { descriptionSection } from './descriptionSection'
+import { titleSection } from './titleSection'
+import { copyLinkSection } from './copyLinkSection'
+import { dividerSection } from './dividerSection'
+import { alertMessageSection } from './alertMessageSection'
+import { accordionSection } from './accordionSection'
+import { actionCardSection } from './actionCardSection'
+import { keyValueSection } from './keyValueSection'
+import { overviewSection } from './overviewSection'
+
+export const mainForm = buildForm({
+  id: 'mainForm',
+  title: 'Main form',
+  renderLastScreenButton: true,
+  children: [
+    descriptionSection,
+    titleSection,
+    copyLinkSection,
+    dividerSection,
+    alertMessageSection,
+    accordionSection,
+    actionCardSection,
+    keyValueSection,
+    overviewSection,
+  ],
+})

--- a/libs/application/templates/examples/example-no-inputs/src/forms/mainForm/keyValueSection.ts
+++ b/libs/application/templates/examples/example-no-inputs/src/forms/mainForm/keyValueSection.ts
@@ -1,0 +1,46 @@
+import {
+  buildKeyValueField,
+  buildMultiField,
+  buildSection,
+} from '@island.is/application/core'
+
+export const keyValueSection = buildSection({
+  id: 'keyValueSection',
+  title: 'Key-Value',
+  children: [
+    buildMultiField({
+      id: 'keyValueMultiField',
+      title: 'BuildKeyValueField',
+      children: [
+        buildKeyValueField({
+          label: 'Key value label',
+          value: 'One value',
+        }),
+        buildKeyValueField({
+          label: 'Key value with divider',
+          value: ['Many values', 'Value 2', 'Value 3'],
+          divider: true,
+        }),
+        buildKeyValueField({
+          label: 'Key value displax flex',
+          value: ['Value', 'Value 2', 'Value 3'],
+          divider: true,
+          display: 'flex',
+        }),
+        buildKeyValueField({
+          label: 'Key value half width',
+          value: 'One value',
+          divider: true,
+          width: 'half',
+        }),
+        buildKeyValueField({
+          label: 'Key value half width',
+          value: 'Custom colspan',
+          divider: true,
+          width: 'half',
+          colSpan: '5/12',
+        }),
+      ],
+    }),
+  ],
+})

--- a/libs/application/templates/examples/example-no-inputs/src/forms/mainForm/overviewSection.ts
+++ b/libs/application/templates/examples/example-no-inputs/src/forms/mainForm/overviewSection.ts
@@ -1,0 +1,41 @@
+import {
+  buildSection,
+  buildMultiField,
+  buildSubmitField,
+  buildOverviewField,
+} from '@island.is/application/core'
+import { DefaultEvents } from '@island.is/application/types'
+import { m } from '../../lib/messages'
+import { getOverviewItems } from '../../utils/overviewUtils'
+
+export const overviewSection = buildSection({
+  id: 'overview',
+  title: 'Overview',
+  children: [
+    buildMultiField({
+      id: 'overviewMultiField',
+      title: 'BuildOverviewField',
+      children: [
+        buildOverviewField({
+          id: 'overviewX',
+          title: 'Upplýsingar um þig',
+          description: m.overviewInfoDescripton2,
+          backId: 'tableRepeater',
+          bottomLine: false,
+          items: getOverviewItems,
+        }),
+        buildSubmitField({
+          id: 'submitApplication',
+          refetchApplicationAfterSubmit: true,
+          actions: [
+            {
+              event: DefaultEvents.SUBMIT,
+              name: m.overviewSubmit,
+              type: 'primary',
+            },
+          ],
+        }),
+      ],
+    }),
+  ],
+})

--- a/libs/application/templates/examples/example-no-inputs/src/forms/mainForm/overviewSection.ts
+++ b/libs/application/templates/examples/example-no-inputs/src/forms/mainForm/overviewSection.ts
@@ -20,7 +20,7 @@ export const overviewSection = buildSection({
           id: 'overviewX',
           title: 'Upplýsingar um þig',
           description: m.overviewInfoDescripton2,
-          backId: 'tableRepeater',
+          backId: 'id-of-some-field-to-go-to',
           bottomLine: false,
           items: getOverviewItems,
         }),

--- a/libs/application/templates/examples/example-no-inputs/src/forms/mainForm/titleSection.ts
+++ b/libs/application/templates/examples/example-no-inputs/src/forms/mainForm/titleSection.ts
@@ -1,0 +1,62 @@
+import {
+  buildMultiField,
+  buildSection,
+  buildTitleField,
+} from '@island.is/application/core'
+
+export const titleSection = buildSection({
+  id: 'titleSection',
+  title: 'Title',
+  children: [
+    buildMultiField({
+      id: 'titleMultiField',
+      title: 'BuildTitleField',
+      children: [
+        buildTitleField({
+          title:
+            'The title form field is a simpler version of the description field, but with the ability to customize color.',
+          titleVariant: 'h3',
+          marginTop: 0,
+          marginBottom: 3,
+        }),
+        buildTitleField({
+          title: 'This is a simple H1 title',
+          titleVariant: 'h1',
+          marginTop: 0,
+          marginBottom: 3,
+        }),
+        buildTitleField({
+          title: 'This is a simple H2 title',
+          titleVariant: 'h2',
+          marginTop: 0,
+          marginBottom: 3,
+        }),
+        buildTitleField({
+          title: 'This is a simple H3 title',
+          titleVariant: 'h3',
+          marginTop: 0,
+          marginBottom: 3,
+        }),
+        buildTitleField({
+          title: 'This is a simple H4 title',
+          titleVariant: 'h4',
+          marginTop: 0,
+          marginBottom: 3,
+        }),
+        buildTitleField({
+          title: 'This is a simple H5 title',
+          titleVariant: 'h5',
+          marginTop: 0,
+          marginBottom: 5,
+        }),
+        buildTitleField({
+          title: 'This is a simple H1 title with a different color',
+          titleVariant: 'h1',
+          color: 'mint400',
+          marginTop: 0,
+          marginBottom: 3,
+        }),
+      ],
+    }),
+  ],
+})

--- a/libs/application/templates/examples/example-no-inputs/src/forms/prerequisitesForm/index.ts
+++ b/libs/application/templates/examples/example-no-inputs/src/forms/prerequisitesForm/index.ts
@@ -1,0 +1,60 @@
+import {
+  buildForm,
+  buildSection,
+  buildExternalDataProvider,
+  buildDataProviderItem,
+  buildSubmitField,
+  coreMessages,
+} from '@island.is/application/core'
+import { DefaultEvents, Form, FormModes } from '@island.is/application/types'
+import { UserProfileApi } from '@island.is/application/types'
+import { NationalRegistryApi, ReferenceDataApi } from '../../dataProviders'
+
+export const prerequisites: Form = buildForm({
+  id: 'PrerequisitesDraft',
+  title: '',
+  mode: FormModes.NOT_STARTED,
+  renderLastScreenButton: true,
+  children: [
+    buildSection({
+      id: 'conditions',
+      tabTitle: 'Prerequisites', // If there is no stepper, add tabTitle to have a title on the browser tab.
+      children: [
+        buildExternalDataProvider({
+          id: 'approveExternalData',
+          title: 'External data',
+          dataProviders: [
+            buildDataProviderItem({
+              provider: UserProfileApi,
+              title: 'User profile',
+              subTitle: 'User profile',
+            }),
+            buildDataProviderItem({
+              provider: ReferenceDataApi,
+              title: 'getReferenceData',
+              subTitle: 'Reference data',
+            }),
+            buildDataProviderItem({
+              provider: NationalRegistryApi,
+              title: 'National Registry',
+              subTitle: 'Information about you in the National Registry.',
+            }),
+          ],
+          // Button to trigger the submit event to move the application from the NOT_STARTED state to the DRAFT state.
+          submitField: buildSubmitField({
+            id: 'submit',
+            placement: 'footer',
+            refetchApplicationAfterSubmit: true,
+            actions: [
+              {
+                event: DefaultEvents.SUBMIT,
+                name: coreMessages.buttonNext,
+                type: 'primary',
+              },
+            ],
+          }),
+        }),
+      ],
+    }),
+  ],
+})

--- a/libs/application/templates/examples/example-no-inputs/src/index.ts
+++ b/libs/application/templates/examples/example-no-inputs/src/index.ts
@@ -1,0 +1,5 @@
+import template from './lib/template'
+
+export const getDataProviders = () => import('./dataProviders')
+
+export default template

--- a/libs/application/templates/examples/example-no-inputs/src/lib/dataSchema.ts
+++ b/libs/application/templates/examples/example-no-inputs/src/lib/dataSchema.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod'
+
+const validationSchema = z.object({
+  validationTextField: z.string(),
+})
+
+export const dataSchema = z.object({
+  validation: validationSchema,
+})
+
+export type ExampleFieldsAnswers = z.TypeOf<typeof dataSchema>

--- a/libs/application/templates/examples/example-no-inputs/src/lib/messages.ts
+++ b/libs/application/templates/examples/example-no-inputs/src/lib/messages.ts
@@ -1,0 +1,91 @@
+import { defineMessages } from 'react-intl'
+
+export const m = defineMessages({
+  descriptionFieldDescription: {
+    id: 'eni.application:descriptionFieldDescription',
+    defaultMessage:
+      'All text that appears in applications should come from `lib/messages.ts`. This text is then loaded into contentful by running `yarn nx run <template-name>:extract-strings`, where `<template-name>` is the name of the application as it is written in `project.json` in the relevant template. For this application it is `yarn nx run application-templates-reference-template:extract-strings`. In contentful, the content manager or administrator of the organization is responsible for adding English translations and updating the text from what the developer puts in `defaultMessage`.',
+    description: 'Description field description',
+  },
+  descriptionFieldDescription2: {
+    id: 'eni.application:descriptionFieldDescription2',
+    defaultMessage:
+      'Here is a list of all the options for text from buildDescriptionField. Most of them are related to adding `#markdown` to the id to be able to use markdown in the text. It is also possible to put variables into the text and control title font sizes. Please note that any linebreaks in the text must be represented as two escaped newlines. See the `messages.ts` file for examples of how to use markdown in the text.',
+    description: 'Description field description',
+  },
+  regularTextExample: {
+    id: 'eni.application:regularTextExample',
+    defaultMessage:
+      'Regular text coming from a message file, this can be overwritten in contentful by webmaster',
+    description: 'Example use of messages',
+  },
+  markdownHeadingExample: {
+    id: 'eni.application:markdownHeadingExample#markdown',
+    defaultMessage:
+      '# Markdown heading 1\\n\\n ## Markdown heading 2\\n\\n ### Markdown heading 3\\n\\n #### Markdown heading 4\\n\\n Regular markdown text',
+    description: 'Example use of markdown',
+  },
+  markdownBulletListExample: {
+    id: 'eni.application:markdownBulletListExample#markdown',
+    defaultMessage:
+      'Markdown bullet list\\n\\n * bullet 1\\n\\n * bullet 2\\n\\n * bullet 3',
+    description: 'Example use of markdown',
+  },
+  markdownNumberedListExample: {
+    id: 'eni.application:markdownNumberedListExample#markdown',
+    defaultMessage:
+      'Markdown numbered list\\n\\n 1. number 1\\n\\n 2. number 2\\n\\n 3. number 3',
+    description: 'Example use of markdown',
+  },
+  markdownMiscExample: {
+    id: 'eni.application:markdownMiscExample#markdown',
+    defaultMessage:
+      'A markdown link will open in a new tab: [This is a link to Google!](http://google.com)\\n\\n Markdown value inserted {value1}\\n\\n **Bold text**\\n\\n *Italic text*\\n\\n ***Bold and italic text***',
+    description: 'Example use of markdown link',
+  },
+  markdownCodeExample: {
+    id: 'eni.application:markdownCodeExample#markdown',
+    defaultMessage:
+      'Markdown code inline `const x = 123` with text Code block ``` const x = 123\\n\\n if (x < 100) {\\n\\n return true\\n\\n }```',
+    description: 'Example use of markdown code',
+  },
+  overviewTitle: {
+    id: 'eni.application:overviewTitle',
+    defaultMessage: 'Overview',
+    description: 'Overview title',
+  },
+  overviewDescriptionText: {
+    id: 'eni.application:overviewDescriptionText',
+    defaultMessage:
+      'The overview section is made up of buildOverviewFields, each one is a block with an edit button. The best organization for this screen is that each buildOverviewField has values corresponding to one screen.',
+    description: 'Overview description',
+  },
+  overviewInfoDescripton2: {
+    id: 'eni.application:overviewInfoDescripton2',
+    defaultMessage:
+      'See more examples using the buildOverviewField in the example-inputs template.',
+    description: 'Overview description for the info section',
+  },
+  overviewFileDescription: {
+    id: 'eni.application:overviewFileDescription',
+    defaultMessage:
+      'The file overview can have width "full" or "half". The file name is the only required property.',
+    description: 'Overview description for the file section',
+  },
+  overviewDescription: {
+    id: 'eni.application:overviewDescription',
+    defaultMessage:
+      'At the moment the form overview is a custom component. The plan is to make this a shared component in the near future.',
+    description: 'Overview description',
+  },
+  overviewSubmit: {
+    id: 'eni.application:overviewSubmit',
+    defaultMessage: 'Submit',
+    description: 'Overview submit button',
+  },
+  number1: {
+    id: 'eni.application:number1',
+    defaultMessage: 'Number 1',
+    description: 'key for number 1',
+  },
+})

--- a/libs/application/templates/examples/example-no-inputs/src/lib/template.ts
+++ b/libs/application/templates/examples/example-no-inputs/src/lib/template.ts
@@ -1,0 +1,129 @@
+import {
+  ApplicationTemplate,
+  ApplicationTypes,
+  ApplicationContext,
+  ApplicationStateSchema,
+  ApplicationConfigurations,
+  DefaultEvents,
+  FormModes,
+  UserProfileApi,
+} from '@island.is/application/types'
+import { CodeOwners } from '@island.is/shared/constants'
+import { Events, Roles, States } from '../utils/types'
+import {
+  DefaultStateLifeCycle,
+  EphemeralStateLifeCycle,
+} from '@island.is/application/core'
+import { NationalRegistryApi, ReferenceDataApi } from '../dataProviders'
+import { dataSchema } from './dataSchema'
+
+const template: ApplicationTemplate<
+  ApplicationContext,
+  ApplicationStateSchema<Events>,
+  Events
+> = {
+  type: ApplicationTypes.EXAMPLE_NO_INPUTS,
+  name: 'Example No Inputs',
+  codeOwner: CodeOwners.NordaApplications,
+  translationNamespaces: [
+    ApplicationConfigurations.ExampleNoInputs.translation,
+  ],
+  dataSchema,
+  stateMachineConfig: {
+    initial: States.PREREQUISITES,
+    states: {
+      [States.PREREQUISITES]: {
+        meta: {
+          name: 'Prerequisites',
+          progress: 0,
+          status: FormModes.DRAFT,
+          lifecycle: EphemeralStateLifeCycle,
+          roles: [
+            {
+              id: Roles.APPLICANT,
+              formLoader: () =>
+                import('../forms/prerequisitesForm').then(
+                  (module) => module.prerequisites,
+                ),
+              actions: [
+                { event: 'SUBMIT', name: 'Staðfesta', type: 'primary' },
+              ],
+              write: 'all',
+              read: 'all',
+              delete: true,
+              api: [
+                ReferenceDataApi.configure({
+                  params: {
+                    id: 1986,
+                  },
+                }),
+                NationalRegistryApi.configure({
+                  params: {
+                    ageToValidate: 18,
+                  },
+                }),
+                UserProfileApi,
+              ],
+            },
+          ],
+        },
+        on: {
+          [DefaultEvents.SUBMIT]: {
+            target: States.DRAFT,
+          },
+        },
+      },
+      [States.DRAFT]: {
+        meta: {
+          name: 'Main form',
+          progress: 0.4,
+          status: FormModes.DRAFT,
+          lifecycle: DefaultStateLifeCycle,
+          roles: [
+            {
+              id: Roles.APPLICANT,
+              formLoader: () =>
+                import('../forms/mainForm').then((module) =>
+                  Promise.resolve(module.mainForm),
+                ),
+              actions: [
+                { event: 'SUBMIT', name: 'Staðfesta', type: 'primary' },
+              ],
+              write: 'all',
+              read: 'all',
+              delete: true,
+            },
+          ],
+        },
+        on: {
+          [DefaultEvents.SUBMIT]: {
+            target: States.COMPLETED,
+          },
+        },
+      },
+      [States.COMPLETED]: {
+        meta: {
+          name: 'Completed',
+          progress: 1,
+          status: FormModes.COMPLETED,
+          lifecycle: DefaultStateLifeCycle,
+          roles: [
+            {
+              id: Roles.APPLICANT,
+              formLoader: () =>
+                import('../forms/completedForm').then((module) =>
+                  Promise.resolve(module.completedForm),
+                ),
+              read: 'all',
+              delete: true,
+            },
+          ],
+        },
+      },
+    },
+  },
+  stateMachineOptions: {},
+  mapUserToRole: () => Roles.APPLICANT,
+}
+
+export default template

--- a/libs/application/templates/examples/example-no-inputs/src/utils/overviewUtils.ts
+++ b/libs/application/templates/examples/example-no-inputs/src/utils/overviewUtils.ts
@@ -1,0 +1,73 @@
+import { getValueViaPath } from '@island.is/application/core'
+import {
+  ExternalData,
+  FormValue,
+  KeyValueItem,
+} from '@island.is/application/types'
+
+export const getOverviewItems = (
+  answers: FormValue,
+  _externalData: ExternalData,
+): Array<KeyValueItem> => {
+  return [
+    {
+      width: 'full',
+      keyText: 'Full width',
+      valueText: getValueViaPath<string>(answers, 'applicant.name') ?? '',
+    },
+    {
+      width: 'half',
+      keyText: 'Half width',
+      valueText:
+        getValueViaPath<string>(answers, 'applicant.phoneNumber') ?? '',
+    },
+    {
+      width: 'half',
+      keyText: 'Half width',
+      valueText: 'Hvassaleiti 5',
+    },
+    {
+      width: 'full',
+      // empty item to end line
+    },
+    {
+      width: 'snug',
+      keyText: 'Snug width',
+      valueText: 'test@test.is',
+    },
+    {
+      width: 'snug',
+      keyText: 'Snug width',
+      valueText: '+354 123 4567',
+    },
+    {
+      width: 'snug',
+      keyText: 'Snug width',
+      valueText: '+354 123 4567',
+    },
+    {
+      width: 'snug',
+      keyText: 'Snug width',
+      valueText: '+354 123 4567',
+    },
+    {
+      width: 'full',
+      // empty item to end line
+    },
+    {
+      width: 'snug',
+      keyText: 'Snug width',
+      valueText: 'Reykjavík',
+    },
+    {
+      width: 'half',
+      keyText: 'Half width',
+      valueText: 'test@test.is',
+    },
+    {
+      width: 'snug',
+      keyText: 'Snug width',
+      valueText: 'test@test.is',
+    },
+  ]
+}

--- a/libs/application/templates/examples/example-no-inputs/src/utils/types.ts
+++ b/libs/application/templates/examples/example-no-inputs/src/utils/types.ts
@@ -1,0 +1,25 @@
+import { DefaultEvents } from '@island.is/application/types'
+
+export enum ApiActions {
+  createApplication = 'createApplication',
+  doStuffThatFails = 'doStuffThatFails',
+  completeApplication = 'completeApplication',
+  getReferenceData = 'getReferenceData',
+  getAnotherReferenceData = 'getAnotherReferenceData',
+}
+
+export type Events = {
+  type: DefaultEvents.SUBMIT | DefaultEvents.ABORT
+}
+
+export enum States {
+  PREREQUISITES = 'prerequisites',
+  DRAFT = 'draft',
+  COMPLETED = 'completed',
+  PAYMENT = 'payment',
+  REVIEW = 'review',
+}
+
+export enum Roles {
+  APPLICANT = 'applicant',
+}

--- a/libs/application/templates/examples/example-no-inputs/tsconfig.json
+++ b/libs/application/templates/examples/example-no-inputs/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "allowJs": false,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "extends": "../../../../../tsconfig.base.json"
+}

--- a/libs/application/templates/examples/example-no-inputs/tsconfig.lib.json
+++ b/libs/application/templates/examples/example-no-inputs/tsconfig.lib.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../../dist/out-tsc",
+    "types": ["node"]
+  },
+  "exclude": [
+    "jest.config.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.js",
+    "src/**/*.test.js",
+    "src/**/*.spec.jsx",
+    "src/**/*.test.jsx"
+  ],
+  "include": ["src/**/*.js", "src/**/*.jsx", "src/**/*.ts", "src/**/*.tsx"]
+}

--- a/libs/application/templates/examples/example-no-inputs/tsconfig.spec.json
+++ b/libs/application/templates/examples/example-no-inputs/tsconfig.spec.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.d.ts"
+  ]
+}

--- a/libs/application/types/src/lib/ApplicationTypes.ts
+++ b/libs/application/types/src/lib/ApplicationTypes.ts
@@ -82,6 +82,7 @@ export enum ApplicationTypes {
   EXAMPLE_STATE_TRANSFERS = 'ExampleStateTransfers',
   EXAMPLE_COMMON_ACTIONS = 'ExampleCommonActions',
   EXAMPLE_INPUTS = 'ExampleInputs',
+  EXAMPLE_NO_INPUTS = 'ExampleNoInputs',
 }
 
 export const ApplicationConfigurations = {
@@ -100,6 +101,10 @@ export const ApplicationConfigurations = {
   [ApplicationTypes.EXAMPLE_INPUTS]: {
     slug: 'example-inputs',
     translation: 'ef.application',
+  },
+  [ApplicationTypes.EXAMPLE_NO_INPUTS]: {
+    slug: 'example-no-inputs',
+    translation: 'eni.application',
   },
   [ApplicationTypes.PASSPORT]: {
     slug: 'vegabref',

--- a/libs/application/types/src/lib/InstitutionMapper.ts
+++ b/libs/application/types/src/lib/InstitutionMapper.ts
@@ -24,6 +24,11 @@ export const institutionMapper = {
     slug: InstitutionTypes.STAFRAENT_ISLAND,
     contentfulId: InstitutionContentfulIds.STAFRAENT_ISLAND,
   },
+  [ApplicationTypes.EXAMPLE_NO_INPUTS]: {
+    nationalId: InstitutionNationalIds.STAFRAENT_ISLAND,
+    slug: InstitutionTypes.STAFRAENT_ISLAND,
+    contentfulId: InstitutionContentfulIds.STAFRAENT_ISLAND,
+  },
   [ApplicationTypes.PASSPORT]: {
     nationalId: InstitutionNationalIds.SYSLUMENN,
     slug: InstitutionTypes.SYSLUMENN,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -390,6 +390,9 @@
       "@island.is/application/templates/examples/example-inputs": [
         "libs/application/templates/examples/example-inputs/src/index.ts"
       ],
+      "@island.is/application/templates/examples/example-no-inputs": [
+        "libs/application/templates/examples/example-no-inputs/src/index.ts"
+      ],
       "@island.is/application/templates/examples/example-state-transfers": [
         "libs/application/templates/examples/example-state-transfers/src/index.ts"
       ],
@@ -1162,8 +1165,14 @@
       "api/domains/financial-statement-cemetery": [
         "libs/api/domains/financial-statement-cemetery/src/index.ts"
       ],
+      "application/templates/examples/example-no-inputs": [
+        "libs/application/templates/examples/example-no-inputs/src/index.ts"
+      ],
       "application/templates/inao/financial-statement-political-party": [
         "libs/application/templates/inao/financial-statement-political-party/src/index.ts"
+      ],
+      "application/templates/name-of-application": [
+        "libs/application/templates/name-of-application/src/index.ts"
       ],
       "delegation-admin": ["libs/portals/admin/delegation-admin/src/index.ts"]
     }


### PR DESCRIPTION
## What

Make a new example application that shows all fields that don't have an input. This is pulled from the no-inputs section in the reference template

## Why
The reference template was becoming too big so we are splitting it into more bite sized chunks.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new application template offering a streamlined, multi-step process with distinct stages for prerequisites, main interactions, and completion.
  - Enhanced the user interface with dynamic elements such as accordions, action cards, alert messages, copyable links, descriptive sections, dividers, key-value displays, overviews, and titles to guide users smoothly through the experience.
  - Added support for a new application type, `EXAMPLE_NO_INPUTS`, expanding the application's capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->