### PR TITLE
feat(j-s): Add court case number to appeal pages

### DIFF
--- a/apps/judicial-system/web/src/components/DateLabel/DateLabel.tsx
+++ b/apps/judicial-system/web/src/components/DateLabel/DateLabel.tsx
@@ -8,14 +8,15 @@ interface Props {
   date: string | Date
   text?: string
   hideTime?: boolean
+  as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'p'
 }
 
-const DateLabel: FC<Props> = ({ date, text, hideTime }) => {
+const DateLabel: FC<Props> = ({ date, text, hideTime, as }) => {
   const formattedDate = formatDate(date, 'PPP')
   const formattedTime = `kl. ${formatDate(date, constants.TIME_FORMAT)}`
 
   return (
-    <Text as="h5" variant="h5">
+    <Text as={as ?? 'h5'} variant="h5">
       {`${text ?? ''} ${formattedDate} ${!hideTime ? formattedTime : ''}`}
     </Text>
   )

--- a/apps/judicial-system/web/src/components/DateLabel/RulingDateLabel.tsx
+++ b/apps/judicial-system/web/src/components/DateLabel/RulingDateLabel.tsx
@@ -6,12 +6,15 @@ import { rulingDateLabel as strings } from './RulingDateLabel.strings'
 
 interface Props {
   rulingDate: string
+  as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'p'
 }
 
-const RulingDateLabel: FC<Props> = ({ rulingDate }) => {
+const RulingDateLabel: FC<Props> = ({ rulingDate, as }) => {
   const { formatMessage } = useIntl()
 
-  return <DateLabel text={formatMessage(strings.text)} date={rulingDate} />
+  return (
+    <DateLabel text={formatMessage(strings.text)} date={rulingDate} as={as} />
+  )
 }
 
 export default RulingDateLabel

--- a/apps/judicial-system/web/src/routes/Shared/AppealToCourtOfAppeals/AppealToCourtOfAppeals.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/AppealToCourtOfAppeals/AppealToCourtOfAppeals.tsx
@@ -119,11 +119,14 @@ const AppealToCourtOfAppeals = () => {
         <PageTitle previousUrl={previousUrl}>
           {formatMessage(strings.title)}
         </PageTitle>
-        {workingCase.rulingDate && (
-          <Box marginBottom={7}>
-            <RulingDateLabel rulingDate={workingCase.rulingDate} />
-          </Box>
-        )}
+        <Box component="section" marginBottom={5}>
+          <Text variant="h2" as="h2">
+            {`Mál nr. ${workingCase.courtCaseNumber}`}
+          </Text>
+          {workingCase.rulingDate && (
+            <RulingDateLabel rulingDate={workingCase.rulingDate} as="h3" />
+          )}
+        </Box>
         <Box component="section" marginBottom={5}>
           <SectionHeading
             title={formatMessage(strings.appealBriefTitle)}


### PR DESCRIPTION
# Add court case number to appeal pages

[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1207422975415573?focus=true)

## What

Add court case number to appeal pages for prosecutors and defenders.

## Why

Users sometimes have a lot of cases open in different tabs and this gives clarity on what case you are working on at any given time.

## Screenshots / Gifs

<img width="928" alt="Screenshot 2025-06-12 at 11 22 41" src="https://github.com/user-attachments/assets/4acd97f9-a04a-4a81-8919-3b3dab42e1c0" />

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for customizing the HTML element type (heading or paragraph) used to display date labels, allowing improved semantic structure.
- **Refactor**
  - Updated the layout of the appeal section to group the court case number and ruling date together, with improved heading levels and spacing for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->