### PR TITLE
fix(ci): Failure when newlint checking a project with no lints

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -337,7 +337,7 @@ jobs:
           for f in "${BASE_LINT_FILE}" "${HEAD_LINT_FILE}"; do
             # Make "Remote cache..." and "Local cache" be the same
             sed -i -E 's/\s*\[[^[]*cache[^]]*\]\s*//g' "${f}" || echo "No cached targets found in $f"
-            grep -oP "(?<=$PWD/).*" "${f}" | sort -n | uniq -c | awk '{print($2 " #lints: " $1)}' > "${f}_files.out" || { echo "No lints found in $f"; exit 1; }
+            grep -oP "(?<=$PWD/).*" "${f}" | sort -n | uniq -c | awk '{print($2 " #lints: " $1)}' > "${f}_files.out" || { echo "No lints found in $f"; }
           done
           NEW_LINTS=$(comm -13 "${BASE_LINT_FILE}_files.out" "${HEAD_LINT_FILE}_files.out" | wc -l) || { echo "Failed comparing output files"; exit 1; }
           COUNT_DIFF=$(( HEAD_LINT_COUNT - BASE_LINT_COUNT )) || :


### PR DESCRIPTION
https://github.com/island-is/island.is/pull/18907 was failing due to a 0-lint project. Fixing here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved error handling in the workflow so that the lint check step no longer fails if no lints are found, allowing the workflow to continue running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->