### PR TITLE
feat(hms-ra): Add desctiption to termination reson screen

### DIFF
--- a/libs/application/templates/hms/terminate-rental-agreement/src/forms/mainForm/cancelationSection.ts
+++ b/libs/application/templates/hms/terminate-rental-agreement/src/forms/mainForm/cancelationSection.ts
@@ -26,6 +26,7 @@ export const cancelationSection = buildSection({
     buildMultiField({
       id: 'cancelationMultiField',
       title: m.cancelationMessages.title,
+      description: m.cancelationMessages.description,
       children: [
         buildDateField({
           id: 'cancelation.cancelationDate',

--- a/libs/application/templates/hms/terminate-rental-agreement/src/lib/messages/cancelationMessages.ts
+++ b/libs/application/templates/hms/terminate-rental-agreement/src/lib/messages/cancelationMessages.ts
@@ -6,6 +6,12 @@ export const cancelationMessages = defineMessages({
     defaultMessage: 'Riftun leigusamnings',
     description: 'Cancelation title',
   },
+  description: {
+    id: 'tra.application:cancelation.description#markdown',
+    defaultMessage:
+      'Riftun leigusamnings er heimild aðilum í tilteknum tilvikum. Sjá nánar á [hér](https://island.is/leiga-a-ibudarhusnaedi/uppsogn-eda-riftun-leigusamnings).',
+    description: 'Cancelation description',
+  },
   dateTitle: {
     id: 'tra.application:cancelation.dateTitle',
     defaultMessage: 'Dagsetning riftunar',


### PR DESCRIPTION
## What

Add description with markdown link to cancelation reason screen

## Why

Requested by HMS

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
