### PR TITLE
fix(ui-shell): prevent duplicate form submissions in application system

### DIFF
--- a/libs/application/ui-shell/src/components/Screen.tsx
+++ b/libs/application/ui-shell/src/components/Screen.tsx
@@ -176,6 +176,8 @@ const Screen: FC<React.PropsWithChildren<ScreenProps>> = ({
 
   const [beforeSubmitError, setBeforeSubmitError] = useState({})
   const beforeSubmitCallback = useRef<BeforeSubmitCallback | null>(null)
+  const lastSubmissionTime = useRef<number>(0)
+  const submissionCount = useRef<number>(0)
 
   const setBeforeSubmitCallback = useCallback(
     (callback: BeforeSubmitCallback | null) => {
@@ -202,6 +204,29 @@ const Screen: FC<React.PropsWithChildren<ScreenProps>> = ({
   }, [formValue, prevScreen, reset])
 
   const onSubmit: SubmitHandler<FormValue> = async (data, e) => {
+    const now = Date.now()
+
+    if (isSubmitting) {
+      console.warn(
+        `[SUBMIT] Blocked duplicate submission for application ${applicationId} - already submitting`,
+      )
+      return
+    }
+
+    const timeSinceLastSubmission = now - lastSubmissionTime.current
+    const isWithinDebounceWindow =
+      timeSinceLastSubmission < 1000 && timeSinceLastSubmission > 0
+
+    if (isWithinDebounceWindow) {
+      submissionCount.current++
+      console.warn(
+        `[SUBMIT] Blocked rapid submission #${submissionCount.current} for application ${applicationId} - debounce active (${timeSinceLastSubmission}ms since last)`,
+      )
+      return
+    }
+
+    submissionCount.current = 0
+    lastSubmissionTime.current = now
     let response
 
     setIsSubmitting(true)
@@ -239,56 +264,74 @@ const Screen: FC<React.PropsWithChildren<ScreenProps>> = ({
       }
     }
 
-    if (submitField !== undefined) {
-      const finalAnswers = { ...formValue, ...data }
+    try {
+      if (submitField !== undefined) {
+        const finalAnswers = { ...formValue, ...data }
 
-      response = await submitApplication({
-        variables: {
-          input: {
-            id: applicationId,
-            event,
-            answers: finalAnswers,
-          },
-        },
-      })
+        const requestId = `${applicationId}-${event}-${now}`
 
-      if (response?.data) {
-        addExternalData(response.data?.submitApplication.externalData)
-
-        if (
-          submitField.refetchApplicationAfterSubmit === true ||
-          (typeof submitField.refetchApplicationAfterSubmit === 'function' &&
-            submitField.refetchApplicationAfterSubmit(event))
-        ) {
-          refetch()
-        }
-      }
-    } else {
-      const extractedAnswers = extractAnswersToSubmitFromScreen(
-        mergeAnswers(formValue, data),
-        screen,
-      )
-
-      response = await updateApplication({
-        variables: {
-          input: {
-            id: applicationId,
-            answers: extractedAnswers,
-            draftProgress: {
-              stepsFinished: currentDraftScreen ?? screen.sectionIndex,
-              totalSteps: totalDraftScreens ?? sections.length - 1,
+        response = await submitApplication({
+          variables: {
+            input: {
+              id: applicationId,
+              event,
+              answers: finalAnswers,
             },
           },
-          locale,
-        },
-      })
-    }
+          context: {
+            headers: {
+              'X-Request-ID': requestId,
+            },
+          },
+        })
 
-    if (response?.data) {
-      answerAndGoToNextScreen(data)
-    }
+        if (response?.data) {
+          addExternalData(response.data?.submitApplication.externalData)
 
-    setIsSubmitting(false)
+          if (
+            submitField.refetchApplicationAfterSubmit === true ||
+            (typeof submitField.refetchApplicationAfterSubmit === 'function' &&
+              submitField.refetchApplicationAfterSubmit(event))
+          ) {
+            refetch()
+          }
+        } else {
+          console.warn(
+            `[SUBMIT] No data received for application ${applicationId} with requestId ${requestId}`,
+          )
+        }
+      } else {
+        const extractedAnswers = extractAnswersToSubmitFromScreen(
+          mergeAnswers(formValue, data),
+          screen,
+        )
+
+        response = await updateApplication({
+          variables: {
+            input: {
+              id: applicationId,
+              answers: extractedAnswers,
+              draftProgress: {
+                stepsFinished: currentDraftScreen ?? screen.sectionIndex,
+                totalSteps: totalDraftScreens ?? sections.length - 1,
+              },
+            },
+            locale,
+          },
+        })
+      }
+
+      if (response?.data) {
+        answerAndGoToNextScreen(data)
+      }
+    } catch (error) {
+      console.error(
+        `[SUBMIT] Submission error for application ${applicationId}:`,
+        error,
+      )
+    } finally {
+      setIsSubmitting(false)
+    }
   }
 
   const [isMobile, setIsMobile] = useState(false)
@@ -439,7 +482,7 @@ const Screen: FC<React.PropsWithChildren<ScreenProps>> = ({
 
         <ToastContainer hideProgressBar closeButton useKeyframeStyles={false} />
         <ScreenFooter
-          submitButtonDisabled={submitButtonDisabled}
+          submitButtonDisabled={submitButtonDisabled || isSubmitting}
           application={application}
           renderLastScreenButton={renderLastScreenButton}
           renderLastScreenBackButton={renderLastScreenBackButton}
@@ -449,7 +492,7 @@ const Screen: FC<React.PropsWithChildren<ScreenProps>> = ({
           goBack={goBack}
           canGoBack={canGoBack}
           submitField={submitField}
-          loading={loading}
+          loading={loading || isSubmitting}
           canProceed={!isLoadingOrPending}
           nextButtonText={nextButtonText}
         />


### PR DESCRIPTION
The marriage-conditions application template (and potentially other application templates) was experiencing duplicate submissions where ~20% of applications were being submitted twice with the same applicationId within short time intervals. This was causing issues in the backend system and creating duplicate records.

See [Datadog logs](https://app.datadoghq.eu/logs?query=env%3Aprod%20%40templateId%3AMarriageConditions%20%22Performing%20actions%20submitApplication%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1756982312034&to_ts=1758278312034&live=true) showing instances of submissions with the same applicationId in close proximity to each other.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
