### PR TITLE
fix(web): Hotfix, Team List - Pass prefixes prop down to rendered component (#19612)

### DIFF
--- a/libs/island-ui/contentful/src/lib/TeamList/TeamList.tsx
+++ b/libs/island-ui/contentful/src/lib/TeamList/TeamList.tsx
@@ -213,9 +213,15 @@ const TeamMemberAccordionList = ({
   )
 }
 
-export const TeamList = ({ teamMembers, variant = 'card' }: TeamListProps) => {
+export const TeamList = ({
+  teamMembers,
+  variant = 'card',
+  prefixes,
+}: TeamListProps) => {
   if (variant === 'accordion') {
-    return <TeamMemberAccordionList teamMembers={teamMembers} />
+    return (
+      <TeamMemberAccordionList teamMembers={teamMembers} prefixes={prefixes} />
+    )
   }
   return <TeamMemberCardList teamMembers={teamMembers} />
 }


### PR DESCRIPTION
# Hotfix, Team List - Pass prefixes prop down to rendered component (#19612)