### PR TITLE
fix(buildFileUploadField): Make sure totalMaxSize is used in buildFileUploadField

### DIFF
--- a/libs/application/ui-fields/src/lib/FileUploadFormField/FileUploadFormField.tsx
+++ b/libs/application/ui-fields/src/lib/FileUploadFormField/FileUploadFormField.tsx
@@ -27,6 +27,7 @@ export const FileUploadFormField = ({
     uploadAccept,
     maxSize,
     maxSizeErrorText,
+    totalMaxSize,
     forImageUpload,
     marginTop,
     marginBottom,
@@ -81,6 +82,7 @@ export const FileUploadFormField = ({
             maxSizeErrorText &&
             formatText(maxSizeErrorText, application, formatMessage)
           }
+          totalMaxSize={totalMaxSize}
           forImageUpload={forImageUpload}
           onRemove={onFileRemoveWhenInAnswers}
         />


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying a maximum total file size in the file upload form field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->