### PR TITLE
fix(web): Fix max width on content in sidebar layout

### DIFF
--- a/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
+++ b/apps/web/components/Organization/Wrapper/OrganizationWrapper.tsx
@@ -45,7 +45,10 @@ import {
   Webreader,
 } from '@island.is/web/components'
 import { DefaultHeader, WatsonChatPanel } from '@island.is/web/components'
-import { SLICE_SPACING, STICKY_NAV_MAX_WIDTH } from '@island.is/web/constants'
+import {
+  SLICE_SPACING,
+  STICKY_NAV_MAX_WIDTH_LG,
+} from '@island.is/web/constants'
 import { GlobalContext } from '@island.is/web/context'
 import {
   Image,
@@ -1132,7 +1135,7 @@ export const OrganizationWrapper: React.FC<
                           card.image?.url ||
                           'https://images.ctfassets.net/8k0h54kbe6bj/6jpT5mePCNk02nVrzVLzt2/6adca7c10cc927d25597452d59c2a873/bitmap.png'
 
-                        imageUrl += `?w=${STICKY_NAV_MAX_WIDTH}`
+                        imageUrl += `?w=${STICKY_NAV_MAX_WIDTH_LG}`
 
                         return (
                           <ProfileCard

--- a/apps/web/constants/index.ts
+++ b/apps/web/constants/index.ts
@@ -1,7 +1,8 @@
 import type { ResponsiveSpace } from '@island.is/island-ui/core'
 
 export const STICKY_NAV_HEIGHT = 64
-export const STICKY_NAV_MAX_WIDTH = 318
+export const STICKY_NAV_MAX_WIDTH_DEFAULT = 230
+export const STICKY_NAV_MAX_WIDTH_LG = 318
 export const SLICE_SPACING: ResponsiveSpace = 7
 export const PROJECT_STORIES_TAG_ID = '9yqOTwQYzgyej5kItFTtd'
 export const FRONTPAGE_NEWS_TAG_SLUG = 'forsidufrettir'

--- a/apps/web/screens/Layouts/SidebarLayout.css.ts
+++ b/apps/web/screens/Layouts/SidebarLayout.css.ts
@@ -3,19 +3,31 @@ import { style } from '@vanilla-extract/css'
 import { theme, themeUtils } from '@island.is/island-ui/theme'
 import {
   STICKY_NAV_HEIGHT,
-  STICKY_NAV_MAX_WIDTH,
+  STICKY_NAV_MAX_WIDTH_LG,
+  STICKY_NAV_MAX_WIDTH_DEFAULT,
 } from '@island.is/web/constants'
 
 const top = STICKY_NAV_HEIGHT + theme.spacing[1]
 
 export const sidebarWrapper = style({
   top,
-  maxWidth: '230px',
-  minWidth: '230px',
+  maxWidth: `${STICKY_NAV_MAX_WIDTH_DEFAULT}px`,
+  minWidth: `${STICKY_NAV_MAX_WIDTH_DEFAULT}px`,
   ...themeUtils.responsiveStyle({
     lg: {
-      minWidth: `${STICKY_NAV_MAX_WIDTH}px`,
-      maxWidth: `${STICKY_NAV_MAX_WIDTH}px`,
+      minWidth: `${STICKY_NAV_MAX_WIDTH_LG}px`,
+      maxWidth: `${STICKY_NAV_MAX_WIDTH_LG}px`,
+    },
+  }),
+})
+
+export const contentWrapper = style({
+  ...themeUtils.responsiveStyle({
+    md: {
+      maxWidth: `calc(100% - ${STICKY_NAV_MAX_WIDTH_DEFAULT}px)`,
+    },
+    lg: {
+      maxWidth: `calc(100% - ${STICKY_NAV_MAX_WIDTH_LG}px)`,
     },
   }),
 })

--- a/apps/web/screens/Layouts/SidebarLayout.tsx
+++ b/apps/web/screens/Layouts/SidebarLayout.tsx
@@ -56,7 +56,7 @@ export const SidebarLayout: FC<React.PropsWithChildren<SidebarLayoutProps>> = ({
           >
             {sidebarContent}
           </Box>
-          <GridContainer>
+          <GridContainer className={styles.contentWrapper}>
             <GridRow>
               <GridColumn
                 offset={fullWidthContent ? '0' : ['0', '0', '0', '0', '1/9']}


### PR DESCRIPTION
# Fix max width on content in sidebar layout

Add max-width based on the size of sidebar in desktop and tablet when using sidebar layout. 

## Screenshots / Gifs

### Before
![image](https://github.com/user-attachments/assets/cf880039-e822-470f-803b-1598831c58fb)

![image](https://github.com/user-attachments/assets/1953ca7b-1bd6-4b37-8715-d9b45edd2a9d)

### After
![image](https://github.com/user-attachments/assets/8b3a9144-ded2-4b10-8570-ac32d8188e17)

![image](https://github.com/user-attachments/assets/a3588a7c-fa6a-4ee6-971b-928a612ae477)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced image rendering with improved display dimensions.
	- Upgraded sidebar and content layout for more responsive and dynamic viewing across devices.
- **Refactor**
	- Updated navigation width settings to streamline layout styling and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->