### PR TITLE
fix(contentful-apps): Organization subpage slug check logic adjustments

### DIFF
--- a/apps/contentful-apps/pages/fields/organization-parent-subpage-slug-field.tsx
+++ b/apps/contentful-apps/pages/fields/organization-parent-subpage-slug-field.tsx
@@ -109,7 +109,7 @@ const OrganizationParentSubpageSlugField = () => {
         return
       }
 
-      // Is there another org subpage that does not belong to a parent subpage that has the same slug?
+      // Is there an org subpage that does not belong to a parent subpage that has the same slug?
       if (subpagesWithSameSlugThatBelongToSameOrganizationPage.length > 0) {
         // Check to see if those org subpages with the same slug belong to a parent subpage
         const subpageParents = await cma.entry.getMany({

--- a/apps/contentful-apps/pages/fields/organization-parent-subpage-slug-field.tsx
+++ b/apps/contentful-apps/pages/fields/organization-parent-subpage-slug-field.tsx
@@ -82,7 +82,6 @@ const OrganizationParentSubpageSlugField = () => {
             locale: sdk.field.locale,
             content_type: 'organizationSubpage',
             'fields.slug': value,
-            'sys.id[ne]': entryId,
             'sys.archivedVersion[exists]': false,
             limit: 1000,
             'fields.organizationPage.sys.id': organizationPageId,
@@ -92,6 +91,7 @@ const OrganizationParentSubpageSlugField = () => {
           query: {
             locale: sdk.field.locale,
             content_type: 'organizationParentSubpage',
+            'sys.id[ne]': entryId,
             'fields.slug': value,
             'sys.archivedVersion[exists]': false,
             limit: 1000,

--- a/apps/contentful-apps/pages/fields/organization-parent-subpage-slug-field.tsx
+++ b/apps/contentful-apps/pages/fields/organization-parent-subpage-slug-field.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useRef, useState } from 'react'
+import { useDebounce } from 'react-use'
+import { FieldExtensionSDK } from '@contentful/app-sdk'
+import { Stack, Text, TextInput } from '@contentful/f36-components'
+import { useCMA, useSDK } from '@contentful/react-apps-toolkit'
+import slugify from '@sindresorhus/slugify'
+
+import { CUSTOM_SLUGIFY_REPLACEMENTS } from '../../constants'
+
+const DEBOUNCE_TIME = 100
+
+const OrganizationParentSubpageSlugField = () => {
+  const sdk = useSDK<FieldExtensionSDK>()
+  const cma = useCMA()
+  const [value, setValue] = useState(sdk.field?.getValue() ?? '')
+  const [isValid, setIsValid] = useState(true)
+  const [organizationPageId, setOrganizationPageId] = useState(
+    sdk.entry.fields.organizationPage.getValue()?.sys?.id,
+  )
+  const initialTitleChange = useRef(true)
+  const [hasEntryBeenPublished, setHasEntryBeenPublished] = useState(
+    Boolean(sdk.entry.getSys()?.firstPublishedAt),
+  )
+
+  const defaultLocale = sdk.locales.default
+
+  useEffect(() => {
+    sdk.entry.onSysChanged((newSys) => {
+      setHasEntryBeenPublished(Boolean(newSys?.firstPublishedAt))
+    })
+  }, [sdk.entry])
+
+  // Update slug field if the title field changes
+  useEffect(() => {
+    return sdk.entry.fields.title
+      .getForLocale(sdk.field.locale)
+      .onValueChanged((newTitle) => {
+        if (hasEntryBeenPublished) {
+          return
+        }
+
+        // Callback gets called on initial render, so we  want to ignore that
+        if (initialTitleChange.current) {
+          initialTitleChange.current = false
+          return
+        }
+
+        if (newTitle) {
+          setValue(
+            slugify(String(newTitle), {
+              customReplacements: CUSTOM_SLUGIFY_REPLACEMENTS,
+            }),
+          )
+        }
+      })
+  }, [hasEntryBeenPublished, sdk.entry.fields.title, sdk.field.locale])
+
+  // Store in state what organization page id is being referenced
+  useEffect(() => {
+    return sdk.entry.fields.organizationPage.onValueChanged((newOrgPage) => {
+      setOrganizationPageId(newOrgPage?.sys?.id)
+    })
+  }, [sdk.entry.fields.organizationPage])
+
+  useEffect(() => {
+    sdk.window.startAutoResizer()
+  }, [sdk.window])
+
+  // Validate the user input
+  useDebounce(
+    async () => {
+      if (!organizationPageId || !value) {
+        setIsValid(true)
+        return
+      }
+
+      const entryId = sdk.entry.getSys().id
+
+      const [subpageResponse, parentSubpageResponse] = await Promise.all([
+        cma.entry.getMany({
+          query: {
+            locale: sdk.field.locale,
+            content_type: 'organizationSubpage',
+            'fields.slug': value,
+            'sys.id[ne]': entryId,
+            'sys.archivedVersion[exists]': false,
+            limit: 1000,
+            'fields.organizationPage.sys.id': organizationPageId,
+          },
+        }),
+        cma.entry.getMany({
+          query: {
+            locale: sdk.field.locale,
+            content_type: 'organizationParentSubpage',
+            'fields.slug': value,
+            'sys.archivedVersion[exists]': false,
+            limit: 1000,
+            'fields.organizationPage.sys.id': organizationPageId,
+          },
+        }),
+      ])
+
+      const subpagesWithSameSlugThatBelongToSameOrganizationPage =
+        subpageResponse.items
+
+      // Parent subpage with the same org page and slug
+      if (parentSubpageResponse.items.length > 0) {
+        setIsValid(false)
+        return
+      }
+
+      // Is there another org subpage that does not belong to a parent subpage that has the same slug?
+      if (subpagesWithSameSlugThatBelongToSameOrganizationPage.length > 0) {
+        // Check to see if those org subpages with the same slug belong to a parent subpage
+        const subpageParents = await cma.entry.getMany({
+          query: {
+            locale: sdk.field.locale,
+            content_type: 'organizationParentSubpage',
+            'sys.archivedVersion[exists]': false,
+            limit: 1000,
+            'fields.organizationPage.sys.id': organizationPageId,
+            'fields.pages.sys.id[in]':
+              subpagesWithSameSlugThatBelongToSameOrganizationPage
+                .map((s) => s.sys.id)
+                .join(', '),
+          },
+        })
+
+        const subpagesThatDontBelongToParent =
+          subpagesWithSameSlugThatBelongToSameOrganizationPage.filter(
+            (subpage) =>
+              !subpageParents.items.some((parent) =>
+                parent.fields.pages[sdk.locales.default].some(
+                  (s) => s.sys.id === subpage.sys.id,
+                ),
+              ),
+          )
+
+        if (subpagesThatDontBelongToParent.length > 0) {
+          setIsValid(false)
+          return
+        }
+      }
+
+      setIsValid(true)
+    },
+    DEBOUNCE_TIME,
+    [value, organizationPageId],
+  )
+
+  useDebounce(
+    () => {
+      if (isValid) {
+        sdk.field.setValue(value)
+      } else {
+        sdk.field.setValue(null) // Set to null to prevent entry publish
+      }
+      sdk.field.setInvalid(!isValid)
+    },
+    DEBOUNCE_TIME,
+    [isValid, value],
+  )
+
+  const isInvalid = value.length === 0 || !isValid
+
+  return (
+    <Stack spacing="spacingXs" flexDirection="column" alignItems="flex-start">
+      <TextInput
+        value={value}
+        onChange={(ev) => {
+          setValue(ev.target.value)
+        }}
+        isInvalid={isInvalid}
+      />
+      {value.length === 0 && sdk.field.locale === defaultLocale && (
+        <Text fontColor="red400">Invalid slug</Text>
+      )}
+      {value.length > 0 && isInvalid && (
+        <Text fontColor="red400">
+          Another page already exists with this slug
+        </Text>
+      )}
+    </Stack>
+  )
+}
+
+export default OrganizationParentSubpageSlugField

--- a/apps/contentful-apps/pages/fields/organization-subpage-slug-field.tsx
+++ b/apps/contentful-apps/pages/fields/organization-subpage-slug-field.tsx
@@ -101,7 +101,7 @@ const OrganizationSubpageSlugField = () => {
             content_type: 'organizationParentSubpage',
             'fields.slug': value,
             'sys.archivedVersion[exists]': false,
-            limit: 1000,
+            limit: 1,
             'fields.organizationPage.sys.id': organizationPageId,
           },
         }),

--- a/apps/contentful-apps/pages/fields/organization-subpage-slug-field.tsx
+++ b/apps/contentful-apps/pages/fields/organization-subpage-slug-field.tsx
@@ -101,21 +101,31 @@ const OrganizationSubpageSlugField = () => {
             organizationPageId,
         )
 
-      if (subpagesWithSameSlugThatBelongToSameOrganizationPage.length > 0) {
-        if (
-          parentSubpageResponse.items.some((parentSubpage) => {
-            const pages: { sys: { id: string } }[] =
-              parentSubpage.fields['pages']?.[sdk.locales.default] ?? []
-            return pages.some((page) =>
-              subpagesWithSameSlugThatBelongToSameOrganizationPage.some(
-                (s) => s.sys.id === page.sys.id,
-              ),
-            )
-          })
-        )
-          setIsValid(false)
+      if (subpagesWithSameSlugThatBelongToSameOrganizationPage.length === 0) {
+        setIsValid(true)
         return
       }
+
+      if (parentSubpageResponse.items.length === 0) {
+        setIsValid(false)
+        return
+      }
+
+      if (
+        parentSubpageResponse.items.some((parentSubpage) => {
+          const pages: { sys: { id: string } }[] =
+            parentSubpage.fields['pages']?.[sdk.locales.default] ?? []
+          return pages.some((page) =>
+            subpagesWithSameSlugThatBelongToSameOrganizationPage.some(
+              (s) => s.sys.id === page.sys.id,
+            ),
+          )
+        })
+      ) {
+        setIsValid(false)
+        return
+      }
+
       setIsValid(true)
     },
     DEBOUNCE_TIME,

--- a/apps/contentful-apps/pages/fields/organization-subpage-slug-field.tsx
+++ b/apps/contentful-apps/pages/fields/organization-subpage-slug-field.tsx
@@ -152,9 +152,9 @@ const OrganizationSubpageSlugField = () => {
         const subpagesThatDontBelongToParent =
           subpagesWithSameSlugThatBelongToSameOrganizationPage.filter(
             (subpage) =>
-              subpageParents.items.some((parent) =>
+              !subpageParents.items.some((parent) =>
                 parent.fields.pages[sdk.locales.default].some(
-                  (s) => s.sys.id !== subpage.sys.id,
+                  (s) => s.sys.id === subpage.sys.id,
                 ),
               ),
           )

--- a/apps/contentful-apps/pages/fields/organization-subpage-slug-field.tsx
+++ b/apps/contentful-apps/pages/fields/organization-subpage-slug-field.tsx
@@ -200,7 +200,7 @@ const OrganizationSubpageSlugField = () => {
       )}
       {value.length > 0 && isInvalid && (
         <Text fontColor="red400">
-          Organization subpage already exists with this slug
+          Another page already exists with this slug
         </Text>
       )}
     </Stack>

--- a/apps/contentful-apps/pages/sidebars/preview-link.tsx
+++ b/apps/contentful-apps/pages/sidebars/preview-link.tsx
@@ -1,104 +1,10 @@
 import { useEffect, useState } from 'react'
-import { EntryProps, KeyValueMap } from 'contentful-management'
-import { CMAClient, SidebarExtensionSDK } from '@contentful/app-sdk'
+import { SidebarExtensionSDK } from '@contentful/app-sdk'
 import { Button, Text } from '@contentful/f36-components'
 import { useCMA, useSDK } from '@contentful/react-apps-toolkit'
 
-import {
-  CONTENTFUL_ENVIRONMENT,
-  CONTENTFUL_SPACE,
-  DEFAULT_LOCALE,
-  DEV_WEB_BASE_URL,
-} from '../../constants'
-
-const previewLinkHandler = {
-  vacancy: (entry: EntryProps<KeyValueMap>) => {
-    return `${DEV_WEB_BASE_URL}/starfatorg/c-${entry.sys.id}`
-  },
-  article: (entry: EntryProps<KeyValueMap>) => {
-    return `${DEV_WEB_BASE_URL}/${entry.fields.slug[DEFAULT_LOCALE]}`
-  },
-  subArticle: async (entry: EntryProps<KeyValueMap>, cma: CMAClient) => {
-    const parentArticleId = entry.fields.parent?.[DEFAULT_LOCALE]?.sys?.id
-    const parentArticle = await cma.entry.get({
-      entryId: parentArticleId,
-      environmentId: CONTENTFUL_ENVIRONMENT,
-      spaceId: CONTENTFUL_SPACE,
-    })
-    return `${DEV_WEB_BASE_URL}/${
-      parentArticle?.fields?.slug[DEFAULT_LOCALE]
-    }/${entry.fields.url[DEFAULT_LOCALE]?.split('/')?.pop() ?? ''}`
-  },
-  organizationPage: (entry: EntryProps<KeyValueMap>) => {
-    return `${DEV_WEB_BASE_URL}/s/${entry.fields.slug[DEFAULT_LOCALE]}`
-  },
-  projectPage: (entry: EntryProps<KeyValueMap>) => {
-    return `${DEV_WEB_BASE_URL}/v/${entry.fields.slug[DEFAULT_LOCALE]}`
-  },
-  organizationSubpage: async (
-    entry: EntryProps<KeyValueMap>,
-    cma: CMAClient,
-  ) => {
-    const organizationPageId =
-      entry.fields.organizationPage?.[DEFAULT_LOCALE]?.sys?.id
-    const [organizationPage, organizationParentSubpageResponse] =
-      await Promise.all([
-        cma.entry.get({
-          entryId: organizationPageId,
-          environmentId: CONTENTFUL_ENVIRONMENT,
-          spaceId: CONTENTFUL_SPACE,
-        }),
-        cma.entry.getMany({
-          query: {
-            content_type: 'organizationParentSubpage',
-            include: 1,
-            links_to_entry: entry.sys.id,
-            'sys.archivedAt[exists]': false,
-          },
-        }),
-      ])
-
-    const orgPageSlug = organizationPage?.fields?.slug?.[DEFAULT_LOCALE]
-    const slug = entry.fields.slug[DEFAULT_LOCALE]
-
-    if (!organizationParentSubpageResponse?.items?.length) {
-      return `${DEV_WEB_BASE_URL}/s/${orgPageSlug}/${slug}`
-    }
-    return `${DEV_WEB_BASE_URL}/s/${orgPageSlug}/${organizationParentSubpageResponse.items[0].fields.slug[DEFAULT_LOCALE]}/${slug}`
-  },
-  anchorPage: (entry: EntryProps<KeyValueMap>) => {
-    const middlePart =
-      entry.fields.pageType?.[DEFAULT_LOCALE] === 'Digital Iceland Service'
-        ? 's/stafraent-island/thjonustur'
-        : 'lifsvidburdir'
-
-    return `${DEV_WEB_BASE_URL}/${middlePart}/${entry.fields.slug[DEFAULT_LOCALE]}`
-  },
-  lifeEventPage: (entry: EntryProps<KeyValueMap>) => {
-    return `${DEV_WEB_BASE_URL}/lifsvidburdir/${entry.fields.slug[DEFAULT_LOCALE]}`
-  },
-  news: (entry: EntryProps<KeyValueMap>) => {
-    return `${DEV_WEB_BASE_URL}/frett/${entry.fields.slug[DEFAULT_LOCALE]}`
-  },
-  manual: (entry: EntryProps<KeyValueMap>) => {
-    return `${DEV_WEB_BASE_URL}/handbaekur/${entry.fields.slug[DEFAULT_LOCALE]}`
-  },
-  organizationParentSubpage: async (
-    entry: EntryProps<KeyValueMap>,
-    cma: CMAClient,
-  ) => {
-    const organizationPageId =
-      entry.fields.organizationPage?.[DEFAULT_LOCALE]?.sys?.id
-    const organizationPage = await cma.entry.get({
-      entryId: organizationPageId,
-      environmentId: CONTENTFUL_ENVIRONMENT,
-      spaceId: CONTENTFUL_SPACE,
-    })
-    const orgPageSlug = organizationPage?.fields?.slug?.[DEFAULT_LOCALE]
-
-    return `${DEV_WEB_BASE_URL}/s/${orgPageSlug}/${entry.fields.slug[DEFAULT_LOCALE]}`
-  },
-}
+import { CONTENTFUL_ENVIRONMENT, CONTENTFUL_SPACE } from '../../constants'
+import { previewLinkHandler } from '../../utils'
 
 const PreviewLinkSidebar = () => {
   const sdk = useSDK<SidebarExtensionSDK>()

--- a/apps/contentful-apps/utils/index.ts
+++ b/apps/contentful-apps/utils/index.ts
@@ -1,7 +1,12 @@
 import { CollectionProp, EntryProps, KeyValueMap } from 'contentful-management'
 import { CMAClient } from '@contentful/app-sdk'
 
-import { CONTENTFUL_ENVIRONMENT, CONTENTFUL_SPACE } from '../constants'
+import {
+  CONTENTFUL_ENVIRONMENT,
+  CONTENTFUL_SPACE,
+  DEFAULT_LOCALE,
+  DEV_WEB_BASE_URL,
+} from '../constants'
 
 export const getContentfulEntries = async (
   cma: CMAClient,
@@ -69,4 +74,89 @@ export const slugifyDate = (value: string) => {
   } catch {
     return ''
   }
+}
+
+export const previewLinkHandler = {
+  vacancy: (entry: EntryProps<KeyValueMap>) => {
+    return `${DEV_WEB_BASE_URL}/starfatorg/c-${entry.sys.id}`
+  },
+  article: (entry: EntryProps<KeyValueMap>) => {
+    return `${DEV_WEB_BASE_URL}/${entry.fields.slug[DEFAULT_LOCALE]}`
+  },
+  subArticle: async (entry: EntryProps<KeyValueMap>, cma: CMAClient) => {
+    const parentArticleId = entry.fields.parent?.[DEFAULT_LOCALE]?.sys?.id
+    const parentArticle = await cma.entry.get({
+      entryId: parentArticleId,
+    })
+    return `${DEV_WEB_BASE_URL}/${
+      parentArticle?.fields?.slug[DEFAULT_LOCALE]
+    }/${entry.fields.url[DEFAULT_LOCALE]?.split('/')?.pop() ?? ''}`
+  },
+  organizationPage: (entry: EntryProps<KeyValueMap>) => {
+    return `${DEV_WEB_BASE_URL}/s/${entry.fields.slug[DEFAULT_LOCALE]}`
+  },
+  projectPage: (entry: EntryProps<KeyValueMap>) => {
+    return `${DEV_WEB_BASE_URL}/v/${entry.fields.slug[DEFAULT_LOCALE]}`
+  },
+  organizationSubpage: async (
+    entry: EntryProps<KeyValueMap>,
+    cma: CMAClient,
+  ) => {
+    const organizationPageId =
+      entry.fields.organizationPage?.[DEFAULT_LOCALE]?.sys?.id
+    const [organizationPage, organizationParentSubpageResponse] =
+      await Promise.all([
+        cma.entry.get({
+          entryId: organizationPageId,
+        }),
+        cma.entry.getMany({
+          query: {
+            content_type: 'organizationParentSubpage',
+            include: 1,
+            links_to_entry: entry.sys.id,
+            'sys.archivedAt[exists]': false,
+          },
+        }),
+      ])
+
+    const orgPageSlug = organizationPage?.fields?.slug?.[DEFAULT_LOCALE]
+    const slug = entry.fields.slug[DEFAULT_LOCALE]
+
+    if (!organizationParentSubpageResponse?.items?.length) {
+      return `${DEV_WEB_BASE_URL}/s/${orgPageSlug}/${slug}`
+    }
+    return `${DEV_WEB_BASE_URL}/s/${orgPageSlug}/${organizationParentSubpageResponse.items[0].fields.slug[DEFAULT_LOCALE]}/${slug}`
+  },
+  anchorPage: (entry: EntryProps<KeyValueMap>) => {
+    const middlePart =
+      entry.fields.pageType?.[DEFAULT_LOCALE] === 'Digital Iceland Service'
+        ? 's/stafraent-island/thjonustur'
+        : 'lifsvidburdir'
+
+    return `${DEV_WEB_BASE_URL}/${middlePart}/${entry.fields.slug[DEFAULT_LOCALE]}`
+  },
+  lifeEventPage: (entry: EntryProps<KeyValueMap>) => {
+    return `${DEV_WEB_BASE_URL}/lifsvidburdir/${entry.fields.slug[DEFAULT_LOCALE]}`
+  },
+  news: (entry: EntryProps<KeyValueMap>) => {
+    return `${DEV_WEB_BASE_URL}/frett/${entry.fields.slug[DEFAULT_LOCALE]}`
+  },
+  manual: (entry: EntryProps<KeyValueMap>) => {
+    return `${DEV_WEB_BASE_URL}/handbaekur/${entry.fields.slug[DEFAULT_LOCALE]}`
+  },
+  organizationParentSubpage: async (
+    entry: EntryProps<KeyValueMap>,
+    cma: CMAClient,
+  ) => {
+    const organizationPageId =
+      entry.fields.organizationPage?.[DEFAULT_LOCALE]?.sys?.id
+    const organizationPage = await cma.entry.get({
+      entryId: organizationPageId,
+      environmentId: CONTENTFUL_ENVIRONMENT,
+      spaceId: CONTENTFUL_SPACE,
+    })
+    const orgPageSlug = organizationPage?.fields?.slug?.[DEFAULT_LOCALE]
+
+    return `${DEV_WEB_BASE_URL}/s/${orgPageSlug}/${entry.fields.slug[DEFAULT_LOCALE]}`
+  },
 }


### PR DESCRIPTION
# Organization subpage slug check logic adjustments

* Now organization subpages can either belong to a "parent subpage" or not

If it belongs to a parent subpage then the slug validation only occurs for sibling pages (that also belong to the parent subpage)

If not, then we:
1. check if there exists another subpage with the same slug and is not a part of a parent subpage
2. check if there exists a parent subpage with the same slug and belongs to the same organization page 

![Screenshot 2025-03-11 at 14 48 51](https://github.com/user-attachments/assets/0f23fa38-c7e5-401c-9a37-936f2e4da6b2)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced validation for organization subpage URLs to more reliably prevent duplicates.
- **New Features**
	- Introduced a structured method for generating preview links for various content types, improving functionality.
	- Added a new component for managing and validating slug inputs for organization subpages.
- **Refactor**
	- Streamlined content preview link generation by centralizing URL construction into a dedicated module, improving overall consistency and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->