### PR TITLE
fix(user-profile): Fix that allows all delegations to have an actor profile

### DIFF
--- a/apps/services/auth/delegation-api/src/app/delegations/delegations.controller.ts
+++ b/apps/services/auth/delegation-api/src/app/delegations/delegations.controller.ts
@@ -3,6 +3,7 @@ import { ApiSecurity, ApiTags } from '@nestjs/swagger'
 
 import {
   DelegationDirection,
+  DelegationRecordDTO,
   DelegationsIndexService,
   PaginatedDelegationRecordDTO,
 } from '@island.is/auth-api-lib'
@@ -85,6 +86,27 @@ export class DelegationsController {
         scope,
         nationalId,
         direction,
+      }),
+    )
+  }
+
+  @Get('/all')
+  @Documentation({
+    description: 'Get all delegations for a national id',
+    response: { status: 200, type: [DelegationRecordDTO] },
+  })
+  async getAllDelegations(
+    @CurrentAuth() auth: Auth,
+    @Headers('X-Query-National-Id') nationalId: string,
+  ): Promise<DelegationRecordDTO[]> {
+    return this.auditService.auditPromise(
+      {
+        auth,
+        action: 'getAllDelegations',
+        resources: [nationalId],
+      },
+      this.delegationIndexService.getDelegationRecordWithoutScope({
+        nationalId,
       }),
     )
   }

--- a/apps/services/auth/delegation-api/src/app/delegations/test/delegations-controller/get-all-delegations.controller.spec.ts
+++ b/apps/services/auth/delegation-api/src/app/delegations/test/delegations-controller/get-all-delegations.controller.spec.ts
@@ -1,0 +1,433 @@
+import { Type } from '@nestjs/common'
+import { getConnectionToken } from '@nestjs/sequelize'
+import { Sequelize } from 'sequelize-typescript'
+import request from 'supertest'
+
+import { DelegationRecordDTO } from '@island.is/auth-api-lib'
+import { FixtureFactory } from '@island.is/services/auth/testing'
+import { TestApp, truncate } from '@island.is/testing/nest'
+import { createNationalId } from '@island.is/testing/fixtures'
+import {
+  AuthDelegationProvider,
+  AuthDelegationType,
+} from '@island.is/shared/types'
+import { PersonalRepresentativeDelegationType } from '@island.is/auth-api-lib'
+
+import { setupWithAuth } from '../../../../../test/setup'
+import {
+  TestCase,
+  user,
+  userWithWrongScope,
+  scopes,
+  personalRepresentativeRightTypeCodePostholf,
+} from './delegations.controller-test-types'
+
+const path = '/v1/delegations/all'
+
+// Test data
+const person1 = createNationalId('person')
+const person2 = createNationalId('person')
+const person3 = createNationalId('person')
+const person4 = createNationalId('person')
+const parent1 = createNationalId('person')
+const child1 = createNationalId('residentChild')
+const company1 = createNationalId('company')
+const company2 = createNationalId('company')
+
+describe('DelegationsController - getAllDelegations', () => {
+  let app: TestApp
+  let server: request.SuperTest<request.Test>
+  let factory: FixtureFactory
+  let sequelize: Sequelize
+
+  const setup = async (testcase: TestCase) => {
+    server = request(app.getHttpServer())
+    factory = new FixtureFactory(app)
+    sequelize = await app.resolve(getConnectionToken() as Type<Sequelize>)
+
+    await truncate(sequelize)
+
+    await factory.createClient(testcase.client)
+    await factory.createDomain(testcase.domain)
+
+    // create api scopes in db
+    await Promise.all(
+      testcase.apiScopes.map((scope) => factory.createApiScope(scope)),
+    )
+
+    // Create delegation index records in db
+    await Promise.all(
+      testcase.procurationDelegationRecords.map((record) =>
+        factory.createDelegationIndexRecord(record),
+      ),
+    )
+    await Promise.all(
+      testcase.wardDelegationRecords.map((record) =>
+        factory.createDelegationIndexRecord(record),
+      ),
+    )
+    await Promise.all(
+      testcase.customDelegationRecord.map((record) =>
+        factory.createDelegationIndexRecord(record),
+      ),
+    )
+    await Promise.all(
+      testcase.personalRepresentativeDelegationRecords.map((record) =>
+        factory.createDelegationIndexRecord(record),
+      ),
+    )
+
+    // create personal representation scope permissions in db
+    await Promise.all(
+      testcase.personalRepresentativeScopePermissions.map((permission) =>
+        factory.createPersonalRepresentativeScopePermission(permission),
+      ),
+    )
+  }
+
+  describe('GET /all - Valid test cases', () => {
+    describe('when user has multiple types of incoming delegations', () => {
+      const testCase = new TestCase({
+        requestUser: {
+          nationalId: person1,
+          scope: scopes.all.name,
+        },
+        toCustom: [
+          {
+            fromNationalId: person2,
+            toNationalId: person1,
+            scopes: [scopes.custom.name],
+          },
+          {
+            fromNationalId: person3,
+            toNationalId: person1,
+            scopes: [scopes.custom2.name],
+          },
+        ],
+        toProcurationHolders: [
+          {
+            fromNationalId: company1,
+            toNationalId: person1,
+          },
+        ],
+        toParents: [
+          {
+            fromNationalId: child1,
+            toNationalId: person1,
+          },
+        ],
+        toRepresentative: [
+          {
+            fromNationalId: person4,
+            toNationalId: person1,
+            type: PersonalRepresentativeDelegationType.PersonalRepresentativePostholf,
+          },
+        ],
+        scopes: [scopes.all],
+        expectedFrom: [person2, person3, company1, child1, person4],
+      })
+
+      beforeAll(async () => {
+        app = await setupWithAuth({ user })
+        await setup(testCase)
+      })
+
+      afterAll(async () => {
+        await app.cleanUp()
+      })
+
+      it('should return all incoming delegations regardless of scope', async () => {
+        // Act
+        const response = await server
+          .get(path)
+          .set('X-Query-National-Id', testCase.requestUser.nationalId)
+
+        // Assert
+        expect(response.status).toBe(200)
+        expect(response.body).toHaveLength(5)
+
+        const fromNationalIds = response.body.map(
+          (d: DelegationRecordDTO) => d.fromNationalId,
+        )
+        expect(fromNationalIds).toEqual(
+          expect.arrayContaining([person2, person3, company1, child1, person4]),
+        )
+
+        // Verify each delegation has the correct toNationalId
+        response.body.forEach((delegation: DelegationRecordDTO) => {
+          expect(delegation.toNationalId).toBe(person1)
+        })
+      })
+    })
+
+    describe('when user has only custom delegations', () => {
+      const testCase = new TestCase({
+        requestUser: {
+          nationalId: person1,
+          scope: scopes.custom.name,
+        },
+        toCustom: [
+          {
+            fromNationalId: person2,
+            toNationalId: person1,
+            scopes: [scopes.custom.name],
+          },
+          {
+            fromNationalId: person3,
+            toNationalId: person1,
+            scopes: [scopes.custom2.name],
+            validTo: new Date(Date.now() + 86400000), // Valid delegation (expires tomorrow)
+          },
+        ],
+        scopes: [scopes.custom, scopes.custom2],
+        expectedFrom: [person2, person3],
+      })
+
+      beforeAll(async () => {
+        app = await setupWithAuth({ user })
+        await setup(testCase)
+      })
+
+      afterAll(async () => {
+        await app.cleanUp()
+      })
+
+      it('should return all custom delegations with different scopes', async () => {
+        // Act
+        const response = await server
+          .get(path)
+          .set('X-Query-National-Id', testCase.requestUser.nationalId)
+
+        // Assert
+        expect(response.status).toBe(200)
+        expect(response.body).toHaveLength(2)
+
+        const fromNationalIds = response.body.map(
+          (d: DelegationRecordDTO) => d.fromNationalId,
+        )
+        expect(fromNationalIds).toEqual(
+          expect.arrayContaining([person2, person3]),
+        )
+      })
+    })
+
+    describe('when user has expired delegations', () => {
+      const testCase = new TestCase({
+        requestUser: {
+          nationalId: person1,
+          scope: scopes.all.name,
+        },
+        toCustom: [
+          {
+            fromNationalId: person2,
+            toNationalId: person1,
+            scopes: [scopes.custom.name],
+            validTo: new Date('2021-01-01'), // Expired delegation
+          },
+          {
+            fromNationalId: person3,
+            toNationalId: person1,
+            scopes: [scopes.custom.name],
+          },
+        ],
+        toRepresentative: [
+          {
+            fromNationalId: person4,
+            toNationalId: person1,
+            type: PersonalRepresentativeDelegationType.PersonalRepresentativePostholf,
+            validTo: new Date('2021-01-01'), // Expired delegation
+          },
+        ],
+        scopes: [scopes.all],
+        expectedFrom: [person3], // Only person3 should be returned as others are expired
+      })
+
+      beforeAll(async () => {
+        app = await setupWithAuth({ user })
+        await setup(testCase)
+      })
+
+      afterAll(async () => {
+        await app.cleanUp()
+      })
+
+      it('should include expired delegations in the response', async () => {
+        // Act
+        const response = await server
+          .get(path)
+          .set('X-Query-National-Id', testCase.requestUser.nationalId)
+
+        // Assert
+        expect(response.status).toBe(200)
+        // The service should return all delegations, including expired ones
+        // The filtering of expired delegations should be done by the service layer
+        expect(response.body.length).toBeGreaterThanOrEqual(1)
+      })
+    })
+
+    describe('when user has no delegations', () => {
+      const testCase = new TestCase({
+        requestUser: {
+          nationalId: person1,
+          scope: scopes.all.name,
+        },
+        // No delegations set up
+        scopes: [scopes.all],
+        expectedFrom: [],
+      })
+
+      beforeAll(async () => {
+        app = await setupWithAuth({ user })
+        await setup(testCase)
+      })
+
+      afterAll(async () => {
+        await app.cleanUp()
+      })
+
+      it('should return empty array', async () => {
+        // Act
+        const response = await server
+          .get(path)
+          .set('X-Query-National-Id', testCase.requestUser.nationalId)
+
+        // Assert
+        expect(response.status).toBe(200)
+        expect(response.body).toEqual([])
+      })
+    })
+
+    describe('when querying with company national id', () => {
+      const testCase = new TestCase({
+        requestUser: {
+          nationalId: company1,
+          scope: scopes.all.name,
+        },
+        toCustom: [
+          {
+            fromNationalId: person1,
+            toNationalId: company1,
+            scopes: [scopes.custom.name],
+          },
+        ],
+        toProcurationHolders: [
+          {
+            fromNationalId: company2,
+            toNationalId: company1,
+          },
+        ],
+        scopes: [scopes.all],
+        expectedFrom: [person1, company2],
+      })
+
+      beforeAll(async () => {
+        app = await setupWithAuth({ user })
+        await setup(testCase)
+      })
+
+      afterAll(async () => {
+        await app.cleanUp()
+      })
+
+      it('should return delegations for company', async () => {
+        // Act
+        const response = await server
+          .get(path)
+          .set('X-Query-National-Id', testCase.requestUser.nationalId)
+
+        // Assert
+        expect(response.status).toBe(200)
+        expect(response.body).toHaveLength(2)
+
+        const fromNationalIds = response.body.map(
+          (d: DelegationRecordDTO) => d.fromNationalId,
+        )
+        expect(fromNationalIds).toEqual(
+          expect.arrayContaining([person1, company2]),
+        )
+      })
+    })
+  })
+
+  describe('GET /all - Invalid test cases', () => {
+    describe('when using invalid national id', () => {
+      beforeAll(async () => {
+        app = await setupWithAuth({ user })
+        server = request(app.getHttpServer())
+      })
+
+      afterAll(async () => {
+        await app.cleanUp()
+      })
+
+      it('should return 400 for invalid national id format', async () => {
+        // Act
+        const response = await server
+          .get(path)
+          .set('X-Query-National-Id', 'invalid-national-id')
+
+        // Assert
+        expect(response.status).toBe(400)
+        expect(response.body.detail).toBe('Invalid national id')
+      })
+    })
+
+    describe('when missing X-Query-National-Id header', () => {
+      beforeAll(async () => {
+        app = await setupWithAuth({ user })
+        server = request(app.getHttpServer())
+      })
+
+      afterAll(async () => {
+        await app.cleanUp()
+      })
+
+      it('should return 400 when header is missing', async () => {
+        // Act
+        const response = await server.get(path)
+
+        // Assert
+        expect(response.status).toBe(400)
+      })
+    })
+  })
+
+  describe('GET /all - Authorization', () => {
+    const testCase = new TestCase({
+      requestUser: {
+        nationalId: person1,
+        scope: scopes.all.name,
+      },
+      toCustom: [
+        {
+          fromNationalId: person2,
+          toNationalId: person1,
+          scopes: [scopes.custom.name],
+        },
+      ],
+      scopes: [scopes.all],
+      expectedFrom: [person2],
+    })
+
+    describe('when user has wrong scope', () => {
+      beforeAll(async () => {
+        app = await setupWithAuth({ user: userWithWrongScope })
+        await setup(testCase)
+      })
+
+      afterAll(async () => {
+        await app.cleanUp()
+      })
+
+      it('should return 403 status if client has wrong scope', async () => {
+        // Act
+        const response = await server
+          .get(path)
+          .set('X-Query-National-Id', person1)
+
+        // Assert
+        expect(response.status).toBe(403)
+      })
+    })
+  })
+})

--- a/apps/services/auth/delegation-api/src/app/delegations/test/delegations-controller/get-all-delegations.controller.spec.ts
+++ b/apps/services/auth/delegation-api/src/app/delegations/test/delegations-controller/get-all-delegations.controller.spec.ts
@@ -7,10 +7,6 @@ import { DelegationRecordDTO } from '@island.is/auth-api-lib'
 import { FixtureFactory } from '@island.is/services/auth/testing'
 import { TestApp, truncate } from '@island.is/testing/nest'
 import { createNationalId } from '@island.is/testing/fixtures'
-import {
-  AuthDelegationProvider,
-  AuthDelegationType,
-} from '@island.is/shared/types'
 import { PersonalRepresentativeDelegationType } from '@island.is/auth-api-lib'
 
 import { setupWithAuth } from '../../../../../test/setup'
@@ -19,7 +15,6 @@ import {
   user,
   userWithWrongScope,
   scopes,
-  personalRepresentativeRightTypeCodePostholf,
 } from './delegations.controller-test-types'
 
 const path = '/v1/delegations/all'
@@ -29,7 +24,6 @@ const person1 = createNationalId('person')
 const person2 = createNationalId('person')
 const person3 = createNationalId('person')
 const person4 = createNationalId('person')
-const parent1 = createNationalId('person')
 const child1 = createNationalId('residentChild')
 const company1 = createNationalId('company')
 const company2 = createNationalId('company')

--- a/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/notificationsWorker.service.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/notificationsWorker.service.ts
@@ -345,10 +345,12 @@ export class NotificationsWorkerService {
 
         if (message.onBehalfOf) {
           profile =
-            await this.userProfileApi.userProfileControllerGetActorProfile({
-              xParamToNationalId: message.recipient,
-              xParamFromNationalId: message.onBehalfOf.nationalId,
-            })
+            await this.userProfileApi.userProfileControllerGetActorProfileByDelegation(
+              {
+                xParamToNationalId: message.recipient,
+                xParamFromNationalId: message.onBehalfOf.nationalId,
+              },
+            )
         } else {
           profile =
             await this.userProfileApi.userProfileControllerFindUserProfile({

--- a/apps/services/user-profile/src/app/v2/test/actor-user-profile.controller.spec.ts
+++ b/apps/services/user-profile/src/app/v2/test/actor-user-profile.controller.spec.ts
@@ -99,24 +99,15 @@ describe('GET v2/actor/actor-profile', () => {
 
     // Mock delegations API to return a delegation between the test user and testNationalId1
     jest
-      .spyOn(delegationsApi, 'delegationsControllerGetDelegationRecords')
-      .mockResolvedValue({
-        data: [
-          {
-            toNationalId: testNationalId1,
-            fromNationalId: testUserProfile.nationalId,
-            subjectId: null,
-            type: 'delegation',
-          },
-        ],
-        pageInfo: {
-          hasNextPage: false,
-          hasPreviousPage: false,
-          startCursor: '',
-          endCursor: '',
+      .spyOn(delegationsApi, 'delegationsControllerGetAllDelegations')
+      .mockResolvedValue([
+        {
+          toNationalId: testNationalId1,
+          fromNationalId: testUserProfile.nationalId,
+          subjectId: null,
+          type: 'delegation',
         },
-        totalCount: 1,
-      })
+      ])
   })
 
   afterAll(async () => {
@@ -303,17 +294,8 @@ describe('GET v2/actor/actor-profile', () => {
   it('should return 400 when delegation does not exist', async () => {
     // Mock delegations API to return empty result
     jest
-      .spyOn(delegationsApi, 'delegationsControllerGetDelegationRecords')
-      .mockResolvedValueOnce({
-        data: [], // No delegations
-        pageInfo: {
-          hasNextPage: false,
-          hasPreviousPage: false,
-          startCursor: '',
-          endCursor: '',
-        },
-        totalCount: 0,
-      })
+      .spyOn(delegationsApi, 'delegationsControllerGetAllDelegations')
+      .mockResolvedValue([])
 
     try {
       // Create the actor profile directly without creating a user profile first
@@ -388,24 +370,15 @@ describe('POST /v2/actor/actor-profile/nudge', () => {
 
     // Mock delegations API to return a delegation between the test user and testNationalId1
     jest
-      .spyOn(delegationsApi, 'delegationsControllerGetDelegationRecords')
-      .mockResolvedValue({
-        data: [
-          {
-            toNationalId: testNationalId1,
-            fromNationalId: testUserProfile.nationalId,
-            subjectId: null,
-            type: 'delegation',
-          },
-        ],
-        pageInfo: {
-          hasNextPage: false,
-          hasPreviousPage: false,
-          startCursor: '',
-          endCursor: '',
+      .spyOn(delegationsApi, 'delegationsControllerGetAllDelegations')
+      .mockResolvedValue([
+        {
+          toNationalId: testNationalId1,
+          fromNationalId: testUserProfile.nationalId,
+          subjectId: null,
+          type: 'delegation',
         },
-        totalCount: 1,
-      })
+      ])
   })
 
   afterAll(async () => {
@@ -675,17 +648,8 @@ describe('POST /v2/actor/actor-profile/nudge', () => {
     // Arrange
     // Mock delegations API to return empty result
     jest
-      .spyOn(delegationsApi, 'delegationsControllerGetDelegationRecords')
-      .mockResolvedValueOnce({
-        data: [], // No delegations
-        pageInfo: {
-          hasNextPage: false,
-          hasPreviousPage: false,
-          startCursor: '',
-          endCursor: '',
-        },
-        totalCount: 0,
-      })
+      .spyOn(delegationsApi, 'delegationsControllerGetAllDelegations')
+      .mockResolvedValue([])
 
     // Act
     const res = await server
@@ -808,30 +772,21 @@ describe('GET v2/actor/actor-profiles', () => {
 
     // Arrange
     jest
-      .spyOn(delegationsApi, 'delegationsControllerGetDelegationRecords')
-      .mockResolvedValue({
-        data: [
-          {
-            toNationalId: testUserProfile.nationalId,
-            fromNationalId: testNationalId1,
-            subjectId: null,
-            type: 'delegation',
-          },
-          {
-            toNationalId: testUserProfile.nationalId,
-            fromNationalId: testNationalId2,
-            subjectId: null,
-            type: 'delegation',
-          },
-        ],
-        pageInfo: {
-          hasNextPage: false,
-          hasPreviousPage: false,
-          startCursor: '',
-          endCursor: '',
+      .spyOn(delegationsApi, 'delegationsControllerGetAllDelegations')
+      .mockResolvedValue([
+        {
+          toNationalId: testUserProfile.nationalId,
+          fromNationalId: testNationalId1,
+          subjectId: null,
+          type: 'delegation',
         },
-        totalCount: 2,
-      })
+        {
+          toNationalId: testUserProfile.nationalId,
+          fromNationalId: testNationalId2,
+          subjectId: null,
+          type: 'delegation',
+        },
+      ])
 
     await fixtureFactory.createUserProfile({
       nationalId: testNationalId1,
@@ -874,28 +829,15 @@ describe('GET v2/actor/actor-profiles', () => {
     })
 
     expect(
-      delegationsApi.delegationsControllerGetDelegationRecords,
-    ).toHaveBeenCalledWith({
-      xQueryNationalId: testUserProfile.nationalId,
-      scope: '@island.is/documents',
-      direction: 'incoming',
-    })
+      delegationsApi.delegationsControllerGetAllDelegations,
+    ).toHaveBeenCalledWith({ xQueryNationalId: testUserProfile.nationalId })
   })
 
   it('should return an empty array when there are no delegations', async () => {
     // Arrange
     jest
-      .spyOn(delegationsApi, 'delegationsControllerGetDelegationRecords')
-      .mockResolvedValue({
-        data: [],
-        pageInfo: {
-          hasNextPage: false,
-          hasPreviousPage: false,
-          startCursor: '',
-          endCursor: '',
-        },
-        totalCount: 0,
-      })
+      .spyOn(delegationsApi, 'delegationsControllerGetAllDelegations')
+      .mockResolvedValue([])
 
     // Act
     const res = await server.get('/v2/actor/actor-profiles')
@@ -917,30 +859,21 @@ describe('GET v2/actor/actor-profiles', () => {
 
     // Arrange
     jest
-      .spyOn(delegationsApi, 'delegationsControllerGetDelegationRecords')
-      .mockResolvedValue({
-        data: [
-          {
-            toNationalId: testUserProfile.nationalId,
-            fromNationalId: testNationalId1,
-            subjectId: null,
-            type: 'delegation',
-          },
-          {
-            toNationalId: testUserProfile.nationalId,
-            fromNationalId: testNationalId2,
-            subjectId: null,
-            type: 'delegation',
-          },
-        ],
-        pageInfo: {
-          hasNextPage: false,
-          hasPreviousPage: false,
-          startCursor: '',
-          endCursor: '',
+      .spyOn(delegationsApi, 'delegationsControllerGetAllDelegations')
+      .mockResolvedValue([
+        {
+          toNationalId: testUserProfile.nationalId,
+          fromNationalId: testNationalId1,
+          subjectId: null,
+          type: 'delegation',
         },
-        totalCount: 2,
-      })
+        {
+          toNationalId: testUserProfile.nationalId,
+          fromNationalId: testNationalId2,
+          subjectId: null,
+          type: 'delegation',
+        },
+      ])
 
     // Create user profiles and emails for both delegations
     await fixtureFactory.createUserProfile({
@@ -1007,7 +940,7 @@ describe('GET v2/actor/actor-profiles', () => {
   it('should handle delegations API errors gracefully', async () => {
     // Arrange
     jest
-      .spyOn(delegationsApi, 'delegationsControllerGetDelegationRecords')
+      .spyOn(delegationsApi, 'delegationsControllerGetAllDelegations')
       .mockRejectedValue(new Error('Service unavailable'))
 
     // Act
@@ -1023,30 +956,21 @@ describe('GET v2/actor/actor-profiles', () => {
 
     // Arrange
     jest
-      .spyOn(delegationsApi, 'delegationsControllerGetDelegationRecords')
-      .mockResolvedValue({
-        data: [
-          {
-            toNationalId: testUserProfile.nationalId,
-            fromNationalId: testNationalId1,
-            subjectId: null,
-            type: 'delegation',
-          },
-          {
-            toNationalId: testUserProfile.nationalId,
-            fromNationalId: testNationalId2,
-            subjectId: 'document-123',
-            type: 'document-delegation',
-          },
-        ],
-        pageInfo: {
-          hasNextPage: false,
-          hasPreviousPage: false,
-          startCursor: '',
-          endCursor: '',
+      .spyOn(delegationsApi, 'delegationsControllerGetAllDelegations')
+      .mockResolvedValue([
+        {
+          toNationalId: testUserProfile.nationalId,
+          fromNationalId: testNationalId1,
+          subjectId: null,
+          type: 'delegation',
         },
-        totalCount: 2,
-      })
+        {
+          toNationalId: testUserProfile.nationalId,
+          fromNationalId: testNationalId2,
+          subjectId: 'document-123',
+          type: 'document-delegation',
+        },
+      ])
 
     // Create actor profile for the first delegation only
     await fixtureFactory.createActorProfile({
@@ -1076,11 +1000,9 @@ describe('GET v2/actor/actor-profiles', () => {
 
     // Verify it used the correct parameters
     expect(
-      delegationsApi.delegationsControllerGetDelegationRecords,
+      delegationsApi.delegationsControllerGetAllDelegations,
     ).toHaveBeenCalledWith({
       xQueryNationalId: testUserProfile.nationalId,
-      scope: '@island.is/documents',
-      direction: 'incoming',
     })
   })
 })
@@ -1161,24 +1083,15 @@ describe('PATCH /v2/actor/actor-profile/email', () => {
 
     // Mock delegations API to return a delegation between the test user and testNationalId1
     jest
-      .spyOn(delegationsApi, 'delegationsControllerGetDelegationRecords')
-      .mockResolvedValue({
-        data: [
-          {
-            toNationalId: testNationalId1,
-            fromNationalId: testUserProfile.nationalId,
-            subjectId: null,
-            type: 'delegation',
-          },
-        ],
-        pageInfo: {
-          hasNextPage: false,
-          hasPreviousPage: false,
-          startCursor: '',
-          endCursor: '',
+      .spyOn(delegationsApi, 'delegationsControllerGetAllDelegations')
+      .mockResolvedValue([
+        {
+          toNationalId: testNationalId1,
+          fromNationalId: testUserProfile.nationalId,
+          subjectId: null,
+          type: 'delegation',
         },
-        totalCount: 1,
-      })
+      ])
   })
 
   afterAll(async () => {
@@ -1362,24 +1275,15 @@ describe('PATCH /v2/actor/actor-profile', () => {
 
     // Mock delegations API to return a delegation between the test user and testNationalId1
     jest
-      .spyOn(delegationsApi, 'delegationsControllerGetDelegationRecords')
-      .mockResolvedValue({
-        data: [
-          {
-            toNationalId: testUserProfile.nationalId,
-            fromNationalId: testNationalId1,
-            subjectId: null,
-            type: 'delegation',
-          },
-        ],
-        pageInfo: {
-          hasNextPage: false,
-          hasPreviousPage: false,
-          startCursor: '',
-          endCursor: '',
+      .spyOn(delegationsApi, 'delegationsControllerGetAllDelegations')
+      .mockResolvedValue([
+        {
+          toNationalId: testUserProfile.nationalId,
+          fromNationalId: testNationalId1,
+          subjectId: null,
+          type: 'delegation',
         },
-        totalCount: 1,
-      })
+      ])
 
     // Mock email verification
     jest
@@ -1798,24 +1702,15 @@ describe('PATCH v2/actor/actor-profiles/.from-national-id', () => {
     })
 
     jest
-      .spyOn(delegationsApi, 'delegationsControllerGetDelegationRecords')
-      .mockResolvedValue({
-        data: [
-          {
-            toNationalId: testUserProfile.nationalId,
-            fromNationalId: testNationalId1,
-            subjectId: null,
-            type: 'delegation',
-          },
-        ],
-        pageInfo: {
-          hasNextPage: false,
-          hasPreviousPage: false,
-          startCursor: '',
-          endCursor: '',
+      .spyOn(delegationsApi, 'delegationsControllerGetAllDelegations')
+      .mockResolvedValue([
+        {
+          toNationalId: testUserProfile.nationalId,
+          fromNationalId: testNationalId1,
+          subjectId: null,
+          type: 'delegation',
         },
-        totalCount: 1,
-      })
+      ])
 
     await fixtureFactory.createUserProfile({
       nationalId: testNationalId1,
@@ -1867,12 +1762,8 @@ describe('PATCH v2/actor/actor-profiles/.from-national-id', () => {
     expect(actorProfile[0]).not.toBeNull()
     expect(actorProfile[0].emailNotifications).toBe(false)
     expect(
-      delegationsApi.delegationsControllerGetDelegationRecords,
-    ).toHaveBeenCalledWith({
-      xQueryNationalId: testUserProfile.nationalId,
-      scope: '@island.is/documents',
-      direction: 'incoming',
-    })
+      delegationsApi.delegationsControllerGetAllDelegations,
+    ).toHaveBeenCalledWith({ xQueryNationalId: testUserProfile.nationalId })
   })
 
   it('should update existing actor profile', async () => {
@@ -1988,20 +1879,11 @@ describe('PATCH v2/actor/actor-profiles/.from-national-id', () => {
     expect(actorProfile[0].emailsId).toBe(testEmail2Id)
   })
 
-  it('should throw no content exception if delegation is not found', async () => {
+  it('should throw bad request exception if delegation is not found', async () => {
     // Arrange
     jest
-      .spyOn(delegationsApi, 'delegationsControllerGetDelegationRecords')
-      .mockResolvedValue({
-        data: [], // No delegations
-        pageInfo: {
-          hasNextPage: false,
-          hasPreviousPage: false,
-          startCursor: '',
-          endCursor: '',
-        },
-        totalCount: 1,
-      })
+      .spyOn(delegationsApi, 'delegationsControllerGetAllDelegations')
+      .mockResolvedValue([])
 
     // Act
     const res = await server
@@ -2010,6 +1892,11 @@ describe('PATCH v2/actor/actor-profiles/.from-national-id', () => {
       .send({ emailNotifications: false })
 
     // Assert
-    expect(res.status).toEqual(204)
+    expect(res.status).toEqual(400)
+    expect(res.body).toMatchObject({
+      title: 'Bad Request',
+      status: 400,
+      detail: 'Delegation does not exist',
+    })
   })
 })

--- a/apps/services/user-profile/src/app/v2/test/me-user-profile.controller.spec.ts
+++ b/apps/services/user-profile/src/app/v2/test/me-user-profile.controller.spec.ts
@@ -1393,30 +1393,21 @@ describe('MeUserProfileController', () => {
 
       // Arrange
       jest
-        .spyOn(delegationsApi, 'delegationsControllerGetDelegationRecords')
-        .mockResolvedValue({
-          data: [
-            {
-              toNationalId: testUserProfile.nationalId,
-              fromNationalId: testNationalId1,
-              subjectId: null,
-              type: 'delegation',
-            },
-            {
-              toNationalId: testUserProfile.nationalId,
-              fromNationalId: testNationalId2,
-              subjectId: null,
-              type: 'delegation',
-            },
-          ],
-          pageInfo: {
-            hasNextPage: false,
-            hasPreviousPage: false,
-            startCursor: '',
-            endCursor: '',
+        .spyOn(delegationsApi, 'delegationsControllerGetAllDelegations')
+        .mockResolvedValue([
+          {
+            toNationalId: testUserProfile.nationalId,
+            fromNationalId: testNationalId1,
+            subjectId: null,
+            type: 'delegation',
           },
-          totalCount: 2,
-        })
+          {
+            toNationalId: testUserProfile.nationalId,
+            fromNationalId: testNationalId2,
+            subjectId: null,
+            type: 'delegation',
+          },
+        ])
 
       await fixtureFactory.createUserProfile({
         nationalId: testNationalId1,
@@ -1459,28 +1450,17 @@ describe('MeUserProfileController', () => {
       })
 
       expect(
-        delegationsApi.delegationsControllerGetDelegationRecords,
+        delegationsApi.delegationsControllerGetAllDelegations,
       ).toHaveBeenCalledWith({
         xQueryNationalId: testUserProfile.nationalId,
-        scope: '@island.is/documents',
-        direction: 'incoming',
       })
     })
 
     it('should return an empty array when there are no delegations', async () => {
       // Arrange
       jest
-        .spyOn(delegationsApi, 'delegationsControllerGetDelegationRecords')
-        .mockResolvedValue({
-          data: [],
-          pageInfo: {
-            hasNextPage: false,
-            hasPreviousPage: false,
-            startCursor: '',
-            endCursor: '',
-          },
-          totalCount: 0,
-        })
+        .spyOn(delegationsApi, 'delegationsControllerGetAllDelegations')
+        .mockResolvedValue([])
 
       // Act
       const res = await server.get('/v2/me/actor-profiles')
@@ -1502,30 +1482,21 @@ describe('MeUserProfileController', () => {
 
       // Arrange
       jest
-        .spyOn(delegationsApi, 'delegationsControllerGetDelegationRecords')
-        .mockResolvedValue({
-          data: [
-            {
-              toNationalId: testUserProfile.nationalId,
-              fromNationalId: testNationalId1,
-              subjectId: null,
-              type: 'delegation',
-            },
-            {
-              toNationalId: testUserProfile.nationalId,
-              fromNationalId: testNationalId2,
-              subjectId: null,
-              type: 'delegation',
-            },
-          ],
-          pageInfo: {
-            hasNextPage: false,
-            hasPreviousPage: false,
-            startCursor: '',
-            endCursor: '',
+        .spyOn(delegationsApi, 'delegationsControllerGetAllDelegations')
+        .mockResolvedValue([
+          {
+            toNationalId: testUserProfile.nationalId,
+            fromNationalId: testNationalId1,
+            subjectId: null,
+            type: 'delegation',
           },
-          totalCount: 2,
-        })
+          {
+            toNationalId: testUserProfile.nationalId,
+            fromNationalId: testNationalId2,
+            subjectId: null,
+            type: 'delegation',
+          },
+        ])
 
       // Create user profiles and emails for both delegations
       await fixtureFactory.createUserProfile({
@@ -1592,7 +1563,7 @@ describe('MeUserProfileController', () => {
     it('should handle delegations API errors gracefully', async () => {
       // Arrange
       jest
-        .spyOn(delegationsApi, 'delegationsControllerGetDelegationRecords')
+        .spyOn(delegationsApi, 'delegationsControllerGetAllDelegations')
         .mockRejectedValue(new Error('Service unavailable'))
 
       // Act
@@ -1608,30 +1579,21 @@ describe('MeUserProfileController', () => {
 
       // Arrange
       jest
-        .spyOn(delegationsApi, 'delegationsControllerGetDelegationRecords')
-        .mockResolvedValue({
-          data: [
-            {
-              toNationalId: testUserProfile.nationalId,
-              fromNationalId: testNationalId1,
-              subjectId: null,
-              type: 'delegation',
-            },
-            {
-              toNationalId: testUserProfile.nationalId,
-              fromNationalId: testNationalId2,
-              subjectId: 'document-123',
-              type: 'document-delegation',
-            },
-          ],
-          pageInfo: {
-            hasNextPage: false,
-            hasPreviousPage: false,
-            startCursor: '',
-            endCursor: '',
+        .spyOn(delegationsApi, 'delegationsControllerGetAllDelegations')
+        .mockResolvedValue([
+          {
+            toNationalId: testUserProfile.nationalId,
+            fromNationalId: testNationalId1,
+            subjectId: null,
+            type: 'delegation',
           },
-          totalCount: 2,
-        })
+          {
+            toNationalId: testUserProfile.nationalId,
+            fromNationalId: testNationalId2,
+            subjectId: 'document-123',
+            type: 'document-delegation',
+          },
+        ])
 
       // Create actor profile for the first delegation only
       await fixtureFactory.createActorProfile({
@@ -1662,11 +1624,9 @@ describe('MeUserProfileController', () => {
 
       // Verify it used the correct parameters
       expect(
-        delegationsApi.delegationsControllerGetDelegationRecords,
+        delegationsApi.delegationsControllerGetAllDelegations,
       ).toHaveBeenCalledWith({
         xQueryNationalId: testUserProfile.nationalId,
-        scope: '@island.is/documents',
-        direction: 'incoming',
       })
     })
   })
@@ -2066,24 +2026,15 @@ describe('MeUserProfileController', () => {
 
       // Mock delegations API to return a delegation between the test user and testNationalId1
       jest
-        .spyOn(delegationsApi, 'delegationsControllerGetDelegationRecords')
-        .mockResolvedValue({
-          data: [
-            {
-              toNationalId: testUserProfile.nationalId,
-              fromNationalId: actorNationalId,
-              subjectId: null,
-              type: 'delegation',
-            },
-          ],
-          pageInfo: {
-            hasNextPage: false,
-            hasPreviousPage: false,
-            startCursor: '',
-            endCursor: '',
+        .spyOn(delegationsApi, 'delegationsControllerGetAllDelegations')
+        .mockResolvedValue([
+          {
+            toNationalId: testUserProfile.nationalId,
+            fromNationalId: actorNationalId,
+            subjectId: null,
+            type: 'delegation',
           },
-          totalCount: 1,
-        })
+        ])
 
       // Mock email verification
       jest

--- a/apps/services/user-profile/src/app/v2/test/user-profile-all.controller.spec.ts
+++ b/apps/services/user-profile/src/app/v2/test/user-profile-all.controller.spec.ts
@@ -271,30 +271,21 @@ describe('UserProfileController', () => {
 
       beforeEach(async () => {
         jest
-          .spyOn(delegationsApi, 'delegationsControllerGetDelegationRecords')
-          .mockResolvedValue({
-            data: [
-              {
-                toNationalId: testUserProfile.nationalId,
-                fromNationalId: testNationalId1,
-                subjectId: null,
-                type: 'fromNational',
-              },
-              {
-                toNationalId: testUserProfile.nationalId,
-                fromNationalId: testNationalId2,
-                subjectId: null,
-                type: 'fromNational',
-              },
-            ],
-            pageInfo: {
-              hasNextPage: false,
-              hasPreviousPage: false,
-              startCursor: '',
-              endCursor: '',
+          .spyOn(delegationsApi, 'delegationsControllerGetAllDelegations')
+          .mockResolvedValue([
+            {
+              toNationalId: testUserProfile.nationalId,
+              fromNationalId: testNationalId1,
+              subjectId: null,
+              type: 'fromNational',
             },
-            totalCount: 2,
-          })
+            {
+              toNationalId: testUserProfile.nationalId,
+              fromNationalId: testNationalId2,
+              subjectId: null,
+              type: 'fromNational',
+            },
+          ])
       })
 
       it('should return 200 and the extended actor profile if user profile exists', async () => {
@@ -332,11 +323,9 @@ describe('UserProfileController', () => {
         })
 
         expect(
-          delegationsApi.delegationsControllerGetDelegationRecords,
+          delegationsApi.delegationsControllerGetAllDelegations,
         ).toHaveBeenCalledWith({
           xQueryNationalId: testUserProfile.nationalId,
-          scope: '@island.is/documents',
-          direction: 'incoming',
         })
       })
 

--- a/apps/services/user-profile/src/app/v2/user-profile.controller.ts
+++ b/apps/services/user-profile/src/app/v2/user-profile.controller.ts
@@ -105,6 +105,43 @@ export class UserProfileController {
     return this.userProfileService.findById(nationalId, false, clientType)
   }
 
+  @Get('/.from-national-id/.to-national-id/actor-profiles')
+  @Documentation({
+    description: 'Get actor profiles for nationalId.',
+    request: {
+      header: {
+        'X-Param-To-National-Id': {
+          required: true,
+          description: 'National id of the user the actor profile is for',
+        },
+        'X-Param-From-National-Id': {
+          required: true,
+          description: 'National id of the user the delegation is from',
+        },
+      },
+    },
+    response: { status: 200, type: ActorProfileDto },
+  })
+  @Audit<ActorProfileDto>({
+    resources: (profile) => profile.fromNationalId,
+  })
+  async getActorProfileByDelegation(
+    @Headers('X-Param-To-National-Id') toNationalId: string,
+    @Headers('X-Param-From-National-Id') fromNationalId: string,
+  ): Promise<ActorProfileDto> {
+    if (
+      !kennitala.isValid(toNationalId) ||
+      !kennitala.isValid(fromNationalId)
+    ) {
+      throw new BadRequestException('National id is not valid')
+    }
+
+    return this.userProfileService.getActorProfileWithDocumentsScope({
+      toNationalId,
+      fromNationalId,
+    })
+  }
+
   @Get('/.to-national-id/actor-profiles/.from-national-id')
   @Documentation({
     description: 'Get actor profiles for nationalId.',
@@ -136,7 +173,7 @@ export class UserProfileController {
       throw new BadRequestException('National id is not valid')
     }
 
-    return this.userProfileService.getActorProfile({
+    return this.userProfileService.getActorProfileWithDocumentsScope({
       toNationalId,
       fromNationalId,
     })

--- a/apps/services/user-profile/src/app/v2/user-profile.controller.ts
+++ b/apps/services/user-profile/src/app/v2/user-profile.controller.ts
@@ -173,7 +173,7 @@ export class UserProfileController {
       throw new BadRequestException('National id is not valid')
     }
 
-    return this.userProfileService.getActorProfileWithDocumentsScope({
+    return this.userProfileService.getActorProfile({
       toNationalId,
       fromNationalId,
     })

--- a/libs/portals/my-pages/information/src/module.tsx
+++ b/libs/portals/my-pages/information/src/module.tsx
@@ -30,33 +30,31 @@ const UserNotificationsSettings = lazy(() =>
 )
 
 const sharedRoutes = (scopes: string[], isCompany = false) => {
-  const isSettingsEnabled =
-    scopes.includes(UserProfileScope.read) &&
-    scopes.includes(DocumentsScope.main)
+  const enabled = scopes.includes(UserProfileScope.read)
 
   return [
     {
       name: isCompany ? m.settings : m.mySettings,
       path: InformationPaths.SettingsOld,
-      enabled: isSettingsEnabled,
+      enabled,
       element: <Navigate to={InformationPaths.Settings} replace />,
     },
     {
       name: isCompany ? m.settings : m.mySettings,
       path: InformationPaths.Settings,
-      enabled: isSettingsEnabled,
+      enabled,
       element: <UserProfileSettings />,
     },
     {
       name: m.userInfo,
       path: InformationPaths.SettingsNotifications,
-      enabled: isSettingsEnabled,
+      enabled,
       element: <UserNotificationsSettings />,
     },
     {
       name: 'Notifications',
       path: InformationPaths.Notifications,
-      enabled: scopes.includes(DocumentsScope.main),
+      enabled,
       element: <Notifications />,
     },
   ]

--- a/libs/portals/my-pages/information/src/module.tsx
+++ b/libs/portals/my-pages/information/src/module.tsx
@@ -1,14 +1,9 @@
-import { lazy } from 'react'
-import {
-  ApiScope,
-  DocumentsScope,
-  UserProfileScope,
-} from '@island.is/auth/scopes'
-import { m } from '@island.is/portals/my-pages/core'
+import { ApiScope, UserProfileScope } from '@island.is/auth/scopes'
 import { PortalModule } from '@island.is/portals/core'
-import { InformationPaths } from './lib/paths'
+import { m } from '@island.is/portals/my-pages/core'
+import { lazy } from 'react'
 import { Navigate } from 'react-router-dom'
-
+import { InformationPaths } from './lib/paths'
 const UserInfoOverview = lazy(() =>
   import('./screens/UserInfoOverview/UserInfoOverview'),
 )


### PR DESCRIPTION
## What

Change that allows all delegations to have an actor profile and not just those delegations that have @island.is/documents

## Why

So users can set where they would like to recieve their emails for each delegation

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new endpoint to retrieve all delegations for a user, accessible via the Delegations API.
  - Introduced a new endpoint for fetching actor profiles based on delegation between two users in the User Profile API.

- **Bug Fixes**
  - Improved validation and error handling for invalid or missing national IDs, returning appropriate error responses.

- **Refactor**
  - Unified and simplified delegation existence checks, reducing code duplication and standardizing error handling.
  - Updated internal service calls to use new, streamlined delegation retrieval methods.

- **Tests**
  - Added comprehensive tests for the new delegation retrieval endpoint, covering valid, invalid, and authorization scenarios.
  - Updated existing test suites to align with the new delegation API structure and improved error assertions.

- **Style**
  - Simplified route enabling logic for user settings and notifications in the My Pages portal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->