### PR TITLE
fix(native-app): Fix Android back button navigation bug

### DIFF
--- a/apps/native/app/src/hooks/use-throttle-state.ts
+++ b/apps/native/app/src/hooks/use-throttle-state.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react'
+
+export const useThrottleState = (state: string, delay = 500) => {
+  const [throttledState, setThrottledState] = useState(state)
+
+  useEffect(() => {
+    const timeout = setTimeout(
+      () => setThrottledState(state),
+      state === '' ? 0 : delay,
+    )
+
+    return () => clearTimeout(timeout)
+  }, [state, delay])
+
+  return throttledState
+}

--- a/apps/native/app/src/screens/document-detail/document-detail.tsx
+++ b/apps/native/app/src/screens/document-detail/document-detail.tsx
@@ -49,7 +49,7 @@ import {
   ButtonRegistry,
   ComponentRegistry,
 } from '../../utils/component-registry'
-import { ListParams } from '../inbox/inbox'
+import { ListParams } from '../inbox/components/pressable-list-item'
 import { ButtonDrawer } from './components/button-drawer'
 import { getButtonsForActions } from './utils/get-buttons-for-actions'
 import { shareFile } from './utils/share-file'

--- a/apps/native/app/src/screens/inbox/components/pressable-list-item.tsx
+++ b/apps/native/app/src/screens/inbox/components/pressable-list-item.tsx
@@ -1,0 +1,66 @@
+import React, { memo } from 'react'
+
+import { DocumentCategory, DocumentV2 } from '../../../graphql/types/schema'
+import { navigateTo } from '../../../lib/deep-linking'
+import { useOrganizationsStore } from '../../../stores/organizations-store'
+import { InboxCard } from '../../../ui'
+import { Filters } from '../utils/inbox-filters'
+
+export type ListParams = Filters & { category?: DocumentCategory }
+
+type PressableListItemProps = {
+  item: DocumentV2
+  listParams: ListParams
+  selectable: boolean
+  selectedItems: string[]
+  setSelectedItems: React.Dispatch<React.SetStateAction<string[]>>
+  setSelectedState: React.Dispatch<React.SetStateAction<boolean>>
+  isFeature2WayMailboxEnabled: boolean
+}
+
+export const PressableListItem = memo(
+  ({
+    item,
+    listParams,
+    selectable,
+    selectedItems,
+    setSelectedItems,
+    setSelectedState,
+    isFeature2WayMailboxEnabled,
+  }: PressableListItemProps) => {
+    const { getOrganizationLogoUrl } = useOrganizationsStore()
+    const isSelected = selectable && selectedItems.includes(item.id)
+
+    return (
+      <InboxCard
+        key={item.id}
+        subject={item.subject}
+        publicationDate={item.publicationDate}
+        id={item.id}
+        unread={!item.opened}
+        senderName={item.sender.name}
+        icon={item.sender.name && getOrganizationLogoUrl(item.sender.name, 75)}
+        isUrgent={item.isUrgent}
+        replyable={isFeature2WayMailboxEnabled ? item.replyable : false}
+        bookmarked={item.bookmarked}
+        selectable={selectable}
+        selected={isSelected}
+        onPressIcon={() => {
+          setSelectedState((prev) => !prev)
+          setSelectedItems([...selectedItems, item.id])
+        }}
+        onPress={() =>
+          selectable
+            ? isSelected
+              ? setSelectedItems(selectedItems.filter((id) => id !== item.id))
+              : setSelectedItems([...selectedItems, item.id])
+            : navigateTo(`/inbox/${item.id}`, {
+                title: item.sender.name,
+                isUrgent: item.isUrgent,
+                listParams,
+              })
+        }
+      />
+    )
+  },
+)

--- a/apps/native/app/src/screens/inbox/utils/inbox-filters.ts
+++ b/apps/native/app/src/screens/inbox/utils/inbox-filters.ts
@@ -1,0 +1,23 @@
+export type Filters = {
+  opened?: boolean
+  archived?: boolean
+  bookmarked?: boolean
+  subjectContains?: string
+  senderNationalId?: string[]
+  categoryIds?: string[]
+  dateFrom?: Date
+  dateTo?: Date
+}
+
+export const applyFilters = (filters?: Filters) => {
+  return {
+    archived: filters?.archived ? true : undefined,
+    bookmarked: filters?.bookmarked ? true : undefined,
+    opened: filters?.opened ? false : undefined,
+    subjectContains: filters?.subjectContains ?? '',
+    senderNationalId: filters?.senderNationalId ?? [],
+    categoryIds: filters?.categoryIds ?? [],
+    dateFrom: filters?.dateFrom,
+    dateTo: filters?.dateTo,
+  }
+}


### PR DESCRIPTION
# Fix Android back button inbox bug and refactor inbox screen

Note! This issue is caused by a bug in the React Native Navigation (RNN) library: when Navigation.mergeOptions sets leftButtons during a render cycle (e.g., inside a useEffect), the native Android toolbar can get stuck, causing the back button to persist on the root screen after navigating back. And setting `leftButtons: undefined | null | []` does not work!

## What

- **Back Button Fix on Android**:  
  - Fixed issue where the back button persisted on the Inbox root screen after navigating back from the Document Details screen and Inbox filters screen.

- Little Inbox screen refactor since the component had grown too large and was becoming difficult to read through
- Removes unread count red bubble from inbox tab.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Inbox supports multi-select with Select All/Deselect All.
  - Bulk actions added, including bookmarking multiple items.
  - Sender logos now appear on list items for quicker recognition.

- Bug Fixes
  - Search is more responsive with reduced input lag.
  - Improved Android top bar/back button behavior to match expectations.
  - More consistent filter defaults for categories, sender, and dates.

- Refactor
  - Inbox screen rebuilt with modular components and optimized navigation, improving stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->