### PR TITLE
feat(contentful-apps): Custom character replacement when slugifying strings

### DIFF
--- a/apps/contentful-apps/constants/index.ts
+++ b/apps/contentful-apps/constants/index.ts
@@ -8,5 +8,7 @@ export const SLUGIFIED_POSTFIX = '--slugified'
 
 export const CUSTOM_SLUGIFY_REPLACEMENTS: ReadonlyArray<[string, string]> = [
   ['ö', 'o'],
+  ['Ö', 'o'],
   ['þ', 'th'],
+  ['Þ', 'th'],
 ]

--- a/apps/contentful-apps/next-env.d.ts
+++ b/apps/contentful-apps/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/apps/contentful-apps/pages/fields/event-slug-field.tsx
+++ b/apps/contentful-apps/pages/fields/event-slug-field.tsx
@@ -3,9 +3,8 @@ import { useDebounce } from 'react-use'
 import { FieldExtensionSDK } from '@contentful/app-sdk'
 import { TextInput } from '@contentful/f36-components'
 import { useSDK } from '@contentful/react-apps-toolkit'
-import slugify from '@sindresorhus/slugify'
 
-import { slugifyDate } from '../../utils'
+import { slugify, slugifyDate } from '../../utils'
 
 const EventSlugField = () => {
   const sdk = useSDK<FieldExtensionSDK>()
@@ -41,11 +40,7 @@ const EventSlugField = () => {
           return
         }
         const date = sdk.entry.fields.startDate.getValue()
-        setValue(
-          `${slugify(newTitle, { customReplacements: [['ö', 'o']] })}${
-            date ? '-' + slugifyDate(date) : ''
-          }`,
-        )
+        setValue(`${slugify(newTitle)}${date ? '-' + slugifyDate(date) : ''}`)
       })
 
     const unsubscribeFromDateValueChanges =

--- a/apps/contentful-apps/pages/fields/generic-list-item-slug-field.tsx
+++ b/apps/contentful-apps/pages/fields/generic-list-item-slug-field.tsx
@@ -3,10 +3,8 @@ import { useDebounce } from 'react-use'
 import type { FieldExtensionSDK } from '@contentful/app-sdk'
 import { Stack, Text, TextInput } from '@contentful/f36-components'
 import { useCMA, useSDK } from '@contentful/react-apps-toolkit'
-import slugify from '@sindresorhus/slugify'
 
-import { CUSTOM_SLUGIFY_REPLACEMENTS } from '../../constants'
-import { slugifyDate } from '../../utils'
+import { slugify, slugifyDate } from '../../utils'
 
 const DEBOUNCE_TIME = 100
 
@@ -58,11 +56,7 @@ const GenericListItemSlugField = () => {
           return
         }
         const date = sdk.entry.fields.date.getValue()
-        setValue(
-          `${slugify(newTitle, {
-            customReplacements: CUSTOM_SLUGIFY_REPLACEMENTS,
-          })}${date ? '-' + slugifyDate(date) : ''}`,
-        )
+        setValue(`${slugify(newTitle)}${date ? '-' + slugifyDate(date) : ''}`)
       })
 
     const unsubscribeFromDateValueChanges =
@@ -74,11 +68,7 @@ const GenericListItemSlugField = () => {
         if (!title || hasEntryBeenPublished) {
           return
         }
-        setValue(
-          `${slugify(title, {
-            customReplacements: CUSTOM_SLUGIFY_REPLACEMENTS,
-          })}${date ? `-${slugifyDate(date)}` : ''}`,
-        )
+        setValue(`${slugify(title)}${date ? `-${slugifyDate(date)}` : ''}`)
       })
 
     return () => {

--- a/apps/contentful-apps/pages/fields/organization-parent-subpage-slug-field.tsx
+++ b/apps/contentful-apps/pages/fields/organization-parent-subpage-slug-field.tsx
@@ -3,9 +3,8 @@ import { useDebounce } from 'react-use'
 import { FieldExtensionSDK } from '@contentful/app-sdk'
 import { Stack, Text, TextInput } from '@contentful/f36-components'
 import { useCMA, useSDK } from '@contentful/react-apps-toolkit'
-import slugify from '@sindresorhus/slugify'
 
-import { CUSTOM_SLUGIFY_REPLACEMENTS } from '../../constants'
+import { slugify } from '../../utils'
 
 const DEBOUNCE_TIME = 100
 
@@ -46,11 +45,7 @@ const OrganizationParentSubpageSlugField = () => {
         }
 
         if (newTitle) {
-          setValue(
-            slugify(String(newTitle), {
-              customReplacements: CUSTOM_SLUGIFY_REPLACEMENTS,
-            }),
-          )
+          setValue(slugify(String(newTitle)))
         }
       })
   }, [hasEntryBeenPublished, sdk.entry.fields.title, sdk.field.locale])

--- a/apps/contentful-apps/pages/fields/organization-subpage-slug-field.tsx
+++ b/apps/contentful-apps/pages/fields/organization-subpage-slug-field.tsx
@@ -3,7 +3,8 @@ import { useDebounce } from 'react-use'
 import { FieldExtensionSDK } from '@contentful/app-sdk'
 import { Stack, Text, TextInput } from '@contentful/f36-components'
 import { useCMA, useSDK } from '@contentful/react-apps-toolkit'
-import slugify from '@sindresorhus/slugify'
+
+import { slugify } from '../../utils'
 
 const DEBOUNCE_TIME = 100
 

--- a/apps/contentful-apps/pages/fields/project-subpage-slug-field.tsx
+++ b/apps/contentful-apps/pages/fields/project-subpage-slug-field.tsx
@@ -4,7 +4,8 @@ import type { EntryProps } from 'contentful-management'
 import { FieldExtensionSDK } from '@contentful/app-sdk'
 import { Stack, Text, TextInput } from '@contentful/f36-components'
 import { useCMA, useSDK } from '@contentful/react-apps-toolkit'
-import slugify from '@sindresorhus/slugify'
+
+import { slugify } from '../../utils'
 
 const DEBOUNCE_TIME = 100
 

--- a/apps/contentful-apps/pages/fields/subarticle-url-field.tsx
+++ b/apps/contentful-apps/pages/fields/subarticle-url-field.tsx
@@ -4,13 +4,13 @@ import { EntryProps, SysLink } from 'contentful-management'
 import { FieldExtensionSDK } from '@contentful/app-sdk'
 import { Spinner, Text, TextInput } from '@contentful/f36-components'
 import { useCMA, useSDK } from '@contentful/react-apps-toolkit'
-import slugify from '@sindresorhus/slugify'
 
 import {
   CONTENTFUL_ENVIRONMENT,
   CONTENTFUL_SPACE,
   DEFAULT_LOCALE,
 } from '../../constants'
+import { slugify } from '../../utils'
 
 type Article = EntryProps<{
   subArticles: { [DEFAULT_LOCALE]: SysLink[] }

--- a/apps/contentful-apps/pages/screens/content-import-screen.tsx
+++ b/apps/contentful-apps/pages/screens/content-import-screen.tsx
@@ -15,7 +15,6 @@ import {
 } from '@contentful/f36-components'
 import { useCMA, useSDK } from '@contentful/react-apps-toolkit'
 import { richTextFromMarkdown } from '@contentful/rich-text-from-markdown'
-import slugify from '@sindresorhus/slugify'
 
 import { GridContainer } from '@island.is/island-ui/core'
 
@@ -41,7 +40,11 @@ import {
   TITLE_SEARCH_POSTFIX,
 } from '../../constants'
 import { useContentTypeData } from '../../hooks/useContentTypeData'
-import { getContentfulEntries, parseContentfulErrorMessage } from '../../utils'
+import {
+  getContentfulEntries,
+  parseContentfulErrorMessage,
+  slugify,
+} from '../../utils'
 
 const convertHtmlToContentfulRichText = (html: string) => {
   const markdown = NodeHtmlMarkdown.translate(html || '')
@@ -115,9 +118,7 @@ const ContentImportScreen = () => {
 
         fields[field.contentfulField.data.id] = {
           ...fields[field.contentfulField.data.id],
-          [field.contentfulField.locale]: slugify(row[i], {
-            customReplacements: [['ö', 'o']],
-          }),
+          [field.contentfulField.locale]: slugify(row[i]),
         }
       }
 

--- a/apps/contentful-apps/utils/index.ts
+++ b/apps/contentful-apps/utils/index.ts
@@ -1,9 +1,11 @@
 import { CollectionProp, EntryProps, KeyValueMap } from 'contentful-management'
 import { CMAClient } from '@contentful/app-sdk'
+import sindresorhusSlugify from '@sindresorhus/slugify'
 
 import {
   CONTENTFUL_ENVIRONMENT,
   CONTENTFUL_SPACE,
+  CUSTOM_SLUGIFY_REPLACEMENTS,
   DEFAULT_LOCALE,
   DEV_WEB_BASE_URL,
 } from '../constants'
@@ -159,4 +161,10 @@ export const previewLinkHandler = {
 
     return `${DEV_WEB_BASE_URL}/s/${orgPageSlug}/${entry.fields.slug[DEFAULT_LOCALE]}`
   },
+}
+
+export const slugify = (value: string) => {
+  return sindresorhusSlugify(value, {
+    customReplacements: CUSTOM_SLUGIFY_REPLACEMENTS,
+  })
 }


### PR DESCRIPTION
#  Custom character replacement when slugifying strings

## What

* Set our own rules when it comes to character replacements when slugifying
* Create a wrapper around the slugify function so we can have a central place to change the rules

## Why

We don't want the following character character changes when slugifying

Ö -> oe
Þ -> t-h

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated slug generation across various fields to use a unified local utility for consistent behavior.
  - Simplified slug creation by removing custom character replacement options in affected fields.
- **Chores**
  - Centralized the slugify logic to a shared utility, improving maintainability and consistency.
  - Extended character replacement rules to handle uppercase special characters for better slug accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->