### PR TITLE
chore(infra): Flags back to original state

### DIFF
--- a/infra/src/cli/cli.ts
+++ b/infra/src/cli/cli.ts
@@ -7,7 +7,7 @@ import { OpsEnv } from '../dsl/types/input-types'
 import { renderServiceEnvVars } from './render-env-vars'
 import { renderLocalServices, runLocalServices } from './render-local-mocks'
 
-yargs(process.argv.slice(2))
+const cli = yargs(process.argv.slice(2))
   .scriptName('yarn infra')
   .command(
     'render-env',
@@ -66,12 +66,11 @@ yargs(process.argv.slice(2))
           })
           .option('json', { type: 'boolean', default: false })
           .option('dry', { type: 'boolean', default: false })
-          .option('secrets', {
+          .option('no-update-secrets', {
             type: 'boolean',
-            default: true,
-            alias: ['update-secrets'],
+            default: false,
+            alias: ['nosecrets', 'no-secrets'],
           })
-          .option('print', { type: 'boolean', default: true })
           // Custom check for 'services' since yargs lack built-in validation
           .check((argv) => {
             const svc = argv.services
@@ -88,8 +87,8 @@ yargs(process.argv.slice(2))
         services: argv.services,
         dryRun: argv.dry,
         json: argv.json,
-        print: argv.print,
-        updateSecrets: argv['secrets'],
+        print: true,
+        noUpdateSecrets: argv['no-update-secrets'],
       })
     },
   )
@@ -107,13 +106,18 @@ yargs(process.argv.slice(2))
           .option('dependencies', { array: true, type: 'string', default: [] })
           .option('json', { type: 'boolean', default: false })
           .option('dry', { type: 'boolean', default: false })
-          .option('secrets', {
+          .option('no-update-secrets', {
             type: 'boolean',
-            default: true,
-            alias: ['update-secrets'],
+            default: false,
+            alias: ['nosecrets', 'no-secrets'],
           })
           .option('print', { type: 'boolean', default: false })
           .option('proxies', { type: 'boolean', default: false })
+          .option('never-fail', {
+            alias: 'nofail',
+            type: 'boolean',
+            default: false,
+          })
           // Custom check for 'services' since yargs lack built-in validation
           .check((argv) => {
             const svc = argv.services
@@ -126,12 +130,11 @@ yargs(process.argv.slice(2))
       )
     },
     async (argv) => {
-      await runLocalServices({
-        services: argv.services,
-        dependencies: argv.dependencies,
+      await runLocalServices(argv.services, argv.dependencies, {
         dryRun: argv.dry,
         json: argv.json,
-        updateSecrets: argv['secrets'],
+        neverFail: argv['never-fail'],
+        noUpdateSecrets: argv['no-update-secrets'],
         print: argv.print,
         startProxies: argv.proxies,
       })

--- a/infra/src/cli/render-local-mocks.ts
+++ b/infra/src/cli/render-local-mocks.ts
@@ -6,27 +6,25 @@ import { logger, runCommand } from '../common'
 import { ChildProcess } from 'child_process'
 import { LocalrunValueFile } from '../dsl/types/output-types'
 
-type LocalServicesArgs = {
-  services: string[]
-  print?: boolean
-  json?: boolean
-  dryRun?: boolean
-  updateSecrets?: boolean
-}
-
 export async function renderLocalServices({
   services,
   print = false,
   json = false,
   dryRun = false,
-  updateSecrets = true,
-}: LocalServicesArgs): Promise<LocalrunValueFile> {
+  noUpdateSecrets = false,
+}: {
+  services: string[]
+  print?: boolean
+  json?: boolean
+  dryRun?: boolean
+  noUpdateSecrets?: boolean
+}): Promise<LocalrunValueFile> {
   logger.debug('renderLocalServices', {
     services,
     print,
     json,
     dryRun,
-    updateSecrets,
+    noUpdateSecrets,
   })
   const chartName = 'islandis'
   const env = 'dev'
@@ -39,7 +37,7 @@ export async function renderLocalServices({
     habitat,
     uberChart,
     habitat.filter((s) => services.includes(s.name())),
-    { dryRun, noUpdateSecrets: !updateSecrets },
+    { dryRun, noUpdateSecrets },
   )
 
   if (print) {
@@ -57,33 +55,42 @@ export async function renderLocalServices({
   return renderedLocalServices
 }
 
-export async function runLocalServices({
-  services,
-  dryRun = false,
-  print = false,
-  json = false,
-  updateSecrets = true,
-  dependencies = [],
-  startProxies = false,
-}: LocalServicesArgs & {
-  dependencies: string[]
-  startProxies: boolean
-}) {
+export async function runLocalServices(
+  services: string[],
+  dependencies: string[] = [],
+  {
+    dryRun = false,
+    neverFail = !!dryRun,
+    print = false,
+    json = false,
+    noUpdateSecrets = false,
+    startProxies = false,
+  }: {
+    dryRun?: boolean
+    neverFail?: boolean
+    print?: boolean
+    json?: boolean
+    noUpdateSecrets?: boolean
+    startProxies?: boolean
+  } = {},
+) {
   logger.debug('runLocalServices', { services, dependencies })
-  const neverFail = !!dryRun
+
+  // Add the service itself to the list of dependencies
+  dependencies.push(...services)
 
   const renderedLocalServices = await renderLocalServices({
     services,
     print,
     json,
     dryRun,
-    updateSecrets,
+    noUpdateSecrets,
   })
 
   // Verify that all dependencies exist in the rendered dependency list
-  for (const app of dependencies.concat(services)) {
-    if (!renderedLocalServices.services[app]) {
-      throw new Error(`Application ${app} not found`)
+  for (const dependency of dependencies) {
+    if (!renderedLocalServices.services[dependency]) {
+      throw new Error(`Dependency ${dependency} not found`)
     }
   }
 
@@ -114,20 +121,8 @@ export async function runLocalServices({
   for (const [name, service] of Object.entries(
     renderedLocalServices.services,
   )) {
-    if (services.length >= 2 && !services.includes(name)) {
-      logger.info(
-        `Skipping ${name} (not in service list [${services.join(',')}])`,
-      )
-      continue
-    }
-    if (
-      dependencies.length > 0 &&
-      !dependencies.includes(name) &&
-      !services.includes(name)
-    ) {
-      logger.info(
-        `Skipping ${name} (not in dependency list [${dependencies.join(',')}])`,
-      )
+    if (dependencies.length > 0 && !dependencies.includes(name)) {
+      logger.info(`Skipping ${name} (not a dependency)`)
       continue
     }
     const chainedCommand = [

--- a/infra/src/dsl/value-files-generators/local-setup.spec.ts
+++ b/infra/src/dsl/value-files-generators/local-setup.spec.ts
@@ -48,7 +48,7 @@ describe('Local setup', () => {
   })
   it('Should have mocks', async () => {
     expect(serviceDef.mocks).toStrictEqual(
-      `docker run --name mountebank --rm -p 2525:2525 -p 9453:9453 -v ${path.resolve(
+      `docker run --name mountebank -it --rm -p 2525:2525 -p 9453:9453 -v ${path.resolve(
         __dirname,
         '..',
         '..',

--- a/infra/src/dsl/value-files-generators/local-setup.ts
+++ b/infra/src/dsl/value-files-generators/local-setup.ts
@@ -90,13 +90,14 @@ export const getLocalrunValueFile = async (
       ) as Record<string, string>,
       commands: [
         // Enable verbose logging for shell commands
-        // Expand as array to get empty or a string, never an empty string
         ...(logger.logLevel === 'debug' || logger.logLevel === 'trace'
           ? ['set -x']
           : []),
         `cd "${rootDir}"`, // Change directory to the root directory
         `. ./.env.${serviceNXName}`, // Source the environment variables for the service
-        `yarn nx run-many -t dev-services -p ${serviceNXName}`, // Check and set up dev-services if needed
+        `echo "Preparing dev-services for ${name}"`, // Log preparation message
+        `if yarn nx show projects --with-target dev-services | grep -q '^${serviceNXName}$'; then yarn nx dev-services ${serviceNXName} || exit $?; fi`, // Check and set up dev-services if needed
+        `echo "Starting ${name} in $PWD"`,
         `yarn nx serve ${serviceNXName}`, // Log start message and start the service
       ],
     }
@@ -196,7 +197,7 @@ export const getLocalrunValueFile = async (
   const mocksObj = {
     containerer: 'docker',
     containererCommand: 'run',
-    containererFlags: '--rm',
+    containererFlags: '-it --rm',
     ports: ['2525', ...mocksConfigs.ports],
     mounts: [`${process.cwd()}/${defaultMountebankConfig}:/app/default.json:z`],
     image: 'docker.io/bbyars/mountebank:2.8.1',


### PR DESCRIPTION
This reverts commit 14da905100860116401e5fb25fb9c342d7e70b46.

# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new CLI option to prevent command failure (`never-fail`) in local environment runs.
  * Updated CLI options for managing secrets, providing more explicit control.

* **Bug Fixes**
  * Improved logic for handling service dependencies and filtering in local environment commands.

* **Style**
  * Docker run commands in local mocks now use interactive terminal flags for better usability.

* **Tests**
  * Updated test assertions to reflect changes in Docker command flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->