### PR TITLE
fix(driving-license): clear health certificate when no longer needed

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.service.ts
@@ -128,6 +128,20 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
 
       if (e instanceof Error && e.name === 'FetchError') {
         const err = e as unknown as FetchError
+
+        if (
+          err.problem?.title === 'INSTRUCTOR_DOES_NOT_HAVE_BE_CATEGORY'
+        ) {
+          throw new TemplateApiError(
+            {
+              title: coreErrorMessages.failedDataProviderSubmit,
+              summary:
+                'Ökukennari er ekki með BE réttindi á ökuskírteini sínu. Vinsamlegast veldu annan ökukennara.',
+            },
+            400,
+          )
+        }
+
         throw new TemplateApiError(
           {
             title:

--- a/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/transport-authority/driving-license-submission/driving-license-submission.service.ts
@@ -129,9 +129,7 @@ export class DrivingLicenseSubmissionService extends BaseTemplateApiService {
       if (e instanceof Error && e.name === 'FetchError') {
         const err = e as unknown as FetchError
 
-        if (
-          err.problem?.title === 'INSTRUCTOR_DOES_NOT_HAVE_BE_CATEGORY'
-        ) {
+        if (err.problem?.title === 'INSTRUCTOR_DOES_NOT_HAVE_BE_CATEGORY') {
           throw new TemplateApiError(
             {
               title: coreErrorMessages.failedDataProviderSubmit,

--- a/libs/application/templates/driving-license/src/fields/HealthDeclaration.tsx
+++ b/libs/application/templates/driving-license/src/fields/HealthDeclaration.tsx
@@ -4,6 +4,8 @@ import { Box, Text } from '@island.is/island-ui/core'
 import { getValueViaPath, NO, YES } from '@island.is/application/core'
 import { CustomField, FieldBaseProps } from '@island.is/application/types'
 import { m } from '../lib/messages'
+import { BE } from '../lib/constants'
+import { needsHealthCertificateCondition } from '../lib/utils/formUtils'
 import { useFormContext } from 'react-hook-form'
 
 interface PropTypes extends FieldBaseProps {
@@ -19,6 +21,27 @@ const HealthDeclaration = ({
   const props = field.props as { title?: string; label: string }
 
   const { setValue, getValues } = useFormContext()
+
+  const clearHealthCertificateIfNotNeeded = (value: string) => {
+    if (getValueViaPath(application.answers, 'applicationFor') !== BE) {
+      return
+    }
+
+    // Build answers snapshot with the just-changed value so we don't
+    // read stale form state for the current field
+    const formValues = getValues()
+    const currentAnswers = {
+      ...formValues,
+      healthDeclaration: {
+        ...formValues.healthDeclaration,
+        [field.id.replace('healthDeclaration.', '')]: value,
+      },
+    }
+
+    if (!needsHealthCertificateCondition(YES)(currentAnswers, application.externalData)) {
+      setValue('healthCertificate', undefined)
+    }
+  }
 
   const checkForVisionMismatch = (value: string) => {
     if (
@@ -88,6 +111,7 @@ const HealthDeclaration = ({
           ]}
           onSelect={(value) => {
             checkForVisionMismatch(value)
+            clearHealthCertificateIfNotNeeded(value)
           }}
         />
       </Box>

--- a/libs/application/templates/driving-license/src/fields/HealthDeclaration.tsx
+++ b/libs/application/templates/driving-license/src/fields/HealthDeclaration.tsx
@@ -38,7 +38,12 @@ const HealthDeclaration = ({
       },
     }
 
-    if (!needsHealthCertificateCondition(YES)(currentAnswers, application.externalData)) {
+    if (
+      !needsHealthCertificateCondition(YES)(
+        currentAnswers,
+        application.externalData,
+      )
+    ) {
       setValue('healthCertificate', undefined)
     }
   }

--- a/libs/application/templates/driving-license/src/fields/PaymentPending/index.tsx
+++ b/libs/application/templates/driving-license/src/fields/PaymentPending/index.tsx
@@ -111,9 +111,7 @@ const PollingForPayment: FC<Props> = ({ error, application, refetch }) => {
 
     return (
       <PaymentError
-        title={formatMessage(
-          errorReason?.title ?? m.submitErrorTitle,
-        )}
+        title={formatMessage(errorReason?.title ?? m.submitErrorTitle)}
         errorMessage={formatMessage(
           errorReason?.summary ?? m.submitErrorMessage,
         )}

--- a/libs/application/templates/driving-license/src/fields/PaymentPending/index.tsx
+++ b/libs/application/templates/driving-license/src/fields/PaymentPending/index.tsx
@@ -1,5 +1,8 @@
 import { FC, useEffect } from 'react'
-import { getValueViaPath } from '@island.is/application/core'
+import {
+  getValueViaPath,
+  getErrorReasonIfPresent,
+} from '@island.is/application/core'
 import {
   CustomField,
   DefaultEvents,
@@ -11,6 +14,7 @@ import { useSubmitApplication, usePaymentStatus } from './hooks'
 import { getRedirectUrl, isComingFromRedirect } from './util'
 import { PersonsOnComputers } from '@island.is/application/assets/graphics'
 import { useLocale } from '@island.is/localization'
+import { findProblemInApolloError } from '@island.is/shared/problem'
 
 export interface Props extends FieldBaseProps {
   field: CustomField
@@ -99,10 +103,20 @@ const PollingForPayment: FC<Props> = ({ error, application, refetch }) => {
   }
 
   if (submitError) {
+    const problem = findProblemInApolloError(submitError)
+    const errorReason =
+      problem && 'errorReason' in problem
+        ? getErrorReasonIfPresent(problem.errorReason)
+        : null
+
     return (
       <PaymentError
-        title={formatMessage(m.submitErrorTitle)}
-        errorMessage={formatMessage(m.submitErrorMessage)}
+        title={formatMessage(
+          errorReason?.title ?? m.submitErrorTitle,
+        )}
+        errorMessage={formatMessage(
+          errorReason?.summary ?? m.submitErrorMessage,
+        )}
         buttonCaption={formatMessage(m.submitErrorButtonCaption)}
         onClick={() => refetch?.()}
       />

--- a/libs/application/templates/driving-license/src/forms/done.ts
+++ b/libs/application/templates/driving-license/src/forms/done.ts
@@ -21,6 +21,10 @@ export const done: Form = buildForm({
           ? m.applicationDoneAlertMessage65Renewal
           : m.applicationDoneAlertMessageBFull,
       expandableHeader: m.nextStepsTitle,
+      expandableIntro: ({ answers }) =>
+        answers.applicationFor === BE
+          ? m.nextStepsIntroBE
+          : m.nextStepsIntroDefault,
       expandableDescription: ({ answers, externalData }) =>
         answers.applicationFor === B_TEMP
           ? m.nextStepsDescription

--- a/libs/application/templates/driving-license/src/forms/draft/subSectionQualityPhotoBE.ts
+++ b/libs/application/templates/driving-license/src/forms/draft/subSectionQualityPhotoBE.ts
@@ -37,18 +37,6 @@ export const subSectionQualityPhotoBE = buildSubSection({
           defaultValue: (application: Application) => {
             const { externalData } = application
 
-            const photoAndSig = getValueViaPath<{
-              imageTypeId?: number | null
-              pohto?: string | null
-            }>(externalData, 'qualityPhotoAndSignature.data')
-
-            if (
-              photoAndSig?.pohto &&
-              QUALITY_IMAGE_TYPE_IDS.includes(photoAndSig?.imageTypeId ?? 0)
-            ) {
-              return 'qualityPhoto'
-            }
-
             const thjodskraPhotos =
               getValueViaPath<ThjodskraImage[]>(
                 externalData,
@@ -61,6 +49,18 @@ export const subSectionQualityPhotoBE = buildSubSection({
 
             if (facialPhotos.length > 0) {
               return facialPhotos[0].biometricId
+            }
+
+            const photoAndSig = getValueViaPath<{
+              imageTypeId?: number | null
+              pohto?: string | null
+            }>(externalData, 'qualityPhotoAndSignature.data')
+
+            if (
+              photoAndSig?.pohto &&
+              QUALITY_IMAGE_TYPE_IDS.includes(photoAndSig?.imageTypeId ?? 0)
+            ) {
+              return 'qualityPhoto'
             }
 
             return undefined

--- a/libs/application/templates/driving-license/src/lib/messages.ts
+++ b/libs/application/templates/driving-license/src/lib/messages.ts
@@ -573,10 +573,21 @@ export const m = defineMessages({
       'Næst þarf umsækjandi að mæta til sýslumanns. \n[Stafræn ökunámsbók - starfsreglur](https://island.is/stafraen-oekunamsbok/upplysingar-um-personuvernd)',
     description: '',
   },
+  nextStepsIntroDefault: {
+    id: 'dl.application:nextStepsIntroDefault',
+    defaultMessage: 'Umsókn þín hefur verið móttekin og verður skoðuð.',
+    description: '',
+  },
+  nextStepsIntroBE: {
+    id: 'dl.application:nextStepsIntroBE',
+    defaultMessage:
+      'Umsókn þín verður nú yfirfarin, þegar því er lokið er stafræn ökunámsbók virkjuð.',
+    description: '',
+  },
   nextStepsDescriptionBE: {
     id: 'dl.application:nextStepsDescriptionBE#markdown',
     defaultMessage:
-      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. \n[Stafræn ökunámsbók - starfsreglur](https://island.is/stafraen-oekunamsbok/upplysingar-um-personuvernd)',
+      'Þegar ökunámi og prófi er lokið, pöntum við nýtt ökuskírteini sem við afhendum eftir afhendingamáta sem þú valdir í umsókninni. \n[Stafræn ökunámsbók - starfsreglur](https://island.is/stafraen-oekunamsbok/upplysingar-um-personuvernd)',
     description: '',
   },
   nextStepsDescription65Renewal: {

--- a/libs/application/templates/driving-license/src/lib/messages.ts
+++ b/libs/application/templates/driving-license/src/lib/messages.ts
@@ -719,6 +719,13 @@ export const m = defineMessages({
     description:
       'Text that shows up when an error occurs while submitting the application',
   },
+  instructorDoesNotHaveBECategory: {
+    id: 'dl.application:instructorDoesNotHaveBECategory',
+    defaultMessage:
+      'Ökukennari er ekki með BE réttindi á ökuskírteini sínu. Vinsamlegast veldu annan ökukennara.',
+    description:
+      'Error message when selected driving instructor does not have BE category on their license',
+  },
   informationTitle: {
     id: 'dl.application:informationTitle',
     defaultMessage: 'Upplýsingar',

--- a/libs/application/ui-components/src/components/PaymentPending/PaymentPending.tsx
+++ b/libs/application/ui-components/src/components/PaymentPending/PaymentPending.tsx
@@ -1,5 +1,9 @@
 import React, { FC, useEffect, useRef } from 'react'
-import { coreErrorMessages, coreMessages } from '@island.is/application/core'
+import {
+  coreErrorMessages,
+  coreMessages,
+  getErrorReasonIfPresent,
+} from '@island.is/application/core'
 import {
   Application,
   DefaultEvents,
@@ -15,6 +19,7 @@ import {
 import { useSubmitApplication, usePaymentStatus, useMsg } from './hooks'
 import { getRedirectStatus, isComingFromRedirect } from './util'
 import { useSearchParams } from 'react-router-dom'
+import { findProblemInApolloError } from '@island.is/shared/problem'
 
 export interface PaymentPendingProps {
   application: Application
@@ -87,6 +92,24 @@ export const PaymentPending: FC<
   }
 
   if (submitError) {
+    const problem = findProblemInApolloError(submitError)
+    const errorReason =
+      problem && 'errorReason' in problem
+        ? getErrorReasonIfPresent(problem.errorReason)
+        : null
+
+    const errorTitle = errorReason?.title
+      ? typeof errorReason.title === 'string'
+        ? errorReason.title
+        : msg(errorReason.title)
+      : msg(coreErrorMessages.paymentSubmitFailed)
+
+    const errorMessage = errorReason?.summary
+      ? typeof errorReason.summary === 'string'
+        ? errorReason.summary
+        : msg(errorReason.summary)
+      : msg(coreErrorMessages.paymentSubmitFailedDescription)
+
     return (
       <Box>
         <Box
@@ -101,8 +124,8 @@ export const PaymentPending: FC<
         >
           <AlertMessage
             type="error"
-            title={msg(coreErrorMessages.paymentSubmitFailed)}
-            message={msg(coreErrorMessages.paymentSubmitFailedDescription)}
+            title={errorTitle}
+            message={errorMessage}
           />
         </Box>
         <Box display="flex" justifyContent="spaceBetween" marginTop={2}>

--- a/libs/application/ui-components/src/components/PaymentPending/PaymentPending.tsx
+++ b/libs/application/ui-components/src/components/PaymentPending/PaymentPending.tsx
@@ -1,9 +1,5 @@
 import React, { FC, useEffect, useRef } from 'react'
-import {
-  coreErrorMessages,
-  coreMessages,
-  isProviderErrorReason,
-} from '@island.is/application/core'
+import { coreErrorMessages, coreMessages } from '@island.is/application/core'
 import {
   Application,
   DefaultEvents,
@@ -19,7 +15,6 @@ import {
 import { useSubmitApplication, usePaymentStatus, useMsg } from './hooks'
 import { getRedirectStatus, isComingFromRedirect } from './util'
 import { useSearchParams } from 'react-router-dom'
-import { findProblemInApolloError } from '@island.is/shared/problem'
 
 export interface PaymentPendingProps {
   application: Application
@@ -92,26 +87,6 @@ export const PaymentPending: FC<
   }
 
   if (submitError) {
-    const problem = findProblemInApolloError(submitError)
-    const errorReason =
-      problem &&
-      'errorReason' in problem &&
-      isProviderErrorReason(problem.errorReason)
-        ? problem.errorReason
-        : null
-
-    const errorTitle = errorReason
-      ? typeof errorReason.title === 'string'
-        ? errorReason.title
-        : msg(errorReason.title)
-      : msg(coreErrorMessages.paymentSubmitFailed)
-
-    const errorMessage = errorReason
-      ? typeof errorReason.summary === 'string'
-        ? errorReason.summary
-        : msg(errorReason.summary)
-      : msg(coreErrorMessages.paymentSubmitFailedDescription)
-
     return (
       <Box>
         <Box
@@ -126,8 +101,8 @@ export const PaymentPending: FC<
         >
           <AlertMessage
             type="error"
-            title={errorTitle}
-            message={errorMessage}
+            title={msg(coreErrorMessages.paymentSubmitFailed)}
+            message={msg(coreErrorMessages.paymentSubmitFailedDescription)}
           />
         </Box>
         <Box display="flex" justifyContent="spaceBetween" marginTop={2}>

--- a/libs/application/ui-components/src/components/PaymentPending/PaymentPending.tsx
+++ b/libs/application/ui-components/src/components/PaymentPending/PaymentPending.tsx
@@ -2,7 +2,7 @@ import React, { FC, useEffect, useRef } from 'react'
 import {
   coreErrorMessages,
   coreMessages,
-  getErrorReasonIfPresent,
+  isProviderErrorReason,
 } from '@island.is/application/core'
 import {
   Application,
@@ -94,17 +94,19 @@ export const PaymentPending: FC<
   if (submitError) {
     const problem = findProblemInApolloError(submitError)
     const errorReason =
-      problem && 'errorReason' in problem
-        ? getErrorReasonIfPresent(problem.errorReason)
+      problem &&
+      'errorReason' in problem &&
+      isProviderErrorReason(problem.errorReason)
+        ? problem.errorReason
         : null
 
-    const errorTitle = errorReason?.title
+    const errorTitle = errorReason
       ? typeof errorReason.title === 'string'
         ? errorReason.title
         : msg(errorReason.title)
       : msg(coreErrorMessages.paymentSubmitFailed)
 
-    const errorMessage = errorReason?.summary
+    const errorMessage = errorReason
       ? typeof errorReason.summary === 'string'
         ? errorReason.summary
         : msg(errorReason.summary)


### PR DESCRIPTION
When a BE applicant answers "yes" to a health question, the file upload field initializes healthCertificate as []. If they change back to "no", the field hides but the empty array remains, failing the schema's .refine(files => files.length > 0) validation and blocking progress.

Reset healthCertificate to undefined when needsHealthCertificateCondition is no longer met (covers health questions, remarks, and glasses check).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Health certificate field now automatically clears when a health-declaration choice makes it unnecessary.

* **Bug Fixes**
  * Submission now surfaces a clear, localized error instructing the applicant to choose another instructor if the selected instructor lacks BE entitlement.
  * Payment flow error pages now prefer specific provider error titles and summaries when available for clearer troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->