### PR TITLE
fix(services-payments): Only use first two characters of error codes

### DIFF
--- a/apps/services/payments/src/app/cardPayment/cardPayment.utils.ts
+++ b/apps/services/payments/src/app/cardPayment/cardPayment.utils.ts
@@ -198,6 +198,9 @@ export const getPayloadFromMd = ({
 }
 
 export function mapToCardErrorCode(originalCode: string): CardErrorCode {
+  // Only the first two characters are used to map the error code
+  const firstTwoCharacters = originalCode?.slice(0, 2)
+
   const errorCodeMap: Record<string, CardErrorCode> = {
     '51': CardErrorCode.InsufficientFunds,
     '54': CardErrorCode.ExpiredCard,
@@ -222,7 +225,7 @@ export function mapToCardErrorCode(originalCode: string): CardErrorCode {
   }
 
   // Return the mapped value or the default
-  return errorCodeMap[originalCode] || CardErrorCode.GenericDecline
+  return errorCodeMap[firstTwoCharacters] || CardErrorCode.GenericDecline
 }
 
 export const generateCardChargeFJSPayload = ({


### PR DESCRIPTION
## What

Error codes are `XX-Y` and we are only interested in XX

## Why

Any additional characters returned should be omitted as they are only [for monitoring purposes](https://valitorpay.com/ResponseCodes).

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error code handling for card payments to provide more accurate error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->