### PR TITLE
feat(payments): add invoice-specific redirect URL support

### DIFF
--- a/apps/payments/graphql/queries.graphql.ts
+++ b/apps/payments/graphql/queries.graphql.ts
@@ -30,6 +30,8 @@ export const GetPaymentFlow = gql`
       returnUrl
       cancelUrl
       redirectToReturnUrlOnSuccess
+      invoiceReturnUrl
+      redirectOnInvoiceCreation
       updatedAt
     }
   }

--- a/apps/payments/hooks/usePaymentOrchestration.ts
+++ b/apps/payments/hooks/usePaymentOrchestration.ts
@@ -36,9 +36,15 @@ export const usePaymentOrchestration = ({
 
   const commonOnPaymentSuccess = useCallback(
     (paymentMethod: 'card' | 'invoice') => {
-      // For invoice payments, always reload to show the "invoice created" screen
       if (paymentMethod === 'invoice') {
-        router.reload()
+        if (
+          paymentFlow?.redirectOnInvoiceCreation &&
+          paymentFlow?.invoiceReturnUrl
+        ) {
+          window.location.assign(paymentFlow.invoiceReturnUrl)
+        } else {
+          router.reload()
+        }
         return
       }
 

--- a/apps/payments/pages/[locale]/[paymentFlowId]/index.tsx
+++ b/apps/payments/pages/[locale]/[paymentFlowId]/index.tsx
@@ -301,7 +301,15 @@ function PaymentPage({
               />
 
               <Box marginTop={4} width="full">
-                <LinkV2 href={paymentFlow.returnUrl ?? 'https://island.is'}>
+                <LinkV2
+                  href={
+                    isInvoicePending
+                      ? (paymentFlow.invoiceReturnUrl ??
+                        paymentFlow.returnUrl ??
+                        'https://island.is')
+                      : (paymentFlow.returnUrl ?? 'https://island.is')
+                  }
+                >
                   <Button fluid unfocusable>
                     {formatMessage(generic.buttonFinishAndReturn)}
                   </Button>

--- a/apps/payments/pages/[locale]/[paymentFlowId]/index.tsx
+++ b/apps/payments/pages/[locale]/[paymentFlowId]/index.tsx
@@ -304,10 +304,10 @@ function PaymentPage({
                 <LinkV2
                   href={
                     isInvoicePending
-                      ? (paymentFlow.invoiceReturnUrl ??
+                      ? paymentFlow.invoiceReturnUrl ??
                         paymentFlow.returnUrl ??
-                        'https://island.is')
-                      : (paymentFlow.returnUrl ?? 'https://island.is')
+                        'https://island.is'
+                      : paymentFlow.returnUrl ?? 'https://island.is'
                   }
                 >
                   <Button fluid unfocusable>

--- a/apps/services/payments/migrations/20260409000000-add-invoice-redirect-fields.js
+++ b/apps/services/payments/migrations/20260409000000-add-invoice-redirect-fields.js
@@ -1,0 +1,41 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.addColumn(
+        'payment_flow',
+        'invoice_return_url',
+        {
+          type: Sequelize.STRING,
+          allowNull: true,
+        },
+        { transaction: t },
+      )
+
+      await queryInterface.addColumn(
+        'payment_flow',
+        'redirect_on_invoice_creation',
+        {
+          type: Sequelize.BOOLEAN,
+          allowNull: true,
+        },
+        { transaction: t },
+      )
+    })
+  },
+
+  down: async (queryInterface) => {
+    return queryInterface.sequelize.transaction(async (t) => {
+      await queryInterface.removeColumn('payment_flow', 'invoice_return_url', {
+        transaction: t,
+      })
+
+      await queryInterface.removeColumn(
+        'payment_flow',
+        'redirect_on_invoice_creation',
+        { transaction: t },
+      )
+    })
+  },
+}

--- a/apps/services/payments/src/app/paymentFlow/dtos/createPaymentFlow.input.ts
+++ b/apps/services/payments/src/app/paymentFlow/dtos/createPaymentFlow.input.ts
@@ -47,6 +47,29 @@ const ReturnUrlRequired = (validationOptions?: ValidationOptions) => {
   }
 }
 
+const InvoiceReturnUrlRequired = (validationOptions?: ValidationOptions) => {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'invoiceReturnUrlRequired',
+      target: (object as { constructor: NewableFunction }).constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: unknown, args: ValidationArguments) {
+          const obj = args.object as { invoiceReturnUrl?: string }
+          if (value && !obj.invoiceReturnUrl) {
+            return false
+          }
+          return true
+        },
+        defaultMessage(args: ValidationArguments) {
+          return `${args.property} can only have a value if invoiceReturnUrl is also provided.`
+        },
+      },
+    })
+  }
+}
+
 export class ExtraDataItem {
   @IsString()
   @ApiProperty({
@@ -213,6 +236,23 @@ export class CreatePaymentFlowInput {
   })
   @ReturnUrlRequired() // See validator above
   redirectToReturnUrlOnSuccess?: boolean
+
+  @ApiPropertyOptional({
+    description: 'The url to redirect to when an invoice is created',
+  })
+  @IsOptional()
+  @IsUrl({ require_tld: isRunningOnEnvironment('production') })
+  invoiceReturnUrl?: string
+
+  @IsBoolean()
+  @IsOptional()
+  @ApiPropertyOptional({
+    description:
+      'If true the user will be redirected to the invoiceReturnUrl after an invoice has been created',
+    type: Boolean,
+  })
+  @InvoiceReturnUrlRequired()
+  redirectOnInvoiceCreation?: boolean
 
   @ApiPropertyOptional({
     description:

--- a/apps/services/payments/src/app/paymentFlow/dtos/getPaymentFlow.dto.ts
+++ b/apps/services/payments/src/app/paymentFlow/dtos/getPaymentFlow.dto.ts
@@ -182,6 +182,19 @@ export class GetPaymentFlowDTO {
   redirectToReturnUrlOnSuccess?: boolean
 
   @ApiPropertyOptional({
+    description: 'The URL to redirect the user to after an invoice is created',
+    type: String,
+  })
+  invoiceReturnUrl?: string
+
+  @ApiPropertyOptional({
+    description:
+      'If user should be redirected to the invoiceReturnUrl after an invoice has been created',
+    type: Boolean,
+  })
+  redirectOnInvoiceCreation?: boolean
+
+  @ApiPropertyOptional({
     description: 'Events associated with the payment flow',
     type: [PaymentFlowEventDTO],
   })

--- a/apps/services/payments/src/app/paymentFlow/models/paymentFlow.model.ts
+++ b/apps/services/payments/src/app/paymentFlow/models/paymentFlow.model.ts
@@ -220,6 +220,22 @@ export class PaymentFlow extends Model<
   })
   redirectToReturnUrlOnSuccess?: boolean
 
+  @ApiPropertyOptional()
+  @Column({
+    type: DataType.STRING,
+    allowNull: true,
+    field: 'invoice_return_url',
+  })
+  invoiceReturnUrl?: string
+
+  @ApiPropertyOptional()
+  @Column({
+    type: DataType.BOOLEAN,
+    allowNull: true,
+    field: 'redirect_on_invoice_creation',
+  })
+  redirectOnInvoiceCreation?: boolean
+
   @ApiPropertyOptional({
     description:
       'Define key-value pairs of extra data, e.g., car license plate, house address, etc.',

--- a/libs/api/domains/payments/src/lib/dto/createPaymentFlow.input.ts
+++ b/libs/api/domains/payments/src/lib/dto/createPaymentFlow.input.ts
@@ -145,6 +145,23 @@ export class CreatePaymentFlowInput {
   @IsOptional()
   redirectToReturnUrlOnSuccess?: boolean
 
+  @Field(() => String, {
+    nullable: true,
+    description: 'URL to redirect the user to after an invoice is created',
+  })
+  @IsString()
+  @IsOptional()
+  invoiceReturnUrl?: string
+
+  @Field(() => Boolean, {
+    nullable: true,
+    description:
+      'If true the user will be redirected to the invoiceReturnUrl after an invoice has been created',
+  })
+  @IsBoolean()
+  @IsOptional()
+  redirectOnInvoiceCreation?: boolean
+
   @Field(() => [ExtraDataItem], {
     nullable: true,
     description:

--- a/libs/api/domains/payments/src/lib/dto/getPaymentFlow.response.ts
+++ b/libs/api/domains/payments/src/lib/dto/getPaymentFlow.response.ts
@@ -52,6 +52,12 @@ export class GetPaymentFlowResponse {
   @Field(() => Boolean, { nullable: true })
   redirectToReturnUrlOnSuccess?: boolean
 
+  @Field(() => String, { nullable: true })
+  invoiceReturnUrl?: string
+
+  @Field(() => Boolean, { nullable: true })
+  redirectOnInvoiceCreation?: boolean
+
   @Field(() => Date)
   updatedAt!: Date
 }


### PR DESCRIPTION
## What

Adds two new optional fields to the payment flow: `invoiceReturnUrl` and `redirectOnInvoiceCreation`.

When a calling system creates a payment flow, it can now configure a separate redirect URL for when the user chooses to pay by invoice instead of card. If `invoiceReturnUrl` is set, the "Finish" button on the invoice success screen links to that URL instead of the general `returnUrl`. If `redirectOnInvoiceCreation` is also set to true, the success screen is skipped entirely and the user is redirected immediately, matching the existing behavior of `redirectToReturnUrlOnSuccess` for card payments.

## Why

For better UX when creating invoices

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added invoiceReturnUrl to configure custom redirect destinations after invoice creation.
  * Added redirectOnInvoiceCreation flag to control automatic redirect behavior after invoice generation.
  * Payment completion pages now prefer invoice-specific redirects for invoice_pending status, with fallbacks to standard return URLs.
  * Invoice payments can trigger an immediate browser redirect when enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->