### PR TITLE
fix(j-s): Add submittedDate as default to EditableCaseFile

### DIFF
--- a/apps/judicial-system/web/src/components/EditableCaseFile/EditableCaseFile.tsx
+++ b/apps/judicial-system/web/src/components/EditableCaseFile/EditableCaseFile.tsx
@@ -35,6 +35,7 @@ export interface TEditableCaseFile {
   canEdit?: boolean
   status?: FileUploadStatus
   size?: number | null
+  submissionDate?: string | null
 }
 
 interface Props {
@@ -61,16 +62,20 @@ const EditableCaseFile: FC<Props> = (props) => {
   } = props
   const { formatMessage } = useIntl()
   const [ref, { width }] = useMeasure<HTMLDivElement>()
+
+  const initialDate =
+    caseFile.displayDate || caseFile.submissionDate || caseFile.created
+  const displayName = caseFile.userGeneratedFilename ?? caseFile.displayText
+
+  const [editedDisplayDate, setEditedDisplayDate] = useState<
+    string | undefined
+  >(formatDate(initialDate))
+
   const [isEditing, setIsEditing] = useState<boolean>(false)
 
   const [editedFilename, setEditedFilename] = useState<
     string | undefined | null
   >(caseFile.userGeneratedFilename)
-
-  const [editedDisplayDate, setEditedDisplayDate] = useState<
-    string | undefined
-  >(formatDate(caseFile.displayDate ?? caseFile.created) ?? undefined)
-  const displayName = caseFile.userGeneratedFilename ?? caseFile.displayText
 
   const handleEditFileButtonClick = () => {
     const trimmedFilename = editedFilename?.trim()

--- a/apps/judicial-system/web/src/components/UploadFiles/UploadFiles.css.ts
+++ b/apps/judicial-system/web/src/components/UploadFiles/UploadFiles.css.ts
@@ -10,13 +10,19 @@ export const container = style({
   border: `1px dashed ${theme.color.blue200}`,
   borderRadius: theme.border.radius.large,
 
-  padding: `${theme.spacing[10]}px`,
+  padding: `${theme.spacing[2]}px`,
   marginBottom: `${theme.spacing[10]}px`,
   transition: 'border-color 0.2s ease-in-out',
 
   selectors: {
     '&:hover': {
       borderColor: theme.color.blue400,
+    },
+  },
+
+  '@media': {
+    [`screen and (min-width: ${theme.breakpoints.md}px)`]: {
+      padding: `${theme.spacing[10]}px`,
     },
   },
 })


### PR DESCRIPTION
# Add submittedDate as default to EditableCaseFile

[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1210317577787096?focus=true)

## What

There is no default date on files that are added by court users. This PR sets the submittedDate as the default date.

## Why

If you were to change the name of the file, you'd also need to set a date.

## Screenshots / Gifs

<img width="806" alt="Screenshot 2025-05-23 at 13 20 35" src="https://github.com/user-attachments/assets/5688c17a-ec81-4564-8a43-48d49d87969c" />

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved date handling in case file editing by considering submission date in addition to existing display and creation dates.

- **Style**
  - Updated file upload container padding to be responsive, providing smaller padding on small screens and larger padding on medium and larger screens for better usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->