### PR TITLE
feat(web): Add keywords to verdict list cards

### DIFF
--- a/apps/web/screens/Verdicts/VerdictsList.tsx
+++ b/apps/web/screens/Verdicts/VerdictsList.tsx
@@ -1278,6 +1278,7 @@ const VerdictsList: CustomScreen<VerdictsListProps> = (props) => {
                       id: verdict.id,
                       link: { href: `/domar/${verdict.id}`, label: '' },
                       title: verdict.caseNumber,
+                      subDescription: verdict.keywords.join(', '),
                       borderColor: 'blue200',
                       detailLines,
                       revealMoreButtonProps: {


### PR DESCRIPTION
# Add keywords to verdict list cards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Verdict cards now display a secondary description listing associated keywords beneath the title in the Verdicts list.
  * This additional text appears alongside existing card content without altering navigation, interactions, or data loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->