### PR TITLE
fix(j-s): Ruling Text Box

### DIFF
--- a/apps/judicial-system/web/src/routes/Court/Indictments/Completed/Completed.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/Completed/Completed.tsx
@@ -508,19 +508,21 @@ const Completed: FC = () => {
             ))}
           </Box>
         )}
-        {features?.includes(Feature.SERVICE_PORTAL) && (
-          <Box>
-            <SectionHeading title={'Dómsorð'} marginBottom={2} heading="h4" />
-            <RulingInput
-              workingCase={workingCase}
-              setWorkingCase={setWorkingCase}
-              rows={8}
-              label="Dómsorð"
-              placeholder="Hvert er dómsorðið?"
-              required
-            />
-          </Box>
-        )}
+        {features?.includes(Feature.SERVICE_PORTAL) &&
+          workingCase.indictmentRulingDecision ===
+            CaseIndictmentRulingDecision.RULING && (
+            <Box>
+              <SectionHeading title={'Dómsorð'} marginBottom={2} heading="h4" />
+              <RulingInput
+                workingCase={workingCase}
+                setWorkingCase={setWorkingCase}
+                rows={8}
+                label="Dómsorð"
+                placeholder="Hvert er dómsorðið?"
+                required
+              />
+            </Box>
+          )}
       </FormContentContainer>
       <Box marginBottom={10} />
       <FormContentContainer isFooter>

--- a/libs/judicial-system/types/src/lib/feature.ts
+++ b/libs/judicial-system/types/src/lib/feature.ts
@@ -1,6 +1,4 @@
 export enum Feature {
   NONE = 'NONE', // must be at least one
-  VICTIMS = 'VICTIMS',
   SERVICE_PORTAL = 'SERVICE_PORTAL',
-  CRIMINAL_RECORD_ENDPOINT = 'CRIMINAL_RECORD_ENDPOINT',
 }


### PR DESCRIPTION
# Ruling Text Box

[Bara birta dómsorð á máli lokið síðu þegar mál klárast með dómi (ekki t.d. viðurlagaákvörðun, afturköllun osfrv)](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1210599015698324)

## What

- Only shows ruling box for indictments that complete with a ruling.

## Why

- Verified bug.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The visibility of the "Dómsorð" (Ruling) input section is now more strictly controlled and will only appear when specific case conditions are met.

* **Refactor**
  * Removed unused feature options related to victims and criminal record endpoints from feature settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->