### PR TITLE
chore(j-s): Support both heading and variant in SectionHeading component

### DIFF
--- a/apps/judicial-system/web/src/components/SectionHeading/SectionHeading.tsx
+++ b/apps/judicial-system/web/src/components/SectionHeading/SectionHeading.tsx
@@ -4,13 +4,16 @@ import { Box, ResponsiveProp, Space, Text } from '@island.is/island-ui/core'
 
 import RequiredStar from '../RequiredStar/RequiredStar'
 
+type Heading = 'h1' | 'h2' | 'h3' | 'h4' | 'h5'
+
 interface Props {
   title: string
   required?: boolean
   tooltip?: ReactNode
   description?: ReactNode | string
   marginBottom?: ResponsiveProp<Space | 'auto'>
-  heading?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5'
+  heading?: Heading
+  variant?: Heading
 }
 
 const SectionHeading: FC<Props> = ({
@@ -20,9 +23,10 @@ const SectionHeading: FC<Props> = ({
   description,
   marginBottom = 3,
   heading = 'h3',
+  variant = 'h3',
 }) => (
   <Box marginBottom={marginBottom}>
-    <Text as={heading} variant={heading}>
+    <Text as={heading} variant={variant}>
       {title}
       {required && ' '}
       {required && <RequiredStar />}

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/CaseFiles/CaseFiles.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/CaseFiles/CaseFiles.tsx
@@ -62,6 +62,7 @@ const CaseFiles = () => {
         <Box component="section" marginBottom={5}>
           <SectionHeading
             title={formatMessage(strings.caseFiles.criminalRecordSection)}
+            heading="h2"
           />
           <InputFileUpload
             fileList={uploadFiles.filter(
@@ -85,6 +86,7 @@ const CaseFiles = () => {
         <Box component="section" marginBottom={5}>
           <SectionHeading
             title={formatMessage(strings.caseFiles.costBreakdownSection)}
+            heading="h2"
           />
           <InputFileUpload
             fileList={uploadFiles.filter(
@@ -111,6 +113,7 @@ const CaseFiles = () => {
         >
           <SectionHeading
             title={formatMessage(strings.caseFiles.otherDocumentsSection)}
+            heading="h2"
           />
           <InputFileUpload
             fileList={uploadFiles.filter(
@@ -133,6 +136,7 @@ const CaseFiles = () => {
           <Box component="section" marginBottom={10}>
             <SectionHeading
               title={formatMessage(strings.caseFiles.civilClaimSection)}
+              heading="h2"
             />
             <InputFileUpload
               fileList={uploadFiles.filter(


### PR DESCRIPTION
# Support both heading and variant in SectionHeading component

[Asana](https://app.asana.com/0/1199153462262248/1209602081769418/f)

## What

Support both heading and variant in SectionHeading component.

## Why

Now developers can choose both what html element is used and what styles are used for SectionHeadings. This is primarily done for a11y's sake. 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced section headings now offer flexible styling options with improved default settings.
  - Key interface sections have been updated to use these new header configurations, ensuring a more consistent and customizable appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->