### PR TITLE
fix(web): Organization Page - Bottom slices spacing

### DIFF
--- a/apps/web/screens/Organization/Home/Home.tsx
+++ b/apps/web/screens/Organization/Home/Home.tsx
@@ -207,7 +207,7 @@ const OrganizationHomePage = ({
             : 0
         }
       >
-        {organizationPage?.bottomSlices.map((slice) => {
+        {organizationPage?.bottomSlices.map((slice, index) => {
           if (
             organizationHasDigitalIcelandNewsVisuals(organizationPage.slug) &&
             slice.__typename === 'LatestNewsSlice' &&
@@ -223,21 +223,29 @@ const OrganizationHomePage = ({
             )
           }
           return (
-            <SliceMachine
-              key={slice.id}
-              slice={slice}
-              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-              // @ts-ignore make web strict
-              namespace={namespace}
-              slug={organizationPage.slug}
-              fullWidth={true}
-              params={{
-                latestNewsSliceColorVariant:
-                  organizationPage.theme === 'landing_page'
-                    ? 'blue'
-                    : 'default',
-              }}
-            />
+            <Box
+              paddingBottom={
+                index === organizationPage.bottomSlices.length - 1
+                  ? SLICE_SPACING
+                  : 0
+              }
+            >
+              <SliceMachine
+                key={slice.id}
+                slice={slice}
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore make web strict
+                namespace={namespace}
+                slug={organizationPage.slug}
+                fullWidth={true}
+                params={{
+                  latestNewsSliceColorVariant:
+                    organizationPage.theme === 'landing_page'
+                      ? 'blue'
+                      : 'default',
+                }}
+              />
+            </Box>
           )
         })}
       </Stack>

--- a/apps/web/screens/Organization/Home/Home.tsx
+++ b/apps/web/screens/Organization/Home/Home.tsx
@@ -214,7 +214,11 @@ const OrganizationHomePage = ({
             slice.news.length >= 3
           ) {
             return (
-              <Box paddingTop={[5, 5, 8]} paddingBottom={[2, 2, 5]}>
+              <Box
+                paddingTop={[5, 5, 8]}
+                paddingBottom={[2, 2, 5]}
+                key={slice.id}
+              >
                 <DigitalIcelandLatestNewsSlice
                   slice={slice}
                   slug={organizationPage.slug}
@@ -224,6 +228,7 @@ const OrganizationHomePage = ({
           }
           return (
             <Box
+              key={slice.id}
               paddingBottom={
                 index === organizationPage.bottomSlices.length - 1
                   ? SLICE_SPACING
@@ -231,7 +236,6 @@ const OrganizationHomePage = ({
               }
             >
               <SliceMachine
-                key={slice.id}
                 slice={slice}
                 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 // @ts-ignore make web strict


### PR DESCRIPTION
# Organization Page - Bottom slices spacing

Add paddingBottom to the last item in the bottom slices array (similar to how the slices array is handled):

![Screenshot 2025-06-10 at 10 21 17](https://github.com/user-attachments/assets/6352c1f2-b500-41f3-84db-72b8cbfd7247)

## Before

![Screenshot 2025-06-10 at 10 20 01](https://github.com/user-attachments/assets/655fa09e-d069-40be-b827-2fec4a54f712)

## After

![Screenshot 2025-06-10 at 10 20 25](https://github.com/user-attachments/assets/2822579f-5438-403e-bb95-5d3c3799e841)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved layout consistency by adding conditional bottom padding to organization page sections.  
- **Refactor**
  - Enhanced rendering logic for organization page sections to ensure consistent key assignment and structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->