### PR TITLE
fix(j-s): Overflowing filenames

### DIFF
--- a/apps/judicial-system/web/src/components/PdfButton/PdfButton.css.ts
+++ b/apps/judicial-system/web/src/components/PdfButton/PdfButton.css.ts
@@ -20,13 +20,15 @@ export const disabled = style({
   opacity: 0.5,
 })
 
-export const fileNameContainer = style({
-  marginRight: theme.spacing[2],
-  wordBreak: 'break-all',
-
+export const fileNameContainerWithChildren = style({
   '@media': {
     [`screen and (min-width: ${theme.breakpoints.md}px)`]: {
       flexBasis: '70%',
     },
   },
+})
+
+export const fileNameContainer = style({
+  marginRight: theme.spacing[2],
+  wordBreak: 'break-all',
 })

--- a/apps/judicial-system/web/src/components/PdfButton/PdfButton.tsx
+++ b/apps/judicial-system/web/src/components/PdfButton/PdfButton.tsx
@@ -1,4 +1,5 @@
 import { FC, PropsWithChildren, useContext } from 'react'
+import cn from 'classnames'
 
 import { Box, Button, Text } from '@island.is/island-ui/core'
 import { api } from '@island.is/judicial-system-web/src/services'
@@ -90,7 +91,11 @@ const PdfButton: FC<PropsWithChildren<Props>> = ({
         }
       }}
     >
-      <span className={styles.fileNameContainer}>
+      <span
+        className={cn(styles.fileNameContainer, {
+          [styles.fileNameContainerWithChildren]: !!children,
+        })}
+      >
         <Text color="blue400" variant="h4">
           {title}
         </Text>

--- a/apps/judicial-system/web/src/components/Table/CaseFileTable/CaseFileTable.css.ts
+++ b/apps/judicial-system/web/src/components/Table/CaseFileTable/CaseFileTable.css.ts
@@ -2,7 +2,7 @@ import { style } from '@vanilla-extract/css'
 
 import { theme } from '@island.is/island-ui/theme'
 
-export const linkButton = style({ cursor: 'pointer' })
+export const linkButton = style({ cursor: 'pointer', wordBreak: 'break-all' })
 
 export const noWrapColumn = style({
   '@media': {


### PR DESCRIPTION
# Fix overflowing filenames

[Asana](https://app.asana.com/0/1199153462262248/1208259727040506/f)

## What

Wrap long filenames in case files table.

## Why

This is a UI bug

## Screenshots / Gifs

### Before

<img width="1005" alt="Justice League Sound of Music" src="https://github.com/user-attachments/assets/c05b8644-746d-4144-b4f0-d126e66c1b74" />

### After

<img width="855" alt="Screenshot 2025-03-19 at 14 08 17" src="https://github.com/user-attachments/assets/0b618980-bfa8-4684-8118-6d88544bcf78" />

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated styling for file display components to dynamically adjust layout when additional elements are present.
  - Enhanced button text handling to support automatic word wrapping, improving overall readability and preventing layout issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->