### PR TITLE
fix(hms-fca): hms file upload message hotfix

### DIFF
--- a/libs/application/templates/hms/fire-compensation-appraisal/src/forms/mainForm/photoSection.ts
+++ b/libs/application/templates/hms/fire-compensation-appraisal/src/forms/mainForm/photoSection.ts
@@ -1,9 +1,12 @@
 import {
+  buildAlertMessageField,
   buildFileUploadField,
   buildMultiField,
   buildSection,
+  getValueViaPath,
 } from '@island.is/application/core'
 import * as m from '../../lib/messages'
+import { AttachmentItem } from '@island.is/application/types'
 
 export const photoSection = buildSection({
   id: 'photoSection',
@@ -14,6 +17,24 @@ export const photoSection = buildSection({
       title: m.photoMessages.title,
       description: m.photoMessages.description,
       children: [
+        buildAlertMessageField({
+          condition: (answers) => {
+            const photos = getValueViaPath<Array<AttachmentItem>>(
+              answers,
+              'photos',
+            )
+
+            if (!photos || photos.length === 0) {
+              return false
+            }
+
+            return photos.length < 3
+          },
+          id: 'photoAlertMessage',
+          title: m.photoMessages.alertMessageTitle,
+          message: m.photoMessages.alertMessage,
+          alertType: 'warning',
+        }),
         buildFileUploadField({
           id: 'photos',
           uploadMultiple: true,

--- a/libs/application/templates/hms/fire-compensation-appraisal/src/forms/mainForm/photoSection.ts
+++ b/libs/application/templates/hms/fire-compensation-appraisal/src/forms/mainForm/photoSection.ts
@@ -1,12 +1,9 @@
 import {
-  buildAlertMessageField,
   buildFileUploadField,
   buildMultiField,
   buildSection,
-  getValueViaPath,
 } from '@island.is/application/core'
 import * as m from '../../lib/messages'
-import { AttachmentItem } from '@island.is/application/types'
 
 export const photoSection = buildSection({
   id: 'photoSection',
@@ -17,24 +14,6 @@ export const photoSection = buildSection({
       title: m.photoMessages.title,
       description: m.photoMessages.description,
       children: [
-        buildAlertMessageField({
-          condition: (answers) => {
-            const photos = getValueViaPath<Array<AttachmentItem>>(
-              answers,
-              'photos',
-            )
-
-            if (!photos || photos.length === 0) {
-              return false
-            }
-
-            return photos.length < 3
-          },
-          id: 'photoAlertMessage',
-          title: m.photoMessages.alertMessageTitle,
-          message: m.photoMessages.alertMessage,
-          alertType: 'warning',
-        }),
         buildFileUploadField({
           id: 'photos',
           uploadMultiple: true,

--- a/libs/application/templates/hms/fire-compensation-appraisal/src/forms/mainForm/realEstateSection.ts
+++ b/libs/application/templates/hms/fire-compensation-appraisal/src/forms/mainForm/realEstateSection.ts
@@ -35,7 +35,7 @@ export const realEstateSection = buildSection({
 
             return (
               properties?.map((property) => ({
-                label: property?.sjalfgefidStadfang?.birting ?? '',
+                label: `(F${property.fasteignanumer}) ${property?.sjalfgefidStadfang?.birting} `,
                 value: property.fasteignanumer ?? '',
               })) ?? []
             )

--- a/libs/application/templates/hms/fire-compensation-appraisal/src/lib/dataSchema.ts
+++ b/libs/application/templates/hms/fire-compensation-appraisal/src/lib/dataSchema.ts
@@ -1,5 +1,6 @@
 import { YES } from '@island.is/application/core'
 import { z } from 'zod'
+import * as m from './messages'
 
 const fileSchema = z.object({ key: z.string(), name: z.string() })
 
@@ -35,7 +36,14 @@ export const dataSchema = z.object({
   applicant: applicantSchema,
   realEstate: realEstateSchema,
   usageUnits: usageUnitsSchema,
-  photos: z.array(fileSchema).min(3),
+  photos: z.array(fileSchema).superRefine((data, ctx) => {
+    if (data.length < 3) {
+      ctx.addIssue({
+        params: m.photoMessages.alertMessage,
+        code: z.ZodIssueCode.custom,
+      })
+    }
+  }),
   appraisalMethod: appraisalMethodSchema,
   description: descriptionSchema,
 })

--- a/libs/application/templates/hms/fire-compensation-appraisal/src/lib/messages/photoMessages.ts
+++ b/libs/application/templates/hms/fire-compensation-appraisal/src/lib/messages/photoMessages.ts
@@ -12,15 +12,10 @@ export const photoMessages = defineMessages({
       'Hér setur þú inn myndir af því sem þú taldir upp á lýsingu á framkvæmdum og sýnir frágang.\n\nUmsækjandi er hvattur til að hlaða upp myndum sem gagnast við gerð brunabótamatsins svo að það byggi á réttum upplýsingum.\n\nTakið eftir að það þarf að hlaða upp í það minnsta **3 myndum** til að geta sótt um endurmat brunabótamats.',
     description: 'Photo section description',
   },
-  alertMessageTitle: {
-    id: 'fca.application:photo.alertMessageTitle',
-    defaultMessage: 'Fleiri myndir vantar',
-    description: 'Photo section alert message title',
-  },
   alertMessage: {
     id: 'fca.application:photo.alertMessage',
     defaultMessage:
-      'Þú þarft að hlaða upp í það minnsta **3 myndum** til að geta sótt um endurmat brunabótamats.',
+      'Þú þarft að hlaða upp í það minnsta 3 myndum til að geta sótt um endurmat brunabótamats.',
     description: 'Photo section alert message',
   },
 })

--- a/libs/application/templates/hms/fire-compensation-appraisal/src/lib/messages/photoMessages.ts
+++ b/libs/application/templates/hms/fire-compensation-appraisal/src/lib/messages/photoMessages.ts
@@ -12,4 +12,15 @@ export const photoMessages = defineMessages({
       'Hér setur þú inn myndir af því sem þú taldir upp á lýsingu á framkvæmdum og sýnir frágang.\n\nUmsækjandi er hvattur til að hlaða upp myndum sem gagnast við gerð brunabótamatsins svo að það byggi á réttum upplýsingum.\n\nTakið eftir að það þarf að hlaða upp í það minnsta **3 myndum** til að geta sótt um endurmat brunabótamats.',
     description: 'Photo section description',
   },
+  alertMessageTitle: {
+    id: 'fca.application:photo.alertMessageTitle',
+    defaultMessage: 'Fleiri myndir vantar',
+    description: 'Photo section alert message title',
+  },
+  alertMessage: {
+    id: 'fca.application:photo.alertMessage',
+    defaultMessage:
+      'Þú þarft að hlaða upp í það minnsta **3 myndum** til að geta sótt um endurmat brunabótamats.',
+    description: 'Photo section alert message',
+  },
 })


### PR DESCRIPTION
## What

Add custom error message that gives better guidance to the user if he doesn't upload enough photos
Add fasteignaId to the real estate select field to distinguish properties with the same house and street number

## Screenshots / Gifs

![Screenshot 2025-06-26 at 10 54 12](https://github.com/user-attachments/assets/039b322a-8899-4a1b-b9c4-36af52f55024)
![Screenshot 2025-06-26 at 10 32 58](https://github.com/user-attachments/assets/c475292b-bf43-42cf-a5ee-0c881709f4a4)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
