### PR TITLE
fix(form-system): fix basesettings update

### DIFF
--- a/apps/services/form-system/migrations/20250523110335-update-form.js
+++ b/apps/services/form-system/migrations/20250523110335-update-form.js
@@ -1,0 +1,35 @@
+'use strict'
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // 1. Add a new temporary column with JSON type
+    await queryInterface.addColumn('form', 'organization_display_name_json', {
+      type: Sequelize.JSON,
+      allowNull: true,
+    })
+    // 2. Copy/cast data from old column to new column (as string JSON)
+    await queryInterface.sequelize.query(
+      `UPDATE form SET organization_display_name_json = to_jsonb(organization_display_name)`
+    )
+    // 3. Remove the old column
+    await queryInterface.removeColumn('form', 'organization_display_name')
+    // 4. Rename the new column to the original name
+    await queryInterface.renameColumn('form', 'organization_display_name_json', 'organization_display_name')
+  },
+
+  async down(queryInterface, Sequelize) {
+    // 1. Add back the old column as STRING
+    await queryInterface.addColumn('form', 'organization_display_name_str', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    })
+    // 2. Copy data from JSON column to STRING column (as text)
+    await queryInterface.sequelize.query(
+      `UPDATE form SET organization_display_name_str = organization_display_name::text`
+    )
+    // 3. Remove the JSON column
+    await queryInterface.removeColumn('form', 'organization_display_name')
+    // 4. Rename the string column back to the original name
+    await queryInterface.renameColumn('form', 'organization_display_name_str', 'organization_display_name')
+  },
+}

--- a/apps/services/form-system/src/app/modules/forms/models/form.model.ts
+++ b/apps/services/form-system/src/app/modules/forms/models/form.model.ts
@@ -58,6 +58,7 @@ export class Form extends Model<Form> {
   @Column({
     type: DataType.JSON,
     allowNull: true,
+    defaultValue: new LanguageType(),
   })
   organizationDisplayName?: LanguageType
 

--- a/libs/api/domains/form-system/src/lib/forms/forms.resolver.ts
+++ b/libs/api/domains/form-system/src/lib/forms/forms.resolver.ts
@@ -81,7 +81,7 @@ export class FormsResolver {
     return this.formsService.getAllForms(user, input)
   }
 
-  @Mutation(() => Boolean, {
+  @Mutation(() => UpdateFormResponse, {
     name: 'updateFormSystemForm',
     nullable: true,
   })

--- a/libs/portals/admin/form-system/src/components/MainContent/components/BaseSettings/BaseSettings.tsx
+++ b/libs/portals/admin/form-system/src/components/MainContent/components/BaseSettings/BaseSettings.tsx
@@ -166,7 +166,7 @@ export const BaseSettings = () => {
             onBlur={async (e) => {
               if (e.target.value !== focus) {
                 const response: UpdateFormResponse = await formUpdate()
-                if (response.errors) {
+                if (response && response.errors) {
                   setErrorMsg(response.errors[0].message as string)
                 } else {
                   setErrorMsg('')


### PR DESCRIPTION
## What

Fix updating base settings

## Why

It was broken for organization-display-name and slug 

## Checklist:

- [x ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The form system now supports storing organization display names as JSON, allowing for enhanced flexibility and localization.
	- The GraphQL mutation for updating forms now returns a detailed response object instead of a simple boolean, providing more comprehensive feedback to users.

- **Bug Fixes**
	- Improved error handling in the admin portal to prevent runtime errors when updating form slugs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->