### PR TITLE
fix(web): Generic List Item - Change how we detect org subpage slug in case depth is 4

### DIFF
--- a/apps/web/screens/GenericList/OrganizationSubPageGenericListItem.tsx
+++ b/apps/web/screens/GenericList/OrganizationSubPageGenericListItem.tsx
@@ -86,8 +86,20 @@ const OrganizationSubPageGenericListItem: Screen<
 }
 
 OrganizationSubPageGenericListItem.getProps = async (context) => {
+  const organizationPageSlug = context.query.slugs?.[0] ?? ''
+  const organizationSubpageSlug =
+    context.query.slugs?.length === 4
+      ? context.query.slugs[2]
+      : context.query.slugs?.[1] ?? ''
+
   const [subPageProps, genericListItemProps] = await Promise.all([
-    SubPage.getProps(context),
+    SubPage.getProps({
+      ...context,
+      query: {
+        ...context.query,
+        slugs: [organizationPageSlug, organizationSubpageSlug],
+      },
+    }),
     GenericListItemPage.getProps(context),
   ])
   return {


### PR DESCRIPTION
# Generic List Item - Change how we detect org subpage slug in case depth is 4

If depth is 4, this is the layout:
[Org page slug, Org parent subpage slug, Org subpage slug, generic list item slug]

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced organization page navigation by refining how URL segments are interpreted, ensuring that the correct page and subpage are displayed consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->