### PR TITLE
fix(web): Fine calculator width adjustment

### DIFF
--- a/apps/web/components/connected/logreglan/FineAndSpeedMeasurementCalculator/FineAndSpeedMeasurementCalculator.tsx
+++ b/apps/web/components/connected/logreglan/FineAndSpeedMeasurementCalculator/FineAndSpeedMeasurementCalculator.tsx
@@ -334,28 +334,30 @@ export const FineAndSpeedMeasurementCalculator = ({
           </Box>
         </Box>
 
-        <Stack space={3}>
-          <Stack space={2}>
-            <Text variant="h2" as="h2">
-              {formatMessage(m.speedMeasurementCalculator.heading)}
-            </Text>
-            <SpeedMeasurementCalculator
-              measuredSpeed={measuredSpeed}
-              speedLimit={speedLimit}
-              over3500kgOrWithTrailer={over3500kgOrWithTrailer}
-              setMeasuredSpeed={setMeasuredSpeed}
-              setSpeedLimit={setSpeedLimit}
-              setOver3500kgOrWithTrailer={setOver3500kgOrWithTrailer}
-              speedLimitOptions={speedLimitOptions}
-            />
+        <Box width="full">
+          <Stack space={3}>
+            <Stack space={2}>
+              <Text variant="h2" as="h2">
+                {formatMessage(m.speedMeasurementCalculator.heading)}
+              </Text>
+              <SpeedMeasurementCalculator
+                measuredSpeed={measuredSpeed}
+                speedLimit={speedLimit}
+                over3500kgOrWithTrailer={over3500kgOrWithTrailer}
+                setMeasuredSpeed={setMeasuredSpeed}
+                setSpeedLimit={setSpeedLimit}
+                setOver3500kgOrWithTrailer={setOver3500kgOrWithTrailer}
+                speedLimitOptions={speedLimitOptions}
+              />
+            </Stack>
+            <Stack space={2}>
+              <Text variant="h2" as="h2">
+                {formatMessage(m.fines.heading)}
+              </Text>
+              <FineCalculator fines={fines} setFines={setFines} />
+            </Stack>
           </Stack>
-          <Stack space={2}>
-            <Text variant="h2" as="h2">
-              {formatMessage(m.fines.heading)}
-            </Text>
-            <FineCalculator fines={fines} setFines={setFines} />
-          </Stack>
-        </Stack>
+        </Box>
       </Box>
       <Box ref={breakdownRef}>
         <Stack space={2}>


### PR DESCRIPTION
# Fine calculator width adjustment

When a user types in the search box and there are no results then the cards dissapear, causing the container to shrink. 

By setting the width of the container to 100%, that fixes the issue.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Refined the layout of the Speed Measurement and Fines calculators using a full-width container with improved spacing and grouping.
  - Delivers a cleaner, more consistent visual hierarchy with aligned headers and reduced visual clutter; the order remains speed first, then fines.
  - Enhances readability across screen sizes without altering functionality or data, providing a smoother, more polished UI experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->