### PR TITLE
feat(j-s): Add CourtSession to limited access case to show them with document number

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/case/limitedAccessCase.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/case/limitedAccessCase.service.ts
@@ -347,6 +347,22 @@ export const include: Includeable[] = [
         },
         separate: true,
       },
+      {
+        model: CourtSession,
+        as: 'courtSessions',
+        required: false,
+        order: [['created', 'ASC']],
+        separate: true,
+        include: [
+          {
+            model: CourtDocument,
+            as: 'filedDocuments',
+            required: false,
+            order: [['documentOrder', 'ASC']],
+            separate: true,
+          },
+        ],
+      },
       { model: Institution, as: 'court' },
       { model: User, as: 'judge' },
       { model: Institution, as: 'prosecutorsOffice' },

--- a/apps/judicial-system/web/src/components/FormProvider/limitedAccessCase.graphql
+++ b/apps/judicial-system/web/src/components/FormProvider/limitedAccessCase.graphql
@@ -250,6 +250,19 @@ query LimitedAccessCase($input: CaseQueryInput!) {
         startDate
         endDate
         ruling
+        isConfirmed
+        filedDocuments {
+          id
+          created
+          modified
+          caseId
+          courtSessionId
+          documentType
+          documentOrder
+          name
+          caseFileId
+          generatedPdfUri
+        }
       }
       caseFiles {
         id


### PR DESCRIPTION
# Add CourtSession to limited access case to show them with document number

[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1211288869338456?focus=true)

## What

Do the same thing as in #20294 but with limited access cases 

## Why

So defenders can see the filed doucments and court document number in merged cases

## Screenshots / Gifs

<img width="852" height="804" alt="Screenshot 2025-10-07 at 11 22 07" src="https://github.com/user-attachments/assets/76dcc668-b4a9-4270-8e45-3a0af1e35c03" />

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
