### PR TITLE
fix(web): Pension Calculator, getDateOfCalculationsOptions() - Copy array so we can .unshift() later

### DIFF
--- a/apps/web/screens/Organization/SocialInsuranceAdministration/utils.ts
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/utils.ts
@@ -95,28 +95,29 @@ export const convertToQueryParams = <T>(data: T) => {
 }
 
 export const getDateOfCalculationsOptions = (pageData?: CustomPage | null) => {
-  const options: Option<string>[] = pageData?.configJson
-    ?.dateOfCalculationOptions ?? [
-    {
-      label: '2024',
-      value: new Date(2024, 11, 31).toISOString(),
-    },
-    {
-      label: '2023 (júl-des)',
-      value: new Date(2023, 11, 31).toISOString(),
-    },
-    {
-      label: '2023 (jan-jún)',
-      value: new Date(2023, 5, 30).toISOString(),
-    },
-    {
-      label: '2022 (jún-des)',
-      value: new Date(2022, 11, 31).toISOString(),
-    },
-    {
-      label: '2022 (jan-maí)',
-      value: new Date(2022, 5, 31).toISOString(),
-    },
+  const options: Option<string>[] = [
+    ...(pageData?.configJson?.dateOfCalculationOptions ?? [
+      {
+        label: '2024',
+        value: new Date(2024, 11, 31).toISOString(),
+      },
+      {
+        label: '2023 (júl-des)',
+        value: new Date(2023, 11, 31).toISOString(),
+      },
+      {
+        label: '2023 (jan-jún)',
+        value: new Date(2023, 5, 30).toISOString(),
+      },
+      {
+        label: '2022 (jún-des)',
+        value: new Date(2022, 11, 31).toISOString(),
+      },
+      {
+        label: '2022 (jan-maí)',
+        value: new Date(2022, 5, 31).toISOString(),
+      },
+    ]),
   ]
 
   const missingYearOptions: Option<string>[] = []


### PR DESCRIPTION
# Pension Calculator, getDateOfCalculationsOptions() - Copy array so we can .unshift() later

## What

If there is a value in the config coming from the cms then the code will have the following error since the cms data isn't happy with us mutating it 😅 

![Screenshot 2025-06-05 at 10 06 23](https://github.com/user-attachments/assets/b580557e-bc32-49ef-a4f7-699cc03fb58c)

The solution is to simply copy the array instead.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the handling of date options to ensure more reliable and consistent display of calculation date choices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->