### PR TITLE
feat(j-s): Apply case to defendant address in indictment intro

### DIFF
--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Indictment.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Indictment.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useContext, useState } from 'react'
 import { IntlShape, useIntl } from 'react-intl'
-import { applyCase } from 'beygla/strict'
 import { applyCase as applyCaseToAddress } from 'beygla/addresses'
+import { applyCase } from 'beygla/strict'
 import { AnimatePresence, motion } from 'motion/react'
 import router from 'next/router'
 


### PR DESCRIPTION
# Apply case to defendant address in indictment intro

[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1210438483850602?focus=true)

## What

Apply case to defendant address in indictment intro

## Why

Feedback from user

## Screenshots / Gifs

<img width="836" alt="Screenshot 2025-06-19 at 22 15 06" src="https://github.com/user-attachments/assets/c899b8e4-4c40-4e5d-8007-ed742f1cd11a" />

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Defendant addresses in indictment introductions are now automatically formatted with the appropriate grammatical case when available.

- **Bug Fixes**
	- Ensured that missing defendant addresses continue to display the placeholder text as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->