### PR TITLE
fix(web): Change urls for genesys messenger serviceDesk connection in IBM watson chat

### DIFF
--- a/apps/web/screens/Article/components/ArticleChatPanel/config.ts
+++ b/apps/web/screens/Article/components/ArticleChatPanel/config.ts
@@ -303,7 +303,7 @@ export const watsonConfig: Record<
         integrationType: 'genesyswebmessenger',
         genesysMessenger: {
           scriptURL:
-            'https://apps.mypurecloud.com/genesys-bootstrap/genesys.min.js',
+            'https://apps.mypurecloud.de/genesys-bootstrap/genesys.min.js',
           deploymentID: 'cbc43df8-d5de-4eeb-bd0c-6503cbffcf6d',
           environment: 'prod-euc1',
         },
@@ -329,7 +329,7 @@ export const watsonConfig: Record<
         integrationType: 'genesyswebmessenger',
         genesysMessenger: {
           scriptURL:
-            'https://apps.mypurecloud.com/genesys-bootstrap/genesys.min.js',
+            'https://apps.mypurecloud.de/genesys-bootstrap/genesys.min.js',
           deploymentID: 'cbc43df8-d5de-4eeb-bd0c-6503cbffcf6d',
           environment: 'prod-euc1',
         },
@@ -355,7 +355,7 @@ export const watsonConfig: Record<
         integrationType: 'genesyswebmessenger',
         genesysMessenger: {
           scriptURL:
-            'https://apps.mypurecloud.com/genesys-bootstrap/genesys.min.js',
+            'https://apps.mypurecloud.de/genesys-bootstrap/genesys.min.js',
           deploymentID: 'cbc43df8-d5de-4eeb-bd0c-6503cbffcf6d',
           environment: 'prod-euc1',
         },
@@ -381,7 +381,7 @@ export const watsonConfig: Record<
         integrationType: 'genesyswebmessenger',
         genesysMessenger: {
           scriptURL:
-            'https://apps.mypurecloud.com/genesys-bootstrap/genesys.min.js',
+            'https://apps.mypurecloud.de/genesys-bootstrap/genesys.min.js',
           deploymentID: 'cbc43df8-d5de-4eeb-bd0c-6503cbffcf6d',
           environment: 'prod-euc1',
         },
@@ -407,7 +407,7 @@ export const watsonConfig: Record<
         integrationType: 'genesyswebmessenger',
         genesysMessenger: {
           scriptURL:
-            'https://apps.mypurecloud.com/genesys-bootstrap/genesys.min.js',
+            'https://apps.mypurecloud.de/genesys-bootstrap/genesys.min.js',
           deploymentID: 'cbc43df8-d5de-4eeb-bd0c-6503cbffcf6d',
           environment: 'prod-euc1',
         },
@@ -433,7 +433,7 @@ export const watsonConfig: Record<
         integrationType: 'genesyswebmessenger',
         genesysMessenger: {
           scriptURL:
-            'https://apps.mypurecloud.com/genesys-bootstrap/genesys.min.js',
+            'https://apps.mypurecloud.de/genesys-bootstrap/genesys.min.js',
           deploymentID: 'cbc43df8-d5de-4eeb-bd0c-6503cbffcf6d',
           environment: 'prod-euc1',
         },
@@ -459,7 +459,7 @@ export const watsonConfig: Record<
         integrationType: 'genesyswebmessenger',
         genesysMessenger: {
           scriptURL:
-            'https://apps.mypurecloud.com/genesys-bootstrap/genesys.min.js',
+            'https://apps.mypurecloud.de/genesys-bootstrap/genesys.min.js',
           deploymentID: 'cbc43df8-d5de-4eeb-bd0c-6503cbffcf6d',
           environment: 'prod-euc1',
         },
@@ -485,7 +485,7 @@ export const watsonConfig: Record<
         integrationType: 'genesyswebmessenger',
         genesysMessenger: {
           scriptURL:
-            'https://apps.mypurecloud.com/genesys-bootstrap/genesys.min.js',
+            'https://apps.mypurecloud.de/genesys-bootstrap/genesys.min.js',
           deploymentID: 'cbc43df8-d5de-4eeb-bd0c-6503cbffcf6d',
           environment: 'prod-euc1',
         },
@@ -511,7 +511,7 @@ export const watsonConfig: Record<
         integrationType: 'genesyswebmessenger',
         genesysMessenger: {
           scriptURL:
-            'https://apps.mypurecloud.com/genesys-bootstrap/genesys.min.js',
+            'https://apps.mypurecloud.de/genesys-bootstrap/genesys.min.js',
           deploymentID: 'cbc43df8-d5de-4eeb-bd0c-6503cbffcf6d',
           environment: 'prod-euc1',
         },
@@ -537,7 +537,7 @@ export const watsonConfig: Record<
         integrationType: 'genesyswebmessenger',
         genesysMessenger: {
           scriptURL:
-            'https://apps.mypurecloud.com/genesys-bootstrap/genesys.min.js',
+            'https://apps.mypurecloud.de/genesys-bootstrap/genesys.min.js',
           deploymentID: 'cbc43df8-d5de-4eeb-bd0c-6503cbffcf6d',
           environment: 'prod-euc1',
         },

--- a/apps/web/screens/Home/Home.tsx
+++ b/apps/web/screens/Home/Home.tsx
@@ -53,25 +53,27 @@ const Home: Screen<HomeProps> = ({ categories, news, page, locale }) => {
 
   return (
     <Box id="main-content" width="full" overflow="hidden">
-      <Box
-        component="section"
-        aria-labelledby="search-section-title"
-        borderBottomWidth="standard"
-        borderStyle="solid"
-        borderColor="blue200"
-      >
-        <SearchSection
-          headingId="search-section-title"
-          quickContentLabel={n('quickContentLabel', 'Beint að efninu')}
-          placeholder={n('heroSearchPlaceholder')}
-          activeLocale={activeLocale}
-          page={page}
-          browserVideoUnsupported={n(
-            'browserVideoUnsupported',
-            'Vafrinn þinn getur ekki spilað HTML myndbönd.',
-          )}
-        />
-      </Box>
+      {Boolean(page) && (
+        <Box
+          component="section"
+          aria-labelledby="search-section-title"
+          borderBottomWidth="standard"
+          borderStyle="solid"
+          borderColor="blue200"
+        >
+          <SearchSection
+            headingId="search-section-title"
+            quickContentLabel={n('quickContentLabel', 'Beint að efninu')}
+            placeholder={n('heroSearchPlaceholder')}
+            activeLocale={activeLocale}
+            page={page}
+            browserVideoUnsupported={n(
+              'browserVideoUnsupported',
+              'Vafrinn þinn getur ekki spilað HTML myndbönd.',
+            )}
+          />
+        </Box>
+      )}
       <Box
         component="section"
         paddingTop={6}

--- a/apps/web/screens/Home/Home.tsx
+++ b/apps/web/screens/Home/Home.tsx
@@ -53,27 +53,25 @@ const Home: Screen<HomeProps> = ({ categories, news, page, locale }) => {
 
   return (
     <Box id="main-content" width="full" overflow="hidden">
-      {Boolean(page) && (
-        <Box
-          component="section"
-          aria-labelledby="search-section-title"
-          borderBottomWidth="standard"
-          borderStyle="solid"
-          borderColor="blue200"
-        >
-          <SearchSection
-            headingId="search-section-title"
-            quickContentLabel={n('quickContentLabel', 'Beint að efninu')}
-            placeholder={n('heroSearchPlaceholder')}
-            activeLocale={activeLocale}
-            page={page}
-            browserVideoUnsupported={n(
-              'browserVideoUnsupported',
-              'Vafrinn þinn getur ekki spilað HTML myndbönd.',
-            )}
-          />
-        </Box>
-      )}
+      <Box
+        component="section"
+        aria-labelledby="search-section-title"
+        borderBottomWidth="standard"
+        borderStyle="solid"
+        borderColor="blue200"
+      >
+        <SearchSection
+          headingId="search-section-title"
+          quickContentLabel={n('quickContentLabel', 'Beint að efninu')}
+          placeholder={n('heroSearchPlaceholder')}
+          activeLocale={activeLocale}
+          page={page}
+          browserVideoUnsupported={n(
+            'browserVideoUnsupported',
+            'Vafrinn þinn getur ekki spilað HTML myndbönd.',
+          )}
+        />
+      </Box>
       <Box
         component="section"
         paddingTop={6}

--- a/apps/web/screens/LifeEventPage/config.ts
+++ b/apps/web/screens/LifeEventPage/config.ts
@@ -37,7 +37,7 @@ export const watsonConfig: Record<
         integrationType: 'genesyswebmessenger',
         genesysMessenger: {
           scriptURL:
-            'https://apps.mypurecloud.com/genesys-bootstrap/genesys.min.js',
+            'https://apps.mypurecloud.de/genesys-bootstrap/genesys.min.js',
           deploymentID: 'cbc43df8-d5de-4eeb-bd0c-6503cbffcf6d',
           environment: 'prod-euc1',
         },


### PR DESCRIPTION
# Change urls for genesys messenger serviceDesk connection in IBM watson chat

This was requested by Digital Iceland

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated chat service integration to use a new external endpoint, ensuring consistent region-specific support across both the article chat panel and the life event page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->