### PR TITLE
fix(application-system): Adding required to asyncSelect

### DIFF
--- a/libs/application/core/src/lib/fieldBuilders.ts
+++ b/libs/application/core/src/lib/fieldBuilders.ts
@@ -254,6 +254,7 @@ export const buildAsyncSelectField = (
     isMulti,
     updateOnSelect,
     isClearable,
+    required,
   } = data
 
   return {
@@ -270,6 +271,7 @@ export const buildAsyncSelectField = (
     isMulti,
     updateOnSelect,
     isClearable,
+    required,
   }
 }
 


### PR DESCRIPTION
# Adding required to asyncSelectField

## What

Make the red star * show up

## Why

The red star ( * ) was not showing up when setting required: true, this shows the users that the field is required

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Async select fields now support a “required” setting, allowing selections to be marked as mandatory.
  - The required status is honored during rendering and validation, aligning behavior with other field types.
  - Users receive clearer feedback when a selection is missing, helping prevent incomplete form submissions.
  - Improves form configuration flexibility for builders who need to enforce mandatory choices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->