### PR TITLE
fix(services-payments): Process incoming charges and merge similar

### DIFF
--- a/apps/services/payments/src/app/paymentFlow/models/paymentFlow.model.ts
+++ b/apps/services/payments/src/app/paymentFlow/models/paymentFlow.model.ts
@@ -220,3 +220,4 @@ export class PaymentFlow extends Model<
 }
 
 export type PaymentFlowAttributes = InferAttributes<PaymentFlow>
+export type PaymentFlowChargeAttributes = InferAttributes<PaymentFlowCharge>

--- a/apps/services/payments/src/app/paymentFlow/paymentFlow.service.ts
+++ b/apps/services/payments/src/app/paymentFlow/paymentFlow.service.ts
@@ -37,11 +37,13 @@ import {
   generateChargeFJSPayload,
   mapFjsErrorToCode,
 } from '../../utils/fjsCharge'
+import { processCharges } from '../../utils/chargeUtils'
 import { PaymentFlowPaymentConfirmation } from './models/paymentFlowPaymentConfirmation.model'
 import { ChargeResponse } from '../cardPayment/cardPayment.types'
 import { retry } from '@island.is/shared/utils/server'
 import { PaymentTrackingData } from '../../types/cardPayment'
 import { onlyReturnKnownErrorCode } from '../../utils/paymentErrors'
+import { ChargeItem } from '../../utils/chargeUtils'
 
 interface PaymentFlowUpdateConfig {
   /**
@@ -81,10 +83,11 @@ export class PaymentFlowService {
   ): Promise<CreatePaymentFlowDTO> {
     try {
       const paymentFlowId = uuid()
+      const processedCharges = processCharges(paymentInfo.charges)
 
       const chargeDetails = await this.getPaymentFlowChargeDetails(
         paymentInfo.organisationId,
-        paymentInfo.charges,
+        processedCharges,
       )
 
       await this.chargeFjsV2ClientService.validateCharge(
@@ -110,7 +113,7 @@ export class PaymentFlowService {
       })
 
       await this.paymentFlowChargeModel.bulkCreate(
-        paymentInfo.charges.map((charge) => ({
+        processedCharges.map((charge) => ({
           ...charge,
           paymentFlowId,
         })),
@@ -119,7 +122,7 @@ export class PaymentFlowService {
       this.logger.info(
         `[${paymentFlow.id}] Payment flow created [${paymentFlow.organisationId}]`,
         {
-          charges: paymentInfo.charges.map((c) => c.chargeItemCode),
+          charges: processedCharges.map((c) => c.chargeItemCode),
         },
       )
 
@@ -150,7 +153,7 @@ export class PaymentFlowService {
 
   async getPaymentFlowChargeDetails(
     organisationId: string,
-    charges: Pick<PaymentFlowCharge, 'chargeItemCode' | 'price' | 'quantity'>[],
+    charges: ChargeItem[],
   ) {
     const { item } =
       await this.chargeFjsV2ClientService.getCatalogByPerformingOrg(
@@ -159,29 +162,31 @@ export class PaymentFlowService {
 
     const filteredChargeInformation: CatalogItemWithQuantity[] = []
 
-    for (const product of item) {
-      const matchingCharge = charges.find(
-        (c) => c.chargeItemCode === product.chargeItemCode,
+    for (const charge of charges) {
+      const catalogProduct = item.find(
+        (p) => p.chargeItemCode === charge.chargeItemCode,
       )
 
-      if (!matchingCharge) {
+      if (!catalogProduct) {
         continue
       }
 
-      const price = matchingCharge.price ?? product.priceAmount
+      const price = charge.price ?? catalogProduct.priceAmount
 
       filteredChargeInformation.push({
-        ...product,
+        ...catalogProduct,
         priceAmount: price,
-        quantity: matchingCharge.quantity,
+        quantity: charge.quantity,
+        chargeItemCode: catalogProduct.chargeItemCode,
       })
     }
 
     if (filteredChargeInformation.length !== charges.length) {
       this.logger.error(
-        `[${organisationId}] Failed to create payment flow: charge item codes not found`,
+        `[${organisationId}] Failed to create payment flow: charge item codes not found in FJS catalog or other mismatch.`,
         {
-          charges: charges.map((c) => c.chargeItemCode),
+          originalCharges: charges.map((c) => c.chargeItemCode),
+          processedCharges: charges.map((c) => c.chargeItemCode),
           filteredCharges: filteredChargeInformation.map(
             (c) => c.chargeItemCode,
           ),

--- a/apps/services/payments/src/app/paymentFlow/paymentFlow.service.ts
+++ b/apps/services/payments/src/app/paymentFlow/paymentFlow.service.ts
@@ -185,8 +185,7 @@ export class PaymentFlowService {
       this.logger.error(
         `[${organisationId}] Failed to create payment flow: charge item codes not found in FJS catalog or other mismatch.`,
         {
-          originalCharges: charges.map((c) => c.chargeItemCode),
-          processedCharges: charges.map((c) => c.chargeItemCode),
+          inputCharges: charges.map((c) => c.chargeItemCode),
           filteredCharges: filteredChargeInformation.map(
             (c) => c.chargeItemCode,
           ),

--- a/apps/services/payments/src/utils/chargeUtils.spec.ts
+++ b/apps/services/payments/src/utils/chargeUtils.spec.ts
@@ -1,0 +1,121 @@
+import { processCharges, ChargeItem } from './chargeUtils'
+
+const createCharge = (
+  chargeItemCode: string,
+  quantity: number,
+  price?: number,
+): ChargeItem => ({
+  chargeItemCode,
+  quantity,
+  price,
+  chargeType: 'test',
+})
+
+describe('processCharges', () => {
+  it('should return an empty array if input is empty or null', () => {
+    expect(processCharges([])).toEqual([])
+    expect(processCharges(null as any)).toEqual([])
+    expect(processCharges(undefined as any)).toEqual([])
+  })
+
+  it('should handle a simple list of unique charges', () => {
+    const charges: ChargeItem[] = [
+      createCharge('AY1', 1),
+      createCharge('AY2', 2),
+    ]
+    const expected: ChargeItem[] = [
+      createCharge('AY1', 1),
+      createCharge('AY2', 2),
+    ]
+    expect(processCharges(charges)).toEqual(expect.arrayContaining(expected))
+    expect(processCharges(charges).length).toBe(expected.length)
+  })
+
+  it('should combine charges with the same code and default price', () => {
+    const charges: ChargeItem[] = [
+      createCharge('AY1', 1),
+      createCharge('AY1', 2),
+      createCharge('AY2', 3),
+    ]
+    const expected: ChargeItem[] = [
+      createCharge('AY1', 3),
+      createCharge('AY2', 3),
+    ]
+    expect(processCharges(charges)).toEqual(expect.arrayContaining(expected))
+    expect(processCharges(charges).length).toBe(expected.length)
+  })
+
+  it('should not combine charges with the same code but different prices', () => {
+    const charges: ChargeItem[] = [
+      createCharge('AY1', 1), // Default price (undefined)
+      createCharge('AY1', 2, 100),
+      createCharge('AY2', 3),
+    ]
+    const expected: ChargeItem[] = [
+      createCharge('AY1', 1),
+      createCharge('AY1', 2, 100),
+      createCharge('AY2', 3),
+    ]
+    expect(processCharges(charges)).toEqual(expect.arrayContaining(expected))
+    expect(processCharges(charges).length).toBe(expected.length)
+  })
+
+  it('should handle a complex case with multiple combinations and distinct items', () => {
+    const charges: ChargeItem[] = [
+      createCharge('AY1', 1), // No price changes
+      createCharge('AY2', 2, 50), // Custom price (50)
+      createCharge('AY1', 3), // No price changes
+      createCharge('AY3', 4), // Unique charge
+      createCharge('AY2', 5, 50), // Custom price (50)
+      createCharge('AY1', 2, 200), // Custom price (200)
+      createCharge('AY1', 1), // No price changes
+      createCharge('AY2', 1, 75), // Custom price (75)
+    ]
+    const expected: ChargeItem[] = [
+      createCharge('AY1', 5), // No price changes
+      createCharge('AY2', 7, 50), // Custom price (50)
+      createCharge('AY3', 4), // Unique charge
+      createCharge('AY1', 2, 200), // Custom price (200)
+      createCharge('AY2', 1, 75), // Custom price (75)
+    ]
+
+    const result = processCharges(charges)
+    // Using arrayContaining because the order of items from Map.values() is not guaranteed
+    expect(result).toEqual(expect.arrayContaining(expected))
+    expect(result.length).toBe(expected.length)
+  })
+
+  it('should handle charges with different charge types (derived from code)', () => {
+    const charges: ChargeItem[] = [
+      createCharge('AY1', 1),
+      createCharge('AY1', 2),
+      createCharge('AY1', 3),
+      createCharge('BX1', 4), // Different charge type (BX)
+      createCharge('BX1', 5), // Different charge type (BX)
+    ]
+    const expected: ChargeItem[] = [
+      createCharge('AY1', 6),
+      createCharge('BX1', 9),
+    ]
+    const result = processCharges(charges)
+    expect(result).toEqual(expect.arrayContaining(expected))
+    expect(result.length).toBe(expected.length)
+  })
+
+  it('should handle charges with same code, different prices, and different charge types', () => {
+    const charges: ChargeItem[] = [
+      createCharge('AY1', 1, 10),
+      createCharge('AY1', 2, 20),
+      createCharge('BX1', 3, 10),
+      createCharge('AY1', 4, 10),
+    ]
+    const expected: ChargeItem[] = [
+      createCharge('AY1', 5, 10),
+      createCharge('AY1', 2, 20),
+      createCharge('BX1', 3, 10),
+    ]
+    const result = processCharges(charges)
+    expect(result).toEqual(expect.arrayContaining(expected))
+    expect(result.length).toBe(expected.length)
+  })
+})

--- a/apps/services/payments/src/utils/chargeUtils.spec.ts
+++ b/apps/services/payments/src/utils/chargeUtils.spec.ts
@@ -14,7 +14,9 @@ const createCharge = (
 describe('processCharges', () => {
   it('should return an empty array if input is empty or null', () => {
     expect(processCharges([])).toEqual([])
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect(processCharges(null as any)).toEqual([])
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect(processCharges(undefined as any)).toEqual([])
   })
 

--- a/apps/services/payments/src/utils/chargeUtils.ts
+++ b/apps/services/payments/src/utils/chargeUtils.ts
@@ -1,0 +1,34 @@
+import { PaymentFlowChargeAttributes } from '../app/paymentFlow/models/paymentFlow.model'
+
+export type ChargeItem = Pick<
+  PaymentFlowChargeAttributes,
+  'chargeItemCode' | 'quantity' | 'price' | 'chargeType'
+>
+
+export const processCharges = (charges: ChargeItem[]): ChargeItem[] => {
+  if (!charges || charges.length === 0) {
+    return []
+  }
+
+  const chargeMap = new Map<string, ChargeItem>()
+
+  for (const charge of charges) {
+    // Use a composite key of chargeItemCode and price.
+    // If price is undefined, use "default" string to differentiate from a price of 0.
+    const priceKey = charge.price === undefined ? 'default' : charge.price
+    const key = `${charge.chargeItemCode}-${priceKey}`
+
+    if (chargeMap.has(key)) {
+      const existingCharge = chargeMap.get(key) as ChargeItem
+
+      chargeMap.set(key, {
+        ...existingCharge,
+        quantity: existingCharge.quantity + charge.quantity,
+      })
+    } else {
+      chargeMap.set(key, { ...charge })
+    }
+  }
+
+  return Array.from(chargeMap.values())
+}


### PR DESCRIPTION
## What

Upstream systems might try to create payment flows with non-consistent list of charges, perhaps like

```typescript
[{ chargeItemCode: 'A', quantity: 1 }, { chargeItemCode: 'A', quantity: 1 }]
```

Instead of

```typescript
[{ chargeItemCode: 'A', quantity: 2 }]
```

This PR processes incoming charges and merges similar into one.

## Why

To avoid validation issues

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved processing of payment charges to automatically combine charges with the same code and price, resulting in clearer and more accurate payment summaries.
  - Added support for detailed charge handling in payment flows, enhancing price and quantity accuracy.

- **Bug Fixes**
  - Enhanced error logging for payment charge mismatches, providing more detailed diagnostic information.

- **Tests**
  - Added comprehensive tests to ensure correct handling and grouping of payment charges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->