### PR TITLE
fix(ids-api): Mark uuidv4 as external

### DIFF
--- a/apps/services/auth/ids-api/esbuild.json
+++ b/apps/services/auth/ids-api/esbuild.json
@@ -55,7 +55,8 @@
     "safer-buffer",
     "ioredis",
     "path-scurry",
-    "@mikro-orm/core"
+    "@mikro-orm/core",
+    "uuidv4"
   ],
   "keepNames": true
 }


### PR DESCRIPTION
## What

Mark `uuidv4` package as external so it will be available in node_modules to use in migrations.

## Why

Migrations use it.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
