### PR TITLE
fix: `git remote prune` nag

### DIFF
--- a/.github/workflows/pullrequest-close.yml
+++ b/.github/workflows/pullrequest-close.yml
@@ -61,7 +61,7 @@ jobs:
         id: create_pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_BRANCH: ${{ github.head_ref}}/cherry-pick
+          PR_BRANCH: cherry-picks/${{ github.head_ref}}
           TARGET_BRANCH: release/${{ steps.get_latest_release.outputs.LATEST_RELEASE }}
         run: |
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"


### PR DESCRIPTION
Frequently getting nagged by git to run `git remote prune origin` to clean conflicting upstream branch because git fails to create the `/cherry-pick` postfixed branch, because the original branch still exists locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the naming convention for branches created during cherry-pick pull requests. Branches will now be prefixed with "cherry-picks/" instead of having "/cherry-pick" appended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->