### PR TITLE
fix(web): Remove border from parental leave calculator result card

### DIFF
--- a/apps/web/components/connected/ParentalLeaveCalculator/ParentalLeaveCalculator.css.ts
+++ b/apps/web/components/connected/ParentalLeaveCalculator/ParentalLeaveCalculator.css.ts
@@ -1,7 +1,0 @@
-import { style } from '@vanilla-extract/css'
-
-import { theme } from '@island.is/island-ui/theme'
-
-export const resultBorder = style({
-  border: `1px dashed ${theme.color.blue300}`,
-})

--- a/apps/web/components/connected/ParentalLeaveCalculator/ParentalLeaveCalculator.tsx
+++ b/apps/web/components/connected/ParentalLeaveCalculator/ParentalLeaveCalculator.tsx
@@ -32,7 +32,6 @@ import { formatCurrency as formatCurrencyUtil } from '@island.is/web/utils/curre
 import { MarkdownText } from '../../Organization'
 import { translations as t } from './translations.strings'
 import { Calculator, Status, Union, WorkPercentage } from './utils'
-import * as styles from './ParentalLeaveCalculator.css'
 
 interface FieldProps {
   heading: string
@@ -731,37 +730,35 @@ const ResultsScreen = ({ slice, changeScreen }: ScreenProps) => {
     <Stack space={5}>
       <Stack space={3}>
         <Box background="blue100" paddingY={3} paddingX={4}>
-          <Box className={styles.resultBorder} paddingY={2} paddingX={3}>
-            <Stack space={2}>
-              <Text variant="h3">
-                {status === Status.PARENTAL_LEAVE
-                  ? formatMessage(
-                      mainSectionKeys[status][
-                        parentalLeavePeriod ?? ParentalLeavePeriod.MONTH
-                      ].heading,
-                    )
-                  : formatMessage(mainSectionKeys[status].heading)}
-              </Text>
-              <Text>
-                {status === Status.PARENTAL_LEAVE
-                  ? formatMessage(
-                      mainSectionKeys[status][
-                        parentalLeavePeriod ?? ParentalLeavePeriod.MONTH
-                      ].description,
-                      {
-                        ratio,
-                      },
-                    )
-                  : formatMessage(mainSectionKeys[status].description, {
+          <Stack space={2}>
+            <Text variant="h3">
+              {status === Status.PARENTAL_LEAVE
+                ? formatMessage(
+                    mainSectionKeys[status][
+                      parentalLeavePeriod ?? ParentalLeavePeriod.MONTH
+                    ].heading,
+                  )
+                : formatMessage(mainSectionKeys[status].heading)}
+            </Text>
+            <Text>
+              {status === Status.PARENTAL_LEAVE
+                ? formatMessage(
+                    mainSectionKeys[status][
+                      parentalLeavePeriod ?? ParentalLeavePeriod.MONTH
+                    ].description,
+                    {
                       ratio,
-                    })}
-              </Text>
-              <Text fontWeight="semiBold" variant="h3">
-                {formatCurrency(results.mainResultAfterDeduction)}
-              </Text>
-              <Text>{formatMessage(t.results.mainDisclaimer)}</Text>
-            </Stack>
-          </Box>
+                    },
+                  )
+                : formatMessage(mainSectionKeys[status].description, {
+                    ratio,
+                  })}
+            </Text>
+            <Text fontWeight="semiBold" variant="h3">
+              {formatCurrency(results.mainResultAfterDeduction)}
+            </Text>
+            <Text>{formatMessage(t.results.mainDisclaimer)}</Text>
+          </Stack>
         </Box>
 
         <Button onClick={changeScreen} variant="text" preTextIcon="arrowBack">


### PR DESCRIPTION
# Remove border from parental leave calculator result card

## Screenshots / Gifs

### Before

![Screenshot 2025-03-31 at 10 36 21](https://github.com/user-attachments/assets/fdf409a5-ddbd-41c7-8aaa-ad13114126ee)

### After

![Screenshot 2025-03-31 at 10 36 32](https://github.com/user-attachments/assets/e54c74b1-f90f-46cd-9515-23cd4d4e9e53)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
