### PR TITLE
fix(application-system): Fix renter validation regression

### DIFF
--- a/libs/application/templates/rental-agreement/src/lib/schemas/landlordAndTenantSchema.ts
+++ b/libs/application/templates/rental-agreement/src/lib/schemas/landlordAndTenantSchema.ts
@@ -182,6 +182,10 @@ export const parties = z
     const landlordTable = landlordInfo.table || []
     const tenantTable = tenantInfo.table || []
 
+    // Create arrays of national IDs from landlord and tenant tables
+    const landlordNationalIds = landlordTable
+      .map((rep) => rep.nationalIdWithName?.nationalId)
+      .filter((id) => !!id) as string[]
     const tenantNationalIds = tenantTable
       .map((tenant) => tenant.nationalIdWithName?.nationalId)
       .filter((id) => !!id) as string[]
@@ -203,6 +207,29 @@ export const parties = z
           'landlordInfo',
           'table',
           duplicateIndexInLandlordTable,
+          'nationalIdWithName',
+          'nationalId',
+        ],
+      })
+    }
+
+    // Check tenantTable for duplicates in landlordTable and representativeTable
+    const {
+      hasDuplicates: hasDuplicatesInTenantTable,
+      duplicateIndex: duplicateIndexInTenantTable,
+    } = checkforDuplicatesHelper(tenantTable, landlordNationalIds)
+
+    if (
+      hasDuplicatesInTenantTable &&
+      duplicateIndexInTenantTable !== undefined
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        params: m.partiesDetails.duplicateNationalIdError,
+        path: [
+          'tenantInfo',
+          'table',
+          duplicateIndexInTenantTable,
           'nationalIdWithName',
           'nationalId',
         ],


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What
Fix duplication checking for renters -> landlords

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The rental agreement form now flags duplicate national IDs across landlord and tenant entries, preventing the same ID from being used in both tables.
  - Errors are shown on the exact row and national ID field, providing clear guidance to resolve issues.
  - Maintains existing per-table duplicate checks while adding cross-table validation, improving accuracy and data quality during submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->