### PR TITLE
fix(user-notifications): Infra flag fix for birthday worker

### DIFF
--- a/apps/services/user-notification/infra/user-notification.ts
+++ b/apps/services/user-notification/infra/user-notification.ts
@@ -209,7 +209,12 @@ export const userNotificationBirthdayWorkerSetup = (services: {
     .codeOwner(CodeOwners.Juni)
     .db({ name: 'user-notification' })
     .command('node')
-    .args('--no-experimental-fetch', 'main.js', '--job=worker')
+    .args(
+      '--no-experimental-fetch',
+      'main.js',
+      '--job=worker',
+      '--isBirthdayWorker',
+    )
     .redis()
     .env({ ...getEnv(services) })
     .secrets({

--- a/charts/islandis-services/user-notification-birthday-worker/values.dev.yaml
+++ b/charts/islandis-services/user-notification-birthday-worker/values.dev.yaml
@@ -21,6 +21,7 @@ args:
   - '--no-experimental-fetch'
   - 'main.js'
   - '--job=worker'
+  - '--isBirthdayWorker'
 command:
   - 'node'
 enabled: true

--- a/charts/islandis-services/user-notification-birthday-worker/values.prod.yaml
+++ b/charts/islandis-services/user-notification-birthday-worker/values.prod.yaml
@@ -21,6 +21,7 @@ args:
   - '--no-experimental-fetch'
   - 'main.js'
   - '--job=worker'
+  - '--isBirthdayWorker'
 command:
   - 'node'
 enabled: true

--- a/charts/islandis-services/user-notification-birthday-worker/values.staging.yaml
+++ b/charts/islandis-services/user-notification-birthday-worker/values.staging.yaml
@@ -21,6 +21,7 @@ args:
   - '--no-experimental-fetch'
   - 'main.js'
   - '--job=worker'
+  - '--isBirthdayWorker'
 command:
   - 'node'
 enabled: true

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -3648,6 +3648,7 @@ user-notification-birthday-worker:
     - '--no-experimental-fetch'
     - 'main.js'
     - '--job=worker'
+    - '--isBirthdayWorker'
   command:
     - 'node'
   enabled: true

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -3439,6 +3439,7 @@ user-notification-birthday-worker:
     - '--no-experimental-fetch'
     - 'main.js'
     - '--job=worker'
+    - '--isBirthdayWorker'
   command:
     - 'node'
   enabled: true

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -3296,6 +3296,7 @@ user-notification-birthday-worker:
     - '--no-experimental-fetch'
     - 'main.js'
     - '--job=worker'
+    - '--isBirthdayWorker'
   command:
     - 'node'
   enabled: true


### PR DESCRIPTION
The infra definition for the user-notification-birthday-worker was missing a flag for control flow
## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new flag to the birthday notification worker, improving identification and handling of birthday-related notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->