### PR TITLE
fix(native-app): filter out empty states in licenses module on home screen

### DIFF
--- a/apps/native/app/src/screens/home/licenses-module.tsx
+++ b/apps/native/app/src/screens/home/licenses-module.tsx
@@ -55,7 +55,7 @@ const validateLicensesInitialData = ({
   return false
 }
 
-const isLicenseEmptyState = (license: GenericUserLicense) => {
+const isLicenseEmptyStateOrChildLicense = (license: GenericUserLicense) => {
   const isPassportOrIdentityDocument =
     license.license.type === GenericLicenseType.Passport ||
     license.license.type === GenericLicenseType.IdentityDocument
@@ -67,7 +67,7 @@ const isLicenseEmptyState = (license: GenericUserLicense) => {
     !license?.payload?.metadata?.licenseNumber &&
     !license?.payload?.data?.length
 
-  return !!noLicense
+  return !!(noLicense || license?.isOwnerChildOfUser)
 }
 
 const LicensesModule = React.memo(
@@ -88,7 +88,7 @@ const LicensesModule = React.memo(
 
     const items = allLicenses
       .filter((license) => license.__typename === 'GenericUserLicense')
-      ?.filter((license) => !isLicenseEmptyState(license))
+      ?.filter((license) => !isLicenseEmptyStateOrChildLicense(license))
       ?.slice(0, 3)
       .map((item, index) => (
         <WalletItem

--- a/apps/native/app/src/screens/home/licenses-module.tsx
+++ b/apps/native/app/src/screens/home/licenses-module.tsx
@@ -15,6 +15,7 @@ import {
 import { navigateTo } from '../../lib/deep-linking'
 import {
   GenericLicenseType,
+  GenericUserLicense,
   ListLicensesQuery,
   useListLicensesQuery,
 } from '../../graphql/types/schema'
@@ -54,6 +55,21 @@ const validateLicensesInitialData = ({
   return false
 }
 
+const isLicenseEmptyState = (license: GenericUserLicense) => {
+  const isPassportOrIdentityDocument =
+    license.license.type === GenericLicenseType.Passport ||
+    license.license.type === GenericLicenseType.IdentityDocument
+
+  // We receive an "empty" license item if the user has no passport or identity document
+  // We don't want to show them on the home screen
+  const noLicense =
+    isPassportOrIdentityDocument &&
+    !license?.payload?.metadata?.licenseNumber &&
+    !license?.payload?.data?.length
+
+  return !!noLicense
+}
+
 const LicensesModule = React.memo(
   ({ data, loading, error }: LicenseModuleProps) => {
     const theme = useTheme()
@@ -72,6 +88,7 @@ const LicensesModule = React.memo(
 
     const items = allLicenses
       .filter((license) => license.__typename === 'GenericUserLicense')
+      ?.filter((license) => !isLicenseEmptyState(license))
       ?.slice(0, 3)
       .map((item, index) => (
         <WalletItem


### PR DESCRIPTION
## What

We get empty states for both Identity cards and passports if the user (or his children) do not have one, we don't want to show them in the license module on the home screen so we filter them out.

## Screenshots / Gifs
Before and after:
<div><img height = "800" src="https://github.com/user-attachments/assets/d5808d38-3fea-4c52-8e09-177cf05358e0">
<img height = "800" src="https://github.com/user-attachments/assets/57fb728a-69ac-4340-8286-fdd2c7f62fd1"></div>

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the home screen experience by refining the criteria for displaying license information. Now, only licenses with complete and valid details are shown while entries lacking key information are filtered out, for a streamlined view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->