### PR TITLE
feat(estate): add custom headings for the final screen for each application type

### DIFF
--- a/libs/application/templates/estate/src/forms/Done.ts
+++ b/libs/application/templates/estate/src/forms/Done.ts
@@ -17,7 +17,21 @@ export const done: Form = buildForm({
   children: [
     buildMultiField({
       id: 'done',
-      title: m.doneTitle,
+      title: (application) => {
+        const selectedEstate = getValueViaPath(
+          application.answers,
+          'selectedEstate',
+        )
+        return selectedEstate === EstateTypes.officialDivision
+          ? m.officialDivisionDoneTitle
+          : selectedEstate === EstateTypes.estateWithoutAssets
+          ? m.estateWithoutAssetsDoneTitle
+          : selectedEstate === EstateTypes.permitForUndividedEstate
+          ? m.undividedEstateDoneTitle
+          : selectedEstate === EstateTypes.divisionOfEstateByHeirs
+          ? m.privateDivisionDoneTitle
+          : m.doneTitle
+      },
       description: (application) => {
         const selectedEstate = getValueViaPath(
           application.answers,

--- a/libs/application/templates/estate/src/lib/messages.ts
+++ b/libs/application/templates/estate/src/lib/messages.ts
@@ -923,6 +923,26 @@ export const m = defineMessages({
     defaultMessage: 'Beiðni móttekin',
     description: '',
   },
+  privateDivisionDoneTitle: {
+    id: 'es.application:privateDivisionDoneTitle',
+    defaultMessage: 'Beiðni um einkaskipti móttekin',
+    description: '',
+  },
+  undividedEstateDoneTitle: {
+    id: 'es.application:undividedEstateDoneTitle',
+    defaultMessage: 'Beiðni um leyfi til setu í óskiptu búi móttekin',
+    description: '',
+  },
+  estateWithoutAssetsDoneTitle: {
+    id: 'es.application:estateWithoutAssetsDoneTitle',
+    defaultMessage: 'Yfirlýsing um eignaleysi dánarbús móttekin',
+    description: '',
+  },
+  officialDivisionDoneTitle: {
+    id: 'es.application:officialDivisionDoneTitle',
+    defaultMessage: 'Yfirlýsing um opinber skipti móttekin',
+    description: '',
+  },
   divisionOfEstateDoneSubtitle: {
     id: 'es.application:divisionOfEstateDoneSubtitle#markdown',
     defaultMessage:


### PR DESCRIPTION
Each estate application type has its own custom heading now.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - The completion screen now shows a dynamic title that adapts to the selected estate path (official division, estate without assets, permit for undivided estate, or division by heirs), with a sensible fallback when unspecified.

- Localization
  - Added new localized titles for each completion scenario to improve clarity and relevance for users based on their chosen estate type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->