### PR TITLE
feat(application-system): only set postPruneAt if prune was success 

### DIFF
--- a/apps/application-system/api/src/app/modules/application/lifecycle/application-lifecycle.service.ts
+++ b/apps/application-system/api/src/app/modules/application/lifecycle/application-lifecycle.service.ts
@@ -162,7 +162,7 @@ export class ApplicationLifeCycleService {
           postPruneAt = addMilliseconds(
             new Date(),
             template?.adminDataConfig?.postPruneDelayOverride ??
-            DEFAULT_POST_PRUNE_DELAY,
+              DEFAULT_POST_PRUNE_DELAY,
           )
         }
 


### PR DESCRIPTION
# ...

adding if sentence to make sure prune was a success before assigning postPruneAt date

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Post-prune actions are now scheduled only when data is actually pruned, avoiding unnecessary post-prune timestamps.
  * Prevents unintended follow-up tasks and reduces noise in lifecycle events.
  * Improves accuracy of cleanup timelines displayed in the application.
  * Users will see fewer misleading status updates when pruning is skipped or unsuccessful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->