### PR TITLE
feat(web): Remove text highlighting in global search

### DIFF
--- a/apps/web/components/Card/Card.tsx
+++ b/apps/web/components/Card/Card.tsx
@@ -125,7 +125,12 @@ export const Card = ({
                   <span dangerouslySetInnerHTML={{ __html: title }}></span>
                 </Text>
               ) : (
-                <Text as="h3" variant="h3" color={titleColor}>
+                <Text
+                  as="h3"
+                  variant="h3"
+                  color={titleColor}
+                  fontWeight="medium"
+                >
                   <Hyphen>{title}</Hyphen>
                 </Text>
               )}

--- a/apps/web/components/SearchInput/SearchInput.tsx
+++ b/apps/web/components/SearchInput/SearchInput.tsx
@@ -136,7 +136,7 @@ const useSearch = (
                   SearchableContentTypes['WebManual'],
                   SearchableContentTypes['WebOrganizationParentSubpage'],
                 ],
-                highlightResults: true,
+                highlightResults: false,
                 useQuery: 'suggestions',
                 tags: organization
                   ? [{ key: organization, type: SearchableTags.Organization }]
@@ -396,7 +396,7 @@ export const SearchInput = forwardRef<
                     onRouting()
                   }
                 }}
-                highlightedResults={true}
+                highlightedResults={false}
               />
             )}
           </AsyncSearchInput>

--- a/apps/web/screens/Search/Search.tsx
+++ b/apps/web/screens/Search/Search.tsx
@@ -815,7 +815,7 @@ const Search: Screen<CategoryProps> = ({
                         dataTestId="search-result"
                         image={thumbnail ? thumbnail : image}
                         subTitle={parentTitle}
-                        highlightedResults={true}
+                        highlightedResults={false}
                         link={{ href: linkHref }}
                         {...rest}
                       />
@@ -928,7 +928,7 @@ Search.getProps = async ({ apolloClient, locale, query }) => {
           countTypes: true,
           size: PERPAGE,
           page,
-          highlightResults: true,
+          highlightResults: false,
         },
       },
     }),

--- a/libs/cms/src/lib/models/article.model.ts
+++ b/libs/cms/src/lib/models/article.model.ts
@@ -1,5 +1,7 @@
 import graphqlTypeJson from 'graphql-type-json'
 import { Field, ObjectType, ID } from '@nestjs/graphql'
+import { BLOCKS } from '@contentful/rich-text-types'
+import { documentToPlainTextString } from '@contentful/rich-text-plain-text-renderer'
 import { CacheField } from '@island.is/nest/graphql'
 import { SystemMetadata } from '@island.is/shared/types'
 import { IArticle } from '../generated/contentfulTypes'
@@ -103,57 +105,94 @@ export class Article {
   keywords?: string[] | null
 }
 
+const endsWithDot = (str: string) => /\.\.*$/.test(str.trim())
+const shortenText = (text: string, maxLength: number): string => {
+  if (!text || text.length <= maxLength) return text
+
+  const shortenedText = text.slice(0, maxLength)
+
+  if (text[maxLength] === ' ')
+    return endsWithDot(shortenedText) ? shortenedText : `${shortenedText} ...`
+
+  const spaceIndex = shortenedText.lastIndexOf(' ')
+  if (spaceIndex < 0)
+    return endsWithDot(shortenedText) ? shortenedText : `${shortenedText} ...`
+
+  const finalText = text.slice(0, spaceIndex)
+  return endsWithDot(finalText) ? finalText : `${finalText} ...`
+}
+
 export const mapArticle = ({
   fields,
   sys,
-}: IArticle): SystemMetadata<Article> => ({
-  typename: 'Article',
-  id: sys.id,
-  title: fields.title ?? '',
-  shortTitle: fields.shortTitle ?? '',
-  slug: (fields.slug ?? '').trim(),
-  intro: fields.intro ?? '',
-  importance: fields.importance ?? 0,
-  body: fields.content ? mapDocument(fields.content, sys.id + ':body') : [],
-  processEntry: fields.processEntry
-    ? mapProcessEntry(fields.processEntry)
-    : null,
-  category: fields.category ? mapArticleCategory(fields.category) : null,
-  otherCategories: (fields.otherCategories ?? []).map(mapArticleCategory),
-  group: fields.group ? mapArticleGroup(fields.group) : null,
-  otherGroups: (fields.otherGroups ?? []).map(mapArticleGroup),
-  subgroup: fields.subgroup ? mapArticleSubgroup(fields.subgroup) : null,
-  otherSubgroups: (fields.otherSubgroups ?? []).map(mapArticleSubgroup),
-  organization: (fields.organization ?? [])
-    .filter(
-      (organization) => organization.fields?.title && organization.fields?.slug,
+}: IArticle): SystemMetadata<Article> => {
+  let intro = fields.intro ?? ''
+  if (!intro && fields.content) {
+    const firstParagraph = fields.content.content?.find(
+      (node) => node.nodeType === BLOCKS.PARAGRAPH,
     )
-    .map(mapOrganization),
-  relatedOrganization: (fields.relatedOrganization ?? [])
-    .filter(
-      (relatedOrganization) =>
-        relatedOrganization.fields?.title && relatedOrganization.fields?.slug,
-    )
-    .map(mapOrganization),
-  responsibleParty: (fields.responsibleParty ?? [])
-    .filter(
-      (responsibleParty) =>
-        responsibleParty.fields?.title && responsibleParty.fields?.slug,
-    )
-    .map(mapOrganization),
-  subArticles: (fields.subArticles ?? [])
-    .filter((subArticle) => subArticle.fields?.title && subArticle.fields?.url)
-    .map(mapSubArticle),
-  relatedArticles: [], // populated by resolver
-  relatedContent: (fields.relatedContent ?? []).map(mapLink),
-  featuredImage: fields.featuredImage ? mapImage(fields.featuredImage) : null,
-  showTableOfContents: fields.showTableOfContents ?? false,
-  stepper: fields.stepper ? mapStepper(fields.stepper) : null,
-  processEntryButtonText: fields.processEntryButtonText ?? '',
-  alertBanner: fields.alertBanner ? mapAlertBanner(fields.alertBanner) : null,
-  activeTranslations: fields.activeTranslations ?? { en: true },
-  signLanguageVideo: fields.signLanguageVideo
-    ? mapEmbeddedVideo(fields.signLanguageVideo)
-    : null,
-  keywords: fields.keywords ?? [],
-})
+    if (firstParagraph)
+      intro = shortenText(
+        documentToPlainTextString({
+          nodeType: BLOCKS.DOCUMENT,
+          data: {},
+          content: [firstParagraph],
+        }),
+        160,
+      )
+  }
+  return {
+    typename: 'Article',
+    id: sys.id,
+    title: fields.title ?? '',
+    shortTitle: fields.shortTitle ?? '',
+    slug: (fields.slug ?? '').trim(),
+    intro,
+    importance: fields.importance ?? 0,
+    body: fields.content ? mapDocument(fields.content, sys.id + ':body') : [],
+    processEntry: fields.processEntry
+      ? mapProcessEntry(fields.processEntry)
+      : null,
+    category: fields.category ? mapArticleCategory(fields.category) : null,
+    otherCategories: (fields.otherCategories ?? []).map(mapArticleCategory),
+    group: fields.group ? mapArticleGroup(fields.group) : null,
+    otherGroups: (fields.otherGroups ?? []).map(mapArticleGroup),
+    subgroup: fields.subgroup ? mapArticleSubgroup(fields.subgroup) : null,
+    otherSubgroups: (fields.otherSubgroups ?? []).map(mapArticleSubgroup),
+    organization: (fields.organization ?? [])
+      .filter(
+        (organization) =>
+          organization.fields?.title && organization.fields?.slug,
+      )
+      .map(mapOrganization),
+    relatedOrganization: (fields.relatedOrganization ?? [])
+      .filter(
+        (relatedOrganization) =>
+          relatedOrganization.fields?.title && relatedOrganization.fields?.slug,
+      )
+      .map(mapOrganization),
+    responsibleParty: (fields.responsibleParty ?? [])
+      .filter(
+        (responsibleParty) =>
+          responsibleParty.fields?.title && responsibleParty.fields?.slug,
+      )
+      .map(mapOrganization),
+    subArticles: (fields.subArticles ?? [])
+      .filter(
+        (subArticle) => subArticle.fields?.title && subArticle.fields?.url,
+      )
+      .map(mapSubArticle),
+    relatedArticles: [], // populated by resolver
+    relatedContent: (fields.relatedContent ?? []).map(mapLink),
+    featuredImage: fields.featuredImage ? mapImage(fields.featuredImage) : null,
+    showTableOfContents: fields.showTableOfContents ?? false,
+    stepper: fields.stepper ? mapStepper(fields.stepper) : null,
+    processEntryButtonText: fields.processEntryButtonText ?? '',
+    alertBanner: fields.alertBanner ? mapAlertBanner(fields.alertBanner) : null,
+    activeTranslations: fields.activeTranslations ?? { en: true },
+    signLanguageVideo: fields.signLanguageVideo
+      ? mapEmbeddedVideo(fields.signLanguageVideo)
+      : null,
+    keywords: fields.keywords ?? [],
+  }
+}

--- a/libs/cms/src/lib/models/article.model.ts
+++ b/libs/cms/src/lib/models/article.model.ts
@@ -126,7 +126,7 @@ export const mapArticle = ({
   fields,
   sys,
 }: IArticle): SystemMetadata<Article> => {
-  let intro = fields.intro ?? ''
+  let intro = fields.intro?.trim() ?? ''
   if (!intro && fields.content) {
     const firstParagraph = fields.content.content?.find(
       (node) => node.nodeType === BLOCKS.PARAGRAPH,


### PR DESCRIPTION
# Remove text highlighting in global search

* Instead show the article summary on the search result card
* If there is no article summary in the cms we extract the first paragraph in the content field

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Changes**
  * Removed result highlighting from search results and suggestions for a cleaner, plain-text display.
  * Enhanced automatic article intro generation: when no intro is provided, the system now derives and truncates a first-paragraph summary for clearer previews.
  * Improved visual consistency of card titles by unifying font weight between highlighted and non-highlighted states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->