### PR TITLE
chore(web): Remove command for extracting strings for all translation namespaces

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -82,10 +82,10 @@ yarn start web
 
 This starts a server on `localhost:4200`
 
-### To update translation namespaces in Contentful
+### To update a translation namespace in Contentful
 
 ```bash
-yarn nx extract-strings web
+yarn ts-node -P libs/localization/tsconfig.lib.json libs/localization/scripts/extract 'relative/path/to/file/containing/translations'
 ```
 
 Currently, in this project, only the `Custom Page` content type utilizes the `Translation Namespace` content type for translations

--- a/apps/web/project.json
+++ b/apps/web/project.json
@@ -79,12 +79,6 @@
         }
       }
     },
-    "extract-strings": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "yarn ts-node -P libs/localization/tsconfig.lib.json libs/localization/scripts/extract 'apps/web/{screens,components}/**/!(*.d).{js,ts,tsx}'"
-      }
-    },
     "export": {
       "executor": "@nx/next:export",
       "options": {


### PR DESCRIPTION
# Remove command for extracting strings for all translation namespaces

## What

It's way better to generate/update just the translation namespace you are implementing instead of having the side effect of updating all other translation namespaces

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Revised instructions for updating translation namespaces with updated command syntax.
- **Chores**
  - Removed the outdated configuration for translation string extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->