### PR TITLE
fix(contentful-apps): Content type validations can be undefined

### DIFF
--- a/apps/contentful-apps/components/content-import/utils.ts
+++ b/apps/contentful-apps/components/content-import/utils.ts
@@ -15,7 +15,7 @@ export const extractContentType = (
 ) => {
   let validations = field.contentfulField.data.validations ?? []
   if (validations.length === 0) {
-    validations = field.contentfulField.data.items.validations ?? []
+    validations = field.contentfulField.data.items?.validations ?? []
   }
   return validations.find((v) => v?.linkContentType)?.linkContentType?.[0] ?? ''
 }


### PR DESCRIPTION
# Content type validations can be undefined

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a rare crash during content import when item validations were missing, improving overall stability.
  * Improved handling of missing linked content types by safely applying defaults, preventing unexpected errors during imports.
  * Enhanced error tolerance in edge cases so imports proceed reliably even when certain field metadata is absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->