### PR TITLE
feat(web): Organization parent subpage, resolve link type locally when toggling languages

### DIFF
--- a/apps/web/screens/Organization/ParentSubpage.tsx
+++ b/apps/web/screens/Organization/ParentSubpage.tsx
@@ -50,8 +50,8 @@ const OrganizationParentSubpage: Screen<
   const { activeLocale } = useI18n()
   const { linkResolver } = useLinkResolver()
   const n = useNamespace(namespace)
-  useContentfulId(organizationPage.id, parentSubpage.id, subpage.id)
   useLocalLinkTypeResolver()
+  useContentfulId(organizationPage.id, parentSubpage.id, subpage.id)
 
   return (
     <OrganizationWrapper

--- a/apps/web/screens/Organization/ParentSubpage.tsx
+++ b/apps/web/screens/Organization/ParentSubpage.tsx
@@ -13,6 +13,7 @@ import { getThemeConfig, OrganizationWrapper } from '@island.is/web/components'
 import { Query } from '@island.is/web/graphql/schema'
 import { useLinkResolver, useNamespace } from '@island.is/web/hooks'
 import useContentfulId from '@island.is/web/hooks/useContentfulId'
+import useLocalLinkTypeResolver from '@island.is/web/hooks/useLocalLinkTypeResolver'
 import { useI18n } from '@island.is/web/i18n'
 import { withMainLayout } from '@island.is/web/layouts/main'
 import type { Screen, ScreenContext } from '@island.is/web/types'
@@ -50,6 +51,7 @@ const OrganizationParentSubpage: Screen<
   const { linkResolver } = useLinkResolver()
   const n = useNamespace(namespace)
   useContentfulId(organizationPage.id, parentSubpage.id, subpage.id)
+  useLocalLinkTypeResolver()
 
   return (
     <OrganizationWrapper


### PR DESCRIPTION
# Organization parent subpage, resolve link type locally when toggling languages

## Why

* So when language is changed we see the exact same subpage but translated

## Screenshots / Gifs


https://github.com/user-attachments/assets/79b930c9-0b48-483d-a2c1-8d63aee1271f



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Internal improvements made to support future enhancements. No visible changes for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->