### PR TITLE
feat(j-s): Add court case number to stepper

### DIFF
--- a/apps/judicial-system/web/src/components/PageLayout/PageLayout.tsx
+++ b/apps/judicial-system/web/src/components/PageLayout/PageLayout.tsx
@@ -17,6 +17,7 @@ import {
 import { getStandardUserDashboardRoute } from '@island.is/judicial-system/consts'
 import {
   isDefenceUser,
+  isDistrictCourtUser,
   isIndictmentCase,
 } from '@island.is/judicial-system/types'
 import {
@@ -136,6 +137,8 @@ const SidePanel: FC<SidePanelProps> = ({
   const activeSubSection = sections[activeSection]?.children.findIndex(
     (s) => s.isActive,
   )
+  const showCourtCaseNumber = isDistrictCourtUser(user)
+
   return (
     <GridColumn span={['12/12', '12/12', '4/12', '3/12']}>
       <div className={styles.formStepperContainer}>
@@ -145,7 +148,11 @@ const SidePanel: FC<SidePanelProps> = ({
               <Logo defaultInstitution={workingCase.court?.name} />
             </Box>
           )}
-          <Box marginBottom={6}>
+          <Box
+            marginBottom={[1, 1, showCourtCaseNumber ? 4 : 6]}
+            marginLeft={[3, 3, 0]}
+            marginTop={[2, 2, 0]}
+          >
             <Text variant="h3" as="h3">
               {formatMessage(
                 user?.institution?.type === InstitutionType.COURT_OF_APPEALS
@@ -155,6 +162,11 @@ const SidePanel: FC<SidePanelProps> = ({
                   : formStepperSections.title,
                 { caseType: workingCase.type },
               )}
+            </Text>
+            <Text>
+              {showCourtCaseNumber && workingCase.courtCaseNumber
+                ? workingCase.courtCaseNumber
+                : '\u00A0'}
             </Text>
           </Box>
           <FormStepperV2


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1210457401556074)

## What

Display the court case number above the side stepper for district court users 
Also made the UI a bit nicer in the smallest screen sizes 

## Why

So it's easier for users to keep track of which case they're currently working on without needing to scroll to the top. 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The court case number is now displayed below the case title for district court users when available.
- **Style**
  - Improved layout spacing for the case title and court case number to ensure consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->