### PR TITLE
fix(payments): Fix 3ds success layout inside iframe

### DIFF
--- a/apps/payments/components/ThreeDSecure/ThreeDSecure.tsx
+++ b/apps/payments/components/ThreeDSecure/ThreeDSecure.tsx
@@ -102,7 +102,7 @@ export const ThreeDSecure: React.FC<ThreeDSecureProps> = ({
                 }}
                 style={{
                   width: '100%',
-                  height: iframeContainerRef.current?.offsetWidth ?? '500px',
+                  height: '100%',
                   border: 'none',
                   zIndex: 2,
                 }}

--- a/apps/payments/pages/_app.tsx
+++ b/apps/payments/pages/_app.tsx
@@ -9,7 +9,7 @@ import './app.css'
 
 const Layout: FC<React.PropsWithChildren<unknown>> = ({ children }) => {
   return (
-    <div>
+    <div style={{ height: '100%' }}>
       <Head>
         <title>Ísland.is | Greiðslur</title>
         <link rel="icon" href="/favicon.ico" type="image/x-icon" />

--- a/apps/payments/pages/app.css
+++ b/apps/payments/pages/app.css
@@ -1,1 +1,9 @@
 @import '../../../libs/island-ui/fonts/fonts.css';
+
+html,
+body,
+#__next {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+}


### PR DESCRIPTION
## What

Let 3DS success page fill the modal

## Why

To match design

## Screenshots / Gifs

### Before
![image](https://github.com/user-attachments/assets/60ffa2d8-7838-478d-b9f2-63ba9da4c18a)

### After
![image](https://github.com/user-attachments/assets/715271d5-7f5a-4710-987f-284dc3acdd70)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated global and component styles to ensure the application and embedded elements occupy the full height of the viewport.
  - Removed default margin and padding from key layout elements for a more consistent appearance.
  - Adjusted iframe height handling to better fit its container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->