### PR TITLE
fix(j-s): Alternative Service Defender

### DIFF
--- a/apps/judicial-system/web/src/components/ServiceAnnouncement/ServiceAnnouncements.tsx
+++ b/apps/judicial-system/web/src/components/ServiceAnnouncement/ServiceAnnouncements.tsx
@@ -164,7 +164,7 @@ interface AlternativeServiceAnnouncementProps {
   defendantName: string | null | undefined
 }
 
-const AlternativeServiceAnnouncement: FC<
+export const AlternativeServiceAnnouncement: FC<
   AlternativeServiceAnnouncementProps
 > = (props) => {
   const { alternativeServiceDescription, defendantName } = props

--- a/apps/judicial-system/web/src/components/ServiceAnnouncement/ServiceAnnouncements.tsx
+++ b/apps/judicial-system/web/src/components/ServiceAnnouncement/ServiceAnnouncements.tsx
@@ -198,6 +198,7 @@ const ServiceAnnouncements: FC<ServiceAnnouncementsProps> = (props) => {
       <>
         {defendant.alternativeServiceDescription && (
           <AlternativeServiceAnnouncement
+            key={defendant.id}
             alternativeServiceDescription={
               defendant.alternativeServiceDescription
             }

--- a/apps/judicial-system/web/src/components/index.ts
+++ b/apps/judicial-system/web/src/components/index.ts
@@ -63,7 +63,10 @@ export { default as RestrictionTags } from './RestrictionTags/RestrictionTags'
 export { default as RulingAccordionItem } from './AccordionItems/RulingAccordionItem/RulingAccordionItem'
 export { default as RulingInput } from './RulingInput/RulingInput'
 export { default as SectionHeading } from './SectionHeading/SectionHeading'
-export { default as ServiceAnnouncements } from './ServiceAnnouncement/ServiceAnnouncements'
+export {
+  default as ServiceAnnouncements,
+  AlternativeServiceAnnouncement,
+} from './ServiceAnnouncement/ServiceAnnouncements'
 export { strings as serviceAnnouncementsStrings } from './ServiceAnnouncement/ServiceAnnouncements.strings'
 export { default as ServiceInterruptionBanner } from './ServiceInterruptionBanner/ServiceInterruptionBanner'
 export { default as SignedDocument } from './SignedDocument/SignedDocument'

--- a/apps/judicial-system/web/src/routes/Defender/Cases/defenderCases.graphql
+++ b/apps/judicial-system/web/src/routes/Defender/Cases/defenderCases.graphql
@@ -22,6 +22,7 @@ query DefenderCases($input: CaseListQueryInput) {
       name
       noNationalId
       defenderChoice
+      isAlternativeService
       subpoenas {
         id
         serviceStatus

--- a/apps/judicial-system/web/src/routes/Shared/IndictmentOverview/IndictmentOverview.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/IndictmentOverview/IndictmentOverview.tsx
@@ -15,6 +15,7 @@ import {
 } from '@island.is/judicial-system/types'
 import { titles } from '@island.is/judicial-system-web/messages'
 import {
+  AlternativeServiceAnnouncement,
   ConnectedCaseFilesAccordionItem,
   CourtCaseInfo,
   FormContentContainer,
@@ -171,20 +172,30 @@ const IndictmentOverview: FC = () => {
           </PageTitle>
           <CourtCaseInfo workingCase={workingCase} />
           {isDefenceUser(user) &&
-            workingCase.defendants?.map((defendant) =>
-              (defendant.subpoenas ?? [])
-                .filter((subpoena) =>
-                  isSuccessfulServiceStatus(subpoena.serviceStatus),
-                )
-                .map((subpoena) => (
-                  <Box key={`${defendant.id}${subpoena.id}`} marginBottom={2}>
-                    <ServiceAnnouncement
-                      defendant={defendant}
-                      subpoena={subpoena}
-                    />
-                  </Box>
-                )),
-            )}
+            workingCase.defendants?.map((defendant) => (
+              <>
+                {defendant.alternativeServiceDescription && (
+                  <AlternativeServiceAnnouncement
+                    alternativeServiceDescription={
+                      defendant.alternativeServiceDescription
+                    }
+                    defendantName={defendant.name}
+                  />
+                )}
+                {defendant.subpoenas
+                  ?.filter((subpoena) =>
+                    isSuccessfulServiceStatus(subpoena.serviceStatus),
+                  )
+                  .map((subpoena) => (
+                    <Box key={`${defendant.id}${subpoena.id}`} marginBottom={2}>
+                      <ServiceAnnouncement
+                        defendant={defendant}
+                        subpoena={subpoena}
+                      />
+                    </Box>
+                  ))}
+              </>
+            ))}
           {caseHasBeenReceivedByCourt &&
             workingCase.court &&
             latestDate?.date &&

--- a/apps/judicial-system/web/src/routes/Shared/IndictmentOverview/IndictmentOverview.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/IndictmentOverview/IndictmentOverview.tsx
@@ -176,6 +176,7 @@ const IndictmentOverview: FC = () => {
               <>
                 {defendant.alternativeServiceDescription && (
                   <AlternativeServiceAnnouncement
+                    key={defendant.id}
                     alternativeServiceDescription={
                       defendant.alternativeServiceDescription
                     }


### PR DESCRIPTION
# Alternative Service Defender

[Birt á annan máta - tagg á málalista hjá verjanda og info box um birtingastöðu](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1209950459477689)

## What

- Shows the correct service status on defender case lists.
- Shows alternative service card on defender case overview.

## Why

- The defender should see this information.

## Screenshots / Gifs

<img width="1288" alt="image" src="https://github.com/user-attachments/assets/e41dab2f-4ba7-4dd5-83a0-7e685803401f" />
<img width="665" alt="image" src="https://github.com/user-attachments/assets/b18f0a45-b7f7-4047-8b08-ad64661975bb" />

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the `AlternativeServiceAnnouncement` component to display alternative service descriptions for defendants.
  - Enhanced data retrieval to include an `isAlternativeService` field, indicating the applicability of alternative service for each defendant.
  - Expanded module exports to include the `AlternativeServiceAnnouncement` alongside the existing `ServiceAnnouncements`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->