### PR TITLE
chore: remove spinnaker webhook and always run feature cleanup on pr close

### DIFF
--- a/.github/workflows/feature-close.yml
+++ b/.github/workflows/feature-close.yml
@@ -21,7 +21,7 @@ jobs:
   close_feature:
     name: Terminate feature deployment
     runs-on: arc-shared
-    if: ${{ github.event.label.name == 'deploy-feature' }} || github.event.pull_request.merged == true
+    if: ${{ github.event.label.name == 'deploy-feature' || github.event.pull_request.merged == true }}
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/feature-close.yml
+++ b/.github/workflows/feature-close.yml
@@ -21,7 +21,7 @@ jobs:
   close_feature:
     name: Terminate feature deployment
     runs-on: arc-shared
-    if: ${{ github.event.label.name == 'deploy-feature' }}
+    if: ${{ github.event.label.name == 'deploy-feature' }} || github.event.pull_request.merged == true
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/pullrequest-close.yml
+++ b/.github/workflows/pullrequest-close.yml
@@ -87,39 +87,3 @@ jobs:
           payload: |
             channel: ${{ secrets.SLACK_CHANNEL_ID }}
             text: "A new PR has been created: ${{ steps.create_pr.outputs.PR }}"
-
-  cleanup:
-    name: Clean up feature deployment
-    runs-on: arc-shared
-    steps:
-      - name: Get git branch
-        run: |
-          set -euo pipefail
-          GIT_BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF/refs\/heads\//}}"
-          echo "GIT_BRANCH=$GIT_BRANCH" >> "$GITHUB_ENV"
-      - name: Generate deployment branch name
-        id: git-branch-deploy
-        run: |
-          set -euo pipefail
-          GIT_BRANCH_DEPLOY="$GIT_BRANCH"
-          if [[ ! ("$GIT_BRANCH_DEPLOY" =~ "feature/") ]]; then
-            # If event is pull request but branch is not prefixed with feature/
-            GIT_BRANCH_DEPLOY=feature/$GIT_BRANCH_DEPLOY
-          fi
-          # Avoid too long resource names
-          GIT_BRANCH_DEPLOY="${GIT_BRANCH_DEPLOY:0:50}"
-          echo "GIT_BRANCH_DEPLOY=$GIT_BRANCH_DEPLOY" >> "$GITHUB_ENV"
-      - name: Clean up feature
-        env:
-          SPINNAKER_WEBHOOK_TOKEN: ${{ secrets.SPINNAKER_WEBHOOK_TOKEN }}
-          SPINNAKER_URL: https://spinnaker-gate.shared.devland.is
-        run: |
-          set -euo pipefail
-          curl "$SPINNAKER_URL/webhooks/webhook/feature-cleanup" -H "content-type: application/json" --data-binary @- <<BODY
-          {
-            "token": "$SPINNAKER_WEBHOOK_TOKEN",
-            "parameters": {
-              "feature_name": "$(echo "$GIT_BRANCH_DEPLOY" | cut -d"/" -f2- | tr -cd '[:alnum:]-' | tr '[:upper:]' '[:lower:]' | cut -c1-50)"
-            }
-          }
-          BODY


### PR DESCRIPTION
# Fix fd destroy

Always run feature destroy script and remove the spinnaker webhook for feature close since spinnaker is long deprecated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated workflow conditions to trigger feature closure when a specific label is applied or a pull request is merged.
  * Removed the cleanup process from the pull request close workflow, retaining only the existing check job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->