### PR TITLE
fix(rental-agreement): revert searchresult input validation

### DIFF
--- a/libs/application/templates/rental-agreement/src/fields/PropertySearch/components/PropertyTableUnits.tsx
+++ b/libs/application/templates/rental-agreement/src/fields/PropertySearch/components/PropertyTableUnits.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { Checkbox, Table as T } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
 import {

--- a/libs/application/templates/rental-agreement/src/fields/PropertySearch/components/PropertyTableUnits.tsx
+++ b/libs/application/templates/rental-agreement/src/fields/PropertySearch/components/PropertyTableUnits.tsx
@@ -49,8 +49,6 @@ export const PropertyTableUnits = ({
   onUnitRoomsChange,
 }: PropertyUnitsProps) => {
   const { formatMessage } = useLocale()
-  const [isRoomsFocused, setIsRoomsFocused] = useState(false)
-  const [isUnitsFocused, setIsUnitsFocused] = useState(false)
 
   // Prevent scrolling from changing the number input value
   const preventScrollChange = (event: React.WheelEvent<HTMLInputElement>) => {
@@ -131,11 +129,7 @@ export const PropertyTableUnits = ({
                 name="propertySize"
                 min={0}
                 step={0.1}
-                value={
-                  isUnitsFocused && unitSizeValue === 0 ? '' : unitSizeValue
-                }
-                onFocus={() => setIsUnitsFocused(true)}
-                onBlur={() => setIsUnitsFocused(false)}
+                value={unitSizeValue}
                 onChange={onUnitSizeChange}
                 onWheel={preventScrollChange}
                 disabled={isUnitSizeDisabled}
@@ -155,11 +149,7 @@ export const PropertyTableUnits = ({
               type="number"
               name="numOfRooms"
               min={0}
-              value={
-                isRoomsFocused && numOfRoomsValue === 0 ? '' : numOfRoomsValue
-              }
-              onFocus={() => setIsRoomsFocused(true)}
-              onBlur={() => setIsRoomsFocused(false)}
+              value={numOfRoomsValue}
               onChange={onUnitRoomsChange}
               onWheel={preventScrollChange}
               disabled={isNumOfRoomsDisabled}

--- a/libs/application/templates/rental-agreement/src/fields/PropertySearch/index.tsx
+++ b/libs/application/templates/rental-agreement/src/fields/PropertySearch/index.tsx
@@ -37,8 +37,6 @@ interface Props extends FieldBaseProps {
   errors?: Record<string, Record<string, string>>
 }
 
-const ERROR_ID = 'registerProperty'
-
 export const PropertySearch: FC<React.PropsWithChildren<Props>> = ({
   field,
   errors,
@@ -291,7 +289,6 @@ export const PropertySearch: FC<React.PropsWithChildren<Props>> = ({
       units: chosenUnits,
     })
     setCheckedUnits(updateCheckedUnits)
-    clearErrors(ERROR_ID)
   }
 
   const handleUnitSizeChange = (unit: Unit, value: number) => {
@@ -319,7 +316,6 @@ export const PropertySearch: FC<React.PropsWithChildren<Props>> = ({
       })
       return newValues
     })
-    clearErrors(ERROR_ID)
   }
 
   const handleUnitRoomsChange = (unit: Unit, value: number) => {
@@ -347,7 +343,6 @@ export const PropertySearch: FC<React.PropsWithChildren<Props>> = ({
       })
       return newValues
     })
-    clearErrors(ERROR_ID)
   }
 
   const handleAddressSelectionChange = (

--- a/libs/application/templates/rental-agreement/src/lib/schemas/propertySearchSchema.ts
+++ b/libs/application/templates/rental-agreement/src/lib/schemas/propertySearchSchema.ts
@@ -52,10 +52,7 @@ export const registerProperty = z
       .optional(),
   })
   .superRefine((data, ctx) => {
-    if (
-      !data?.searchresults?.units ||
-      (data?.searchresults?.units && data.searchresults.units.length < 1)
-    ) {
+    if (data?.searchresults?.units && data.searchresults.units.length < 1) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'Custom error message',


### PR DESCRIPTION
# revert searchresult input validation

These changes causing unexpected behavior in production, reverting.
https://github.com/island-is/island.is/pull/19132/files

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved input field behavior in the property unit table to consistently display values regardless of focus.
  - Adjusted property validation to require units only if present, reducing unnecessary validation errors.
- **Chores**
  - Simplified error handling by removing redundant error clearing logic for property registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->