### PR TITLE
fix(web): 404 redirects, encode url before redirecting

### DIFF
--- a/apps/web/utils/fetch404RedirectUrl.ts
+++ b/apps/web/utils/fetch404RedirectUrl.ts
@@ -52,7 +52,7 @@ export const fetch404RedirectUrl = async (
     const page = redirectProps.data.getUrl.page
     const explicitRedirect = redirectProps.data.getUrl.explicitRedirect
     if (!page && explicitRedirect) {
-      return explicitRedirect
+      return encodeURI(explicitRedirect)
     } else if (page) {
       let url = linkResolver(page.type as LinkType, [page.slug], locale).href
 
@@ -65,7 +65,7 @@ export const fetch404RedirectUrl = async (
         ).href
       }
 
-      return url
+      return encodeURI(url)
     }
   }
 


### PR DESCRIPTION
# 404 redirects, encode url before redirecting

## Why

So browsers handle Icelandic characters like 'ð' correctly

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Redirect URLs are now safely encoded, preventing broken links or errors when special or international characters are present.
  * Improves reliability and consistency of 404 redirects by ensuring returned redirect targets are properly formatted.
  * No behavioral change when no redirect is available; only successful redirects are affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->