### PR TITLE
fix(j-s): Activate User

### DIFF
--- a/apps/judicial-system/api/src/app/modules/auth/auth.service.ts
+++ b/apps/judicial-system/api/src/app/modules/auth/auth.service.ts
@@ -32,9 +32,7 @@ export class AuthService {
   async findUsersByNationalId(nationalId: string): Promise<User[] | undefined> {
     const res = await fetch(
       `${this.config.backendUrl}/api/user/?nationalId=${nationalId}`,
-      {
-        headers: { authorization: `Bearer ${this.config.secretToken}` },
-      },
+      { headers: { authorization: `Bearer ${this.config.secretToken}` } },
     )
 
     if (!res.ok) {
@@ -48,9 +46,7 @@ export class AuthService {
     try {
       const res = await fetch(
         `${this.config.backendUrl}/api/cases/limitedAccess/defender?nationalId=${nationalId}`,
-        {
-          headers: { authorization: `Bearer ${this.config.secretToken}` },
-        },
+        { headers: { authorization: `Bearer ${this.config.secretToken}` } },
       )
       if (res.ok) {
         return await res.json()

--- a/apps/judicial-system/backend/src/app/modules/case/state/case.state.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/state/case.state.spec.ts
@@ -4,6 +4,7 @@ import { ForbiddenException } from '@nestjs/common'
 
 import {
   CaseAppealState,
+  CaseIndictmentRulingDecision,
   CaseState,
   CaseTransition,
   indictmentCases,
@@ -27,11 +28,7 @@ describe('Transition Case', () => {
           transitionCase(
             CaseTransition.OPEN,
             { id: uuid(), state: fromState, type } as Case,
-            {
-              id: uuid(),
-              role: UserRole.PROSECUTOR,
-              institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-            } as User,
+            { id: uuid() } as User,
           )
 
         // Act and assert
@@ -59,11 +56,7 @@ describe('Transition Case', () => {
                 appealState: fromAppealState,
                 type,
               } as Case,
-              {
-                id: uuid(),
-                role: UserRole.PROSECUTOR,
-                institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-              } as User,
+              { id: uuid() } as User,
             )
 
             // Assert
@@ -84,11 +77,7 @@ describe('Transition Case', () => {
                   appealState: fromAppealState,
                   type,
                 } as Case,
-                {
-                  id: uuid(),
-                  role: UserRole.PROSECUTOR,
-                  institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-                } as User,
+                { id: uuid() } as User,
               )
 
             // Act and assert
@@ -115,11 +104,7 @@ describe('Transition Case', () => {
                   appealState: fromAppealState,
                   type,
                 } as Case,
-                {
-                  id: uuid(),
-                  role: UserRole.PROSECUTOR,
-                  institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-                } as User,
+                { id: uuid() } as User,
               )
 
             // Act and assert
@@ -140,11 +125,7 @@ describe('Transition Case', () => {
         const res = transitionCase(
           CaseTransition.ASK_FOR_CONFIRMATION,
           { id: uuid(), state: fromState, type } as Case,
-          {
-            id: uuid(),
-            role: UserRole.PROSECUTOR,
-            institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-          } as User,
+          { id: uuid() } as User,
         )
 
         // Assert
@@ -162,11 +143,7 @@ describe('Transition Case', () => {
         transitionCase(
           CaseTransition.ASK_FOR_CONFIRMATION,
           { id: uuid(), state: fromState, type } as Case,
-          {
-            id: uuid(),
-            role: UserRole.PROSECUTOR,
-            institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-          } as User,
+          { id: uuid() } as User,
         )
 
       // Act and assert
@@ -191,11 +168,7 @@ describe('Transition Case', () => {
                   appealState: fromAppealState,
                   type,
                 } as Case,
-                {
-                  id: uuid(),
-                  role: UserRole.PROSECUTOR,
-                  institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-                } as User,
+                { id: uuid() } as User,
               )
 
             // Act and assert
@@ -216,11 +189,7 @@ describe('Transition Case', () => {
         const res = transitionCase(
           CaseTransition.DENY_INDICTMENT,
           { id: uuid(), state: fromState, type } as Case,
-          {
-            id: uuid(),
-            role: UserRole.PROSECUTOR,
-            institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-          } as User,
+          { id: uuid() } as User,
         )
 
         // Assert
@@ -238,11 +207,7 @@ describe('Transition Case', () => {
         transitionCase(
           CaseTransition.DENY_INDICTMENT,
           { id: uuid(), state: fromState, type } as Case,
-          {
-            id: uuid(),
-            role: UserRole.PROSECUTOR,
-            institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-          } as User,
+          { id: uuid() } as User,
         )
 
       // Act and assert
@@ -267,11 +232,7 @@ describe('Transition Case', () => {
                   appealState: fromAppealState,
                   type,
                 } as Case,
-                {
-                  id: uuid(),
-                  role: UserRole.PROSECUTOR,
-                  institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-                } as User,
+                { id: uuid() } as User,
               )
 
             // Act and assert
@@ -292,11 +253,7 @@ describe('Transition Case', () => {
         const res = transitionCase(
           CaseTransition.SUBMIT,
           { id: uuid(), state: fromState, type } as Case,
-          {
-            id: uuid(),
-            role: UserRole.PROSECUTOR,
-            institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-          } as User,
+          { id: uuid() } as User,
         )
 
         // Assert
@@ -314,11 +271,7 @@ describe('Transition Case', () => {
         transitionCase(
           CaseTransition.SUBMIT,
           { id: uuid(), state: fromState, type } as Case,
-          {
-            id: uuid(),
-            role: UserRole.PROSECUTOR,
-            institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-          } as User,
+          { id: uuid() } as User,
         )
 
       // Act and assert
@@ -345,11 +298,7 @@ describe('Transition Case', () => {
                 appealState: fromAppealState,
                 type,
               } as Case,
-              {
-                id: uuid(),
-                role: UserRole.PROSECUTOR,
-                institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-              } as User,
+              { id: uuid() } as User,
             )
 
             // Assert
@@ -370,11 +319,7 @@ describe('Transition Case', () => {
                   appealState: fromAppealState,
                   type,
                 } as Case,
-                {
-                  id: uuid(),
-                  role: UserRole.PROSECUTOR,
-                  institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-                } as User,
+                { id: uuid() } as User,
               )
 
             // Act and assert
@@ -401,11 +346,7 @@ describe('Transition Case', () => {
                   appealState: fromAppealState,
                   type,
                 } as Case,
-                {
-                  id: uuid(),
-                  role: UserRole.PROSECUTOR,
-                  institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-                } as User,
+                { id: uuid() } as User,
               )
 
             // Act and assert
@@ -426,11 +367,7 @@ describe('Transition Case', () => {
         const res = transitionCase(
           CaseTransition.ASK_FOR_CANCELLATION,
           { id: uuid(), state: fromState, type } as Case,
-          {
-            id: uuid(),
-            role: UserRole.PROSECUTOR,
-            institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-          } as User,
+          { id: uuid() } as User,
         )
 
         // Assert
@@ -448,11 +385,7 @@ describe('Transition Case', () => {
         transitionCase(
           CaseTransition.ASK_FOR_CANCELLATION,
           { id: uuid(), state: fromState, type } as Case,
-          {
-            id: uuid(),
-            role: UserRole.PROSECUTOR,
-            institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-          } as User,
+          { id: uuid() } as User,
         )
 
       // Act and assert
@@ -477,11 +410,7 @@ describe('Transition Case', () => {
                   appealState: fromAppealState,
                   type,
                 } as Case,
-                {
-                  id: uuid(),
-                  role: UserRole.PROSECUTOR,
-                  institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-                } as User,
+                { id: uuid() } as User,
               )
 
             // Act and assert
@@ -502,11 +431,7 @@ describe('Transition Case', () => {
         const res = transitionCase(
           CaseTransition.RECEIVE,
           { id: uuid(), state: fromState, type } as Case,
-          {
-            id: uuid(),
-            role: UserRole.PROSECUTOR,
-            institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-          } as User,
+          { id: uuid() } as User,
         )
 
         // Assert
@@ -524,11 +449,7 @@ describe('Transition Case', () => {
         transitionCase(
           CaseTransition.RECEIVE,
           { id: uuid(), state: fromState, type } as Case,
-          {
-            id: uuid(),
-            role: UserRole.PROSECUTOR,
-            institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-          } as User,
+          { id: uuid() } as User,
         )
 
       // Act and assert
@@ -555,11 +476,7 @@ describe('Transition Case', () => {
                 appealState: fromAppealState,
                 type,
               } as Case,
-              {
-                id: uuid(),
-                role: UserRole.PROSECUTOR,
-                institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-              } as User,
+              { id: uuid() } as User,
             )
 
             // Assert
@@ -580,11 +497,7 @@ describe('Transition Case', () => {
                   appealState: fromAppealState,
                   type,
                 } as Case,
-                {
-                  id: uuid(),
-                  role: UserRole.PROSECUTOR,
-                  institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-                } as User,
+                { id: uuid() } as User,
               )
 
             // Act and assert
@@ -611,11 +524,7 @@ describe('Transition Case', () => {
                   appealState: fromAppealState,
                   type,
                 } as Case,
-                {
-                  id: uuid(),
-                  role: UserRole.PROSECUTOR,
-                  institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-                } as User,
+                { id: uuid() } as User,
               )
 
             // Act and assert
@@ -636,11 +545,7 @@ describe('Transition Case', () => {
         const res = transitionCase(
           CaseTransition.RETURN_INDICTMENT,
           { id: uuid(), state: fromState, type } as Case,
-          {
-            id: uuid(),
-            role: UserRole.PROSECUTOR,
-            institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-          } as User,
+          { id: uuid() } as User,
         )
 
         // Assert
@@ -658,11 +563,7 @@ describe('Transition Case', () => {
         transitionCase(
           CaseTransition.RETURN_INDICTMENT,
           { id: uuid(), state: fromState, type } as Case,
-          {
-            id: uuid(),
-            role: UserRole.PROSECUTOR,
-            institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-          } as User,
+          { id: uuid() } as User,
         )
 
       // Act and assert
@@ -687,11 +588,7 @@ describe('Transition Case', () => {
                   appealState: fromAppealState,
                   type,
                 } as Case,
-                {
-                  id: uuid(),
-                  role: UserRole.PROSECUTOR,
-                  institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-                } as User,
+                { id: uuid() } as User,
               )
 
             // Act and assert
@@ -715,11 +612,7 @@ describe('Transition Case', () => {
         const res = transitionCase(
           CaseTransition.COMPLETE,
           { id: uuid(), state: fromState, type } as Case,
-          {
-            id: uuid(),
-            role: UserRole.PROSECUTOR,
-            institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-          } as User,
+          { id: uuid() } as User,
         )
 
         // Assert
@@ -737,11 +630,7 @@ describe('Transition Case', () => {
         transitionCase(
           CaseTransition.COMPLETE,
           { id: uuid(), state: fromState, type } as Case,
-          {
-            id: uuid(),
-            role: UserRole.PROSECUTOR,
-            institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-          } as User,
+          { id: uuid() } as User,
         )
 
       // Act and assert
@@ -766,11 +655,7 @@ describe('Transition Case', () => {
                   appealState: fromAppealState,
                   type,
                 } as Case,
-                {
-                  id: uuid(),
-                  role: UserRole.PROSECUTOR,
-                  institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-                } as User,
+                { id: uuid() } as User,
               )
 
             // Act and assert
@@ -790,11 +675,7 @@ describe('Transition Case', () => {
           transitionCase(
             CaseTransition.ACCEPT,
             { id: uuid(), state: fromState, type } as Case,
-            {
-              id: uuid(),
-              role: UserRole.PROSECUTOR,
-              institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-            } as User,
+            { id: uuid() } as User,
           )
 
         // Act and assert
@@ -825,11 +706,7 @@ describe('Transition Case', () => {
                 appealState: fromAppealState,
                 type,
               } as Case,
-              {
-                id: uuid(),
-                role: UserRole.PROSECUTOR,
-                institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-              } as User,
+              { id: uuid() } as User,
             )
 
             // Assert
@@ -856,11 +733,7 @@ describe('Transition Case', () => {
                   appealState: fromAppealState,
                   type,
                 } as Case,
-                {
-                  id: uuid(),
-                  role: UserRole.PROSECUTOR,
-                  institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-                } as User,
+                { id: uuid() } as User,
               )
 
             // Act and assert
@@ -880,11 +753,7 @@ describe('Transition Case', () => {
           transitionCase(
             CaseTransition.REJECT,
             { id: uuid(), state: fromState, type } as Case,
-            {
-              id: uuid(),
-              role: UserRole.PROSECUTOR,
-              institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-            } as User,
+            { id: uuid() } as User,
           )
 
         // Act and assert
@@ -915,11 +784,7 @@ describe('Transition Case', () => {
                 appealState: fromAppealState,
                 type,
               } as Case,
-              {
-                id: uuid(),
-                role: UserRole.PROSECUTOR,
-                institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-              } as User,
+              { id: uuid() } as User,
             )
 
             // Assert
@@ -946,11 +811,7 @@ describe('Transition Case', () => {
                   appealState: fromAppealState,
                   type,
                 } as Case,
-                {
-                  id: uuid(),
-                  role: UserRole.PROSECUTOR,
-                  institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-                } as User,
+                { id: uuid() } as User,
               )
 
             // Act and assert
@@ -970,11 +831,7 @@ describe('Transition Case', () => {
           transitionCase(
             CaseTransition.DISMISS,
             { id: uuid(), state: fromState, type } as Case,
-            {
-              id: uuid(),
-              role: UserRole.PROSECUTOR,
-              institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-            } as User,
+            { id: uuid() } as User,
           )
 
         // Act and assert
@@ -1005,11 +862,7 @@ describe('Transition Case', () => {
                 appealState: fromAppealState,
                 type,
               } as Case,
-              {
-                id: uuid(),
-                role: UserRole.PROSECUTOR,
-                institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-              } as User,
+              { id: uuid() } as User,
             )
 
             // Assert
@@ -1036,11 +889,7 @@ describe('Transition Case', () => {
                   appealState: fromAppealState,
                   type,
                 } as Case,
-                {
-                  id: uuid(),
-                  role: UserRole.PROSECUTOR,
-                  institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-                } as User,
+                { id: uuid() } as User,
               )
 
             // Act and assert
@@ -1064,11 +913,7 @@ describe('Transition Case', () => {
         const res = transitionCase(
           CaseTransition.DELETE,
           { id: uuid(), state: fromState, type } as Case,
-          {
-            id: uuid(),
-            role: UserRole.PROSECUTOR,
-            institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-          } as User,
+          { id: uuid() } as User,
         )
 
         // Assert
@@ -1086,11 +931,7 @@ describe('Transition Case', () => {
         transitionCase(
           CaseTransition.DELETE,
           { id: uuid(), state: fromState, type } as Case,
-          {
-            id: uuid(),
-            role: UserRole.PROSECUTOR,
-            institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-          } as User,
+          { id: uuid() } as User,
         )
 
       // Act and assert
@@ -1122,11 +963,7 @@ describe('Transition Case', () => {
                 appealState: fromAppealState,
                 type,
               } as Case,
-              {
-                id: uuid(),
-                role: UserRole.PROSECUTOR,
-                institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-              } as User,
+              { id: uuid() } as User,
             )
 
             // Assert
@@ -1147,11 +984,7 @@ describe('Transition Case', () => {
                   appealState: fromAppealState,
                   type,
                 } as Case,
-                {
-                  id: uuid(),
-                  role: UserRole.PROSECUTOR,
-                  institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-                } as User,
+                { id: uuid() } as User,
               )
 
             // Act and assert
@@ -1178,11 +1011,7 @@ describe('Transition Case', () => {
                   appealState: fromAppealState,
                   type,
                 } as Case,
-                {
-                  id: uuid(),
-                  role: UserRole.PROSECUTOR,
-                  institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-                } as User,
+                { id: uuid() } as User,
               )
 
             // Act and assert
@@ -1194,25 +1023,83 @@ describe('Transition Case', () => {
   )
 
   describe.each(indictmentCases)('reopen %s', (type) => {
-    describe.each(Object.values(CaseState))(
-      'state %s - should not reopen',
-      (fromState) => {
-        // Arrange
-        const act = () =>
-          transitionCase(
+    const allowedFromStates = [CaseState.COMPLETED]
+
+    describe.each(allowedFromStates)('state %s', (fromState) => {
+      const allowedIndictmentRulingDecisions = [
+        undefined,
+        CaseIndictmentRulingDecision.RULING,
+        CaseIndictmentRulingDecision.FINE,
+        CaseIndictmentRulingDecision.DISMISSAL,
+        CaseIndictmentRulingDecision.CANCELLATION,
+        CaseIndictmentRulingDecision.MERGE,
+      ]
+
+      describe.each(allowedIndictmentRulingDecisions)(
+        'indictment ruling decision %s - should reopen',
+        (indictmentRulingDecision) => {
+          // Act
+          const res = transitionCase(
             CaseTransition.REOPEN,
-            { id: uuid(), state: fromState, type } as Case,
             {
               id: uuid(),
-              role: UserRole.PROSECUTOR,
-              institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-            } as User,
+              state: fromState,
+              type,
+              indictmentRulingDecision,
+            } as Case,
+            { id: uuid() } as User,
           )
 
-        // Act and assert
-        expect(act).toThrow(ForbiddenException)
-      },
-    )
+          // Assert
+          expect(res).toMatchObject({ state: CaseState.RECEIVED })
+        },
+      )
+
+      describe.each(
+        Object.values(CaseIndictmentRulingDecision).filter(
+          (indictmentRulingDecision) =>
+            !allowedIndictmentRulingDecisions.includes(
+              indictmentRulingDecision,
+            ),
+        ),
+      )(
+        'indictment ruling decision %s - should not reopen',
+        (indictmentRulingDecision) => {
+          // Arrange
+          const act = () =>
+            transitionCase(
+              CaseTransition.REOPEN,
+              {
+                id: uuid(),
+                state: fromState,
+                type,
+                indictmentRulingDecision,
+              } as Case,
+              { id: uuid() } as User,
+            )
+
+          // Act and assert
+          expect(act).toThrow(ForbiddenException)
+        },
+      )
+    })
+
+    describe.each(
+      Object.values(CaseState).filter(
+        (state) => !allowedFromStates.includes(state),
+      ),
+    )('state %s - should not reopen', (fromState) => {
+      // Arrange
+      const act = () =>
+        transitionCase(
+          CaseTransition.REOPEN,
+          { id: uuid(), state: fromState, type } as Case,
+          { id: uuid() } as User,
+        )
+
+      // Act and assert
+      expect(act).toThrow(ForbiddenException)
+    })
   })
 
   describe.each([...restrictionCases, ...investigationCases])(
@@ -1241,11 +1128,7 @@ describe('Transition Case', () => {
                 appealState: fromAppealState,
                 type,
               } as Case,
-              {
-                id: uuid(),
-                role: UserRole.PROSECUTOR,
-                institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-              } as User,
+              { id: uuid() } as User,
             )
 
             // Assert
@@ -1272,11 +1155,7 @@ describe('Transition Case', () => {
                   appealState: fromAppealState,
                   type,
                 } as Case,
-                {
-                  id: uuid(),
-                  role: UserRole.PROSECUTOR,
-                  institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-                } as User,
+                { id: uuid() } as User,
               )
 
             // Act and assert
@@ -1296,11 +1175,7 @@ describe('Transition Case', () => {
           transitionCase(
             CaseTransition.APPEAL,
             { id: uuid(), state: fromState, type } as Case,
-            {
-              id: uuid(),
-              role: UserRole.PROSECUTOR,
-              institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-            } as User,
+            { id: uuid() } as User,
           )
 
         // Act and assert
@@ -1412,11 +1287,7 @@ describe('Transition Case', () => {
           transitionCase(
             CaseTransition.WITHDRAW_APPEAL,
             { id: uuid(), state: fromState, type } as Case,
-            {
-              id: uuid(),
-              role: UserRole.PROSECUTOR,
-              institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-            } as User,
+            { id: uuid() } as User,
           )
 
         // Act and assert
@@ -1451,11 +1322,7 @@ describe('Transition Case', () => {
                 appealState: fromAppealState,
                 type,
               } as Case,
-              {
-                id: uuid(),
-                role: UserRole.PROSECUTOR,
-                institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-              } as User,
+              { id: uuid() } as User,
             )
 
             // Assert
@@ -1480,11 +1347,7 @@ describe('Transition Case', () => {
                 appealState: fromAppealState,
                 type,
               } as Case,
-              {
-                id: uuid(),
-                role: UserRole.PROSECUTOR,
-                institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-              } as User,
+              { id: uuid() } as User,
             )
 
           // Act and assert
@@ -1510,11 +1373,7 @@ describe('Transition Case', () => {
                   appealState: fromAppealState,
                   type,
                 } as Case,
-                {
-                  id: uuid(),
-                  role: UserRole.PROSECUTOR,
-                  institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-                } as User,
+                { id: uuid() } as User,
               )
 
             // Act and assert
@@ -1534,11 +1393,7 @@ describe('Transition Case', () => {
           transitionCase(
             CaseTransition.RECEIVE_APPEAL,
             { id: uuid(), state: fromState, type } as Case,
-            {
-              id: uuid(),
-              role: UserRole.PROSECUTOR,
-              institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-            } as User,
+            { id: uuid() } as User,
           )
 
         // Act and assert
@@ -1570,11 +1425,7 @@ describe('Transition Case', () => {
                 appealState: fromAppealState,
                 type,
               } as Case,
-              {
-                id: uuid(),
-                role: UserRole.PROSECUTOR,
-                institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-              } as User,
+              { id: uuid() } as User,
             )
 
             // Assert
@@ -1597,11 +1448,7 @@ describe('Transition Case', () => {
                 appealState: fromAppealState,
                 type,
               } as Case,
-              {
-                id: uuid(),
-                role: UserRole.PROSECUTOR,
-                institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-              } as User,
+              { id: uuid() } as User,
             )
 
           // Act and assert
@@ -1627,11 +1474,7 @@ describe('Transition Case', () => {
                   appealState: fromAppealState,
                   type,
                 } as Case,
-                {
-                  id: uuid(),
-                  role: UserRole.PROSECUTOR,
-                  institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-                } as User,
+                { id: uuid() } as User,
               )
 
             // Act and assert
@@ -1651,11 +1494,7 @@ describe('Transition Case', () => {
           transitionCase(
             CaseTransition.COMPLETE_APPEAL,
             { id: uuid(), state: fromState, type } as Case,
-            {
-              id: uuid(),
-              role: UserRole.PROSECUTOR,
-              institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-            } as User,
+            { id: uuid() } as User,
           )
 
         // Act and assert
@@ -1690,11 +1529,7 @@ describe('Transition Case', () => {
                 appealState: fromAppealState,
                 type,
               } as Case,
-              {
-                id: uuid(),
-                role: UserRole.PROSECUTOR,
-                institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-              } as User,
+              { id: uuid() } as User,
             )
 
             // Assert
@@ -1719,11 +1554,7 @@ describe('Transition Case', () => {
                 appealState: fromAppealState,
                 type,
               } as Case,
-              {
-                id: uuid(),
-                role: UserRole.PROSECUTOR,
-                institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-              } as User,
+              { id: uuid() } as User,
             )
 
           // Act and assert
@@ -1749,11 +1580,7 @@ describe('Transition Case', () => {
                   appealState: fromAppealState,
                   type,
                 } as Case,
-                {
-                  id: uuid(),
-                  role: UserRole.PROSECUTOR,
-                  institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-                } as User,
+                { id: uuid() } as User,
               )
 
             // Act and assert
@@ -1773,11 +1600,7 @@ describe('Transition Case', () => {
           transitionCase(
             CaseTransition.REOPEN_APPEAL,
             { id: uuid(), state: fromState, type } as Case,
-            {
-              id: uuid(),
-              role: UserRole.PROSECUTOR,
-              institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-            } as User,
+            { id: uuid() } as User,
           )
 
         // Act and assert
@@ -1809,11 +1632,7 @@ describe('Transition Case', () => {
                 appealState: fromAppealState,
                 type,
               } as Case,
-              {
-                id: uuid(),
-                role: UserRole.PROSECUTOR,
-                institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-              } as User,
+              { id: uuid() } as User,
             )
 
             // Assert
@@ -1836,11 +1655,7 @@ describe('Transition Case', () => {
                 appealState: fromAppealState,
                 type,
               } as Case,
-              {
-                id: uuid(),
-                role: UserRole.PROSECUTOR,
-                institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-              } as User,
+              { id: uuid() } as User,
             )
 
           // Act and assert
@@ -1866,11 +1681,7 @@ describe('Transition Case', () => {
                   appealState: fromAppealState,
                   type,
                 } as Case,
-                {
-                  id: uuid(),
-                  role: UserRole.PROSECUTOR,
-                  institution: { type: InstitutionType.PROSECUTORS_OFFICE },
-                } as User,
+                { id: uuid() } as User,
               )
 
             // Act and assert

--- a/apps/judicial-system/backend/src/app/modules/case/state/case.state.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/state/case.state.ts
@@ -5,6 +5,7 @@ import {
   CaseAppealRulingDecision,
   CaseAppealState,
   CaseDecision,
+  CaseIndictmentRulingDecision,
   CaseState,
   CaseTransition,
   IndictmentCaseState,
@@ -146,6 +147,28 @@ const indictmentCaseStateMachine: Map<
         ...update,
         state: CaseState.DELETED,
       }),
+    },
+  ],
+  [
+    IndictmentCaseTransition.REOPEN,
+    {
+      fromStates: [IndictmentCaseState.COMPLETED],
+      transition: (update: UpdateCase, theCase: Case) => {
+        if (
+          theCase.indictmentRulingDecision ===
+          CaseIndictmentRulingDecision.WITHDRAWAL
+        ) {
+          throw new ForbiddenException(
+            'Cannot reopen a case that has been withdrawn',
+          )
+        }
+
+        return {
+          ...update,
+          state: CaseState.RECEIVED,
+          rulingDate: null,
+        }
+      },
     },
   ],
 ])

--- a/apps/judicial-system/web/src/routes/Shared/Landing/MultipleInstitutions/MultipleInstitutions.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/Landing/MultipleInstitutions/MultipleInstitutions.tsx
@@ -1,5 +1,4 @@
 import { useContext, useState } from 'react'
-import { useRouter } from 'next/router'
 
 import { Box, Select, Text } from '@island.is/island-ui/core'
 import { capitalize } from '@island.is/judicial-system/formatters'
@@ -9,12 +8,11 @@ import {
   PageTitle,
   UserContext,
 } from '@island.is/judicial-system-web/src/components'
+import { api } from '@island.is/judicial-system-web/src/services'
 
 import * as styles from './MultipleInstitutions.css'
 
 const Login = () => {
-  const router = useRouter()
-
   const [userId, setUserId] = useState<string>()
 
   const { eligibleUsers } = useContext(UserContext)
@@ -48,7 +46,7 @@ const Login = () => {
           nextButtonIcon="arrowForward"
           nextButtonText="Halda áfram"
           nextIsDisabled={!userId}
-          onNextButtonClick={() => router.push(`/api/auth/activate/${userId}`)}
+          onNextButtonClick={() => userId && api.activate(userId)}
         />
       </FormContentContainer>
     </>

--- a/apps/judicial-system/web/src/services/api.ts
+++ b/apps/judicial-system/web/src/services/api.ts
@@ -1,3 +1,5 @@
+import Cookie from 'js-cookie'
+
 import { CSRF_COOKIE_NAME } from '@island.is/judicial-system/consts'
 import { deleteCookie } from '@island.is/judicial-system-web/src/utils/cookies'
 
@@ -8,7 +10,18 @@ export const apiUrl = API_URL
 
 export const logout = () => {
   deleteCookie(CSRF_COOKIE_NAME)
-  window.location.href = `${apiUrl}/api/auth/logout`
+  window.location.assign(`${apiUrl}/api/auth/logout`)
+}
+
+export const activate = async (userId: string) => {
+  const token = Cookie.get(CSRF_COOKIE_NAME)
+  const options = token ? { headers: { authorization: `Bearer ${token}` } } : {}
+
+  const res = await fetch(`/api/auth/activate/${userId}`, options)
+
+  if (res.ok) {
+    window.location.assign(res.url)
+  }
 }
 
 export const getFeature = async (name: string): Promise<boolean> => {

--- a/libs/judicial-system/types/src/lib/case.ts
+++ b/libs/judicial-system/types/src/lib/case.ts
@@ -161,6 +161,7 @@ export enum IndictmentCaseTransition {
   DELETE = CaseTransition.DELETE,
   DENY_INDICTMENT = CaseTransition.DENY_INDICTMENT,
   RECEIVE = CaseTransition.RECEIVE,
+  REOPEN = CaseTransition.REOPEN,
   RETURN_INDICTMENT = CaseTransition.RETURN_INDICTMENT,
   SUBMIT = CaseTransition.SUBMIT,
 }


### PR DESCRIPTION
# Activate User

[Styðja user id í login og deep links](https://app.asana.com/0/1199153462262248/1209524374225368/f)

## What

- Adds authorization header for bearer token to actiate user callse.
- Allows indictments that were not withdrawn to be reopened after completion - not supported by the frontend yet.

## Why

- Without the header, activation fails.
- Reopening indictments allows the team to fix common user problems.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Streamlined account activation now uses a direct API call when the activation button is clicked for a smoother experience.
	- Enhanced logout behavior with improved redirection for a more seamless sign-out process.
	- Added functionality to allow the reopening of completed indictment cases under specific conditions.
- **Refactor**
	- Made internal improvements to enhance consistency and code quality without altering visible functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->