### PR TITLE
fix(web): Organization Parent Subpage - Fetch org subpages by id instead of slug

### DIFF
--- a/apps/web/screens/Organization/Standalone/ParentSubpage.tsx
+++ b/apps/web/screens/Organization/Standalone/ParentSubpage.tsx
@@ -19,6 +19,7 @@ import {
   QueryGetOrganizationPageArgs,
   QueryGetOrganizationParentSubpageArgs,
   QueryGetOrganizationSubpageArgs,
+  QueryGetOrganizationSubpageByIdArgs,
 } from '@island.is/web/graphql/schema'
 import { useLinkResolver } from '@island.is/web/hooks'
 import useContentfulId from '@island.is/web/hooks/useContentfulId'
@@ -31,6 +32,7 @@ import {
   GET_NAMESPACE_QUERY,
   GET_ORGANIZATION_PAGE_QUERY,
   GET_ORGANIZATION_PARENT_SUBPAGE_QUERY,
+  GET_ORGANIZATION_SUBPAGE_BY_ID_QUERY,
   GET_ORGANIZATION_SUBPAGE_QUERY,
 } from '../../queries'
 import { SubPageContent } from '../SubPage'
@@ -220,20 +222,32 @@ export const getProps: typeof StandaloneParentSubpage['getProps'] = async ({
     }
   }
 
-  const subpage = (
-    await apolloClient.query<Query, QueryGetOrganizationSubpageArgs>({
-      query: GET_ORGANIZATION_SUBPAGE_QUERY,
-      variables: {
-        input: {
-          organizationSlug: organizationPageSlug,
-          slug: getOrganizationParentSubpage.childLinks[selectedIndex].href
-            .split('/')
-            .pop() as string,
-          lang: locale as ContentLanguage,
-        },
-      },
-    })
-  ).data.getOrganizationSubpage
+  const subpageLink = getOrganizationParentSubpage.childLinks[selectedIndex]
+
+  const subpage = !subpageLink.id
+    ? (
+        await apolloClient.query<Query, QueryGetOrganizationSubpageArgs>({
+          query: GET_ORGANIZATION_SUBPAGE_QUERY,
+          variables: {
+            input: {
+              organizationSlug: organizationPageSlug,
+              slug: subpageLink.href.split('/').pop() as string,
+              lang: locale as ContentLanguage,
+            },
+          },
+        })
+      ).data.getOrganizationSubpage
+    : (
+        await apolloClient.query<Query, QueryGetOrganizationSubpageByIdArgs>({
+          query: GET_ORGANIZATION_SUBPAGE_BY_ID_QUERY,
+          variables: {
+            input: {
+              id: subpageLink.id,
+              lang: locale as ContentLanguage,
+            },
+          },
+        })
+      ).data.getOrganizationSubpageById
 
   if (!subpage) {
     throw new CustomNextError(

--- a/apps/web/screens/queries/Organization.tsx
+++ b/apps/web/screens/queries/Organization.tsx
@@ -293,6 +293,45 @@ export const GET_ORGANIZATION_SUBPAGE_QUERY = gql`
   ${slices}
 `
 
+export const GET_ORGANIZATION_SUBPAGE_BY_ID_QUERY = gql`
+  query GetOrganizationSubpageById($input: GetOrganizationSubpageByIdInput!) {
+    getOrganizationSubpageById(input: $input) {
+      id
+      title
+      slug
+      signLanguageVideo {
+        url
+        thumbnailImageUrl
+      }
+      description {
+        ...AllSlices
+        ${nestedFields}
+      }
+      links {
+        text
+        url
+      }
+      slices {
+        ...AllSlices
+        ${nestedFields}
+      }
+      bottomSlices {
+        ...AllSlices
+      }
+      showTableOfContents
+      sliceCustomRenderer
+      sliceExtraText
+      featuredImage {
+        url
+        title
+        width
+        height
+      }
+    }
+  }
+  ${slices}
+`
+
 export const GET_ORGANIZATION_SERVICES_QUERY = gql`
   query GetOrganizationServices($input: GetArticlesInput!) {
     getArticles(input: $input) {

--- a/apps/web/screens/queries/Organization.tsx
+++ b/apps/web/screens/queries/Organization.tsx
@@ -430,6 +430,7 @@ export const GET_ORGANIZATION_PARENT_SUBPAGE_QUERY = gql`
       id
       title
       childLinks {
+        id
         label
         href
       }

--- a/libs/cms/src/lib/cms.contentful.service.ts
+++ b/libs/cms/src/lib/cms.contentful.service.ts
@@ -377,6 +377,27 @@ export class CmsContentfulService {
     )
   }
 
+  async getOrganizationSubpageById(
+    id: string,
+    lang: string,
+  ): Promise<OrganizationSubpage> {
+    const params = {
+      ['content_type']: 'organizationSubpage',
+      include: 5,
+      'sys.id': id,
+      limit: 1,
+    }
+    const result = await this.contentfulRepository
+      .getLocalizedEntries<types.IOrganizationSubpageFields>(lang, params)
+      .catch(errorHandler('getOrganizationSubpage'))
+
+    return (
+      (result.items as types.IOrganizationSubpage[]).map(
+        mapOrganizationSubpage,
+      )[0] ?? null
+    )
+  }
+
   async getServiceWebPage(slug: string, lang: string) {
     const params = {
       ['content_type']: 'serviceWebPage',

--- a/libs/cms/src/lib/cms.resolver.ts
+++ b/libs/cms/src/lib/cms.resolver.ts
@@ -45,7 +45,10 @@ import { SubpageHeader } from './models/subpageHeader.model'
 import { GetSubpageHeaderInput } from './dto/getSubpageHeader.input'
 import { ErrorPage } from './models/errorPage.model'
 import { OrganizationSubpage } from './models/organizationSubpage.model'
-import { GetOrganizationSubpageInput } from './dto/getOrganizationSubpage.input'
+import {
+  GetOrganizationSubpageByIdInput,
+  GetOrganizationSubpageInput,
+} from './dto/getOrganizationSubpage.input'
 import { getElasticsearchIndex } from '@island.is/content-search-index-manager'
 import { OrganizationPage } from './models/organizationPage.model'
 import { GetOrganizationPageInput } from './dto/getOrganizationPage.input'
@@ -256,6 +259,17 @@ export class CmsResolver {
     return this.cmsContentfulService.getOrganizationSubpage(
       input.organizationSlug,
       input.slug,
+      input.lang,
+    )
+  }
+
+  @CacheControl(defaultCache)
+  @Query(() => OrganizationSubpage, { nullable: true })
+  async getOrganizationSubpageById(
+    @Args('input') input: GetOrganizationSubpageByIdInput,
+  ): Promise<OrganizationSubpage | null> {
+    return this.cmsContentfulService.getOrganizationSubpageById(
+      input.id,
       input.lang,
     )
   }

--- a/libs/cms/src/lib/dto/getOrganizationSubpage.input.ts
+++ b/libs/cms/src/lib/dto/getOrganizationSubpage.input.ts
@@ -16,3 +16,14 @@ export class GetOrganizationSubpageInput {
   @IsString()
   lang: ElasticsearchIndexLocale = 'is'
 }
+
+@InputType()
+export class GetOrganizationSubpageByIdInput {
+  @Field()
+  @IsString()
+  id!: string
+
+  @Field(() => String)
+  @IsString()
+  lang: ElasticsearchIndexLocale = 'is'
+}

--- a/libs/cms/src/lib/models/organizationParentSubpage.model.ts
+++ b/libs/cms/src/lib/models/organizationParentSubpage.model.ts
@@ -5,6 +5,9 @@ import { getOrganizationPageUrlPrefix } from '@island.is/shared/utils'
 
 @ObjectType()
 class OrganizationSubpageLink {
+  @Field(() => String, { nullable: true })
+  id?: string | null
+
   @Field()
   label!: string
 
@@ -42,6 +45,7 @@ export const mapOrganizationParentSubpage = ({
             Boolean(page.fields.slug),
         )
         .map((page) => ({
+          id: page.sys.id,
           label: page.fields.title,
           href: `/${getOrganizationPageUrlPrefix(sys.locale)}/${
             page.fields.organizationPage.fields.slug


### PR DESCRIPTION
# Organization Parent Subpage - Fetch org subpages by id instead of slug

## What

Slug is no longer unique for org subpages so we now need to fetch them by id instead

### Before 

Another org subpage with the same slug gets fetched (see there is no content)

![Screenshot 2025-03-17 at 12 35 48](https://github.com/user-attachments/assets/223ed7ce-fe1c-45af-9b63-4530e4fb700c)

### After

Appropriate org subpage gets fetched

![Screenshot 2025-03-17 at 12 34 26](https://github.com/user-attachments/assets/5a40993c-68c0-47e0-8f61-e87ca910210f)



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced ID-based querying for organization subpages, enabling more precise content retrieval.
	- Enhanced query logic to dynamically select between ID-based and slug-based data fetching.
	- Updated subpage link data to include an optional identifier, improving content mapping and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->