### PR TITLE
fix(payment step): Set shouldDeleteChargeIfPaymentFulfilled=true for PAYMENT state

### DIFF
--- a/libs/application/utils/src/lib/builders/paymentStateBuilder.ts
+++ b/libs/application/utils/src/lib/builders/paymentStateBuilder.ts
@@ -129,6 +129,7 @@ export const buildPaymentState = <
       status: 'inprogress',
       lifecycle: {
         ...pruneAfterDays(1),
+        shouldDeleteChargeIfPaymentFulfilled: true,
         ...options.lifecycle,
       },
       actionCard: {


### PR DESCRIPTION
## What

Set shouldDeleteChargeIfPaymentFulfilled=true for PAYMENT state, in case applications get pruned/deleted in the PAYMENT state after charge has been paid

## Why

When the application system failed last week (11 march) where we were getting a bunch of timeout errors on state change, we ended up having a bunch of application in PAYMENT state that was pruned (after being paid), or user deleted them in PAYMENT state (after being paid). This results in user not being re-paid and not getting the application completed.
Happened at least in transfer of maching ownership and transfer of vehicle ownership

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an automated option to manage payment lifecycles. Charges are now automatically handled after payment fulfillment, complementing the existing behavior without affecting other operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->