### PR TITLE
fix(web): Keep parent subpage primitive fields when pruning organization subpage entry hyperlink fields

### DIFF
--- a/libs/cms/src/lib/search/importers/utils.ts
+++ b/libs/cms/src/lib/search/importers/utils.ts
@@ -162,6 +162,14 @@ export const pruneEntryHyperlink = (node: any) => {
           ...target.fields.organizationPage,
           fields: extractPrimitiveFields(target.fields.organizationPage.fields),
         },
+        organizationParentSubpage: target.fields.organizationParentSubpage
+          ? {
+              ...target.fields.organizationParentSubpage,
+              fields: extractPrimitiveFields(
+                target.fields.organizationParentSubpage.fields,
+              ),
+            }
+          : null,
       },
     }
   } else if (contentTypeId === 'price' && target.fields?.organization?.fields) {


### PR DESCRIPTION
# Keep parent subpage primitive fields when pruning organization subpage entry hyperlink fields

So that entry hyperlinks for subpages that belong to a parent subpage are correctly populated

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved the handling of organization-related content by conditionally including additional parent subpage details, resulting in a more comprehensive representation of organizational data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->