### PR TITLE
fix(web): Team List - Pass prefixes prop down to rendered component

### DIFF
--- a/libs/island-ui/contentful/src/lib/TeamList/TeamList.tsx
+++ b/libs/island-ui/contentful/src/lib/TeamList/TeamList.tsx
@@ -213,9 +213,15 @@ const TeamMemberAccordionList = ({
   )
 }
 
-export const TeamList = ({ teamMembers, variant = 'card' }: TeamListProps) => {
+export const TeamList = ({
+  teamMembers,
+  variant = 'card',
+  prefixes,
+}: TeamListProps) => {
   if (variant === 'accordion') {
-    return <TeamMemberAccordionList teamMembers={teamMembers} />
+    return (
+      <TeamMemberAccordionList teamMembers={teamMembers} prefixes={prefixes} />
+    )
   }
   return <TeamMemberCardList teamMembers={teamMembers} />
 }


### PR DESCRIPTION
# Team List - Pass prefixes prop down to rendered component

## What

* The "Email" and "Phone" prefixes weren't being translated on the web (they still said "Netfang" and "Sími" when locale was set to 'en')

Turns out the prefixes property isn't being passed down to the rendered component, the fix is to simply pass the prop down

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for customizing label prefixes for email and phone fields in the team list when displayed in accordion view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->