### PR TITLE
fix(j-s): Investigation case completed without ruling 

### DIFF
--- a/apps/judicial-system/web/src/routes/Court/InvestigationCase/CourtRecord/CourtRecord.tsx
+++ b/apps/judicial-system/web/src/routes/Court/InvestigationCase/CourtRecord/CourtRecord.tsx
@@ -117,6 +117,10 @@ const CourtRecord: FC = () => {
     'endOfSessionBookings',
   ])
 
+  const hasMissingInfoInRulingStep = workingCase.isCompletedWithoutRuling
+    ? !workingCase.decision
+    : !workingCase.decision || !workingCase.ruling || !workingCase.conclusion
+
   const initialize = useCallback(() => {
     const autofillAttendees = []
 
@@ -511,17 +515,9 @@ const CourtRecord: FC = () => {
             handleNavigationTo(constants.INVESTIGATION_CASE_CONFIRMATION_ROUTE)
           }
           nextIsDisabled={!stepIsValid}
-          hideNextButton={
-            !workingCase.isCompletedWithoutRuling
-              ? !workingCase.decision ||
-                !workingCase.conclusion ||
-                !workingCase.ruling
-              : !workingCase.decision
-          }
+          hideNextButton={hasMissingInfoInRulingStep}
           infoBoxText={
-            !workingCase.decision ||
-            !workingCase.conclusion ||
-            !workingCase.ruling
+            hasMissingInfoInRulingStep
               ? formatMessage(m.sections.nextButtonInfo.text, {
                   isCompletedWithoutRuling:
                     workingCase.isCompletedWithoutRuling,

--- a/apps/judicial-system/web/src/utils/validate.ts
+++ b/apps/judicial-system/web/src/utils/validate.ts
@@ -460,6 +460,10 @@ export const isRulingValidRC = (workingCase: Case): boolean => {
 }
 
 export const isRulingValidIC = (workingCase: Case): boolean => {
+  if (workingCase.isCompletedWithoutRuling) {
+    return true
+  }
+
   return validate([
     [workingCase.prosecutorDemands, ['empty']],
     [workingCase.courtCaseFacts, ['empty']],
@@ -491,7 +495,6 @@ export const isCourtRecordStepValidIC = (workingCase: Case): boolean => {
       ]
     : []
 
-  console.log({ validationsWithRuling })
   const validations = [
     [workingCase.courtStartDate, ['empty', 'date-format']],
     [workingCase.courtLocation, ['empty']],

--- a/apps/judicial-system/web/src/utils/validate.ts
+++ b/apps/judicial-system/web/src/utils/validate.ts
@@ -484,13 +484,20 @@ export const isCourtRecordStepValidRC = (workingCase: Case): boolean => {
 }
 
 export const isCourtRecordStepValidIC = (workingCase: Case): boolean => {
+  const validationsWithRuling = !workingCase.isCompletedWithoutRuling
+    ? [
+        [workingCase.conclusion, ['empty']],
+        [workingCase.ruling, ['empty']],
+      ]
+    : []
+
+  console.log({ validationsWithRuling })
   const validations = [
     [workingCase.courtStartDate, ['empty', 'date-format']],
     [workingCase.courtLocation, ['empty']],
     [workingCase.courtEndTime, ['empty', 'date-format']],
     [workingCase.decision, ['empty']],
-    [workingCase.conclusion, ['empty']],
-    [workingCase.ruling, ['empty']],
+    ...validationsWithRuling,
   ] as ValidateItem[]
 
   if (workingCase.sessionArrangements !== SessionArrangements.NONE_PRESENT) {


### PR DESCRIPTION
# [Bugfix when completing case without ruling](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1211137142660121)

## What
- When users where completing investigation cases without ruling and had empty fields (that are actually disabled) they were being prevented to continue. 
- This PR fixes the state for the next button and info callout

## Why

Specify why you need to achieve this


## Screenshots / Gifs
Before the state looked like this
<img width="1448" height="958" alt="image (4)" src="https://github.com/user-attachments/assets/2f129193-cf11-437e-aaa0-a51cbb6a4b72" />


Now fixed it looks like this. Note that the required error state is unlikely to happen since all the required fields are populated before the completion without ruling is selected. 

https://github.com/user-attachments/assets/7bdb6248-f34a-495b-a013-94e264817d71



## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Validation no longer requires ruling, conclusion, or ruling text when a case is marked completed without ruling, preventing unnecessary blocking.
  * UI guidance now accurately reflects when information is missing in the ruling step.

* **Refactor**
  * Centralized missing-information logic for the ruling step into a single flag used across the screen.
  * Simplified “Next” button visibility and info box text by relying on the centralized flag instead of scattered conditionals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->