### PR TITLE
fix(application-system-form): Removing some old versions of parsing phone numbers

### DIFF
--- a/libs/application/templates/estate/src/forms/OverviewSections/representative.ts
+++ b/libs/application/templates/estate/src/forms/OverviewSections/representative.ts
@@ -7,7 +7,7 @@ import {
 import { m } from '../../lib/messages'
 import { format as formatNationalId } from 'kennitala'
 import { formatPhoneNumber } from '@island.is/application/ui-components'
-import { parse } from 'libphonenumber-js'
+import { parsePhoneNumberFromString } from 'libphonenumber-js'
 
 export const representativeOverview = [
   buildDividerField({}),
@@ -45,10 +45,10 @@ export const representativeOverview = [
     width: 'half',
     label: m.phone,
     value: ({ answers }) => {
-      const parsedPhoneNumber = parse(
+      const parsedPhoneNumber = parsePhoneNumberFromString(
         getValueViaPath<string>(answers, 'representative.phone') ?? '',
       )
-      return formatPhoneNumber((parsedPhoneNumber.phone as string) || '')
+      return formatPhoneNumber(parsedPhoneNumber?.nationalNumber.toString() || '')
     },
     condition: (answers) =>
       !!getValueViaPath<string>(answers, 'representative.phone'),

--- a/libs/application/templates/estate/src/forms/OverviewSections/representative.ts
+++ b/libs/application/templates/estate/src/forms/OverviewSections/representative.ts
@@ -48,7 +48,7 @@ export const representativeOverview = [
       const parsedPhoneNumber = parsePhoneNumberFromString(
         getValueViaPath<string>(answers, 'representative.phone') ?? '',
       )
-      return formatPhoneNumber(parsedPhoneNumber?.nationalNumber.toString() || '')
+      return formatPhoneNumber(parsedPhoneNumber?.nationalNumber?.toString() || '')
     },
     condition: (answers) =>
       !!getValueViaPath<string>(answers, 'representative.phone'),

--- a/libs/application/templates/general-petition/src/forms/form.ts
+++ b/libs/application/templates/general-petition/src/forms/form.ts
@@ -25,7 +25,7 @@ import format from 'date-fns/format'
 import is from 'date-fns/locale/is'
 import { Application } from '@island.is/application/types'
 import { formatPhoneNumber } from '@island.is/application/ui-components'
-import { parse } from 'libphonenumber-js'
+import { parsePhoneNumberFromString } from 'libphonenumber-js'
 import { getExcludedDates } from '../lib/generalPetitionUtils'
 import addMonths from 'date-fns/addMonths'
 
@@ -188,10 +188,10 @@ export const form: Form = buildForm({
             buildKeyValueField({
               label: m.phone,
               value: ({ answers }) => {
-                const parsedPhoneNumber = parse(
+                const parsedPhoneNumber = parsePhoneNumberFromString(
                   getValueViaPath<string>(answers, 'phone') ?? '',
                 )
-                return formatPhoneNumber(parsedPhoneNumber.phone as string)
+                return formatPhoneNumber(parsedPhoneNumber?.nationalNumber.toString() || '')
               },
             }),
             buildKeyValueField({

--- a/libs/application/templates/general-petition/src/forms/form.ts
+++ b/libs/application/templates/general-petition/src/forms/form.ts
@@ -191,7 +191,7 @@ export const form: Form = buildForm({
                 const parsedPhoneNumber = parsePhoneNumberFromString(
                   getValueViaPath<string>(answers, 'phone') ?? '',
                 )
-                return formatPhoneNumber(parsedPhoneNumber?.nationalNumber.toString() || '')
+                return formatPhoneNumber(parsedPhoneNumber?.nationalNumber?.toString() || '')
               },
             }),
             buildKeyValueField({


### PR DESCRIPTION
## What

Replacing parse with parsePhoneNumberFromString since it appears to be depricated in the library we are using

## Why

Future proofing. Although I think these 2 instance werent failing yet like others in the backend have been. This will make sure if we ever update the package that we wont have to deal with any depricated issues.

After changes, there is no difference in these 2 applications

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Representative Overview phone numbers now render in a consistent national format.
  * General Petition form phone fields format more reliably and gracefully handle missing values.
  * Improved consistency of phone number display across multiple forms, reducing edge-case rendering issues and unexpected blanks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->