### PR TITLE
fix(native): Document reply fixes

### DIFF
--- a/apps/native/app/src/screens/document-detail/document-reply.tsx
+++ b/apps/native/app/src/screens/document-detail/document-reply.tsx
@@ -54,15 +54,13 @@ const HeaderTitle = styled(Row)`
 
 const TextAreaWrapper = styled.View`
   flex: 1;
-  height: 170px;
+  height: 170;
 `
 
 const TextArea = styled(TextField)(({ theme }) => ({
   flex: 1,
-  // Android needs extra padding to make sure when multiline is present, then the last line is not cut off.
-  ...(isAndroid && {
-    paddingBottom: theme.spacing[4],
-  }),
+  // Extra padding is needed to make sure when multiline is present, then the last line is not cut off.
+  paddingBottom: theme.spacing[isAndroid ? 4 : 2],
 }))
 
 const Footer = styled(Container)(({ theme }) => ({

--- a/apps/native/app/src/screens/document-detail/document-reply.tsx
+++ b/apps/native/app/src/screens/document-detail/document-reply.tsx
@@ -3,6 +3,7 @@ import { useIntl } from 'react-intl'
 
 import { NavigationFunctionComponent } from 'react-native-navigation'
 
+import { ScrollView } from 'react-native'
 import styled from 'styled-components/native'
 import { LoadingIcon } from '../../components/nav-loading-spinner/loading-icon'
 import { Pressable } from '../../components/pressable/pressable'
@@ -25,6 +26,10 @@ import {
 } from '../../ui'
 import { ComponentRegistry } from '../../utils/component-registry'
 import { isAndroid } from '../../utils/devices'
+
+const Wrapper = styled.View`
+  flex: 1;
+`
 
 const Host = styled.SafeAreaView`
   flex: 1;
@@ -49,14 +54,18 @@ const HeaderTitle = styled(Row)`
 
 const TextAreaWrapper = styled.View`
   flex: 1;
-`
-
-const TextArea = styled(TextField)`
   height: 170px;
 `
 
-const Footer = styled(Container)(({ theme }) => ({
+const TextArea = styled(TextField)(({ theme }) => ({
   flex: 1,
+  // Android needs extra padding to make sure when multiline is present, then the last line is not cut off.
+  ...(isAndroid && {
+    paddingBottom: theme.spacing[4],
+  }),
+}))
+
+const Footer = styled(Container)(({ theme }) => ({
   justifyContent: 'flex-end',
   ...(isAndroid && {
     paddingBottom: theme.spacing.p2,
@@ -159,70 +168,77 @@ export const DocumentReplyScreen: NavigationFunctionComponent<
         ) : error ? (
           <Problem type="error" error={error} withContainer />
         ) : (
-          <>
-            <HeaderTitle>
-              <Typography
-                variant="heading5"
-                numberOfLines={1}
-                ellipsizeMode="tail"
-              >
-                {subject}
-              </Typography>
-            </HeaderTitle>
-            <Row>
-              <Typography
-                variant="body3"
-                numberOfLines={1}
-                ellipsizeMode="tail"
-              >
-                {intl.formatMessage({ id: 'documentReply.to' })}
-                {': '}
-              </Typography>
-              <Typography
-                variant="eyebrow"
-                numberOfLines={1}
-                ellipsizeMode="tail"
-              >
-                {senderName}
-              </Typography>
-            </Row>
-            <Row>
-              <Typography
-                variant="body3"
-                numberOfLines={1}
-                ellipsizeMode="tail"
-              >
-                {intl.formatMessage({ id: 'documentReply.from' })}
-                {': '}
-              </Typography>
-              <Typography
-                variant="eyebrow"
-                numberOfLines={1}
-                ellipsizeMode="tail"
-              >
-                {userProfile?.email}
-              </Typography>
-              <EmailIconWrapper onPress={onEmailPress}>
-                <Icon
-                  source={require('../../assets/icons/chevron-forward.png')}
-                  width={16}
-                  height={16}
-                />
-              </EmailIconWrapper>
-            </Row>
-            <Row hasBottomBorder={false} paddingVertical={2}>
-              <TextAreaWrapper>
-                <TextArea
-                  label={intl.formatMessage({ id: 'documentReply.message' })}
-                  multiline
-                  value={message}
-                  placeholder={intl.formatMessage({
-                    id: 'documentReply.messagePlaceholder',
-                  })}
-                  onChangeText={setMessage}
-                />
-              </TextAreaWrapper>
-            </Row>
+          <ScrollView
+            contentContainerStyle={{ flexGrow: 1 }}
+            keyboardShouldPersistTaps="handled"
+          >
+            <Wrapper>
+              <HeaderTitle>
+                <Typography
+                  variant="heading5"
+                  numberOfLines={1}
+                  ellipsizeMode="tail"
+                >
+                  {subject}
+                </Typography>
+              </HeaderTitle>
+              <Row>
+                <Typography
+                  variant="body3"
+                  numberOfLines={1}
+                  ellipsizeMode="tail"
+                >
+                  {intl.formatMessage({ id: 'documentReply.to' })}
+                  {': '}
+                </Typography>
+                <Typography
+                  variant="eyebrow"
+                  numberOfLines={1}
+                  ellipsizeMode="tail"
+                >
+                  {senderName}
+                </Typography>
+              </Row>
+              <Row>
+                <Typography
+                  variant="body3"
+                  numberOfLines={1}
+                  ellipsizeMode="tail"
+                >
+                  {intl.formatMessage({ id: 'documentReply.from' })}
+                  {': '}
+                </Typography>
+                <Typography
+                  variant="eyebrow"
+                  numberOfLines={1}
+                  ellipsizeMode="tail"
+                >
+                  {userProfile?.email}
+                </Typography>
+                <EmailIconWrapper onPress={onEmailPress}>
+                  <Icon
+                    source={require('../../assets/icons/chevron-forward.png')}
+                    width={16}
+                    height={16}
+                  />
+                </EmailIconWrapper>
+              </Row>
+              <Row hasBottomBorder={false} paddingVertical={2}>
+                <TextAreaWrapper>
+                  <TextArea
+                    label={intl.formatMessage({ id: 'documentReply.message' })}
+                    multiline
+                    value={message}
+                    placeholder={intl.formatMessage({
+                      id: 'documentReply.messagePlaceholder',
+                    })}
+                    textAlignVertical="top"
+                    scrollEnabled
+                    onChangeText={setMessage}
+                  />
+                </TextAreaWrapper>
+              </Row>
+            </Wrapper>
             <Footer>
               <Button
                 title={intl.formatMessage({ id: 'documentReply.sendMessage' })}
@@ -230,7 +246,7 @@ export const DocumentReplyScreen: NavigationFunctionComponent<
                 disabled={!message.trim() || sendMessageLoading}
               />
             </Footer>
-          </>
+          </ScrollView>
         )}
       </Host>
     </>

--- a/apps/native/app/src/ui/lib/text-field/text-field.tsx
+++ b/apps/native/app/src/ui/lib/text-field/text-field.tsx
@@ -30,7 +30,7 @@ const Label = styled(Typography)`
   margin-bottom: ${({ theme }) => theme.spacing.smallGutter}px;
 `
 
-const Input = styled.TextInput<{ value: string }>`
+const Input = styled(TextInput)<{ value: string }>`
   padding-left: ${({ theme }) => theme.spacing[1]}px;
   padding-top: 0px;
   padding-bottom: 0px;


### PR DESCRIPTION
# Document reply fixes


## What
- Fix Android submit button being clammed on small screens when keyboard is open
- Android and IOS fix multiline text area text overflow.
- Add ScrollView for small devices, to make content scrollable for access to submit button.
- Fix Typescript error on TextField ref prop.

## Screenshots / Gifs

Before on IOS, same goes for Android
![Screenshot 2025-07-14 at 11 23 44](https://github.com/user-attachments/assets/b865b54d-8818-45f6-982f-517173618af1)

After on IOS
![IMG_B581AC7AF8A2-1](https://github.com/user-attachments/assets/80b551ff-fc4b-4953-aefe-45933d820725)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
