### PR TITLE
feat(medical-and-rehabilitation-payments): Add union name to union obj and dash to bankInfo

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/social-insurance-administration/social-insurance-administration-utils.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/social-insurance-administration/social-insurance-administration-utils.ts
@@ -415,7 +415,7 @@ export const transformApplicationToMedicalAndRehabilitationPaymentsDTO = (
     employeeSickPayEndDate,
     hasUtilizedUnionSickPayRights,
     unionSickPayEndDate,
-    unionNationalId,
+    unionInfo,
     comment,
     questionnaire,
     currentEmploymentStatus,
@@ -502,7 +502,8 @@ export const transformApplicationToMedicalAndRehabilitationPaymentsDTO = (
         ),
         ...((hasUtilizedUnionSickPayRights === YES ||
           hasUtilizedUnionSickPayRights === NO) && {
-          unionNationalId,
+          unionNationalId: unionInfo.split('::')[0],
+          unionName: unionInfo.split('::')[1],
           unionSickPayEndDate,
         }),
       },

--- a/libs/application/template-api-modules/src/lib/modules/templates/social-insurance-administration/social-insurance-administration-utils.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/social-insurance-administration/social-insurance-administration-utils.ts
@@ -453,7 +453,7 @@ export const transformApplicationToMedicalAndRehabilitationPaymentsDTO = (
     applicationId: application.id,
     ...(!shouldNotUpdateBankAccount(bankInfo, paymentInfo) && {
       domesticBankInfo: {
-        bank: getBankIsk(paymentInfo),
+        bank: formatBank(getBankIsk(paymentInfo)),
       },
     }),
     taxInfo: {

--- a/libs/application/templates/social-insurance-administration/core/src/lib/socialInsuranceAdministrationUtils.ts
+++ b/libs/application/templates/social-insurance-administration/core/src/lib/socialInsuranceAdministrationUtils.ts
@@ -31,7 +31,7 @@ export const getBankIsk = (bankInfo?: BankInfo | PaymentInfo) => {
   const bank = 'bankNumber' in bankInfo ? bankInfo.bankNumber : bankInfo.bank
 
   return bank && bankInfo.ledger && bankInfo.accountNumber
-    ? bank + bankInfo.ledger + bankInfo.accountNumber
+    ? bank + '-' + bankInfo.ledger + '-' + bankInfo.accountNumber
     : ''
 }
 

--- a/libs/application/templates/social-insurance-administration/core/src/lib/socialInsuranceAdministrationUtils.ts
+++ b/libs/application/templates/social-insurance-administration/core/src/lib/socialInsuranceAdministrationUtils.ts
@@ -31,7 +31,7 @@ export const getBankIsk = (bankInfo?: BankInfo | PaymentInfo) => {
   const bank = 'bankNumber' in bankInfo ? bankInfo.bankNumber : bankInfo.bank
 
   return bank && bankInfo.ledger && bankInfo.accountNumber
-    ? bank + '-' + bankInfo.ledger + '-' + bankInfo.accountNumber
+    ? bank + bankInfo.ledger + bankInfo.accountNumber
     : ''
 }
 

--- a/libs/application/templates/social-insurance-administration/medical-and-rehabilitation-payments/src/forms/MedicalAndRehabilitationPaymentsForm/generalInformationSection/unionSickPaySubSection.ts
+++ b/libs/application/templates/social-insurance-administration/medical-and-rehabilitation-payments/src/forms/MedicalAndRehabilitationPaymentsForm/generalInformationSection/unionSickPaySubSection.ts
@@ -82,7 +82,7 @@ export const unionSickPaySubSection = buildSubSection({
           required: true,
         }),
         buildDescriptionField({
-          id: 'unionSickPay.unionNationalId.description',
+          id: 'unionSickPay.unionInfo.description',
           title:
             medicalAndRehabilitationPaymentsFormMessage.generalInformation
               .unionSickPayUnionDescriptionTitle,

--- a/libs/application/templates/social-insurance-administration/medical-and-rehabilitation-payments/src/forms/MedicalAndRehabilitationPaymentsForm/generalInformationSection/unionSickPaySubSection.ts
+++ b/libs/application/templates/social-insurance-administration/medical-and-rehabilitation-payments/src/forms/MedicalAndRehabilitationPaymentsForm/generalInformationSection/unionSickPaySubSection.ts
@@ -92,7 +92,7 @@ export const unionSickPaySubSection = buildSubSection({
             shouldShowUnionSickPayUnionAndEndDate(answers),
         }),
         buildAsyncSelectField({
-          id: 'unionSickPay.unionNationalId',
+          id: 'unionSickPay.unionInfo',
           title:
             medicalAndRehabilitationPaymentsFormMessage.generalInformation
               .unionSickPayUnionSelectTitle,
@@ -109,7 +109,7 @@ export const unionSickPaySubSection = buildSubSection({
             return (
               data?.socialInsuranceGeneral?.unions
                 ?.map(({ name, nationalId }) => ({
-                  value: nationalId || '',
+                  value: `${nationalId}::${name}` || '',
                   label: name || '',
                 }))
                 .sort((a, b) => a.label.localeCompare(b.label)) ?? []

--- a/libs/application/templates/social-insurance-administration/medical-and-rehabilitation-payments/src/lib/dataSchema.ts
+++ b/libs/application/templates/social-insurance-administration/medical-and-rehabilitation-payments/src/lib/dataSchema.ts
@@ -258,7 +258,7 @@ export const dataSchema = z.object({
   unionSickPay: z
     .object({
       hasUtilizedUnionSickPayRights: z.string().optional().nullable(),
-      unionNationalId: z.string().optional().nullable(),
+      unionInfo: z.string().optional().nullable(),
       endDate: z.string().optional().nullable(),
       unionName: z.string().optional().nullable(),
     })
@@ -276,18 +276,18 @@ export const dataSchema = z.object({
       },
     )
     .refine(
-      ({ hasUtilizedUnionSickPayRights, unionNationalId, unionName }) => {
+      ({ hasUtilizedUnionSickPayRights, unionInfo, unionName }) => {
         // If the union name is set then we don't need to check the union
         if (unionName) {
           return true
         }
 
         return hasUtilizedUnionSickPayRights !== NOT_APPLICABLE
-          ? !!unionNationalId
+          ? !!unionInfo
           : true
       },
       {
-        path: ['unionNationalId'],
+        path: ['unionInfo'],
       },
     )
     .refine(

--- a/libs/application/templates/social-insurance-administration/medical-and-rehabilitation-payments/src/utils/medicalAndRehabilitationPaymentsUtils.ts
+++ b/libs/application/templates/social-insurance-administration/medical-and-rehabilitation-payments/src/utils/medicalAndRehabilitationPaymentsUtils.ts
@@ -104,10 +104,8 @@ export const getApplicationAnswers = (answers: Application['answers']) => {
     'unionSickPay.endDate',
   )
 
-  const unionNationalId = getValueViaPath<string>(
-    answers,
-    'unionSickPay.unionNationalId',
-  )
+  const unionInfo =
+    getValueViaPath<string>(answers, 'unionSickPay.unionInfo') ?? ''
 
   const certificateForSicknessAndRehabilitationReferenceId =
     getValueViaPath<string>(
@@ -241,7 +239,7 @@ export const getApplicationAnswers = (answers: Application['answers']) => {
     employeeSickPayEndDate,
     hasUtilizedUnionSickPayRights,
     unionSickPayEndDate,
-    unionNationalId,
+    unionInfo,
     certificateForSicknessAndRehabilitationReferenceId,
     rehabilitationPlanConfirmation,
     rehabilitationPlanReferenceId,

--- a/libs/application/templates/social-insurance-administration/medical-and-rehabilitation-payments/src/utils/overviewItems.ts
+++ b/libs/application/templates/social-insurance-administration/medical-and-rehabilitation-payments/src/utils/overviewItems.ts
@@ -1,12 +1,10 @@
-import { ApolloClient } from '@apollo/client'
 import { NO, YES } from '@island.is/application/core'
-import { siaUnionsQuery } from '@island.is/application/templates/social-insurance-administration-core/graphql/queries'
 import { socialInsuranceAdministrationMessage } from '@island.is/application/templates/social-insurance-administration-core/lib/messages'
 import {
   formatBankAccount,
   getTaxLevelOption,
 } from '@island.is/application/templates/social-insurance-administration-core/lib/socialInsuranceAdministrationUtils'
-import { SiaUnionsQuery } from '@island.is/application/templates/social-insurance-administration-core/types/schema'
+
 import {
   ExternalData,
   FormValue,

--- a/libs/application/templates/social-insurance-administration/medical-and-rehabilitation-payments/src/utils/overviewItems.ts
+++ b/libs/application/templates/social-insurance-administration/medical-and-rehabilitation-payments/src/utils/overviewItems.ts
@@ -352,20 +352,11 @@ export const unionSickPayItems = async (
   answers: FormValue,
   _externalData: ExternalData,
   _userNationalId: string,
-  apolloClient: ApolloClient<object>,
 ): Promise<KeyValueItem[]> => {
-  const {
-    hasUtilizedUnionSickPayRights,
-    unionSickPayEndDate,
-    unionNationalId,
-  } = getApplicationAnswers(answers)
+  const { hasUtilizedUnionSickPayRights, unionSickPayEndDate, unionInfo } =
+    getApplicationAnswers(answers)
 
-  const { data } = await apolloClient.query<SiaUnionsQuery>({
-    query: siaUnionsQuery,
-  })
-  const unionName = data?.socialInsuranceGeneral?.unions?.find(
-    (union) => union?.nationalId === unionNationalId,
-  )?.name
+  const unionName = unionInfo.split('::')[1]
 
   const baseItems: Array<KeyValueItem> = [
     {

--- a/libs/clients/social-insurance-administration/src/lib/socialInsuranceAdministrationClient.type.ts
+++ b/libs/clients/social-insurance-administration/src/lib/socialInsuranceAdministrationClient.type.ts
@@ -166,7 +166,8 @@ export interface EmployeeSickPay {
 
 export interface UnionSickPay {
   hasUtilizedUnionSickPayRights: number | null
-  unionInfo?: string
+  unionNationalId?: string
+  unionName?: string
   unionSickPayEndDate?: string
 }
 

--- a/libs/clients/social-insurance-administration/src/lib/socialInsuranceAdministrationClient.type.ts
+++ b/libs/clients/social-insurance-administration/src/lib/socialInsuranceAdministrationClient.type.ts
@@ -166,7 +166,7 @@ export interface EmployeeSickPay {
 
 export interface UnionSickPay {
   hasUtilizedUnionSickPayRights: number | null
-  unionNationalId?: string
+  unionInfo?: string
   unionSickPayEndDate?: string
 }
 


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Union sick pay selections now display the union name where applicable.
  - Applications can include the union name with union sick pay details.
  - Bank details are shown in a more readable format.

- Refactor
  - Union selection stores both ID and name together to simplify display.
  - Removed background lookup for union names, streamlining the overview experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->