### PR TITLE
feat(parental-leave): fix VMST error handling and give-days validation

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/parental-leave.service.spec.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/parental-leave.service.spec.ts
@@ -602,4 +602,69 @@ describe('ParentalLeaveService', () => {
       expect(mockedSendEmail.mock.calls.length).toBe(0)
     })
   })
+
+  describe('parseErrors', () => {
+    it('should return error message from Error instance', () => {
+      const error = new Error('Something went wrong')
+      const result = (parentalLeaveService as any).parseErrors(error)
+      expect(result).toBe('Something went wrong')
+    })
+
+    it('should return joined error values when errors object is present', () => {
+      const vmstError = {
+        type: 'https://tools.ietf.org/html/rfc7231#section-6.5.1',
+        title: 'Bad Request',
+        status: 400,
+        traceId: 'abc-123',
+        errors: {
+          field1: ['Error one', 'Error two'],
+          field2: ['Error three'],
+        },
+      }
+      const result = (parentalLeaveService as any).parseErrors(vmstError)
+      expect(result).toEqual({
+        message: ['Error one, Error two', 'Error three'],
+      })
+    })
+
+    it('should return status string when VMST returns error message in status field', () => {
+      // This is the format VMST uses for transfer-day errors:
+      // { status: "Ekki hægt að úthluta meir en 44 framsalsdögum" }
+      const vmstError = {
+        type: '',
+        title: '',
+        status: 'Ekki hægt að úthluta meir en 44 framsalsdögum',
+        traceId: '',
+        errors: undefined as unknown as Record<string, string[]>,
+      }
+      const result = (parentalLeaveService as any).parseErrors(vmstError)
+      expect(result).toEqual({
+        message: 'Ekki hægt að úthluta meir en 44 framsalsdögum',
+      })
+    })
+
+    it('should return title as fallback when status is a number and no errors object', () => {
+      const vmstError = {
+        type: '',
+        title: 'Internal Server Error',
+        status: 500,
+        traceId: '',
+        errors: undefined as unknown as Record<string, string[]>,
+      }
+      const result = (parentalLeaveService as any).parseErrors(vmstError)
+      expect(result).toEqual({ message: 'Internal Server Error' })
+    })
+
+    it('should return default message when title is missing', () => {
+      const vmstError = {
+        type: '',
+        title: undefined as unknown as string,
+        status: 500,
+        traceId: '',
+        errors: undefined as unknown as Record<string, string[]>,
+      }
+      const result = (parentalLeaveService as any).parseErrors(vmstError)
+      expect(result).toEqual({ message: 'Villa kom upp' })
+    })
+  })
 })

--- a/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/parental-leave.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/parental-leave/parental-leave.service.ts
@@ -94,7 +94,7 @@ import { NationalRegistryV3Service } from '../../shared/api/national-registry-v3
 interface VMSTError {
   type: string
   title: string
-  status: number
+  status: number | string
   traceId: string
   errors: Record<string, string[]>
 }
@@ -121,11 +121,20 @@ export class ParentalLeaveService extends BaseTemplateApiService {
       return e.message
     }
 
-    return {
-      message: e.errors
-        ? Object.entries(e.errors).map(([, values]) => values.join(', '))
-        : e.status,
+    if (e.errors) {
+      return {
+        message: Object.entries(e.errors).map(([, values]) =>
+          values.join(', '),
+        ),
+      }
     }
+
+    // VMST may return the error message in the status field as a string
+    if (typeof e.status === 'string') {
+      return { message: e.status }
+    }
+
+    return { message: e.title ?? 'Villa kom upp' }
   }
 
   async getChildren({ application, auth }: TemplateApiModuleActionProps) {

--- a/libs/application/templates/parental-leave/src/lib/parentalLeaveUtils.spec.ts
+++ b/libs/application/templates/parental-leave/src/lib/parentalLeaveUtils.spec.ts
@@ -693,6 +693,201 @@ describe('getAvailableRightsInDays', () => {
 
     expect(res).toBe(150)
   })
+
+  it('should return VMSTApplicationRights days when present and no give-days', () => {
+    const application = buildApplication({
+      answers: {
+        selectedChild: 0,
+      },
+      externalData: {
+        children: {
+          data: {
+            children: [
+              {
+                hasRights: true,
+                remainingDays: 180,
+                transferredDays: 0,
+                parentalRelation: ParentalRelations.primary,
+                expectedDateOfBirth: '2021-05-17',
+              },
+            ],
+            existingApplications: [],
+          },
+          date: new Date(),
+          status: 'success',
+        },
+        VMSTApplicationRights: {
+          data: [
+            {
+              rightsUnit: 'M-L-GR',
+              rightsDescription: 'Grunnréttur móður',
+              months: '6.0',
+              days: '180',
+              daysLeft: '0',
+            },
+          ],
+          date: new Date(),
+          status: 'success',
+        },
+      },
+    })
+
+    const res = getAvailableRightsInDays(application)
+
+    expect(res).toBe(180)
+  })
+
+  it('should subtract give-days from VMSTApplicationRights when primary parent is giving days', () => {
+    // This is the scenario from the bug: primary parent declares giving 45 days
+    // but VMSTApplicationRights reports the full 180-day entitlement.
+    // getAvailableRightsInDays must return 180 - 45 = 135 so period validation
+    // catches that 136 days of periods exceed the available 135 days.
+    const application = buildApplication({
+      answers: {
+        selectedChild: 0,
+        giveRights: {
+          isGivingRights: YES,
+          giveDays: 45,
+        },
+      },
+      externalData: {
+        children: {
+          data: {
+            children: [
+              {
+                hasRights: true,
+                remainingDays: 180,
+                transferredDays: -45,
+                parentalRelation: ParentalRelations.primary,
+                expectedDateOfBirth: '2021-05-17',
+              },
+            ],
+            existingApplications: [],
+          },
+          date: new Date(),
+          status: 'success',
+        },
+        VMSTApplicationRights: {
+          data: [
+            {
+              rightsUnit: 'M-L-GR',
+              rightsDescription: 'Grunnréttur móður',
+              months: '6.0',
+              days: '180',
+              daysLeft: '0',
+            },
+          ],
+          date: new Date(),
+          status: 'success',
+        },
+      },
+    })
+
+    const res = getAvailableRightsInDays(application)
+
+    expect(res).toBe(135)
+  })
+
+  it('should not double-subtract give-days when VMSTApplicationRights already accounts for them', () => {
+    // If VMST already subtracted the give-days (VMSTDays < remainingDays),
+    // we should not subtract again.
+    const application = buildApplication({
+      answers: {
+        selectedChild: 0,
+        giveRights: {
+          isGivingRights: YES,
+          giveDays: 45,
+        },
+      },
+      externalData: {
+        children: {
+          data: {
+            children: [
+              {
+                hasRights: true,
+                remainingDays: 180,
+                transferredDays: -45,
+                parentalRelation: ParentalRelations.primary,
+                expectedDateOfBirth: '2021-05-17',
+              },
+            ],
+            existingApplications: [],
+          },
+          date: new Date(),
+          status: 'success',
+        },
+        VMSTApplicationRights: {
+          data: [
+            {
+              rightsUnit: 'M-L-GR',
+              rightsDescription: 'Grunnréttur móður',
+              months: '4.5',
+              days: '135',
+              daysLeft: '0',
+            },
+          ],
+          date: new Date(),
+          status: 'success',
+        },
+      },
+    })
+
+    const res = getAvailableRightsInDays(application)
+
+    // VMST reports 135 which is already 180 - 45, so no further subtraction
+    expect(res).toBe(135)
+  })
+
+  it('should return VMSTApplicationRights days as-is for secondary parent', () => {
+    const application = buildApplication({
+      answers: {
+        selectedChild: 0,
+      },
+      externalData: {
+        children: {
+          data: {
+            children: [
+              {
+                hasRights: true,
+                remainingDays: 210,
+                transferredDays: 30,
+                parentalRelation: ParentalRelations.secondary,
+                expectedDateOfBirth: '2021-05-17',
+              },
+            ],
+            existingApplications: [],
+          },
+          date: new Date(),
+          status: 'success',
+        },
+        VMSTApplicationRights: {
+          data: [
+            {
+              rightsUnit: 'F-L-GR',
+              rightsDescription: 'Grunnréttur föður',
+              months: '6.0',
+              days: '180',
+              daysLeft: '0',
+            },
+            {
+              rightsUnit: 'F-FS',
+              rightsDescription: 'Framsal',
+              months: '1.0',
+              days: '30',
+              daysLeft: '0',
+            },
+          ],
+          date: new Date(),
+          status: 'success',
+        },
+      },
+    })
+
+    const res = getAvailableRightsInDays(application)
+
+    // Secondary parent: 180 + 30 = 210 from VMST, returned as-is
+    expect(res).toBe(210)
+  })
 })
 
 describe('getAvailablePersonalRightsInDays', () => {

--- a/libs/application/templates/parental-leave/src/lib/parentalLeaveUtils.ts
+++ b/libs/application/templates/parental-leave/src/lib/parentalLeaveUtils.ts
@@ -368,6 +368,26 @@ export const getAvailableRightsInDays = (application: Application) => {
       0,
     )
 
+    // VMSTApplicationRights may report the full entitlement without
+    // accounting for days the primary parent is giving away.
+    // Ensure give-days are subtracted so period validation is correct.
+    const selectedChild = getSelectedChild(
+      application.answers,
+      application.externalData,
+    )
+    if (selectedChild?.parentalRelation === ParentalRelations.primary) {
+      const transferredDays = getTransferredDays(application, selectedChild)
+      if (transferredDays < 0) {
+        // transferredDays is negative when giving days away
+        // Only subtract if VMSTDays doesn't already account for it
+        // (i.e., VMSTDays is close to the full entitlement)
+        const baseRemainingDays = selectedChild.remainingDays
+        if (VMSTDays >= baseRemainingDays) {
+          return VMSTDays + transferredDays
+        }
+      }
+    }
+
     return VMSTDays
   }
 

--- a/libs/clients/vmst/src/lib/utils.ts
+++ b/libs/clients/vmst/src/lib/utils.ts
@@ -128,7 +128,7 @@ export const createWrappedFetchWithLogging = (
               success: false,
             },
           })
-          return reject(requestBody)
+          return reject(responseBody)
         }
 
         return resolve(response)


### PR DESCRIPTION
Note: These changes were made while investigating a [Zendesk support ticket](https://digitaliceland.zendesk.com/agent/tickets/396729). I don't have domain knowledge of the parental leave application, so I'd appreciate a careful review from someone on the team who does
— particularly the logic change in getAvailableRightsInDays.

---

Fix three bugs in the parental leave application:

1. VMST fetch wrapper rejected with request body instead of response body, hiding the actual VMST error message from users (e.g. "Ekki hægt að úthluta meir en 44 framsalsdögum").

2. parseErrors did not handle VMST responses where the error message is in the status field as a string, falling through to a generic "Villa kom upp" message.

3. getAvailableRightsInDays returned the full VMST entitlement without subtracting give-days for the primary parent, so period validation passed even when periods + give-days exceeded total rights.

Adds tests for the VMSTApplicationRights path in getAvailableRightsInDays and for parseErrors covering all VMST error response formats.