### PR TITLE
feat(delegation-index): Fix index issues when removing last delegation of each type

### DIFF
--- a/libs/auth-api-lib/src/lib/delegations/delegations-index.service.ts
+++ b/libs/auth-api-lib/src/lib/delegations/delegations-index.service.ts
@@ -350,7 +350,12 @@ export class DelegationsIndexService {
       this.getWardDelegations(user),
     ]).then((d) => d.flat())
 
-    await this.saveToIndex(user.nationalId, delegations, user)
+    await this.saveToIndex(
+      user.nationalId,
+      delegations,
+      user,
+      Object.values(AuthDelegationType),
+    )
 
     // set next reindex to one week in the future
     await this.delegationIndexMetaModel.update(
@@ -369,13 +374,17 @@ export class DelegationsIndexService {
   /* Index incoming custom delegations */
   async indexCustomDelegations(nationalId: string, auth: Auth) {
     const delegations = await this.getCustomDelegations(nationalId, true)
-    await this.saveToIndex(nationalId, delegations, auth)
+    await this.saveToIndex(nationalId, delegations, auth, [
+      AuthDelegationType.Custom,
+    ])
   }
 
   /* Index incoming general mandate delegations */
   async indexGeneralMandateDelegations(nationalId: string, auth?: Auth) {
     const delegations = await this.getGeneralMandateDelegation(nationalId, true)
-    await this.saveToIndex(nationalId, delegations, auth)
+    await this.saveToIndex(nationalId, delegations, auth, [
+      AuthDelegationType.GeneralMandate,
+    ])
   }
 
   /* Index incoming personal representative delegations */
@@ -384,7 +393,9 @@ export class DelegationsIndexService {
       nationalId,
       true,
     )
-    await this.saveToIndex(nationalId, delegations, auth)
+    await this.saveToIndex(nationalId, delegations, auth, [
+      AuthDelegationType.PersonalRepresentative,
+    ])
   }
 
   /* Add item to index */
@@ -497,8 +508,14 @@ export class DelegationsIndexService {
     // Some entrypoints to indexing do not have a user auth object or have a 3rd party user
     // so we take the auth separately from the subject nationalId
     auth?: Auth,
+    typesToForceIndex?: AuthDelegationType[],
   ) {
-    const types = Array.from(new Set(delegations.map((d) => d.type)))
+    const types = Array.from(
+      new Set([
+        ...delegations.map((d) => d.type),
+        ...(typesToForceIndex ?? []),
+      ]),
+    )
 
     const currRecords = await this.delegationIndexModel.findAll({
       where: {
@@ -519,9 +536,11 @@ export class DelegationsIndexService {
       currRecords,
     })
 
-    const indexingPromises = await Promise.allSettled([
-      this.delegationIndexModel.bulkCreate(created),
-      updated.map((d) =>
+    const ops = [
+      ...(created.length
+        ? [this.delegationIndexModel.bulkCreate(created)]
+        : []),
+      ...updated.map((d) =>
         this.delegationIndexModel.update(d, {
           where: {
             fromNationalId: d.fromNationalId,
@@ -531,7 +550,7 @@ export class DelegationsIndexService {
           },
         }),
       ),
-      deleted.map((d) =>
+      ...deleted.map((d) =>
         this.delegationIndexModel.destroy({
           where: {
             fromNationalId: d.fromNationalId,
@@ -541,10 +560,12 @@ export class DelegationsIndexService {
           },
         }),
       ),
-    ])
+    ]
+
+    const indexingResults = await Promise.allSettled(ops)
 
     // log any errors
-    indexingPromises.forEach((p) => {
+    indexingResults.forEach((p) => {
       if (p.status === 'rejected') {
         console.error(p.reason)
       }
@@ -605,6 +626,11 @@ export class DelegationsIndexService {
       },
     )
 
+    console.log({
+      indexCurrRecords: currRecords,
+      inComingNewRecords: newRecords,
+    })
+
     const deleted = currRecords.filter(
       (delegation) =>
         !newRecords.some(
@@ -614,6 +640,12 @@ export class DelegationsIndexService {
             d.provider === delegation.provider,
         ),
     )
+
+    console.log({
+      deleted,
+      created,
+      updated,
+    })
 
     return { deleted, created, updated }
   }

--- a/libs/auth-api-lib/src/lib/delegations/delegations-index.service.ts
+++ b/libs/auth-api-lib/src/lib/delegations/delegations-index.service.ts
@@ -626,11 +626,6 @@ export class DelegationsIndexService {
       },
     )
 
-    console.log({
-      indexCurrRecords: currRecords,
-      inComingNewRecords: newRecords,
-    })
-
     const deleted = currRecords.filter(
       (delegation) =>
         !newRecords.some(
@@ -640,12 +635,6 @@ export class DelegationsIndexService {
             d.provider === delegation.provider,
         ),
     )
-
-    console.log({
-      deleted,
-      created,
-      updated,
-    })
 
     return { deleted, created, updated }
   }


### PR DESCRIPTION
## What

There where reported issues when removing last delegation of each type, the delegation_index record was not removed.

## Why

So all delegations can be removed from delegation_index

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Bug Fixes
  - Ensures deleted delegations are reliably removed from the index, preventing stale entries in delegation views.

* Refactor
  - Streamlined internal indexing flow and batching for more reliable, granular index operations across delegation types.

* Performance/Stability
  - Enables broader or targeted reindexing to keep delegation data fresher after changes.

* Tests
  - Added tests covering deletion scenarios to verify index cleanup and correct behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->