### PR TITLE
feat(contentful-role-permissions): Featured content type should be by default editable

### DIFF
--- a/apps/tools/contentful-role-permissions/constants/index.ts
+++ b/apps/tools/contentful-role-permissions/constants/index.ts
@@ -64,6 +64,7 @@ export const DEFAULT_EDITABLE_ENTRY_TYPE_IDS = [
   'featuredLinks',
   'manual',
   'manualChapter',
+  'featured',
 ]
 
 export const DEFAULT_READ_ONLY_ENTRY_IDS = [


### PR DESCRIPTION
# Featured content type should be by default editable

Since we recently allowed for the "Featured Links" content type to be editable we also need to add a permission for the "Featured" content type
