### PR TITLE
feat(web): Verdict list, filter tags

### DIFF
--- a/apps/web/components/FilterTag/FilterTag.tsx
+++ b/apps/web/components/FilterTag/FilterTag.tsx
@@ -1,21 +1,23 @@
 import React from 'react'
 
-import { Box, Tag } from '@island.is/island-ui/core'
+import { Box, Tag, type TagProps } from '@island.is/island-ui/core'
 
 import * as styles from './FilterTag.css'
 
 interface FilterTagProps {
   onClick?: () => void
   active?: boolean
+  variant?: TagProps['variant']
 }
 
 export const FilterTag: React.FC<React.PropsWithChildren<FilterTagProps>> = ({
   children,
   onClick,
   active,
+  variant,
 }) => {
   return (
-    <Tag onClick={onClick} active={active}>
+    <Tag onClick={onClick} active={active} variant={variant}>
       <Box flexDirection="row" alignItems="center">
         {children}
         <span className={styles.crossmark}>&#10005;</span>

--- a/apps/web/screens/Verdicts/VerdictsList.tsx
+++ b/apps/web/screens/Verdicts/VerdictsList.tsx
@@ -27,7 +27,11 @@ import {
   Tag,
   Text,
 } from '@island.is/island-ui/core'
-import { HeadWithSocialSharing, Webreader } from '@island.is/web/components'
+import {
+  FilterTag,
+  HeadWithSocialSharing,
+  Webreader,
+} from '@island.is/web/components'
 import {
   CustomPageUniqueIdentifier,
   type GetVerdictCaseCategoriesQuery,
@@ -66,6 +70,7 @@ import * as styles from './VerdictsList.css'
 
 const ITEMS_PER_PAGE = 10
 const DEBOUNCE_TIME_IN_MS = 500
+const DATE_FORMAT = 'd. MMMM yyyy'
 
 const ALL_COURTS_TAG = ''
 const DEFAULT_DISTRICT_COURT_TAG = 'Héraðsdómur Reykjavíkur'
@@ -820,6 +825,132 @@ const VerdictsList: CustomScreen<VerdictsListProps> = (props) => {
 
   const districtCourtTagValues = districtCourtTags.map(({ value }) => value)
 
+  const filterTags = useMemo(() => {
+    const tags: { label: string; onClick: () => void }[] = []
+    if (queryState[QueryParam.CASE_NUMBER]) {
+      tags.push({
+        label: `${formatMessage(m.listPage.caseNumberAccordionLabel)}: ${
+          queryState[QueryParam.CASE_NUMBER]
+        }`,
+        onClick: () => {
+          updateQueryState(QueryParam.CASE_NUMBER, '')
+        },
+      })
+    }
+
+    if (queryState[QueryParam.LAWS]) {
+      tags.push({
+        label: `${formatMessage(m.listPage.lawsAccordionLabel)}: ${
+          queryState[QueryParam.LAWS]
+        }`,
+        onClick: () => {
+          updateQueryState(QueryParam.LAWS, '')
+        },
+      })
+    }
+
+    if (queryState[QueryParam.KEYWORD]) {
+      tags.push({
+        label: `${formatMessage(m.listPage.keywordAccordionLabel)}: ${
+          queryState[QueryParam.KEYWORD]
+        }`,
+        onClick: () => {
+          updateQueryState(QueryParam.KEYWORD, null)
+          updateRenderKey()
+        },
+      })
+    }
+
+    if (queryState[QueryParam.CASE_CATEGORIES]) {
+      if (queryState[QueryParam.CASE_CATEGORIES].length > 0) {
+        for (const category of queryState[QueryParam.CASE_CATEGORIES]) {
+          tags.push({
+            label: `${formatMessage(
+              m.listPage.caseCategoryAccordionLabel,
+            )}: ${category}`,
+            onClick: () => {
+              updateQueryState(QueryParam.CASE_CATEGORIES, (previousState) => {
+                let previousCategories =
+                  previousState[QueryParam.CASE_CATEGORIES]
+                if (previousCategories) {
+                  previousCategories = previousCategories.filter(
+                    (previousCategory) => previousCategory !== category,
+                  )
+                  if (previousCategories.length === 0) {
+                    previousCategories = null
+                  }
+                }
+                return {
+                  ...previousState,
+                  [QueryParam.CASE_CATEGORIES]: previousCategories,
+                }
+              })
+              updateRenderKey()
+            },
+          })
+        }
+      }
+    }
+
+    if (queryState[QueryParam.CASE_TYPES]) {
+      if (queryState[QueryParam.CASE_TYPES].length > 0) {
+        for (const caseType of queryState[QueryParam.CASE_TYPES]) {
+          tags.push({
+            label: `${formatMessage(
+              m.listPage.caseTypeAccordionLabel,
+            )}: ${caseType}`,
+            onClick: () => {
+              updateQueryState(QueryParam.CASE_TYPES, (previousState) => {
+                let previousCaseTypes = previousState[QueryParam.CASE_TYPES]
+                if (previousCaseTypes) {
+                  previousCaseTypes = previousCaseTypes.filter(
+                    (previousCaseType) => previousCaseType !== caseType,
+                  )
+                  if (previousCaseTypes.length === 0) {
+                    previousCaseTypes = null
+                  }
+                }
+                return {
+                  ...previousState,
+                  [QueryParam.CASE_TYPES]: previousCaseTypes,
+                }
+              })
+              updateRenderKey()
+            },
+          })
+        }
+      }
+    }
+
+    if (queryState[QueryParam.DATE_FROM]) {
+      tags.push({
+        label: `${formatMessage(m.listPage.dateFromLabel)}: ${format(
+          queryState[QueryParam.DATE_FROM],
+          'P',
+        )}`,
+        onClick: () => {
+          updateQueryState(QueryParam.DATE_FROM, null)
+          updateRenderKey()
+        },
+      })
+    }
+
+    if (queryState[QueryParam.DATE_TO]) {
+      tags.push({
+        label: `${formatMessage(m.listPage.dateToLabel)}: ${format(
+          queryState[QueryParam.DATE_TO],
+          'P',
+        )}`,
+        onClick: () => {
+          updateQueryState(QueryParam.DATE_TO, null)
+          updateRenderKey()
+        },
+      })
+    }
+
+    return tags
+  }, [format, formatMessage, queryState, updateQueryState, updateRenderKey])
+
   return (
     <Box className="rs_read">
       <HeadWithSocialSharing title={customPageData?.ogTitle ?? heading}>
@@ -1001,6 +1132,19 @@ const VerdictsList: CustomScreen<VerdictsListProps> = (props) => {
             }
           >
             <Stack space={3}>
+              {filterTags.length > 0 && (
+                <Inline alignY="center" space={2}>
+                  {filterTags.map((tag) => (
+                    <FilterTag
+                      key={tag.label}
+                      variant="darkerBlue"
+                      onClick={tag.onClick}
+                    >
+                      {tag.label}
+                    </FilterTag>
+                  ))}
+                </Inline>
+              )}
               <Inline justifyContent="spaceBetween" alignY="center" space={2}>
                 <Text>
                   <strong>{data.total}</strong>{' '}
@@ -1051,10 +1195,7 @@ const VerdictsList: CustomScreen<VerdictsListProps> = (props) => {
                       {
                         icon: 'calendar',
                         text: verdict.verdictDate
-                          ? format(
-                              new Date(verdict.verdictDate),
-                              'd. MMMM yyyy',
-                            )
+                          ? format(new Date(verdict.verdictDate), DATE_FORMAT)
                           : '',
                       },
                       { icon: 'hammer', text: verdict.court ?? '' },

--- a/apps/web/screens/Verdicts/VerdictsList.tsx
+++ b/apps/web/screens/Verdicts/VerdictsList.tsx
@@ -834,6 +834,7 @@ const VerdictsList: CustomScreen<VerdictsListProps> = (props) => {
         }`,
         onClick: () => {
           updateQueryState(QueryParam.CASE_NUMBER, '')
+          updateRenderKey()
         },
       })
     }
@@ -845,6 +846,7 @@ const VerdictsList: CustomScreen<VerdictsListProps> = (props) => {
         }`,
         onClick: () => {
           updateQueryState(QueryParam.LAWS, '')
+          updateRenderKey()
         },
       })
     }

--- a/apps/web/screens/Verdicts/VerdictsList.tsx
+++ b/apps/web/screens/Verdicts/VerdictsList.tsx
@@ -1135,7 +1135,7 @@ const VerdictsList: CustomScreen<VerdictsListProps> = (props) => {
           >
             <Stack space={3}>
               {filterTags.length > 0 && (
-                <Inline alignY="center" space={2}>
+                <Inline alignY="center" space={1}>
                   {filterTags.map((tag) => (
                     <FilterTag
                       key={tag.label}

--- a/apps/web/screens/Verdicts/VerdictsList.tsx
+++ b/apps/web/screens/Verdicts/VerdictsList.tsx
@@ -775,6 +775,10 @@ const VerdictsList: CustomScreen<VerdictsListProps> = (props) => {
         label: formatMessage(m.listPage.showSupremeCourt),
         value: 'Hæstiréttur',
       },
+      {
+        label: formatMessage(m.listPage.showRetrialCourt),
+        value: 'Endurupptökudómur',
+      },
     ]
   }, [formatMessage])
   const districtCourtTags = useMemo(() => {

--- a/apps/web/screens/Verdicts/translations.strings.ts
+++ b/apps/web/screens/Verdicts/translations.strings.ts
@@ -74,8 +74,8 @@ export const m = {
     },
     showRetrialCourt: {
       id: 'web.verdicts:listPage.showRetrialCourt',
-      defaultMessage: 'Enduruppökudómur',
-      description: 'Enduruppökudómur',
+      defaultMessage: 'Endurupptökudómur',
+      description: 'Endurupptökudómur',
     },
     searchInputPlaceholder: {
       id: 'web.verdicts:listPage.searchInputPlaceholder',

--- a/apps/web/screens/Verdicts/translations.strings.ts
+++ b/apps/web/screens/Verdicts/translations.strings.ts
@@ -72,6 +72,11 @@ export const m = {
       defaultMessage: 'Hæstiréttur',
       description: 'Hæstiréttur',
     },
+    showRetrialCourt: {
+      id: 'web.verdicts:listPage.showRetrialCourt',
+      defaultMessage: 'Enduruppökudómur',
+      description: 'Enduruppökudómur',
+    },
     searchInputPlaceholder: {
       id: 'web.verdicts:listPage.searchInputPlaceholder',
       defaultMessage: 'Sláðu inn orð, málsnúmer, málsaðila',


### PR DESCRIPTION
# Verdict list, filter tags

Show "Endurupptökudómur" as a filter tag

![Screenshot 2025-04-30 at 12 36 03](https://github.com/user-attachments/assets/df6e6186-eaa8-49c5-90a5-ea99784104ff)

Display "ítarleit" options as filter tags as well

https://github.com/user-attachments/assets/70bccfa0-816b-4971-9b15-58ddcc62eafe



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added a new court filter option for "Endurupptökudómur" (Retrial Court) in the verdicts list.
  - Introduced clickable filter tags above the verdict list to display and clear active filters.
  - Standardized date formatting for verdict dates.
  - Added a new translation entry to support the display of the Retrial Court filter.
  - Enabled customizable styling for filter tags with a new variant option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->