### PR TITLE
fix(web): Section with image content length check adjustment

### DIFF
--- a/libs/island-ui/contentful/src/lib/SectionWithImage/SectionWithImage.tsx
+++ b/libs/island-ui/contentful/src/lib/SectionWithImage/SectionWithImage.tsx
@@ -26,7 +26,7 @@ export const SectionWithImage: FC<
   contain = false,
   reverse = false,
 }) => {
-  if (!image && content.length) {
+  if (!image && content.length > 0) {
     return (
       <>
         {title && (
@@ -79,7 +79,7 @@ export const SectionWithImage: FC<
               {title}
             </Text>
           )}
-          {content.length && richText(content as SliceType[], undefined)}
+          {content.length > 0 && richText(content as SliceType[], undefined)}
         </GridColumn>
       </GridRow>
     </Box>


### PR DESCRIPTION
#  Section with image content length check adjustment

If content.length is 0 then it gets displayed, we don't want that

## Before 

![Screenshot 2025-04-28 at 10 08 32](https://github.com/user-attachments/assets/2da50e3b-8d91-4bf0-8978-467118a00201)

## After

![Screenshot 2025-04-28 at 10 09 06](https://github.com/user-attachments/assets/7ebffa78-b496-483d-b00e-88b9845e229c)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved content display logic to ensure sections are only shown when content is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->