### PR TITLE
feat(contentful-apps): Sitemap - Categories can now have a status (draft, changed, published)

### DIFF
--- a/apps/contentful-apps/components/sitemap/EditMenu.tsx
+++ b/apps/contentful-apps/components/sitemap/EditMenu.tsx
@@ -8,6 +8,7 @@ interface EditMenuProps {
   onEdit: () => void
   onRemove: () => void
   onMarkEntryAsPrimary: (nodeId: number, entryId: string) => void
+  onPublish?: () => void
   entryId?: string
   entryNodeId: number
   root: Tree
@@ -18,6 +19,7 @@ export const EditMenu = ({
   onEdit,
   onRemove,
   onMarkEntryAsPrimary,
+  onPublish,
   isEntryNodePrimaryLocation,
   entryId,
   entryNodeId,
@@ -39,6 +41,7 @@ export const EditMenu = ({
       </Menu.Trigger>
       <Menu.List>
         <Menu.Item onClick={onEdit}>Edit</Menu.Item>
+        {onPublish && <Menu.Item onClick={onPublish}>Publish</Menu.Item>}
         {sameEntryNodes.length > 1 && (
           <Menu.Item
             disabled={isEntryNodePrimaryLocation}

--- a/apps/contentful-apps/components/sitemap/SitemapTreeFieldDialog.tsx
+++ b/apps/contentful-apps/components/sitemap/SitemapTreeFieldDialog.tsx
@@ -44,7 +44,7 @@ const CategoryForm = ({
   return (
     <FormControl className={styles.formContainer}>
       <div>
-        <FormControl.Label>Label (Icelandic)</FormControl.Label>
+        <FormControl.Label>Title (Icelandic)</FormControl.Label>
         <TextInput
           value={state.label}
           onChange={(ev) => {
@@ -53,7 +53,7 @@ const CategoryForm = ({
         />
       </div>
       <div>
-        <FormControl.Label>Label (English)</FormControl.Label>
+        <FormControl.Label>Title (English)</FormControl.Label>
         <div>
           <TextInput
             value={state.labelEN}
@@ -156,7 +156,7 @@ const UrlForm = ({ initialState, onSubmit }: FormProps<UrlState>) => {
     <FormControl className={styles.formContainer}>
       <div>
         <Box paddingBottom="spacingXs">
-          <FormControl.Label>Label (Icelandic)</FormControl.Label>
+          <FormControl.Label>Title (Icelandic)</FormControl.Label>
           <TextInput
             value={state.label}
             onChange={(ev) => {
@@ -168,7 +168,7 @@ const UrlForm = ({ initialState, onSubmit }: FormProps<UrlState>) => {
           />
         </Box>
         <div>
-          <FormControl.Label>Label (English)</FormControl.Label>
+          <FormControl.Label>Title (English)</FormControl.Label>
           <TextInput
             value={state.labelEN}
             onChange={(ev) => {

--- a/apps/contentful-apps/components/sitemap/SitemapTreeFieldDialog.tsx
+++ b/apps/contentful-apps/components/sitemap/SitemapTreeFieldDialog.tsx
@@ -26,6 +26,9 @@ interface CategoryState {
   slugEN?: string
   description: string
   descriptionEN?: string
+  status?: 'draft' | 'changed' | 'published'
+  version?: number
+  publishedVersion?: number
 }
 
 interface FormProps<State> {
@@ -69,7 +72,7 @@ const CategoryForm = ({
       <div>
         <FormControl.Label>Slug (Icelandic)</FormControl.Label>
         <TextInput
-          placeholder={slugify(state.label)}
+          placeholder={slugify(state.label ?? '')}
           value={state.slug}
           onChange={(ev) => {
             setState((prevState) => ({ ...prevState, slug: ev.target.value }))
@@ -82,7 +85,7 @@ const CategoryForm = ({
 
         <div>
           <TextInput
-            placeholder={slugify(state.labelEN)}
+            placeholder={slugify(state.labelEN ?? '')}
             value={state.slugEN}
             onChange={(ev) => {
               setState((prevState) => ({
@@ -106,6 +109,7 @@ const CategoryForm = ({
               description: ev.target.value,
             }))
           }}
+          resize="none"
         />
       </div>
       <div>
@@ -119,6 +123,7 @@ const CategoryForm = ({
                 descriptionEN: ev.target.value,
               }))
             }}
+            resize="none"
           />
         </div>
       </div>
@@ -127,10 +132,19 @@ const CategoryForm = ({
         onClick={() => {
           const stateToSubmit = { ...state }
           if (!stateToSubmit.slug) {
-            stateToSubmit.slug = slugify(stateToSubmit.label)
+            stateToSubmit.slug = slugify(stateToSubmit.label ?? '')
           }
           if (!stateToSubmit.slugEN) {
-            stateToSubmit.slugEN = slugify(stateToSubmit.labelEN)
+            stateToSubmit.slugEN = slugify(stateToSubmit.labelEN ?? '')
+          }
+
+          if (!stateToSubmit.status) {
+            stateToSubmit.status = 'draft'
+          } else if (
+            stateToSubmit.status === 'published' &&
+            initialState.status === 'published'
+          ) {
+            stateToSubmit.status = 'changed'
           }
           onSubmit(stateToSubmit)
         }}

--- a/apps/contentful-apps/components/sitemap/entryContext.ts
+++ b/apps/contentful-apps/components/sitemap/entryContext.ts
@@ -25,7 +25,6 @@ export const useEntryContext = () => {
       const response = await cma.entry.getMany({
         query: {
           'sys.id[in]': entryIds.join(','),
-          'sys.archivedVersion[exists]': false,
           limit: 1000,
         },
       })

--- a/apps/contentful-apps/components/sitemap/utils.ts
+++ b/apps/contentful-apps/components/sitemap/utils.ts
@@ -272,6 +272,9 @@ export const addNode = async (
           slugEN,
           description,
           descriptionEN,
+          status: 'draft',
+          version: 1,
+          publishedVersion: undefined,
         }
       : {
           type: TreeNodeType.URL,
@@ -290,6 +293,28 @@ export const updateNode = (parentNode: Tree, updatedNode: TreeNode) => {
     (node) => node.id === updatedNode.id,
   )
   if (nodeIndex >= 0) {
+    const existingNode = parentNode.childNodes[nodeIndex]
+
+    // Handle version tracking for categories
+    if (
+      existingNode.type === TreeNodeType.CATEGORY &&
+      updatedNode.type === TreeNodeType.CATEGORY
+    ) {
+      // If the category is being published, update the publishedVersion
+      if (updatedNode.status === 'published') {
+        updatedNode.publishedVersion = updatedNode.version
+      }
+      // If the category is being modified but not published, increment version
+      else if (
+        updatedNode.status === 'draft' ||
+        updatedNode.status === 'changed'
+      ) {
+        updatedNode.version = (existingNode.version || 1) + 1
+        // Keep the publishedVersion unchanged if not publishing
+        updatedNode.publishedVersion = existingNode.publishedVersion
+      }
+    }
+
     parentNode.childNodes[nodeIndex] = updatedNode
   }
 }

--- a/libs/shared/types/src/lib/api-cms-domain.ts
+++ b/libs/shared/types/src/lib/api-cms-domain.ts
@@ -51,6 +51,9 @@ export type SitemapTreeNode = SitemapTree &
         slugEN?: string
         description: string
         descriptionEN?: string
+        status?: 'draft' | 'changed' | 'published'
+        version?: number
+        publishedVersion?: number
       }
     | {
         type: SitemapTreeNodeType.URL


### PR DESCRIPTION
# Sitemap - Categories can now have a status (draft, changed, published)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
