### PR TITLE
fix(j-s): Enable double clicking input to select text

### DIFF
--- a/apps/judicial-system/web/src/components/AccordionItems/IndictmentsCaseFilesAccordionItem/IndictmentsCaseFilesAccordionItem.tsx
+++ b/apps/judicial-system/web/src/components/AccordionItems/IndictmentsCaseFilesAccordionItem/IndictmentsCaseFilesAccordionItem.tsx
@@ -210,8 +210,13 @@ const CaseFile: FC<CaseFileProps> = (props) => {
       return
     }
 
-    // Prevents text selection when dragging
-    evt.preventDefault()
+    const target = evt.target as HTMLElement
+    const tag = target.tagName.toLowerCase()
+
+    if (tag !== 'input') {
+      // Prevents text selection when dragging
+      evt.preventDefault()
+    }
 
     setIsDragging(true)
     controls.start(evt)


### PR DESCRIPTION
# Enable double clicking input to select text

[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1208380432049318?focus=true)

## What

Users were unable to double click text in input fields when editing a case file on the case file screen.

## Why

This is the expected behaveour

## Screenshots / Gifs


https://github.com/user-attachments/assets/b1a2831f-3ba5-4e23-a775-517ae9135b47



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved drag behavior by allowing normal interactions within input fields, while still preventing unwanted text selection elsewhere during drag operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->