### PR TITLE
ci: Conditionally enable RunsOn, and add default value for `AWS_REGION`

### DIFF
--- a/.github/actions/load-deps/action.yml
+++ b/.github/actions/load-deps/action.yml
@@ -16,7 +16,7 @@ runs:
   steps:
     - name: Set RUNS_ON_S3_BUCKET_CACHE
       shell: bash
-      if: ${{ !github.event.localrun }}
+      if: ${{ !github.event.localrun && env.RUNS_ON_BUCKET_NAME }}
       run: echo "RUNS_ON_S3_BUCKET_CACHE=${{ env.RUNS_ON_BUCKET_NAME }}" >> $GITHUB_ENV
 
     - name: Set env

--- a/.github/actions/setup-yarn/action.yml
+++ b/.github/actions/setup-yarn/action.yml
@@ -5,10 +5,6 @@ inputs:
     description: 'Directory to run the action in'
     required: false
     default: '.'
-  aws-region:
-    description: 'AWS region to use'
-    required: false
-    default: 'eu-west-1'
 
 runs:
   using: 'composite'
@@ -61,7 +57,7 @@ runs:
           yarn.lock-hash=${{ hashFiles('yarn.lock') }}
           working-directory=${{ inputs.working-directory }}
       env:
-        AWS_REGION: ${{ inputs.aws-region }}
+        AWS_REGION: ${{ env.AWS_REGION || 'eu-west-1' }}
 
     - name: Yarn install
       working-directory: ${{ inputs.working-directory }}

--- a/.github/actions/setup-yarn/action.yml
+++ b/.github/actions/setup-yarn/action.yml
@@ -55,7 +55,11 @@ runs:
           ${{ steps.yarn-cache-dir-path.outputs.dir }}
           ${{ inputs.working-directory }}/node_modules
           ${{ github.workspace }}/.cypress-cache
-        key: ${{ runner.os }}-deps-cypress-${{ hashFiles('yarn.lock') }}-1-node_modules${{ inputs.working-directory != '.' && format('-workdir={0}', inputs.working-directory) || '' }}
+        key: >-
+          OS=${{ runner.os }}
+          deps=cypress:node_modules
+          yarn.lock-hash=${{ hashFiles('yarn.lock') }}
+          working-directory=${{ inputs.working-directory }}
       env:
         AWS_REGION: ${{ inputs.aws-region }}
 

--- a/.github/actions/setup-yarn/action.yml
+++ b/.github/actions/setup-yarn/action.yml
@@ -55,11 +55,7 @@ runs:
           ${{ steps.yarn-cache-dir-path.outputs.dir }}
           ${{ inputs.working-directory }}/node_modules
           ${{ github.workspace }}/.cypress-cache
-        key: >-
-          OS=${{ runner.os }}
-          deps=cypress:node_modules
-          yarn.lock-hash=${{ hashFiles('yarn.lock') }}
-          working-directory=${{ inputs.working-directory }}
+        key: ${{ runner.os }}-deps-cypress-${{ hashFiles('yarn.lock') }}-1-node_modules${{ inputs.working-directory != '.' && format('-workdir={0}', inputs.working-directory) || '' }}
       env:
         AWS_REGION: ${{ inputs.aws-region }}
 

--- a/.github/actions/setup-yarn/action.yml
+++ b/.github/actions/setup-yarn/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'Directory to run the action in'
     required: false
     default: '.'
+  aws-region:
+    description: 'AWS region to use'
+    required: false
+    default: 'eu-west-1'
 
 runs:
   using: 'composite'
@@ -51,7 +55,13 @@ runs:
           ${{ steps.yarn-cache-dir-path.outputs.dir }}
           ${{ inputs.working-directory }}/node_modules
           ${{ github.workspace }}/.cypress-cache
-        key: ${{ runner.os }}-deps-cypress-${{ hashFiles('yarn.lock') }}-1-node_modules
+        key: >-
+          OS=${{ runner.os }}
+          deps=cypress:node_modules
+          yarn.lock-hash=${{ hashFiles('yarn.lock') }}
+          working-directory=${{ inputs.working-directory }}
+      env:
+        AWS_REGION: ${{ inputs.aws-region }}
 
     - name: Yarn install
       working-directory: ${{ inputs.working-directory }}

--- a/.github/actions/setup-yarn/action.yml
+++ b/.github/actions/setup-yarn/action.yml
@@ -51,11 +51,7 @@ runs:
           ${{ steps.yarn-cache-dir-path.outputs.dir }}
           ${{ inputs.working-directory }}/node_modules
           ${{ github.workspace }}/.cypress-cache
-        key: >-
-          OS=${{ runner.os }}
-          deps=cypress:node_modules
-          yarn.lock-hash=${{ hashFiles('yarn.lock') }}
-          working-directory=${{ inputs.working-directory }}
+        key: ${{ runner.os }}-deps-cypress-${{ hashFiles('yarn.lock') }}-1-node_modules
       env:
         AWS_REGION: ${{ env.AWS_REGION || 'eu-west-1' }}
 

--- a/.github/actions/setup-yarn/action.yml
+++ b/.github/actions/setup-yarn/action.yml
@@ -40,7 +40,7 @@ runs:
     # version of.
     - name: Set env for RunsOn
       shell: bash
-      if: ${{ !github.event.localrun }}
+      if: ${{ !github.event.localrun && env.RUNS_ON_BUCKET_NAME }}
       run: echo "RUNS_ON_S3_BUCKET_CACHE=${{ env.RUNS_ON_BUCKET_NAME }}" >> $GITHUB_ENV
 
     - name: Cache Dependencies

--- a/.github/workflows/config-values.yaml
+++ b/.github/workflows/config-values.yaml
@@ -27,7 +27,7 @@ env:
   AWS_MAX_ATTEMPTS: 10
   AWS_REGION: eu-west-1
   GITHUB_ACTIONS_CACHE_URL: https://cache.dev01.devland.is/
-  RUNS_ON_BUCKET_NAME: ${{ vars.RUNS_ON_BUCKET_NAME }}
+  # RUNS_ON_BUCKET_NAME: ${{ vars.RUNS_ON_BUCKET_NAME }}
 
 jobs:
   prepare:

--- a/.github/workflows/config-values.yaml
+++ b/.github/workflows/config-values.yaml
@@ -27,7 +27,7 @@ env:
   AWS_MAX_ATTEMPTS: 10
   AWS_REGION: eu-west-1
   GITHUB_ACTIONS_CACHE_URL: https://cache.dev01.devland.is/
-  # RUNS_ON_BUCKET_NAME: ${{ vars.RUNS_ON_BUCKET_NAME }}
+  RUNS_ON_BUCKET_NAME: ${{ vars.RUNS_ON_BUCKET_NAME }}
 
 jobs:
   prepare:
@@ -40,6 +40,7 @@ jobs:
         run: |
           set -euo pipefail
           GIT_BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF/refs\/heads\//}}"
+          # ENVS=("dev" "staging")
           ENVS=("dev" "staging")
           if [[ "$GIT_BRANCH" =~ ^release\/ ]]; then
             echo "Adding prod environments to test set"
@@ -63,8 +64,10 @@ jobs:
 
       - name: Setup yarn
         uses: ./.github/actions/setup-yarn
-        with:
-          working-directory: infra
+
+      - name: Install yarn in infra
+        working-directory: infra
+        run: yarn install --immutable
 
       - name: Run unit tests
         working-directory: infra
@@ -92,8 +95,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup yarn
         uses: ./.github/actions/setup-yarn
-        with:
-          working-directory: infra
 
       - name: Install yarn in infra
         working-directory: infra

--- a/.github/workflows/config-values.yaml
+++ b/.github/workflows/config-values.yaml
@@ -40,7 +40,6 @@ jobs:
         run: |
           set -euo pipefail
           GIT_BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF/refs\/heads\//}}"
-          # ENVS=("dev" "staging")
           ENVS=("dev" "staging")
           if [[ "$GIT_BRANCH" =~ ^release\/ ]]; then
             echo "Adding prod environments to test set"
@@ -54,13 +53,13 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' && !github.event.localrun }}
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.DIRTY_FIX_BOT_TOKEN }}
 
       - uses: actions/checkout@v4
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ github.event_name != 'pull_request' || github.event.localrun }}
 
       - name: Setup yarn
         uses: ./.github/actions/setup-yarn

--- a/.github/workflows/config-values.yaml
+++ b/.github/workflows/config-values.yaml
@@ -63,10 +63,8 @@ jobs:
 
       - name: Setup yarn
         uses: ./.github/actions/setup-yarn
-
-      - name: Install yarn in infra
-        working-directory: infra
-        run: yarn install --immutable
+        with:
+          working-directory: infra
 
       - name: Run unit tests
         working-directory: infra
@@ -94,6 +92,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup yarn
         uses: ./.github/actions/setup-yarn
+        with:
+          working-directory: infra
 
       - name: Install yarn in infra
         working-directory: infra

--- a/infra/package.json
+++ b/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infra",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "index.js",
   "engines": {
     "npm": "please-use-yarn",


### PR DESCRIPTION
The `Config Values` workflow runs in the `infra/` folder, so it seems to misbehave, causing [Region is missing](https://github.com/island-is/island.is/actions/runs/15589363079/job/43904215199?pr=19119#step:21:7) error in `Post Setup Yarn`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal workflow steps to refine when certain actions execute, improving environment variable checks and conditional logic.
  - Set a default region for dependency caching if not specified.
  - Updated version number from 1.0.0 to 1.0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->