### PR TITLE
fix(web): Organization subpage url in suggested search

### DIFF
--- a/apps/web/components/SearchInput/SearchInput.tsx
+++ b/apps/web/components/SearchInput/SearchInput.tsx
@@ -470,10 +470,7 @@ const Results = ({
                 let variables = item.slug?.split('/')
 
                 if (typename === 'organizationsubpage') {
-                  variables = [
-                    (item as OrganizationSubpage)?.organizationPage?.slug,
-                    item.slug,
-                  ]
+                  variables = (item as OrganizationSubpage).url
                 }
 
                 const { onClick, ...itemProps } = getItemProps({
@@ -482,6 +479,9 @@ const Results = ({
                     string: linkResolver(
                       typename === 'anchorpage'
                         ? extractAnchorPageLinkType(item as AnchorPage)
+                        : typename === 'organizationsubpage' &&
+                          (item as OrganizationSubpage)?.url?.length === 3
+                        ? 'organizationparentsubpagechild'
                         : typename,
                       variables,
                     )?.href,

--- a/apps/web/screens/queries/Search.tsx
+++ b/apps/web/screens/queries/Search.tsx
@@ -47,6 +47,7 @@ export const GET_SEARCH_RESULTS_QUERY = gql`
           id
           title
           slug
+          url
           organizationPage {
             slug
           }


### PR DESCRIPTION
# Organization subpage url in suggested search

Url in suggested search can be wrong in those cases when the url is of depth 3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced search navigation for organization-related pages with refined link resolution for improved user experience.
  - Updated search functionality now retrieves additional URL information for organization subpages, enabling smoother and more accurate navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->