### PR TITLE
fix(j-s): Tweeks to FMST marking cases as registered

### DIFF
--- a/apps/judicial-system/web/src/routes/Prison/IndictmentOverview/IndictmentOverview.strings.ts
+++ b/apps/judicial-system/web/src/routes/Prison/IndictmentOverview/IndictmentOverview.strings.ts
@@ -79,20 +79,4 @@ export const strings = defineMessages({
     defaultMessage: 'Tilkynning til sakaskrár',
     description: 'Titill á Tilkynning til sakaskrár',
   },
-  verdictRegistered: {
-    id: 'judicial.system.core:indictment_overview.verdict_registered',
-    defaultMessage: 'Dómur skráður',
-    description:
-      'Titill á takkanum sem leyfir að skrá dóm/ skilaboð í toast þegar dómur hefur verið skráður',
-  },
-  verdictDeRegisteredInfo: {
-    id: 'judicial.system.core:indictment_overview.verdict_deregistered_info',
-    defaultMessage: 'Dómur afskráður',
-    description: 'Skilaboð í toast þegar dómur hefur verið afskráður',
-  },
-  verdictDeregister: {
-    id: 'judicial.system.core:indictment_overview.verdict_deregister',
-    defaultMessage: 'Afskrá dóm',
-    description: 'Titill á takkanum sem leyfir að afskrá dóm',
-  },
 })

--- a/apps/judicial-system/web/src/routes/Prison/IndictmentOverview/IndictmentOverview.tsx
+++ b/apps/judicial-system/web/src/routes/Prison/IndictmentOverview/IndictmentOverview.tsx
@@ -43,7 +43,7 @@ const IndictmentOverview = () => {
   const { workingCase, setWorkingCase, isLoadingWorkingCase, caseNotFound } =
     useContext(FormContext)
 
-  const { updateCase } = useCase()
+  const { updateCase, isUpdatingCase } = useCase()
 
   const { formatMessage } = useIntl()
   const { limitedAccessUpdateDefendant, updateDefendantState } = useDefendants()
@@ -101,11 +101,13 @@ const IndictmentOverview = () => {
       toast.error('Tókst ekki að skrá í fangelsiskerfi')
       return
     }
-    toast.info(
+
+    toast.success(
       !updatedCase.isRegisteredInPrisonSystem
-        ? formatMessage(strings.verdictDeRegisteredInfo)
-        : formatMessage(strings.verdictRegistered),
+        ? 'Dómur afskráður'
+        : 'Dómur skráður',
     )
+
     setWorkingCase((prevWorkingCase) => ({
       ...prevWorkingCase,
       isRegisteredInPrisonSystem: updatedCase.isRegisteredInPrisonSystem,
@@ -118,12 +120,12 @@ const IndictmentOverview = () => {
     icon: IconMapIcon
   } = !workingCase?.isRegisteredInPrisonSystem
     ? {
-        title: formatMessage(strings.verdictRegistered),
+        title: 'Dómur skráður',
         colorScheme: 'default',
         icon: 'checkmark',
       }
     : {
-        title: formatMessage(strings.verdictDeregister),
+        title: 'Afskrá dóm',
         colorScheme: 'destructive',
         icon: 'close',
       }
@@ -320,6 +322,7 @@ const IndictmentOverview = () => {
           onNextButtonClick={savePunishmentType}
           nextButtonColorScheme={footerNextButtonText.colorScheme}
           nextButtonIcon={footerNextButtonText.icon}
+          nextIsLoading={isUpdatingCase}
         />
       </FormContentContainer>
     </PageLayout>

--- a/apps/judicial-system/web/src/routes/Shared/Cases/Cases.strings.ts
+++ b/apps/judicial-system/web/src/routes/Shared/Cases/Cases.strings.ts
@@ -45,18 +45,6 @@ export const cases = {
         defaultMessage: 'Virkt gæsluvarðhald og farbann',
         description: 'Notaður sem titill í fyrsta málalista á heimaskjá FMST.',
       },
-      infoContainerTitle: {
-        id: 'judicial.system.core:cases.active_requests.prison_staff_users.info_container_title',
-        defaultMessage: 'Engin mál fundust.',
-        description:
-          'Notaður sem titill í upplýsingasvæði sem segir að engin mál fundust á heimaskjá fangelsisstarfsmanna.',
-      },
-      infoContainerText: {
-        id: 'judicial.system.core:cases.active_requests.prison_staff_users.info_container_text',
-        defaultMessage: 'Engar samþykktar kröfur fundust.',
-        description:
-          'Notaður sem texti í upplýsingasvæði sem segir að engin mál fundust á heimaskjá fangelsisstarfsmanna.',
-      },
       prisonAdminIndictmentCaseTitle: {
         id: 'judicial.system.core:cases.active_requests.prison_staff_users.prison_admin_indictment_case_title',
         defaultMessage: 'Mál til fullnustu',

--- a/apps/judicial-system/web/src/routes/Shared/Cases/PrisonCases.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/Cases/PrisonCases.tsx
@@ -279,12 +279,8 @@ export const PrisonCases: FC = () => {
       <div className={styles.infoContainer}>
         <AlertMessage
           type="info"
-          title={formatMessage(
-            m.activeRequests.prisonStaffUsers.infoContainerTitle,
-          )}
-          message={formatMessage(
-            m.activeRequests.prisonStaffUsers.infoContainerText,
-          )}
+          title="Engin mál fundust"
+          message="Engin mál fundust í þessum flokk"
         />
       </div>
     )


### PR DESCRIPTION
# Tweeks to FMST marking cases as registered

[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1210049829167024?focus=true)

## What

- When FMST marks or de-marks cases as "registered", there is now a loading indicator in the button while the update is happening.
- The info toasts are now success toasts.
- Text change to the alert message when there are no cases to be shown on the cases page.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
