### PR TITLE
fix(services-payments): Update amount to be total price for line

### DIFF
--- a/apps/services/payments/src/app/paymentFlow/paymentFlow.service.ts
+++ b/apps/services/payments/src/app/paymentFlow/paymentFlow.service.ts
@@ -165,7 +165,7 @@ export class PaymentFlowService {
 
       filteredChargeInformation.push({
         ...product,
-        priceAmount: price * matchingCharge.quantity,
+        priceAmount: price,
         quantity: matchingCharge.quantity,
       })
     }

--- a/apps/services/payments/src/app/paymentFlow/paymentFlow.service.ts
+++ b/apps/services/payments/src/app/paymentFlow/paymentFlow.service.ts
@@ -177,7 +177,7 @@ export class PaymentFlowService {
     return {
       firstProductTitle: filteredChargeInformation?.[0]?.chargeItemName ?? null,
       totalPrice: filteredChargeInformation.reduce(
-        (acc, charge) => acc + charge.priceAmount,
+        (acc, charge) => acc + charge.priceAmount * charge.quantity,
         0,
       ),
       catalogItems: filteredChargeInformation,

--- a/apps/services/payments/src/utils/fjsCharge.spec.ts
+++ b/apps/services/payments/src/utils/fjsCharge.spec.ts
@@ -124,4 +124,96 @@ describe('generateChargeFJSPayload', () => {
     expect(result.chargeItemSubject).toBe(chargeItemSubjectId)
     expect(result.chargeItemSubject).not.toBe(input.paymentFlow.id)
   })
+
+  it('should calculate the amount as priceAmount * quantity', () => {
+    const oneItemOneQuantity = [
+      {
+        chargeItemCode: 'A101',
+        quantity: 1,
+        chargeType: 'A',
+        priceAmount: 1000,
+      },
+    ]
+
+    const oneItemTwoQuantity = [
+      {
+        chargeItemCode: 'A101',
+        quantity: 2,
+        chargeType: 'A',
+        priceAmount: 1000,
+      },
+    ]
+
+    const twoItemsOneQuantity = [
+      {
+        chargeItemCode: 'A101',
+        quantity: 1,
+        chargeType: 'A',
+        priceAmount: 1000,
+      },
+      {
+        chargeItemCode: 'B101',
+        quantity: 1,
+        chargeType: 'B',
+        priceAmount: 1000,
+      },
+    ]
+
+    const twoItemsTwoQuantity = [
+      {
+        chargeItemCode: 'A101',
+        quantity: 2,
+        chargeType: 'A',
+        priceAmount: 1000,
+      },
+      {
+        chargeItemCode: 'B101',
+        quantity: 2,
+        chargeType: 'B',
+        priceAmount: 1000,
+      },
+    ]
+
+    const oneItemOneQuantityResult = generateChargeFJSPayload({
+      ...sampleInput,
+      charges: oneItemOneQuantity,
+    })
+
+    expect(oneItemOneQuantityResult.charges[0].priceAmount).toBe(1000)
+    expect(oneItemOneQuantityResult.charges[0].amount).toBe(1000)
+    expect(oneItemOneQuantityResult.charges[0].quantity).toBe(1)
+
+    const oneItemTwoQuantityResultResult = generateChargeFJSPayload({
+      ...sampleInput,
+      charges: oneItemTwoQuantity,
+    })
+
+    expect(oneItemTwoQuantityResultResult.charges[0].priceAmount).toBe(1000)
+    expect(oneItemTwoQuantityResultResult.charges[0].amount).toBe(2000)
+    expect(oneItemTwoQuantityResultResult.charges[0].quantity).toBe(2)
+
+    const twoItemsOneQuantityResult = generateChargeFJSPayload({
+      ...sampleInput,
+      charges: twoItemsOneQuantity,
+    })
+
+    expect(twoItemsOneQuantityResult.charges[0].priceAmount).toBe(1000)
+    expect(twoItemsOneQuantityResult.charges[0].amount).toBe(1000)
+    expect(twoItemsOneQuantityResult.charges[0].quantity).toBe(1)
+    expect(twoItemsOneQuantityResult.charges[1].priceAmount).toBe(1000)
+    expect(twoItemsOneQuantityResult.charges[1].amount).toBe(1000)
+    expect(twoItemsOneQuantityResult.charges[1].quantity).toBe(1)
+
+    const twoItemsTwoQuantityResult = generateChargeFJSPayload({
+      ...sampleInput,
+      charges: twoItemsTwoQuantity,
+    })
+
+    expect(twoItemsTwoQuantityResult.charges[0].priceAmount).toBe(1000)
+    expect(twoItemsTwoQuantityResult.charges[0].amount).toBe(2000)
+    expect(twoItemsTwoQuantityResult.charges[0].quantity).toBe(2)
+    expect(twoItemsTwoQuantityResult.charges[1].priceAmount).toBe(1000)
+    expect(twoItemsTwoQuantityResult.charges[1].amount).toBe(2000)
+    expect(twoItemsTwoQuantityResult.charges[1].quantity).toBe(2)
+  })
 })

--- a/apps/services/payments/src/utils/fjsCharge.ts
+++ b/apps/services/payments/src/utils/fjsCharge.ts
@@ -30,7 +30,6 @@ export const generateChargeFJSPayload = ({
   systemId,
   payInfo,
   returnUrl = '',
-  totalPrice,
 }: GenerateChargeFJSPayloadInput): Charge => {
   const chargeItemSubjectId = paymentFlow.chargeItemSubjectId
     ? paymentFlow.chargeItemSubjectId
@@ -41,7 +40,7 @@ export const generateChargeFJSPayload = ({
     chargeItemSubject: chargeItemSubjectId.substring(0, 22),
     chargeType: charges[0].chargeType,
     charges: charges.map((charge) => ({
-      amount: totalPrice,
+      amount: charge.priceAmount * charge.quantity,
       chargeItemCode: charge.chargeItemCode,
       priceAmount: charge.priceAmount,
       quantity: charge.quantity,


### PR DESCRIPTION
## What

Put priceAmount * quantity in amount so that it holds total price per line not total price for payment

## Why

To be valid

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the calculation of individual charge item amounts to ensure each is based on unit price and quantity, improving the accuracy of total price calculations.

- **Tests**
  - Added new test cases to verify that charge amounts are correctly computed as the product of unit price and quantity for various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->