### PR TITLE
fix(cms-importer): Retry contentful api calls on 429

### DIFF
--- a/apps/services/cms-importer/infra/cms-importer-worker.ts
+++ b/apps/services/cms-importer/infra/cms-importer-worker.ts
@@ -84,5 +84,5 @@ export const webSitemapImportSetup =
       .extraAttributes({
         dev: { schedule: '0 0 * * *' },
         staging: { schedule: '0 0 * * 0' },
-        prod: { schedule: '0 */2 * * *' },
+        prod: { schedule: '0 */3 * * *' },
       })

--- a/apps/services/cms-importer/infra/cms-importer-worker.ts
+++ b/apps/services/cms-importer/infra/cms-importer-worker.ts
@@ -82,7 +82,7 @@ export const webSitemapImportSetup =
       .command('node')
       .args('main.cjs', '--job', 'web-sitemap')
       .extraAttributes({
-        dev: { schedule: '0 * * * *' },
-        staging: { schedule: '0 * * * *' },
-        prod: { schedule: '0 * * * *' },
+        dev: { schedule: '0 0 * * *' },
+        staging: { schedule: '0 0 * * 0' },
+        prod: { schedule: '0 */2 * * *' },
       })

--- a/apps/services/cms-importer/src/app/repositories/web-sitemap/content-types/article.repository.ts
+++ b/apps/services/cms-importer/src/app/repositories/web-sitemap/content-types/article.repository.ts
@@ -54,7 +54,7 @@ export class ArticleRepository implements SitemapUrlFetcher {
       .filter((url) => url !== null)
 
     while (subArticleIds.length > 0) {
-      const ids = subArticleIds.splice(0, 10)
+      const ids = subArticleIds.splice(0, 15)
       const subArticleResponse = await this.managementClient.getEntries({
         content_type: 'subArticle',
         select: 'sys,fields.url,fields.title',

--- a/apps/services/cms-importer/src/app/repositories/web-sitemap/content-types/manual.repository.ts
+++ b/apps/services/cms-importer/src/app/repositories/web-sitemap/content-types/manual.repository.ts
@@ -34,7 +34,7 @@ export class ManualRepository implements SitemapUrlFetcher {
       }
     >()
     while (manualChapterIds.length > 0) {
-      const ids = manualChapterIds.splice(0, 10)
+      const ids = manualChapterIds.splice(0, 15)
       const manualChapterResponse = await this.managementClient.getEntries({
         content_type: 'manualChapter',
         select: 'fields.slug,fields.title,sys',

--- a/apps/services/cms-importer/src/app/repositories/web-sitemap/content-types/organization-parent-subpage.repository.ts
+++ b/apps/services/cms-importer/src/app/repositories/web-sitemap/content-types/organization-parent-subpage.repository.ts
@@ -57,7 +57,7 @@ export class OrganizationParentSubpageRepository implements SitemapUrlFetcher {
     >()
 
     while (organizationPageIds.length > 0) {
-      const ids = organizationPageIds.splice(0, 10)
+      const ids = organizationPageIds.splice(0, 15)
       const organizationPageResponse = await this.managementClient.getEntries({
         content_type: 'organizationPage',
         select: 'fields.slug,fields.title,sys',
@@ -74,7 +74,7 @@ export class OrganizationParentSubpageRepository implements SitemapUrlFetcher {
     }
 
     while (organizationSubpageIds.length > 0) {
-      const ids = organizationSubpageIds.splice(0, 10)
+      const ids = organizationSubpageIds.splice(0, 15)
       const organizationSubpageResponse =
         await this.managementClient.getEntries({
           content_type: 'organizationSubpage',

--- a/apps/services/cms-importer/src/app/repositories/web-sitemap/content-types/organization-subpage.repository.ts
+++ b/apps/services/cms-importer/src/app/repositories/web-sitemap/content-types/organization-subpage.repository.ts
@@ -42,7 +42,7 @@ export class OrganizationSubpageRepository implements SitemapUrlFetcher {
     >()
 
     while (organizationPageIds.length > 0) {
-      const ids = organizationPageIds.splice(0, 10)
+      const ids = organizationPageIds.splice(0, 15)
       const organizationPageResponse = await this.managementClient.getEntries({
         content_type: 'organizationPage',
         select: 'fields.slug,fields.title,sys',

--- a/apps/services/cms-importer/src/app/repositories/web-sitemap/content-types/project-page.repository.ts
+++ b/apps/services/cms-importer/src/app/repositories/web-sitemap/content-types/project-page.repository.ts
@@ -36,7 +36,7 @@ export class ProjectPageRepository implements SitemapUrlFetcher {
     >()
 
     while (projectSubpageIds.length > 0) {
-      const ids = projectSubpageIds.splice(0, 10)
+      const ids = projectSubpageIds.splice(0, 15)
       const projectSubpageResponse = await this.managementClient.getEntries({
         content_type: 'projectSubpage',
         select: 'fields.slug,fields.title,sys',

--- a/apps/services/cms-importer/src/app/web-sitemap/web-sitemap.service.ts
+++ b/apps/services/cms-importer/src/app/web-sitemap/web-sitemap.service.ts
@@ -105,7 +105,11 @@ export class WebSitemapService {
       } catch (error) {
         if (
           !this.isRateLimitError(
-            error as { code?: number; status?: number; response?: { status?: number } },
+            error as {
+              code?: number
+              status?: number
+              response?: { status?: number }
+            },
           ) ||
           attempt === WebSitemapService.MAX_RETRIES
         )

--- a/apps/services/cms-importer/src/app/web-sitemap/web-sitemap.service.ts
+++ b/apps/services/cms-importer/src/app/web-sitemap/web-sitemap.service.ts
@@ -79,8 +79,14 @@ export class WebSitemapService {
     )
   }
 
-  private isRateLimitError = (error: { code?: number; status?: number }) =>
-    error?.code === 429 || error?.status === 429
+  private isRateLimitError = (error: {
+    code?: number
+    status?: number
+    response?: { status?: number }
+  }) =>
+    error?.code === 429 ||
+    error?.status === 429 ||
+    error?.response?.status === 429
 
   private wait = (ms: number) =>
     new Promise((resolve) => setTimeout(resolve, ms))
@@ -98,7 +104,9 @@ export class WebSitemapService {
         return result
       } catch (error) {
         if (
-          !this.isRateLimitError(error as { code?: number; status?: number }) ||
+          !this.isRateLimitError(
+            error as { code?: number; status?: number; response?: { status?: number } },
+          ) ||
           attempt === WebSitemapService.MAX_RETRIES
         )
           throw error

--- a/apps/services/cms-importer/src/app/web-sitemap/web-sitemap.service.ts
+++ b/apps/services/cms-importer/src/app/web-sitemap/web-sitemap.service.ts
@@ -104,13 +104,7 @@ export class WebSitemapService {
         return result
       } catch (error) {
         if (
-          !this.isRateLimitError(
-            error as {
-              code?: number
-              status?: number
-              response?: { status?: number }
-            },
-          ) ||
+          !this.isRateLimitError(error) ||
           attempt === WebSitemapService.MAX_RETRIES
         )
           throw error
@@ -162,6 +156,7 @@ export class WebSitemapService {
         pageIndex = response.nextPageIndex
         urls.push(...response.urls)
         if (urls.length >= maxUrlsPerFile) await flushSitemapUrlsToFile()
+        await this.wait(100)
       }
     }
 

--- a/apps/services/cms-importer/src/app/web-sitemap/web-sitemap.service.ts
+++ b/apps/services/cms-importer/src/app/web-sitemap/web-sitemap.service.ts
@@ -115,7 +115,7 @@ export class WebSitemapService {
           maxRetries: WebSitemapService.MAX_RETRIES,
           retryDelayMs: WebSitemapService.RETRY_DELAY_MS,
         })
-        await this.wait(WebSitemapService.RETRY_DELAY_MS)
+        await this.wait(WebSitemapService.RETRY_DELAY_MS * attempt)
       }
     }
 

--- a/apps/services/cms-importer/src/app/web-sitemap/web-sitemap.service.ts
+++ b/apps/services/cms-importer/src/app/web-sitemap/web-sitemap.service.ts
@@ -25,6 +25,8 @@ import { SupportCategoryRepository } from '../repositories/web-sitemap/content-t
 
 @Injectable()
 export class WebSitemapService {
+  private static readonly RETRY_DELAY_MS = 3000
+  private static readonly MAX_RETRIES = 3
   private readonly fetchers: SitemapUrlFetcher[]
 
   constructor(
@@ -77,6 +79,43 @@ export class WebSitemapService {
     )
   }
 
+  private isRateLimitError = (error: { code?: number; status?: number }) =>
+    error?.code === 429 || error?.status === 429
+
+  private wait = (ms: number) =>
+    new Promise((resolve) => setTimeout(resolve, ms))
+
+  private fetchSitemapUrlsWithRetry = async (
+    fetcher: SitemapUrlFetcher,
+    itemsPerPage: number,
+    pageIndex: number,
+  ): Promise<{ urls: SitemapUrl[]; nextPageIndex: number }> => {
+    let attempt = 0
+
+    while (attempt <= WebSitemapService.MAX_RETRIES) {
+      try {
+        const result = await fetcher.getSitemapUrls(itemsPerPage, pageIndex)
+        return result
+      } catch (error) {
+        if (
+          !this.isRateLimitError(error as { code?: number; status?: number }) ||
+          attempt === WebSitemapService.MAX_RETRIES
+        )
+          throw error
+
+        attempt += 1
+        this.logger.warn('Rate limited by Contentful, retrying sitemap fetch', {
+          attempt,
+          maxRetries: WebSitemapService.MAX_RETRIES,
+          retryDelayMs: WebSitemapService.RETRY_DELAY_MS,
+        })
+        await this.wait(WebSitemapService.RETRY_DELAY_MS)
+      }
+    }
+
+    return fetcher.getSitemapUrls(itemsPerPage, pageIndex)
+  }
+
   public async run() {
     this.logger.info('Web sitemap worker starting...')
 
@@ -103,7 +142,11 @@ export class WebSitemapService {
     for (const fetcher of this.fetchers) {
       let pageIndex = 0
       while (pageIndex >= 0) {
-        const response = await fetcher.getSitemapUrls(itemsPerPage, pageIndex)
+        const response = await this.fetchSitemapUrlsWithRetry(
+          fetcher,
+          itemsPerPage,
+          pageIndex,
+        )
         pageIndex = response.nextPageIndex
         urls.push(...response.urls)
         if (urls.length >= maxUrlsPerFile) await flushSitemapUrlsToFile()

--- a/charts/islandis-services/cms-importer-web-sitemap/values.dev.yaml
+++ b/charts/islandis-services/cms-importer-web-sitemap/values.dev.yaml
@@ -68,7 +68,7 @@ resources:
   requests:
     cpu: '100m'
     memory: '128Mi'
-schedule: '0 * * * *'
+schedule: '0 0 * * *'
 secrets:
   CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
   CONTENTFUL_MANAGEMENT_ACCESS_TOKEN: '/k8s/contentful-entry-tagger/CONTENTFUL_MANAGEMENT_ACCESS_TOKEN'

--- a/charts/islandis-services/cms-importer-web-sitemap/values.prod.yaml
+++ b/charts/islandis-services/cms-importer-web-sitemap/values.prod.yaml
@@ -68,7 +68,7 @@ resources:
   requests:
     cpu: '100m'
     memory: '128Mi'
-schedule: '0 * * * *'
+schedule: '0 */3 * * *'
 secrets:
   CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
   CONTENTFUL_MANAGEMENT_ACCESS_TOKEN: '/k8s/contentful-entry-tagger/CONTENTFUL_MANAGEMENT_ACCESS_TOKEN'

--- a/charts/islandis-services/cms-importer-web-sitemap/values.staging.yaml
+++ b/charts/islandis-services/cms-importer-web-sitemap/values.staging.yaml
@@ -68,7 +68,7 @@ resources:
   requests:
     cpu: '100m'
     memory: '128Mi'
-schedule: '0 * * * *'
+schedule: '0 0 * * 0'
 secrets:
   CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
   CONTENTFUL_MANAGEMENT_ACCESS_TOKEN: '/k8s/contentful-entry-tagger/CONTENTFUL_MANAGEMENT_ACCESS_TOKEN'

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -1355,7 +1355,7 @@ cms-importer-web-sitemap:
     requests:
       cpu: '100m'
       memory: '128Mi'
-  schedule: '0 * * * *'
+  schedule: '0 0 * * *'
   secrets:
     CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
     CONTENTFUL_MANAGEMENT_ACCESS_TOKEN: '/k8s/contentful-entry-tagger/CONTENTFUL_MANAGEMENT_ACCESS_TOKEN'

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -1343,7 +1343,7 @@ cms-importer-web-sitemap:
     requests:
       cpu: '100m'
       memory: '128Mi'
-  schedule: '0 * * * *'
+  schedule: '0 */3 * * *'
   secrets:
     CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
     CONTENTFUL_MANAGEMENT_ACCESS_TOKEN: '/k8s/contentful-entry-tagger/CONTENTFUL_MANAGEMENT_ACCESS_TOKEN'

--- a/charts/islandis/values.staging.yaml
+++ b/charts/islandis/values.staging.yaml
@@ -1350,7 +1350,7 @@ cms-importer-web-sitemap:
     requests:
       cpu: '100m'
       memory: '128Mi'
-  schedule: '0 * * * *'
+  schedule: '0 0 * * 0'
   secrets:
     CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
     CONTENTFUL_MANAGEMENT_ACCESS_TOKEN: '/k8s/contentful-entry-tagger/CONTENTFUL_MANAGEMENT_ACCESS_TOKEN'


### PR DESCRIPTION
# Retry contentful api calls on 429

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added automatic retry for HTTP 429 (rate-limited) responses with delay and capped retries.

* **Performance**
  * Increased content-fetch batch size (from 10 to 15 items per request) to reduce fetch calls and improve throughput.

* **Chores**
  * Updated sitemap import schedules: dev → daily at midnight, staging → Sundays at midnight, prod → every 2 hours.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->