### PR TITLE
Fix(rental-agreement): Conditionally rendered input connected to wrong field

### DIFF
--- a/libs/application/templates/rental-agreement/src/forms/draft/rentalPeriodSubsections/rentalPeriodAmount.ts
+++ b/libs/application/templates/rental-agreement/src/forms/draft/rentalPeriodSubsections/rentalPeriodAmount.ts
@@ -22,8 +22,9 @@ import {
 import {
   rentalAmountConnectedToIndex,
   rentalInsuranceRequired,
-  rentalPaymentIsBankTransfer,
-  rentalPaymentIsOther,
+  rentalPaymentDateIsOther,
+  rentalPaymentMethodIsBankTransfer,
+  rentalPaymentMethodIsOther,
 } from '../../../utils/rentalPeriodUtils'
 import { rentalAmount } from '../../../lib/messages'
 
@@ -90,7 +91,7 @@ export const RentalPeriodAmount = buildSubSection({
           title: rentalAmount.paymentDateOtherOptionLabel,
           placeholder: rentalAmount.paymentDateOtherOptionPlaceholder,
           maxLength: 100,
-          condition: rentalPaymentIsOther,
+          condition: rentalPaymentDateIsOther,
         }),
 
         // Payment method
@@ -111,20 +112,20 @@ export const RentalPeriodAmount = buildSubSection({
           title: rentalAmount.paymentMethodNationalIdLabel,
           format: '######-####',
           width: 'half',
-          condition: rentalPaymentIsBankTransfer,
+          condition: rentalPaymentMethodIsBankTransfer,
         }),
         buildTextField({
           id: 'rentalAmount.paymentMethodBankAccountNumber',
           title: rentalAmount.paymentMethodBankAccountNumberLabel,
           format: '####-##-######',
           width: 'half',
-          condition: rentalPaymentIsBankTransfer,
+          condition: rentalPaymentMethodIsBankTransfer,
         }),
         buildTextField({
           id: 'rentalAmount.paymentMethodOtherTextField',
           title: rentalAmount.paymentMethodOtherTextFieldLabel,
           maxLength: 50,
-          condition: rentalPaymentIsOther,
+          condition: rentalPaymentMethodIsOther,
         }),
 
         // SecurityDeposit

--- a/libs/application/templates/rental-agreement/src/utils/enums.ts
+++ b/libs/application/templates/rental-agreement/src/utils/enums.ts
@@ -60,8 +60,6 @@ export enum RentalHousingConditionInspector {
 
 export enum RentalAmountIndexTypes {
   CONSUMER_PRICE_INDEX = 'consumerPriceIndex',
-  CONSTRUCTION_COST_INDEX = 'constructionCostIndex',
-  WAGE_INDEX = 'wageIndex',
 }
 
 export enum RentalAmountPaymentDateOptions {

--- a/libs/application/templates/rental-agreement/src/utils/rentalPeriodUtils.ts
+++ b/libs/application/templates/rental-agreement/src/utils/rentalPeriodUtils.ts
@@ -2,6 +2,7 @@ import { getValueViaPath, YesOrNoEnum } from '@island.is/application/core'
 import { FormValue } from '@island.is/application/types'
 import {
   OtherFeesPayeeOptions,
+  RentalAmountPaymentDateOptions,
   RentalPaymentMethodOptions,
   SecurityDepositAmountOptions,
   SecurityDepositTypeOptions,
@@ -16,20 +17,28 @@ export const rentalAmountConnectedToIndex = (answers: FormValue) => {
   return isAmountConnectedToIndex?.includes(YesOrNoEnum.YES) || false
 }
 
-export const rentalPaymentIsOther = (answers: FormValue) => {
-  const paymentMethod = getValueViaPath<string>(
+export const rentalPaymentDateIsOther = (answers: FormValue) => {
+  const paymentDate = getValueViaPath<string>(
     answers,
-    'rentalAmount.paymentMethodOptions',
+    'rentalAmount.paymentDateOptions',
   )
-  return paymentMethod === RentalPaymentMethodOptions.OTHER
+  return paymentDate === RentalAmountPaymentDateOptions.OTHER
 }
 
-export const rentalPaymentIsBankTransfer = (answers: FormValue) => {
+export const rentalPaymentMethodIsBankTransfer = (answers: FormValue) => {
   const paymentMethod = getValueViaPath<string>(
     answers,
     'rentalAmount.paymentMethodOptions',
   )
   return paymentMethod === RentalPaymentMethodOptions.BANK_TRANSFER
+}
+
+export const rentalPaymentMethodIsOther = (answers: FormValue) => {
+  const paymentMethod = getValueViaPath<string>(
+    answers,
+    'rentalAmount.paymentMethodOptions',
+  )
+  return paymentMethod === RentalPaymentMethodOptions.OTHER
 }
 
 export const rentalInsuranceRequired = (answers: FormValue) => {

--- a/libs/application/templates/rental-agreement/src/utils/utils.ts
+++ b/libs/application/templates/rental-agreement/src/utils/utils.ts
@@ -215,14 +215,6 @@ export const getRentalAmountIndexTypes = () => [
     value: RentalAmountIndexTypes.CONSUMER_PRICE_INDEX,
     label: m.rentalAmount.indexOptionConsumerPriceIndex,
   },
-  {
-    value: RentalAmountIndexTypes.CONSTRUCTION_COST_INDEX,
-    label: m.rentalAmount.indexOptionConstructionCostIndex,
-  },
-  {
-    value: RentalAmountIndexTypes.WAGE_INDEX,
-    label: m.rentalAmount.indexOptionWageIndex,
-  },
 ]
 
 export const getRentalAmountPaymentDateOptions = () => [


### PR DESCRIPTION
# Conditionally rendered input connected to wrong field

## What

- Fix an issue where a conditionally rendered input was not being rendered as expected and was accidentally connected to an option of a different dropdown element.
- Removed options for "index type", should only be one option as is.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
