### PR TITLE
fix(secondary school): Add state DISMISSED + add possibility to go from IN_REVIEW -> SUBMITTED

### DIFF
--- a/libs/application/templates/secondary-school/src/lib/messages/application.ts
+++ b/libs/application/templates/secondary-school/src/lib/messages/application.ts
@@ -113,6 +113,16 @@ export const historyMessages = defineMessages({
     defaultMessage: 'Yfirferð lokið',
     description: 'History message application review finished',
   },
+  reviewWithdrawn: {
+    id: 'ss.application:historyMessages.reviewWithdrawn',
+    defaultMessage: 'Yfirferð hafin á ný',
+    description: 'History message application review withdrawn',
+  },
+  applicationDismissed: {
+    id: 'ss.application:historyMessages.applicationDismissed',
+    defaultMessage: 'Umsókn vísað frá',
+    description: 'History message application dismissed',
+  },
 })
 
 export const pendingActionMessages = defineMessages({

--- a/libs/application/templates/secondary-school/src/lib/messages/overview.ts
+++ b/libs/application/templates/secondary-school/src/lib/messages/overview.ts
@@ -165,10 +165,20 @@ export const overview = {
       defaultMessage: 'Hætta við breytingar',
       description: 'Abort changes button',
     },
+    withdrawn: {
+      id: 'ss.application:overview.buttons.withdrawn',
+      defaultMessage: 'Afturkalla rýni',
+      description: 'Withdrawn application button',
+    },
     received: {
       id: 'ss.application:overview.buttons.received',
       defaultMessage: 'Móttekin',
       description: 'Received application button',
+    },
+    dismissed: {
+      id: 'ss.application:overview.buttons.dismissed',
+      defaultMessage: 'Vísað frá',
+      description: 'Dismissed application button',
     },
   }),
   applicationDataHasBeenPruned: defineMessages({

--- a/libs/application/templates/secondary-school/src/utils/enums/index.ts
+++ b/libs/application/templates/secondary-school/src/utils/enums/index.ts
@@ -23,6 +23,7 @@ export enum States {
   EDIT = 'edit',
   SUBMITTED = 'submitted',
   IN_REVIEW = 'inReview',
+  IN_REVIEW_FROM_EDIT = 'inReviewFromEdit',
   COMPLETED = 'completed',
   DISMISSED = 'dismissed',
 }


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new "Dismissed" state for secondary school applications, enabling dismissal from multiple stages.
  - Added an intermediate "In Review From Edit" state to better track application review progress.
  - Included localized labels and descriptions for dismissed and withdrawn states in the user interface.

- **Improvements**
  - Enhanced event handling with new actions for dismissing applications and withdrawing reviews, providing greater control over application status transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->