### PR TITLE
fix(web): Service web form, add label so that form submissions include "Kennitala þess sem málið varðar"

### DIFF
--- a/apps/web/components/ServiceWeb/Forms/StandardForm/StandardForm.tsx
+++ b/apps/web/components/ServiceWeb/Forms/StandardForm/StandardForm.tsx
@@ -106,6 +106,7 @@ const labels: Record<string, string> = {
   nafn_fyrirtaekis: 'Nafn fyrirtækis',
   starfsstod: 'Starfsstöð',
   oska_eftir_vernd_uppljostrara: 'Óska eftir vernd uppljóstrara',
+  kennitala_thess_sem_malid_vardar: 'Kennitala þess sem málið varðar',
 }
 
 // these should be skipped in the message itself


### PR DESCRIPTION
# Service web form, add label so that form submissions include "Kennitala þess sem málið varðar"

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - A new field label has been added to the service web form, displaying the text "Kennitala þess sem málið varðar" to enhance clarity when entering personal identification details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->