### PR TITLE
fix(j-s): Court Token Expiration

### DIFF
--- a/libs/judicial-system/court-client/src/lib/courtClient.service.ts
+++ b/libs/judicial-system/court-client/src/lib/courtClient.service.ts
@@ -266,13 +266,19 @@ export class CourtClientServiceImplementation implements CourtClientService {
 
         return stripResult(res)
       })
+
       return res
     } catch (reason) {
-      // Error responses from the court service are a bit tricky.
       // Check for authentication token expiration.
+      // Error responses from the court service are a bit tricky.
+      // When a token expires, the court service responds with 400 bad request
+      // and a specific error message. The 400 response is too generic
+      // to be useful, so we need to check the error message for more details.
       if (
-        reason.message ===
-        `authenticationToken is expired - ${currentAuthenticationToken}`
+        reason.message &&
+        reason.message.includes(
+          `authenticationToken is expired - ${currentAuthenticationToken}`,
+        )
       ) {
         this.logger.info('Authentication token expired, attempting relogin', {
           reason,

--- a/libs/judicial-system/court-client/src/lib/uploadStreamApi/uploadStreamApi.ts
+++ b/libs/judicial-system/court-client/src/lib/uploadStreamApi/uploadStreamApi.ts
@@ -43,6 +43,7 @@ export class UploadStreamApi {
 
     try {
       const response = await axios(url, requestOptions)
+
       return response.data
     } catch (error) {
       if (axios.isAxiosError(error)) {
@@ -50,6 +51,7 @@ export class UploadStreamApi {
         const message = error.response?.data || error.message
         throw new Error(`Upload failed with status ${status}: ${message}`)
       }
+
       throw new Error(
         `Request failed: ${
           error instanceof Error ? error.message : String(error)


### PR DESCRIPTION
# Court Token Expiration

[Brotin villumeðhöndlun fyrir útrunnið token í samskiptum við Auði](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1211202216145480)

## What

- Fixes broken error handling when an expired auth token is used to upload a stream.

## Why

- Verified bug.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of expired authentication tokens to reduce unexpected login errors and automatically retry requests after re-authentication.
  * Ensured responses are correctly returned after requests, improving reliability of request results.

* **Style**
  * Minor formatting adjustments in upload functionality with no impact on behavior.

* **Chores**
  * Clarified internal comments around error handling for better maintainability; no changes to public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->