### PR TITLE
fix(application-system): using name instead of givenName

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/shared/api/national-registry/national-registry.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/shared/api/national-registry/national-registry.service.ts
@@ -617,8 +617,7 @@ export class NationalRegistryService extends BaseTemplateApiService {
       if (details) {
         custodians.push({
           nationalId: details.nationalId,
-          givenName: details.givenName,
-          familyName: details.familyName,
+          name: details.name,
           legalDomicile: details.legalDomicile,
         })
       }

--- a/libs/application/template-api-modules/src/lib/modules/templates/secondary-school/utils.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/secondary-school/utils.ts
@@ -48,7 +48,7 @@ export const getRecipients = (
   custodiansExternalData.forEach((custodian, index) => {
     recipientList.push({
       nationalId: custodian.nationalId,
-      name: `${custodian.givenName || ''} ${custodian.familyName || ''}`,
+      name: custodian.name || '',
       email: custodiansAnswers[index]?.person?.email || '',
     })
   })
@@ -76,7 +76,7 @@ export const getCleanContacts = (
   custodiansExternalData.forEach((custodian, index) => {
     result.push({
       nationalId: custodian.nationalId,
-      name: `${custodian.givenName || ''} ${custodian.familyName || ''}`,
+      name: custodian.name || '',
       phone: custodiansAnswers[index]?.person?.phone || '',
       email: custodiansAnswers[index]?.person?.email || '',
       address: custodian.legalDomicile?.streetAddress,

--- a/libs/application/templates/secondary-school/src/fields/overview/CustodianOverview.tsx
+++ b/libs/application/templates/secondary-school/src/fields/overview/CustodianOverview.tsx
@@ -102,7 +102,7 @@ export const CustodianOverview: FC<FieldBaseProps> = ({
                     </Text>
                   )}
                   <Text>
-                    {custodian.givenName} {custodian.familyName}
+                    {custodian.name}
                   </Text>
                   <Text>{formatKennitala(custodian.nationalId)}</Text>
                   <Text>{custodian.legalDomicile?.streetAddress}</Text>

--- a/libs/application/templates/secondary-school/src/forms/secondarySchoolForm/userInformationSection/custodianSubSection.ts
+++ b/libs/application/templates/secondary-school/src/forms/secondarySchoolForm/userInformationSection/custodianSubSection.ts
@@ -54,7 +54,7 @@ export const custodianSubSection = buildSubSection({
           condition: (_, externalData) => getHasCustodian(externalData, 0),
           defaultValue: (application: Application) => {
             const parent = getCustodian(application.externalData, 0)
-            return `${parent?.givenName} ${parent?.familyName}`
+            return `${parent?.name}`
           },
         }),
         buildTextField({
@@ -128,7 +128,7 @@ export const custodianSubSection = buildSubSection({
           condition: (_, externalData) => getHasCustodian(externalData, 1),
           defaultValue: (application: Application) => {
             const parent = getCustodian(application.externalData, 1)
-            return `${parent?.givenName} ${parent?.familyName}`
+            return `${parent?.name}`
           },
         }),
         buildTextField({

--- a/libs/application/types/src/lib/template-api/shared-api/models/national-registry/custodian.ts
+++ b/libs/application/types/src/lib/template-api/shared-api/models/national-registry/custodian.ts
@@ -1,7 +1,6 @@
 export interface NationalRegistryCustodian {
   nationalId: string
-  givenName: string | null
-  familyName: string | null
+  name: string | null
   legalDomicile?: {
     streetAddress: string
     postalCode: string | null


### PR DESCRIPTION
# ...

Some individuals don't have a separate given name and family name so we use name instead.

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated custodian name handling across the application to use a single name field instead of separate given and family names.
- **Bug Fixes**
	- Improved consistency in how custodian names are displayed in forms and overviews.
- **Refactor**
	- Simplified internal data structures and logic by consolidating name properties for custodians.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->