### PR TITLE
fix(application-system): OverviewFormField wrapping long attachment names

### DIFF
--- a/libs/application/ui-fields/src/lib/OverviewFormField/FileItem.tsx
+++ b/libs/application/ui-fields/src/lib/OverviewFormField/FileItem.tsx
@@ -11,6 +11,14 @@ export const FileItem = ({ fileName, fileSize, fileType }: Props) => {
     <Box>
       <ActionCard
         heading={fileName}
+        renderHeading={(headingEl) => (
+          <Box
+            minWidth={0}
+            style={{ wordBreak: 'break-word', overflowWrap: 'anywhere' }}
+          >
+            {headingEl}
+          </Box>
+        )}
         text={fileSize ?? ''}
         headingVariant="h4"
         cta={{

--- a/libs/application/ui-fields/src/lib/OverviewFormField/OverviewFormField.tsx
+++ b/libs/application/ui-fields/src/lib/OverviewFormField/OverviewFormField.tsx
@@ -146,7 +146,7 @@ export const OverviewFormField = ({
 
     if (!item.keyText && !item.valueText) {
       return (
-        <GridColumn span={span}>
+        <GridColumn key={`renderItems-${i}`} span={span}>
           {item.lineAboveKeyText && (
             <Box paddingBottom={3}>
               <Divider weight="black" thickness="thick" />


### PR DESCRIPTION
# Updating overviewFormField to handle long file names and fixed uniqueKey error

## Screenshots / Gifs
Before:
<img width="1240" height="552" alt="image" src="https://github.com/user-attachments/assets/b13b7268-42ab-4299-afb0-bb29e785fd7e" />

 
After:
<img width="660" height="552" alt="image" src="https://github.com/user-attachments/assets/0494e0d6-0a11-4701-ad98-340b1c8cc48a" />


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Long file names now wrap correctly in file items, preventing layout breakage and preserving readability.
  * Eliminated React key warnings when displaying items without labels, improving rendering stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->