### PR TITLE
fix(application-ir): Default values for numerical strings

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/inheritance-report/utils/mappers.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/inheritance-report/utils/mappers.ts
@@ -125,7 +125,7 @@ export const expandAnswers = (
         data: (answers.assets.bankAccounts?.data ?? []).map((account) => {
           return {
             assetNumber: account.assetNumber ?? '',
-            propertyValuation: account.propertyValuation ?? '',
+            propertyValuation: account.propertyValuation ?? '0',
             exchangeRateOrInterest: account.exchangeRateOrInterest ?? '',
             foreignBankAccount: account?.foreignBankAccount ?? [],
             deceasedShare: account.deceasedShare ?? '0',
@@ -141,7 +141,7 @@ export const expandAnswers = (
           return {
             assetNumber: claim.assetNumber ?? '',
             description: claim.description ?? '',
-            propertyValuation: claim.propertyValuation ?? '',
+            propertyValuation: claim.propertyValuation ?? '0',
             deceasedShare: claim.deceasedShare ?? '0',
             deceasedShareEnabled: claim.deceasedShareEnabled ?? [],
             deceasedShareAmount: claim.deceasedShareAmount ?? 0,
@@ -155,7 +155,7 @@ export const expandAnswers = (
           return {
             assetNumber: gun.assetNumber ?? '',
             description: gun.description ?? '',
-            propertyValuation: gun.propertyValuation ?? '',
+            propertyValuation: gun.propertyValuation ?? '0',
             deceasedShare: gun.deceasedShare ?? '0',
             deceasedShareEnabled: gun.deceasedShareEnabled ?? [],
             deceasedShareAmount: gun.deceasedShareAmount ?? 0,
@@ -228,7 +228,7 @@ export const expandAnswers = (
           return {
             assetNumber: vehicle.assetNumber ?? '',
             description: vehicle.description ?? '',
-            propertyValuation: vehicle.propertyValuation ?? '',
+            propertyValuation: vehicle.propertyValuation ?? '0',
             deceasedShare: vehicle.deceasedShare ?? '0',
             deceasedShareEnabled: vehicle.deceasedShareEnabled ?? [],
             deceasedShareAmount: vehicle?.deceasedShareAmount ?? 0,

--- a/libs/application/template-api-modules/src/lib/modules/templates/inheritance-report/utils/mappers.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/inheritance-report/utils/mappers.ts
@@ -128,7 +128,7 @@ export const expandAnswers = (
             propertyValuation: account.propertyValuation ?? '',
             exchangeRateOrInterest: account.exchangeRateOrInterest ?? '',
             foreignBankAccount: account?.foreignBankAccount ?? [],
-            deceasedShare: account.deceasedShare ?? '',
+            deceasedShare: account.deceasedShare ?? '0',
             deceasedShareEnabled: account.deceasedShareEnabled ?? [],
             deceasedShareAmount: account.deceasedShareAmount ?? 0,
             enabled: account.enabled ?? true,
@@ -142,7 +142,7 @@ export const expandAnswers = (
             assetNumber: claim.assetNumber ?? '',
             description: claim.description ?? '',
             propertyValuation: claim.propertyValuation ?? '',
-            deceasedShare: claim.deceasedShare ?? '',
+            deceasedShare: claim.deceasedShare ?? '0',
             deceasedShareEnabled: claim.deceasedShareEnabled ?? [],
             deceasedShareAmount: claim.deceasedShareAmount ?? 0,
             enabled: claim.enabled ?? true,
@@ -156,7 +156,7 @@ export const expandAnswers = (
             assetNumber: gun.assetNumber ?? '',
             description: gun.description ?? '',
             propertyValuation: gun.propertyValuation ?? '',
-            deceasedShare: gun.deceasedShare ?? '',
+            deceasedShare: gun.deceasedShare ?? '0',
             deceasedShareEnabled: gun.deceasedShareEnabled ?? [],
             deceasedShareAmount: gun.deceasedShareAmount ?? 0,
             enabled: gun.enabled ?? true,
@@ -167,7 +167,7 @@ export const expandAnswers = (
       inventory: {
         info: answers.assets.inventory?.info ?? '',
         value: answers.assets.inventory?.value ?? '',
-        deceasedShare: answers.assets.inventory?.deceasedShare ?? '',
+        deceasedShare: answers.assets.inventory?.deceasedShare ?? '0',
         deceasedShareEnabled:
           answers.assets.inventory?.deceasedShareEnabled ?? [],
         deceasedShareAmount: answers.assets.inventory?.deceasedShareAmount ?? 0,
@@ -175,7 +175,7 @@ export const expandAnswers = (
       money: {
         info: answers.assets.money?.info ?? '',
         value: answers.assets.money?.value ?? '',
-        deceasedShare: answers.assets.money?.deceasedShare ?? '',
+        deceasedShare: answers.assets.money?.deceasedShare ?? '0',
         deceasedShareEnabled: answers.assets.money?.deceasedShareEnabled ?? [],
         deceasedShareAmount: answers.assets.money?.deceasedShareAmount ?? 0,
       },
@@ -184,7 +184,7 @@ export const expandAnswers = (
           return {
             info: otherAsset?.info ?? '',
             value: otherAsset?.value ?? '',
-            deceasedShare: otherAsset?.deceasedShare ?? '',
+            deceasedShare: otherAsset?.deceasedShare ?? '0',
             deceasedShareEnabled: otherAsset?.deceasedShareEnabled ?? [],
             deceasedShareAmount: otherAsset?.deceasedShareAmount ?? 0,
           }
@@ -215,7 +215,7 @@ export const expandAnswers = (
             description: stock.description ?? '',
             exchangeRateOrInterest: stock.exchangeRateOrInterest ?? '',
             value: stock.value ?? '',
-            deceasedShare: stock?.deceasedShare ?? '',
+            deceasedShare: stock?.deceasedShare ?? '0',
             deceasedShareEnabled: stock?.deceasedShareEnabled ?? [],
             deceasedShareAmount: stock?.deceasedShareAmount ?? 0,
             enabled: stock.enabled ?? true,

--- a/libs/application/templates/inheritance-report/src/fields/CalculateShare/index.tsx
+++ b/libs/application/templates/inheritance-report/src/fields/CalculateShare/index.tsx
@@ -36,7 +36,6 @@ type ShareItem = {
 
 export const CalculateShare: FC<React.PropsWithChildren<FieldBaseProps>> = ({
   application,
-  errors,
 }) => {
   const { answers } = application
   const [, updateState] = useState<unknown>()
@@ -50,12 +49,14 @@ export const CalculateShare: FC<React.PropsWithChildren<FieldBaseProps>> = ({
   const [estateTotal, setEstateTotal] = useState(0)
   const [netPropertyForExchange, setNetPropertyForExchange] = useState(0)
   const formValues = getValues()
-  const [customSpouseSharePercentage, setCustomSpouseSharePercentage] =
-    useState(
-      formValues?.customShare?.customSpouseSharePercentage
-        ? formValues.customShare?.customSpouseSharePercentage / 100
-        : 50 / 100,
-    )
+  const [
+    customSpouseSharePercentage,
+    setCustomSpouseSharePercentage,
+  ] = useState(
+    formValues?.customShare?.customSpouseSharePercentage
+      ? formValues.customShare?.customSpouseSharePercentage / 100
+      : 50 / 100,
+  )
 
   const deceasedHadAssets = getDeceasedHadAssets(application)
   const deceasedWasInCohabitation = getDeceasedWasInCohabitation(application)
@@ -108,7 +109,7 @@ export const CalculateShare: FC<React.PropsWithChildren<FieldBaseProps>> = ({
 
   const updateShareCalculations = useCallback(() => {
     const bankAccounts: CalcShared = (
-      (answers.assets as unknown as EstateAssets)?.bankAccounts?.data ?? []
+      ((answers.assets as unknown) as EstateAssets)?.bankAccounts?.data ?? []
     )
       .filter((item) => !!item.enabled)
       .map((item) => {
@@ -133,7 +134,7 @@ export const CalculateShare: FC<React.PropsWithChildren<FieldBaseProps>> = ({
       })
 
     const claims: CalcShared = (
-      (answers.assets as unknown as EstateAssets)?.claims?.data ?? []
+      ((answers.assets as unknown) as EstateAssets)?.claims?.data ?? []
     )
       .filter((item) => !!item.enabled)
       .map((item) => {
@@ -154,7 +155,7 @@ export const CalculateShare: FC<React.PropsWithChildren<FieldBaseProps>> = ({
       })
 
     const guns: CalcShared = (
-      (answers.assets as unknown as EstateAssets)?.guns?.data ?? []
+      ((answers.assets as unknown) as EstateAssets)?.guns?.data ?? []
     )
       .filter((item) => !!item.enabled)
       .map((item) => {
@@ -175,7 +176,7 @@ export const CalculateShare: FC<React.PropsWithChildren<FieldBaseProps>> = ({
       })
 
     const inventory: CalcShared = [
-      (answers.assets as unknown as EstateAssets)?.inventory ?? [],
+      ((answers.assets as unknown) as EstateAssets)?.inventory ?? [],
     ].map((item) => {
       const value = valueToNumber(item.value)
       const deceasedShare = valueToNumber(item.deceasedShare)
@@ -194,7 +195,7 @@ export const CalculateShare: FC<React.PropsWithChildren<FieldBaseProps>> = ({
     })
 
     const money: CalcShared = [
-      (answers.assets as unknown as EstateAssets)?.money ?? [],
+      ((answers.assets as unknown) as EstateAssets)?.money ?? [],
     ].map((item) => {
       const value = valueToNumber(item.value)
       const deceasedShare = valueToNumber(item.deceasedShare)
@@ -213,7 +214,7 @@ export const CalculateShare: FC<React.PropsWithChildren<FieldBaseProps>> = ({
     })
 
     const otherAssets: CalcShared = (
-      (answers.assets as unknown as EstateAssets)?.otherAssets?.data ?? []
+      ((answers.assets as unknown) as EstateAssets)?.otherAssets?.data ?? []
     ).map((item) => {
       const value = valueToNumber(item.value)
       const deceasedShare = valueToNumber(item.deceasedShare)
@@ -232,7 +233,7 @@ export const CalculateShare: FC<React.PropsWithChildren<FieldBaseProps>> = ({
     })
 
     const realEstate: CalcShared = (
-      (answers.assets as unknown as EstateAssets)?.realEstate?.data ?? []
+      ((answers.assets as unknown) as EstateAssets)?.realEstate?.data ?? []
     )
       .filter((item) => item?.enabled)
       .map((item) => {
@@ -253,7 +254,7 @@ export const CalculateShare: FC<React.PropsWithChildren<FieldBaseProps>> = ({
       })
 
     const stocks: CalcShared = (
-      (answers.assets as unknown as EstateAssets)?.stocks?.data ?? []
+      ((answers.assets as unknown) as EstateAssets)?.stocks?.data ?? []
     )
       .filter((item) => !!item.enabled)
       .map((item) => {
@@ -274,7 +275,7 @@ export const CalculateShare: FC<React.PropsWithChildren<FieldBaseProps>> = ({
       })
 
     const vehicles: CalcShared = (
-      (answers.assets as unknown as EstateAssets)?.vehicles?.data ?? []
+      ((answers.assets as unknown) as EstateAssets)?.vehicles?.data ?? []
     )
       .filter((item) => !!item.enabled)
       .map((item) => {
@@ -455,10 +456,6 @@ export const CalculateShare: FC<React.PropsWithChildren<FieldBaseProps>> = ({
     hasCustomSpouseSharePercentage,
     updateShareCalculations,
   ])
-
-  const inputError =
-    (errors?.customShare as { customSpouseSharePercentage: string })
-      ?.customSpouseSharePercentage ?? ''
 
   return (
     <Box>

--- a/libs/application/templates/inheritance-report/src/fields/CalculateShare/index.tsx
+++ b/libs/application/templates/inheritance-report/src/fields/CalculateShare/index.tsx
@@ -49,14 +49,12 @@ export const CalculateShare: FC<React.PropsWithChildren<FieldBaseProps>> = ({
   const [estateTotal, setEstateTotal] = useState(0)
   const [netPropertyForExchange, setNetPropertyForExchange] = useState(0)
   const formValues = getValues()
-  const [
-    customSpouseSharePercentage,
-    setCustomSpouseSharePercentage,
-  ] = useState(
-    formValues?.customShare?.customSpouseSharePercentage
-      ? formValues.customShare?.customSpouseSharePercentage / 100
-      : 50 / 100,
-  )
+  const [customSpouseSharePercentage, setCustomSpouseSharePercentage] =
+    useState(
+      formValues?.customShare?.customSpouseSharePercentage
+        ? formValues.customShare?.customSpouseSharePercentage / 100
+        : 50 / 100,
+    )
 
   const deceasedHadAssets = getDeceasedHadAssets(application)
   const deceasedWasInCohabitation = getDeceasedWasInCohabitation(application)
@@ -109,7 +107,7 @@ export const CalculateShare: FC<React.PropsWithChildren<FieldBaseProps>> = ({
 
   const updateShareCalculations = useCallback(() => {
     const bankAccounts: CalcShared = (
-      ((answers.assets as unknown) as EstateAssets)?.bankAccounts?.data ?? []
+      (answers.assets as unknown as EstateAssets)?.bankAccounts?.data ?? []
     )
       .filter((item) => !!item.enabled)
       .map((item) => {
@@ -134,7 +132,7 @@ export const CalculateShare: FC<React.PropsWithChildren<FieldBaseProps>> = ({
       })
 
     const claims: CalcShared = (
-      ((answers.assets as unknown) as EstateAssets)?.claims?.data ?? []
+      (answers.assets as unknown as EstateAssets)?.claims?.data ?? []
     )
       .filter((item) => !!item.enabled)
       .map((item) => {
@@ -155,7 +153,7 @@ export const CalculateShare: FC<React.PropsWithChildren<FieldBaseProps>> = ({
       })
 
     const guns: CalcShared = (
-      ((answers.assets as unknown) as EstateAssets)?.guns?.data ?? []
+      (answers.assets as unknown as EstateAssets)?.guns?.data ?? []
     )
       .filter((item) => !!item.enabled)
       .map((item) => {
@@ -176,7 +174,7 @@ export const CalculateShare: FC<React.PropsWithChildren<FieldBaseProps>> = ({
       })
 
     const inventory: CalcShared = [
-      ((answers.assets as unknown) as EstateAssets)?.inventory ?? [],
+      (answers.assets as unknown as EstateAssets)?.inventory ?? [],
     ].map((item) => {
       const value = valueToNumber(item.value)
       const deceasedShare = valueToNumber(item.deceasedShare)
@@ -195,7 +193,7 @@ export const CalculateShare: FC<React.PropsWithChildren<FieldBaseProps>> = ({
     })
 
     const money: CalcShared = [
-      ((answers.assets as unknown) as EstateAssets)?.money ?? [],
+      (answers.assets as unknown as EstateAssets)?.money ?? [],
     ].map((item) => {
       const value = valueToNumber(item.value)
       const deceasedShare = valueToNumber(item.deceasedShare)
@@ -214,7 +212,7 @@ export const CalculateShare: FC<React.PropsWithChildren<FieldBaseProps>> = ({
     })
 
     const otherAssets: CalcShared = (
-      ((answers.assets as unknown) as EstateAssets)?.otherAssets?.data ?? []
+      (answers.assets as unknown as EstateAssets)?.otherAssets?.data ?? []
     ).map((item) => {
       const value = valueToNumber(item.value)
       const deceasedShare = valueToNumber(item.deceasedShare)
@@ -233,7 +231,7 @@ export const CalculateShare: FC<React.PropsWithChildren<FieldBaseProps>> = ({
     })
 
     const realEstate: CalcShared = (
-      ((answers.assets as unknown) as EstateAssets)?.realEstate?.data ?? []
+      (answers.assets as unknown as EstateAssets)?.realEstate?.data ?? []
     )
       .filter((item) => item?.enabled)
       .map((item) => {
@@ -254,7 +252,7 @@ export const CalculateShare: FC<React.PropsWithChildren<FieldBaseProps>> = ({
       })
 
     const stocks: CalcShared = (
-      ((answers.assets as unknown) as EstateAssets)?.stocks?.data ?? []
+      (answers.assets as unknown as EstateAssets)?.stocks?.data ?? []
     )
       .filter((item) => !!item.enabled)
       .map((item) => {
@@ -275,7 +273,7 @@ export const CalculateShare: FC<React.PropsWithChildren<FieldBaseProps>> = ({
       })
 
     const vehicles: CalcShared = (
-      ((answers.assets as unknown) as EstateAssets)?.vehicles?.data ?? []
+      (answers.assets as unknown as EstateAssets)?.vehicles?.data ?? []
     )
       .filter((item) => !!item.enabled)
       .map((item) => {

--- a/libs/application/templates/inheritance-report/src/fields/Overview/OverviewAssets/rows.ts
+++ b/libs/application/templates/inheritance-report/src/fields/Overview/OverviewAssets/rows.ts
@@ -15,9 +15,9 @@ import { format as formatNationalId } from 'kennitala'
 import { PREPAID_INHERITANCE } from '../../../lib/constants'
 
 export const getRealEstateDataRow = (answers: FormValue): RowType[] => {
-  const values = ((answers.assets as unknown) as EstateAssets)?.realEstate?.data?.filter(
-    (item) => item.enabled,
-  )
+  const values = (
+    answers.assets as unknown as EstateAssets
+  )?.realEstate?.data?.filter((item) => item.enabled)
 
   const data = (values ?? []).map((item) => {
     const propertyValuation = roundedValueToNumber(item.propertyValuation)
@@ -54,9 +54,9 @@ export const getRealEstateDataRow = (answers: FormValue): RowType[] => {
 }
 
 export const getVehiclesDataRow = (answers: FormValue): RowType[] => {
-  const values = ((answers.assets as unknown) as EstateAssets)?.vehicles?.data.filter(
-    (item) => item.enabled,
-  )
+  const values = (
+    answers.assets as unknown as EstateAssets
+  )?.vehicles?.data.filter((item) => item.enabled)
 
   const data = (values ?? []).map((item) => {
     const propertyValuation = roundedValueToNumber(item.propertyValuation)
@@ -88,7 +88,7 @@ export const getVehiclesDataRow = (answers: FormValue): RowType[] => {
 }
 
 export const getGunsDataRow = (answers: FormValue): RowType[] => {
-  const values = ((answers.assets as unknown) as EstateAssets)?.guns?.data.filter(
+  const values = (answers.assets as unknown as EstateAssets)?.guns?.data.filter(
     (item) => item.enabled,
   )
 
@@ -122,7 +122,7 @@ export const getGunsDataRow = (answers: FormValue): RowType[] => {
 }
 
 export const getInventoryDataRow = (answers: FormValue): RowType[] => {
-  const values = ((answers.assets as unknown) as EstateAssets)?.inventory
+  const values = (answers.assets as unknown as EstateAssets)?.inventory
 
   const items: RowItemsType = []
 
@@ -151,9 +151,9 @@ export const getInventoryDataRow = (answers: FormValue): RowType[] => {
 }
 
 export const getStocksDataRow = (answers: FormValue): RowType[] => {
-  const values = ((answers.assets as unknown) as EstateAssets)?.stocks?.data.filter(
-    (item) => item.enabled,
-  )
+  const values = (
+    answers.assets as unknown as EstateAssets
+  )?.stocks?.data.filter((item) => item.enabled)
 
   const data = (values ?? []).map((item) => {
     const items: RowItemsType = [
@@ -191,9 +191,9 @@ export const getStocksDataRow = (answers: FormValue): RowType[] => {
 }
 
 export const getBankAccountsDataRow = (answers: FormValue): RowType[] => {
-  const values = ((answers.assets as unknown) as EstateAssets)?.bankAccounts?.data.filter(
-    (item) => item.enabled,
-  )
+  const values = (
+    answers.assets as unknown as EstateAssets
+  )?.bankAccounts?.data.filter((item) => item.enabled)
 
   const data = (values ?? []).map((item) => {
     const propertyValuation = roundedValueToNumber(item.propertyValuation)
@@ -231,8 +231,7 @@ export const getBankAccountsDataRow = (answers: FormValue): RowType[] => {
 }
 
 export const getOtherAssetsDataRow = (answers: FormValue): RowType[] => {
-  const values = ((answers.assets as unknown) as EstateAssets)?.otherAssets
-    ?.data
+  const values = (answers.assets as unknown as EstateAssets)?.otherAssets?.data
 
   const data = (values ?? []).map((item) => {
     const value = roundedValueToNumber(item.value)
@@ -262,7 +261,7 @@ export const getOtherAssetsDataRow = (answers: FormValue): RowType[] => {
 }
 
 export const getMoneyDataRow = (answers: FormValue): RowType[] => {
-  const values = ((answers.assets as unknown) as EstateAssets)?.money
+  const values = (answers.assets as unknown as EstateAssets)?.money
   const items: RowItemsType = []
   return [
     {

--- a/libs/application/templates/inheritance-report/src/fields/Overview/OverviewAssets/rows.ts
+++ b/libs/application/templates/inheritance-report/src/fields/Overview/OverviewAssets/rows.ts
@@ -15,9 +15,9 @@ import { format as formatNationalId } from 'kennitala'
 import { PREPAID_INHERITANCE } from '../../../lib/constants'
 
 export const getRealEstateDataRow = (answers: FormValue): RowType[] => {
-  const values = (
-    answers.assets as unknown as EstateAssets
-  )?.realEstate?.data?.filter((item) => item.enabled)
+  const values = ((answers.assets as unknown) as EstateAssets)?.realEstate?.data?.filter(
+    (item) => item.enabled,
+  )
 
   const data = (values ?? []).map((item) => {
     const propertyValuation = roundedValueToNumber(item.propertyValuation)
@@ -54,9 +54,9 @@ export const getRealEstateDataRow = (answers: FormValue): RowType[] => {
 }
 
 export const getVehiclesDataRow = (answers: FormValue): RowType[] => {
-  const values = (
-    answers.assets as unknown as EstateAssets
-  )?.vehicles?.data.filter((item) => item.enabled)
+  const values = ((answers.assets as unknown) as EstateAssets)?.vehicles?.data.filter(
+    (item) => item.enabled,
+  )
 
   const data = (values ?? []).map((item) => {
     const propertyValuation = roundedValueToNumber(item.propertyValuation)
@@ -88,7 +88,7 @@ export const getVehiclesDataRow = (answers: FormValue): RowType[] => {
 }
 
 export const getGunsDataRow = (answers: FormValue): RowType[] => {
-  const values = (answers.assets as unknown as EstateAssets)?.guns?.data.filter(
+  const values = ((answers.assets as unknown) as EstateAssets)?.guns?.data.filter(
     (item) => item.enabled,
   )
 
@@ -122,7 +122,7 @@ export const getGunsDataRow = (answers: FormValue): RowType[] => {
 }
 
 export const getInventoryDataRow = (answers: FormValue): RowType[] => {
-  const values = (answers.assets as unknown as EstateAssets)?.inventory
+  const values = ((answers.assets as unknown) as EstateAssets)?.inventory
 
   const items: RowItemsType = []
 
@@ -151,9 +151,9 @@ export const getInventoryDataRow = (answers: FormValue): RowType[] => {
 }
 
 export const getStocksDataRow = (answers: FormValue): RowType[] => {
-  const values = (
-    answers.assets as unknown as EstateAssets
-  )?.stocks?.data.filter((item) => item.enabled)
+  const values = ((answers.assets as unknown) as EstateAssets)?.stocks?.data.filter(
+    (item) => item.enabled,
+  )
 
   const data = (values ?? []).map((item) => {
     const items: RowItemsType = [
@@ -191,9 +191,9 @@ export const getStocksDataRow = (answers: FormValue): RowType[] => {
 }
 
 export const getBankAccountsDataRow = (answers: FormValue): RowType[] => {
-  const values = (
-    answers.assets as unknown as EstateAssets
-  )?.bankAccounts?.data.filter((item) => item.enabled)
+  const values = ((answers.assets as unknown) as EstateAssets)?.bankAccounts?.data.filter(
+    (item) => item.enabled,
+  )
 
   const data = (values ?? []).map((item) => {
     const propertyValuation = roundedValueToNumber(item.propertyValuation)
@@ -231,8 +231,8 @@ export const getBankAccountsDataRow = (answers: FormValue): RowType[] => {
 }
 
 export const getOtherAssetsDataRow = (answers: FormValue): RowType[] => {
-  const values = (answers.assets as unknown as EstateAssets)?.otherAssets?.data
-  const isPrePaid = answers.applicationFor === PREPAID_INHERITANCE
+  const values = ((answers.assets as unknown) as EstateAssets)?.otherAssets
+    ?.data
 
   const data = (values ?? []).map((item) => {
     const value = roundedValueToNumber(item.value)
@@ -262,7 +262,7 @@ export const getOtherAssetsDataRow = (answers: FormValue): RowType[] => {
 }
 
 export const getMoneyDataRow = (answers: FormValue): RowType[] => {
-  const values = (answers.assets as unknown as EstateAssets)?.money
+  const values = ((answers.assets as unknown) as EstateAssets)?.money
   const items: RowItemsType = []
   return [
     {

--- a/libs/application/templates/inheritance-report/src/lib/dataSchema.ts
+++ b/libs/application/templates/inheritance-report/src/lib/dataSchema.ts
@@ -17,7 +17,7 @@ import {
 } from './constants'
 
 const deceasedShare = {
-  deceasedShare: z.string().nonempty().optional(),
+  deceasedShare: z.string().min(1).optional(),
   deceasedShareEnabled: z.array(z.enum([YES])).optional(),
   deceasedShareAmount: z.number().min(0).max(100).optional(),
 }

--- a/libs/application/templates/inheritance-report/src/types.ts
+++ b/libs/application/templates/inheritance-report/src/types.ts
@@ -231,14 +231,6 @@ export interface ApplicationDebts {
   domesticAndForeignDebts: DomesticAndForeignDebts
 }
 
-interface DomesticAndForeignDebtsData {
-  balance: string
-  nationalId: string
-  loanIdentity: string
-  creditorName: string
-  taxFreeInheritance: number
-}
-
 interface DomesticAndForeignDebts {
   data: Debt[]
   total: number


### PR DESCRIPTION
Numerical valuations kept in strings.
Some default values where being set as `''` when it should've been `'0'`.
Used the opportunity to fix some linter errors at the same time.

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Asset fields now default to a numeric value ("0") instead of an empty string, ensuring consistent data display.
  - Error messaging in share calculations has been simplified, streamlining user interactions.
  - Redundant checks for prepaid inheritance have been removed for smoother asset data processing.
  - Input validation now enforces a non-empty share value when provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209904553692948