### PR TITLE
fix(web): Organization parent subpage edge case when child subpage is not published

### DIFF
--- a/apps/web/screens/Organization/Standalone/ParentSubpage.tsx
+++ b/apps/web/screens/Organization/Standalone/ParentSubpage.tsx
@@ -224,6 +224,13 @@ export const getProps: typeof StandaloneParentSubpage['getProps'] = async ({
 
   const subpageLink = getOrganizationParentSubpage.childLinks[selectedIndex]
 
+  if (!subpageLink) {
+    throw new CustomNextError(
+      404,
+      'Subpage belonging to an organization parent subpage was not found',
+    )
+  }
+
   const subpage = !subpageLink.id
     ? (
         await apolloClient.query<Query, QueryGetOrganizationSubpageArgs>({


### PR DESCRIPTION
# Organization parent subpage edge case when child subpage is not published

If a subpage is in draft mode in the cms but the parent page is published then the user sees a 500 error when visiting the page since the code expects the value to be there.

This PR simply changes that 500 error message to be a 404 error message


---

This error came to our attention in Datadog: 

<img width="505" alt="Screenshot 2025-04-09 at 14 10 15" src="https://github.com/user-attachments/assets/8ecd08a1-1494-4e60-ba08-59b05c53e036" />

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling on organization-related subpages to ensure a clear 404 error is displayed when a subpage link is unavailable, providing smoother navigation and improved user feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->