### PR TITLE
feat(payments): Update message ids and extract translations

### DIFF
--- a/apps/payments/components/PageCard/PageCard.css.ts
+++ b/apps/payments/components/PageCard/PageCard.css.ts
@@ -81,4 +81,5 @@ export const linkSeparator = style({
 export const link = style({
   fontWeight: theme.typography.semiBold,
   fontSize: 16,
+  color: theme.color.blue400,
 })

--- a/apps/payments/components/PageCard/PageCard.tsx
+++ b/apps/payments/components/PageCard/PageCard.tsx
@@ -28,7 +28,7 @@ export const PageCard = ({ headerSlot, bodySlot }: PageCardWrapperProps) => {
 
   const changeLanguageHandler = (lang: Locale) => {
     changeLanguage(lang)
-    router.push(getPath(lang === 'is' ? 'en' : 'is', path))
+    router.replace(getPath(lang === 'is' ? 'en' : 'is', path))
   }
 
   const path = usePathname()

--- a/apps/payments/components/PageCard/PageCard.tsx
+++ b/apps/payments/components/PageCard/PageCard.tsx
@@ -80,6 +80,11 @@ export const PageCard = ({ headerSlot, bodySlot }: PageCardWrapperProps) => {
                 onClick={() =>
                   changeLanguageHandler(locale === 'is' ? 'en' : 'is')
                 }
+                aria-label={formatMessage(
+                  locale === 'is'
+                    ? generic.toggleLanguageToEnglish
+                    : generic.toggleLanguageToIcelandic,
+                )}
               >
                 {formatMessage(
                   locale === 'en'

--- a/apps/payments/components/PageCard/PageCard.tsx
+++ b/apps/payments/components/PageCard/PageCard.tsx
@@ -1,11 +1,13 @@
-import { usePathname } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 
 import { Box, LinkV2, Logo } from '@island.is/island-ui/core'
+import { Locale } from '@island.is/shared/types'
+import { useLocale } from '@island.is/localization'
+
+import { PageCenter } from '../PageCenter/PageCenter'
+import { generic } from '../../messages'
 
 import * as styles from './PageCard.css'
-import { PageCenter } from '../PageCenter/PageCenter'
-import { useLocale } from '@island.is/localization'
-import { generic } from '../../messages'
 
 type PageCardWrapperProps = {
   headerSlot: React.ReactNode
@@ -21,7 +23,13 @@ const getPath = (currentLocale: string, currentPath: string) => {
 }
 
 export const PageCard = ({ headerSlot, bodySlot }: PageCardWrapperProps) => {
-  const { locale, formatMessage } = useLocale()
+  const { locale, formatMessage, changeLanguage } = useLocale()
+  const router = useRouter()
+
+  const changeLanguageHandler = (lang: Locale) => {
+    changeLanguage(lang)
+    router.push(getPath(lang === 'is' ? 'en' : 'is', path))
+  }
 
   const path = usePathname()
 
@@ -66,17 +74,19 @@ export const PageCard = ({ headerSlot, bodySlot }: PageCardWrapperProps) => {
               <Logo width={87} />
             </LinkV2>
             <Box display="flex" columnGap={2}>
-              <LinkV2
-                href={getPath(locale, path)}
-                color="blue400"
+              <button
+                type="button"
                 className={styles.link}
+                onClick={() =>
+                  changeLanguageHandler(locale === 'is' ? 'en' : 'is')
+                }
               >
                 {formatMessage(
                   locale === 'en'
                     ? generic.footerLocaleIS
                     : generic.footerLocaleEN,
                 )}
-              </LinkV2>
+              </button>
               <span className={styles.linkSeparator} />
               <LinkV2
                 href={

--- a/apps/payments/i18n/withLocale.tsx
+++ b/apps/payments/i18n/withLocale.tsx
@@ -1,5 +1,7 @@
 import { withLocale as baseWithLocale } from '@island.is/localization'
 
-export const withLocale = (Component) => {
+export const withLocale = <P extends object>(
+  Component: React.ComponentType<P>,
+) => {
   return baseWithLocale(['payments'])(Component)
 }

--- a/apps/payments/i18n/withLocale.tsx
+++ b/apps/payments/i18n/withLocale.tsx
@@ -1,0 +1,5 @@
+import { withLocale as baseWithLocale } from '@island.is/localization'
+
+export const withLocale = (Component) => {
+  return baseWithLocale(['payments'])(Component)
+}

--- a/apps/payments/messages/3ds.ts
+++ b/apps/payments/messages/3ds.ts
@@ -2,12 +2,12 @@ import { defineMessages } from 'react-intl'
 
 export const threeDSecure = defineMessages({
   title: {
-    id: 'payments.threeDSecure:title',
+    id: 'payments:threeDSecure.title',
     defaultMessage: 'Auðkenning tókst',
     description: '3DS was successful',
   },
   pleaseWait: {
-    id: 'payments.threeDSecure:pleaseWait',
+    id: 'payments:threeDSecure.pleaseWait',
     defaultMessage: 'Hinkraðu á meðan við klárum greiðslu',
     description: 'Please wait while we finish the payment',
   },

--- a/apps/payments/messages/card.ts
+++ b/apps/payments/messages/card.ts
@@ -2,42 +2,42 @@ import { defineMessages } from 'react-intl'
 
 export const card = defineMessages({
   paymentMethodTitle: {
-    id: 'payments.card:title',
+    id: 'payments:card.title',
     defaultMessage: 'Greiðslukort',
     description: 'Title for card payment method',
   },
   cardNumber: {
-    id: 'payments.card:cardNumber',
+    id: 'payments:card.cardNumber',
     defaultMessage: 'Kortanúmer',
     description: 'Card number',
   },
   cardNumberPlaceholder: {
-    id: 'payments.card:cardNumberPlaceholder',
+    id: 'payments:card.cardNumberPlaceholder',
     defaultMessage: '**** **** **** ****',
     description: 'Card number placeholder',
   },
   cardExpiry: {
-    id: 'payments.card:cardExpiry',
+    id: 'payments:card.cardExpiry',
     defaultMessage: 'Gildistími',
     description: 'Card expiry',
   },
   cardExpiryPlaceholder: {
-    id: 'payments.card:cardExpiryPlaceholder',
+    id: 'payments:card.cardExpiryPlaceholder',
     defaultMessage: 'MM/ÁÁ',
     description: 'MM/YY',
   },
   cardCVC: {
-    id: 'payments.card:cardCVC',
+    id: 'payments:card.cardCVC',
     defaultMessage: 'CVC',
     description: 'Card CVC',
   },
   cardCVCPlaceholder: {
-    id: 'payments.card:cardCVCPlaceholder',
+    id: 'payments:card.cardCVCPlaceholder',
     defaultMessage: '***',
     description: 'Card CVC placeholder',
   },
   pay: {
-    id: 'payments.card:pay',
+    id: 'payments:card.pay',
     defaultMessage: 'Greiða',
     description: 'Pay',
   },
@@ -45,12 +45,12 @@ export const card = defineMessages({
 
 export const cardSuccess = defineMessages({
   title: {
-    id: 'payments.cardSuccess:title',
+    id: 'payments:cardSuccess.title',
     defaultMessage: 'Greiðsla tókst',
     description: 'Payment successful',
   },
   subTitle: {
-    id: 'payments.cardSuccess:subTitle',
+    id: 'payments:cardSuccess.subTitle',
     defaultMessage: 'Kvittun verður send í pósthólfið',
     description: 'Receipt will be sent to your islandis inbox',
   },
@@ -58,47 +58,47 @@ export const cardSuccess = defineMessages({
 
 export const cardValidationError = defineMessages({
   cardNumber: {
-    id: 'payments.validationError.card:cardNumberError',
+    id: 'payments:validationError.card.cardNumberError',
     defaultMessage: 'Kortanúmer er nauðsynlegt',
     description: 'Card number is required',
   },
   invalidCardNumber: {
-    id: 'payments.validationError.card:invalidCardNumberError',
+    id: 'payments:validationError.card.invalidCardNumberError',
     defaultMessage: 'Ógilt kortanúmer',
     description: 'Invalid card number',
   },
   cardNumberTooShort: {
-    id: 'payments.validationError.card:cardNumberTooShortError',
+    id: 'payments:validationError.card.cardNumberTooShortError',
     defaultMessage: 'Kortanúmer er of stutt',
     description: 'Card number is too short',
   },
   cardExpiry: {
-    id: 'payments.validationError.card:cardExpiryError',
+    id: 'payments:validationError.card.cardExpiryError',
     defaultMessage: 'Gildistími er nauðsynlegur',
     description: 'Card expiry is required',
   },
   cardExpiryExpired: {
-    id: 'payments.validationError.card:cardExpiryExpiredError',
+    id: 'payments:validationError.card.cardExpiryExpiredError',
     defaultMessage: 'Kort er útrunnið',
     description: 'Card is expired',
   },
   cardExpiryInvalid: {
-    id: 'payments.validationError.card:cardExpiryInvalidError',
+    id: 'payments:validationError.card.cardExpiryInvalidError',
     defaultMessage: 'Ógildur gildistími',
     description: 'Invalid expiry date',
   },
   cardExpiryInvalidMonth: {
-    id: 'payments.validationError.card:cardExpiryInvalidMonth',
+    id: 'payments:validationError.card.cardExpiryInvalidMonth',
     defaultMessage: 'Ógildur mánuður',
     description: 'Invalid expiry date month',
   },
   cardCVC: {
-    id: 'payments.validationError.card:cardCVCError',
+    id: 'payments:validationError.card.cardCVCError',
     defaultMessage: 'Öryggiskóði er nauðsynlegur',
     description: 'Card CVC is required',
   },
   cardCVCTooShort: {
-    id: 'payments.validationError.card:cardCVCTooShortError',
+    id: 'payments:validationError.card.cardCVCTooShortError',
     defaultMessage: 'Öryggiskóði er of stuttur',
     description: 'Card CVC is too short',
   },
@@ -106,279 +106,279 @@ export const cardValidationError = defineMessages({
 
 export const cardError = defineMessages({
   insufficientFundsTitle: {
-    id: 'payments.cardError:insufficientFundsTitle',
+    id: 'payments:cardError.insufficientFundsTitle',
     defaultMessage: 'Ekki heimild',
     description: 'Insufficient funds',
   },
   insufficientFunds: {
-    id: 'payments.cardError:insufficientFunds',
+    id: 'payments:cardError.insufficientFunds',
     defaultMessage:
       'Ekki var hægt að framkvæma kortagreiðslu vegna ónægrar ráðstöfunar á kortinu',
     description: 'Insufficient funds',
   },
   expiredCardTitle: {
-    id: 'payments.cardError:expiredCardTitle',
+    id: 'payments:cardError.expiredCardTitle',
     defaultMessage: 'Kort útrunnið',
     description: 'Expired card',
   },
   expiredCard: {
-    id: 'payments.cardError:expiredCard',
+    id: 'payments:cardError.expiredCard',
     defaultMessage:
       'Ekki var hægt að framkvæma kortagreiðslu vegna þess að kortið er útrunnið',
     description: 'Expired card',
   },
   invalidCardNumberTitle: {
-    id: 'payments.cardError:invalidCardNumberTitle',
+    id: 'payments:cardError.invalidCardNumberTitle',
     defaultMessage: 'Ógilt kortanúmer',
     description: 'Invalid card number',
   },
   invalidCardNumber: {
-    id: 'payments.cardError:invalidCardNumber',
+    id: 'payments:cardError.invalidCardNumber',
     defaultMessage:
       'Ekki var hægt að framkvæma kortagreiðslu vegna ógilds kortanúmers',
     description: 'Invalid card number',
   },
   invalidCardExpiryTitle: {
-    id: 'payments.cardError:invalidCardExpiryTitle',
+    id: 'payments:cardError.invalidCardExpiryTitle',
     defaultMessage: 'Ógildur gildistími',
     description: 'Invalid expiry date',
   },
   invalidCardExpiry: {
-    id: 'payments.cardError:invalidCardExpiry',
+    id: 'payments:cardError.invalidCardExpiry',
     defaultMessage:
       'Ekki var hægt að framkvæma kortagreiðslu vegna ógilds gildistíma',
     description: 'Invalid expiry date',
   },
   invalidCardCVCTitle: {
-    id: 'payments.cardError:invalidCardCVCTitle',
+    id: 'payments:cardError.invalidCardCVCTitle',
     defaultMessage: 'Ógildur öryggiskóði',
     description: 'Invalid CVC',
   },
   invalidCardCVC: {
-    id: 'payments.cardError:invalidCardCVC',
+    id: 'payments:cardError.invalidCardCVC',
     defaultMessage:
       'Ekki var hægt að framkvæma kortagreiðslu vegna ógilds öryggiskóða',
     description: 'Invalid CVC',
   },
   invalidCardTitle: {
-    id: 'payments.cardError:invalidCardTitle',
+    id: 'payments:cardError.invalidCardTitle',
     defaultMessage: 'Ógilt kort',
     description: 'Invalid card',
   },
   invalidCard: {
-    id: 'payments.cardError:invalidCard',
+    id: 'payments:cardError.invalidCard',
     defaultMessage:
       'Ekki var hægt að framkvæma kortagreiðslu vegna ógilds kort',
     description: 'Invalid card',
   },
   lostCardTitle: {
-    id: 'payments.cardError:lostCardTitle',
+    id: 'payments:cardError.lostCardTitle',
     defaultMessage: 'Týnt kort',
     description: 'Lost card',
   },
   lostCard: {
-    id: 'payments.cardError:lostCard',
+    id: 'payments:cardError.lostCard',
     defaultMessage:
       'Kortið hefur verið tilkynnt týnt og er lokað. Hafðu samband við kortaútgefanda.',
     description: 'Lost card description',
   },
   stolenCardTitle: {
-    id: 'payments.cardError:stolenCardTitle',
+    id: 'payments:cardError.stolenCardTitle',
     defaultMessage: 'Stolið kort',
     description: 'Stolen card',
   },
   stolenCard: {
-    id: 'payments.cardError:stolenCard',
+    id: 'payments:cardError.stolenCard',
     defaultMessage:
       'Kortið hefur verið tilkynnt stolið og er lokað. Hafðu samband við kortaútgefanda.',
     description: 'Stolen card description',
   },
   closedAccountTitle: {
-    id: 'payments.cardError:closedAccountTitle',
+    id: 'payments:cardError.closedAccountTitle',
     defaultMessage: 'Reikningur lokaður',
     description: 'Closed account',
   },
   closedAccount: {
-    id: 'payments.cardError:closedAccount',
+    id: 'payments:cardError.closedAccount',
     defaultMessage: 'Reikningnum tengdum þessu korti hefur verið lokað.',
     description: 'Closed account description',
   },
   transactionNotPermittedTitle: {
-    id: 'payments.cardError:transactionNotPermittedTitle',
+    id: 'payments:cardError.transactionNotPermittedTitle',
     defaultMessage: 'Aðgerð ekki leyfð',
     description: 'Transaction not permitted',
   },
   transactionNotPermitted: {
-    id: 'payments.cardError:transactionNotPermitted',
+    id: 'payments:cardError.transactionNotPermitted',
     defaultMessage:
       'Kortið þitt leyfir ekki þessa aðgerð. Hafðu samband við kortaútgefanda.',
     description: 'Transaction not permitted description',
   },
   restrictedCardTitle: {
-    id: 'payments.cardError:restrictedCardTitle',
+    id: 'payments:cardError.restrictedCardTitle',
     defaultMessage: 'Takmarkað kort',
     description: 'Restricted card',
   },
   restrictedCard: {
-    id: 'payments.cardError:restrictedCard',
+    id: 'payments:cardError.restrictedCard',
     defaultMessage:
       'Kortið þitt hefur takmarkanir og getur ekki verið notað fyrir þessa greiðslu.',
     description: 'Restricted card description',
   },
   suspectedFraudTitle: {
-    id: 'payments.cardError:suspectedFraudTitle',
+    id: 'payments:cardError.suspectedFraudTitle',
     defaultMessage: 'Grunur um svik',
     description: 'Suspected fraud',
   },
   suspectedFraud: {
-    id: 'payments.cardError:suspectedFraud',
+    id: 'payments:cardError.suspectedFraud',
     defaultMessage:
       'Greiðslan var stöðvuð vegna gruns um svik. Hafðu samband við kortaútgefanda.',
     description: 'Suspected fraud description',
   },
   exceedsWithdrawalLimitTitle: {
-    id: 'payments.cardError:exceedsWithdrawalLimitTitle',
+    id: 'payments:cardError.exceedsWithdrawalLimitTitle',
     defaultMessage: 'Yfir dregnum mörkum',
     description: 'Exceeds withdrawal limit',
   },
   exceedsWithdrawalLimit: {
-    id: 'payments.cardError:exceedsWithdrawalLimit',
+    id: 'payments:cardError.exceedsWithdrawalLimit',
     defaultMessage: 'Þú hefur náð hámarksúttektarmörkum tengdum kortinu þínu.',
     description: 'Exceeds withdrawal limit description',
   },
   securityViolationTitle: {
-    id: 'payments.cardError:securityViolationTitle',
+    id: 'payments:cardError.securityViolationTitle',
     defaultMessage: 'Öryggisbrot',
     description: 'Security violation',
   },
   securityViolation: {
-    id: 'payments.cardError:securityViolation',
+    id: 'payments:cardError.securityViolation',
     defaultMessage:
       'Kortinu hefur verið lokað vegna öryggisbrests. Hafðu samband við kortaútgefanda.',
     description: 'Security violation description',
   },
   additionalAuthenticationRequiredTitle: {
-    id: 'payments.cardError:additionalAuthenticationRequiredTitle',
+    id: 'payments:cardError.additionalAuthenticationRequiredTitle',
     defaultMessage: 'Viðbótarauðkenning krafist',
     description: 'Additional authentication required',
   },
   additionalAuthenticationRequired: {
-    id: 'payments.cardError:additionalAuthenticationRequired',
+    id: 'payments:cardError.additionalAuthenticationRequired',
     defaultMessage: 'Til að ljúka greiðslunni þarf frekari auðkenningu.',
     description: 'Additional authentication required description',
   },
   contactIssuerTitle: {
-    id: 'payments.cardError:contactIssuerTitle',
+    id: 'payments:cardError.contactIssuerTitle',
     defaultMessage: 'Hafðu samband við kortaútgefanda',
     description: 'Contact issuer',
   },
   contactIssuer: {
-    id: 'payments.cardError:contactIssuer',
+    id: 'payments:cardError.contactIssuer',
     defaultMessage:
       'Kortið þarf sérstakt samþykki. Vinsamlegast hafðu samband við kortaútgefanda.',
     description: 'Contact issuer description',
   },
   issuerUnavailableTitle: {
-    id: 'payments.cardError:issuerUnavailableTitle',
+    id: 'payments:cardError.issuerUnavailableTitle',
     defaultMessage: 'Kortaútgefandi ekki tiltækur',
     description: 'Issuer unavailable',
   },
   issuerUnavailable: {
-    id: 'payments.cardError:issuerUnavailable',
+    id: 'payments:cardError.issuerUnavailable',
     defaultMessage:
       'Ekki var hægt að ná sambandi við kortaútgefanda. Reyndu aftur síðar.',
     description: 'Issuer unavailable description',
   },
   duplicateTransactionTitle: {
-    id: 'payments.cardError:duplicateTransactionTitle',
+    id: 'payments:cardError.duplicateTransactionTitle',
     defaultMessage: 'Tvítalin færsla',
     description: 'Duplicate transaction',
   },
   duplicateTransaction: {
-    id: 'payments.cardError:duplicateTransaction',
+    id: 'payments:cardError.duplicateTransaction',
     defaultMessage: 'Þessi greiðsla virðist vera afrit af fyrri greiðslu.',
     description: 'Duplicate transaction description',
   },
   transactionTimedOutTitle: {
-    id: 'payments.cardError:transactionTimedOutTitle',
+    id: 'payments:cardError.transactionTimedOutTitle',
     defaultMessage: 'Greiðsla rann út á tíma',
     description: 'Transaction timed out',
   },
   transactionTimedOut: {
-    id: 'payments.cardError:transactionTimedOut',
+    id: 'payments:cardError.transactionTimedOut',
     defaultMessage: 'Tenging við greiðslukerfið rann út. Reyndu aftur síðar.',
     description: 'Transaction timed out description',
   },
   stopPaymentOrderTitle: {
-    id: 'payments.cardError:stopPaymentOrderTitle',
+    id: 'payments:cardError.stopPaymentOrderTitle',
     defaultMessage: 'Stöðvunargjaldskipun',
     description: 'Stop payment order',
   },
   stopPaymentOrder: {
-    id: 'payments.cardError:stopPaymentOrder',
+    id: 'payments:cardError.stopPaymentOrder',
     defaultMessage: 'Greiðslan var stöðvuð samkvæmt beiðni frá kortaeiganda.',
     description: 'Stop payment order description',
   },
   revocationOfAuthorizationTitle: {
-    id: 'payments.cardError:revocationOfAuthorizationTitle',
+    id: 'payments:cardError.revocationOfAuthorizationTitle',
     defaultMessage: 'Heimild afturkölluð',
     description: 'Revocation of authorization',
   },
   revocationOfAuthorization: {
-    id: 'payments.cardError:revocationOfAuthorization',
+    id: 'payments:cardError.revocationOfAuthorization',
     defaultMessage: 'Kortaeigandi afturkallaði heimild fyrir þessa greiðslu.',
     description: 'Revocation of authorization description',
   },
   revocationOfAllAuthorizationsTitle: {
-    id: 'payments.cardError:revocationOfAllAuthorizationsTitle',
+    id: 'payments:cardError.revocationOfAllAuthorizationsTitle',
     defaultMessage: 'Allar heimildir afturkallaðar',
     description: 'Revocation of all authorizations',
   },
   revocationOfAllAuthorizations: {
-    id: 'payments.cardError:revocationOfAllAuthorizations',
+    id: 'payments:cardError.revocationOfAllAuthorizations',
     defaultMessage:
       'Kortaeigandi afturkallaði allar heimildir tengdar kortinu.',
     description: 'Revocation of all authorizations description',
   },
   paymentSystemUnavailableTitle: {
-    id: 'payments.cardError:paymentSystemUnavailableTitle',
+    id: 'payments:cardError.paymentSystemUnavailableTitle',
     defaultMessage: 'Greiðslukerfi ekki tiltækt',
     description: 'Payment system unavailable',
   },
   paymentSystemUnavailable: {
-    id: 'payments.cardError:paymentSystemUnavailable',
+    id: 'payments:cardError.paymentSystemUnavailable',
     defaultMessage:
       'Ekki var hægt að tengjast greiðslukerfinu. Reyndu aftur síðar.',
     description: 'Payment system unavailable description',
   },
   genericDeclineTitle: {
-    id: 'payments.cardError:genericDeclineTitle',
+    id: 'payments:cardError.genericDeclineTitle',
     defaultMessage: 'Greiðslu hafnað',
     description: 'Generic decline',
   },
   genericDecline: {
-    id: 'payments.cardError:genericDecline',
+    id: 'payments:cardError.genericDecline',
     defaultMessage:
       'Greiðslunni var hafnað. Reyndu annað kort eða hafðu samband við kortaútgefanda.',
     description: 'Generic decline description',
   },
   verificationDeadlineExceededTitle: {
-    id: 'payments.cardError:verificationDeadlineExceededTitle',
+    id: 'payments:cardError.verificationDeadlineExceededTitle',
     defaultMessage: 'Beiðni útrunnin',
     description: 'Exceeded time limit to verify card',
   },
   verificationDeadlineExceeded: {
-    id: 'payments.cardError:verificationDeadlineExceeded',
+    id: 'payments:cardError.verificationDeadlineExceeded',
     defaultMessage: 'Tími til að staðfesta kort er útrunninn.',
     description: 'Generic decline description',
   },
   unknownTitle: {
-    id: 'payments.cardError:unknownTitle',
+    id: 'payments:cardError.unknownTitle',
     defaultMessage: 'Óvænt villa',
     description: 'Unknown error',
   },
   unknown: {
-    id: 'payments.cardError:unknown',
+    id: 'payments:cardError.unknown',
     defaultMessage: 'Óvænt villa kom upp við að reyna framkvæma kortagreiðslu',
     description: 'Unknown error description',
   },

--- a/apps/payments/messages/card.ts
+++ b/apps/payments/messages/card.ts
@@ -257,6 +257,18 @@ export const cardError = defineMessages({
       'Kortinu hefur verið lokað vegna öryggisbrests. Hafðu samband við kortaútgefanda.',
     description: 'Security violation description',
   },
+  refundedBecauseOfSystemErrorTitle: {
+    id: 'payments:cardError.refundedBecauseOfSystemErrorTitle',
+    defaultMessage: 'Greiðsla endurgreidd',
+    description: 'Payment refunded',
+  },
+  refundedBecauseOfSystemError: {
+    id: 'payments:cardError.refundedBecauseOfSystemError',
+    defaultMessage:
+      'Greiðslan fór í gegn en var endurgreidd vegna kerfisvillu. Vinsamlegast reyndu aftur.',
+    description:
+      'Payment was refunded due to a system error. Please try again.',
+  },
   additionalAuthenticationRequiredTitle: {
     id: 'payments:cardError.additionalAuthenticationRequiredTitle',
     defaultMessage: 'Viðbótarauðkenning krafist',

--- a/apps/payments/messages/generic.ts
+++ b/apps/payments/messages/generic.ts
@@ -56,6 +56,16 @@ export const generic = defineMessages({
     defaultMessage: 'Nafn',
     description: 'Name',
   },
+  toggleLanguageToEnglish: {
+    id: 'payments:generic.toggleLanguageToEnglish',
+    defaultMessage: 'Skipta yfir á ensku',
+    description: 'Switch to English',
+  },
+  toggleLanguageToIcelandic: {
+    id: 'payments:generic.toggleLanguageToIcelandic',
+    defaultMessage: 'Skipta yfir á íslensku',
+    description: 'Switch to Icelandic',
+  },
 })
 
 export const genericError = defineMessages({

--- a/apps/payments/messages/generic.ts
+++ b/apps/payments/messages/generic.ts
@@ -2,57 +2,57 @@ import { defineMessages } from 'react-intl'
 
 export const generic = defineMessages({
   buttonCancel: {
-    id: 'payments.generic:buttonCancel',
+    id: 'payments:generic.buttonCancel',
     defaultMessage: 'Hætta við',
     description: 'Cancel',
   },
   buttonFinishAndReturn: {
-    id: 'payments.generic:buttonFinishAndReturn',
+    id: 'payments:generic.buttonFinishAndReturn',
     defaultMessage: 'Ljúka',
     description: 'Finish',
   },
   footerHelp: {
-    id: 'payments.generic:footerHelp',
+    id: 'payments:generic.footerHelp',
     defaultMessage: 'Aðstoð',
     description: 'FAQ',
   },
   footerLocaleIS: {
-    id: 'payments.generic:footerLocaleIS',
+    id: 'payments:generic.footerLocaleIS',
     defaultMessage: 'Íslenska',
     description: 'Icelandic',
   },
   footerLocaleEN: {
-    id: 'payments.generic:footerLocaleEN',
+    id: 'payments:generic.footerLocaleEN',
     defaultMessage: 'English',
     description: 'English',
   },
   back: {
-    id: 'payments.generic:back',
+    id: 'payments:generic.back',
     defaultMessage: 'Til baka',
     description: 'Back',
   },
   product: {
-    id: 'payments.generic:product',
+    id: 'payments:generic.product',
     defaultMessage: 'Vara',
     description: 'Product',
   },
   amount: {
-    id: 'payments.generic:amount',
+    id: 'payments:generic.amount',
     defaultMessage: 'Upphæð',
     description: 'Amount',
   },
   paidAt: {
-    id: 'payments.generic:paidAt',
+    id: 'payments:generic.paidAt',
     defaultMessage: 'Greiðslutími',
     description: 'Paid at',
   },
   nationalId: {
-    id: 'payments.generic:nationalId',
+    id: 'payments:generic.nationalId',
     defaultMessage: 'Kennitala',
     description: 'National id',
   },
   name: {
-    id: 'payments.generic:name',
+    id: 'payments:generic.name',
     defaultMessage: 'Nafn',
     description: 'Name',
   },
@@ -60,52 +60,52 @@ export const generic = defineMessages({
 
 export const genericError = defineMessages({
   title: {
-    id: 'payments.genericError:title',
+    id: 'payments:genericError.title',
     defaultMessage: 'Eitthvað fór úrskeiðis',
     description: 'Something went wrong',
   },
   description: {
-    id: 'payments.genericError:description',
+    id: 'payments:genericError.description',
     defaultMessage: 'Vinsamlegast reynið aftur',
     description: 'Please try again',
   },
   fetchFailedTitle: {
-    id: 'payments.generic:fetchFailedTitle',
+    id: 'payments:generic.fetchFailedTitle',
     defaultMessage: 'Greiðsluflæði fannst ekki',
     description: 'Failed to fetch data for flow',
   },
   fetchFailed: {
-    id: 'payments.generic:fetchFailed',
+    id: 'payments:generic.fetchFailed',
     defaultMessage: '[Lengri skýring um hvað fór úrskeiðis]',
     description: 'Failed to fetch data for flow',
   },
   genericError: {
-    id: 'payments.generic:genericError',
+    id: 'payments:generic.genericError',
     defaultMessage: 'Eitthvað fór úrskeiðis',
     description: 'Something went wrong',
   },
   buttonTryAgain: {
-    id: 'payments.generic:buttonTryAgain',
+    id: 'payments:generic.buttonTryAgain',
     defaultMessage: 'Reyna aftur',
     description: 'Try again',
   },
   alreadyPaidTitle: {
-    id: 'payments.generic:alreadyPaidTitle',
+    id: 'payments:generic.alreadyPaidTitle',
     defaultMessage: 'Greiðsla þegar framkvæmd',
     description: 'Payment already made',
   },
   alreadyPaid: {
-    id: 'payments.generic:alreadyPaid',
+    id: 'payments:generic.alreadyPaid',
     defaultMessage: 'Það er nú þegar búið að greiða fyrir þessa vöru',
     description: 'Payment already made',
   },
   amountMismatchTitle: {
-    id: 'payments.generic:amountMismatchTitle',
+    id: 'payments:generic.amountMismatchTitle',
     defaultMessage: 'Upphæð ekki rétt',
     description: 'Amount mismatch',
   },
   amountMismatch: {
-    id: 'payments.generic:amountMismatch',
+    id: 'payments:generic.amountMismatch',
     defaultMessage: 'Upphæðin sem þú reyndir að greiða er ekki rétt',
     description: 'Amount mismatch',
   },

--- a/apps/payments/messages/invoice.ts
+++ b/apps/payments/messages/invoice.ts
@@ -2,22 +2,22 @@ import { defineMessages } from 'react-intl'
 
 export const invoice = defineMessages({
   paymentMethodTitle: {
-    id: 'payments.invoice:title',
+    id: 'payments:invoice.title',
     defaultMessage: 'Krafa í netbanka',
     description: 'Title for invoice payment method',
   },
   nationalIdOfPayer: {
-    id: 'payments.invoice:nationalIdOfPayer',
+    id: 'payments:invoice.nationalIdOfPayer',
     defaultMessage: 'Kennitala greiðanda',
     description: 'National id of payer',
   },
   invoiceReference: {
-    id: 'payments.invoice:invoiceReference',
+    id: 'payments:invoice.invoiceReference',
     defaultMessage: 'Tilvísun',
     description: 'Invoice reference',
   },
   create: {
-    id: 'payments.invoice:create',
+    id: 'payments:invoice.create',
     defaultMessage: 'Stofna kröfu',
     description: 'Create invoice',
   },
@@ -25,12 +25,12 @@ export const invoice = defineMessages({
 
 export const invoiceSuccess = defineMessages({
   title: {
-    id: 'payments.invoiceSuccess:title',
+    id: 'payments:invoiceSuccess.title',
     defaultMessage: 'Krafa stofnuð',
     description: 'Invoice created successfuly',
   },
   subTitle: {
-    id: 'payments.invoiceSuccess:subTitle',
+    id: 'payments:invoiceSuccess.subTitle',
     defaultMessage:
       '[Einhver texti um að krafa hafi verið stofnuð og verði send í netbanka]',
     description: 'Description on invoice creation and online bank',

--- a/apps/payments/pages/3ds/index.tsx
+++ b/apps/payments/pages/3ds/index.tsx
@@ -3,8 +3,9 @@ import { useLocale } from '@island.is/localization'
 
 import { PaymentCompleteIcon } from '../../components/PaymentCompleteIcon'
 import { threeDSecure } from '../../messages'
+import { withLocale } from '../../i18n/withLocale'
 
-export default function ThreeDSecureSuccessPage() {
+function ThreeDSecureSuccessPage() {
   const { formatMessage } = useLocale()
 
   return (
@@ -34,3 +35,5 @@ export default function ThreeDSecureSuccessPage() {
     </div>
   )
 }
+
+export default withLocale(ThreeDSecureSuccessPage)

--- a/apps/payments/pages/3ds/index.tsx
+++ b/apps/payments/pages/3ds/index.tsx
@@ -5,6 +5,7 @@ import { PaymentCompleteIcon } from '../../components/PaymentCompleteIcon'
 import { threeDSecure } from '../../messages'
 import { withLocale } from '../../i18n/withLocale'
 
+// eslint-disable-next-line func-style
 function ThreeDSecureSuccessPage() {
   const { formatMessage } = useLocale()
 

--- a/apps/payments/pages/[locale]/[paymentFlowId]/index.tsx
+++ b/apps/payments/pages/[locale]/[paymentFlowId]/index.tsx
@@ -1,9 +1,7 @@
 import { GetServerSideProps } from 'next'
 import { FormProvider, useForm } from 'react-hook-form'
-import { useRouter } from 'next/router'
-import Link from 'next/link'
 
-import { Box, Button } from '@island.is/island-ui/core'
+import { Box, Button, Link, LinkV2 } from '@island.is/island-ui/core'
 import { Features } from '@island.is/feature-flags'
 import { useLocale } from '@island.is/localization'
 import { findProblemInApolloError } from '@island.is/shared/problem'
@@ -176,7 +174,6 @@ function PaymentPage({
   organization,
   productInformation,
 }: PaymentPageProps) {
-  const router = useRouter()
   const methods = useForm({
     mode: 'onBlur',
     reValidateMode: 'onChange',
@@ -251,11 +248,11 @@ function PaymentPage({
               />
 
               <Box marginTop={4} width="full">
-                <Link href={paymentFlow.returnUrl ?? 'https://island.is'}>
-                  <Button fluid>
+                <LinkV2 href={paymentFlow.returnUrl ?? 'https://island.is'}>
+                  <Button fluid unfocusable>
                     {formatMessage(generic.buttonFinishAndReturn)}
                   </Button>
-                </Link>
+                </LinkV2>
               </Box>
             </>
           }
@@ -314,19 +311,11 @@ function PaymentPage({
                       : formatMessage(invoice.create)}
                   </Button>
                   <Box display="flex" justifyContent="center">
-                    <Button
-                      variant="text"
-                      disabled={overallIsSubmitting}
-                      onClick={() => {
-                        if (!overallIsSubmitting) {
-                          router.push(
-                            paymentFlow.returnUrl ?? 'https://island.is',
-                          )
-                        }
-                      }}
-                    >
-                      {formatMessage(generic.buttonCancel)}
-                    </Button>
+                    <LinkV2 href={paymentFlow.returnUrl ?? 'https://island.is'}>
+                      <Button unfocusable variant="text">
+                        {formatMessage(generic.buttonCancel)}
+                      </Button>
+                    </LinkV2>
                   </Box>
                 </Box>
               </form>

--- a/apps/payments/pages/[locale]/[paymentFlowId]/index.tsx
+++ b/apps/payments/pages/[locale]/[paymentFlowId]/index.tsx
@@ -42,6 +42,7 @@ import { PaymentReceipt } from '../../../components/PaymentReceipt'
 import { ThreeDSecure } from '../../../components/ThreeDSecure/ThreeDSecure'
 import { InvoiceReceipt } from '../../../components/InvoiceReceipt'
 import { usePaymentOrchestration } from '../../../hooks/usePaymentOrchestration'
+import { withLocale } from '../../../i18n/withLocale'
 
 interface PaymentPageProps {
   locale: string
@@ -170,7 +171,7 @@ export const getServerSideProps: GetServerSideProps<PaymentPageProps> = async (
   }
 }
 
-export default function PaymentPage({
+function PaymentPage({
   paymentFlow,
   organization,
   productInformation,
@@ -362,3 +363,5 @@ export default function PaymentPage({
     </>
   )
 }
+
+export default withLocale(PaymentPage)

--- a/apps/payments/pages/index.tsx
+++ b/apps/payments/pages/index.tsx
@@ -1,7 +1,11 @@
+import { GetServerSideProps } from 'next'
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  return {
+    notFound: true,
+  }
+}
+
 export default function HomePage() {
-  return (
-    <div>
-      <h1>Payments</h1>
-    </div>
-  )
+  return null
 }

--- a/apps/payments/project.json
+++ b/apps/payments/project.json
@@ -101,6 +101,12 @@
     "lint": {
       "executor": "@nx/eslint:lint"
     },
+    "extract-strings": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "yarn ts-node -P libs/localization/tsconfig.lib.json libs/localization/scripts/extract 'apps/payments/messages/*.ts'"
+      }
+    },
     "docker-next": {
       "executor": "Intentionally left blank, only so this target is valid when using `nx show projects --with-target docker-next`"
     }

--- a/apps/payments/utils/error/error.ts
+++ b/apps/payments/utils/error/error.ts
@@ -154,6 +154,11 @@ export const paymentErrorToTitleAndMessage = (
         title: genericError.amountMismatchTitle,
         message: genericError.amountMismatch,
       }
+    case CardErrorCode.RefundedBecauseOfSystemError:
+      return {
+        title: cardError.refundedBecauseOfSystemErrorTitle,
+        message: cardError.refundedBecauseOfSystemError,
+      }
     default:
       return {
         title: cardError.unknownTitle,


### PR DESCRIPTION
## What

Update message ids to use `payments` namespace, add extract script and extract translations to contentful

## Why

To be able to edit translations in Contentful and change locales

## Screenshots / Gifs

### Icelandic 
![image](https://github.com/user-attachments/assets/139d3561-22e4-4ba9-b603-f1149d0bd1f4)

### English
![image](https://github.com/user-attachments/assets/c029fa4e-9b85-42e9-907e-ad5ee51a536c)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced language toggle UI with programmatic route updates.
  - Added a localized higher-order component for payment components.
  - Updated message IDs for consistent internationalization keys.
  - Introduced a new extraction script for localized strings.

- **Bug Fixes**
  - Changed navigation from `<Link>` to `<LinkV2>` for better routing control.
  - Replaced anonymous page component with a named one for clarity.
  - Made the index page always return a 404 error.

- **Refactor**
  - Standardized message ID naming conventions across message files.
  - Converted default page exports to named functions wrapped with localization.
  - Updated route components to use new navigation components.
  - Added a new build target for extracting translation strings.

- **Style**
  - Updated link text color to a specific blue shade.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->