### PR TITLE
fix: use correct collection id for candidate

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/signature-collection/municipal-list-creation/municipal-list-creation.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/signature-collection/municipal-list-creation/municipal-list-creation.service.ts
@@ -129,7 +129,9 @@ export class MunicipalListCreationService extends BaseTemplateApiService {
 
     const input = {
       collectionType: this.collectionType,
-      collectionId: municipalCollection.id,
+      collectionId:
+        municipalCollection.areas.find((area) => area.id === candidateAreaId)
+          ?.collectionId ?? '',
       owner: {
         ...answers.applicant,
         nationalId: application?.applicantActors?.[0]

--- a/libs/clients/signature-collection/src/lib/signature-collection.service.ts
+++ b/libs/clients/signature-collection/src/lib/signature-collection.service.ts
@@ -169,10 +169,10 @@ export class SignatureCollectionClientService {
       throw new Error('Collection not found')
     }
 
-    const { isActive, areas: collectionAreas } = currentCollection
+    const { areas: collectionAreas } = currentCollection
 
     // check if collection is open
-    if (!isActive) {
+    if (!collectionAreas.find((area) => area.id === inputAreaId)?.isActive) {
       // TODO: create ApplicationTemplateError
       throw new Error('Collection is not open')
     }

--- a/libs/clients/signature-collection/src/lib/signature-collection.service.ts
+++ b/libs/clients/signature-collection/src/lib/signature-collection.service.ts
@@ -159,14 +159,20 @@ export class SignatureCollectionClientService {
     const currentCollection = await this.getLatestCollectionForType(
       CollectionType.LocalGovernmental,
     )
-    if (currentCollection.id !== collectionId) {
+
+    const inputAreaId = areas?.[0].areaId
+    const currentAreaCollectionId = currentCollection.areas.find(
+      (area) => area.id === inputAreaId,
+    )?.collectionId
+
+    if (currentAreaCollectionId !== collectionId) {
       throw new Error('Collection not found')
     }
 
-    const { id, isActive, areas: collectionAreas } = currentCollection
+    const { isActive, areas: collectionAreas } = currentCollection
 
-    // check if collectionId is current collection and current collection is open
-    if (collectionId !== id.toString() || !isActive) {
+    // check if collection is open
+    if (!isActive) {
       // TODO: create ApplicationTemplateError
       throw new Error('Collection is not open')
     }
@@ -191,7 +197,7 @@ export class SignatureCollectionClientService {
       auth,
     ).frambodPost({
       frambodRequestDTO: {
-        sofnunID: parseInt(id),
+        sofnunID: parseInt(collectionId),
         kennitala: owner.nationalId.replace(/\D/g, ''),
         frambodNafn: `${listName ?? partyBallotLetterInfo?.name}`,
         simi: owner.phone,


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Submissions now use the selected area's collection identifier, preventing misrouted municipal list entries.
  - Validation tightened to ensure a submission's collection matches the specific area before accepting candidacies.
  - National ID input is sanitized to digits-only for municipal candidacy submissions, reducing validation errors.

- Reliability
  - More stable behavior when switching areas during list creation by reliably mapping submissions to the correct area-specific collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->