### PR TITLE
feat(disability-pension): hard restrict employment capability input through js from 0-100

### DIFF
--- a/libs/application/templates/social-insurance-administration/disability-pension/src/fields/RestrictedNumericInput/index.tsx
+++ b/libs/application/templates/social-insurance-administration/disability-pension/src/fields/RestrictedNumericInput/index.tsx
@@ -1,0 +1,77 @@
+import { FC } from 'react'
+import { useFormContext, Controller } from 'react-hook-form'
+import { Application, Field } from '@island.is/application/types'
+import { Box, Input } from '@island.is/island-ui/core'
+import NumberFormat from 'react-number-format'
+import { useLocale } from '@island.is/localization'
+import { formatTextWithLocale } from '@island.is/application/core'
+import { Locale } from '@island.is/shared/types'
+
+interface RestrictedNumericInputProps {
+  application: Application
+  error?: string
+  field: Field & {
+    props?: {
+      min?: number
+      max?: number
+      label?: string
+      placeholder?: string
+    }
+  }
+}
+
+export const RestrictedNumericInput: FC<RestrictedNumericInputProps> = ({
+  application,
+  error,
+  field,
+}) => {
+  const { id, props } = field
+  const { min = 0, max = 100, label, placeholder } = props ?? {}
+  const { clearErrors } = useFormContext()
+  const { formatMessage, lang: locale } = useLocale()
+
+  const formattedLabel = label
+    ? formatTextWithLocale(label, application, locale as Locale, formatMessage)
+    : undefined
+
+  const formattedPlaceholder = placeholder
+    ? formatTextWithLocale(
+        placeholder,
+        application,
+        locale as Locale,
+        formatMessage,
+      )
+    : undefined
+
+  return (
+    <Box>
+      <Controller
+        name={id}
+        render={({ field: { onChange, value, name } }) => (
+          <NumberFormat
+            customInput={Input}
+            id={id}
+            name={name}
+            label={formattedLabel}
+            placeholder={formattedPlaceholder}
+            value={value}
+            hasError={error !== undefined}
+            errorMessage={error}
+            required
+            isAllowed={(values) => {
+              const { floatValue } = values
+              if (floatValue === undefined) return true
+              return floatValue >= min && floatValue <= max
+            }}
+            onValueChange={({ value: newValue }) => {
+              if (error) {
+                clearErrors(id)
+              }
+              onChange(newValue)
+            }}
+          />
+        )}
+      />
+    </Box>
+  )
+}

--- a/libs/application/templates/social-insurance-administration/disability-pension/src/fields/index.tsx
+++ b/libs/application/templates/social-insurance-administration/disability-pension/src/fields/index.tsx
@@ -1,2 +1,3 @@
 export { DisabilityPensionCertificate } from './DisabilityPensionCertificate'
 export { CertificateOverview } from './CertificateOverview'
+export { RestrictedNumericInput } from './RestrictedNumericInput'

--- a/libs/application/templates/social-insurance-administration/disability-pension/src/forms/mainForm/selfEvaluation/backgroundSubSection/employmentCapability.ts
+++ b/libs/application/templates/social-insurance-administration/disability-pension/src/forms/mainForm/selfEvaluation/backgroundSubSection/employmentCapability.ts
@@ -1,6 +1,6 @@
 import {
+  buildCustomField,
   buildMultiField,
-  buildTextField,
   buildTitleField,
 } from '@island.is/application/core'
 import * as m from '../../../../lib/messages'
@@ -14,15 +14,19 @@ export const employmentCapabilityField = buildMultiField({
     buildTitleField({
       title: m.questions.employmentCapabilityTitle,
     }),
-    buildTextField({
-      id: `${SectionRouteEnum.BACKGROUND_INFO_EMPLOYMENT_CAPABILITY}.capability`,
-      title: m.questions.employmentCapabilityLabel,
-      variant: 'number',
-      maxLength: 3,
-      min: 0,
-      max: 100,
-      required: true,
-      width: 'full',
-    }),
+    buildCustomField(
+      {
+        id: `${SectionRouteEnum.BACKGROUND_INFO_EMPLOYMENT_CAPABILITY}.capability`,
+        component: 'RestrictedNumericInput',
+        childInputIds: [
+          `${SectionRouteEnum.BACKGROUND_INFO_EMPLOYMENT_CAPABILITY}.capability`,
+        ],
+      },
+      {
+        min: 0,
+        max: 100,
+        label: m.questions.employmentCapabilityLabel,
+      },
+    ),
   ],
 })


### PR DESCRIPTION
# ...

[Attach a link to issue if relevant
](https://digitaliceland.zendesk.com/agent/tickets/375345)

<img width="480" height="253" alt="image" src="https://github.com/user-attachments/assets/fec52dd8-d486-4ce0-93fe-c54a3a27d792" />

## What

restrict through javascript numbers higher than 100 in the employment capability field. previously it allowed you to do higher but the validation happened on input blur. if this is not desired from the hugsmiðjan team or does not follow established patterns then let me know so i can let the TR team know.

## Why

request from TR

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a numeric input component with configurable validation constraints (0-100 range by default), locale-aware labels and placeholders, and automatic error clearing on value changes. This enhances the disability pension application's employment capability assessment with improved input validation and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->