### PR TITLE
fix(web): Blood donation restriction list, only order by score if no query string is present

### DIFF
--- a/libs/cms/src/lib/cms.elasticsearch.service.ts
+++ b/libs/cms/src/lib/cms.elasticsearch.service.ts
@@ -1380,10 +1380,7 @@ export class CmsElasticsearchService {
       { 'title.sort': { order: SortDirection.ASC } },
     ]
 
-    if (
-      queryString.length === 0 &&
-      (!input.tagKeys || input.tagKeys.length === 0)
-    ) {
+    if (queryString.length === 0) {
       sort = [{ 'title.sort': { order: SortDirection.ASC } }]
     }
 


### PR DESCRIPTION
# Blood donation restriction list, only order by score if no querystring is present

We only want to order by score when there is no query string, since the filter tags essentially filter out irrelevant items from the list we still want those items to be in title order if there is no query string

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved sorting behavior for the blood donation restriction list when no search query is provided, ensuring results are consistently sorted by title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->