### PR TITLE
feat(web): Set image alt text for components

### DIFF
--- a/apps/web/components/Organization/Slice/Districts/DistrictsSlice.tsx
+++ b/apps/web/components/Organization/Slice/Districts/DistrictsSlice.tsx
@@ -69,10 +69,16 @@ export const DistrictsSlice: React.FC<React.PropsWithChildren<SliceProps>> = ({
               <GridColumn span={['10/10', '10/10', '10/10', '10/10', '5/10']}>
                 {slice.image.url.split('.').pop() === 'svg' ? (
                   <object data={slice.image.url} type="image/svg+xml">
-                    <img src={slice.image.url} alt="" />
+                    <img
+                      src={slice.image.url}
+                      alt={slice.image.description ?? ''}
+                    />
                   </object>
                 ) : (
-                  <img src={slice.image.url} alt="" />
+                  <img
+                    src={slice.image.url}
+                    alt={slice.image.description ?? ''}
+                  />
                 )}
               </GridColumn>
             )}

--- a/apps/web/components/Organization/Slice/IntroLinkImageComponent/IntroLinkImageComponent.tsx
+++ b/apps/web/components/Organization/Slice/IntroLinkImageComponent/IntroLinkImageComponent.tsx
@@ -39,7 +39,7 @@ export const IntroLinkImageComponent = ({
             <img
               className={styles.image}
               src={`${image.url}?w=774&fm=webp&q=80`}
-              alt=""
+              alt={image.description ?? ''}
             />
           </Box>
         </GridColumn>

--- a/apps/web/components/Organization/Slice/TabSection/TabSection.tsx
+++ b/apps/web/components/Organization/Slice/TabSection/TabSection.tsx
@@ -103,7 +103,7 @@ export const TabSectionSlice: React.FC<React.PropsWithChildren<SliceProps>> = ({
                   <img
                     src={tab.image.url}
                     className={styles.tabSectionImg}
-                    alt=""
+                    alt={tab.image.description ?? ''}
                   />
                 )}
                 <Text variant="h2" as="h2" marginBottom={3}>

--- a/apps/web/screens/Organization/OrganizationEvents/OrganizationEventArticle.tsx
+++ b/apps/web/screens/Organization/OrganizationEvents/OrganizationEventArticle.tsx
@@ -82,7 +82,7 @@ const EventItemImage = ({
             ? eventItem.contentImage?.url + '?w=1000&fm=webp&q=80'
             : ''
         }
-        alt=""
+        alt={eventItem.contentImage?.description ?? ''}
       />
     </Box>
   )

--- a/apps/web/screens/ServiceWeb/ContactBanner/OrganizationContactBanner.tsx
+++ b/apps/web/screens/ServiceWeb/ContactBanner/OrganizationContactBanner.tsx
@@ -26,12 +26,7 @@ const OrganizationContactBanner = ({
       <GridRow direction="row">
         <GridColumn>
           {organizationLogoUrl && (
-            <img
-              width={64}
-              height={64}
-              src={organizationLogoUrl}
-              alt="organization-logo"
-            ></img>
+            <img width={64} height={64} src={organizationLogoUrl} alt="" />
           )}
         </GridColumn>
         <GridColumn>

--- a/apps/web/screens/queries/Events.ts
+++ b/apps/web/screens/queries/Events.ts
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag'
 
-import { slices } from './fragments'
+import { imageFields, slices } from './fragments'
 
 export const GET_SINGLE_EVENT_QUERY = gql`
   query GetSingleEvent($input: GetSingleEventInput!) {
@@ -21,26 +21,17 @@ export const GET_SINGLE_EVENT_QUERY = gql`
         freeText
       }
       contentImage {
-        url
-        title
-        width
-        height
+        ...ImageFields
       }
       thumbnailImage {
-        url
-        title
-        width
-        height
+        ...ImageFields
       }
       fullWidthImageInContent
       content {
         ...AllSlices
       }
       featuredImage {
-        url
-        title
-        width
-        height
+        ...ImageFields
       }
       video {
         ...EmbeddedVideoFields
@@ -72,12 +63,10 @@ export const GET_EVENTS_QUERY = gql`
           freeText
         }
         thumbnailImage {
-          url
-          title
-          width
-          height
+          ...ImageFields
         }
       }
     }
   }
+  ${imageFields}
 `

--- a/apps/web/screens/queries/fragments.ts
+++ b/apps/web/screens/queries/fragments.ts
@@ -521,10 +521,7 @@ export const slices = gql`
       }
       leftImage
       image {
-        title
-        url
-        width
-        height
+        ...ImageFields
       }
       openLinkInNewTab
     }
@@ -545,10 +542,7 @@ export const slices = gql`
       url
     }
     backgroundImage {
-      title
-      url
-      width
-      height
+      ...ImageFields
     }
   }
 
@@ -608,12 +602,7 @@ export const slices = gql`
     type
     displayAsCard
     organizationLogo {
-      id
-      url
-      title
-      contentType
-      width
-      height
+      ...ImageFields
     }
   }
 
@@ -644,10 +633,7 @@ export const slices = gql`
     contentString
     type
     image {
-      url
-      title
-      width
-      height
+      ...ImageFields
     }
     link {
       text
@@ -730,10 +716,7 @@ export const slices = gql`
           freeText
         }
         thumbnailImage {
-          url
-          title
-          width
-          height
+          ...ImageFields
         }
         organization {
           slug
@@ -882,10 +865,7 @@ export const slices = gql`
         useFreeText
       }
       thumbnailImage {
-        url
-        title
-        width
-        height
+        ...ImageFields
       }
     }
   }
@@ -972,10 +952,7 @@ export const slices = gql`
     }
     leftImage
     image {
-      title
-      url
-      width
-      height
+      ...ImageFields
     }
     openLinkInNewTab
   }
@@ -1012,10 +989,7 @@ export const slices = gql`
         slug
         assetUrl
         image {
-          url
-          title
-          width
-          height
+          ...ImageFields
         }
       }
     }


### PR DESCRIPTION
# Set image alt text for components

In #18866 we changed it so that the description field on assets from Contentful get used as the alt text on images.

This PR is a follow up to edit individual components

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved image accessibility by updating the alternative text (`alt` attribute) for images to use their descriptions when available, enhancing screen reader support across multiple components.

- **Refactor**
  - Streamlined GraphQL queries and fragments by consolidating image field selections into a reusable fragment for better consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->