### PR TITLE
fix(j-s): Regex for filename chunks

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/caseFilesRecordPdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/caseFilesRecordPdf.ts
@@ -223,7 +223,7 @@ export const createCaseFilesRecord = async (
 
       const nameChunks =
         pageReference.name.length > 40
-          ? pageReference.name.match(/(.{1,40})(?=.|$)/g)
+          ? pageReference.name.match(/.{1,40}(?=\s|$)/g)
           : [pageReference.name]
 
       for (const chunck of nameChunks ?? []) {

--- a/apps/judicial-system/backend/src/app/formatters/caseFilesRecordPdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/caseFilesRecordPdf.ts
@@ -226,8 +226,8 @@ export const createCaseFilesRecord = async (
           ? pageReference.name.match(/.{1,40}(?=\s|$)/g)
           : [pageReference.name]
 
-      for (const chunck of nameChunks ?? []) {
-        pdfDocument.addText(chunck, textFontSize, {
+      for (const chunk of nameChunks ?? []) {
+        pdfDocument.addText(chunk, textFontSize, {
           newLine: true,
           pageLink: pageReference.pageLink,
           position: { x: pageReferenceIndent },

--- a/apps/judicial-system/backend/src/app/formatters/caseFilesRecordPdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/caseFilesRecordPdf.ts
@@ -221,10 +221,7 @@ export const createCaseFilesRecord = async (
         marginTop: 1,
       })
 
-      const nameChunks =
-        pageReference.name.length > 40
-          ? pageReference.name.match(/.{1,40}(?=\s|$)/g)
-          : [pageReference.name]
+      const nameChunks = pageReference.name.match(/.{1,40}(?=\s|$)/g)
 
       for (const chunk of nameChunks ?? []) {
         pdfDocument.addText(chunk, textFontSize, {

--- a/apps/judicial-system/backend/src/app/messages/pdfCaseFilesRecord.ts
+++ b/apps/judicial-system/backend/src/app/messages/pdfCaseFilesRecord.ts
@@ -20,7 +20,7 @@ export const caseFilesRecord = defineMessages({
   accused: {
     id: 'judicial.system.backend:case_files_record.accused_heading',
     defaultMessage: 'Sakborningur:',
-    description: 'Nota[ur fyrir titil á skborningi í PDF skjalaskrá',
+    description: 'Notaður fyrir titil á skborningi í PDF skjalaskrá',
   },
   accusedOf: {
     id: 'judicial.system.backend:case_files_record.accused_of',


### PR DESCRIPTION
# Regex for filename chunks

[Asana](https://app.asana.com/0/1199153462262248/1207492848537168/f)

## What

Fix regex for filenames in `caseFilesRecord` pdf. 

## Screenshots / Gifs

<img width="877" alt="Screenshot 2025-03-21 at 16 07 06" src="https://github.com/user-attachments/assets/43f96718-6491-40b9-b565-df6aa89bf839" />

### Before

<img width="714" alt="Screenshot 2025-03-21 at 16 05 10" src="https://github.com/user-attachments/assets/a287b01d-b275-4b47-a1bd-5c3453609ad7" />

### After

<img width="696" alt="Screenshot 2025-03-21 at 16 04 39" src="https://github.com/user-attachments/assets/b1dbf43d-e64e-47e7-bb0a-308e94d65223" />

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the formatting logic for displaying case file record names in PDFs for enhanced consistency and readability.
- **Bug Fixes**
  - Corrected a typographical error in the accused description, ensuring it now appears as intended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->