### PR TITLE
fix(carrecycling-application): Enabling GeneralMandate on CarRecycling application

### DIFF
--- a/libs/application/templates/car-recycling/src/lib/CarRecyclingTemplate.ts
+++ b/libs/application/templates/car-recycling/src/lib/CarRecyclingTemplate.ts
@@ -55,6 +55,9 @@ const CarRecyclingTemplate: ApplicationTemplate<
     {
       type: AuthDelegationType.Custom,
     },
+    {
+      type: AuthDelegationType.GeneralMandate,
+    },
   ],
   allowMultipleApplicationsInDraft: true,
   requiredScopes: [ApiScope.carRecycling],


### PR DESCRIPTION
## What

Adding the `GeneralMandate` delegation type to the CarRecyling (Skilavottorð) application.

## Why

To allow users with the `GeneralMandate` to access the application.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the types of delegations allowed in the Car Recycling application to include general mandates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->