### PR TITLE
feat(user-profile): Add seed to user profile db

### DIFF
--- a/apps/portals/my-pages/src/Main.tsx
+++ b/apps/portals/my-pages/src/Main.tsx
@@ -1,3 +1,4 @@
+/** Service portal (Mínar síður) entry point */
 import '@island.is/api/mocks'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'

--- a/apps/services/user-profile/infra/service-portal-api.ts
+++ b/apps/services/user-profile/infra/service-portal-api.ts
@@ -71,6 +71,7 @@ export const serviceSetup = (): ServiceBuilder<typeof serviceId> =>
     .secrets(secrets)
     .xroad(Base, Client, NationalRegistryB2C)
     .migrations()
+    .seed()
     .liveness('/liveness')
     .readiness('/health/check')
     .replicaCount({

--- a/apps/services/user-profile/project.json
+++ b/apps/services/user-profile/project.json
@@ -24,6 +24,11 @@
             "output": "./migrations"
           },
           {
+            "glob": "*",
+            "input": "apps/services/user-profile/seeders",
+            "output": "./seeders"
+          },
+          {
             "glob": ".sequelizerc",
             "input": "apps/services/user-profile",
             "output": "./"

--- a/apps/services/user-profile/seeders/20250217100000-fake-users-and-actor-profile.js
+++ b/apps/services/user-profile/seeders/20250217100000-fake-users-and-actor-profile.js
@@ -1,0 +1,122 @@
+'use strict'
+
+const { v5: uuidV5 } = require('uuid')
+
+const now = new Date()
+const nextNudge = new Date(now.getTime() + 6 * 30 * 24 * 60 * 60 * 1000)
+
+const NAMESPACE = '6ba7b810-9dad-11d1-80b4-00c04fd430c8'
+const uuidFor = (nationalId, kind) =>
+  uuidV5(`user-profile-seed-${kind}-${nationalId}`, NAMESPACE)
+
+const FAEREYJAR_NATIONAL_ID = '0101302399'
+const FAEREYJAR_EMAIL_ID = uuidFor(FAEREYJAR_NATIONAL_ID, 'email')
+
+const GERVIMENN = [
+  { name: 'Gervimaður færeyjar', national_id: '0101302399', phone: '0102399' },
+  { name: 'Gervimaður útlönd', national_id: '0101307789', phone: '0107789' },
+  { name: 'Gervimaður Danmörk', national_id: '0101302479', phone: '0102479' },
+  { name: 'Gervimaður Evrópa', national_id: '0101302719', phone: '0102719' },
+  { name: 'Gervimaður Afríka', national_id: '0101303019', phone: '0103019' },
+  { name: 'Gervimaður Ameríku', national_id: '0101302989', phone: '0102989' },
+  {
+    name: 'Gervimaður Bandaríkin',
+    national_id: '0101305069',
+    phone: '0105069',
+  },
+  { name: 'Gervimaður Finnland', national_id: '0101302209', phone: '0102209' },
+  { name: 'Gervimaður Grænland', national_id: '0101302639', phone: '0102639' },
+  { name: 'Gervimaður Noregur', national_id: '0101302129', phone: '0102129' },
+]
+
+const userProfiles = GERVIMENN.map(({ national_id, phone }) => ({
+  id: uuidFor(national_id, 'user-profile'),
+  national_id,
+  mobile_phone_number: `+354-${phone}`,
+  locale: 'is',
+  mobile_phone_number_verified: true,
+  document_notifications: true,
+  mobile_status: 'VERIFIED',
+  email_notifications: true,
+  last_nudge: now,
+  next_nudge: nextNudge,
+  created: now,
+  modified: now,
+}))
+
+const emails = GERVIMENN.map(({ national_id }) => ({
+  id: uuidFor(national_id, 'email'),
+  national_id,
+  email_status: 'VERIFIED',
+  primary: true,
+  email: 'mockEmail@island.is',
+  created: now,
+  modified: now,
+}))
+
+const emailVerifications = GERVIMENN.map(({ national_id }) => ({
+  id: uuidFor(national_id, 'email-verification'),
+  national_id,
+  hash: 'seed-verified',
+  email: 'mockEmail@island.is',
+  confirmed: true,
+  tries: 0,
+  created: now,
+  modified: now,
+}))
+
+const actorProfiles = [
+  {
+    // Færeyjar delegated by 65 artic
+    id: uuidFor(FAEREYJAR_NATIONAL_ID, 'actor-profile'),
+    to_national_id: FAEREYJAR_NATIONAL_ID,
+    from_national_id: '5005101370',
+    email_notifications: true,
+    emails_id: FAEREYJAR_EMAIL_ID,
+    last_nudge: now,
+    next_nudge: nextNudge,
+    created: now,
+    modified: now,
+  },
+]
+
+module.exports = {
+  up: async (queryInterface) => {
+    await queryInterface.bulkInsert('user_profile', userProfiles, {})
+    await queryInterface.bulkInsert('emails', emails, {})
+    await queryInterface.bulkInsert(
+      'email_verification',
+      emailVerifications,
+      {},
+    )
+    await queryInterface.bulkInsert('actor_profile', actorProfiles, {})
+  },
+
+  down: async (queryInterface) => {
+    const { Op } = require('sequelize')
+    const nationalIds = GERVIMENN.map((g) => g.national_id)
+    await queryInterface.bulkDelete(
+      'actor_profile',
+      {
+        to_national_id: FAEREYJAR_NATIONAL_ID,
+        from_national_id: '5005101370',
+      },
+      {},
+    )
+    await queryInterface.bulkDelete(
+      'email_verification',
+      { national_id: { [Op.in]: nationalIds } },
+      {},
+    )
+    await queryInterface.bulkDelete(
+      'emails',
+      { national_id: { [Op.in]: nationalIds } },
+      {},
+    )
+    await queryInterface.bulkDelete(
+      'user_profile',
+      { national_id: { [Op.in]: nationalIds } },
+      {},
+    )
+  },
+}

--- a/apps/services/user-profile/sequelize.config.js
+++ b/apps/services/user-profile/sequelize.config.js
@@ -23,5 +23,6 @@ module.exports = {
     database: process.env.DB_NAME,
     host: process.env.DB_HOST,
     dialect: 'postgres',
+    seederStorage: 'sequelize',
   },
 }

--- a/charts/islandis-services/service-portal-api/values.dev.yaml
+++ b/charts/islandis-services/service-portal-api/values.dev.yaml
@@ -94,6 +94,19 @@ initContainer:
         requests:
           cpu: '50m'
           memory: '128Mi'
+    - args:
+        - 'sequelize-cli'
+        - 'db:seed:all'
+      command:
+        - 'npx'
+      name: 'seed'
+      resources:
+        limits:
+          cpu: '200m'
+          memory: '256Mi'
+        requests:
+          cpu: '50m'
+          memory: '128Mi'
   env:
     DB_HOST: 'postgres-applications.internal'
     DB_NAME: 'service_portal_api'

--- a/charts/islandis-services/service-portal-api/values.prod.yaml
+++ b/charts/islandis-services/service-portal-api/values.prod.yaml
@@ -94,6 +94,19 @@ initContainer:
         requests:
           cpu: '50m'
           memory: '128Mi'
+    - args:
+        - 'sequelize-cli'
+        - 'db:seed:all'
+      command:
+        - 'npx'
+      name: 'seed'
+      resources:
+        limits:
+          cpu: '200m'
+          memory: '256Mi'
+        requests:
+          cpu: '50m'
+          memory: '128Mi'
   env:
     DB_HOST: 'postgres-applications.internal'
     DB_NAME: 'service_portal_api'

--- a/charts/islandis-services/service-portal-api/values.staging.yaml
+++ b/charts/islandis-services/service-portal-api/values.staging.yaml
@@ -94,6 +94,19 @@ initContainer:
         requests:
           cpu: '50m'
           memory: '128Mi'
+    - args:
+        - 'sequelize-cli'
+        - 'db:seed:all'
+      command:
+        - 'npx'
+      name: 'seed'
+      resources:
+        limits:
+          cpu: '200m'
+          memory: '256Mi'
+        requests:
+          cpu: '50m'
+          memory: '128Mi'
   env:
     DB_HOST: 'postgres-applications.internal'
     DB_NAME: 'service_portal_api'

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -2692,6 +2692,19 @@ service-portal-api:
           requests:
             cpu: '50m'
             memory: '128Mi'
+      - args:
+          - 'sequelize-cli'
+          - 'db:seed:all'
+        command:
+          - 'npx'
+        name: 'seed'
+        resources:
+          limits:
+            cpu: '200m'
+            memory: '256Mi'
+          requests:
+            cpu: '50m'
+            memory: '128Mi'
     env:
       DB_HOST: 'postgres-applications.internal'
       DB_NAME: 'service_portal_api'

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -2621,6 +2621,19 @@ service-portal-api:
           requests:
             cpu: '50m'
             memory: '128Mi'
+      - args:
+          - 'sequelize-cli'
+          - 'db:seed:all'
+        command:
+          - 'npx'
+        name: 'seed'
+        resources:
+          limits:
+            cpu: '200m'
+            memory: '256Mi'
+          requests:
+            cpu: '50m'
+            memory: '128Mi'
     env:
       DB_HOST: 'postgres-applications.internal'
       DB_NAME: 'service_portal_api'

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -2482,6 +2482,19 @@ service-portal-api:
           requests:
             cpu: '50m'
             memory: '128Mi'
+      - args:
+          - 'sequelize-cli'
+          - 'db:seed:all'
+        command:
+          - 'npx'
+        name: 'seed'
+        resources:
+          limits:
+            cpu: '200m'
+            memory: '256Mi'
+          requests:
+            cpu: '50m'
+            memory: '128Mi'
     env:
       DB_HOST: 'postgres-applications.internal'
       DB_NAME: 'service_portal_api'


### PR DESCRIPTION
The user profile db is empty on pre-release and feature releases. This adds a seed script with user profiles for some heavily used gervimenn. 

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated database seeding to service startup and build artifacts to include seeder files.
  * Enabled production seeder storage configuration for managed seeding during deploy.

* **New Features**
  * Pre-populated initial user profiles, emails, verifications, and delegated actor profiles to ensure starter data is available after deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->