### PR TITLE
fix(web): Remove margin from richText rendering wrapper

### DIFF
--- a/apps/web/components/Organization/Slice/AccordionSlice/AccordionSlice.tsx
+++ b/apps/web/components/Organization/Slice/AccordionSlice/AccordionSlice.tsx
@@ -104,8 +104,8 @@ export const AccordionSlice: React.FC<React.PropsWithChildren<SliceProps>> = ({
           ))}
 
         {slice.type === 'category_card' &&
-          (slice.accordionItems ?? []).map((item, index) => (
-            <Box marginTop={index ? 4 : 0} key={item.id}>
+          (slice.accordionItems ?? []).map((item) => (
+            <Box marginTop={4} key={item.id}>
               <CategoryCard
                 href={item.link?.url}
                 heading={item.title}

--- a/apps/web/utils/richText.tsx
+++ b/apps/web/utils/richText.tsx
@@ -363,5 +363,7 @@ export const webRichText = (
       },
     },
     activeLocale,
+    0,
+    0,
   )
 }

--- a/libs/island-ui/contentful/src/lib/RichTextRC/RichText.tsx
+++ b/libs/island-ui/contentful/src/lib/RichTextRC/RichText.tsx
@@ -22,7 +22,7 @@ import { TellUsAStoryFormProps } from '../TellUsAStoryForm/TellUsAStoryForm'
 import { defaultRenderNodeObject } from './defaultRenderNode'
 import { defaultRenderMarkObject } from './defaultRenderMark'
 import { defaultRenderComponentObject } from './defaultRenderComponents'
-import { Box } from '@island.is/island-ui/core'
+import { Box, type ResponsiveSpace } from '@island.is/island-ui/core'
 
 type HtmlSlice = { __typename: 'Html'; id: string; document: Document }
 type FaqListSlice = { __typename: 'FaqList'; id: string } & FaqListProps
@@ -118,12 +118,16 @@ type RichText = (
       }
     | { renderNode?: {}; renderMark?: {}; renderComponent?: {} },
   locale?: Locale,
+  marginBottom?: ResponsiveSpace ,
+  marginTop?: ResponsiveSpace ,
 ) => React.ReactNode
 
 export const richText: RichText = (
   documents,
   opt = { renderNode: {}, renderMark: {}, renderComponent: {} },
   locale = 'is',
+  marginBottom = [5, 5, 5, 6],
+  marginTop = [5, 5, 5, 6],
 ) => {
   const options = {
     renderText: (text: string) => {
@@ -157,8 +161,8 @@ export const richText: RichText = (
       <Box
         key={slice.id}
         id={slice.id}
-        marginBottom={[5, 5, 5, 6]}
-        marginTop={[5, 5, 5, 6]}
+        marginBottom={marginBottom}
+        marginTop={marginTop}
       >
         {
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment


### PR DESCRIPTION
# Remove margin from richText rendering wrapper

## Screenshots / Gifs

### Before

![Screenshot 2025-06-05 at 15 59 34](https://github.com/user-attachments/assets/1c1cd9ed-7f40-49db-b881-98f23aae3f16)

### After

![Screenshot 2025-06-05 at 16 00 42](https://github.com/user-attachments/assets/49ae2cd5-25bc-4b94-b04d-e92981c763b5)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
