### PR TITLE
feat(contentful-apps): Sitemap - Display short title for entry nodes if present

### DIFF
--- a/apps/contentful-apps/components/sitemap/utils.ts
+++ b/apps/contentful-apps/components/sitemap/utils.ts
@@ -350,7 +350,9 @@ export const extractNodeContent = (
       ? language === 'en'
         ? node.labelEN
         : node.label
-      : entries[node.entryId]?.fields?.title?.[language] || ''
+      : entries[node.entryId]?.fields?.shortTitle?.[language] ||
+        entries[node.entryId]?.fields?.title?.[language] ||
+        ''
   const slug =
     node.type === TreeNodeType.CATEGORY
       ? language === 'en'


### PR DESCRIPTION
# Sitemap - Display short title for entry nodes if present

## What

Like on the web, let's show the shortTitle if it's present.
This'll give a more accurate look at how the actual navigation menu on the web will look like.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
