### PR TITLE
feat(web): News image aspect ratio change

### DIFF
--- a/apps/web/components/DigitalIcelandNewsCard/DigitalIcelandLatestNewsCard.tsx
+++ b/apps/web/components/DigitalIcelandNewsCard/DigitalIcelandLatestNewsCard.tsx
@@ -32,7 +32,7 @@ export const DigitalIcelandLatestNewsCard = (item: ItemProps) => {
         <BackgroundImage
           backgroundSize="cover"
           image={{ url: item.imageSrc }}
-          ratio="64:40"
+          ratio="10:7"
           boxProps={{
             alignItems: 'center',
             width: 'full',

--- a/apps/web/components/DigitalIcelandNewsCard/DigitalIcelandNewsCard.tsx
+++ b/apps/web/components/DigitalIcelandNewsCard/DigitalIcelandNewsCard.tsx
@@ -97,7 +97,7 @@ export const DigitalIcelandNewsCard = (item: ItemProps) => {
             <BackgroundImage
               backgroundSize="cover"
               image={{ url: item.imageSrc }}
-              ratio="64:40"
+              ratio="10:7"
               boxProps={{
                 alignItems: 'center',
                 width: 'full',


### PR DESCRIPTION
# News image aspect ratio change

Design was changed in Figma, let's make the web reflect that

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the image aspect ratio on News Cards to 10:7 for more consistent visuals, improved cropping, and better balance across devices and grid layouts.
  * Applied the same 10:7 ratio to Latest News Cards to align presentation with standard cards, reducing whitespace or clipping and making thumbnails appear more uniform in feeds and widgets for a cleaner browsing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->