### PR TITLE
fix(user-notifications): dont save delgations notifications in db (#2…

### DIFF
--- a/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/notificationsWorker.service.spec.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/notificationsWorker.service.spec.ts
@@ -225,12 +225,12 @@ describe('NotificationsWorkerService', () => {
 
     expect(emailService.sendEmail).toHaveBeenCalledTimes(2)
 
-    // should write the messages to db
+    // should write only the primary recipient message to db (delegation notifications are not saved)
     const messages = await notificationModel.findAll()
     const recipientMessage = messages.find(
       (message) => message.recipient === userWithDelegations.nationalId,
     )
-    expect(messages).toHaveLength(2)
+    expect(messages).toHaveLength(1)
     expect(recipientMessage).toBeDefined()
 
     // should only send push notification for primary recipient

--- a/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/notificationsWorker.service.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/notificationsWorker.service.ts
@@ -311,32 +311,40 @@ export class NotificationsWorkerService {
         this.logger.info('Message received by worker', { messageId })
 
         const notification = { messageId, ...message }
-        let dbNotification = await this.notificationModel.findOne({
-          where: { messageId },
-          attributes: ['id'],
-        })
+        let dbNotification = null
 
-        if (dbNotification) {
-          // messageId exists in db, do nothing
-          this.logger.info('notification with messageId already exists in db', {
-            messageId,
+        // Only save notifications for the main recipient, delegation notifications are not saved since they should not show up under the user's notifications
+        if (!message.onBehalfOf) {
+          dbNotification = await this.notificationModel.findOne({
+            where: { messageId },
+            attributes: ['id'],
           })
-        } else {
-          // messageId does not exist
-          // write to db
-          try {
-            dbNotification = await this.notificationModel.create(notification)
-            if (dbNotification) {
-              this.logger.info('notification written to db', {
-                notification,
+
+          if (dbNotification) {
+            // messageId exists in db, do nothing
+            this.logger.info(
+              'notification with messageId already exists in db',
+              {
+                messageId,
+              },
+            )
+          } else {
+            // messageId does not exist
+            // write to db
+            try {
+              dbNotification = await this.notificationModel.create(notification)
+              if (dbNotification) {
+                this.logger.info('notification written to db', {
+                  notification,
+                  messageId,
+                })
+              }
+            } catch (e) {
+              this.logger.error('error writing notification to db', {
+                e,
                 messageId,
               })
             }
-          } catch (e) {
-            this.logger.error('error writing notification to db', {
-              e,
-              messageId,
-            })
           }
         }
 


### PR DESCRIPTION
Hotfix
We are sending email notifications do delegation but these should not show up in the users notifications bell on the app so we do not want to save them in the db

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
