### PR TITLE
feat(web): Pension Calculator - Change text to markdown

### DIFF
--- a/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculator.tsx
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculator.tsx
@@ -745,9 +745,9 @@ const PensionCalculator: CustomScreen<PensionCalculatorProps> = ({
 
                             {startYearOptions?.length > 0 && (
                               <Box className={styles.textMaxWidth}>
-                                <Text>
+                                <MarkdownText>
                                   {formatMessage(
-                                    translationStrings.startMonthAndYearDescription,
+                                    translationStrings.startMonthAndYearDescriptionMarkdown,
                                     {
                                       month:
                                         activeLocale !== 'en'
@@ -758,7 +758,7 @@ const PensionCalculator: CustomScreen<PensionCalculatorProps> = ({
                                       year: startYearOptions?.[2]?.label,
                                     },
                                   )}
-                                </Text>
+                                </MarkdownText>
                               </Box>
                             )}
 

--- a/apps/web/screens/Organization/SocialInsuranceAdministration/translationStrings.ts
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/translationStrings.ts
@@ -614,7 +614,7 @@ export const translationStrings = defineMessages({
     description: 'Lýsing fyrir ofan fæðingarmánuð og ár reiti',
   },
   startMonthAndYearDescription: {
-    id: 'web.pensionCalculator:startMonthAndYearDescription#markdown',
+    id: 'web.pensionCalculator:startMonthAndYearDescription',
     defaultMessage:
       'Þú getur byrjað töku ellilífeyris frá {month} {year}. Þú getur flýtt um 2 ár eða frestað töku ellilífeyris.',
     description:

--- a/apps/web/screens/Organization/SocialInsuranceAdministration/translationStrings.ts
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/translationStrings.ts
@@ -614,7 +614,14 @@ export const translationStrings = defineMessages({
     description: 'Lýsing fyrir ofan fæðingarmánuð og ár reiti',
   },
   startMonthAndYearDescription: {
-    id: 'web.pensionCalculator:startMonthAndYearDescription',
+    id: 'web.pensionCalculator:startMonthAndYearDescription#markdown',
+    defaultMessage:
+      'Þú getur byrjað töku ellilífeyris frá {month} {year}. Þú getur flýtt um 2 ár eða frestað töku ellilífeyris.',
+    description:
+      'Lýsing fyrir ofan mánuð og ár reit varðandi hvenær notandi vill hefja töku á ellilífeyri',
+  },
+  startMonthAndYearDescriptionMarkdown: {
+    id: 'web.pensionCalculator:startMonthAndYearDescriptionMarkdown#markdown',
     defaultMessage:
       'Þú getur byrjað töku ellilífeyris frá {month} {year}. Þú getur flýtt um 2 ár eða frestað töku ellilífeyris.',
     description:


### PR DESCRIPTION
# Pension Calculator - Change text to markdown

Add new markdown field that'll replace a text field.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the pension calculator display by enabling Markdown formatting for the description text.
	- Introduced updated content that now renders more richly styled information regarding pension start details.
	- Added a new translation entry for the Markdown description of pension start options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->