### PR TITLE
fix: do not allow closing 3DS modal with esc

### DIFF
--- a/apps/payments/components/ThreeDSecure/ThreeDSecure.tsx
+++ b/apps/payments/components/ThreeDSecure/ThreeDSecure.tsx
@@ -57,6 +57,7 @@ export const ThreeDSecure: React.FC<ThreeDSecureProps> = ({
       isVisible={isActive}
       className={styles.container}
       hideOnClickOutside={false}
+      hideOnEsc={false}
     >
       <Box
         position="relative"


### PR DESCRIPTION
Closing the 3DS modal can disrupt active payment confirmations being sent to upstream systems and from them forward to their institutions. Do not allow closing of 3DS modal until it completes either by itself or with an error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified Three D Secure modal to no longer close when the Escape key is pressed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->