### PR TITLE
fix(cms): Skip syncing blood donation restrictions with no title

### DIFF
--- a/libs/cms/src/lib/search/importers/bloodDonationRestriction.service.ts
+++ b/libs/cms/src/lib/search/importers/bloodDonationRestriction.service.ts
@@ -13,7 +13,9 @@ export class BloodDonationRestrictionSyncService
 {
   processSyncData(entries: processSyncDataInput<IBloodDonationRestriction>) {
     return entries.filter(
-      (entry) => entry.sys.contentType.sys.id === 'bloodDonationRestriction',
+      (entry) =>
+        entry.sys.contentType.sys.id === 'bloodDonationRestriction' &&
+        !!entry.fields.title,
     )
   }
 


### PR DESCRIPTION
# Skip syncing blood donation restrictions with no title




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the data processing to include an additional check for required details, improving the accuracy of displayed blood donation records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->