### PR TITLE
fix(service-portal): Fix layouts issues with the portal provider

### DIFF
--- a/libs/portals/core/src/components/PortalProvider.tsx
+++ b/libs/portals/core/src/components/PortalProvider.tsx
@@ -5,7 +5,7 @@ import {
 } from '@apollo/client'
 import { useLocale } from '@island.is/localization'
 import { useUserInfo } from '@island.is/react-spa/bff'
-import { createContext, useContext, useMemo } from 'react'
+import { createContext, useContext, useMemo, useState, useEffect } from 'react'
 import { Outlet, matchPath, useLocation } from 'react-router-dom'
 import { PortalModule, PortalRoute, PortalType } from '../types/portalCore'
 import { useFeatureFlagClient } from '@island.is/react/feature-flags'
@@ -50,28 +50,40 @@ export const PortalProvider = ({
   const client = useApolloClient() as ApolloClient<NormalizedCacheObject>
   const featureFlagClient = useFeatureFlagClient()
 
-  const activeModule = useMemo(
-    () =>
-      userInfo
-        ? modules.find(async (module) => {
-            return (
-              spreadRoutsChildren(
-                await module.routes({
-                  userInfo,
-                  client,
-                  formatMessage,
-                  featureFlagClient,
-                }),
-              )
-                // Extract the path from each route
-                .map(({ path }) => path)
-                // Find the route path that matches the current pathname
-                .find((path) => path && matchPath(path, pathname))
-            )
-          })
-        : undefined,
-    [modules, pathname, userInfo, featureFlagClient],
-  )
+  const [activeModule, setActiveModule] = useState<PortalModule | undefined>()
+
+  useEffect(() => {
+    const findActiveModule = async () => {
+      if (!userInfo) {
+        setActiveModule(undefined)
+        return
+      }
+
+      for (const module of modules) {
+        const routes = await module.routes({
+          userInfo,
+          client,
+          formatMessage,
+          featureFlagClient,
+        })
+
+        const hasMatchingRoute = await Promise.all(
+          spreadRoutsChildren(routes).map(({ path }) => path),
+        ).then((paths) => {
+          return paths.find((path) => path && matchPath(path, pathname))
+        })
+
+        if (hasMatchingRoute) {
+          setActiveModule(module)
+          return
+        }
+      }
+
+      setActiveModule(undefined)
+    }
+
+    findActiveModule()
+  }, [modules, pathname, userInfo, featureFlagClient, client, formatMessage])
 
   return (
     <PortalContext.Provider

--- a/libs/portals/core/src/components/PortalProvider.tsx
+++ b/libs/portals/core/src/components/PortalProvider.tsx
@@ -67,11 +67,10 @@ export const PortalProvider = ({
           featureFlagClient,
         })
 
-        const hasMatchingRoute = await Promise.all(
-          spreadRoutsChildren(routes).map(({ path }) => path),
-        ).then((paths) => {
-          return paths.find((path) => path && matchPath(path, pathname))
-        })
+        const paths = spreadRoutsChildren(routes).map(({ path }) => path)
+        const hasMatchingRoute = paths.find(
+          (path) => path && matchPath(path, pathname),
+        )
 
         if (hasMatchingRoute) {
           setActiveModule(module)


### PR DESCRIPTION
## What

Fix layout issue after `routes` became async function

## Why

So PortalProvider will set correct `activeModule` and display the desired layout for that module

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability in detecting and displaying the active portal module when navigating between routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->