### PR TITLE
fix(j-s): Side Bar Court Case Number

### DIFF
--- a/apps/judicial-system/web/src/components/PageLayout/PageLayout.tsx
+++ b/apps/judicial-system/web/src/components/PageLayout/PageLayout.tsx
@@ -1,4 +1,4 @@
-import { FC, PropsWithChildren, ReactNode, useContext } from 'react'
+import { FC, PropsWithChildren, ReactNode, useContext, useRef } from 'react'
 import { useIntl } from 'react-intl'
 import cn from 'classnames'
 
@@ -133,11 +133,14 @@ const SidePanel: FC<SidePanelProps> = ({
   const { getSections } = useSections(isValid, onNavigationTo)
   const sections = getSections(workingCase, user)
   const { formatMessage } = useIntl()
+
   const activeSection = sections.findIndex((s) => s.isActive)
   const activeSubSection = sections[activeSection]?.children.findIndex(
     (s) => s.isActive,
   )
   const showCourtCaseNumber = isDistrictCourtUser(user)
+
+  const courtCaseNumber = useRef(() => workingCase.courtCaseNumber)
 
   return (
     <GridColumn span={['12/12', '12/12', '4/12', '3/12']}>
@@ -164,8 +167,8 @@ const SidePanel: FC<SidePanelProps> = ({
               )}
             </Text>
             <Text>
-              {showCourtCaseNumber && workingCase.courtCaseNumber
-                ? workingCase.courtCaseNumber
+              {showCourtCaseNumber && courtCaseNumber.current()
+                ? courtCaseNumber.current()
                 : '\u00A0'}
             </Text>
           </Box>

--- a/apps/judicial-system/web/src/components/PageLayout/PageLayout.tsx
+++ b/apps/judicial-system/web/src/components/PageLayout/PageLayout.tsx
@@ -140,7 +140,7 @@ const SidePanel: FC<SidePanelProps> = ({
   )
   const showCourtCaseNumber = isDistrictCourtUser(user)
 
-  const courtCaseNumber = useRef(() => workingCase.courtCaseNumber)
+  const courtCaseNumber = useRef(workingCase.courtCaseNumber)
 
   return (
     <GridColumn span={['12/12', '12/12', '4/12', '3/12']}>
@@ -167,8 +167,8 @@ const SidePanel: FC<SidePanelProps> = ({
               )}
             </Text>
             <Text>
-              {showCourtCaseNumber && courtCaseNumber.current()
-                ? courtCaseNumber.current()
+              {showCourtCaseNumber && courtCaseNumber.current
+                ? courtCaseNumber.current
                 : '\u00A0'}
             </Text>
           </Box>


### PR DESCRIPTION
# Side Bar Court Case Number

[Ekki sýna málsnúmer héraðsdóms í hliðarstiku á "Móttaka og úthlutun" skjá](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1210691170282043)

## What

- Sýnir ekki breytingar á málsnúmeri héraðsdóms í hliðarstiku.
- Þetta er ekki sama lausn og lögð var til upphaflega.

## Why

- Betra UX.

## Screenshots / Gifs

https://github.com/user-attachments/assets/d8adf6b2-07d8-4f4b-91c8-7dc9b395eeed

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the way the court case number is referenced and displayed in the side panel for improved consistency. No visible changes to the user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->