### PR TITLE
fix(native-app): Change copy in info box for identity cards

### DIFF
--- a/apps/native/app/src/messages/is.ts
+++ b/apps/native/app/src/messages/is.ts
@@ -446,7 +446,7 @@ export const is = {
   'licenseDetail.identityDocument.alert.description':
     'Einungis skilríkið sjálft er fullgilt persónuskilríki.',
   'licenseDetail.identityTravelDocument.alert.title':
-    'Mundu eftir ferðaskilríkinu!',
+    'Mundu eftir nafnskírteininu!',
   'licenseDetail.identityTravelDocument.alert.description':
     'Þetta yfirlit gildir ekki sem ferðaskilríki.',
   'licenseDetail.warning.title': 'Rennur út innan 6 mánaða',

--- a/apps/native/app/src/screens/home/applications-module.tsx
+++ b/apps/native/app/src/screens/home/applications-module.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
-import { useIntl } from 'react-intl'
-import styled from 'styled-components'
+import { FormattedMessage, useIntl } from 'react-intl'
+import styled from 'styled-components/native'
 import { Image, SafeAreaView, View } from 'react-native'
 import { ApolloError } from '@apollo/client'
 
-import { EmptyCard, StatusCardSkeleton } from '../../ui'
+import { EmptyCard, StatusCardSkeleton, Heading } from '../../ui'
 import leJobss3 from '../../assets/illustrations/le-jobs-s3.png'
 import {
   Application,
@@ -22,6 +22,14 @@ interface ApplicationsModuleProps {
 }
 
 const Wrapper = styled(View)`
+  margin-horizontal: ${({ theme }) => theme.spacing[2]}px;
+`
+
+const Host = styled.View`
+  margin-bottom: ${({ theme }) => theme.spacing[2]}px;
+`
+
+const EmptyHeading = styled.View`
   margin-horizontal: ${({ theme }) => theme.spacing[2]}px;
 `
 
@@ -64,21 +72,28 @@ const ApplicationsModule = React.memo(
         ) : (
           <>
             {count === 0 && (
-              <Wrapper>
-                <EmptyCard
-                  text={intl.formatMessage({
-                    id: 'applications.emptyDescription',
-                  })}
-                  image={
-                    <Image
-                      source={leJobss3}
-                      resizeMode="contain"
-                      style={{ height: 87, width: 69 }}
-                    />
-                  }
-                  link={null}
-                />
-              </Wrapper>
+              <Host>
+                <EmptyHeading>
+                  <Heading>
+                    <FormattedMessage id="homeOptions.applications" />
+                  </Heading>
+                </EmptyHeading>
+                <Wrapper>
+                  <EmptyCard
+                    text={intl.formatMessage({
+                      id: 'applications.emptyDescription',
+                    })}
+                    image={
+                      <Image
+                        source={leJobss3}
+                        resizeMode="contain"
+                        style={{ height: 87, width: 69 }}
+                      />
+                    }
+                    link={null}
+                  />
+                </Wrapper>
+              </Host>
             )}
             {count !== 0 && (
               <ApplicationsPreview

--- a/apps/native/app/src/screens/wallet-pass/wallet-pass.tsx
+++ b/apps/native/app/src/screens/wallet-pass/wallet-pass.tsx
@@ -136,7 +136,7 @@ const getInfoAlertMessageIds = (
 ) => {
   const isTravelIdentityDocument =
     licenseType === GenericLicenseType.IdentityDocument &&
-    licenseNumber?.startsWith('II')
+    licenseNumber?.startsWith('ID')
   switch (licenseType) {
     case GenericLicenseType.PCard:
       return {


### PR DESCRIPTION
## What

* Update info box copy for identity cards
* Fix logic that checks if identity document is travel identity document or not (was the opposite for some reason)
* Add header for empty state for applications module on home screen (saw by a coincidence it was missing) 

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a heading above the empty state card in the applications section for improved clarity.

- **Bug Fixes**
  - Updated the alert title in Icelandic for identity cards in the license details section.
  - Corrected the logic for identifying travel identity documents based on license number prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->