### PR TITLE
fix(auth-apis): Updating PK on the client_claim model

### DIFF
--- a/libs/auth-api-lib/migrations/20250128101940-clients-sso.js
+++ b/libs/auth-api-lib/migrations/20250128101940-clients-sso.js
@@ -1,25 +1,50 @@
-'use strict';
+'use strict'
 
 module.exports = {
-  async up (queryInterface, Sequelize) {
-    return queryInterface.sequelize.transaction((t) =>
-      queryInterface.addColumn('client', 'sso', {
-        type: Sequelize.ENUM('enabled', 'disabled'),
-        defaultValue: 'disabled',
-        allowNull: false,
-      })
-      .then(() =>
-        queryInterface.sequelize.query('UPDATE "client" SET sso = \'enabled\';', { transaction: t })
-      )
+  // The migration syntax was updated afterwards to fix migrations locally. It had already been executed in prod.
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(
+      `
+        DO $$
+        BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'enum_client_sso') THEN
+          CREATE TYPE "enum_client_sso" AS ENUM ('enabled', 'disabled');
+        END IF;
+        END$$;
+      `,
+    )
+
+    await queryInterface.sequelize.transaction((t) =>
+      queryInterface
+        .addColumn(
+          'client',
+          'sso',
+          {
+            type: 'enum_client_sso',
+            defaultValue: 'disabled',
+            allowNull: false,
+          },
+          { transaction: t },
+        )
+        .then(() =>
+          queryInterface.sequelize.query(
+            'UPDATE "client" SET sso = \'enabled\';',
+            { transaction: t },
+          ),
+        ),
     )
   },
 
-  async down (queryInterface, Sequelize) {
+  async down(queryInterface, Sequelize) {
     return queryInterface.sequelize.transaction((t) =>
-      queryInterface.removeColumn('client', 'sso', { transaction: t },)
-      .then(() =>
-        queryInterface.sequelize.query('DROP TYPE IF EXISTS "enum_client_sso";', { transaction: t })
-      )
+      queryInterface
+        .removeColumn('client', 'sso', { transaction: t })
+        .then(() =>
+          queryInterface.sequelize.query(
+            'DROP TYPE IF EXISTS "enum_client_sso";',
+            { transaction: t },
+          ),
+        ),
     )
-  }
-};
+  },
+}

--- a/libs/auth-api-lib/migrations/20250426080619-update-client-claim-pk.js
+++ b/libs/auth-api-lib/migrations/20250426080619-update-client-claim-pk.js
@@ -1,0 +1,43 @@
+'use strict'
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.sequelize.query(
+        `
+          ALTER TABLE "client_claim"
+          DROP CONSTRAINT "client_claim_pkey"
+        `,
+        { transaction: t },
+      )
+
+      await queryInterface.sequelize.query(
+        `
+          ALTER TABLE "client_claim"
+          ADD CONSTRAINT "client_claim_pkey" PRIMARY KEY ("client_id", "type")
+        `,
+        { transaction: t },
+      )
+    })
+  },
+
+  async down(queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.sequelize.query(
+        `
+          ALTER TABLE "client_claim"
+          DROP CONSTRAINT "client_claim_pkey"
+        `,
+        { transaction: t },
+      )
+
+      await queryInterface.sequelize.query(
+        `
+          ALTER TABLE "client_claim"
+          ADD CONSTRAINT "client_claim_pkey" PRIMARY KEY ("client_id", "value")
+        `,
+        { transaction: t },
+      )
+    })
+  },
+}

--- a/libs/auth-api-lib/src/lib/clients/models/client-claim.model.ts
+++ b/libs/auth-api-lib/src/lib/clients/models/client-claim.model.ts
@@ -24,6 +24,7 @@ export class ClientClaim extends Model {
   @ApiProperty()
   clientId!: string
 
+  @PrimaryKey
   @Column({
     type: DataType.STRING,
     allowNull: false,
@@ -31,7 +32,6 @@ export class ClientClaim extends Model {
   @ApiProperty()
   type!: string
 
-  @PrimaryKey
   @Column({
     type: DataType.STRING,
     allowNull: false,


### PR DESCRIPTION
## What

Updating the PK on the `client_claim` model as the `value` was used in the PK instead of the `type`. This caused the custom claims to allow for same keys with multiple values, while unable to update the key name.

## Why

We should only allow a single key in custom claim as unique.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
