### PR TITLE
fix(application-system): Trying to add more application id context to base logging

### DIFF
--- a/libs/nest/problem/src/lib/base-problem.filter.ts
+++ b/libs/nest/problem/src/lib/base-problem.filter.ts
@@ -14,7 +14,6 @@ import { Problem, ProblemType } from '@island.is/shared/problem'
 import { ProblemError } from './ProblemError'
 import { PROBLEM_OPTIONS } from './problem.options'
 import type { ProblemOptions } from './problem.options'
-import { validate as isUuid } from 'uuid'
 
 // Add a URL to this array to bypass the error filter and the ProblemJSON transformation
 export const BYPASS_ERROR_FILTER_URLS = ['/health/check']
@@ -92,7 +91,12 @@ export abstract class BaseProblemFilter implements ExceptionFilter {
     const request = ctx.getRequest<Request>()
     const applicationId = request?.url?.split('/').pop()
 
-    return applicationId && isUuid(applicationId) ? applicationId : undefined
+    return applicationId &&
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+        applicationId,
+      )
+      ? applicationId
+      : undefined
   }
 
   abstract getProblem(error: Error): Problem


### PR DESCRIPTION
# Adding application id if it exists to base-problem filter

## What
Add application id to base error logs if it exists. Totally open to suggestions that improve the idea behind this tho.

## Why

Trying to address vague application-system-api logs such as [this](https://app.datadoghq.eu/logs?query=env%3Aprod%20%22Request%20Entity%20Too%20Large%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40http.url_details.path&event=AwAAAZwPfUVn8wAhfQAAABhBWndQZlU0YkFBREhWVjhrRVc4MUhBQUEAAABdMTE5YzBmOTQtNjM4OC00M2FjLTljYjEtM2ZhMDZjNDc5ZjIwLXN5bnRoZXRpYy10aW1lLTE3Njk3ODUyMDAwMDAwMDAwMDBjLTE3Njk3ODc5MDkwMDAwMDAwMDFvAAA32Q&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1769785200000&to_ts=1769787000000&live=false)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
