### PR TITLE
chore(app): Upgrade node version to fix android build error

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -15,7 +15,7 @@ definitions:
     #        include: true
     #        source: true
   environment: &environment
-    node: 20.15.0
+    node: 20.19.5
     # TODO: Remove/upgrade after upgrading to react-native 0.76.9 or higher, fixing 16.3 build issues:
     # https://github.com/facebook/react-native/issues/50411#issuecomment-2776681575
     xcode: 16.2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build environment to use Node.js 20.19.5. This change standardizes the runtime used during builds and deployments, improving consistency and future compatibility.
  * No user-facing functionality or interface changes.
  * No action required from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->