### PR TITLE
feat(web): Supreme court verdict text search

### DIFF
--- a/libs/clients/verdicts/project.json
+++ b/libs/clients/verdicts/project.json
@@ -33,7 +33,7 @@
       "options": {
         "commands": [
           "yarn openapi-generator -o libs/clients/verdicts/gen/fetch/gopro -i libs/clients/verdicts/src/goproClientConfig.json --skip-validate-spec",
-          "yarn openapi-generator -o libs/clients/verdicts/gen/fetch/supreme-court -i libs/clients/verdicts/src/supremeCourtClientConfig.yaml --skip-validate-spec"
+          "yarn openapi-generator -o libs/clients/verdicts/gen/fetch/supreme-court -i libs/clients/verdicts/src/supremeCourtClientConfig.yaml"
         ]
       },
       "outputs": [

--- a/libs/clients/verdicts/src/lib/verdicts-client.service.ts
+++ b/libs/clients/verdicts/src/lib/verdicts-client.service.ts
@@ -47,11 +47,14 @@ export class VerdictsClientService {
             },
           })
         : { status: 'rejected', items: [], total: 0 },
-      !input.searchTerm && (!input.courtLevel || onlyFetchSupremeCourtVerdicts)
-        ? this.supremeCourtApi.apiV2VerdictGetVerdictsGet({
-            page: input.pageNumber,
-            limit: ITEMS_PER_PAGE,
-            orderBy: 'publishDate DESC',
+      !input.courtLevel || onlyFetchSupremeCourtVerdicts
+        ? this.supremeCourtApi.apiV2VerdictGetVerdictsPost({
+            verdictSearchRequest: {
+              page: input.pageNumber,
+              limit: ITEMS_PER_PAGE,
+              orderBy: 'publishDate DESC',
+              searchTerm: input.searchTerm,
+            },
           })
         : { status: 'rejected', items: [], total: 0 },
     ])

--- a/libs/clients/verdicts/src/supremeCourtClientConfig.yaml
+++ b/libs/clients/verdicts/src/supremeCourtClientConfig.yaml
@@ -92,6 +92,53 @@ components:
         label:
           type: string
 
+    VerdictSearchRequest:
+      type: object
+      properties:
+        searchTerm:
+          type: string
+          description: Text to search for in verdict content
+        orderBy:
+          type: string
+          description: Field to order results by, with optional direction (e.g., 'caseNumber DESC')
+        caseTypes:
+          type: array
+          items:
+            type: string
+          description: Filter by case types
+        keywords:
+          type: array
+          items:
+            type: string
+          description: Filter by keywords
+        laws:
+          type: array
+          items:
+            type: string
+          description: Filter by law citations
+        title:
+          type: string
+          description: Filter by title
+        caseNumber:
+          type: string
+          description: Filter by case number
+        dateFrom:
+          type: string
+          format: date
+          description: Filter for verdicts on or after this date (format YYYY-MM-DD)
+        dateTo:
+          type: string
+          format: date
+          description: Filter for verdicts on or before this date (format YYYY-MM-DD)
+        page:
+          type: integer
+          default: 1
+          description: Page number for pagination
+        limit:
+          type: integer
+          default: 100
+          description: Results per page
+
   responses:
     InputError:
       description: Input error
@@ -186,22 +233,15 @@ paths:
           $ref: '#/components/responses/InternalError'
 
   /api/v2/Verdict/getVerdicts:
-    get:
-      summary: Get all verdicts
-      parameters:
-        - name: orderBy
-          in: query
-          schema:
-            type: string
-          description: "Field and order (e.g., 'publishDate ASC')"
-        - name: page
-          in: query
-          schema:
-            type: integer
-        - name: limit
-          in: query
-          schema:
-            type: integer
+    post:
+      summary: Search and retrieve verdicts with filters
+      description: Retrieve verdicts with optional filters including text search, dates, case types, and more
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VerdictSearchRequest'
       responses:
         '200':
           description: Successful response
@@ -215,7 +255,7 @@ paths:
                     items:
                       $ref: '#/components/schemas/DetailedVerdictData'
                   total:
-                    type: integer
+                    type: string
                   currentPage:
                     type: integer
                   itemsPerPage:
@@ -226,8 +266,6 @@ paths:
                     type: integer
                   message:
                     type: string
-        '500':
-          $ref: '#/components/responses/InternalError'
 
   /api/v2/Verdict/getAgenda/{id}:
     get:


### PR DESCRIPTION
# Supreme court verdict text search

We now have an endpoint from the supreme court that allows us to filter verdicts via text search

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The Supreme Court verdict search now offers enhanced filtering and sorting options with improved pagination. Users can refine their search criteria more effectively, leading to more accurate and tailored results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->