### PR TITLE
fix(web): Team list member order - Only order by score if there is a text input

### DIFF
--- a/libs/cms/src/lib/cms.elasticsearch.service.ts
+++ b/libs/cms/src/lib/cms.elasticsearch.service.ts
@@ -674,7 +674,6 @@ export class CmsElasticsearchService {
 
     if (!input.orderBy) {
       sort = [
-        { _score: { order: SortDirection.DESC } },
         {
           [SortField.RELEASE_DATE]: {
             order: SortDirection.DESC,
@@ -682,33 +681,31 @@ export class CmsElasticsearchService {
         },
         { 'title.sort': { order: SortDirection.ASC } },
         { dateCreated: { order: SortDirection.DESC } },
+      ]
+    } else if (input.orderBy === GetTeamMembersInputOrderBy.Name) {
+      sort = [
+        { 'title.sort': { order: SortDirection.ASC } },
+        {
+          [SortField.RELEASE_DATE]: {
+            order: SortDirection.DESC,
+          },
+        },
+        { dateCreated: { order: SortDirection.DESC } },
+      ]
+    } else if (input.orderBy === GetTeamMembersInputOrderBy.Manual) {
+      sort = [
+        { dateCreated: { order: SortDirection.DESC } },
+        { 'title.sort': { order: SortDirection.ASC } },
+        {
+          [SortField.RELEASE_DATE]: {
+            order: SortDirection.DESC,
+          },
+        },
       ]
     }
 
-    if (input.orderBy === GetTeamMembersInputOrderBy.Name) {
-      sort = [
-        { _score: { order: SortDirection.DESC } },
-        { 'title.sort': { order: SortDirection.ASC } },
-        {
-          [SortField.RELEASE_DATE]: {
-            order: SortDirection.DESC,
-          },
-        },
-        { dateCreated: { order: SortDirection.DESC } },
-      ]
-    }
-
-    if (input.orderBy === GetTeamMembersInputOrderBy.Manual) {
-      sort = [
-        { _score: { order: SortDirection.DESC } },
-        { dateCreated: { order: SortDirection.DESC } },
-        { 'title.sort': { order: SortDirection.ASC } },
-        {
-          [SortField.RELEASE_DATE]: {
-            order: SortDirection.DESC,
-          },
-        },
-      ]
+    if (queryString.length > 0) {
+      sort.unshift({ _score: { order: SortDirection.DESC } })
     }
 
     if (input.tags && input.tags.length > 0 && input.tagGroups) {


### PR DESCRIPTION
# Team list member order - Only order by score if there is a text input

The order of team members seems random when there isn't any text input, to address that I simply stopped ordering by score unless there is a text input.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Redesigned the result sorting behavior to ensure a more intuitive display of items.
	- When search queries are used, items are now prioritized by relevance, followed by additional criteria.
	- Enhanced consistency and predictability in how results are ordered across different search conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->