### PR TITLE
fix(new-primary-school): Add international school type when selecting a school

### DIFF
--- a/libs/api/domains/education/src/lib/graphql/frigg/address.model.ts
+++ b/libs/api/domains/education/src/lib/graphql/frigg/address.model.ts
@@ -1,18 +1,18 @@
 import { Field, ObjectType } from '@nestjs/graphql'
 
-@ObjectType()
+@ObjectType('EducationFriggKeyAddressModel')
 export class AddressModel {
-  @Field({ nullable: true })
-  id?: string
+  @Field()
+  id!: string
 
-  @Field({ nullable: true })
-  address?: string
+  @Field()
+  address!: string
 
   @Field({ nullable: true })
   municipality?: string
 
-  @Field({ nullable: true })
-  postCode?: string
+  @Field()
+  postCode!: string
 
   @Field({ nullable: true })
   country?: string

--- a/libs/api/domains/education/src/lib/graphql/frigg/address.model.ts
+++ b/libs/api/domains/education/src/lib/graphql/frigg/address.model.ts
@@ -1,6 +1,6 @@
 import { Field, ObjectType } from '@nestjs/graphql'
 
-@ObjectType('EducationFriggKeyAddressModel')
+@ObjectType('EducationFriggAddressModel')
 export class AddressModel {
   @Field()
   id!: string

--- a/libs/application/templates/new-primary-school/src/forms/NewPrimarySchoolForm/primarySchoolSection/newSchoolSubSection.ts
+++ b/libs/application/templates/new-primary-school/src/forms/NewPrimarySchoolForm/primarySchoolSection/newSchoolSubSection.ts
@@ -7,7 +7,7 @@ import {
   NO,
 } from '@island.is/application/core'
 import { friggSchoolsByMunicipalityQuery } from '../../../graphql/queries'
-import { ApplicationType } from '../../../lib/constants'
+import { ApplicationType, SchoolType } from '../../../lib/constants'
 import { newPrimarySchoolMessages } from '../../../lib/messages'
 import {
   getApplicationAnswers,
@@ -88,6 +88,14 @@ export const newSchoolSubSection = buildSubSection({
 
             const municipality = selectedValues?.[0]
 
+            // Since the data from Frigg is not structured for international schools, we need to manually identify them
+            const internationalSchoolsIds = [
+              'G-2250-A',
+              'G-2250-B',
+              'G-1157-A',
+              'G-1157-B',
+            ] //Alþjóðaskólinn G-2250-x & Landkotsskóli G-1157-x
+
             const { childGradeLevel } = getApplicationExternalData(
               application.externalData,
             )
@@ -109,7 +117,11 @@ export const newSchoolSubSection = buildSubSection({
                       )
                       ?.map((school) => ({
                         ...school,
-                        type: OrganizationModelTypeEnum.PrivateOwner,
+                        type: internationalSchoolsIds.some(
+                          (id) => id === school.unitId, // Hack to identify international schools from private ownded schools
+                        )
+                          ? SchoolType.INTERNATIONAL_SCHOOL
+                          : SchoolType.PRIVATE_SCHOOL,
                       })) || [],
                 ) || []
 

--- a/libs/application/templates/new-primary-school/src/forms/NewPrimarySchoolForm/primarySchoolSection/newSchoolSubSection.ts
+++ b/libs/application/templates/new-primary-school/src/forms/NewPrimarySchoolForm/primarySchoolSection/newSchoolSubSection.ts
@@ -133,7 +133,11 @@ export const newSchoolSubSection = buildSubSection({
                   ({ type, gradeLevels }) =>
                     type === OrganizationModelTypeEnum.School &&
                     gradeLevels?.includes(childGradeLevel),
-                ) || []
+                )
+                ?.map((school) => ({
+                  ...school,
+                  type: SchoolType.PUBLIC_SCHOOL,
+                })) || []
 
             // Merge the private owned schools and the municipality schools together
             const allMunicipalitySchools = [

--- a/libs/application/templates/new-primary-school/src/lib/constants.ts
+++ b/libs/application/templates/new-primary-school/src/lib/constants.ts
@@ -69,3 +69,10 @@ export enum ApplicationType {
   NEW_PRIMARY_SCHOOL = 'newPrimarySchool',
   ENROLLMENT_IN_PRIMARY_SCHOOL = 'enrollmentInPrimarySchool',
 }
+
+export enum SchoolType {
+  PUBLIC_SCHOOL = 'publicSchool',
+  PRIVATE_SCHOOL = 'privateSchool',
+  INTERNATIONAL_SCHOOL = 'internationalSchool',
+  NURSERY_SCHOOL = 'nurserySchool',
+}


### PR DESCRIPTION
[TS-1002](https://dit-iceland.atlassian.net/browse/TS-1002)
## Why

We need to know for the next pages in the application if a selected school is an international school, private owned or a municipality school.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new school classification system with options for Public, Private, International, and Nursery schools.
  - Enhanced municipality school processing to clearly categorize schools as Public Schools.

- **Refactor**
  - Updated the naming convention for the education address API to ensure consistency in external GraphQL interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->