### PR TITLE
fix(form-system): try another method to consume secret

### DIFF
--- a/libs/api/domains/form-system/src/lib/translations/translations.service.ts
+++ b/libs/api/domains/form-system/src/lib/translations/translations.service.ts
@@ -29,9 +29,9 @@ export class TranslationsService {
     auth: User,
     input: GoogleTranslationInput,
   ): Promise<GoogleTranslation> {
-    const { FORM_SYSTEM_GOOGLE_TRANSLATE_API_KEY } = process.env
+    const apiKey = process.env.FORM_SYSTEM_GOOGLE_TRANSLATE_API_KEY as string
 
-    if (!FORM_SYSTEM_GOOGLE_TRANSLATE_API_KEY) {
+    if (!apiKey) {
       throw new Error(
         'Api key for Google translation service is not configured',
       )
@@ -52,7 +52,7 @@ export class TranslationsService {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            'X-goog-api-key': FORM_SYSTEM_GOOGLE_TRANSLATE_API_KEY,
+            'X-goog-api-key': apiKey,
           },
           body: JSON.stringify({
             q: input.q,

--- a/libs/portals/admin/form-system/src/components/Admin/components/Permission.tsx
+++ b/libs/portals/admin/form-system/src/components/Admin/components/Permission.tsx
@@ -1,8 +1,11 @@
-import { useContext } from "react"
-import { FormsContext } from "../../../context/FormsContext"
+import { useContext } from 'react'
+import { FormsContext } from '../../../context/FormsContext'
 import { Box, Checkbox, GridRow, Stack } from '@island.is/island-ui/core'
-import { useMutation } from "@apollo/client"
-import { CREATE_ORGANIZATION_PERMISSION, DELETE_ORGANIZATION_PERMISSION } from '@island.is/form-system/graphql'
+import { useMutation } from '@apollo/client'
+import {
+  CREATE_ORGANIZATION_PERMISSION,
+  DELETE_ORGANIZATION_PERMISSION,
+} from '@island.is/form-system/graphql'
 import { FormSystemPermissionType } from '@island.is/api/schema'
 
 type PermissionType = 'certificate' | 'list' | 'field'
@@ -22,7 +25,7 @@ export const Permission = ({ type }: Props) => {
     fieldTypes,
     selectedFieldTypes,
     setSelectedFieldTypes,
-    organizationId
+    organizationId,
   } = useContext(FormsContext)
 
   const sortedPermissionsList = (list: FormSystemPermissionType[]) => {
@@ -54,12 +57,12 @@ export const Permission = ({ type }: Props) => {
             updateOrganizationPermissionDto: {
               permission: id,
               organizationId: organizationId,
-            }
-          }
-        }
+            },
+          },
+        },
       })
     } catch (error) {
-      console.error('Failed to add permission:', error);
+      console.error('Failed to add permission:', error)
     }
   }
 
@@ -77,7 +80,7 @@ export const Permission = ({ type }: Props) => {
       })
       setSelectedTypes(getSelectedTypes().filter((type) => type !== id))
     } catch (error) {
-      console.error('Failed to remove permission:', error);
+      console.error('Failed to remove permission:', error)
     }
   }
 
@@ -151,7 +154,7 @@ export const Permission = ({ type }: Props) => {
                 name={permission?.name?.is ?? ''}
                 checked={isSelected(permission.id ?? '')}
                 onChange={async (e) => {
-                  if (e) {
+                  if (e.target.checked) {
                     await addPermission(permission.id ?? '')
                   } else {
                     await removePermission(permission.id ?? '')


### PR DESCRIPTION
## What

The application was not successful consuming a secret from the parameter store. 
Worked on my local development environment so this is a shot in the dark

## Why

Try to make the application consume a secret from the parameter store on dev

## Checklist:

- [x ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
