### PR TITLE
fix(rental-agreement): Add assignee management to SIGNING state 

### DIFF
--- a/libs/application/templates/rental-agreement/src/lib/RentalAgreementTemplate.ts
+++ b/libs/application/templates/rental-agreement/src/lib/RentalAgreementTemplate.ts
@@ -170,6 +170,8 @@ const RentalAgreementTemplate: ApplicationTemplate<
         },
       },
       [States.SIGNING]: {
+        entry: 'assignToInstitution',
+        exit: 'clearAssignees',
         meta: {
           name: States.SIGNING,
           status: 'inprogress',
@@ -197,9 +199,6 @@ const RentalAgreementTemplate: ApplicationTemplate<
           ],
         },
         on: {
-          [DefaultEvents.EDIT]: {
-            target: States.INREVIEW,
-          },
           [DefaultEvents.APPROVE]: {
             target: States.COMPLETED,
           },
@@ -239,6 +238,15 @@ const RentalAgreementTemplate: ApplicationTemplate<
         if (assigneesNationalIds && assigneesNationalIds.length > 0) {
           set(application, 'assignees', assigneesNationalIds)
         }
+
+        return context
+      }),
+      assignToInstitution: assign((context) => {
+        const { application } = context
+
+        set(application, 'assignees', [
+          InstitutionNationalIds.HUSNAEDIS_OG_MANNVIRKJASTOFNUN,
+        ])
 
         return context
       }),


### PR DESCRIPTION
https://app.asana.com/1/203394141643832/project/1208271027457465/task/1209555373134642

## What

Introduces 'assignToInstitution' and 'clearAssignees' actions to the SIGNING state in the rental agreement template. The SIGNING state now assigns the application to a specific institution on entry and clears assignees on exit. Also removes the EDIT event transition from the SIGNING state.

## Why

So the state of the application can be changed through the api.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The relevant institution is now automatically assigned as an assignee when entering the signing phase of the rental agreement application.

* **Changes**
  * It is no longer possible to revert from the signing phase back to the review phase via the edit option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->