### PR TITLE
fix(j-s): Driving license suspended email notification on manual ruling service date entry

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/verdict/verdict.controller.ts
+++ b/apps/judicial-system/backend/src/app/modules/verdict/verdict.controller.ts
@@ -155,10 +155,7 @@ export class VerdictController {
       verdictToUpdate.serviceDate &&
       verdict.serviceRequirement === ServiceRequirement.REQUIRED
     const defendant = theCase.defendants?.find((d) => d.id === defendantId)
-    if (
-      isNowServedByManualEntry &&
-      defendant?.isDrivingLicenseSuspended
-    ) {
+    if (isNowServedByManualEntry && defendant?.isDrivingLicenseSuspended) {
       addMessagesToQueue({
         type: MessageType.INDICTMENT_CASE_NOTIFICATION,
         caseId: theCase.id,

--- a/apps/judicial-system/backend/src/app/modules/verdict/verdict.controller.ts
+++ b/apps/judicial-system/backend/src/app/modules/verdict/verdict.controller.ts
@@ -26,8 +26,16 @@ import {
   RolesRules,
 } from '@island.is/judicial-system/auth'
 import { getVerdictServiceStatusText } from '@island.is/judicial-system/formatters'
-import { indictmentCases } from '@island.is/judicial-system/types'
-import { type User } from '@island.is/judicial-system/types'
+import {
+  addMessagesToQueue,
+  MessageType,
+} from '@island.is/judicial-system/message'
+import {
+  IndictmentCaseNotificationType,
+  indictmentCases,
+  ServiceRequirement,
+  type User,
+} from '@island.is/judicial-system/types'
 
 import {
   districtCourtAssistantRule,
@@ -129,7 +137,7 @@ export class VerdictController {
       `Updating verdict for ${verdict.id} of ${defendantId} in ${caseId}`,
     )
 
-    return this.sequelize.transaction((transaction) =>
+    const updatedVerdict = await this.sequelize.transaction((transaction) =>
       this.verdictService.update(
         verdict,
         verdictToUpdate,
@@ -137,6 +145,30 @@ export class VerdictController {
         theCase.rulingDate,
       ),
     )
+
+    // When prosecution office manually records service date (defendant did not
+    // open ruling on island.is), send driving license suspension notification
+    // so the office can register it in the separate system.
+    const wasNotServedBefore = !verdict.serviceDate
+    const isNowServedByManualEntry =
+      wasNotServedBefore &&
+      verdictToUpdate.serviceDate &&
+      verdict.serviceRequirement === ServiceRequirement.REQUIRED
+    const defendant = theCase.defendants?.find((d) => d.id === defendantId)
+    if (
+      isNowServedByManualEntry &&
+      defendant?.isDrivingLicenseSuspended
+    ) {
+      addMessagesToQueue({
+        type: MessageType.INDICTMENT_CASE_NOTIFICATION,
+        caseId: theCase.id,
+        body: {
+          type: IndictmentCaseNotificationType.DRIVING_LICENSE_SUSPENSION,
+        },
+      })
+    }
+
+    return updatedVerdict
   }
 
   @UseGuards(


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1213396227349207?focus=true)

## What

We didn't send the email notification when prosecution office manually entered the ruling service date.

## Why

So the notification is sent in all cases 

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated notification system now sends driving license suspension alerts when a verdict is manually entered for defendants with suspended driving licenses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->