### PR TITLE
fix(marriage-conditions): fix rare empty answers submission on firefox

### DIFF
--- a/libs/application/templates/marriage-conditions/src/fields/PhoneWithElectronicId/index.tsx
+++ b/libs/application/templates/marriage-conditions/src/fields/PhoneWithElectronicId/index.tsx
@@ -2,7 +2,6 @@ import React, { FC, useEffect, useState } from 'react'
 import { useLocale } from '@island.is/localization'
 import { m } from '../../lib/messages'
 import {
-  InputController,
   PhoneInputController,
 } from '@island.is/shared/form-fields'
 import { Box } from '@island.is/island-ui/core'
@@ -68,7 +67,7 @@ export const PhoneWithElectronicId: FC<
         setLoading(false)
       })
     }
-  }, [phoneNumber, nationalId])
+  }, [phoneNumber, nationalId, answers, getElectronicIdStatus, setValue, topId])
 
   return (
     <Box marginTop={2}>

--- a/libs/application/templates/marriage-conditions/src/fields/PhoneWithElectronicId/index.tsx
+++ b/libs/application/templates/marriage-conditions/src/fields/PhoneWithElectronicId/index.tsx
@@ -1,9 +1,7 @@
 import React, { FC, useEffect, useState } from 'react'
 import { useLocale } from '@island.is/localization'
 import { m } from '../../lib/messages'
-import {
-  PhoneInputController,
-} from '@island.is/shared/form-fields'
+import { PhoneInputController } from '@island.is/shared/form-fields'
 import { Box } from '@island.is/island-ui/core'
 import { FieldBaseProps } from '@island.is/application/types'
 import { getErrorViaPath } from '@island.is/application/core'

--- a/libs/application/templates/marriage-conditions/src/fields/PhoneWithElectronicId/index.tsx
+++ b/libs/application/templates/marriage-conditions/src/fields/PhoneWithElectronicId/index.tsx
@@ -81,10 +81,8 @@ export const PhoneWithElectronicId: FC<
         loading={loading}
         error={errors ? getErrorViaPath(errors, id) : undefined}
         onChange={(e) => setPhoneNumber(e.target.value)}
+        defaultValue=""
       />
-      <Box hidden={true}>
-        <InputController id={id} defaultValue={''} />
-      </Box>
     </Box>
   )
 }


### PR DESCRIPTION
## What

Fix rare submissions of empty answers in marriage-conditions (seen with Mozilla user agents) by removing a duplicate hidden input that conflicted with react-hook-form registration.

## Why

A rare issue affecting users on Firefox resulted in an empty answers object being sent to the backend, causing the application to be stuck in a broken state.

## Screenshots / Gifs

None (no visible changes) 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Phone number field now initializes empty by default to prevent stray or pre-filled values.
  * Removed an unnecessary hidden element to reduce rendering glitches.
  * Improved reliability and sync of phone input updates during loading and electronic ID verification flows.

* **Refactor**
  * Simplified field setup to use a direct default value, reducing complexity without changing user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->