### PR TITLE
fix(exemption for transportation): Dont use defaultValue in tableRepeater

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/exemption-for-transportation/utils.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/exemption-for-transportation/utils.ts
@@ -245,7 +245,7 @@ export const mapHaulUnits = (application: Application): HaulUnitModel[] => {
         // Freight pairing
         cargoAssignments: getAllFreightForConvoy(
           freightPairingAnswers || [],
-          item.convoyId,
+          item.convoyId ?? '',
         ).map((item) => ({
           cargoCode: item.freightId,
           height: Number(item.height),

--- a/libs/application/templates/transport-authority/exemption-for-transportation/src/forms/mainForm/convoySection/convoyLongTerm.ts
+++ b/libs/application/templates/transport-authority/exemption-for-transportation/src/forms/mainForm/convoySection/convoyLongTerm.ts
@@ -45,14 +45,17 @@ export const ConvoyLongTermMultiField = buildMultiField({
           },
         },
       },
+      onSubmitLoad: async ({ tableItems }) => {
+        const index = tableItems.length - 1
+        return {
+          dictionaryOfItems: [
+            { path: `convoy.items[${index}].convoyId`, value: getRandomId() },
+          ],
+        }
+      },
       fields: {
         index: {
           component: 'hiddenInput',
-        },
-        convoyId: {
-          component: 'hiddenInput',
-          defaultValue: () => getRandomId(),
-          displayInTable: false,
         },
         vehicle: {
           component: 'vehiclePermnoWithInfo',

--- a/libs/application/templates/transport-authority/exemption-for-transportation/src/lib/dataSchema.ts
+++ b/libs/application/templates/transport-authority/exemption-for-transportation/src/lib/dataSchema.ts
@@ -103,7 +103,8 @@ const TransporterSchema = z
 const ConvoySchema = z.object({
   items: z.array(
     z.object({
-      convoyId: z.string(),
+      // Note: this field is actually required, but setting as optional so it is possible to use onSubmitLoad in tableRepeater
+      convoyId: z.string().optional(),
       vehicle: z.object({
         permno: z.string().length(5),
         makeAndColor: z.string().min(1),

--- a/libs/application/templates/transport-authority/exemption-for-transportation/src/utils/helperFunctions/convoyUtils.ts
+++ b/libs/application/templates/transport-authority/exemption-for-transportation/src/utils/helperFunctions/convoyUtils.ts
@@ -18,6 +18,7 @@ export const getConvoyItems = (answers: FormValue): Convoy[] => {
 
   return items.map((item) => ({
     ...item,
+    convoyId: item.convoyId ?? '',
     trailer: item.trailer?.permno
       ? {
           permno: item.trailer.permno,

--- a/libs/application/templates/transport-authority/exemption-for-transportation/src/utils/helperFunctions/handleBeforeSubmit.ts
+++ b/libs/application/templates/transport-authority/exemption-for-transportation/src/utils/helperFunctions/handleBeforeSubmit.ts
@@ -103,7 +103,7 @@ export const getUpdatedFreightPairingList = (
       )
 
       freightPairing.items = convoy.items.map(
-        (convoyItem) => convoyItemMap.get(convoyItem.convoyId) ?? null,
+        (convoyItem) => convoyItemMap.get(convoyItem.convoyId ?? '') ?? null,
       )
     }
 
@@ -122,8 +122,8 @@ export const getUpdatedVehicleSpacing = (
 
   vehicleSpacing.convoyList = convoy.items.map(
     (convoyItem) =>
-      map.get(convoyItem.convoyId) ?? {
-        convoyId: convoyItem.convoyId,
+      map.get(convoyItem.convoyId ?? '') ?? {
+        convoyId: convoyItem.convoyId ?? '',
         hasTrailer: false,
       },
   )


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved stability when adding convoy items in the long-term convoy section by generating IDs during submission, preventing rare submission errors.
  - Enhanced reliability of freight pairing and vehicle spacing calculations by gracefully handling missing convoy identifiers.
  - Reduced chance of validation blockers by tolerating temporarily missing convoy IDs during form entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->