### PR TITLE
J s/fix email notifications for defenders in indictment cases

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/formatters.ts
+++ b/apps/judicial-system/backend/src/app/formatters/formatters.ts
@@ -330,20 +330,17 @@ export const formatProsecutorCourtDateEmailNotification = (
   sessionArrangements?: SessionArrangements,
 ): SubjectAndBody => {
   const cf = notifications.prosecutorCourtDateEmail
-  const scheduledCaseText = isIndictmentCase(type)
-    ? formatMessage(cf.sheduledIndictmentCase, { court, courtCaseNumber })
-    : formatMessage(cf.scheduledCase, {
-        court,
-        investigationPrefix:
-          type === CaseType.OTHER
-            ? 'onlyPrefix'
-            : isInvestigationCase(type)
-            ? 'withPrefix'
-            : 'noPrefix',
-        courtTypeName: formatCaseType(type),
-      })
+  const scheduledCaseText = formatMessage(cf.scheduledCase, {
+    court,
+    investigationPrefix:
+      type === CaseType.OTHER
+        ? 'onlyPrefix'
+        : isInvestigationCase(type)
+        ? 'withPrefix'
+        : 'noPrefix',
+    courtTypeName: formatCaseType(type),
+  })
   const courtDateText = formatMessage(cf.courtDate, {
-    isIndictment: isIndictmentCase(type),
     courtDate: courtDate
       ? formatDate(courtDate, 'PPPp')?.replace(' kl.', ', kl.')
       : 'NONE',
@@ -363,99 +360,21 @@ export const formatProsecutorCourtDateEmailNotification = (
     sessionArrangements,
   })
 
-  const body = isIndictmentCase(type)
-    ? formatMessage(cf.bodyIndictments, {
-        scheduledCaseText,
-        courtDateText,
-        courtRoomText,
-        judgeText,
-        registrarText: registrarText || 'NONE',
-      })
-    : formatMessage(cf.body, {
-        scheduledCaseText,
-        courtDateText,
-        courtRoomText,
-        judgeText,
-        registrarText: registrarText || 'NONE',
-        defenderText,
-        sessionArrangements,
-      })
+  const body = formatMessage(cf.body, {
+    scheduledCaseText,
+    courtDateText,
+    courtRoomText,
+    judgeText,
+    registrarText: registrarText || 'NONE',
+    defenderText,
+    sessionArrangements,
+  })
 
   const subject = formatMessage(cf.subject, {
-    isIndictment: isIndictmentCase(type),
     courtCaseNumber: courtCaseNumber || '',
   })
 
   return { body, subject }
-}
-
-export const formatPrisonCourtDateEmailNotification = (
-  formatMessage: FormatMessage,
-  type: CaseType,
-  prosecutorOffice?: string,
-  court?: string,
-  courtDate?: Date,
-  accusedGender?: Gender,
-  requestedValidToDate?: Date,
-  isolation?: boolean,
-  defenderName?: string,
-  isExtension?: boolean,
-  sessionArrangements?: SessionArrangements,
-  courtCaseNumber?: string,
-): string => {
-  const courtText = formatMessage(
-    notifications.prisonCourtDateEmail.courtText,
-    { court: court || 'NONE' },
-  ).replace('dómur', 'dóms')
-  const courtDateText = formatMessage(
-    notifications.prisonCourtDateEmail.courtDateText,
-    {
-      courtDate: courtDate
-        ? formatDate(courtDate, 'PPPPp')
-            ?.replace('dagur,', 'daginn')
-            ?.replace(' kl.', ', kl.')
-        : 'NONE',
-    },
-  )
-  const requestedValidToDateText = formatMessage(
-    notifications.prisonCourtDateEmail.requestedValidToDateText,
-    {
-      requestedValidToDate: requestedValidToDate
-        ? formatDate(requestedValidToDate, 'PPPPp')
-            ?.replace('dagur,', 'dagsins')
-            ?.replace(' kl.', ', kl.')
-        : 'NONE',
-    },
-  )
-  const requestText = formatMessage(
-    notifications.prisonCourtDateEmail.requestText,
-    {
-      caseType: type,
-      gender: accusedGender,
-      requestedValidToDateText,
-    },
-  )
-  const isolationText = formatMessage(
-    notifications.prisonCourtDateEmail.isolationTextV2,
-    { isolation: Boolean(isolation) },
-  )
-  const defenderText = formatMessage(notifications.defender, {
-    defenderName: defenderName ?? 'NONE',
-    sessionArrangements,
-  })
-
-  return formatMessage(notifications.prisonCourtDateEmail.body, {
-    caseType: type,
-    prosecutorOffice: prosecutorOffice || 'NONE',
-    courtText,
-    isExtension,
-    courtDateText,
-    requestText,
-    isolationText,
-    defenderText,
-    sessionArrangements,
-    courtCaseNumber,
-  })
 }
 
 export const formatDefenderCourtDateEmailNotification = (

--- a/apps/judicial-system/backend/src/app/formatters/formatters.ts
+++ b/apps/judicial-system/backend/src/app/formatters/formatters.ts
@@ -267,6 +267,56 @@ export const formatPostponedCourtDateEmailNotification = (
   return { subject, body }
 }
 
+export const formatArraignmentDateEmailNotification = ({
+  formatMessage,
+  theCase,
+  arraignmentDateLog,
+}: {
+  formatMessage: FormatMessage
+  theCase: Case
+  arraignmentDateLog: DateLog
+}) => {
+  const { court, courtCaseNumber, judge, registrar } = theCase
+  const { date: arraignmentDate, location: courtRoom } = arraignmentDateLog
+  const cf = notifications.indictmentArraignmentDateEmail
+
+  const scheduledCaseText = formatMessage(cf.scheduledCase, {
+    court: court?.name,
+    courtCaseNumber,
+  })
+
+  const arraignmentDateText = formatMessage(cf.arraignmentDate, {
+    arraignmentDate: formatDate(arraignmentDate, 'PPPp')?.replace(
+      ' kl.',
+      ', kl.',
+    ),
+  })
+
+  const courtRoomText = formatMessage(notifications.courtRoom, {
+    courtRoom: courtRoom || 'NONE',
+  })
+
+  const judgeText = formatMessage(notifications.judge, {
+    judgeName: judge?.name || 'NONE',
+  })
+  const registrarText = registrar
+    ? formatMessage(notifications.registrar, { registrarName: registrar.name })
+    : undefined
+
+  return {
+    body: formatMessage(cf.body, {
+      scheduledCaseText,
+      arraignmentDateText,
+      courtRoomText,
+      judgeText,
+      registrarText: registrarText || 'NONE',
+    }),
+    subject: formatMessage(cf.subject, {
+      courtCaseNumber: courtCaseNumber || '',
+    }),
+  }
+}
+
 export const formatProsecutorCourtDateEmailNotification = (
   formatMessage: FormatMessage,
   type: CaseType,

--- a/apps/judicial-system/backend/src/app/formatters/index.ts
+++ b/apps/judicial-system/backend/src/app/formatters/index.ts
@@ -16,6 +16,7 @@ export {
   formatPrisonCourtDateEmailNotification,
   formatPrisonRevokedEmailNotification,
   formatProsecutorCourtDateEmailNotification,
+  formatArraignmentDateEmailNotification,
   formatProsecutorReadyForCourtEmailNotification,
   formatProsecutorReceivedByCourtSmsNotification,
   formatDefenderCourtDateLinkEmailNotification,

--- a/apps/judicial-system/backend/src/app/messages/notifications.ts
+++ b/apps/judicial-system/backend/src/app/messages/notifications.ts
@@ -228,24 +228,16 @@ export const notifications = {
       description:
         'Notaður sem texti í pósti sem tilgreinir að dómstól hefur staðfest fyrirtökutíma',
     },
-    sheduledIndictmentCase: {
-      id: 'judicial.system.backend:notifications.prosecutor_court_date_email.scheduled_indictment_case',
-      defaultMessage:
-        '{court} boðar til þingfestingar í máli {courtCaseNumber}.',
-      description:
-        'Notaður sem texti í pósti sem tilgreinir að dómstóll boði til þingfestingar',
-    },
     courtDate: {
-      id: 'judicial.system.backend:notifications.prosecutor_court_date_email.court_date',
+      id: 'judicial.system.backend:notifications.prosecutor_court_date_email.court_date_vol2',
       defaultMessage:
-        '{isIndictment, select, true {Þingfesting} other {Fyrirtaka}} mun fara fram {courtDate, select, NONE {á ótilgreindum tíma} other {{courtDate}}}.',
+        'Fyrirtaka mun fara fram {courtDate, select, NONE {á ótilgreindum tíma} other {{courtDate}}}.',
       description:
         'Notaður sem texti í pósti sem tilgreinir hvenær fyrirtaka fer fram',
     },
     subject: {
       id: 'judicial.system.backend:notifications.prosecutor_court_date_email.subject_v2',
-      defaultMessage:
-        '{isIndictment, select, true {Þingfesting} other {Fyrirtaka}} í máli: {courtCaseNumber}',
+      defaultMessage: 'Fyrirtaka í máli: {courtCaseNumber}',
       description:
         'Notaður sem titil á  pósti til sækjanda þegar fyrirtökutími er staðfestur',
     },
@@ -255,13 +247,6 @@ export const notifications = {
         '{sessionArrangements, select, NONE_PRESENT {Krafan verður tekin fyrir án boðunar í þinghald.<br /><br />} other {}}{scheduledCaseText}<br /><br />{courtDateText}<br /><br />{courtRoomText}<br /><br />{judgeText}{registrarText, select, NONE {} other {<br /><br />{registrarText}}}{sessionArrangements, select, PROSECUTOR_PRESENT {} NONE_PRESENT {} other {<br /><br />{defenderText}.}}',
       description:
         'Notaður fyrir beinagrind á pósti til sækjanda þegar fyrirtökutími er staðfestur',
-    },
-    bodyIndictments: {
-      id: 'judicial.system.backend:notifications.prosecutor_court_date_email.body_indictments',
-      defaultMessage:
-        '{scheduledCaseText}<br /><br />{courtDateText}<br /><br />{courtRoomText}<br /><br />{judgeText}{registrarText, select, NONE {} other {<br /><br />{registrarText}}}',
-      description:
-        'Notaður fyrir beinagrind á pósti til sækjanda þegar fyrirtökutími er staðfestur í ákærum',
     },
   }),
   indictmentArraignmentDateEmail: defineMessages({

--- a/apps/judicial-system/backend/src/app/messages/notifications.ts
+++ b/apps/judicial-system/backend/src/app/messages/notifications.ts
@@ -243,7 +243,7 @@ export const notifications = {
         'Notaður sem texti í pósti sem tilgreinir hvenær fyrirtaka fer fram',
     },
     subject: {
-      id: 'judicial.system.backend:notifications.prosecutor_court_date_email.subject',
+      id: 'judicial.system.backend:notifications.prosecutor_court_date_email.subject_v2',
       defaultMessage:
         '{isIndictment, select, true {Þingfesting} other {Fyrirtaka}} í máli: {courtCaseNumber}',
       description:
@@ -262,6 +262,34 @@ export const notifications = {
         '{scheduledCaseText}<br /><br />{courtDateText}<br /><br />{courtRoomText}<br /><br />{judgeText}{registrarText, select, NONE {} other {<br /><br />{registrarText}}}',
       description:
         'Notaður fyrir beinagrind á pósti til sækjanda þegar fyrirtökutími er staðfestur í ákærum',
+    },
+  }),
+  indictmentArraignmentDateEmail: defineMessages({
+    scheduledCase: {
+      id: 'judicial.system.backend:notifications.indictment_arraignment_date_email.scheduled_indictment_case',
+      defaultMessage:
+        '{court} boðar til þingfestingar í máli {courtCaseNumber}.',
+      description:
+        'Notaður sem texti í pósti sem tilgreinir að dómstóll boði til þingfestingar',
+    },
+    arraignmentDate: {
+      id: 'judicial.system.backend:notifications.indictment_arraignment_date_email.arraignmentDate',
+      defaultMessage: 'Þingfesting mun fara fram {arraignmentDate}.',
+      description:
+        'Notaður sem texti í pósti sem tilgreinir hvenær þingfesting fer fram',
+    },
+    subject: {
+      id: 'judicial.system.backend:notifications.indictment_arraignment_date_email.subject',
+      defaultMessage: 'Þingfesting í máli: {courtCaseNumber}',
+      description:
+        'Notaður sem titil á pósti þegar fyrirtökutími er staðfestur',
+    },
+    body: {
+      id: 'judicial.system.backend:notifications.indictment_arraignment_date_email.body_indictments',
+      defaultMessage:
+        '{scheduledCaseText}<br /><br />{arraignmentDateText}<br /><br />{courtRoomText}<br /><br />{judgeText}{registrarText, select, NONE {} other {<br /><br />{registrarText}}}',
+      description:
+        'Notaður fyrir beinagrind á pósti til aðila máls þegar fyrirtökutími er staðfestur í ákærum',
     },
   }),
   signedRuling: defineMessages({

--- a/apps/judicial-system/backend/src/app/modules/defendant/defendant.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/defendant.service.ts
@@ -164,6 +164,7 @@ export class DefendantService {
       ) {
         // Defender was just confirmed by judge
         if (!oldDefendant.isDefenderChoiceConfirmed) {
+          // TODO: If there is an court date in the future send court date invite to defender
           messages.push({
             type: MessageType.DEFENDANT_NOTIFICATION,
             caseId: theCase.id,

--- a/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/caseNotification/caseNotification.service.ts
@@ -623,7 +623,7 @@ export class CaseNotificationService extends BaseNotificationService {
     })
   }
 
-  // this is only relevant for non-indictment cases
+  // NOTE: this is only relevant for non-indictment cases
   private sendCourtDateEmailNotificationToProsecutor(
     theCase: Case,
     user: User,
@@ -639,7 +639,7 @@ export class CaseNotificationService extends BaseNotificationService {
       arraignmentDate?.location,
       theCase.judge?.name,
       theCase.registrar?.name,
-      theCase.defenderName, 
+      theCase.defenderName,
       theCase.sessionArrangements,
     )
 


### PR DESCRIPTION
# [Defender is not receiving notifications for certain court dates](https://app.asana.com/0/home/1208883002434307/1209964067553878)

## What
- Add missing notifications when arraignment date is scheduled when a confirmed defender exists on the case.
- Send a notification to defender when assigned to a case if an court date is in the future and they have not received such notifications (TODO)
- Refactor court date email notifications to separate indictment from non-indictment.

## Why
- Defenders should get email notification + email invite to cases they are assigned to. 

## Screenshots / Gifs
![Screenshot 2025-04-25 at 15 45 44](https://github.com/user-attachments/assets/4d0bdafc-f15f-4072-8009-95d44407db4b)

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
