### PR TITLE
fix(signature-collection): ui spacings

### DIFF
--- a/libs/application/templates/signature-collection/municipal-list-creation/src/lib/dataSchema.ts
+++ b/libs/application/templates/signature-collection/municipal-list-creation/src/lib/dataSchema.ts
@@ -11,7 +11,7 @@ export const dataSchema = z.object({
   }),
   list: z.object({
     municipality: z.string().min(1),
-    name: z.string().min(1),
+    name: z.string().trim().min(1),
   }),
   confirmCreationCheckbox: z.array(z.enum([YES])).length(1),
 })

--- a/libs/portals/my-pages/signature-collection/src/screens/Municipal/OwnerView/ViewList/ListActions/index.tsx
+++ b/libs/portals/my-pages/signature-collection/src/screens/Municipal/OwnerView/ViewList/ListActions/index.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   Button,
+  Divider,
   Drawer,
   Icon,
   Stack,
@@ -53,6 +54,9 @@ const ListActions = ({ list }: { list: SignatureCollectionList }) => {
           <CancelCollection list={list} />
         </Stack>
       </Drawer>
+      <Box marginTop={3}>
+        <Divider />
+      </Box>
     </Box>
   )
 }

--- a/libs/portals/my-pages/signature-collection/src/screens/Municipal/OwnerView/ViewList/index.tsx
+++ b/libs/portals/my-pages/signature-collection/src/screens/Municipal/OwnerView/ViewList/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Divider, Stack, Text } from '@island.is/island-ui/core'
+import { Box, Stack, Text } from '@island.is/island-ui/core'
 import { useLocale, useNamespaces } from '@island.is/localization'
 import { m } from '../../../../lib/messages'
 import { useParams } from 'react-router-dom'
@@ -26,7 +26,7 @@ const ViewList = () => {
         <Stack space={5}>
           <Text variant="h3">{listInfo.title}</Text>
           <Box>
-            <Text variant="h5">{formatMessage(m.listPeriod)}</Text>
+            <Text variant="h4">{formatMessage(m.listPeriod)}</Text>
             <Text>
               {`${format(
                 new Date(listInfo.startTime ?? new Date()),
@@ -37,7 +37,6 @@ const ViewList = () => {
               )}`}
             </Text>
             <ListActions list={listInfo} />
-            <Divider />
           </Box>
           <Signees
             collectionType={collectionType}

--- a/libs/portals/my-pages/signature-collection/src/screens/Parliamentary/OwnerView/AddConstituency/index.tsx
+++ b/libs/portals/my-pages/signature-collection/src/screens/Parliamentary/OwnerView/AddConstituency/index.tsx
@@ -1,5 +1,12 @@
 import { useState } from 'react'
-import { Box, Button, Text, Checkbox, toast } from '@island.is/island-ui/core'
+import {
+  Box,
+  Button,
+  Text,
+  Checkbox,
+  toast,
+  Stack,
+} from '@island.is/island-ui/core'
 import { Modal } from '@island.is/portals/my-pages/core'
 import { useLocale } from '@island.is/localization'
 import { m } from '../../../../lib/messages'
@@ -66,65 +73,64 @@ const AddConstituencyModal = ({
   }
 
   return (
-    <Box>
-      <Button
-        variant="utility"
-        icon="add"
-        onClick={() => {
-          setModalIsOpen(true)
-        }}
-      >
-        {formatMessage(m.addConstituency)}
-      </Button>
-      <Modal
-        id="addConstituency"
-        isVisible={modalIsOpen}
-        initialVisibility={false}
-        onCloseModal={() => {
-          setModalIsOpen(false)
-          setSelectedConstituencies([])
-        }}
-      >
-        <Box>
-          <Text marginBottom={2} variant="h2">
-            {formatMessage(m.addConstituency)}
-          </Text>
-          <Text marginBottom={5} variant="default">
-            {formatMessage(m.addConstituencyDescription)}
-          </Text>
+    <Modal
+      id="addConstituency"
+      isVisible={modalIsOpen}
+      initialVisibility={false}
+      onCloseModal={() => {
+        setModalIsOpen(false)
+        setSelectedConstituencies([])
+      }}
+      disclosure={
+        <Button
+          variant="utility"
+          icon="add"
+          onClick={() => {
+            setModalIsOpen(true)
+          }}
+        >
+          {formatMessage(m.addConstituency)}
+        </Button>
+      }
+    >
+      <Box display="block" width="full">
+        <Text variant="h2" marginBottom={2}>
+          {formatMessage(m.addConstituency)}
+        </Text>
+        <Text variant="default" marginBottom={5}>
+          {formatMessage(m.addConstituencyDescription)}
+        </Text>
+        <Stack space={3}>
           {filteredConstituencies.map((constituency) => (
-            <Box key={constituency.id} marginBottom={3}>
-              <Checkbox
-                large
-                backgroundColor="blue"
-                label={constituency.name}
-                value={constituency.id}
-                checked={selectedConstituencies.includes(constituency.id)}
-                onChange={(e) => {
-                  if (e.target.checked) {
-                    setSelectedConstituencies([
-                      ...selectedConstituencies,
-                      constituency.id,
-                    ])
-                  } else {
-                    setSelectedConstituencies(
-                      selectedConstituencies.filter(
-                        (c) => c !== constituency.id,
-                      ),
-                    )
-                  }
-                }}
-              />
-            </Box>
+            <Checkbox
+              key={constituency.id}
+              large
+              backgroundColor="blue"
+              label={constituency.name}
+              value={constituency.id}
+              checked={selectedConstituencies.includes(constituency.id)}
+              onChange={(e) => {
+                if (e.target.checked) {
+                  setSelectedConstituencies([
+                    ...selectedConstituencies,
+                    constituency.id,
+                  ])
+                } else {
+                  setSelectedConstituencies(
+                    selectedConstituencies.filter((c) => c !== constituency.id),
+                  )
+                }
+              }}
+            />
           ))}
-          <Box display="flex" justifyContent="center" marginTop={7}>
-            <Button onClick={() => onAddConstituency()} loading={loading}>
-              {formatMessage(m.add)}
-            </Button>
-          </Box>
+        </Stack>
+        <Box display="flex" justifyContent="center" marginTop={7}>
+          <Button onClick={() => onAddConstituency()} loading={loading}>
+            {formatMessage(m.add)}
+          </Button>
         </Box>
-      </Modal>
-    </Box>
+      </Box>
+    </Modal>
   )
 }
 

--- a/libs/portals/my-pages/signature-collection/src/screens/Parliamentary/OwnerView/ViewList/ListActions/index.tsx
+++ b/libs/portals/my-pages/signature-collection/src/screens/Parliamentary/OwnerView/ViewList/ListActions/index.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   Button,
+  Divider,
   Drawer,
   Icon,
   Stack,
@@ -53,6 +54,9 @@ const ListActions = ({ list }: { list: SignatureCollectionList }) => {
           <CancelCollection list={list} />
         </Stack>
       </Drawer>
+      <Box marginTop={3}>
+        <Divider />
+      </Box>
     </Box>
   )
 }

--- a/libs/portals/my-pages/signature-collection/src/screens/Parliamentary/OwnerView/ViewList/index.tsx
+++ b/libs/portals/my-pages/signature-collection/src/screens/Parliamentary/OwnerView/ViewList/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Divider, Stack, Text } from '@island.is/island-ui/core'
+import { Box, Stack, Text } from '@island.is/island-ui/core'
 import { useLocale, useNamespaces } from '@island.is/localization'
 import { m } from '../../../../lib/messages'
 import { useParams } from 'react-router-dom'
@@ -36,7 +36,6 @@ const ViewList = () => {
               )} - ${format(new Date(listInfo.endTime), 'dd.MM.yyyy')}`}
             </Text>
             <ListActions list={listInfo} />
-            <Divider />
           </Box>
           <Signees
             collectionType={collectionType}

--- a/libs/portals/my-pages/signature-collection/src/screens/Presidential/OwnerView/ActionDrawer/index.tsx
+++ b/libs/portals/my-pages/signature-collection/src/screens/Presidential/OwnerView/ActionDrawer/index.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   Button,
+  Divider,
   Drawer,
   Icon,
   Stack,
@@ -23,7 +24,7 @@ const ActionDrawer = ({
   const { formatMessage } = useLocale()
 
   return (
-    <Box marginBottom={5}>
+    <Box>
       <Drawer
         ariaLabel="listActions"
         baseId="listActions"
@@ -59,6 +60,9 @@ const ActionDrawer = ({
           <CancelCandidacy />
         </Stack>
       </Drawer>
+      <Box marginTop={3}>
+        <Divider />
+      </Box>
     </Box>
   )
 }

--- a/libs/portals/my-pages/signature-collection/src/screens/Presidential/OwnerView/CancelCandidacy/index.tsx
+++ b/libs/portals/my-pages/signature-collection/src/screens/Presidential/OwnerView/CancelCandidacy/index.tsx
@@ -79,14 +79,14 @@ const CancelCandidacy = () => {
           }
         >
           <Box display="block" width="full">
-            <Text variant="h2" marginTop={[5, 0]}>
+            <Text variant="h2" marginBottom={2}>
               {formatMessage(m.cancelCollectionButton)}
             </Text>
-            <Text variant="default" marginTop={2}>
+            <Text variant="default">
               {formatMessage(m.cancelCollectionModalMessage)}
             </Text>
             <Box
-              marginTop={[7, 10]}
+              marginTop={[3, 5]}
               marginBottom={5}
               display="flex"
               justifyContent="center"

--- a/libs/portals/my-pages/signature-collection/src/screens/Presidential/OwnerView/ViewList/index.tsx
+++ b/libs/portals/my-pages/signature-collection/src/screens/Presidential/OwnerView/ViewList/index.tsx
@@ -24,7 +24,7 @@ const ViewList = () => {
             {listInfo.candidate.name + ' - ' + listInfo.area.name}
           </Text>
           <Box>
-            <Text variant="h5">{formatMessage(m.listPeriod)}</Text>
+            <Text variant="h4">{formatMessage(m.listPeriod)}</Text>
             <Text>
               {`${format(
                 new Date(listInfo.startTime),

--- a/libs/portals/my-pages/signature-collection/src/screens/Presidential/OwnerView/index.tsx
+++ b/libs/portals/my-pages/signature-collection/src/screens/Presidential/OwnerView/index.tsx
@@ -36,7 +36,7 @@ const OwnerView = ({
 
       {/* Candidate created lists */}
       {listsForOwner?.length > 0 && (
-        <Box>
+        <Box marginTop={8}>
           <Text variant="h4" marginBottom={2}>
             {formatMessage(m.myListsDescription)}
           </Text>

--- a/libs/portals/my-pages/signature-collection/src/screens/Presidential/index.tsx
+++ b/libs/portals/my-pages/signature-collection/src/screens/Presidential/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Divider } from '@island.is/island-ui/core'
+import { Box } from '@island.is/island-ui/core'
 import { useLocale, useNamespaces } from '@island.is/localization'
 import OwnerView from './OwnerView'
 import {
@@ -53,6 +53,7 @@ const SignatureCollectionPresidential = () => {
         title={formatMessage(m.pageTitlePresidential)}
         intro={formatMessage(m.pageIntro)}
         slug={listsForOwner?.[0]?.slug}
+        withLessSpace={isOwner?.success}
       />
       {isOwner?.success || user?.profile.actor ? (
         isOwner?.success ? (
@@ -61,7 +62,6 @@ const SignatureCollectionPresidential = () => {
               candidateId={listsForOwner?.[0]?.candidate?.id}
               collectionType={collectionType}
             />
-            <Divider />
             <OwnerView
               collectionType={collectionType}
               listsForOwner={listsForOwner}

--- a/libs/portals/my-pages/signature-collection/src/screens/shared/Intro/index.tsx
+++ b/libs/portals/my-pages/signature-collection/src/screens/shared/Intro/index.tsx
@@ -9,13 +9,16 @@ const Intro = ({
   slug,
   title,
   intro,
+  withLessSpace = false,
 }: {
   slug: string
   title: string
   intro: string
+  withLessSpace?: boolean
 }) => {
   return (
-    <Box marginBottom={5}>
+    // Adjust margin bottom for presidential as it comes with the action drawer
+    <Box marginBottom={withLessSpace ? 3 : 8}>
       <IntroWrapper
         title={title}
         intro={intro}

--- a/libs/portals/my-pages/signature-collection/src/screens/shared/Managers/index.tsx
+++ b/libs/portals/my-pages/signature-collection/src/screens/shared/Managers/index.tsx
@@ -20,7 +20,7 @@ const Managers = ({
       <Text variant="h4" marginBottom={1}>
         {formatMessage(m.managers)}
       </Text>
-      <Box marginBottom={5}>
+      <Box marginBottom={3}>
         <Markdown>{formatMessage(m.managersDescription)}</Markdown>
       </Box>
       <T.Table>

--- a/libs/portals/my-pages/signature-collection/src/screens/shared/SignedLists/index.tsx
+++ b/libs/portals/my-pages/signature-collection/src/screens/shared/SignedLists/index.tsx
@@ -1,4 +1,11 @@
-import { ActionCard, Box, Button, Text, toast } from '@island.is/island-ui/core'
+import {
+  ActionCard,
+  Box,
+  Button,
+  Stack,
+  Text,
+  toast,
+} from '@island.is/island-ui/core'
 import { useLocale, useNamespaces } from '@island.is/localization'
 import { m } from '../../../lib/messages'
 import { Modal } from '@island.is/portals/my-pages/core'
@@ -57,16 +64,17 @@ const SignedLists = ({
   }
 
   return (
-    <Box marginTop={[5, 7]}>
+    <Box>
       {signedLists?.length > 0 && (
-        <Text marginBottom={2} variant="h4">
+        <Text variant="h4" marginBottom={2}>
           {formatMessage(m.mySigneeListsHeader)}
         </Text>
       )}
-      {signedLists?.map((list) => {
-        return (
-          <Box marginBottom={3} key={list.id}>
+      <Stack space={[3, 5]}>
+        {signedLists?.map((list) => {
+          return (
             <ActionCard
+              key={list.id}
               heading={
                 collectionType ===
                 SignatureCollectionCollectionType.LocalGovernmental
@@ -138,9 +146,9 @@ const SignedLists = ({
                   : undefined
               }
             />
-          </Box>
-        )
-      })}
+          )
+        })}
+      </Stack>
       <Modal
         id="unSignList"
         isVisible={modalIsOpen}
@@ -151,15 +159,13 @@ const SignedLists = ({
           setModalIsOpen(false)
         }}
       >
-        <Box display="block" width="full">
-          <Text variant="h2" marginTop={[5, 0]}>
+        <Box>
+          <Text variant="h2" marginBottom={2}>
             {formatMessage(m.unSignList)}
           </Text>
-          <Text variant="default" marginTop={2}>
-            {formatMessage(m.unSignModalMessage)}
-          </Text>
+          <Text variant="default">{formatMessage(m.unSignModalMessage)}</Text>
           <Box
-            marginTop={[7, 10]}
+            marginTop={[3, 5]}
             marginBottom={5}
             display="flex"
             justifyContent="center"

--- a/libs/portals/my-pages/signature-collection/src/screens/shared/Signees/index.tsx
+++ b/libs/portals/my-pages/signature-collection/src/screens/shared/Signees/index.tsx
@@ -181,14 +181,14 @@ const Signees = ({
             </Box>
           </Box>
         ) : searchTerm.length > 0 ? (
-          <Box display="flex" marginTop={3}>
+          <Box display="flex" marginTop={2}>
             <Text>{formatMessage(m.noSigneesFoundBySearch)}</Text>
             <Box marginLeft={1}>
               <Text variant="h5">{searchTerm}</Text>
             </Box>
           </Box>
         ) : (
-          <Text marginTop={3}>{formatMessage(m.noSignees)}</Text>
+          <Text marginTop={2}>{formatMessage(m.noSignees)}</Text>
         )
       ) : (
         <SkeletonTable />

--- a/libs/portals/my-pages/signature-collection/src/screens/shared/cancelCollection/index.tsx
+++ b/libs/portals/my-pages/signature-collection/src/screens/shared/cancelCollection/index.tsx
@@ -85,14 +85,14 @@ const CancelCollection = ({ list }: { list: SignatureCollectionList }) => {
           }
         >
           <Box display="block" width="full">
-            <Text variant="h2" marginTop={[5, 0]}>
+            <Text variant="h2" marginBottom={2}>
               {formatMessage(m.cancelCollectionButton)}
             </Text>
-            <Text variant="default" marginTop={2}>
+            <Text variant="default">
               {formatMessage(m.cancelCollectionModalMessage)}
             </Text>
             <Box
-              marginTop={[7, 10]}
+              marginTop={[3, 5]}
               marginBottom={5}
               display="flex"
               justifyContent="center"


### PR DESCRIPTION
## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Intro section now supports a compact spacing mode in Presidential view when applicable.
- Bug Fixes
  - List names must contain non-whitespace characters (whitespace-only names no longer allowed).
- Style
  - Added visual dividers below action drawers; removed redundant dividers elsewhere for cleaner layouts.
  - Increased list period heading size to improve readability.
  - Reduced and standardized vertical spacing across modals and lists (Presidential, Parliamentary, Municipal, Managers, Signees, Signed Lists).
  - Simplified modal structures and checkbox list layouts for a more consistent UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->