### PR TITLE
ci(staleness): Allow `write` to `actions`

### DIFF
--- a/.github/workflows/staleness.yml
+++ b/.github/workflows/staleness.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: arc-runners
     permissions:
       pull-requests: write
+      actions: write
     steps:
       - name: Clean up `deploy-feature` label usage
         uses: actions/stale@v9


### PR DESCRIPTION
The stale action needs `actions: write` according to a [bug report](https://github.com/actions/stale/issues/1133#issuecomment-2416591020) on the CI warning `Warning: Error delete _state: [403] Resource not accessible by integration`.

- [Example warning in CI](https://github.com/island-is/island.is/actions/runs/14699533268/job/41246487785#step:2:497)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow permissions to enhance access for GitHub Actions resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209910755903722