### PR TITLE
fix(j-s): use transitionCase when court id is changed

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/case/case.controller.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/case.controller.ts
@@ -41,6 +41,7 @@ import type { User } from '@island.is/judicial-system/types'
 import {
   CaseOrigin,
   CaseState,
+  CaseTransition,
   CaseType,
   indictmentCases,
   investigationCases,
@@ -291,10 +292,7 @@ export class CaseController {
     const hasCourtIdUpdate =
       theCase.courtId && update.courtId && theCase.courtId !== update.courtId
     if (hasCourtIdUpdate) {
-      update.courtCaseNumber = null
-      update.judgeId = null
-      update.registrarId = null
-      update.state = CaseState.SUBMITTED
+      transitionCase(CaseTransition.SUBMIT, theCase, user)
     }
 
     return this.caseService.update(theCase, update, user) as Promise<Case> // Never returns undefined

--- a/apps/judicial-system/backend/src/app/modules/case/state/case.state.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/state/case.state.ts
@@ -75,9 +75,15 @@ const indictmentCaseStateMachine: Map<
   [
     IndictmentCaseTransition.SUBMIT,
     {
-      fromStates: [IndictmentCaseState.WAITING_FOR_CONFIRMATION],
+      fromStates: [
+        IndictmentCaseState.WAITING_FOR_CONFIRMATION,
+        IndictmentCaseState.RECEIVED,
+      ],
       transition: (update: UpdateCase) => ({
         ...update,
+        courtCaseNumber: null,
+        judgeId: null,
+        registrarId: null,
         state: CaseState.SUBMITTED,
         indictmentDeniedExplanation: null,
       }),


### PR DESCRIPTION
# [Laga state breytingu ](https://app.asana.com/0/1199153462262248/1209797193351298)

## What
- Use transitionCase when court id is changed

## Why
- Because we want to use our internal state machine when states are changing

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
