### PR TITLE
fix(j-s): render uploaded file in an error state when its empty

### DIFF
--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/PoliceCaseFiles/PoliceCaseFilesRoute.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/PoliceCaseFiles/PoliceCaseFilesRoute.tsx
@@ -100,6 +100,9 @@ const UploadFilesToPoliceCase: FC<UploadFilesToPoliceCaseProps> = ({
   const errorMessage = useMemo(() => {
     if (uploadFiles.some((file) => file.status === 'error')) {
       return formatMessage(errorMessages.general)
+    }
+    if (uploadFiles.some((file) => file.size === 0)) {
+      return 'Villa kom upp. Tómt skjal.'
     } else {
       return undefined
     }

--- a/libs/island-ui/core/src/lib/InputFileUpload/InputFileUpload.tsx
+++ b/libs/island-ui/core/src/lib/InputFileUpload/InputFileUpload.tsx
@@ -100,6 +100,9 @@ export const UploadedFile = ({
       case 'error':
         return { background: 'red100', border: 'red200', icon: 'red600' }
       case 'done':
+        if (!file.size) {
+          return { background: 'red100', border: 'red200', icon: 'red600' }
+        }
         return {
           background: 'blue100',
           border: 'blue200',
@@ -114,7 +117,7 @@ export const UploadedFile = ({
           }
         )
     }
-  }, [file.status, defaultBackgroundColor])
+  }, [file.status, file.size, defaultBackgroundColor])
 
   const statusIcon = (status?: UploadFileStatus): IconTypes => {
     switch (status) {
@@ -177,8 +180,8 @@ export const UploadedFile = ({
       <Text truncate fontWeight="semiBold">
         <Box component="span" className={{ [styles.fileName]: onOpenFile }}>
           {truncateInMiddle(file.name)}
-          {showFileSize && file.size && (
-            <Text as="span">{` (${kb(file.size)}KB)`}</Text>
+          {showFileSize && (
+            <Text as="span">{` (${file.size ? kb(file.size) : 0}KB)`}</Text>
           )}
           {onOpenFile && (
             <Box component="span" marginLeft={1}>


### PR DESCRIPTION
# [Render empty files with error styles on upload](https://app.asana.com/0/1199153462262248/1209330913054519)

## What
- Render empty files in an error state on upload

## Why
- It sometimes happens (at least in the justice-system) that users upload empty files and thus we want to make those "mistakes" more visible. 

## Screenshots / Gifs
<img width="645" alt="Screenshot 2025-03-27 at 15 30 49" src="https://github.com/user-attachments/assets/374d3a36-d4a1-4e99-b447-c34277331011" />


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
