### PR TITLE
feat(ci): Add workflow for staleness

### DIFF
--- a/.github/workflows/staleness.yml
+++ b/.github/workflows/staleness.yml
@@ -5,10 +5,12 @@ on:
   workflow_dispatch: # Allow manual run
 
 jobs:
-  stale:
+  deploy-feature:
+    name: Stale `deploy-feature`
     runs-on: arc-runners
     steps:
-      - uses: actions/stale@v9
+      - name: Clean up `deploy-feature` label usage
+        uses: actions/stale@v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 7

--- a/.github/workflows/staleness.yml
+++ b/.github/workflows/staleness.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: arc-runners
     steps:
       - uses: actions/stale@v9
         with:

--- a/.github/workflows/staleness.yml
+++ b/.github/workflows/staleness.yml
@@ -1,0 +1,20 @@
+name: 'Staleness'
+on:
+  schedule:
+    - cron: '0 3 * * *' # Daily at 03:00 UTC
+  workflow_dispatch: # Allow manual run
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 7
+          days-before-close: -1 # Never auto-close
+          only-pr-labels: deploy-feature
+          remove-labels: deploy-feature
+          stale-pr-message: |
+            This PR has been inactive for over a week. The `deploy-feature` label has been removed. Re-add the label to re-enable automatic deploy previews.
+          operations-per-run: 100

--- a/.github/workflows/staleness.yml
+++ b/.github/workflows/staleness.yml
@@ -8,6 +8,8 @@ jobs:
   deploy-feature:
     name: Stale `deploy-feature`
     runs-on: arc-runners
+    permissions:
+      pull-requests: write
     steps:
       - name: Clean up `deploy-feature` label usage
         uses: actions/stale@v9
@@ -16,7 +18,7 @@ jobs:
           days-before-stale: 7
           days-before-close: -1 # Never auto-close
           only-pr-labels: deploy-feature
-          remove-labels: deploy-feature
+          labels-to-remove-when-stale: deploy-feature
           stale-pr-message: |
             This PR has been inactive for over a week. The `deploy-feature` label has been removed. Re-add the label to re-enable automatic deploy previews.
           operations-per-run: 100


### PR DESCRIPTION
For now, only remove the `deploy-feature` label, freeing up deployment resources on dormant/stale pull requests.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209910755903722

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an automated process that monitors activity on preview-related pull requests. If a request shows no activity for 7 days, a notification is posted and its preview trigger is cleared, prompting users to re-enable the preview when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->