### PR TITLE
fix(user-notification): update SMS content link text and adjust formatting for clarity

### DIFF
--- a/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/notificationsWorker.service.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/notificationsWorker.service.ts
@@ -73,13 +73,13 @@ const createSmsContent = ({
   template: HnippTemplate
   isEnglish: boolean
 }): string => {
-  const linkText = isEnglish ? 'View on Island.is' : 'Skoda a Island.is'
+  const linkText = isEnglish ? 'View details' : 'Skoda nanar'
   const namePrefix = onBehalfOf
     ? getOnBehalfOfLabel(onBehalfOf, onBehalfOfNationalId, isEnglish)
     : fullName
   return `${namePrefix}: ${template.title}\n\n${template.externalBody}${
     template.clickActionUrl
-      ? `\n\n${linkText}: \n\n${template.clickActionUrl}`
+      ? `\n\n${linkText}: \n${template.clickActionUrl}`
       : ''
   }
     `.trim()

--- a/libs/nova-sms/src/lib/sms.config.ts
+++ b/libs/nova-sms/src/lib/sms.config.ts
@@ -4,7 +4,7 @@ export const smsModuleConfig = defineConfig({
   name: 'SmsModule',
   load: (env) => ({
     url: env.required('NOVA_URL', 'https://sms.nova.is/v1/'),
-    username: env.required('NOVA_USERNAME', 'S56572'),
+    username: env.required('NOVA_USERNAME', 'S56664'),
     password: env.required('NOVA_PASSWORD', ''),
     senderName: env.optional('NOVA_SENDER_NAME', 'Island Dev'),
   }),


### PR DESCRIPTION
## What

- Updated SMS link text from "View on Island.is" / "Skoda a Island.is" to "View details" / "Skoda nanar"
- Updated default Nova SMS username to dev user

## Why

- Shorter, clearer link text for SMS messages
- Cleaner formatting with less whitespace in SMS body
- Updated Nova SMS account credentials

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated SMS notification link labels to use simpler wording across all supported languages
  * Refined SMS message formatting by optimizing line breaks and spacing around URLs for cleaner message display

* **Chores**
  * Updated notification service configuration parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->