### PR TITLE
fix(web): Hotfix - Wrap div around header and footer so they don't shrink #18632

### DIFF
--- a/apps/web/screens/Article/Article.tsx
+++ b/apps/web/screens/Article/Article.tsx
@@ -851,9 +851,11 @@ const ArticleScreen: Screen<ArticleProps> = ({
         // @ts-expect-error make web strict
         pushUp={isVisible && processEntry?.processLink && mounted}
       />
-      <OrganizationFooter
-        organizations={article?.organization as Organization[]}
-      />
+      <div>
+        <OrganizationFooter
+          organizations={article?.organization as Organization[]}
+        />
+      </div>
     </>
   )
 }

--- a/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculatorWrapper.tsx
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculatorWrapper.tsx
@@ -36,9 +36,13 @@ export const PensionCalculatorWrapper = ({
           <meta name="robots" content="noindex, nofollow" />
         )}
       </HeadWithSocialSharing>
-      <OrganizationHeader organizationPage={organizationPage} />
+      <div>
+        <OrganizationHeader organizationPage={organizationPage} />
+      </div>
       {children}
-      <OrganizationFooter organizations={[organization]} />
+      <div>
+        <OrganizationFooter organizations={[organization]} />
+      </div>
     </>
   )
 }


### PR DESCRIPTION
# Wrap div around header and footer so they don't shrink #18632
