### PR TITLE
feat(skilavottord): Autogenerate companyId when municipality user

### DIFF
--- a/apps/skilavottord/web/graphql/queries.ts
+++ b/apps/skilavottord/web/graphql/queries.ts
@@ -94,3 +94,45 @@ export const DeleteSkilavottordAccessControlMutation = gql`
     deleteSkilavottordAccessControl(input: $input)
   }
 `
+
+export const UpdateSkilavottordRecyclingPartnerMutation = gql`
+  mutation updateSkilavottordRecyclingPartnerMutation(
+    $input: UpdateRecyclingPartnerInput!
+  ) {
+    updateSkilavottordRecyclingPartner(input: $input) {
+      companyId
+      companyName
+      nationalId
+      email
+      address
+      postnumber
+      city
+      website
+      phone
+      active
+      municipalityId
+    }
+  }
+`
+
+export const SkilavottordRecyclingPartnersQuery = gql`
+  query 
+  (
+    $isMunicipalityPage: Boolean!
+    $municipalityId: String
+  ) {
+    skilavottordRecyclingPartners(
+      isMunicipalityPage: $isMunicipalityPage
+      municipalityId: $municipalityId
+    ) {
+      companyId
+      companyName
+      address
+      postnumber
+      email
+      active
+      municipalityId
+      isMunicipality
+    }
+  }
+`

--- a/apps/skilavottord/web/graphql/queries.ts
+++ b/apps/skilavottord/web/graphql/queries.ts
@@ -95,6 +95,27 @@ export const DeleteSkilavottordAccessControlMutation = gql`
   }
 `
 
+export const CreateSkilavottordRecyclingPartnerMutation = gql`
+  mutation createSkilavottordRecyclingPartnerMutation(
+    $input: CreateRecyclingPartnerInput!
+  ) {
+    createSkilavottordRecyclingPartner(input: $input) {
+      companyId
+      companyName
+      email
+      nationalId
+      address
+      postnumber
+      city
+      website
+      phone
+      active
+      isMunicipality
+      municipalityId
+    }
+  }
+`
+
 export const UpdateSkilavottordRecyclingPartnerMutation = gql`
   mutation updateSkilavottordRecyclingPartnerMutation(
     $input: UpdateRecyclingPartnerInput!
@@ -116,8 +137,7 @@ export const UpdateSkilavottordRecyclingPartnerMutation = gql`
 `
 
 export const SkilavottordRecyclingPartnersQuery = gql`
-  query 
-  (
+  query skilavottordRecyclingPartnersQuery(
     $isMunicipalityPage: Boolean!
     $municipalityId: String
   ) {

--- a/apps/skilavottord/web/screens/AccessControl/AccessControl.tsx
+++ b/apps/skilavottord/web/screens/AccessControl/AccessControl.tsx
@@ -47,9 +47,10 @@ import {
   SkilavottordAccessControlsQuery,
   SkilavottordAllRecyclingPartnersQuery,
   SkilavottordRecyclingPartnerQuery,
+  SkilavottordRecyclingPartnersQuery,
   UpdateSkilavottordAccessControlMutation,
-} from '@island.is/skilavottord-web/graphql/queries'
-import { SkilavottordRecyclingPartnersQuery } from '../RecyclingCompanies/RecyclingCompanies'
+} from '@island.is/skilavottord-web/graphql/'
+
 import * as styles from './AccessControl.css'
 
 const AccessControl: FC<React.PropsWithChildren<unknown>> = () => {

--- a/apps/skilavottord/web/screens/RecyclingCompanies/RecyclingCompanies.tsx
+++ b/apps/skilavottord/web/screens/RecyclingCompanies/RecyclingCompanies.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from '@apollo/client'
-import gql from 'graphql-tag'
 import NextLink from 'next/link'
 import { useRouter } from 'next/router'
 import React, { FC, useContext } from 'react'
@@ -29,27 +28,7 @@ import { filterInternalPartners } from '@island.is/skilavottord-web/utils'
 
 import NavigationLinks from '@island.is/skilavottord-web/components/NavigationLinks/NavigationLinks'
 import PageHeader from '@island.is/skilavottord-web/components/PageHeader/PageHeader'
-
-export const SkilavottordRecyclingPartnersQuery = gql`
-  query skilavottordRecyclingPartnersQuery(
-    $isMunicipalityPage: Boolean!
-    $municipalityId: String
-  ) {
-    skilavottordRecyclingPartners(
-      isMunicipalityPage: $isMunicipalityPage
-      municipalityId: $municipalityId
-    ) {
-      companyId
-      companyName
-      address
-      postnumber
-      email
-      active
-      municipalityId
-      isMunicipality
-    }
-  }
-`
+import { SkilavottordRecyclingPartnersQuery } from '@island.is/skilavottord-web/graphql/queries'
 
 const RecyclingCompanies: FC<React.PropsWithChildren<unknown>> = () => {
   const { Table, Head, Row, HeadData, Body, Data } = T
@@ -90,6 +69,7 @@ const RecyclingCompanies: FC<React.PropsWithChildren<unknown>> = () => {
         isMunicipalityPage: isMunicipalityPage,
         municipalityId: partnerId,
       },
+      fetchPolicy: 'cache-and-network',
     },
   )
 

--- a/apps/skilavottord/web/screens/RecyclingCompanies/RecyclingCompanyCreate/RecyclingCompanyCreate.tsx
+++ b/apps/skilavottord/web/screens/RecyclingCompanies/RecyclingCompanyCreate/RecyclingCompanyCreate.tsx
@@ -76,6 +76,7 @@ const RecyclingCompanyCreate: FC<React.PropsWithChildren<unknown>> = () => {
     control,
     handleSubmit,
     formState: { errors },
+    setValue,
   } = useForm({
     mode: 'onChange',
     defaultValues: isMunicipalityPage
@@ -173,6 +174,7 @@ const RecyclingCompanyCreate: FC<React.PropsWithChildren<unknown>> = () => {
           control={control}
           errors={errors}
           isMunicipalityPage={isMunicipalityPage}
+          setValue={setValue}
         />
       </Box>
     </PartnerPageLayout>

--- a/apps/skilavottord/web/screens/RecyclingCompanies/RecyclingCompanyCreate/RecyclingCompanyCreate.tsx
+++ b/apps/skilavottord/web/screens/RecyclingCompanies/RecyclingCompanyCreate/RecyclingCompanyCreate.tsx
@@ -3,12 +3,12 @@ import gql from 'graphql-tag'
 import NextLink from 'next/link'
 import { useRouter } from 'next/router'
 import React, { FC, useContext } from 'react'
-import { useForm } from 'react-hook-form'
+import { FormProvider, useForm } from 'react-hook-form'
 
 import { Box, Breadcrumbs, Stack, toast } from '@island.is/island-ui/core'
 import {
-  hasPermission,
   hasMunicipalityRole,
+  hasPermission,
 } from '@island.is/skilavottord-web/auth/utils'
 import { NotFound } from '@island.is/skilavottord-web/components'
 import { PartnerPageLayout } from '@island.is/skilavottord-web/components/Layouts'
@@ -19,7 +19,7 @@ import { useI18n } from '@island.is/skilavottord-web/i18n'
 import NavigationLinks from '@island.is/skilavottord-web/components/NavigationLinks/NavigationLinks'
 import PageHeader from '@island.is/skilavottord-web/components/PageHeader/PageHeader'
 import { RecyclingCompanyForm } from '../components'
-import { SkilavottordRecyclingPartnersQuery } from '../RecyclingCompanies'
+import { SkilavottordRecyclingPartnersQuery } from '@island.is/skilavottord-web/graphql'
 
 export const CreateSkilavottordRecyclingPartnerMutation = gql`
   mutation createSkilavottordRecyclingPartnerMutation(
@@ -42,6 +42,12 @@ export const CreateSkilavottordRecyclingPartnerMutation = gql`
   }
 `
 
+type FormData = {
+  municipalityId?: string | { value?: string }
+  isMunicipality?: boolean
+  active?: boolean
+}
+
 const RecyclingCompanyCreate: FC<React.PropsWithChildren<unknown>> = () => {
   const { user } = useContext(UserContext)
   const router = useRouter()
@@ -58,9 +64,9 @@ const RecyclingCompanyCreate: FC<React.PropsWithChildren<unknown>> = () => {
   const isMunicipalityPage = router.route === routes.municipalities.add
 
   // Show only recycling companies for the municipality
-  let partnerId = null
+  let partnerId = ''
   if (hasMunicipalityRole(user?.role)) {
-    partnerId = user?.partnerId
+    partnerId = user?.partnerId || ''
   }
 
   // If coming from municipality page
@@ -72,17 +78,21 @@ const RecyclingCompanyCreate: FC<React.PropsWithChildren<unknown>> = () => {
     route = routes.municipalities.baseRoute
   }
 
-  const {
-    control,
-    handleSubmit,
-    formState: { errors },
-    setValue,
-  } = useForm({
+  const methods = useForm<FormData>({
     mode: 'onChange',
     defaultValues: isMunicipalityPage
-      ? { isMunicipality: isMunicipalityPage }
-      : { isMunicipality: isMunicipalityPage, municipalityId: partnerId },
+      ? { isMunicipality: isMunicipalityPage, active: false }
+      : {
+          isMunicipality: isMunicipalityPage,
+          municipalityId: partnerId,
+          active: false,
+        },
   })
+
+  const {
+    handleSubmit,
+    formState: { errors },
+  } = methods
 
   const [createSkilavottordRecyclingPartner] = useMutation(
     CreateSkilavottordRecyclingPartnerMutation,
@@ -105,7 +115,7 @@ const RecyclingCompanyCreate: FC<React.PropsWithChildren<unknown>> = () => {
     return <NotFound />
   }
 
-  const handleCreateRecyclingPartner = handleSubmit(async (input) => {
+  const handleCreateRecyclingPartner = handleSubmit(async (input: FormData) => {
     if (typeof input.municipalityId !== 'string') {
       input.municipalityId = input.municipalityId?.value || ''
     }
@@ -168,14 +178,14 @@ const RecyclingCompanyCreate: FC<React.PropsWithChildren<unknown>> = () => {
         <PageHeader title={title} info={info} />
       </Stack>
       <Box marginTop={7}>
-        <RecyclingCompanyForm
-          onSubmit={handleCreateRecyclingPartner}
-          onCancel={handleCancel}
-          control={control}
-          errors={errors}
-          isMunicipalityPage={isMunicipalityPage}
-          setValue={setValue}
-        />
+        <FormProvider {...methods}>
+          <RecyclingCompanyForm
+            onSubmit={handleCreateRecyclingPartner}
+            onCancel={handleCancel}
+            errors={errors}
+            isMunicipalityPage={isMunicipalityPage}
+          />
+        </FormProvider>
       </Box>
     </PartnerPageLayout>
   )

--- a/apps/skilavottord/web/screens/RecyclingCompanies/RecyclingCompanyCreate/RecyclingCompanyCreate.tsx
+++ b/apps/skilavottord/web/screens/RecyclingCompanies/RecyclingCompanyCreate/RecyclingCompanyCreate.tsx
@@ -1,5 +1,4 @@
 import { useMutation } from '@apollo/client'
-import gql from 'graphql-tag'
 import NextLink from 'next/link'
 import { useRouter } from 'next/router'
 import React, { FC, useContext } from 'react'
@@ -18,29 +17,11 @@ import { useI18n } from '@island.is/skilavottord-web/i18n'
 
 import NavigationLinks from '@island.is/skilavottord-web/components/NavigationLinks/NavigationLinks'
 import PageHeader from '@island.is/skilavottord-web/components/PageHeader/PageHeader'
+import {
+  CreateSkilavottordRecyclingPartnerMutation,
+  SkilavottordRecyclingPartnersQuery,
+} from '@island.is/skilavottord-web/graphql'
 import { RecyclingCompanyForm } from '../components'
-import { SkilavottordRecyclingPartnersQuery } from '@island.is/skilavottord-web/graphql'
-
-export const CreateSkilavottordRecyclingPartnerMutation = gql`
-  mutation createSkilavottordRecyclingPartnerMutation(
-    $input: CreateRecyclingPartnerInput!
-  ) {
-    createSkilavottordRecyclingPartner(input: $input) {
-      companyId
-      companyName
-      email
-      nationalId
-      address
-      postnumber
-      city
-      website
-      phone
-      active
-      isMunicipality
-      municipalityId
-    }
-  }
-`
 
 type FormData = {
   municipalityId?: string | { value?: string }

--- a/apps/skilavottord/web/screens/RecyclingCompanies/RecyclingCompanyUpdate/RecyclingCompanyUpdate.tsx
+++ b/apps/skilavottord/web/screens/RecyclingCompanies/RecyclingCompanyUpdate/RecyclingCompanyUpdate.tsx
@@ -1,9 +1,8 @@
 import { useMutation, useQuery } from '@apollo/client'
-import gql from 'graphql-tag'
 import NextLink from 'next/link'
 import { useRouter } from 'next/router'
 import React, { FC, useContext, useEffect } from 'react'
-import { useForm } from 'react-hook-form'
+import { FormProvider, useForm } from 'react-hook-form'
 
 import {
   Box,
@@ -13,8 +12,8 @@ import {
   toast,
 } from '@island.is/island-ui/core'
 import {
-  hasPermission,
   hasMunicipalityRole,
+  hasPermission,
 } from '@island.is/skilavottord-web/auth/utils'
 import { NotFound } from '@island.is/skilavottord-web/components'
 import { PartnerPageLayout } from '@island.is/skilavottord-web/components/Layouts'
@@ -24,57 +23,26 @@ import { useI18n } from '@island.is/skilavottord-web/i18n'
 
 import NavigationLinks from '@island.is/skilavottord-web/components/NavigationLinks/NavigationLinks'
 import PageHeader from '@island.is/skilavottord-web/components/PageHeader/PageHeader'
+
 import { RecyclingCompanyForm } from '../components'
-import { SkilavottordRecyclingPartnersQuery } from '../RecyclingCompanies'
-
-const SkilavottordRecyclingPartnerQuery = gql`
-  query SkilavottordRecyclingPartnerQuery($input: RecyclingPartnerInput!) {
-    skilavottordRecyclingPartner(input: $input) {
-      companyId
-      companyName
-      nationalId
-      email
-      address
-      postnumber
-      city
-      website
-      phone
-      active
-      municipalityId
-    }
-  }
-`
-
-const UpdateSkilavottordRecyclingPartnerMutation = gql`
-  mutation updateSkilavottordRecyclingPartnerMutation(
-    $input: UpdateRecyclingPartnerInput!
-  ) {
-    updateSkilavottordRecyclingPartner(input: $input) {
-      companyId
-      companyName
-      nationalId
-      email
-      address
-      postnumber
-      city
-      website
-      phone
-      active
-      municipalityId
-    }
-  }
-`
+import {
+  SkilavottordRecyclingPartnersQuery,
+  SkilavottordRecyclingPartnerQuery,
+  UpdateSkilavottordRecyclingPartnerMutation,
+} from '@island.is/skilavottord-web/graphql'
 
 const RecyclingCompanyUpdate: FC<React.PropsWithChildren<unknown>> = () => {
-  const {
-    control,
-    reset,
-    handleSubmit,
-    setValue,
-    formState: { errors },
-  } = useForm({
+  const methods = useForm({
     mode: 'onChange',
   })
+
+  const {
+    setValue,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = methods
+
   const {
     t: { recyclingCompanies: t, municipalities: mt, routes },
   } = useI18n()
@@ -210,15 +178,15 @@ const RecyclingCompanyUpdate: FC<React.PropsWithChildren<unknown>> = () => {
         {loading ? (
           <SkeletonLoader width="100%" space={3} repeat={5} height={78} />
         ) : (
-          <RecyclingCompanyForm
-            onSubmit={handleUpdateRecyclingPartner}
-            onCancel={handleCancel}
-            control={control}
-            errors={errors}
-            editView
-            isMunicipalityPage={isMunicipalityPage}
-            setValue={setValue}
-          />
+          <FormProvider {...methods}>
+            <RecyclingCompanyForm
+              onSubmit={handleUpdateRecyclingPartner}
+              onCancel={handleCancel}
+              errors={errors}
+              editView
+              isMunicipalityPage={isMunicipalityPage}
+            />
+          </FormProvider>
         )}
       </Box>
     </PartnerPageLayout>

--- a/apps/skilavottord/web/screens/RecyclingCompanies/RecyclingCompanyUpdate/RecyclingCompanyUpdate.tsx
+++ b/apps/skilavottord/web/screens/RecyclingCompanies/RecyclingCompanyUpdate/RecyclingCompanyUpdate.tsx
@@ -217,6 +217,7 @@ const RecyclingCompanyUpdate: FC<React.PropsWithChildren<unknown>> = () => {
             errors={errors}
             editView
             isMunicipalityPage={isMunicipalityPage}
+            setValue={setValue}
           />
         )}
       </Box>

--- a/apps/skilavottord/web/screens/RecyclingCompanies/RecyclingCompanyUpdate/RecyclingCompanyUpdate.tsx
+++ b/apps/skilavottord/web/screens/RecyclingCompanies/RecyclingCompanyUpdate/RecyclingCompanyUpdate.tsx
@@ -29,7 +29,7 @@ import {
   SkilavottordRecyclingPartnersQuery,
   SkilavottordRecyclingPartnerQuery,
   UpdateSkilavottordRecyclingPartnerMutation,
-} from '@island.is/skilavottord-web/graphql'
+} from '@island.is/skilavottord-web/graphql/queries'
 
 const RecyclingCompanyUpdate: FC<React.PropsWithChildren<unknown>> = () => {
   const methods = useForm({

--- a/apps/skilavottord/web/screens/RecyclingCompanies/components/RecyclingCompanyForm/RecyclingCompanyForm.tsx
+++ b/apps/skilavottord/web/screens/RecyclingCompanies/components/RecyclingCompanyForm/RecyclingCompanyForm.tsx
@@ -125,7 +125,7 @@ const RecyclingCompanyForm: FC<
                 error={errors?.companyName?.message}
                 backgroundColor="blue"
                 onChange={(event) => {
-                  // User the the municipality should not be able to create his own companyId
+                  // User with the municipality role should not be able to create his own companyId
                   if (!editView && user?.role === Role.municipality) {
                     setValue(
                       'companyId',

--- a/apps/skilavottord/web/screens/RecyclingCompanies/components/RecyclingCompanyForm/RecyclingCompanyForm.tsx
+++ b/apps/skilavottord/web/screens/RecyclingCompanies/components/RecyclingCompanyForm/RecyclingCompanyForm.tsx
@@ -1,7 +1,7 @@
 import * as kennitala from 'kennitala'
 import React, { BaseSyntheticEvent, FC, useContext } from 'react'
-import { Control, Controller, FieldError } from 'react-hook-form'
-import { FieldValues, UseFormSetValue } from 'react-hook-form/dist/types'
+import { Controller, FieldError, useFormContext } from 'react-hook-form'
+import { FieldValues } from 'react-hook-form/dist/types'
 import { DeepMap } from 'react-hook-form/dist/types/utils'
 
 import { gql, useQuery } from '@apollo/client'
@@ -31,10 +31,8 @@ interface RecyclingCompanyForm {
   ) => Promise<void>
   onCancel: () => void
   errors: DeepMap<FieldValues, FieldError>
-  control: Control<FieldValues>
   editView?: boolean
   isMunicipalityPage?: boolean | undefined
-  setValue: UseFormSetValue<FieldValues>
 }
 
 export const SkilavottordAllMunicipalitiesQuery = gql`
@@ -51,13 +49,12 @@ const RecyclingCompanyForm: FC<
 > = ({
   onSubmit,
   onCancel,
-  control,
   errors,
   editView = false,
   isMunicipalityPage = false,
-  setValue,
 }) => {
   const { user } = useContext(UserContext)
+  const { setValue, control } = useFormContext()
 
   const {
     t: { recyclingCompanies: t },
@@ -162,7 +159,7 @@ const RecyclingCompanyForm: FC<
                     value: (value: number) => {
                       if (
                         value.toString().length === 10 &&
-                        !kennitala.isValid(value)
+                        !kennitala.isValid(value.toString())
                       ) {
                         return t.recyclingCompany.form.inputs.nationalId.rules
                           ?.validate

--- a/apps/skilavottord/web/utils/encodeUtils.test.ts
+++ b/apps/skilavottord/web/utils/encodeUtils.test.ts
@@ -1,0 +1,31 @@
+import { encode } from './encodeUtils'
+
+describe('encode', () => {
+  it('should normalize and remove diacritics from a string', () => {
+    expect(encode('áéíóúý')).toBe('aeiouy')
+  })
+
+  it('should replace Icelandic characters with their equivalents', () => {
+    expect(encode('ðþæÞÆ')).toBe('dthaethae')
+  })
+
+  it('should remove special characters', () => {
+    expect(encode('hello@world!')).toBe('helloworld')
+  })
+
+  it('should handle a mix of diacritics, Icelandic characters, and special characters', () => {
+    expect(encode('hëlló ðþæ!')).toBe('hellodthae')
+  })
+
+  it('should return an empty string for an input with only special characters', () => {
+    expect(encode('!@#$%^&*()')).toBe('')
+  })
+
+  it('should handle an empty string input', () => {
+    expect(encode('')).toBe('')
+  })
+
+  it('should handle strings with only alphanumeric characters', () => {
+    expect(encode('abc123')).toBe('abc123')
+  })
+})

--- a/apps/skilavottord/web/utils/encodeUtils.ts
+++ b/apps/skilavottord/web/utils/encodeUtils.ts
@@ -1,0 +1,17 @@
+export const encode = (input: string): string => {
+  // Normalize the string to decompose characters with diacritics
+  const normalized = input.normalize('NFD')
+
+  // Replace specific Icelandic characters not handled by diacritic removal
+  let replaced = normalized.replace(/[ðÐ]/g, 'd')
+  replaced = replaced.replace(/[þÞ]/g, 'th')
+  replaced = replaced.replace(/[æÆ]/g, 'ae')
+
+  // Remove diacritical marks
+  const noDiacritics = replaced.replace(/[\u0300-\u036f]/g, '')
+
+  // Remove special characters
+  const cleaned = noDiacritics.replace(/[^a-zA-Z0-9]/g, '')
+
+  return cleaned.toLocaleLowerCase()
+}

--- a/apps/skilavottord/web/utils/encodeUtils.ts
+++ b/apps/skilavottord/web/utils/encodeUtils.ts
@@ -8,7 +8,7 @@ export const encode = (input: string): string => {
   replaced = replaced.replace(/[æÆ]/g, 'ae')
 
   // Remove diacritical marks
-  const noDiacritics = replaced.replace(/[\u0300-\u036f]/g, '')
+  const noDiacritics = replaced.replace(/(?:[\u0300-\u036f])/g, '')
 
   // Remove special characters
   const cleaned = noDiacritics.replace(/[^a-zA-Z0-9]/g, '')

--- a/apps/skilavottord/web/utils/index.ts
+++ b/apps/skilavottord/web/utils/index.ts
@@ -1,5 +1,6 @@
 export { default as isBrowser } from './isBrowser'
 export * from './filterUtils'
 export * from './dateUtils'
+export * from './encodeUtils'
 export * from './roleUtils'
 export * from './accessUtils'


### PR DESCRIPTION
[TS-1010](https://dit-iceland.atlassian.net/browse/TS-1010)

## What

When a user with the role “municipality“ creates a new vehicle reception centre (Móttökustöð) we should disable the companyId field an auto populate the id. The companyId should be combined from the user’s partner id and the new name of the vehicle reception centre, formatted without special chars and Icelandic letters. 

## Why

Urvinnslusjodur has reserved certain numbers. If a user enters one of these reserved numbers as the companyId, it can cause issues for Urvinnslusjodur, preventing them from registering a new municipality or vehicle reception centre with that number.

## Screenshots / Gifs

<img width="786" alt="image" src="https://github.com/user-attachments/assets/8b4d02c0-4a91-47ac-9f0b-3fa5bb00d142" />

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the recycling company creation and update forms with improved type safety and form handling.
  - Introduced a new text normalization tool to ensure consistent processing of user inputs.
  - Added new GraphQL operations for creating and updating recycling partners, as well as querying for multiple partners based on municipality criteria.

- **Tests**
  - Added a comprehensive test suite to validate the robustness of the new text normalization functionality across various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->