### PR TITLE
feat(web): Verdict list - Hide icon if no judge returned

### DIFF
--- a/apps/web/screens/Verdicts/VerdictsList.tsx
+++ b/apps/web/screens/Verdicts/VerdictsList.tsx
@@ -1043,6 +1043,28 @@ const VerdictsList: CustomScreen<VerdictsListProps> = (props) => {
                 cards={data.visibleVerdicts
                   .filter((verdict) => Boolean(verdict.id))
                   .map((verdict) => {
+                    const detailLines = [
+                      {
+                        icon: 'calendar',
+                        text: verdict.verdictDate
+                          ? format(
+                              new Date(verdict.verdictDate),
+                              'd. MMMM yyyy',
+                            )
+                          : '',
+                      },
+                      { icon: 'hammer', text: verdict.court ?? '' },
+                    ]
+
+                    if (verdict.presidentJudge?.name) {
+                      detailLines.push({
+                        icon: 'person',
+                        text: `${verdict.presidentJudge?.name ?? ''} ${
+                          verdict.presidentJudge?.title ?? ''
+                        }`,
+                      })
+                    }
+
                     return {
                       description: verdict.title,
                       eyebrow: '',
@@ -1050,24 +1072,7 @@ const VerdictsList: CustomScreen<VerdictsListProps> = (props) => {
                       link: { href: `/domar/${verdict.id}`, label: '' },
                       title: verdict.caseNumber,
                       borderColor: 'blue200',
-                      detailLines: [
-                        {
-                          icon: 'calendar',
-                          text: verdict.verdictDate
-                            ? format(
-                                new Date(verdict.verdictDate),
-                                'd. MMMM yyyy',
-                              )
-                            : '',
-                        },
-                        { icon: 'hammer', text: verdict.court ?? '' },
-                        {
-                          icon: 'person',
-                          text: `${verdict.presidentJudge?.name ?? ''} ${
-                            verdict.presidentJudge?.title ?? ''
-                          }`,
-                        },
-                      ],
+                      detailLines,
                     }
                   })}
               />


### PR DESCRIPTION
# Verdict list - Hide icon if no judge returned

We'd like to hide the icon in case no judge is returned


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal structure for displaying verdict details. No changes to visible information or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->