### PR TITLE
fix(rental-agreement): Clear units on new search

### DIFF
--- a/libs/application/templates/rental-agreement/src/fields/PropertySearch/index.tsx
+++ b/libs/application/templates/rental-agreement/src/fields/PropertySearch/index.tsx
@@ -1,4 +1,4 @@
-import { FC, Fragment, useEffect, useState } from 'react'
+import { FC, Fragment, useEffect, useMemo, useState } from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
 import { useLazyQuery } from '@apollo/client'
 import { CustomField, FieldBaseProps } from '@island.is/application/types'
@@ -166,6 +166,7 @@ export const PropertySearch: FC<React.PropsWithChildren<Props>> = ({
         formatMessage(registerProperty.search.addressSearchError) ||
           'Failed to search addresses',
       )
+      setPropertiesByAddressCode(undefined)
     },
     onCompleted: (data) => {
       setAddressSearchError(null)
@@ -193,6 +194,7 @@ export const PropertySearch: FC<React.PropsWithChildren<Props>> = ({
         formatMessage(registerProperty.search.propertyInfoError) ||
           'Failed to fetch properties',
       )
+      setPropertiesByAddressCode(undefined)
     },
     onCompleted: (data) => {
       setPropertyInfoError(null)
@@ -372,6 +374,12 @@ export const PropertySearch: FC<React.PropsWithChildren<Props>> = ({
   }
 
   const hasValidationErrors = errors ? Object.keys(errors).length > 0 : false
+  const propertySectionHasContent = useMemo(() => {
+    return (
+      propertiesLoading ||
+      (propertiesByAddressCode && propertiesByAddressCode.length > 0)
+    )
+  }, [propertiesLoading, propertiesByAddressCode])
 
   return (
     <>
@@ -405,20 +413,20 @@ export const PropertySearch: FC<React.PropsWithChildren<Props>> = ({
             )
           }}
         />
-        {addressSearchError && (
-          <Box marginTop={2}>
-            <AlertMessage type="error" message={addressSearchError} />
+        {!propertiesLoading && addressSearchError && (
+          <Box marginTop={4}>
+            <AlertMessage type="error" title={addressSearchError} />
+          </Box>
+        )}
+        {!propertiesLoading && propertyInfoError && (
+          <Box marginTop={4}>
+            <AlertMessage type="error" title={propertyInfoError} />
           </Box>
         )}
       </Box>
 
       {selectedAddress && (
-        <Box marginTop={6}>
-          {propertyInfoError && (
-            <Box marginBottom={4}>
-              <AlertMessage type="error" message={propertyInfoError} />
-            </Box>
-          )}
+        <Box marginTop={propertySectionHasContent ? 6 : 0}>
           {propertiesLoading ? (
             <div style={{ textAlign: 'center' }}>
               <LoadingDots large />


### PR DESCRIPTION
# Clear units on new search

https://app.asana.com/1/203394141643832/project/1208271027457465/task/1210096275275241

## What

- Clear units displayed for new search, errors
- Updated positioning and spacing for errors for consistency

## Why

- So you cant choose a unit from different address than the current one

## Screenshots / Gifs

Before
![image](https://github.com/user-attachments/assets/0c5cb765-a96f-44c3-a2ee-af5dca8024bf)

After
<img width="1497" alt="Screenshot 2025-06-19 at 10 20 12" src="https://github.com/user-attachments/assets/f22553a4-6ef0-458a-b49a-58e066efae30" />


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
