### PR TITLE
fix(j-s): update react-input-mask to fix deprecate find DOM usage in …

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "@types/pdfkit": "0.11.2",
     "@types/pubsub-js": "1.8.1",
     "@types/react-csv": "1.1.1",
-    "@types/react-input-mask": "3.0.0",
+    "@types/react-input-mask": "3.0.6",
     "@types/react-modal": "3.13.1",
     "@types/react-table": "7.0.24",
     "@vanilla-extract/babel-plugin": "1.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23194,12 +23194,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-input-mask@npm:3.0.0":
-  version: 3.0.0
-  resolution: "@types/react-input-mask@npm:3.0.0"
+"@types/react-input-mask@npm:3.0.6":
+  version: 3.0.6
+  resolution: "@types/react-input-mask@npm:3.0.6"
   dependencies:
     "@types/react": "npm:*"
-  checksum: 10/aead8d91683d92197bd1f6ed1fdaa073033e56f556856c92e2f906ce01f52258d95aa8a9cf68c431d085a648ab405af128a3c465ba2b207d3be4a60eeb418a46
+  checksum: 10/808f55f5d498c06eca86bf2afa24941cc41d2e67498a28ad30db8ed18310bcd063c55cc02371239c6d8056de84408fa3492ad0b223df2583ce69ca420f0c1308
   languageName: node
   linkType: hard
 
@@ -39975,7 +39975,7 @@ __metadata:
     "@types/react-dom": "npm:18.3.0"
     "@types/react-html-parser": "npm:2.0.1"
     "@types/react-infinite-scroller": "npm:^1.2.3"
-    "@types/react-input-mask": "npm:3.0.0"
+    "@types/react-input-mask": "npm:3.0.6"
     "@types/react-modal": "npm:3.13.1"
     "@types/react-table": "npm:7.0.24"
     "@types/request": "npm:2.48.5"


### PR DESCRIPTION
# [Fix warning/errors when web tests are executed](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1207655633907114)

## What
- Update `types/react-input-mask` to resolve deprecation errors triggered within the package

## Why
- Because we want to reduce console errors and warning when running tests

## Screenshots / Gifs
- Test console error when using an old version of `react-input-mask`
![Screenshot 2025-06-12 at 10 54 37](https://github.com/user-attachments/assets/e4a32227-809d-4a37-8226-1ebc5a2f4420)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
