### PR TITLE
feat(j-s): Use user generated file name for caseFile uploads

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/file/file.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/file/file.service.ts
@@ -255,8 +255,12 @@ export class FileService {
       this.logger.info('Previous upload failed', { reason })
     })
 
-    const content = await this.getCaseFileFromS3(theCase, file)
+    const fileName =
+      theCase.caseFiles
+        ?.find((f) => f.key === file.key)
+        ?.userGeneratedFilename?.trim() || file.name
 
+    const content = await this.getCaseFileFromS3(theCase, file)
     const courtDocumentFolder = this.getCourtDocumentFolder(file)
 
     return this.courtService.createDocument(
@@ -265,8 +269,8 @@ export class FileService {
       theCase.courtId,
       theCase.courtCaseNumber,
       courtDocumentFolder,
-      file.name,
-      file.name,
+      fileName,
+      fileName,
       file.type,
       content,
     )


### PR DESCRIPTION
[Asana
](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1209919065072186)

## What

Use user generated file name (if there is one) in the file uploads to the court system.

## Why

So that they are displayed the same as in the judicial system and don't cause confusion. 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved file upload behavior to better handle filenames by using user-provided names when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->