### PR TITLE
chore(ci): Re-enable blocking new lints

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -336,10 +336,10 @@ jobs:
           # Get `<filename> #lints: <n>` lines for easy diff
           for f in "${BASE_LINT_FILE}" "${HEAD_LINT_FILE}"; do
             # Make "Remote cache..." and "Local cache" be the same
-            sed -i -E 's/\s*\[[^[]*cache[^]]*\]\s*//g' "${f}"
-            grep -oP "(?<=$PWD/).*" "${f}" | sort -n | uniq -c | awk '{print($2 " #lints: " $1)}' > "${f}_files.out"
+            sed -i -E 's/\s*\[[^[]*cache[^]]*\]\s*//g' "${f}" || echo "No cached targets found in $f"
+            grep -oP "(?<=$PWD/).*" "${f}" | sort -n | uniq -c | awk '{print($2 " #lints: " $1)}' > "${f}_files.out" || { echo "No lints found in $f"; exit 1; }
           done
-          NEW_LINTS=$(comm -13 "${BASE_LINT_FILE}_files.out" "${HEAD_LINT_FILE}_files.out" | wc -l)
+          NEW_LINTS=$(comm -13 "${BASE_LINT_FILE}_files.out" "${HEAD_LINT_FILE}_files.out" | wc -l) || echo "Failed comparing output files"
           COUNT_DIFF=$(( HEAD_LINT_COUNT - BASE_LINT_COUNT )) || :
           if (( COUNT_DIFF <= 0 )) && [[ "$NEW_LINTS" -eq 0 ]]; then
             echo "Lint count has not increased (𝚫=$COUNT_DIFF)"

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -339,7 +339,7 @@ jobs:
             sed -i -E 's/\s*\[[^[]*cache[^]]*\]\s*//g' "${f}" || echo "No cached targets found in $f"
             grep -oP "(?<=$PWD/).*" "${f}" | sort -n | uniq -c | awk '{print($2 " #lints: " $1)}' > "${f}_files.out" || { echo "No lints found in $f"; exit 1; }
           done
-          NEW_LINTS=$(comm -13 "${BASE_LINT_FILE}_files.out" "${HEAD_LINT_FILE}_files.out" | wc -l) || echo "Failed comparing output files"
+          NEW_LINTS=$(comm -13 "${BASE_LINT_FILE}_files.out" "${HEAD_LINT_FILE}_files.out" | wc -l) || { echo "Failed comparing output files"; exit 1; }
           COUNT_DIFF=$(( HEAD_LINT_COUNT - BASE_LINT_COUNT )) || :
           if (( COUNT_DIFF <= 0 && NEW_LINTS == 0 )); then
             echo "Lint count has not increased (𝚫=$COUNT_DIFF)"

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -341,7 +341,7 @@ jobs:
           done
           NEW_LINTS=$(comm -13 "${BASE_LINT_FILE}_files.out" "${HEAD_LINT_FILE}_files.out" | wc -l) || echo "Failed comparing output files"
           COUNT_DIFF=$(( HEAD_LINT_COUNT - BASE_LINT_COUNT )) || :
-          if (( COUNT_DIFF <= 0 )) && [[ "$NEW_LINTS" -eq 0 ]]; then
+          if (( COUNT_DIFF <= 0 && NEW_LINTS == 0 )); then
             echo "Lint count has not increased (𝚫=$COUNT_DIFF)"
             exit 0
           fi

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -351,6 +351,7 @@ jobs:
           echo "::group::lintdiff"
           diff "${BASE_LINT_FILE}" "${HEAD_LINT_FILE}" || : # Ignore diff exit code
           echo "::endgroup::"
+          exit 1
 
   build:
     needs:


### PR DESCRIPTION
Reverts island-is/island.is#18780

Has been re-thunk

Now:
- Catches early-exit (e.g. when counting, or searching)
- Forces no new lints again
- Minor conditional refactor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved error handling and messaging in the pull request lint workflow to ensure clearer feedback and more reliable failure detection when new lint issues are introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->