### PR TITLE
chore(ci): Make feature close be tied to deploy feature

### DIFF
--- a/.github/workflows/feature-close.yml
+++ b/.github/workflows/feature-close.yml
@@ -6,6 +6,11 @@ on:
       - unlabeled
       - auto_merge_enabled
 
+concurrency:
+  # See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value
+  group: push-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: false
+
 jobs:
   close_feature:
     runs-on: arc-runners
@@ -31,7 +36,7 @@ jobs:
           PRIVATE_KEY: ${{ secrets.HELM_VALUES_SSH_KEY }}
         run: |
           node scripts/ci/docker/get-github-token.mjs
-          
+
       - name: Prepare feature deployment tag
         uses: ./.github/actions/feature-checkout
         id: prepare-docker-tag


### PR DESCRIPTION
Adding and removing the `deploy-feature` label before the job finishes causes orphan deployments. Making destroy wait as well to prevent orphans

![image](https://github.com/user-attachments/assets/267ed26c-5cf4-4465-84b7-af6cc809db88)
> Single deploy running, while destroy waits for completion ([link](https://github.com/island-is/island.is/actions?query=branch%3Achore%2Fconcurrent-feature-close))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow settings to allow multiple runs to proceed concurrently without canceling in-progress runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->