### PR TITLE
feat(web): Blood donation restriction list - Display keywords

### DIFF
--- a/apps/web/screens/Organization/Bloodbank/BloodDonationRestrictionDetails.tsx
+++ b/apps/web/screens/Organization/Bloodbank/BloodDonationRestrictionDetails.tsx
@@ -83,7 +83,7 @@ const BloodDonationRestrictionDetails: CustomScreen<
         <meta name="robots" content="noindex, nofollow" />
       </HeadWithSocialSharing>
       <Box className="rs_read">
-        <Stack space={4}>
+        <Stack space={5}>
           <Stack space={2}>
             <Text variant="h1" as="h1">
               {item.title}
@@ -112,6 +112,12 @@ const BloodDonationRestrictionDetails: CustomScreen<
               </Text>
               <Text as="div">{webRichText(item.detailedText)}</Text>
             </Stack>
+          )}
+          {Boolean(item.keywordsText) && (
+            <Text variant="small">
+              {formatMessage(m.listPage.keywordsTextPrefix)}
+              {item.keywordsText}
+            </Text>
           )}
         </Stack>
       </Box>

--- a/apps/web/screens/Organization/Bloodbank/BloodDonationRestrictionList.tsx
+++ b/apps/web/screens/Organization/Bloodbank/BloodDonationRestrictionList.tsx
@@ -141,9 +141,12 @@ const BloodDonationRestrictionList: CustomScreen<
                     </Box>
                   )}
                   {Boolean(item.description) && (
-                    <Text variant="medium">
-                      {formatMessage(m.listPage.cardDescriptionPrefix)}
-                      {item.description}
+                    <Text variant="medium">{item.description}</Text>
+                  )}
+                  {Boolean(item.keywordsText) && (
+                    <Text variant="small">
+                      {formatMessage(m.listPage.keywordsTextPrefix)}
+                      {item.keywordsText}
                     </Text>
                   )}
                 </FocusableBox>

--- a/apps/web/screens/Organization/Bloodbank/messages.strings.ts
+++ b/apps/web/screens/Organization/Bloodbank/messages.strings.ts
@@ -17,10 +17,10 @@ export const m = {
       defaultMessage: 'Hvenær má gefa blóð',
       description: 'Texti fyrir aðal heading á yfirlitssíðu',
     },
-    cardDescriptionPrefix: {
-      id: 'web.bloodbank.bloodDonationRestrictions:listPage.cardDescriptionPrefix',
-      defaultMessage: 'Lýsing: ',
-      description: 'Texti á undan lýsingu í spjaldi',
+    keywordsTextPrefix: {
+      id: 'web.bloodbank.bloodDonationRestrictions:listPage.keywordsTextPrefix',
+      defaultMessage: 'Lykilorð: ',
+      description: 'Texti á undan lykilorðum í spjaldi',
     },
   }),
   detailsPage: defineMessages({

--- a/apps/web/screens/queries/BloodDonationRestrictions.ts
+++ b/apps/web/screens/queries/BloodDonationRestrictions.ts
@@ -17,6 +17,7 @@ export const GET_BLOOD_DONATION_RESTRICTIONS_QUERY = gql`
         }
         description
         hasDetailedText
+        keywordsText
       }
     }
   }
@@ -39,6 +40,7 @@ export const GET_BLOOD_DONATION_RESTRICTION_DETAILS_QUERY = gql`
       detailedText {
         ...HtmlFields
       }
+      keywordsText
     }
   }
   ${htmlFields}

--- a/libs/cms/src/lib/models/bloodDonationRestriction.model.ts
+++ b/libs/cms/src/lib/models/bloodDonationRestriction.model.ts
@@ -24,6 +24,9 @@ export class BloodDonationRestrictionListItem {
 
   @Field(() => Boolean)
   hasDetailedText!: boolean
+
+  @Field(() => String)
+  keywordsText!: string
 }
 
 @ObjectType()
@@ -44,17 +47,18 @@ export const mapBloodDonationRestrictionListItem = ({
 }: IBloodDonationRestriction): BloodDonationRestrictionListItem => {
   return {
     id: sys.id,
-    title: fields.title ?? '',
+    title: (fields.title ?? '').trim(),
     hasCardText: fields.cardText
       ? documentToPlainTextString(fields.cardText).trim().length > 0
       : false,
     cardText: fields.cardText
       ? mapDocument(fields.cardText, sys.id + ':cardText')
       : [],
-    description: fields.description ?? '',
+    description: (fields.description ?? '').trim(),
     hasDetailedText: fields.detailedText
       ? documentToPlainTextString(fields.detailedText).trim().length > 0
       : false,
+    keywordsText: (fields.keywords ?? '').trim(),
   }
 }
 
@@ -80,6 +84,9 @@ export class BloodDonationRestrictionDetails {
 
   @Field(() => Boolean)
   hasDetailedText!: boolean
+
+  @Field(() => String)
+  keywordsText!: string
 }
 
 export const mapBloodDonationRestrictionDetails = ({
@@ -88,19 +95,20 @@ export const mapBloodDonationRestrictionDetails = ({
 }: IBloodDonationRestriction): BloodDonationRestrictionDetails => {
   return {
     id: sys.id,
-    title: fields.title ?? '',
+    title: (fields.title ?? '').trim(),
     hasCardText: fields.cardText
       ? documentToPlainTextString(fields.cardText).trim().length > 0
       : false,
     cardText: fields.cardText
       ? mapDocument(fields.cardText, sys.id + ':cardText')
       : [],
-    description: fields.description ?? '',
+    description: (fields.description ?? '').trim(),
     hasDetailedText: fields.detailedText
       ? documentToPlainTextString(fields.detailedText).trim().length > 0
       : false,
     detailedText: fields.detailedText
       ? mapDocument(fields.detailedText, sys.id + ':detailedText')
       : [],
+    keywordsText: (fields.keywords ?? '').trim(),
   }
 }


### PR DESCRIPTION
# Blood donation restriction list - Display keywords

We now show to keywords on the cards as well as on the details pages

<img width="530" alt="Screenshot 2025-04-04 at 19 53 10" src="https://github.com/user-attachments/assets/e5fa188d-927d-40ca-b07d-660a82df1b77" />

<img width="859" alt="Screenshot 2025-04-04 at 19 53 35" src="https://github.com/user-attachments/assets/d23dc2d4-f19a-482c-a938-171fff2b3503" />


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
