### PR TITLE
fix(web): Highlight items if the start of path matches

### DIFF
--- a/apps/web/screens/Organization/SubPage.tsx
+++ b/apps/web/screens/Organization/SubPage.tsx
@@ -247,7 +247,19 @@ export const getSubpageNavList = (
     return generateNavigationItems(organizationPage, pathname)
   }
 
-  const items = generateNavigationItems(
+  let items = generateNavigationItems(organizationPage, pathname)
+  const someItemIsActive = items.some(
+    (item) =>
+      Boolean(item.active) ||
+      Boolean(item.items?.some((subItem) => Boolean(subItem.active))),
+  )
+
+  if (someItemIsActive) {
+    return items
+  }
+
+  // Only match a potential smaller depth if no match is found otherwise
+  items = generateNavigationItems(
     organizationPage,
     pathname
       .split('/')

--- a/apps/web/screens/Organization/SubPage.tsx
+++ b/apps/web/screens/Organization/SubPage.tsx
@@ -317,6 +317,7 @@ const SubPage: Screen<SubPageProps, SubPageScreenContext> = ({
   backLink,
 }) => {
   const router = useRouter()
+  const { activeLocale } = useI18n()
 
   const n = useNamespace(namespace)
   const { linkResolver } = useLinkResolver()
@@ -362,7 +363,11 @@ const SubPage: Screen<SubPageProps, SubPageScreenContext> = ({
       }
       navigationData={{
         title: n('navigationTitle', 'Efnisyfirlit'),
-        items: getSubpageNavList(organizationPage, router),
+        items: getSubpageNavList(
+          organizationPage,
+          router,
+          activeLocale === 'is' ? 3 : 4,
+        ),
       }}
       mainContent={
         customContent ? (


### PR DESCRIPTION
# Highlight items if the start of path matches

## Before

![Screenshot 2025-03-27 at 10 21 37](https://github.com/user-attachments/assets/588c5cce-0869-4a33-b920-381455496e98)

![Screenshot 2025-03-27 at 10 21 51](https://github.com/user-attachments/assets/c58feefe-6468-4f38-8039-a26a9d07c830)

## After

![Screenshot 2025-03-27 at 10 22 25](https://github.com/user-attachments/assets/66f7b57a-743d-46c0-af1b-72ed6e2dee64)

![Screenshot 2025-03-27 at 10 22 36](https://github.com/user-attachments/assets/1e25b64f-94d7-4250-8414-b6c4c4af91b4)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced organization page navigation that now adapts based on the current browsing context and language settings. Users will experience a more intuitive interface where visible navigation items more accurately reflect their current position on the site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->