### PR TITLE
fix(j-s): flashing components when data from the context is undefined

### DIFF
--- a/apps/judicial-system/web/src/components/Logo/Logo.tsx
+++ b/apps/judicial-system/web/src/components/Logo/Logo.tsx
@@ -14,6 +14,10 @@ interface Props {
 
 const Logo: FC<Props> = ({ defaultInstitution = '' }) => {
   const { user } = useContext(UserContext)
+  if (!user) {
+    return null
+  }
+
   const institutionName = user?.institution?.name ?? defaultInstitution ?? ''
   const institutionNameArr = institutionName.split(' ')
   const institutionNameFirstHalf = institutionNameArr.slice(

--- a/apps/judicial-system/web/src/components/UserProvider/UserProvider.tsx
+++ b/apps/judicial-system/web/src/components/UserProvider/UserProvider.tsx
@@ -19,6 +19,7 @@ import { User } from '@island.is/judicial-system-web/src/graphql/schema'
 import { useCurrentUserQuery } from './currentUser.generated'
 
 interface UserProvider {
+  isLoading?: boolean
   isAuthenticated?: boolean
   limitedAccess?: boolean
   user?: User
@@ -41,6 +42,7 @@ export const UserProvider: FC<PropsWithChildren<Props>> = ({
 }) => {
   const [user, setUser] = useState<User>()
   const [eligibleUsers, setEligibleUsers] = useState<User[]>()
+  const [isLoading, setIsLoading] = useState(true)
 
   const isAuthenticated =
     authenticated || Boolean(Cookies.get(CSRF_COOKIE_NAME))
@@ -59,6 +61,7 @@ export const UserProvider: FC<PropsWithChildren<Props>> = ({
     const currentUser = data.currentUser
 
     if (currentUser.user) {
+      setIsLoading(false)
       setUser(currentUser.user)
       userRef.current = currentUser.user
     }
@@ -70,6 +73,7 @@ export const UserProvider: FC<PropsWithChildren<Props>> = ({
   return (
     <UserContext.Provider
       value={{
+        isLoading,
         isAuthenticated,
         user,
         eligibleUsers,

--- a/apps/judicial-system/web/src/routes/Shared/Cases/AllCases.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/Cases/AllCases.tsx
@@ -1,13 +1,19 @@
 import { FC, useContext } from 'react'
 
 import { isPublicProsecutionOfficeUser } from '@island.is/judicial-system/types'
-import { UserContext } from '@island.is/judicial-system-web/src/components'
+import {
+  Skeleton,
+  UserContext,
+} from '@island.is/judicial-system-web/src/components'
 
 import PublicProsecutorCases from '../../PublicProsecutor/Cases/PublicProsecutorCases'
 import Cases from './Cases'
 
 export const AllCases: FC = () => {
-  const { user } = useContext(UserContext)
+  const { isLoading, user } = useContext(UserContext)
+  if (isLoading) {
+    return <Skeleton />
+  }
 
   if (isPublicProsecutionOfficeUser(user)) {
     return <PublicProsecutorCases />

--- a/apps/judicial-system/web/src/routes/Shared/Cases/Cases.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/Cases/Cases.tsx
@@ -196,7 +196,7 @@ export const Cases: FC = () => {
         }
       }
 
-      // This componenet is only used for prosecution and district court users
+      // This component is only used for prosecution and district court users
       return false
     })
 


### PR DESCRIPTION
# [Flashing logo when user is undefined during re-renders](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1209712907569192)

## What
- When fetched user from the context is `undefined` we render the default logo for prosecutor which creates a flaky logo render. 
- Other components also show their default states when no data is loaded which also indicates a weird render. 
<img width="1290" alt="Screenshot 2025-05-02 at 15 33 23" src="https://github.com/user-attachments/assets/9d4867c8-4fd1-486e-9886-6c611bbac8da" />

- Thus, we render a `Skeleton` loader (barely visible 😅 ) for the cases and for sanity purposes we return null when user is undefined in the `Logo` component.

## Why
- its a bug

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a loading indicator to the cases view, displaying a skeleton loader while user data is being fetched.
- **Bug Fixes**
  - Improved handling of missing user data to prevent unnecessary rendering of components.
- **Style**
  - Corrected a typo in a code comment for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->