### PR TITLE
feat(j-s): Add ProsecutorCaseInfo component to defendant screen

### DIFF
--- a/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.tsx
+++ b/apps/judicial-system/web/src/components/CaseInfo/CaseInfo.tsx
@@ -96,10 +96,9 @@ const Prosecutor: FC<Props> = ({ workingCase }) => {
   )
 }
 
-export const ProsecutorCaseInfo: FC<Props & { hideCourt?: boolean }> = ({
-  workingCase,
-  hideCourt = false,
-}) => {
+export const ProsecutorCaseInfo: FC<
+  Props & { hideCourt?: boolean; hideDefendants?: boolean }
+> = ({ workingCase, hideCourt = false, hideDefendants = false }) => {
   const { policeCaseNumbers, court } = workingCase
   const { formatMessage } = useIntl()
 
@@ -111,7 +110,7 @@ export const ProsecutorCaseInfo: FC<Props & { hideCourt?: boolean }> = ({
       {!hideCourt && court?.name && (
         <Entry label={formatMessage(core.court)} value={court?.name} />
       )}
-      <Defendants workingCase={workingCase} />
+      {!hideDefendants && <Defendants workingCase={workingCase} />}
     </Box>
   )
 }

--- a/apps/judicial-system/web/src/routes/Prosecutor/InvestigationCase/Defendant/Defendant.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/InvestigationCase/Defendant/Defendant.tsx
@@ -19,6 +19,7 @@ import {
   PageHeader,
   PageLayout,
   PageTitle,
+  ProsecutorCaseInfo,
   SectionHeading,
   VictimInfo,
 } from '@island.is/judicial-system-web/src/components'
@@ -164,7 +165,11 @@ const Defendant = () => {
       <FormContentContainer>
         <Box marginBottom={10}>
           <PageTitle>{formatMessage(m.heading)}</PageTitle>
-
+          <ProsecutorCaseInfo
+            workingCase={workingCase}
+            hideDefendants
+            hideCourt
+          />
           <Box component="section" marginBottom={5}>
             <SectionHeading title="Varnaraðili" />
             <AnimatePresence>


### PR DESCRIPTION
# Add ProsecutorCaseInfo component to defendant screen

[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1210695047192009?focus=true)

## What

Disaplay the police case number on the defendant screen in investigation cases.

## Why

We forgot to add this when we split the first step of the investigation cases flow into two screens

## Screenshots / Gifs

<img width="506" alt="Screenshot 2025-07-08 at 10 27 43" src="https://github.com/user-attachments/assets/07bf7fcd-5806-4f23-827a-fc301a2fe04e" />

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to hide defendant information in the case info display.
  * Updated the defendant view to show case info while hiding both defendants and court details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->