### PR TITLE
chore(ci): Respect the `skip-nx-cache` label

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -17,6 +17,7 @@ env:
   COMPOSE_HTTP_TIMEOUT: 180
   SKIP_GENERATED_CACHE: ${{ contains(github.event.pull_request.labels.*.name, 'skip-generated-cache') }}
   NX_AFFECTED_ALL: ${{ contains(github.event.pull_request.labels.*.name, 'nx-affected-all') }}
+  NX_SKIP_NX_CACHE: ${{ contains(github.event.pull_request.labels.*.name, 'skip-nx-cache') }}
   DISABLE_CHUNKS: 'true'
   DISABLE_GROUPING: 'false'
   DISABLE_PROBLEMATIC: 'false'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -35,6 +35,7 @@ env:
   GITHUB_ACTIONS_CACHE_URL: https://cache.dev01.devland.is/
   SKIP_GENERATED_CACHE: ${{ contains(github.event.pull_request.labels.*.name, 'skip-generated-cache') }}
   NX_AFFECTED_ALL: ${{ contains(github.event.pull_request.labels.*.name, 'nx-affected-all') }}
+  NX_SKIP_NX_CACHE: ${{ contains(github.event.pull_request.labels.*.name, 'skip-nx-cache') }}
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
   NX_TASKS_RUNNER: ci
   CONFIGCAT_MAIN_CONFIG_ID: 08d8c761-021c-46f0-8671-6244663a372f

--- a/scripts/ci/30_test.sh
+++ b/scripts/ci/30_test.sh
@@ -52,6 +52,9 @@ fi
 
 echo $EXTRA_OPTS
 
+# Set Datadog config per-project
+jq -n --arg p "${AFFECTED_PROJECTS}" '$p | split(",").[]' | xargs -I% sh -c 'echo DD_SERVICE=% >> .env.%'
+
 yarn nx run-many \
   --projects "${AFFECTED_PROJECTS}" \
   --target test \

--- a/scripts/ci/30_test.sh
+++ b/scripts/ci/30_test.sh
@@ -52,9 +52,6 @@ fi
 
 echo $EXTRA_OPTS
 
-# Set Datadog config per-project
-jq -n --arg p "${AFFECTED_PROJECTS}" '$p | split(",").[]' | xargs -I% sh -c 'echo DD_SERVICE=% >> .env.%'
-
 yarn nx run-many \
   --projects "${AFFECTED_PROJECTS}" \
   --target test \


### PR DESCRIPTION
Currently, the `skip-nx-label` isn't respected. Setting at the top-level is dead-simple, and "just works"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Introduced a new environment variable `NX_SKIP_NX_CACHE` to conditionally control the caching behavior during workflows based on specific pull request labels.
  - Enhanced Datadog configuration for affected projects by setting the `DD_SERVICE` environment variable in their corresponding `.env` files before running tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->