### PR TITLE
feat(web): Organization page navigation link alternative

### DIFF
--- a/apps/web/pages/s/[...slugs]/index.tsx
+++ b/apps/web/pages/s/[...slugs]/index.tsx
@@ -190,6 +190,7 @@ Component.getProps = async (context) => {
       input: {
         slug: slugs[0],
         lang: locale,
+        subpageSlugs: slugs.slice(1),
       },
     },
   })

--- a/apps/web/screens/Organization/Bloodbank/BloodDonationRestrictionDetails.tsx
+++ b/apps/web/screens/Organization/Bloodbank/BloodDonationRestrictionDetails.tsx
@@ -161,6 +161,9 @@ BloodDonationRestrictionDetails.getProps = async ({
         input: {
           slug: organizationPageSlug,
           lang: locale,
+          subpageSlugs: [
+            locale === 'is' ? 'ahrif-a-blodgjof' : 'affecting-factors',
+          ],
         },
       },
     }),

--- a/apps/web/screens/Organization/Bloodbank/BloodDonationRestrictionList.tsx
+++ b/apps/web/screens/Organization/Bloodbank/BloodDonationRestrictionList.tsx
@@ -434,6 +434,9 @@ BloodDonationRestrictionList.getProps = async ({
         input: {
           slug: organizationPageSlug,
           lang: locale,
+          subpageSlugs: [
+            locale === 'is' ? 'ahrif-a-blodgjof' : 'affecting-factors',
+          ],
         },
       },
     }),

--- a/apps/web/screens/Organization/DirectorateOfLabour/MyPages.tsx
+++ b/apps/web/screens/Organization/DirectorateOfLabour/MyPages.tsx
@@ -140,6 +140,7 @@ MyPages.getProps = async ({ apolloClient, locale }) => {
         input: {
           slug: organizationSlug,
           lang: locale as ContentLanguage,
+          subpageSlugs: [locale === 'is' ? 'minar-sidur' : 'my-pages'],
         },
       },
     }),

--- a/apps/web/screens/Organization/Landspitali/PaymentSuccessful.tsx
+++ b/apps/web/screens/Organization/Landspitali/PaymentSuccessful.tsx
@@ -130,6 +130,9 @@ PaymentSuccessful.getProps = async ({ apolloClient, locale }) => {
         input: {
           slug: 'landspitali',
           lang: locale,
+          subpageSlugs: [
+            locale === 'is' ? 'greidsla-tokst' : 'payment-successful',
+          ],
         },
       },
     }),

--- a/apps/web/screens/Organization/OrganizationEvents/OrganizationEventArticle.tsx
+++ b/apps/web/screens/Organization/OrganizationEvents/OrganizationEventArticle.tsx
@@ -352,6 +352,7 @@ OrganizationEventArticle.getProps = async ({
               input: {
                 slug: organizationPageSlug,
                 lang: locale as Locale,
+                subpageSlugs: [locale === 'is' ? 'vidburdir' : 'events'],
               },
             },
           })

--- a/apps/web/screens/Organization/OrganizationEvents/OrganizationEventList.tsx
+++ b/apps/web/screens/Organization/OrganizationEvents/OrganizationEventList.tsx
@@ -232,6 +232,7 @@ OrganizationEventList.getProps = async ({ apolloClient, query, locale }) => {
         input: {
           slug,
           lang: locale as Locale,
+          subpageSlugs: [locale === 'is' ? 'vidburdir' : 'events'],
         },
       },
     }),

--- a/apps/web/screens/Organization/OrganizationNews/OrganizationNewsArticle.tsx
+++ b/apps/web/screens/Organization/OrganizationNews/OrganizationNewsArticle.tsx
@@ -181,6 +181,7 @@ OrganizationNewsArticle.getProps = async ({
             input: {
               slug: organizationPageSlug,
               lang: locale as Locale,
+              subpageSlugs: [locale === 'is' ? 'frett' : 'news'],
             },
           },
         })

--- a/apps/web/screens/Organization/OrganizationNews/OrganizationNewsList.tsx
+++ b/apps/web/screens/Organization/OrganizationNews/OrganizationNewsList.tsx
@@ -243,6 +243,7 @@ OrganizationNewsList.getProps = async ({ apolloClient, query, locale }) => {
           input: {
             slug: organizationPageSlug,
             lang: locale as Locale,
+            subpageSlugs: [locale === 'is' ? 'frett' : 'news'],
           },
         },
       }),

--- a/apps/web/screens/Organization/PublishedMaterial/PublishedMaterial.tsx
+++ b/apps/web/screens/Organization/PublishedMaterial/PublishedMaterial.tsx
@@ -513,6 +513,9 @@ PublishedMaterial.getProps = async ({ apolloClient, locale, query }) => {
         input: {
           slug: organizationPageSlug,
           lang: locale as ContentLanguage,
+          subpageSlugs: [
+            locale === 'is' ? 'utgefid-efni' : 'published-material',
+          ],
         },
       },
     }),

--- a/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculator.tsx
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculator.tsx
@@ -1369,6 +1369,7 @@ PensionCalculator.getProps = async ({
         input: {
           slug,
           lang: locale,
+          subpageSlugs: [locale === 'is' ? 'reiknivel' : 'calculator'],
         },
       },
     }),

--- a/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculatorResults.tsx
+++ b/apps/web/screens/Organization/SocialInsuranceAdministration/PensionCalculatorResults.tsx
@@ -678,6 +678,7 @@ PensionCalculatorResults.getProps = async ({
         input: {
           slug,
           lang: locale,
+          subpageSlugs: [locale === 'is' ? 'reiknivel' : 'calculator'],
         },
       },
     }),

--- a/apps/web/screens/Organization/StafraentIsland/ApiCatalogue.tsx
+++ b/apps/web/screens/Organization/StafraentIsland/ApiCatalogue.tsx
@@ -376,6 +376,8 @@ ApiCatalogue.getProps = async ({ apolloClient, locale }) => {
   const organizationSlug =
     locale === 'en' ? 'digital-iceland' : 'stafraent-island'
 
+  const apiCatalogueSlug = locale === 'en' ? 'webservices' : 'vefthjonustur'
+
   const [
     {
       data: { getOrganizationPage },
@@ -393,6 +395,7 @@ ApiCatalogue.getProps = async ({ apolloClient, locale }) => {
         input: {
           slug: organizationSlug,
           lang: locale as ContentLanguage,
+          subpageSlugs: [apiCatalogueSlug],
         },
       },
     }),
@@ -401,7 +404,7 @@ ApiCatalogue.getProps = async ({ apolloClient, locale }) => {
       variables: {
         input: {
           organizationSlug,
-          slug: locale === 'en' ? 'webservices' : 'vefthjonustur',
+          slug: apiCatalogueSlug,
           lang: locale as ContentLanguage,
         },
       },

--- a/apps/web/screens/Organization/StafraentIsland/ApiDetails.tsx
+++ b/apps/web/screens/Organization/StafraentIsland/ApiDetails.tsx
@@ -198,6 +198,7 @@ ServiceDetails.getProps = async ({ apolloClient, locale, query }) => {
         input: {
           slug: locale === 'en' ? 'digital-iceland' : 'stafraent-island',
           lang: locale as ContentLanguage,
+          subpageSlugs: [locale === 'en' ? 'webservices' : 'vefthjonustur'],
         },
       },
     }),

--- a/apps/web/screens/Organization/Standalone/ParentSubpage.tsx
+++ b/apps/web/screens/Organization/Standalone/ParentSubpage.tsx
@@ -149,8 +149,8 @@ export const getProps: typeof StandaloneParentSubpage['getProps'] = async ({
   query,
   organizationPage,
 }) => {
-  const [organizationPageSlug, parentSubpageSlug, subpageSlug] = (query.slugs ??
-    []) as string[]
+  const querySlugs = (query.slugs ?? []) as string[]
+  const [organizationPageSlug, parentSubpageSlug, subpageSlug] = querySlugs
 
   const [
     {
@@ -168,6 +168,7 @@ export const getProps: typeof StandaloneParentSubpage['getProps'] = async ({
             input: {
               slug: organizationPageSlug,
               lang: locale as ContentLanguage,
+              subpageSlugs: querySlugs.slice(1),
             },
           },
         })

--- a/apps/web/screens/Organization/SubPage.tsx
+++ b/apps/web/screens/Organization/SubPage.tsx
@@ -490,6 +490,7 @@ SubPage.getProps = async ({
             input: {
               slug: slug as string,
               lang: locale as ContentLanguage,
+              subpageSlugs: subSlug ? [subSlug] : [],
             },
           },
         })

--- a/apps/web/screens/Organization/Syslumenn/Auctions.tsx
+++ b/apps/web/screens/Organization/Syslumenn/Auctions.tsx
@@ -1066,6 +1066,7 @@ Auctions.getProps = async ({ apolloClient, locale, req, res }) => {
         input: {
           slug: slug,
           lang: locale as ContentLanguage,
+          subpageSlugs: [subSlug],
         },
       },
     }),

--- a/apps/web/screens/Organization/Syslumenn/Homestay.tsx
+++ b/apps/web/screens/Organization/Syslumenn/Homestay.tsx
@@ -332,6 +332,7 @@ Homestay.getProps = async ({ apolloClient, locale, req }) => {
         input: {
           slug: slug,
           lang: locale as ContentLanguage,
+          subpageSlugs: [subSlug],
         },
       },
     }),

--- a/apps/web/screens/Organization/Syslumenn/OperatingLicenses.tsx
+++ b/apps/web/screens/Organization/Syslumenn/OperatingLicenses.tsx
@@ -645,6 +645,7 @@ OperatingLicenses.getProps = async ({ apolloClient, locale, req }) => {
         input: {
           slug: slug,
           lang: locale as ContentLanguage,
+          subpageSlugs: [subSlug],
         },
       },
     }),

--- a/apps/web/screens/queries/Organization.tsx
+++ b/apps/web/screens/queries/Organization.tsx
@@ -136,6 +136,20 @@ export const GET_ORGANIZATION_PAGE_QUERY = gql`
           href
         }
       }
+      navigationLinks {
+        topLinks {
+          label
+          href
+          midLinks {
+            label
+            href
+            bottomLinks {
+              label
+              href
+            }
+          }
+        }
+      }
       defaultHeaderImage {
         url
         contentType

--- a/libs/cms/src/lib/cms.module.ts
+++ b/libs/cms/src/lib/cms.module.ts
@@ -35,6 +35,7 @@ import { OrganizationTitleByNationalIdLoader } from './loaders/organizationTitle
 import { OrganizationTitleEnByNationalIdLoader } from './loaders/organizationTitleEnByNationalId.loader'
 import { OrganizationLogoByEntryIdLoader } from './loaders/organizationLogoByEntryId.loader'
 import { OrganizationTitleByEntryIdLoader } from './loaders/organizationTitleByEntryId.loader'
+import { OrganizationPageResolver } from './cms.resolver'
 
 @Module({
   imports: [HttpModule, TerminusModule, PowerBiConfig.registerOptional()],
@@ -70,6 +71,7 @@ import { OrganizationTitleByEntryIdLoader } from './loaders/organizationTitleByE
     IntroLinkImageResolver,
     GenericListResolver,
     FeaturedGenericListItemsResolver,
+    OrganizationPageResolver,
   ],
   exports: [
     ContentfulRepository,

--- a/libs/cms/src/lib/dto/getOrganizationPage.input.ts
+++ b/libs/cms/src/lib/dto/getOrganizationPage.input.ts
@@ -1,5 +1,5 @@
 import { Field, InputType } from '@nestjs/graphql'
-import { IsString } from 'class-validator'
+import { IsArray, IsOptional, IsString } from 'class-validator'
 import { ElasticsearchIndexLocale } from '@island.is/content-search-index-manager'
 
 @InputType()
@@ -11,4 +11,9 @@ export class GetOrganizationPageInput {
   @Field(() => String)
   @IsString()
   lang: ElasticsearchIndexLocale = 'is'
+
+  @Field(() => [String], { nullable: true })
+  @IsArray()
+  @IsOptional()
+  subpageSlugs?: string[]
 }


### PR DESCRIPTION
# Organization page navigation link alternative

TODO: 
1. Resolve the navigationLinks field
2. Display the navigation links
3. Create a breadcrumb

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
