### PR TITLE
fix(rental-agreement): Fix email validation for applicants

### DIFF
--- a/libs/application/templates/rental-agreement/src/lib/messages/housing/landlordAndTenantDetails.ts
+++ b/libs/application/templates/rental-agreement/src/lib/messages/housing/landlordAndTenantDetails.ts
@@ -135,11 +135,11 @@ export const landlordAndTenantDetails = defineMessages({
     defaultMessage: 'Símanúmer þarf að vera skráð',
     description: 'Phone number empty error',
   },
-  emailEmptyError: {
-    id: 'ra.application:landlordAndTenantDetails.emailEmptyError',
+  emailInvalidError: {
+    id: 'ra.application:landlordAndTenantDetails.emailInvalidError',
     defaultMessage:
       'Netfangið er rangt ritað. Vinsamlegast athugaðu hvort vanti @-merkið eða lénið (eins og ".is")',
-    description: 'Email empty error',
+    description: 'Email invalid error',
   },
   addressEmptyError: {
     id: 'ra.application:landlordAndTenantDetails.addressEmptyError',

--- a/libs/application/templates/rental-agreement/src/lib/schemas/landlordAndTenantSchema.ts
+++ b/libs/application/templates/rental-agreement/src/lib/schemas/landlordAndTenantSchema.ts
@@ -31,7 +31,7 @@ const personInfoSchema = z.object({
     .string()
     .optional()
     .refine((val) => !!val && val.trim().length > 0 && isValidEmail(val), {
-      params: m.landlordAndTenantDetails.emailEmptyError,
+      params: m.landlordAndTenantDetails.emailInvalidError,
     }),
   address: z
     .string()


### PR DESCRIPTION
# Fix email validation for applicants

https://app.asana.com/1/203394141643832/project/1208271027457465/task/1211056191707697?focus=true

## What

- Validate email and show error message

## Why

Specify why you need to achieve this

## Screenshots / Gifs

<img width="819" height="581" alt="Screenshot 2025-08-18 at 10 22 28" src="https://github.com/user-attachments/assets/01da7dd0-593b-4604-bbf9-f55bb30b1218" />

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email validation for landlord and tenant details to reject invalid formats and ignore empty/whitespace-only input.
  * Replaced the previous empty-error message with a clearer invalid-email message that guides users to check for missing "@" or domain suffixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->