### PR TITLE
feat(contentful-role-permissions): Default editable content type permission changes

### DIFF
--- a/apps/tools/contentful-role-permissions/components/RoleCard/RoleCard.tsx
+++ b/apps/tools/contentful-role-permissions/components/RoleCard/RoleCard.tsx
@@ -97,6 +97,13 @@ export const RoleCard = ({ role, contentTypes, tags }: RoleCardProps) => {
     return Boolean(tags.find((t) => t.name === slugify(role.name)))
   }, [role.name, tags])
 
+  const sortedDefaultReadOnlyEntryIds = useMemo(() => {
+    return DEFAULT_READ_ONLY_ENTRY_IDS.sort()
+  }, [])
+  const sortedDefaultEditableEntryIds = useMemo(() => {
+    return DEFAULT_EDITABLE_ENTRY_TYPE_IDS.sort()
+  }, [])
+
   return (
     <Box
       border="standard"
@@ -224,7 +231,7 @@ export const RoleCard = ({ role, contentTypes, tags }: RoleCardProps) => {
                     placement="right"
                     text={
                       <div>
-                        {DEFAULT_READ_ONLY_ENTRY_IDS.sort().map((id) => (
+                        {sortedDefaultReadOnlyEntryIds.map((id) => (
                           <Text key={id} variant="small">
                             {id}
                           </Text>
@@ -356,12 +363,45 @@ export const RoleCard = ({ role, contentTypes, tags }: RoleCardProps) => {
                     placement="right"
                     text={
                       <div>
-                        {DEFAULT_EDITABLE_ENTRY_TYPE_IDS.sort().map((id) => (
+                        {sortedDefaultEditableEntryIds.map((id) => (
                           <Text key={id} variant="small">
                             {id}
                           </Text>
                         ))}
                       </div>
+                    }
+                  />
+                </Button>
+                <Button
+                  disabled={isSaving}
+                  variant="text"
+                  size="small"
+                  onClick={() => {
+                    setEditableState((prevState) => {
+                      const newState = { ...prevState }
+                      for (const contentTypeName in newState) {
+                        const contentTypeSysId = contentTypes.find(
+                          (type) => type.name === contentTypeName,
+                        )?.sys?.id
+                        newState[contentTypeName] =
+                          DEFAULT_EDITABLE_ENTRY_TYPE_IDS.includes(
+                            contentTypeSysId,
+                          )
+                            ? true
+                            : newState[contentTypeName]
+                      }
+                      return newState
+                    })
+                  }}
+                >
+                  XOR default
+                  <Tooltip
+                    placement="right"
+                    text={
+                      <Text variant="small">
+                        Only turn on what is in the default editable entry list
+                        and leave everything else like it was
+                      </Text>
                     }
                   />
                 </Button>
@@ -412,7 +452,7 @@ export const RoleCard = ({ role, contentTypes, tags }: RoleCardProps) => {
               />
               <Tooltip
                 placement="right"
-                text={`If this is not checked then roles can only read assets tagged with ${slugify(
+                text={`If this is not checked then role can only view assets tagged with ${slugify(
                   role.name,
                 )}`}
               />

--- a/apps/tools/contentful-role-permissions/components/RoleCard/RoleCard.tsx
+++ b/apps/tools/contentful-role-permissions/components/RoleCard/RoleCard.tsx
@@ -394,13 +394,13 @@ export const RoleCard = ({ role, contentTypes, tags }: RoleCardProps) => {
                     })
                   }}
                 >
-                  XOR default
+                  Bitwise OR default
                   <Tooltip
                     placement="right"
                     text={
                       <Text variant="small">
                         Only turn on what is in the default editable entry list
-                        and leave everything else like it was
+                        and leave everything else like it was (bitwise OR)
                       </Text>
                     }
                   />

--- a/apps/tools/contentful-role-permissions/constants/index.ts
+++ b/apps/tools/contentful-role-permissions/constants/index.ts
@@ -61,6 +61,9 @@ export const DEFAULT_EDITABLE_ENTRY_TYPE_IDS = [
   'tableSlice',
   'genericList',
   'genericListItem',
+  'featuredLinks',
+  'manual',
+  'manualChapter',
 ]
 
 export const DEFAULT_READ_ONLY_ENTRY_IDS = [

--- a/apps/tools/contentful-role-permissions/next-env.d.ts
+++ b/apps/tools/contentful-role-permissions/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.


### PR DESCRIPTION
# Default editable content type permission changes

* Allow 3 content types to be by default "editable" in Contentful
* New button in UI that allows for bitwise "OR"-ing the current editable permissions with the default ones

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a "Bitwise OR default" button to the editable entries section, allowing users to enable default editable entries while preserving existing selections.
  - Added tooltips to explain the new button's behavior.

- **Enhancements**
  - Improved performance by optimizing how default entry lists are handled in tooltips.
  - Updated tooltip text for clarity.

- **Updates**
  - Expanded the default editable entry types to include "featuredLinks", "manual", and "manualChapter".

- **Documentation**
  - Updated a documentation link to the latest Next.js TypeScript guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->