### PR TITLE
feat(services-payments): Add cancel url

### DIFF
--- a/apps/payments/graphql/queries.graphql.ts
+++ b/apps/payments/graphql/queries.graphql.ts
@@ -28,6 +28,7 @@ export const GetPaymentFlow = gql`
       organisationId
       metadata
       returnUrl
+      cancelUrl
       redirectToReturnUrlOnSuccess
       updatedAt
     }

--- a/apps/payments/pages/[locale]/[paymentFlowId]/index.tsx
+++ b/apps/payments/pages/[locale]/[paymentFlowId]/index.tsx
@@ -311,7 +311,13 @@ function PaymentPage({
                       : formatMessage(invoice.create)}
                   </Button>
                   <Box display="flex" justifyContent="center">
-                    <LinkV2 href={paymentFlow.returnUrl ?? 'https://island.is'}>
+                    <LinkV2
+                      href={
+                        paymentFlow.cancelUrl ??
+                        paymentFlow.returnUrl ??
+                        'https://island.is'
+                      }
+                    >
                       <Button unfocusable variant="text">
                         {formatMessage(generic.buttonCancel)}
                       </Button>

--- a/apps/services/payments/migrations/20250624000000-add-cancel-url.js
+++ b/apps/services/payments/migrations/20250624000000-add-cancel-url.js
@@ -1,0 +1,14 @@
+'use strict'
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('payment_flow', 'cancel_url', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    })
+  },
+
+  down: (queryInterface) => {
+    return queryInterface.removeColumn('payment_flow', 'cancel_url')
+  },
+}

--- a/apps/services/payments/src/app/paymentFlow/dtos/createPaymentFlow.input.ts
+++ b/apps/services/payments/src/app/paymentFlow/dtos/createPaymentFlow.input.ts
@@ -12,6 +12,7 @@ import {
   IsPositive,
   ValidateNested,
   IsBoolean,
+  IsUrl,
 } from 'class-validator'
 import { Type } from 'class-transformer'
 
@@ -155,14 +156,19 @@ export class CreatePaymentFlowInput {
   })
   existingInvoiceId?: string
 
-  @IsString()
-  @IsOptional()
   @ApiPropertyOptional({
-    description:
-      'URL to redirect the payer to after the payment flow has been completed successfully',
-    type: String,
+    description: 'The url to redirect to on successful payment',
   })
+  @IsOptional()
+  @IsUrl()
   returnUrl?: string
+
+  @ApiPropertyOptional({
+    description: 'The url to redirect to on cancellation',
+  })
+  @IsOptional()
+  @IsUrl()
+  cancelUrl?: string
 
   @IsBoolean()
   @IsOptional()

--- a/apps/services/payments/src/app/paymentFlow/dtos/getPaymentFlow.dto.ts
+++ b/apps/services/payments/src/app/paymentFlow/dtos/getPaymentFlow.dto.ts
@@ -99,4 +99,7 @@ export class GetPaymentFlowDTO {
     type: Date,
   })
   updatedAt!: Date
+
+  @ApiPropertyOptional()
+  cancelUrl?: string
 }

--- a/apps/services/payments/src/app/paymentFlow/models/paymentFlow.model.ts
+++ b/apps/services/payments/src/app/paymentFlow/models/paymentFlow.model.ts
@@ -171,6 +171,14 @@ export class PaymentFlow extends Model<
 
   @ApiPropertyOptional()
   @Column({
+    type: DataType.STRING,
+    allowNull: true,
+    field: 'cancel_url',
+  })
+  cancelUrl?: string
+
+  @ApiPropertyOptional()
+  @Column({
     type: DataType.BOOLEAN,
     allowNull: true,
     field: 'redirect_to_return_url_on_success',

--- a/apps/services/payments/src/app/paymentFlow/paymentFlow.controller.spec.ts
+++ b/apps/services/payments/src/app/paymentFlow/paymentFlow.controller.spec.ts
@@ -74,5 +74,35 @@ describe('PaymentFlowController', () => {
       expect(response.status).toBe(200)
       expect(response.body.urls).toBeDefined()
     })
+
+    it('should store and retrieve the cancelUrl', async () => {
+      const cancelUrl = 'https://some.url/cancel'
+      const payload: CreatePaymentFlowInput = {
+        charges: [
+          {
+            chargeItemCode: '456',
+            chargeType: 'B',
+            quantity: 2,
+          },
+        ],
+        payerNationalId: '0101302129',
+        availablePaymentMethods: [PaymentMethod.CARD],
+        onUpdateUrl: 'https://www.island.is/greida/update',
+        organisationId: '5534567890',
+        cancelUrl,
+      }
+
+      const createResponse = await server.post('/v1/payments').send(payload)
+      expect(createResponse.status).toBe(200)
+      expect(createResponse.body.urls.is).toBeDefined()
+
+      const paymentFlowId = new URL(createResponse.body.urls.is).pathname
+        .split('/')
+        .pop()
+
+      const getResponse = await server.get(`/v1/payments/${paymentFlowId}`)
+      expect(getResponse.status).toBe(200)
+      expect(getResponse.body.cancelUrl).toBe(cancelUrl)
+    })
   })
 })

--- a/libs/api/domains/payments/src/lib/dto/getPaymentFlow.response.ts
+++ b/libs/api/domains/payments/src/lib/dto/getPaymentFlow.response.ts
@@ -47,6 +47,9 @@ export class GetPaymentFlowResponse {
   @Field(() => String, { nullable: true })
   returnUrl?: string
 
+  @Field(() => String, { nullable: true })
+  cancelUrl?: string
+
   @Field(() => Boolean, { nullable: true })
   redirectToReturnUrlOnSuccess?: boolean
 


### PR DESCRIPTION
## What

- Add `cancel_url` to `payment_flow` table
- Add `cancelUrl` to `payment api` input and dto
- Add `cancelUrl` to `api` query

## Why

In some cases the `returnUrl` is sufficient, for example when the upstream system knows about the state of an application. When it does not, then the same `returnUrl` is used both for `success` and `cancel` of payments leading to bad UX

- The user clicks cancel and gets `payment successful`

By offering `cancelUrl` we can support those cases

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
