### PR TITLE
fix(rental-agreement): Add approve action to rental agreement template

### DIFF
--- a/libs/application/templates/rental-agreement/src/lib/RentalAgreementTemplate.ts
+++ b/libs/application/templates/rental-agreement/src/lib/RentalAgreementTemplate.ts
@@ -195,6 +195,13 @@ const RentalAgreementTemplate: ApplicationTemplate<
               write: 'all',
               read: 'all',
               delete: true,
+              actions: [
+                {
+                  event: DefaultEvents.APPROVE,
+                  name: application.approve,
+                  type: 'primary',
+                },
+              ],
             },
           ],
         },

--- a/libs/application/templates/rental-agreement/src/lib/messages/prerequisites.ts
+++ b/libs/application/templates/rental-agreement/src/lib/messages/prerequisites.ts
@@ -51,6 +51,11 @@ export const application = defineMessages({
     defaultMessage: 'Senda í undirritun',
     description: `Button text for going to signing`,
   },
+  approve: {
+    id: 'ra.application:application.approve',
+    defaultMessage: 'Samþyggja',
+    description: `Button text for approving`,
+  },
 })
 
 export const prerequisites = {


### PR DESCRIPTION
https://app.asana.com/1/203394141643832/project/1208271027457465/task/1209555373134642

## What

Introduces an 'approve' action to the RentalAgreementTemplate with a corresponding button label in the messages. This allows HMS to approve applications.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
