### PR TITLE
fix(application-ir): Account for negatives in cumulations

### DIFF
--- a/libs/application/templates/inheritance-report/src/lib/utils/helpers.spec.ts
+++ b/libs/application/templates/inheritance-report/src/lib/utils/helpers.spec.ts
@@ -29,4 +29,17 @@ describe('valueToNumber', () => {
     expect(valueToNumber({})).toBe(0)
     expect(valueToNumber([])).toBe(0)
   })
+
+  it('should return a negative value if number is negative', () => {
+    expect(valueToNumber('-123')).toBe(-123)
+    expect(valueToNumber('-123.123.123', '.')).toBe(-123.123123)
+    expect(valueToNumber('-123,123,123', ',')).toBe(-123.123123)
+    expect(valueToNumber('-12.123.421.123,4233 kr.', ',')).toBe(
+      -12123421123.4233,
+    )
+    expect(valueToNumber('-12.123.421.123,4233 kr.', '.')).toBe(
+      -12.1234211234233,
+    )
+    expect(valueToNumber('-1.123.123 kr', ',')).toBe(-1123123)
+  })
 })

--- a/libs/application/templates/inheritance-report/src/lib/utils/helpers.ts
+++ b/libs/application/templates/inheritance-report/src/lib/utils/helpers.ts
@@ -30,11 +30,9 @@ export const getEstateDataFromApplication = (
 ): { inheritanceReportInfo?: InheritanceReportInfo } => {
   const selectedEstate = application.answers.estateInfoSelection
 
-  const estateData = (
-    application.externalData.syslumennOnEntry?.data as {
-      inheritanceReportInfos?: Array<InheritanceReportInfo>
-    }
-  ).inheritanceReportInfos?.find(
+  const estateData = (application.externalData.syslumennOnEntry?.data as {
+    inheritanceReportInfos?: Array<InheritanceReportInfo>
+  }).inheritanceReportInfos?.find(
     (estate) => estate.caseNumber === selectedEstate,
   )
 
@@ -134,10 +132,14 @@ export const valueToNumber = (value: unknown, delimiter = '.'): number => {
   }
 
   if (typeof value === 'string' && value.length > 0) {
-    const regex = new RegExp(`[^${delimiter}\\d]+`, 'g')
+    const regex = new RegExp(`[^-${delimiter}\\d]+`, 'g')
     const regex2 = new RegExp(`(?<=\\${delimiter}.*)\\${delimiter}`, 'g')
+    const regex3 = new RegExp('(?!^)-', 'g')
 
-    const parsed = value.replace(regex, '').replace(regex2, '')
+    const parsed = value
+      .replace(regex, '')
+      .replace(regex2, '')
+      .replace(regex3, '')
     return parseFloat(parsed.replace(delimiter, '.'))
   }
 


### PR DESCRIPTION
The function `valueToNumber` did not account for negative numbers.

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210354840002323

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved number parsing to correctly handle negative values, including negative integers and decimals with various formatting and currency symbols. Negative numbers are now accurately recognized and returned in all supported formats.

- **Tests**
  - Added new test cases to verify correct handling of negative numeric values in different string formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->