### PR TITLE
fix(application-system-api): Manually refreshing s3 credentials every 50min

### DIFF
--- a/libs/nest/aws/src/lib/s3.service.ts
+++ b/libs/nest/aws/src/lib/s3.service.ts
@@ -44,9 +44,12 @@ export class S3Service {
 
   getS3Client(): S3Client {
     const now = Date.now()
-    
+
     // Create new client if none exists or credentials are stale
-    if (!this.s3Client || (now - this.lastCredentialTime) > this.CREDENTIAL_REFRESH_INTERVAL) {
+    if (
+      !this.s3Client ||
+      now - this.lastCredentialTime > this.CREDENTIAL_REFRESH_INTERVAL
+    ) {
       this.s3Client = new S3Client({
         credentials: defaultProvider(),
         maxAttempts: 3,

--- a/libs/nest/aws/src/lib/s3.service.ts
+++ b/libs/nest/aws/src/lib/s3.service.ts
@@ -22,7 +22,7 @@ import {
   PresignedPostOptions,
 } from '@aws-sdk/s3-presigned-post'
 import stream, { Readable } from 'stream'
-import { defaultProvider } from '@aws-sdk/credential-provider-node/dist-types/defaultProvider'
+import { defaultProvider } from '@aws-sdk/credential-provider-node'
 
 export interface BucketKeyPair {
   bucket: string

--- a/libs/nest/aws/src/lib/s3.service.ts
+++ b/libs/nest/aws/src/lib/s3.service.ts
@@ -22,6 +22,7 @@ import {
   PresignedPostOptions,
 } from '@aws-sdk/s3-presigned-post'
 import stream, { Readable } from 'stream'
+import { defaultProvider } from '@aws-sdk/credential-provider-node/dist-types/defaultProvider'
 
 export interface BucketKeyPair {
   bucket: string
@@ -38,8 +39,26 @@ export class S3Service {
     @Inject(LOGGER_PROVIDER) protected readonly logger: Logger,
   ) {}
 
+  private lastCredentialTime = 0
+  private readonly CREDENTIAL_REFRESH_INTERVAL = 50 * 60 * 1000 // 50 minutes
+
+  getS3Client(): S3Client {
+    const now = Date.now()
+    
+    // Create new client if none exists or credentials are stale
+    if (!this.s3Client || (now - this.lastCredentialTime) > this.CREDENTIAL_REFRESH_INTERVAL) {
+      this.s3Client = new S3Client({
+        credentials: defaultProvider(),
+        maxAttempts: 3,
+      })
+      this.lastCredentialTime = now
+    }
+
+    return this.s3Client
+  }
+
   public async getClientRegion(): Promise<string> {
-    return this.s3Client.config.region()
+    return this.getS3Client().config.region()
   }
 
   public async getFile(
@@ -69,7 +88,7 @@ export class S3Service {
       CopySource: encodeURIComponent(copySource),
     }
     try {
-      return await this.s3Client.send(new CopyObjectCommand(input))
+      return await this.getS3Client().send(new CopyObjectCommand(input))
     } catch (error) {
       this.logger.error(
         `Error occurred while copying file: ${key} to S3 bucket: ${bucket} from ${copySource}`,
@@ -103,7 +122,7 @@ export class S3Service {
 
     try {
       const parallelUpload = new Upload({
-        client: this.s3Client,
+        client: this.getS3Client(),
         params: uploadParams,
       })
 
@@ -133,7 +152,7 @@ export class S3Service {
     const expiration = expirationOverride ?? SIGNED_GET_EXPIRES
 
     const command = new GetObjectCommand({ Bucket: bucket, Key: key })
-    return getSignedUrl(this.s3Client, command, {
+    return getSignedUrl(this.getS3Client(), command, {
       expiresIn: expiration,
     })
   }
@@ -143,7 +162,7 @@ export class S3Service {
   ): Promise<PresignedPost> {
     try {
       // The S3 Aws sdk v3 returns a trailing forward slash
-      const post = await createPresignedPost(this.s3Client, params)
+      const post = await createPresignedPost(this.getS3Client(), params)
       if (post.url.endsWith('/')) {
         post.url = post.url.slice(0, -1)
       }
@@ -169,7 +188,7 @@ export class S3Service {
         Bucket: bucket,
         Key: key,
       })
-      const results = await this.s3Client.send(command)
+      const results = await this.getS3Client().send(command)
 
       return results?.TagSet ?? []
     } catch (error) {
@@ -190,7 +209,7 @@ export class S3Service {
         Bucket: bucket,
         Key: key,
       })
-      const results = await this.s3Client.send(command)
+      const results = await this.getS3Client().send(command)
 
       return results.$metadata.httpStatusCode === 200
     } catch (error) {
@@ -214,7 +233,7 @@ export class S3Service {
   ): Promise<boolean> {
     const { bucket, key } = this.getBucketKey(BucketKeyPairOrFilename)
     try {
-      const result = await this.s3Client.send(
+      const result = await this.getS3Client().send(
         new DeleteObjectCommand({
           Bucket: bucket,
           Key: key,
@@ -261,7 +280,7 @@ export class S3Service {
     key: string,
   ): Promise<GetObjectCommandOutput | undefined> {
     try {
-      return await this.s3Client.send(
+      return await this.getS3Client().send(
         new GetObjectCommand({
           Bucket: bucket,
           Key: key,


### PR DESCRIPTION
# Checking and refreshing credentials for s3 service manually

Currently using a factory to return new clients in the module that injects into the s3Service, but that is still only happening the first time the module is created. Adjusting now to refresh credentials every 50minutes.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved reliability of S3 operations by automatically refreshing credentials for the S3 client, ensuring up-to-date access for all file-related actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->