### PR TITLE
fix(web): Image fields graphql queries

### DIFF
--- a/apps/web/screens/queries/Events.ts
+++ b/apps/web/screens/queries/Events.ts
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag'
 
-import { imageFields, slices } from './fragments'
+import { slices } from './fragments'
 
 export const GET_SINGLE_EVENT_QUERY = gql`
   query GetSingleEvent($input: GetSingleEventInput!) {
@@ -21,17 +21,29 @@ export const GET_SINGLE_EVENT_QUERY = gql`
         freeText
       }
       contentImage {
-        ...ImageFields
+        url
+        title
+        width
+        height
+        description
       }
       thumbnailImage {
-        ...ImageFields
+        url
+        title
+        width
+        height
+        description
       }
       fullWidthImageInContent
       content {
         ...AllSlices
       }
       featuredImage {
-        ...ImageFields
+        url
+        title
+        width
+        height
+        description
       }
       video {
         ...EmbeddedVideoFields
@@ -63,10 +75,13 @@ export const GET_EVENTS_QUERY = gql`
           freeText
         }
         thumbnailImage {
-          ...ImageFields
+          url
+          title
+          width
+          height
+          description
         }
       }
     }
   }
-  ${imageFields}
 `

--- a/apps/web/screens/queries/fragments.ts
+++ b/apps/web/screens/queries/fragments.ts
@@ -521,7 +521,11 @@ export const slices = gql`
       }
       leftImage
       image {
-        ...ImageFields
+        title
+        url
+        width
+        height
+        description
       }
       openLinkInNewTab
     }
@@ -542,7 +546,11 @@ export const slices = gql`
       url
     }
     backgroundImage {
-      ...ImageFields
+      title
+      url
+      width
+      height
+      description
     }
   }
 
@@ -602,7 +610,13 @@ export const slices = gql`
     type
     displayAsCard
     organizationLogo {
-      ...ImageFields
+      id
+      url
+      title
+      contentType
+      width
+      height
+      description
     }
   }
 
@@ -633,7 +647,11 @@ export const slices = gql`
     contentString
     type
     image {
-      ...ImageFields
+      url
+      title
+      width
+      height
+      description
     }
     link {
       text
@@ -716,7 +734,11 @@ export const slices = gql`
           freeText
         }
         thumbnailImage {
-          ...ImageFields
+          url
+          title
+          width
+          height
+          description
         }
         organization {
           slug
@@ -865,7 +887,11 @@ export const slices = gql`
         useFreeText
       }
       thumbnailImage {
-        ...ImageFields
+        url
+        title
+        width
+        height
+        description
       }
     }
   }
@@ -952,7 +978,11 @@ export const slices = gql`
     }
     leftImage
     image {
-      ...ImageFields
+      title
+      url
+      width
+      height
+      description
     }
     openLinkInNewTab
   }
@@ -989,7 +1019,11 @@ export const slices = gql`
         slug
         assetUrl
         image {
-          ...ImageFields
+          url
+          title
+          width
+          height
+          description
         }
       }
     }


### PR DESCRIPTION
# Image fields graphql queries

Reduce number of fields we fetch in graphql queries when getting images for the web.

Also this'll address a type error

![image](https://github.com/user-attachments/assets/0ee2f076-995e-4ea3-90f5-d67be5b88f35)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated image data handling in event queries and fragments to use explicit image field selections instead of fragment spreads. This change does not affect the visible functionality but improves the structure of image data returned by queries. No changes to public interfaces or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->