### PR TITLE
fix(application-system): tableRepeater validation

### DIFF
--- a/libs/application/core/src/lib/formUtils.ts
+++ b/libs/application/core/src/lib/formUtils.ts
@@ -41,7 +41,16 @@ const containsArray = (obj: RecordObject) => {
 }
 
 export const getErrorViaPath = (obj: RecordObject, path: string): string => {
-  return get(obj, path) as string
+  const error = get(obj, path)
+  if (typeof error === 'string') {
+    return error
+  }
+
+  if (Array.isArray(error)) {
+    return error.join(', ')
+  }
+
+  return ''
 }
 
 export const getValueViaPath = <T = unknown>(

--- a/libs/application/templates/rental-agreement/src/lib/schemas/landlordSchema.ts
+++ b/libs/application/templates/rental-agreement/src/lib/schemas/landlordSchema.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import * as m from '../messages'
+import { IS_REPRESENTATIVE } from '../..'
 
 export const landlordInfo = z
   .object({
@@ -38,11 +39,11 @@ export const landlordInfo = z
   })
   .superRefine((data, ctx) => {
     // TODO: Uncomment this when validation in repeatable table is fixed
-    // const filterNonRepresentatives =
-    //   data.table &&
-    //   data.table.filter(
-    //     (landlord) => !landlord.isRepresentative?.includes(IS_REPRESENTATIVE),
-    //   )
+    const filterNonRepresentatives =
+      data.table &&
+      data.table.filter(
+        (landlord) => !landlord.isRepresentative?.includes(IS_REPRESENTATIVE),
+      )
     if (data.table && data.table.length === 0) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
@@ -52,12 +53,12 @@ export const landlordInfo = z
       })
     }
     // TODO: Uncomment this when validation in repeatable table is fixed
-    // if (filterNonRepresentatives?.length === 0) {
-    //   ctx.addIssue({
-    //     code: z.ZodIssueCode.custom,
-    //     message: 'Custom error message',
-    //     params: m.landlordDetails.landlordOnlyRepresentativeTableError,
-    //     path: ['table'],
-    //   })
-    // }
+    if (filterNonRepresentatives?.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Custom error message',
+        params: m.landlordDetails.landlordOnlyRepresentativeTableError,
+        path: ['table'],
+      })
+    }
   })

--- a/libs/application/ui-fields/src/lib/TableRepeaterFormField/TableRepeaterFormField.tsx
+++ b/libs/application/ui-fields/src/lib/TableRepeaterFormField/TableRepeaterFormField.tsx
@@ -181,6 +181,8 @@ export const TableRepeaterFormField: FC<Props> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  console.log('error: ', error)
+
   return (
     <Box marginTop={marginTop} marginBottom={marginBottom}>
       {showFieldName && (
@@ -346,7 +348,7 @@ export const TableRepeaterFormField: FC<Props> = ({
             </Box>
           )}
         </Stack>
-        {error && typeof error === 'string' && (
+        {error && (
           <Box marginTop={3}>
             <AlertMessage type="error" title={error} />
           </Box>

--- a/libs/application/ui-shell/src/components/FormField.tsx
+++ b/libs/application/ui-shell/src/components/FormField.tsx
@@ -49,6 +49,10 @@ const FormField: FC<
 
   const error = getErrorViaPath(errors, field.id)
 
+  console.log('error in formField: ', error)
+  console.log('errors in formField: ', errors)
+  console.log('field in formField: ', field)
+
   const fieldProps: FieldBaseProps = {
     application,
     setBeforeSubmitCallback,


### PR DESCRIPTION
## What

Fix errors being wrongly typed and sometimes only the first letter of an error message is returned

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error message handling to better support cases where errors are arrays, ensuring they are displayed as readable strings.
  - Enhanced validation in landlord information forms to ensure at least one non-representative landlord is present.

- **Style**
  - Adjusted error alert rendering to display for all truthy error values, not just strings.

- **Chores**
  - Added additional console logging for debugging error and form field states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->