### PR TITLE
fix(application-system-api): Country code phone input fix

### DIFF
--- a/libs/island-ui/core/src/lib/PhoneInput/PhoneInput.tsx
+++ b/libs/island-ui/core/src/lib/PhoneInput/PhoneInput.tsx
@@ -17,7 +17,7 @@ import { StringOption } from '../Select/Select.types'
 import { CountryCodeSelect } from './CountryCodeSelect/CountryCodeSelect'
 import NumberFormat, { NumberFormatValues } from 'react-number-format'
 import { countryCodesIS, countryCodesEN } from './countryCodes'
-import { parse } from 'libphonenumber-js'
+import { parsePhoneNumberFromString } from 'libphonenumber-js'
 import { useEffectOnce } from 'react-use'
 import { Locale } from '@island.is/shared/types'
 
@@ -67,7 +67,7 @@ const getDefaultValue = (
  */
 const getDefaultCountryCode = (lang: Locale, phoneNumber?: string) => {
   if (!phoneNumber) return DEFAULT_COUNTRY_CODE
-  const parsedPhoneNumber = parse(phoneNumber)
+  const parsedPhoneNumber = parsePhoneNumberFromString(phoneNumber)
   const countryCodeList = lang === 'is' ? countryCodesIS : countryCodesEN
 
   if (parsedPhoneNumber && parsedPhoneNumber.country) {


### PR DESCRIPTION
# Fixing country codes not being loaded into their fields correctly

## What

Fixing a bug that would cause numbers to load into fields with answers but put the country code as the first X characters and then skip/cut off the rest of the number. This would sometimes cause numbers to be re-saved incorrectly if the user went through the screen with a country code phone input again and didnt have an icelandic country code (which would always be defaulted to)

## Why

To get correct phone numbers when input.

## Screenshots / Gifs

Before, when user had already saved their number as +244 555 5555

<img width="824" height="367" alt="image" src="https://github.com/user-attachments/assets/52c77908-af3e-4576-8ab0-4b53027d4b5a" />

After:

<img width="778" height="294" alt="image" src="https://github.com/user-attachments/assets/afa7b42c-4105-4712-99ad-9f3946282835" />


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved phone number parsing in Phone Input to more reliably detect the default country code.
  * Reduces misidentified country codes and incorrect formatting, especially for international numbers.
  * Results in fewer validation errors and a smoother entry experience across browsers and locales.
  * Enhances consistency when pre-filling or auto-detecting country codes in forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->