### PR TITLE
feat(core): Show related organisation in problems when possible

### DIFF
--- a/libs/clients/middlewares/src/lib/FetchError.ts
+++ b/libs/clients/middlewares/src/lib/FetchError.ts
@@ -12,14 +12,19 @@ export class FetchError extends Error {
   response: Response
   body?: unknown
   problem?: UnknownProblem
+  organizationSlug?: OrganizationSlugType
 
-  private constructor(response: Response) {
+  private constructor(
+    response: Response,
+    organizationSlug?: OrganizationSlugType,
+  ) {
     super(`Request failed with status code ${response.status}`)
     this.url = response.url
     this.status = response.status
     this.headers = response.headers
     this.statusText = response.statusText
     this.response = response
+    this.organizationSlug = organizationSlug
   }
 
   static async build(
@@ -27,7 +32,7 @@ export class FetchError extends Error {
     includeBody = false,
     organizationSlug?: OrganizationSlugType,
   ) {
-    const error = new FetchError(response)
+    const error = new FetchError(response, organizationSlug)
     const contentType = response.headers.get('content-type') || ''
     const isJson = contentType.startsWith('application/json')
     const isProblem = contentType.startsWith('application/problem+json')
@@ -40,12 +45,7 @@ export class FetchError extends Error {
         error.body = body
       }
 
-      if (organizationSlug && body.status >= 500) {
-        error.problem = {
-          ...body,
-          organizationSlug,
-        }
-      } else if (isProblem) {
+      if (isProblem) {
         error.problem = body
       }
     } else if (includeBody) {

--- a/libs/clients/middlewares/src/lib/withResponseErrors.ts
+++ b/libs/clients/middlewares/src/lib/withResponseErrors.ts
@@ -14,7 +14,12 @@ export function withResponseErrors({
   organizationSlug,
 }: ResponseErrorsOptions): MiddlewareAPI {
   return async (request) => {
-    const response = await fetch(request)
+    const response = await fetch(request).catch((error) => {
+      // Assign organizationSlug to other fetch errors (eg network errors and timeouts).
+      // Consider normalising further with our FetchError.
+      error.organizationSlug = organizationSlug
+      throw error
+    })
     if (!response.ok) {
       throw await FetchError.build(response, includeBody, organizationSlug)
     }

--- a/libs/nest/problem/src/lib/error.filter.ts
+++ b/libs/nest/problem/src/lib/error.filter.ts
@@ -1,3 +1,4 @@
+import type { FetchError } from '@island.is/clients/middlewares'
 import { Catch } from '@nestjs/common'
 import { Problem, ProblemType } from '@island.is/shared/problem'
 import { BaseProblemFilter } from './base-problem.filter'
@@ -8,12 +9,13 @@ export class ErrorFilter extends BaseProblemFilter {
     const extraDetails =
       process.env.NODE_ENV !== 'production'
         ? { detail: error.message, stack: error.stack }
-        : null
+        : undefined
 
     return {
       status: 500,
       type: ProblemType.HTTP_INTERNAL_SERVER_ERROR,
       title: 'Internal server error',
+      organizationSlug: (error as FetchError).organizationSlug,
       ...extraDetails,
     }
   }

--- a/libs/react-spa/shared/src/components/problems/Problem.tsx
+++ b/libs/react-spa/shared/src/components/problems/Problem.tsx
@@ -113,7 +113,7 @@ export const Problem = ({
           return (
             <ThirdPartyServiceError
               organizationSlug={organizationSlug}
-              size={size ?? 'small'}
+              size={size ?? 'large'}
               dataTestId={dataTestId}
               expand={expand}
             />

--- a/libs/react-spa/shared/src/components/problems/ThirdPartyServiceError.tsx
+++ b/libs/react-spa/shared/src/components/problems/ThirdPartyServiceError.tsx
@@ -7,22 +7,25 @@ import {
 } from '@island.is/island-ui/core'
 import { useMemo } from 'react'
 
-import { ProblemSize } from './problem.types'
+import { CommonProblemProps, ProblemSize } from './problem.types'
 import { m } from '../../lib/messages'
 import { useGetOrganizationsQuery } from './GetOrganization.generated'
 
 type ThirdPartyServiceErrorProps = {
   organizationSlug: string
   size?: ProblemSize
-} & Pick<ProblemTemplateProps, 'expand'>
+} & CommonProblemProps
 
 export const ThirdPartyServiceError = ({
   organizationSlug,
   size = 'large',
+  imgSrc,
+  imgAlt,
+  tag,
   ...rest
 }: ThirdPartyServiceErrorProps & TestSupport) => {
   const { formatMessage } = useLocale()
-  const { data, error, loading } = useGetOrganizationsQuery()
+  const { data, loading } = useGetOrganizationsQuery()
 
   const organization = useMemo(
     () =>
@@ -40,6 +43,11 @@ export const ThirdPartyServiceError = ({
     message: formatMessage(m.thirdPartyServiceErrorMessage),
   }
 
+  const imgProps = {
+    src: imgSrc ?? './assets/images/hourglass.svg',
+    alt: imgAlt ?? errorTemplateProps.title,
+  }
+
   if (size === 'small') {
     return <AlertMessage type="warning" {...errorTemplateProps} />
   }
@@ -47,8 +55,12 @@ export const ThirdPartyServiceError = ({
   return (
     <ProblemTemplate
       variant="warning"
-      {...(organization ? { tag: organization.title } : { showIcon: true })}
+      {...(organization || tag
+        ? { tag: organization?.title ?? tag }
+        : { showIcon: true })}
       {...errorTemplateProps}
+      imgSrc={imgProps.src}
+      imgAlt={imgProps.alt}
       {...rest}
       titleSize="h2"
     />

--- a/libs/shared/problem/src/problems.ts
+++ b/libs/shared/problem/src/problems.ts
@@ -14,6 +14,7 @@ export interface HttpProblem extends BaseProblem {
 export interface HttpInternalServerErrorProblem extends BaseProblem {
   type: ProblemType.HTTP_INTERNAL_SERVER_ERROR
   stack?: string
+  organizationSlug?: string
 }
 
 export type ValidationFailedFields = {


### PR DESCRIPTION
## What

Fix error handling so we can track organisation slug from integration (enhanced fetch) errors.

## Why

To distinguish between island.is problems and external problems.

## Screenshot

<img width="1328" height="977" alt="image" src="https://github.com/user-attachments/assets/80f96ccd-c48f-49e4-b5b2-0a5aa7ea17d1" />

Some notes:

- This will start showing organisation names in problems.
- I had to update the problem component logic to make the design similar for errors with or without the organisation slug (eg large, graphic).
- There are some api domains which have improper error handling which hides this information from the frontend, like the asset resolvers. Generally api domains and resolvers should avoid handling/wrapping FetchErrors, so they can be handled in a standard/global way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Error pages can now include the affected organization, improving context for support.
  * Third‑party service error component supports custom image (src/alt) and a tag label.
* **Style**
  * Default size for third‑party service error display increased to “large” for better visibility.
* **Refactor**
  * More precise error body handling and problem responses, reducing noise and ensuring organization context is preserved when available.
* **Chores**
  * Internal typing updates to align error/problem objects with the new optional organization information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->