### PR TITLE
fix(rental-agreement): Fix broken file upload thumbnails

### DIFF
--- a/libs/api/domains/hms/src/lib/api-domains-hms.resolver.ts
+++ b/libs/api/domains/hms/src/lib/api-domains-hms.resolver.ts
@@ -42,7 +42,7 @@ export class HmsResolver {
       return { addresses: addressesArray }
     } catch (error) {
       this.logger.error('Error fetching HMS address search:', error)
-      throw new Error('Failed to get addressses')
+      throw new Error('Failed to get addresses')
     }
   }
 

--- a/libs/application/templates/rental-agreement/src/forms/draft/rentalHousingSubsections/rentalHousingCondition.ts
+++ b/libs/application/templates/rental-agreement/src/forms/draft/rentalHousingSubsections/rentalHousingCondition.ts
@@ -67,7 +67,6 @@ export const RentalHousingCondition = buildSubSection({
           uploadDescription: housingCondition.fileUploadDescription,
           uploadAccept: '.pdf, .doc, .docx, .rtf, .jpg, .jpeg, .png, .heic',
           uploadMultiple: true,
-          forImageUpload: true,
         }),
       ],
     }),


### PR DESCRIPTION
# Fix broken file upload thumbnails

[Attach a link to issue if relevant](https://app.asana.com/1/203394141643832/project/1208271027457465/task/1211021553609564?focus=true)

## What

- Remove broken thumbnail from uploaded files (pdf eg)
- Additionally fixed a typo

## Why

- This file upload field is not solely for images, so all non-images get "broken-image" thumbnail

## Screenshots / Gifs

After:
<img width="1276" height="1292" alt="Screenshot 2025-08-11 at 14 19 40" src="https://github.com/user-attachments/assets/78add04c-30fd-407b-b905-dcfc5a00fcb9" />

Before:
<img width="1258" height="1286" alt="Screenshot 2025-08-11 at 14 31 05" src="https://github.com/user-attachments/assets/2e6935d6-e7e2-46fa-b44d-f680729532de" />


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
