### PR TITLE
fix(user-profile): Update user profile with empty email

### DIFF
--- a/apps/services/user-profile/src/app/v2/test/me-user-profile.controller.spec.ts
+++ b/apps/services/user-profile/src/app/v2/test/me-user-profile.controller.spec.ts
@@ -286,7 +286,7 @@ describe('MeUserProfileController', () => {
     )
   })
 
-  describe('PATCH user-profile - nudge dates', () => {
+  describe('PATCH user-profile - date nudging and edge cases', () => {
     let app: TestApp
     let server: SuperTest<Test>
     let fixtureFactory: FixtureFactory
@@ -501,6 +501,21 @@ describe('MeUserProfileController', () => {
       expect(userProfile.nextNudge.toString()).toBe(
         addMonths(userProfile.lastNudge, NUDGE_INTERVAL).toString(),
       )
+    })
+
+    it('BUG - PATCH /v2/me should return 200 when user has no email addresses registered', async () => {
+      // Arrange
+      await fixtureFactory.createUserProfile({
+        ...testUserProfile,
+        emails: [],
+      })
+
+      // Act - send an empty PATCH request
+      const res = await server.patch('/v2/me').send({})
+
+      // Assert
+      expect(res.status).toEqual(200)
+      expect(res.body.nationalId).toEqual(testUserProfile.nationalId)
     })
   })
 

--- a/apps/services/user-profile/src/app/v2/user-profile.service.ts
+++ b/apps/services/user-profile/src/app/v2/user-profile.service.ts
@@ -292,11 +292,12 @@ export class UserProfileService {
       const calculatedEmailStatus = isEmailDefined
         ? userProfile.email
           ? DataStatus.VERIFIED
-          : currentUserProfile?.emails?.[0].emailStatus ===
+          : currentUserProfile?.emails?.[0]?.emailStatus ===
             DataStatus.NOT_VERIFIED
           ? DataStatus.NOT_DEFINED
           : DataStatus.EMPTY
-        : (currentUserProfile?.emails?.[0].emailStatus as DataStatus)
+        : (currentUserProfile?.emails?.[0]?.emailStatus as DataStatus) ||
+          DataStatus.EMPTY
 
       await this.userProfileModel.upsert(
         {
@@ -314,7 +315,7 @@ export class UserProfileService {
               emailStatus: calculatedEmailStatus,
               emailVerified:
                 updateEmailVerified ??
-                currentUserProfile?.emails?.[0].emailStatus ===
+                currentUserProfile?.emails?.[0]?.emailStatus ===
                   DataStatus.VERIFIED,
               mobileStatus:
                 update.mobileStatus ??
@@ -1292,6 +1293,7 @@ export class UserProfileService {
     mobilePhoneNumberVerified?: boolean
     shouldValidatePhoneNumber?: boolean
   }): boolean | null {
+    // If emailStatus is undefined, we can't consider the email verified
     const isEmailVerified = emailStatus === DataStatus.VERIFIED
     const isPhoneValid = shouldValidatePhoneNumber
       ? mobilePhoneNumber && mobilePhoneNumberVerified


### PR DESCRIPTION
## What

Fix a recent regression where users can't update their bank info if their user profile has no emails stored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of user profiles with missing or empty email addresses to prevent errors and ensure consistent status reporting.

* **Tests**
  * Added a test to verify correct behavior when updating a user profile with no registered email addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->