### PR TITLE
fix(ojoi): Add adverts from today on FP

### DIFF
--- a/apps/web/screens/OfficialJournalOfIceland/lib/getTodayParams.ts
+++ b/apps/web/screens/OfficialJournalOfIceland/lib/getTodayParams.ts
@@ -1,0 +1,13 @@
+import endOfDay from 'date-fns/endOfDay'
+import startOfDay from 'date-fns/startOfDay'
+
+export const getTodayParams = () => {
+  const today = new Date()
+  const startDate = startOfDay(today)
+  const endDate = endOfDay(today)
+
+  return {
+    dateFrom: startDate.toISOString(),
+    dateTo: endDate.toISOString(),
+  }
+}

--- a/libs/application/templates/official-journal-of-iceland/src/lib/messages/signatures.ts
+++ b/libs/application/templates/official-journal-of-iceland/src/lib/messages/signatures.ts
@@ -91,7 +91,7 @@ export const signatures = {
     institution: defineMessages({
       label: {
         id: 'ojoi.application:signatures.inputs.institution.label',
-        defaultMessage: 'Stofnun',
+        defaultMessage: 'Staður eða stofnun (þgf.)',
         description: 'Label for the institution input',
       },
       placeholder: {


### PR DESCRIPTION
## What

Show adverts from today on frontpage.

## Why

Now when default 5, some will be "hidden".

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
