### PR TITLE
fix(web): Fallback to empty string if on mobile for LoginButton

### DIFF
--- a/apps/web/components/Header/LoginButton.tsx
+++ b/apps/web/components/Header/LoginButton.tsx
@@ -124,7 +124,7 @@ function LoginButtonDropdown(props: Props) {
           icon="person"
           title={isMobile ? t.login : undefined}
         >
-          {!isMobile && t.login}
+          {!isMobile ? t.login : ''}
         </Button>
       }
       openOnHover={!isMobile}


### PR DESCRIPTION
# Fallback to empty string if on mobile for LoginButton

To fix a hydration error

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the login button’s rendering logic for a more consistent interface. The button now explicitly displays an empty label on mobile devices while showing the login text on larger screens, ensuring a predictable appearance across all devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->