### PR TITLE
chore(j-s): User Institution

### DIFF
--- a/apps/judicial-system/api/src/app/modules/user/dto/updateUser.input.ts
+++ b/apps/judicial-system/api/src/app/modules/user/dto/updateUser.input.ts
@@ -31,10 +31,6 @@ export class UpdateUserInput {
   readonly role!: UserRole
 
   @Allow()
-  @Field(() => ID)
-  readonly institutionId!: string
-
-  @Allow()
   @Field(() => Boolean)
   readonly active!: boolean
 

--- a/apps/judicial-system/backend/src/app/modules/user/dto/updateUser.dto.ts
+++ b/apps/judicial-system/backend/src/app/modules/user/dto/updateUser.dto.ts
@@ -3,7 +3,6 @@ import {
   IsEnum,
   IsOptional,
   IsString,
-  IsUUID,
   MaxLength,
 } from 'class-validator'
 
@@ -40,11 +39,6 @@ export class UpdateUserDto {
   @IsEnum(UserRole)
   @ApiPropertyOptional({ enum: UserRole })
   readonly role?: UserRole
-
-  @IsOptional()
-  @IsUUID()
-  @ApiPropertyOptional({ type: String })
-  readonly institutionId?: string
 
   @IsOptional()
   @IsBoolean()

--- a/apps/judicial-system/web/src/routes/Admin/ChangeUser/ChangeUser.tsx
+++ b/apps/judicial-system/web/src/routes/Admin/ChangeUser/ChangeUser.tsx
@@ -52,7 +52,6 @@ export const ChangeUser = () => {
             id: user.id,
             name: user.name,
             role: user.role,
-            institutionId: user.institution.id,
             title: user.title,
             mobileNumber: user.mobileNumber,
             email: user.email,

--- a/apps/judicial-system/web/src/routes/Admin/UserForm/UserForm.tsx
+++ b/apps/judicial-system/web/src/routes/Admin/UserForm/UserForm.tsx
@@ -58,6 +58,8 @@ export const UserForm: FC<Props> = ({
     useState<string>()
   const [emailErrorMessage, setEmailErrorMessage] = useState<string>()
 
+  const isNewUser = user.id.length === 0
+
   const setName = useCallback(
     (name: string) => {
       if (name !== user.name) {
@@ -158,7 +160,7 @@ export const UserForm: FC<Props> = ({
                 setNationalIdErrorMessage,
               )
             }
-            readOnly={user.id.length > 0 ? true : false}
+            readOnly={!isNewUser}
           >
             <Input
               data-testid="nationalId"
@@ -211,6 +213,7 @@ export const UserForm: FC<Props> = ({
                 institution: (selectedOption as ExtendedOption).institution,
               })
             }
+            isDisabled={!isNewUser}
             required
           />
         </Box>


### PR DESCRIPTION
# User Institution

[Ekki leyfa breytingu á embætti hjá notendum](https://app.asana.com/0/1199153462262248/1209399518433947/f)

## What

- Does not allow changing a user's institution.

## Why

- It is now possible to create multiple users with the same national id. If a person needs access to a new institution, then a new user should be created and if need be the old user disabled.
- Changing a user's institution sometimes caused problems in the past. For example, if a prosucutor created a case and the moved to a new institution, then the case moved with him. That is not what we want.

## Screenshots / Gifs

<img width="992" alt="image" src="https://github.com/user-attachments/assets/b4b0906c-ee97-449f-861a-31013ce51283" />


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced user update operations by removing the institution selection option, simplifying the update workflow.
  - Improved the administrative user form by introducing a flag that differentiates new users from existing ones, automatically adjusting input field accessibility for a more consistent and intuitive experience.
  - These changes deliver a more straightforward and user-friendly experience for managing user profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->