### PR TITLE
feat(medical-and-rehabilitation-payments): Remove treatment duration

### DIFF
--- a/libs/api/domains/social-insurance/src/lib/models/medicalDocuments/certificateForSicknessAndRehabilitation.model.ts
+++ b/libs/api/domains/social-insurance/src/lib/models/medicalDocuments/certificateForSicknessAndRehabilitation.model.ts
@@ -1,4 +1,4 @@
-import { Field, GraphQLISODateTime, ObjectType, Int } from '@nestjs/graphql'
+import { Field, ObjectType, Int } from '@nestjs/graphql'
 import { EnumType } from './enumType.model'
 
 @ObjectType('SocialInsuranceMedicalDocumentsDoctor')
@@ -46,18 +46,6 @@ class Difficulty {
   explanation?: string
 }
 
-@ObjectType('SocialInsuranceMedicalDocumentsEstimatedDuration')
-class EstimatedDuration {
-  @Field(() => GraphQLISODateTime, { nullable: true })
-  start?: Date
-
-  @Field(() => GraphQLISODateTime, { nullable: true })
-  end?: Date
-
-  @Field(() => Int, { nullable: true })
-  months?: number
-}
-
 @ObjectType('SocialInsuranceMedicalDocumentsConfirmation')
 class Confirmation {
   @Field(() => EnumType, { nullable: true })
@@ -74,9 +62,6 @@ class Confirmation {
 
   @Field({ nullable: true })
   progress?: string
-
-  @Field(() => EstimatedDuration, { nullable: true })
-  estimatedDuration?: EstimatedDuration
 }
 
 @ObjectType(

--- a/libs/application/templates/social-insurance-administration/medical-and-rehabilitation-payments/src/fields/CertificateForSicknessAndRehabilitation/index.tsx
+++ b/libs/application/templates/social-insurance-administration/medical-and-rehabilitation-payments/src/fields/CertificateForSicknessAndRehabilitation/index.tsx
@@ -436,85 +436,6 @@ export const CertificateForSicknessAndRehabilitation: FC<FieldBaseProps> = ({
     </Stack>
   )
 
-  const applicationForMedicalAndRehabilitationPayments = () => (
-    <Stack space={3}>
-      <GridRow rowGap={3}>
-        <GridColumn span="1/1">
-          <Text variant="h3">
-            {formatMessage(
-              medicalAndRehabilitationPaymentsFormMessage
-                .certificateForSicknessAndRehabilitation.application,
-            )}
-          </Text>
-        </GridColumn>
-        <GridColumn span={['1/1', '1/1', '1/1', '1/3']}>
-          <Label>
-            {formatMessage(
-              medicalAndRehabilitationPaymentsFormMessage
-                .certificateForSicknessAndRehabilitation
-                .applicationStartOfTreatment,
-            )}
-          </Label>
-          <Text>
-            {data?.socialInsuranceCertificateForSicknessAndRehabilitation
-              ?.confirmation?.estimatedDuration?.start
-              ? format(
-                  new Date(
-                    data.socialInsuranceCertificateForSicknessAndRehabilitation.confirmation.estimatedDuration.start,
-                  ),
-                  'dd.MM.yyyy',
-                )
-              : '-'}
-          </Text>
-        </GridColumn>
-        <GridColumn span={['1/1', '1/1', '1/1', '1/3']}>
-          <Label>
-            {formatMessage(
-              medicalAndRehabilitationPaymentsFormMessage
-                .certificateForSicknessAndRehabilitation
-                .applicationEstimatedEndOfTreatment,
-            )}
-          </Label>
-          <Text>
-            {data?.socialInsuranceCertificateForSicknessAndRehabilitation
-              ?.confirmation?.estimatedDuration?.start
-              ? format(
-                  new Date(
-                    data.socialInsuranceCertificateForSicknessAndRehabilitation.confirmation.estimatedDuration.start,
-                  ),
-                  'dd.MM.yyyy',
-                )
-              : formatMessage(
-                  medicalAndRehabilitationPaymentsFormMessage
-                    .certificateForSicknessAndRehabilitation
-                    .applicationEstimatedTimeUnclear,
-                )}
-          </Text>
-        </GridColumn>
-        <GridColumn span={['1/1', '1/1', '1/1', '1/3']}>
-          <Label>
-            {formatMessage(
-              medicalAndRehabilitationPaymentsFormMessage
-                .certificateForSicknessAndRehabilitation
-                .applicationEstimatedTime,
-            )}
-          </Label>
-          <Text>
-            {formatMessage(
-              medicalAndRehabilitationPaymentsFormMessage
-                .certificateForSicknessAndRehabilitation
-                .applicationEstimatedTimeMonths,
-              {
-                months:
-                  data?.socialInsuranceCertificateForSicknessAndRehabilitation
-                    ?.confirmation?.estimatedDuration?.months,
-              },
-            )}
-          </Text>
-        </GridColumn>
-      </GridRow>
-    </Stack>
-  )
 
   if (loading) {
     return (
@@ -547,8 +468,6 @@ export const CertificateForSicknessAndRehabilitation: FC<FieldBaseProps> = ({
       {activityAndParticipationImpairment()}
       <Divider />
       {mainImpairment()}
-      <Divider />
-      {applicationForMedicalAndRehabilitationPayments()}
       <input
         type="hidden"
         value={

--- a/libs/application/templates/social-insurance-administration/medical-and-rehabilitation-payments/src/fields/CertificateForSicknessAndRehabilitation/index.tsx
+++ b/libs/application/templates/social-insurance-administration/medical-and-rehabilitation-payments/src/fields/CertificateForSicknessAndRehabilitation/index.tsx
@@ -436,7 +436,6 @@ export const CertificateForSicknessAndRehabilitation: FC<FieldBaseProps> = ({
     </Stack>
   )
 
-
   if (loading) {
     return (
       <SkeletonLoader repeat={2} space={2} height={150} borderRadius="large" />

--- a/libs/application/templates/social-insurance-administration/medical-and-rehabilitation-payments/src/graphql/queries.ts
+++ b/libs/application/templates/social-insurance-administration/medical-and-rehabilitation-payments/src/graphql/queries.ts
@@ -128,11 +128,6 @@ export const siaCertificateForSicknessAndRehabilitationQuery = gql`
         treatmentMeasures
         explanation
         progress
-        estimatedDuration {
-          start
-          end
-          months
-        }
       }
     }
   }

--- a/libs/application/templates/social-insurance-administration/medical-and-rehabilitation-payments/src/lib/messages.ts
+++ b/libs/application/templates/social-insurance-administration/medical-and-rehabilitation-payments/src/lib/messages.ts
@@ -490,38 +490,6 @@ export const medicalAndRehabilitationPaymentsFormMessage: MessageDir = {
       defaultMessage: 'Annað varðandi megin vanda',
       description: 'Further information on main impairment',
     },
-
-    // Application for medical and rehabilitation payments
-    application: {
-      id: 'marp.application:certificate.for.sickness.and.rehabilitation.application',
-      defaultMessage: 'Sótt er um sjúkra- og endurhæfingargreiðslur',
-      description: 'Application for medical and rehabilitation payments',
-    },
-    applicationStartOfTreatment: {
-      id: 'marp.application:certificate.for.sickness.and.rehabilitation.application.start.of.treatment',
-      defaultMessage: 'Upphaf meðferðar',
-      description: 'Start of treatment',
-    },
-    applicationEstimatedEndOfTreatment: {
-      id: 'marp.application:certificate.for.sickness.and.rehabilitation.application.estimated.end.of.treatment',
-      defaultMessage: 'Áætluð lok meðferðar',
-      description: 'Estimated end of treatment',
-    },
-    applicationEstimatedTimeUnclear: {
-      id: 'marp.application:certificate.for.sickness.and.rehabilitation.application.estimated.time.unclear',
-      defaultMessage: 'Óljóst',
-      description: 'Unclear',
-    },
-    applicationEstimatedTime: {
-      id: 'marp.application:certificate.for.sickness.and.rehabilitation.application.estimated.time',
-      defaultMessage: 'Áætluð tímalengd',
-      description: 'Estimated time',
-    },
-    applicationEstimatedTimeMonths: {
-      id: 'marp.application:certificate.for.sickness.and.rehabilitation.application.estimated.time.months',
-      defaultMessage: '{months} mánuðir',
-      description: '{months} months',
-    },
   }),
 
   rehabilitationPlan: defineMessages({


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the “Application for Medical and Rehabilitation Payments” section from the certificate view, including start/end of treatment and estimated time display.
  * Confirmation no longer shows estimated duration information.
  * Updated underlying queries and messages to reflect removed fields.
  * All other sections (managed by, information, physical/mental/activity/participation impairments, main impairment) remain unchanged; loading and error handling are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->