### PR TITLE
fix(web): Generic List Item external url not being fetched in all cases

### DIFF
--- a/apps/web/components/Organization/Slice/FeaturedGenericListItemsSlice/FeaturedGenericListItemsSlice.tsx
+++ b/apps/web/components/Organization/Slice/FeaturedGenericListItemsSlice/FeaturedGenericListItemsSlice.tsx
@@ -31,7 +31,7 @@ export const FeaturedGenericListItemsSlice = ({
           return <NonClickableItem item={item} key={item.id} />
         })}
       </Stack>
-      {Boolean(slice.baseUrl) && (
+      {Boolean(slice.baseUrl) && slice.items.length > 0 && (
         <Box display="flex" justifyContent="flexEnd">
           <LinkV2 href={slice.baseUrl}>
             <Button

--- a/apps/web/components/Organization/Slice/FeaturedGenericListItemsSlice/FeaturedGenericListItemsSlice.tsx
+++ b/apps/web/components/Organization/Slice/FeaturedGenericListItemsSlice/FeaturedGenericListItemsSlice.tsx
@@ -1,4 +1,4 @@
-import { Stack } from '@island.is/island-ui/core'
+import { Box, Button, LinkV2, Stack } from '@island.is/island-ui/core'
 import { ClickableItem, NonClickableItem } from '@island.is/web/components'
 import {
   FeaturedGenericListItems,
@@ -13,18 +13,38 @@ export const FeaturedGenericListItemsSlice = ({
   slice,
 }: FeaturedGenericListItemsSliceProps) => {
   return (
-    <Stack space={2}>
-      {slice.items.map((item) => {
-        if (
-          item.genericList?.itemType === GenericListItemType.Clickable &&
-          Boolean(slice.baseUrl)
-        ) {
-          return (
-            <ClickableItem item={item} key={item.id} baseUrl={slice.baseUrl} />
-          )
-        }
-        return <NonClickableItem item={item} key={item.id} />
-      })}
+    <Stack space={5}>
+      <Stack space={2}>
+        {slice.items.map((item) => {
+          if (
+            item.genericList?.itemType === GenericListItemType.Clickable &&
+            Boolean(slice.baseUrl)
+          ) {
+            return (
+              <ClickableItem
+                item={item}
+                key={item.id}
+                baseUrl={slice.baseUrl}
+              />
+            )
+          }
+          return <NonClickableItem item={item} key={item.id} />
+        })}
+      </Stack>
+      {Boolean(slice.baseUrl) && (
+        <Box display="flex" justifyContent="flexEnd">
+          <LinkV2 href={slice.baseUrl}>
+            <Button
+              variant="text"
+              icon="arrowForward"
+              as="span"
+              unfocusable={true}
+            >
+              {slice.seeMoreLinkTextString}
+            </Button>
+          </LinkV2>
+        </Box>
+      )}
     </Stack>
   )
 }

--- a/apps/web/screens/queries/fragments.ts
+++ b/apps/web/screens/queries/fragments.ts
@@ -1016,6 +1016,7 @@ export const slices = gql`
         }
         slug
         assetUrl
+        externalUrl
         image {
           url
           title
@@ -1081,6 +1082,7 @@ export const slices = gql`
       }
       slug
       assetUrl
+      externalUrl
       image {
         url
         title

--- a/apps/web/screens/queries/fragments.ts
+++ b/apps/web/screens/queries/fragments.ts
@@ -1065,6 +1065,7 @@ export const slices = gql`
     __typename
     id
     baseUrl
+    seeMoreLinkTextString
     items {
       id
       date

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -1303,6 +1303,15 @@ export interface IFeaturedGenericListItemsFields {
   /** Items */
   items?: IGenericListItem[] | undefined
 
+  /** Organization Page */
+  organizationPage: IOrganizationPage
+
+  /** Organization Subpage */
+  organizationSubpage: IOrganizationSubpage
+
+  /** See more link text */
+  seeMoreLinkText?: string | undefined
+
   /** Automatically fetch items */
   automaticallyFetchItems?: boolean | undefined
 
@@ -1311,12 +1320,6 @@ export interface IFeaturedGenericListItemsFields {
 
   /** Filter Tags */
   filterTags?: IGenericTag[] | undefined
-
-  /** Organization Page */
-  organizationPage: IOrganizationPage
-
-  /** Organization Subpage */
-  organizationSubpage: IOrganizationSubpage
 }
 
 export interface IFeaturedGenericListItems

--- a/libs/cms/src/lib/models/featuredGenericListItems.model.ts
+++ b/libs/cms/src/lib/models/featuredGenericListItems.model.ts
@@ -31,6 +31,9 @@ export class FeaturedGenericListItems {
 
   @Field(() => Boolean, { nullable: true })
   automaticallyFetchItems!: boolean
+
+  @Field(() => String, { nullable: true })
+  seeMoreLinkTextString?: string
 }
 
 export const mapFeaturedGenericListItems = ({
@@ -68,6 +71,9 @@ export const mapFeaturedGenericListItems = ({
     id: sys.id,
     automaticallyFetchItems: fields.automaticallyFetchItems ?? false,
     baseUrl,
+    seeMoreLinkTextString:
+      fields.seeMoreLinkText ||
+      (sys.locale === 'is-IS' ? 'Sjá meira' : 'See more'),
     items: {
       items: (fields.items ?? []).map(mapGenericListItem),
       input:
@@ -80,6 +86,7 @@ export const mapFeaturedGenericListItems = ({
                   : (sys.locale as ElasticsearchIndexLocale),
               tags,
               tagGroups,
+              size: 10,
             }
           : null,
     },


### PR DESCRIPTION
# Generic List Item external url not being fetched in all cases

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Items in Latest and Featured lists can include external links so users can open content on external sites when available.
  * Featured lists show a configurable "See more" link text (with locale-aware default) and render a See More action when a list-level link is provided.
  * Item spacing and grouping improved for clearer presentation when base links or external links are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->