### PR TITLE
fix(exemption for transportation): Set default dollyType to NONE if no trailer

### DIFF
--- a/libs/application/templates/transport-authority/exemption-for-transportation/src/forms/mainForm/convoySection/convoyShortTerm.ts
+++ b/libs/application/templates/transport-authority/exemption-for-transportation/src/forms/mainForm/convoySection/convoyShortTerm.ts
@@ -72,5 +72,10 @@ export const ConvoyShortTermMultiField = buildMultiField({
       ],
       width: 'full',
     }),
+    buildHiddenInput({
+      id: `convoy.items.${convoyIndex}.dollyType`,
+      condition: (answers) => !checkIsConvoyWithTrailer(answers, convoyIndex),
+      defaultValue: DollyType.NONE,
+    }),
   ],
 })


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved form handling by ensuring the dolly type is always defined, even when no trailer is present, through the addition of a hidden input field. This enhances data consistency for users completing the convoy short-term form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->