### PR TITLE
feat(web): Blood donation restriction list - scroll to top when page number changes

### DIFF
--- a/apps/web/screens/Organization/Bloodbank/BloodDonationRestrictionList.tsx
+++ b/apps/web/screens/Organization/Bloodbank/BloodDonationRestrictionList.tsx
@@ -104,7 +104,7 @@ const BloodDonationRestrictionList: CustomScreen<
   const [currentPage, setPage] = useQueryState(
     'page',
     parseAsInteger
-      .withOptions({ shallow: true, clearOnDefault: true })
+      .withOptions({ shallow: true, clearOnDefault: true, scroll: true })
       .withDefault(1),
   )
   const { activeLocale } = useI18n()


### PR DESCRIPTION
# Blood donation restriction list - scroll to top when page number changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
	- Improved pagination experience by enabling automatic scrolling to the top of the page when navigating between pages in the blood donation restriction list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->