### PR TITLE
fix(j-s): Handle verdict if it doesn't exist

### DIFF
--- a/apps/judicial-system/digital-mailbox-api/src/app/modules/cases/models/case.response.ts
+++ b/apps/judicial-system/digital-mailbox-api/src/app/modules/cases/models/case.response.ts
@@ -54,7 +54,9 @@ export class CaseResponse {
           subpoenas.length > 0
             ? isSuccessfulServiceStatus(subpoenas[0].serviceStatus)
             : false,
-        hasRulingBeenServed: isSuccessfulServiceStatus(verdict.serviceStatus),
+        hasRulingBeenServed: verdict?.serviceStatus
+          ? isSuccessfulServiceStatus(verdict.serviceStatus)
+          : false,
         groups: [
           {
             label: t.defendant,

--- a/apps/judicial-system/digital-mailbox-api/src/app/modules/cases/models/internal/internalCase.response.ts
+++ b/apps/judicial-system/digital-mailbox-api/src/app/modules/cases/models/internal/internalCase.response.ts
@@ -43,7 +43,7 @@ interface Defendant {
   requestedDefenderNationalId?: string
   requestedDefenderName?: string
   subpoenaType?: SubpoenaType
-  verdict: Verdict
+  verdict?: Verdict
 }
 
 interface DateLog {


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/board/1205106414775586)

## What

Handle cases in digital mailbox where verdict doesn't exist yet 

## Why

Because it's throwing an exception when retrieving cases with no verdict when it shouldn't. 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of cases where verdict details are missing, preventing errors and ensuring the service status is evaluated safely.
  * Enhanced stability when processing defendants without verdict information, avoiding crashes and inconsistent states.
  * Ensures status-related indicators remain reliable even with incomplete data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->