### PR TITLE
feat(application-system): access to the application in the format in the tableRepeater

### DIFF
--- a/apps/web/components/connected/logreglan/FineCalculator/FineCalculator.tsx
+++ b/apps/web/components/connected/logreglan/FineCalculator/FineCalculator.tsx
@@ -143,10 +143,14 @@ const FineCalculatorDetails = ({
                 {fine.law} {fine.title} x {fine.amountSelected}
               </Table.Data>
               <Table.Data align="right">
-                {formatCurrency(fine.price)}
+                {formatCurrency(fine.price * fine.amountSelected)}
               </Table.Data>
               <Table.Data align="right">
-                {formatCurrency(fine.price * QUARTER_OFF_FINE_MULTIPLIER)}
+                {formatCurrency(
+                  fine.price *
+                    fine.amountSelected *
+                    QUARTER_OFF_FINE_MULTIPLIER,
+                )}
               </Table.Data>
               <Table.Data align="right">{fine.points}</Table.Data>
             </Table.Row>

--- a/libs/application/templates/examples/example-inputs/src/forms/mainForm/tablesAndRepeatersSection/tableRepeaterSubsection.ts
+++ b/libs/application/templates/examples/example-inputs/src/forms/mainForm/tablesAndRepeatersSection/tableRepeaterSubsection.ts
@@ -27,6 +27,11 @@ export const tableRepeaterSubsection = buildSubSection({
             'In the table repeater, you can use input, select, radio, checkbox, date, nationalIdWithName and phone as well as async select fields. The nationalIdWithName field can, just like the regular one, be set to enable company search. The async select fields can be used to load data from a remote source and they can also be set to update based on selections in other fields in the current form instance.',
         }),
         buildTableRepeaterField({
+          condition: (answers, externalData) => {
+            console.log('answers', answers)
+            console.log('externalData', externalData)
+            return true
+          },
           id: 'tableRepeater',
           title: 'Table Repeater Field',
           formTitle: 'Table Repeater Form Title', // Todo: doesn't work
@@ -39,6 +44,7 @@ export const tableRepeaterSubsection = buildSubSection({
           getStaticTableData: (_application) => {
             // Possibility to populate the table with data from the answers or external data
             // Populated data will not be editable or deletable
+            // The prepopulated data will not be automatically run through the format function
             return [
               {
                 input: 'John Doe',
@@ -159,8 +165,11 @@ export const tableRepeaterSubsection = buildSubSection({
           },
           table: {
             // Format values for display in the table
+            // In the format function, you can use the value, index in the repeater and the application object
             format: {
-              input: (value) => `${value} - custom format`,
+              input: (value, _i, _application) => {
+                return `${value} - custom format`
+              },
               nationalIdWithName: (value) => {
                 return `${value} - custom format`
               },

--- a/libs/application/templates/examples/example-inputs/src/forms/mainForm/tablesAndRepeatersSection/tableRepeaterSubsection.ts
+++ b/libs/application/templates/examples/example-inputs/src/forms/mainForm/tablesAndRepeatersSection/tableRepeaterSubsection.ts
@@ -27,11 +27,6 @@ export const tableRepeaterSubsection = buildSubSection({
             'In the table repeater, you can use input, select, radio, checkbox, date, nationalIdWithName and phone as well as async select fields. The nationalIdWithName field can, just like the regular one, be set to enable company search. The async select fields can be used to load data from a remote source and they can also be set to update based on selections in other fields in the current form instance.',
         }),
         buildTableRepeaterField({
-          condition: (answers, externalData) => {
-            console.log('answers', answers)
-            console.log('externalData', externalData)
-            return true
-          },
           id: 'tableRepeater',
           title: 'Table Repeater Field',
           formTitle: 'Table Repeater Form Title', // Todo: doesn't work

--- a/libs/application/types/src/lib/Fields.ts
+++ b/libs/application/types/src/lib/Fields.ts
@@ -745,7 +745,14 @@ export type TableRepeaterField = BaseField & {
      * if not provided it will be auto generated from the fields
      */
     rows?: string[]
-    format?: Record<string, (value: string) => string | StaticText>
+    format?: Record<
+      string,
+      (
+        value: string,
+        index: number,
+        application?: Application,
+      ) => string | StaticText
+    >
   }
   initActiveFieldIfEmpty?: boolean
 }

--- a/libs/application/ui-fields/src/lib/TableRepeaterFormField/TableRepeaterFormField.tsx
+++ b/libs/application/ui-fields/src/lib/TableRepeaterFormField/TableRepeaterFormField.tsx
@@ -4,6 +4,7 @@ import {
   formatTextWithLocale,
 } from '@island.is/application/core'
 import {
+  Application,
   FieldBaseProps,
   TableRepeaterField,
 } from '@island.is/application/types'
@@ -151,10 +152,17 @@ export const TableRepeaterFormField: FC<Props> = ({
     setIsEditing(true)
   }
 
-  const formatTableValue = (key: string, item: Record<string, string>) => {
+  const formatTableValue = (
+    key: string,
+    item: Record<string, string>,
+    index: number,
+    application: Application,
+  ) => {
     item[key] = item[key] ?? ''
     const formatFn = table?.format?.[key]
-    const formatted = formatFn ? formatFn(item[key]) : item[key]
+    const formatted = formatFn
+      ? formatFn(item[key], index, application)
+      : item[key]
     return typeof formatted === 'string'
       ? formatted
       : Array.isArray(formatted)
@@ -213,10 +221,8 @@ export const TableRepeaterFormField: FC<Props> = ({
                 staticData.map((item, index) => (
                   <T.Row key={index}>
                     <T.Data></T.Data>
-                    {Object.keys(item).map((key, index) => (
-                      <T.Data key={`static-${key}-${index}`}>
-                        {formatTableValue(key, item)}
-                      </T.Data>
+                    {Object.keys(item).map((key, idx) => (
+                      <T.Data key={`static-${key}-${idx}`}>{item[key]}</T.Data>
                     ))}
                   </T.Row>
                 ))}
@@ -277,6 +283,8 @@ export const TableRepeaterFormField: FC<Props> = ({
                           customMappedValues.length
                             ? customMappedValues[index]
                             : values[index],
+                          index,
+                          application,
                         )}
                       </T.Data>
                     ))}


### PR DESCRIPTION
## What

When formatting a display value in the table of the table repeater, you only had access to the value that was filled in. Now you can have access to the index of the line in the repeater and the application object to handle more complex needs for formatting.

## Why

Requested need to get access to the application object

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced table field formatting to allow custom formatting functions access to additional context, including the row index and application state.

- **Documentation**
  - Added clarifying comments to improve understanding of table data formatting behavior and function parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->