### PR TITLE
fix(native): Fix license barcode placeholder visibility

### DIFF
--- a/apps/native/app/src/screens/wallet-pass/wallet-pass.tsx
+++ b/apps/native/app/src/screens/wallet-pass/wallet-pass.tsx
@@ -111,7 +111,7 @@ const Spacer = styled.View`
 
 const { useNavigationOptions, getNavigationOptions } =
   createNavigationOptionHooks(
-    (theme, intl) => ({
+    (_theme, intl) => ({
       topBar: {
         title: {
           text: intl.formatMessage({ id: 'walletPass.screenTitle' }),
@@ -234,7 +234,7 @@ export const WalletPassScreen: NavigationFunctionComponent<{
 
   const informationTopSpacing =
     (allowLicenseBarcode && ((loading && !data?.barcode) || data?.barcode)) ||
-    ((!isConnected || res.error) && isBarcodeEnabled)
+    ((!isConnected || res.error) && allowLicenseBarcode)
       ? barcodeHeight + LICENSE_CARD_ROW_GAP + theme.spacing[4]
       : theme.spacing[2]
 
@@ -493,7 +493,8 @@ export const WalletPassScreen: NavigationFunctionComponent<{
               height: barcodeHeight,
             },
           })}
-          showBarcodeOfflineMessage={!isConnected && isBarcodeEnabled}
+          showBarcodeOfflineMessage={!isConnected}
+          allowLicenseBarcode={allowLicenseBarcode}
         />
       </LicenseCardWrapper>
       <Information

--- a/apps/native/app/src/ui/lib/card/license-card.tsx
+++ b/apps/native/app/src/ui/lib/card/license-card.tsx
@@ -124,6 +124,7 @@ interface LicenseCardProps {
   backgroundImage?: ImageSourcePropType
   backgroundColor?: string
   showBarcodeOfflineMessage?: boolean
+  allowLicenseBarcode?: boolean
   loading?: boolean
   error?: ApolloError
   barcode?: {
@@ -144,6 +145,7 @@ export function LicenseCard({
   type,
   barcode,
   showBarcodeOfflineMessage,
+  allowLicenseBarcode,
   loading,
   error,
   ...props
@@ -297,7 +299,7 @@ export function LicenseCard({
           )}
         </BarcodeWrapper>
       )}
-      {(error || showBarcodeOfflineMessage) && (
+      {((error && allowLicenseBarcode) || showBarcodeOfflineMessage) && (
         <BarcodeWrapper minHeight={barcodeHeight}>
           <BarcodeContainer
             style={{ backgroundColor: 'rgba(255,255,255,0.4)' }}

--- a/apps/native/app/src/ui/lib/card/license-card.tsx
+++ b/apps/native/app/src/ui/lib/card/license-card.tsx
@@ -299,7 +299,7 @@ export function LicenseCard({
           )}
         </BarcodeWrapper>
       )}
-      {((error && allowLicenseBarcode) || showBarcodeOfflineMessage) && (
+      {allowLicenseBarcode && (error || showBarcodeOfflineMessage) && (
         <BarcodeWrapper minHeight={barcodeHeight}>
           <BarcodeContainer
             style={{ backgroundColor: 'rgba(255,255,255,0.4)' }}


### PR DESCRIPTION
# Fix license barcode placeholder visibility

Barcode placeholder error would show up on none supported barcode licenses

- Fix logic to only display barcode placeholder if license barcode is supported and either has error or is not connected


## Screenshots / Gifs
![IMG_610470DE8B5B-1](https://github.com/user-attachments/assets/027c6988-4e3b-4dee-b9a7-259172a97ee6)
![IMG_13CE24DE1BDB-1](https://github.com/user-attachments/assets/a2b8d919-0342-45c2-b833-c9f812d49d3e)



## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved control over barcode display in the license card, allowing barcode fallback views only when permitted.
* **Bug Fixes**
  * Updated offline message logic to display more accurately when the device is not connected, regardless of barcode feature flag status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->