### PR TITLE
fix(application-system): Adding min date and 1 month requirement for rental period

### DIFF
--- a/libs/application/templates/rental-agreement/src/forms/draft/rentalPeriodSubsections/rentalPeriodDetails.ts
+++ b/libs/application/templates/rental-agreement/src/forms/draft/rentalPeriodSubsections/rentalPeriodDetails.ts
@@ -36,7 +36,7 @@ export const RentalPeriodDetails = buildSubSection({
           required: true,
           minDate: ({ answers }) => {
             const dateFrom =
-              getValueViaPath<string>(answers, 'rentalPeriod.startDate') ?? null
+              getValueViaPath<string>(answers, 'rentalPeriod.startDate') ?? ''
             return addMonths(new Date(dateFrom), 1)
           },
           condition: rentalPeriodIsDefinite,


### PR DESCRIPTION
# ...

[Fá skilaboð ef dags. eða lengd samnings er óleyfileg](https://app.asana.com/1/203394141643832/project/1208271027457465/task/1211021557181399)

## What

- min date 01.01.2023 
- endDate needs to be one month 

## Why

- Wanted from customer 


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Minimum start date set to Jan 1, 2023 for rental periods.
  * End date now must be at least one month after the chosen start date.
  * Changing the start date automatically clears the end date to avoid invalid ranges.
  * Toggling the “is definite” option clears the end date when changed.
  * Improved validation to ensure consistent, valid rental period selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->