### PR TITLE
chore(infra): More consistent '*-local-env' CLI

### DIFF
--- a/infra/src/cli/cli.ts
+++ b/infra/src/cli/cli.ts
@@ -7,7 +7,7 @@ import { OpsEnv } from '../dsl/types/input-types'
 import { renderServiceEnvVars } from './render-env-vars'
 import { renderLocalServices, runLocalServices } from './render-local-mocks'
 
-const cli = yargs(process.argv.slice(2))
+yargs(process.argv.slice(2))
   .scriptName('yarn infra')
   .command(
     'render-env',
@@ -66,11 +66,12 @@ const cli = yargs(process.argv.slice(2))
           })
           .option('json', { type: 'boolean', default: false })
           .option('dry', { type: 'boolean', default: false })
-          .option('no-update-secrets', {
+          .option('secrets', {
             type: 'boolean',
-            default: false,
-            alias: ['nosecrets', 'no-secrets'],
+            default: true,
+            alias: ['update-secrets'],
           })
+          .option('print', { type: 'boolean', default: true })
           // Custom check for 'services' since yargs lack built-in validation
           .check((argv) => {
             const svc = argv.services
@@ -87,8 +88,8 @@ const cli = yargs(process.argv.slice(2))
         services: argv.services,
         dryRun: argv.dry,
         json: argv.json,
-        print: true,
-        noUpdateSecrets: argv['no-update-secrets'],
+        print: argv.print,
+        updateSecrets: argv['secrets'],
       })
     },
   )
@@ -106,18 +107,13 @@ const cli = yargs(process.argv.slice(2))
           .option('dependencies', { array: true, type: 'string', default: [] })
           .option('json', { type: 'boolean', default: false })
           .option('dry', { type: 'boolean', default: false })
-          .option('no-update-secrets', {
+          .option('secrets', {
             type: 'boolean',
-            default: false,
-            alias: ['nosecrets', 'no-secrets'],
+            default: true,
+            alias: ['update-secrets'],
           })
           .option('print', { type: 'boolean', default: false })
           .option('proxies', { type: 'boolean', default: false })
-          .option('never-fail', {
-            alias: 'nofail',
-            type: 'boolean',
-            default: false,
-          })
           // Custom check for 'services' since yargs lack built-in validation
           .check((argv) => {
             const svc = argv.services
@@ -130,11 +126,12 @@ const cli = yargs(process.argv.slice(2))
       )
     },
     async (argv) => {
-      await runLocalServices(argv.services, argv.dependencies, {
+      await runLocalServices({
+        services: argv.services,
+        dependencies: argv.dependencies,
         dryRun: argv.dry,
         json: argv.json,
-        neverFail: argv['never-fail'],
-        noUpdateSecrets: argv['no-update-secrets'],
+        updateSecrets: argv['secrets'],
         print: argv.print,
         startProxies: argv.proxies,
       })

--- a/infra/src/dsl/value-files-generators/local-setup.spec.ts
+++ b/infra/src/dsl/value-files-generators/local-setup.spec.ts
@@ -48,7 +48,7 @@ describe('Local setup', () => {
   })
   it('Should have mocks', async () => {
     expect(serviceDef.mocks).toStrictEqual(
-      `docker run --name mountebank -it --rm -p 2525:2525 -p 9453:9453 -v ${path.resolve(
+      `docker run --name mountebank --rm -p 2525:2525 -p 9453:9453 -v ${path.resolve(
         __dirname,
         '..',
         '..',

--- a/infra/src/dsl/value-files-generators/local-setup.ts
+++ b/infra/src/dsl/value-files-generators/local-setup.ts
@@ -90,14 +90,13 @@ export const getLocalrunValueFile = async (
       ) as Record<string, string>,
       commands: [
         // Enable verbose logging for shell commands
+        // Expand as array to get empty or a string, never an empty string
         ...(logger.logLevel === 'debug' || logger.logLevel === 'trace'
           ? ['set -x']
           : []),
         `cd "${rootDir}"`, // Change directory to the root directory
         `. ./.env.${serviceNXName}`, // Source the environment variables for the service
-        `echo "Preparing dev-services for ${name}"`, // Log preparation message
-        `if yarn nx show projects --with-target dev-services | grep -q '^${serviceNXName}$'; then yarn nx dev-services ${serviceNXName} || exit $?; fi`, // Check and set up dev-services if needed
-        `echo "Starting ${name} in $PWD"`,
+        `yarn nx run-many -t dev-services -p ${serviceNXName}`, // Check and set up dev-services if needed
         `yarn nx serve ${serviceNXName}`, // Log start message and start the service
       ],
     }
@@ -197,7 +196,7 @@ export const getLocalrunValueFile = async (
   const mocksObj = {
     containerer: 'docker',
     containererCommand: 'run',
-    containererFlags: '-it --rm',
+    containererFlags: '--rm',
     ports: ['2525', ...mocksConfigs.ports],
     mounts: [`${process.cwd()}/${defaultMountebankConfig}:/app/default.json:z`],
     image: 'docker.io/bbyars/mountebank:2.8.1',


### PR DESCRIPTION
Makes the `yarn infra {run,render}-local-env` CLI more intuitive, and unifies their flags, and some minor tweaks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new print option (default: true) to the local environment rendering command.

* **Bug Fixes**
  * Improved service filtering and validation during local service startup.

* **Refactor**
  * Simplified and clarified command-line options, including renaming and inverting the secrets update flag.
  * Unified and streamlined argument handling for local service functions.
  * Simplified shell commands for starting development services.

* **Style**
  * Removed the interactive terminal flag from mock service container commands for cleaner execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->