### PR TITLE
fix(ci): `skipped` or `cancelled` jobs parsed as `success`

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -403,20 +403,15 @@ jobs:
         env:
           NEEDS: ${{ toJSON(needs) }}
         run: |
-          echo -n "Dependencies succeeded? "
-          if ! jq -ne --argjson needs "$NEEDS" '$needs | to_entries | map_values(select(.result != "success")) | length == 0'; then
-            failed_dependencies=$(jq -n --argjson needs "$NEEDS" -r '
-              [
-                  $needs
-                | to_entries
-                | map_values(select(.result != "success"))
-                | .[]
-                | "\(.key) (\(.value.result))"
-              ]
-              | join(", ")')
-            echo "::error title=NEEDS::Some dependencies failed: $failed_dependencies"
+          # "failed" here is everything that wasn't successful or skipped (e.g. "failuer", "cancelled")
+          failed_dependencies=$(jq -nr --argjson needs "$NEEDS" ' $needs | with_entries(select(.value.result != "success" and .value.result != "skipped")) ')
+          echo -n "Did any dependency fail? "
+          if jq -ne --argjson failures "$failed_dependencies" '$failures | length > 0'; then
+            failure_statuses=$(jq -nr --argjson failures "$failed_dependencies" '[ $failures | to_entries | .[] | "\(.key) (\(.value.result))" ] | join(", ")')
+            echo "::error title=NEEDS::Some dependencies failed: $failure_statuses"
             exit 1
           fi
+          echo "::info title=NEEDS::No failing dependencies 🎉"
           exit 0
 
       - name: Announce success

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -393,26 +393,31 @@ jobs:
       - build
       - unicorn-tests
     steps:
-      - name: Check prepare success
-        run: '[[ ${{ needs.prepare.result }} == "success" ]] || exit 1'
       - name: Notify about deploy-feature label
         if: ${{ github.event.pull_request.auto_merge && needs.prepare.outputs.DEPLOY_FEATURE == 'true' }}
         run: |
           echo "- 👉 Remove the \`deploy-feature\` label if you want this PR to be merged automatically" >> $GITHUB_STEP_SUMMARY
           exit 1
-      - name: Check tests success
-        run: '[[ ${{ needs.tests.result }} != "failure" ]] || exit 1'
-      - name: Check e2e success
-        run: '[[ ${{ needs.e2e.result }} != "failure" ]] || exit 1'
-      - name: Check linting success
-        run: '[[ ${{ needs.linting.result }} != "failure" ]] || exit 1'
-      - name: Check run-shellcheck success
-        run: '[[ ${{ needs.run-shellcheck.result }} != "failure" ]] || exit 1'
-      - name: Check formatting success
-        run: '[[ ${{ needs.formatting.result }} != "failure" ]] || exit 1'
-      - name: Check build success
-        run: '[[ ${{ needs.build.result }} != "failure" ]] || exit 1'
-      - name: Check Unicorn test success
-        run: '[[ ${{ needs.unicorn-tests.result }} != "failure" ]] || exit 1'
+
+      - name: Collect
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          echo -n "Dependencies succeeded? "
+          if ! jq -ne --argjson needs "$NEEDS" '$needs | to_entries | map_values(select(.result != "success")) | length == 0'; then
+            failed_dependencies=$(jq -n --argjson needs "$NEEDS" -r '
+              [
+                  $needs
+                | to_entries
+                | map_values(select(.result != "success"))
+                | .[]
+                | "\(.key) (\(.value.result))"
+              ]
+              | join(", ")')
+            echo "::error title=NEEDS::Some dependencies failed: $failed_dependencies"
+            exit 1
+          fi
+          exit 0
+
       - name: Announce success
         run: echo "Build is successful"


### PR DESCRIPTION
We only check for non-failure, so if a job was skipped or cancelled, it's still a "success".

Additionally, if the "Success" job is cancelled, it's "skipped", thus a "success" to the merge queue, and would proceed to the merge queue even if jobs failed (because the "success" job didn't fail).

Updating to always run, and require all steps to be success or skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Streamlined our automated dependency verification process to consolidate success checks and enhance error reporting behind the scenes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->