### PR TITLE
feat(web): Verdict list card reveal button

### DIFF
--- a/apps/web/screens/Verdicts/VerdictsList.tsx
+++ b/apps/web/screens/Verdicts/VerdictsList.tsx
@@ -20,7 +20,6 @@ import {
   Filter,
   GridContainer,
   Hidden,
-  InfoCardGrid,
   Inline,
   Select,
   Stack,
@@ -65,6 +64,7 @@ import {
 import { DebouncedCheckbox } from './components/DebouncedCheckbox'
 import { DebouncedDatePicker } from './components/DebouncedDatePicker'
 import { DebouncedInput } from './components/DebouncedInput'
+import { InfoCardGrid } from './components/InfoCardGrid/InfoCardGrid'
 import { m } from './translations.strings'
 import * as styles from './VerdictsList.css'
 
@@ -1248,7 +1248,7 @@ const VerdictsList: CustomScreen<VerdictsListProps> = (props) => {
                 </Hidden>
               </Inline>
               <InfoCardGrid
-                variant="detailed"
+                variant="detailed-reveal"
                 columns={1}
                 cards={data.visibleVerdicts
                   .filter((verdict) => Boolean(verdict.id))
@@ -1281,6 +1281,11 @@ const VerdictsList: CustomScreen<VerdictsListProps> = (props) => {
                       title: verdict.caseNumber,
                       borderColor: 'blue200',
                       detailLines,
+                      revealMoreButtonProps: {
+                        revealLabel: formatMessage(m.listPage.revealMoreLabel),
+                        hideLabel: formatMessage(m.listPage.hideMoreLabel),
+                        revealedText: verdict.presentings,
+                      },
                     }
                   })}
               />

--- a/apps/web/screens/Verdicts/components/InfoCardGrid/DetailedInfoCard.tsx
+++ b/apps/web/screens/Verdicts/components/InfoCardGrid/DetailedInfoCard.tsx
@@ -1,0 +1,208 @@
+import {
+  Box,
+  GridColumn,
+  GridRow,
+  Icon,
+  Inline,
+  Stack,
+  Tag,
+  Text,
+} from '@island.is/island-ui/core'
+import type {
+  ActionCardProps,
+  IconMapIcon,
+} from '@island.is/island-ui/core/types'
+import { isDefined } from '@island.is/shared/utils'
+
+import { BaseProps } from './InfoCard'
+import * as styles from './InfoCard.css'
+
+const eyebrowColor = 'blueberry600'
+
+export type DetailedProps = BaseProps & {
+  logo?: string
+  logoAlt?: string
+  subEyebrow?: string
+  subDescription?: string
+  //max 5 lines
+  detailLines?: Array<{
+    icon: IconMapIcon
+    text: string
+  }>
+  tags?: Array<ActionCardProps['tag']>
+}
+
+export const DetailedInfoCard = ({
+  title,
+  description,
+  size = 'medium',
+  eyebrow,
+  subEyebrow,
+  subDescription,
+  detailLines,
+  tags,
+  logo,
+  logoAlt,
+}: DetailedProps) => {
+  const renderLogo = () => {
+    if (!logo) {
+      return null
+    }
+
+    return (
+      <Box style={{ flex: '0 0 48px' }}>
+        <img height={48} src={logo} alt={logoAlt} />
+      </Box>
+    )
+  }
+
+  const renderDetails = () => {
+    if (!detailLines?.length) {
+      return null
+    }
+
+    return (
+      <Box marginTop={2}>
+        <Stack space={1}>
+          {detailLines?.slice(0, 5).map((d, index) => (
+            <Box
+              key={index}
+              display="flex"
+              flexDirection={'row'}
+              alignItems="center"
+              className={styles.iconBox}
+            >
+              <Icon
+                icon={d.icon}
+                size="medium"
+                type="outline"
+                color="blue400"
+              />
+              <Box marginLeft={2}>
+                <Text variant="small">{d.text}</Text>
+              </Box>
+            </Box>
+          ))}
+        </Stack>
+      </Box>
+    )
+  }
+
+  const renderTags = () => {
+    if (!tags?.length) {
+      return null
+    }
+
+    return (
+      <Inline space={1}>
+        {tags
+          .map((tag, index) => {
+            if (!tag) {
+              return null
+            }
+            return (
+              <Tag
+                outlined
+                key={`${tag.label}-${index}`}
+                disabled
+                variant={tag.variant}
+              >
+                {tag.label}
+              </Tag>
+            )
+          })
+          .filter(isDefined)}
+      </Inline>
+    )
+  }
+
+  const renderHeader = () => {
+    return (
+      <Box display="flex" flexDirection="row" justifyContent="spaceBetween">
+        {subEyebrow ? (
+          <Box>
+            <Text fontWeight="semiBold" variant="eyebrow" color={eyebrowColor}>
+              {eyebrow}
+            </Text>
+            <Text fontWeight="light" variant="eyebrow" color={eyebrowColor}>
+              {subEyebrow}
+            </Text>
+          </Box>
+        ) : (
+          <Text variant="eyebrow" color={eyebrowColor}>
+            {eyebrow}
+          </Text>
+        )}
+        {renderLogo()}
+      </Box>
+    )
+  }
+
+  const renderContent = () => {
+    if (size === 'large') {
+      return (
+        <GridRow direction="row">
+          <GridColumn span="8/12">
+            <Text variant="h3" color="blue400">
+              {title}
+            </Text>
+            {description && (
+              <Box flexGrow={1} marginTop={1}>
+                <Text variant="medium" fontWeight="light">
+                  {description}
+                </Text>
+              </Box>
+            )}
+            {subDescription && (
+              <Box flexGrow={1} marginTop={description ? 3 : 1}>
+                <Text variant="small" fontWeight="regular">
+                  {subDescription}
+                </Text>
+              </Box>
+            )}
+          </GridColumn>
+          <GridColumn span="4/12">{renderDetails()}</GridColumn>
+        </GridRow>
+      )
+    }
+    return (
+      <Box marginTop={2}>
+        <Text variant="h3" color="blue400">
+          {title}
+        </Text>
+        {description && (
+          <Box marginTop={1}>
+            <Text variant="medium" fontWeight="light">
+              {description}
+            </Text>
+          </Box>
+        )}
+        {subDescription && (
+          <Box flexGrow={1} marginTop={description ? 2 : 1}>
+            <Text variant="small" fontWeight="regular">
+              {subDescription}
+            </Text>
+          </Box>
+        )}
+        {renderDetails()}
+      </Box>
+    )
+  }
+
+  return (
+    <Box
+      display="flex"
+      justifyContent="spaceBetween"
+      flexDirection="column"
+      height="full"
+    >
+      <div>
+        {renderHeader()}
+        {renderContent()}
+      </div>
+      <Box marginTop={3} display="flex" justifyContent="spaceBetween">
+        {renderTags()}
+      </Box>
+    </Box>
+  )
+}

--- a/apps/web/screens/Verdicts/components/InfoCardGrid/InfoCard.css.ts
+++ b/apps/web/screens/Verdicts/components/InfoCardGrid/InfoCard.css.ts
@@ -1,0 +1,35 @@
+import { globalStyle, style } from '@vanilla-extract/css'
+
+import { theme, themeUtils } from '@island.is/island-ui/theme'
+
+const gridContainerBase = {
+  display: 'grid',
+  gap: theme.spacing[2],
+  ...themeUtils.responsiveStyle({
+    md: {
+      gap: theme.spacing[3],
+    },
+  }),
+  justifyContent: 'stretch',
+}
+
+export const gridContainerOneColumn = style({
+  ...gridContainerBase,
+  gridTemplateColumns: '1fr',
+})
+
+export const gridContainerTwoColumn = style({
+  ...gridContainerBase,
+  gridTemplateColumns: '1fr 1fr',
+})
+
+export const gridContainerThreeColumn = style({
+  ...gridContainerBase,
+  gridTemplateColumns: '1fr 1fr 1fr',
+})
+
+export const iconBox = style({})
+
+globalStyle(`${iconBox} > svg`, {
+  minWidth: 24,
+})

--- a/apps/web/screens/Verdicts/components/InfoCardGrid/InfoCard.tsx
+++ b/apps/web/screens/Verdicts/components/InfoCardGrid/InfoCard.tsx
@@ -78,6 +78,8 @@ export const InfoCard = ({ size, ...restOfProps }: InfoCardProps) => {
     Boolean(restOfProps.revealMoreButtonProps?.hideLabel) &&
     Boolean(restOfProps.revealMoreButtonProps?.revealedText)
 
+  const revealRegionId = `${restOfProps.id}-reveal`
+
   return (
     <FocusableBox
       background={restOfProps.background ?? 'white'}
@@ -108,13 +110,15 @@ export const InfoCard = ({ size, ...restOfProps }: InfoCardProps) => {
               onClick={() => {
                 setIsAccordionOpen((previousState) => !previousState)
               }}
+              aria-expanded={isAccordionOpen}
+              aria-controls={revealRegionId}
             >
               {isAccordionOpen
                 ? restOfProps.revealMoreButtonProps?.hideLabel
                 : restOfProps.revealMoreButtonProps?.revealLabel}
             </Button>
             <AnimateHeight duration={300} height={isAccordionOpen ? 'auto' : 0}>
-              <Text variant="small">
+              <Text variant="small" id={revealRegionId}>
                 {restOfProps.revealMoreButtonProps?.revealedText}
               </Text>
             </AnimateHeight>

--- a/apps/web/screens/Verdicts/components/InfoCardGrid/InfoCard.tsx
+++ b/apps/web/screens/Verdicts/components/InfoCardGrid/InfoCard.tsx
@@ -1,0 +1,126 @@
+import { useState } from 'react'
+import AnimateHeight from 'react-animate-height'
+
+import {
+  Box,
+  type BoxProps,
+  Button,
+  FocusableBox,
+  LinkV2,
+  Stack,
+  Text,
+} from '@island.is/island-ui/core'
+
+import { DetailedInfoCard, DetailedProps } from './DetailedInfoCard'
+import { SimpleInfoCard } from './SimpleInfoCard'
+
+export interface BaseProps {
+  id: string
+  title: string
+  description: string
+  eyebrow: string
+  background?: BoxProps['background']
+  size: 'large' | 'medium' | 'small'
+  padding?: BoxProps['padding']
+  borderColor?: BoxProps['borderColor']
+  link: {
+    label: string
+    href: string
+  }
+}
+
+export type InfoCardProps =
+  | (BaseProps & {
+      variant?: 'simple'
+    })
+  | (DetailedProps & {
+      variant: 'detailed'
+    })
+  | (DetailedProps & {
+      variant: 'detailed-reveal'
+      revealMoreButtonProps?: {
+        revealLabel: string
+        hideLabel: string
+        revealedText: string
+      }
+    })
+
+export const InfoCard = ({ size, ...restOfProps }: InfoCardProps) => {
+  const paddingValue = restOfProps.padding ?? 3
+  const [isAccordionOpen, setIsAccordionOpen] = useState(false)
+
+  if (restOfProps.variant !== 'detailed-reveal') {
+    return (
+      <FocusableBox
+        aria-label={restOfProps.title}
+        component={LinkV2}
+        href={restOfProps.link.href}
+        background={restOfProps.background ?? 'white'}
+        borderColor={restOfProps.borderColor ?? 'white'}
+        color="blue"
+        borderWidth="standard"
+        width="full"
+        borderRadius="large"
+      >
+        <Box width="full" padding={paddingValue}>
+          {restOfProps.variant === 'simple' ? (
+            <SimpleInfoCard size={size} {...restOfProps} />
+          ) : (
+            <DetailedInfoCard size={size} {...restOfProps} />
+          )}
+        </Box>
+      </FocusableBox>
+    )
+  }
+
+  const hasRevealProps =
+    Boolean(restOfProps.revealMoreButtonProps?.revealLabel) &&
+    Boolean(restOfProps.revealMoreButtonProps?.hideLabel) &&
+    Boolean(restOfProps.revealMoreButtonProps?.revealedText)
+
+  return (
+    <FocusableBox
+      background={restOfProps.background ?? 'white'}
+      borderColor={restOfProps.borderColor ?? 'white'}
+      color="blue"
+      borderWidth="standard"
+      width="full"
+      borderRadius="large"
+      flexDirection="column"
+      component="div"
+    >
+      <LinkV2 href={restOfProps.link.href}>
+        <Box
+          paddingX={paddingValue}
+          paddingTop={paddingValue}
+          paddingBottom={hasRevealProps ? 1 : paddingValue}
+        >
+          <DetailedInfoCard size={size} {...restOfProps} />
+        </Box>
+      </LinkV2>
+      {hasRevealProps && (
+        <Box paddingX={paddingValue} paddingBottom={paddingValue}>
+          <Stack space={2}>
+            <Button
+              variant="text"
+              size="small"
+              icon={isAccordionOpen ? 'chevronUp' : 'chevronDown'}
+              onClick={() => {
+                setIsAccordionOpen((previousState) => !previousState)
+              }}
+            >
+              {isAccordionOpen
+                ? restOfProps.revealMoreButtonProps?.hideLabel
+                : restOfProps.revealMoreButtonProps?.revealLabel}
+            </Button>
+            <AnimateHeight duration={300} height={isAccordionOpen ? 'auto' : 0}>
+              <Text variant="small">
+                {restOfProps.revealMoreButtonProps?.revealedText}
+              </Text>
+            </AnimateHeight>
+          </Stack>
+        </Box>
+      )}
+    </FocusableBox>
+  )
+}

--- a/apps/web/screens/Verdicts/components/InfoCardGrid/InfoCardGrid.tsx
+++ b/apps/web/screens/Verdicts/components/InfoCardGrid/InfoCardGrid.tsx
@@ -17,7 +17,6 @@ interface Props {
   columns?: 1 | 2 | 3
   cardsBackground?: BoxProps['background']
   cardsBorder?: BoxProps['borderColor']
-  notFoundText?: string
 }
 
 type CardSize = 'small' | 'medium' | 'large'

--- a/apps/web/screens/Verdicts/components/InfoCardGrid/InfoCardGrid.tsx
+++ b/apps/web/screens/Verdicts/components/InfoCardGrid/InfoCardGrid.tsx
@@ -1,0 +1,78 @@
+import { useWindowSize } from 'react-use'
+
+import { Box, type BoxProps } from '@island.is/island-ui/core'
+import { theme } from '@island.is/island-ui/theme'
+
+import { InfoCard, type InfoCardProps } from './InfoCard'
+import * as styles from './InfoCard.css'
+
+export type InfoCardItemProps = Omit<
+  InfoCardProps,
+  'size' | 'variant' | 'background' | 'padding'
+>
+
+interface Props {
+  cards: Array<InfoCardItemProps>
+  variant?: 'detailed' | 'simple' | 'detailed-reveal'
+  columns?: 1 | 2 | 3
+  cardsBackground?: BoxProps['background']
+  cardsBorder?: BoxProps['borderColor']
+  notFoundText?: string
+}
+
+type CardSize = 'small' | 'medium' | 'large'
+
+const mapColumnCountToCardSize = (
+  columns: Props['columns'],
+  isMobile?: boolean,
+): CardSize => {
+  if (isMobile) {
+    return 'large'
+  }
+  switch (columns) {
+    case 1:
+      return 'large'
+    case 2:
+      return 'medium'
+    default:
+      return 'small'
+  }
+}
+
+export const InfoCardGrid = ({
+  cards,
+  cardsBackground,
+  cardsBorder,
+  variant,
+  columns,
+}: Props) => {
+  const { width } = useWindowSize()
+  const isMobile = width < theme.breakpoints.sm
+
+  const cardSize = mapColumnCountToCardSize(columns, isMobile)
+
+  return (
+    <Box
+      hidden={cards.length < 1}
+      className={
+        cardSize === 'small'
+          ? styles.gridContainerThreeColumn
+          : cardSize === 'medium'
+          ? styles.gridContainerTwoColumn
+          : styles.gridContainerOneColumn
+      }
+    >
+      {cards.map((c, index) => (
+        <InfoCard
+          key={`${c.title}-${index}`}
+          background={cardsBackground}
+          padding={isMobile ? 2 : 3}
+          borderColor={cardsBorder}
+          variant={variant}
+          size={isMobile ? 'medium' : cardSize}
+          {...c}
+        />
+      ))}
+    </Box>
+  )
+}

--- a/apps/web/screens/Verdicts/components/InfoCardGrid/SimpleInfoCard.tsx
+++ b/apps/web/screens/Verdicts/components/InfoCardGrid/SimpleInfoCard.tsx
@@ -1,0 +1,69 @@
+import { Box, GridColumn, GridRow, Text } from '@island.is/island-ui/core'
+
+import { BaseProps } from './InfoCard'
+
+const eyebrowColor = 'blueberry600'
+
+export const SimpleInfoCard = ({
+  title,
+  description,
+  size = 'medium',
+  eyebrow,
+}: BaseProps) => {
+  const renderHeader = () => {
+    if (!eyebrow) {
+      return
+    }
+    return (
+      <Box
+        display="flex"
+        flexDirection="row"
+        justifyContent="spaceBetween"
+        marginBottom={3}
+        role="heading"
+      >
+        <Text variant="eyebrow" color={eyebrowColor}>
+          {eyebrow}
+        </Text>
+      </Box>
+    )
+  }
+
+  const renderContent = () => {
+    if (size === 'large') {
+      return (
+        <GridRow direction="row">
+          <GridColumn span="12/12">
+            <Text variant="h3" color="blue400">
+              {title}
+            </Text>
+            {description && (
+              <Box flexGrow={1} marginTop={1}>
+                <Text>{description}</Text>
+              </Box>
+            )}
+          </GridColumn>
+        </GridRow>
+      )
+    }
+    return (
+      <>
+        <Text variant="h3" color="blue400">
+          {title}
+        </Text>
+        {description && (
+          <Box marginTop={1}>
+            <Text>{description}</Text>
+          </Box>
+        )}
+      </>
+    )
+  }
+
+  return (
+    <>
+      {renderHeader()}
+      {renderContent()}
+    </>
+  )
+}

--- a/apps/web/screens/Verdicts/components/InfoCardGrid/index.ts
+++ b/apps/web/screens/Verdicts/components/InfoCardGrid/index.ts
@@ -1,0 +1,2 @@
+export { InfoCardGrid } from './InfoCardGrid'
+export { InfoCard } from './InfoCard'

--- a/apps/web/screens/Verdicts/translations.strings.ts
+++ b/apps/web/screens/Verdicts/translations.strings.ts
@@ -2,6 +2,16 @@ import { defineMessages } from 'react-intl'
 
 export const m = {
   listPage: defineMessages({
+    revealMoreLabel: {
+      id: 'web.verdicts:listPage.revealMoreLabel',
+      defaultMessage: 'Sjá reifun',
+      description: 'Sjá reifun',
+    },
+    hideMoreLabel: {
+      id: 'web.verdicts:listPage.hideMoreLabel',
+      defaultMessage: 'Fela reifun',
+      description: 'Fela reifun',
+    },
     heading: {
       id: 'web.verdicts:listPage.heading',
       defaultMessage: 'Dómar og úrskurðir',


### PR DESCRIPTION
# Verdict list card reveal button

* Copy InfoCard island-ui component into the web project and edit it so we can have a subDescription and reveal button
* Display verdict presentings when user clicks on the reveal button

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Responsive card grid on Verdicts with 1–3 column layouts and improved mobile sizing.
  - New card types: simple, detailed (icons, tags, structured detail lines) and detailed-reveal with expandable "Reveal more"/"Hide" content.
  - Localized labels for reveal/hide and revealed content support.

- **Style**
  - Updated card presentation, spacing and responsive grid styles for clearer headers, descriptions and detail layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->