### PR TITLE
fix: add delete device token endpoint to me-user-profile controller

### DIFF
--- a/apps/services/user-profile/src/app/user-profile/me-user-profile.controller.ts
+++ b/apps/services/user-profile/src/app/user-profile/me-user-profile.controller.ts
@@ -8,6 +8,7 @@ import {
   BadRequestException,
   Body,
   Controller,
+  Delete,
   Get,
   Headers,
   Param,
@@ -329,5 +330,24 @@ export class MeUserProfileController {
     // It should respond with 303 See Other and a Location header to the existing resource
     // But as the v1 of the user profile is not following this, we will keep the same behaviour.
     return this.userTokenService.addDeviceToken(body.deviceToken, user)
+  }
+
+  @Delete('/device-tokens/:deviceToken')
+  @ApiOperation({
+    summary: 'Deletes a device token for notifications for a user device ',
+  })
+  @Scopes(UserProfileScope.write)
+  @ApiSecurity('oauth2', [UserProfileScope.write])
+  @Audit({
+    resources: (deviceToken: string) => deviceToken,
+  })
+  deleteDeviceToken(
+    @CurrentUser() user: User,
+    @Param('deviceToken') deviceToken: string,
+  ): Promise<void> {
+    return this.userTokenService.deleteUserTokenByNationalId(
+      deviceToken,
+      user.nationalId,
+    )
   }
 }

--- a/libs/api/domains/user-profile/src/lib/userProfile.service.ts
+++ b/libs/api/domains/user-profile/src/lib/userProfile.service.ts
@@ -294,10 +294,9 @@ export class UserProfileService {
   }
 
   deleteDeviceToken(input: UserDeviceTokenInput, user: User) {
-    return this.v2UserProfileApiWithAuth(
+    return this.v2MeUserProfileApiWithAuth(
       user,
-    ).userTokenControllerDeleteUserDeviceToken({
-      xParamNationalId: user.nationalId,
+    ).meUserProfileControllerDeleteDeviceToken({
       deviceToken: input.deviceToken,
     })
   }


### PR DESCRIPTION
Delete device token is returning Forbidden error since the userToken controller is protected by a admin scope, this endpoint needs to be in the me user profile controller allowing the app to call the mutation with the user profile write scope.  
This bug was introduced in the refactoring of the user profile service where v1 and v2 where merged.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
