### PR TITLE
feat: add subject field support and improve argument validation for e…

### DIFF
--- a/apps/services/user-notification/src/app/modules/notifications/notifications.controller.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/notifications.controller.ts
@@ -118,16 +118,27 @@ export class NotificationsController {
   async createHnippNotification(
     @Body() body: CreateHnippNotificationDto,
   ): Promise<CreateNotificationResponse> {
+    // Validate required arguments and sanitize invalid ones
     await this.notificationsService.validate(body.templateId, body.args)
-    const id = await this.queue.add(body)
+    const validArgs = await this.notificationsService.sanitize(
+      body.templateId,
+      body.args,
+    )
+
+    const sanitizedBody = {
+      ...body,
+      args: validArgs,
+    }
+
+    const id = await this.queue.add(sanitizedBody)
     const flattenedArgs: Record<string, string> = {}
-    for (const arg of body.args) {
+    for (const arg of validArgs) {
       flattenedArgs[arg.key] = arg.value
     }
     this.logger.info('Message queued', {
       messageId: id,
       ...flattenedArgs,
-      ...body,
+      ...sanitizedBody,
       args: {}, // Remove args, since they're in a better format in `flattenedArgs`
       queue: { url: this.queue.url, name: this.queue.queueName },
     })

--- a/apps/services/user-notification/src/app/modules/notifications/notifications.service.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/notifications.service.ts
@@ -149,50 +149,61 @@ export class NotificationsService {
     const items = res.hnippTemplateCollection.items
     if (items.length > 0) {
       const template = items[0]
+
       return { ...template, args: template.args || [] } // Ensure args is an array
     } else {
       throw new NotFoundException(`Template not found for ID: ${templateId}`)
     }
   }
-  /**
-   * Checks if the arguments provided in the request body are valid for the template and checks if the number of arguments match
-   */
-  async validate(templateId: string, args: ArgumentDto[]) {
-    const template = await this.getTemplate(templateId)
 
-    if (!this.validateArgCounts(args, template)) {
+  /**
+   * Validates that all required arguments are provided for the template.
+   * Throws BadRequestException if any required arguments are missing.
+   */
+  async validate(templateId: string, args: ArgumentDto[]): Promise<void> {
+    const template = await this.getTemplate(templateId)
+    const providedKeys = args.map((arg) => arg.key)
+
+    const missingArgs = template.args.filter(
+      (requiredKey) => !providedKeys.includes(requiredKey),
+    )
+    if (missingArgs.length > 0) {
       throw new BadRequestException(
-        `Number of arguments doesn't match, template requires ${template.args.length} arguments but ${args.length} were provided`,
+        `Missing required arguments for template '${
+          template.templateId
+        }': ${missingArgs.join(', ')}. Required args are: ${template.args.join(
+          ', ',
+        )}`,
       )
     }
-
-    const validArgs = this.validateArgs(args, template)
-
-    if (!validArgs.isValid && validArgs.message) {
-      throw new BadRequestException(validArgs.message)
-    }
-  }
-
-  validateArgCounts(args: ArgumentDto[], template: HnippTemplate): boolean {
-    return args.length == template.args.length
   }
 
   /**
-   * Checks if the arguments provided in the request body are valid for the template
+   * Sanitizes arguments by filtering out any that don't exist in the template.
+   * Logs warnings for invalid args and returns only valid ones.
    */
-  validateArgs(args: ArgumentDto[], template: HnippTemplate) {
+  async sanitize(
+    templateId: string,
+    args: ArgumentDto[],
+  ): Promise<ArgumentDto[]> {
+    const template = await this.getTemplate(templateId)
+
+    const validArgs: ArgumentDto[] = []
+
+    // Filter args and log warnings for invalid ones
     for (const arg of args) {
-      if (!template.args.includes(arg.key)) {
-        return {
-          isValid: false,
-          message: `${arg.key} is not a valid argument for template: ${template.templateId}`,
-        }
+      if (template.args.includes(arg.key)) {
+        validArgs.push(arg)
+      } else {
+        this.logger.warn(
+          `Filtering out invalid argument '${arg.key}' for template '${
+            template.templateId
+          }'. Valid args are: ${template.args.join(', ')}`,
+        )
       }
     }
 
-    return {
-      isValid: true,
-    }
+    return validArgs
   }
 
   /**

--- a/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/notificationsWorker.service.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/notificationsWorker.service.ts
@@ -129,12 +129,14 @@ export class NotificationsWorkerService {
     formattedTemplate,
     fullName,
     subjectId,
+    processedArgs,
   }: {
     isEnglish: boolean
     recipientEmail: string | null
     formattedTemplate: HnippTemplate
     fullName: string
     subjectId?: string
+    processedArgs: any[]
   }): Message {
     if (!recipientEmail) {
       throw new Error('Missing recipient email address')
@@ -214,7 +216,9 @@ export class NotificationsWorkerService {
         name: fullName,
         address: recipientEmail,
       },
-      subject: formattedTemplate.title,
+      subject:
+        processedArgs.find((arg) => arg.key === 'subject')?.value ||
+        formattedTemplate.title,
       template: {
         title: formattedTemplate.title,
         body: generateBody(),
@@ -289,6 +293,7 @@ export class NotificationsWorkerService {
         recipientEmail: profile.email ?? null,
         fullName,
         subjectId: message.onBehalfOf?.subjectId,
+        processedArgs: message.args,
       })
 
       await this.emailService.sendEmail(emailContent)


### PR DESCRIPTION
Adds support for dynamic email subjects and improves argument validation for hnipp templates.

## Changes

- **Subject Support**: Email subjects can now be provided via the `args` array, this will be used by the new document hnipp, subject will come from the document index
- **Refactored Validation**: Refactored validation logic to not break when new args are added to Contentful templates, now we validate that required args are provided but filter out others that are not defined in the template
- 
## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
