### PR TITLE
feat(services-payments): Be able to delete unpaid payment flows

### DIFF
--- a/apps/services/payments/migrations/20250623000000-add-indices-on-payment-flow-relations.js
+++ b/apps/services/payments/migrations/20250623000000-add-indices-on-payment-flow-relations.js
@@ -1,0 +1,38 @@
+'use strict'
+
+module.exports = {
+  up: (queryInterface) => {
+    return Promise.all([
+      queryInterface.addIndex(
+        'payment_flow_fjs_charge_confirmation',
+        ['payment_flow_id'],
+        {
+          name: 'payment_flow_fjs_charge_confirmation_payment_flow_id_idx',
+        },
+      ),
+      queryInterface.addIndex('payment_flow_charge', ['payment_flow_id'], {
+        name: 'payment_flow_charge_payment_flow_id_idx',
+      }),
+      queryInterface.addIndex('payment_flow_event', ['payment_flow_id'], {
+        name: 'payment_flow_event_payment_flow_id_idx',
+      }),
+    ])
+  },
+
+  down: (queryInterface) => {
+    return Promise.all([
+      queryInterface.removeIndex(
+        'payment_flow_fjs_charge_confirmation',
+        'payment_flow_fjs_charge_confirmation_payment_flow_id_idx',
+      ),
+      queryInterface.removeIndex(
+        'payment_flow_charge',
+        'payment_flow_charge_payment_flow_id_idx',
+      ),
+      queryInterface.removeIndex(
+        'payment_flow_event',
+        'payment_flow_event_payment_flow_id_idx',
+      ),
+    ])
+  },
+}

--- a/apps/services/payments/src/app/paymentFlow/models/paymentFlow.model.ts
+++ b/apps/services/payments/src/app/paymentFlow/models/paymentFlow.model.ts
@@ -10,11 +10,13 @@ import {
   DataType,
   ForeignKey,
   HasMany,
+  HasOne,
   Model,
   PrimaryKey,
   Table,
   UpdatedAt,
 } from 'sequelize-typescript'
+import { PaymentFlowFjsChargeConfirmation } from './paymentFlowFjsChargeConfirmation.model'
 
 @Table({
   tableName: 'payment_flow_charge',
@@ -129,6 +131,9 @@ export class PaymentFlow extends Model<
   @ApiProperty({ type: [PaymentFlowCharge] }) // Link to the charges model
   @HasMany(() => PaymentFlowCharge, 'paymentFlowId')
   charges!: PaymentFlowCharge[]
+
+  @HasOne(() => PaymentFlowFjsChargeConfirmation, 'paymentFlowId')
+  fjsChargeConfirmation?: PaymentFlowFjsChargeConfirmation
 
   @ApiProperty({ type: [String] })
   @Column({

--- a/apps/services/payments/src/app/paymentFlow/models/paymentFlow.model.ts
+++ b/apps/services/payments/src/app/paymentFlow/models/paymentFlow.model.ts
@@ -20,6 +20,12 @@ import { PaymentFlowFjsChargeConfirmation } from './paymentFlowFjsChargeConfirma
 
 @Table({
   tableName: 'payment_flow_charge',
+  indexes: [
+    {
+      name: 'payment_flow_charge_payment_flow_id_idx',
+      fields: ['payment_flow_id'],
+    },
+  ],
 })
 export class PaymentFlowCharge extends Model<
   InferAttributes<PaymentFlowCharge>,

--- a/apps/services/payments/src/app/paymentFlow/models/paymentFlowEvent.model.ts
+++ b/apps/services/payments/src/app/paymentFlow/models/paymentFlowEvent.model.ts
@@ -18,6 +18,26 @@ import { PaymentFlow } from './paymentFlow.model' // Update the import path as n
 
 @Table({
   tableName: 'payment_flow_event',
+  indexes: [
+    {
+      name: 'payment_flow_event_payment_flow_id_type_idx',
+      fields: ['payment_flow_id', 'type'],
+      where: {
+        type: 'success',
+      },
+    },
+    {
+      name: 'payment_flow_event_payment_completed_idx',
+      fields: ['payment_flow_id'],
+      where: {
+        reason: 'payment_completed',
+      },
+    },
+    {
+      name: 'payment_flow_event_payment_flow_id_idx',
+      fields: ['payment_flow_id'],
+    },
+  ],
 })
 export class PaymentFlowEvent extends Model<
   InferAttributes<PaymentFlowEvent>,

--- a/apps/services/payments/src/app/paymentFlow/models/paymentFlowFjsChargeConfirmation.model.ts
+++ b/apps/services/payments/src/app/paymentFlow/models/paymentFlowFjsChargeConfirmation.model.ts
@@ -18,6 +18,12 @@ import {
 
 @Table({
   tableName: 'payment_flow_fjs_charge_confirmation',
+  indexes: [
+    {
+      name: 'payment_flow_fjs_charge_confirmation_payment_flow_id_idx',
+      fields: ['payment_flow_id'],
+    },
+  ],
 })
 export class PaymentFlowFjsChargeConfirmation extends Model<
   InferAttributes<PaymentFlowFjsChargeConfirmation>,

--- a/apps/services/payments/src/app/paymentFlow/paymentFlow.controller.ts
+++ b/apps/services/payments/src/app/paymentFlow/paymentFlow.controller.ts
@@ -67,7 +67,7 @@ export class PaymentFlowController {
     description: 'Deletes a PaymentFlow.',
     response: { status: 200, type: GetPaymentFlowDTO },
   })
-  async deletePaymentFlow(
+  deletePaymentFlow(
     @Param('id', new ParseUUIDPipe()) id: string,
   ): Promise<GetPaymentFlowDTO | null> {
     return this.paymentFlowService.deletePaymentFlow(id)

--- a/apps/services/payments/src/app/paymentFlow/paymentFlow.controller.ts
+++ b/apps/services/payments/src/app/paymentFlow/paymentFlow.controller.ts
@@ -67,17 +67,10 @@ export class PaymentFlowController {
     description: 'Deletes a PaymentFlow.',
     response: { status: 200, type: GetPaymentFlowDTO },
   })
-  deletePaymentFlow(
+  async deletePaymentFlow(
     @Param('id', new ParseUUIDPipe()) id: string,
   ): Promise<GetPaymentFlowDTO | null> {
-    // Check if exists
-    // Check if has been paid
-    // Check if existing invoice
-    //   - Delete invoice if exists
-    // Delete payment flow
-    // Notify onUpdateUrl with status
-
-    return {} as any
+    return this.paymentFlowService.deletePaymentFlow(id)
   }
 
   @Post()

--- a/apps/services/payments/src/app/paymentFlow/paymentFlow.service.spec.ts
+++ b/apps/services/payments/src/app/paymentFlow/paymentFlow.service.spec.ts
@@ -12,6 +12,10 @@ import { CreatePaymentFlowInput } from './dtos/createPaymentFlow.input'
 import { PaymentFlow } from './models/paymentFlow.model'
 import { getModelToken } from '@nestjs/sequelize'
 
+// A helper type to satisfy the linter for partial mocks.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type TestPartial = any
+
 describe('PaymentFlowService', () => {
   let app: TestApp
   let service: PaymentFlowService
@@ -48,14 +52,16 @@ describe('PaymentFlowService', () => {
         },
       ]
 
-      jest.spyOn(service as any, 'getPaymentFlowChargeDetails').mockReturnValue(
-        Promise.resolve({
-          catalogItems: charges,
-          totalPrice: 0,
-          isAlreadyPaid: false,
-          hasInvoice: false,
-        }),
-      )
+      jest
+        .spyOn(service as TestPartial, 'getPaymentFlowChargeDetails')
+        .mockReturnValue(
+          Promise.resolve({
+            catalogItems: charges,
+            totalPrice: 0,
+            isAlreadyPaid: false,
+            hasInvoice: false,
+          }),
+        )
 
       const paymentInfo: CreatePaymentFlowInput = {
         availablePaymentMethods: [PaymentMethod.CARD],
@@ -111,7 +117,7 @@ describe('PaymentFlowService', () => {
     it('should throw an already paid error if flow is paid', async () => {
       jest
         .spyOn(service, 'getPaymentFlowDetails')
-        .mockResolvedValue(mockPaymentFlowDetails as any)
+        .mockResolvedValue(mockPaymentFlowDetails as TestPartial)
       jest.spyOn(service, 'getPaymentFlowStatus').mockResolvedValue({
         paymentStatus: PaymentStatus.PAID,
         updatedAt: new Date(),
@@ -138,7 +144,7 @@ describe('PaymentFlowService', () => {
 
       jest
         .spyOn(service, 'getPaymentFlowDetails')
-        .mockResolvedValue(paymentFlowWithInvoice as any)
+        .mockResolvedValue(paymentFlowWithInvoice as TestPartial)
       jest.spyOn(service, 'getPaymentFlowStatus').mockResolvedValue({
         paymentStatus: PaymentStatus.INVOICE_PENDING,
         updatedAt: new Date(),
@@ -146,9 +152,9 @@ describe('PaymentFlowService', () => {
       jest.spyOn(service, 'getPaymentFlowChargeDetails').mockResolvedValue({
         firstProductTitle: 'Test Product',
         totalPrice: 100,
-      } as any)
+      } as TestPartial)
       jest
-        .spyOn(service as any, 'getPayerName')
+        .spyOn(service as TestPartial, 'getPayerName')
         .mockResolvedValue(mockPayer.name)
       jest.spyOn(service, 'logPaymentFlowUpdate').mockResolvedValue(undefined)
       const deletePaymentChargeSpy = jest
@@ -177,7 +183,7 @@ describe('PaymentFlowService', () => {
 
       jest
         .spyOn(service, 'getPaymentFlowDetails')
-        .mockResolvedValue(paymentFlowWithoutInvoice as any)
+        .mockResolvedValue(paymentFlowWithoutInvoice as TestPartial)
       jest.spyOn(service, 'getPaymentFlowStatus').mockResolvedValue({
         paymentStatus: PaymentStatus.UNPAID,
         updatedAt: new Date(),
@@ -185,9 +191,9 @@ describe('PaymentFlowService', () => {
       jest.spyOn(service, 'getPaymentFlowChargeDetails').mockResolvedValue({
         firstProductTitle: 'Test Product',
         totalPrice: 100,
-      } as any)
+      } as TestPartial)
       jest
-        .spyOn(service as any, 'getPayerName')
+        .spyOn(service as TestPartial, 'getPayerName')
         .mockResolvedValue(mockPayer.name)
       jest.spyOn(service, 'logPaymentFlowUpdate').mockResolvedValue(undefined)
       const deletePaymentChargeSpy = jest
@@ -217,7 +223,7 @@ describe('PaymentFlowService', () => {
 
       jest
         .spyOn(service, 'getPaymentFlowDetails')
-        .mockResolvedValue(paymentFlowWithoutUrl as any)
+        .mockResolvedValue(paymentFlowWithoutUrl as TestPartial)
       jest.spyOn(service, 'getPaymentFlowStatus').mockResolvedValue({
         paymentStatus: PaymentStatus.UNPAID,
         updatedAt: new Date(),
@@ -225,9 +231,9 @@ describe('PaymentFlowService', () => {
       jest.spyOn(service, 'getPaymentFlowChargeDetails').mockResolvedValue({
         firstProductTitle: 'Test Product',
         totalPrice: 100,
-      } as any)
+      } as TestPartial)
       jest
-        .spyOn(service as any, 'getPayerName')
+        .spyOn(service as TestPartial, 'getPayerName')
         .mockResolvedValue(mockPayer.name)
       const logSpy = jest
         .spyOn(service, 'logPaymentFlowUpdate')

--- a/apps/services/payments/src/app/paymentFlow/paymentFlow.service.spec.ts
+++ b/apps/services/payments/src/app/paymentFlow/paymentFlow.service.spec.ts
@@ -1,11 +1,16 @@
-import { PaymentFlowService } from './paymentFlow.service'
-import { PaymentMethod } from '../../types'
+import { BadRequestException } from '@nestjs/common'
 
 import { TestApp } from '@island.is/testing/nest'
+import { ChargeFjsV2ClientService } from '@island.is/clients/charge-fjs-v2'
+import { PaymentServiceCode } from '@island.is/shared/constants'
 
 import { setupTestApp } from '../../../test/setup'
+import { PaymentMethod, PaymentStatus } from '../../types'
+
+import { PaymentFlowService } from './paymentFlow.service'
 import { CreatePaymentFlowInput } from './dtos/createPaymentFlow.input'
-import { ChargeFjsV2ClientService } from '@island.is/clients/charge-fjs-v2'
+import { PaymentFlow } from './models/paymentFlow.model'
+import { getModelToken } from '@nestjs/sequelize'
 
 describe('PaymentFlowService', () => {
   let app: TestApp
@@ -63,6 +68,179 @@ describe('PaymentFlowService', () => {
       const result = await service.createPaymentUrl(paymentInfo)
 
       expect(result.urls).toBeDefined()
+    })
+  })
+
+  describe('deletePaymentFlow', () => {
+    const paymentFlowId = 'test-id'
+    const mockPayer = {
+      payerNationalId: '1234567890',
+      name: 'Tester Testsson',
+    }
+    const mockPaymentFlowDetails = {
+      id: paymentFlowId,
+      organisationId: '5534567890',
+      payerNationalId: mockPayer.payerNationalId,
+      charges: [],
+      availablePaymentMethods: [PaymentMethod.CARD],
+      onUpdateUrl: 'http://some.url/update',
+    }
+
+    let paymentFlowModel: typeof PaymentFlow
+
+    beforeAll(() => {
+      paymentFlowModel = app.get<typeof PaymentFlow>(getModelToken(PaymentFlow))
+    })
+
+    beforeEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    it('should throw a not found error if flow does not exist', async () => {
+      const error = new BadRequestException(
+        PaymentServiceCode.PaymentFlowNotFound,
+      )
+      jest.spyOn(service, 'getPaymentFlowDetails').mockRejectedValue(error)
+
+      const promise = service.deletePaymentFlow(paymentFlowId)
+      await expect(promise).rejects.toThrow(error)
+
+      expect(service.getPaymentFlowDetails).toHaveBeenCalledWith(paymentFlowId)
+    })
+
+    it('should throw an already paid error if flow is paid', async () => {
+      jest
+        .spyOn(service, 'getPaymentFlowDetails')
+        .mockResolvedValue(mockPaymentFlowDetails as any)
+      jest.spyOn(service, 'getPaymentFlowStatus').mockResolvedValue({
+        paymentStatus: PaymentStatus.PAID,
+        updatedAt: new Date(),
+      })
+
+      const error = new BadRequestException(
+        PaymentServiceCode.PaymentFlowAlreadyPaid,
+      )
+
+      const promise = service.deletePaymentFlow(paymentFlowId)
+      await expect(promise).rejects.toThrow(error)
+
+      expect(service.getPaymentFlowDetails).toHaveBeenCalledWith(paymentFlowId)
+      expect(service.getPaymentFlowStatus).toHaveBeenCalledWith(
+        mockPaymentFlowDetails,
+      )
+    })
+
+    it('should delete a flow with a pending invoice', async () => {
+      const paymentFlowWithInvoice = {
+        ...mockPaymentFlowDetails,
+        fjsChargeConfirmation: { id: 'fjs-confirm' },
+      }
+
+      jest
+        .spyOn(service, 'getPaymentFlowDetails')
+        .mockResolvedValue(paymentFlowWithInvoice as any)
+      jest.spyOn(service, 'getPaymentFlowStatus').mockResolvedValue({
+        paymentStatus: PaymentStatus.INVOICE_PENDING,
+        updatedAt: new Date(),
+      })
+      jest.spyOn(service, 'getPaymentFlowChargeDetails').mockResolvedValue({
+        firstProductTitle: 'Test Product',
+        totalPrice: 100,
+      } as any)
+      jest
+        .spyOn(service as any, 'getPayerName')
+        .mockResolvedValue(mockPayer.name)
+      jest.spyOn(service, 'logPaymentFlowUpdate').mockResolvedValue(undefined)
+      const deletePaymentChargeSpy = jest
+        .spyOn(service, 'deletePaymentCharge')
+        .mockResolvedValue(undefined)
+
+      const destroySpy = jest
+        .spyOn(paymentFlowModel, 'destroy')
+        .mockResolvedValue(1)
+
+      const result = await service.deletePaymentFlow(paymentFlowId)
+
+      expect(result).toBeDefined()
+      expect(result.paymentStatus).toBe(PaymentStatus.INVOICE_PENDING)
+      expect(service.getPaymentFlowDetails).toHaveBeenCalledWith(paymentFlowId)
+      expect(deletePaymentChargeSpy).toHaveBeenCalledWith(paymentFlowId)
+      expect(destroySpy).toHaveBeenCalledWith({ where: { id: paymentFlowId } })
+      expect(service.logPaymentFlowUpdate).toHaveBeenCalled()
+    })
+
+    it('should delete a flow that is unpaid and has no invoice', async () => {
+      const paymentFlowWithoutInvoice = {
+        ...mockPaymentFlowDetails,
+        fjsChargeConfirmation: null,
+      }
+
+      jest
+        .spyOn(service, 'getPaymentFlowDetails')
+        .mockResolvedValue(paymentFlowWithoutInvoice as any)
+      jest.spyOn(service, 'getPaymentFlowStatus').mockResolvedValue({
+        paymentStatus: PaymentStatus.UNPAID,
+        updatedAt: new Date(),
+      })
+      jest.spyOn(service, 'getPaymentFlowChargeDetails').mockResolvedValue({
+        firstProductTitle: 'Test Product',
+        totalPrice: 100,
+      } as any)
+      jest
+        .spyOn(service as any, 'getPayerName')
+        .mockResolvedValue(mockPayer.name)
+      jest.spyOn(service, 'logPaymentFlowUpdate').mockResolvedValue(undefined)
+      const deletePaymentChargeSpy = jest
+        .spyOn(service, 'deletePaymentCharge')
+        .mockResolvedValue(undefined)
+
+      const destroySpy = jest
+        .spyOn(paymentFlowModel, 'destroy')
+        .mockResolvedValue(1)
+
+      const result = await service.deletePaymentFlow(paymentFlowId)
+
+      expect(result).toBeDefined()
+      expect(result.paymentStatus).toBe(PaymentStatus.UNPAID)
+      expect(service.getPaymentFlowDetails).toHaveBeenCalledWith(paymentFlowId)
+      expect(deletePaymentChargeSpy).not.toHaveBeenCalled()
+      expect(destroySpy).toHaveBeenCalledWith({ where: { id: paymentFlowId } })
+      expect(service.logPaymentFlowUpdate).toHaveBeenCalled()
+    })
+
+    it('should not send notification if onUpdateUrl is missing', async () => {
+      const paymentFlowWithoutUrl = {
+        ...mockPaymentFlowDetails,
+        onUpdateUrl: null,
+        fjsChargeConfirmation: null,
+      }
+
+      jest
+        .spyOn(service, 'getPaymentFlowDetails')
+        .mockResolvedValue(paymentFlowWithoutUrl as any)
+      jest.spyOn(service, 'getPaymentFlowStatus').mockResolvedValue({
+        paymentStatus: PaymentStatus.UNPAID,
+        updatedAt: new Date(),
+      })
+      jest.spyOn(service, 'getPaymentFlowChargeDetails').mockResolvedValue({
+        firstProductTitle: 'Test Product',
+        totalPrice: 100,
+      } as any)
+      jest
+        .spyOn(service as any, 'getPayerName')
+        .mockResolvedValue(mockPayer.name)
+      const logSpy = jest
+        .spyOn(service, 'logPaymentFlowUpdate')
+        .mockResolvedValue(undefined)
+
+      const destroySpy = jest
+        .spyOn(paymentFlowModel, 'destroy')
+        .mockResolvedValue(1)
+
+      await service.deletePaymentFlow(paymentFlowId)
+
+      expect(logSpy).not.toHaveBeenCalled()
+      expect(destroySpy).toHaveBeenCalledWith({ where: { id: paymentFlowId } })
     })
   })
 })

--- a/apps/services/payments/src/app/paymentFlow/paymentFlow.service.ts
+++ b/apps/services/payments/src/app/paymentFlow/paymentFlow.service.ts
@@ -286,6 +286,9 @@ export class PaymentFlowService {
           {
             model: PaymentFlowCharge,
           },
+          {
+            model: PaymentFlowFjsChargeConfirmation,
+          },
         ],
       })
     )?.toJSON()
@@ -576,23 +579,6 @@ export class PaymentFlowService {
       this.logger.info(
         `[${paymentFlowId}] Successfully requested deletion of FJS charge (or it was already deleted/cancelled)`,
       )
-
-      // Delete local confirmation
-      const deletedConfirmations =
-        await this.paymentFlowFjsChargeConfirmationModel.destroy({
-          where: {
-            paymentFlowId,
-          },
-        })
-      if (deletedConfirmations > 0) {
-        this.logger.info(
-          `[${paymentFlowId}] Deleted PaymentFlowFjsChargeConfirmation`,
-        )
-      } else {
-        this.logger.warn(
-          `[${paymentFlowId}] No PaymentFlowFjsChargeConfirmation found to delete`,
-        )
-      }
     } catch (error) {
       this.logger.error(
         `[${paymentFlowId}] Failed to fully process FJS charge deletion or update local records`,
@@ -604,8 +590,58 @@ export class PaymentFlowService {
     }
   }
 
-  async deletePaymentFlow(id: string) {
-    // TODO
+  async deletePaymentFlow(id: string): Promise<GetPaymentFlowDTO> {
+    const paymentFlowDetails = await this.getPaymentFlowDetails(id)
+
+    const { paymentStatus, updatedAt } = await this.getPaymentFlowStatus(
+      paymentFlowDetails,
+    )
+
+    if (paymentStatus === PaymentStatus.PAID) {
+      throw new BadRequestException(PaymentServiceCode.PaymentFlowAlreadyPaid)
+    }
+
+    // Construct the DTO to be returned before deleting
+    const paymentDetails = await this.getPaymentFlowChargeDetails(
+      paymentFlowDetails.organisationId,
+      paymentFlowDetails.charges,
+    )
+    const payerName = await this.getPayerName(
+      paymentFlowDetails.payerNationalId,
+    )
+
+    const paymentFlowDTO: GetPaymentFlowDTO = {
+      ...paymentFlowDetails,
+      productTitle:
+        paymentFlowDetails.productTitle ?? paymentDetails.firstProductTitle,
+      productPrice: paymentDetails.totalPrice,
+      payerName,
+      availablePaymentMethods:
+        paymentFlowDetails.availablePaymentMethods as PaymentMethod[],
+      paymentStatus,
+      updatedAt,
+    }
+
+    if (paymentFlowDetails.onUpdateUrl) {
+      await this.logPaymentFlowUpdate({
+        paymentFlowId: id,
+        type: 'deleted',
+        occurredAt: new Date(),
+        paymentMethod: 'system' as PaymentMethod,
+        reason: 'deleted_admin', // TODO: connect with systemId when we have machine clients?
+        message: 'Payment flow deleted by admin action.', // TODO: same as above?
+      })
+    }
+
+    if (paymentFlowDetails.fjsChargeConfirmation) {
+      await this.deletePaymentCharge(id)
+    }
+
+    // By deleting the payment flow, the related charges, events, and other
+    // associated records will be deleted automatically by the database cascade.
+    await this.paymentFlowModel.destroy({ where: { id } })
+
+    return paymentFlowDTO
   }
 
   async deletePaymentConfirmation(

--- a/apps/services/payments/src/app/paymentFlow/paymentFlow.service.ts
+++ b/apps/services/payments/src/app/paymentFlow/paymentFlow.service.ts
@@ -579,6 +579,23 @@ export class PaymentFlowService {
       this.logger.info(
         `[${paymentFlowId}] Successfully requested deletion of FJS charge (or it was already deleted/cancelled)`,
       )
+
+      // Delete local confirmation
+      const deletedConfirmations =
+        await this.paymentFlowFjsChargeConfirmationModel.destroy({
+          where: {
+            paymentFlowId,
+          },
+        })
+      if (deletedConfirmations > 0) {
+        this.logger.info(
+          `[${paymentFlowId}] Deleted PaymentFlowFjsChargeConfirmation`,
+        )
+      } else {
+        this.logger.warn(
+          `[${paymentFlowId}] No PaymentFlowFjsChargeConfirmation found to delete`,
+        )
+      }
     } catch (error) {
       this.logger.error(
         `[${paymentFlowId}] Failed to fully process FJS charge deletion or update local records`,


### PR DESCRIPTION
## What

☝️ 

## Why

So that it is possible to prune out stale payments

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving charge confirmation details when viewing payment flows.
  - Implemented full deletion process for payment flows, including cleanup and event logging.

- **Bug Fixes**
  - Improved error handling and validation when deleting payment flows, including checks for payment status and existence.
  - Added database indices to optimize queries related to payment flows and their associated records.

- **Tests**
  - Expanded test coverage for payment flow deletion, covering various scenarios and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->