### PR TITLE
fix(application-system): Increasing timeout time

### DIFF
--- a/libs/clients/vmst-unemployment/src/lib/vmstUnemploymentClient.config.ts
+++ b/libs/clients/vmst-unemployment/src/lib/vmstUnemploymentClient.config.ts
@@ -20,7 +20,7 @@ export const VmstUnemploymentClientConfig = defineConfig({
         'IS-DEV/GOV/10003/VMST-Protected/XRoadDev-v1',
       ),
       fetch: {
-        timeout: 60000,
+        timeout: 35000,
       },
       username: env.required('XROAD_VMST_UNEMPLOYMENT_USERNAME', ''),
       password: env.required('XROAD_VMST_UNEMPLOYMENT_PASSWORD', ''),


### PR DESCRIPTION
Increasing timeout for vmst-unemployment client to match VMST timeouts, "Virknistyrkur" is 30 sec but unemployment is 60 sec for VMST and since we use the same client I'll set this to 60 already

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced request failures by increasing the default network timeout from 20s to 35s for external service calls, improving reliability under slow or high-load conditions.

* **Chores**
  * Updated runtime configuration to use the extended timeout. No user action required and no visible UI changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->