### PR TITLE
fix(native): Update app lock attempts messaging for clarity

### DIFF
--- a/apps/native/app/src/messages/en.ts
+++ b/apps/native/app/src/messages/en.ts
@@ -24,6 +24,7 @@ export const en: TranslatedMessages = {
   // app lock
   'applock.title': 'Enter a 4-digit PIN',
   'applock.attempts': 'attempts left',
+  'applock.attempt': 'attempt left',
 
   // onboarding
   'onboarding.notifications.title':

--- a/apps/native/app/src/messages/is.ts
+++ b/apps/native/app/src/messages/is.ts
@@ -23,6 +23,7 @@ export const is = {
   // app lock
   'applock.title': 'Sláðu inn 4 tölustafa PIN',
   'applock.attempts': 'tilraunir eftir',
+  'applock.attempt': 'tilraun eftir',
 
   // onboarding
   'onboarding.notifications.title':

--- a/apps/native/app/src/screens/app-lock/app-lock.tsx
+++ b/apps/native/app/src/screens/app-lock/app-lock.tsx
@@ -51,7 +51,6 @@ const Subtitle = styled.Text`
   ${font({
     fontSize: 20,
   })}
-  height: 22px;
 `
 
 const Center = styled.View`
@@ -81,6 +80,9 @@ export const AppLockScreen: NavigationFunctionComponent<{
   const [invalidCode, setInvalidCode] = useState(false)
   const pinTries = preferencesStore.getState().pinTries
   const [attempts, setAttempts] = useState(pinTries)
+  // Add 1 to offset the attempts counter, ensuring we display "1 attempt left" instead of "0 attempts left"
+  const attemptsLeft = MAX_ATTEMPTS + 1 - attempts
+
   const { useBiometrics } = usePreferencesStore()
   const biometricType = useBiometricType()
   const intl = useIntl()
@@ -219,8 +221,9 @@ export const AppLockScreen: NavigationFunctionComponent<{
           <Title>{intl.formatMessage({ id: 'applock.title' })}</Title>
           <Subtitle>
             {attempts > 0
-              ? `${MAX_ATTEMPTS - attempts} ${intl.formatMessage({
-                  id: 'applock.attempts',
+              ? `${attemptsLeft} ${intl.formatMessage({
+                  id:
+                    attemptsLeft === 1 ? 'applock.attempt' : 'applock.attempts',
                 })}`
               : ''}
           </Subtitle>


### PR DESCRIPTION
#  Update app lock attempts messaging for clarity

## What

- Added singular 'attempt left' message for better user experience.
- Adjusted attempts counter logic to ensure correct display of remaining attempts.
- Updated translations for English and Icelandic languages.


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
