### PR TITLE
Revert "fix(ci): Conditionally install cypress"

### DIFF
--- a/.github/actions/setup-yarn/action.yml
+++ b/.github/actions/setup-yarn/action.yml
@@ -30,13 +30,9 @@ runs:
       id: cache-paths
       run: |
         echo "yarn-cache=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-        # Set output only if cypress exists (empty otherwise)
-        CYPRESS_CACHE_FOLDER=
-        if jq -e '(.dependencies // {}) * (.devDependencies // {}) | keys | .[] | select(. == "cypress")' package.json; then
-          CYPRESS_CACHE_FOLDER="${{ runner.temp }}/.cypress-cache"
-        fi
-        echo "CYPRESS_CACHE_FOLDER=$CYPRESS_CACHE_FOLDER" >> "$GITHUB_ENV"
+        CYPRESS_CACHE_FOLDER="${{ runner.temp }}/.cypress-cache"
         echo "cypress-cache=$CYPRESS_CACHE_FOLDER" >> "$GITHUB_OUTPUT"
+        echo "CYPRESS_CACHE_FOLDER=$CYPRESS_CACHE_FOLDER" >> "$GITHUB_ENV"
 
     # Set RunsOn S3 cache bucket only for CI runs
     #
@@ -59,12 +55,7 @@ runs:
           ${{ steps.cache-paths.outputs.yarn-cache }}
           ${{ steps.cache-paths.outputs.cypress-cache }}
           ${{ inputs.working-directory }}/node_modules
-        key: >-
-          ${{ runner.os }}-
-          deps-
-          ${{ steps.cache-paths.cypress-cache && 'cypress' || '' }}-
-          ${{ hashFiles(format('{0}/yarn.lock', inputs.working-directory)) }}-
-          1-node_modules
+        key: ${{ runner.os }}-deps-cypress-${{ hashFiles('yarn.lock') }}-1-node_modules
       env:
         AWS_REGION: ${{ env.AWS_REGION || 'eu-west-1' }}
 
@@ -74,4 +65,4 @@ runs:
       if: ${{ steps.restore-cache.outputs.cache-hit != 'true' }}
       run: |
         yarn install --immutable
-        if [[ -n "$CYPRESS_CACHE_FOLDER" ]]; then yarn cypress install; fi
+        yarn cypress install

--- a/.github/workflows/config-values.yaml
+++ b/.github/workflows/config-values.yaml
@@ -11,7 +11,6 @@ on:
       - 'infra/**'
       - '**/infra/**'
       - 'libs/auth/scopes/src/lib/clients/**'
-      - '.github/**'
   workflow_dispatch: {}
   pull_request:
     paths:
@@ -19,7 +18,6 @@ on:
       - 'infra/**'
       - '**/infra/**'
       - 'libs/auth/scopes/src/lib/clients/**'
-      - '.github/**'
 
 defaults:
   run:
@@ -99,7 +97,7 @@ jobs:
       - name: Setup yarn
         uses: ./.github/actions/setup-yarn
 
-      - name: Setup yarn (infra)
+      - name: Setup yarn (infra
         uses: ./.github/actions/setup-yarn
         with:
           working-directory: infra


### PR DESCRIPTION
fix: Reverts island-is/island.is#19438

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow configuration to prevent changes in the `.github` directory from triggering certain workflows.
  - Simplified and standardized Cypress cache and install steps in GitHub Actions.
  - Corrected a minor typo in job step names within workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->