### PR TITLE
chore(my-pages): remove vacc button

### DIFF
--- a/libs/portals/my-pages/health/src/screens/Vaccinations/VaccinationsWrapper.tsx
+++ b/libs/portals/my-pages/health/src/screens/Vaccinations/VaccinationsWrapper.tsx
@@ -55,13 +55,6 @@ export const VaccinationsWrapper = () => {
           variant="utility"
           text={formatMessage(m.readAboutVaccinations)}
         />,
-        <LinkButton
-          key="vaccinations-make-appointment"
-          to={formatMessage(m.makeVaccinationAppointmentLink)}
-          icon="open"
-          variant="utility"
-          text={formatMessage(m.makeVaccinationAppointment)}
-        />,
         <Button
           key="vaccinations-status-info"
           icon="informationCircle"


### PR DESCRIPTION
# My pages - Health - Vaccinations

## What

Remove "order vaccination" button as requested from Heilsugæslan

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the direct vaccination appointment option from the interface, modifying the navigation flow on the Vaccinations page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->