### PR TITLE
feat(web): Blood donation restriction details, increase font size for h2

### DIFF
--- a/apps/web/screens/Organization/Bloodbank/BloodDonationRestrictionDetails.tsx
+++ b/apps/web/screens/Organization/Bloodbank/BloodDonationRestrictionDetails.tsx
@@ -99,7 +99,7 @@ const BloodDonationRestrictionDetails: CustomScreen<
               borderRadius="standard"
               width="full"
             >
-              <Text variant="h3" as="h2">
+              <Text variant="h2" as="h2">
                 {formatMessage(m.detailsPage.cardSubheading)}
               </Text>
               <Text as="div">{webRichText(item.cardText)}</Text>
@@ -107,7 +107,7 @@ const BloodDonationRestrictionDetails: CustomScreen<
           )}
           {item.hasDetailedText && (
             <Stack space={0}>
-              <Text variant="h3" as="h2">
+              <Text variant="h2" as="h2">
                 {formatMessage(m.detailsPage.detailTextHeading)}
               </Text>
               <Text as="div">{webRichText(item.detailedText)}</Text>


### PR DESCRIPTION
# Blood donation restriction details, increase font size for h2

Previously the two h2 elements at the top had the visual look of h3. Now that we allow h3's in the rich text below it then we no longer can see the dom hierarchy by looking at heading font sizes. This PR addresses that by making h2 actually look like h2.



## Before

<img width="1205" height="809" alt="Screenshot 2025-07-21 at 10 47 32" src="https://github.com/user-attachments/assets/db35b318-91e4-475a-8728-bf607b8087cc" />


## After

<img width="1197" height="836" alt="Screenshot 2025-07-21 at 10 46 59" src="https://github.com/user-attachments/assets/dcbd7696-4a01-414d-862d-e02a13d41bf5" />

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated heading styles in the Blood Donation Restriction Details screen for improved visual hierarchy and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->