### PR TITLE
fix: round monetary values sent to syslumenn API from inheritance-report

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/inheritance-report/inheritance-report.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/inheritance-report/inheritance-report.service.ts
@@ -6,7 +6,7 @@ import {
   PersonType,
   SyslumennService,
 } from '@island.is/clients/syslumenn'
-import { getFakeData } from './utils'
+import { getFakeData, roundMonetaryFieldsDeep, stringifyObject } from './utils'
 import { BaseTemplateApiService } from '../../base-template-api.service'
 import { LOGGER_PROVIDER } from '@island.is/logging'
 import {
@@ -34,19 +34,6 @@ export class InheritanceReportService extends BaseTemplateApiService {
     private readonly s3Service: S3Service,
   ) {
     super(ApplicationTypes.INHERITANCE_REPORT)
-  }
-
-  stringifyObject(obj: Record<string, unknown>): Record<string, string> {
-    const result: Record<string, string> = {}
-    for (const key in obj) {
-      if (typeof obj[key] === 'string') {
-        result[key] = obj[key] as string
-      } else {
-        result[key] = JSON.stringify(obj[key])
-      }
-    }
-
-    return result
   }
 
   async syslumennOnEntry({ application }: TemplateApiModuleActionProps) {
@@ -120,7 +107,12 @@ export class InheritanceReportService extends BaseTemplateApiService {
       type: PersonType.AnnouncerOfDeathCertificate,
     }
 
-    const uploadData = this.stringifyObject(expandAnswers(answers))
+    const expanded = expandAnswers(answers)
+    const roundedExpanded = roundMonetaryFieldsDeep(expanded) as Record<
+      string,
+      unknown
+    >
+    const uploadData = stringifyObject(roundedExpanded)
 
     const uploadDataName = 'erfdafjarskysla1.0'
     const uploadDataId = 'erfdafjarskysla1.0'

--- a/libs/application/template-api-modules/src/lib/modules/templates/inheritance-report/utils/index.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/inheritance-report/utils/index.ts
@@ -1,2 +1,8 @@
 import { getFakeData } from './fakeData'
-export { getFakeData }
+import {
+  roundToInt,
+  roundMonetaryFieldsDeep,
+  stringifyObject,
+} from './roundToInt'
+
+export { getFakeData, roundToInt, roundMonetaryFieldsDeep, stringifyObject }

--- a/libs/application/template-api-modules/src/lib/modules/templates/inheritance-report/utils/roundToInt.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/inheritance-report/utils/roundToInt.ts
@@ -1,0 +1,165 @@
+/**
+ * Rounds a numeric value to the nearest integer
+ * @param input - String or number to round
+ * @returns Rounded integer as string or number (same type as input)
+ * @throws Error if input is invalid
+ */
+export const roundToInt = (input: string | number): string | number => {
+  if (typeof input === 'number') {
+    if (!isFinite(input)) return input
+    return Math.round(input)
+  }
+
+  const str = input?.toString().trim()
+  if (!str) {
+    throw new Error('Invalid numeric string: empty value')
+  }
+
+  // Reject any string containing characters other than digits, whitespace, '.', ',', '+', '-'
+  if (!/^[0-9\s.,+-]+$/.test(str)) {
+    throw new Error(`Invalid numeric string: ${input}`)
+  }
+
+  // Detect and normalize decimal/thousand separators
+  let s = str.replace(/\s/g, '')
+  const hasComma = s.includes(',')
+  const hasDot = s.includes('.')
+
+  if (hasComma && hasDot) {
+    // Assume '.' thousand separator and ',' decimal
+    s = s.replace(/\./g, '').replace(/,/g, '.')
+  } else if (hasComma) {
+    s = s.replace(/,/g, '.')
+  }
+
+  // Remove any characters not part of a JS numeric literal after normalization
+  s = s.replace(/[^0-9.+-]/g, '')
+  const parsed = Number(s)
+
+  if (isNaN(parsed) || !isFinite(parsed)) {
+    throw new Error(`Invalid numeric string: ${input}`)
+  }
+
+  return String(Math.round(parsed))
+}
+
+/**
+ * Monetary field keys that should be rounded to integers
+ */
+const MONETARY_KEYS = new Set<string>([
+  'propertyValuation',
+  'value',
+  'total',
+  'publicCharges',
+  'inheritance',
+  'inheritanceTax',
+  'taxableInheritance',
+  'taxFreeInheritance',
+  'spouseTotalDeduction',
+  'spouseTotalSeparateProperty',
+  'estateTotal',
+  'totalDeduction',
+  'debtsTotal',
+  'netTotal',
+  'spouseTotal',
+  'netPropertyForExchange',
+  'assetsTotal',
+  // Funeral costs
+  'build',
+  'cremation',
+  'print',
+  'flowers',
+  'music',
+  'rent',
+  'food',
+  'tombstone',
+  'service',
+  // Business related (if present)
+  'businessAssetValue',
+  'debtValue',
+])
+
+/**
+ * Keys that should be skipped from rounding
+ */
+const KEYS_TO_SKIP = new Set<string>([
+  'shareTotal',
+  'deceasedShareAmount',
+  'amount',
+  'exchangeRateOrInterest',
+  'share',
+])
+
+/**
+ * Recursively rounds monetary fields in an object to integers
+ * @param value - The value to process (can be object, array, or primitive)
+ * @param parentKey - The parent key name for context
+ * @returns The processed value with monetary fields rounded
+ */
+export const roundMonetaryFieldsDeep = (
+  value: unknown,
+  parentKey?: string,
+): unknown => {
+  if (Array.isArray(value)) {
+    return value.map((v) => roundMonetaryFieldsDeep(v))
+  }
+
+  if (value && typeof value === 'object') {
+    const obj = value as Record<string, unknown>
+    const out: Record<string, unknown> = {}
+
+    for (const [key, v] of Object.entries(obj)) {
+      if (KEYS_TO_SKIP.has(key)) {
+        out[key] = roundMonetaryFieldsDeep(v, key)
+        continue
+      }
+
+      if (MONETARY_KEYS.has(key)) {
+        if (
+          (typeof v === 'string' && v.trim() !== '') ||
+          typeof v === 'number'
+        ) {
+          out[key] = roundToInt(v as string | number)
+          continue
+        }
+      }
+
+      out[key] = roundMonetaryFieldsDeep(v, key)
+    }
+
+    return out
+  }
+
+  // Primitive
+  if (parentKey && MONETARY_KEYS.has(parentKey)) {
+    if (
+      (typeof value === 'string' && value.trim() !== '') ||
+      typeof value === 'number'
+    ) {
+      return roundToInt(value as string | number)
+    }
+  }
+
+  return value
+}
+
+/**
+ * Converts all values in an object to strings
+ * @param obj - The object to stringify
+ * @returns Object with all values converted to strings
+ */
+export const stringifyObject = (
+  obj: Record<string, unknown>,
+): Record<string, string> => {
+  const result: Record<string, string> = {}
+
+  for (const key in obj) {
+    if (typeof obj[key] === 'string') {
+      result[key] = obj[key] as string
+    } else {
+      result[key] = JSON.stringify(obj[key])
+    }
+  }
+
+  return result
+}


### PR DESCRIPTION
# ...

[Attach a link to issue if relevant](https://app.asana.com/1/23849317865981/project/1209098675429236/task/1211519935273042?focus=true)

## What

Fix inheritance-report sending decimals to syslumenn for monetary values. Round to nearest integer. 

## Why

They don't want decimals, only integers

## Screenshots / Gifs

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Monetary amounts in the inheritance report are now consistently rounded to whole numbers.
  - Improved handling of numeric input and locale-style formats, reducing errors in report generation.
  - More reliable serialization of report data for uploads and downstream use.

- Refactor
  - Centralized rounding and serialization logic into shared utilities for consistent behavior across the module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->