### PR TITLE
fix(web): Fine calculator, multiply price by amount selected

### DIFF
--- a/apps/web/components/connected/logreglan/FineCalculator/FineCalculator.tsx
+++ b/apps/web/components/connected/logreglan/FineCalculator/FineCalculator.tsx
@@ -146,7 +146,11 @@ const FineCalculatorDetails = ({
                 {formatCurrency(fine.price * fine.amountSelected)}
               </Table.Data>
               <Table.Data align="right">
-                {formatCurrency(fine.price * QUARTER_OFF_FINE_MULTIPLIER)}
+                {formatCurrency(
+                  fine.price *
+                    fine.amountSelected *
+                    QUARTER_OFF_FINE_MULTIPLIER,
+                )}
               </Table.Data>
               <Table.Data align="right">{fine.points}</Table.Data>
             </Table.Row>

--- a/apps/web/components/connected/logreglan/FineCalculator/FineCalculator.tsx
+++ b/apps/web/components/connected/logreglan/FineCalculator/FineCalculator.tsx
@@ -143,7 +143,7 @@ const FineCalculatorDetails = ({
                 {fine.law} {fine.title} x {fine.amountSelected}
               </Table.Data>
               <Table.Data align="right">
-                {formatCurrency(fine.price)}
+                {formatCurrency(fine.price * fine.amountSelected)}
               </Table.Data>
               <Table.Data align="right">
                 {formatCurrency(fine.price * QUARTER_OFF_FINE_MULTIPLIER)}


### PR DESCRIPTION
# Fine calculator, multiply price by amount selected

Now we aren't showing the correct price (the 2nd row should display 60.000kr not 20.000kr), this PR will change that.
![image](https://github.com/user-attachments/assets/67d9f37f-4524-48ea-8d63-a4a3fa17db23)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the fine calculator to correctly display total fine prices based on the selected quantity, ensuring both full and discounted prices reflect the total amount chosen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->