### PR TITLE
fix(native-app): Fix apply filters logic

### DIFF
--- a/apps/native/app/src/screens/inbox/inbox-filter.tsx
+++ b/apps/native/app/src/screens/inbox/inbox-filter.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { ScrollView, View } from 'react-native'
 import { Navigation } from 'react-native-navigation'
@@ -42,7 +42,7 @@ const { useNavigationOptions, getNavigationOptions } =
     },
   }))
 
-export function InboxFilterScreen(props: {
+type InboxFilterScreenProps = {
   opened: boolean
   bookmarked: boolean
   archived: boolean
@@ -53,8 +53,13 @@ export function InboxFilterScreen(props: {
   dateFrom?: Date
   dateTo?: Date
   componentId: string
-}) {
-  useConnectivityIndicator({ componentId: props.componentId })
+}
+
+export function InboxFilterScreen({
+  componentId,
+  ...props
+}: InboxFilterScreenProps) {
+  useConnectivityIndicator({ componentId })
 
   const intl = useIntl()
   const [opened, setOpened] = useState(props.opened)
@@ -89,36 +94,16 @@ export function InboxFilterScreen(props: {
     dateTo
   )
 
-  useNavigationOptions(props.componentId)
+  useNavigationOptions(componentId)
 
   useNavigationButtonPress(({ buttonId }) => {
     if (buttonId === ButtonRegistry.InboxFilterClearButton) {
       clearAllFilters()
     }
-  }, props.componentId)
+  }, componentId)
 
   useEffect(() => {
-    Navigation.updateProps(ComponentRegistry.InboxScreen, {
-      opened,
-      bookmarked,
-      archived,
-      senderNationalId: selectedSenders,
-      categoryIds: selectedCategories,
-      dateFrom,
-      dateTo,
-    })
-  }, [
-    opened,
-    bookmarked,
-    archived,
-    selectedSenders,
-    selectedCategories,
-    dateFrom,
-    dateTo,
-  ])
-
-  useEffect(() => {
-    Navigation.mergeOptions(props.componentId, {
+    Navigation.mergeOptions(componentId, {
       topBar: {
         rightButtons: isSelected
           ? [
@@ -132,7 +117,34 @@ export function InboxFilterScreen(props: {
           : [],
       },
     })
-  }, [isSelected, props.componentId, intl])
+  }, [isSelected, componentId, intl])
+
+  const onApplyFilters = useCallback(() => {
+    Navigation.updateProps(
+      ComponentRegistry.InboxScreen,
+      {
+        opened,
+        bookmarked,
+        archived,
+        senderNationalId: selectedSenders,
+        categoryIds: selectedCategories,
+        dateFrom,
+        dateTo,
+      },
+      () => {
+        Navigation.pop(componentId)
+      },
+    )
+  }, [
+    componentId,
+    opened,
+    bookmarked,
+    archived,
+    selectedSenders,
+    selectedCategories,
+    dateFrom,
+    dateTo,
+  ])
 
   return (
     <View
@@ -255,9 +267,7 @@ export function InboxFilterScreen(props: {
         <ButtonContainer>
           <Button
             title={intl.formatMessage({ id: 'inbox.filterApplyButton' })}
-            onPress={() => {
-              Navigation.pop(props.componentId)
-            }}
+            onPress={onApplyFilters}
           />
         </ButtonContainer>
       )}

--- a/apps/native/app/src/screens/inbox/inbox.tsx
+++ b/apps/native/app/src/screens/inbox/inbox.tsx
@@ -55,7 +55,7 @@ import { testIDs } from '../../utils/test-ids'
 import { ActionBar } from './components/action-bar'
 import { PressableListItem } from './components/pressable-list-item'
 import { Toast, ToastVariant } from './components/toast'
-import { applyFilters } from './utils/inbox-filters'
+import { normalizesFilters } from './utils/inbox-filters'
 
 type ListItem =
   | { id: string; type: 'skeleton' | 'empty' }
@@ -196,7 +196,7 @@ export const InboxScreen: NavigationFunctionComponent<InboxScreenProps> = ({
     dateTo,
   ])
 
-  const [filters, setFilters] = useState(applyFilters(incomingFilters))
+  const [filters, setFilters] = useState(normalizesFilters(incomingFilters))
   const [selectState, setSelectedState] = useState(false)
   const [selectedItems, setSelectedItems] = useState<string[]>([])
 
@@ -316,7 +316,7 @@ export const InboxScreen: NavigationFunctionComponent<InboxScreenProps> = ({
   }, componentId)
 
   useEffect(() => {
-    const appliedFilters = applyFilters(incomingFilters)
+    const appliedFilters = normalizesFilters(incomingFilters)
     // deep equal incoming filters
     if (
       JSON.stringify(appliedFilters) === JSON.stringify(filters) ||

--- a/apps/native/app/src/screens/inbox/utils/inbox-filters.ts
+++ b/apps/native/app/src/screens/inbox/utils/inbox-filters.ts
@@ -9,7 +9,7 @@ export type Filters = {
   dateTo?: Date
 }
 
-export const applyFilters = (filters?: Filters) => {
+export const normalizesFilters = (filters?: Filters) => {
   return {
     archived: filters?.archived ? true : undefined,
     bookmarked: filters?.bookmarked ? true : undefined,


### PR DESCRIPTION
# Fix apply filters logic

## What

Previously, our inbox filters were applied immediately on each change, making the Apply Filters button redundant. This update ensures that all selected filters are applied together at once, reducing unnecessary network requests and improving performance.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inbox filters now apply only when you tap “Apply,” then return you to the Inbox with the chosen filters active.

* **Bug Fixes**
  * Prevents unintended updates to the Inbox while adjusting filters, ensuring changes aren’t applied until confirmed.

* **Refactor**
  * Streamlined navigation behavior for the filter screen to improve stability and responsiveness.
  * Standardized filter computation for consistent results across the Inbox experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->