### PR TITLE
feat(applicaton-system): Add support for lite endpoint

### DIFF
--- a/libs/clients/national-registry/v3-applications/src/clientConfig.json
+++ b/libs/clients/national-registry/v3-applications/src/clientConfig.json
@@ -8,7 +8,9 @@
   "paths": {
     "/Einstaklingar/{kennitala}": {
       "get": {
-        "tags": ["Einstaklingar"],
+        "tags": [
+          "Einstaklingar"
+        ],
         "summary": "GET fyrir einstaklinga.",
         "description": "Skilar grunnupplýsingum um raunskráningu einstaklings í þjóðskrá út frá kennitölu.<para />\r\nUndir lögheimili - Ættu alltaf að birtast einhverjar upplýsingar, ef einstaklingur er ekki með skráð lögheimili á Íslandi þá birtist í flestum tilfellum það land sem viðkomandi hefur upplýst Þjóðskrá Íslands um að flutt hafi verið til.<para />\r\nUndir aðsetur - Ef einstaklingur er með skráð aðsetur í þjóðskrá þá birtast upplýsingar undir aðsetur, annars birtast engar upplýsingar.",
         "parameters": [
@@ -17,7 +19,9 @@
             "in": "path",
             "description": "Kennitala einstaklings sem verið er að leita eftir.",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -25,15 +29,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/EinstaklingurDTO" }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProblemDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/EinstaklingurDTO"
+                }
               }
             }
           },
@@ -41,7 +39,19 @@
             "description": "Unauthorized",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProblemDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
               }
             }
           },
@@ -49,7 +59,71 @@
             "description": "Internal Server Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Error" }
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/Einstaklingar/{kennitala}/lite": {
+      "get": {
+        "tags": [
+          "Einstaklingar"
+        ],
+        "summary": "GET fyrir einstaklingaLite.",
+        "description": "Skilar grunnupplýsingum um raunskráningu einstaklings í þjóðskrá út frá kennitölu.<para />\r\nUndir lögheimili - Ættu alltaf að birtast einhverjar upplýsingar, ef einstaklingur er ekki með skráð lögheimili á Íslandi þá birtist í flestum tilfellum það land sem viðkomandi hefur upplýst Þjóðskrá Íslands um að flutt hafi verið til.<para />\r\nUndir aðsetur - Ef einstaklingur er með skráð aðsetur í þjóðskrá þá birtast upplýsingar undir aðsetur, annars birtast engar upplýsingar.",
+        "parameters": [
+          {
+            "name": "kennitala",
+            "in": "path",
+            "description": "Kennitala einstaklings sem verið er að leita eftir.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EinstaklingurLiteDTO"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
               }
             }
           }
@@ -58,7 +132,9 @@
     },
     "/Einstaklingar/{kennitala}/faedingarstadur": {
       "get": {
-        "tags": ["Einstaklingar"],
+        "tags": [
+          "Einstaklingar"
+        ],
         "summary": "GET fyrir fæðingarstað.",
         "description": "Skilar upplýsingum um sveitarfélag/land sem einstaklingur fæðist í ásamt upplýsingum um fæðingardag einstaklings.<para />\r\nFæðingarstaður einstaklings segir í mörgum tilfellum ekkert um upprunaland einstaklings.<para />\r\nEinstaklingar geta fæðst í landi sem þeir eru ekki búsettir í og hafa aldrei búið í, hafa enga aðra tengingu við landið en að hafa fæðst þar af einhverjum ástæðum.",
         "parameters": [
@@ -67,7 +143,9 @@
             "in": "path",
             "description": "Kennitala þess sem þarf fæðingarstað fyrir.",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -75,15 +153,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/FaedingarstadurDTO" }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProblemDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/FaedingarstadurDTO"
+                }
               }
             }
           },
@@ -91,7 +163,19 @@
             "description": "Unauthorized",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProblemDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
               }
             }
           },
@@ -99,7 +183,9 @@
             "description": "Internal Server Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Error" }
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
               }
             }
           }
@@ -108,16 +194,20 @@
     },
     "/Einstaklingar/{kennitala}/forsjaUndir": {
       "get": {
-        "tags": ["Einstaklingar"],
+        "tags": [
+          "Einstaklingar"
+        ],
         "summary": "Sækir upplýsingar um börn sem einstaklingur hefur forsjá yfir.",
-        "description": "Endapunkturinn er læstur á notendur + börn.<para />\r\n Tekur inn kennitölu forsjáraðila og skilar upplýsingum um barn/börn sem forsjáraðili fer með forsjá yfir.",
+        "description": "Endapunkturinn er læstur á notendur + börn.<para />\r\n            Tekur inn kennitölu forsjáraðila og skilar upplýsingum um barn/börn sem forsjáraðili fer með forsjá yfir.",
         "parameters": [
           {
             "name": "kennitala",
             "in": "path",
             "description": "Kennitala forsjáraðila.",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -125,15 +215,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ForsjaAdiliDTO" }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProblemDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/ForsjaAdiliDTO"
+                }
               }
             }
           },
@@ -141,7 +225,19 @@
             "description": "Unauthorized",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProblemDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
               }
             }
           },
@@ -149,7 +245,9 @@
             "description": "Internal Server Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Error" }
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
               }
             }
           }
@@ -158,7 +256,9 @@
     },
     "/Einstaklingar/{kennitala}/forsjaYfir": {
       "get": {
-        "tags": ["Einstaklingar"],
+        "tags": [
+          "Einstaklingar"
+        ],
         "summary": "Sækir upplýsingar um einstakling/a hefur/hafa forsjá yfir barni.",
         "description": "Endapunkturinn er læstur á notendur + börn.<para />\r\nTekur inn kennitölu barns og skilar upplýsingum um skráða forsjáraðila barnsins.",
         "parameters": [
@@ -167,7 +267,9 @@
             "in": "path",
             "description": "Kennitala forsjáraðila.",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -175,15 +277,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ForsjaBarnDTO" }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProblemDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/ForsjaBarnDTO"
+                }
               }
             }
           },
@@ -191,7 +287,19 @@
             "description": "Unauthorized",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProblemDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
               }
             }
           },
@@ -199,7 +307,9 @@
             "description": "Internal Server Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Error" }
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
               }
             }
           }
@@ -208,16 +318,20 @@
     },
     "/Einstaklingar/{kennitala}/rikisfang": {
       "get": {
-        "tags": ["Einstaklingar"],
+        "tags": [
+          "Einstaklingar"
+        ],
         "summary": "Sækir upplýsingar um ríkisfang fyrir innsenda kennitölu.",
-        "description": "Skilar upplýsingum um skráð ríkisfang einstaklings í þjóðskrá.<para />\r\n Einungi eitt ríkisfang er skráð í þjóðskrá þó svo að einstaklingur geti verið með tvöfalt ríkisfang.",
+        "description": "Skilar upplýsingum um skráð ríkisfang einstaklings í þjóðskrá.<para />\r\n            Einungi eitt ríkisfang er skráð í þjóðskrá þó svo að einstaklingur geti verið með tvöfalt ríkisfang.",
         "parameters": [
           {
             "name": "kennitala",
             "in": "path",
             "description": "Kennitala.",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -225,15 +339,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/RikisfangDTO" }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProblemDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/RikisfangDTO"
+                }
               }
             }
           },
@@ -241,7 +349,19 @@
             "description": "Unauthorized",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProblemDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
               }
             }
           },
@@ -249,7 +369,9 @@
             "description": "Internal Server Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Error" }
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
               }
             }
           }
@@ -258,7 +380,9 @@
     },
     "/Einstaklingar/{kennitala}/adsetur": {
       "get": {
-        "tags": ["Einstaklingar"],
+        "tags": [
+          "Einstaklingar"
+        ],
         "summary": "Sækir upplýsingar um aðsetur fyrir innsenda kennitölu.",
         "description": "Skilar upplýsingum um raunskráningu aðseturs einstaklings í þjóðskrá út frá kennitölu ef viðkomandi er með skráð aðsetur í þjóðskrá, skilar annars tómu.",
         "parameters": [
@@ -267,7 +391,9 @@
             "in": "path",
             "description": "Kennitala.",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -275,15 +401,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/AdseturDTO" }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProblemDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/AdseturDTO"
+                }
               }
             }
           },
@@ -291,7 +411,19 @@
             "description": "Unauthorized",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProblemDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
               }
             }
           },
@@ -299,7 +431,9 @@
             "description": "Internal Server Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Error" }
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
               }
             }
           }
@@ -308,16 +442,20 @@
     },
     "/Einstaklingar/{kennitala}/hjuskapur": {
       "get": {
-        "tags": ["Einstaklingar"],
+        "tags": [
+          "Einstaklingar"
+        ],
         "summary": "Sækir upplýsingar um hjúskap fyrir innsenda kennitölu.",
-        "description": "Skilar upplýsingum um skráða hjúskaparstöðu einstaklings í þjóðskrá, allir einstaklingar í þjóðskrá eru með skráða hjúskaparstöðu. <para />\r\n Undir sambud – Ef einstaklingur er í skráðri sambúð birtast upplýsingar um skráðan sambúðaraðilia, kennitala, nafn og dagsetning skráðrar sambúðar, skilar annars tómu.",
+        "description": "Skilar upplýsingum um skráða hjúskaparstöðu einstaklings í þjóðskrá, allir einstaklingar í þjóðskrá eru með skráða hjúskaparstöðu. <para />\r\n            Undir sambud – Ef einstaklingur er í skráðri sambúð birtast upplýsingar um skráðan sambúðaraðilia, kennitala, nafn og dagsetning skráðrar sambúðar, skilar annars tómu.",
         "parameters": [
           {
             "name": "kennitala",
             "in": "path",
             "description": "Kennitala.",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -325,15 +463,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HjuskapurDTO" }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProblemDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/HjuskapurDTO"
+                }
               }
             }
           },
@@ -341,7 +473,19 @@
             "description": "Unauthorized",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProblemDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
               }
             }
           },
@@ -349,7 +493,9 @@
             "description": "Internal Server Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Error" }
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
               }
             }
           }
@@ -358,16 +504,20 @@
     },
     "/Einstaklingar/{kennitala}/logheimili": {
       "get": {
-        "tags": ["Einstaklingar"],
+        "tags": [
+          "Einstaklingar"
+        ],
         "summary": "Skilar lögheimilisupplýsingum fyrir innsenda kennitölu.",
-        "description": "Skilar upplýsingum um raunskráningu á lögheimili einstaklings í þjóðskrá út frá kennitölu.<para />\r\n Svæðið „breytt“ er dagsetninginn þegar einstaklingurinn flutti lögheimili sitt á á skráð lögheimili.<para />\r\n Ef engar upplýsingar koma í „breytt“ þá hefur einstaklingurinn að öllum líkindum verið með sama lögheimili frá því áður en rafræn skráning hófst 1986.",
+        "description": "Skilar upplýsingum um raunskráningu á lögheimili einstaklings í þjóðskrá út frá kennitölu.<para />\r\n            Svæðið „breytt“ er dagsetninginn þegar einstaklingurinn flutti lögheimili sitt á á skráð lögheimili.<para />\r\n            Ef engar upplýsingar koma í „breytt“ þá hefur einstaklingurinn að öllum líkindum verið með sama lögheimili frá því áður en rafræn skráning hófst 1986.",
         "parameters": [
           {
             "name": "kennitala",
             "in": "path",
             "description": "Kennitala þess sem á að skila lögheimili fyrir.",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -375,15 +525,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LogheimiliDTO" }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProblemDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/LogheimiliDTO"
+                }
               }
             }
           },
@@ -391,7 +535,19 @@
             "description": "Unauthorized",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProblemDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
               }
             }
           },
@@ -399,7 +555,9 @@
             "description": "Internal Server Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Error" }
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
               }
             }
           }
@@ -408,16 +566,20 @@
     },
     "/Einstaklingar/{kennitala}/logheimilistengsl": {
       "get": {
-        "tags": ["Einstaklingar"],
+        "tags": [
+          "Einstaklingar"
+        ],
         "summary": "Skilar lögheimilistengslum fyrir innsenda kennitölu.",
-        "description": "Skilar upplýsingum um raunskráningu einstaklinga í þjóðskrá sem eru skráðir með sömu lögheimilistengsl þeirrar kennitölu sem kallað er í.<para />\r\n Ef innsend kennitala er ekki skráða lögheimilistengsla kennitalan þá eru samt sem áður lögheimilistengslin fundin og öllum aðilum með sömu lögheimilistengsl skilað í kallinu.",
+        "description": "Skilar upplýsingum um raunskráningu einstaklinga í þjóðskrá sem eru skráðir með sömu lögheimilistengsl þeirrar kennitölu sem kallað er í.<para />\r\n            Ef innsend kennitala er ekki skráða lögheimilistengsla kennitalan þá eru samt sem áður lögheimilistengslin fundin og öllum aðilum með sömu lögheimilistengsl skilað í kallinu.",
         "parameters": [
           {
             "name": "kennitala",
             "in": "path",
             "description": "Kennitala þess sem á að skila lögheimilistengslum fyrir.",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -431,19 +593,23 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProblemDetails" }
-              }
-            }
-          },
           "401": {
             "description": "Unauthorized",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProblemDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
               }
             }
           },
@@ -451,7 +617,9 @@
             "description": "Internal Server Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Error" }
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
               }
             }
           }
@@ -460,16 +628,20 @@
     },
     "/Einstaklingar/{kennitala}/logheimilistengslItar": {
       "get": {
-        "tags": ["Einstaklingar"],
+        "tags": [
+          "Einstaklingar"
+        ],
         "summary": "Skilar ítarlegum upplýsingum um fjölskyldumeðlimi með lögheimilistengsl fyrir innsenda kennitölu.",
-        "description": "Skilar grunnupplýsingum um raunskráningu einstaklinga sem eru með sömu lögheimilistengsl þeirrar kennitölu sem kallað er í.<para />\r\n Ef innsend kennitala er ekki lögheimilistengsla kennitalan þá eru lögheimilistengslin samt sem áður fundin og öllum aðilum með sömu lögheimilistengs skilað í kallinu.<para />\r\n Undir lögheimili - Ættu alltaf að birtast einhverjar upplýsingar, ef einstaklingur er ekki með skráð lögheimili á Íslandi þá birtist í flestum tilfellum það land sem viðkomandi er búsettur í.<para />\r\n Undir aðsetur - Ef einstaklingur er með skráð aðsetur í þjóðskrá þá birtast upplýsingar undir aðsetur, annars birtast engar upplýsingar.",
+        "description": "Skilar grunnupplýsingum um raunskráningu einstaklinga sem eru með sömu lögheimilistengsl þeirrar kennitölu sem kallað er í.<para />\r\n            Ef innsend kennitala er ekki lögheimilistengsla kennitalan þá eru lögheimilistengslin samt sem áður fundin og öllum aðilum með sömu lögheimilistengs skilað í kallinu.<para />\r\n            Undir lögheimili - Ættu alltaf að birtast einhverjar upplýsingar, ef einstaklingur er ekki með skráð lögheimili á Íslandi þá birtist í flestum tilfellum það land sem viðkomandi er búsettur í.<para />\r\n            Undir aðsetur - Ef einstaklingur er með skráð aðsetur í þjóðskrá þá birtast upplýsingar undir aðsetur, annars birtast engar upplýsingar.",
         "parameters": [
           {
             "name": "kennitala",
             "in": "path",
             "description": "Kennitala þess sem á að skila upplýsingum um fjölskyldumeðlimi.",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -483,19 +655,23 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProblemDetails" }
-              }
-            }
-          },
           "401": {
             "description": "Unauthorized",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProblemDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
               }
             }
           },
@@ -503,7 +679,9 @@
             "description": "Internal Server Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Error" }
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
               }
             }
           }
@@ -512,7 +690,9 @@
     },
     "/Einstaklingar/{kennitala}/logheimilisforeldri": {
       "get": {
-        "tags": ["Einstaklingar"],
+        "tags": [
+          "Einstaklingar"
+        ],
         "summary": "Sækir upplýsingar um einstakling/a sem eru skráðir lögheimilisforeldrar barns.",
         "description": "Endapunkturinn er læstur á notendur + börn.<para />\r\nTekur inn kennitölu barns og skilar upplýsingum um skráða forsjáraðila barnsins sem eru skráðir lögheimilisforeldrar þess.\r\nEf skráður forsjáraðili barnsins er með annarskonar forsjárskráningu skilar kallið ekki þeim forsjáraðila.",
         "parameters": [
@@ -521,7 +701,9 @@
             "in": "path",
             "description": "Kennitala.",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -529,15 +711,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ForsjaBarnDTO" }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProblemDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/ForsjaBarnDTO"
+                }
               }
             }
           },
@@ -545,7 +721,19 @@
             "description": "Unauthorized",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProblemDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
               }
             }
           },
@@ -553,7 +741,9 @@
             "description": "Internal Server Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Error" }
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
               }
             }
           }
@@ -562,7 +752,9 @@
     },
     "/Einstaklingar/{kennitala}/busetuforeldri": {
       "get": {
-        "tags": ["Einstaklingar"],
+        "tags": [
+          "Einstaklingar"
+        ],
         "summary": "Sækir upplýsingar um einstakling/a sem eru skráðir búsetuforeldrar barns.",
         "description": "Endapunkturinn er læstur á notendur + börn.<para />\r\nTekur inn kennitölu barns og skilar upplýsingum um skráða forsjáraðila barnsins sem eru skráðir búsetuforeldrar þess.\r\nEf skráður forsjáraðili barnsins er með annarskonar forsjárskráningu skilar kallið ekki þeim forsjáraðila.",
         "parameters": [
@@ -571,7 +763,9 @@
             "in": "path",
             "description": "Kennitala.",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -579,15 +773,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ForsjaBarnDTO" }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProblemDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/ForsjaBarnDTO"
+                }
               }
             }
           },
@@ -595,7 +783,19 @@
             "description": "Unauthorized",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProblemDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
               }
             }
           },
@@ -603,7 +803,9 @@
             "description": "Internal Server Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Error" }
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
               }
             }
           }
@@ -612,16 +814,20 @@
     },
     "/Einstaklingar/{kennitala}/busetusaga": {
       "get": {
-        "tags": ["Einstaklingar"],
+        "tags": [
+          "Einstaklingar"
+        ],
         "summary": "Skilar búsetusögu, þ.e. lista af heimilisföngum/lögheimilum sem viðkomandi hefur verið skráður á.",
-        "description": "Endapunkturinn skilar lögheimilissögu einstaklings út frá kennitölu.\r\n Svæðið „breytt“ er dagsetninginn þegar einstaklingurinn flutti lögheimili sitt á tiltekið lögheimili. \\n\r\n Skráning einstaklinga niður á íbúðir hefst ekki fyrr en um 2015/2016, \\n\r\n Rafræn skráning nær ekki lengra aftur en til 1986 ef flutningur einstaklings átti sér stað fyrir þann tíma þá kemur það ekki fram hér.Hægt er að sjá núverandi skráð lögheimili einstakling með endapunktinum:/ api/v1/einstaklingar/{ kennitala}/ logheimili",
+        "description": "Endapunkturinn skilar lögheimilissögu einstaklings út frá kennitölu.\r\n            Svæðið „breytt“ er dagsetninginn þegar einstaklingurinn flutti lögheimili sitt á tiltekið lögheimili. \\n\r\n            Skráning einstaklinga niður á íbúðir hefst ekki fyrr en um 2015/2016, \\n\r\n            Rafræn skráning nær ekki lengra aftur en til 1986 ef flutningur einstaklings átti sér stað fyrir þann tíma þá kemur það ekki fram hér.Hægt er að sjá núverandi skráð lögheimili einstakling með endapunktinum:/ api/v1/einstaklingar/{ kennitala}/ logheimili",
         "parameters": [
           {
             "name": "kennitala",
             "in": "path",
             "description": "Kennitala þess sem á að skila búsetu fyrir.",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -631,7 +837,19 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/BusetaDTO" }
+                  "items": {
+                    "$ref": "#/components/schemas/BusetaDTO"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -640,15 +858,9 @@
             "description": "Not Found",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProblemDetails" }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProblemDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
               }
             }
           },
@@ -656,7 +868,9 @@
             "description": "Internal Server Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Error" }
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
               }
             }
           }
@@ -665,7 +879,9 @@
     },
     "/IslandIs/18IDag": {
       "get": {
-        "tags": ["IslandIs"],
+        "tags": [
+          "IslandIs"
+        ],
         "summary": "Skilar lista af kennitölum þeirra sem eiga 18 ára afmæli í dag",
         "responses": {
           "200": {
@@ -678,19 +894,23 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProblemDetails" }
-              }
-            }
-          },
           "401": {
             "description": "Unauthorized",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProblemDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
               }
             }
           }
@@ -699,13 +919,17 @@
     },
     "/Utl/{Kennitala}": {
       "get": {
-        "tags": ["Utl"],
+        "tags": [
+          "Utl"
+        ],
         "parameters": [
           {
             "name": "Kennitala",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -713,7 +937,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/EinstaklingurUtlDTO" }
+                "schema": {
+                  "$ref": "#/components/schemas/EinstaklingurUtlDTO"
+                }
               }
             }
           }
@@ -726,13 +952,34 @@
       "AdseturDTO": {
         "type": "object",
         "properties": {
-          "ibudanumer": { "type": "string", "nullable": true },
-          "postnumer": { "type": "string", "nullable": true },
-          "stadur": { "type": "string", "nullable": true },
-          "sveitarfelagsnumer": { "type": "string", "nullable": true },
-          "huskodi": { "type": "string", "nullable": true },
-          "heimilisfang": { "type": "string", "nullable": true },
-          "landakodi": { "type": "string", "nullable": true },
+          "ibudanumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "postnumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "stadur": {
+            "type": "string",
+            "nullable": true
+          },
+          "sveitarfelagsnumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "huskodi": {
+            "type": "string",
+            "nullable": true
+          },
+          "heimilisfang": {
+            "type": "string",
+            "nullable": true
+          },
+          "landakodi": {
+            "type": "string",
+            "nullable": true
+          },
           "breytt": {
             "type": "string",
             "format": "date-time",
@@ -744,18 +991,39 @@
       "BusetaDTO": {
         "type": "object",
         "properties": {
-          "ibudanumer": { "type": "string", "nullable": true },
-          "postnumer": { "type": "string", "nullable": true },
-          "stadur": { "type": "string", "nullable": true },
-          "sveitarfelagsnumer": { "type": "string", "nullable": true },
-          "huskodi": { "type": "string", "nullable": true },
+          "ibudanumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "postnumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "stadur": {
+            "type": "string",
+            "nullable": true
+          },
+          "sveitarfelagsnumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "huskodi": {
+            "type": "string",
+            "nullable": true
+          },
           "fasteignanumer": {
             "type": "integer",
             "format": "int32",
             "nullable": true
           },
-          "heimilisfang": { "type": "string", "nullable": true },
-          "landakodi": { "type": "string", "nullable": true },
+          "heimilisfang": {
+            "type": "string",
+            "nullable": true
+          },
+          "landakodi": {
+            "type": "string",
+            "nullable": true
+          },
           "breytt": {
             "type": "string",
             "format": "date-time",
@@ -778,40 +1046,105 @@
         "additionalProperties": false
       },
       "Einstaklingur18IDagItemDTO": {
-        "required": ["kennitala", "nafn"],
+        "required": [
+          "kennitala",
+          "nafn"
+        ],
         "type": "object",
         "properties": {
-          "kennitala": { "type": "string", "nullable": true },
-          "nafn": { "type": "string", "nullable": true }
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          },
+          "nafn": {
+            "type": "string",
+            "nullable": true
+          }
         },
         "additionalProperties": false
       },
       "EinstaklingurDTO": {
-        "required": ["kennitala"],
+        "required": [
+          "kennitala"
+        ],
         "type": "object",
         "properties": {
-          "kennitala": { "type": "string", "nullable": true },
-          "nafn": { "type": "string", "nullable": true },
-          "kynKodi": { "type": "string", "nullable": true },
-          "kynTexti": { "type": "string", "nullable": true },
-          "bannmerking": { "type": "boolean", "nullable": true },
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          },
+          "nafn": {
+            "type": "string",
+            "nullable": true
+          },
+          "kynKodi": {
+            "type": "string",
+            "nullable": true
+          },
+          "kynTexti": {
+            "type": "string",
+            "nullable": true
+          },
+          "bannmerking": {
+            "type": "boolean",
+            "nullable": true
+          },
           "faedingardagur": {
             "type": "string",
             "format": "date-time",
             "nullable": true
           },
-          "logheimili": { "$ref": "#/components/schemas/HeimilisfangBaseDTO" },
-          "adsetur": { "$ref": "#/components/schemas/HeimilisfangBaseDTO" }
+          "logheimili": {
+            "$ref": "#/components/schemas/HeimilisfangBaseDTO"
+          },
+          "adsetur": {
+            "$ref": "#/components/schemas/HeimilisfangBaseDTO"
+          }
+        },
+        "additionalProperties": false
+      },
+      "EinstaklingurLiteDTO": {
+        "required": [
+          "kennitala"
+        ],
+        "type": "object",
+        "properties": {
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          },
+          "nafn": {
+            "type": "string",
+            "nullable": true
+          },
+          "logheimili": {
+            "$ref": "#/components/schemas/HeimilisfangBaseDTO"
+          },
+          "adsetur": {
+            "$ref": "#/components/schemas/HeimilisfangBaseDTO"
+          }
         },
         "additionalProperties": false
       },
       "EinstaklingurUtlBaseDTO": {
         "type": "object",
         "properties": {
-          "kennitala": { "type": "string", "nullable": true },
-          "nafn": { "type": "string", "nullable": true },
-          "rikisfangKodi": { "type": "string", "nullable": true },
-          "rikisfangLand": { "type": "string", "nullable": true },
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          },
+          "nafn": {
+            "type": "string",
+            "nullable": true
+          },
+          "rikisfangKodi": {
+            "type": "string",
+            "nullable": true
+          },
+          "rikisfangLand": {
+            "type": "string",
+            "nullable": true
+          },
           "rikisfangBrDagur": {
             "type": "string",
             "format": "date-time",
@@ -823,16 +1156,30 @@
       "EinstaklingurUtlDTO": {
         "type": "object",
         "properties": {
-          "kennitala": { "type": "string", "nullable": true },
-          "nafn": { "type": "string", "nullable": true },
-          "rikisfangKodi": { "type": "string", "nullable": true },
-          "rikisfangLand": { "type": "string", "nullable": true },
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          },
+          "nafn": {
+            "type": "string",
+            "nullable": true
+          },
+          "rikisfangKodi": {
+            "type": "string",
+            "nullable": true
+          },
+          "rikisfangLand": {
+            "type": "string",
+            "nullable": true
+          },
           "rikisfangBrDagur": {
             "type": "string",
             "format": "date-time",
             "nullable": true
           },
-          "maki": { "$ref": "#/components/schemas/EinstaklingurUtlBaseDTO" },
+          "maki": {
+            "$ref": "#/components/schemas/EinstaklingurUtlBaseDTO"
+          },
           "hjuSambudBrDagur": {
             "type": "string",
             "format": "date-time",
@@ -846,12 +1193,21 @@
         },
         "additionalProperties": false
       },
-      "Error": { "type": "object", "additionalProperties": false },
+      "Error": {
+        "type": "object",
+        "additionalProperties": false
+      },
       "FaedingarstadurDTO": {
         "type": "object",
         "properties": {
-          "sveitarfelagsnumer": { "type": "string", "nullable": true },
-          "stadur": { "type": "string", "nullable": true },
+          "sveitarfelagsnumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "stadur": {
+            "type": "string",
+            "nullable": true
+          },
           "faedingardagur": {
             "type": "string",
             "format": "date-time",
@@ -863,19 +1219,33 @@
       "ForsjaAdiliBaseDTO": {
         "type": "object",
         "properties": {
-          "forsjaKt": { "type": "string", "nullable": true },
-          "forsjaNafn": { "type": "string", "nullable": true }
+          "forsjaKt": {
+            "type": "string",
+            "nullable": true
+          },
+          "forsjaNafn": {
+            "type": "string",
+            "nullable": true
+          }
         },
         "additionalProperties": false
       },
       "ForsjaAdiliDTO": {
         "type": "object",
         "properties": {
-          "forsjaKt": { "type": "string", "nullable": true },
-          "forsjaNafn": { "type": "string", "nullable": true },
+          "forsjaKt": {
+            "type": "string",
+            "nullable": true
+          },
+          "forsjaNafn": {
+            "type": "string",
+            "nullable": true
+          },
           "forsjaBornList": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/ForsjaBarnBaseDTO" },
+            "items": {
+              "$ref": "#/components/schemas/ForsjaBarnBaseDTO"
+            },
             "nullable": true
           }
         },
@@ -884,19 +1254,33 @@
       "ForsjaBarnBaseDTO": {
         "type": "object",
         "properties": {
-          "barnKt": { "type": "string", "nullable": true },
-          "barnNafn": { "type": "string", "nullable": true }
+          "barnKt": {
+            "type": "string",
+            "nullable": true
+          },
+          "barnNafn": {
+            "type": "string",
+            "nullable": true
+          }
         },
         "additionalProperties": false
       },
       "ForsjaBarnDTO": {
         "type": "object",
         "properties": {
-          "barnKt": { "type": "string", "nullable": true },
-          "barnNafn": { "type": "string", "nullable": true },
+          "barnKt": {
+            "type": "string",
+            "nullable": true
+          },
+          "barnNafn": {
+            "type": "string",
+            "nullable": true
+          },
           "forsjaAdilarList": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/ForsjaAdiliBaseDTO" },
+            "items": {
+              "$ref": "#/components/schemas/ForsjaAdiliBaseDTO"
+            },
             "nullable": true
           }
         },
@@ -905,21 +1289,48 @@
       "HeimilisfangBaseDTO": {
         "type": "object",
         "properties": {
-          "heimilisfang": { "type": "string", "nullable": true },
-          "ibudanumer": { "type": "string", "nullable": true },
-          "postnumer": { "type": "string", "nullable": true },
-          "stadur": { "type": "string", "nullable": true },
-          "sveitarfelagsnumer": { "type": "string", "nullable": true }
+          "heimilisfang": {
+            "type": "string",
+            "nullable": true
+          },
+          "ibudanumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "postnumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "stadur": {
+            "type": "string",
+            "nullable": true
+          },
+          "sveitarfelagsnumer": {
+            "type": "string",
+            "nullable": true
+          }
         },
         "additionalProperties": false
       },
       "HjuDTO": {
         "type": "object",
         "properties": {
-          "kennitalaMaka": { "type": "string", "nullable": true },
-          "nafnMaka": { "type": "string", "nullable": true },
-          "hjuskaparKodi": { "type": "string", "nullable": true },
-          "hjuskaparTexti": { "type": "string", "nullable": true },
+          "kennitalaMaka": {
+            "type": "string",
+            "nullable": true
+          },
+          "nafnMaka": {
+            "type": "string",
+            "nullable": true
+          },
+          "hjuskaparKodi": {
+            "type": "string",
+            "nullable": true
+          },
+          "hjuskaparTexti": {
+            "type": "string",
+            "nullable": true
+          },
           "dagsetningBreytt": {
             "type": "string",
             "format": "date-time",
@@ -931,21 +1342,46 @@
       "HjuskapurDTO": {
         "type": "object",
         "properties": {
-          "hjuskapur": { "$ref": "#/components/schemas/HjuDTO" },
-          "sambud": { "$ref": "#/components/schemas/SamDTO" }
+          "hjuskapur": {
+            "$ref": "#/components/schemas/HjuDTO"
+          },
+          "sambud": {
+            "$ref": "#/components/schemas/SamDTO"
+          }
         },
         "additionalProperties": false
       },
       "LogheimiliDTO": {
         "type": "object",
         "properties": {
-          "ibudanumer": { "type": "string", "nullable": true },
-          "postnumer": { "type": "string", "nullable": true },
-          "stadur": { "type": "string", "nullable": true },
-          "sveitarfelagsnumer": { "type": "string", "nullable": true },
-          "huskodi": { "type": "string", "nullable": true },
-          "heimilisfang": { "type": "string", "nullable": true },
-          "landakodi": { "type": "string", "nullable": true },
+          "ibudanumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "postnumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "stadur": {
+            "type": "string",
+            "nullable": true
+          },
+          "sveitarfelagsnumer": {
+            "type": "string",
+            "nullable": true
+          },
+          "huskodi": {
+            "type": "string",
+            "nullable": true
+          },
+          "heimilisfang": {
+            "type": "string",
+            "nullable": true
+          },
+          "landakodi": {
+            "type": "string",
+            "nullable": true
+          },
           "breytt": {
             "type": "string",
             "format": "date-time",
@@ -960,23 +1396,42 @@
         "additionalProperties": false
       },
       "LogheimilismedlimurDTO": {
-        "required": ["kennitala"],
+        "required": [
+          "kennitala"
+        ],
         "type": "object",
         "properties": {
-          "nafn": { "type": "string", "nullable": true },
-          "kennitala": { "type": "string", "nullable": true },
-          "kynkodi": { "type": "string", "nullable": true },
-          "kyntexti": { "type": "string", "nullable": true }
+          "nafn": {
+            "type": "string",
+            "nullable": true
+          },
+          "kennitala": {
+            "type": "string",
+            "nullable": true
+          },
+          "kynkodi": {
+            "type": "string",
+            "nullable": true
+          },
+          "kyntexti": {
+            "type": "string",
+            "nullable": true
+          }
         },
         "additionalProperties": false
       },
       "LogheimilistengslDTO": {
         "type": "object",
         "properties": {
-          "logheimilisTengsl": { "type": "string", "nullable": true },
+          "logheimilisTengsl": {
+            "type": "string",
+            "nullable": true
+          },
           "logheimilistengslmedlimir": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/LogheimilismedlimurDTO" },
+            "items": {
+              "$ref": "#/components/schemas/LogheimilismedlimurDTO"
+            },
             "nullable": true
           }
         },
@@ -985,10 +1440,15 @@
       "LogheimilistengslItarDTO": {
         "type": "object",
         "properties": {
-          "logheimilisTengsl": { "type": "string", "nullable": true },
+          "logheimilisTengsl": {
+            "type": "string",
+            "nullable": true
+          },
           "logheimiliseinstaklingar": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/EinstaklingurDTO" },
+            "items": {
+              "$ref": "#/components/schemas/EinstaklingurDTO"
+            },
             "nullable": true
           }
         },
@@ -997,29 +1457,62 @@
       "ProblemDetails": {
         "type": "object",
         "properties": {
-          "type": { "type": "string", "nullable": true },
-          "title": { "type": "string", "nullable": true },
-          "status": { "type": "integer", "format": "int32", "nullable": true },
-          "detail": { "type": "string", "nullable": true },
-          "instance": { "type": "string", "nullable": true }
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "detail": {
+            "type": "string",
+            "nullable": true
+          },
+          "instance": {
+            "type": "string",
+            "nullable": true
+          }
         },
         "additionalProperties": false
       },
       "RikisfangDTO": {
         "type": "object",
         "properties": {
-          "kodi": { "type": "string", "nullable": true },
-          "land": { "type": "string", "nullable": true }
+          "kodi": {
+            "type": "string",
+            "nullable": true
+          },
+          "land": {
+            "type": "string",
+            "nullable": true
+          }
         },
         "additionalProperties": false
       },
       "SamDTO": {
         "type": "object",
         "properties": {
-          "kennitalaMaka": { "type": "string", "nullable": true },
-          "nafnMaka": { "type": "string", "nullable": true },
-          "sambud": { "type": "boolean" },
-          "sambudTexti": { "type": "string", "nullable": true },
+          "kennitalaMaka": {
+            "type": "string",
+            "nullable": true
+          },
+          "nafnMaka": {
+            "type": "string",
+            "nullable": true
+          },
+          "sambud": {
+            "type": "boolean"
+          },
+          "sambudTexti": {
+            "type": "string",
+            "nullable": true
+          },
           "dagsetningBreytt": {
             "type": "string",
             "format": "date-time",
@@ -1030,8 +1523,16 @@
       }
     },
     "securitySchemes": {
-      "Bearer": { "type": "http", "scheme": "Bearer", "bearerFormat": "Bearer" }
+      "Bearer": {
+        "type": "http",
+        "scheme": "Bearer",
+        "bearerFormat": "Bearer"
+      }
     }
   },
-  "security": [{ "Bearer": [] }]
+  "security": [
+    {
+      "Bearer": []
+    }
+  ]
 }

--- a/libs/clients/national-registry/v3-applications/src/lib/nationalRegistryV3Applications.service.ts
+++ b/libs/clients/national-registry/v3-applications/src/lib/nationalRegistryV3Applications.service.ts
@@ -17,8 +17,12 @@ import {
 import { formatFamilyDto, FamilyDto } from './types/family.dto'
 import { formatBirthplaceDto, BirthplaceDto } from './types/birthplace.dto'
 import { formatCitizenshipDto, CitizenshipDto } from './types/citizenship.dto'
-import { formatIndividualDto } from './types/individual.dto'
-import { IndividualDto } from './types/individual.dto'
+import {
+  formatIndividualDto,
+  formatIndividualLiteDto,
+  IndividualDto,
+  IndividualLiteDto,
+} from './types/individual.dto'
 
 /**
  *
@@ -26,9 +30,9 @@ import { IndividualDto } from './types/individual.dto'
  * than the old V2 endpoint.
  * As a rule of thumb, you can assume that all endpoints are locked down to the logged
  * in user. The only exceptions apply to data about a user's custody children.
- * There is also an endpoint forthcoming that provides minimal data about individuals
- * which can be used to look up data such as names and addresses based on a national id.
- * Support for the forthcoming endpoint is not yet implemented.
+ * There is also an endpoint that provides less data about individuals than the full individual endpoint.
+ * This endpoint called einstaklingarKennitalaLiteGet can be used to look up data such as
+ * names and addresses based on a national id and is available in the gotOtherIndividual method.
  */
 
 @Injectable()
@@ -60,6 +64,7 @@ export class NationalRegistryV3ApplicationsClientService {
     )
   }
 
+  //Get full individual data
   async getIndividual(
     nationalId: string,
     auth: User,
@@ -71,6 +76,20 @@ export class NationalRegistryV3ApplicationsClientService {
     })
 
     return formatIndividualDto(res)
+  }
+
+  // Get name and address based on a national id for people other than the logged in user.
+  async getOtherIndividual(
+    nationalId: string,
+    auth: User,
+  ): Promise<IndividualLiteDto | null> {
+    const res = await this.einstaklingarApiWithAuth(
+      auth,
+    ).einstaklingarKennitalaLiteGet({
+      kennitala: nationalId,
+    })
+
+    return formatIndividualLiteDto(res)
   }
 
   async getCustodyChildren(user: User): Promise<string[]> {

--- a/libs/clients/national-registry/v3-applications/src/lib/types/individual.dto.ts
+++ b/libs/clients/national-registry/v3-applications/src/lib/types/individual.dto.ts
@@ -1,5 +1,5 @@
 import { AddressDto, formatAddressDto } from './address.dto'
-import { EinstaklingurDTO } from '../../../gen/fetch'
+import { EinstaklingurDTO, EinstaklingurLiteDTO } from '../../../gen/fetch'
 
 export interface IndividualDto {
   nationalId: string
@@ -12,6 +12,13 @@ export interface IndividualDto {
   genderDescription: string
   exceptionFromDirectMarketing: boolean
   birthdate: Date
+  legalDomicile: AddressDto | null
+  residence: AddressDto | null
+}
+
+export interface IndividualLiteDto {
+  nationalId: string
+  name: string
   legalDomicile: AddressDto | null
   residence: AddressDto | null
 }
@@ -44,6 +51,20 @@ export const formatIndividualDto = (
     genderDescription: individual.kynTexti ?? '',
     exceptionFromDirectMarketing: individual.bannmerking ?? false,
     birthdate: individual.faedingardagur ?? new Date(),
+    legalDomicile: formatAddressDto(individual.logheimili),
+    residence: formatAddressDto(individual.adsetur),
+  }
+}
+
+export const formatIndividualLiteDto = (
+  individual: EinstaklingurLiteDTO | null | undefined,
+): IndividualLiteDto | null => {
+  if (individual == null) {
+    return null
+  }
+  return {
+    nationalId: individual.kennitala ?? '',
+    name: individual.nafn ?? '',
     legalDomicile: formatAddressDto(individual.logheimili),
     residence: formatAddressDto(individual.adsetur),
   }


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Add support to the v3Application client for a new lite endpoint

## Why

The `einstaklingarKennitalaGet` endpoint used in the V3Application client can only be used to fetch information for the currently logged in user and their children.
The `einstaklingarKennitalaLiteGet` endpoint has been added to allow fetching name and address info for other users.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new endpoint to retrieve limited individual data.
  * Introduced a new method to fetch minimal information about individuals other than the logged-in user.
  * Added a new data type and formatter for lightweight individual information.

* **Bug Fixes**
  * Improved error response definitions for unauthorized and server errors across endpoints.

* **Documentation**
  * Updated descriptions to clarify the availability of the new endpoint and data type.

* **Style**
  * Reformatted API specifications and schema definitions for improved readability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->