### PR TITLE
fix(hms-ra): allow fetching index to 2023-01-01

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/hms/rental-agreement/rental-agreement.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/hms/rental-agreement/rental-agreement.service.ts
@@ -11,7 +11,7 @@ import { BaseTemplateApiService } from '../../../base-template-api.service'
 import { mapRentalApplicationData } from './utils/mapRentalApplicationData'
 import {
   fetchFinancialIndexationForMonths,
-  listOfLastMonths,
+  listMonthsFromDate,
   FinancialIndexationEntry,
   errorMapper,
 } from './utils/utils'
@@ -27,8 +27,9 @@ export class RentalAgreementService extends BaseTemplateApiService {
   }
 
   async consumerIndex(): Promise<FinancialIndexationEntry[]> {
-    const numberOfMonths = 8 // Number of months to fetch
-    const months = listOfLastMonths(numberOfMonths)
+    // Fetch from January 2023 (UI minDate for contract start) through next month
+    // This ensures all valid contract start dates have corresponding index values
+    const months = listMonthsFromDate(2023, 1)
 
     return await fetchFinancialIndexationForMonths(months)
   }

--- a/libs/application/template-api-modules/src/lib/modules/templates/hms/rental-agreement/utils/utils.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/hms/rental-agreement/utils/utils.ts
@@ -135,6 +135,57 @@ export const listOfLastMonths = (numberOfMonths: number) => {
   return months
 }
 
+// Maximum number of months to fetch to prevent excessive API requests
+const MAX_MONTHS_TO_FETCH = 120
+
+/**
+ * Generates a list of months from a start date to the next month (inclusive)
+ * in the format required by Hagstofan PX API (YYYYMmm)
+ *
+ * @param fromYear - Start year (e.g., 2023)
+ * @param fromMonth - Start month (1-12)
+ * @returns Array of month strings in format "YYYYMmm" (e.g., ["2023M01", "2023M02", ...])
+ */
+export const listMonthsFromDate = (
+  fromYear: number,
+  fromMonth: number,
+): string[] => {
+  const months: string[] = []
+  const now = new Date()
+
+  // End at next month
+  let endYear = now.getFullYear()
+  let endMonth = now.getMonth() + 2 // JS months are 0-based, so +1 for current, +1 for next
+
+  if (endMonth > 12) {
+    endMonth = 1
+    endYear += 1
+  }
+
+  let currentYear = fromYear
+  let currentMonth = fromMonth
+
+  while (
+    currentYear < endYear ||
+    (currentYear === endYear && currentMonth <= endMonth)
+  ) {
+    if (months.length >= MAX_MONTHS_TO_FETCH) {
+      break
+    }
+
+    const mm = currentMonth < 10 ? `0${currentMonth}` : `${currentMonth}`
+    months.push(`${currentYear}M${mm}`)
+
+    currentMonth++
+    if (currentMonth > 12) {
+      currentMonth = 1
+      currentYear++
+    }
+  }
+
+  return months
+}
+
 const parsePXMonth = (monthStr: string): Date => {
   // Expects format: "YYYYMmm" (e.g. "2025M06")
   const match = /^(\d{4})M(\d{2})$/.exec(monthStr)


### PR DESCRIPTION
# ...

https://digitaliceland.zendesk.com/agent/tickets/336771

> Það þarf að laga í leigusamningsgerðinni það er hægt að gera samning aftur til 1.jan 2023 (eða e-ð svoleiðis), en svo er ekki hægt að sækja vísitöluna lengra aftur en 6 mánuði (eða e-ð). Þetta mun bjaga alla tölfræði hjá okkur og því akút mál að laga.
> Það sem þarf að gera er að hægt sé að ná í vísitölu lengra aftur eða til upphafs dags samnings.

Not a tested fix, I haven't been able to run HMS rental agreements locally.

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated rental agreement index data fetching to use a date-bound range starting from January 2023, replacing the previous fixed monthly window.

* **Improvements**
  * Added a safety limit to prevent excessive month data requests during rental agreement processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->