### PR TITLE
feat(web): Overview links, "english locale" in JSON field

### DIFF
--- a/apps/contentful-apps/components/editors/OverviewLinksEditor/OverviewLinksEditor.tsx
+++ b/apps/contentful-apps/components/editors/OverviewLinksEditor/OverviewLinksEditor.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { type Dispatch, type SetStateAction, useMemo, useState } from 'react'
 import { useDebounce } from 'react-use'
 import dynamic from 'next/dynamic'
 import { type EditorExtensionSDK } from '@contentful/app-sdk'
@@ -8,6 +8,7 @@ import {
   FormControl,
   MenuItem,
   Select,
+  Text,
 } from '@contentful/f36-components'
 import { PlusIcon } from '@contentful/f36-icons'
 import { useSDK } from '@contentful/react-apps-toolkit'
@@ -49,9 +50,15 @@ const createLocaleToFieldMapping = (sdk: EditorExtensionSDK) => {
   }
 }
 
-const generateUniqueId = (linkData: LinkData): string => {
+const generateUniqueId = (
+  linkData: LinkData,
+  isEnglishLocale?: boolean,
+): string => {
+  const categoryItemKey = isEnglishLocale
+    ? 'categoryCardItemsEn'
+    : 'categoryCardItems'
   let highestId = 0
-  for (const { id } of linkData.categoryCardItems) {
+  for (const { id } of linkData[categoryItemKey] ?? []) {
     if (Number(id) > highestId) highestId = Number(id)
   }
   return String(highestId + 1)
@@ -70,6 +77,109 @@ interface LinkData {
     description: string
     href: string
   }[]
+  categoryCardItemsEn: LinkData['categoryCardItems']
+}
+
+interface CategoryCardItemWrapperProps {
+  categoryCardItems: LinkData['categoryCardItems']
+  sdk: EditorExtensionSDK
+  setLinkData: Dispatch<SetStateAction<LinkData>>
+  localeName: string
+  isEnglishLocale?: boolean
+}
+
+const CategoryCardItemWrapper = ({
+  categoryCardItems,
+  setLinkData,
+  sdk,
+  localeName,
+  isEnglishLocale = false,
+}: CategoryCardItemWrapperProps) => {
+  const categoryItemKey = isEnglishLocale
+    ? 'categoryCardItemsEn'
+    : 'categoryCardItems'
+  return (
+    <FormControl>
+      <FormControl.Label>
+        Overview Links <Text fontSize="fontSizeS"> | {localeName}</Text>
+      </FormControl.Label>
+      <CustomSortableContext
+        containerClassName={styles.itemContainer}
+        items={categoryCardItems}
+        updateItems={(updatedItems: LinkData['categoryCardItems']) => {
+          setLinkData((prevLinkData) => ({
+            ...prevLinkData,
+            categoryCardItems: updatedItems,
+          }))
+        }}
+        renderItem={(item: LinkData['categoryCardItems'][number]) => {
+          const onEdit = async () => {
+            const updatedItem = await sdk.dialogs.openCurrentApp({
+              parameters: {
+                state: item,
+              },
+              minHeight: 400,
+            })
+            setLinkData((prevLinkData) => ({
+              ...prevLinkData,
+              [categoryItemKey]: prevLinkData[categoryItemKey].map(
+                (prevItem) => {
+                  if (prevItem.id !== item.id) return prevItem
+                  return updatedItem
+                },
+              ),
+            }))
+          }
+          return (
+            <SortableEntryCard
+              key={item.id}
+              id={item.id}
+              contentType="Category Card"
+              title={item.title || 'Untitled'}
+              description={item.description}
+              onClick={onEdit}
+              actions={[
+                <MenuItem key="edit" onClick={onEdit}>
+                  Edit
+                </MenuItem>,
+                <MenuItem
+                  key="remove"
+                  onClick={() => {
+                    setLinkData((prevLinkData) => ({
+                      ...prevLinkData,
+                      [categoryItemKey]: prevLinkData[categoryItemKey].filter(
+                        ({ id }) => item.id !== id,
+                      ),
+                    }))
+                  }}
+                >
+                  Remove
+                </MenuItem>,
+              ]}
+            />
+          )
+        }}
+      />
+      <div className={styles.createCategoryCardButtonContainer}>
+        <Button
+          startIcon={<PlusIcon />}
+          onClick={() => {
+            setLinkData((prevLinkData) => ({
+              ...prevLinkData,
+              [categoryItemKey]: (prevLinkData[categoryItemKey] ?? []).concat({
+                id: generateUniqueId(prevLinkData, isEnglishLocale),
+                title: '',
+                description: '',
+                href: '',
+              }),
+            }))
+          }}
+        >
+          Create new card
+        </Button>
+      </div>
+    </FormControl>
+  )
 }
 
 const DEBOUNCE_TIME_IN_MS = 100
@@ -157,84 +267,21 @@ export const OverviewLinksEditor = () => {
       )}
 
       {linkData.variant === LinkDataVariant.CategoryCard && (
-        <FormControl>
-          <FormControl.Label>Overview Links</FormControl.Label>
-          <CustomSortableContext
-            containerClassName={styles.itemContainer}
-            items={linkData.categoryCardItems}
-            updateItems={(updatedItems: LinkData['categoryCardItems']) => {
-              setLinkData((prevLinkData) => ({
-                ...prevLinkData,
-                categoryCardItems: updatedItems,
-              }))
-            }}
-            renderItem={(item: LinkData['categoryCardItems'][number]) => (
-              <SortableEntryCard
-                key={item.id}
-                id={item.id}
-                contentType="Category Card"
-                title={item.title || 'Untitled'}
-                description={item.description}
-                actions={[
-                  <MenuItem
-                    key="edit"
-                    onClick={async () => {
-                      const updatedItem = await sdk.dialogs.openCurrentApp({
-                        parameters: {
-                          state: item,
-                        },
-                        minHeight: 400,
-                      })
-                      setLinkData((prevLinkData) => ({
-                        ...prevLinkData,
-                        categoryCardItems: prevLinkData.categoryCardItems.map(
-                          (prevItem) => {
-                            if (prevItem.id !== item.id) return prevItem
-                            return updatedItem
-                          },
-                        ),
-                      }))
-                    }}
-                  >
-                    Edit
-                  </MenuItem>,
-                  <MenuItem
-                    key="remove"
-                    onClick={() => {
-                      setLinkData((prevLinkData) => ({
-                        ...prevLinkData,
-                        categoryCardItems:
-                          prevLinkData.categoryCardItems.filter(
-                            ({ id }) => item.id !== id,
-                          ),
-                      }))
-                    }}
-                  >
-                    Remove
-                  </MenuItem>,
-                ]}
-              />
-            )}
+        <div>
+          <CategoryCardItemWrapper
+            categoryCardItems={linkData.categoryCardItems}
+            sdk={sdk}
+            setLinkData={setLinkData}
+            localeName={sdk.locales.names['is-IS']}
           />
-          <div className={styles.createCategoryCardButtonContainer}>
-            <Button
-              startIcon={<PlusIcon />}
-              onClick={() => {
-                setLinkData((prevLinkData) => ({
-                  ...prevLinkData,
-                  categoryCardItems: prevLinkData.categoryCardItems.concat({
-                    id: generateUniqueId(prevLinkData),
-                    title: '',
-                    description: '',
-                    href: '',
-                  }),
-                }))
-              }}
-            >
-              Create new card
-            </Button>
-          </div>
-        </FormControl>
+          <CategoryCardItemWrapper
+            categoryCardItems={linkData.categoryCardItemsEn ?? []}
+            sdk={sdk}
+            setLinkData={setLinkData}
+            localeName={sdk.locales.names['en']}
+            isEnglishLocale={true}
+          />
+        </div>
       )}
 
       {linkData.variant === LinkDataVariant.CategoryCard && (

--- a/apps/contentful-apps/components/editors/OverviewLinksEditor/OverviewLinksEditor.tsx
+++ b/apps/contentful-apps/components/editors/OverviewLinksEditor/OverviewLinksEditor.tsx
@@ -109,7 +109,7 @@ const CategoryCardItemWrapper = ({
         updateItems={(updatedItems: LinkData['categoryCardItems']) => {
           setLinkData((prevLinkData) => ({
             ...prevLinkData,
-            categoryCardItems: updatedItems,
+            [categoryItemKey]: updatedItems,
           }))
         }}
         renderItem={(item: LinkData['categoryCardItems'][number]) => {

--- a/apps/contentful-apps/components/editors/OverviewLinksEditor/OverviewLinksEditor.tsx
+++ b/apps/contentful-apps/components/editors/OverviewLinksEditor/OverviewLinksEditor.tsx
@@ -122,7 +122,7 @@ const CategoryCardItemWrapper = ({
             })
             setLinkData((prevLinkData) => ({
               ...prevLinkData,
-              [categoryItemKey]: prevLinkData[categoryItemKey].map(
+              [categoryItemKey]: (prevLinkData[categoryItemKey] ?? []).map(
                 (prevItem) => {
                   if (prevItem.id !== item.id) return prevItem
                   return updatedItem
@@ -147,9 +147,9 @@ const CategoryCardItemWrapper = ({
                   onClick={() => {
                     setLinkData((prevLinkData) => ({
                       ...prevLinkData,
-                      [categoryItemKey]: prevLinkData[categoryItemKey].filter(
-                        ({ id }) => item.id !== id,
-                      ),
+                      [categoryItemKey]: (
+                        prevLinkData[categoryItemKey] ?? []
+                      ).filter(({ id }) => item.id !== id),
                     }))
                   }}
                 >

--- a/apps/contentful-apps/components/editors/OverviewLinksEditor/OverviewLinksEditor.tsx
+++ b/apps/contentful-apps/components/editors/OverviewLinksEditor/OverviewLinksEditor.tsx
@@ -194,6 +194,7 @@ export const OverviewLinksEditor = () => {
     sdk.entry.fields.linkData.getValue() || {
       variant: LinkDataVariant.IntroLinkImage,
       categoryCardItems: [],
+      categoryCardItemsEn: [],
     },
   )
 

--- a/libs/cms/src/lib/models/overviewLinks.model.ts
+++ b/libs/cms/src/lib/models/overviewLinks.model.ts
@@ -63,8 +63,11 @@ const mapLinkData = (
 ): LinkData => {
   const categoryCardItems: CategoryCardItem[] = []
 
+  // broaden English check to cover "en", "en-US", "en-GB", etc.
+  const isEnglish = locale?.toLowerCase().startsWith('en')
+
   for (const item of linkData?.[
-    `categoryCardItems${locale === 'en' ? 'En' : ''}`
+    `categoryCardItems${isEnglish ? 'En' : ''}`
   ] ?? []) {
     if (Boolean(item?.title) && Boolean(item?.href)) {
       categoryCardItems.push(item)

--- a/libs/cms/src/lib/models/overviewLinks.model.ts
+++ b/libs/cms/src/lib/models/overviewLinks.model.ts
@@ -59,17 +59,24 @@ export class OverviewLinks {
 
 const mapLinkData = (
   linkData: IOverviewLinks['fields']['linkData'],
+  locale: string,
 ): LinkData => {
+  const categoryCardItems: CategoryCardItem[] = []
+
+  for (const item of linkData?.[
+    `categoryCardItems${locale === 'en' ? 'En' : ''}`
+  ] ?? []) {
+    if (Boolean(item?.title) && Boolean(item?.href)) {
+      categoryCardItems.push(item)
+    }
+  }
+
   return {
     variant:
       linkData?.['variant'] === LinkDataVariant.CategoryCard
         ? LinkDataVariant.CategoryCard
         : LinkDataVariant.IntroLinkImage,
-    categoryCardItems:
-      linkData?.['categoryCardItems']?.filter(
-        (item: { title?: string; href?: string }) =>
-          Boolean(item?.title) && Boolean(item?.href),
-      ) ?? [],
+    categoryCardItems,
   }
 }
 
@@ -83,5 +90,5 @@ export const mapOverviewLinks = ({
   overviewLinks: (fields.overviewLinks ?? []).map(mapIntroLinkImage),
   link: fields.link ? mapLink(fields.link) : null,
   hasBorderAbove: fields.hasBorderAbove ?? true,
-  linkData: mapLinkData(fields.linkData),
+  linkData: mapLinkData(fields.linkData, sys.locale),
 })

--- a/libs/cms/src/lib/models/overviewLinks.model.ts
+++ b/libs/cms/src/lib/models/overviewLinks.model.ts
@@ -64,11 +64,10 @@ const mapLinkData = (
   const categoryCardItems: CategoryCardItem[] = []
 
   // broaden English check to cover "en", "en-US", "en-GB", etc.
-  const isEnglish = locale?.toLowerCase().startsWith('en')
+  const isEnglish = locale.toLowerCase().startsWith('en')
 
-  for (const item of linkData?.[
-    `categoryCardItems${isEnglish ? 'En' : ''}`
-  ] ?? []) {
+  for (const item of linkData?.[`categoryCardItems${isEnglish ? 'En' : ''}`] ??
+    []) {
     if (Boolean(item?.title) && Boolean(item?.href)) {
       categoryCardItems.push(item)
     }


### PR DESCRIPTION
# Overview links, "english locale" in JSON field

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for managing and editing category card items separately for the default locale and English within the overview links editor.
  - The editor now displays and allows editing of two sets of category cards, clearly labeled by locale.

- **Refactor**
  - Modularized the category card editing interface for improved bilingual content management.
  - Enhanced data mapping to dynamically handle locale-specific category card items based on the content locale.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->