### PR TITLE
fix(j-s): Return licence plate from police service

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/police/police.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/police.service.ts
@@ -470,7 +470,7 @@ export class PoliceService {
               )
 
               if (!foundCase) {
-                cases.push({ policeCaseNumber, place, date })
+                cases.push({ policeCaseNumber, place, date, licencePlate })
               } else if (date && (!foundCase.date || date > foundCase.date)) {
                 foundCase.place = place
                 foundCase.date = date


### PR DESCRIPTION
## What

Return licence plate number for new police case in the police service

## Why

Because currently we only set it if we find the case but we also want to set it if the case is being pushed to the list. 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Licence plate information is now included when viewing police case details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->