### PR TITLE
feat(my-pages-assets): Add link to finance mileage transactions

### DIFF
--- a/libs/portals/my-pages/assets/src/lib/messages.ts
+++ b/libs/portals/my-pages/assets/src/lib/messages.ts
@@ -958,6 +958,10 @@ export const vehicleMessage = defineMessages({
     id: 'sp.vehicles:bulk-post-mileage',
     defaultMessage: 'Magnskrá kílómetrastöðu',
   },
+  financeMileageLink: {
+    id: 'sp.vehicles:finance-mileage-link',
+    defaultMessage: 'Skoða kílómetragjaldshreyfingar',
+  },
   bulkPostMileageWithFile: {
     id: 'sp.vehicles:bulk-post-mileage-with-file',
     defaultMessage: 'Magnskrá með skjali',

--- a/libs/portals/my-pages/assets/src/lib/paths.ts
+++ b/libs/portals/my-pages/assets/src/lib/paths.ts
@@ -6,7 +6,10 @@ export enum AssetsPaths {
   AssetsMyVehicles = '/eignir/okutaeki/min-okutaeki',
   AssetsVehiclesDetail = '/eignir/okutaeki/min-okutaeki/:id',
   AssetsVehiclesDetailMileage = '/eignir/okutaeki/min-okutaeki/:id/kilometrastada',
+
+  // If updated, also update `LinkAssetsVehiclesBulkMileage` in the finance paths file (libs/portals/my-pages/finance/src/lib/paths.ts)
   AssetsVehiclesBulkMileage = '/eignir/okutaeki/skra-kilometrastodu',
+
   AssetsVehiclesBulkMileageUpload = '/eignir/okutaeki/skra-kilometrastodu/hlada-upp',
   AssetsVehiclesBulkMileageJobOverview = '/eignir/okutaeki/skra-kilometrastodu/runuverk',
   AssetsVehiclesBulkMileageJobDetail = '/eignir/okutaeki/skra-kilometrastodu/runuverk/:id',
@@ -24,5 +27,6 @@ export enum AssetsPaths {
   AssetsIntellectualPropertiesDesign = '/eignir/hugverkarettindi/honnun/:id',
 
   //LINKS
+  //If updated, also update `FinanceTransactionVehicleMileage` in the finance paths file (libs/portals/my-pages/finance/src/lib/paths.ts)
   LinkFinanceTransactionVehicleMileage = '/fjarmal/faerslur/kilometragjald',
 }

--- a/libs/portals/my-pages/assets/src/lib/paths.ts
+++ b/libs/portals/my-pages/assets/src/lib/paths.ts
@@ -22,4 +22,7 @@ export enum AssetsPaths {
   AssetsIntellectualPropertiesTrademark = '/eignir/hugverkarettindi/vorumerki/:id',
   AssetsIntellectualPropertiesPatent = '/eignir/hugverkarettindi/einkaleyfi/:id',
   AssetsIntellectualPropertiesDesign = '/eignir/hugverkarettindi/honnun/:id',
+
+  //LINKS
+  LinkFinanceTransactionVehicleMileage = '/fjarmal/faerslur/kilometragjald',
 }

--- a/libs/portals/my-pages/assets/src/screens/VehicleBulkMileage/VehicleBulkMileage.tsx
+++ b/libs/portals/my-pages/assets/src/screens/VehicleBulkMileage/VehicleBulkMileage.tsx
@@ -148,15 +148,8 @@ const VehicleBulkMileage = () => {
           }
           serviceProviderSlug={SAMGONGUSTOFA_SLUG}
           serviceProviderTooltip={formatMessage(m.vehiclesTooltip)}
-          buttonGroup={[
-            <LinkButton
-              key="finance"
-              to={AssetsPaths.LinkFinanceTransactionVehicleMileage}
-              text={formatMessage(vehicleMessage.financeMileageLink)}
-              icon="bank"
-              variant="utility"
-            />,
-            ...(displayFilters
+          buttonGroup={
+            displayFilters
               ? [
                   <LinkButton
                     key="upload"
@@ -173,8 +166,8 @@ const VehicleBulkMileage = () => {
                     variant="utility"
                   />,
                 ]
-              : []),
-          ]}
+              : undefined
+          }
         >
           {displayFilters && (
             <Box marginBottom={2}>

--- a/libs/portals/my-pages/assets/src/screens/VehicleBulkMileage/VehicleBulkMileage.tsx
+++ b/libs/portals/my-pages/assets/src/screens/VehicleBulkMileage/VehicleBulkMileage.tsx
@@ -25,7 +25,6 @@ import { FormProvider, useForm } from 'react-hook-form'
 import { useVehiclesListLazyQuery } from './VehicleBulkMileage.generated'
 import { isDefined } from '@island.is/shared/utils'
 import { AssetsPaths } from '../../lib/paths'
-import { FinancePaths } from '@island.is/portals/my-pages/finance'
 import { Problem } from '@island.is/react-spa/shared'
 
 interface FormData {
@@ -41,7 +40,7 @@ const VehicleBulkMileage = () => {
   const [search, setSearch] = useState<string>()
   const [displayFilters, setDisplayFilters] = useState<boolean>(false)
 
-  const [vehicleListQuery, { data, loading, error, called }] =
+  const [vehicleListQuery, { data, loading, error }] =
     useVehiclesListLazyQuery()
 
   useEffect(() => {
@@ -152,7 +151,7 @@ const VehicleBulkMileage = () => {
           buttonGroup={[
             <LinkButton
               key="finance"
-              to={FinancePaths.FinanceTransactionVehicleMileage}
+              to={AssetsPaths.LinkFinanceTransactionVehicleMileage}
               text={formatMessage(vehicleMessage.financeMileageLink)}
               icon="bank"
               variant="utility"

--- a/libs/portals/my-pages/assets/src/screens/VehicleBulkMileage/VehicleBulkMileage.tsx
+++ b/libs/portals/my-pages/assets/src/screens/VehicleBulkMileage/VehicleBulkMileage.tsx
@@ -25,6 +25,7 @@ import { FormProvider, useForm } from 'react-hook-form'
 import { useVehiclesListLazyQuery } from './VehicleBulkMileage.generated'
 import { isDefined } from '@island.is/shared/utils'
 import { AssetsPaths } from '../../lib/paths'
+import { FinancePaths } from '@island.is/portals/my-pages/finance'
 import { Problem } from '@island.is/react-spa/shared'
 
 interface FormData {
@@ -148,8 +149,15 @@ const VehicleBulkMileage = () => {
           }
           serviceProviderSlug={SAMGONGUSTOFA_SLUG}
           serviceProviderTooltip={formatMessage(m.vehiclesTooltip)}
-          buttonGroup={
-            displayFilters
+          buttonGroup={[
+            <LinkButton
+              key="finance"
+              to={FinancePaths.FinanceTransactionVehicleMileage}
+              text={formatMessage(vehicleMessage.financeMileageLink)}
+              icon="bank"
+              variant="utility"
+            />,
+            ...(displayFilters
               ? [
                   <LinkButton
                     key="upload"
@@ -166,8 +174,8 @@ const VehicleBulkMileage = () => {
                     variant="utility"
                   />,
                 ]
-              : undefined
-          }
+              : []),
+          ]}
         >
           {displayFilters && (
             <Box marginBottom={2}>

--- a/libs/portals/my-pages/assets/src/screens/VehicleBulkMileage/VehicleBulkMileageSubData.tsx
+++ b/libs/portals/my-pages/assets/src/screens/VehicleBulkMileage/VehicleBulkMileageSubData.tsx
@@ -4,8 +4,9 @@ import {
   SimpleBarChart,
   formatDate,
   numberFormat,
+  LinkButton,
 } from '@island.is/portals/my-pages/core'
-import { Box, Text, Button } from '@island.is/island-ui/core'
+import { Box, Text, Button, Inline } from '@island.is/island-ui/core'
 import { AssetsPaths } from '../../lib/paths'
 import { vehicleMessage } from '../../lib/messages'
 import { useLocale } from '@island.is/localization'
@@ -143,22 +144,32 @@ export const VehicleBulkMileageSubData = ({
         />
       ) : undefined}
       <Box marginTop={2}>
-        <LinkResolver
-          href={AssetsPaths.AssetsVehiclesDetailMileage.replace(
-            ':id',
-            vehicleId.toString(),
-          )}
-        >
-          <Button
-            colorScheme="white"
-            icon="arrowForward"
-            iconType="outline"
-            size="small"
-            variant="utility"
+        <Inline space={1}>
+          <LinkResolver
+            href={AssetsPaths.AssetsVehiclesDetailMileage.replace(
+              ':id',
+              vehicleId.toString(),
+            )}
           >
-            {formatMessage(vehicleMessage.viewRegistrationHistory)}
-          </Button>
-        </LinkResolver>
+            <Button
+              icon="arrowForward"
+              iconType="outline"
+              size="small"
+              variant="utility"
+              colorScheme="white"
+            >
+              {formatMessage(vehicleMessage.viewRegistrationHistory)}
+            </Button>
+          </LinkResolver>
+          <LinkButton
+            key="finance"
+            to={AssetsPaths.LinkFinanceTransactionVehicleMileage}
+            text={formatMessage(vehicleMessage.financeMileageLink)}
+            icon="arrowForward"
+            variant="utility"
+            colorScheme="white"
+          />
+        </Inline>
       </Box>
     </Box>
   )

--- a/libs/portals/my-pages/core/src/components/InfoLine/InfoLine.tsx
+++ b/libs/portals/my-pages/core/src/components/InfoLine/InfoLine.tsx
@@ -155,6 +155,7 @@ export const InfoLine = ({
                 {button.type === 'link' ? (
                   <LinkButton
                     to={button.to}
+                    variant="text"
                     text={
                       button.label
                         ? formatMessage(button.label)

--- a/libs/portals/my-pages/core/src/components/LinkButton/LinkButton.tsx
+++ b/libs/portals/my-pages/core/src/components/LinkButton/LinkButton.tsx
@@ -50,7 +50,6 @@ export const LinkButton = (props: LinkButtonProps) => {
       </LinkResolver>
     )
   }
-  console.log(props.variant)
   return disabled ? (
     <Button
       icon={icon}

--- a/libs/portals/my-pages/core/src/components/LinkButton/LinkButton.tsx
+++ b/libs/portals/my-pages/core/src/components/LinkButton/LinkButton.tsx
@@ -1,34 +1,24 @@
-import { Button, ButtonProps, Icon } from '@island.is/island-ui/core'
+import { Button, ButtonProps, ButtonTypes } from '@island.is/island-ui/core'
 import { isExternalLink } from '../../utils/isExternalLink'
 import LinkResolver from '../LinkResolver/LinkResolver'
 import * as styles from './LinkButton.css'
 
-interface SharedProps {
+interface Props {
   to: string
   text: string
+  icon?: ButtonProps['icon']
   size?: ButtonProps['size']
   disabled?: ButtonProps['disabled']
   skipOutboundTrack?: boolean
 }
 
-type Props = {
-  variant?: 'primary' | 'ghost' | 'utility' | 'text'
-  icon?: ButtonProps['icon']
-}
+type LinkButtonProps = Props & ButtonTypes
 
-type LinkButtonProps = SharedProps & Props
-
-export const LinkButton = ({
-  variant = 'text',
-  size,
-  to,
-  text,
-  icon,
-  disabled,
-  skipOutboundTrack,
-}: LinkButtonProps) => {
+export const LinkButton = (props: LinkButtonProps) => {
+  const { size, to, text, icon, disabled, skipOutboundTrack, ...rest } = props
   const isExternal = isExternalLink(to)
-  if (variant === 'text') {
+
+  if (rest.variant === 'text') {
     return disabled ? (
       <Button
         size={size ?? 'small'}
@@ -36,6 +26,7 @@ export const LinkButton = ({
         disabled
         icon={isExternal ? 'open' : undefined}
         iconType={isExternal ? 'outline' : undefined}
+        {...rest}
       >
         {text}
       </Button>
@@ -52,21 +43,22 @@ export const LinkButton = ({
           unfocusable
           icon={isExternal ? 'open' : icon ?? undefined}
           iconType={isExternal ? 'outline' : undefined}
+          {...rest}
         >
           {text}
         </Button>
       </LinkResolver>
     )
   }
+  console.log(props.variant)
   return disabled ? (
     <Button
-      colorScheme="default"
       icon={icon}
       iconType="outline"
       size={size ?? 'default'}
       disabled
-      variant={variant ?? 'utility'}
       unfocusable
+      {...rest}
     >
       {text}
     </Button>
@@ -77,14 +69,13 @@ export const LinkButton = ({
       href={to}
     >
       <Button
-        colorScheme="default"
         icon={icon}
         iconType="outline"
         size={size ?? 'default'}
         type="text"
         as="span"
-        variant={variant ?? 'utility'}
         unfocusable
+        {...rest}
       >
         {text}
       </Button>

--- a/libs/portals/my-pages/core/src/components/UserInfoLine/UserInfoLine.tsx
+++ b/libs/portals/my-pages/core/src/components/UserInfoLine/UserInfoLine.tsx
@@ -163,6 +163,7 @@ export const UserInfoLine: FC<React.PropsWithChildren<Props>> = ({
             >
               <LinkButton
                 to={editLink.url}
+                variant="text"
                 icon={editLink.icon}
                 text={
                   editLink.title

--- a/libs/portals/my-pages/finance/src/lib/paths.ts
+++ b/libs/portals/my-pages/finance/src/lib/paths.ts
@@ -14,6 +14,9 @@ export enum FinancePaths {
   FinancePaymentsSchedule = '/fjarmal/greidslur/greidsluaetlanir',
   FinancePaymentsHousingBenefits = '/fjarmal/greidslur/husnaedisbaetur',
 
+  // LINKS
+  LinkAssetsVehiclesBulkMileage = '/eignir/okutaeki/skra-kilometrastodu',
+
   // Deprecated with redirects
   FinanceBills = '/fjarmal/greidslusedlar-og-greidslukvittanir',
   FinanceSchedule = '/fjarmal/greidsluaetlanir',

--- a/libs/portals/my-pages/finance/src/lib/paths.ts
+++ b/libs/portals/my-pages/finance/src/lib/paths.ts
@@ -3,7 +3,10 @@ export enum FinancePaths {
   FinanceStatus = '/fjarmal/stada',
   FinanceTransactions = '/fjarmal/faerslur',
   FinanceTransactionCategories = '/fjarmal/faerslur/flokkar',
+
+  // If updated, also update `LinkFinanceTransactionVehicleMileage` in the assets paths file (libs/portals/my-pages/assets/src/lib/paths.ts)
   FinanceTransactionVehicleMileage = '/fjarmal/faerslur/kilometragjald',
+
   FinanceTransactionPeriods = '/fjarmal/faerslur/timabil',
   FinanceEmployeeClaims = '/fjarmal/laungreidendakrofur',
   FinanceLocalTax = '/fjarmal/utsvar',
@@ -15,6 +18,7 @@ export enum FinancePaths {
   FinancePaymentsHousingBenefits = '/fjarmal/greidslur/husnaedisbaetur',
 
   // LINKS
+  // If updated, also update `AssetsVehiclesBulkMileage` in the assets paths file (libs/portals/my-pages/assets/src/lib/paths.ts)
   LinkAssetsVehiclesBulkMileage = '/eignir/okutaeki/skra-kilometrastodu',
 
   // Deprecated with redirects

--- a/libs/portals/my-pages/finance/src/screens/FinanceTransactionsVehicleMileage/FinanceTransactionsVehicleMileage.tsx
+++ b/libs/portals/my-pages/finance/src/screens/FinanceTransactionsVehicleMileage/FinanceTransactionsVehicleMileage.tsx
@@ -111,6 +111,7 @@ const FinanceTransactions = () => {
         <LinkButton
           to={formatMessage(messages.mileageFeeLink)}
           text={formatMessage(messages.mileageFeeLinkLabel)}
+          variant="text"
         />
       </Box>
       <DynamicWrapper>

--- a/libs/portals/my-pages/finance/src/screens/FinanceTransactionsVehicleMileage/FinanceTransactionsVehicleMileage.tsx
+++ b/libs/portals/my-pages/finance/src/screens/FinanceTransactionsVehicleMileage/FinanceTransactionsVehicleMileage.tsx
@@ -20,7 +20,6 @@ import {
   LinkButton,
   m,
 } from '@island.is/portals/my-pages/core'
-import { AssetsPaths } from '@island.is/portals/my-pages/assets'
 import { m as messages } from '../../lib/messages'
 
 import format from 'date-fns/format'
@@ -38,6 +37,7 @@ import * as extraStyles from './FinanceTransactionsVehicleMileage.css'
 import { useFinanceSwapHook } from '../../utils/financeSwapHook'
 import { CustomerRecords } from '../../lib/types'
 import { useGetCustomerRecordsLazyQuery } from './FinanceTransactionsVehicleMileage.generated'
+import { FinancePaths } from '../../lib/paths'
 
 const VEHICLE_MILEAGE_CHARGE_TYPE = 'BM'
 
@@ -214,7 +214,7 @@ const FinanceTransactions = () => {
                 </Filter>
 
                 <LinkButton
-                  to={AssetsPaths.AssetsVehiclesBulkMileage}
+                  to={FinancePaths.LinkAssetsVehiclesBulkMileage}
                   variant="utility"
                   icon="pencil"
                   size="medium"

--- a/libs/portals/my-pages/health/src/components/FootNote/helper.tsx
+++ b/libs/portals/my-pages/health/src/components/FootNote/helper.tsx
@@ -22,6 +22,7 @@ export const getFootNoteByType = (
             <LinkButton
               to={formatMessage(messages['physioDisclaimerLink'])}
               text={String(str ?? '')}
+              variant="text"
             />
           ),
         }),
@@ -35,6 +36,7 @@ export const getFootNoteByType = (
             <LinkButton
               to={formatMessage(messages['physioDisclaimerLink'])}
               text={String(str ?? '')}
+              variant="text"
             />
           ),
         }),
@@ -47,6 +49,7 @@ export const getFootNoteByType = (
             <LinkButton
               to={formatMessage(messages['physioDisclaimerLink'])}
               text={String(str ?? '')}
+              variant="text"
             />
           ),
         }),
@@ -63,6 +66,7 @@ export const getFootNoteByType = (
             <LinkButton
               to={formatMessage(messages['occupationalDisclaimerLink'])}
               text={String(str ?? '')}
+              variant="text"
             />
           ),
         }),
@@ -72,7 +76,7 @@ export const getFootNoteByType = (
         first: formatMessage(messages['physioDisclaimer1']),
         second: formatMessage(messages['physioDisclaimer2'], {
           link: (str: React.ReactNode) => (
-            <LinkButton to="" text={String(str ?? '')} />
+            <LinkButton to="" text={String(str ?? '')} variant="text" />
           ),
         }),
       }

--- a/libs/portals/my-pages/health/src/components/Table/HealthTable.tsx
+++ b/libs/portals/my-pages/health/src/components/Table/HealthTable.tsx
@@ -35,7 +35,11 @@ export const HealthTable = ({
                 {row.map((item, ii) => (
                   <T.Data key={ii}>
                     {item.type === 'link' && item.url ? (
-                      <LinkButton to={item.url} text={item.value} />
+                      <LinkButton
+                        to={item.url}
+                        text={item.value}
+                        variant="text"
+                      />
                     ) : (
                       <Text variant="small" as="span">
                         {item.value}

--- a/libs/portals/my-pages/health/src/screens/AidsAndNutrition/Aids.tsx
+++ b/libs/portals/my-pages/health/src/screens/AidsAndNutrition/Aids.tsx
@@ -123,6 +123,7 @@ const Aids = ({ data }: Props) => {
         <LinkButton
           to={formatMessage(messages['aidsDescriptionLink'])}
           text={formatMessage(messages.aidsDescriptionInfo)}
+          variant="text"
         />
       </Box>
     </Box>

--- a/libs/portals/my-pages/health/src/screens/AidsAndNutrition/Nutrition.tsx
+++ b/libs/portals/my-pages/health/src/screens/AidsAndNutrition/Nutrition.tsx
@@ -95,6 +95,7 @@ const Nutrition = ({ data }: Props) => {
         <LinkButton
           to={formatMessage(messages['nutritionDescriptionLink'])}
           text={formatMessage(messages.nutritionDescriptionInfo)}
+          variant="text"
         />
       </Box>
     </Box>

--- a/libs/portals/my-pages/health/src/screens/Payments/wrapper/PaymentsWrapper.tsx
+++ b/libs/portals/my-pages/health/src/screens/Payments/wrapper/PaymentsWrapper.tsx
@@ -40,6 +40,7 @@ export const PaymentsWrapper = ({ children, pathname }: Props) => {
         <LinkButton
           to={formatMessage(messages.readAboutPaymentParticipationSystemsLink)}
           text={formatMessage(messages.readAboutPaymentParticipationSystems)}
+          variant="text"
         />
       </Box>
     </IntroWrapper>

--- a/libs/portals/my-pages/health/src/screens/Therapies/components/TherapiesTabContent/TherapiesTabContent.tsx
+++ b/libs/portals/my-pages/health/src/screens/Therapies/components/TherapiesTabContent/TherapiesTabContent.tsx
@@ -136,7 +136,9 @@ export const TherapiesTabContent = ({
         <Divider />
       </Stack>
       <FootNote type={data?.[0]?.id.toString()} />
-      {link && linkText && <LinkButton to={link} text={linkText} />}
+      {link && linkText && (
+        <LinkButton to={link} text={linkText} variant="text" />
+      )}
     </Box>
   )
 }

--- a/libs/portals/my-pages/health/src/screens/Vaccinations/tables/SortedVaccinationsTable.tsx
+++ b/libs/portals/my-pages/health/src/screens/Vaccinations/tables/SortedVaccinationsTable.tsx
@@ -89,6 +89,7 @@ export const SortedVaccinationsTable = ({ data }: Props) => {
                             size="small"
                             to={vaccination.url ?? '/'}
                             text={vaccination.name ?? ''}
+                            variant="text"
                           />
                         ) : (
                           vaccination.name ?? ''

--- a/libs/portals/my-pages/licenses/src/utils/dataMapper.tsx
+++ b/libs/portals/my-pages/licenses/src/utils/dataMapper.tsx
@@ -532,6 +532,7 @@ export const getLicenseDetailHeading = (
                 <LinkButton
                   to={formatMessage(m.ehicDescriptionLink)}
                   text={str ?? ''}
+                  variant="text"
                 />
               ),
             })}

--- a/libs/portals/my-pages/social-insurance-maintenance/src/screens/PaymentPlan/PaymentPlan.tsx
+++ b/libs/portals/my-pages/social-insurance-maintenance/src/screens/PaymentPlan/PaymentPlan.tsx
@@ -83,6 +83,7 @@ const PaymentPlan = () => {
                     <LinkButton
                       to={formatMessage(m.maintenanceFooterLinkUrl)}
                       text={str ?? ''}
+                      variant="text"
                     />
                   ),
                 })}


### PR DESCRIPTION
## What

* Add a link button from assets to finance

## Why

* So the user sees his kilometer fee transaction history

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new finance mileage link and updated navigation paths related to vehicle mileage and finance transactions.
  - Introduced an additional action button for accessing finance-related mileage pages in the vehicle mileage section.

- **Style**
  - Updated all instances of LinkButton across various sections to use a "text" variant, improving visual consistency and button appearance.

- **Refactor**
  - Simplified and unified LinkButton component props handling for easier maintenance and enhanced flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->