### PR TITLE
fix(web): Organization parent subpages now get tagged with organization tag in elasticsearch

### DIFF
--- a/libs/cms/src/lib/search/importers/organizationParentSubpage.service.ts
+++ b/libs/cms/src/lib/search/importers/organizationParentSubpage.service.ts
@@ -58,6 +58,18 @@ export class OrganizationParentSubpageSyncService
 
           const content = contentSections.join(' ')
 
+          const tags = childEntryIds.map((id) => ({
+            key: id,
+            type: 'hasChildEntryWithId',
+          }))
+
+          if (entry.fields?.organizationPage?.fields?.slug) {
+            tags.push({
+              key: entry.fields.organizationPage.fields.slug,
+              type: 'organization',
+            })
+          }
+
           return {
             _id: mapped.id,
             title: mapped.title,
@@ -68,16 +80,7 @@ export class OrganizationParentSubpageSyncService
               ...mapped,
               typename: 'OrganizationParentSubpage',
             }),
-            tags: [
-              {
-                key: entry.fields?.organizationPage?.fields?.slug,
-                type: 'organization',
-              },
-              ...childEntryIds.map((id) => ({
-                key: id,
-                type: 'hasChildEntryWithId',
-              })),
-            ],
+            tags,
             dateCreated: entry.sys.createdAt,
             dateUpdated: new Date().getTime().toString(),
           }

--- a/libs/cms/src/lib/search/importers/organizationParentSubpage.service.ts
+++ b/libs/cms/src/lib/search/importers/organizationParentSubpage.service.ts
@@ -69,6 +69,10 @@ export class OrganizationParentSubpageSyncService
               typename: 'OrganizationParentSubpage',
             }),
             tags: [
+              {
+                key: entry.fields?.organizationPage?.fields?.slug,
+                type: 'organization',
+              },
               ...childEntryIds.map((id) => ({
                 key: id,
                 type: 'hasChildEntryWithId',


### PR DESCRIPTION
# Organization parent subpages now get tagged with organization tag in elasticsearch

Results are not appearing when using organization filter.

The fix is to do the same as for the organization subpage content type (tag the document with an organization tag)
https://github.com/island-is/island.is/blob/27c7822b3a175c461f2a9d1ca631630ae7986419/libs/cms/src/lib/search/importers/organizationSubpage.service.ts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal handling of tags for organization subpages to streamline processing. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->