### PR TITLE
fix(j-s): rename subpoenaId to policeSubpoenaId

### DIFF
--- a/apps/judicial-system/api/src/app/modules/subpoena/models/subpoena.model.ts
+++ b/apps/judicial-system/api/src/app/modules/subpoena/models/subpoena.model.ts
@@ -16,7 +16,7 @@ export class Subpoena {
   modified?: string
 
   @Field(() => String, { nullable: true })
-  subpoenaId?: string
+  policeSubpoenaId?: string
 
   @Field(() => String, { nullable: true })
   defendantId?: string

--- a/apps/judicial-system/backend/migrations/20250422152214-update-supoena-id.js
+++ b/apps/judicial-system/backend/migrations/20250422152214-update-supoena-id.js
@@ -1,0 +1,33 @@
+'use strict'
+
+module.exports = {
+  up: (queryInterface) => {
+    return queryInterface.sequelize.transaction((t) =>
+      Promise.all([
+        queryInterface.renameColumn(
+          'subpoena',
+          'subpoena_id',
+          'police_subpoena_id',
+          {
+            transaction: t,
+          },
+        ),
+      ]),
+    )
+  },
+
+  down: (queryInterface) => {
+    return queryInterface.sequelize.transaction((t) =>
+      Promise.all([
+        queryInterface.renameColumn(
+          'subpoena',
+          'police_subpoena_id',
+          'subpoena_id',
+          {
+            transaction: t,
+          },
+        ),
+      ]),
+    )
+  },
+}

--- a/apps/judicial-system/backend/src/app/modules/police/models/createSubpoena.response.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/models/createSubpoena.response.ts
@@ -2,5 +2,5 @@ import { ApiProperty } from '@nestjs/swagger'
 
 export class CreateSubpoenaResponse {
   @ApiProperty({ type: String })
-  subpoenaId!: string
+  policeSubpoenaId!: string
 }

--- a/apps/judicial-system/backend/src/app/modules/police/police.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/police.service.ts
@@ -663,7 +663,7 @@ export class PoliceService {
 
       if (res.ok) {
         const subpoenaResponse = await res.json()
-        return { subpoenaId: subpoenaResponse.id }
+        return { policeSubpoenaId: subpoenaResponse.id }
       }
 
       throw await res.text()

--- a/apps/judicial-system/backend/src/app/modules/police/police.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/police.service.ts
@@ -345,11 +345,11 @@ export class PoliceService {
   }
 
   async getSubpoenaStatus(
-    subpoenaId: string,
+    policeSubpoenaId: string,
     user?: User,
   ): Promise<SubpoenaInfo> {
     return this.fetchPoliceDocumentApi(
-      `${this.xRoadPath}/GetSubpoenaStatus?id=${subpoenaId}`,
+      `${this.xRoadPath}/GetSubpoenaStatus?id=${policeSubpoenaId}`,
     )
       .then(async (res: Response) => {
         if (res.ok) {
@@ -383,7 +383,7 @@ export class PoliceService {
         // The police system does not provide a structured error response.
         // When a subpoena does not exist, a stack trace is returned.
         throw new NotFoundException({
-          message: `Subpoena with id ${subpoenaId} does not exist`,
+          message: `Subpoena with police subpoena id ${policeSubpoenaId} does not exist`,
           detail: reason,
         })
       })
@@ -396,7 +396,7 @@ export class PoliceService {
           // Act as if the subpoena does not exist
           throw new NotFoundException({
             ...reason,
-            message: `Subpoena ${subpoenaId} does not exist`,
+            message: `Subpoena ${policeSubpoenaId} does not exist`,
             detail: reason.message,
           })
         }
@@ -404,7 +404,7 @@ export class PoliceService {
         this.eventService.postErrorEvent(
           'Failed to get subpoena',
           {
-            subpoenaId,
+            policeSubpoenaId,
             actor: user?.name || 'Digital-mailbox',
             institution: user?.institution?.name,
           },
@@ -413,7 +413,7 @@ export class PoliceService {
 
         throw new BadGatewayException({
           ...reason,
-          message: `Failed to get subpoena ${subpoenaId}`,
+          message: `Failed to get subpoena ${policeSubpoenaId}`,
           detail: reason.message,
         })
       })
@@ -688,14 +688,14 @@ export class PoliceService {
 
   async revokeSubpoena(
     theCase: Case,
-    subpoenaId: string,
+    policeSubpoenaId: string,
     user: User,
   ): Promise<boolean> {
     const { name: actor } = user
 
     try {
       const res = await this.fetchPoliceCaseApi(
-        `${this.xRoadPath}/InvalidateCourtSummon?sekGuid=${subpoenaId}`,
+        `${this.xRoadPath}/InvalidateCourtSummon?sekGuid=${policeSubpoenaId}`,
         {
           method: 'POST',
           headers: {
@@ -714,7 +714,7 @@ export class PoliceService {
       throw await res.text()
     } catch (error) {
       this.logger.error(
-        `Failed revoke subpoena with id ${subpoenaId} for case ${theCase.id} from police`,
+        `Failed revoke subpoena with police subpoena id ${policeSubpoenaId} for case ${theCase.id} from police`,
         {
           error,
         },
@@ -724,7 +724,7 @@ export class PoliceService {
         'Failed to revoke subpoena from police',
         {
           caseId: theCase.id,
-          subpoenaId,
+          policeSubpoenaId,
           actor,
         },
         error,

--- a/apps/judicial-system/backend/src/app/modules/subpoena/guards/policeSubpoenaExists.guard.ts
+++ b/apps/judicial-system/backend/src/app/modules/subpoena/guards/policeSubpoenaExists.guard.ts
@@ -21,7 +21,9 @@ export class PoliceSubpoenaExistsGuard implements CanActivate {
     }
 
     // subpoenaId is the external police document id
-    request.subpoena = await this.subpoenaService.findBySubpoenaId(subpoenaId)
+    request.subpoena = await this.subpoenaService.findByPoliceSubpoenaId(
+      subpoenaId,
+    )
 
     return true
   }

--- a/apps/judicial-system/backend/src/app/modules/subpoena/guards/policeSubpoenaExists.guard.ts
+++ b/apps/judicial-system/backend/src/app/modules/subpoena/guards/policeSubpoenaExists.guard.ts
@@ -14,15 +14,15 @@ export class PoliceSubpoenaExistsGuard implements CanActivate {
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest()
 
-    const subpoenaId = request.params.subpoenaId
+    const policeSubpoenaId = request.params.policeSubpoenaId
 
-    if (!subpoenaId) {
+    if (!policeSubpoenaId) {
       throw new BadRequestException('Missing police subpoena id')
     }
 
-    // subpoenaId is the external police document id
+    // policeSubpoenaId is the external police document id
     request.subpoena = await this.subpoenaService.findByPoliceSubpoenaId(
-      subpoenaId,
+      policeSubpoenaId,
     )
 
     return true

--- a/apps/judicial-system/backend/src/app/modules/subpoena/guards/test/policeSubpoenaExistsGuard.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/subpoena/guards/test/policeSubpoenaExistsGuard.spec.ts
@@ -48,9 +48,9 @@ describe('Police Subpoena Exists Guard', () => {
 
   describe('subpoena exists', () => {
     const policeSubpoenaId = uuid()
-    const subpoena = { id: uuid(), subpoenaId: policeSubpoenaId }
+    const subpoena = { id: uuid(), policeSubpoenaId }
     const request = {
-      params: { subpoenaId: policeSubpoenaId },
+      params: { policeSubpoenaId },
       subpoena: undefined,
     }
     let then: Then
@@ -66,7 +66,7 @@ describe('Police Subpoena Exists Guard', () => {
     it('should activate', () => {
       expect(mockSubpoenaModel.findOne).toHaveBeenCalledWith({
         include,
-        where: { subpoenaId: policeSubpoenaId },
+        where: { policeSubpoenaId },
       })
       expect(then.result).toBe(true)
       expect(request.subpoena).toBe(subpoena)
@@ -79,7 +79,7 @@ describe('Police Subpoena Exists Guard', () => {
 
     beforeEach(async () => {
       mockRequest.mockReturnValueOnce({
-        params: { subpoenaId: policeSubpoenaId },
+        params: { policeSubpoenaId },
       })
 
       then = await givenWhenThen()

--- a/apps/judicial-system/backend/src/app/modules/subpoena/internalSubpoena.controller.ts
+++ b/apps/judicial-system/backend/src/app/modules/subpoena/internalSubpoena.controller.ts
@@ -48,13 +48,13 @@ export class InternalSubpoenaController {
   ) {}
 
   @UseGuards(PoliceSubpoenaExistsGuard)
-  @Patch('subpoena/:subpoenaId')
+  @Patch('subpoena/:policeSubpoenaId')
   updateSubpoena(
-    @Param('subpoenaId') subpoenaId: string,
+    @Param('policeSubpoenaId') policeSubpoenaId: string,
     @CurrentSubpoena() subpoena: Subpoena,
     @Body() update: UpdateSubpoenaDto,
   ): Promise<Subpoena> {
-    this.logger.debug(`Updating subpoena by subpoena id ${subpoenaId}`)
+    this.logger.debug(`Updating subpoena by police subpoena id ${policeSubpoenaId}`)
 
     return this.subpoenaService.update(subpoena, update)
   }

--- a/apps/judicial-system/backend/src/app/modules/subpoena/internalSubpoena.controller.ts
+++ b/apps/judicial-system/backend/src/app/modules/subpoena/internalSubpoena.controller.ts
@@ -96,7 +96,7 @@ export class InternalSubpoenaController {
         deliveredToPolice: results.delivered,
         subpoenaId: subpoena.id,
         subpoenaCreated: subpoena.created,
-        policeSubpoenaId: currentSubpoena.subpoenaId,
+        policeSubpoenaId: currentSubpoena.policeSubpoenaId,
         subpoenaHash: currentSubpoena.hash,
         subpoenaDeliveredToPolice: new Date(),
         indictmentHash: theCase.indictmentHash,

--- a/apps/judicial-system/backend/src/app/modules/subpoena/models/subpoena.model.ts
+++ b/apps/judicial-system/backend/src/app/modules/subpoena/models/subpoena.model.ts
@@ -54,7 +54,7 @@ export class Subpoena extends Model {
 
   @ApiPropertyOptional({ type: String })
   @Column({ type: DataType.STRING, allowNull: true })
-  subpoenaId?: string
+  policeSubpoenaId?: string
 
   @ForeignKey(() => Defendant)
   @Column({ type: DataType.UUID, allowNull: false })

--- a/apps/judicial-system/backend/src/app/modules/subpoena/subpoena.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/subpoena/subpoena.service.ts
@@ -286,10 +286,10 @@ export class SubpoenaService {
     return subpoena
   }
 
-  async findBySubpoenaId(policeSubpoenaId?: string): Promise<Subpoena> {
+  async findByPoliceSubpoenaId(policeSubpoenaId?: string): Promise<Subpoena> {
     const subpoena = await this.subpoenaModel.findOne({
       include,
-      where: { subpoenaId: policeSubpoenaId },
+      where: { policeSubpoenaId: policeSubpoenaId },
     })
 
     if (!subpoena) {
@@ -353,7 +353,7 @@ export class SubpoenaService {
       }
 
       const [numberOfAffectedRows] = await this.subpoenaModel.update(
-        { subpoenaId: createdSubpoena.subpoenaId },
+        { policeSubpoenaId: createdSubpoena.policeSubpoenaId },
         { where: { id: subpoena.id } },
       )
 
@@ -364,7 +364,7 @@ export class SubpoenaService {
       }
 
       this.logger.info(
-        `Subpoena ${createdSubpoena.subpoenaId} delivered to the police centralized file service`,
+        `Subpoena with police subpoena id ${createdSubpoena.policeSubpoenaId} delivered to the police centralized file service`,
       )
 
       return { delivered: true }
@@ -486,7 +486,7 @@ export class SubpoenaService {
     subpoena: Subpoena,
     user: TUser,
   ): Promise<DeliverResponse> {
-    if (!subpoena.subpoenaId) {
+    if (!subpoena.policeSubpoenaId) {
       this.logger.warn(
         `Attempted to revoke a subpoena with id ${subpoena.id} that had not been delivered to the police`,
       )
@@ -495,13 +495,13 @@ export class SubpoenaService {
 
     const subpoenaRevoked = await this.policeService.revokeSubpoena(
       theCase,
-      subpoena.subpoenaId,
+      subpoena.policeSubpoenaId,
       user,
     )
 
     if (subpoenaRevoked) {
       this.logger.info(
-        `Subpoena ${subpoena.subpoenaId} successfully revoked from police`,
+        `Subpoena ${subpoena.policeSubpoenaId} successfully revoked from police`,
       )
       return { delivered: true }
     } else {
@@ -510,7 +510,7 @@ export class SubpoenaService {
   }
 
   async getSubpoena(subpoena: Subpoena, user?: TUser): Promise<Subpoena> {
-    if (!subpoena.subpoenaId) {
+    if (!subpoena.policeSubpoenaId) {
       // The subpoena has not been delivered to the police
       return subpoena
     }
@@ -523,7 +523,7 @@ export class SubpoenaService {
     // We don't know if the subpoena has been served to the defendant
     // so we need to check the police service
     const subpoenaInfo = await this.policeService.getSubpoenaStatus(
-      subpoena.subpoenaId,
+      subpoena.policeSubpoenaId,
       user,
     )
 

--- a/apps/judicial-system/backend/src/app/modules/subpoena/subpoena.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/subpoena/subpoena.service.ts
@@ -289,7 +289,7 @@ export class SubpoenaService {
   async findByPoliceSubpoenaId(policeSubpoenaId?: string): Promise<Subpoena> {
     const subpoena = await this.subpoenaModel.findOne({
       include,
-      where: { policeSubpoenaId: policeSubpoenaId },
+      where: { policeSubpoenaId },
     })
 
     if (!subpoena) {

--- a/apps/judicial-system/backend/src/app/modules/subpoena/test/internalSubpoenaController/deliverSubpoenaRevocationToPolice.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/subpoena/test/internalSubpoenaController/deliverSubpoenaRevocationToPolice.spec.ts
@@ -20,7 +20,7 @@ describe('InternalSubpoenaController - Deliver subpoena revocation to police', (
   const policeSubpoenaId = uuid()
   const defendantId = uuid()
 
-  const subpoena = { id: subpoenaId, subpoenaId: policeSubpoenaId } as Subpoena
+  const subpoena = { id: subpoenaId, policeSubpoenaId } as Subpoena
   const theCase = { id: caseId } as Case
 
   const userId = uuid()

--- a/apps/judicial-system/web/src/components/FormProvider/case.graphql
+++ b/apps/judicial-system/web/src/components/FormProvider/case.graphql
@@ -50,7 +50,7 @@ query Case($input: CaseQueryInput!) {
         defenderNationalId
         caseId
         defendantId
-        subpoenaId
+        policeSubpoenaId
       }
     }
     defenderName
@@ -369,7 +369,7 @@ query Case($input: CaseQueryInput!) {
           comment
           defenderNationalId
           caseId
-          subpoenaId
+          policeSubpoenaId
         }
       }
       caseFiles {

--- a/apps/judicial-system/web/src/components/FormProvider/limitedAccessCase.graphql
+++ b/apps/judicial-system/web/src/components/FormProvider/limitedAccessCase.graphql
@@ -62,7 +62,7 @@ query LimitedAccessCase($input: CaseQueryInput!) {
         defenderNationalId
         caseId
         defendantId
-        subpoenaId
+        policeSubpoenaId
       }
     }
     defenderName

--- a/apps/judicial-system/web/src/routes/Defender/Cases/defenderCases.graphql
+++ b/apps/judicial-system/web/src/routes/Defender/Cases/defenderCases.graphql
@@ -26,7 +26,7 @@ query DefenderCases($input: CaseListQueryInput) {
       subpoenas {
         id
         serviceStatus
-        subpoenaId
+        policeSubpoenaId
       }
     }
     initialRulingDate

--- a/apps/judicial-system/web/src/routes/Shared/Cases/cases.graphql
+++ b/apps/judicial-system/web/src/routes/Shared/Cases/cases.graphql
@@ -34,7 +34,7 @@ query Cases {
       subpoenas {
         id
         serviceStatus
-        subpoenaId
+        policeSubpoenaId
       }
       verdictAppealDate
     }

--- a/apps/judicial-system/web/src/utils/hooks/useSubpoena/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useSubpoena/index.ts
@@ -7,7 +7,8 @@ const useSubpoena = (subpoena: Subpoena) => {
   // Skip if the subpoena has not been sent to the police
   // or if the subpoena already has a service status
   const skip =
-    !subpoena.subpoenaId || isSuccessfulServiceStatus(subpoena.serviceStatus)
+    !subpoena.policeSubpoenaId ||
+    isSuccessfulServiceStatus(subpoena.serviceStatus)
 
   const { data, loading, error } = useSubpoenaQuery({
     skip,

--- a/apps/judicial-system/web/src/utils/hooks/useSubpoena/subpoena.graphql
+++ b/apps/judicial-system/web/src/utils/hooks/useSubpoena/subpoena.graphql
@@ -9,6 +9,6 @@ query Subpoena($input: SubpoenaQueryInput!) {
     defenderNationalId
     caseId
     defendantId
-    subpoenaId
+    policeSubpoenaId
   }
 }

--- a/apps/judicial-system/xrd-api/src/app/app.controller.ts
+++ b/apps/judicial-system/xrd-api/src/app/app.controller.ts
@@ -71,15 +71,16 @@ export class AppController {
     }
   }
 
-  @Patch('subpoena/:subpoenaId')
+  // update by police subpoena id
+  @Patch('subpoena/:policeSubpoenaId')
   @ApiResponse({ status: 400, description: 'Invalid input' })
   @ApiResponse({ status: 502, description: 'Failed to update subpoena' })
   async updateSubpoena(
-    @Param('subpoenaId', new ParseUUIDPipe()) subpoenaId: string,
+    @Param('policeSubpoenaId', new ParseUUIDPipe()) policeSubpoenaId: string,
     @Body() updateSubpoena: UpdateSubpoenaDto,
   ): Promise<SubpoenaResponse> {
-    this.logger.info(`Updating subpoena ${subpoenaId}`)
+    this.logger.info(`Updating subpoena ${policeSubpoenaId}`)
 
-    return this.appService.updateSubpoena(subpoenaId, updateSubpoena)
+    return this.appService.updateSubpoena(policeSubpoenaId, updateSubpoena)
   }
 }

--- a/apps/judicial-system/xrd-api/src/app/app.service.ts
+++ b/apps/judicial-system/xrd-api/src/app/app.service.ts
@@ -81,19 +81,19 @@ export class AppService {
   }
 
   async updateSubpoena(
-    subpoenaId: string,
+    policeSubpoenaId: string,
     updateSubpoena: UpdateSubpoenaDto,
   ): Promise<SubpoenaResponse> {
     return await this.auditTrailService.audit(
       'digital-mailbox-api',
       AuditedAction.UPDATE_SUBPOENA,
-      this.updateSubpoenaInfo(subpoenaId, updateSubpoena),
-      subpoenaId,
+      this.updateSubpoenaInfo(policeSubpoenaId, updateSubpoena),
+      policeSubpoenaId,
     )
   }
 
   private async updateSubpoenaInfo(
-    subpoenaId: string,
+    policeSubpoenaId: string,
     updateSubpoena: UpdateSubpoenaDto,
   ): Promise<SubpoenaResponse> {
     let defenderInfo: {
@@ -165,8 +165,9 @@ export class AppService {
     }
 
     try {
+      // TODO: this is now police subpoena id
       const res = await fetch(
-        `${this.config.backend.url}/api/internal/subpoena/${subpoenaId}`,
+        `${this.config.backend.url}/api/internal/subpoena/${policeSubpoenaId}`,
         {
           method: 'PATCH',
           headers: {

--- a/apps/judicial-system/xrd-api/src/app/app.service.ts
+++ b/apps/judicial-system/xrd-api/src/app/app.service.ts
@@ -165,7 +165,6 @@ export class AppService {
     }
 
     try {
-      // TODO: this is now police subpoena id
       const res = await fetch(
         `${this.config.backend.url}/api/internal/subpoena/${policeSubpoenaId}`,
         {


### PR DESCRIPTION
# [Rename subpoenaId to policeSubpoenaId](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1209431684853011)

## What
- Rename `subpoenaId` to `policeSubpoenaId` to avoid confusing `subpoena.subpoenaId` and `subpoena.id`

## Why
- we use `subpoenaId` all over the place for the `subpoenaId` and we have made one bug on mixing id with police subpoena id, so we rename it to make it more clear

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Renamed the subpoena identifier field from subpoenaId to policeSubpoenaId across the system for improved clarity and consistency.
  - Updated API endpoints, service methods, GraphQL queries, and UI components to use policeSubpoenaId.
  - Modified database schema and migration scripts to reflect the new field name.
- **Bug Fixes**
  - Corrected validation and guard logic to use policeSubpoenaId, ensuring accurate data retrieval and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->