### PR TITLE
fix(application-system): Fix handling of unknown spouse

### DIFF
--- a/libs/clients/national-registry/v3-applications/src/lib/nationalRegistryV3Applications.service.ts
+++ b/libs/clients/national-registry/v3-applications/src/lib/nationalRegistryV3Applications.service.ts
@@ -174,7 +174,14 @@ export class NationalRegistryV3ApplicationsClientService {
 
     if (res.sambud?.sambud) {
       return formatCohabitationDtoV3FromSam(res.sambud, res.hjuskapur)
-    } else if (res.hjuskapur && res.hjuskapur.kennitalaMaka) {
+    } else if (
+      // NOTE: If a user is married but their spouse does not have a national id,
+      // the national registry will return a string of 10 spaces for the spouse's national id.
+      // Luckily the spouse's name will be null in that case so we can check for that.
+      res.hjuskapur &&
+      res.hjuskapur.kennitalaMaka &&
+      res.hjuskapur.nafnMaka
+    ) {
       return formatCohabitationDtoV3FromHju(res.hjuskapur)
     } else {
       return null


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Stop applications using the `getSpouse` function in the shared national-registry service from getting passed a `nationalId` consisting of 10 spaces.

Changing behavior to mirror the behavior in the old `V2` client.

## Why

If a user is married but their user does not exist in the national registry a call to the `getCohabitationInfo` will return a `nationalId` consisting of 10 spaces and an empty name. This would cause the `getspouse` function to try to fetch an individual from said `nationalId` of 10 spaces resulting in an error.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of cohabitation information to prevent incorrect spouse data from appearing when the spouse's national ID is invalid or missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->