### PR TITLE
feat(web): Change news component on frontpage

### DIFF
--- a/apps/web/components/Organization/Slice/LatestNewsSlice/DigitalIcelandLatestNewsSlice/DigitalIcelandLatestNewsSlice.tsx
+++ b/apps/web/components/Organization/Slice/LatestNewsSlice/DigitalIcelandLatestNewsSlice/DigitalIcelandLatestNewsSlice.tsx
@@ -11,7 +11,6 @@ import {
 } from '@island.is/island-ui/core'
 import { DigitalIcelandLatestNewsCard } from '@island.is/web/components'
 import { FRONTPAGE_NEWS_TAG_SLUG } from '@island.is/web/constants'
-import { LatestNewsSlice as LatestNewsSliceSchema } from '@island.is/web/graphql/schema'
 import { useLinkResolver } from '@island.is/web/hooks'
 
 import * as styles from './DigitalIcelandLatestNewsSlice.css'
@@ -30,8 +29,10 @@ const SeeMoreLink = ({
           : linkResolver(
               seeMoreLinkVariant === 'organization'
                 ? 'organizationnewsoverview'
-                : 'projectnewsoverview',
-              [slug],
+                : seeMoreLinkVariant === 'project'
+                ? 'projectnewsoverview'
+                : 'newsoverview',
+              slug ? [slug] : [],
             ).href
       }
     >
@@ -43,9 +44,34 @@ const SeeMoreLink = ({
 }
 
 interface SliceProps {
-  slice: LatestNewsSliceSchema
-  slug: string
-  seeMoreLinkVariant?: 'organization' | 'project'
+  slice: {
+    title: string
+    news: {
+      id: string
+      title: string
+      subtitle: string
+      date: string
+      slug: string
+      intro?: string | null
+      image?: {
+        url: string
+        title: string
+        width: number
+        height: number
+      } | null
+      genericTags: Array<{
+        id: string
+        title: string
+        slug: string
+      }>
+    }[]
+    readMoreText: string
+    readMoreLink?: {
+      url: string
+    }
+  }
+  slug?: string
+  seeMoreLinkVariant?: 'organization' | 'project' | 'frontpage'
 }
 
 export const DigitalIcelandLatestNewsSlice: React.FC<
@@ -88,8 +114,10 @@ export const DigitalIcelandLatestNewsSlice: React.FC<
                   linkResolver(
                     seeMoreLinkVariant === 'organization'
                       ? 'organizationnews'
-                      : 'projectnews',
-                    [slug, news.slug],
+                      : seeMoreLinkVariant === 'project'
+                      ? 'projectnews'
+                      : 'news',
+                    slug ? [slug, news.slug] : [news.slug],
                   ).href
                 }
                 date={news.date}

--- a/apps/web/components/Organization/Slice/LatestNewsSlice/DigitalIcelandLatestNewsSlice/DigitalIcelandLatestNewsSlice.tsx
+++ b/apps/web/components/Organization/Slice/LatestNewsSlice/DigitalIcelandLatestNewsSlice/DigitalIcelandLatestNewsSlice.tsx
@@ -68,7 +68,7 @@ interface SliceProps {
     readMoreText: string
     readMoreLink?: {
       url: string
-    }
+    } | null
   }
   slug?: string
   seeMoreLinkVariant?: 'organization' | 'project' | 'frontpage'

--- a/apps/web/screens/Home/Home.tsx
+++ b/apps/web/screens/Home/Home.tsx
@@ -4,8 +4,8 @@ import { Box } from '@island.is/island-ui/core'
 import { Locale } from '@island.is/shared/types'
 import {
   CategoryItems,
+  DigitalIcelandLatestNewsSlice,
   LifeEventsSection,
-  NewsItems,
   SearchSection,
   WatsonChatPanel,
 } from '@island.is/web/components'
@@ -125,19 +125,21 @@ const Home: Screen<HomeProps> = ({ categories, news, page, locale }) => {
         paddingTop={[8, 8, 6]}
         aria-labelledby="news-items-title"
       >
-        <NewsItems
-          heading={gn(
-            'newsAndAnnouncements',
-            activeLocale === 'is'
-              ? 'Fréttir og tilkynningar'
-              : 'News and announcements',
-          )}
-          headingTitle="news-items-title"
-          seeMoreText={gn(
-            'seeMore',
-            activeLocale === 'is' ? 'Sjá meira' : 'See more',
-          )}
-          items={news}
+        <DigitalIcelandLatestNewsSlice
+          slice={{
+            title: gn(
+              'newsAndAnnouncements',
+              activeLocale === 'is'
+                ? 'Fréttir og tilkynningar'
+                : 'News and announcements',
+            ),
+            news: news,
+            readMoreText: gn(
+              'seeMore',
+              activeLocale === 'is' ? 'Sjá meira' : 'See more',
+            ),
+          }}
+          seeMoreLinkVariant="frontpage"
         />
       </Box>
       {watsonConfig[locale] && (

--- a/apps/web/screens/Home/Home.tsx
+++ b/apps/web/screens/Home/Home.tsx
@@ -120,11 +120,7 @@ const Home: Screen<HomeProps> = ({ categories, news, page, locale }) => {
           items={categories}
         />
       </Box>
-      <Box
-        component="section"
-        paddingTop={[8, 8, 6]}
-        aria-labelledby="news-items-title"
-      >
+      <Box paddingTop={[8, 8, 6]}>
         <DigitalIcelandLatestNewsSlice
           slice={{
             title: gn(


### PR DESCRIPTION
# Change news component on frontpage

## What

* 3 column view for news on frontpage

## Why

This was requested by Digital Iceland

## Screenshots / Gifs

### Before

<img width="1278" height="739" alt="Screenshot 2025-07-18 at 10 57 10" src="https://github.com/user-attachments/assets/aa04bf7d-9231-4e20-b285-fc1e717f2cfe" />

### After

<img width="1292" height="565" alt="Screenshot 2025-07-18 at 10 56 16" src="https://github.com/user-attachments/assets/69eb0edc-af74-4e6b-991a-0b7e08bed93e" />

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the home screen to display the latest news using a new component with improved support for different link variants, including a new "frontpage" option.

* **Refactor**
  * Replaced the previous news component with a more flexible one that uses an explicit type definition for news items and enhanced link resolution logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->