### PR TITLE
fix(rental-agreement): Validation when registering property via search results

### DIFF
--- a/libs/application/templates/rental-agreement/src/fields/PropertySearch/components/PropertyTableUnits.tsx
+++ b/libs/application/templates/rental-agreement/src/fields/PropertySearch/components/PropertyTableUnits.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { Checkbox, Table as T } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
 import {
@@ -48,6 +49,8 @@ export const PropertyTableUnits = ({
   onUnitRoomsChange,
 }: PropertyUnitsProps) => {
   const { formatMessage } = useLocale()
+  const [isRoomsFocused, setIsRoomsFocused] = useState(false)
+  const [isUnitsFocused, setIsUnitsFocused] = useState(false)
 
   // Prevent scrolling from changing the number input value
   const preventScrollChange = (event: React.WheelEvent<HTMLInputElement>) => {
@@ -128,7 +131,11 @@ export const PropertyTableUnits = ({
                 name="propertySize"
                 min={0}
                 step={0.1}
-                value={unitSizeValue}
+                value={
+                  isUnitsFocused && unitSizeValue === 0 ? '' : unitSizeValue
+                }
+                onFocus={() => setIsUnitsFocused(true)}
+                onBlur={() => setIsUnitsFocused(false)}
                 onChange={onUnitSizeChange}
                 onWheel={preventScrollChange}
                 disabled={isUnitSizeDisabled}
@@ -148,7 +155,11 @@ export const PropertyTableUnits = ({
               type="number"
               name="numOfRooms"
               min={0}
-              value={numOfRoomsValue}
+              value={
+                isRoomsFocused && numOfRoomsValue === 0 ? '' : numOfRoomsValue
+              }
+              onFocus={() => setIsRoomsFocused(true)}
+              onBlur={() => setIsRoomsFocused(false)}
               onChange={onUnitRoomsChange}
               onWheel={preventScrollChange}
               disabled={isNumOfRoomsDisabled}

--- a/libs/application/templates/rental-agreement/src/fields/PropertySearch/index.tsx
+++ b/libs/application/templates/rental-agreement/src/fields/PropertySearch/index.tsx
@@ -37,6 +37,8 @@ interface Props extends FieldBaseProps {
   errors?: Record<string, Record<string, string>>
 }
 
+const ERROR_ID = 'registerProperty'
+
 export const PropertySearch: FC<React.PropsWithChildren<Props>> = ({
   field,
   errors,
@@ -289,6 +291,7 @@ export const PropertySearch: FC<React.PropsWithChildren<Props>> = ({
       units: chosenUnits,
     })
     setCheckedUnits(updateCheckedUnits)
+    clearErrors(ERROR_ID)
   }
 
   const handleUnitSizeChange = (unit: Unit, value: number) => {
@@ -316,6 +319,7 @@ export const PropertySearch: FC<React.PropsWithChildren<Props>> = ({
       })
       return newValues
     })
+    clearErrors(ERROR_ID)
   }
 
   const handleUnitRoomsChange = (unit: Unit, value: number) => {
@@ -343,6 +347,7 @@ export const PropertySearch: FC<React.PropsWithChildren<Props>> = ({
       })
       return newValues
     })
+    clearErrors(ERROR_ID)
   }
 
   const handleAddressSelectionChange = (

--- a/libs/application/templates/rental-agreement/src/lib/schemas/propertySearchSchema.ts
+++ b/libs/application/templates/rental-agreement/src/lib/schemas/propertySearchSchema.ts
@@ -52,7 +52,10 @@ export const registerProperty = z
       .optional(),
   })
   .superRefine((data, ctx) => {
-    if (data?.searchresults?.units && data.searchresults.units.length < 1) {
+    if (
+      !data?.searchresults?.units ||
+      (data?.searchresults?.units && data.searchresults.units.length < 1)
+    ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'Custom error message',


### PR DESCRIPTION
# Validation when registering property via search results

https://app.asana.com/1/203394141643832/project/1208203457124855/task/1210223463608889

## What
- Clearing validation errors when user updates values
- Clears '0' from number input for better user experience
- Stops users when no unit is selected when registering property

## Why

To validate form and to give user better user experience

## Screenshots / Gifs

![registerProperty-validation](https://github.com/user-attachments/assets/841821ab-9e12-423b-890d-9d2f7fd68d62)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
