### PR TITLE
fix(ci): `newlints` fails if a project has no lint warnings

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -295,12 +295,13 @@ jobs:
       - name: Lint head
         id: lint-head
         run: |
+          set -euo pipefail
           lints=$(mktemp -t lint-head.XXXXXX)
           echo "lints-file=$lints" | tee -a "$GITHUB_OUTPUT"
-          yarn nx run-many -t lint --projects "$AFFECTED_PROJECTS" |
+          yarn nx run-many -t lint --output-style=static --projects "$AFFECTED_PROJECTS" |
             tee -a "$lints" | # Show output when running, but preserve pipe-chaining
-            grep -oP '(?<=✖ )(\d+)(?= problems)' | # Find number of problems
-            awk '{ SUM += $1} END { SUM /= 2; printf "lint-count=%d",SUM }' | # sum number of problems, divide by 2 because each problem summary occurs twice
+            (grep -oP '(?<=✖ )(\d+)(?= problems)' || echo '0') | # Find number of problems
+            awk '{ SUM += $1} END { SUM /= 2; printf "lint-count=%d", SUM }' | # sum number of problems, divide by 2 because each problem summary occurs twice
             tee -a "$GITHUB_OUTPUT" # Finally create output
 
       # Checkout for linting base
@@ -314,12 +315,13 @@ jobs:
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'dirty bypass') }}
         id: lint-base
         run: |
+          set -euo pipefail
           lints=$(mktemp -t lint-base.XXXXXX)
           echo "lints-file=$lints" | tee -a "$GITHUB_OUTPUT"
-          yarn nx run-many -t lint --projects "$AFFECTED_PROJECTS" |
+          yarn nx run-many -t lint --output-style=static --projects "$AFFECTED_PROJECTS" |
             tee -a "$lints" | # Show output when running, but preserve pipe-chaining
-            grep -oP '(?<=✖ )(\d+)(?= problems)' | # Find number of problems
-            awk '{ SUM += $1} END { SUM /= 2; printf "lint-count=%d",SUM }' | # sum number of problems, divide by 2 because each problem summary occurs twice
+            (grep -oP '(?<=✖ )(\d+)(?= problems)' || echo '0') | # Find number of problems
+            awk '{ SUM += $1} END { SUM /= 2; printf "lint-count=%d", SUM }' | # sum number of problems, divide by 2 because each problem summary occurs twice
             tee -a "$GITHUB_OUTPUT" # Finally create output
 
       - name: No new lints

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -305,11 +305,13 @@ jobs:
 
       # Checkout for linting base
       - uses: actions/checkout@v4
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'dirty bypass') }}
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           clean: false
 
       - name: Lint base
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'dirty bypass') }}
         id: lint-base
         run: |
           lints=$(mktemp -t lint-base.XXXXXX)
@@ -321,6 +323,7 @@ jobs:
             tee -a "$GITHUB_OUTPUT" # Finally create output
 
       - name: No new lints
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'dirty bypass') }}
         env:
           HEAD_LINT_COUNT: ${{steps.lint-head.outputs.lint-count}}
           BASE_LINT_COUNT: ${{steps.lint-base.outputs.lint-count}}


### PR DESCRIPTION
Some pull requests (e.g. https://github.com/island-is/island.is/actions/runs/14331611112/job/40169034100) are failing because they don't have any lint warnings, thus `grep` fails finding any `problems`.

Also, re-adds skipping with `dirty bypass` for new lint detection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced error handling and output formatting for code quality checks.
  - Introduced a conditional bypass to streamline the process based on specific labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->