### PR TITLE
feat(web): Blood donation restriction list - Move description on cards and change subtitle for detail page

### DIFF
--- a/apps/web/screens/Organization/Bloodbank/BloodDonationRestrictionDetails.tsx
+++ b/apps/web/screens/Organization/Bloodbank/BloodDonationRestrictionDetails.tsx
@@ -100,7 +100,7 @@ const BloodDonationRestrictionDetails: CustomScreen<
               width="full"
             >
               <Text variant="h3" as="h2">
-                {formatMessage(m.listPage.cardSubheading)}
+                {formatMessage(m.detailsPage.cardSubheading)}
               </Text>
               <Text as="div">{webRichText(item.cardText)}</Text>
             </Box>

--- a/apps/web/screens/Organization/Bloodbank/BloodDonationRestrictionList.tsx
+++ b/apps/web/screens/Organization/Bloodbank/BloodDonationRestrictionList.tsx
@@ -305,6 +305,11 @@ const BloodDonationRestrictionList: CustomScreen<
                   <Text variant="h4" color="blue400">
                     {item.title}
                   </Text>
+                  {Boolean(item.description) && (
+                    <Text variant="medium">
+                      {highlightMatch(item.description, trimmedQueryString)}
+                    </Text>
+                  )}
                   {item.hasCardText && (
                     <Box
                       background="dark100"
@@ -329,11 +334,6 @@ const BloodDonationRestrictionList: CustomScreen<
                         </Button>
                       )}
                     </Box>
-                  )}
-                  {Boolean(item.description) && (
-                    <Text variant="medium">
-                      {highlightMatch(item.description, trimmedQueryString)}
-                    </Text>
                   )}
                   {Boolean(item.keywordsText) && (
                     <Text variant="small">

--- a/apps/web/screens/Organization/Bloodbank/messages.strings.ts
+++ b/apps/web/screens/Organization/Bloodbank/messages.strings.ts
@@ -46,5 +46,10 @@ export const m = {
       defaultMessage: 'Nánar um áhrif',
       description: 'Nánar um áhrif (heading fyrir ofan texta á details síðu)',
     },
+    cardSubheading: {
+      id: 'web.bloodbank.bloodDonationRestrictions:listPage.cardSubheading',
+      defaultMessage: 'Undantekningar og athugasemdir',
+      description: 'Texti undirtitil í spjaldi',
+    },
   }),
 }

--- a/apps/web/screens/Organization/Bloodbank/messages.strings.ts
+++ b/apps/web/screens/Organization/Bloodbank/messages.strings.ts
@@ -47,7 +47,7 @@ export const m = {
       description: 'Nánar um áhrif (heading fyrir ofan texta á details síðu)',
     },
     cardSubheading: {
-      id: 'web.bloodbank.bloodDonationRestrictions:listPage.cardSubheading',
+      id: 'web.bloodbank.bloodDonationRestrictions:detailsPage.cardSubheading',
       defaultMessage: 'Undantekningar og athugasemdir',
       description: 'Texti undirtitil í spjaldi',
     },


### PR DESCRIPTION
# Blood donation restriction list - Move description on cards and change subtitle for detail page

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed duplicate display of description text in the blood donation restriction list.
- **Style**
	- Updated card subheading text in the blood donation restriction details view for improved clarity.
- **Documentation**
	- Added a new localized message for the card subheading in the details page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->