### PR TITLE
fix(rental-agreement): Fix wrong security amount in summary

### DIFF
--- a/libs/application/templates/rental-agreement/src/forms/draft/rentalPeriodSubsections/rentalPeriodSecurityDeposit.ts
+++ b/libs/application/templates/rental-agreement/src/forms/draft/rentalPeriodSubsections/rentalPeriodSecurityDeposit.ts
@@ -60,6 +60,7 @@ export const RentalPeriodSecurityDeposit = buildSubSection({
             'securityDeposit.insuranceCompanyInfo',
             'securityDeposit.mutualFundInfo',
             'securityDeposit.otherInfo',
+            'securityDeposit.securityAmountOther',
           ],
           placeholder: securityDeposit.typeSelectionPlaceholder,
         }),


### PR DESCRIPTION
# Fix wrong security amount in summary

https://app.asana.com/1/203394141643832/project/1208203457124855/task/1211044413414335?focus=true

## What

- If I choose specific security amount but then change security deposit type, the previously selected security amount is still displayed in the summary. Fix: security amount cleared during security deposit type change.

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Changing the Security Type in the rental agreement form now clears the “Other security deposit amount” field to prevent outdated values from persisting. This ensures users don’t accidentally submit mismatched security deposit details and improves overall form accuracy and consistency. No other fields or behaviors are affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->