### PR TITLE
fix(island-ui): Stop waiting for client mount until icon appears

### DIFF
--- a/libs/island-ui/core/src/lib/IconRC/Icon.tsx
+++ b/libs/island-ui/core/src/lib/IconRC/Icon.tsx
@@ -40,26 +40,11 @@ export const Icon = ({
   skipPlaceholderSize,
   ariaHidden,
 }: IconProps) => {
-  const [isMounted, setIsMounted] = useState(false)
   const path = iconMap[type][icon]
   const IconSvg = useMemo(
     () => React.lazy(() => import('./icons/' + path)),
     [path],
   )
-
-  useEffect(() => {
-    setIsMounted(true)
-  }, [])
-
-  if (!isMounted) {
-    return (
-      <Placeholder
-        skipPlaceholderSize={skipPlaceholderSize}
-        size={size}
-        className={className}
-      />
-    )
-  }
 
   const optionalProps: SvgProps = {}
   if (className) {

--- a/libs/island-ui/core/src/lib/IconRC/Icon.tsx
+++ b/libs/island-ui/core/src/lib/IconRC/Icon.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useEffect, useMemo, useState } from 'react'
+import React, { Suspense, useMemo } from 'react'
 import cn from 'classnames'
 import { theme } from '@island.is/island-ui/theme'
 import iconMap from './iconMap'


### PR DESCRIPTION
# Stop waiting for client mount until icon appears

## Screenshots / Gifs

### Before

https://github.com/user-attachments/assets/0bb0e875-c811-4897-a58c-e8d2d111ba66

### After

https://github.com/user-attachments/assets/79953ab0-a11b-4c1d-a17a-fa90deff85c2

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced icon loading experience by streamlining placeholder display using React's Suspense fallback for smoother and more efficient rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->