### PR TITLE
fix(j-s): add missing field

### DIFF
--- a/apps/system-e2e/src/tests/judicial-system/regression/indictment-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/indictment-tests.spec.ts
@@ -280,7 +280,13 @@ test.describe.serial('Indictment tests', () => {
     // Completed case overview
     await expect(page).toHaveURL(`domur/akaera/lokid/${caseId}`)
 
-    await page.getByText('Birta skal dómfellda dóminn').click()
+    await page
+      .locator('label')
+      .filter({ hasText: 'Birta skal dómfellda dóminn' })
+      .click()
+
+    await page.locator('label').filter({ hasText: 'Dómsorð' }).fill('Dómsorð')
+
     await page.getByTestId('continueButton').click()
     await page.getByTestId('modalPrimaryButton').click()
   })


### PR DESCRIPTION
# [Add missing field population in e2e test](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1210541638410279)

Attach a link to issue if relevant

## What
- Add missing field population in e2e test

## Why
- It is a bug

## Screenshots / Gifs

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Improved reliability of indictment test steps by using more specific element locators and adding a form fill action for "Dómsorð".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->