### PR TITLE
fix(signature-collection): tweak scope municipality

### DIFF
--- a/libs/portals/admin/signature-collection/src/lib/utils.ts
+++ b/libs/portals/admin/signature-collection/src/lib/utils.ts
@@ -22,6 +22,10 @@ export const allowedScopesAdmin: string[] = [
   AdminPortalScope.signatureCollectionProcess,
 ]
 
+export const allowedScopesMunicipality: string[] = [
+  AdminPortalScope.signatureCollectionMunicipality,
+]
+
 export const countryAreas = [
   { value: 'Sunnlendingafjórðungur', label: 'Sunnlendingafjórðungur' },
   { value: 'Vestfirðingafjórðungur', label: 'Vestfirðingafjórðungur' },

--- a/libs/portals/admin/signature-collection/src/module.tsx
+++ b/libs/portals/admin/signature-collection/src/module.tsx
@@ -56,11 +56,14 @@ export const signatureCollectionModule: PortalModule = {
       element: (
         <AllMunicipalities
           // If the user is NOT an admin (LKS or ÞÍ) but a municipality
-          isMunicipality={props.userInfo.scopes.some(
-            (scope) =>
-              !allowedScopesAdmin.includes(scope) &&
+          isMunicipality={
+            !props.userInfo.scopes.some((scope) =>
+              allowedScopesAdmin.includes(scope),
+            ) &&
+            props.userInfo.scopes.some((scope) =>
               allowedScopesMunicipality.includes(scope),
-          )}
+            )
+          }
         />
       ),
       loader: municipalListsLoader(props),

--- a/libs/portals/admin/signature-collection/src/module.tsx
+++ b/libs/portals/admin/signature-collection/src/module.tsx
@@ -15,8 +15,8 @@ import {
 import {
   allowedScopesAdmin,
   allowedScopesAdminAndMunicipality,
+  allowedScopesMunicipality,
 } from './lib/utils'
-import { AuthDelegationType } from '@island.is/api/schema'
 
 /* Parliamentary */
 const ParliamentaryRoot = lazy(() =>
@@ -55,16 +55,12 @@ export const signatureCollectionModule: PortalModule = {
       path: SignatureCollectionPaths.MunicipalRoot,
       element: (
         <AllMunicipalities
-          // If the user is NOT an admin (LKS or ÞÍ) & have a procuration holder delegation type
-          isProcurationHolder={
-            !props.userInfo.scopes.some(
-              (scope) =>
-                allowedScopesAdmin.includes(scope) &&
-                props.userInfo.profile.delegationType?.includes(
-                  AuthDelegationType.ProcurationHolder,
-                ),
-            )
-          }
+          // If the user is NOT an admin (LKS or ÞÍ) but a municipality
+          isMunicipality={props.userInfo.scopes.some(
+            (scope) =>
+              !allowedScopesAdmin.includes(scope) &&
+              allowedScopesMunicipality.includes(scope),
+          )}
         />
       ),
       loader: municipalListsLoader(props),

--- a/libs/portals/admin/signature-collection/src/screens-municipal/AllMunicipalities/index.tsx
+++ b/libs/portals/admin/signature-collection/src/screens-municipal/AllMunicipalities/index.tsx
@@ -28,9 +28,9 @@ import sortBy from 'lodash/sortBy'
 import { CollectionStatus } from '@island.is/api/schema'
 
 const AllMunicipalities = ({
-  isProcurationHolder,
+  isMunicipality,
 }: {
-  isProcurationHolder: boolean
+  isMunicipality: boolean
 }) => {
   const { collection, allLists } = useLoaderData() as ListsLoaderReturn
   const { formatMessage } = useLocale()
@@ -115,7 +115,7 @@ const AllMunicipalities = ({
           )}
           {/* For municipalities to start their collection if its not already active.
               Note: municipalities only see their own area. */}
-          {isProcurationHolder &&
+          {isMunicipality &&
             collection.areas?.length > 0 &&
             !collection.areas[0]?.isActive && (
               <StartAreaCollection areaId={collection.areas[0]?.id} />
@@ -146,7 +146,7 @@ const AllMunicipalities = ({
                 }}
                 tag={
                   // This action is only available for the Admins (LKS and ÞÍ)
-                  !isProcurationHolder && !area.isActive
+                  !isMunicipality && !area.isActive
                     ? {
                         label: 'Open collection',
                         renderTag: () => (


### PR DESCRIPTION
## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added municipality-level access for the Signature Collection portal.
  - Municipality users are identified by municipal scope and can initiate area collections when the first area is defined and inactive.
  - Admin-only controls clarified: the “Open collection” tag now appears only for admins when an area is inactive.
  - Role-based visibility improved so municipality users see start actions appropriate to them while admins retain oversight actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->