### PR TITLE
fix(new-primary-school): Allow 6 years old to enter the application

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/new-primary-school/new-primary-school.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/new-primary-school/new-primary-school.service.ts
@@ -1,9 +1,11 @@
 import { NationalRegistryXRoadService } from '@island.is/api/domains/national-registry-x-road'
 import {
   errorMessages,
+  FIRST_GRADE_AGE,
   getApplicationAnswers,
   getOtherGuardian,
   getSelectedChild,
+  TENTH_GRADE_AGE,
 } from '@island.is/application/templates/new-primary-school'
 import { ApplicationTypes } from '@island.is/application/types'
 import { FriggClientService } from '@island.is/clients/mms/frigg'
@@ -39,8 +41,8 @@ export class NewPrimarySchoolService extends BaseTemplateApiService {
 
   async getChildren({ auth }: TemplateApiModuleActionProps) {
     const currentYear = new Date().getFullYear()
-    const maxYear = currentYear - 7 // 2nd grade
-    const minYear = currentYear - 16 // 10th grade
+    const firstGradeYear = currentYear - FIRST_GRADE_AGE
+    const tenthGradeYear = currentYear - TENTH_GRADE_AGE
 
     const children =
       await this.nationalRegistryService.getChildrenCustodyInformation(auth)
@@ -71,8 +73,8 @@ export class NewPrimarySchoolService extends BaseTemplateApiService {
 
       return (
         child.livesWithApplicant &&
-        yearOfBirth >= minYear &&
-        yearOfBirth <= maxYear
+        yearOfBirth >= tenthGradeYear &&
+        yearOfBirth <= firstGradeYear
       )
     })
 

--- a/libs/application/templates/new-primary-school/src/utils/constants.ts
+++ b/libs/application/templates/new-primary-school/src/utils/constants.ts
@@ -1,6 +1,7 @@
 import { DefaultEvents } from '@island.is/application/types'
 
 export const FIRST_GRADE_AGE = 6
+export const TENTH_GRADE_AGE = 16
 
 export enum Actions {
   SEND_APPLICATION = 'sendApplication',

--- a/libs/application/templates/new-primary-school/src/utils/newPrimarySchoolUtils.spec.ts
+++ b/libs/application/templates/new-primary-school/src/utils/newPrimarySchoolUtils.spec.ts
@@ -178,23 +178,24 @@ describe('getApplicationType', () => {
     )
   })
 
-  it('should return ENROLLMENT_IN_PRIMARY_SCHOOL for child in first grade', () => {
-    const yearBorn = currentDate.getFullYear() - FIRST_GRADE_AGE
+  // ADD BACK WHEN ENROLLMENT_IN_PRIMARY_SCHOOL GOES LIVE
+  // it('should return ENROLLMENT_IN_PRIMARY_SCHOOL for child in first grade', () => {
+  //   const yearBorn = currentDate.getFullYear() - FIRST_GRADE_AGE
 
-    const answers = {
-      childNationalId: kennitala.generatePerson(new Date(yearBorn, 0, 1)),
-    }
+  //   const answers = {
+  //     childNationalId: kennitala.generatePerson(new Date(yearBorn, 0, 1)),
+  //   }
 
-    const externalData = {
-      childInformation: {
-        data: {},
-      },
-    } as unknown as ExternalData
+  //   const externalData = {
+  //     childInformation: {
+  //       data: {},
+  //     },
+  //   } as unknown as ExternalData
 
-    expect(getApplicationType(answers, externalData)).toBe(
-      ApplicationType.ENROLLMENT_IN_PRIMARY_SCHOOL,
-    )
-  })
+  //   expect(getApplicationType(answers, externalData)).toBe(
+  //     ApplicationType.ENROLLMENT_IN_PRIMARY_SCHOOL,
+  //   )
+  // })
 
   it('should return NEW_PRIMARY_SCHOOL for child in first grade, if child has enrolled before (data is found in Frigg)', () => {
     const yearBorn = currentDate.getFullYear() - FIRST_GRADE_AGE

--- a/libs/application/templates/new-primary-school/src/utils/newPrimarySchoolUtils.ts
+++ b/libs/application/templates/new-primary-school/src/utils/newPrimarySchoolUtils.ts
@@ -29,6 +29,7 @@ import {
   ReasonForApplicationOptions,
   SchoolType,
 } from './constants'
+import { isRunningOnEnvironment } from '@island.is/shared/utils'
 
 export const getApplicationAnswers = (answers: Application['answers']) => {
   const applicationType = getValueViaPath<ApplicationType>(
@@ -601,10 +602,13 @@ export const getApplicationType = (
   }
 
   // If there is no data in Frigg about the child, we need to determine the application type based on the year of birth
-  if (!childInformation?.primaryOrgId) {
-    return yearOfBirth === firstGradeYear
-      ? ApplicationType.ENROLLMENT_IN_PRIMARY_SCHOOL
-      : ApplicationType.NEW_PRIMARY_SCHOOL
+  // REMOVE THIS WHEN ENROLLMENT_IN_PRIMARY_SCHOOL GOES LIVE
+  if (isRunningOnEnvironment('local') || isRunningOnEnvironment('dev')) {
+    if (!childInformation?.primaryOrgId) {
+      return yearOfBirth === firstGradeYear
+        ? ApplicationType.ENROLLMENT_IN_PRIMARY_SCHOOL
+        : ApplicationType.NEW_PRIMARY_SCHOOL
+    }
   }
 
   return ApplicationType.NEW_PRIMARY_SCHOOL


### PR DESCRIPTION
[TS-798 ](https://dit-iceland.atlassian.net/browse/TS-798)


## What

Allow applicant to apply for a new school for 6 years old child

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Dynamic age-based eligibility using configurable first- and tenth-grade ages for more precise child selection.
  * Environment-gated behavior: in local/dev, the app differentiates between enrollment and new primary based on year of birth; other environments default to new primary.
* Tests
  * Temporarily disabled the enrollment-related test pending feature go-live.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->