### PR TITLE
fix(ui): Mobile users can now scroll through an applications steps

### DIFF
--- a/libs/island-ui/core/src/lib/FormStepper/FormStepper.css.ts
+++ b/libs/island-ui/core/src/lib/FormStepper/FormStepper.css.ts
@@ -1,5 +1,5 @@
 import { theme } from '@island.is/island-ui/theme'
-import { style } from '@vanilla-extract/css'
+import { globalStyle, style } from '@vanilla-extract/css'
 
 export const head = style({
   display: 'none',
@@ -29,7 +29,8 @@ export const list = style({
   padding: '20px 24px',
 
   backgroundColor: theme.color.purple100,
-  overflowX: 'hidden',
+  overflowX: 'auto',
+  scrollbarWidth: 'none',
 
   '@media': {
     [`screen and (min-width: ${theme.breakpoints.md}px)`]: {
@@ -38,8 +39,13 @@ export const list = style({
       padding: 0,
 
       backgroundColor: 'transparent',
+      overflowX: 'hidden',
     },
   },
+})
+
+globalStyle(`${list}::-webkit-scrollbar`, {
+  display: 'none',
 })
 
 export const historyList = style({

--- a/libs/island-ui/core/src/lib/FormStepper/Section.css.ts
+++ b/libs/island-ui/core/src/lib/FormStepper/Section.css.ts
@@ -5,13 +5,12 @@ export const container = style({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-  transition: 'margin-left .35s ease .5s',
+  flexShrink: 0,
 
   '@media': {
     [`screen and (min-width: ${theme.breakpoints.md}px)`]: {
       flexDirection: 'column',
       alignItems: 'flex-start',
-      transition: 'none',
     },
   },
 })

--- a/libs/island-ui/core/src/lib/FormStepper/Section.tsx
+++ b/libs/island-ui/core/src/lib/FormStepper/Section.tsx
@@ -30,11 +30,9 @@ export const Section: FC<
   isComplete = false,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null)
-  const { height: activeHeight, width: activeWidth } =
-    useComponentSize(containerRef)
+  const { height: activeHeight } = useComponentSize(containerRef)
   const { width } = useWindowSize()
   const [containerHeight, setContainerHeight] = useState(0)
-  const [containerWidth, setContainerWidth] = useState(0)
   const isClient = typeof window === 'object'
   const isSmallScreen = width <= islandUITheme.breakpoints.md
 
@@ -47,21 +45,17 @@ export const Section: FC<
   }, [isActive, isClient, activeHeight])
 
   useEffect(() => {
-    if (!isClient) return
+    if (!isClient || !isSmallScreen || !isActive) return
 
-    if (containerRef.current) {
-      setContainerWidth(activeWidth)
-    }
-  }, [isComplete, isActive, activeWidth, isClient])
+    containerRef.current?.scrollIntoView({
+      behavior: 'smooth',
+      inline: 'center',
+      block: 'nearest',
+    })
+  }, [isActive, isSmallScreen, isClient])
 
   return (
-    <Box
-      ref={containerRef}
-      className={styles.container}
-      style={{
-        marginLeft: isSmallScreen && isComplete ? `-${containerWidth}px` : '0',
-      }}
-    >
+    <Box ref={containerRef} className={styles.container}>
       <Box display="flex" alignItems="center" marginBottom={[0, 0, 1]}>
         <Box paddingTop={[0, 0, 2]}>
           <SectionNumber


### PR DESCRIPTION
## What

Making it possible to scroll through the steps of an application when on small reactive screens.

## Why

It was requested and makes sense.

## Screenshots
<img width="1170" height="2532" alt="Untitled" src="https://github.com/user-attachments/assets/8d5fbbb0-4a34-459e-99b3-7556f2128f4a" />

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Improved FormStepper scrolling behavior on small screens with hidden scrollbars for a cleaner appearance
  * Sections now automatically scroll into view when activated on mobile devices for better usability
  * Enhanced flex sizing to prevent content from shrinking unexpectedly

<!-- end of auto-generated comment: release notes by coderabbit.ai -->