### PR TITLE
feat(j-s): Make cases grid row the same height

### DIFF
--- a/apps/judicial-system/web/src/components/Layouts/CasesDashboardLayout/index.css.ts
+++ b/apps/judicial-system/web/src/components/Layouts/CasesDashboardLayout/index.css.ts
@@ -10,13 +10,15 @@ export const gridContainer = style({
   '@media': {
     [`screen and (min-width: ${theme.breakpoints.md}px)`]: {
       gridTemplateColumns: 'repeat(3, 1fr)',
+
       columnGap: theme.spacing[2],
-      rowGap: theme.spacing[3],
+      rowGap: theme.spacing[2],
+      gridAutoRows: '240px',
     },
     [`screen and (min-width: ${theme.breakpoints.lg}px)`]: {
       gridTemplateColumns: 'repeat(4, 1fr)',
       columnGap: theme.spacing[3],
-      rowGap: theme.spacing[4],
+      rowGap: theme.spacing[3],
     },
   },
 })


### PR DESCRIPTION
# Make cases grid row the same height

[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1210591600096997?focus=true)

## What

Currently, the height of items in the cases grid is determined by the highest item in the row. This PR sets an explicit height for these grid items

## Why

Looks better

## Screenshots / Gifs

### Before

https://github.com/user-attachments/assets/3a8f23a6-e4f7-49ae-82a5-eece4023d26d

### After

https://github.com/user-attachments/assets/37fc6a4a-bbe6-457c-8005-1e6436dc708e

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
