### PR TITLE
fix(application-system): Make city and postcode optional

### DIFF
--- a/libs/application/templates/hms/fire-compensation-appraisal/src/forms/mainForm/personalInformationSection.ts
+++ b/libs/application/templates/hms/fire-compensation-appraisal/src/forms/mainForm/personalInformationSection.ts
@@ -5,5 +5,10 @@ import * as m from '../../lib/messages'
 export const personalInformationSection = buildSection({
   id: 'personalInformationSection',
   title: m.personalInformationMessages.title,
-  children: [applicantInformationMultiField()],
+  children: [
+    applicantInformationMultiField({
+      postalCodeRequired: false,
+      cityRequired: false,
+    }),
+  ],
 })

--- a/libs/application/templates/hms/fire-compensation-appraisal/src/lib/dataSchema.ts
+++ b/libs/application/templates/hms/fire-compensation-appraisal/src/lib/dataSchema.ts
@@ -11,18 +11,12 @@ const readFireCompensationInfo = z.array(z.literal(YES)).length(1)
 // Main form
 const applicantSchema = z.object({
   address: z.string().refine((v) => !!v),
-  city: z
-    .string()
-    // .refine((v) => !!v)
-    .optional(),
+  city: z.string().optional(),
   email: z.string().refine((v) => !!v),
   name: z.string().refine((v) => !!v),
   nationalId: z.string().refine((v) => !!v),
   phoneNumber: z.string().refine((v) => !!v),
-  postalCode: z
-    .string()
-    // .refine((v) => !!v)
-    .optional(),
+  postalCode: z.string().optional(),
 })
 
 const realEstateSchema = z.string()

--- a/libs/application/templates/hms/fire-compensation-appraisal/src/lib/dataSchema.ts
+++ b/libs/application/templates/hms/fire-compensation-appraisal/src/lib/dataSchema.ts
@@ -11,12 +11,18 @@ const readFireCompensationInfo = z.array(z.literal(YES)).length(1)
 // Main form
 const applicantSchema = z.object({
   address: z.string().refine((v) => !!v),
-  city: z.string().refine((v) => !!v),
+  city: z
+    .string()
+    // .refine((v) => !!v)
+    .optional(),
   email: z.string().refine((v) => !!v),
   name: z.string().refine((v) => !!v),
   nationalId: z.string().refine((v) => !!v),
   phoneNumber: z.string().refine((v) => !!v),
-  postalCode: z.string().refine((v) => !!v),
+  postalCode: z
+    .string()
+    // .refine((v) => !!v)
+    .optional(),
 })
 
 const realEstateSchema = z.string()

--- a/libs/application/ui-forms/src/lib/applicantInformationMultiField/applicantInformationMultiField.ts
+++ b/libs/application/ui-forms/src/lib/applicantInformationMultiField/applicantInformationMultiField.ts
@@ -24,6 +24,9 @@ export const applicantInformationArray = (
     emailCondition,
     emailRequired = true,
     emailDisabled = false,
+    addressRequired = true,
+    postalCodeRequired = true,
+    cityRequired = true,
     baseInfoReadOnly = false,
     emailAndPhoneReadOnly = false,
     compactFields = false,
@@ -66,6 +69,7 @@ export const applicantInformationArray = (
       backgroundColor: 'white',
       disabled: baseInfoDisabled,
       readOnly: baseInfoReadOnly,
+      required: addressRequired,
       defaultValue: (application: ApplicantInformationInterface) =>
         application.externalData?.nationalRegistry?.data?.address
           ?.streetAddress ??
@@ -80,6 +84,7 @@ export const applicantInformationArray = (
       backgroundColor: 'white',
       disabled: baseInfoDisabled,
       readOnly: baseInfoReadOnly,
+      required: postalCodeRequired,
       defaultValue: (application: ApplicantInformationInterface) => {
         return (
           application.externalData?.nationalRegistry?.data?.address
@@ -109,6 +114,7 @@ export const applicantInformationArray = (
       backgroundColor: 'white',
       disabled: baseInfoDisabled,
       readOnly: baseInfoReadOnly,
+      required: cityRequired,
       defaultValue: (application: ApplicantInformationInterface) =>
         application.externalData?.nationalRegistry?.data?.address?.city ??
         application.externalData?.identity?.data?.address?.city ??

--- a/libs/application/ui-forms/src/lib/applicantInformationMultiField/types.ts
+++ b/libs/application/ui-forms/src/lib/applicantInformationMultiField/types.ts
@@ -43,6 +43,9 @@ export type applicantInformationProps = {
   emailCondition?: Condition
   emailRequired?: boolean
   emailDisabled?: boolean
+  addressRequired?: boolean
+  postalCodeRequired?: boolean
+  cityRequired?: boolean
   applicantInformationTitle?: FormText
   applicantInformationDescription?: FormText
   baseInfoReadOnly?: boolean


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * In the Fire Compensation Appraisal application, City and Postal Code in the applicant information section are now optional, allowing submission without these fields.
  * Address-related fields now support configurable requirements, enabling a more flexible form experience across applications.
  * Validation and error messaging reflect the new optional fields, with no changes to other fields or form behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->