### PR TITLE
fix(native-app): Remove login chrome check warning on Android

### DIFF
--- a/apps/native/app/src/screens/login/login.tsx
+++ b/apps/native/app/src/screens/login/login.tsx
@@ -3,8 +3,6 @@ import { FormattedMessage, useIntl } from 'react-intl'
 import {
   Alert,
   Image,
-  Linking,
-  NativeModules,
   SafeAreaView,
   TouchableOpacity,
   View,
@@ -17,7 +15,6 @@ import { useBrowser } from '../../lib/use-browser'
 import { useAuthStore } from '../../stores/auth-store'
 import { preferencesStore } from '../../stores/preferences-store'
 import { Button, dynamicColor, font, Illustration } from '../../ui'
-import { isAndroid } from '../../utils/devices'
 import { nextOnboardingStep } from '../../utils/onboarding'
 import { testIDs } from '../../utils/test-ids'
 
@@ -50,21 +47,6 @@ const LightButtonText = styled.Text`
   })}
 `
 
-function getChromeVersion(): Promise<number> {
-  return new Promise((resolve) => {
-    NativeModules.IslandModule.getAppVersion(
-      'com.android.chrome',
-      (version: string) => {
-        if (version) {
-          resolve(Number(version?.split('.')?.[0] || 0))
-        } else {
-          resolve(0)
-        }
-      },
-    )
-  })
-}
-
 export const LoginScreen: NavigationFunctionComponent = ({ componentId }) => {
   const authStore = useAuthStore()
   const { openBrowser } = useBrowser()
@@ -72,35 +54,6 @@ export const LoginScreen: NavigationFunctionComponent = ({ componentId }) => {
   const [isLoggingIn, setIsLoggingIn] = useState(false)
 
   const onLoginPress = async () => {
-    if (isAndroid) {
-      const chromeVersion = await getChromeVersion()
-      if (chromeVersion < 55) {
-        // Show dialog on how to update.
-        Alert.alert(
-          intl.formatMessage({ id: 'login.outdatedBrowserTitle' }),
-          intl.formatMessage({ id: 'login.outdatedBrowserMessage' }),
-          [
-            {
-              text: intl.formatMessage({
-                id: 'login.outdatedBrowserUpdateButton',
-              }),
-              style: 'default',
-              onPress() {
-                Linking.openURL('market://details?id=com.android.chrome')
-              },
-            },
-            {
-              style: 'cancel',
-              text: intl.formatMessage({
-                id: 'login.outdatedBrowserCancelButton',
-              }),
-            },
-          ],
-        )
-        return
-      }
-    }
-
     if (isLoggingIn) {
       return
     }

--- a/apps/native/app/src/screens/login/testing-login.tsx
+++ b/apps/native/app/src/screens/login/testing-login.tsx
@@ -66,21 +66,6 @@ const Text = styled.Text`
   }))};
 `
 
-function getChromeVersion(): Promise<number> {
-  return new Promise((resolve) => {
-    NativeModules.IslandModule.getAppVersion(
-      'com.android.chrome',
-      (version: string) => {
-        if (version) {
-          resolve(Number(version?.split('.')?.[0] || 0))
-        } else {
-          resolve(0)
-        }
-      },
-    )
-  })
-}
-
 export const TestingLoginScreen: NavigationFunctionComponent = ({
   componentId,
 }) => {
@@ -115,35 +100,6 @@ export const TestingLoginScreen: NavigationFunctionComponent = ({
         'Please authenticate with cognito before logging in.',
       )
       return
-    }
-
-    if (Platform.OS === 'android') {
-      const chromeVersion = await getChromeVersion()
-      if (chromeVersion < 55) {
-        // Show dialog on how to update.
-        Alert.alert(
-          intl.formatMessage({ id: 'login.outdatedBrowserTitle' }),
-          intl.formatMessage({ id: 'login.outdatedBrowserMessage' }),
-          [
-            {
-              text: intl.formatMessage({
-                id: 'login.outdatedBrowserUpdateButton',
-              }),
-              style: 'default',
-              onPress() {
-                Linking.openURL('market://details?id=com.android.chrome')
-              },
-            },
-            {
-              style: 'cancel',
-              text: intl.formatMessage({
-                id: 'login.outdatedBrowserCancelButton',
-              }),
-            },
-          ],
-        )
-        return
-      }
     }
 
     if (isLoggingIn) {

--- a/apps/native/app/src/screens/login/testing-login.tsx
+++ b/apps/native/app/src/screens/login/testing-login.tsx
@@ -4,8 +4,6 @@ import {
   Alert,
   AlertButton,
   Image,
-  Linking,
-  NativeModules,
   Platform,
   SafeAreaView,
   TouchableOpacity,


### PR DESCRIPTION
# Remove login chrome check warning on Android

[Notion task](https://www.notion.so/Remove-Chrome-version-check-on-Android-1605a76701d680fb81e0c8aaf54baeb4?source=copy_link)

## What

Removes login chrome check on Android

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Android users no longer see the outdated Chrome prompt during login; the flow proceeds directly without interruption.

* **Chores**
  * Removed obsolete Android Chrome version check and update dialog from login screens.
  * Cleaned up related unused imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->