### PR TITLE
chore(auth-api): Creating migration script to add MMS OneRoster scopes

### DIFF
--- a/libs/auth-api-lib/migrations/20250704134932-add-mms-oneroster-scopes.js
+++ b/libs/auth-api-lib/migrations/20250704134932-add-mms-oneroster-scopes.js
@@ -1,0 +1,27 @@
+'use strict'
+
+module.exports = {
+  async up(queryInterface) {
+    /**
+     * Adding scopes for MMS Oneroster as they don't conform to the naming convention we need to do it by migration script.
+     * See specification here https://www.imsglobal.org/sites/default/files/spec/oneroster/v1p2/rostering-restbinding/OneRosterv1p2RosteringService_RESTBindv1p0.html#Main4p3
+     */
+    await queryInterface.sequelize.query(`
+      INSERT INTO api_scope (name, display_name, description, domain_name, enabled, show_in_discovery_document, required, emphasize, allow_explicit_delegation_grant, automatic_delegation_grant, also_for_delegated_user, is_access_controlled, grant_to_legal_guardians, grant_to_procuring_holders, grant_to_personal_representatives)
+      VALUES
+        ('https://purl.imsglobal.org/spec/or/v1p2/scope/roster-core.readonly','Roster Core ReadOnly', 'The core set of read operations to enable information about collections or a single object to be obtained.', '@mms.is', true, false, false, false, false, false, false, false, false, false, false),
+        ('https://purl.imsglobal.org/spec/or/v1p2/scope/roster-demographics.readonly', 'Roster Demographics ReadOnly', 'The read operations to provide all demographics or a single demographics object to be obtained.', '
+        '@mms.is', true, false, false, false, false, false, false, false, false, false, false),
+        ('https://purl.imsglobal.org/spec/or/v1p2/scope/roster.readonly', 'Roster ReadOnly', 'Support for all of the read operations (excluding demographics) to enable information about collections or a single object to be obtained.', '@mms.is', true, false, false, false, false, false, false, false, false, false, false);
+    `)
+  },
+
+  async down() {
+    /**
+     * As the db is not using ON Cascade it is unsafe to remove the scopes as they could have been granted to clients
+     * or used by delegations.
+     *
+     * If we need to remove the scopes we need to do it manually.
+     */
+  },
+}

--- a/libs/auth-api-lib/migrations/20250704134932-add-mms-oneroster-scopes.js
+++ b/libs/auth-api-lib/migrations/20250704134932-add-mms-oneroster-scopes.js
@@ -10,8 +10,7 @@ module.exports = {
       INSERT INTO api_scope (name, display_name, description, domain_name, enabled, show_in_discovery_document, required, emphasize, allow_explicit_delegation_grant, automatic_delegation_grant, also_for_delegated_user, is_access_controlled, grant_to_legal_guardians, grant_to_procuring_holders, grant_to_personal_representatives)
       VALUES
         ('https://purl.imsglobal.org/spec/or/v1p2/scope/roster-core.readonly','Roster Core ReadOnly', 'The core set of read operations to enable information about collections or a single object to be obtained.', '@mms.is', true, false, false, false, false, false, false, false, false, false, false),
-        ('https://purl.imsglobal.org/spec/or/v1p2/scope/roster-demographics.readonly', 'Roster Demographics ReadOnly', 'The read operations to provide all demographics or a single demographics object to be obtained.', '
-        '@mms.is', true, false, false, false, false, false, false, false, false, false, false),
+        ('https://purl.imsglobal.org/spec/or/v1p2/scope/roster-demographics.readonly', 'Roster Demographics ReadOnly', 'The read operations to provide all demographics or a single demographics object to be obtained.', '@mms.is', true, false, false, false, false, false, false, false, false, false, false),
         ('https://purl.imsglobal.org/spec/or/v1p2/scope/roster.readonly', 'Roster ReadOnly', 'Support for all of the read operations (excluding demographics) to enable information about collections or a single object to be obtained.', '@mms.is', true, false, false, false, false, false, false, false, false, false, false);
     `)
   },


### PR DESCRIPTION
## What

Adding OneRoster scopes as required by the [OneRoster spec](https://www.imsglobal.org/sites/default/files/spec/oneroster/v1p2/rostering-restbinding/OneRosterv1p2RosteringService_RESTBindv1p0.html#Main4p3) for MMS which is developing an API by the spec.

## Why

Our admin UIs both the old and the new are requiring the scopes to match our naming convention.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new API scopes for IMS Global OneRoster v1.2 to support MMS integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->