### PR TITLE
feat(j-s): Delivery supplements added to update type from police

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/verdict/dto/policeUpdateVerdict.dto.ts
+++ b/apps/judicial-system/backend/src/app/modules/verdict/dto/policeUpdateVerdict.dto.ts
@@ -10,7 +10,10 @@ import {
 
 import { ApiPropertyOptional } from '@nestjs/swagger'
 
-import { VerdictServiceStatus } from '@island.is/judicial-system/types'
+import {
+  VerdictAppealDecision,
+  VerdictServiceStatus,
+} from '@island.is/judicial-system/types'
 
 import { nationalIdTransformer } from '../../../transformers'
 
@@ -43,4 +46,9 @@ export class PoliceUpdateVerdictDto {
   @Transform(nationalIdTransformer)
   @ApiPropertyOptional({ type: String })
   readonly deliveredToDefenderNationalId?: string
+
+  @IsOptional()
+  @IsEnum(VerdictAppealDecision)
+  @ApiPropertyOptional({ enum: VerdictAppealDecision })
+  readonly appealDecision?: VerdictAppealDecision
 }

--- a/apps/judicial-system/xrd-api/src/app/app.service.ts
+++ b/apps/judicial-system/xrd-api/src/app/app.service.ts
@@ -296,8 +296,10 @@ export class AppService {
         if (deliveredToLawyer) {
           return ServiceStatus.DEFENDER
         }
+        return ServiceStatus.FAILED
       }
-      return ServiceStatus.FAILED
+
+      return undefined
     }
 
     if (updatePoliceDocumentDelivery.deliverySupplements?.appeal_decision) {

--- a/apps/judicial-system/xrd-api/src/app/app.service.ts
+++ b/apps/judicial-system/xrd-api/src/app/app.service.ts
@@ -23,6 +23,7 @@ import {
   LawyerType,
   PoliceFileTypeCode,
   ServiceStatus,
+  VerdictAppealDecision,
 } from '@island.is/judicial-system/types'
 
 import { CreateCaseDto } from './dto/createCase.dto'
@@ -299,6 +300,23 @@ export class AppService {
       return ServiceStatus.FAILED
     }
 
+    if (updatePoliceDocumentDelivery.deliverySupplements?.appeal_decision) {
+      const appealDecision =
+        updatePoliceDocumentDelivery.deliverySupplements.appeal_decision
+
+      if (
+        !Object.values(VerdictAppealDecision).includes(
+          appealDecision as VerdictAppealDecision,
+        )
+      ) {
+        throw new BadRequestException(
+          `Invalid appeal_decision: ${appealDecision}. Must be one of: ${Object.values(
+            VerdictAppealDecision,
+          ).join(', ')}`,
+        )
+      }
+    }
+
     const parsedPoliceUpdate = {
       serviceDate: updatePoliceDocumentDelivery.servedAt,
       servedBy: updatePoliceDocumentDelivery.servedBy,
@@ -308,6 +326,9 @@ export class AppService {
       ),
       deliveredToDefenderNationalId:
         updatePoliceDocumentDelivery.defenderNationalId,
+      appealDecision:
+        updatePoliceDocumentDelivery.deliverySupplements?.appeal_decision ??
+        undefined,
     }
     try {
       const res = await fetch(

--- a/apps/judicial-system/xrd-api/src/app/app.service.ts
+++ b/apps/judicial-system/xrd-api/src/app/app.service.ts
@@ -302,9 +302,9 @@ export class AppService {
       return undefined
     }
 
-    if (updatePoliceDocumentDelivery.deliverySupplements?.appeal_decision) {
+    if (updatePoliceDocumentDelivery.deliverySupplements?.appealDecision) {
       const appealDecision =
-        updatePoliceDocumentDelivery.deliverySupplements.appeal_decision
+        updatePoliceDocumentDelivery.deliverySupplements.appealDecision
 
       if (
         !Object.values(VerdictAppealDecision).includes(

--- a/apps/judicial-system/xrd-api/src/app/app.service.ts
+++ b/apps/judicial-system/xrd-api/src/app/app.service.ts
@@ -329,7 +329,7 @@ export class AppService {
       deliveredToDefenderNationalId:
         updatePoliceDocumentDelivery.defenderNationalId,
       appealDecision:
-        updatePoliceDocumentDelivery.deliverySupplements?.appeal_decision ??
+        updatePoliceDocumentDelivery.deliverySupplements?.appealDecision ??
         undefined,
     }
     try {

--- a/apps/judicial-system/xrd-api/src/app/dto/policeDocument.dto.ts
+++ b/apps/judicial-system/xrd-api/src/app/dto/policeDocument.dto.ts
@@ -2,6 +2,7 @@ import {
   IsBoolean,
   IsEnum,
   IsNotEmpty,
+  IsObject,
   IsOptional,
   IsString,
 } from 'class-validator'
@@ -55,4 +56,9 @@ export class UpdatePoliceDocumentDeliveryDto {
   @IsBoolean()
   @ApiPropertyOptional({ type: Boolean, required: false })
   deliveredToLawyer?: boolean
+
+  @IsOptional()
+  @IsObject()
+  @ApiPropertyOptional({ type: 'object', required: false })
+  deliverySupplements?: Record<string, unknown>
 }


### PR DESCRIPTION
[Asana task](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1211370802113507)

## What

Add a parameter that allows the police system to send supplementary information about a document delivery.  

## Why

We need to know what the appeal decision for a verdict is, and we may need other information in the future for other documents.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Support submitting an optional appeal decision with police verdict updates.
  - Added optional delivery supplements to police document delivery updates.
- Bug Fixes
  - Improved delivery status determination: returns Failed when delivered but no other delivery flags apply; returns no status when conditions aren’t met.
  - Enforced strict validation for appeal decision values with clear error responses for invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->