### PR TITLE
fix(rental-agreement): validate descriptionInput set when required

### DIFF
--- a/libs/application/templates/rental-agreement/src/forms/draft/rentalHousing/rentalHousingSpecialProvisions.ts
+++ b/libs/application/templates/rental-agreement/src/forms/draft/rentalHousing/rentalHousingSpecialProvisions.ts
@@ -5,6 +5,7 @@ import {
   buildTextField,
   buildAlertMessageField,
   getValueViaPath,
+  buildHiddenInput,
 } from '@island.is/application/core'
 import { Routes } from '../../../lib/constants'
 import { specialProvisions } from '../../../lib/messages'
@@ -18,6 +19,19 @@ export const RentalHousingSpecialProvisions = buildSubSection({
       title: specialProvisions.subsection.pageTitle,
       description: specialProvisions.subsection.pageDescription,
       children: [
+        buildHiddenInput({
+          id: 'specialProvisions.descriptionInputRequired',
+          defaultValue: true,
+          // TODO: change condition to check if m2 have been altered
+          condition: (answers) => {
+            return (
+              getValueViaPath<string>(
+                answers,
+                'registerProperty.categoryClassGroup',
+              ) === 'studentHousing'
+            )
+          },
+        }),
         buildAlertMessageField({
           id: 'specialProvisions.descriptionInputAlert',
           alertType: 'warning',

--- a/libs/application/templates/rental-agreement/src/lib/dataSchema.ts
+++ b/libs/application/templates/rental-agreement/src/lib/dataSchema.ts
@@ -234,10 +234,23 @@ const registerProperty = z
     }
   })
 
-const specialProvisions = z.object({
-  descriptionInput: z.string().optional(),
-  rulesInput: z.string().optional(),
-}) // TODO: Add validation for descriptionInput if property size has been altered for chosen property unit/s
+const specialProvisions = z
+  .object({
+    descriptionInput: z.string().optional(),
+    rulesInput: z.string().optional(),
+    // This field is only available when descriptionInput is required
+    descriptionInputRequired: z.boolean().optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data?.descriptionInputRequired && !data.descriptionInput) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Custom error message',
+        params: m.specialProvisions.housingInfo.inputRequiredErrorMessage,
+        path: ['descriptionInput'],
+      })
+    }
+  })
 
 const condition = z
   .object({


### PR DESCRIPTION
# fix(rental-agreement): validate form, check descriptionInput when required

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request
![Screenshot 2025-03-26 at 14 48 08](https://github.com/user-attachments/assets/c7ca250d-7d70-497d-91a1-06f1376c1cc2)



## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
