### PR TITLE
fix(citizenship): Adding multipleUploads option

### DIFF
--- a/libs/application/templates/directorate-of-immigration/citizenship/src/fields/CriminalRecords/index.tsx
+++ b/libs/application/templates/directorate-of-immigration/citizenship/src/fields/CriminalRecords/index.tsx
@@ -58,6 +58,7 @@ export const CriminalRecords: FC<FieldBaseProps> = ({
               <FileUploadController
                 application={application}
                 id={`${field.id}[${index}].attachment`}
+                multiple={true}
                 error={
                   errors &&
                   getErrorViaPath(errors, `${field.id}[${index}].attachment`)

--- a/libs/application/templates/directorate-of-immigration/citizenship/src/forms/CitizenshipForm/SupportingDocumentsSection/OtherDocumentsSubSection.ts
+++ b/libs/application/templates/directorate-of-immigration/citizenship/src/forms/CitizenshipForm/SupportingDocumentsSection/OtherDocumentsSubSection.ts
@@ -63,6 +63,7 @@ export const OtherDocumentsSubSection = buildSubSection({
           introduction: '',
           maxSize: FILE_SIZE_LIMIT,
           uploadAccept: FILE_TYPES_ALLOWED,
+          uploadMultiple: true,
           condition: (answer: Answer) => {
             const answers = answer as Citizenship
             if (answers?.parentInformation?.hasValidParents === YES) {
@@ -84,6 +85,7 @@ export const OtherDocumentsSubSection = buildSubSection({
           uploadAccept: FILE_TYPES_ALLOWED,
           introduction: '',
           maxSize: FILE_SIZE_LIMIT,
+          uploadMultiple: true,
           uploadHeader:
             supportingDocuments.labels.otherDocuments.incomeConfirmation,
           uploadDescription:
@@ -99,6 +101,7 @@ export const OtherDocumentsSubSection = buildSubSection({
           introduction: '',
           uploadAccept: FILE_TYPES_ALLOWED,
           maxSize: FILE_SIZE_LIMIT,
+          uploadMultiple: true,
           uploadHeader:
             supportingDocuments.labels.otherDocuments.incomeConfirmationTown,
           uploadDescription:
@@ -113,6 +116,7 @@ export const OtherDocumentsSubSection = buildSubSection({
           introduction: '',
           uploadAccept: FILE_TYPES_ALLOWED,
           maxSize: FILE_SIZE_LIMIT,
+          uploadMultiple: true,
           uploadHeader: supportingDocuments.labels.otherDocuments.legalHome,
           uploadDescription:
             supportingDocuments.labels.otherDocuments.acceptedFileTypes,
@@ -126,6 +130,7 @@ export const OtherDocumentsSubSection = buildSubSection({
           introduction: '',
           uploadAccept: FILE_TYPES_ALLOWED,
           maxSize: FILE_SIZE_LIMIT,
+          uploadMultiple: true,
           uploadHeader: supportingDocuments.labels.otherDocuments.icelandicTest,
           uploadDescription:
             supportingDocuments.labels.otherDocuments.acceptedFileTypes,


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - You can now upload multiple files for criminal record attachments within the citizenship application.
  - Supporting documents now accept multiple files per field, including:
    - Birth certificate
    - Subsistence certificate
    - Subsistence certificate for town
    - Certificate of legal residence history
    - Icelandic test certificate
  - Improves flexibility when submitting comprehensive documentation without creating separate entries for each file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->