### PR TITLE
fix(secondary school): Contacts optional for applicants over 18 years old, and cleanup schema

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/secondary-school/utils.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/secondary-school/utils.ts
@@ -72,18 +72,6 @@ export const getCleanContacts = (
     })
   })
 
-  // Main other contact
-  const mainOtherContact = getValueViaPath<
-    SecondarySchoolAnswers['mainOtherContact']
-  >(application.answers, 'mainOtherContact')
-  if (mainOtherContact?.person?.nationalId)
-    result.push({
-      nationalId: mainOtherContact.person?.nationalId,
-      name: mainOtherContact.person?.name || '',
-      phone: mainOtherContact.person?.phone || '',
-      email: mainOtherContact.person?.email || '',
-    })
-
   // Other contacts
   const otherContacts = (
     getValueViaPath<SecondarySchoolAnswers['otherContacts']>(

--- a/libs/application/templates/secondary-school/src/fields/overview/CustodianOverview.tsx
+++ b/libs/application/templates/secondary-school/src/fields/overview/CustodianOverview.tsx
@@ -34,32 +34,12 @@ export const CustodianOverview: FC<FieldBaseProps> = ({
     (x) => !!x.person?.nationalId,
   )
 
-  const mainOtherContact = getValueViaPath<
-    SecondarySchoolAnswers['mainOtherContact']
-  >(application.answers, copyPrefix + 'mainOtherContact')
-
-  const otherContacts = (
+  const contacts = (
     getValueViaPath<SecondarySchoolAnswers['otherContacts']>(
       application.answers,
       copyPrefix + 'otherContacts',
     ) || []
   ).filter((x) => !!x.person.nationalId)
-
-  // merge together list of main other contact + other contacts
-  let contacts: {
-    person?: {
-      nationalId?: string
-      name?: string
-      email?: string
-      phone?: string
-    }
-  }[] = []
-  if (mainOtherContact?.person?.nationalId) {
-    contacts.push(mainOtherContact)
-  }
-  if (otherContacts.length > 0) {
-    contacts = contacts.concat(otherContacts)
-  }
 
   const onClick = (page: string) => {
     if (goToScreen) goToScreen(page)

--- a/libs/application/templates/secondary-school/src/forms/secondarySchoolForm/userInformationSection/custodianSubSection.ts
+++ b/libs/application/templates/secondary-school/src/forms/secondarySchoolForm/userInformationSection/custodianSubSection.ts
@@ -24,7 +24,7 @@ export const custodianSubSection = buildSubSection({
           ? ''
           : userInformation.otherContact.description,
       children: [
-        // If applicant is under 18 years old
+        // If applicant has any custodians
         // Custodians
         buildFieldsRepeaterField({
           id: 'custodians',
@@ -95,7 +95,7 @@ export const custodianSubSection = buildSubSection({
           },
         }),
 
-        // If applicant is over 18 years old
+        // If applicant does not have any custodians
         // Contacts
         buildFieldsRepeaterField({
           id: 'otherContacts',

--- a/libs/application/templates/secondary-school/src/forms/secondarySchoolForm/userInformationSection/custodianSubSection.ts
+++ b/libs/application/templates/secondary-school/src/forms/secondarySchoolForm/userInformationSection/custodianSubSection.ts
@@ -1,13 +1,9 @@
 import {
   buildFieldsRepeaterField,
-  buildHiddenInput,
   buildMultiField,
-  buildNationalIdWithNameField,
   buildSubSection,
-  getValueViaPath,
 } from '@island.is/application/core'
 import { userInformation } from '../../../lib/messages'
-import { Application } from '@island.is/application/types'
 import { checkHasAnyCustodians, Routes } from '../../../utils'
 
 export const custodianSubSection = buildSubSection({
@@ -28,6 +24,7 @@ export const custodianSubSection = buildSubSection({
           ? ''
           : userInformation.otherContact.description,
       children: [
+        // If applicant is under 18 years old
         // Custodians
         buildFieldsRepeaterField({
           id: 'custodians',
@@ -73,47 +70,42 @@ export const custodianSubSection = buildSubSection({
             },
           },
         }),
-
-        // Main other contact
-        buildHiddenInput({
-          id: 'mainOtherContact.applicantNationalId',
-          defaultValue: (application: Application) => {
-            return application.applicant
-          },
-        }),
-        buildHiddenInput({
-          id: 'mainOtherContact.required',
-          defaultValue: (application: Application) => {
-            return !checkHasAnyCustodians(application.externalData)
-          },
-        }),
-        buildNationalIdWithNameField({
-          id: 'mainOtherContact.person',
-          required: true,
-          showPhoneField: true,
-          showEmailField: true,
-          phoneRequired: true,
-          emailRequired: true,
-          phoneLabel: userInformation.otherContact.phone,
-          emailLabel: userInformation.otherContact.email,
-          condition: (answers) => {
-            return (
-              getValueViaPath<boolean>(answers, 'mainOtherContact.required') ||
-              false
-            )
-          },
-        }),
-
         // Other contacts
         buildFieldsRepeaterField({
           id: 'otherContacts',
           title: userInformation.otherContact.subtitle,
           titleVariant: 'h5',
+          condition: (_, externalData) => checkHasAnyCustodians(externalData),
           formTitleNumbering: 'none',
           addItemButtonText: userInformation.otherContact.addButtonLabel,
           removeItemButtonText: userInformation.otherContact.removeButtonLabel,
           minRows: 0,
           maxRows: 1,
+          fields: {
+            person: {
+              component: 'nationalIdWithName',
+              required: true,
+              showPhoneField: true,
+              phoneLabel: userInformation.otherContact.phone,
+              phoneRequired: true,
+              showEmailField: true,
+              emailLabel: userInformation.otherContact.email,
+              emailRequired: true,
+            },
+          },
+        }),
+
+        // If applicant is over 18 years old
+        // Contacts
+        buildFieldsRepeaterField({
+          id: 'otherContacts',
+          condition: (_, externalData) => !checkHasAnyCustodians(externalData),
+          formTitleNumbering: 'none',
+          addItemButtonText: userInformation.otherContact.addButtonLabel,
+          removeItemButtonText: userInformation.otherContact.removeButtonLabel,
+          marginTop: 0,
+          minRows: 0,
+          maxRows: 2,
           fields: {
             person: {
               component: 'nationalIdWithName',

--- a/libs/application/templates/secondary-school/src/lib/dataSchema.ts
+++ b/libs/application/templates/secondary-school/src/lib/dataSchema.ts
@@ -13,7 +13,10 @@ const FileDocumentSchema = z.object({
 
 const CustodianSchema = z.object({
   person: z.object({
-    nationalId: z.string().min(1),
+    nationalId: z
+      .string()
+      .min(1)
+      .refine((nationalId) => kennitala.isValid(nationalId)),
     name: z.string().min(1),
     email: z.string().min(1),
     phone: z.string().min(1),
@@ -24,55 +27,6 @@ const CustodianSchema = z.object({
     city: z.string().optional(),
   }),
 })
-
-const MainOtherContactSchema = z
-  .object({
-    applicantNationalId: z.string(),
-    required: z.boolean(),
-    person: z
-      .object({
-        nationalId: z.string().optional(),
-        name: z.string().optional(),
-        email: z.string().optional(),
-        phone: z.string().optional(),
-      })
-      .optional(),
-  })
-  .refine(
-    ({ required, person }) => {
-      if (!required) return true
-      return !!person?.nationalId && kennitala.isValid(person.nationalId)
-    },
-    { path: ['person', 'nationalId'] },
-  )
-  .refine(
-    ({ required, person }) => {
-      if (!required) return true
-      return !!person?.name
-    },
-    { path: ['person', 'name'] },
-  )
-  .refine(
-    ({ required, person }) => {
-      if (!required) return true
-      return !!person?.email
-    },
-    { path: ['person', 'email'] },
-  )
-  .refine(
-    ({ required, person }) => {
-      if (!required) return true
-      return !!person?.phone
-    },
-    { path: ['person', 'phone'] },
-  )
-  .refine(
-    ({ person, applicantNationalId }) => {
-      if (person?.nationalId === applicantNationalId) return false
-      return true
-    },
-    { path: ['person', 'nationalId'], params: error.errorSameAsApplicant },
-  )
 
 const OtherContactSchema = z.object({
   person: z.object({
@@ -182,8 +136,7 @@ export const SecondarySchoolSchema = z.object({
       },
     ),
   custodians: z.array(CustodianSchema).max(2),
-  mainOtherContact: MainOtherContactSchema,
-  otherContacts: z.array(OtherContactSchema).max(1),
+  otherContacts: z.array(OtherContactSchema).max(2),
   selection: z
     .array(SelectionSchema)
     .refine(


### PR DESCRIPTION
## What

Not sure why I didnt implement it this way to begin with. But now all otherContacts for applicants over 18 years old is in repeaterField.
The check for if contact is same as applicant is gone, but not as necessary anymore since we are not requiring users to enter any contacts. Will look into adding hiddenInput in repeaterFields so that adding that check will be simple (can then be added to both custodians and otherContacts) => #18603

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added a conditional section for applicants without custodians, enabling entry of multiple other contacts.
- **Refactor**
  - Streamlined contact management by removing the main other contact field and consolidating contact inputs.
- **Chores**
  - Enhanced national ID validation.
  - Increased the allowed number of other contacts from one to two.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->