### PR TITLE
feat(app): Clearer alerts for passports and identity documents

### DIFF
--- a/apps/native/app/src/messages/en.ts
+++ b/apps/native/app/src/messages/en.ts
@@ -302,17 +302,18 @@ export const en: TranslatedMessages = {
   'licenseDetail.ehic.alert.title': 'Remember the card!',
   'licenseDetail.ehic.alert.description':
     'This summary is not valid as a European Health Insurance card.',
-  'licenseDetail.passport.alert.title': 'Remember the passport!',
+  'licenseDetail.passport.alert.title':
+    'This is for information only and is not valid for identification or travel',
   'licenseDetail.passport.alert.description':
-    'This summary is not valid as a travel document.',
+    'Only the physical document is valid for identification and travel.',
   'licenseDetail.identityDocument.alert.title':
     'This is for information only and is not valid for identification purposes',
   'licenseDetail.identityDocument.alert.description':
     'Only the physical document is valid for identification.',
   'licenseDetail.identityTravelDocument.alert.title':
-    'Please remember your travel document!',
+    'This is for information only and is not valid for identification or travel',
   'licenseDetail.identityTravelDocument.alert.description':
-    'This is not valid as a travel document.',
+    'Only the physical document is valid for identification and travel.',
   'licenseDetail.warning.title': 'Expires within 6 months',
   'licenseDetail.passport.warning.description':
     'Note that your passport will expire within the next 6 months.',

--- a/apps/native/app/src/messages/is.ts
+++ b/apps/native/app/src/messages/is.ts
@@ -439,17 +439,17 @@ export const is = {
   'licenseDetail.ehic.alert.description':
     'Þetta yfirlit gildir ekki sem sjúkratryggingakort.',
   'licenseDetail.passport.alert.title':
-    'Þetta er eingöngu yfirlit og gildir ekki sem persónu-, eða ferðaskilríki',
+    'Þetta er eingöngu yfirlit og gildir ekki sem persónu- eða ferðaskilríki',
   'licenseDetail.passport.alert.description':
-    'Einungis skilríkið sjálft er gilt persónu-, og ferðaskilríki.',
+    'Einungis skilríkið sjálft er gilt persónu- og ferðaskilríki.',
   'licenseDetail.identityDocument.alert.title':
     'Þetta er eingöngu yfirlit og gildir ekki sem persónuskilríki',
   'licenseDetail.identityDocument.alert.description':
     'Einungis skilríkið sjálft er fullgilt persónuskilríki.',
   'licenseDetail.identityTravelDocument.alert.title':
-    'Þetta er eingöngu yfirlit og gildir ekki sem persónu-, eða ferðaskilríki',
+    'Þetta er eingöngu yfirlit og gildir ekki sem persónu- eða ferðaskilríki',
   'licenseDetail.identityTravelDocument.alert.description':
-    'Einungis skilríkið sjálft er gilt persónu-, og ferðaskilríki.',
+    'Einungis skilríkið sjálft er gilt persónu- og ferðaskilríki.',
   'licenseDetail.warning.title': 'Rennur út innan 6 mánaða',
   'licenseDetail.passport.warning.description':
     'Athugið að vegabréfið þitt mun renna út innan næstu 6 mánaða.',

--- a/apps/native/app/src/messages/is.ts
+++ b/apps/native/app/src/messages/is.ts
@@ -438,17 +438,18 @@ export const is = {
   'licenseDetail.ehic.alert.title': 'Mundu eftir kortinu!',
   'licenseDetail.ehic.alert.description':
     'Þetta yfirlit gildir ekki sem sjúkratryggingakort.',
-  'licenseDetail.passport.alert.title': 'Mundu eftir vegabréfinu!',
+  'licenseDetail.passport.alert.title':
+    'Þetta er eingöngu yfirlit og gildir ekki sem persónu-, eða ferðaskilríki',
   'licenseDetail.passport.alert.description':
-    'Þetta yfirlit gildir ekki sem ferðaskilríki.',
+    'Einungis skilríkið sjálft er gilt persónu-, og ferðaskilríki.',
   'licenseDetail.identityDocument.alert.title':
     'Þetta er eingöngu yfirlit og gildir ekki sem persónuskilríki',
   'licenseDetail.identityDocument.alert.description':
     'Einungis skilríkið sjálft er fullgilt persónuskilríki.',
   'licenseDetail.identityTravelDocument.alert.title':
-    'Mundu eftir nafnskírteininu!',
+    'Þetta er eingöngu yfirlit og gildir ekki sem persónu-, eða ferðaskilríki',
   'licenseDetail.identityTravelDocument.alert.description':
-    'Þetta yfirlit gildir ekki sem ferðaskilríki.',
+    'Einungis skilríkið sjálft er gilt persónu-, og ferðaskilríki.',
   'licenseDetail.warning.title': 'Rennur út innan 6 mánaða',
   'licenseDetail.passport.warning.description':
     'Athugið að vegabréfið þitt mun renna út innan næstu 6 mánaða.',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated alert titles and descriptions for passport and identity travel document messages to clarify that the displayed summaries are for informational purposes only and not valid for identification or travel. Only the physical documents are valid for official use. No functional changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->