### PR TITLE
feat(household-supplement): Move maritalStatuses to core

### DIFF
--- a/libs/application/templates/social-insurance-administration/core/src/lib/constants.ts
+++ b/libs/application/templates/social-insurance-administration/core/src/lib/constants.ts
@@ -118,3 +118,20 @@ export const fileUploadSharedProps = {
     socialInsuranceAdministrationMessage.fileUpload.attachmentButton,
   uploadMultiple: true,
 }
+
+const married = 'Gift/ur'
+
+export const maritalStatuses: {
+  [key: string]: string
+} = {
+  '1': 'Ógift/ur',
+  '3': married,
+  '4': 'Ekkja/Ekkill',
+  '5': 'Skilin/nn/ð að borði og sæng',
+  '6': 'Fráskilin/nn/ð',
+  '7': married,
+  '8': married,
+  '9': 'Óupplýst',
+  '0': married,
+  L: married,
+}

--- a/libs/application/templates/social-insurance-administration/household-supplement/src/forms/HouseholdSupplementForm.ts
+++ b/libs/application/templates/social-insurance-administration/household-supplement/src/forms/HouseholdSupplementForm.ts
@@ -16,7 +16,10 @@ import {
   buildTextField,
 } from '@island.is/application/core'
 import Logo from '@island.is/application/templates/social-insurance-administration-core/assets/Logo'
-import { fileUploadSharedProps } from '@island.is/application/templates/social-insurance-administration-core/lib/constants'
+import {
+  fileUploadSharedProps,
+  maritalStatuses,
+} from '@island.is/application/templates/social-insurance-administration-core/lib/constants'
 import { socialInsuranceAdministrationMessage } from '@island.is/application/templates/social-insurance-administration-core/lib/messages'
 import {
   getBankIsk,
@@ -31,7 +34,6 @@ import {
 } from '@island.is/application/types'
 import { buildFormConclusionSection } from '@island.is/application/ui-forms'
 import * as kennitala from 'kennitala'
-import { maritalStatuses } from '../lib/constants'
 import {
   getApplicationAnswers,
   getApplicationExternalData,

--- a/libs/application/templates/social-insurance-administration/household-supplement/src/lib/constants.ts
+++ b/libs/application/templates/social-insurance-administration/household-supplement/src/lib/constants.ts
@@ -15,20 +15,3 @@ export enum AttachmentTypes {
   SCHOOL_CONFIRMATION = 'schoolConfirmation',
   ADDITIONAL_DOCUMENTS = 'additionalDocuments',
 }
-
-const married = 'Gift/ur'
-
-export const maritalStatuses: {
-  [key: string]: string
-} = {
-  '1': 'Ógift/ur',
-  '3': married,
-  '4': 'Ekkja/Ekkill',
-  '5': 'Skilin/nn/ð að borði og sæng',
-  '6': 'Fráskilin/nn/ð',
-  '7': married,
-  '8': married,
-  '9': 'Óupplýst',
-  '0': married,
-  L: married,
-}


### PR DESCRIPTION
[[TS-1038] Use maritalStatus in core](https://dit-iceland.atlassian.net/jira/software/c/projects/TS/boards/82?selectedIssue=TS-1038)

## What

Move `maritalStatuses` to core

## Why

Because this is used in more than one application

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Centralized marital status labels into a single shared location for improved consistency across the application.
  - Updated references to use the new centralized marital status labels.
- **Chores**
  - Cleaned up redundant code by removing duplicate marital status definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->