### PR TITLE
fix(license-service): remove empty docs

### DIFF
--- a/libs/api/domains/license-service/src/lib/mappers/identityDocumentMapper.ts
+++ b/libs/api/domains/license-service/src/lib/mappers/identityDocumentMapper.ts
@@ -44,27 +44,7 @@ export class IdentityDocumentMapper implements GenericLicenseMapper {
       locale,
     )
 
-    const emptyIdentityDocument = {
-      licenseName: formatMessage(m.identityDocument),
-      type: 'user' as const,
-      payload: {
-        data: [],
-        rawData: '',
-        metadata: {
-          title: formatMessage(m.identityDocument),
-          name: formatMessage(m.identityDocument),
-          subtitle: formatMessage(m.noValidIdentityDocument),
-          ctaLink: {
-            label: formatMessage(m.apply),
-            value: formatMessage(m.identityDocumentApplyUrl),
-          },
-        },
-      },
-    }
-
-    if (!payload.length) {
-      return [emptyIdentityDocument]
-    }
+    if (!payload) return Promise.resolve([])
 
     const typedPayload = payload as Array<
       IdentityDocument | IdentityDocumentChild
@@ -92,10 +72,6 @@ export class IdentityDocumentMapper implements GenericLicenseMapper {
           }
         })
         .flat()
-
-    if (mappedLicenses.findIndex((ml) => ml.type === 'user') < 0) {
-      mappedLicenses.push(emptyIdentityDocument)
-    }
 
     return mappedLicenses
   }


### PR DESCRIPTION

## What

* Remove empty identity documents placeholders

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined identity data processing: The system now returns an empty result when no valid identity details are available, ensuring that no default placeholder is inserted.
  - Improved output behavior: The update removes redundant data elements, leading to more accurate and predictable responses, especially in cases where expected identity details are missing or incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->