### PR TITLE
fix(ci): Show lint output

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -299,6 +299,9 @@ jobs:
           set -euo pipefail
           lints=$(mktemp -t lint-head.XXXXXX)
           echo "lints-file=$lints" | tee -a "$GITHUB_OUTPUT"
+          echo "::group::Lints"
+          cat "$lints"
+          echo "::endgroup::"
           yarn nx run-many -t lint --output-style=static --projects "$AFFECTED_PROJECTS" |
             tee -a "$lints" | # Show output when running, but preserve pipe-chaining
             (grep -oP '(?<=✖ )(\d+)(?= problems)' || echo '0') | # Find number of problems
@@ -319,6 +322,9 @@ jobs:
           set -euo pipefail
           lints=$(mktemp -t lint-base.XXXXXX)
           echo "lints-file=$lints" | tee -a "$GITHUB_OUTPUT"
+          echo "::group::Lints"
+          cat "$lints"
+          echo "::endgroup::"
           yarn nx run-many -t lint --output-style=static --projects "$AFFECTED_PROJECTS" |
             tee -a "$lints" | # Show output when running, but preserve pipe-chaining
             (grep -oP '(?<=✖ )(\d+)(?= problems)' || echo '0') | # Find number of problems

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -299,14 +299,14 @@ jobs:
           set -euo pipefail
           lints=$(mktemp -t lint-head.XXXXXX)
           echo "lints-file=$lints" | tee -a "$GITHUB_OUTPUT"
-          echo "::group::Lints"
-          cat "$lints"
-          echo "::endgroup::"
           yarn nx run-many -t lint --output-style=static --projects "$AFFECTED_PROJECTS" |
             tee -a "$lints" | # Show output when running, but preserve pipe-chaining
             (grep -oP '(?<=✖ )(\d+)(?= problems)' || echo '0') | # Find number of problems
             awk '{ SUM += $1} END { SUM /= 2; printf "lint-count=%d", SUM }' | # sum number of problems, divide by 2 because each problem summary occurs twice
             tee -a "$GITHUB_OUTPUT" # Finally create output
+          echo "::group::Lints"
+          cat "$lints"
+          echo "::endgroup::"
 
       # Checkout for linting base
       - uses: actions/checkout@v4
@@ -322,14 +322,14 @@ jobs:
           set -euo pipefail
           lints=$(mktemp -t lint-base.XXXXXX)
           echo "lints-file=$lints" | tee -a "$GITHUB_OUTPUT"
-          echo "::group::Lints"
-          cat "$lints"
-          echo "::endgroup::"
           yarn nx run-many -t lint --output-style=static --projects "$AFFECTED_PROJECTS" |
             tee -a "$lints" | # Show output when running, but preserve pipe-chaining
             (grep -oP '(?<=✖ )(\d+)(?= problems)' || echo '0') | # Find number of problems
             awk '{ SUM += $1} END { SUM /= 2; printf "lint-count=%d", SUM }' | # sum number of problems, divide by 2 because each problem summary occurs twice
             tee -a "$GITHUB_OUTPUT" # Finally create output
+          echo "::group::Lints"
+          cat "$lints"
+          echo "::endgroup::"
 
       - name: No new lints
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'dirty bypass') }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved readability of lint output in pull request checks by grouping lint logs in the GitHub Actions UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->