### PR TITLE
fix(application-system): Update buildOverviewField and buildTableRepeaterField

### DIFF
--- a/libs/application/templates/examples/example-inputs/src/forms/mainForm/tablesAndRepeatersSection/tableRepeaterSubsection.ts
+++ b/libs/application/templates/examples/example-inputs/src/forms/mainForm/tablesAndRepeatersSection/tableRepeaterSubsection.ts
@@ -3,9 +3,10 @@ import {
   buildMultiField,
   buildSubSection,
   buildTableRepeaterField,
+  coreErrorMessages,
 } from '@island.is/application/core'
-import { FriggSchoolsByMunicipality } from '../../../utils/types'
 import { friggSchoolsByMunicipalityQuery } from '../../../graphql/sampleQuery'
+import { FriggSchoolsByMunicipality } from '../../../utils/types'
 
 export const tableRepeaterSubsection = buildSubSection({
   id: 'repeater',
@@ -116,6 +117,8 @@ export const tableRepeaterSubsection = buildSubSection({
             selectAsyncPrimary: {
               component: 'selectAsync',
               label: 'Primary Select Async',
+              placeholder: 'Placeholder...',
+              loadingError: coreErrorMessages.failedDataProvider,
               loadOptions: async ({ apolloClient }) => {
                 const { data } =
                   await apolloClient.query<FriggSchoolsByMunicipality>({
@@ -134,6 +137,7 @@ export const tableRepeaterSubsection = buildSubSection({
               component: 'selectAsync',
               label: 'Reliant Select Async',
               updateOnSelect: ['selectAsyncPrimary'],
+              loadingError: coreErrorMessages.failedDataProvider,
               loadOptions: async ({ apolloClient, selectedValues }) => {
                 try {
                   const { data } =

--- a/libs/application/types/src/lib/Fields.ts
+++ b/libs/application/types/src/lib/Fields.ts
@@ -231,6 +231,7 @@ export type RepeaterItem = {
         setValueAtIndex?: (key: string, value: any) => void,
       ): Promise<Option[]>
       updateOnSelect?: MaybeWithIndex<string[]>
+      loadingError?: FormText
     }
   | { component: 'hiddenInput' }
   | {

--- a/libs/application/ui-fields/src/lib/OverviewFormField/OverviewFormField.tsx
+++ b/libs/application/ui-fields/src/lib/OverviewFormField/OverviewFormField.tsx
@@ -264,9 +264,13 @@ export const OverviewFormField = ({
             </GridColumn>
           )
         })}
-      {tableData && (
+      {tableData && tableData.header.length > 0 && (
         <GridColumn span={['12/12', '12/12', '12/12', '12/12']}>
-          <Box marginTop={description || title ? 0 : 8}>
+          <Box
+            marginTop={
+              filteredItems || loadedItems || description || title ? 0 : 8
+            }
+          >
             <Table.Table>
               <Table.Head>
                 <Table.Row>

--- a/libs/application/ui-fields/src/lib/TableRepeaterFormField/TableRepeaterItem.tsx
+++ b/libs/application/ui-fields/src/lib/TableRepeaterFormField/TableRepeaterItem.tsx
@@ -308,6 +308,7 @@ export const Item = ({
     selectAsyncProps = {
       id: id,
       title: label,
+      placeholder: placeholder,
       type: FieldTypes.ASYNC_SELECT,
       component: FieldComponents.ASYNC_SELECT,
       children: undefined,
@@ -328,6 +329,7 @@ export const Item = ({
       defaultValue: defaultVal,
       clearOnChange: clearOnChangeVal,
       setOnChange: setOnChangeFunc,
+      loadingError: item.loadingError,
     }
   }
 
@@ -396,7 +398,9 @@ export const Item = ({
       span={['1/1', '1/1', '1/1', span]}
       position={component === 'hiddenInput' ? 'absolute' : 'relative'}
       className={
-        component === 'nationalIdWithName' ? styles.removePaddingTop : undefined
+        component === 'nationalIdWithName' || component === 'selectAsync'
+          ? styles.removePaddingTop
+          : undefined
       }
     >
       {component === 'radio' && label && (


### PR DESCRIPTION
## What

Updated `OverviewFormField`
- Fixed tableData margin and handled if empty table 

Updated `TableRepeaterFormField` 
- Added loadingError and placeholder to selectAsync 
- Removed paddingTop for selectAsync

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

`TableRepeaterFormField` before:
<img width="550" alt="image" src="https://github.com/user-attachments/assets/9f2e3e3c-ab00-40a8-bd38-16ead9a95c14" />


`TableRepeaterFormField` after:
<img width="550" alt="image" src="https://github.com/user-attachments/assets/9e784c5a-1a72-4eac-bbae-d8e584d5bd89" />


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
