### PR TITLE
chore(core): Also stop the nx daemon if we catch an error in codegen script

### DIFF
--- a/scripts/codegen.js
+++ b/scripts/codegen.js
@@ -27,6 +27,7 @@ const fileExists = async (path) =>
   !!(await promisify(stat)(path).catch((_) => false))
 
 const main = async () => {
+  let exitCode = 0
   const schemaExists = await fileExists(SCHEMA_PATH)
   const nxParallel = parseInt(process.env.NX_PARALLEL ?? '6', 10)
   // NX_MAX_PARALLEL sets the parallelism for file system operations in Nx.
@@ -56,12 +57,15 @@ const main = async () => {
       )
     } catch (err) {
       console.error(`Error running command: ${err.message}`)
-      process.exit(err.code || 1)
+      exitCode = err.code || 1
+      break
     }
   }
 
   // In NX 21.2.2 daemon slows down significantly after codegen, so we restart it.
   await exec('nx daemon --stop')
+
+  process.exit(exitCode)
 }
 
 main()


### PR DESCRIPTION
## What

After Nx 21.2.2 upgrade the Nx daemon leaks thread after our codegen script so we are explicitly stopping the daemon. This PR also stops the daemon if an error occurs in one of the commands.

## Why

When there is an error the daemon also leaks thread so we need to handle that also.

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Code generation workflow now handles errors without abrupt termination, ensuring a single, reliable exit path.
  * Accurate exit codes are returned (0 on success, non‑zero on failure), improving CI feedback and scripting.
  * Background services are cleanly stopped after runs, preventing lingering processes and resource leaks.
  * Overall stability and reliability of the code generation process have been improved for both local and CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->