### PR TITLE
fix(j-s): Updating title on table and undoing change on title on case table group

### DIFF
--- a/libs/judicial-system/types/src/lib/tables/caseTable.ts
+++ b/libs/judicial-system/types/src/lib/tables/caseTable.ts
@@ -134,7 +134,7 @@ const districtCourtRequestCasesInProgressColumnKeys: CaseTableColumnKey[] = [
 ]
 
 const districtCourtRequestCasesInProgress: CaseTable = {
-  title: 'Mál í vinnslu',
+  title: 'Rannsóknarmál í vinnslu',
   hasMyCasesFilter: true,
   columnKeys: districtCourtRequestCasesInProgressColumnKeys,
   columns: pickColumns(districtCourtRequestCasesInProgressColumnKeys),

--- a/libs/judicial-system/types/src/lib/tables/caseTableGroup.ts
+++ b/libs/judicial-system/types/src/lib/tables/caseTableGroup.ts
@@ -90,7 +90,7 @@ const courtOfAppealsTableGroups: CaseTableGroup[] = [
       {
         type: CaseTableType.COURT_OF_APPEALS_IN_PROGRESS,
         route: 'mal-i-vinnslu',
-        title: 'Rannsóknarmál mál í vinnslu',
+        title: 'Mál í vinnslu',
         description: 'Kærð sakamál sem eru til meðferðar.',
       },
       {


### PR DESCRIPTION
# ...

[Málalisti héraðsdóms - Rannsóknarmál í vinnslu, laga titil (textabreyting)](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1210398905824360)

## What

- Updating name on table 
- Taking back the case table group the updated name 

## Why

- title was updated on the wrong place 

## Screenshots / Gifs
<img width="1370" alt="Screenshot 2025-06-03 at 13 10 12" src="https://github.com/user-attachments/assets/866b08a5-bc8d-4955-af28-2639e1a8768f" />

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated table titles for ongoing cases to improve clarity in both district court and court of appeals sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->