### PR TITLE
feat(web): Blood donation restriction list items should be in ascending title order

### DIFF
--- a/libs/cms/src/lib/cms.elasticsearch.service.ts
+++ b/libs/cms/src/lib/cms.elasticsearch.service.ts
@@ -1375,6 +1375,15 @@ export class CmsElasticsearchService {
 
     const size = 10
 
+    let sort = [
+      { _score: { order: SortDirection.DESC } },
+      { 'title.sort': { order: SortDirection.ASC } },
+    ]
+
+    if (queryString.length === 0) {
+      sort = [{ 'title.sort': { order: SortDirection.ASC } }]
+    }
+
     const response: ApiResponse<SearchResponse<MappedData>> =
       await this.elasticService.findByQuery(index, {
         query: {
@@ -1382,7 +1391,7 @@ export class CmsElasticsearchService {
             must,
           },
         },
-        sort: [{ _score: { order: SortDirection.DESC } }],
+        sort,
         size,
         from: ((input.page ?? 1) - 1) * size,
       })

--- a/libs/cms/src/lib/models/genericListItem.model.ts
+++ b/libs/cms/src/lib/models/genericListItem.model.ts
@@ -62,7 +62,7 @@ export const mapGenericListItem = ({
     genericList: fields.genericList
       ? mapGenericList(fields.genericList)
       : undefined,
-    title: fields.title ?? '',
+    title: (fields.title ?? '').trim(),
     date: fields.date || null,
     cardIntro: fields.cardIntro
       ? mapDocument(fields.cardIntro, `${sys.id}:cardIntro`)

--- a/libs/cms/src/lib/models/genericListItem.model.ts
+++ b/libs/cms/src/lib/models/genericListItem.model.ts
@@ -62,7 +62,7 @@ export const mapGenericListItem = ({
     genericList: fields.genericList
       ? mapGenericList(fields.genericList)
       : undefined,
-    title: (fields.title ?? '').trim(),
+    title: fields.title ?? '',
     date: fields.date || null,
     cardIntro: fields.cardIntro
       ? mapDocument(fields.cardIntro, `${sys.id}:cardIntro`)

--- a/libs/cms/src/lib/search/importers/bloodDonationRestriction.service.ts
+++ b/libs/cms/src/lib/search/importers/bloodDonationRestriction.service.ts
@@ -72,7 +72,7 @@ export class BloodDonationRestrictionSyncService
 
           return {
             _id: mapped.id,
-            title: entry.fields.title || '',
+            title: (entry.fields.title || '').trim(),
             content,
             contentWordCount: content.split(' ').length,
             type: 'webBloodDonationRestriction',


### PR DESCRIPTION
# Blood donation restriction list items should be in ascending title order

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
