### PR TITLE
fix(my-pages): Settings notifications link

### DIFF
--- a/libs/portals/my-pages/information/src/components/PersonalInformation/Forms/ProfileForm/ProfileForm.css.ts
+++ b/libs/portals/my-pages/information/src/components/PersonalInformation/Forms/ProfileForm/ProfileForm.css.ts
@@ -1,0 +1,11 @@
+import { theme } from '@island.is/island-ui/theme'
+import { style } from '@vanilla-extract/css'
+
+export const link = style({
+  transition: 'color 200ms',
+  color: theme.color.blue400,
+  textDecoration: 'underline',
+  ':hover': {
+    color: theme.color.blueberry400,
+  },
+})

--- a/libs/portals/my-pages/information/src/components/PersonalInformation/Forms/ProfileForm/ProfileForm.tsx
+++ b/libs/portals/my-pages/information/src/components/PersonalInformation/Forms/ProfileForm/ProfileForm.tsx
@@ -6,11 +6,11 @@ import {
   GridColumn,
   GridContainer,
   GridRow,
-  Link,
   PhoneInput,
   SkeletonLoader,
 } from '@island.is/island-ui/core'
 import { useLocale, useNamespaces } from '@island.is/localization'
+import { Link } from 'react-router-dom'
 import { LoadModal, m, parseNumber } from '@island.is/portals/my-pages/core'
 import {
   useDeleteEmailOrPhoneValue,
@@ -38,6 +38,7 @@ import { DropModalType } from './types/form'
 import { InputEmail } from './components/Inputs/Email'
 import { AccessDenied } from '@island.is/portals/core'
 import { Problem } from '@island.is/react-spa/shared'
+import * as s from './ProfileForm.css'
 
 enum IdsUserProfileLinks {
   EMAIL = '/app/user-profile/email',
@@ -203,10 +204,8 @@ export const ProfileForm = ({
                     values={{
                       link: (
                         <Link
-                          color="blue400"
-                          href={InformationPaths.Notifications}
-                          underlineVisibility="always"
-                          underline="small"
+                          to={InformationPaths.SettingsNotifications}
+                          className={s.link}
                         >
                           {formatMessage(emailsMsg.emailListTextLink)}
                         </Link>

--- a/libs/portals/my-pages/information/src/lib/messages.ts
+++ b/libs/portals/my-pages/information/src/lib/messages.ts
@@ -472,7 +472,7 @@ export const emailsMsg = defineMessages({
   emailListText: {
     id: 'sp.settings:email-list-text',
     defaultMessage:
-      'Hér er listi yfir netföng sem eru skráð hjá þér og umboðum tengt þér.Þú getur stillt {link}',
+      'Hér er listi yfir netföng sem eru skráð hjá þér og umboðum tengt þér. Þú getur stillt {link}',
   },
   emailListTextLink: {
     id: 'sp.settings:email-list-text-link',


### PR DESCRIPTION
## What

Fix Settings notifications link

## Why

Its pointing to the wrong path.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Refactor
  - Updated navigation link to use in-app routing for smoother transitions within the profile form.

- Style
  - Introduced enhanced link styling: underlined by default, blue color with hover transition to a deeper blue for improved clarity and feedback.

- Bug Fixes
  - Corrected spacing in an email-related message to improve readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->