### PR TITLE
feat(rental-agreement): Open to api changes

### DIFF
--- a/libs/application/templates/rental-agreement/src/forms/completed/index.ts
+++ b/libs/application/templates/rental-agreement/src/forms/completed/index.ts
@@ -1,0 +1,19 @@
+import { buildFormConclusionSection } from '@island.is/application/ui-forms'
+import { buildForm } from '@island.is/application/core'
+import Logo from '../../assets/Logo'
+import { FormModes } from '@island.is/application/types'
+
+export const completedForm = buildForm({
+  id: 'PrerequisitesForm',
+  logo: Logo,
+  mode: FormModes.COMPLETED,
+  children: [
+    buildFormConclusionSection({
+      alertTitle: 'conclusion.general.alertTitle',
+      alertMessage: 'conclusion.information.title',
+      expandableHeader: 'conclusion.information.title',
+      expandableIntro: 'conclusion.information.description',
+      expandableDescription: 'conclusion.information.bulletList',
+    }),
+  ],
+})

--- a/libs/application/templates/rental-agreement/src/lib/RentalAgreementTemplate.ts
+++ b/libs/application/templates/rental-agreement/src/lib/RentalAgreementTemplate.ts
@@ -1,6 +1,7 @@
 import set from 'lodash/set'
 import { assign } from 'xstate'
 import {
+  DefaultStateLifeCycle,
   EphemeralStateLifeCycle,
   pruneAfterDays,
 } from '@island.is/application/core'
@@ -18,6 +19,7 @@ import {
   ApplicationConfigurations,
   ApplicationRole,
   defineTemplateApi,
+  InstitutionNationalIds,
 } from '@island.is/application/types'
 import { Events } from '../utils/types'
 import { States, Roles } from '../utils/enums'
@@ -166,7 +168,7 @@ const RentalAgreementTemplate: ApplicationTemplate<
       [States.SIGNING]: {
         meta: {
           name: States.SIGNING,
-          status: 'completed',
+          status: 'inprogress',
           lifecycle: pruneAfterDays(30),
           onEntry: defineTemplateApi({
             action: TemplateApiActions.submitApplicationToHmsRentalService,
@@ -182,6 +184,12 @@ const RentalAgreementTemplate: ApplicationTemplate<
               read: 'all',
               delete: true,
             },
+            {
+              id: Roles.INSTITUTION,
+              write: 'all',
+              read: 'all',
+              delete: true,
+            },
           ],
         },
         on: {
@@ -191,6 +199,32 @@ const RentalAgreementTemplate: ApplicationTemplate<
           [DefaultEvents.EDIT]: {
             target: States.INREVIEW,
           },
+          [DefaultEvents.APPROVE]: {
+            target: States.COMPLETED,
+          },
+        },
+      },
+      [States.COMPLETED]: {
+        meta: {
+          name: States.COMPLETED,
+          status: 'completed',
+          lifecycle: DefaultStateLifeCycle,
+          roles: [
+            {
+              id: Roles.APPLICANT,
+              formLoader: () =>
+                import('../forms/completed').then((module) =>
+                  Promise.resolve(module.completedForm),
+                ),
+              read: 'all',
+            },
+            {
+              id: Roles.INSTITUTION,
+              write: 'all',
+              read: 'all',
+              delete: true,
+            },
+          ],
         },
       },
     },
@@ -219,6 +253,11 @@ const RentalAgreementTemplate: ApplicationTemplate<
     application: Application,
   ): ApplicationRole | undefined {
     const { applicant, assignees } = application
+
+    if (id === InstitutionNationalIds.HUSNAEDIS_OG_MANNVIRKJASTOFNUN) {
+      return Roles.INSTITUTION
+    }
+
     if (id === applicant) {
       return Roles.APPLICANT
     }

--- a/libs/application/templates/rental-agreement/src/utils/types.ts
+++ b/libs/application/templates/rental-agreement/src/utils/types.ts
@@ -15,7 +15,9 @@ import {
   SecurityDepositTypeOptions,
 } from './enums'
 
-export type Events = { type: DefaultEvents.SUBMIT | DefaultEvents.EDIT }
+export type Events = {
+  type: DefaultEvents.SUBMIT | DefaultEvents.EDIT | DefaultEvents.APPROVE
+}
 
 export type StatusProvider = 'failure' | 'success'
 


### PR DESCRIPTION
# Open the rental agreement application to api changes

https://app.asana.com/1/203394141643832/project/1208271027457465/task/1209555373134642

## What

Opened up the rental agreement application to api changes from HMS

## Why

So a server in the HMS cloud can get the application files and change the state of the application.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
