### PR TITLE
chore(core): Reset NX daemon after running codegen

### DIFF
--- a/scripts/codegen.js
+++ b/scripts/codegen.js
@@ -60,8 +60,8 @@ const main = async () => {
     }
   }
 
-  // In NX 21.2.2 daemon slows down significantly after codegen, so we reset it.
-  await exec(`nx reset`)
+  // In NX 21.2.2 daemon slows down significantly after codegen, so we restart it.
+  await exec('nx daemon --stop')
 }
 
 main()


### PR DESCRIPTION
## What

Reset NX Daemon after running codegen.

## Why

After upgrading NX, the operations which depend on the NX daemon become very slow in some cases. The problem seems to be worse after running codegen, indicating some kind of performance degradation after running hundreds of codegen targets.

In this PR, we try to reset the NX daemon after running the codegen. It may cause the next job to require more NX initialisation, but hopefully the overall DX is improved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a post-generation workspace cleanup step to stop the background workspace daemon, improving consistency between runs and reducing intermittent build slowdowns.
  * Error handling was not changed for per-target failures; cleanup runs only on successful generation and failures still surface to aid troubleshooting.
  * No user-facing changes; improvements affect development/build stability only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->