### PR TITLE
feat(web): Add short title field to organization parent subpage

### DIFF
--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -3412,6 +3412,9 @@ export interface IOrganizationParentSubpageFields {
   /** Displayed Title */
   title: string
 
+  /** Short Title */
+  shortTitle?: string | undefined
+
   /** Slug */
   slug?: string | undefined
 

--- a/libs/cms/src/lib/models/linkGroup.model.ts
+++ b/libs/cms/src/lib/models/linkGroup.model.ts
@@ -97,9 +97,7 @@ const generateOrganizationSubpageLink = (
       },
     },
     fields: {
-      text:
-        (subpage as IOrganizationSubpage).fields.shortTitle ||
-        subpage.fields.title,
+      text: subpage.fields.shortTitle || subpage.fields.title,
       url: `/${prefix}/${subpage.fields.organizationPage.fields.slug}/${subpage.fields.slug}`,
     },
   })

--- a/libs/cms/src/lib/models/organizationParentSubpage.model.ts
+++ b/libs/cms/src/lib/models/organizationParentSubpage.model.ts
@@ -23,6 +23,9 @@ export class OrganizationParentSubpage {
   @Field()
   title!: string
 
+  @Field(() => String, { nullable: true })
+  shortTitle?: string
+
   @CacheField(() => [OrganizationSubpageLink])
   childLinks!: OrganizationSubpageLink[]
 }
@@ -34,6 +37,7 @@ export const mapOrganizationParentSubpage = ({
   return {
     id: sys.id,
     title: fields.title,
+    shortTitle: fields.shortTitle ?? '',
     childLinks:
       fields.pages
         ?.filter(


### PR DESCRIPTION
# Add short title field to organization parent subpage

## Why

- To be able to display a shorter title for links to organization parent subpages

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new optional "shortTitle" field to organization parent subpages, allowing for more concise titles where applicable.
- **Refactor**
  - Improved internal handling of subpage titles for greater clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->