### PR TITLE
fix(web): Assets inside of bullet list render as [object Object]

### DIFF
--- a/libs/island-ui/contentful/src/lib/RichTextRC/defaultRenderNode.tsx
+++ b/libs/island-ui/contentful/src/lib/RichTextRC/defaultRenderNode.tsx
@@ -173,10 +173,12 @@ export const defaultRenderNodeObject: RenderNode = {
 
     const contentType = node?.data?.target?.fields?.file?.contentType
 
+    const secureUrl = url?.startsWith('//') ? `https:${url}` : url
+
     if (!contentType || contentType.startsWith('image/')) {
       return (
         <Box marginTop={url ? 5 : 0}>
-          <img src={url} alt={description || ''} />
+          <img src={secureUrl} alt={description || ''} loading="lazy" />
         </Box>
       )
     }
@@ -184,7 +186,7 @@ export const defaultRenderNodeObject: RenderNode = {
     if (url && title) {
       return (
         <Box marginTop={5}>
-          <AssetLink title={title} url={url} />
+          <AssetLink title={title} url={secureUrl} />
         </Box>
       )
     }


### PR DESCRIPTION
# Assets inside of bullet list render as [object Object]

## Before

<img width="656" height="343" alt="Screenshot 2025-08-29 at 11 04 59" src="https://github.com/user-attachments/assets/874f4d5c-1a17-40a9-889b-5846119755b2" />


## After

<img width="677" height="497" alt="Screenshot 2025-08-29 at 11 04 33" src="https://github.com/user-attachments/assets/cc256fa6-0a9b-459b-890e-140ad4564e00" />

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rich text now supports non-image embedded assets by rendering them as titled links.

* **Bug Fixes**
  * Correctly distinguishes image assets from other file types when rendering.
  * Images use the asset description as alt text for improved accessibility.
  * Normalizes asset URLs to ensure secure links are used.
  * Ensures consistent spacing above rendered assets.

* **Style**
  * Improved visual consistency for embedded assets and links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->