### PR TITLE
fix(clients-documents-v2): Fix opened input logic

### DIFF
--- a/libs/clients/documents-v2/src/lib/documentsClientV2.service.ts
+++ b/libs/clients/documents-v2/src/lib/documentsClientV2.service.ts
@@ -39,7 +39,8 @@ export class DocumentsClientV2Service {
       const sanitizedObj = {} as T
 
       for (const key in obj) {
-        if (obj[key]) {
+        // Include "opened" when false since it's a meaningful falsy value
+        if (obj[key] || (key === 'opened' && obj[key] === false)) {
           if (Array.isArray(obj[key]) && obj[key].length === 0) {
             continue
           }


### PR DESCRIPTION
# Fix opened input logic

## What

Fix opened filtering logic in documents since it is broken in app and my pages

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures documents marked as unopened are accurately retained in lists, preventing loss of the unopened status.
  * Fixes inconsistencies in badges, counters, filters, and sorting that depended on the unopened state.
  * Improves reliability of document status display across views without changing any user controls or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->