### PR TITLE
fix(rental-agreement): Valid national id and age over 18

### DIFF
--- a/libs/application/templates/rental-agreement/src/lib/messages/housing/landlordAndTenantDetails.ts
+++ b/libs/application/templates/rental-agreement/src/lib/messages/housing/landlordAndTenantDetails.ts
@@ -155,10 +155,15 @@ export const landlordAndTenantDetails = defineMessages({
   },
 
   // Error messages
-  nationalIdEmptyError: {
-    id: 'ra.application:landlordAndTenantDetails.nationalIdEmptyError',
-    defaultMessage: 'Kennitala þarf að vera skráð',
-    description: 'National id empty error',
+  nationalIdError: {
+    id: 'ra.application:landlordAndTenantDetails.nationalIdError',
+    defaultMessage: 'Kennitala ógild eða ekki á réttu formi',
+    description: 'National id error',
+  },
+  nationalIdAgeError: {
+    id: 'ra.application:landlordAndTenantDetails.nationalIdAgeError',
+    defaultMessage: 'Aðili leigusamnings verður að vera 18 ára eða eldri',
+    description: 'National id age error',
   },
   phoneNumberEmptyError: {
     id: 'ra.application:landlordAndTenantDetails.phoneNumberEmptyError',

--- a/libs/application/templates/rental-agreement/src/lib/schemas/landlordAndTenantSchema.ts
+++ b/libs/application/templates/rental-agreement/src/lib/schemas/landlordAndTenantSchema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import * as kennitala from 'kennitala'
 import * as m from '../messages'
 
 const personInfoSchema = z.object({
@@ -6,10 +7,16 @@ const personInfoSchema = z.object({
     nationalId: z
       .string()
       .optional()
-      .refine((x) => !!x && x.trim().length > 0, {
-        params: m.landlordAndTenantDetails.nationalIdEmptyError,
+      .refine((val) => (val ? kennitala.info(val).age >= 18 : false), {
+        params: m.landlordAndTenantDetails.nationalIdAgeError,
+      })
+      .refine((val) => (val ? kennitala.isValid(val) : false), {
+        params: m.landlordAndTenantDetails.nationalIdError,
       }),
-    name: z.string().optional(),
+    name: z
+      .string()
+      .optional()
+      .refine((name) => !!name && name.trim().length > 0),
   }),
   phone: z
     .string()


### PR DESCRIPTION
# Valid national id and age over 18

https://app.asana.com/1/203394141643832/project/1208271027457465/task/1211021557181402?focus=true

## What

- Fix being able to save when national-id is invalid / name not found
- Everybody in the rental agreement need to be 18 or older

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced national ID validation with clearer, specific errors for invalid format and for users under 18, improving guidance during landlord/tenant details entry.
  * Removed generic “empty national ID” error in favor of targeted messages, reducing confusion and preventing invalid submissions.
  * Strengthened name validation to reject whitespace-only inputs, ensuring a proper name is provided when entered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->