### PR TITLE
feat(web): Parent subpage - redirect to first child subpage slug in case no slug is present

### DIFF
--- a/apps/web/screens/Organization/Standalone/ParentSubpage.tsx
+++ b/apps/web/screens/Organization/Standalone/ParentSubpage.tsx
@@ -21,7 +21,7 @@ import {
   QueryGetOrganizationSubpageArgs,
   QueryGetOrganizationSubpageByIdArgs,
 } from '@island.is/web/graphql/schema'
-import { useLinkResolver } from '@island.is/web/hooks'
+import { linkResolver, useLinkResolver } from '@island.is/web/hooks'
 import useContentfulId from '@island.is/web/hooks/useContentfulId'
 import { useI18n } from '@island.is/web/i18n'
 import { StandaloneLayout } from '@island.is/web/layouts/organization/standalone'
@@ -145,6 +145,7 @@ export const getProps: typeof StandaloneParentSubpage['getProps'] = async ({
   locale,
   query,
   organizationPage,
+  res,
 }) => {
   const [organizationPageSlug, parentSubpageSlug, subpageSlug] = (query.slugs ??
     []) as string[]
@@ -261,6 +262,19 @@ export const getProps: typeof StandaloneParentSubpage['getProps'] = async ({
       404,
       'Subpage belonging to an organization parent subpage was not found',
     )
+  }
+
+  if (res && !subpageSlug) {
+    res.writeHead(302, {
+      Location: encodeURI(
+        linkResolver(
+          'organizationparentsubpagechild',
+          [organizationPageSlug, parentSubpageSlug, subpage.slug],
+          locale as Locale,
+        ).href,
+      ),
+    })
+    res.end()
   }
 
   const tableOfContentHeadings = getOrganizationParentSubpage.childLinks.map(

--- a/apps/web/screens/Organization/Standalone/ParentSubpage.tsx
+++ b/apps/web/screens/Organization/Standalone/ParentSubpage.tsx
@@ -270,7 +270,7 @@ export const getProps: typeof StandaloneParentSubpage['getProps'] = async ({
         linkResolver(
           'organizationparentsubpagechild',
           [organizationPageSlug, parentSubpageSlug, subpage.slug],
-          locale as Locale,
+          locale as ContentLanguage,
         ).href,
       ),
     })


### PR DESCRIPTION
# Parent subpage - redirect to first child subpage slug in case no slug is present

Today you can visit /s/:orgPageSlug/:parentSubpageSlug and /s/:orgPageSlug/:parentSubpageSlug/:firstChildSubpageSlug and you'll reach the same page.

Instead of having two separate urls we are now redirecting the first one the the second one and therefore will only have one url per page.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added automatic redirect to the first available child subpage when accessing a parent subpage without specifying a subpage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->