### PR TITLE
fix(web): Use iso string for event endDate

### DIFF
--- a/libs/cms/src/lib/models/event.model.ts
+++ b/libs/cms/src/lib/models/event.model.ts
@@ -95,13 +95,13 @@ export const mapEvent = ({ sys, fields }: IEvent): SystemMetadata<Event> => {
       date.setHours(Number(hours))
       date.setMinutes(Number(minutes))
     }
-    endDate = date.getTime().toString()
+    endDate = date.toISOString()
   } else if (fields.startDate && fields.time?.endTime) {
     const date = new Date(fields.startDate)
     const [hours, minutes] = fields.time.endTime.split(':')
     date.setHours(Number(hours))
     date.setMinutes(Number(minutes))
-    endDate = date.getTime().toString()
+    endDate = date.toISOString()
   }
 
   return {


### PR DESCRIPTION
# Use iso string for event endDate

Since startDate is an iso string, let's also have the endDate as an iso string

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized event end date formatting to ISO 8601 for consistent display across locales and time zones.
  * Improves compatibility with integrations and calendar clients that expect ISO-formatted dates.
  * Prevents issues where end dates appeared as raw numeric timestamps in some views and exports.
  * No changes to event times or scheduling behavior; only the displayed/returned format of end dates is updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->