### PR TITLE
fix(user-profile): Add a bankInfoError boolean flag in GQL to handle Islykla errors.

### DIFF
--- a/libs/api/domains/user-profile/src/lib/V2/userProfile.service.ts
+++ b/libs/api/domains/user-profile/src/lib/V2/userProfile.service.ts
@@ -92,11 +92,18 @@ export class UserProfileServiceV2 {
       user,
     ).meUserProfileControllerFindUserProfile()
 
-    const bankInfo = await this.getBankInfo(user)
+    let bankInfo
+    let bankInfoError = false
+    try {
+      bankInfo = await this.getBankInfo(user)
+    } catch (error) {
+      bankInfoError = true
+    }
 
     return {
       ...userProfile,
       bankInfo,
+      bankInfoError,
       canNudge: userProfile.emailNotifications,
     }
   }

--- a/libs/api/domains/user-profile/src/lib/islykill.service.ts
+++ b/libs/api/domains/user-profile/src/lib/islykill.service.ts
@@ -77,6 +77,7 @@ export class IslykillService {
             noUserFound: true,
           }
         }
+        console.log('Error getting islykill settings', e)
         throw new BadRequestException(e, errorMsg)
       })
     return apiData

--- a/libs/api/domains/user-profile/src/lib/userProfile.model.ts
+++ b/libs/api/domains/user-profile/src/lib/userProfile.model.ts
@@ -52,4 +52,7 @@ export class UserProfile {
 
   @Field(() => String, { nullable: true })
   bankInfo?: string
+
+  @Field(() => Boolean, { nullable: true })
+  bankInfoError?: boolean
 }

--- a/libs/portals/my-pages/graphql/src/lib/queries/getUserProfile.ts
+++ b/libs/portals/my-pages/graphql/src/lib/queries/getUserProfile.ts
@@ -8,6 +8,7 @@ export const USER_PROFILE = gql`
       locale
       email
       bankInfo
+      bankInfoError
       emailStatus
       emailVerified
       mobileStatus

--- a/libs/portals/my-pages/information/src/components/PersonalInformation/Forms/ProfileForm/ProfileForm.tsx
+++ b/libs/portals/my-pages/information/src/components/PersonalInformation/Forms/ProfileForm/ProfileForm.tsx
@@ -37,6 +37,7 @@ import { useConfirmNudgeMutation } from './confirmNudge.generated'
 import { DropModalType } from './types/form'
 import { InputEmail } from './components/Inputs/Email'
 import { AccessDenied } from '@island.is/portals/core'
+import { Problem } from '@island.is/react-spa/shared'
 
 enum IdsUserProfileLinks {
   EMAIL = '/app/user-profile/email',
@@ -48,7 +49,6 @@ interface ProfileFormProps {
   onCloseDropModal?: () => void
   canDrop?: boolean
   title: string
-  showDetails?: boolean
   showIntroTitle?: boolean
   showIntroText?: boolean
   setFormLoading?: (isLoading: boolean) => void
@@ -59,7 +59,6 @@ export const ProfileForm = ({
   onCloseDropModal,
   canDrop,
   title,
-  showDetails,
   setFormLoading,
   showIntroTitle,
   showIntroText = true,
@@ -301,20 +300,21 @@ export const ProfileForm = ({
                     />
                   ))}
               </InputSection>
-              {showDetails && (
-                <InputSection
-                  title={formatMessage(m.bankAccountInfo)}
-                  text={formatMessage(msg.editBankInfoText)}
-                  loading={userLoading}
-                  divider={false}
-                >
-                  {!userLoading && (
-                    <BankInfoForm
-                      bankInfo={bankInfoObject(userProfile?.bankInfo || '')}
-                    />
-                  )}
-                </InputSection>
-              )}
+              <InputSection
+                title={formatMessage(m.bankAccountInfo)}
+                text={formatMessage(msg.editBankInfoText)}
+                loading={userLoading}
+                divider={false}
+              >
+                {!userLoading && !userProfile?.bankInfoError && (
+                  <BankInfoForm
+                    bankInfo={bankInfoObject(userProfile?.bankInfo || '')}
+                  />
+                )}
+                {!userLoading && userProfile?.bankInfoError && (
+                  <Problem size="small" />
+                )}
+              </InputSection>
             </>
           )}
           {showDropModal && onCloseOverlay && !internalLoading && (

--- a/libs/portals/my-pages/information/src/screens/UserProfile/UserProfile.tsx
+++ b/libs/portals/my-pages/information/src/screens/UserProfile/UserProfile.tsx
@@ -23,11 +23,7 @@ const UserProfile = () => {
         serviceProviderTooltip={formatMessage(m.userProfileTooltip)}
         serviceProviderSlug={ISLANDIS_SLUG}
       />
-      <ProfileForm
-        showIntroText={false}
-        showDetails={!!data}
-        title={profile.name || ''}
-      />
+      <ProfileForm showIntroText={false} title={profile.name || ''} />
     </>
   )
 }


### PR DESCRIPTION
## What

Gracefully handle errors from the Íslyklar service.

## Why

We are only depending on the bankInfo from the Íslyklar service but when it fails it makes the complete user profile unavailable in GQL.

This is a temporary fix as PR #18683 will remove the Íslyklar service from the repo and use FJS bankInfo service. We are waiting for the bankInfo service to be ready and shipped to PROD.

## Screenshots / Gifs

![image](https://github.com/user-attachments/assets/9509f74d-c23f-4dce-a807-20f2893b7619)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
