### PR TITLE
fix(core): allow circular dependency for test functionality

### DIFF
--- a/libs/testing/nest/src/lib/testServer.ts
+++ b/libs/testing/nest/src/lib/testServer.ts
@@ -2,6 +2,8 @@ import { ValidationPipe, INestApplication, Type } from '@nestjs/common'
 import { Test } from '@nestjs/testing'
 import { TestingModuleBuilder } from '@nestjs/testing/testing-module.builder'
 
+// Intentional circular dependency as infra-nest-server has tests which use this function.
+// eslint-disable-next-line @nx/enforce-module-boundaries
 import { InfraModule, HealthCheckOptions } from '@island.is/infra-nest-server'
 
 import cookieParser from 'cookie-parser'


### PR DESCRIPTION
Add an intentional circular dependency in testServer.ts to enable 
testing of functions in infra-nest-server. This change is necessary 
to facilitate the testing process while adhering to module boundaries.