### PR TITLE
fix(medical-and-rehabilitation-payments):  Date picker in employee sick pay and union sick pay can have wrong dates

### DIFF
--- a/libs/application/templates/social-insurance-administration/medical-and-rehabilitation-payments/src/forms/MedicalAndRehabilitationPaymentsForm/generalInformationSection/employeeSickPaySubSection.ts
+++ b/libs/application/templates/social-insurance-administration/medical-and-rehabilitation-payments/src/forms/MedicalAndRehabilitationPaymentsForm/generalInformationSection/employeeSickPaySubSection.ts
@@ -35,6 +35,7 @@ export const employeeSickPaySubSection = buildSubSection({
           id: 'employeeSickPay.hasUtilizedEmployeeSickPayRights',
           options: getYesNoNotApplicableOptions(),
           required: true,
+          clearOnChange: [`employeeSickPay.endDate`],
         }),
         buildDescriptionField({
           id: 'employeeSickPay.endDate.description',

--- a/libs/application/templates/social-insurance-administration/medical-and-rehabilitation-payments/src/forms/MedicalAndRehabilitationPaymentsForm/generalInformationSection/unionSickPaySubSection.ts
+++ b/libs/application/templates/social-insurance-administration/medical-and-rehabilitation-payments/src/forms/MedicalAndRehabilitationPaymentsForm/generalInformationSection/unionSickPaySubSection.ts
@@ -80,6 +80,7 @@ export const unionSickPaySubSection = buildSubSection({
           id: 'unionSickPay.hasUtilizedUnionSickPayRights',
           options: getYesNoNotApplicableOptions(),
           required: true,
+          clearOnChange: [`unionSickPay.endDate`],
         }),
         buildDescriptionField({
           id: 'unionSickPay.unionInfo.description',


### PR DESCRIPTION
[TS-1104](https://dit-iceland.atlassian.net/browse/TS-1104)

## What

Clear the selected date if applicant chooses different option for the sick pay

## Why

You can choose “yes“ and pick a date in the past and then change to “no“ and send the date already picked.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Changing the answer to “Have you utilized Employee Sick Pay rights?” now clears any previously entered end date, preventing stale or conflicting data.
  - Changing the answer to “Have you utilized Union Sick Pay rights?” now clears any previously entered end date, ensuring consistent and accurate form entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->