### PR TITLE
fix(web): Frontpage - Handle case where frontpage data could not be loaded

### DIFF
--- a/apps/web/components/SearchSection/SearchSection.tsx
+++ b/apps/web/components/SearchSection/SearchSection.tsx
@@ -15,7 +15,6 @@ import { TestSupport } from '@island.is/island-ui/utils'
 import { Locale } from '@island.is/shared/types'
 import { FeaturedLinks, SearchInput } from '@island.is/web/components'
 import { GetFrontpageQuery } from '@island.is/web/graphql/schema'
-import { useLinkResolver } from '@island.is/web/hooks/useLinkResolver'
 
 import * as styles from './SearchSection.css'
 
@@ -24,7 +23,7 @@ const DefaultIllustration = dynamic(() => import('./Illustration'), {
 })
 
 type SearchSectionProps = {
-  page: GetFrontpageQuery['getFrontpage']
+  page?: GetFrontpageQuery['getFrontpage']
   headingId: string
   activeLocale: Locale
   quickContentLabel: string
@@ -41,31 +40,16 @@ export const SearchSection = ({
 }: SearchSectionProps) => {
   const { width } = useWindowSize()
   const [isMobile, setIsMobile] = useState<boolean | null>(null)
-  const { linkResolver } = useLinkResolver()
 
   const {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore make web strict
     featured,
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore make web strict
     heading,
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore make web strict
     image,
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore make web strict
     imageAlternativeText,
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore make web strict
     imageMobile,
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore make web strict
     videos,
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore make web strict
     videosMobile,
-  } = page
+  } = page ?? {}
 
   useEffect(() => {
     const shouldBeMobile = width < theme.breakpoints.md
@@ -104,7 +88,7 @@ export const SearchSection = ({
                   dataTestId="search-box"
                   colored
                 />
-                <FeaturedLinks links={featured} />
+                <FeaturedLinks links={featured ?? []} />
               </Stack>
             </Box>
           </GridColumn>
@@ -126,7 +110,7 @@ export const SearchSection = ({
                 {videos?.length ? (
                   <Video
                     name="desktop"
-                    title={imageAlternativeText}
+                    title={imageAlternativeText ?? ''}
                     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                     // @ts-ignore make web strict
                     sources={videos.map(({ url, contentType }) => {
@@ -138,14 +122,14 @@ export const SearchSection = ({
                     fallback={
                       <ImageOrDefault
                         url={image?.url}
-                        imageAlternativeText={imageAlternativeText}
+                        imageAlternativeText={imageAlternativeText ?? ''}
                       />
                     }
                   />
                 ) : (
                   <ImageOrDefault
                     url={image?.url}
-                    imageAlternativeText={imageAlternativeText}
+                    imageAlternativeText={imageAlternativeText ?? ''}
                   />
                 )}
               </Box>
@@ -166,7 +150,7 @@ export const SearchSection = ({
           {videosMobile?.length ? (
             <Video
               name="mobile"
-              title={imageAlternativeText}
+              title={imageAlternativeText ?? ''}
               dataTestId="home-banner"
               // eslint-disable-next-line @typescript-eslint/ban-ts-comment
               // @ts-ignore make web strict
@@ -179,7 +163,7 @@ export const SearchSection = ({
               fallback={
                 <ImageOrDefault
                   url={imageMobile?.url}
-                  imageAlternativeText={imageAlternativeText}
+                  imageAlternativeText={imageAlternativeText ?? ''}
                   isMobile={isMobile}
                 />
               }
@@ -187,7 +171,7 @@ export const SearchSection = ({
           ) : (
             <ImageOrDefault
               url={imageMobile?.url}
-              imageAlternativeText={imageAlternativeText}
+              imageAlternativeText={imageAlternativeText ?? ''}
               isMobile={isMobile}
             />
           )}

--- a/apps/web/screens/Home/Home.tsx
+++ b/apps/web/screens/Home/Home.tsx
@@ -36,7 +36,7 @@ import { watsonConfig } from './config'
 interface HomeProps {
   categories: GetArticleCategoriesQuery['getArticleCategories']
   news: GetNewsQuery['getNews']['items']
-  page: GetFrontpageQuery['getFrontpage']
+  page?: GetFrontpageQuery['getFrontpage']
   locale: Locale
 }
 
@@ -63,12 +63,17 @@ const Home: Screen<HomeProps> = ({ categories, news, page, locale }) => {
         <SearchSection
           headingId="search-section-title"
           quickContentLabel={n('quickContentLabel', 'Beint að efninu')}
-          placeholder={n('heroSearchPlaceholder')}
+          placeholder={n(
+            'heroSearchPlaceholder',
+            activeLocale === 'is' ? 'Leitaðu á Ísland.is' : 'Search Ísland.is',
+          )}
           activeLocale={activeLocale}
           page={page}
           browserVideoUnsupported={n(
             'browserVideoUnsupported',
-            'Vafrinn þinn getur ekki spilað HTML myndbönd.',
+            activeLocale === 'is'
+              ? 'Vafrinn þinn getur ekki spilað HTML myndbönd.'
+              : 'Your browser can not play HTML videos',
           )}
         />
       </Box>
@@ -81,13 +86,21 @@ const Home: Screen<HomeProps> = ({ categories, news, page, locale }) => {
         aria-labelledby="life-events-title"
       >
         <LifeEventsSection
-          heading={n('lifeEventsTitle')}
+          heading={n(
+            'lifeEventsTitle',
+            activeLocale === 'is' ? 'Lífsviðburðir' : 'Life events',
+          )}
           headingId="life-events-title"
           items={(page?.lifeEvents as LifeEventPage[]) ?? []}
-          seeMoreText={n('seeMoreLifeEvents')}
+          seeMoreText={n(
+            'seeMoreLifeEvents',
+            activeLocale === 'is'
+              ? 'Skoða alla lífsviðburði'
+              : 'See all life events',
+          )}
           cardsButtonTitle={n(
             'LifeEventsCardsButtonTitle',
-            'Skoða lífsviðburð',
+            activeLocale === 'is' ? 'Skoða lífsviðburð' : 'See life event',
           )}
         />
       </Box>
@@ -99,7 +112,10 @@ const Home: Screen<HomeProps> = ({ categories, news, page, locale }) => {
         aria-labelledby="categories-title"
       >
         <CategoryItems
-          heading={n('articlesTitle')}
+          heading={n(
+            'articlesTitle',
+            activeLocale === 'is' ? 'Þjónustuflokkar' : 'Services',
+          )}
           headingId="categories-title"
           items={categories}
         />
@@ -110,9 +126,17 @@ const Home: Screen<HomeProps> = ({ categories, news, page, locale }) => {
         aria-labelledby="news-items-title"
       >
         <NewsItems
-          heading={gn('newsAndAnnouncements')}
+          heading={gn(
+            'newsAndAnnouncements',
+            activeLocale === 'is'
+              ? 'Fréttir og tilkynningar'
+              : 'News and announcements',
+          )}
           headingTitle="news-items-title"
-          seeMoreText={gn('seeMore')}
+          seeMoreText={gn(
+            'seeMore',
+            activeLocale === 'is' ? 'Sjá meira' : 'See more',
+          )}
           items={news}
         />
       </Box>


### PR DESCRIPTION
# Frontpage - Handle case where frontpage data could not be loaded

## What

I recently nuked my elasticsearch local instance and re-synced data back in using the search-indexer service and noticed that after it was done syncing the frontpage wasn't included in the sync data. In case such an event ever occurs on dev/staging/prod I'd like to suggest we handle such cases by still showing the frontpage (with all data present except for the life events)

## Screenshots / Gifs

### Before

![Screenshot 2025-03-17 at 10 26 13](https://github.com/user-attachments/assets/0955f5ea-6afc-43e6-aa2f-0be57013db6c)


### After

https://github.com/user-attachments/assets/0af09871-7bdf-4e51-b18f-4597cbb81796

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced component stability by providing default values when content is missing, reducing the risk of display errors.
  
- **New Features**
  - Improved language support on the homepage with dynamic text adjustments based on the user’s locale, ensuring a tailored experience in both Icelandic and English.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->