### PR TITLE
fix(web): Keep parent subpage primitive fields when pruning organization subpage entry hyperlink fields

### DIFF
--- a/libs/cms/src/lib/search/importers/utils.ts
+++ b/libs/cms/src/lib/search/importers/utils.ts
@@ -162,6 +162,14 @@ export const pruneEntryHyperlink = (node: any) => {
           ...target.fields.organizationPage,
           fields: extractPrimitiveFields(target.fields.organizationPage.fields),
         },
+        organizationParentSubpage: target.fields.organizationParentSubpage
+          ? {
+              ...target.fields.organizationParentSubpage,
+              fields: extractPrimitiveFields(
+                target.fields.organizationParentSubpage.fields,
+              ),
+            }
+          : null,
       },
     }
   } else if (contentTypeId === 'price' && target.fields?.organization?.fields) {


### PR DESCRIPTION
# Keep parent subpage primitive fields when pruning organization subpage entry hyperlink fields

Cherry picked from #18621
