### PR TITLE
fix(j-s): fix space in file

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/indictmentCourtRecordPdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/indictmentCourtRecordPdf.ts
@@ -42,14 +42,14 @@ export const createIndictmentCourtRecordPdf = (
 
   setTitle(doc, `Þingbók ${theCase.courtCaseNumber}`)
 
+  addCoatOfArms(doc, undefined, 90)
+
   if (confirmation) {
-    console.log({ confirmation })
     addIndictmentCourtRecordConfirmation(doc, confirmation)
   }
 
-  addCoatOfArms(doc)
-  addEmptyLines(doc, 5)
-  setLineGap(doc, 4)
+  addEmptyLines(doc, confirmation ? 11 : 6, doc.page.margins.left)
+  setLineGap(doc, 2)
   addLargeHeading(doc, theCase.court?.name ?? 'Héraðsdómur', 'Times-Roman')
   addMediumHeading(doc, 'Þingbók')
   addMediumHeading(doc, `Mál nr. ${theCase.courtCaseNumber}`)

--- a/apps/judicial-system/backend/src/app/modules/case/pdf.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/pdf.service.ts
@@ -195,16 +195,10 @@ export class PdfService {
       }
     }
 
-    const test = {
-      actor: 'Test',
-      title: 'Test',
-      institution: 'Test',
-      date: new Date(),
-    }
     const generatedPdf = await createIndictmentCourtRecordPdf(
       theCase,
       isDistrictCourtUser(user),
-      test,
+      confirmation,
     )
 
     if (isCompletedCase(theCase.state) && confirmation) {


### PR DESCRIPTION
# [fix space in pdf file](https://app.asana.com/1/203394141643832/inbox/1208883002434307/item/1211537047125079/story/1211563440957801)

## What
- Fix space in pdf file

## Why
- It was too wide

## Screenshots / Gifs
<img width="801" height="379" alt="Screenshot 2025-10-07 at 09 49 36" src="https://github.com/user-attachments/assets/427d5bdf-8c72-470c-bde0-fef6f7da32c5" />
<img width="801" height="335" alt="Screenshot 2025-10-07 at 09 49 31" src="https://github.com/user-attachments/assets/e67c9e05-175a-4319-970a-94f15d855308" />


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Style
  * Refined vertical spacing in the indictment court record PDF when the confirmation section is absent, reducing excess blank space so main content appears sooner.
  * Keeps existing spacing when the confirmation section is present; no changes to text or data.
  * Improves on-screen and printed readability by minimizing unnecessary whitespace without altering user workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->