### PR TITLE
fix(web): Verdict search - DatePicker year select

### DIFF
--- a/apps/web/screens/Verdicts/components/DebouncedDatePicker.tsx
+++ b/apps/web/screens/Verdicts/components/DebouncedDatePicker.tsx
@@ -3,6 +3,9 @@ import { useDebounce } from 'react-use'
 
 import { DatePicker } from '@island.is/island-ui/core'
 
+const CURRENT_YEAR = new Date().getFullYear()
+const MIN_YEAR = 1900
+
 interface DebouncedDatePickerProps {
   label: string
   name: string
@@ -48,6 +51,8 @@ export const DebouncedDatePicker = ({
       selected={state}
       maxDate={maxDate}
       minDate={minDate}
+      minYear={minDate ? minDate.getFullYear() : MIN_YEAR}
+      maxYear={maxDate ? maxDate.getFullYear() : CURRENT_YEAR}
     />
   )
 }

--- a/apps/web/screens/Verdicts/components/DebouncedDatePicker.tsx
+++ b/apps/web/screens/Verdicts/components/DebouncedDatePicker.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from 'react'
 import { useDebounce } from 'react-use'
 
 import { DatePicker } from '@island.is/island-ui/core'
+import { useI18n } from '@island.is/web/i18n'
 
 const CURRENT_YEAR = new Date().getFullYear()
 const MIN_YEAR = 1900
@@ -25,6 +26,7 @@ export const DebouncedDatePicker = ({
   handleChange,
   debounceTimeInMs,
 }: DebouncedDatePickerProps) => {
+  const { activeLocale } = useI18n()
   const [state, setState] = useState(value)
   const initialRender = useRef(true)
   useDebounce(
@@ -53,6 +55,7 @@ export const DebouncedDatePicker = ({
       minDate={minDate}
       minYear={minDate ? minDate.getFullYear() : MIN_YEAR}
       maxYear={maxDate ? maxDate.getFullYear() : CURRENT_YEAR}
+      locale={activeLocale}
     />
   )
 }


### PR DESCRIPTION
# Verdict search - DatePicker year select

Add minYear and maxYear props to DatePicker component so the user can get a year dropdown

<img width="300" alt="Screenshot 2025-04-10 at 09 37 54" src="https://github.com/user-attachments/assets/b79c9c3f-7ca3-4272-8872-0e3ab9f52af8" />

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the date picker to support localization, adapting to the user's language.
  - Improved the date picker’s flexibility by dynamically adjusting its date range boundaries, ensuring a more intuitive user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->