### PR TITLE
fix(seminars-ver): removing alert box

### DIFF
--- a/libs/application/templates/aosh/seminars/src/forms/SeminarRegistrationForm/SeminarInformation/index.ts
+++ b/libs/application/templates/aosh/seminars/src/forms/SeminarRegistrationForm/SeminarInformation/index.ts
@@ -1,13 +1,11 @@
 import {
-  buildAlertMessageField,
   buildInformationFormField,
   buildMultiField,
   buildSection,
   getValueViaPath,
 } from '@island.is/application/core'
 import { seminar as seminarMessages } from '../../../lib/messages'
-import { ExternalData, PaymentCatalogItem } from '@island.is/application/types'
-import { isPersonType } from '../../../utils'
+import { PaymentCatalogItem } from '@island.is/application/types'
 import { CourseDTO } from '@island.is/clients/seminars-ver'
 import { getSeminarInfo } from '../../../utils/getSeminarInfo'
 
@@ -38,15 +36,6 @@ export const seminarInformationSection = buildSection({
 
             return getSeminarInfo(seminar, paymentItem)
           },
-        }),
-        buildAlertMessageField({
-          id: 'seminarInformationAlert',
-          message: seminarMessages.labels.alertMessage,
-          alertType: 'info',
-          marginTop: 4,
-          doesNotRequireAnswer: true,
-          condition: (_, externalData: ExternalData) =>
-            isPersonType(externalData),
         }),
       ],
     }),

--- a/libs/application/templates/aosh/seminars/src/lib/messages/conclusion.ts
+++ b/libs/application/templates/aosh/seminars/src/lib/messages/conclusion.ts
@@ -20,7 +20,7 @@ export const conclusion = {
   }),
   default: defineMessages({
     alertTitle: {
-      id: 'aosh.sem.application:conclusion.default.alertMessage',
+      id: 'aosh.sem.application:conclusion.default.alertTitle',
       defaultMessage: 'Skráning á námskeið {seminar} móttekin.',
       description: 'Conclusion alert message',
     },

--- a/libs/application/templates/aosh/seminars/src/lib/messages/seminar.ts
+++ b/libs/application/templates/aosh/seminars/src/lib/messages/seminar.ts
@@ -65,11 +65,5 @@ export const seminar = {
       defaultMessage: 'Staðsetning:',
       description: `seminar location label `,
     },
-    alertMessage: {
-      id: 'aosh.sem.application:seminar.labels.alertMessage',
-      defaultMessage:
-        'Boðið er upp á tvenns konar flæði eftir því hvort að sá sem er að skrá sé einstaklingur sem greiðir þá sjálfur eða fyrirtæki sem mun greiða fyrir einn eða fleiri þátttakendur.',
-      description: `seminar alert message `,
-    },
   }),
 }


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the seminar registration form by removing an outdated informational alert for a cleaner user interface.
  - Updated alert messaging to ensure that titles clearly reflect their purpose.
  - Simplified seminar labels by eliminating redundant alert information, enhancing overall clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->