### PR TITLE
feat(web): Change variant for news on organization and project pages

### DIFF
--- a/apps/web/components/Organization/Slice/LatestNewsSlice/DigitalIcelandLatestNewsSlice/DigitalIcelandLatestNewsSlice.tsx
+++ b/apps/web/components/Organization/Slice/LatestNewsSlice/DigitalIcelandLatestNewsSlice/DigitalIcelandLatestNewsSlice.tsx
@@ -16,14 +16,23 @@ import { useLinkResolver } from '@island.is/web/hooks'
 
 import * as styles from './DigitalIcelandLatestNewsSlice.css'
 
-const SeeMoreLink = ({ slice, slug }: SliceProps) => {
+const SeeMoreLink = ({
+  slice,
+  slug,
+  seeMoreLinkVariant = 'organization',
+}: SliceProps) => {
   const { linkResolver } = useLinkResolver()
   return (
     <LinkV2
       href={
         slice.readMoreLink?.url
           ? slice.readMoreLink.url
-          : linkResolver('organizationnewsoverview', [slug]).href
+          : linkResolver(
+              seeMoreLinkVariant === 'organization'
+                ? 'organizationnewsoverview'
+                : 'projectnewsoverview',
+              [slug],
+            ).href
       }
     >
       <Button as="span" unfocusable={true} variant="text" icon="arrowForward">
@@ -36,11 +45,12 @@ const SeeMoreLink = ({ slice, slug }: SliceProps) => {
 interface SliceProps {
   slice: LatestNewsSliceSchema
   slug: string
+  seeMoreLinkVariant?: 'organization' | 'project'
 }
 
 export const DigitalIcelandLatestNewsSlice: React.FC<
   React.PropsWithChildren<SliceProps>
-> = ({ slice, slug }) => {
+> = ({ slice, slug, seeMoreLinkVariant = 'organization' }) => {
   const { linkResolver } = useLinkResolver()
   return (
     <Box component="section" aria-labelledby="news-items-title">
@@ -63,14 +73,25 @@ export const DigitalIcelandLatestNewsSlice: React.FC<
               {slice.title}
             </Text>
             <Hidden below="md">
-              <SeeMoreLink slice={slice} slug={slug} />
+              <SeeMoreLink
+                slice={slice}
+                slug={slug}
+                seeMoreLinkVariant={seeMoreLinkVariant}
+              />
             </Hidden>
           </Box>
           <Box className={styles.itemListContainer}>
             {slice.news.slice(0, 3).map((news) => (
               <DigitalIcelandLatestNewsCard
                 key={news.id}
-                href={linkResolver('organizationnews', [slug, news.slug]).href}
+                href={
+                  linkResolver(
+                    seeMoreLinkVariant === 'organization'
+                      ? 'organizationnews'
+                      : 'projectnews',
+                    [slug, news.slug],
+                  ).href
+                }
                 date={news.date}
                 description={news.intro}
                 imageSrc={news.image?.url ?? ''}
@@ -83,7 +104,11 @@ export const DigitalIcelandLatestNewsSlice: React.FC<
           </Box>
           <Hidden above="sm">
             <Box display="flex" justifyContent="center">
-              <SeeMoreLink slice={slice} slug={slug} />
+              <SeeMoreLink
+                slice={slice}
+                slug={slug}
+                seeMoreLinkVariant={seeMoreLinkVariant}
+              />
             </Box>
           </Hidden>
         </Stack>

--- a/apps/web/screens/Organization/Home/Home.tsx
+++ b/apps/web/screens/Organization/Home/Home.tsx
@@ -31,7 +31,6 @@ import useContentfulId from '@island.is/web/hooks/useContentfulId'
 import { withMainLayout } from '@island.is/web/layouts/main'
 import { CustomNextError } from '@island.is/web/units/errors'
 import { extractNamespaceFromOrganization } from '@island.is/web/utils/extractNamespaceFromOrganization'
-import { organizationHasDigitalIcelandNewsVisuals } from '@island.is/web/utils/organization'
 
 import { Screen, ScreenContext } from '../../../types'
 import {

--- a/apps/web/screens/Organization/Home/Home.tsx
+++ b/apps/web/screens/Organization/Home/Home.tsx
@@ -209,7 +209,6 @@ const OrganizationHomePage = ({
       >
         {organizationPage?.bottomSlices.map((slice, index) => {
           if (
-            organizationHasDigitalIcelandNewsVisuals(organizationPage.slug) &&
             slice.__typename === 'LatestNewsSlice' &&
             slice.news.length >= 3
           ) {

--- a/apps/web/screens/Organization/OrganizationNews/OrganizationNewsList.tsx
+++ b/apps/web/screens/Organization/OrganizationNews/OrganizationNewsList.tsx
@@ -32,7 +32,6 @@ import { LayoutProps, withMainLayout } from '@island.is/web/layouts/main'
 import type { Screen } from '@island.is/web/types'
 import { CustomNextError } from '@island.is/web/units/errors'
 import { extractNamespaceFromOrganization } from '@island.is/web/utils/extractNamespaceFromOrganization'
-import { organizationHasDigitalIcelandNewsVisuals } from '@island.is/web/utils/organization'
 import { getIntParam } from '@island.is/web/utils/queryParams'
 
 import {

--- a/apps/web/screens/Organization/OrganizationNews/OrganizationNewsList.tsx
+++ b/apps/web/screens/Organization/OrganizationNews/OrganizationNewsList.tsx
@@ -206,14 +206,7 @@ const OrganizationNewsList: Screen<OrganizationNewsListProps> = ({
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore make web strict
         newsTags={organizationPage.secondaryNewsTags}
-        variant={
-          organizationPage.slug === 'stafraent-island' ||
-          organizationPage.slug === 'digital-iceland' ||
-          (organizationHasDigitalIcelandNewsVisuals(organizationPage.slug) &&
-            (namespace?.digitalIcelandNewsVisualsEnabled ?? false))
-            ? 'digital-iceland'
-            : 'default'
-        }
+        variant="digital-iceland"
       />
     </OrganizationWrapper>
   )

--- a/apps/web/screens/Project/Project.tsx
+++ b/apps/web/screens/Project/Project.tsx
@@ -12,7 +12,7 @@ import {
 } from '@island.is/island-ui/core'
 import { Locale } from '@island.is/shared/types'
 import {
-  Form,
+  DigitalIcelandLatestNewsSlice,
   HeadWithSocialSharing,
   OneColumnTextSlice,
   SliceMachine,
@@ -310,6 +310,21 @@ const ProjectPage: Screen<PageProps> = ({
             return (
               <Box paddingBottom={6}>
                 <OneColumnTextSlice slice={slice} />
+              </Box>
+            )
+          }
+          if (
+            slice.__typename === 'LatestNewsSlice' &&
+            slice.news.length >= 3 &&
+            projectPage?.slug
+          ) {
+            return (
+              <Box paddingBottom={[2, 2, 5]} key={slice.id}>
+                <DigitalIcelandLatestNewsSlice
+                  slice={slice}
+                  slug={projectPage.slug}
+                  seeMoreLinkVariant="project"
+                />
               </Box>
             )
           }

--- a/apps/web/screens/Project/ProjectNewsList.tsx
+++ b/apps/web/screens/Project/ProjectNewsList.tsx
@@ -172,6 +172,7 @@ const ProjectNewsList: Screen<ProjectNewsListProps> = ({
           monthOptions={monthOptions}
           title={newsTitle}
           newsPerPage={10}
+          variant="digital-iceland"
         />
       </ProjectWrapper>
       <HeadWithSocialSharing

--- a/apps/web/utils/organization.ts
+++ b/apps/web/utils/organization.ts
@@ -60,17 +60,3 @@ export const extractOrganizationSlugFromPathname = (
   const localeSegment = isLocale(segments[0]) ? segments[0] : ''
   return (localeSegment ? segments[2] : segments[1]) ?? ''
 }
-
-const ORGANIZATION_SLUGS_WITH_DIGITAL_ICELAND_VISUALS = [
-  'stafraent-island',
-  'digital-iceland',
-  'logreglan',
-  'icelandic-police',
-  'heilsugaesla-hofudborgarsvaedisins',
-  'capital-area-health-care-centre',
-  'domstolar',
-  'the-courts',
-]
-export const organizationHasDigitalIcelandNewsVisuals = (slug: string) => {
-  return ORGANIZATION_SLUGS_WITH_DIGITAL_ICELAND_VISUALS.includes(slug)
-}


### PR DESCRIPTION
# Change variant for news on organization and project pages

Have the same news visuals between organizations and project pages

## Before

![Screenshot 2025-06-19 at 13 13 23](https://github.com/user-attachments/assets/6ad859ae-64ab-41ac-85ba-e32d94025764)

## After

![Screenshot 2025-06-19 at 13 13 54](https://github.com/user-attachments/assets/f7bc2e4c-41bb-4199-b125-b45ec5416c20)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for displaying the latest news slice on project pages, with links and navigation tailored for project-specific news.
  - News lists on both organization and project news pages now use the "digital-iceland" visual variant for a unified appearance.

- **Refactor**
  - Simplified and unified logic for determining news visual variants by removing conditional checks based on organization slugs.
  - Streamlined the rendering logic for news slices on organization and project pages.

- **Chores**
  - Removed unused utility functions and constants related to digital Iceland news visuals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->