### PR TITLE
chore(web): Remove "Endurupptökudómar" court filter tag

### DIFF
--- a/apps/web/screens/Verdicts/VerdictsList.tsx
+++ b/apps/web/screens/Verdicts/VerdictsList.tsx
@@ -780,10 +780,6 @@ const VerdictsList: CustomScreen<VerdictsListProps> = (props) => {
         label: formatMessage(m.listPage.showSupremeCourt),
         value: 'Hæstiréttur',
       },
-      {
-        label: formatMessage(m.listPage.showRetrialCourt),
-        value: 'Endurupptökudómur',
-      },
     ]
   }, [formatMessage])
   const districtCourtTags = useMemo(() => {


### PR DESCRIPTION
# Remove "Endurupptökudómar" court filter tag


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed the "Retrial Court" option from the court filter list when viewing verdicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->