### PR TITLE
fix(j-s): arraignmentDate formatting

### DIFF
--- a/apps/judicial-system/web/src/routes/Shared/CaseTable/CaseTable.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/CaseTable/CaseTable.tsx
@@ -44,11 +44,7 @@ const compare = (a: CaseTableCell, b: CaseTableCell): number => {
 }
 
 const renderString = (value: StringValue) => {
-  return (
-    <Text as="span" variant="small">
-      {value.str}
-    </Text>
-  )
+  return <Text>{value.str}</Text>
 }
 
 const renderStringGroup = (value: StringGroupValue) => {


### PR DESCRIPTION
# [Fix arraignmentDate format](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1210468369838871)

## What
- Fix indictment arraignment dates
- Fix investigation arraignment date format
- Fix styles in `str` cell render component

## Why
- It is the expected formatting

## Screenshots / Gifs
R-case arraignment column
<img width="1415" alt="Screenshot 2025-06-05 at 13 14 49" src="https://github.com/user-attachments/assets/35a84fcb-b867-4a1e-80ba-5f6b3beed2bb" />

S-case arraignment column
<img width="1339" alt="Screenshot 2025-06-05 at 13 12 28" src="https://github.com/user-attachments/assets/90e105f4-e6cc-46f4-9892-b6c6708b711e" />

Str column before
![Screenshot 2025-06-05 at 13 19 49](https://github.com/user-attachments/assets/48a0b157-e566-408e-9641-8fb3255a632a)

Str column after
<img width="273" alt="Screenshot 2025-06-05 at 13 20 23" src="https://github.com/user-attachments/assets/51fdab2e-4a2b-4f29-9a38-449fd8332828" />


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
