### PR TITLE
feat(hms-ra): add usage units to overview

### DIFF
--- a/libs/application/templates/rental-agreement/src/utils/overviewUtils.ts
+++ b/libs/application/templates/rental-agreement/src/utils/overviewUtils.ts
@@ -663,20 +663,24 @@ export const rentalPropertyOverview = (
       'registerProperty.searchresults.units',
     ) ?? []
 
-  const unitIdsAsString = units
-    ?.map((unit) => `F${unit.propertyCode}`)
-    .join(', ')
-
+  const uniqueUnitIds = new Set(units.map((unit) => unit.propertyCode))
+  const unitIdsAsString = [...uniqueUnitIds].join(', ')
+  const usageUnits = units.map(
+    (unit) => `${unit.propertyUsageDescription} - ${unit.unitCode}`,
+  )
   return [
     {
       width: 'full',
       keyText: searchResults?.label,
-      valueText: {
-        ...m.summary.rentalPropertyId,
-        values: {
-          propertyId: unitIdsAsString,
+      valueText: [
+        {
+          ...m.summary.rentalPropertyId,
+          values: {
+            propertyId: unitIdsAsString,
+          },
         },
-      },
+        ...usageUnits,
+      ],
     },
   ]
 }


### PR DESCRIPTION
## What

Add usage units to the overview screen

## Why

It was missing and was requested by HMS

## Screenshots / Gifs

<img width="1397" height="1203" alt="image" src="https://github.com/user-attachments/assets/6a114b7c-87f6-478c-9aac-dcd9f8e6f7f9" />

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rental property overview now displays per‑unit usage details as additional lines (e.g., “Usage description - UnitCode”).
  * Property identifiers shown in the overview are deduplicated and no longer include the leading “F”.
  * The overview section now presents multiple lines (property ID plus usage details) instead of a single combined entry, improving clarity for properties with multiple units.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->