### PR TITLE
fix(rental-agreement): Fix duplicate applicant flow

### DIFF
--- a/libs/application/templates/rental-agreement/src/forms/draft/rentalHousingSubsections/rentalHousingLandlordInfo.ts
+++ b/libs/application/templates/rental-agreement/src/forms/draft/rentalHousingSubsections/rentalHousingLandlordInfo.ts
@@ -45,9 +45,8 @@ export const RentalHousingLandlordInfo = buildSubSection({
         }),
         buildAlertMessageField({
           id: 'landlordInfo.uniqueApplicantsError',
-          alertType: 'error',
+          alertType: 'warning',
           title: landlordDetails.uniqueApplicantsError,
-          shouldBlockInSetBeforeSubmitCallback: true,
           condition: (answers) => {
             const {
               landlords,


### PR DESCRIPTION
# Fix duplicate applicant flow

https://app.asana.com/1/203394141643832/project/1208271027457465/task/1211021557181409

## What

- Allow users to continue application from landlord (step 1) to tenant (step 2) with a warning about duplicate applicants but make it a hard stop on the tenant step. This allows the user to go back and forth between these two steps and fix the duplicate applicants error.

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate applicant entries in the landlord information section now trigger a warning instead of an error and no longer block form submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->