### PR TITLE
fix(contentful-apps): Sitemap, adding an existing org subpage does not label it correctly in UI

### DIFF
--- a/apps/contentful-apps/components/sitemap/SitemapNode.tsx
+++ b/apps/contentful-apps/components/sitemap/SitemapNode.tsx
@@ -290,10 +290,11 @@ export const SitemapNode = ({
 
   const nodeStatus = getNodeStatus(node, entries)
 
+  const nodeContent = extractNodeContent(node, language, entries)
+
   if (
     status === 'published' &&
-    (nodeStatus !== 'published' ||
-      !extractNodeContent(node, language, entries)?.label)
+    (nodeStatus !== 'published' || !nodeContent.label)
   ) {
     return null
   }
@@ -310,9 +311,7 @@ export const SitemapNode = ({
               <div className={styles.nodeTopRowContainerLeft}>
                 <Text fontColor="gray600">
                   {node.type === TreeNodeType.ENTRY
-                    ? entryTypeMap[
-                        node.contentType ?? 'organizationParentSubpage'
-                      ]
+                    ? entryTypeMap[nodeContent.entryContentType]
                     : optionMap[node.type]}
                 </Text>
                 {node.type === TreeNodeType.ENTRY && language === 'is-IS' && (

--- a/apps/contentful-apps/components/sitemap/utils.ts
+++ b/apps/contentful-apps/components/sitemap/utils.ts
@@ -361,8 +361,12 @@ export const extractNodeContent = (
         ? node.urlEN
         : node.url
       : entries[node.entryId]?.fields?.slug?.[language] || ''
+  const entryContentType =
+    node.type === TreeNodeType.ENTRY
+      ? entries[node.entryId]?.sys?.contentType?.sys?.id ?? node.contentType
+      : ''
 
-  return { label, slug }
+  return { label, slug, entryContentType }
 }
 
 export const findParentNode = (root: Tree, nodeId: number) => {


### PR DESCRIPTION
# Sitemap, adding an existing org subpage does not label it correctly in UI

The add existing functionality doesn't check for the content type being added, after this PR it does.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance and consistency in the sitemap by reusing extracted node content instead of recalculating it multiple times.
  * Node type labels now display more accurately based on the underlying entry content type.

* **New Features**
  * Node content extraction now provides additional detail by including the entry content type, enhancing label and type display in the sitemap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->