### PR TITLE
chore(island-ui): Update react-toastify to v11

### DIFF
--- a/apps/judicial-system/web/pages/_app.tsx
+++ b/apps/judicial-system/web/pages/_app.tsx
@@ -105,7 +105,7 @@ class JudicialSystemApplication extends App<Props> {
                     <HeaderContainer />
                     <FormProvider>
                       <Component {...pageProps} />
-                      <ToastContainer useKeyframeStyles />
+                      <ToastContainer />
                     </FormProvider>
                     <style jsx global>{`
                       @font-face {

--- a/libs/island-ui/core/src/lib/Toast/Toast.css.ts
+++ b/libs/island-ui/core/src/lib/Toast/Toast.css.ts
@@ -186,7 +186,7 @@ globalStyle(`${root} .Toastify__progress-bar`, {
   width: '100%',
   height: '5px',
   zIndex: 9999,
-  opacity: 0.7,
+  opacity: 1,
   backgroundColor: theme.color.mint400,
   transformOrigin: 'left',
 })

--- a/libs/island-ui/core/src/lib/Toast/Toast.tsx
+++ b/libs/island-ui/core/src/lib/Toast/Toast.tsx
@@ -73,6 +73,7 @@ export const ToastContainer: FC<ToastProps> = ({
         draggable
         pauseOnHover
         transition={Slide}
+        icon={false}
       />
     </div>
   )

--- a/package.json
+++ b/package.json
@@ -273,7 +273,7 @@
     "react-router-dom": "6.11.2",
     "react-select": "5.8.2",
     "react-table": "7.7.0",
-    "react-toastify": "6.0.8",
+    "react-toastify": "11.0.0",
     "react-top-loading-bar": "2.3.1",
     "react-use": "15.3.3",
     "reakit": "1.3.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -29022,6 +29022,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"clsx@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "clsx@npm:2.1.1"
+  checksum: 10/cdfb57fa6c7649bbff98d9028c2f0de2f91c86f551179541cf784b1cfdc1562dcb951955f46d54d930a3879931a980e32a46b598acaea274728dbe068deca919
+  languageName: node
+  linkType: hard
+
 "cluster-key-slot@npm:^1.1.0":
   version: 1.1.0
   resolution: "cluster-key-slot@npm:1.1.0"
@@ -39900,7 +39907,7 @@ __metadata:
     react-select: "npm:5.8.2"
     react-table: "npm:7.7.0"
     react-test-renderer: "npm:18.2.0"
-    react-toastify: "npm:6.0.8"
+    react-toastify: "npm:11.0.0"
     react-top-loading-bar: "npm:2.3.1"
     react-use: "npm:15.3.3"
     reakit: "npm:1.3.11"
@@ -51203,16 +51210,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-toastify@npm:6.0.8":
-  version: 6.0.8
-  resolution: "react-toastify@npm:6.0.8"
+"react-toastify@npm:11.0.0":
+  version: 11.0.0
+  resolution: "react-toastify@npm:11.0.0"
   dependencies:
-    classnames: "npm:^2.2.6"
-    prop-types: "npm:^15.7.2"
-    react-transition-group: "npm:^4.4.1"
+    clsx: "npm:^2.1.1"
   peerDependencies:
-    react: ">=16"
-  checksum: 10/c10a04f3017d4d000500cbda09c1ff0eeef0e382856270d912a9f46fce5572fe300430d2167d7dc91e64ab1a38f0d596d4e834191582b6acc2145a50f4c9ef1f
+    react: ^18 || ^19
+    react-dom: ^18 || ^19
+  checksum: 10/b825d584f1db52a380a8bd16d9b81b94c9b2a9b91d666c0126f3d69a2921f4c3229ad877add79a407257fcffbd7bd6b1cf150c3474c27352cf6eb7dfadaa59ac
   languageName: node
   linkType: hard
 
@@ -51260,7 +51266,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-transition-group@npm:^4.3.0, react-transition-group@npm:^4.4.1":
+"react-transition-group@npm:^4.3.0":
   version: 4.4.1
   resolution: "react-transition-group@npm:4.4.1"
   dependencies:


### PR DESCRIPTION
# Update react-toastify to v11

[Asana](https://app.asana.com/1/203394141643832/project/322488613152836/task/1209972674800169?focus=true)

## What

Update react-toastify to v11

## Why

The current version displays a console error and is outdated.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Increased the opacity of the toast notification progress bar for improved visibility.

- **New Features**
  - Toast notifications no longer display icons by default.

- **Chores**
  - Updated the "react-toastify" library to the latest version.
  - Adjusted toast notification settings for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->