### PR TITLE
feat(web): add caption to news image

### DIFF
--- a/apps/web/components/Organization/NewsArticle/NewsArticle.tsx
+++ b/apps/web/components/Organization/NewsArticle/NewsArticle.tsx
@@ -36,6 +36,7 @@ const NewsItemImage = ({ newsItem }: NewsArticleProps) =>
         {...newsItem?.image}
         url={newsItem?.image?.url ? newsItem.image?.url : ''}
         height={newsItem.image.height ?? ''}
+        caption={newsItem?.imageText ?? undefined}
       />
     </Box>
   )

--- a/apps/web/screens/queries/News.tsx
+++ b/apps/web/screens/queries/News.tsx
@@ -19,6 +19,7 @@ export const GET_NEWS_QUERY = gql`
           width
           height
         }
+        imageText
         genericTags {
           id
           title
@@ -50,6 +51,7 @@ export const GET_NEWS_WITH_CONTENT_QUERY = gql`
           width
           height
         }
+        imageText
         genericTags {
           id
           title
@@ -86,6 +88,7 @@ export const GET_SINGLE_NEWS_ITEM_QUERY = gql`
         width
         height
       }
+      imageText
       featuredImage {
         url
         title

--- a/libs/api/mocks/src/domains/cms/factories.ts
+++ b/libs/api/mocks/src/domains/cms/factories.ts
@@ -169,6 +169,7 @@ export const news = factory<News>({
   date: () => faker.date.past().toISOString(),
   intro: () => faker.lorem.paragraph(),
   subtitle: () => faker.lorem.sentence(),
+  imageText: () => faker.lorem.sentence(),
   image: () => image(),
   content: () => slice.list(3),
   genericTags: () => [],

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -2931,6 +2931,9 @@ export interface INewsFields {
   /** Featured image */
   image: Asset
 
+  /** Image text */
+  imageText?: string | undefined
+
   /** Full Width Image In Content */
   fullWidthImageInContent?: boolean | undefined
 

--- a/libs/cms/src/lib/models/news.model.ts
+++ b/libs/cms/src/lib/models/news.model.ts
@@ -39,6 +39,9 @@ export class News {
   @CacheField(() => [GenericTag])
   genericTags: GenericTag[] = []
 
+  @Field({nullable: true})
+  imageText?: string
+
   @Field(() => Boolean, { nullable: true })
   fullWidthImageInContent?: boolean
 
@@ -64,6 +67,7 @@ export const mapNews = ({ fields, sys }: INews): News => ({
     ? mapDocument(fields.content, sys.id + ':content')
     : [],
   genericTags: (fields.genericTags ?? []).map(mapGenericTag),
+  imageText: fields.imageText,
   fullWidthImageInContent: fields.fullWidthImageInContent ?? true,
   initialPublishDate: fields.initialPublishDate ?? '',
   featuredImage: fields.featuredImage ? mapImage(fields.featuredImage) : null,

--- a/libs/cms/src/lib/models/news.model.ts
+++ b/libs/cms/src/lib/models/news.model.ts
@@ -39,7 +39,7 @@ export class News {
   @CacheField(() => [GenericTag])
   genericTags: GenericTag[] = []
 
-  @Field({nullable: true})
+  @Field({ nullable: true })
   imageText?: string
 
   @Field(() => Boolean, { nullable: true })

--- a/libs/island-ui/contentful/src/lib/Image/Image.tsx
+++ b/libs/island-ui/contentful/src/lib/Image/Image.tsx
@@ -1,28 +1,49 @@
+import { Box, Text } from '@island.is/island-ui/core'
 import * as styles from './Image.css'
 
 export interface ImageProps {
   url: string
   description?: string | null
+  caption?: string
   width: number
   height: number
 }
 
-export const Image = ({ url, description, width, height }: ImageProps) => {
+export const Image = ({
+  url,
+  description,
+  caption,
+  width,
+  height,
+}: ImageProps) => {
   if (!url) return null
   return (
-    <img
-      src={`${url}?w=1000&fm=webp&q=75`}
-      srcSet={`
-          ${url}?w=1000&fm=webp&q=75 1x,
-          ${url}?w=1500&fm=webp&q=75 2x,
-          ${url}?w=2000&fm=webp&q=75 3x
-        `}
-      alt={description || ''}
-      height={height}
-      width={width}
-      loading="lazy"
-      className={styles.image}
-    />
+    <Box
+      display="flex"
+      height="full"
+      justifyContent="center"
+      alignItems="center"
+      flexDirection={'column'}
+    >
+      <img
+        src={`${url}?w=1000&fm=webp&q=75`}
+        srcSet={`
+            ${url}?w=1000&fm=webp&q=75 1x,
+            ${url}?w=1500&fm=webp&q=75 2x,
+            ${url}?w=2000&fm=webp&q=75 3x
+          `}
+        alt={description || ''}
+        height={height}
+        width={width}
+        loading="lazy"
+        className={styles.image}
+      />
+      {caption && (
+        <Text variant="medium" fontWeight="light" marginTop={1}>
+          {caption}
+        </Text>
+      )}
+    </Box>
   )
 }
 


### PR DESCRIPTION
## What

* Add `imageText` to News
* Integrate imageText as a caption below image in news

## Why

* Cool captions

## Screenshots / Gifs

<img width="742" height="1115" alt="image" src="https://github.com/user-attachments/assets/5814e351-69c5-49dc-8f42-cceefb0c20bb" />

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Image captions are now displayed beneath news images when available.
  - Captions are supported across the app’s image component for a consistent experience.
- Style
  - Improved image presentation with centered layout and spacing to accommodate captions.
- Chores
  - Expanded data fetching to include image caption text for news items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->