### PR TITLE
feat(services-payments): Include reference id with payment to link with FJS charges

### DIFF
--- a/apps/services/payments/migrations/20250408000000-card-payment-reference-data.js
+++ b/apps/services/payments/migrations/20250408000000-card-payment-reference-data.js
@@ -1,0 +1,30 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.addColumn(
+        'payment_flow_payment_confirmation',
+        'merchant_reference_data',
+        {
+          type: Sequelize.STRING,
+          allowNull: false,
+          defaultValue: '',
+        },
+        { transaction: t },
+      )
+    })
+  },
+
+  down: async (queryInterface) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.removeColumn(
+        'payment_flow_payment_confirmation',
+        'merchant_reference_data',
+        {
+          transaction: t,
+        },
+      )
+    })
+  },
+}

--- a/apps/services/payments/src/app/cardPayment/cardPayment.service.ts
+++ b/apps/services/payments/src/app/cardPayment/cardPayment.service.ts
@@ -33,6 +33,7 @@ import { VerifyCardInput } from './dtos/verifyCard.input'
 import { PaymentFlowAttributes } from '../paymentFlow/models/paymentFlow.model'
 import { CatalogItemWithQuantity } from '../../types/charges'
 import { environment } from '../../environments'
+import { PaymentTrackingData } from '../../types/cardPayment'
 
 @Injectable()
 export class CardPaymentService {
@@ -222,7 +223,10 @@ export class CardPaymentService {
     }
   }
 
-  async charge(chargeCardInput: ChargeCardInput) {
+  async charge(
+    chargeCardInput: ChargeCardInput,
+    paymentTrackingData: PaymentTrackingData,
+  ) {
     const status = await this.getFullVerificationStatus(
       chargeCardInput.paymentFlowId,
     )
@@ -258,6 +262,7 @@ export class CardPaymentService {
       chargeCardInput,
       verificationData,
       paymentApiConfig: this.config.paymentGateway,
+      paymentTrackingData,
     })
 
     const response = await fetch(
@@ -347,11 +352,13 @@ export class CardPaymentService {
     charges,
     chargeResponse,
     totalPrice,
+    merchantReferenceData,
   }: {
     paymentFlow: PaymentFlowAttributes
     charges: CatalogItemWithQuantity[]
     chargeResponse: ChargeResponse
     totalPrice: number
+    merchantReferenceData: string
   }) {
     return generateCardChargeFJSPayload({
       paymentFlow,
@@ -359,6 +366,7 @@ export class CardPaymentService {
       chargeResponse,
       totalPrice,
       systemId: environment.chargeFjs.systemId,
+      merchantReferenceData,
     })
   }
 }

--- a/apps/services/payments/src/app/paymentFlow/models/paymentFlowPaymentConfirmation.model.ts
+++ b/apps/services/payments/src/app/paymentFlow/models/paymentFlowPaymentConfirmation.model.ts
@@ -14,7 +14,7 @@ import {
   Table,
   UpdatedAt,
 } from 'sequelize-typescript'
-import { PaymentFlow } from './paymentFlow.model' // Update the path to match your project structure
+import { PaymentFlow } from './paymentFlow.model'
 
 @Table({
   tableName: 'payment_flow_payment_confirmation',
@@ -88,6 +88,14 @@ export class PaymentFlowPaymentConfirmation extends Model<
     field: 'card_usage',
   })
   cardUsage!: string
+
+  @ApiProperty()
+  @Column({
+    type: DataType.STRING,
+    allowNull: false,
+    field: 'merchant_reference_data',
+  })
+  merchantReferenceData!: string
 
   @CreatedAt
   @ApiProperty()

--- a/apps/services/payments/src/app/paymentFlow/paymentFlow.service.ts
+++ b/apps/services/payments/src/app/paymentFlow/paymentFlow.service.ts
@@ -40,6 +40,7 @@ import {
 import { PaymentFlowPaymentConfirmation } from './models/paymentFlowPaymentConfirmation.model'
 import { ChargeResponse } from '../cardPayment/cardPayment.types'
 import { retry } from '@island.is/shared/utils/server'
+import { PaymentTrackingData } from '../../types/cardPayment'
 
 @Injectable()
 export class PaymentFlowService {
@@ -372,15 +373,18 @@ export class PaymentFlowService {
     paymentResult,
     paymentFlowId,
     totalPrice,
+    paymentTrackingData,
   }: {
     paymentResult: ChargeResponse
     paymentFlowId: string
     totalPrice: number
+    paymentTrackingData: PaymentTrackingData
   }) {
     try {
       return await retry(
         () =>
           this.paymentFlowConfirmationModel.create({
+            id: paymentTrackingData.correlationId,
             acquirerReferenceNumber: paymentResult.acquirerReferenceNumber,
             authorizationCode: paymentResult.authorizationCode,
             cardScheme: paymentResult.cardInformation.cardScheme,
@@ -388,6 +392,7 @@ export class PaymentFlowService {
             paymentFlowId,
             cardUsage: paymentResult.cardInformation.cardUsage,
             totalPrice,
+            merchantReferenceData: paymentTrackingData.merchantReferenceData,
           }),
         {
           maxRetries: 3,

--- a/apps/services/payments/src/types/cardPayment.ts
+++ b/apps/services/payments/src/types/cardPayment.ts
@@ -1,0 +1,4 @@
+export interface PaymentTrackingData {
+  merchantReferenceData: string
+  correlationId: string
+}


### PR DESCRIPTION
## What

Send the same guid with the payment as with the charge.

## Why

To be able to "afstemma"

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Payment processes now include unique reference identifiers for enhanced traceability and robust transaction monitoring, resulting in smoother payment confirmations and improved error handling.
  
- **Chores**
  - Updated backend data storage for payment confirmations to support additional reference information, ensuring greater consistency and reliability in payment operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->