### PR TITLE
fix(application-system): Remove filetype ending from filename in FCA

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/hms/fire-compensation-appraisal/utils.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/hms/fire-compensation-appraisal/utils.ts
@@ -69,11 +69,13 @@ export const mapAnswersToApplicationDto = (
   )?.find((realEstate) => realEstate.fasteignanumer === selectedRealEstateId)
 
   const parsedFiles = files?.map((file) => {
-    const ending = file.key.split('.').pop()
+    const nameArray = file.key.split('.')
+    const ending = nameArray.pop()
+    const heiti = nameArray.join('.').replace(/^[^_]*_/, '')
     const tegund = ending === 'pdf' ? 'application/pdf' : 'image/jpeg'
     return {
       flokkur: ending === 'pdf' ? 5 : 2,
-      heiti: file.key.replace(/^[^_]*_/, ''),
+      heiti,
       dags: new Date(),
       tegund,
       fileID: hashToLength20(file.key.split('_')[0]),

--- a/libs/application/template-api-modules/src/lib/modules/templates/hms/fire-compensation-appraisal/utils.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/hms/fire-compensation-appraisal/utils.ts
@@ -70,7 +70,7 @@ export const mapAnswersToApplicationDto = (
 
   const parsedFiles = files?.map((file) => {
     const parts = file.key.split('.')
-    const ending = (parts.length > 1 ? parts.pop()! : '').toLowerCase()
+    const ending = (parts.length > 1 ? parts.pop() ?? '' : '').toLowerCase()
     const heiti = parts.join('.').replace(/^[^_]*_/, '')
     const tegund = ending === 'pdf' ? 'application/pdf' : 'image/jpeg'
     return {

--- a/libs/application/template-api-modules/src/lib/modules/templates/hms/fire-compensation-appraisal/utils.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/hms/fire-compensation-appraisal/utils.ts
@@ -69,9 +69,9 @@ export const mapAnswersToApplicationDto = (
   )?.find((realEstate) => realEstate.fasteignanumer === selectedRealEstateId)
 
   const parsedFiles = files?.map((file) => {
-    const nameArray = file.key.split('.')
-    const ending = nameArray.pop()
-    const heiti = nameArray.join('.').replace(/^[^_]*_/, '')
+    const parts = file.key.split('.')
+    const ending = (parts.length > 1 ? parts.pop()! : '').toLowerCase()
+    const heiti = parts.join('.').replace(/^[^_]*_/, '')
     const tegund = ending === 'pdf' ? 'application/pdf' : 'image/jpeg'
     return {
       flokkur: ending === 'pdf' ? 5 : 2,


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Document names are now derived and normalized from their original metadata for clearer display in the fire compensation appraisal flow.
  - File extensions are explicitly shown (e.g., ".pdf") for each document.
  - Document type/category detection remains consistent and continues to rely on the file extension for reliable categorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->