### PR TITLE
fix(signature-collection): admin - collection name input field

### DIFF
--- a/libs/application/templates/signature-collection/municipal-list-signing/src/forms/Draft.ts
+++ b/libs/application/templates/signature-collection/municipal-list-signing/src/forms/Draft.ts
@@ -88,19 +88,6 @@ export const Draft: Form = buildForm({
           description: m.listDescription,
           children: [
             buildTextField({
-              id: 'municipality',
-              title: m.municipality,
-              width: 'full',
-              readOnly: true,
-              defaultValue: ({ externalData }: Application) => {
-                const municipalIdentity = getValueViaPath<IndividualDto>(
-                  externalData,
-                  'municipalIdentity.data',
-                )
-                return municipalIdentity?.legalDomicile?.locality
-              },
-            }),
-            buildTextField({
               id: 'candidateName',
               title: m.candidateName,
               width: 'full',
@@ -123,24 +110,36 @@ export const Draft: Form = buildForm({
               title: m.guarantorsNationalId,
               width: 'half',
               readOnly: true,
-              defaultValue: ({ externalData }: Application) =>
-                formatNationalId(
-                  getValueViaPath(
+              defaultValue: ({ answers, externalData }: Application) => {
+                const lists =
+                  getValueViaPath<SignatureCollectionList[]>(
                     externalData,
-                    'nationalRegistry.data.nationalId',
-                  ) ?? '',
-                ),
+                    'getList.data',
+                  ) || []
+
+                const nationalId =
+                  lists.length === 1
+                    ? lists[0].candidate.nationalId
+                    : lists.find((list) => list.id === answers.listId)
+                        ?.candidate.nationalId
+
+                return nationalId
+                  ? formatNationalId(nationalId)
+                  : undefined
+              },
             }),
             buildTextField({
-              id: 'guarantorsName',
-              title: m.guarantorsName,
+              id: 'municipality',
+              title: m.municipality,
               width: 'half',
               readOnly: true,
-              defaultValue: ({ externalData }: Application) =>
-                getValueViaPath(
+              defaultValue: ({ externalData }: Application) => {
+                const municipalIdentity = getValueViaPath<IndividualDto>(
                   externalData,
-                  'nationalRegistry.data.fullName',
-                ) ?? '',
+                  'municipalIdentity.data',
+                )
+                return municipalIdentity?.legalDomicile?.locality
+              },
             }),
             buildSubmitField({
               id: 'submit',

--- a/libs/portals/admin/signature-collection/src/shared-components/createCollection/index.tsx
+++ b/libs/portals/admin/signature-collection/src/shared-components/createCollection/index.tsx
@@ -134,6 +134,7 @@ const CreateCollection = ({
       })
     } else {
       setName('')
+      setCollectionName('')
       setNationalIdInput('')
       setNationalIdNotFound(false)
       setCanCreate(true)
@@ -174,6 +175,7 @@ const CreateCollection = ({
           setModalIsOpen(false)
           setNationalIdInput('')
           setName('')
+          setCollectionName('')
           setCanCreate(true)
         }}
         hideOnClickOutside={false}

--- a/libs/portals/admin/signature-collection/src/shared-components/createCollection/index.tsx
+++ b/libs/portals/admin/signature-collection/src/shared-components/createCollection/index.tsx
@@ -65,6 +65,7 @@ const CreateCollection = ({
   const [nationalIdInput, setNationalIdInput] = useState('')
   const [nationalIdNotFound, setNationalIdNotFound] = useState(false)
   const [name, setName] = useState('')
+  const [collectionName, setCollectionName] = useState('')
   const [canCreate, setCanCreate] = useState(true)
   const [canCreateErrorReason, setCanCreateErrorReason] = useState('')
 
@@ -75,6 +76,7 @@ const CreateCollection = ({
       input: {
         collectionType: collectionType,
         collectionId: id,
+        collectionName: collectionName || undefined,
         owner: {
           name: name,
           nationalId: nationalIdInput,
@@ -201,10 +203,23 @@ const CreateCollection = ({
               />
               <Input
                 name="candidateName"
-                label={formatMessage(m.candidateName)}
+                label={formatMessage(m.name)}
                 readOnly
                 value={name}
               />
+              {collectionType ===
+                SignatureCollectionCollectionType.LocalGovernmental && (
+                <Input
+                  name="collectionName"
+                  id="collectionName"
+                  label={formatMessage(m.candidateName)}
+                  backgroundColor="blue"
+                  value={collectionName}
+                    onChange={(v) =>
+                    setCollectionName(v.target.value)
+                  }
+                />
+              )}
               {currentArea?.id && (
                 <Input
                   name="candidateArea"


### PR DESCRIPTION
## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new input field for collection name when the collection type is Local Governmental.
- **Style**
	- The new input field features a blue background for improved visibility.
- **Enhancements**
	- Updated the label for the existing read-only name input for better clarity.
	- Repositioned and relabeled the municipality field for improved form layout.
	- Enhanced candidate information retrieval for more accurate default values in forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->