### PR TITLE
fix(j-s): file preview for limited access

### DIFF
--- a/apps/judicial-system/web/src/utils/hooks/useFileList/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useFileList/index.ts
@@ -140,6 +140,7 @@ const useFileList = ({ caseId, connectedCaseParentId }: Parameters) => {
       if (!validateUuid(file.id)) {
         const previewUrl = URL.createObjectURL(file.originalFileObj as Blob)
         openFile(previewUrl)
+        setTimeout(() => URL.revokeObjectURL(previewUrl), 1000 * 60) // revoke url in 1 minute
       } else {
         const query = limitedAccess ? limitedAccessGetSignedUrl : getSignedUrl
 


### PR DESCRIPTION
# [Fix preview for defendants](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1210512398130932)

## What
- We were unable to open preview links for defenders
- We were throwing an internal server error for every file preview were we had invalid id

## Why
- It was a bug

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file opening behavior, especially for temporary files not yet uploaded, ensuring they can be previewed directly.
  - Enhanced error handling by displaying immediate toast messages when file access fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->