### PR TITLE
feat(web): Allow cms to edit what the email subject is for form submissions on web

### DIFF
--- a/libs/api/domains/communications/src/lib/communications.service.ts
+++ b/libs/api/domains/communications/src/lib/communications.service.ts
@@ -214,6 +214,12 @@ export class CommunicationsService {
       }) ?? [],
     )
 
+    let subject = `Island.is form: ${form.title}`
+
+    if (form.emailSubject?.trim()) {
+      subject = form.emailSubject.trim()
+    }
+
     const emailOptions = {
       from: {
         name: input.name,
@@ -224,7 +230,7 @@ export class CommunicationsService {
         address: input.email,
       },
       to: recipient,
-      subject: `Island.is form: ${form.title}`,
+      subject,
       text: input.message,
       attachments,
     }

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -1432,6 +1432,9 @@ export interface IFormFields {
 
   /** Recipient List */
   recipientList?: string[] | undefined
+
+  /** Email subject */
+  emailSubject?: string | undefined
 }
 
 export interface IForm extends Entry<IFormFields> {

--- a/libs/cms/src/lib/models/form.model.ts
+++ b/libs/cms/src/lib/models/form.model.ts
@@ -41,6 +41,9 @@ export class Form {
 
   @Field(() => [String], { nullable: true })
   recipientList?: string[]
+
+  @Field(() => String, { nullable: true })
+  emailSubject?: string
 }
 
 export const mapForm = ({ sys, fields }: IForm): SystemMetadata<Form> => {
@@ -62,5 +65,6 @@ export const mapForm = ({ sys, fields }: IForm): SystemMetadata<Form> => {
       ? mapFormField(fields.recipientFormFieldDecider)
       : undefined,
     recipientList: recipientList,
+    emailSubject: fields.emailSubject ?? '',
   }
 }


### PR DESCRIPTION
# Allow cms to edit what the email subject is for form submissions on web

## What

New field on the Form content type in the cms for email subject in form submissions on the web.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an optional “Email subject” setting for forms, enabling custom subjects for submission notification emails.
  - If no subject is provided or it’s blank, a default subject based on the form title is used automatically.
  - The new subject is reflected in outgoing emails without affecting other email fields or delivery behavior.
  - The setting is available when configuring forms and is included in form data returned by APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->