### PR TITLE
fix(web): Speed measurement and fine calculator - Result card is now sticky

### DIFF
--- a/apps/web/components/connected/logreglan/FineAndSpeedMeasurementCalculator/FineAndSpeedMeasurementCalculator.css.ts
+++ b/apps/web/components/connected/logreglan/FineAndSpeedMeasurementCalculator/FineAndSpeedMeasurementCalculator.css.ts
@@ -1,5 +1,20 @@
 import { style } from '@vanilla-extract/css'
 
+import { themeUtils } from '@island.is/island-ui/theme'
+
 export const totalContainer = style({
-  minWidth: '180px',
+  ...themeUtils.responsiveStyle({
+    xs: {
+      minWidth: '70px',
+    },
+    sm: {
+      minWidth: '140px',
+    },
+    lg: {
+      minWidth: '160px',
+    },
+    xl: {
+      minWidth: '180px',
+    },
+  }),
 })

--- a/apps/web/components/connected/logreglan/FineAndSpeedMeasurementCalculator/FineAndSpeedMeasurementCalculator.tsx
+++ b/apps/web/components/connected/logreglan/FineAndSpeedMeasurementCalculator/FineAndSpeedMeasurementCalculator.tsx
@@ -1,13 +1,7 @@
 import { useState } from 'react'
 import { useIntl } from 'react-intl'
 
-import {
-  Box,
-  Stack,
-  Table,
-  TableOfContents,
-  Text,
-} from '@island.is/island-ui/core'
+import { Box, Stack, Table, Text } from '@island.is/island-ui/core'
 import type { ConnectedComponent } from '@island.is/web/graphql/schema'
 import { formatCurrency } from '@island.is/web/utils/currency'
 
@@ -77,7 +71,6 @@ interface FineState extends Fine {
 
 interface FineCalculatorDetailsProps {
   fines: FineState[]
-  goBack: () => void
   slice: ConnectedComponent
   speedMeasurementData?: {
     points: number
@@ -235,12 +228,6 @@ const FineCalculatorDetails = ({
   )
 }
 
-enum HeadingId {
-  Fine = 'fine',
-  SpeedMeasurement = 'speed-measurement',
-  Results = 'results',
-}
-
 interface FineAndSpeedMeasurementCalculatorProps {
   slice: ConnectedComponent
 }
@@ -248,10 +235,6 @@ interface FineAndSpeedMeasurementCalculatorProps {
 export const FineAndSpeedMeasurementCalculator = ({
   slice,
 }: FineAndSpeedMeasurementCalculatorProps) => {
-  const [selectedHeadingId, setSelectedHeadingId] = useState<HeadingId>(
-    HeadingId.Fine,
-  )
-
   const { formatMessage } = useIntl()
 
   const speedLimitOptions: typeof DEFAULT_SPEED_LIMIT_OPTIONS =
@@ -290,72 +273,64 @@ export const FineAndSpeedMeasurementCalculator = ({
 
   return (
     <Stack space={3}>
-      <TableOfContents
-        headings={[
-          {
-            headingId: HeadingId.Fine,
-            headingTitle: formatMessage(m.fines.fineTableOfContentHeading),
-          },
-          {
-            headingId: HeadingId.SpeedMeasurement,
-            headingTitle: formatMessage(
-              m.fines.speedMeasurementTableOfContentHeading,
-            ),
-          },
-          {
-            headingId: HeadingId.Results,
-            headingTitle: formatMessage(m.fines.resultsTableOfContentHeading),
-          },
-        ]}
-        onClick={(headingId) => {
-          setSelectedHeadingId(headingId as HeadingId)
-        }}
-        tableOfContentsTitle={formatMessage(m.fines.tableOfContentsTitle)}
-        selectedHeadingId={selectedHeadingId}
-      />
-      <Stack space={3}>
-        <Box display="flex" justifyContent="flexEnd">
-          <Box
-            borderRadius="standard"
-            background="purple100"
-            padding={2}
-            className={styles.totalContainer}
-          >
-            <Stack space={0}>
-              <Text variant="eyebrow" fontWeight="semiBold">
-                {formatMessage(m.fines.total)}
-              </Text>
-              <Text textAlign="right" variant="small" fontWeight="semiBold">
-                {formatCurrency(price)}
-              </Text>
-              <Text textAlign="right" variant="small" fontWeight="semiBold">
-                {points}
-                {points === 1
-                  ? formatMessage(m.fines.pointsPostfixSingular)
-                  : formatMessage(m.fines.pointsPostfixPlural)}
-              </Text>
-            </Stack>
+      <Box display="flex" flexDirection="rowReverse" columnGap={[1, 3, 3, 5]}>
+        <Box position="relative">
+          <Box position="sticky" top={9}>
+            <Box display="flex" justifyContent="flexEnd">
+              <Box
+                borderRadius="standard"
+                background="purple100"
+                padding={[1, 2]}
+                className={styles.totalContainer}
+              >
+                <Stack space={0}>
+                  <Text variant="eyebrow" fontWeight="semiBold">
+                    {formatMessage(m.fines.total)}
+                  </Text>
+                  <Text textAlign="right" variant="small" fontWeight="semiBold">
+                    {formatCurrency(price)}
+                  </Text>
+                  <Text textAlign="right" variant="small" fontWeight="semiBold">
+                    {points}
+                    {points === 1
+                      ? formatMessage(m.fines.pointsPostfixSingular)
+                      : formatMessage(m.fines.pointsPostfixPlural)}
+                  </Text>
+                </Stack>
+              </Box>
+            </Box>
           </Box>
         </Box>
-      </Stack>
-      {selectedHeadingId === HeadingId.Fine && (
-        <FineCalculator fines={fines} setFines={setFines} />
-      )}
-      {selectedHeadingId === HeadingId.SpeedMeasurement && (
-        <SpeedMeasurementCalculator
-          measuredSpeed={measuredSpeed}
-          speedLimit={speedLimit}
-          over3500kgOrWithTrailer={over3500kgOrWithTrailer}
-          setMeasuredSpeed={setMeasuredSpeed}
-          setSpeedLimit={setSpeedLimit}
-          setOver3500kgOrWithTrailer={setOver3500kgOrWithTrailer}
-          speedLimitOptions={speedLimitOptions}
-        />
-      )}
-      {selectedHeadingId === HeadingId.Results && (
+
+        <Stack space={3}>
+          <Stack space={2}>
+            <Text variant="h2" as="h2">
+              {formatMessage(m.speedMeasurementCalculator.heading)}
+            </Text>
+            <SpeedMeasurementCalculator
+              measuredSpeed={measuredSpeed}
+              speedLimit={speedLimit}
+              over3500kgOrWithTrailer={over3500kgOrWithTrailer}
+              setMeasuredSpeed={setMeasuredSpeed}
+              setSpeedLimit={setSpeedLimit}
+              setOver3500kgOrWithTrailer={setOver3500kgOrWithTrailer}
+              speedLimitOptions={speedLimitOptions}
+            />
+          </Stack>
+          <Stack space={2}>
+            <Text variant="h2" as="h2">
+              {formatMessage(m.fines.heading)}
+            </Text>
+            <FineCalculator fines={fines} setFines={setFines} />
+          </Stack>
+        </Stack>
+      </Box>
+      <Stack space={2}>
+        <Text variant="h2" as="h2">
+          {formatMessage(m.results.heading)}
+        </Text>
         <FineCalculatorDetails
           fines={fines}
-          goBack={() => setSelectedHeadingId(HeadingId.Fine)}
           slice={slice}
           speedMeasurementData={{
             points: speedMeasurementPoints ?? 0,
@@ -367,7 +342,7 @@ export const FineAndSpeedMeasurementCalculator = ({
             akaera,
           }}
         />
-      )}
+      </Stack>
     </Stack>
   )
 }

--- a/apps/web/components/connected/logreglan/FineAndSpeedMeasurementCalculator/components/FineCalculator.tsx
+++ b/apps/web/components/connected/logreglan/FineAndSpeedMeasurementCalculator/components/FineCalculator.tsx
@@ -61,6 +61,12 @@ const FineCardList = ({
           onChange={(e) => {
             setSearchValue(e.target.value)
           }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              e.currentTarget.blur()
+            }
+          }}
         />
         <GridContainer>
           <GridRow rowGap={2}>
@@ -89,10 +95,7 @@ const FineCardList = ({
                   )
                 }
                 return (
-                  <GridColumn
-                    key={fine.id}
-                    span={['1/1', '1/2', '1/1', '1/2', '1/3']}
-                  >
+                  <GridColumn key={fine.id} span="1/1">
                     <FocusableBox
                       padding={[2, 2, 3]}
                       border="standard"

--- a/apps/web/components/connected/logreglan/FineAndSpeedMeasurementCalculator/components/SpeedMeasurementCalculator.tsx
+++ b/apps/web/components/connected/logreglan/FineAndSpeedMeasurementCalculator/components/SpeedMeasurementCalculator.tsx
@@ -90,7 +90,7 @@ export const SpeedMeasurementCalculator = ({
   return (
     <Stack space={3}>
       <GridRow rowGap={2}>
-        <GridColumn span={['6/12', '6/12', '1/1', '6/12']}>
+        <GridColumn span={['1/1', '1/1', '1/1', '6/12']}>
           <Input
             label={formatMessage(
               m.speedMeasurementCalculator.measuredSpeedInputLabel,
@@ -108,7 +108,7 @@ export const SpeedMeasurementCalculator = ({
             }}
           />
         </GridColumn>
-        <GridColumn span={['3/12', '3/12', '1/2', '3/12']}>
+        <GridColumn span={['6/12', '6/12', '1/2', '3/12']}>
           <Input
             label={formatMessage(
               m.speedMeasurementCalculator.vikmorkInputLabel,
@@ -121,7 +121,7 @@ export const SpeedMeasurementCalculator = ({
             readOnly={true}
           />
         </GridColumn>
-        <GridColumn span={['3/12', '3/12', '1/2', '3/12']}>
+        <GridColumn span={['6/12', '6/12', '1/2', '3/12']}>
           <Input
             label={formatMessage(
               m.speedMeasurementCalculator.nidurstadaInputLabel,

--- a/apps/web/components/connected/logreglan/FineAndSpeedMeasurementCalculator/translation.strings.ts
+++ b/apps/web/components/connected/logreglan/FineAndSpeedMeasurementCalculator/translation.strings.ts
@@ -2,20 +2,10 @@ import { defineMessages } from 'react-intl'
 
 export const m = {
   fines: defineMessages({
-    fineTableOfContentHeading: {
-      id: 'web.logreglan.fineAndSpeedMeasurementCalculator:fines.fineTableOfContentHeading',
-      defaultMessage: 'Sektir',
-      description: 'Sektir',
-    },
-    speedMeasurementTableOfContentHeading: {
-      id: 'web.logreglan.fineAndSpeedMeasurementCalculator:fines.speedMeasurementTableOfContentHeading',
-      defaultMessage: 'Hraðamæling',
-      description: 'Hraðamæling',
-    },
-    tableOfContentsTitle: {
-      id: 'web.logreglan.fineAndSpeedMeasurementCalculator:fines.tableOfContentsTitle',
-      defaultMessage: 'Yfirlit',
-      description: 'Yfirlit',
+    heading: {
+      id: 'web.logreglan.fineAndSpeedMeasurementCalculator:fines.heading',
+      defaultMessage: 'Umferðarlagabrot',
+      description: 'Umferðarlagabrot',
     },
     total: {
       id: 'web.logreglan.fineAndSpeedMeasurementCalculator:fines.total',
@@ -52,13 +42,13 @@ export const m = {
       defaultMessage: 'Sjá sundurliðun',
       description: 'Reikna',
     },
-    resultsTableOfContentHeading: {
-      id: 'web.logreglan.fineAndSpeedMeasurementCalculator:fines.resultsTableOfContentHeading',
+  }),
+  results: defineMessages({
+    heading: {
+      id: 'web.logreglan.fineAndSpeedMeasurementCalculator:results.heading',
       defaultMessage: 'Sundurliðun',
       description: 'Sundurliðun',
     },
-  }),
-  results: defineMessages({
     goBack: {
       id: 'web.logreglan.fineAndSpeedMeasurementCalculator:results.goBack',
       defaultMessage: 'Sjá sektir',
@@ -113,6 +103,11 @@ export const m = {
     },
   }),
   speedMeasurementCalculator: defineMessages({
+    heading: {
+      id: 'web.logreglan.fineAndSpeedMeasurementCalculator:speedMeasurementCalculator.heading',
+      defaultMessage: 'Hraðamæling',
+      description: 'Hraðamæling',
+    },
     measuredSpeedInputLabel: {
       id: 'web.logreglan.fineAndSpeedMeasurementCalculator:speedMeasurementCalculator.measuredSpeedInputLabel',
       defaultMessage: 'Mældur hraði',


### PR DESCRIPTION
# Speed measurement and fine calculator - Result card is now sticky

## Screenshots / Gifs

### Before

https://github.com/user-attachments/assets/2afafbd7-aefd-4d67-b766-16577828f816

### After


https://github.com/user-attachments/assets/f2b0413a-0927-4cdf-89be-74a70f46e682




## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
