### PR TITLE
fix(application-system): Adding so that employee workday can start 36hrs after accident

### DIFF
--- a/libs/application/templates/aosh/work-accident-notification/src/utils/dateManipulation.ts
+++ b/libs/application/templates/aosh/work-accident-notification/src/utils/dateManipulation.ts
@@ -8,6 +8,8 @@ export const getMaxDate = (application: Application) => {
   const time =
     getValueViaPath<string>(application.answers, 'accident.time') ?? '00:00'
 
+  // Add 1 day if time is before noon, else add 2 days
+  // time.slice(0,2) -> hour part of "HH:MM"
   const maxDate = new Date(date)
   maxDate.setDate(
     maxDate.getDate() + (parseInt(time.slice(0, 2), 10) < 12 ? 1 : 2),
@@ -22,6 +24,9 @@ export const getMinDate = (application: Application) => {
   const time =
     getValueViaPath<string>(application.answers, 'accident.time') ?? '00:00'
   const minDate = new Date(date)
+
+  // Subtract 2 days if time is before noon, else subtract 1 day
+  // time.slice(0,2) -> hour part of "HH:MM"
   minDate.setDate(
     minDate.getDate() - (parseInt(time.slice(0, 2), 10) < 12 ? 2 : 1),
   )


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Date selection now adapts to accident time, shifting minimum and maximum allowed dates by 1–2 days as appropriate rather than defaulting to today.
* **Bug Fixes**
  * Reporting-window check updated to use an absolute time-difference comparison (36-hour window) for more accurate validation between accident and employee timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->