### PR TITLE
fix(web): Verdict List - Return presentings field for supreme court verdicts

### DIFF
--- a/libs/clients/verdicts/src/lib/verdicts-client.service.ts
+++ b/libs/clients/verdicts/src/lib/verdicts-client.service.ts
@@ -141,7 +141,7 @@ export class VerdictsClientService {
             Boolean(judge?.isPresident),
           ),
           keywords: supremeCourtItem.keywords ?? [],
-          presentings: '',
+          presentings: supremeCourtItem.presentings ?? '',
         })
       }
     }


### PR DESCRIPTION
# Verdict List - Return presentings field for supreme court verdicts

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Supreme Court verdicts now display “Presentings” information when available, instead of showing it as blank.
  * Ensures more complete case details without altering other fields or behaviors.
  * Improves consistency of verdict data across sources, enhancing readability and user confidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->