### PR TITLE
fix(j-s): check file.size is zero

### DIFF
--- a/libs/island-ui/core/src/lib/InputFileUpload/InputFileUpload.tsx
+++ b/libs/island-ui/core/src/lib/InputFileUpload/InputFileUpload.tsx
@@ -100,7 +100,7 @@ export const UploadedFile = ({
       case 'error':
         return { background: 'red100', border: 'red200', icon: 'red600' }
       case 'done':
-        if (!file.size) {
+        if (file.size === 0) {
           return { background: 'red100', border: 'red200', icon: 'red600' }
         }
         return {


### PR DESCRIPTION
## What
- The file size property is often `undefined` in various applications, so only render the red error styles if the size is actually zero. 

## Why
- It was a bug

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved file upload validation to only display an error for files with a size of exactly zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->