### PR TITLE
fix: disappearing fastanumer for vehicles in inheritance report

### DIFF
--- a/libs/application/templates/inheritance-report/src/fields/EstateAndVehiclesRepeater/VehicleLookup.tsx
+++ b/libs/application/templates/inheritance-report/src/fields/EstateAndVehiclesRepeater/VehicleLookup.tsx
@@ -20,13 +20,18 @@ export const VehicleLookup = ({
   const descriptionFieldName = `${fieldIndex}.description`
   const vehicleNumberInput = useWatch({
     name: fieldName,
-    defaultValue: '',
+  })
+  const isInitial = useWatch({
+    name: `${fieldIndex}.initial`,
+    defaultValue: false,
   })
 
   const [getProperty, { loading: queryLoading, error: _queryError }] =
     useLazyQuery<Query, { input: GetVehicleInput }>(GET_VEHICLE_QUERY, {
       onError: (_e) => {
-        setValue(descriptionFieldName, '')
+        if (!isInitial) {
+          setValue(descriptionFieldName, '')
+        }
       },
       onCompleted: (data) => {
         const carName =
@@ -36,7 +41,9 @@ export const VehicleLookup = ({
           carName.startsWith('null') ||
           carName.endsWith('null')
         ) {
-          setValue(descriptionFieldName, '')
+          if (!isInitial) {
+            setValue(descriptionFieldName, '')
+          }
           return
         }
         clearErrors(descriptionFieldName)
@@ -51,19 +58,24 @@ export const VehicleLookup = ({
   }, [queryLoading])
 
   useEffect(() => {
-    if (vehicleNumberInput.trim().length > 0) {
+    if (vehicleNumberInput === undefined) {
+      return
+    }
+
+    const value = String(vehicleNumberInput)
+    if (value.trim().length > 0) {
       getProperty({
         variables: {
           input: {
-            vehicleId: vehicleNumberInput.trim().toUpperCase(),
+            vehicleId: value.trim().toUpperCase(),
           },
         },
       })
-    } else {
+    } else if (!isInitial) {
       setValue(descriptionFieldName, '')
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [vehicleNumberInput])
+  }, [vehicleNumberInput, isInitial])
 
   return (
     <InputController


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What

Fix an issue where the fastanumer of preloaded assets in the inheritance report would disappear 

## Why

they should not disappear 

## Screenshots / Gifs

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Improvements
  - More reliable vehicle lookup: only searches when a non-empty vehicle number is entered.
  - Preserves existing description during initial setup to avoid unintended changes.
  - Normalized vehicle number handling for more consistent matching.

- Bug Fixes
  - Prevents description from being cleared on errors or empty results during initial state.
  - Avoids processing when the vehicle number is undefined or empty, reducing flicker and unnecessary updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->