### PR TITLE
fix(my-pages): revert moving translations strings

### DIFF
--- a/libs/portals/my-pages/core/src/lib/messages.ts
+++ b/libs/portals/my-pages/core/src/lib/messages.ts
@@ -666,18 +666,6 @@ export const m = defineMessages({
     id: 'service.portal:licenses-description',
     defaultMessage: 'Upplýsingar um skírteini og réttindi sem þeim fylgja',
   },
-  singleLicense: {
-    id: 'sp.occupational-licenses:single-license',
-    defaultMessage: 'Stakt starfsleyfi',
-  },
-  singleHealthLicense: {
-    id: 'sp.occupational-licenses:single-health-license',
-    defaultMessage: 'Stakt starfsleyfi heilbrigðisstarfsmanns',
-  },
-  singleEducationLicense: {
-    id: 'sp.occupational-licenses:single-education-license',
-    defaultMessage: 'Stakt leyfisbréf kennara',
-  },
   occupationalLicensesDescription: {
     id: 'service.portal:occupational-licenses-description',
     defaultMessage:

--- a/libs/portals/my-pages/occupational-licenses/src/module.tsx
+++ b/libs/portals/my-pages/occupational-licenses/src/module.tsx
@@ -3,6 +3,7 @@ import { PortalModule } from '@island.is/portals/core'
 import { OccupationalLicensesPaths } from './lib/paths'
 import { ApiScope } from '@island.is/auth/scopes'
 import { m } from '@island.is/portals/my-pages/core'
+import { olMessage as om } from './lib/messages'
 
 const EducationalDetailScreen = lazy(() =>
   import('./screens/v1/EducationalDetail/EducationalDetail'),
@@ -32,21 +33,21 @@ export const occupationalLicensesModule: PortalModule = {
       element: <OccupationalLicensesOverviewScreen />,
     },
     {
-      name: m.singleLicense,
+      name: om.singleLicense,
       path: OccupationalLicensesPaths.OccupationalLicensesDetail,
       enabled: userInfo.scopes.includes(ApiScope.internal),
 
       element: <OccupationalLicensesDetailScreen />,
     },
     {
-      name: m.singleHealthLicense,
+      name: om.singleHealthLicense,
       path: OccupationalLicensesPaths.OccupationalLicensesHealthDirectorateDetail,
       enabled: userInfo.scopes.includes(ApiScope.internal),
 
       element: <HealthDirectorateDetailScreen />,
     },
     {
-      name: m.singleEducationLicense,
+      name: om.singleEducationLicense,
       path: OccupationalLicensesPaths.OccupationalLicensesEducationDetail,
       enabled: userInfo.scopes.includes(ApiScope.internal),
 


### PR DESCRIPTION
# My pages - Translations strings revert 

Revert moving translations strings from Occupational Licenses to Core


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed three redundant licensing text entries for occupational license details, streamlining the displayed information.
  - Updated navigation labels on occupational license pages to use a unified language resource, ensuring a consistent and improved user experience.
  - Enhanced overall clarity by simplifying occupational licensing messages.
  - These updates result in a more intuitive and straightforward presentation of licensing content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->