### PR TITLE
feat(my-pages): add residence tooltip

### DIFF
--- a/libs/portals/my-pages/information/src/lib/messages.ts
+++ b/libs/portals/my-pages/information/src/lib/messages.ts
@@ -142,6 +142,10 @@ export const spmm = defineMessages({
     id: 'sp.family:edit-link',
     defaultMessage: 'Breyta hjá Þjóðskrá',
   },
+  legalResidenceTooltip: {
+    id: 'sp.family:legal-residence-tooltip',
+    defaultMessage: 'Götuheiti, Húsnúmer, Íbúðarnúmer, Póstnúmer, Sveitarfélag',
+  },
 })
 
 export const mInformationNotifications = defineMessages({

--- a/libs/portals/my-pages/information/src/screens/UserInfo/UserInfo.tsx
+++ b/libs/portals/my-pages/information/src/screens/UserInfo/UserInfo.tsx
@@ -84,6 +84,7 @@ const SubjectInfo = () => {
 
             <InfoLine
               label={m.legalResidence}
+              tooltip={formatMessage(spmm.legalResidenceTooltip)}
               content={
                 formatAddress(
                   nationalRegistryPerson?.housing?.address ?? null,


### PR DESCRIPTION
# My pages - User Info

## What

Add tooltip to describe the legal residence string

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
