### PR TITLE
fix: remove sso from super user fields

### DIFF
--- a/libs/auth-api-lib/src/lib/clients/admin/dto/admin-patch-client.dto.ts
+++ b/libs/auth-api-lib/src/lib/clients/admin/dto/admin-patch-client.dto.ts
@@ -228,5 +228,4 @@ export const superUserFields = [
   'customClaims',
   'singleSession',
   'allowedAcr',
-  'sso',
 ]


### PR DESCRIPTION
SSO settings is marked as a super admin field in the backend but not the front end, causing the patch client to fail silently, sso settings should not be a super admin field 

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted admin permissions: SSO settings are no longer included in the super-user preset when updating client details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->