### PR TITLE
fix(j-s): hanging app when defender navigates email link

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/notification/services/defendantNotification/defendantNotification.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/notification/services/defendantNotification/defendantNotification.service.ts
@@ -199,6 +199,7 @@ export class DefendantNotificationService extends BaseNotificationService {
         courtName,
         courtCaseNumber: theCase.courtCaseNumber,
         defenderHasAccessToRVG,
+        // This link only works if the user is already logged in
         linkStart: `<a href="${this.config.clientUrl}${DEFENDER_INDICTMENT_ROUTE}/${theCase.id}">`,
         linkEnd: '</a>',
       })

--- a/apps/judicial-system/web/src/components/FormProvider/FormProvider.tsx
+++ b/apps/judicial-system/web/src/components/FormProvider/FormProvider.tsx
@@ -19,6 +19,7 @@ import {
   Defendant,
 } from '@island.is/judicial-system-web/src/graphql/schema'
 
+import { api } from '../../services'
 import { UserContext } from '../UserProvider/UserProvider'
 import { CaseQuery, useCaseLazyQuery } from './case.generated'
 import {
@@ -170,6 +171,12 @@ const FormProvider = ({ children }: Props) => {
   )
 
   useEffect(() => {
+    if (!isAuthenticated) {
+      window.location.assign(
+        `${api.apiUrl}/api/auth/login?redirectRoute=${window.location.pathname}`,
+      )
+    }
+
     if (
       limitedAccess !== undefined && // Wait until limitedAccess is defined
       id &&


### PR DESCRIPTION
# [Fix hanging app after defenders navigates from an deep link from an email](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1209925002107071)

## What
- When a defender is not logged into RVG and tries to navigate and case link from an email, they will just navigate to a "hanging" page in RVG
- Added a redirect snippet that was also added in this PR: https://github.com/island-is/island.is/pull/13263 but removed from this one: https://github.com/island-is/island.is/pull/18174
- Open for other suggestions how to resolve this, but this does fix the problems for users navigating to RVG via email link and are not logged in

## Why 
- Because its a bug

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
