### PR TITLE
chore(application-ir): Update pruning for application

### DIFF
--- a/libs/application/templates/inheritance-report/src/lib/InheritanceReportTemplate.ts
+++ b/libs/application/templates/inheritance-report/src/lib/InheritanceReportTemplate.ts
@@ -66,7 +66,7 @@ const InheritanceReportTemplate: ApplicationTemplate<
           name: '',
           status: 'draft',
           progress: 0,
-          lifecycle: EphemeralStateLifeCycle,
+          lifecycle: pruneAfterDays(14),
           roles: [
             {
               id: Roles.ESTATE_INHERITANCE_APPLICANT,
@@ -115,7 +115,7 @@ const InheritanceReportTemplate: ApplicationTemplate<
           name: '',
           status: 'draft',
           progress: 0.15,
-          lifecycle: EphemeralStateLifeCycle,
+          lifecycle: pruneAfterDays(14),
           roles: [
             {
               id: Roles.ESTATE_INHERITANCE_APPLICANT,


### PR DESCRIPTION
A request came in from Vésteinn to prolong the data lifetime of the inheritance report application.
The previous 24h ephemeral should be replaced with a lifetime of two weeks(14 days).

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Adjusted the automatic cleanup timing for in-progress entries so that items in temporary states are cleared after 14 days, while completed entries remain available for a longer period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->