### PR TITLE
fix(j-s): hide couple of null Item fields in info card for prosecutor

### DIFF
--- a/apps/judicial-system/web/src/components/InfoCard/InfoCardActiveIndictment.tsx
+++ b/apps/judicial-system/web/src/components/InfoCard/InfoCardActiveIndictment.tsx
@@ -25,6 +25,7 @@ const InfoCardActiveIndictment: React.FC<Props> = (props) => {
     mergedCaseCourt,
     civilClaimants,
     courtCaseNumber,
+    showItem
   } = useInfoCardItems()
 
   return (
@@ -42,11 +43,11 @@ const InfoCardActiveIndictment: React.FC<Props> = (props) => {
         {
           id: 'case-info-section',
           items: [
-            indictmentCreated,
+            ...(showItem(indictmentCreated) ? [indictmentCreated] : []),
             prosecutor(workingCase.type),
             policeCaseNumbers,
             court,
-            courtCaseNumber,
+            ...(showItem(courtCaseNumber) ? [courtCaseNumber] : []),
             offenses,
           ],
           columns: 2,


### PR DESCRIPTION
# [Fix undefined values in Info card for prosecutor](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1209579048098788)

## What
- Fix undefined values in Info card for prosecutor

## Why
- Bc its a bug

## Screenshots / Gifs
<img width="638" alt="Screenshot 2025-03-11 at 11 52 28" src="https://github.com/user-attachments/assets/e7b377b9-5176-4e8c-b2d7-9e059a1dcb13" />

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the active indictment information display to dynamically show relevant details, ensuring that only appropriate case information is presented to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->