### PR TITLE
feat(contentful-apps): Team List - Automatically archive team members on removal from list

### DIFF
--- a/apps/contentful-apps/pages/fields/team-list-team-members-field.tsx
+++ b/apps/contentful-apps/pages/fields/team-list-team-members-field.tsx
@@ -1,0 +1,72 @@
+import { useEffect } from 'react'
+import { FieldExtensionSDK } from '@contentful/app-sdk'
+import { MultipleEntryReferenceEditor } from '@contentful/field-editor-reference'
+import { useCMA, useSDK } from '@contentful/react-apps-toolkit'
+
+const TeamListTeamMembersField = () => {
+  const sdk = useSDK<FieldExtensionSDK>()
+  const cma = useCMA()
+
+  useEffect(() => {
+    const unregister = sdk.field.onValueChanged((items) => {
+      if (items?.length > 1) {
+        sdk.window.startAutoResizer()
+      } else {
+        if (!items?.length) {
+          sdk.window.stopAutoResizer()
+          sdk.window.updateHeight(210)
+        } else {
+          sdk.window.stopAutoResizer()
+          sdk.window.updateHeight(300)
+        }
+      }
+    })
+
+    return () => {
+      unregister()
+    }
+  }, [sdk.field, sdk.window])
+
+  return (
+    <MultipleEntryReferenceEditor
+      hasCardEditActions={false}
+      viewType="link"
+      sdk={sdk}
+      isInitiallyDisabled={false}
+      parameters={{
+        instance: {
+          showCreateEntityAction: true,
+          showLinkEntityAction: false,
+        },
+      }}
+      onAction={async (action) => {
+        if (action.type === 'delete') {
+          try {
+            const entryId = action.id
+
+            const entry = await cma.entry.get({ entryId })
+
+            if (entry.sys.publishedVersion) {
+              await cma.entry.unpublish({ entryId })
+            }
+
+            await cma.entry.archive({
+              entryId,
+            })
+
+            sdk.notifier.success(
+              'Team member has been archived and removed from the list',
+            )
+          } catch (error) {
+            console.error(error)
+            sdk.notifier.warning(
+              'Team member was removed from list but could not be archived',
+            )
+          }
+        }
+      }}
+    />
+  )
+}
+
+export default TeamListTeamMembersField

--- a/libs/cms/src/lib/search/importers/teamList.service.ts
+++ b/libs/cms/src/lib/search/importers/teamList.service.ts
@@ -28,6 +28,9 @@ export class TeamListSyncService implements CmsSyncProvider<ITeamList> {
       const teamList = mapTeamList(teamListEntry)
       let counter = teamList.teamMembers?.length ?? 9999
       for (const member of teamList.teamMembers ?? []) {
+        if (!member.name) {
+          continue
+        }
         try {
           const memberEntry = teamListEntry.fields.teamMembers?.find(
             (m) => m.sys.id === member.id,
@@ -63,7 +66,7 @@ export class TeamListSyncService implements CmsSyncProvider<ITeamList> {
             ],
             dateCreated: member.createdAt ?? '',
             dateUpdated: new Date().getTime().toString(),
-            // Use the release date field as a way to order search results inthe  same order as the team members list in the CMS
+            // Use the release date field as a way to order search results in the  same order as the team members list in the CMS
             releaseDate: String(counter--),
           })
         } catch (error) {
@@ -76,7 +79,7 @@ export class TeamListSyncService implements CmsSyncProvider<ITeamList> {
     }
 
     return teamMembers.concat(
-      // Append the team list document tagged with the ids of its members so we can later look up what list a member belongs to
+      // Append the team list document tagged with the id's of its members so we can later look up what list a member belongs to
       entries.map((teamListEntry) => {
         const childEntryIds = extractChildEntryIds(teamListEntry)
         return {


### PR DESCRIPTION
# Team List - Automatically archive team members on removal from list

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a custom field editor for managing team members in Contentful, including support for creating new entries and dynamic resizing based on the number of entries.

- **Bug Fixes**
  - Improved handling to skip team members without names during import, ensuring only valid entries are processed.

- **Documentation**
  - Corrected minor typos in code comments for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->