### PR TITLE
fix(crc): remove throw for empty postal code

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/children-residence-change-v2/children-residence-change.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/children-residence-change-v2/children-residence-change.service.ts
@@ -126,10 +126,6 @@ export class ChildrenResidenceChangeServiceV2 extends BaseTemplateApiService {
           : durationType,
     }
 
-    if (!childResidenceInfo.future?.address?.postalCode) {
-      throw new Error('Future residence postal code was not found')
-    }
-
     // Validate phone numbers of parents before sending to syslumenn
     if (!isValidNumberForRegion(parentA.phoneNumber ?? '', 'IS')) {
       throw new Error('Parent A phone number is not valid')
@@ -140,7 +136,7 @@ export class ChildrenResidenceChangeServiceV2 extends BaseTemplateApiService {
     }
 
     const syslumennData = syslumennDataFromPostalCode(
-      childResidenceInfo.future.address.postalCode,
+      childResidenceInfo.future?.address?.postalCode ?? '101',
     )
 
     const uploadDataName = 'Samningur Forsjá Og Meðlag'


### PR DESCRIPTION

## What

 remove throw for empty postal code

## Why

User with no postalcode due to living abroad gets stuck in the process.


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling for missing postal codes during address updates by providing a default value, ensuring the process continues smoothly without interruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->