### PR TITLE
fix(my-pages): Sortable dashboard items in CMS

### DIFF
--- a/libs/portals/my-pages/core/src/hooks/useDynamicRoutes/useDynamicRoutes.ts
+++ b/libs/portals/my-pages/core/src/hooks/useDynamicRoutes/useDynamicRoutes.ts
@@ -5,7 +5,7 @@ import { Query, QueryGetNamespaceArgs } from '@island.is/api/schema'
 import uniq from 'lodash/uniq'
 import { PortalNavigationItem, useNavigation } from '@island.is/portals/core'
 import { DynamicPaths } from './paths'
-import { orderRoutes } from '../../utils/oderRoutes'
+import { orderRoutes } from '../../utils/orderRoutes'
 
 export const GET_TAPS_QUERY = gql`
   query GetTapsQuery {

--- a/libs/portals/my-pages/core/src/hooks/useDynamicRoutes/useDynamicRoutes.ts
+++ b/libs/portals/my-pages/core/src/hooks/useDynamicRoutes/useDynamicRoutes.ts
@@ -95,6 +95,7 @@ export const useDynamicRoutesWithNavigation = (nav: PortalNavigationItem) => {
     variables: {
       input: {
         namespace: 'Mínar síður Ísland.is',
+        lang: 'is-IS', // No translation needed.
       },
     },
   })

--- a/libs/portals/my-pages/core/src/hooks/useDynamicRoutes/useDynamicRoutes.ts
+++ b/libs/portals/my-pages/core/src/hooks/useDynamicRoutes/useDynamicRoutes.ts
@@ -1,10 +1,11 @@
 import { useEffect, useState } from 'react'
 import { gql } from '@apollo/client'
 import { useQuery } from '@apollo/client'
-import { Query } from '@island.is/api/schema'
+import { Query, QueryGetNamespaceArgs } from '@island.is/api/schema'
 import uniq from 'lodash/uniq'
 import { PortalNavigationItem, useNavigation } from '@island.is/portals/core'
 import { DynamicPaths } from './paths'
+import { orderRoutes } from '../../utils/oderRoutes'
 
 export const GET_TAPS_QUERY = gql`
   query GetTapsQuery {
@@ -23,6 +24,14 @@ export const GET_DRIVING_LICENSE_BOOK_QUERY = gql`
       book {
         id
       }
+    }
+  }
+`
+
+export const GET_NAMESPACE_QUERY = gql`
+  query GetNamespace($input: GetNamespaceInput!) {
+    getNamespace(input: $input) {
+      fields
     }
   }
 `
@@ -82,7 +91,17 @@ export const useDynamicRoutes = () => {
 
 export const useDynamicRoutesWithNavigation = (nav: PortalNavigationItem) => {
   const { activeDynamicRoutes } = useDynamicRoutes()
-  const navigation = useNavigation(nav, activeDynamicRoutes)
+  const { data } = useQuery<Query, QueryGetNamespaceArgs>(GET_NAMESPACE_QUERY, {
+    variables: {
+      input: {
+        namespace: 'Mínar síður Ísland.is',
+      },
+    },
+  })
+
+  const sortedNavigation = orderRoutes(nav, data?.getNamespace?.fields)
+
+  const navigation = useNavigation(sortedNavigation, activeDynamicRoutes)
 
   return navigation
 }

--- a/libs/portals/my-pages/core/src/utils/oderRoutes.ts
+++ b/libs/portals/my-pages/core/src/utils/oderRoutes.ts
@@ -1,0 +1,41 @@
+import { PortalNavigationItem } from '@island.is/portals/core'
+
+function toOrderArray(input?: string | string[]): string[] {
+  if (!input) return []
+  if (Array.isArray(input)) return input
+
+  try {
+    const parsed = JSON.parse(input)
+    if (Array.isArray(parsed)) return parsed as string[]
+    if (parsed && Array.isArray((parsed as any).menu))
+      return (parsed as any).menu as string[]
+  } catch {
+    return input
+      .split(/[,\n;]/)
+      .map((s) => s.trim())
+      .filter(Boolean)
+  }
+  return []
+}
+
+export const orderRoutes = (
+  nav: PortalNavigationItem,
+  orderInput?: string | string[],
+): PortalNavigationItem => {
+  const orderedArray = toOrderArray(orderInput)
+
+  if (!nav.children || orderedArray.length === 0) {
+    return nav
+  }
+
+  const sorted = [...nav.children].sort((a, b) => {
+    const ia = orderedArray.indexOf(a.path ?? '')
+    const ib = orderedArray.indexOf(b.path ?? '')
+    const sa = ia === -1 ? Number.MAX_SAFE_INTEGER : ia
+    const sb = ib === -1 ? Number.MAX_SAFE_INTEGER : ib
+    return sa - sb
+  })
+
+  nav.children = sorted.map((child) => orderRoutes(child, orderedArray))
+  return nav
+}

--- a/libs/portals/my-pages/core/src/utils/orderRoutes.ts
+++ b/libs/portals/my-pages/core/src/utils/orderRoutes.ts
@@ -1,48 +1,38 @@
 import { PortalNavigationItem } from '@island.is/portals/core'
+import { z } from 'zod'
 
-type MenuConfig = { menu: string[] }
-
-const isStringArray = (v: unknown): v is string[] =>
-  Array.isArray(v) && v.every((x) => typeof x === 'string')
-
-const isMenuConfig = (v: unknown): v is MenuConfig =>
-  typeof v === 'object' &&
-  v !== null &&
-  'menu' in v &&
-  isStringArray((v as Record<string, unknown>).menu)
-
-const toOrderArray = (input?: string | string[]): string[] => {
-  if (!input) return []
-  if (Array.isArray(input)) return input
-
-  try {
-    const parsed: unknown = JSON.parse(input)
-    if (isStringArray(parsed)) return parsed
-    if (isMenuConfig(parsed)) return parsed.menu
-  } catch {
-    return input
-      .split(/[,\n;]/)
-      .map((s) => s.trim())
-      .filter(Boolean)
-  }
-  return []
-}
+const menuConfigSchema = z.object({
+  menu: z.array(z.string()),
+})
 
 export const orderRoutes = (
   nav: PortalNavigationItem,
   orderInput?: string | string[],
 ): PortalNavigationItem => {
-  const orderedArray = toOrderArray(orderInput)
-  if (!nav.children || orderedArray.length === 0) return nav
+  try {
+    if (typeof orderInput !== 'string') {
+      return nav
+    }
+    const menuObject = JSON.parse(orderInput)
+    const menu = menuConfigSchema.safeParse(menuObject)
 
-  const sorted = [...nav.children].sort((a, b) => {
-    const ia = orderedArray.indexOf(a.path ?? '')
-    const ib = orderedArray.indexOf(b.path ?? '')
-    const sa = ia === -1 ? Number.MAX_SAFE_INTEGER : ia
-    const sb = ib === -1 ? Number.MAX_SAFE_INTEGER : ib
-    return sa - sb
-  })
+    if (!nav.children) return nav
+    if (!menu.success) return nav
 
-  nav.children = sorted.map((child) => orderRoutes(child, orderedArray))
-  return nav
+    const orderedArray = menu.data.menu
+    if (orderedArray.length === 0) return nav
+
+    const sorted = [...nav.children].sort((a, b) => {
+      const ia = orderedArray.indexOf(a.path ?? '')
+      const ib = orderedArray.indexOf(b.path ?? '')
+      const sa = ia === -1 ? Number.MAX_SAFE_INTEGER : ia
+      const sb = ib === -1 ? Number.MAX_SAFE_INTEGER : ib
+      return sa - sb
+    })
+
+    nav.children = sorted.map((child) => orderRoutes(child, orderedArray))
+    return nav
+  } catch {
+    return nav
+  }
 }


### PR DESCRIPTION
## What

Sortable dashboard items in CMS on My-Pages.

## Why

Dynamic items on the dashboard. Editor can sort items.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Navigation now automatically reflects content-defined ordering, ensuring menus and submenus appear in a predictable sequence.
  * Dynamic navigation is fetched from the configured namespace and language, keeping the menu up to date without manual changes.
  * Ordering is applied recursively, so nested items follow the same defined structure throughout the portal.
  * Navigation is pre-sorted before rendering, improving consistency across sections and reducing unexpected menu changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->