### PR TITLE
fix(application-system): Stop applications in prereqs screen when no contracts

### DIFF
--- a/libs/application/core/src/lib/messages.ts
+++ b/libs/application/core/src/lib/messages.ts
@@ -830,6 +830,17 @@ export const coreErrorMessages = defineMessages({
     description:
       'Error message if there was no vehicle associated with given permno',
   },
+  noContractFoundTitle: {
+    id: 'application.system:core.fetch.data.noContractFoundTitle',
+    defaultMessage: 'Engir samningar fundust',
+    description: 'No contract found title',
+  },
+  noContractFoundSummary: {
+    id: 'application.system:core.fetch.data.noContractFoundSummary',
+    defaultMessage:
+      'Engir gildir samningar fundust skráðir fyrir þessa kennitölu.',
+    description: 'No contract found summary',
+  },
 })
 
 export const coreDelegationsMessages = defineMessages({

--- a/libs/application/template-api-modules/src/lib/modules/templates/hms/terminate-rental-agreement/terminate-rental-agreement.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/hms/terminate-rental-agreement/terminate-rental-agreement.service.ts
@@ -14,6 +14,7 @@ import {
 } from './utils'
 import { AttachmentS3Service } from '../../../shared/services'
 import { ContractStatus } from './types'
+import { coreErrorMessages } from '@island.is/application/core'
 import { isRunningOnEnvironment } from '@island.is/shared/utils'
 import { mockGetRentalAgreements } from './mockedRentalAgreements'
 
@@ -55,9 +56,23 @@ export class TerminateRentalAgreementService extends BaseTemplateApiService {
         return mockGetRentalAgreements()
       }
 
+      if (contracts.length === 0) {
+        throw new TemplateApiError(
+          {
+            title: coreErrorMessages.noContractFoundTitle,
+            summary: coreErrorMessages.noContractFoundSummary,
+          },
+          400,
+        )
+      }
+
       return contracts
     } catch (e) {
-      this.logger.error('Failed to fetch properties:', e.message)
+      if (e instanceof TemplateApiError) {
+        // If it's already a TemplateApiError, throw it
+        throw e
+      }
+      this.logger.error('Failed to fetch rental agreements:', e.message)
       throw new TemplateApiError(e, 500)
     }
   }


### PR DESCRIPTION
… 

# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Display a clear “No contract found” error when no rental agreements are available for the entered ID.
  - Provide a concise summary explaining that no valid contracts are registered.

- Bug Fixes
  - Improved error handling to surface user-friendly error messages and appropriate status codes (400 when no contracts found, 500 for unexpected errors).
  - Ensures consistent behavior across environments without affecting existing mock data flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->