### PR TITLE
fix(api): Blood donation restriction keyword search

### DIFF
--- a/libs/cms/src/lib/cms.elasticsearch.service.ts
+++ b/libs/cms/src/lib/cms.elasticsearch.service.ts
@@ -1382,6 +1382,7 @@ export class CmsElasticsearchService {
         },
       },
     ]
+    const should: Record<string, unknown>[] = []
 
     if (!!input.tagKeys && input.tagKeys.length > 0) {
       must.push({
@@ -1415,16 +1416,14 @@ export class CmsElasticsearchService {
       ? input.queryString.replace('´', '').trim().toLowerCase()
       : ''
 
-    must.push({
+    const simpleQuery = {
       simple_query_string: {
         query: queryString + '*',
         fields: ['title^100', 'content'],
         analyze_wildcard: true,
         default_operator: 'and',
       },
-    })
-
-    const size = 10
+    }
 
     let sort = [
       { _score: { order: SortDirection.DESC } },
@@ -1432,14 +1431,33 @@ export class CmsElasticsearchService {
     ]
 
     if (queryString.length === 0) {
+      must.push(simpleQuery)
       sort = [{ 'title.sort': { order: SortDirection.ASC } }]
+    } else {
+      should.push(simpleQuery)
+      should.push({
+        nested: {
+          path: 'tags',
+          query: {
+            bool: {
+              must: [
+                { term: { 'tags.type': 'keyword' } },
+                { match: { 'tags.value': queryString } },
+              ],
+            },
+          },
+        },
+      })
     }
+
+    const size = 10
 
     const response: ApiResponse<SearchResponse<MappedData>> =
       await this.elasticService.findByQuery(index, {
         query: {
           bool: {
             must,
+            ...(should.length > 0 ? { should, minimum_should_match: 1 } : {}),
           },
         },
         sort,

--- a/libs/cms/src/lib/search/importers/bloodDonationRestriction.service.ts
+++ b/libs/cms/src/lib/search/importers/bloodDonationRestriction.service.ts
@@ -76,6 +76,7 @@ export class BloodDonationRestrictionSyncService
             const keywords = mapped.keywordsText
               .split(',')
               .map((keyword) => keyword.trim())
+              .filter(Boolean)
             for (const keyword of keywords)
               tags.push({
                 key: keyword,

--- a/libs/cms/src/lib/search/importers/bloodDonationRestriction.service.ts
+++ b/libs/cms/src/lib/search/importers/bloodDonationRestriction.service.ts
@@ -73,7 +73,15 @@ export class BloodDonationRestrictionSyncService
             contentSections.push(mapped.description)
           }
           if (mapped.keywordsText) {
-            contentSections.push(mapped.keywordsText)
+            const keywords = mapped.keywordsText
+              .split(',')
+              .map((keyword) => keyword.trim())
+            for (const keyword of keywords)
+              tags.push({
+                key: keyword,
+                value: keyword,
+                type: 'keyword',
+              })
           }
           if (entry.fields.cardText) {
             contentSections.push(


### PR DESCRIPTION
# Blood donation restriction keyword search

* Store keywords in elasticsearch tag field
* Boost search by keyword matches

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Improved blood donation restriction search logic for more accurate, relevant results when queries are empty or contain text.
* Fixed keyword handling in blood donation restriction imports so comma-separated keywords are stored as individual searchable tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->