### PR TITLE
feat(api): Add "Tákntölur" to drivers license data [HOTFIX #19410]

### DIFF
--- a/libs/api/domains/license-service/src/lib/mappers/drivingLicenseMapper.ts
+++ b/libs/api/domains/license-service/src/lib/mappers/drivingLicenseMapper.ts
@@ -13,7 +13,10 @@ import {
 import isAfter from 'date-fns/isAfter'
 import { Locale } from '@island.is/shared/types'
 import { Injectable } from '@nestjs/common'
-import { DriverLicenseDto as DriversLicense } from '@island.is/clients/driving-license'
+import {
+  DriverLicenseDto as DriversLicense,
+  LicenseComments,
+} from '@island.is/clients/driving-license'
 import { isDefined } from '@island.is/shared/utils'
 import { IntlService } from '@island.is/cms-translations'
 import { m } from '../messages'
@@ -107,6 +110,11 @@ export class DrivingLicensePayloadMapper implements GenericLicenseMapper {
               ].filter(isDefined),
             })),
           },
+          {
+            type: GenericLicenseDataFieldType.Value,
+            label: formatMessage(m.extraCodes),
+            value: t.comments ? this.formatComments(t.comments) : '',
+          },
         ]
 
         return {
@@ -162,5 +170,14 @@ export class DrivingLicensePayloadMapper implements GenericLicenseMapper {
         }
       })
     return mappedPayload
+  }
+
+  formatComments(comments: Array<LicenseComments>): string {
+    return comments
+      .filter((comment) => comment.nr)
+      .map((comment) =>
+        comment.comment ? `${comment.nr} (${comment.comment})` : comment.nr,
+      )
+      .join('\n')
   }
 }

--- a/libs/api/domains/license-service/src/lib/messages.ts
+++ b/libs/api/domains/license-service/src/lib/messages.ts
@@ -65,6 +65,10 @@ export const m = defineMessages({
     id: 'api.license-service:valid-to',
     defaultMessage: 'Gildir til',
   },
+  extraCodes: {
+    id: 'api.license-service:extra-codes',
+    defaultMessage: 'Tákntölur',
+  },
   fullName: {
     id: 'api.license-service:full-name',
     defaultMessage: 'Fullt nafn',

--- a/libs/clients/driving-license/src/lib/drivingLicenseApi.types.ts
+++ b/libs/clients/driving-license/src/lib/drivingLicenseApi.types.ts
@@ -93,7 +93,7 @@ interface Deprivation {
   retakeLicense?: boolean | null
 }
 
-interface LicenseComments {
+export interface LicenseComments {
   id?: number
   nr?: string | null
   comment?: string | null

--- a/libs/portals/my-pages/licenses/src/components/LicenseDataFields/LicenseDataFields.tsx
+++ b/libs/portals/my-pages/licenses/src/components/LicenseDataFields/LicenseDataFields.tsx
@@ -87,7 +87,7 @@ export const LicenseDataFields = ({
                   field.value
                     ? () => (
                         <Box display="flex" alignItems="center">
-                          <Text>{field.value}</Text>
+                          <Text whiteSpace="preLine">{field.value}</Text>
                           <Box
                             marginLeft={2}
                             display="flex"


### PR DESCRIPTION
> **Hotfix reason:** This feature request came in late and missed the release deadline but needs to roll out before July 1st, to support the deprecation schedule of pkpass driving licenses.

Tákntölur were only implemented for pkpass but not on minar sidur or the app.

This MVP only shows the number and a date, like on plastic licenses. Needs further refactoring to look up and explain what these numbers mean, like in the pkpass.

### Pkpass
![image.png](https://app.gitbutler.com/uploads/9dbf2b89-0d60-456f-91cc-759a013ebd0f)

### App
![image.png](https://app.gitbutler.com/uploads/3f5fe037-77ce-4ac8-a6ab-8fe29f301867)

### Plastic
![image.png](https://frettatiminn.is/wp-content/uploads/2023/03/okuskirteinid-750x375.png)

### Mínar síður
![image.png](https://app.gitbutler.com/uploads/4a7cabfd-8c0e-4793-9b2e-a791af0e8779)
