### PR TITLE
fix(web): Remove subDescription field from InfoCard component

### DIFF
--- a/apps/web/screens/Verdicts/VerdictsList.tsx
+++ b/apps/web/screens/Verdicts/VerdictsList.tsx
@@ -1274,7 +1274,6 @@ const VerdictsList: CustomScreen<VerdictsListProps> = (props) => {
 
                     return {
                       description: verdict.title,
-                      subDescription: verdict.keywords.join(', '),
                       eyebrow: '',
                       id: verdict.id,
                       link: { href: `/domar/${verdict.id}`, label: '' },

--- a/libs/island-ui/core/src/lib/InfoCardGrid/DetailedInfoCard.tsx
+++ b/libs/island-ui/core/src/lib/InfoCardGrid/DetailedInfoCard.tsx
@@ -21,7 +21,6 @@ export type DetailedProps = BaseProps & {
   logo?: string
   logoAlt?: string
   subEyebrow?: string
-  subDescription?: string
   //max 5 lines
   detailLines?: Array<{
     icon: IconMapIcon
@@ -36,7 +35,6 @@ export const DetailedInfoCard = ({
   size = 'medium',
   eyebrow,
   subEyebrow,
-  subDescription,
   detailLines,
   tags,
   logo,
@@ -151,13 +149,6 @@ export const DetailedInfoCard = ({
                 </Text>
               </Box>
             )}
-            {subDescription && (
-              <Box flexGrow={1} marginTop={description ? 3 : 1}>
-                <Text variant="small" fontWeight="regular">
-                  {subDescription}
-                </Text>
-              </Box>
-            )}
           </GridColumn>
           <GridColumn span="4/12">{renderDetails()}</GridColumn>
         </GridRow>
@@ -172,13 +163,6 @@ export const DetailedInfoCard = ({
           <Box marginTop={1}>
             <Text variant="medium" fontWeight="light">
               {description}
-            </Text>
-          </Box>
-        )}
-        {subDescription && (
-          <Box flexGrow={1} marginTop={description ? 2 : 1}>
-            <Text variant="small" fontWeight="regular">
-              {subDescription}
             </Text>
           </Box>
         )}


### PR DESCRIPTION
# Remove subDescription field from InfoCard component

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Simplified verdict cards by removing the secondary description/keywords line for a cleaner, more focused presentation.
  - Updated info cards to no longer display sub-descriptions across all sizes, improving visual clarity and consistency.

- Refactor
  - Streamlined card components by removing the sub-description option to reduce visual noise and maintain a consistent layout.
  - No functional changes to navigation or interactions; existing titles, details, and tags remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->