### PR TITLE
fix(signature-collection): Pass collectionType via connected component config

### DIFF
--- a/libs/island-ui/contentful/src/lib/RichTextRC/defaultRenderComponents.tsx
+++ b/libs/island-ui/contentful/src/lib/RichTextRC/defaultRenderComponents.tsx
@@ -44,11 +44,13 @@ export const renderConnectedComponent = (slice) => {
     case 'Lögmenn/Lawyers':
       return <LawyersList slice={slice} />
     case 'Meðmælalistar/SignatureLists':
-      // TODO: Urgent! Determine how to propagate the type
       return (
         <SignatureLists
           slice={slice}
-          collectionType={SignatureCollectionCollectionType.OtherUnknown}
+          collectionType={
+            (slice?.configJson?.collectionType ??
+              (SignatureCollectionCollectionType.OtherUnknown as unknown)) as SignatureCollectionCollectionType
+          }
         />
       )
     default:

--- a/libs/shared/connected/src/lib/SignatureLists/useGetSignatureLists.ts
+++ b/libs/shared/connected/src/lib/SignatureLists/useGetSignatureLists.ts
@@ -8,7 +8,9 @@ import {
 import { Query } from '@island.is/api/schema'
 
 export const GetLatestCollectionForType = gql`
-  query currentCollection($input: SignatureCollectionCollectionTypeInput) {
+  query collectionLatestForType(
+    $input: SignatureCollectionCollectionTypeInput!
+  ) {
     signatureCollectionLatestForType(input: $input) {
       id
       endTime


### PR DESCRIPTION
The connected component for the slicetype has been updated to contain information about the collection type in the jsonConfig.

This is so that the system can determine which collection to query from the signature-collection system (which now services Parliamentary, Presidential and Municipal).

Take note of the `CollectionType` enum.
At the time of this PR it is found here: https://github.com/island-is/island.is/blob/6cd81de19c5a39f2d0e0935cae7a6c09c057e422/libs/clients/signature-collection/src/lib/types/collection.dto.ts#L21-L30

Since this enum has a simple string representation we simply use the correct string for the collectionType in configJson for the connected component.


## Screens

### Presidential (not published, from draft state)
![image](https://github.com/user-attachments/assets/632d6606-203d-4feb-961a-bad28dffddb3)

### Example configuration in Contentful
![image](https://github.com/user-attachments/assets/f15d86bb-236f-4791-8916-a0df4bfeab65)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of the collection type in signature lists, allowing dynamic assignment based on configuration when available.

- **Chores**
  - Updated the GraphQL query for fetching signature collections to use a stricter, non-nullable input and a new query name for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->