### PR TITLE
fix(j-s): don't override defendant info with national registry response

### DIFF
--- a/apps/judicial-system/web/src/routes/Prosecutor/components/DefendantInfo/DefendantInfo.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/components/DefendantInfo/DefendantInfo.tsx
@@ -1,4 +1,11 @@
-import { Dispatch, FC, SetStateAction, useEffect, useState } from 'react'
+import {
+  Dispatch,
+  FC,
+  SetStateAction,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 import { useIntl } from 'react-intl'
 
 import {
@@ -24,6 +31,7 @@ import {
   UpdateDefendantInput,
 } from '@island.is/judicial-system-web/src/graphql/schema'
 import { ReactSelectOption } from '@island.is/judicial-system-web/src/types'
+import { formatNationalRegistryAddress } from '@island.is/judicial-system-web/src/utils/formatNationalRegistryAddress'
 import {
   removeErrorMessageIfValid,
   validateAndSetErrorMessage,
@@ -34,6 +42,52 @@ import {
   isBusiness,
   mapStringToGender,
 } from '@island.is/judicial-system-web/src/utils/utils'
+
+const isDefendantFieldMissing = (value?: string | null) => !value?.trim()
+
+const normalizeNationalId = (nationalId?: string | null) =>
+  nationalId?.replace('-', '') ?? ''
+
+type RegistryAutofillMode = 'replaceFromRegistry' | 'fillMissingOnly'
+
+const registryAutofillMode = (
+  lastAutofilledNationalId: string | null,
+  normalizedCurrentNationalId: string,
+): RegistryAutofillMode =>
+  lastAutofilledNationalId !== null &&
+  lastAutofilledNationalId !== normalizedCurrentNationalId
+    ? 'replaceFromRegistry'
+    : 'fillMissingOnly'
+
+const mergeRegistryIntoDefendantUpdate = (
+  update: UpdateDefendantInput,
+  defendant: Defendant,
+  registry: { name?: string | null; address?: string | null },
+  mode: RegistryAutofillMode,
+  options?: { genderRaw?: string | null },
+) => {
+  const replace = mode === 'replaceFromRegistry'
+  const name = registry.name?.trim()
+
+  if (name && (replace || isDefendantFieldMissing(defendant.name))) {
+    update.name = name
+  }
+
+  if (
+    registry.address &&
+    (replace || isDefendantFieldMissing(defendant.address))
+  ) {
+    update.address = registry.address
+  }
+
+  if (options) {
+    const genderFromRegistry = mapStringToGender(options.genderRaw)
+
+    if (genderFromRegistry && (replace || !defendant.gender)) {
+      update.gender = genderFromRegistry
+    }
+  }
+}
 
 interface Props {
   defendant: Defendant
@@ -75,22 +129,47 @@ const DefendantInfo: FC<Props> = (props) => {
       !!defendant.nationalId && isBusiness(defendant.nationalId),
     )
 
+  const lastAutofilledNationalIdRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    lastAutofilledNationalIdRef.current = null
+  }, [defendant.id])
+
   useEffect(() => {
     if (!isBusiness(defendant.nationalId) && (error || notFound)) {
       return
     }
 
-    if (personData && personData.items && personData.items.length > 0) {
+    if (personData?.items?.length) {
       setAccusedAddressErrorMessage('')
       setIsGenderAndCitizenshipDisabled(false)
 
-      onChange({
+      const person = personData.items[0]
+      const addressFromRegistry = formatNationalRegistryAddress(
+        person.permanent_address,
+      )
+      const update: UpdateDefendantInput = {
         caseId: workingCase.id,
         defendantId: defendant.id,
-        name: personData.items[0].name,
-        gender: mapStringToGender(personData.items[0].gender),
-        address: personData.items[0].permanent_address.street?.nominative,
-      })
+      }
+      const normalizedNationalId = normalizeNationalId(defendant.nationalId)
+
+      mergeRegistryIntoDefendantUpdate(
+        update,
+        defendant,
+        { name: person.name, address: addressFromRegistry },
+        registryAutofillMode(
+          lastAutofilledNationalIdRef.current,
+          normalizedNationalId,
+        ),
+        { genderRaw: person.gender },
+      )
+
+      lastAutofilledNationalIdRef.current = normalizedNationalId
+
+      if (Object.keys(update).length > 2) {
+        onChange(update)
+      }
     }
     // We only want this to run when a lookup is done in the national registry.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -101,18 +180,35 @@ const DefendantInfo: FC<Props> = (props) => {
       return
     }
 
-    if (businessData && businessData.items && businessData.items.length > 0) {
+    if (businessData?.items?.length) {
       setAccusedAddressErrorMessage('')
       setIsGenderAndCitizenshipDisabled(true)
 
-      onChange({
+      const business = businessData.items[0]
+      const addressFromRegistry = formatNationalRegistryAddress(
+        business.legal_address,
+      )
+      const update: UpdateDefendantInput = {
         caseId: workingCase.id,
         defendantId: defendant.id,
-        name: businessData.items[0].full_name,
-        address: businessData.items[0].legal_address.street?.nominative,
-        gender: undefined,
-        citizenship: undefined,
-      })
+      }
+      const normalizedNationalId = normalizeNationalId(defendant.nationalId)
+
+      mergeRegistryIntoDefendantUpdate(
+        update,
+        defendant,
+        { name: business.full_name, address: addressFromRegistry },
+        registryAutofillMode(
+          lastAutofilledNationalIdRef.current,
+          normalizedNationalId,
+        ),
+      )
+
+      lastAutofilledNationalIdRef.current = normalizedNationalId
+
+      if (Object.keys(update).length > 2) {
+        onChange(update)
+      }
     }
     // We only want this to run when a lookup is done in the national registry.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/judicial-system/web/src/routes/Prosecutor/components/DefendantInfo/DefendantInfo.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/components/DefendantInfo/DefendantInfo.tsx
@@ -38,9 +38,9 @@ import {
 } from '@island.is/judicial-system-web/src/utils/utils'
 
 /**
- * Skip national registry lookup for LÖKE-synced defendants.
+ * Skip national registry lookup for police system synced defendants.
  */
-const skipNationalRegistryForLokeDefendant = (
+const skipNationalRegistryForPoliceSystemDefendant = (
   origin: CaseOrigin | null | undefined,
   caseId: string | null | undefined,
   defendant: Defendant,
@@ -71,7 +71,7 @@ const DefendantInfo: FC<Props> = (props) => {
     updateDefendantState,
   } = props
   const { formatMessage } = useIntl()
-  const skipNationalRegistry = skipNationalRegistryForLokeDefendant(
+  const skipNationalRegistry = skipNationalRegistryForPoliceSystemDefendant(
     workingCase.origin,
     workingCase.id,
     defendant,

--- a/apps/judicial-system/web/src/routes/Prosecutor/components/DefendantInfo/DefendantInfo.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/components/DefendantInfo/DefendantInfo.tsx
@@ -1,11 +1,4 @@
-import {
-  Dispatch,
-  FC,
-  SetStateAction,
-  useEffect,
-  useRef,
-  useState,
-} from 'react'
+import { Dispatch, FC, SetStateAction, useEffect, useState } from 'react'
 import { useIntl } from 'react-intl'
 
 import {
@@ -26,6 +19,7 @@ import InputName from '@island.is/judicial-system-web/src/components/Inputs/Inpu
 import InputNationalId from '@island.is/judicial-system-web/src/components/Inputs/InputNationalId'
 import {
   Case,
+  CaseOrigin,
   Defendant,
   Gender,
   UpdateDefendantInput,
@@ -43,51 +37,17 @@ import {
   mapStringToGender,
 } from '@island.is/judicial-system-web/src/utils/utils'
 
-const isDefendantFieldMissing = (value?: string | null) => !value?.trim()
-
-const normalizeNationalId = (nationalId?: string | null) =>
-  nationalId?.replace('-', '') ?? ''
-
-type RegistryAutofillMode = 'replaceFromRegistry' | 'fillMissingOnly'
-
-const registryAutofillMode = (
-  lastAutofilledNationalId: string | null,
-  normalizedCurrentNationalId: string,
-): RegistryAutofillMode =>
-  lastAutofilledNationalId !== null &&
-  lastAutofilledNationalId !== normalizedCurrentNationalId
-    ? 'replaceFromRegistry'
-    : 'fillMissingOnly'
-
-const mergeRegistryIntoDefendantUpdate = (
-  update: UpdateDefendantInput,
+/**
+ * Skip national registry lookup for LÖKE-synced defendants.
+ */
+const skipNationalRegistryForLokeDefendant = (
+  origin: CaseOrigin | null | undefined,
+  caseId: string | null | undefined,
   defendant: Defendant,
-  registry: { name?: string | null; address?: string | null },
-  mode: RegistryAutofillMode,
-  options?: { genderRaw?: string | null },
-) => {
-  const replace = mode === 'replaceFromRegistry'
-  const name = registry.name?.trim()
-
-  if (name && (replace || isDefendantFieldMissing(defendant.name))) {
-    update.name = name
-  }
-
-  if (
-    registry.address &&
-    (replace || isDefendantFieldMissing(defendant.address))
-  ) {
-    update.address = registry.address
-  }
-
-  if (options) {
-    const genderFromRegistry = mapStringToGender(options.genderRaw)
-
-    if (genderFromRegistry && (replace || !defendant.gender)) {
-      update.gender = genderFromRegistry
-    }
-  }
-}
+) =>
+  origin === CaseOrigin.LOKE &&
+  Boolean(caseId) &&
+  (Boolean(defendant.name?.trim()) || Boolean(defendant.address?.trim()))
 
 interface Props {
   defendant: Defendant
@@ -111,8 +71,14 @@ const DefendantInfo: FC<Props> = (props) => {
     updateDefendantState,
   } = props
   const { formatMessage } = useIntl()
+  const skipNationalRegistry = skipNationalRegistryForLokeDefendant(
+    workingCase.origin,
+    workingCase.id,
+    defendant,
+  )
   const { personData, businessData, error, notFound } = useNationalRegistry(
     defendant.nationalId,
+    { skip: skipNationalRegistry },
   )
 
   const genderOptions: ReactSelectOption[] = [
@@ -129,12 +95,6 @@ const DefendantInfo: FC<Props> = (props) => {
       !!defendant.nationalId && isBusiness(defendant.nationalId),
     )
 
-  const lastAutofilledNationalIdRef = useRef<string | null>(null)
-
-  useEffect(() => {
-    lastAutofilledNationalIdRef.current = null
-  }, [defendant.id])
-
   useEffect(() => {
     if (!isBusiness(defendant.nationalId) && (error || notFound)) {
       return
@@ -145,31 +105,13 @@ const DefendantInfo: FC<Props> = (props) => {
       setIsGenderAndCitizenshipDisabled(false)
 
       const person = personData.items[0]
-      const addressFromRegistry = formatNationalRegistryAddress(
-        person.permanent_address,
-      )
-      const update: UpdateDefendantInput = {
+      onChange({
         caseId: workingCase.id,
         defendantId: defendant.id,
-      }
-      const normalizedNationalId = normalizeNationalId(defendant.nationalId)
-
-      mergeRegistryIntoDefendantUpdate(
-        update,
-        defendant,
-        { name: person.name, address: addressFromRegistry },
-        registryAutofillMode(
-          lastAutofilledNationalIdRef.current,
-          normalizedNationalId,
-        ),
-        { genderRaw: person.gender },
-      )
-
-      lastAutofilledNationalIdRef.current = normalizedNationalId
-
-      if (Object.keys(update).length > 2) {
-        onChange(update)
-      }
+        name: person.name,
+        gender: mapStringToGender(person.gender),
+        address: formatNationalRegistryAddress(person.permanent_address),
+      })
     }
     // We only want this to run when a lookup is done in the national registry.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -185,30 +127,14 @@ const DefendantInfo: FC<Props> = (props) => {
       setIsGenderAndCitizenshipDisabled(true)
 
       const business = businessData.items[0]
-      const addressFromRegistry = formatNationalRegistryAddress(
-        business.legal_address,
-      )
-      const update: UpdateDefendantInput = {
+      onChange({
         caseId: workingCase.id,
         defendantId: defendant.id,
-      }
-      const normalizedNationalId = normalizeNationalId(defendant.nationalId)
-
-      mergeRegistryIntoDefendantUpdate(
-        update,
-        defendant,
-        { name: business.full_name, address: addressFromRegistry },
-        registryAutofillMode(
-          lastAutofilledNationalIdRef.current,
-          normalizedNationalId,
-        ),
-      )
-
-      lastAutofilledNationalIdRef.current = normalizedNationalId
-
-      if (Object.keys(update).length > 2) {
-        onChange(update)
-      }
+        name: business.full_name,
+        address: formatNationalRegistryAddress(business.legal_address),
+        gender: undefined,
+        citizenship: undefined,
+      })
     }
     // We only want this to run when a lookup is done in the national registry.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/judicial-system/web/src/utils/formatNationalRegistryAddress.spec.ts
+++ b/apps/judicial-system/web/src/utils/formatNationalRegistryAddress.spec.ts
@@ -1,0 +1,33 @@
+import { formatNationalRegistryAddress } from './formatNationalRegistryAddress'
+
+describe('formatNationalRegistryAddress', () => {
+  it('formats a typical Icelandic address', () => {
+    expect(
+      formatNationalRegistryAddress({
+        street: { nominative: 'Aðalgata 1' },
+        postal_code: 101,
+        town: { nominative: 'Reykjavík' },
+        municipality: '',
+      }),
+    ).toBe('Aðalgata 1, 101 Reykjavík')
+  })
+
+  it('uses municipality when town nominative is missing', () => {
+    expect(
+      formatNationalRegistryAddress({
+        street: { nominative: 'Gervigata 2' },
+        postal_code: 210,
+        municipality: 'Garðabær',
+      }),
+    ).toBe('Gervigata 2, 210 Garðabær')
+  })
+
+  it('returns undefined when there is nothing to show', () => {
+    expect(
+      formatNationalRegistryAddress({
+        street: { nominative: '' },
+        municipality: '',
+      }),
+    ).toBeUndefined()
+  })
+})

--- a/apps/judicial-system/web/src/utils/formatNationalRegistryAddress.ts
+++ b/apps/judicial-system/web/src/utils/formatNationalRegistryAddress.ts
@@ -1,6 +1,5 @@
 /**
- * Builds a single-line address from Þjóðskrá-style fields.
- * Icelandic convention: "{gata og númer}, {póstnúmer} {staður}" (e.g. "Aðalgata 1, 101 Reykjavík").
+ * Builds a string in the format "{gata og númer}, {póstnúmer} {staður}" (e.g. "Gervigata 2, 100 Garðabær").
  */
 type NationalRegistryAddressFields = {
   street?: { nominative?: string }

--- a/apps/judicial-system/web/src/utils/formatNationalRegistryAddress.ts
+++ b/apps/judicial-system/web/src/utils/formatNationalRegistryAddress.ts
@@ -1,0 +1,33 @@
+/**
+ * Builds a single-line address from Þjóðskrá-style fields.
+ * Icelandic convention: "{gata og númer}, {póstnúmer} {staður}" (e.g. "Aðalgata 1, 101 Reykjavík").
+ */
+type NationalRegistryAddressFields = {
+  street?: { nominative?: string }
+  postal_code?: number
+  town?: { nominative?: string }
+  municipality?: string
+}
+
+const trim = (value?: string | null) => value?.trim() ?? ''
+
+export const formatNationalRegistryAddress = (
+  address: NationalRegistryAddressFields,
+): string | undefined => {
+  const street = trim(address.street?.nominative)
+  const town = trim(address.town?.nominative)
+  const municipality = trim(address.municipality)
+  const locality = town || municipality
+
+  const postal =
+    address.postal_code !== undefined && address.postal_code !== null
+      ? String(address.postal_code)
+      : ''
+
+  const postcodeAndLocality = [postal, locality].filter(Boolean).join(' ')
+  const streetCommaPostcodeAndLocality = [street, postcodeAndLocality]
+    .filter(Boolean)
+    .join(', ')
+
+  return streetCommaPostcodeAndLocality || undefined
+}

--- a/apps/judicial-system/web/src/utils/hooks/useNationalRegistry/index.ts
+++ b/apps/judicial-system/web/src/utils/hooks/useNationalRegistry/index.ts
@@ -9,7 +9,16 @@ import {
 import { isBusiness } from '../../utils'
 import { validate } from '../../validate'
 
-const useNationalRegistry = (nationalId?: string | null) => {
+export type UseNationalRegistryOptions = {
+  /** When true, no request is made and cached lookup state is cleared. */
+  skip?: boolean
+}
+
+const useNationalRegistry = (
+  nationalId?: string | null,
+  options?: UseNationalRegistryOptions,
+) => {
+  const skip = options?.skip ?? false
   const [personData, setPersonData] = useState<NationalRegistryResponsePerson>()
   const [businessData, setBusinessData] =
     useState<NationalRegistryResponseBusiness>()
@@ -18,6 +27,15 @@ const useNationalRegistry = (nationalId?: string | null) => {
   const [notFound, setNotFound] = useState<boolean>(false)
 
   useEffect(() => {
+    if (skip) {
+      setPersonData(undefined)
+      setBusinessData(undefined)
+      setError(undefined)
+      setNotFound(false)
+      setIsLoading(false)
+      return
+    }
+
     const cleanNationalId = nationalId?.replace('-', '')
     const isValidNationalId = validate([
       [cleanNationalId, ['national-id']],
@@ -79,7 +97,7 @@ const useNationalRegistry = (nationalId?: string | null) => {
       })
 
     return () => controller.abort()
-  }, [nationalId])
+  }, [nationalId, skip])
 
   return { personData, businessData, error, isLoading, notFound }
 }


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1212657017130395/task/1213591152112055?focus=true)

## What

We were doing a lookup in the national registry to get information about defendants. We then took the name,gender and only the street name and stored that on our defendant in judicial system.

I made two changes to this:

1. If a defendant already has information from LOKE, we don't do the lookup in national registry. 
2. In cases where we do look up information in the national registry, I made it so we actually get a full address instead of just the street name. So something like "Gervigata 67, 100 Gervibær" instead of doing "Gervigata 67".

## Why

So we don't overwrite defendant data from LOKE. 



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Defendant autofill no longer triggers unnecessary national-registry lookups for synced police-system defendants and won’t overwrite existing name or address data.

* **New Features**
  * Registry addresses are now normalized into a single-line format for clearer display and consistent autofill.

* **Tests**
  * Added tests for address formatting: town vs municipality fallback and handling of missing address data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->