### PR TITLE
chore(j-s): Update e2e

### DIFF
--- a/apps/system-e2e/src/tests/judicial-system/regression/custody-tests.spec.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/custody-tests.spec.ts
@@ -69,14 +69,6 @@ test.describe.serial('Custody tests', () => {
     await page.locator('input[name=accusedAddress]').fill('Einhversstaðar 1')
     await page.locator('#defendantGender').click()
     await page.locator('#react-select-defendantGender-option-0').click()
-    await page
-      .locator('input[id=react-select-advocateName-input]')
-      .fill('Saul Goodman')
-    await page.locator('#react-select-advocateName-option-0').click()
-    await page
-      .locator('input[name=defenderEmail]')
-      .fill('jl+auto+defender@kolibri.is')
-    await page.locator('input[id=defender-access-ready-for-court]').click()
     await page.locator('input[name=leadInvestigator]').fill('Stjórinn')
     await expect(
       page.getByRole('button', { name: 'Óskir um fyrirtöku' }),
@@ -314,7 +306,6 @@ test.describe.serial('Custody tests', () => {
 
     // Defendant
     await expect(page).toHaveURL(`/krafa/sakborningur/${extendedCaseId}`)
-    await page.locator('input[name=defender-access-no]').click()
     await Promise.all([
       page.getByTestId('continueButton').click(),
       verifyRequestCompletion(page, '/api/graphql', 'Case'),

--- a/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/amend.ts
+++ b/apps/system-e2e/src/tests/judicial-system/regression/shared-steps/amend.ts
@@ -38,6 +38,7 @@ export const judgeAmendsCase = async (page: Page, caseId: string) => {
   await page
     .locator('textarea[id=courtLegalArguments]')
     .fill('Dómari hefur ákveðið að breyta úrskurði')
+  await page.keyboard.press('Tab')
   await Promise.all([
     page.getByTestId('continueButton').click(),
     verifyRequestCompletion(page, '/api/graphql', 'Case'),


### PR DESCRIPTION
# Update e2e

[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1211043491985316?focus=true)

## What

In a previous PR, we disabled selecting a defender that is not in the lawyer registry. We forgot to remove the defender selection from the e2e tests.

## Why

So that e2e tests run successfully.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Streamlined custody-related E2E flows by removing obsolete UI interactions (advocate selection, defender email entry, access toggles) for prosecutor submissions and extended defendant cases.
  * Improved reliability of judge amendment flow by adding a focus shift (Tab) after entering legal arguments to ensure consistent progression.
  * Enhancements reduce test flakiness and speed up regression runs.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->