### PR TITLE
fix(application-system-api): BankAccountFormField UX improvements and validation

### DIFF
--- a/libs/application/ui-fields/src/lib/BankAccountFormField/BankAccountFormField.tsx
+++ b/libs/application/ui-fields/src/lib/BankAccountFormField/BankAccountFormField.tsx
@@ -1,6 +1,7 @@
 import {
   buildFieldRequired,
   coreDefaultFieldMessages,
+  coreErrorMessages,
   formatText,
   formatTextWithLocale,
   getErrorViaPath,
@@ -10,6 +11,7 @@ import { Box, GridColumn, GridRow, Text } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
 import { InputController } from '@island.is/shared/form-fields'
 import { getDefaultValue } from '../../getDefaultValue'
+import { ChangeEvent, useEffect, useRef, useState } from 'react'
 
 interface Props extends FieldBaseProps {
   field: BankAccountField
@@ -66,9 +68,111 @@ export const BankAccountFormField = ({
 
   const safeComponentError = typeof error === 'string' ? error : undefined
 
-  const useBankNumberError = safeComponentError || safeBankNumberError
-  const useLedgerError = safeComponentError || safeLedgerError
-  const useAccountNumberError = safeComponentError || safeAccountNumberError
+  // Local errors set on blur/focus change
+  const [localBankError, setLocalBankError] = useState<string | undefined>(
+    undefined,
+  )
+  const [localLedgerError, setLocalLedgerError] = useState<string | undefined>(
+    undefined,
+  )
+  const [localAccountError, setLocalAccountError] = useState<
+    string | undefined
+  >(undefined)
+
+  // Prefer local (per-field) errors, then component-level, then RHF field errors
+  const useBankNumberError =
+    localBankError ?? safeComponentError ?? safeBankNumberError
+  const useLedgerError =
+    localLedgerError ?? safeComponentError ?? safeLedgerError
+  const useAccountNumberError =
+    localAccountError ?? safeComponentError ?? safeAccountNumberError
+
+  const bankRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null)
+  const ledgerRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null)
+  const accountRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null)
+
+  const BANK_LEN = 4
+  const LEDGER_LEN = 2
+  const ACCOUNT_LEN = 6
+
+  const digits = (s: string) => s.replace(/\D/g, '')
+
+  const selectIfHasValue = (
+    ref: HTMLInputElement | HTMLTextAreaElement | null,
+  ) => {
+    if (ref && /\d/.test(ref.value)) {
+      requestAnimationFrame(() => ref.select())
+    }
+  }
+
+  useEffect(() => {
+    const inputs = [bankRef.current, ledgerRef.current, accountRef.current]
+    const handler = (e: Event) => {
+      const target = e.target as HTMLInputElement | HTMLTextAreaElement
+      if (target && /\d/.test(target.value)) {
+        requestAnimationFrame(() => target.select())
+      }
+    }
+    inputs.forEach((el) => el?.addEventListener('focus', handler))
+    return () =>
+      inputs.forEach((el) => el?.removeEventListener('focus', handler))
+  }, [])
+
+  // Validate on blur (deselect or focusing another field)
+  useEffect(() => {
+    const errMsg = formatMessage(coreErrorMessages.defaultError)
+
+    const validateLength =
+      (requiredLen: number, setErr: (v: string | undefined) => void) =>
+      (e: Event) => {
+        const target = e.target as HTMLInputElement | HTMLTextAreaElement
+        const len = digits(target?.value || '').length
+        // Only show error if something was entered but length is wrong
+        setErr(len === 0 || len === requiredLen ? undefined : errMsg)
+      }
+
+    const b = bankRef.current
+    const l = ledgerRef.current
+    const a = accountRef.current
+
+    const onBlurBank = validateLength(BANK_LEN, setLocalBankError)
+    const onBlurLedger = validateLength(LEDGER_LEN, setLocalLedgerError)
+    const onBlurAccount = validateLength(ACCOUNT_LEN, setLocalAccountError)
+
+    b?.addEventListener('blur', onBlurBank)
+    l?.addEventListener('blur', onBlurLedger)
+    a?.addEventListener('blur', onBlurAccount)
+
+    return () => {
+      b?.removeEventListener('blur', onBlurBank)
+      l?.removeEventListener('blur', onBlurLedger)
+      a?.removeEventListener('blur', onBlurAccount)
+    }
+  }, [formatMessage])
+
+  const handleBankChange = (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    if (digits(e.target.value).length >= BANK_LEN) {
+      ledgerRef.current?.focus()
+      selectIfHasValue(ledgerRef.current)
+    }
+  }
+  const handleLedgerChange = (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    if (digits(e.target.value).length >= LEDGER_LEN) {
+      accountRef.current?.focus()
+      selectIfHasValue(accountRef.current)
+    }
+  }
+  const handleAccountChange = (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    if (digits(e.target.value).length >= ACCOUNT_LEN) {
+      accountRef.current?.blur()
+    }
+  }
 
   return (
     <Box marginTop={marginTop} marginBottom={marginBottom}>
@@ -93,6 +197,8 @@ export const BankAccountFormField = ({
               clearOnChange={clearOnChange}
               required={buildFieldRequired(application, required)}
               error={useBankNumberError}
+              ref={bankRef}
+              onChange={handleBankChange}
             />
           </Box>
         </GridColumn>
@@ -108,6 +214,8 @@ export const BankAccountFormField = ({
               clearOnChange={clearOnChange}
               required={buildFieldRequired(application, required)}
               error={useLedgerError}
+              ref={ledgerRef}
+              onChange={handleLedgerChange}
             />
           </Box>
         </GridColumn>
@@ -123,6 +231,8 @@ export const BankAccountFormField = ({
               clearOnChange={clearOnChange}
               required={buildFieldRequired(application, required)}
               error={useAccountNumberError}
+              ref={accountRef}
+              onChange={handleAccountChange}
             />
           </Box>
         </GridColumn>


### PR DESCRIPTION
# Update BankAccountFormField to behave more like the classic bank account input 

Attach a link to issue if relevant

## What

Have the bank account form field act like the classic bank account input you find in most other places, including:
* auto selecting the next input field when the desired number of digits have been entered
* validating that the desired number of digits have been entered and giving the user an error if not

## Why

Better UX and harder for users to send in bank accounts with not all the digits filled in (people skipping leading zeros in the numbers is a classic)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
