### PR TITLE
feat(native-app): save pin retries in preferences store

### DIFF
--- a/apps/native/app/src/screens/app-lock/app-lock.tsx
+++ b/apps/native/app/src/screens/app-lock/app-lock.tsx
@@ -148,6 +148,7 @@ export const AppLockScreen: NavigationFunctionComponent<{
           .logout()
           .then(() => {
             preferencesStore.setState({ hasOnboardedPinCode: false })
+            preferencesStore.setState({ pinTries: 0 })
             // you are now logged out and navigated to root screen
             resetLockScreen()
             Navigation.dismissAllOverlays()
@@ -159,6 +160,7 @@ export const AppLockScreen: NavigationFunctionComponent<{
         Keychain.getGenericPassword({ service: 'PIN_CODE' })
           .then((res) => {
             if (res && res.password === code) {
+              preferencesStore.setState({ pinTries: 0 })
               unlockApp()
             } else {
               // increment attemps, reset code and display warning

--- a/apps/native/app/src/screens/app-lock/app-lock.tsx
+++ b/apps/native/app/src/screens/app-lock/app-lock.tsx
@@ -147,8 +147,6 @@ export const AppLockScreen: NavigationFunctionComponent<{
           .getState()
           .logout()
           .then(() => {
-            preferencesStore.setState({ hasOnboardedPinCode: false })
-            preferencesStore.setState({ pinTries: 0 })
             // you are now logged out and navigated to root screen
             resetLockScreen()
             Navigation.dismissAllOverlays()

--- a/apps/native/app/src/screens/app-lock/app-lock.tsx
+++ b/apps/native/app/src/screens/app-lock/app-lock.tsx
@@ -74,12 +74,13 @@ function useBiometricType() {
 export const AppLockScreen: NavigationFunctionComponent<{
   lockScreenActivatedAt?: number
   status: string
-}> = ({ componentId, lockScreenActivatedAt, status }) => {
+}> = ({ componentId, status }) => {
   const av = useRef(new Animated.Value(1)).current
   const isPromptRef = useRef(false)
   const [code, setCode] = useState('')
   const [invalidCode, setInvalidCode] = useState(false)
-  const [attempts, setAttempts] = useState(0)
+  const pinTries = preferencesStore.getState().pinTries
+  const [attempts, setAttempts] = useState(pinTries)
   const { useBiometrics } = usePreferencesStore()
   const biometricType = useBiometricType()
   const intl = useIntl()
@@ -162,6 +163,9 @@ export const AppLockScreen: NavigationFunctionComponent<{
             } else {
               // increment attemps, reset code and display warning
               setAttempts((previousAttempts) => previousAttempts + 1)
+              preferencesStore.setState({
+                pinTries: attempts + 1,
+              })
               setInvalidCode(true)
               setTimeout(() => {
                 setCode('')

--- a/apps/native/app/src/screens/app-lock/app-lock.tsx
+++ b/apps/native/app/src/screens/app-lock/app-lock.tsx
@@ -165,9 +165,9 @@ export const AppLockScreen: NavigationFunctionComponent<{
             } else {
               // increment attemps, reset code and display warning
               setAttempts((previousAttempts) => previousAttempts + 1)
-              preferencesStore.setState({
-                pinTries: attempts + 1,
-              })
+              preferencesStore.setState((state) => ({
+                pinTries: state.pinTries + 1,
+              }))
               setInvalidCode(true)
               setTimeout(() => {
                 setCode('')

--- a/apps/native/app/src/stores/preferences-store.ts
+++ b/apps/native/app/src/stores/preferences-store.ts
@@ -42,6 +42,7 @@ export interface PreferencesStore extends State {
   locale: Locale
   appearanceMode: AppearanceMode
   appLockTimeout: number
+  pinTries: number
   setLocale(locale: Locale): void
   getAndSetLocale(): void
   setAppearanceMode(appearanceMode: AppearanceMode): void
@@ -79,6 +80,7 @@ const defaultPreferences = {
   notificationsApplicationStatusUpdates: true,
   dismissed: [] as string[],
   appLockTimeout: 5000,
+  pinTries: 0,
 }
 
 export const preferencesStore = create<PreferencesStore>(


### PR DESCRIPTION
## What

Save pin retries on app lock screen in preferences store so they are not reset when user quits the app and opens again.

## Screenshots

https://github.com/user-attachments/assets/9123ec37-56ad-4caa-98f8-9953f413658f



## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The app lock screen now dynamically tracks PIN entry attempts based on your personalized settings, enhancing the security experience.
  - Introduced a mechanism to monitor and manage the number of PIN entry attempts through the preferences store.

- **Refactor**
  - Streamlined the lock screen flow by simplifying the authentication parameters for a more intuitive user interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->