### PR TITLE
feat(web): Organization Page External Links - Only show lock icon for certain text

### DIFF
--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -513,6 +513,10 @@ export const OrganizationExternalLinks: React.FC<
               organizationPage.slug === 'icelandic-health-insurance' ||
               organizationPage.slug === 'iceland-health'
 
+            const buttonHasLockIcon =
+              isSjukratryggingar &&
+              (link.text.includes('Gagna') || link.text.includes('Data'))
+
             let variant = undefined
             if (
               isSjukratryggingar &&
@@ -533,7 +537,7 @@ export const OrganizationExternalLinks: React.FC<
                   // @ts-ignore make web strict
                   variant={variant}
                   unfocusable
-                  icon={isSjukratryggingar ? 'lockClosed' : 'open'}
+                  icon={buttonHasLockIcon ? 'lockClosed' : 'open'}
                   iconType="outline"
                   size="medium"
                 >


### PR DESCRIPTION
# Organization Page External Links - Only show lock icon for certain text

## Before

![Screenshot 2025-03-18 at 15 05 16](https://github.com/user-attachments/assets/e711511e-3acd-4073-8ca5-22e15b98570b)

## After

![Screenshot 2025-03-18 at 15 05 43](https://github.com/user-attachments/assets/9c1d7cb1-4ae9-483f-bf65-fef32fc9874a)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the display criteria for secure indicators on organization-related buttons. The lock icon now appears only when additional content conditions are met, giving users clearer visual feedback on links that provide access to secure or sensitive information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->