### PR TITLE
fix(j-s): fix async error handling in court robot email methods

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/court/court.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/court/court.service.ts
@@ -437,7 +437,7 @@ export class CourtService {
       })
   }
 
-  updateCaseWithConclusion(
+  async updateCaseWithConclusion(
     user: User,
     caseId: string,
     courtName?: string,
@@ -459,7 +459,7 @@ export class CourtService {
         isolationToDate,
       })
 
-      return this.sendToRobot(
+      return await this.sendToRobot(
         subject,
         content,
         RobotEmailType.CASE_CONCLUSION,
@@ -487,7 +487,7 @@ export class CourtService {
     }
   }
 
-  updateIndictmentCaseWithIndictmentInfo(
+  async updateIndictmentCaseWithIndictmentInfo(
     user: User,
     caseId: string,
     courtName?: string,
@@ -513,7 +513,7 @@ export class CourtService {
         prosecutor,
       })
 
-      return this.sendToRobot(
+      return await this.sendToRobot(
         subject,
         content,
         RobotEmailType.NEW_INDICTMENT_INFO,
@@ -538,7 +538,7 @@ export class CourtService {
     }
   }
 
-  updateIndictmentCaseWithDefenderInfo(
+  async updateIndictmentCaseWithDefenderInfo(
     user: User,
     caseId: string,
     courtName?: string,
@@ -555,7 +555,7 @@ export class CourtService {
         defenderEmail,
       })
 
-      return this.sendToRobot(
+      return await this.sendToRobot(
         subject,
         content,
         RobotEmailType.INDICTMENT_CASE_DEFENDER_INFO,
@@ -577,7 +577,7 @@ export class CourtService {
     }
   }
 
-  updateIndictmentCaseWithAssignedRoles(
+  async updateIndictmentCaseWithAssignedRoles(
     user: User,
     caseId: string,
     courtName?: string,
@@ -588,7 +588,7 @@ export class CourtService {
       const subject = `${courtName} - ${courtCaseNumber} - úthlutun`
       const content = JSON.stringify(assignedRole)
 
-      return this.sendToRobot(
+      return await this.sendToRobot(
         subject,
         content,
         RobotEmailType.INDICTMENT_CASE_ASSIGNED_ROLES,
@@ -609,7 +609,7 @@ export class CourtService {
     }
   }
 
-  updateIndictmentCaseWithArraignmentDate(
+  async updateIndictmentCaseWithArraignmentDate(
     user: User,
     caseId: string,
     courtName?: string,
@@ -620,7 +620,7 @@ export class CourtService {
       const subject = `${courtName} - ${courtCaseNumber} - þingfesting`
       const content = JSON.stringify({ arraignmentDate })
 
-      return this.sendToRobot(
+      return await this.sendToRobot(
         subject,
         content,
         RobotEmailType.INDICTMENT_CASE_ARRAIGNMENT_DATE,
@@ -641,7 +641,7 @@ export class CourtService {
     }
   }
 
-  updateIndictmentCaseWithCancellationNotice(
+  async updateIndictmentCaseWithCancellationNotice(
     user: User,
     caseId: string,
     courtName?: string,
@@ -649,21 +649,36 @@ export class CourtService {
     noticeSubject?: string,
     noticeText?: string,
   ): Promise<unknown> {
-    const subject = `${courtName} - ${courtCaseNumber} - afturköllun`
-    const content = JSON.stringify({
-      subject: noticeSubject,
-      text: noticeText,
-    })
+    try {
+      const subject = `${courtName} - ${courtCaseNumber} - afturköllun`
+      const content = JSON.stringify({
+        subject: noticeSubject,
+        text: noticeText,
+      })
 
-    return this.sendToRobot(
-      subject,
-      content,
-      RobotEmailType.INDICTMENT_CASE_CANCELLATION_NOTICE,
-      caseId,
-    )
+      return await this.sendToRobot(
+        subject,
+        content,
+        RobotEmailType.INDICTMENT_CASE_CANCELLATION_NOTICE,
+        caseId,
+      )
+    } catch (error) {
+      this.eventService.postErrorEvent(
+        'Failed to update indictment case with cancellation notice',
+        {
+          caseId,
+          actor: user.name,
+          institution: user.institution?.name,
+          courtCaseNumber,
+        },
+        error,
+      )
+
+      throw error
+    }
   }
 
-  updateAppealCaseWithReceivedDate(
+  async updateAppealCaseWithReceivedDate(
     user: User,
     caseId: string,
     appealCaseNumber?: string,
@@ -673,7 +688,7 @@ export class CourtService {
       const subject = `Landsréttur - ${appealCaseNumber} - móttaka`
       const content = JSON.stringify({ appealReceivedByCourtDate })
 
-      return this.sendToRobot(
+      return await this.sendToRobot(
         subject,
         content,
         RobotEmailType.APPEAL_CASE_RECEIVED_DATE,
@@ -696,7 +711,7 @@ export class CourtService {
     }
   }
 
-  updateAppealCaseWithAssignedRoles(
+  async updateAppealCaseWithAssignedRoles(
     user: User,
     caseId: string,
     appealCaseNumber?: string,
@@ -722,7 +737,7 @@ export class CourtService {
         appealJudge3Name,
       })
 
-      return this.sendToRobot(
+      return await this.sendToRobot(
         subject,
         content,
         RobotEmailType.APPEAL_CASE_ASSIGNED_ROLES,
@@ -752,7 +767,7 @@ export class CourtService {
     }
   }
 
-  updateAppealCaseWithConclusion(
+  async updateAppealCaseWithConclusion(
     user: User,
     caseId: string,
     appealCaseNumber?: string,
@@ -768,7 +783,7 @@ export class CourtService {
         appealRulingDate,
       })
 
-      return this.sendToRobot(
+      return await this.sendToRobot(
         subject,
         content,
         RobotEmailType.APPEAL_CASE_CONCLUSION,
@@ -793,7 +808,7 @@ export class CourtService {
     }
   }
 
-  updateAppealCaseWithFile(
+  async updateAppealCaseWithFile(
     user: User,
     caseId: string,
     fileId: string,
@@ -812,7 +827,7 @@ export class CourtService {
         url: url && Base64.encode(url),
       })
 
-      return this.sendToRobot(
+      return await this.sendToRobot(
         subject,
         content,
         RobotEmailType.APPEAL_CASE_FILE,


### PR DESCRIPTION
## What

Make all `sendToRobot` caller methods in `CourtService` properly `async` with `return await`, so their existing `try/catch` blocks actually catch rejections. Also adds missing error handling to `updateIndictmentCaseWithCancellationNotice`.

## Why

All 9 methods that wrapped `sendToRobot` in a `try/catch` were not declared `async` and did not `await` the call. Since `sendToRobot` is async, calling it without `await` returns a Promise immediately — it never throws synchronously into the surrounding `try`. This meant the `catch` blocks (and their `postErrorEvent` Slack notifications) were dead code and would never run on `sendToRobot` failures.

`updateIndictmentCaseWithCancellationNotice` had no error handling at all.

## Screenshots / Gifs


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced reliability of court case notification system with more consistent error handling for updates related to case conclusions, indictment information, assigned roles, and hearing dates.
  * Improved error reporting by automatically logging notification failures with detailed case context for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->