### PR TITLE
feat(user-profile): Set first email as primary and subsequent emails as non-primary

### DIFF
--- a/apps/services/user-profile/src/app/v2/emails.service.ts
+++ b/apps/services/user-profile/src/app/v2/emails.service.ts
@@ -96,6 +96,17 @@ export class EmailsService {
         throw new BadRequestException('User profile not found')
       }
 
+      // Check if this is the first email for this national ID
+      const existingEmails = await this.emailsModel.count({
+        where: {
+          nationalId,
+          emailStatus: DataStatus.VERIFIED,
+        },
+        transaction,
+      })
+
+      const isFirstEmail = existingEmails === 0
+
       // Create the email record
       const [emailRecord, created] = await this.emailsModel.findOrCreate({
         where: {
@@ -105,7 +116,7 @@ export class EmailsService {
         defaults: {
           id: uuid(),
           email,
-          primary: false,
+          primary: isFirstEmail,
           nationalId,
           emailStatus: DataStatus.VERIFIED,
         },


### PR DESCRIPTION
## What

Set the first email added to the list of emails as primary

## Why

So user will have a primary email by default

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The first verified email added for a user is now automatically set as primary.
* **Tests**
  * Added tests to confirm that the first email is set as primary and subsequent emails are not.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->