### PR TITLE
fix(j-s): Format National Ids in Case Lists

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/case-table/caseTable.cellGenerators.ts
+++ b/apps/judicial-system/backend/src/app/modules/case-table/caseTable.cellGenerators.ts
@@ -5,6 +5,7 @@ import {
   districtCourtAbbreviation,
   formatCaseType,
   formatDate,
+  formatNationalId,
   getAllReadableIndictmentSubtypes,
   getAppealResultTextByValue,
   getInitials,
@@ -526,7 +527,7 @@ const defendants: CaseTableCellGenerator<StringGroupValue> = {
       c.defendants[0].name ?? '',
       c.defendants.length > 1
         ? `+ ${c.defendants.length - 1}`
-        : c.defendants[0].nationalId ?? '',
+        : formatNationalId(c.defendants[0].nationalId),
     ]
 
     return generateCell({ strList }, strList.join(''))


### PR DESCRIPTION
# Format National Ids in Case Lists

[Format á kennitölu í málalista](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1210718100868169?focus=true)

## What

- Fixes natinal id formating.

## Why

- Verified bug.

## Screenshots / Gifs

<img width="1274" alt="image" src="https://github.com/user-attachments/assets/86c48e2f-8448-49c3-82f6-e7be56ef58d3" />

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the display of defendants' national IDs by formatting them for better readability in the case table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->