### PR TITLE
chore(signature-collection): Filterable current collection

### DIFF
--- a/libs/api/domains/signature-collection/src/lib/dto/collectionTypeFilter.input.ts
+++ b/libs/api/domains/signature-collection/src/lib/dto/collectionTypeFilter.input.ts
@@ -1,0 +1,10 @@
+import { CollectionType } from '@island.is/clients/signature-collection'
+import { Field, InputType, registerEnumType } from '@nestjs/graphql'
+
+registerEnumType(CollectionType, { name: 'SignatureCollectionCollectionType' })
+
+@InputType()
+export class SignatureCollectionCollectionTypeFilterInput {
+  @Field(() => CollectionType, { nullable: true })
+  collectionTypeFilter?: CollectionType
+}

--- a/libs/api/domains/signature-collection/src/lib/signatureCollection.resolver.ts
+++ b/libs/api/domains/signature-collection/src/lib/signatureCollection.resolver.ts
@@ -35,6 +35,7 @@ import { SignatureCollectionListSummary } from './models/areaSummaryReport.model
 import { SignatureCollectionSignatureUpdateInput } from './dto/signatureUpdate.input'
 import { SignatureCollectionCollectionTypeInput } from './dto/collectionType.input'
 import { SignatureCollectionListIdWithTypeInput } from './dto/listId.input'
+import { SignatureCollectionCollectionTypeFilterInput } from './dto/collectionTypeFilter.input'
 
 @UseGuards(IdsUserGuard, ScopesGuard, UserAccessGuard)
 @Resolver()
@@ -54,8 +55,12 @@ export class SignatureCollectionResolver {
 
   @BypassAuth()
   @Query(() => [SignatureCollection])
-  async signatureCollectionCurrent(): Promise<SignatureCollection[]> {
-    return this.signatureCollectionService.currentCollection()
+  async signatureCollectionCurrent(
+    @Args('input') input?: SignatureCollectionCollectionTypeFilterInput,
+  ): Promise<SignatureCollection[]> {
+    return this.signatureCollectionService.currentCollection(
+      input?.collectionTypeFilter,
+    )
   }
 
   @BypassAuth()

--- a/libs/api/domains/signature-collection/src/lib/signatureCollection.service.ts
+++ b/libs/api/domains/signature-collection/src/lib/signatureCollection.service.ts
@@ -34,8 +34,12 @@ export class SignatureCollectionService {
     }
   }
 
-  async currentCollection(): Promise<SignatureCollection[]> {
-    return await this.signatureCollectionClientService.currentCollection()
+  async currentCollection(
+    collectionTypeFilter?: CollectionType,
+  ): Promise<SignatureCollection[]> {
+    return await this.signatureCollectionClientService.currentCollection(
+      collectionTypeFilter,
+    )
   }
 
   async getLatestCollectionForType(
@@ -181,12 +185,11 @@ export class SignatureCollectionService {
     input: SignatureCollectionCanSignFromPaperInput,
     signee: SignatureCollectionSignee,
   ): Promise<boolean> {
-    const signatureSignee =
-      await this.signatureCollectionClientService.getSignee(
-        user,
-        input.collectionType,
-        input.signeeNationalId,
-      )
+    const signatureSignee = await this.signatureCollectionClientService.getSignee(
+      user,
+      input.collectionType,
+      input.signeeNationalId,
+    )
     const list = await this.list(input.listId, user, signee)
     // Current signatures should not prevent paper signatures
     const canSign =

--- a/libs/api/domains/signature-collection/src/lib/signatureCollectionAdmin.service.ts
+++ b/libs/api/domains/signature-collection/src/lib/signatureCollectionAdmin.service.ts
@@ -38,8 +38,14 @@ export class SignatureCollectionAdminService {
     private signatureCollectionBasicService: SignatureCollectionClientService,
   ) {}
 
-  async currentCollection(user: User): Promise<SignatureCollection[]> {
-    return await this.signatureCollectionClientService.currentCollection(user)
+  async currentCollection(
+    user: User,
+    collectionTypeFilter?: CollectionType,
+  ): Promise<SignatureCollection[]> {
+    return await this.signatureCollectionClientService.currentCollection(
+      user,
+      collectionTypeFilter,
+    )
   }
 
   async getLatestCollectionForType(
@@ -69,12 +75,11 @@ export class SignatureCollectionAdminService {
     listId: string,
     collectionType: CollectionType,
   ): Promise<SignatureCollectionSuccess> {
-    const signatureSignee =
-      await this.signatureCollectionBasicService.getSignee(
-        auth,
-        collectionType,
-        nationalId,
-      )
+    const signatureSignee = await this.signatureCollectionBasicService.getSignee(
+      auth,
+      collectionType,
+      nationalId,
+    )
     const list = await this.list(listId, auth)
     // Current signatures should not prevent paper signatures
     const canSign =

--- a/libs/api/domains/signature-collection/src/lib/signatureCollectionManager.service.ts
+++ b/libs/api/domains/signature-collection/src/lib/signatureCollectionManager.service.ts
@@ -16,8 +16,14 @@ export class SignatureCollectionManagerService {
     private signatureCollectionClientService: SignatureCollectionManagerClientService,
   ) {}
 
-  async currentCollection(user: User): Promise<SignatureCollection[]> {
-    return await this.signatureCollectionClientService.currentCollection(user)
+  async currentCollection(
+    user: User,
+    collectionTypeFilter?: CollectionType,
+  ): Promise<SignatureCollection[]> {
+    return await this.signatureCollectionClientService.currentCollection(
+      user,
+      collectionTypeFilter,
+    )
   }
 
   async getLatestCollectionForType(

--- a/libs/application/template-api-modules/src/lib/modules/templates/signature-collection/signature-list-creation/signature-list-creation.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/signature-collection/signature-list-creation/signature-list-creation.service.ts
@@ -76,13 +76,11 @@ export class SignatureListCreationService extends BaseTemplateApiService {
     const collectionType = getCollectionTypeFromApplicationType(
       application.typeId,
     )
-    const {
-      canCreate,
-      canCreateInfo,
-    } = await this.signatureCollectionClientService.getSignee(
-      auth,
-      collectionType,
-    )
+    const { canCreate, canCreateInfo } =
+      await this.signatureCollectionClientService.getSignee(
+        auth,
+        collectionType,
+      )
 
     if (canCreate) {
       return true
@@ -110,7 +108,7 @@ export class SignatureListCreationService extends BaseTemplateApiService {
     throw new TemplateApiError(errors, 405)
   }
 
-  async currentCollection() {
+  async getLatestCollection() {
     return await this.signatureCollectionClientService.getLatestCollectionForType(
       this.collectionType,
     )

--- a/libs/application/templates/signature-collection/parliamentary-list-signing/src/dataProviders/index.ts
+++ b/libs/application/templates/signature-collection/parliamentary-list-signing/src/dataProviders/index.ts
@@ -4,10 +4,6 @@ export const OwnerRequirementsApi = defineTemplateApi({
   action: 'ownerRequirements',
 })
 
-export const CurrentCollectionApi = defineTemplateApi({
-  action: 'currentCollection',
-})
-
 export const CanSignApi = defineTemplateApi({
   action: 'canSign',
   order: 0,

--- a/libs/application/templates/signature-collection/parliamentary-list-signing/src/lib/signListTemplate.ts
+++ b/libs/application/templates/signature-collection/parliamentary-list-signing/src/lib/signListTemplate.ts
@@ -18,7 +18,7 @@ import {
   pruneAfterDays,
 } from '@island.is/application/core'
 import { Features } from '@island.is/feature-flags'
-import { CanSignApi, CurrentCollectionApi, GetListApi } from '../dataProviders'
+import { CanSignApi, GetListApi } from '../dataProviders'
 import { CodeOwners } from '@island.is/shared/constants'
 
 const signListTemplate: ApplicationTemplate<
@@ -66,7 +66,6 @@ const signListTemplate: ApplicationTemplate<
               api: [
                 NationalRegistryUserApi,
                 UserProfileApi,
-                CurrentCollectionApi,
                 CanSignApi,
                 GetListApi,
               ],

--- a/libs/application/templates/signature-collection/presidential-list-creation/src/dataProviders/index.ts
+++ b/libs/application/templates/signature-collection/presidential-list-creation/src/dataProviders/index.ts
@@ -4,6 +4,6 @@ export const OwnerRequirementsApi = defineTemplateApi({
   action: 'ownerRequirements',
 })
 
-export const CurrentCollectionApi = defineTemplateApi({
-  action: 'currentCollection',
+export const LatestCollectionApi = defineTemplateApi({
+  action: 'getLatestCollection',
 })

--- a/libs/application/templates/signature-collection/presidential-list-creation/src/forms/Prerequisites.ts
+++ b/libs/application/templates/signature-collection/presidential-list-creation/src/forms/Prerequisites.ts
@@ -16,7 +16,7 @@ import {
 } from '@island.is/application/types'
 
 import { m } from '../lib/messages'
-import { CurrentCollectionApi, OwnerRequirementsApi } from '../dataProviders'
+import { LatestCollectionApi, OwnerRequirementsApi } from '../dataProviders'
 import Logo from '@island.is/application/templates/signature-collection/assets/Logo'
 
 export const Prerequisites: Form = buildForm({
@@ -76,7 +76,7 @@ export const Prerequisites: Form = buildForm({
               provider: OwnerRequirementsApi,
             }),
             buildDataProviderItem({
-              provider: CurrentCollectionApi,
+              provider: LatestCollectionApi,
             }),
           ],
         }),

--- a/libs/application/templates/signature-collection/presidential-list-creation/src/lib/CreateListTemplate.ts
+++ b/libs/application/templates/signature-collection/presidential-list-creation/src/lib/CreateListTemplate.ts
@@ -17,7 +17,7 @@ import {
   EphemeralStateLifeCycle,
   pruneAfterDays,
 } from '@island.is/application/core'
-import { OwnerRequirementsApi, CurrentCollectionApi } from '../dataProviders'
+import { OwnerRequirementsApi, LatestCollectionApi } from '../dataProviders'
 import { CodeOwners } from '@island.is/shared/constants'
 
 const CreateListTemplate: ApplicationTemplate<
@@ -60,7 +60,7 @@ const CreateListTemplate: ApplicationTemplate<
                 NationalRegistryUserApi,
                 UserProfileApi,
                 OwnerRequirementsApi,
-                CurrentCollectionApi,
+                LatestCollectionApi,
               ],
             },
           ],

--- a/libs/clients/signature-collection/src/lib/signature-collection-admin.service.ts
+++ b/libs/clients/signature-collection/src/lib/signature-collection-admin.service.ts
@@ -55,9 +55,13 @@ export class SignatureCollectionAdminClientService {
     return api.withMiddleware(new AuthMiddleware(auth)) as T
   }
 
-  async currentCollection(auth: Auth): Promise<Collection[]> {
+  async currentCollection(
+    auth: Auth,
+    collectionTypeFilter?: CollectionType,
+  ): Promise<Collection[]> {
     return await this.sharedService.currentCollection(
       this.getApiWithAuth(this.electionsApi, auth),
+      collectionTypeFilter,
     )
   }
 
@@ -137,8 +141,10 @@ export class SignatureCollectionAdminClientService {
     { collectionId, owner, areas, collectionType }: CreateListInput,
     auth: Auth,
   ): Promise<Slug> {
-    const { id, areas: collectionAreas } =
-      await this.getLatestCollectionForType(auth, collectionType)
+    const {
+      id,
+      areas: collectionAreas,
+    } = await this.getLatestCollectionForType(auth, collectionType)
     // check if collectionId is current collection and current collection is open
     if (collectionId !== id) {
       throw new Error('Collection id input wrong')
@@ -234,14 +240,16 @@ export class SignatureCollectionAdminClientService {
         ? user.medmaelalistar?.map((list) => mapListBase(list))
         : []
 
-    const { success: canCreate, reasons: canCreateInfo } =
-      this.sharedService.canCreate({
-        requirementsMet: user.maFrambod,
-        canCreateInfo: user.maFrambodInfo,
-        ownedLists,
-        collectionType,
-        areas,
-      })
+    const {
+      success: canCreate,
+      reasons: canCreateInfo,
+    } = this.sharedService.canCreate({
+      requirementsMet: user.maFrambod,
+      canCreateInfo: user.maFrambodInfo,
+      ownedLists,
+      collectionType,
+      areas,
+    })
 
     return {
       nationalId: user.kennitala ?? '',

--- a/libs/clients/signature-collection/src/lib/signature-collection-manager.service.ts
+++ b/libs/clients/signature-collection/src/lib/signature-collection-manager.service.ts
@@ -33,9 +33,13 @@ export class SignatureCollectionManagerClientService {
     return api.withMiddleware(new AuthMiddleware(auth)) as T
   }
 
-  async currentCollection(auth: Auth): Promise<Collection[]> {
+  async currentCollection(
+    auth: Auth,
+    collectionTypeFilter?: CollectionType,
+  ): Promise<Collection[]> {
     return await this.sharedService.currentCollection(
       this.getApiWithAuth(this.electionsApi, auth),
+      collectionTypeFilter,
     )
   }
 

--- a/libs/clients/signature-collection/src/lib/signature-collection-shared.service.ts
+++ b/libs/clients/signature-collection/src/lib/signature-collection-shared.service.ts
@@ -49,16 +49,14 @@ export class SignatureCollectionSharedClientService {
         }),
     )
 
-    const orderedCollections = (
-      collections
-        .flatMap((_) => _)
-        .map(mapCollection)
-        .filter(
-          (collection) =>
-            collection?.isSignatureCollection &&
-            collection.startTime < new Date(),
-        ) as Collection[]
-    ).sort((a, b) => (a.endTime < b.endTime ? 1 : -1))
+    const orderedCollections = (collections
+      .flatMap((_) => _)
+      .map(mapCollection)
+      .filter(
+        (collection) =>
+          collection?.isSignatureCollection &&
+          collection.startTime < new Date(),
+      ) as Collection[]).sort((a, b) => (a.endTime < b.endTime ? 1 : -1))
 
     if (!orderedCollections.length) {
       throw new Error('No current collection for selected type')
@@ -67,7 +65,10 @@ export class SignatureCollectionSharedClientService {
     return orderedCollections[0]
   }
 
-  async currentCollection(api: ElectionApi): Promise<Collection[]> {
+  async currentCollection(
+    api: ElectionApi,
+    collectionTypeFilter?: CollectionType,
+  ): Promise<Collection[]> {
     // includeInactive: false will return collections as active until electionday for collection has passed
     const baseRes = await api.kosningGet({
       hasSofnun: true,
@@ -85,7 +86,13 @@ export class SignatureCollectionSharedClientService {
     if (!collections.length) {
       throw new Error('No current collection')
     }
-    return collections.flatMap((_) => _).map(mapCollection)
+    let mappedCollections = collections.flatMap((_) => _).map(mapCollection)
+    if (collectionTypeFilter) {
+      mappedCollections = mappedCollections.filter(
+        (collection) => collection.collectionType === collectionTypeFilter,
+      )
+    }
+    return mappedCollections
   }
 
   async getLists(

--- a/libs/clients/signature-collection/src/lib/signature-collection.service.ts
+++ b/libs/clients/signature-collection/src/lib/signature-collection.service.ts
@@ -46,8 +46,13 @@ export class SignatureCollectionClientService {
     return api.withMiddleware(new AuthMiddleware(auth)) as T
   }
 
-  async currentCollection(): Promise<Collection[]> {
-    return await this.sharedService.currentCollection(this.electionsApi)
+  async currentCollection(
+    collectionTypeFilter?: CollectionType,
+  ): Promise<Collection[]> {
+    return await this.sharedService.currentCollection(
+      this.electionsApi,
+      collectionTypeFilter,
+    )
   }
 
   async getLatestCollectionForType(

--- a/libs/portals/my-pages/signature-collection/src/hooks/graphql/queries.ts
+++ b/libs/portals/my-pages/signature-collection/src/hooks/graphql/queries.ts
@@ -139,8 +139,10 @@ export const GetListsForOwner = gql`
 `
 
 export const GetCurrentCollection = gql`
-  query currentCollection {
-    signatureCollectionCurrent {
+  query currentCollection(
+    $input: SignatureCollectionCollectionTypeFilterInput
+  ) {
+    signatureCollectionCurrent(input: $input) {
       id
       endTime
       startTime


### PR DESCRIPTION
Allows filtering on current collection to show only specific types.
Similar to `getLatestCollectionForType` but includes all.

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for filtering signature collections by collection type in relevant queries and services.

- **Bug Fixes**
  - None.

- **Refactor**
  - Renamed certain APIs and methods for clarity (e.g., `CurrentCollectionApi` to `LatestCollectionApi`, `currentCollection` to `getLatestCollection`).
  - Updated method signatures and GraphQL queries to accept optional collection type filters.

- **Chores**
  - Improved code formatting and streamlined destructuring in several methods.

End-users can now filter signature collections by type where available, and may notice updated naming in related features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->