### PR TITLE
fix(web): Encode uri when redirecting on organization parent subpages

### DIFF
--- a/apps/web/screens/Organization/Standalone/ParentSubpage.tsx
+++ b/apps/web/screens/Organization/Standalone/ParentSubpage.tsx
@@ -148,7 +148,6 @@ export const getProps: typeof StandaloneParentSubpage['getProps'] = async ({
   locale,
   query,
   organizationPage,
-  res,
 }) => {
   const [organizationPageSlug, parentSubpageSlug, subpageSlug] = (query.slugs ??
     []) as string[]
@@ -268,7 +267,7 @@ export const getProps: typeof StandaloneParentSubpage['getProps'] = async ({
   }
 
   if (!subpageSlug) {
-    throw new CustomNextRedirect(subpageLink.href)
+    throw new CustomNextRedirect(encodeURI(subpageLink.href))
   }
 
   const tableOfContentHeadings = getOrganizationParentSubpage.childLinks.map(


### PR DESCRIPTION
# Encode uri when redirecting on organization parent subpages

## Before
![Screenshot 2025-05-27 at 08 38 38](https://github.com/user-attachments/assets/e77467fb-92e3-49c8-81c0-974fdae89deb)

## After
![Screenshot 2025-05-27 at 08 38 57](https://github.com/user-attachments/assets/d9248282-c2d7-4c80-b1d6-8d7441a0b7b9)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of redirect URLs to ensure they are properly encoded when navigating due to a missing subpage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->