### PR TITLE
fix(j-s): Make tegundSkjals nullish

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/police/police.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/police.service.ts
@@ -125,7 +125,7 @@ export class PoliceService {
     domsSkjalsFlokkun: z.optional(z.string()),
     dagsStofnad: z.optional(z.string()),
     skjalasnid: z.optional(z.string()),
-    tegundSkjals: z.optional(this.policeCaseFileType),
+    tegundSkjals: this.policeCaseFileType.nullish(),
   })
   private readonly crimeSceneStructure = z.object({
     vettvangur: z.optional(z.string()),


### PR DESCRIPTION
# Make tegundSkjals nullish

[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1211116110268259?focus=true)

## What

When we call endpoints from LÖKE, we take the response and apply types to it with ZOD. Recently we've been getting errors in one case because a entry in the response was `null` where we did not allow `null` to be returned. This PR fixes that.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of police case file metadata: the document type field can now be present as null without causing validation errors, aligning with upstream data sources.
  * Preserves existing behavior for missing values and prevents crashes or rejected imports when the field is null.
  * Enhances system stability when processing diverse police case files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->