### PR TITLE
fix(graphql): Remove perPage parameter from getOrganizations query

### DIFF
--- a/apps/native/app/src/graphql/queries/inbox.graphql
+++ b/apps/native/app/src/graphql/queries/inbox.graphql
@@ -5,7 +5,7 @@ mutation MarkAllDocumentsAsRead {
 }
 
 query ListOrganizations {
-  getOrganizations(input: { lang: "is-IS", perPage: 200 }) {
+  getOrganizations(input: { lang: "is-IS" }) {
     items {
       ...OrganizationFragment
     }


### PR DESCRIPTION
# Remove perPage parameter from getOrganizations query


## What

We where only fetching 200 organizations out of 249

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
