### PR TITLE
fix(email-service): resolve HTML entity escaping and asset copying after NX update

### DIFF
--- a/apps/services/user-notification/project.json
+++ b/apps/services/user-notification/project.json
@@ -23,7 +23,11 @@
         "esbuildConfig": "tools/esbuild.config.js",
         "format": ["cjs"],
         "assets": [
-          "apps/services/user-notification/src/assets",
+          {
+            "glob": "**/*",
+            "input": "apps/services/user-notification/src/assets",
+            "output": "./assets"
+          },
           {
             "glob": "*",
             "input": "apps/services/user-notification/migrations",

--- a/libs/email-service/src/tools/adapter.service.ts
+++ b/libs/email-service/src/tools/adapter.service.ts
@@ -97,6 +97,10 @@ export class AdapterService {
             }
           }
 
+          if (component === 'spacer') {
+            item.context = { ...item.context, nbsp: '\u00A0' }
+          }
+
           return this.cachedComponents[component](item.context, {
             partials: this.cachedComponents,
           })
@@ -118,6 +122,7 @@ export class AdapterService {
       {
         title,
         body,
+        nbsp: '\u00A0',
       },
       { partials: this.cachedComponents },
     )

--- a/libs/email-service/src/tools/design/layout.hbs
+++ b/libs/email-service/src/tools/design/layout.hbs
@@ -35,6 +35,6 @@
       </tr>
     </table>
 
-    <div style="display:none; white-space:nowrap; font:15px courier; line-height:0;"> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;</div>
+    <div style="display:none; white-space:nowrap; font:15px courier; line-height:0;"> {{{nbsp}}} {{{nbsp}}} {{{nbsp}}} {{{nbsp}}} {{{nbsp}}} {{{nbsp}}} {{{nbsp}}} {{{nbsp}}} {{{nbsp}}} {{{nbsp}}} {{{nbsp}}} {{{nbsp}}} {{{nbsp}}} {{{nbsp}}} {{{nbsp}}} {{{nbsp}}} {{{nbsp}}} {{{nbsp}}} {{{nbsp}}} {{{nbsp}}} {{{nbsp}}} {{{nbsp}}} {{{nbsp}}} {{{nbsp}}} {{{nbsp}}} {{{nbsp}}} {{{nbsp}}} {{{nbsp}}} {{{nbsp}}} {{{nbsp}}} {{{nbsp}}} {{{nbsp}}} {{{nbsp}}} {{{nbsp}}}</div>
   </body>
 </html>

--- a/libs/email-service/src/tools/design/spacer.hbs
+++ b/libs/email-service/src/tools/design/spacer.hbs
@@ -1,7 +1,7 @@
 <table class="spacer">
   <tbody>
     <tr>
-      <td height="30" style="font-size:10px;line-height:10px;">&nbsp;</td>
+      <td height="30" style="font-size:10px;line-height:10px;">{{{nbsp}}}</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Fix Email Template Rendering Issues After NX Update

Fixes email templates rendering `&nbsp;` as literal text and broken button images caused by stricter Handlebars escaping and missing asset copying after the recent NX update.

- Updated Handlebars templates to use `{{{nbsp}}}` with Unicode character `\u00A0`
- Fixed asset copying configuration in user-notification build

Before
<img width="741" height="575" alt="Screenshot 2025-09-17 at 13 59 00" src="https://github.com/user-attachments/assets/ee7df1ee-ab8e-4ea0-8a4c-205227151ddd" />

After
<img width="1093" height="608" alt="Screenshot 2025-09-17 at 14 27 08" src="https://github.com/user-attachments/assets/77b75411-7698-4fd9-93f6-e1cfe62f505a" />

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for a spacer component in email templates for flexible, dynamic spacing.

- Bug Fixes
  - Improved email layout consistency by rendering non‑breaking spaces at runtime, reducing spacing anomalies across clients.
  - Prevented issues with overly long or empty spacers, ensuring cleaner presentation.

- Chores
  - Updated asset build configuration to a glob-based pattern for recursive asset handling; no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->