### PR TITLE
fix(application-system): Testing if newing up a new s3 client helps the access denied issue

### DIFF
--- a/libs/nest/aws/src/lib/s3.service.ts
+++ b/libs/nest/aws/src/lib/s3.service.ts
@@ -43,21 +43,26 @@ export class S3Service {
   private readonly CREDENTIAL_REFRESH_INTERVAL = 50 * 60 * 1000 // 50 minutes
 
   getS3Client(): S3Client {
-    const now = Date.now()
+    // const now = Date.now()
 
-    // Create new client if none exists or credentials are stale
-    if (
-      !this.s3Client ||
-      now - this.lastCredentialTime > this.CREDENTIAL_REFRESH_INTERVAL
-    ) {
-      this.s3Client = new S3Client({
-        credentials: defaultProvider(),
-        maxAttempts: 3,
-      })
-      this.lastCredentialTime = now
-    }
+    // // Create new client if none exists or credentials are stale
+    // if (
+    //   !this.s3Client ||
+    //   now - this.lastCredentialTime > this.CREDENTIAL_REFRESH_INTERVAL
+    // ) {
+    //   this.s3Client = new S3Client({
+    //     credentials: defaultProvider(),
+    //     maxAttempts: 3,
+    //   })
+    //   this.lastCredentialTime = now
+    // }
 
-    return this.s3Client
+    // Newing up a new s3 client every time
+    // to see if this works to solve the issue when deployed
+    return new S3Client({
+      credentials: defaultProvider(),
+      maxAttempts: 3,
+    })
   }
 
   public async getClientRegion(): Promise<string> {


### PR DESCRIPTION
# Access denied / credentials issue with s3 clients in aws sdk v3

Attach a link to issue if relevant

## What

Trying to stop getting sporatic access denied errors that stop files from being upload.
This bug happens very inconsistently, so seeing if this helps when deployed.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of cloud storage operations, reducing intermittent authentication errors during uploads, downloads, and asset management.

* **Refactor**
  * Streamlined cloud storage client handling to ensure consistent behavior and retry logic across operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->