### PR TITLE
fix(local build): Set tslib as external

### DIFF
--- a/tools/esbuild.config.js
+++ b/tools/esbuild.config.js
@@ -4,6 +4,7 @@ const svgrPlugin = require('esbuild-plugin-svgr')
 
 module.exports = {
   keepNames: true,
+  external: ['tslib'],
   plugins: [
     // Add eslint plugin for basic emitDecoratorMetadata support.
     // This is required by many features in NestJS.


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Define tslib as external in esbuild.config.js

## Why

Stop local builds for at least api, bff and application-system-api from failing with a "could not resolve tslib" error.

## Screenshots / Gifs

<img width="1522" height="730" alt="image" src="https://github.com/user-attachments/assets/32cc267d-dc30-466e-a415-419163a65320" />


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated the build configuration to externalize a common TypeScript runtime library from the bundle. This change reduces the distributed package size and streamlines dependency handling by relying on the host environment to provide the library. Users should not notice functional differences, but installs and load times may be modestly improved due to less bundled code, and downstream builds can benefit from avoiding duplication of this shared runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->