### PR TITLE
fix(web): Featured Links component - Don't show links that have no label

### DIFF
--- a/apps/web/components/FeaturedLinks/FeaturedLinks.tsx
+++ b/apps/web/components/FeaturedLinks/FeaturedLinks.tsx
@@ -10,42 +10,48 @@ export const FeaturedLinks = ({ links }: FeaturedLinksProps) => {
   const { linkResolver } = useLinkResolver()
   return (
     <Inline space={2}>
-      {links.map(({ title, attention, thing }) => {
-        if (!thing?.type || !thing?.slug) {
-          return (
-            <Tag key={title} variant="blue" attention={attention}>
-              {title}
-            </Tag>
-          )
-        }
-        const cardUrl = linkResolver(thing.type as LinkType, [thing.slug])
-        if (!cardUrl?.href) {
-          return (
-            <Tag key={title} variant="blue" attention={attention}>
-              {title}
-            </Tag>
-          )
-        }
+      {links
+        .filter((link) => Boolean(link.title))
+        .map(({ title, attention, thing }) => {
+          if (!thing?.type || !thing?.slug) {
+            return (
+              <Tag key={title} variant="blue" attention={attention}>
+                {title}
+              </Tag>
+            )
+          }
+          const cardUrl = linkResolver(thing.type as LinkType, [thing.slug])
+          if (!cardUrl?.href) {
+            return (
+              <Tag key={title} variant="blue" attention={attention}>
+                {title}
+              </Tag>
+            )
+          }
 
-        return (
-          <Tag
-            key={title}
-            {...(cardUrl.href.startsWith('/')
-              ? {
-                  CustomLink: ({ children, ...props }) => (
-                    <LinkV2 {...props} {...cardUrl} dataTestId="featured-link">
-                      {children}
-                    </LinkV2>
-                  ),
-                }
-              : { href: cardUrl.href })}
-            variant="blue"
-            attention={attention}
-          >
-            {title}
-          </Tag>
-        )
-      })}
+          return (
+            <Tag
+              key={title}
+              {...(cardUrl.href.startsWith('/')
+                ? {
+                    CustomLink: ({ children, ...props }) => (
+                      <LinkV2
+                        {...props}
+                        {...cardUrl}
+                        dataTestId="featured-link"
+                      >
+                        {children}
+                      </LinkV2>
+                    ),
+                  }
+                : { href: cardUrl.href })}
+              variant="blue"
+              attention={attention}
+            >
+              {title}
+            </Tag>
+          )
+        })}
     </Inline>
   )
 }

--- a/apps/web/components/FeaturedLinks/FeaturedLinks.tsx
+++ b/apps/web/components/FeaturedLinks/FeaturedLinks.tsx
@@ -11,7 +11,7 @@ export const FeaturedLinks = ({ links }: FeaturedLinksProps) => {
   return (
     <Inline space={2}>
       {links
-        .filter((link) => Boolean(link.title))
+        .filter((link) => Boolean(link.title?.trim()))
         .map(({ title, attention, thing }) => {
           if (!thing?.type || !thing?.slug) {
             return (


### PR DESCRIPTION
# Feature Links component - Don't show links that have no label

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Internal featured links now use in-app navigation for smoother, faster transitions.
  - External featured links open normally with standard URLs.
  - Improved URL resolution to determine internal vs external destinations and render accordingly.

- Bug Fixes
  - Hides featured links without titles to prevent empty or broken items.
  - Renders a non-clickable tag when a destination URL can’t be resolved instead of a broken link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->