### PR TITLE
fix(j-s): Fix verdicts

### DIFF
--- a/apps/judicial-system/web/src/routes/PublicProsecutor/Indictments/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/PublicProsecutor/Indictments/Overview/Overview.tsx
@@ -157,24 +157,20 @@ export const Overview = () => {
         {workingCase.defendants?.map((defendant) => {
           const { verdict } = defendant
 
-          if (!verdict) {
-            return null
-          }
-
           const isFine =
             workingCase.indictmentRulingDecision ===
             CaseIndictmentRulingDecision.FINE
 
           const isServiceRequired =
-            verdict.serviceRequirement === ServiceRequirement.REQUIRED
+            verdict?.serviceRequirement === ServiceRequirement.REQUIRED
 
           const isServiceNotApplicable =
-            verdict.serviceRequirement === ServiceRequirement.NOT_APPLICABLE
+            verdict?.serviceRequirement === ServiceRequirement.NOT_APPLICABLE
 
           return (
             <Fragment key={defendant.id}>
               <Box className={styles.container}>
-                {features?.includes(Feature.VERDICT_DELIVERY) && (
+                {features?.includes(Feature.VERDICT_DELIVERY) && verdict && (
                   <VerdictStatusAlert verdict={verdict} defendant={defendant} />
                 )}
                 <Box component="section">


### PR DESCRIPTION
# Fix verdicts

Attach a link to issue if relevant

## What

In a previous PR, we made a mistake and hid the blue box that enables public prosecutors to send cases to fmst and mark them as registered in LOKE. This pr fixes that.

## Why

It's a bug

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented blank screens when an indictment has no verdict; the overview now loads reliably.
  * Improved handling of service requirement indicators to avoid errors when verdict data is missing.
  * Adjusted verdict status alert to display only when a verdict exists and the feature is enabled, reducing confusing or misleading messages.
  * Overall increases stability and clarity for cases without recorded verdicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->