### PR TITLE
feat(rental-agreement): Add replyTo in summary email template.

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/rental-agreement/rental-agreement-email.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/rental-agreement/rental-agreement-email.ts
@@ -9,18 +9,18 @@ export const generateRentalAgreementEmail: EmailTemplateGenerator = (props) => {
     options: { email },
   } = props
 
-  // TODO: Get email of application creator from user profile, user profile datta seems to be empty as of now
-  // const applicationCreator = {
-  //   name:
-  //     getValueViaPath(
-  //       application.externalData,
-  //       'nationalRegistry.fullName',
-  //       '',
-  //     ) || '',
-  //   email:
-  //     getValueViaPath(application.externalData, 'userProfile.data.email', '') ||
-  //     '',
-  // }
+  const applicationCreator = {
+    name:
+      getValueViaPath<string>(
+        application.externalData,
+        'nationalRegistry.fullName',
+      ) || '',
+    email:
+      getValueViaPath<string>(
+        application.externalData,
+        'userProfile.data.email',
+      ) || '',
+  }
 
   const tenants = filterNonRepresentativesAndMapInfo(
     getValueViaPath<Array<ApplicantsInfo>>(
@@ -79,11 +79,10 @@ export const generateRentalAgreementEmail: EmailTemplateGenerator = (props) => {
       name: email.sender,
       address: email.address,
     },
-    // TODO: Get email of application creator from user profile, user profile datta seems to be empty as of now
-    // replyTo: {
-    //   name: applicationCreator.name,
-    //   address: applicationCreator.email,
-    // },
+    replyTo: {
+      name: applicationCreator.name,
+      address: applicationCreator.email,
+    },
     to: allRecipients,
     subject: 'Drög að húsaleigusamningi',
     template: {


### PR DESCRIPTION
# ReplyTo in summary email template.

## What
Applicants email should be the reply to email for summary email sent to assignees of application.

## Why
Email recipients should be able to reply to the application creator.

## Screenshots / Gifs


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The "Reply-To" field is now included in rental agreement emails, displaying the creator's name and email address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->