### PR TITLE
fix(j-s): Make cases cards a bit smaller

### DIFF
--- a/apps/judicial-system/web/src/components/Layouts/CasesDashboardLayout/index.css.ts
+++ b/apps/judicial-system/web/src/components/Layouts/CasesDashboardLayout/index.css.ts
@@ -10,10 +10,9 @@ export const gridContainer = style({
   '@media': {
     [`screen and (min-width: ${theme.breakpoints.md}px)`]: {
       gridTemplateColumns: 'repeat(3, 1fr)',
-
+      gridAutoRows: 'minmax(12rem, auto)',
       columnGap: theme.spacing[2],
       rowGap: theme.spacing[2],
-      gridAutoRows: '240px',
     },
     [`screen and (min-width: ${theme.breakpoints.lg}px)`]: {
       gridTemplateColumns: 'repeat(4, 1fr)',


### PR DESCRIPTION
# Make cases cards a bit smaller

Asana

## What

In a previous PR, we made all cases cards equally big. Perhaps too big. This PR makes them a bit smaller, and uses rems for different screen resolutions.

## Why

Previous boxes were too big.

## Screenshots / Gifs

<img width="1220" height="441" alt="Screenshot 2025-08-11 at 20 58 48" src="https://github.com/user-attachments/assets/eb1f544d-b96c-4787-82f9-dcec53dd7057" />

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
