### PR TITLE
fix(general-fishing-license): Fixing a miss-tranlated type

### DIFF
--- a/libs/application/templates/general-fishing-license/src/dataProviders/mockPaymentCatalog.ts
+++ b/libs/application/templates/general-fishing-license/src/dataProviders/mockPaymentCatalog.ts
@@ -97,7 +97,7 @@ export const MockPaymentCatalog = MockablePaymentCatalogApi.configure({
         performingOrgID: InstitutionNationalIds.FISKISTOFA,
         chargeType: 'L51',
         chargeItemCode: 'L5113',
-        chargeItemName: 'Leyfi til veiða í atvinnuskyni - ígulkerveiðileyfi',
+        chargeItemName: 'Leyfi til veiða á ígulkerjum',
         priceAmount: 22000,
       },
     ],

--- a/libs/application/templates/general-fishing-license/src/lib/messages/shipSelection.ts
+++ b/libs/application/templates/general-fishing-license/src/lib/messages/shipSelection.ts
@@ -167,10 +167,10 @@ export const shipSelection = {
       defaultMessage: 'Krabbaveiðileyfi',
       description: 'Crustaceans',
     },
-    igulker: {
-      id: 'gfl.application:shipSelection.tags.igulker',
+    urchin: {
+      id: 'gfl.application:shipSelection.tags.urchin',
       defaultMessage: 'Ígulkerjaveiðileyfi',
-      description: 'Igulker',
+      description: 'Ígulkerjaveiðileyfi',
     },
   }),
 }

--- a/libs/application/templates/general-fishing-license/src/shared/constants.ts
+++ b/libs/application/templates/general-fishing-license/src/shared/constants.ts
@@ -18,5 +18,5 @@ export const FishingLicenseChargeType = {
   lumpfish: 'L5107',
   northIceOceanCod: 'L5111',
   oceanQuahogin: 'L5110',
-  igulker: 'L5113',
+  urchin: 'L5113',
 }


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Standardized terminology for the urchin (ígulker) fishing license across the UI and translations for clearer, consistent naming; display label updated to "Leyfi til veiða á ígulkerjum".
  - No changes to pricing, codes, or eligibility; behavior remains the same.

- Chores
  - Minor housekeeping to align naming across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->