### PR TITLE
feat(web): Info Card, subDescription prop

### DIFF
--- a/apps/web/screens/Verdicts/VerdictsList.tsx
+++ b/apps/web/screens/Verdicts/VerdictsList.tsx
@@ -1210,6 +1210,7 @@ const VerdictsList: CustomScreen<VerdictsListProps> = (props) => {
 
                     return {
                       description: verdict.title,
+                      subDescription: verdict.keywords.join(', '),
                       eyebrow: '',
                       id: verdict.id,
                       link: { href: `/domar/${verdict.id}`, label: '' },

--- a/libs/island-ui/core/src/lib/InfoCardGrid/DetailedInfoCard.tsx
+++ b/libs/island-ui/core/src/lib/InfoCardGrid/DetailedInfoCard.tsx
@@ -152,7 +152,7 @@ export const DetailedInfoCard = ({
               </Box>
             )}
             {subDescription && (
-              <Box flexGrow={1} marginTop={3}>
+              <Box flexGrow={1} marginTop={description ? 3 : 1}>
                 <Text variant="small" fontWeight="regular">
                   {subDescription}
                 </Text>
@@ -176,7 +176,7 @@ export const DetailedInfoCard = ({
           </Box>
         )}
         {subDescription && (
-          <Box flexGrow={1} marginTop={2}>
+          <Box flexGrow={1} marginTop={description ? 2 : 1}>
             <Text variant="small" fontWeight="regular">
               {subDescription}
             </Text>

--- a/libs/island-ui/core/src/lib/InfoCardGrid/DetailedInfoCard.tsx
+++ b/libs/island-ui/core/src/lib/InfoCardGrid/DetailedInfoCard.tsx
@@ -21,6 +21,7 @@ export type DetailedProps = BaseProps & {
   logo?: string
   logoAlt?: string
   subEyebrow?: string
+  subDescription?: string
   //max 5 lines
   detailLines?: Array<{
     icon: IconMapIcon
@@ -35,6 +36,7 @@ export const DetailedInfoCard = ({
   size = 'medium',
   eyebrow,
   subEyebrow,
+  subDescription,
   detailLines,
   tags,
   logo,
@@ -149,6 +151,13 @@ export const DetailedInfoCard = ({
                 </Text>
               </Box>
             )}
+            {subDescription && (
+              <Box flexGrow={1} marginTop={3}>
+                <Text variant="small" fontWeight="regular">
+                  {subDescription}
+                </Text>
+              </Box>
+            )}
           </GridColumn>
           <GridColumn span="4/12">{renderDetails()}</GridColumn>
         </GridRow>
@@ -163,6 +172,13 @@ export const DetailedInfoCard = ({
           <Box marginTop={1}>
             <Text variant="medium" fontWeight="light">
               {description}
+            </Text>
+          </Box>
+        )}
+        {subDescription && (
+          <Box flexGrow={1} marginTop={2}>
+            <Text variant="small" fontWeight="regular">
+              {subDescription}
             </Text>
           </Box>
         )}


### PR DESCRIPTION
# Info Card, subDescription prop

* `subDescription` prop added to DetailedInfoCard component that renders small text below the description

## Why

- Changes according to the design here: https://www.figma.com/design/6FtxVhE5SHaSCjhuEXJkDV/Stofnun-D%C3%B3mst%C3%B3las%C3%BDslan?node-id=3659-111899 (ignore the "Sjá reifun" button)
- We need to display the keywords on the card and since they are often so many we are opting for the "subDescription" approach

## Screenshots / Gifs

<img width="914" height="217" alt="Screenshot 2025-07-17 at 15 10 29" src="https://github.com/user-attachments/assets/4e588329-8540-499f-b701-3357d6d69201" />

<img width="360" height="296" alt="Screenshot 2025-07-17 at 15 10 50" src="https://github.com/user-attachments/assets/197692a5-9d9b-4282-8dd0-485eda982253" />



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Verdict cards now display a secondary description below the main description, showing relevant keywords for each verdict.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->