### PR TITLE
chore(core): Remove path from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -225,7 +225,6 @@ codemagic.yaml                                                                  
 /libs/application/templates/accident-notification/                                                        @island-is/norda
 /libs/application/templates/complaints-to-althingi-ombudsman/                                             @island-is/norda
 /libs/application/templates/data-protection-complaint/                                                    @island-is/norda
-/libs/application/templates/example-payment/                                                              @island-is/norda
 /libs/application/templates/family-matters/children-residence-change-v2                                   @island-is/norda
 /libs/application/templates/financial-aid/                                                                @island-is/norda
 /libs/application/templates/financial-statements-inao/                                                    @island-is/norda


### PR DESCRIPTION
`/libs/application/templates/example-payment/` does not exist anymore and has been moved into `/libs/application/templates/examples/` (see #18307)

Removing from codeowners to [fix](https://github.com/island-is/island.is/actions/runs/14172638150/job/39699772827):

```
"/libs/application/templates/example-payment/" does not match any files in repository
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal configuration for managing review responsibilities to streamline maintenance processes. This change does not affect the visible functionality for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->