### PR TITLE
fix(cms): Reduce fetch depth for related articles query

### DIFF
--- a/libs/cms/src/lib/cms.contentful.service.ts
+++ b/libs/cms/src/lib/cms.contentful.service.ts
@@ -556,7 +556,7 @@ export class CmsContentfulService {
       ['content_type']: 'article',
       'sys.id[in]': articles.map((a) => a.sys.id).join(','),
       select: ArticleFields,
-      include: 10,
+      include: 5,
     }
 
     const relatedResult = await this.contentfulRepository


### PR DESCRIPTION
# Reduce fetch depth for related articles query

## What

We are getting "Response size too big" error in some cases because we are fetching with a depth of 10 (Which is way more than we need).

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized retrieval of related articles to reduce unnecessary data transfer and improve load times.
  * Minor adjustments to related articles ordering may be observed in some cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->