### PR TITLE
fix(form-system): update foreign key to cascade on delete

### DIFF
--- a/apps/services/form-system/migrations/20250910094919-cascade-onDelete-form.js
+++ b/apps/services/form-system/migrations/20250910094919-cascade-onDelete-form.js
@@ -1,0 +1,41 @@
+'use strict'
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // Remove the existing foreign key constraint on form_certification_type.form_id
+    await queryInterface.removeConstraint(
+      'form_certification_type',
+      'form_certification_type_form_id_fkey',
+    )
+    // Add the foreign key constraint with ON DELETE CASCADE
+    await queryInterface.addConstraint('form_certification_type', {
+      fields: ['form_id'],
+      type: 'foreign key',
+      name: 'form_certification_type_form_id_fkey',
+      references: {
+        table: 'form',
+        field: 'id',
+      },
+      onDelete: 'CASCADE',
+    })
+  },
+
+  async down(queryInterface, Sequelize) {
+    // Remove the CASCADE constraint
+    await queryInterface.removeConstraint(
+      'form_certification_type',
+      'form_certification_type_form_id_fkey',
+    )
+    // Restore the original constraint (no cascade)
+    await queryInterface.addConstraint('form_certification_type', {
+      fields: ['form_id'],
+      type: 'foreign key',
+      name: 'form_certification_type_form_id_fkey',
+      references: {
+        table: 'form',
+        field: 'id',
+      },
+      onDelete: 'RESTRICT',
+    })
+  },
+}


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting a form now automatically removes its associated certification type links, preventing orphaned records and related errors.
  * Improves data consistency and reduces failure cases during form deletion.

* **Chores**
  * Added a reversible database migration to update delete behavior, enabling cascade removal of related records and allowing rollback to the previous restrictive behavior if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->