### PR TITLE
fix(web): Show 404 when news don't belong to organization or project

### DIFF
--- a/apps/web/screens/Organization/OrganizationEvents/OrganizationEventArticle.tsx
+++ b/apps/web/screens/Organization/OrganizationEvents/OrganizationEventArticle.tsx
@@ -391,6 +391,18 @@ OrganizationEventArticle.getProps = async ({
     )
   }
 
+  const eventBelongsToOrganization =
+    Boolean(event.organization?.slug) &&
+    Boolean(organizationPage.organization?.slug) &&
+    event.organization?.slug === organizationPage.organization?.slug
+
+  if (!eventBelongsToOrganization) {
+    throw new CustomNextError(
+      404,
+      `Event ${event.slug} does not belong to organization ${organizationPage.organization?.slug}`,
+    )
+  }
+
   let hasEventOccurred = true
   if (Boolean(event.endDate) || Boolean(event.startDate)) {
     const dateString = event.endDate ? event.endDate : event.startDate

--- a/apps/web/screens/Organization/OrganizationNews/OrganizationNewsArticle.tsx
+++ b/apps/web/screens/Organization/OrganizationNews/OrganizationNewsArticle.tsx
@@ -232,6 +232,18 @@ OrganizationNewsArticle.getProps = async ({
     throw new CustomNextError(404, 'News not found')
   }
 
+  const newsItemBelongsToOrganization =
+    Boolean(newsItem.organization?.slug) &&
+    Boolean(organizationPage.organization?.slug) &&
+    newsItem.organization?.slug === organizationPage.organization?.slug
+
+  if (!newsItemBelongsToOrganization) {
+    throw new CustomNextError(
+      404,
+      `News item ${newsItem.slug} does not belong to organization ${organizationPage.organization?.slug}`,
+    )
+  }
+
   const organizationNamespace = extractNamespaceFromOrganization(
     organizationPage.organization,
   )

--- a/apps/web/screens/Project/ProjectNewsArticle.tsx
+++ b/apps/web/screens/Project/ProjectNewsArticle.tsx
@@ -171,6 +171,17 @@ ProjectNewsArticle.getProps = async ({ apolloClient, locale, query }) => {
     throw new CustomNextError(404, 'News not found')
   }
 
+  const newsItemBelongsToProject = newsItem.genericTags.some(
+    (tag) => tag.id === projectPage.newsTag?.id,
+  )
+
+  if (!newsItemBelongsToProject) {
+    throw new CustomNextError(
+      404,
+      `News item ${newsItem.slug} does not belong to project ${projectPage.slug}`,
+    )
+  }
+
   return {
     projectPage: projectPage,
     newsItem,

--- a/apps/web/screens/queries/Events.ts
+++ b/apps/web/screens/queries/Events.ts
@@ -13,6 +13,9 @@ export const GET_SINGLE_EVENT_QUERY = gql`
         startTime
         endTime
       }
+      organization {
+        slug
+      }
       location {
         streetAddress
         floor


### PR DESCRIPTION
# Show 404 when news don't belong to organization or project

## What

News can be viewed on multiple urls.

Here is a new item from "Sýslumenn": https://island.is/s/syslumenn/frett/ny-thjonusta-i-vedbokarvottordum

It can also be viewed on any other organization page: 
(3 examples)
* https://island.is/s/blodbankinn/frett/ny-thjonusta-i-vedbokarvottordum 
* https://island.is/s/hsn/frett/ny-thjonusta-i-vedbokarvottordum
* https://island.is/s/sak/frett/ny-thjonusta-i-vedbokarvottordum

The same occurs for project pages

https://island.is/v/fyrir-grindavik/frett/ny-thjonusta-i-vedbokarvottordum

---

In this PR I specifically check if the news item belongs to organization or project before rendering it and show a 404 if it's out of place.

(Edit: I noticed that the same happens for events so I added that check to the PR as well)

## Why

* Not good for SEO to have news appearing on multiple urls
* Potential confusion

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation to ensure that event and news articles are correctly associated with their respective organizations or projects. Users will now see a 404 error if they attempt to access an article that does not belong to the selected organization or project.

* **New Features**
  * Event details now display additional information about the associated organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->