### PR TITLE
fix(web): Hide livechat widget when minimized in case we are showing "Hæ, get ég aðstoðað?" bubble

### DIFF
--- a/apps/web/components/ChatPanel/LiveChatIncChatPanel/LiveChatIncChatPanel.tsx
+++ b/apps/web/components/ChatPanel/LiveChatIncChatPanel/LiveChatIncChatPanel.tsx
@@ -60,6 +60,12 @@ export const LiveChatIncChatPanel = ({
       setLoading(false)
     })
 
+    window.LiveChatWidget.on('visibility_changed', ({ visibility }) => {
+      if (visibility === 'minimized' && !showLauncher) {
+        window.LiveChatWidget.call('hide')
+      }
+    })
+
     window.LiveChatWidget.call('maximize')
 
     return () => {


### PR DESCRIPTION
# Hide livechat widget when minimized in case we are showing "Hæ, get ég aðstoðað?" bubble

So we only ever have one "launcher" present at a time.

Here's how things are today for hsn.is:

<img width="253" height="106" alt="Screenshot 2025-10-06 at 09 17 37" src="https://github.com/user-attachments/assets/82340705-9e0d-4c59-8039-a2127b0ec039" />

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The live chat widget now automatically hides when minimized if the launcher button is disabled. This prevents a lingering minimized bubble, aligning visibility with launcher settings for a cleaner interface and fewer distractions. Existing behaviors for loading and maximizing remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->