### PR TITLE
fix(utils): Make distinctCol optional in count params for pagination

### DIFF
--- a/apps/services/payments/src/app/paymentFlow/paymentFlow.service.ts
+++ b/apps/services/payments/src/app/paymentFlow/paymentFlow.service.ts
@@ -745,6 +745,7 @@ export class PaymentFlowService {
       after: after || '',
       before: before,
       limit: limit || 10,
+      distinctCol: this.paymentFlowModel.primaryKeyAttribute,
       include: [
         {
           model: PaymentFlowCharge,

--- a/libs/nest/pagination/src/lib/paginate.ts
+++ b/libs/nest/pagination/src/lib/paginate.ts
@@ -121,6 +121,7 @@ export interface PaginateInput {
   after: string
   before?: string
   limit: number
+  distinctCol?: string
   [key: string]: any
 }
 
@@ -140,6 +141,7 @@ export async function paginate<T = any>({
   before,
   limit,
   attributes,
+  distinctCol,
   ...queryArgs
 }: PaginateInput): Promise<{
   totalCount: number
@@ -174,14 +176,14 @@ export async function paginate<T = any>({
     where,
     ...queryArgs,
     distinct: true,
-    col: Model.primaryKeyAttribute,
+    ...(distinctCol && { col: distinctCol }),
   }
 
   const cursorCountQueryOptions = {
     where: paginationWhere,
     ...queryArgs,
     distinct: true,
-    col: Model.primaryKeyAttribute,
+    ...(distinctCol && { col: distinctCol }),
   }
 
   const [instances, totalCount, cursorCount] = await Promise.all([


### PR DESCRIPTION
The pagination library was using col: Model.primaryKeyAttribute for all DISTINCT counting operations, which caused issues with complex queries

Made the col parameter optional by adding a new distinctCol parameter to the pagination function

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
