### PR TITLE
fix(ojoi): Application publish date status + pdf disclaimer

### DIFF
--- a/apps/web/screens/OfficialJournalOfIceland/OJOIAdvert.tsx
+++ b/apps/web/screens/OfficialJournalOfIceland/OJOIAdvert.tsx
@@ -42,7 +42,7 @@ import {
   ADVERT_QUERY,
   ADVERT_SIMILAR_QUERY,
 } from '../queries/OfficialJournalOfIceland'
-import { isSingleParagraph } from './lib/isSingleParagraph'
+import { isAdvertPdfOnly } from './lib/isAdvertPdfOnly'
 import { ORGANIZATION_SLUG } from './constants'
 import { m } from './messages'
 
@@ -72,19 +72,17 @@ const OJOIAdvertPage: CustomScreen<OJOIAdvertProps> = ({
     },
   ]
 
-  const isAdvertHtmlEmpty =
-    !advert.document.html || advert.document.html.trim() === ''
+  const advertPdfDisclaimer = isAdvertPdfOnly(
+    advert.document.html || '',
+    advert.publicationDate,
+  )
 
   return (
     <OJOIWrapper
       pageTitle={advert.title}
       hideTitle
       organization={organization ?? undefined}
-      pageDescription={
-        isAdvertHtmlEmpty || isSingleParagraph(advert.document.html)
-          ? formatMessage(m.advert.descriptionEmpty)
-          : formatMessage(m.advert.description)
-      }
+      pageDescription={formatMessage(advertPdfDisclaimer)}
       pageFeaturedImage={formatMessage(m.home.featuredImage)}
       breadcrumbItems={breadcrumbItems}
       goBackUrl={searchUrl}

--- a/apps/web/screens/OfficialJournalOfIceland/OJOIAdvert.tsx
+++ b/apps/web/screens/OfficialJournalOfIceland/OJOIAdvert.tsx
@@ -42,6 +42,7 @@ import {
   ADVERT_QUERY,
   ADVERT_SIMILAR_QUERY,
 } from '../queries/OfficialJournalOfIceland'
+import { isSingleParagraph } from './lib/isSingleParagraph'
 import { ORGANIZATION_SLUG } from './constants'
 import { m } from './messages'
 
@@ -80,7 +81,7 @@ const OJOIAdvertPage: CustomScreen<OJOIAdvertProps> = ({
       hideTitle
       organization={organization ?? undefined}
       pageDescription={
-        isAdvertHtmlEmpty
+        isAdvertHtmlEmpty || isSingleParagraph(advert.document.html)
           ? formatMessage(m.advert.descriptionEmpty)
           : formatMessage(m.advert.description)
       }

--- a/apps/web/screens/OfficialJournalOfIceland/lib/isAdvertPdfOnly.ts
+++ b/apps/web/screens/OfficialJournalOfIceland/lib/isAdvertPdfOnly.ts
@@ -16,10 +16,6 @@ export const isAdvertPdfOnly = (
   htmlString: string,
   date?: string,
 ): MessageDescriptor => {
-  if (!date) {
-    return m.advert.description
-  }
-
   const isHtmlEmpty = !htmlString || htmlString.trim() === ''
   const isSinglePara = isSingleParagraph(htmlString)
 
@@ -27,7 +23,7 @@ export const isAdvertPdfOnly = (
 
   if (isMainTextEmpty) {
     const lawChangedDate = new Date('2005-03-22') // 22. mars 2005
-    const isDateBeforeLawChange = new Date(date) < lawChangedDate
+    const isDateBeforeLawChange = date && new Date(date) < lawChangedDate
 
     return isDateBeforeLawChange
       ? m.advert.descriptionEmpty

--- a/apps/web/screens/OfficialJournalOfIceland/lib/isAdvertPdfOnly.ts
+++ b/apps/web/screens/OfficialJournalOfIceland/lib/isAdvertPdfOnly.ts
@@ -20,16 +20,19 @@ export const isAdvertPdfOnly = (
     return m.advert.description
   }
 
-  const lawChangedDate = new Date('2005-03-22') // 22. mars 2005
   const isHtmlEmpty = !htmlString || htmlString.trim() === ''
   const isSinglePara = isSingleParagraph(htmlString)
-  const isDateBeforeLawChange = new Date(date) < lawChangedDate
 
-  if (!isHtmlEmpty || !isSinglePara) {
-    return m.advert.description
+  const isMainTextEmpty = isHtmlEmpty || isSinglePara
+
+  if (isMainTextEmpty) {
+    const lawChangedDate = new Date('2005-03-22') // 22. mars 2005
+    const isDateBeforeLawChange = new Date(date) < lawChangedDate
+
+    return isDateBeforeLawChange
+      ? m.advert.descriptionEmpty
+      : m.advert.descriptionPdfOnly
   }
 
-  return isDateBeforeLawChange
-    ? m.advert.descriptionEmpty
-    : m.advert.descriptionPdfOnly
+  return m.advert.description
 }

--- a/apps/web/screens/OfficialJournalOfIceland/lib/isAdvertPdfOnly.ts
+++ b/apps/web/screens/OfficialJournalOfIceland/lib/isAdvertPdfOnly.ts
@@ -1,0 +1,35 @@
+import { MessageDescriptor } from 'react-intl'
+
+import { m } from '../messages'
+
+export const isSingleParagraph = (htmlString: string) => {
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(htmlString, 'text/html')
+  const bodyChildren = Array.from(doc.body.children)
+
+  return (
+    bodyChildren.length === 1 && bodyChildren[0].tagName.toLowerCase() === 'p'
+  )
+}
+
+export const isAdvertPdfOnly = (
+  htmlString: string,
+  date?: string,
+): MessageDescriptor => {
+  if (!date) {
+    return m.advert.description
+  }
+
+  const lawChangedDate = new Date('2005-03-22') // 22. mars 2005
+  const isHtmlEmpty = !htmlString || htmlString.trim() === ''
+  const isSinglePara = isSingleParagraph(htmlString)
+  const isDateBeforeLawChange = new Date(date) < lawChangedDate
+
+  if (!isHtmlEmpty || !isSinglePara) {
+    return m.advert.description
+  }
+
+  return isDateBeforeLawChange
+    ? m.advert.descriptionEmpty
+    : m.advert.descriptionPdfOnly
+}

--- a/apps/web/screens/OfficialJournalOfIceland/lib/isSingleParagraph.ts
+++ b/apps/web/screens/OfficialJournalOfIceland/lib/isSingleParagraph.ts
@@ -1,9 +1,0 @@
-export const isSingleParagraph = (htmlString: string) => {
-  const parser = new DOMParser()
-  const doc = parser.parseFromString(htmlString, 'text/html')
-  const bodyChildren = Array.from(doc.body.children)
-
-  return (
-    bodyChildren.length === 1 && bodyChildren[0].tagName.toLowerCase() === 'p'
-  )
-}

--- a/apps/web/screens/OfficialJournalOfIceland/lib/isSingleParagraph.ts
+++ b/apps/web/screens/OfficialJournalOfIceland/lib/isSingleParagraph.ts
@@ -1,0 +1,9 @@
+export const isSingleParagraph = (htmlString: string) => {
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(htmlString, 'text/html')
+  const bodyChildren = Array.from(doc.body.children)
+
+  return (
+    bodyChildren.length === 1 && bodyChildren[0].tagName.toLowerCase() === 'p'
+  )
+}

--- a/apps/web/screens/OfficialJournalOfIceland/messages.ts
+++ b/apps/web/screens/OfficialJournalOfIceland/messages.ts
@@ -280,6 +280,10 @@ export const m = {
       defaultMessage:
         'Þessi auglýsing var birt fyrir gildistöku laga nr. 15/2005 og er eingöngu á PDF-formi.',
     },
+    descriptionPdfOnly: {
+      id: 'web.ojoi:advert.description-empty-pdf-only',
+      defaultMessage: 'Þessi auglýsing er eingöngu á PDF-formi.',
+    },
 
     sidebarTitle: {
       id: 'web.ojoi:advert.sidebarTitle',

--- a/libs/api/domains/official-journal-of-iceland-application/src/lib/ojoiApplication.service.ts
+++ b/libs/api/domains/official-journal-of-iceland-application/src/lib/ojoiApplication.service.ts
@@ -263,6 +263,7 @@ export class OfficialJournalOfIcelandApplicationService {
       html: applicationCase.html,
       status: title,
       communicationStatus: applicationCase.communicationStatus.title,
+      expectedPublishDate: applicationCase.expectedPublishDate,
     }
 
     return mapped

--- a/libs/api/domains/official-journal-of-iceland-application/src/models/applicationCase.response.ts
+++ b/libs/api/domains/official-journal-of-iceland-application/src/models/applicationCase.response.ts
@@ -19,4 +19,7 @@ export class OJOIAApplicationCaseResponse {
 
   @Field()
   html!: string
+
+  @Field({ nullable: true })
+  expectedPublishDate?: string
 }

--- a/libs/application/templates/official-journal-of-iceland/src/components/form/FormScreen.tsx
+++ b/libs/application/templates/official-journal-of-iceland/src/components/form/FormScreen.tsx
@@ -22,6 +22,7 @@ type WarningProps = {
 type Props = {
   title?: string
   intro?: React.ReactNode
+  description?: React.ReactNode
   button?: React.ReactNode
   warning?: WarningProps
   children?: React.ReactNode
@@ -32,6 +33,7 @@ type Props = {
 export const FormScreen = ({
   title,
   intro,
+  description,
   button,
   children,
   warning,
@@ -111,6 +113,11 @@ export const FormScreen = ({
         {intro && (
           <Box marginBottom={4} className={styles.contentWrapper}>
             {intro && <Text>{intro}</Text>}
+          </Box>
+        )}
+        {description && (
+          <Box marginBottom={4} className={styles.contentWrapper}>
+            {description}
           </Box>
         )}
         {warning && (

--- a/libs/application/templates/official-journal-of-iceland/src/graphql/queries.ts
+++ b/libs/application/templates/official-journal-of-iceland/src/graphql/queries.ts
@@ -408,6 +408,7 @@ export const GET_APPLICATION_CASE_QUERY = gql`
       communicationStatus
       categories
       html
+      expectedPublishDate
     }
   }
 `

--- a/libs/application/templates/official-journal-of-iceland/src/hooks/useApplicationCase.ts
+++ b/libs/application/templates/official-journal-of-iceland/src/hooks/useApplicationCase.ts
@@ -13,6 +13,7 @@ type GetApplicationCaseResponse = {
     communicationStatus: string
     categories: string[]
     html: string
+    expectedPublishDate?: string
   }
 }
 

--- a/libs/application/templates/official-journal-of-iceland/src/lib/messages/submitted.tsx
+++ b/libs/application/templates/official-journal-of-iceland/src/lib/messages/submitted.tsx
@@ -67,5 +67,10 @@ export const submitted = {
         'Ef auglýsingin þarfnast einhverra breytinga færð þú tilkynningu um það.',
       description: 'Second bullet of the submitted screen',
     },
+    expectedPublishDate: {
+      id: 'ojoi.application:submitted.bullets.expectedPublishDate',
+      defaultMessage: 'Áætlaður birtingardagur auglýsingar:',
+      description: 'expectedPublishDate bullet of the submitted screen',
+    },
   }),
 }

--- a/libs/application/templates/official-journal-of-iceland/src/screens/SubmittedScreen.tsx
+++ b/libs/application/templates/official-journal-of-iceland/src/screens/SubmittedScreen.tsx
@@ -3,18 +3,28 @@ import { OJOIFieldBaseProps } from '../lib/types'
 import { Submitted } from '../fields/Submitted'
 import { submitted } from '../lib/messages/submitted'
 import { useLocale } from '@island.is/localization'
+import { useApplicationCase } from '../hooks/useApplicationCase'
 import { Bullet, BulletList } from '@island.is/island-ui/core'
 
 export const SubmittedScreen = (props: OJOIFieldBaseProps) => {
-  const { formatMessage } = useLocale()
+  const { formatMessage, formatDate } = useLocale()
+
+  const { caseData } = useApplicationCase({
+    applicationId: props.application.id,
+  })
 
   return (
     <FormScreen
       title={formatMessage(submitted.general.title)}
-      intro={
+      description={
         <BulletList>
           <Bullet>{formatMessage(submitted.bullets.first)}</Bullet>
           <Bullet>{formatMessage(submitted.bullets.second)}</Bullet>
+          {caseData?.status ? (
+            <Bullet>{`${formatMessage(
+              submitted.bullets.expectedPublishDate,
+            )} ${formatDate(caseData.expectedPublishDate)}`}</Bullet>
+          ) : null}
         </BulletList>
       }
     >

--- a/libs/clients/official-journal-of-iceland/application/src/clientConfig.json
+++ b/libs/clients/official-journal-of-iceland/application/src/clientConfig.json
@@ -1671,7 +1671,8 @@
           },
           "department": { "$ref": "#/components/schemas/Department" },
           "type": { "$ref": "#/components/schemas/AdvertType" },
-          "html": { "type": "string" }
+          "html": { "type": "string" },
+          "expectedPublishDate": { "type": "string" }
         },
         "required": [
           "categories",

--- a/libs/clients/official-journal-of-iceland/public/src/clientConfig.json
+++ b/libs/clients/official-journal-of-iceland/public/src/clientConfig.json
@@ -87,7 +87,7 @@
             "name": "year",
             "required": false,
             "in": "query",
-            "description": "Year (signature year) to filter by.",
+            "description": "Year (signature year) to filter by",
             "schema": { "type": "string" }
           },
           {


### PR DESCRIPTION
## What

* Add Application publish date status to overview
* Update case for pdf disclaimer

## Why

Improved ui for users

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added display of the expected publish date for adverts in relevant screens and API responses.
  * Enhanced form screens to support an optional description section.
  * Improved advert description logic to better indicate when an advert is available only as a PDF.

* **Bug Fixes**
  * Improved handling and messaging for adverts with empty or minimal HTML content.

* **Documentation**
  * Updated message entries and OpenAPI parameter descriptions for clarity.

* **Chores**
  * Extended data models and GraphQL queries to include the expected publish date field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->