### PR TITLE
feat(web): Fine calculator UI tweaks

### DIFF
--- a/apps/web/components/connected/logreglan/FineAndSpeedMeasurementCalculator/FineAndSpeedMeasurementCalculator.tsx
+++ b/apps/web/components/connected/logreglan/FineAndSpeedMeasurementCalculator/FineAndSpeedMeasurementCalculator.tsx
@@ -226,11 +226,15 @@ const FineCalculatorDetails = ({
           </Table.Row>
         </Table.Foot>
       </Table.Table>
-      {jailTime > 0 && Boolean(slice.configJson?.showJailTime) && (
-        <Text variant="small" fontWeight="semiBold">
-          {formatMessage(m.results.jailTime, { days: jailTime })}
-        </Text>
-      )}
+      {jailTime > 0 &&
+        Boolean(slice.configJson?.showJailTime) &&
+        (typeof slice.configJson?.stopDisplayingJailTimeAfterAmount === 'number'
+          ? totalFine > slice.configJson.stopDisplayingJailTimeAfterAmount
+          : true) && (
+          <Text variant="small" fontWeight="semiBold">
+            {formatMessage(m.results.jailTime, { days: jailTime })}
+          </Text>
+        )}
     </Stack>
   )
 }

--- a/apps/web/components/connected/logreglan/FineAndSpeedMeasurementCalculator/FineAndSpeedMeasurementCalculator.tsx
+++ b/apps/web/components/connected/logreglan/FineAndSpeedMeasurementCalculator/FineAndSpeedMeasurementCalculator.tsx
@@ -170,13 +170,6 @@ const FineCalculatorDetails = ({
 
   return (
     <Stack space={3}>
-      {jailTime > 0 && Boolean(slice.configJson?.showJailTime) && (
-        <Box display="flex" justifyContent="flexEnd">
-          <Text variant="small" fontWeight="semiBold">
-            {formatMessage(m.results.jailTime, { days: jailTime })}
-          </Text>
-        </Box>
-      )}
       <Table.Table>
         <Table.Head>
           <Table.HeadData>
@@ -233,6 +226,11 @@ const FineCalculatorDetails = ({
           </Table.Row>
         </Table.Foot>
       </Table.Table>
+      {jailTime > 0 && Boolean(slice.configJson?.showJailTime) && (
+        <Text variant="small" fontWeight="semiBold">
+          {formatMessage(m.results.jailTime, { days: jailTime })}
+        </Text>
+      )}
     </Stack>
   )
 }

--- a/apps/web/components/connected/logreglan/FineAndSpeedMeasurementCalculator/FineAndSpeedMeasurementCalculator.tsx
+++ b/apps/web/components/connected/logreglan/FineAndSpeedMeasurementCalculator/FineAndSpeedMeasurementCalculator.tsx
@@ -229,7 +229,7 @@ const FineCalculatorDetails = ({
       {jailTime > 0 &&
         Boolean(slice.configJson?.showJailTime) &&
         (typeof slice.configJson?.stopDisplayingJailTimeAfterAmount === 'number'
-          ? totalFine > slice.configJson.stopDisplayingJailTimeAfterAmount
+          ? totalFine < slice.configJson.stopDisplayingJailTimeAfterAmount
           : true) && (
           <Text variant="small" fontWeight="semiBold">
             {formatMessage(m.results.jailTime, { days: jailTime })}

--- a/apps/web/components/connected/logreglan/FineAndSpeedMeasurementCalculator/components/MobileDrawer.tsx
+++ b/apps/web/components/connected/logreglan/FineAndSpeedMeasurementCalculator/components/MobileDrawer.tsx
@@ -32,7 +32,7 @@ export const MobileDrawer = ({
         justifyContent="spaceBetween"
         alignItems="center"
       >
-        <Inline alignY="center" space={2}>
+        <Inline alignY="top" space={2}>
           <Text variant="eyebrow" fontWeight="semiBold">
             {totalText}
           </Text>

--- a/apps/web/screens/Article/components/ArticleChatPanel/ArticleChatPanel.tsx
+++ b/apps/web/screens/Article/components/ArticleChatPanel/ArticleChatPanel.tsx
@@ -27,6 +27,17 @@ export const ArticleChatPanel = ({
 
   let Component = null
 
+  if (
+    article?.body?.findIndex(
+      (slice) =>
+        slice.__typename === 'ConnectedComponent' &&
+        slice.componentType === 'Police/FineAndSpeedMeasurementCalculator',
+    ) !== -1
+  ) {
+    // Any article with the police fine calculator should not have a chat panel
+    return null
+  }
+
   // LiveChatInc
   if (
     article?.organization?.some((o) => o.id in liveChatIncConfig[activeLocale])


### PR DESCRIPTION
# Fine calculator UI tweaks

## What

Small tweaks to UI after user testing

* Stop showing chat on articles with the fine calculator
* Move jail time below table
* Have a way in the CMS to choose when to stop showing jail time given the total fine

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Jail time now appears after the table and only when applicable, respecting configuration and optional fine thresholds.
* Bug Fixes
  * Chat panel is hidden on articles that include the Fine & Speed Measurement Calculator to avoid conflicts and distractions.
* Style
  * Improved vertical alignment in the mobile drawer for clearer presentation of totals and related details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->