### PR TITLE
feat(native-app): Add blood types and introduce general information component

### DIFF
--- a/apps/native/app/src/graphql/queries/health.graphql
+++ b/apps/native/app/src/graphql/queries/health.graphql
@@ -93,3 +93,18 @@ query GetOrganDonorStatus($locale: String) {
     }
   }
 }
+
+query getBloodTypeOverview {
+  rightsPortalBloodType {
+    registered
+    type
+  }
+}
+
+query getDentistOverview($input: RightsPortalDentistBillsInput!) {
+  rightsPortalUserDentistRegistration(input: $input) {
+    dentist {
+      name
+    }
+  }
+}

--- a/apps/native/app/src/messages/en.ts
+++ b/apps/native/app/src/messages/en.ts
@@ -1,6 +1,10 @@
 import { TranslatedMessages } from './index'
 
 export const en: TranslatedMessages = {
+  // General buttons
+  'button.change': 'Change',
+  'button.open': 'Open',
+
   // login
   'login.welcomeMessage': 'Log in to the app with electronic ID',
   'login.loginButtonText': 'Login',
@@ -706,6 +710,12 @@ export const en: TranslatedMessages = {
   'health.overview.levelStatusValue': 'Level {level}, you pay {percentage}%',
   'health.overview.medicinePurchaseNoActivePeriodWarning':
     'A new payment period begins with the next medicine purchase',
+  'health.overview.basicInformation': 'Basic information',
+  'health.overview.bloodType': 'Blood group',
+  'health.overview.bloodTypeDescription': 'Your blood group is {bloodType}',
+  'health.overview.noBloodTypeRegistered': 'No blood type registered',
+  'health.overview.dentist': 'Dentist',
+  'health.overview.noDentistRegistered': 'No dentist registered',
 
   // health - vaccinations
   'health.vaccinations.screenTitle': 'Vaccinations',

--- a/apps/native/app/src/messages/is.ts
+++ b/apps/native/app/src/messages/is.ts
@@ -1,5 +1,9 @@
 // Source of truth for other languages
 export const is = {
+  // General buttons
+  'button.change': 'Breyta',
+  'button.open': 'Skoða',
+
   // login
   'login.welcomeMessage': 'Skráðu þig inn í appið með rafrænum skilríkjum',
   'login.loginButtonText': 'Skrá inn',
@@ -706,6 +710,12 @@ export const is = {
     'Greiðsluþrep {level}, þú greiðir {percentage}%',
   'health.overview.medicinePurchaseNoActivePeriodWarning':
     'Nýtt greiðslutímabil hefst við næstu lyfjakaup',
+  'health.overview.basicInformation': 'Grunnupplýsingar',
+  'health.overview.bloodType': 'Blóðflokkur',
+  'health.overview.bloodTypeDescription': 'Þú ert í blóðflokki {bloodType}',
+  'health.overview.noBloodTypeRegistered': 'Ekki verið flokkaður',
+  'health.overview.dentist': 'Tannlæknir',
+  'health.overview.noDentistRegistered': 'Enginn tannlæknir skráður',
 
   // health - vaccinations
   'health.vaccinations.screenTitle': 'Bólusetningar',

--- a/apps/native/app/src/screens/health/health-overview.tsx
+++ b/apps/native/app/src/screens/health/health-overview.tsx
@@ -665,44 +665,44 @@ export const HealthOverviewScreen: NavigationFunctionComponent = ({
         </InputRow>
         {isOrganDonationEnabled && (
           <InputRow background>
-              <Input
-                label={intl.formatMessage({
-                  id: 'health.organDonation',
-                })}
-                value={`${
-                  organDonationRes.error
-                    ? ''
-                    : intl.formatMessage({
-                        id: isOrganDonor
-                          ? 'health.organDonation.isDonorDescription'
-                          : 'health.organDonation.isNotDonorDescription',
-                      }) ?? ''
-                }`}
-                loading={organDonationRes.loading && !organDonationRes.data}
-                fullWidhtWarning
-                warningText={
-                  organDonationRes.error
-                    ? intl.formatMessage({
-                        id: 'problem.thirdParty.message',
-                      })
-                    : ''
-                }
-                allowEmptyValue
-                rightElement={
-                  <ExternalLink
-                    onPress={() =>
-                      navigateTo('/webview', {
-                        source: {
-                          uri: `${origin}/minarsidur/heilsa/grunnupplysingar/liffaeragjof`,
-                        },
-                      })
-                    }
-                    text="button.open"
-                    topAlign={organDonationRes.error ? true : false}
-                  />
-                }
-              />
-            </InputRow>
+            <Input
+              label={intl.formatMessage({
+                id: 'health.organDonation',
+              })}
+              value={`${
+                organDonationRes.error
+                  ? ''
+                  : intl.formatMessage({
+                      id: isOrganDonor
+                        ? 'health.organDonation.isDonorDescription'
+                        : 'health.organDonation.isNotDonorDescription',
+                    }) ?? ''
+              }`}
+              loading={organDonationRes.loading && !organDonationRes.data}
+              fullWidhtWarning
+              warningText={
+                organDonationRes.error
+                  ? intl.formatMessage({
+                      id: 'problem.thirdParty.message',
+                    })
+                  : ''
+              }
+              allowEmptyValue
+              rightElement={
+                <ExternalLink
+                  onPress={() =>
+                    navigateTo('/webview', {
+                      source: {
+                        uri: `${origin}/minarsidur/heilsa/grunnupplysingar/liffaeragjof`,
+                      },
+                    })
+                  }
+                  text="button.open"
+                  topAlign={organDonationRes.error ? true : false}
+                />
+              }
+            />
+          </InputRow>
         )}
         <InputRow background>
           <Input

--- a/apps/native/app/src/screens/health/health-overview.tsx
+++ b/apps/native/app/src/screens/health/health-overview.tsx
@@ -170,8 +170,7 @@ export const HealthOverviewScreen: NavigationFunctionComponent = ({
   const isVaccinationsEnabled = useFeatureFlag('isVaccinationsEnabled', false)
   const isOrganDonationEnabled = useFeatureFlag('isOrganDonationEnabled', false)
 
-  const newDate = useMemo(() => new Date(), [])
-  const now = useMemo(() => newDate.toISOString(), [newDate])
+  const now = useMemo(() => new Date().toISOString(), [])
 
   const medicinePurchaseRes = useGetMedicineDataQuery()
   const organDonationRes = useGetOrganDonorStatusQuery({
@@ -187,8 +186,8 @@ export const HealthOverviewScreen: NavigationFunctionComponent = ({
   const dentistRes = useGetDentistOverviewQuery({
     variables: {
       input: {
-        dateFrom: newDate as any,
-        dateTo: newDate as any,
+        dateFrom: now,
+        dateTo: now,
       },
     },
   })

--- a/apps/native/app/src/screens/health/health-overview.tsx
+++ b/apps/native/app/src/screens/health/health-overview.tsx
@@ -8,6 +8,7 @@ import {
   ScrollView,
   TouchableOpacity,
   useWindowDimensions,
+  View,
 } from 'react-native'
 import { NavigationFunctionComponent } from 'react-native-navigation'
 import styled, { useTheme } from 'styled-components/native'
@@ -16,6 +17,8 @@ import externalLinkIcon from '../../assets/icons/external-link.png'
 import { getConfig } from '../../config'
 import { useFeatureFlag } from '../../contexts/feature-flag-provider'
 import {
+  useGetBloodTypeOverviewQuery,
+  useGetDentistOverviewQuery,
   useGetHealthCenterQuery,
   useGetHealthInsuranceOverviewQuery,
   useGetMedicineDataQuery,
@@ -35,6 +38,7 @@ import {
   Input,
   InputRow,
   Problem,
+  theme,
   Typography,
 } from '../../ui'
 
@@ -53,7 +57,7 @@ const ButtonWrapper = styled.View`
 interface HeadingSectionProps {
   title: string
   linkTextId?: string
-  onPress: () => void
+  onPress?: () => void
 }
 
 const HeadingSection: React.FC<HeadingSectionProps> = ({
@@ -63,30 +67,78 @@ const HeadingSection: React.FC<HeadingSectionProps> = ({
 }) => {
   const theme = useTheme()
   return (
-    <TouchableOpacity onPress={onPress} style={{ marginTop: theme.spacing[2] }}>
+    <TouchableOpacity
+      onPress={onPress}
+      style={{ marginTop: theme.spacing[2] }}
+      disabled={!onPress}
+    >
       <Heading
         small
         button={
           <TouchableOpacity
             onPress={onPress}
+            disabled={!onPress}
             style={{
               flexDirection: 'row',
               alignItems: 'center',
             }}
           >
-            <Typography
-              variant="heading5"
-              color={theme.color.blue400}
-              style={{ marginRight: 4 }}
-            >
-              <FormattedMessage id={linkTextId ?? 'button.seeAll'} />
-            </Typography>
-            <Image source={externalLinkIcon} />
+            {onPress && (
+              <>
+                <Typography
+                  variant="heading5"
+                  color={theme.color.blue400}
+                  style={{ marginRight: 4 }}
+                >
+                  <FormattedMessage id={linkTextId ?? 'button.seeAll'} />
+                </Typography>
+                <Image source={externalLinkIcon} />
+              </>
+            )}
           </TouchableOpacity>
         }
       >
         {title}
       </Heading>
+    </TouchableOpacity>
+  )
+}
+
+interface ExternalLinkProps {
+  onPress: () => void
+  text: string
+  topAlign?: boolean
+}
+
+const ExternalLink: React.FC<ExternalLinkProps> = ({
+  onPress,
+  text,
+  topAlign = false,
+}) => {
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      style={{
+        flexDirection: 'row',
+        alignItems: topAlign ? 'flex-start' : 'center',
+      }}
+    >
+      <View
+        style={{
+          flexDirection: 'row',
+          borderBottomWidth: 1,
+          borderBottomColor: theme.color.blue400,
+        }}
+      >
+        <Typography
+          variant="eyebrow"
+          color={theme.color.blue400}
+          style={{ marginRight: 4 }}
+        >
+          <FormattedMessage id={text} />
+        </Typography>
+        <Image source={externalLinkIcon} />
+      </View>
     </TouchableOpacity>
   )
 }
@@ -118,7 +170,8 @@ export const HealthOverviewScreen: NavigationFunctionComponent = ({
   const isVaccinationsEnabled = useFeatureFlag('isVaccinationsEnabled', false)
   const isOrganDonationEnabled = useFeatureFlag('isOrganDonationEnabled', false)
 
-  const now = useMemo(() => new Date().toISOString(), [])
+  const newDate = useMemo(() => new Date(), [])
+  const now = useMemo(() => newDate.toISOString(), [newDate])
 
   const medicinePurchaseRes = useGetMedicineDataQuery()
   const organDonationRes = useGetOrganDonorStatusQuery({
@@ -130,6 +183,15 @@ export const HealthOverviewScreen: NavigationFunctionComponent = ({
   const healthInsuranceRes = useGetHealthInsuranceOverviewQuery()
   const healthCenterRes = useGetHealthCenterQuery()
   const paymentStatusRes = useGetPaymentStatusQuery()
+  const bloodTypeRes = useGetBloodTypeOverviewQuery()
+  const dentistRes = useGetDentistOverviewQuery({
+    variables: {
+      input: {
+        dateFrom: newDate as any,
+        dateTo: newDate as any,
+      },
+    },
+  })
   const paymentOverviewRes = useGetPaymentOverviewQuery({
     variables: {
       input: {
@@ -159,23 +221,6 @@ export const HealthOverviewScreen: NavigationFunctionComponent = ({
 
   const isOrganDonor = organDonationData?.isDonor ?? false
 
-  const isOrganDonorWithLimitations =
-    isOrganDonor && (organDonationData?.limitations?.hasLimitations ?? false)
-
-  const organLimitations = isOrganDonorWithLimitations
-    ? organDonationData?.limitations?.limitedOrgansList?.map(
-        (organ) => organ.name,
-      ) ?? []
-    : []
-
-  // Make sure to list both selected organs and the comment if it exists
-  const organLimitationsIncludingComment = [
-    Array.isArray(organLimitations) ? organLimitations.join(', ') : '',
-    organDonationData?.limitations?.comment,
-  ]
-    .filter(Boolean)
-    .join(', ')
-
   useConnectivityIndicator({
     componentId,
     refetching,
@@ -185,6 +230,8 @@ export const HealthOverviewScreen: NavigationFunctionComponent = ({
       healthCenterRes,
       paymentStatusRes,
       paymentOverviewRes,
+      organDonationRes,
+      dentistRes,
     ],
   })
 
@@ -198,7 +245,9 @@ export const HealthOverviewScreen: NavigationFunctionComponent = ({
         healthCenterRes.refetch(),
         paymentStatusRes.refetch(),
         paymentOverviewRes.refetch(),
+        dentistRes.refetch(),
         isOrganDonationEnabled && organDonationRes.refetch(),
+        bloodTypeRes.refetch(),
       ].filter(Boolean)
       await Promise.all(promises)
     } catch (e) {
@@ -214,6 +263,8 @@ export const HealthOverviewScreen: NavigationFunctionComponent = ({
     paymentOverviewRes,
     organDonationRes,
     isOrganDonationEnabled,
+    dentistRes,
+    bloodTypeRes,
   ])
 
   return (
@@ -289,101 +340,6 @@ export const HealthOverviewScreen: NavigationFunctionComponent = ({
             }
           />
         </ButtonWrapper>
-        <HeadingSection
-          title={intl.formatMessage({ id: 'health.overview.healthCenter' })}
-          onPress={() =>
-            openBrowser(`${origin}/minarsidur/heilsa/heilsugaesla`, componentId)
-          }
-        />
-        {(healthCenterRes.data || healthCenterRes.loading) && (
-          <>
-            <InputRow background>
-              <Input
-                label={intl.formatMessage({
-                  id: 'health.overview.healthCenter',
-                })}
-                value={
-                  healthCenterRes.data
-                    ?.rightsPortalHealthCenterRegistrationHistory?.current
-                    ?.healthCenterName ??
-                  intl.formatMessage({
-                    id: 'health.overview.noHealthCenterRegistered',
-                  })
-                }
-                loading={healthCenterRes.loading && !healthCenterRes.data}
-                error={healthCenterRes.error && !healthCenterRes.data}
-                darkBorder
-              />
-            </InputRow>
-            <InputRow background>
-              <Input
-                label={intl.formatMessage({
-                  id: 'health.overview.physician',
-                })}
-                value={
-                  healthCenterRes.data
-                    ?.rightsPortalHealthCenterRegistrationHistory?.current
-                    ?.doctor ??
-                  intl.formatMessage({
-                    id: 'health.overview.noPhysicianRegistered',
-                  })
-                }
-                loading={healthCenterRes.loading && !healthCenterRes.data}
-                error={healthCenterRes.error && !healthCenterRes.data}
-                noBorder
-              />
-            </InputRow>
-          </>
-        )}
-        {healthCenterRes.error &&
-          !healthCenterRes.data &&
-          showErrorComponent(healthCenterRes.error)}
-        <HeadingSection
-          title={intl.formatMessage({ id: 'health.overview.statusOfRights' })}
-          onPress={() =>
-            openBrowser(`${origin}/minarsidur/heilsa/yfirlit`, componentId)
-          }
-        />
-        {(healthInsuranceRes.data && healthInsuranceData?.isInsured) ||
-        healthInsuranceRes.loading ? (
-          <InputRow background>
-            <Input
-              label={intl.formatMessage({
-                id: 'health.overview.insuredFrom',
-              })}
-              value={
-                healthInsuranceData?.from
-                  ? intl.formatDate(healthInsuranceData.from)
-                  : null
-              }
-              loading={healthInsuranceRes.loading && !healthInsuranceRes.data}
-              error={healthInsuranceRes.error && !healthInsuranceRes.data}
-              noBorder
-            />
-            <Input
-              label={intl.formatMessage({
-                id: 'health.overview.status',
-              })}
-              value={healthInsuranceData?.status?.display}
-              loading={healthInsuranceRes.loading && !healthInsuranceRes.data}
-              error={healthInsuranceRes.error && !healthInsuranceRes.data}
-              noBorder
-            />
-          </InputRow>
-        ) : (
-          !healthInsuranceRes.error &&
-          healthInsuranceRes.data && (
-            <Alert
-              type="info"
-              title={intl.formatMessage({ id: 'health.overview.notInsured' })}
-              message={healthInsuranceData?.explanation ?? ''}
-              hasBorder
-            />
-          )
-        )}
-        {healthInsuranceRes.error &&
-          !healthInsuranceRes.data &&
-          showErrorComponent(healthInsuranceRes.error)}
         <HeadingSection
           title={intl.formatMessage({
             id: 'health.overview.coPayments',
@@ -536,56 +492,268 @@ export const HealthOverviewScreen: NavigationFunctionComponent = ({
         {medicinePurchaseRes.error &&
           !medicinePurchaseRes.data &&
           showErrorComponent(medicinePurchaseRes.error)}
-        {isOrganDonationEnabled && (
-          <HeadingSection
-            title={intl.formatMessage({
-              id: 'health.organDonation',
+        <HeadingSection
+          title={intl.formatMessage({ id: 'health.overview.statusOfRights' })}
+          onPress={() =>
+            openBrowser(`${origin}/minarsidur/heilsa/yfirlit`, componentId)
+          }
+        />
+        {(healthInsuranceRes.data && healthInsuranceData?.isInsured) ||
+        healthInsuranceRes.loading ? (
+          <InputRow background>
+            <Input
+              label={intl.formatMessage({
+                id: 'health.overview.insuredFrom',
+              })}
+              value={
+                healthInsuranceData?.from
+                  ? intl.formatDate(healthInsuranceData.from)
+                  : null
+              }
+              loading={healthInsuranceRes.loading && !healthInsuranceRes.data}
+              error={healthInsuranceRes.error && !healthInsuranceRes.data}
+              noBorder
+            />
+            <Input
+              label={intl.formatMessage({
+                id: 'health.overview.status',
+              })}
+              value={healthInsuranceData?.status?.display}
+              loading={healthInsuranceRes.loading && !healthInsuranceRes.data}
+              error={healthInsuranceRes.error && !healthInsuranceRes.data}
+              noBorder
+            />
+          </InputRow>
+        ) : (
+          !healthInsuranceRes.error &&
+          healthInsuranceRes.data && (
+            <Alert
+              type="info"
+              title={intl.formatMessage({ id: 'health.overview.notInsured' })}
+              message={healthInsuranceData?.explanation ?? ''}
+              hasBorder
+            />
+          )
+        )}
+        {healthInsuranceRes.error &&
+          !healthInsuranceRes.data &&
+          showErrorComponent(healthInsuranceRes.error)}
+        {/** General health information */}
+        <HeadingSection
+          title={intl.formatMessage({
+            id: 'health.overview.basicInformation',
+          })}
+        />
+        <InputRow background>
+          <Input
+            label={intl.formatMessage({
+              id: 'health.overview.healthCenter',
             })}
-            linkTextId="health.organDonation.change"
-            onPress={() =>
-              openBrowser(
-                `${origin}/minarsidur/heilsa/liffaeragjof/skraning`,
-                componentId,
-              )
+            value={
+              healthCenterRes.error
+                ? ''
+                : healthCenterRes.data
+                    ?.rightsPortalHealthCenterRegistrationHistory?.current
+                    ?.healthCenterName ??
+                  intl.formatMessage({
+                    id: 'health.overview.noHealthCenterRegistered',
+                  })
+            }
+            loading={healthCenterRes.loading}
+            fullWidhtWarning
+            allowEmptyValue={healthCenterRes.error ? true : false}
+            warningText={
+              healthCenterRes.error
+                ? intl.formatMessage({
+                    id: 'problem.thirdParty.message',
+                  })
+                : ''
+            }
+            rightElement={
+              <ExternalLink
+                onPress={() =>
+                  navigateTo('/webview', {
+                    source: {
+                      uri: `${origin}/minarsidur/heilsa/grunnupplysingar/heilsugaesla`,
+                    },
+                  })
+                }
+                text="button.open"
+                topAlign={healthCenterRes.error ? true : false}
+              />
             }
           />
-        )}
-        {isOrganDonationEnabled &&
-          (organDonationRes.loading || organDonationRes.data) && (
+        </InputRow>
+        <InputRow background>
+          <Input
+            label={intl.formatMessage({
+              id: 'health.overview.physician',
+            })}
+            value={
+              healthCenterRes.error
+                ? ''
+                : healthCenterRes.data
+                    ?.rightsPortalHealthCenterRegistrationHistory?.current
+                    ?.doctor ??
+                  intl.formatMessage({
+                    id: 'health.overview.noPhysicianRegistered',
+                  })
+            }
+            loading={healthCenterRes.loading}
+            fullWidhtWarning
+            allowEmptyValue={healthCenterRes.error ? true : false}
+            warningText={
+              healthCenterRes.error
+                ? intl.formatMessage({
+                    id: 'problem.thirdParty.message',
+                  })
+                : ''
+            }
+            rightElement={
+              <ExternalLink
+                onPress={() =>
+                  navigateTo('/webview', {
+                    source: {
+                      uri: `${origin}/minarsidur/heilsa/grunnupplysingar/heilsugaesla/skraning`,
+                    },
+                  })
+                }
+                text="button.change"
+                topAlign={healthCenterRes.error ? true : false}
+              />
+            }
+          />
+        </InputRow>
+        <InputRow background>
+          <Input
+            label={intl.formatMessage({
+              id: 'health.overview.dentist',
+            })}
+            value={
+              dentistRes.error
+                ? ''
+                : dentistRes.data?.rightsPortalUserDentistRegistration?.dentist
+                    ?.name ??
+                  intl.formatMessage({
+                    id: 'health.overview.noDentistRegistered',
+                  })
+            }
+            allowEmptyValue={dentistRes.error ? true : false}
+            loading={dentistRes.loading}
+            fullWidhtWarning
+            warningText={
+              dentistRes.error
+                ? intl.formatMessage({
+                    id: 'problem.thirdParty.message',
+                  })
+                : ''
+            }
+            rightElement={
+              <ExternalLink
+                onPress={() =>
+                  navigateTo('/webview', {
+                    source: {
+                      uri: `${origin}/minarsidur/heilsa/grunnupplysingar/tannlaeknar`,
+                    },
+                  })
+                }
+                text="button.open"
+                topAlign={dentistRes.error ? true : false}
+              />
+            }
+          />
+        </InputRow>
+        {isOrganDonationEnabled && (
+          <>
             <InputRow background>
               <Input
                 label={intl.formatMessage({
-                  id: isOrganDonorWithLimitations
-                    ? 'health.organDonation.isDonorWithLimitations'
-                    : isOrganDonor
-                    ? 'health.organDonation.isDonor'
-                    : 'health.organDonation.isNotDonor',
+                  id: 'health.organDonation',
                 })}
-                value={`${intl.formatMessage(
-                  {
-                    id: isOrganDonorWithLimitations
-                      ? 'health.organDonation.isDonorWithLimitationsDescription'
-                      : isOrganDonor
-                      ? 'health.organDonation.isDonorDescription'
-                      : 'health.organDonation.isNotDonorDescription',
-                  },
-                  {
-                    limitations: isOrganDonorWithLimitations
-                      ? organLimitationsIncludingComment
-                      : '',
-                  },
-                )}`}
-                loadLabel={true}
+                value={`${
+                  organDonationRes.error
+                    ? ''
+                    : intl.formatMessage({
+                        id: isOrganDonor
+                          ? 'health.organDonation.isDonorDescription'
+                          : 'health.organDonation.isNotDonorDescription',
+                      }) ?? ''
+                }`}
                 loading={organDonationRes.loading && !organDonationRes.data}
-                error={organDonationRes.error && !organDonationRes.data}
-                noBorder
+                fullWidhtWarning
+                warningText={
+                  organDonationRes.error
+                    ? intl.formatMessage({
+                        id: 'problem.thirdParty.message',
+                      })
+                    : ''
+                }
+                allowEmptyValue
+                rightElement={
+                  <ExternalLink
+                    onPress={() =>
+                      navigateTo('/webview', {
+                        source: {
+                          uri: `${origin}/minarsidur/heilsa/grunnupplysingar/liffaeragjof`,
+                        },
+                      })
+                    }
+                    text="button.open"
+                    topAlign={organDonationRes.error ? true : false}
+                  />
+                }
               />
             </InputRow>
-          )}
-        {isOrganDonationEnabled &&
-          organDonationRes.error &&
-          !organDonationRes.data &&
-          showErrorComponent(organDonationRes.error)}
+          </>
+        )}
+        <InputRow background>
+          <Input
+            label={intl.formatMessage({
+              id: 'health.overview.bloodType',
+            })}
+            value={
+              bloodTypeRes.error
+                ? ''
+                : bloodTypeRes.data?.rightsPortalBloodType?.registered
+                ? intl.formatMessage(
+                    {
+                      id: 'health.overview.bloodTypeDescription',
+                    },
+                    {
+                      bloodType:
+                        bloodTypeRes.data?.rightsPortalBloodType?.type ?? '',
+                    },
+                  )
+                : intl.formatMessage({
+                    id: 'health.overview.noBloodTypeRegistered',
+                  })
+            }
+            loading={bloodTypeRes.loading}
+            fullWidhtWarning
+            warningText={
+              bloodTypeRes.error
+                ? intl.formatMessage({
+                    id: 'problem.thirdParty.message',
+                  })
+                : ''
+            }
+            allowEmptyValue
+            rightElement={
+              <ExternalLink
+                onPress={() =>
+                  navigateTo('/webview', {
+                    source: {
+                      uri: `${origin}/minarsidur/heilsa/blodflokkur`,
+                    },
+                  })
+                }
+                text="button.open"
+                topAlign={bloodTypeRes.error ? true : false}
+              />
+            }
+            noBorder
+          />
+        </InputRow>
       </ScrollView>
     </Host>
   )

--- a/apps/native/app/src/screens/health/health-overview.tsx
+++ b/apps/native/app/src/screens/health/health-overview.tsx
@@ -664,8 +664,7 @@ export const HealthOverviewScreen: NavigationFunctionComponent = ({
           />
         </InputRow>
         {isOrganDonationEnabled && (
-          <>
-            <InputRow background>
+          <InputRow background>
               <Input
                 label={intl.formatMessage({
                   id: 'health.organDonation',
@@ -704,7 +703,6 @@ export const HealthOverviewScreen: NavigationFunctionComponent = ({
                 }
               />
             </InputRow>
-          </>
         )}
         <InputRow background>
           <Input

--- a/apps/native/app/src/screens/health/health-overview.tsx
+++ b/apps/native/app/src/screens/health/health-overview.tsx
@@ -559,7 +559,7 @@ export const HealthOverviewScreen: NavigationFunctionComponent = ({
                   })
             }
             loading={healthCenterRes.loading}
-            fullWidhtWarning
+            fullWidthWarning
             allowEmptyValue={healthCenterRes.error ? true : false}
             warningText={
               healthCenterRes.error
@@ -599,7 +599,7 @@ export const HealthOverviewScreen: NavigationFunctionComponent = ({
                   })
             }
             loading={healthCenterRes.loading}
-            fullWidhtWarning
+            fullWidthWarning
             allowEmptyValue={healthCenterRes.error ? true : false}
             warningText={
               healthCenterRes.error
@@ -639,7 +639,7 @@ export const HealthOverviewScreen: NavigationFunctionComponent = ({
             }
             allowEmptyValue={dentistRes.error ? true : false}
             loading={dentistRes.loading}
-            fullWidhtWarning
+            fullWidthWarning
             warningText={
               dentistRes.error
                 ? intl.formatMessage({
@@ -678,7 +678,7 @@ export const HealthOverviewScreen: NavigationFunctionComponent = ({
                     }) ?? ''
               }`}
               loading={organDonationRes.loading && !organDonationRes.data}
-              fullWidhtWarning
+              fullWidthWarning
               warningText={
                 organDonationRes.error
                   ? intl.formatMessage({
@@ -726,7 +726,7 @@ export const HealthOverviewScreen: NavigationFunctionComponent = ({
                   })
             }
             loading={bloodTypeRes.loading}
-            fullWidhtWarning
+            fullWidthWarning
             warningText={
               bloodTypeRes.error
                 ? intl.formatMessage({

--- a/apps/native/app/src/screens/health/health-overview.tsx
+++ b/apps/native/app/src/screens/health/health-overview.tsx
@@ -38,7 +38,6 @@ import {
   Input,
   InputRow,
   Problem,
-  theme,
   Typography,
 } from '../../ui'
 

--- a/apps/native/app/src/screens/health/health-overview.tsx
+++ b/apps/native/app/src/screens/health/health-overview.tsx
@@ -115,6 +115,7 @@ const ExternalLink: React.FC<ExternalLinkProps> = ({
   text,
   topAlign = false,
 }) => {
+  const theme = useTheme()
   return (
     <TouchableOpacity
       onPress={onPress}
@@ -127,7 +128,7 @@ const ExternalLink: React.FC<ExternalLinkProps> = ({
         style={{
           flexDirection: 'row',
           borderBottomWidth: 1,
-          borderBottomColor: theme.color.blue400,
+          borderBottomColor: theme.color.dark300,
         }}
       >
         <Typography

--- a/apps/native/app/src/ui/lib/input/input.tsx
+++ b/apps/native/app/src/ui/lib/input/input.tsx
@@ -59,6 +59,9 @@ interface InputProps {
   darkBorder?: boolean
   copy?: boolean
   warningText?: string
+  rightElement?: React.ReactNode
+  allowEmptyValue?: boolean
+  fullWidhtWarning?: boolean
 }
 
 export function Input({
@@ -74,6 +77,9 @@ export function Input({
   darkBorder = false,
   copy = false,
   warningText = '',
+  rightElement,
+  allowEmptyValue = false,
+  fullWidhtWarning = false,
 }: InputProps) {
   const theme = useTheme()
   const tvalue =
@@ -82,52 +88,64 @@ export function Input({
   return (
     <Host noBorder={noBorder} darkBorder={darkBorder}>
       <Content isCompact={isCompact}>
-        {loadLabel && loading ? (
-          <Skeleton
-            active={loading}
-            error={error}
-            style={{ marginBottom: theme.spacing[1], width: '50%' }}
-          />
-        ) : (
-          <LabelText variant="body3">{label}</LabelText>
-        )}
-        {loading || error ? (
-          <Skeleton
-            active={loading}
-            error={error}
-            height={size === 'big' ? 26 : undefined}
-          />
-        ) : (
-          <>
-            <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-              <Typography
-                testID={valueTestID}
-                selectable
-                variant={size === 'normal' ? 'heading5' : 'heading3'}
-              >
-                {tvalue === '' || !value ? '-' : value}
-              </Typography>
-              {copy && (
-                <TouchableOpacity
-                  onPress={() => Clipboard.setString(value ?? '')}
-                  style={{ marginLeft: 4 }}
-                >
-                  <Image
-                    source={CopyIcon}
-                    style={{ width: 24, height: 24 }}
-                    resizeMode="contain"
-                  />
-                </TouchableOpacity>
-              )}
-            </View>
-            {warningText && (
-              <WarningMessage>
-                <Label color="warning" icon>
-                  {warningText}
-                </Label>
-              </WarningMessage>
+        <View
+          style={{
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+          }}
+        >
+          <View style={{ flex: 1, marginRight: theme.spacing[2] }}>
+            {loadLabel && loading ? (
+              <Skeleton
+                active={loading}
+                error={error}
+                style={{ marginBottom: theme.spacing[1], width: '50%' }}
+              />
+            ) : (
+              <LabelText variant="body3">{label}</LabelText>
             )}
-          </>
+            {loading || error ? (
+              <Skeleton
+                active={loading}
+                error={error}
+                height={size === 'big' ? 26 : undefined}
+              />
+            ) : (
+              <>
+                {allowEmptyValue && value === '' ? null : (
+                  <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+                    <Typography
+                      testID={valueTestID}
+                      selectable
+                      variant={size === 'normal' ? 'heading5' : 'heading3'}
+                    >
+                      {tvalue === '' || !value ? '-' : value}
+                    </Typography>
+                    {copy && (
+                      <TouchableOpacity
+                        onPress={() => Clipboard.setString(value ?? '')}
+                        style={{ marginLeft: 4 }}
+                      >
+                        <Image
+                          source={CopyIcon}
+                          style={{ width: 24, height: 24 }}
+                          resizeMode="contain"
+                        />
+                      </TouchableOpacity>
+                    )}
+                  </View>
+                )}
+              </>
+            )}
+          </View>
+          {rightElement}
+        </View>
+        {!loading && !error && warningText && (
+          <WarningMessage>
+            <Label color="warning" icon fullWidth={fullWidhtWarning}>
+              {warningText}
+            </Label>
+          </WarningMessage>
         )}
       </Content>
     </Host>

--- a/apps/native/app/src/ui/lib/input/input.tsx
+++ b/apps/native/app/src/ui/lib/input/input.tsx
@@ -110,32 +110,28 @@ export function Input({
                 error={error}
                 height={size === 'big' ? 26 : undefined}
               />
-            ) : (
-              <>
-                {allowEmptyValue && value === '' ? null : (
-                  <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-                    <Typography
-                      testID={valueTestID}
-                      selectable
-                      variant={size === 'normal' ? 'heading5' : 'heading3'}
-                    >
-                      {tvalue === '' || !value ? '-' : value}
-                    </Typography>
-                    {copy && (
-                      <TouchableOpacity
-                        onPress={() => Clipboard.setString(value ?? '')}
-                        style={{ marginLeft: 4 }}
-                      >
-                        <Image
-                          source={CopyIcon}
-                          style={{ width: 24, height: 24 }}
-                          resizeMode="contain"
-                        />
-                      </TouchableOpacity>
-                    )}
-                  </View>
+            ) : allowEmptyValue && value === '' ? null : (
+              <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+                <Typography
+                  testID={valueTestID}
+                  selectable
+                  variant={size === 'normal' ? 'heading5' : 'heading3'}
+                >
+                  {tvalue === '' || !value ? '-' : value}
+                </Typography>
+                {copy && (
+                  <TouchableOpacity
+                    onPress={() => Clipboard.setString(value ?? '')}
+                    style={{ marginLeft: 4 }}
+                  >
+                    <Image
+                      source={CopyIcon}
+                      style={{ width: 24, height: 24 }}
+                      resizeMode="contain"
+                    />
+                  </TouchableOpacity>
                 )}
-              </>
+              </View>
             )}
           </View>
           {rightElement}

--- a/apps/native/app/src/ui/lib/input/input.tsx
+++ b/apps/native/app/src/ui/lib/input/input.tsx
@@ -61,7 +61,7 @@ interface InputProps {
   warningText?: string
   rightElement?: React.ReactNode
   allowEmptyValue?: boolean
-  fullWidhtWarning?: boolean
+  fullWidthWarning?: boolean
 }
 
 export function Input({
@@ -79,7 +79,7 @@ export function Input({
   warningText = '',
   rightElement,
   allowEmptyValue = false,
-  fullWidhtWarning = false,
+  fullWidthWarning = false,
 }: InputProps) {
   const theme = useTheme()
   const tvalue =
@@ -138,7 +138,7 @@ export function Input({
         </View>
         {!loading && !error && warningText && (
           <WarningMessage>
-            <Label color="warning" icon fullWidth={fullWidhtWarning}>
+            <Label color="warning" icon fullWidth={fullWidthWarning}>
               {warningText}
             </Label>
           </WarningMessage>

--- a/apps/native/app/src/ui/lib/label/label.tsx
+++ b/apps/native/app/src/ui/lib/label/label.tsx
@@ -17,6 +17,7 @@ interface LabelProps {
   color?: LabelColor
   icon?: React.ReactNode | boolean
   children?: React.ReactNode
+  fullWidth?: boolean
 }
 
 const getBorderColor = ({ theme, color }: HelperProps) => {
@@ -71,20 +72,20 @@ const getIconByColor = (color: LabelColor) => {
       return null
   }
 }
-
-const LabelHost = styled.View<{ color: LabelColor }>`
+const LabelHost = styled.View<{ color: LabelColor; fullWidth?: boolean }>`
+  align-items: center;
+  justify-content: ${({ fullWidth }) => (fullWidth ? 'flex-start' : 'center')};
   padding: ${({ theme }) => theme.spacing[1]}px;
   padding-top: 6px;
   padding-bottom: 6px;
   gap: 6px;
   flex-direction: row;
-  align-items: center;
-  justify-content: center;
   border-width: ${({ theme }) => theme.border.width.standard}px;
   border-style: solid;
   border-radius: ${({ theme }) => theme.border.radius.large};
   border-color: ${dynamicColor(getBorderColor, true)};
   background-color: ${dynamicColor(getBackgroundColor)};
+  ${({ fullWidth }) => fullWidth && 'flex: 1'};
 `
 
 const LabelText = styled(Typography)<{
@@ -93,7 +94,12 @@ const LabelText = styled(Typography)<{
   color: ${dynamicColor(getTextColor, true)};
 `
 
-export function Label({ color = 'default', children, icon }: LabelProps) {
+export function Label({
+  color = 'default',
+  children,
+  icon,
+  fullWidth = false,
+}: LabelProps) {
   const iconElement =
     typeof icon === 'boolean' && icon === true ? (
       <Image
@@ -106,7 +112,7 @@ export function Label({ color = 'default', children, icon }: LabelProps) {
     )
 
   return (
-    <LabelHost color={color}>
+    <LabelHost color={color} fullWidth={fullWidth}>
       {iconElement}
       <LabelText variant={'eyebrow'} color={color}>
         {children}

--- a/libs/api/domains/rights-portal/src/lib/dentist/dentist.resolver.ts
+++ b/libs/api/domains/rights-portal/src/lib/dentist/dentist.resolver.ts
@@ -24,7 +24,7 @@ import { DentistRegisterResponse } from './models/registerResponse.model'
 export class DentistResolver {
   constructor(private readonly service: DentistService) {}
 
-  @Scopes(ApiScope.healthDentists)
+  @Scopes(ApiScope.healthDentists, ApiScope.healthHealthcare)
   @Query(() => DentistRegistration, {
     name: 'rightsPortalUserDentistRegistration',
     nullable: true,

--- a/libs/api/domains/rights-portal/src/lib/dentist/dentist.service.ts
+++ b/libs/api/domains/rights-portal/src/lib/dentist/dentist.service.ts
@@ -49,30 +49,14 @@ export class DentistService {
     dateTo?: Date,
   ): Promise<DentistRegistration | null> {
     const api = this.api.withMiddleware(new AuthMiddleware(user as Auth))
-    // Backward-compatible coercion: accept Dates, ISO strings, timestamps, or missing values
-    const coerceToDate = (value: unknown, fallback: Date): Date => {
-      if (value instanceof Date) {
-        return isNaN(value.getTime()) ? fallback : value
-      }
-      if (typeof value === 'string' || typeof value === 'number') {
-        const parsed = new Date(value)
-        return isNaN(parsed.getTime()) ? fallback : parsed
-      }
-      return fallback
-    }
 
-    const defaultFrom = subYears(new Date(), 5)
-    const defaultTo = new Date()
-
-    const safeFrom = coerceToDate(dateFrom, defaultFrom)
-    const safeTo = coerceToDate(dateTo, defaultTo)
     const res = await Promise.all([
       api.getCurrentDentist().catch(handle404),
       api.dentiststatus().catch(handle404),
       api
         .getDentistBills({
-          dateFrom: safeFrom,
-          dateTo: safeTo,
+          dateFrom: dateFrom ? dateFrom : subYears(new Date(), 5),
+          dateTo: dateTo ? dateTo : new Date(),
         })
         .catch(handle404),
     ])

--- a/libs/api/domains/rights-portal/src/lib/dentist/dentist.service.ts
+++ b/libs/api/domains/rights-portal/src/lib/dentist/dentist.service.ts
@@ -49,7 +49,6 @@ export class DentistService {
     dateTo?: Date,
   ): Promise<DentistRegistration | null> {
     const api = this.api.withMiddleware(new AuthMiddleware(user as Auth))
-
     const res = await Promise.all([
       api.getCurrentDentist().catch(handle404),
       api.dentiststatus().catch(handle404),


### PR DESCRIPTION
## What

App --> More --> Health
- Introduce general information column.
- Add blood group 
- Add dentist information

## Why

Specify why you need to achieve this

## Screenshots / Gifs

<img width="451" height="898" alt="image" src="https://github.com/user-attachments/assets/c0a71abc-9a1c-4ad0-bbb6-9127ff750131" />

_With error from database_

<img width="462" height="933" alt="image" src="https://github.com/user-attachments/assets/5680a1e8-3d08-4a19-9cc3-d09f8962988a" />

_Empty data_

<img width="468" height="927" alt="image" src="https://github.com/user-attachments/assets/42e93196-87e8-4c9f-917e-8b938130f1a9" />

_With all data_


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added “Basic Information” to Health showing blood type and dentist overview, with loading/error handling and pull-to-refresh.

- UI
  - Inputs support a right-side action/link and improved warning/display behavior.
  - Labels can expand to full width for better alignment.
  - Added a consistent external-link pattern (opens related details in an in-app web view).

- Localization
  - Added English and Icelandic strings for Health overview and common buttons (“Change”, “Open”).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->