### PR TITLE
feat(web): Add linked page to link in one column text

### DIFF
--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -3032,6 +3032,9 @@ export interface IOneColumnTextFields {
 
   /** Show Title */
   showTitle?: boolean | undefined
+
+  /** Filter tags */
+  filterTags?: IGenericTag[] | undefined
 }
 
 export interface IOneColumnText extends Entry<IOneColumnTextFields> {

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -84,7 +84,6 @@ export interface IAlertBannerFields {
         | 'loftbru'
         | 'heilsa'
         | 'fjarmal/stada'
-        | 'heilsa/greidslur/greidsluyfirlit'
       )[]
     | undefined
 }
@@ -218,14 +217,13 @@ export interface IAppUri extends Entry<IAppUriFields> {
 
 export interface IArticleFields {
   /** Content status */
-  contentStatus?:
+  contentStatus:
     | 'Undefined'
     | 'Needs work'
     | 'In review'
     | 'Needs translation'
     | 'In translation'
     | 'Done'
-    | undefined
 
   /** Title */
   title: string
@@ -270,7 +268,7 @@ export interface IArticleFields {
   otherSubgroups?: IArticleSubgroup[] | undefined
 
   /** Organization */
-  organization: IOrganization[]
+  organization?: IOrganization[] | undefined
 
   /** Related organization */
   relatedOrganization?: IOrganization[] | undefined
@@ -815,7 +813,6 @@ export interface ICustomPageFields {
     | 'Verdicts'
     | 'OfficialJournalOfIcelandHelp'
     | 'BloodDonationRestrictions'
-    | 'Unknown'
     | undefined
 
   /** Alert Banner */
@@ -1098,9 +1095,6 @@ export interface IEventFields {
 
   /** og:image */
   featuredImage?: Asset | undefined
-
-  /** Filter Tags */
-  filterTags?: IGenericTag[] | undefined
 }
 
 export interface IEvent extends Entry<IEventFields> {
@@ -1190,7 +1184,13 @@ export interface IFeaturedFields {
   attention?: boolean | undefined
 
   /** Link */
-  thing?: IArticle | ILinkUrl | undefined
+  thing?:
+    | IAboutSubPage
+    | IArticle
+    | ILinkUrl
+    | IVidspyrnaFrontpage
+    | IVidspyrnaPage
+    | undefined
 }
 
 export interface IFeatured extends Entry<IFeaturedFields> {
@@ -1473,7 +1473,6 @@ export interface IFormFieldFields {
     | 'file'
     | 'nationalId (kennitala)'
     | 'information'
-    | 'date'
 
   /** Required */
   required?: boolean | undefined
@@ -1912,11 +1911,11 @@ export interface IGrantFields {
   /** How to apply? */
   grantHowToApply?: Document | undefined
 
-  /** Answering questions */
-  grantAnsweringQuestions?: Document | undefined
-
   /** Application hints */
   grantApplicationHints?: Document | undefined
+
+  /** Answering questions */
+  grantAnsweringQuestions?: Document | undefined
 
   /** Application url */
   granApplicationUrl?: ILinkUrl | undefined
@@ -2384,6 +2383,34 @@ export interface ILifeEventPage extends Entry<ILifeEventPageFields> {
   }
 }
 
+export interface ILifeEventPageListSliceFields {
+  /** Title */
+  title?: string | undefined
+
+  /** List */
+  lifeEventPageList?: (ILifeEventPage | IAnchorPage)[] | undefined
+}
+
+/** !!DO NOT USE!! - This content type has been deprecated. Use Anchor Page List */
+
+export interface ILifeEventPageListSlice
+  extends Entry<ILifeEventPageListSliceFields> {
+  sys: {
+    id: string
+    type: string
+    createdAt: string
+    updatedAt: string
+    locale: string
+    contentType: {
+      sys: {
+        id: 'lifeEventPageListSlice'
+        linkType: 'ContentType'
+        type: 'Link'
+      }
+    }
+  }
+}
+
 export interface ILinkFields {
   /** Text */
   text: string
@@ -2395,7 +2422,7 @@ export interface ILinkFields {
   url: string
 
   /** Link reference */
-  linkReference?: IOrganizationSubpage | IOrganizationParentSubpage | undefined
+  linkReference?: IArticle | IArticleCategory | ILinkUrl | INews | undefined
 
   /** Display link in search results */
   searchable?: boolean | undefined
@@ -3254,9 +3281,6 @@ export interface IOrganizationPageFields {
         | ISectionWithImage
         | IChartNumberBox
         | ILatestGenericListItems
-        | ILatestNewsSlice
-        | IFeaturedLinks
-        | IOrganizationParentSubpageList
       )[]
     | undefined
 
@@ -3275,8 +3299,6 @@ export interface IOrganizationPageFields {
         | ITimeline
         | ITwoColumnText
         | ILatestEventsSlice
-        | IOverviewLinks
-        | ISliceConnectedComponent
       )[]
     | undefined
 
@@ -4228,11 +4250,6 @@ export interface ISliceConnectedComponentFields {
     | 'Starfsrettindi/ProfessionRights'
     | 'VMST/ParentalLeaveCalculator'
     | 'DigitalIceland/BenefitsOfDigitalProcesses'
-    | 'WHODAS/Calculator'
-    | 'Brennuleyfi/BurningPermitList'
-    | 'DigitalIcelandMailingListThumbnailCard'
-    | 'DigitalIcelandStatistics'
-    | 'Trufelog/Lifsskodunarfelog'
     | undefined
 
   /** Localized JSON */
@@ -5285,7 +5302,6 @@ export type CONTENT_TYPE =
   | 'articleSubgroup'
   | 'auction'
   | 'bigBulletList'
-  | 'bloodDonationRestriction'
   | 'card'
   | 'cardSection'
   | 'chart'
@@ -5305,7 +5321,6 @@ export type CONTENT_TYPE =
   | 'featured'
   | 'featuredArticles'
   | 'featuredEvents'
-  | 'featuredLinks'
   | 'featuredSupportQNAs'
   | 'footerItem'
   | 'form'
@@ -5330,6 +5345,7 @@ export type CONTENT_TYPE =
   | 'latestGenericListItems'
   | 'latestNewsSlice'
   | 'lifeEventPage'
+  | 'lifeEventPageListSlice'
   | 'link'
   | 'linkedPage'
   | 'linkGroup'

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -84,6 +84,7 @@ export interface IAlertBannerFields {
         | 'loftbru'
         | 'heilsa'
         | 'fjarmal/stada'
+        | 'heilsa/greidslur/greidsluyfirlit'
       )[]
     | undefined
 }
@@ -217,13 +218,14 @@ export interface IAppUri extends Entry<IAppUriFields> {
 
 export interface IArticleFields {
   /** Content status */
-  contentStatus:
+  contentStatus?:
     | 'Undefined'
     | 'Needs work'
     | 'In review'
     | 'Needs translation'
     | 'In translation'
     | 'Done'
+    | undefined
 
   /** Title */
   title: string
@@ -268,7 +270,7 @@ export interface IArticleFields {
   otherSubgroups?: IArticleSubgroup[] | undefined
 
   /** Organization */
-  organization?: IOrganization[] | undefined
+  organization: IOrganization[]
 
   /** Related organization */
   relatedOrganization?: IOrganization[] | undefined
@@ -813,6 +815,7 @@ export interface ICustomPageFields {
     | 'Verdicts'
     | 'OfficialJournalOfIcelandHelp'
     | 'BloodDonationRestrictions'
+    | 'Unknown'
     | undefined
 
   /** Alert Banner */
@@ -1095,6 +1098,9 @@ export interface IEventFields {
 
   /** og:image */
   featuredImage?: Asset | undefined
+
+  /** Filter Tags */
+  filterTags?: IGenericTag[] | undefined
 }
 
 export interface IEvent extends Entry<IEventFields> {
@@ -1184,13 +1190,7 @@ export interface IFeaturedFields {
   attention?: boolean | undefined
 
   /** Link */
-  thing?:
-    | IAboutSubPage
-    | IArticle
-    | ILinkUrl
-    | IVidspyrnaFrontpage
-    | IVidspyrnaPage
-    | undefined
+  thing?: IArticle | ILinkUrl | undefined
 }
 
 export interface IFeatured extends Entry<IFeaturedFields> {
@@ -1473,6 +1473,7 @@ export interface IFormFieldFields {
     | 'file'
     | 'nationalId (kennitala)'
     | 'information'
+    | 'date'
 
   /** Required */
   required?: boolean | undefined
@@ -1911,11 +1912,11 @@ export interface IGrantFields {
   /** How to apply? */
   grantHowToApply?: Document | undefined
 
-  /** Application hints */
-  grantApplicationHints?: Document | undefined
-
   /** Answering questions */
   grantAnsweringQuestions?: Document | undefined
+
+  /** Application hints */
+  grantApplicationHints?: Document | undefined
 
   /** Application url */
   granApplicationUrl?: ILinkUrl | undefined
@@ -2383,34 +2384,6 @@ export interface ILifeEventPage extends Entry<ILifeEventPageFields> {
   }
 }
 
-export interface ILifeEventPageListSliceFields {
-  /** Title */
-  title?: string | undefined
-
-  /** List */
-  lifeEventPageList?: (ILifeEventPage | IAnchorPage)[] | undefined
-}
-
-/** !!DO NOT USE!! - This content type has been deprecated. Use Anchor Page List */
-
-export interface ILifeEventPageListSlice
-  extends Entry<ILifeEventPageListSliceFields> {
-  sys: {
-    id: string
-    type: string
-    createdAt: string
-    updatedAt: string
-    locale: string
-    contentType: {
-      sys: {
-        id: 'lifeEventPageListSlice'
-        linkType: 'ContentType'
-        type: 'Link'
-      }
-    }
-  }
-}
-
 export interface ILinkFields {
   /** Text */
   text: string
@@ -2422,7 +2395,7 @@ export interface ILinkFields {
   url: string
 
   /** Link reference */
-  linkReference?: IArticle | IArticleCategory | ILinkUrl | INews | undefined
+  linkReference?: IOrganizationSubpage | IOrganizationParentSubpage | undefined
 
   /** Display link in search results */
   searchable?: boolean | undefined
@@ -2452,11 +2425,19 @@ export interface ILink extends Entry<ILinkFields> {
 }
 
 export interface ILinkedPageFields {
+  /** Internal Title */
+  internalTitle: string
+
   /** Title */
   title: string
 
   /** page */
-  page: IArticle | IArticleCategory | INews
+  page:
+    | IArticle
+    | IArticleCategory
+    | INews
+    | IOrganizationSubpage
+    | IOrganizationParentSubpage
 }
 
 export interface ILinkedPage extends Entry<ILinkedPageFields> {
@@ -3017,16 +2998,13 @@ export interface IOneColumnTextFields {
   content?: Document | undefined
 
   /** Link */
-  link?: ILink | undefined
+  link?: ILink | ILinkedPage | undefined
 
   /** Divider On Top */
   dividerOnTop?: boolean | undefined
 
   /** Show Title */
   showTitle?: boolean | undefined
-
-  /** Filter tags */
-  filterTags?: IGenericTag[] | undefined
 }
 
 export interface IOneColumnText extends Entry<IOneColumnTextFields> {
@@ -3276,6 +3254,9 @@ export interface IOrganizationPageFields {
         | ISectionWithImage
         | IChartNumberBox
         | ILatestGenericListItems
+        | ILatestNewsSlice
+        | IFeaturedLinks
+        | IOrganizationParentSubpageList
       )[]
     | undefined
 
@@ -3294,6 +3275,8 @@ export interface IOrganizationPageFields {
         | ITimeline
         | ITwoColumnText
         | ILatestEventsSlice
+        | IOverviewLinks
+        | ISliceConnectedComponent
       )[]
     | undefined
 
@@ -4245,6 +4228,11 @@ export interface ISliceConnectedComponentFields {
     | 'Starfsrettindi/ProfessionRights'
     | 'VMST/ParentalLeaveCalculator'
     | 'DigitalIceland/BenefitsOfDigitalProcesses'
+    | 'WHODAS/Calculator'
+    | 'Brennuleyfi/BurningPermitList'
+    | 'DigitalIcelandMailingListThumbnailCard'
+    | 'DigitalIcelandStatistics'
+    | 'Trufelog/Lifsskodunarfelog'
     | undefined
 
   /** Localized JSON */
@@ -5297,6 +5285,7 @@ export type CONTENT_TYPE =
   | 'articleSubgroup'
   | 'auction'
   | 'bigBulletList'
+  | 'bloodDonationRestriction'
   | 'card'
   | 'cardSection'
   | 'chart'
@@ -5316,6 +5305,7 @@ export type CONTENT_TYPE =
   | 'featured'
   | 'featuredArticles'
   | 'featuredEvents'
+  | 'featuredLinks'
   | 'featuredSupportQNAs'
   | 'footerItem'
   | 'form'
@@ -5340,7 +5330,6 @@ export type CONTENT_TYPE =
   | 'latestGenericListItems'
   | 'latestNewsSlice'
   | 'lifeEventPage'
-  | 'lifeEventPageListSlice'
   | 'link'
   | 'linkedPage'
   | 'linkGroup'

--- a/libs/cms/src/lib/models/oneColumnText.model.ts
+++ b/libs/cms/src/lib/models/oneColumnText.model.ts
@@ -4,8 +4,9 @@ import { SystemMetadata } from '@island.is/shared/types'
 
 import { IOneColumnText } from '../generated/contentfulTypes'
 
-import { Link, mapLink } from './link.model'
+import { Link } from './link.model'
 import { mapDocument, SliceUnion } from '../unions/slice.union'
+import { mapReferenceLink } from './utils'
 
 @ObjectType()
 export class OneColumnText {
@@ -35,9 +36,9 @@ export const mapOneColumnText = ({
   typename: 'OneColumnText',
   id: sys.id,
   title: fields.title ?? '',
-  link: fields.link ? mapLink(fields.link) : null,
+  link: mapReferenceLink(fields.link),
   content: fields.content
-    ? mapDocument(fields.content, sys.id + ':content')
+    ? mapDocument(fields.content, `${sys.id}:content`)
     : [],
   dividerOnTop: fields.dividerOnTop ?? true,
   showTitle: fields.showTitle ?? true,

--- a/libs/cms/src/lib/models/utils.ts
+++ b/libs/cms/src/lib/models/utils.ts
@@ -1,3 +1,12 @@
+import {
+  ILink,
+  ILinkedPage,
+  IOrganizationParentSubpage,
+  IOrganizationSubpage,
+} from '../generated/contentfulTypes'
+import { getOrganizationPageUrlPrefix } from '@island.is/shared/utils'
+import { mapLink, Link } from '../models/link.model'
+
 /** Make sure that links are relative in case someone links to production directly */
 export const getRelativeUrl = (url: string) => {
   const urlObject = new URL(url.trim(), 'https://island.is')
@@ -5,4 +14,62 @@ export const getRelativeUrl = (url: string) => {
     return `${urlObject.pathname}${urlObject.search}${urlObject.hash}`
   }
   return urlObject.href
+}
+
+type LinkType = Omit<ILink | ILinkedPage, 'update' | 'toPlainObject'>
+
+export const mapReferenceLink = (link?: LinkType): Link | null => {
+  if (!link || !link.sys?.contentType?.sys?.id) return null
+
+  const contentTypeId = link.sys.contentType.sys.id
+
+  if (contentTypeId === 'linkedPage') {
+    return generateOrganizationSubpageLinkFromLinkedPage(link as ILinkedPage)
+  }
+
+  if (contentTypeId === 'link') {
+    return mapLink(link as ILink)
+  }
+
+  return null
+}
+
+const generateOrganizationSubpageLinkFromLinkedPage = (
+  linkedPage: ILinkedPage,
+): Link | null => {
+  const contentTypeId = linkedPage.fields.page.sys.contentType.sys.id
+  let slug: string
+
+  if (contentTypeId === 'organizationParentSubpage') {
+    const subpage = linkedPage.fields.page as IOrganizationParentSubpage
+    slug = `${subpage.fields.organizationPage.fields.slug}/${subpage.fields.slug}`
+  } else if (contentTypeId === 'organizationSubpage') {
+    const subpage = linkedPage.fields.page as IOrganizationSubpage
+    const parentSlug = subpage.fields.organizationParentSubpage?.fields.slug
+    slug = parentSlug
+      ? `${subpage.fields.organizationPage.fields.slug}/${parentSlug}/${subpage.fields.slug}`
+      : `${subpage.fields.organizationPage.fields.slug}/${subpage.fields.slug}`
+  } else {
+    return null
+  }
+
+  const prefix = getOrganizationPageUrlPrefix(linkedPage.sys.locale)
+
+  return mapLink({
+    ...linkedPage,
+    sys: {
+      ...linkedPage.sys,
+      contentType: {
+        sys: {
+          id: 'link',
+          linkType: 'ContentType',
+          type: 'Link',
+        },
+      },
+    },
+    fields: {
+      text: linkedPage.fields.title ?? '',
+      url: `/${prefix}/${slug}`,
+    },
+  })
 }

--- a/libs/cms/src/lib/models/utils.ts
+++ b/libs/cms/src/lib/models/utils.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ILink,
   ILinkedPage,
   IOrganizationParentSubpage,
@@ -38,7 +38,7 @@ const generateOrganizationSubpageLinkFromLinkedPage = (
   linkedPage: ILinkedPage,
 ): Link | null => {
   const contentTypeId = linkedPage.fields.page.sys.contentType.sys.id
-  let slug: string
+  let slug = ''
 
   if (contentTypeId === 'organizationParentSubpage') {
     const subpage = linkedPage.fields.page as IOrganizationParentSubpage


### PR DESCRIPTION
# Add linked page to link in one column text

## What

- Add Linked Page content type to link in One Column Text content type.
- Add organization subpage and organization parent subpage as possible reference in page on Linked page content type

## Why

- More stable using reference to page instead of using direct url 

## Screenshots / Gifs
### Now it is possible to set Linked page on link field in one column text
![image](https://github.com/user-attachments/assets/1307f83d-7b27-49c1-b956-cc8bb1392629)

### And Linked page can reference an Organization subpage and Organization parent subpage in the page field
![image](https://github.com/user-attachments/assets/6f2a2daa-79a0-4756-9e1e-7acb114db633)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved handling of linked references, enabling support for additional link types and more consistent URL generation for organization subpages.
- **Refactor**
  - Enhanced internal mapping logic for links to streamline and unify how different link types are processed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->