### PR TITLE
feat(web): Numeric form field type

### DIFF
--- a/apps/web/components/Form/Form.tsx
+++ b/apps/web/components/Form/Form.tsx
@@ -61,6 +61,7 @@ export enum FormFieldType {
   DROPDOWN = 'dropdown',
   RADIO = 'radio',
   DATE = 'date',
+  NUMERIC = 'numeric',
 }
 
 interface FormFieldProps {
@@ -97,6 +98,21 @@ export const FormField = ({
           errorMessage={error}
           value={value}
           onChange={(e) => onChange(slug, e.target.value)}
+        />
+      )
+    case FormFieldType.NUMERIC:
+      return (
+        <Input
+          key={slug}
+          placeholder={field.placeholder}
+          name={slug}
+          label={field.title}
+          required={field.required}
+          hasError={!!error}
+          errorMessage={error}
+          value={value}
+          inputMode="numeric"
+          onChange={(e) => onChange(slug, e.target.value.replace(/\D/g, ''))}
         />
       )
     case FormFieldType.TEXT:

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -1476,6 +1476,7 @@ export interface IFormFieldFields {
     | 'file'
     | 'nationalId (kennitala)'
     | 'information'
+    | 'numeric'
 
   /** Required */
   required?: boolean | undefined

--- a/libs/cms/src/lib/models/formField.model.ts
+++ b/libs/cms/src/lib/models/formField.model.ts
@@ -28,6 +28,7 @@ export class FormField {
     | 'file'
     | 'nationalId (kennitala)'
     | 'information'
+    | 'numeric'
 
   @Field()
   required!: boolean


### PR DESCRIPTION
# Numeric form field type

New form field type: 'numeric'.

Allow cms user to create a form field that can only allows an integer input

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a numeric-only form field type that accepts digits only.
  - Automatic input sanitization removes non-numeric characters as you type.
  - Improved mobile experience by triggering the numeric keypad on supported devices.
  - Extended form configuration to support the new numeric field across the app.
  - Ensures consistent validation and data handling for numeric inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->