### PR TITLE
fix(web): Add types to english search result query

### DIFF
--- a/apps/web/screens/Search/Search.tsx
+++ b/apps/web/screens/Search/Search.tsx
@@ -84,6 +84,21 @@ import { ActionType, initialState, reducer } from './Search.state'
 
 const PERPAGE = 10
 
+const ALL_TYPES: `${SearchableContentTypes}`[] = [
+  'webArticle',
+  'webLifeEventPage',
+  'webDigitalIcelandService',
+  'webDigitalIcelandCommunityPage',
+  'webSubArticle',
+  'webLink',
+  'webNews',
+  'webOrganizationSubpage',
+  'webOrganizationPage',
+  'webProjectPage',
+  'webManual',
+  'webManualChapterItem',
+]
+
 type SearchQueryFilters = {
   category: string
   type: string
@@ -851,25 +866,11 @@ Search.getProps = async ({ apolloClient, locale, query }) => {
     // @ts-ignore make web strict
     (x: SearchableContentTypes) => x,
   )
-  const allTypes: `${SearchableContentTypes}`[] = [
-    'webArticle',
-    'webLifeEventPage',
-    'webDigitalIcelandService',
-    'webDigitalIcelandCommunityPage',
-    'webSubArticle',
-    'webLink',
-    'webNews',
-    'webOrganizationSubpage',
-    'webOrganizationPage',
-    'webProjectPage',
-    'webManual',
-    'webManualChapterItem',
-  ]
 
   const ensureContentTypeExists = (
     types: string[],
   ): types is SearchableContentTypes[] =>
-    !!types.length && allTypes.every((type) => allTypes.includes(type))
+    !!types.length && ALL_TYPES.every((type) => ALL_TYPES.includes(type))
 
   const [
     {
@@ -890,8 +891,8 @@ Search.getProps = async ({ apolloClient, locale, query }) => {
           queryString,
           types: types.length
             ? types
-            : ensureContentTypeExists(allTypes)
-            ? allTypes
+            : ensureContentTypeExists(ALL_TYPES)
+            ? ALL_TYPES
             : [],
           ...(tags.length && { tags }),
           ...countTag,
@@ -914,7 +915,7 @@ Search.getProps = async ({ apolloClient, locale, query }) => {
             'organization' as SearchableTags,
             'processentry' as SearchableTags,
           ],
-          types: ensureContentTypeExists(allTypes) ? allTypes : [],
+          types: ensureContentTypeExists(ALL_TYPES) ? ALL_TYPES : [],
           countTypes: true,
           countProcessEntry: true,
         },
@@ -995,19 +996,13 @@ const EnglishResultsLink: FC<
     QuerySearchResultsArgs
   >(GET_SEARCH_RESULTS_TOTAL)
 
-  const excludedType = SearchableContentTypes.WebQna
-
-  const types = Object.values(SearchableContentTypes).filter(
-    (type) => !excludedType.includes(type),
-  )
-
   useMemo(() => {
     getCount({
       variables: {
         query: {
           queryString: q,
           language: 'en' as ContentLanguage,
-          types,
+          types: ALL_TYPES as SearchableContentTypes[],
         },
       },
     })

--- a/apps/web/screens/Search/Search.tsx
+++ b/apps/web/screens/Search/Search.tsx
@@ -995,12 +995,19 @@ const EnglishResultsLink: FC<
     QuerySearchResultsArgs
   >(GET_SEARCH_RESULTS_TOTAL)
 
+  const excludedType = SearchableContentTypes.WebQna
+
+  const types = Object.values(SearchableContentTypes).filter(
+    (type) => !excludedType.includes(type),
+  )
+
   useMemo(() => {
     getCount({
       variables: {
         query: {
           queryString: q,
           language: 'en' as ContentLanguage,
+          types,
         },
       },
     })


### PR DESCRIPTION
# Add types to english search result query

## What

Added same types in query for english search result as is for icelandic search results.

## Why

So the link on english search results total matches the search results total on english version of the web.

## Screenshots / Gifs

### Before 
#### IS
![image](https://github.com/user-attachments/assets/eb39d579-751b-4bb1-bcc4-a6b1375d0a1f)

#### EN
![image](https://github.com/user-attachments/assets/5e80226c-da17-4653-a079-ff34fea53a61)

### After
#### IS
![image](https://github.com/user-attachments/assets/022e8cc1-c201-4f4b-b8eb-124a0ef698ce)

#### EN
![image](https://github.com/user-attachments/assets/7598bda2-dc30-4d6f-bf22-7e964b703959)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- English search results now exclude the "WebQna" content type from the results count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->