### PR TITLE
fix(application-system): Add the uiForms.application translation namespace where needed

### DIFF
--- a/libs/application/templates/accident-notification/src/lib/AccidentNotificationTemplate.ts
+++ b/libs/application/templates/accident-notification/src/lib/AccidentNotificationTemplate.ts
@@ -49,9 +49,8 @@ const AccidentNotificationTemplate: ApplicationTemplate<
   name: application.general.name,
   codeOwner: CodeOwners.NordaApplications,
   institution: application.general.institutionName,
-  translationNamespaces: [
+  translationNamespaces:
     ApplicationConfigurations.AccidentNotification.translation,
-  ],
   dataSchema: AccidentNotificationSchema,
   allowedDelegations: [
     {

--- a/libs/application/templates/car-rental-fee-category/src/lib/template.ts
+++ b/libs/application/templates/car-rental-fee-category/src/lib/template.ts
@@ -31,9 +31,8 @@ const template: ApplicationTemplate<
   name: 'Bílaleigu gjaldflokkar',
   codeOwner: CodeOwners.NordaApplications,
   institution: 'Skatturinn',
-  translationNamespaces: [
+  translationNamespaces:
     ApplicationConfigurations.CarRentalFeeCategory.translation,
-  ],
   dataSchema,
   stateMachineConfig: {
     initial: States.PREREQUISITES,

--- a/libs/application/templates/criminal-record/src/lib/CriminalRecordTemplate.ts
+++ b/libs/application/templates/criminal-record/src/lib/CriminalRecordTemplate.ts
@@ -43,7 +43,7 @@ const template: ApplicationTemplate<
   name: m.name,
   codeOwner: CodeOwners.Origo,
   institution: m.institutionName,
-  translationNamespaces: [ApplicationConfigurations.CriminalRecord.translation],
+  translationNamespaces: ApplicationConfigurations.CriminalRecord.translation,
   dataSchema: CriminalRecordSchema,
   stateMachineConfig: {
     initial: States.DRAFT,

--- a/libs/application/templates/data-protection-complaint/src/lib/DataProtectionComplaintTemplate.ts
+++ b/libs/application/templates/data-protection-complaint/src/lib/DataProtectionComplaintTemplate.ts
@@ -9,6 +9,7 @@ import {
   defineTemplateApi,
   NationalRegistryUserApi,
   UserProfileApi,
+  ApplicationConfigurations,
 } from '@island.is/application/types'
 import { DataProtectionComplaintSchema } from './dataSchema'
 import { application } from './messages'
@@ -33,6 +34,8 @@ const DataProtectionComplaintTemplate: ApplicationTemplate<
   codeOwner: CodeOwners.NordaApplications,
   institution: application.institutionName,
   dataSchema: DataProtectionComplaintSchema,
+  translationNamespaces:
+    ApplicationConfigurations.DataProtectionAuthorityComplaint.translation,
   stateMachineConfig: {
     initial: 'draft',
     states: {

--- a/libs/application/templates/driving-license-duplicate/src/lib/drivingLicenseDuplicateTemplate.ts
+++ b/libs/application/templates/driving-license-duplicate/src/lib/drivingLicenseDuplicateTemplate.ts
@@ -93,7 +93,7 @@ const DrivingLicenseDuplicateTemplate: ApplicationTemplate<
   type: ApplicationTypes.DRIVING_LICENSE_DUPLICATE,
   codeOwner: CodeOwners.Juni,
   dataSchema: dataSchema,
-  translationNamespaces: [configuration.translation],
+  translationNamespaces: configuration.translation,
   institution: m.applicantInstitution,
   name: m.applicationTitle,
   stateMachineConfig: {

--- a/libs/application/templates/driving-license/src/lib/drivingLicenseTemplate.ts
+++ b/libs/application/templates/driving-license/src/lib/drivingLicenseTemplate.ts
@@ -75,7 +75,7 @@ const DrivingLicenseTemplate: ApplicationTemplate<
   codeOwner: CodeOwners.Juni,
   institution: m.nationalCommissionerOfPolice,
   dataSchema,
-  translationNamespaces: [configuration.translation],
+  translationNamespaces: configuration.translation,
   stateMachineConfig: {
     initial: States.PREREQUISITES,
     states: {

--- a/libs/application/templates/examples/example-inputs/src/lib/template.ts
+++ b/libs/application/templates/examples/example-inputs/src/lib/template.ts
@@ -27,7 +27,7 @@ const template: ApplicationTemplate<
   name: 'Example Inputs',
   codeOwner: CodeOwners.NordaApplications,
   institution: 'Stafrænt Ísland',
-  translationNamespaces: [ApplicationConfigurations.ExampleInputs.translation],
+  translationNamespaces: ApplicationConfigurations.ExampleInputs.translation,
   dataSchema,
   featureFlag: Features.exampleApplication,
   allowMultipleApplicationsInDraft: true,

--- a/libs/application/templates/funding-government-projects/src/lib/FundingGovernmentProjectsTemplate.ts
+++ b/libs/application/templates/funding-government-projects/src/lib/FundingGovernmentProjectsTemplate.ts
@@ -45,9 +45,8 @@ const FundingGovernmentProjectsTemplate: ApplicationTemplate<
   name: application.name,
   codeOwner: CodeOwners.NordaApplications,
   institution: application.institutionName,
-  translationNamespaces: [
+  translationNamespaces:
     ApplicationConfigurations.FundingGovernmentProjects.translation,
-  ],
   dataSchema: FundingGovernmentProjectsSchema,
   stateMachineConfig: {
     initial: States.draft,

--- a/libs/application/templates/general-fishing-license/src/lib/GeneralFishingLicenseTemplate.ts
+++ b/libs/application/templates/general-fishing-license/src/lib/GeneralFishingLicenseTemplate.ts
@@ -102,9 +102,8 @@ const GeneralFishingLicenseTemplate: ApplicationTemplate<
   name: application.general.name,
   codeOwner: CodeOwners.NordaApplications,
   institution: application.general.institutionName,
-  translationNamespaces: [
+  translationNamespaces:
     ApplicationConfigurations.GeneralFishingLicense.translation,
-  ],
   dataSchema: GeneralFishingLicenseSchema,
   allowedDelegations: [
     { type: AuthDelegationType.ProcurationHolder },

--- a/libs/application/templates/health-insurance/src/lib/HealthInsuranceTemplate.ts
+++ b/libs/application/templates/health-insurance/src/lib/HealthInsuranceTemplate.ts
@@ -47,7 +47,7 @@ const HealthInsuranceTemplate: ApplicationTemplate<
   name: applicationName,
   codeOwner: CodeOwners.NordaApplications,
   dataSchema,
-  translationNamespaces: [configuration.translation],
+  translationNamespaces: configuration.translation,
   allowMultipleApplicationsInDraft: false,
   stateMachineConfig: {
     initial: ApplicationStates.PREREQUESITES,

--- a/libs/application/templates/healthcare-license-certificate/src/lib/HealthcareLicenseCertificateTemplate.ts
+++ b/libs/application/templates/healthcare-license-certificate/src/lib/HealthcareLicenseCertificateTemplate.ts
@@ -39,9 +39,8 @@ const template: ApplicationTemplate<
   name: applicationMessage.name,
   codeOwner: CodeOwners.Origo,
   institution: applicationMessage.institutionName,
-  translationNamespaces: [
+  translationNamespaces:
     ApplicationConfigurations.HealthcareLicenseCertificate.translation,
-  ],
   dataSchema: HealthcareLicenseCertificateSchema,
   stateMachineConfig: {
     initial: States.PREREQUISITES,

--- a/libs/application/templates/healthcare-work-permit/src/lib/HealthcareWorkPermitTemplate.ts
+++ b/libs/application/templates/healthcare-work-permit/src/lib/HealthcareWorkPermitTemplate.ts
@@ -41,9 +41,8 @@ const template: ApplicationTemplate<
   name: applicationMessage.name,
   codeOwner: CodeOwners.Origo,
   institution: applicationMessage.institutionName,
-  translationNamespaces: [
+  translationNamespaces:
     ApplicationConfigurations.HealthcareWorkPermit.translation,
-  ],
   dataSchema: HealthcareWorkPermitSchema,
   stateMachineConfig: {
     initial: States.PREREQUISITES,

--- a/libs/application/templates/hms/terminate-rental-agreement/src/lib/template.ts
+++ b/libs/application/templates/hms/terminate-rental-agreement/src/lib/template.ts
@@ -37,9 +37,8 @@ const template: ApplicationTemplate<
   codeOwner: CodeOwners.NordaApplications,
   institution: 'Húsnæðis og mannvirkjastofnun',
   featureFlag: Features.TerminateRentalAgreementEnabled,
-  translationNamespaces: [
+  translationNamespaces:
     ApplicationConfigurations.TerminateRentalAgreement.translation,
-  ],
   dataSchema,
   allowedDelegations: [
     {

--- a/libs/application/templates/id-card/src/lib/IdCardTemplate.ts
+++ b/libs/application/templates/id-card/src/lib/IdCardTemplate.ts
@@ -85,7 +85,7 @@ const IdCardTemplate: ApplicationTemplate<
   name: applicationMessage.name,
   codeOwner: CodeOwners.Origo,
   dataSchema: IdCardSchema,
-  translationNamespaces: [ApplicationConfigurations.IdCard.translation],
+  translationNamespaces: ApplicationConfigurations.IdCard.translation,
   stateMachineConfig: {
     initial: States.PREREQUISITES,
     states: {

--- a/libs/application/templates/inheritance-report/src/lib/InheritanceReportTemplate.ts
+++ b/libs/application/templates/inheritance-report/src/lib/InheritanceReportTemplate.ts
@@ -55,7 +55,7 @@ const InheritanceReportTemplate: ApplicationTemplate<
   codeOwner: CodeOwners.Juni,
   institution: m.institution,
   dataSchema: inheritanceReportSchema,
-  translationNamespaces: [configuration.translation],
+  translationNamespaces: configuration.translation,
   allowMultipleApplicationsInDraft: false,
   stateMachineConfig: {
     initial: States.prerequisites,

--- a/libs/application/templates/institution-collaboration/src/lib/template.ts
+++ b/libs/application/templates/institution-collaboration/src/lib/template.ts
@@ -1,5 +1,6 @@
 import {
   Application,
+  ApplicationConfigurations,
   ApplicationContext,
   ApplicationRole,
   ApplicationStateSchema,
@@ -40,6 +41,8 @@ const template: ApplicationTemplate<
   codeOwner: CodeOwners.NordaApplications,
   institution: m.application.institutionName,
   dataSchema,
+  translationNamespaces:
+    ApplicationConfigurations.InstitutionCollaboration.translation,
   stateMachineConfig: {
     initial: States.DRAFT,
     states: {

--- a/libs/application/templates/login-service/src/lib/LoginServiceTemplate.ts
+++ b/libs/application/templates/login-service/src/lib/LoginServiceTemplate.ts
@@ -42,7 +42,7 @@ const ReferenceApplicationTemplate: ApplicationTemplate<
   name: application.name,
   codeOwner: CodeOwners.NordaApplications,
   institution: application.institutionName,
-  translationNamespaces: [ApplicationConfigurations.LoginService.translation],
+  translationNamespaces: ApplicationConfigurations.LoginService.translation,
   dataSchema: LoginServiceSchema,
   stateMachineConfig: {
     initial: States.draft,

--- a/libs/application/templates/mortgage-certificate/src/lib/mortgageCertificateTemplate.ts
+++ b/libs/application/templates/mortgage-certificate/src/lib/mortgageCertificateTemplate.ts
@@ -41,9 +41,8 @@ const template: ApplicationTemplate<
   name: application.general.name,
   codeOwner: CodeOwners.Origo,
   institution: application.general.institutionName,
-  translationNamespaces: [
+  translationNamespaces:
     ApplicationConfigurations.MortgageCertificate.translation,
-  ],
   dataSchema: MortgageCertificateSchema,
   allowedDelegations: [
     {

--- a/libs/application/templates/official-journal-of-iceland/src/lib/OJOIApplication.ts
+++ b/libs/application/templates/official-journal-of-iceland/src/lib/OJOIApplication.ts
@@ -71,9 +71,8 @@ const OJOITemplate: ApplicationTemplate<
   codeOwner: CodeOwners.Hugsmidjan,
   institution: general.ministryOfJustice,
   featureFlag: Features.officialJournalOfIceland,
-  translationNamespaces: [
+  translationNamespaces:
     ApplicationConfigurations.OfficialJournalOfIceland.translation,
-  ],
   dataSchema: partialSchema,
   allowedDelegations: [
     {

--- a/libs/application/templates/passport-annulment/src/lib/PassportAnnulmentTemplate.ts
+++ b/libs/application/templates/passport-annulment/src/lib/PassportAnnulmentTemplate.ts
@@ -1,5 +1,6 @@
 import {
   Application,
+  ApplicationConfigurations,
   ApplicationContext,
   ApplicationRole,
   ApplicationStateSchema,
@@ -40,6 +41,8 @@ const PassportAnnulmentTemplate: ApplicationTemplate<
   name: m.formName.defaultMessage,
   codeOwner: CodeOwners.Juni,
   featureFlag: Features.passportAnnulmentApplication,
+  translationNamespaces:
+    ApplicationConfigurations.PassportAnnulment.translation,
   dataSchema,
   stateMachineConfig: {
     initial: States.DRAFT,

--- a/libs/application/templates/public-debt-payment-plan/src/lib/PublicDebtPaymentPlanTemplate.ts
+++ b/libs/application/templates/public-debt-payment-plan/src/lib/PublicDebtPaymentPlanTemplate.ts
@@ -50,9 +50,8 @@ const PublicDebtPaymentPlanTemplate: ApplicationTemplate<
   codeOwner: CodeOwners.NordaApplications,
   institution: application.institutionName,
   allowedDelegations: [{ type: AuthDelegationType.ProcurationHolder }],
-  translationNamespaces: [
+  translationNamespaces:
     ApplicationConfigurations.PublicDebtPaymentPlan.translation,
-  ],
   dataSchema: PublicDebtPaymentPlanSchema,
   stateMachineConfig: {
     initial: States.prerequisites,

--- a/libs/application/templates/secondary-school/src/lib/SecondarySchoolTemplate.ts
+++ b/libs/application/templates/secondary-school/src/lib/SecondarySchoolTemplate.ts
@@ -73,9 +73,7 @@ const template: ApplicationTemplate<
   name: applicationMessage.name,
   codeOwner: CodeOwners.Origo,
   institution: applicationMessage.institutionName,
-  translationNamespaces: [
-    ApplicationConfigurations.SecondarySchool.translation,
-  ],
+  translationNamespaces: ApplicationConfigurations.SecondarySchool.translation,
   dataSchema: SecondarySchoolSchema,
   allowMultipleApplicationsInDraft: false,
   allowedDelegations: [

--- a/libs/application/templates/transport-authority/anonymity-in-vehicle-registry/src/lib/AnonymityInVehicleRegistryTemplate.ts
+++ b/libs/application/templates/transport-authority/anonymity-in-vehicle-registry/src/lib/AnonymityInVehicleRegistryTemplate.ts
@@ -30,9 +30,8 @@ const template: ApplicationTemplate<
   name: application.name,
   codeOwner: CodeOwners.Origo,
   institution: application.institutionName,
-  translationNamespaces: [
+  translationNamespaces:
     ApplicationConfigurations.AnonymityInVehicleRegistry.translation,
-  ],
   dataSchema: AnonymityInVehicleRegistrySchema,
   stateMachineConfig: {
     initial: States.DRAFT,

--- a/libs/application/templates/transport-authority/digital-tachograph-drivers-card/src/lib/DigitalTachographDriversCardTemplate.ts
+++ b/libs/application/templates/transport-authority/digital-tachograph-drivers-card/src/lib/DigitalTachographDriversCardTemplate.ts
@@ -44,9 +44,8 @@ const template: ApplicationTemplate<
   name: application.name,
   codeOwner: CodeOwners.Origo,
   institution: application.institutionName,
-  translationNamespaces: [
+  translationNamespaces:
     ApplicationConfigurations.DigitalTachographDriversCard.translation,
-  ],
   dataSchema: DigitalTachographDriversCardSchema,
   stateMachineConfig: {
     initial: States.DRAFT,

--- a/libs/application/templates/transport-authority/exemption-for-transportation/src/lib/ExemptionForTransportationTemplate.ts
+++ b/libs/application/templates/transport-authority/exemption-for-transportation/src/lib/ExemptionForTransportationTemplate.ts
@@ -52,9 +52,8 @@ const ExemptionForTransportationTemplate: ApplicationTemplate<
   name: determineMessageFromApplicationAnswers,
   codeOwner: CodeOwners.Origo,
   institution: applicationMessage.institutionName,
-  translationNamespaces: [
+  translationNamespaces:
     ApplicationConfigurations.ExemptionForTransportation.translation,
-  ],
   dataSchema: ExemptionForTransportationSchema,
   featureFlag: Features.ExemptionForTransportation,
   stateMachineConfig: {

--- a/libs/application/templates/transport-authority/license-plate-renewal/src/lib/LicensePlateRenewalTemplate.ts
+++ b/libs/application/templates/transport-authority/license-plate-renewal/src/lib/LicensePlateRenewalTemplate.ts
@@ -55,9 +55,8 @@ const template: ApplicationTemplate<
   name: determineMessageFromApplicationAnswers,
   codeOwner: CodeOwners.Origo,
   institution: applicationMessage.institutionName,
-  translationNamespaces: [
+  translationNamespaces:
     ApplicationConfigurations.LicensePlateRenewal.translation,
-  ],
   dataSchema: LicensePlateRenewalSchema,
   allowedDelegations: [
     {

--- a/libs/application/templates/transport-authority/order-vehicle-license-plate/src/lib/OrderVehicleLicensePlateTemplate.ts
+++ b/libs/application/templates/transport-authority/order-vehicle-license-plate/src/lib/OrderVehicleLicensePlateTemplate.ts
@@ -55,9 +55,8 @@ const template: ApplicationTemplate<
   name: determineMessageFromApplicationAnswers,
   codeOwner: CodeOwners.Origo,
   institution: applicationMessage.institutionName,
-  translationNamespaces: [
+  translationNamespaces:
     ApplicationConfigurations.OrderVehicleLicensePlate.translation,
-  ],
   dataSchema: OrderVehicleLicensePlateSchema,
   allowedDelegations: [
     {

--- a/libs/application/templates/transport-authority/order-vehicle-registration-certificate/src/lib/OrderVehicleRegistrationCertificateTemplate.ts
+++ b/libs/application/templates/transport-authority/order-vehicle-registration-certificate/src/lib/OrderVehicleRegistrationCertificateTemplate.ts
@@ -53,9 +53,8 @@ const template: ApplicationTemplate<
   name: determineMessageFromApplicationAnswers,
   codeOwner: CodeOwners.Origo,
   institution: applicationMessage.institutionName,
-  translationNamespaces: [
+  translationNamespaces:
     ApplicationConfigurations.OrderVehicleRegistrationCertificate.translation,
-  ],
   dataSchema: OrderVehicleRegistrationCertificateSchema,
   allowedDelegations: [
     {

--- a/libs/application/templates/university/src/lib/UniversityTemplate.ts
+++ b/libs/application/templates/university/src/lib/UniversityTemplate.ts
@@ -38,7 +38,7 @@ const template: ApplicationTemplate<
   name: applicationMessage.name,
   codeOwner: CodeOwners.Origo,
   institution: applicationMessage.institutionName,
-  translationNamespaces: [ApplicationConfigurations.University.translation],
+  translationNamespaces: ApplicationConfigurations.University.translation,
   initialQueryParameter: 'program',
   dataSchema: UniversitySchema,
   featureFlag: Features.university,

--- a/libs/application/types/src/lib/ApplicationTypes.ts
+++ b/libs/application/types/src/lib/ApplicationTypes.ts
@@ -108,7 +108,7 @@ export const ApplicationConfigurations = {
   },
   [ApplicationTypes.EXAMPLE_INPUTS]: {
     slug: 'example-inputs',
-    translation: 'exi.application',
+    translation: ['exi.application', 'uiForms.application'],
   },
   [ApplicationTypes.EXAMPLE_NO_INPUTS]: {
     slug: 'example-no-inputs',
@@ -156,7 +156,7 @@ export const ApplicationConfigurations = {
   },
   [ApplicationTypes.HEALTH_INSURANCE]: {
     slug: 'sjukratryggingar',
-    translation: 'hi.application',
+    translation: ['hi.application', 'uiForms.application'],
   },
   [ApplicationTypes.CHILDREN_RESIDENCE_CHANGE_V2]: {
     slug: 'breytt-logheimili-barns',
@@ -164,7 +164,7 @@ export const ApplicationConfigurations = {
   },
   [ApplicationTypes.DATA_PROTECTION_AUTHORITY_COMPLAINT]: {
     slug: 'kvortun-til-personuverndar',
-    translation: 'dpac.application',
+    translation: ['dpac.application', 'uiForms.application'],
   },
   [ApplicationTypes.LOGIN_SERVICE]: {
     slug: 'innskraningarthjonusta',
@@ -184,7 +184,7 @@ export const ApplicationConfigurations = {
   },
   [ApplicationTypes.PUBLIC_DEBT_PAYMENT_PLAN]: {
     slug: 'greidsluaaetlun',
-    translation: 'pdpp.application',
+    translation: ['pdpp.application', 'uiForms.application'],
   },
   [ApplicationTypes.COMPLAINTS_TO_ALTHINGI_OMBUDSMAN]: {
     slug: 'kvortun-til-umbodsmanns-althingis',
@@ -192,7 +192,7 @@ export const ApplicationConfigurations = {
   },
   [ApplicationTypes.ACCIDENT_NOTIFICATION]: {
     slug: 'slysatilkynning',
-    translation: 'an.application',
+    translation: ['an.application', 'uiForms.application'],
   },
   [ApplicationTypes.GENERAL_PETITION]: {
     slug: 'undirskriftalisti',
@@ -200,7 +200,7 @@ export const ApplicationConfigurations = {
   },
   [ApplicationTypes.GENERAL_FISHING_LICENSE]: {
     slug: 'veidileyfi',
-    translation: 'gfl.application',
+    translation: ['gfl.application', 'uiForms.application'],
   },
   [ApplicationTypes.P_SIGN]: {
     slug: 'p-merki',
@@ -448,7 +448,7 @@ export const ApplicationConfigurations = {
   },
   [ApplicationTypes.TERMINATE_RENTAL_AGREEMENT]: {
     slug: 'uppsogn-eda-riftun-leigusamnings',
-    translation: 'tra.application',
+    translation: ['tra.application', 'uiForms.application'],
   },
   [ApplicationTypes.SEMINAR_REGISTRATION]: {
     slug: 'vinnueftirlitid-namskeid',
@@ -460,11 +460,11 @@ export const ApplicationConfigurations = {
   },
   [ApplicationTypes.SECONDARY_SCHOOL]: {
     slug: 'framhaldsskoli',
-    translation: 'ss.application',
+    translation: ['ss.application', 'uiForms.application'],
   },
   [ApplicationTypes.ACTIVATION_ALLOWANCE]: {
     slug: 'virknistyrkur',
-    translation: ['aa.application'],
+    translation: ['aa.application', 'uiForms.application'],
   },
   [ApplicationTypes.CAR_RENTAL_FEE_CATEGORY]: {
     slug: 'bilaleigu-gjaldflokkur',
@@ -484,6 +484,6 @@ export const ApplicationConfigurations = {
   },
   [ApplicationTypes.EXEMPTION_FOR_TRANSPORTATION]: {
     slug: 'undanthaga-vegna-flutnings',
-    translation: 'ta.eft.application',
+    translation: ['ta.eft.application', 'uiForms.application'],
   },
 }

--- a/libs/application/types/src/lib/ApplicationTypes.ts
+++ b/libs/application/types/src/lib/ApplicationTypes.ts
@@ -132,7 +132,7 @@ export const ApplicationConfigurations = {
   },
   [ApplicationTypes.PASSPORT_ANNULMENT]: {
     slug: 'tilkynna-vegabref',
-    translation: 'paa.application',
+    translation: ['paa.application', 'uiForms.application'],
   },
   [ApplicationTypes.DRIVING_LEARNERS_PERMIT]: {
     slug: 'aefingaakstur',
@@ -140,7 +140,7 @@ export const ApplicationConfigurations = {
   },
   [ApplicationTypes.DRIVING_LICENSE]: {
     slug: 'okuskirteini',
-    translation: 'dl.application',
+    translation: ['dl.application', 'uiForms.application'],
   },
   [ApplicationTypes.DRIVING_ASSESSMENT_APPROVAL]: {
     slug: 'akstursmat',
@@ -168,19 +168,19 @@ export const ApplicationConfigurations = {
   },
   [ApplicationTypes.LOGIN_SERVICE]: {
     slug: 'innskraningarthjonusta',
-    translation: 'ls.application',
+    translation: ['ls.application', 'uiForms.application'],
   },
   [ApplicationTypes.INHERITANCE_REPORT]: {
     slug: 'erfdafjarskyrsla',
-    translation: 'ir.application',
+    translation: ['ir.application', 'uiForms.application'],
   },
   [ApplicationTypes.INSTITUTION_COLLABORATION]: {
     slug: 'samstarf',
-    translation: 'ia.application',
+    translation: ['ia.application', 'uiForms.application'],
   },
   [ApplicationTypes.FUNDING_GOVERNMENT_PROJECTS]: {
     slug: 'fjarmognun-rikisverkefni',
-    translation: 'affgp.application',
+    translation: ['affgp.application', 'uiForms.application'],
   },
   [ApplicationTypes.PUBLIC_DEBT_PAYMENT_PLAN]: {
     slug: 'greidsluaaetlun',
@@ -212,7 +212,7 @@ export const ApplicationConfigurations = {
   },
   [ApplicationTypes.CRIMINAL_RECORD]: {
     slug: 'sakavottord',
-    translation: 'cr.application',
+    translation: ['cr.application', 'uiForms.application'],
   },
   [ApplicationTypes.FINANCIAL_AID]: {
     slug: 'fjarhagsadstod',
@@ -232,7 +232,7 @@ export const ApplicationConfigurations = {
   },
   [ApplicationTypes.MORTGAGE_CERTIFICATE]: {
     slug: 'vedbokarvottord',
-    translation: 'mc.application',
+    translation: ['mc.application', 'uiForms.application'],
   },
   [ApplicationTypes.MARRIAGE_CONDITIONS]: {
     slug: 'hjonavigsla',
@@ -260,11 +260,11 @@ export const ApplicationConfigurations = {
   },
   [ApplicationTypes.DRIVING_LICENSE_DUPLICATE]: {
     slug: 'samrit',
-    translation: 'dld.application',
+    translation: ['dld.application', 'uiForms.application'],
   },
   [ApplicationTypes.ANONYMITY_IN_VEHICLE_REGISTRY]: {
     slug: 'nafnleynd-i-okutaekjaskra',
-    translation: 'ta.avr.application',
+    translation: ['ta.avr.application', 'uiForms.application'],
   },
   [ApplicationTypes.CHANGE_CO_OWNER_OF_VEHICLE]: {
     slug: 'medeigandi-okutaekis',
@@ -276,19 +276,19 @@ export const ApplicationConfigurations = {
   },
   [ApplicationTypes.DIGITAL_TACHOGRAPH_DRIVERS_CARD]: {
     slug: 'okuritakort-okumannskort',
-    translation: 'ta.dtdc.application',
+    translation: ['ta.dtdc.application', 'uiForms.application'],
   },
   [ApplicationTypes.LICENSE_PLATE_RENEWAL]: {
     slug: 'endurnyja-einkanumer',
-    translation: 'ta.lpr.application',
+    translation: ['ta.lpr.application', 'uiForms.application'],
   },
   [ApplicationTypes.ORDER_VEHICLE_LICENSE_PLATE]: {
     slug: 'panta-numeraplotu',
-    translation: 'ta.ovlp.application',
+    translation: ['ta.ovlp.application', 'uiForms.application'],
   },
   [ApplicationTypes.ORDER_VEHICLE_REGISTRATION_CERTIFICATE]: {
     slug: 'panta-skraningarskirteini',
-    translation: 'ta.ovrc.application',
+    translation: ['ta.ovrc.application', 'uiForms.application'],
   },
   [ApplicationTypes.TRANSFER_OF_VEHICLE_OWNERSHIP]: {
     slug: 'eigendaskipti-okutaekis',
@@ -364,11 +364,11 @@ export const ApplicationConfigurations = {
   },
   [ApplicationTypes.HEALTHCARE_LICENSE_CERTIFICATE]: {
     slug: 'starfsleyfis-vottord',
-    translation: 'hlc.application',
+    translation: ['hlc.application', 'uiForms.application'],
   },
   [ApplicationTypes.HEALTHCARE_WORK_PERMIT]: {
     slug: 'starfsleyfis-umsokn',
-    translation: 'hwp.application',
+    translation: ['hwp.application', 'uiForms.application'],
   },
   [ApplicationTypes.PENSION_SUPPLEMENT]: {
     slug: 'uppbot-a-lifeyri',
@@ -392,7 +392,7 @@ export const ApplicationConfigurations = {
   },
   [ApplicationTypes.UNIVERSITY]: {
     slug: 'haskolanam',
-    translation: 'uni.application',
+    translation: ['uni.application', 'uiForms.application'],
   },
   [ApplicationTypes.DEREGISTER_MACHINE]: {
     slug: 'afskraning-taekis',
@@ -412,11 +412,11 @@ export const ApplicationConfigurations = {
   },
   [ApplicationTypes.OFFICIAL_JOURNAL_OF_ICELAND]: {
     slug: 'stjornartidindi',
-    translation: 'ojoi.application',
+    translation: ['ojoi.application', 'uiForms.application'],
   },
   [ApplicationTypes.ID_CARD]: {
     slug: 'nafnskirteini',
-    translation: 'id.application',
+    translation: ['id.application', 'uiForms.application'],
   },
   [ApplicationTypes.HEALTH_INSURANCE_DECLARATION]: {
     slug: 'tryggingaryfirlysing',
@@ -436,11 +436,11 @@ export const ApplicationConfigurations = {
   },
   [ApplicationTypes.MACHINE_REGISTRATION]: {
     slug: 'nyskraning-taekis',
-    translation: ['aosh.rnm.application'],
+    translation: ['aosh.rnm.application', 'uiForms.application'],
   },
   [ApplicationTypes.PRACTICAL_EXAM]: {
     slug: 'verklegt-prof',
-    translation: ['aosh.pe.application'],
+    translation: ['aosh.pe.application', 'uiForms.application'],
   },
   [ApplicationTypes.RENTAL_AGREEMENT]: {
     slug: 'leigusamningur',
@@ -452,11 +452,11 @@ export const ApplicationConfigurations = {
   },
   [ApplicationTypes.SEMINAR_REGISTRATION]: {
     slug: 'vinnueftirlitid-namskeid',
-    translation: ['aosh.sem.application'],
+    translation: ['aosh.sem.application', 'uiForms.application'],
   },
   [ApplicationTypes.TRAINING_LICENSE_ON_A_WORK_MACHINE]: {
     slug: 'kennslurettindi-a-vinnuvel',
-    translation: ['aosh.tlwm.application'],
+    translation: ['aosh.tlwm.application', 'uiForms.application'],
   },
   [ApplicationTypes.SECONDARY_SCHOOL]: {
     slug: 'framhaldsskoli',
@@ -468,7 +468,7 @@ export const ApplicationConfigurations = {
   },
   [ApplicationTypes.CAR_RENTAL_FEE_CATEGORY]: {
     slug: 'bilaleigu-gjaldflokkur',
-    translation: 'crfc.application',
+    translation: ['crfc.application', 'uiForms.application'],
   },
   [ApplicationTypes.MEDICAL_AND_REHABILITATION_PAYMENTS]: {
     slug: 'sjukra-og-endurhaefingargreidslur',


### PR DESCRIPTION


# ...

Attach a link to issue if relevant

## What

Add the uiForms.application translation namespace where needed

## Why

Several applications using uiForms components were missing this translation namespace meaning that those components were not being translated and would dump errors into the console.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
