### PR TITLE
feat(web): Image component - Use description field as alt text

### DIFF
--- a/apps/web/screens/queries/fragments.ts
+++ b/apps/web/screens/queries/fragments.ts
@@ -34,6 +34,7 @@ export const imageFields = gql`
     __typename
     id
     title
+    description
     url
     contentType
     width

--- a/libs/cms/src/lib/models/image.model.ts
+++ b/libs/cms/src/lib/models/image.model.ts
@@ -13,6 +13,9 @@ export class Image {
   @Field()
   title?: string
 
+  @Field(() => String, { nullable: true })
+  description?: string
+
   @Field()
   contentType?: string
 
@@ -43,6 +46,7 @@ export const mapImage = (entry: Asset): SystemMetadata<Image> => {
     id: sys?.id ?? '',
     url: url,
     title: fields?.title ?? '',
+    description: fields?.description ?? '',
     contentType: fields?.file?.contentType ?? '',
     width: fields?.file?.details?.image?.width ?? 0,
     height: fields?.file?.details?.image?.height ?? 0,

--- a/libs/cms/src/lib/models/image.model.ts
+++ b/libs/cms/src/lib/models/image.model.ts
@@ -46,7 +46,7 @@ export const mapImage = (entry: Asset): SystemMetadata<Image> => {
     id: sys?.id ?? '',
     url: url,
     title: fields?.title ?? '',
-    description: fields?.description ?? '',
+    description: fields?.description?.trim() ?? '',
     contentType: fields?.file?.contentType ?? '',
     width: fields?.file?.details?.image?.width ?? 0,
     height: fields?.file?.details?.image?.height ?? 0,

--- a/libs/island-ui/contentful/src/lib/Image/Image.tsx
+++ b/libs/island-ui/contentful/src/lib/Image/Image.tsx
@@ -2,7 +2,7 @@ import * as styles from './Image.css'
 
 export interface ImageProps {
   url: string
-  description?: string
+  description?: string | null
   width: number
   height: number
 }

--- a/libs/island-ui/contentful/src/lib/Image/Image.tsx
+++ b/libs/island-ui/contentful/src/lib/Image/Image.tsx
@@ -2,12 +2,12 @@ import * as styles from './Image.css'
 
 export interface ImageProps {
   url: string
-  title?: string
+  description?: string
   width: number
   height: number
 }
 
-export const Image = ({ url, title, width, height }: ImageProps) => {
+export const Image = ({ url, description, width, height }: ImageProps) => {
   if (!url) return null
   return (
     <img
@@ -17,7 +17,7 @@ export const Image = ({ url, title, width, height }: ImageProps) => {
           ${url}?w=1500&fm=webp&q=75 2x,
           ${url}?w=2000&fm=webp&q=75 3x
         `}
-      alt={title || ''}
+      alt={description || ''}
       height={height}
       width={width}
       loading="lazy"


### PR DESCRIPTION
#  Image component - Use description field as alt text

By default in Contentful when a file gets uploaded in an asset then the title becomes the filename which isn't helpful to have as an alt text.

It was decided by Digital Iceland that we should instead use the description field as an alt text for images

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for image descriptions, making image metadata more informative and accessible.
- **Refactor**
  - Updated image components and properties to use "description" instead of "title" for improved clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->