### PR TITLE
fix(application-system): Handle 3xx and 4xx status codes separately from 500 errors

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/template-api.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/template-api.service.ts
@@ -75,18 +75,17 @@ export class TemplateAPIService {
 
     const httpError = error as unknown as HttpError
 
-    if (httpError.http) {
-      if (
-        httpError.http.status_code >= 300 &&
-        httpError.http.status_code < 500
-      ) {
-        this.logger.info(`PerformAction error`, {
-          stack: error?.stack,
-          templateId: action.templateId,
-          actionId: action.actionId,
-          applicationId: action.props.application.id,
-        })
-      }
+    if (
+      httpError.http &&
+      httpError.http.status_code >= 300 &&
+      httpError.http.status_code < 500
+    ) {
+      this.logger.info(`PerformAction error`, {
+        stack: error?.stack,
+        templateId: action.templateId,
+        actionId: action.actionId,
+        applicationId: action.props.application.id,
+      })
     } else if (
       problemError?.problem?.status &&
       problemError?.problem?.status >= 500

--- a/libs/application/template-api-modules/src/lib/modules/template-api.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/template-api.service.ts
@@ -67,7 +67,21 @@ export class TemplateAPIService {
         ? (error as TemplateApiError)
         : new TemplateApiError(coreErrorMessages.defaultTemplateApiError, 500)
 
-    if (problemError?.problem?.status && problemError?.problem?.status >= 500) {
+    if (
+      problemError?.problem?.status &&
+      problemError?.problem?.status >= 300 &&
+      problemError?.problem?.status < 500
+    ) {
+      this.logger.info(`PerformAction error`, {
+        stack: error?.stack,
+        templateId: action.templateId,
+        actionId: action.actionId,
+        applicationId: action.props.application.id,
+      })
+    } else if (
+      problemError?.problem?.status &&
+      problemError?.problem?.status >= 500
+    ) {
       this.logger.error(`PerformAction error`, {
         ...error,
         stack: error?.stack,

--- a/libs/application/template-api-modules/src/lib/modules/template-api.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/template-api.service.ts
@@ -15,6 +15,12 @@ export interface ApplicationApiAction<Params = unknown> {
   props: TemplateApiModuleActionProps<Params>
 }
 
+interface HttpError {
+  http?: {
+    status_code: number
+  }
+}
+
 @Injectable()
 export class TemplateAPIService {
   constructor(
@@ -67,17 +73,20 @@ export class TemplateAPIService {
         ? (error as TemplateApiError)
         : new TemplateApiError(coreErrorMessages.defaultTemplateApiError, 500)
 
-    if (
-      problemError?.problem?.status &&
-      problemError?.problem?.status >= 300 &&
-      problemError?.problem?.status < 500
-    ) {
-      this.logger.info(`PerformAction error`, {
-        stack: error?.stack,
-        templateId: action.templateId,
-        actionId: action.actionId,
-        applicationId: action.props.application.id,
-      })
+    const httpError = error as unknown as HttpError
+
+    if (httpError.http) {
+      if (
+        httpError.http.status_code >= 300 &&
+        httpError.http.status_code < 500
+      ) {
+        this.logger.info(`PerformAction error`, {
+          stack: error?.stack,
+          templateId: action.templateId,
+          actionId: action.actionId,
+          applicationId: action.props.application.id,
+        })
+      }
     } else if (
       problemError?.problem?.status &&
       problemError?.problem?.status >= 500


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Stop logging 3xx and 4xx statuses as errors and log them as info instead and no longer log the entire http response.

## Why

4xx class responses should not be handled as system errors as they represent user errors.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error logging to provide clearer information based on the type of error encountered. Errors with status codes from 300 to 499 now generate informational logs, while errors with status codes 500 or above continue to generate error-level logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->