### PR TITLE
fix(j-s): civil claimants file upload

### DIFF
--- a/apps/judicial-system/web/src/components/FormProvider/limitedAccessCase.graphql
+++ b/apps/judicial-system/web/src/components/FormProvider/limitedAccessCase.graphql
@@ -265,6 +265,7 @@ query LimitedAccessCase($input: CaseQueryInput!) {
       spokespersonEmail
       spokespersonPhoneNumber
       caseFilesSharedWithSpokesperson
+      isSpokespersonConfirmed
     }
     isCompletedWithoutRuling
     caseSentToCourtDate


### PR DESCRIPTION
# [Fixing civil claimant update feedback ](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1209987998823204)
## What
- Don't send users uploading files notifications
- Civil claimants should see the same docs as defenders

## Why
- Bc its not expected behaviour

## Screenshots / Gifs
<img width="460" alt="Screenshot 2025-04-15 at 13 59 17" src="https://github.com/user-attachments/assets/584fcddb-8d08-45c9-837d-1b29d16b64a6" />


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `isSpokespersonConfirmed` field to the civil claimants section of the Limited Access Case view.

- **Bug Fixes**
  - Improved notification handling to prevent users from receiving notifications about their own actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->