### PR TITLE
fix(hms-fca): hms fire comp appraisal submit

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/hms/fire-compensation-appraisal/fire-compensation-appraisal.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/hms/fire-compensation-appraisal/fire-compensation-appraisal.service.ts
@@ -51,20 +51,14 @@ export class FireCompensationAppraisalService extends BaseTemplateApiService {
         ).fasteignirGetFasteignir({ kennitala: auth.nationalId })
 
         properties = await Promise.all(
-          simpleProperties?.fasteignir
-            ?.map((property) => {
-              if (!property.fasteignanumer) {
-                return
-              }
-
-              return this.propertiesApi.fasteignirGetFasteign({
-                fasteignanumer:
-                  // fasteignirGetFasteignir returns the fasteignanumer with and "F" in front
-                  // but fasteignirGetFasteign throws an error if the fasteignanumer is not only numbers
-                  property.fasteignanumer.replace(/\D/g, '') ?? '',
-              })
+          simpleProperties?.fasteignir?.map((property) => {
+            return this.propertiesApi.fasteignirGetFasteign({
+              fasteignanumer:
+                // fasteignirGetFasteignir returns the fasteignanumer with and "F" in front
+                // but fasteignirGetFasteign throws an error if the fasteignanumer is not only numbers
+                property.fasteignanumer?.replace(/\D/g, '') ?? '',
             })
-            .filter((property) => property !== undefined) ?? [],
+          }) ?? [],
         )
       } catch (e) {
         this.logger.error('Failed to fetch properties:', e.message)

--- a/libs/application/templates/hms/fire-compensation-appraisal/src/forms/mainForm/photoSection.ts
+++ b/libs/application/templates/hms/fire-compensation-appraisal/src/forms/mainForm/photoSection.ts
@@ -17,6 +17,8 @@ export const photoSection = buildSection({
         buildFileUploadField({
           id: 'photos',
           uploadMultiple: true,
+          maxSize: 100000000,
+          totalMaxSize: 10000000000,
         }),
       ],
     }),


### PR DESCRIPTION
## What

fix submit of fire compensation appraisal application, application should be submitted and then photos.
fix real estate data provider. An endpoint should get the real estate id only as a string of numbers but no "F" prefix

## Why

So that the application works

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
