### PR TITLE
fix(j-s): Limited access subpoena endpoint

### DIFF
--- a/apps/judicial-system/api/src/app/modules/file/limitedAccessFile.controller.ts
+++ b/apps/judicial-system/api/src/app/modules/file/limitedAccessFile.controller.ts
@@ -180,7 +180,10 @@ export class LimitedAccessFileController {
     )
   }
 
-  @Get('subpoena/:defendantId/:subpoenaId')
+  @Get([
+    'subpoena/:defendantId/:subpoenaId',
+    'subpoena/:defendantId/:subpoenaId/:fileName',
+  ])
   @Header('Content-Type', 'application/pdf')
   getSubpoenaPdf(
     @Param('id') id: string,


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1209630068986189)

## What

Fix limited access subpoena endpoint

## Why

Because limited access users can't open files if the file name is appended to the request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced file access functionality: The file retrieval endpoint now accepts an additional optional parameter, offering more flexible access to files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->