### PR TITLE
fix(applications): Prevent graphql injection for chargeItemCodes

### DIFF
--- a/libs/application/templates/examples/example-payment/src/lib/examplePaymentTemplate.ts
+++ b/libs/application/templates/examples/example-payment/src/lib/examplePaymentTemplate.ts
@@ -31,6 +31,8 @@ const getCodes = (application: Application): BasicChargeItem[] => {
   // with FJS
   // NOTE: This is a simplified example, in a real application you should inspect the application
   // answers and external data to pick the correct charge item code.
+  // Furthermore you should not generate the chargeItemCode from any answer in the
+  // application, but rather recalculate it to avoid payment manipulation in the graphql
   const chargeItemCode = getValueViaPath<CatalogItem['chargeItemCode']>(
     application.answers,
     'userSelectedChargeItemCode',

--- a/libs/application/templates/operating-license/src/lib/OperatingLicenseTemplate.ts
+++ b/libs/application/templates/operating-license/src/lib/OperatingLicenseTemplate.ts
@@ -27,12 +27,10 @@ import {
   SyslumadurPaymentCatalogApi,
 } from '../dataProviders'
 import { AuthDelegationType } from '@island.is/shared/types'
-import {
-  coreHistoryMessages,
-  getValueViaPath,
-} from '@island.is/application/core'
+import { coreHistoryMessages } from '@island.is/application/core'
 import { buildPaymentState } from '@island.is/application/utils'
 import { CodeOwners } from '@island.is/shared/constants'
+import { getChargeItemCode } from './utils'
 
 const oneDay = 24 * 3600 * 1000
 const thirtyDays = 24 * 3600 * 1000 * 30
@@ -46,10 +44,7 @@ const pruneAfter = (time: number) => {
 }
 
 const getCodes = (application: Application): BasicChargeItem[] => {
-  const chargeItemCode = getValueViaPath<string>(
-    application.answers,
-    'chargeItemCode',
-  )
+  const chargeItemCode = getChargeItemCode(application.answers)
   if (!chargeItemCode) {
     throw new Error('chargeItemCode missing in request')
   }


### PR DESCRIPTION
Some applications have a `chargeItemCode` to be able to display price. These form answers were also being used to generate the chargeItemCodes in the payment build steps. These have been disconnected.

NOTE: The passport application was not fixed since a fellow team member is already fixing that one in another PR.
## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
