### PR TITLE
fix(parental-leave): Change otherParent approve button conditions

### DIFF
--- a/libs/application/templates/parental-leave/src/forms/OtherParentApproval.ts
+++ b/libs/application/templates/parental-leave/src/forms/OtherParentApproval.ts
@@ -15,9 +15,9 @@ import { otherParentApprovalFormMessages } from '../lib/messages'
 import {
   getApplicationAnswers,
   getBeginningOfMonth3MonthsAgo,
-  getLastDayOfLastMonth,
+
 } from '../lib/parentalLeaveUtils'
-import { addDays } from 'date-fns'
+
 
 export const OtherParentApproval: Form = buildForm({
   id: 'OtherParentApprovalForParentalLeave',

--- a/libs/application/templates/parental-leave/src/forms/OtherParentApproval.ts
+++ b/libs/application/templates/parental-leave/src/forms/OtherParentApproval.ts
@@ -14,8 +14,10 @@ import Logo from '../assets/Logo'
 import { otherParentApprovalFormMessages } from '../lib/messages'
 import {
   getApplicationAnswers,
+  getBeginningOfMonth3MonthsAgo,
   getLastDayOfLastMonth,
 } from '../lib/parentalLeaveUtils'
+import { addDays } from 'date-fns'
 
 export const OtherParentApproval: Form = buildForm({
   id: 'OtherParentApprovalForParentalLeave',
@@ -97,12 +99,12 @@ export const OtherParentApproval: Form = buildForm({
               titleVariant: 'h4',
               description: otherParentApprovalFormMessages.startDateInThePast,
               condition: (answers) => {
-                const lastDateOfLastMonth = getLastDayOfLastMonth()
+                const beginningOfMonth3MonthsAgo = getBeginningOfMonth3MonthsAgo()
                 const startDateTime = new Date(
                   getApplicationAnswers(answers).periods[0].startDate,
                 ).getTime()
 
-                return startDateTime <= lastDateOfLastMonth.getTime()
+                return startDateTime < beginningOfMonth3MonthsAgo.getTime()
               },
             }),
             buildSubmitField({
@@ -120,12 +122,12 @@ export const OtherParentApproval: Form = buildForm({
                   type: 'primary',
                   event: 'APPROVE',
                   condition: (answers) => {
-                    const lastDateOfLastMonth = getLastDayOfLastMonth()
+                    const beginningOfMonth3MonthsAgo = getBeginningOfMonth3MonthsAgo()
                     const startDateTime = new Date(
                       getApplicationAnswers(answers).periods[0].startDate,
                     ).getTime()
 
-                    return startDateTime > lastDateOfLastMonth.getTime()
+                    return startDateTime >= beginningOfMonth3MonthsAgo.getTime()
                   },
                 },
               ],

--- a/libs/application/templates/parental-leave/src/lib/messages.ts
+++ b/libs/application/templates/parental-leave/src/lib/messages.ts
@@ -2733,8 +2733,8 @@ export const errorMessages = defineMessages({
   startDateInThePast: {
     id: 'pl.application:errors.start.date.in.the.past',
     defaultMessage:
-      'icel-trans: "Start date is in the past. The form will not be sent!"',
-    description: 'Start date is in the past. The form will not be sent!',
+      'Upphafsdagur fæðingarorlofs er lengra aftur í tímann en þrír mánuðir. Ekki er hægt að halda áfram með umsókn án breytinga.',
+    description: 'Start date is more than 3 months in the past. It is not possible to continue without editing the period.',
   },
   missingMultipleBirthsAnswer: {
     id: 'pl.application:errors.missing.multiple.births.answer',


### PR DESCRIPTION
# ...

## What

Allow other parent to approve 3 months back in time

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Revised the parental leave form’s date validation to ensure the start date is within three months in the past.
	- Updated the error message to instruct users that dates over three months ago require correction before the application can proceed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->