### PR TITLE
fix(application-system): Add max number of uploaded files for FileUpload

### DIFF
--- a/libs/application/core/src/lib/fieldBuilders.ts
+++ b/libs/application/core/src/lib/fieldBuilders.ts
@@ -394,6 +394,7 @@ export const buildFileUploadField = (
     maxSize,
     maxSizeErrorText,
     totalMaxSize,
+    maxFileCount,
     forImageUpload,
   } = data
   return {
@@ -413,6 +414,7 @@ export const buildFileUploadField = (
     maxSize: maxSize ?? DEFAULT_FILE_SIZE_LIMIT,
     maxSizeErrorText,
     totalMaxSize: totalMaxSize ?? DEFAULT_TOTAL_FILE_SIZE_SUM,
+    maxFileCount,
     forImageUpload,
     type: FieldTypes.FILEUPLOAD,
     component: FieldComponents.FILEUPLOAD,

--- a/libs/application/core/src/lib/messages.ts
+++ b/libs/application/core/src/lib/messages.ts
@@ -429,6 +429,12 @@ export const coreErrorMessages = defineMessages({
       'Skrárnar eru samtals of stórar. Hægt er að hlaða inn skrám sem eru samtals {maxSizeInMb}MB eða minni.',
     description: 'Error message when sum of file sizes exceeds max size limit',
   },
+  fileMaxCountLimitExceeded: {
+    id: 'application.system:core.error.file.maxCountLimitExceeded',
+    defaultMessage:
+      'Of margar skrár. Mest er hægt að hlaða inn {maxFileCount} skrám.',
+    description: 'Error message when file count exceeds max count limit',
+  },
   fileInvalidExtension: {
     id: 'application.system:core.error.file.invalidExtension',
     defaultMessage:

--- a/libs/application/templates/hms/fire-compensation-appraisal/src/forms/mainForm/photoSection.ts
+++ b/libs/application/templates/hms/fire-compensation-appraisal/src/forms/mainForm/photoSection.ts
@@ -19,6 +19,7 @@ export const photoSection = buildSection({
           uploadMultiple: true,
           maxSize: 100000000,
           totalMaxSize: 10000000000,
+          maxFileCount: 10,
         }),
       ],
     }),

--- a/libs/application/templates/hms/fire-compensation-appraisal/src/lib/messages/photoMessages.ts
+++ b/libs/application/templates/hms/fire-compensation-appraisal/src/lib/messages/photoMessages.ts
@@ -9,7 +9,7 @@ export const photoMessages = defineMessages({
   description: {
     id: 'fca.application:photo.description',
     defaultMessage:
-      'Hér setur þú inn myndir af því sem þú taldir upp á lýsingu á framkvæmdum og sýnir frágang.\n\nUmsækjandi er hvattur til að hlaða upp myndum sem gagnast við gerð brunabótamatsins svo að það byggi á réttum upplýsingum.\n\nTakið eftir að það þarf að hlaða upp í það minnsta **3 myndum** til að geta sótt um endurmat brunabótamats.',
+      'Hér setur þú inn myndir af því sem þú taldir upp á lýsingu á framkvæmdum og sýnir frágang.\n\nUmsækjandi er hvattur til að hlaða upp myndum sem gagnast við gerð brunabótamatsins svo að það byggi á réttum upplýsingum.\n\nTakið eftir að það þarf að hlaða upp í það minnsta **3 myndum** og í mesta lagi **10 myndum** til að geta sótt um endurmat brunabótamats.',
     description: 'Photo section description',
   },
   alertMessage: {

--- a/libs/application/types/src/lib/Fields.ts
+++ b/libs/application/types/src/lib/Fields.ts
@@ -541,6 +541,10 @@ export interface FileUploadField extends BaseField {
    * Defaults to 100MB
    */
   readonly totalMaxSize?: number
+  /**
+   * Defaults to no limit
+   */
+  readonly maxFileCount?: number
   readonly forImageUpload?: boolean
 }
 

--- a/libs/application/ui-fields/src/lib/FileUploadFormField/FileUploadFormField.tsx
+++ b/libs/application/ui-fields/src/lib/FileUploadFormField/FileUploadFormField.tsx
@@ -28,6 +28,7 @@ export const FileUploadFormField = ({
     maxSize,
     maxSizeErrorText,
     totalMaxSize,
+    maxFileCount,
     forImageUpload,
     marginTop,
     marginBottom,
@@ -83,6 +84,7 @@ export const FileUploadFormField = ({
             formatText(maxSizeErrorText, application, formatMessage)
           }
           totalMaxSize={totalMaxSize}
+          maxFileCount={maxFileCount}
           forImageUpload={forImageUpload}
           onRemove={onFileRemoveWhenInAnswers}
         />


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a maximum file upload limit to file upload fields, allowing configuration of the maximum number of files users can upload.
  * Enforced a 10-file upload limit in the photo section of the fire compensation appraisal application form.

* **Enhancements**
  * Updated error messaging to inform users when they exceed the allowed number of uploaded files.
  * Clarified form instructions to specify both minimum and maximum photo upload requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->