### PR TITLE
fix(ojoi): Persist current type for selection + mentioned in base

### DIFF
--- a/libs/api/domains/official-journal-of-iceland-application/src/lib/ojoiApplication.resolver.ts
+++ b/libs/api/domains/official-journal-of-iceland-application/src/lib/ojoiApplication.resolver.ts
@@ -45,6 +45,7 @@ import {
   OJOIACreateDraftResponse,
 } from '../models/regulation.response'
 import { OJOIAGetRegulationsSearchInput } from '../models/getRegulationsSearch.input'
+import { OJOIAGetRegulationOptionListInput } from '../models/getRegulationOptionList.input'
 import { OJOIAGetRegulationFromApiInput } from '../models/getRegulationFromApi.input'
 import { OJOIAGetRegulationImpactsInput } from '../models/getRegulationImpacts.input'
 import { OJOIACreateDraftRegulationInput } from '../models/createDraftRegulation.input'
@@ -227,6 +228,16 @@ export class OfficialJournalOfIcelandApplicationResolver {
     @Args('input') input: OJOIAGetRegulationsSearchInput,
   ) {
     return this.ojoiApplicationService.getRegulationsOptionSearch(input)
+  }
+
+  @Query(() => OJOIARegulationOptionSearchResponse, {
+    name: 'OJOIAGetRegulationOptionList',
+    nullable: true,
+  })
+  getRegulationOptionList(
+    @Args('input') input: OJOIAGetRegulationOptionListInput,
+  ) {
+    return this.ojoiApplicationService.getRegulationOptionList(input.names)
   }
 
   @Query(() => graphqlTypeJson, {

--- a/libs/api/domains/official-journal-of-iceland-application/src/lib/ojoiApplication.service.ts
+++ b/libs/api/domains/official-journal-of-iceland-application/src/lib/ojoiApplication.service.ts
@@ -46,7 +46,7 @@ import { RegulationsService } from '@island.is/clients/regulations'
 import { RegulationsAdminClientService } from '@island.is/clients/regulations-admin'
 import { RegulationViewTypes } from '@island.is/regulations/web'
 import { ensureRegName, nameToSlug } from '@island.is/regulations'
-import type { Year, ISODate } from '@island.is/regulations'
+import type { Year, ISODate, RegName } from '@island.is/regulations'
 import { OJOIAGetRegulationsSearchInput } from '../models/getRegulationsSearch.input'
 import { OJOIAGetRegulationFromApiInput } from '../models/getRegulationFromApi.input'
 import {
@@ -429,6 +429,15 @@ export class OfficialJournalOfIcelandApplicationService {
     }
 
     return { regulations: results }
+  }
+
+  async getRegulationOptionList(
+    names: string[],
+  ): Promise<OJOIARegulationOptionSearchResponse> {
+    const regulations = await this.regulationsService.getRegulationOptionList(
+      names as RegName[],
+    )
+    return { regulations: regulations ?? [] }
   }
 
   async getRegulationFromApi(input: OJOIAGetRegulationFromApiInput) {

--- a/libs/api/domains/official-journal-of-iceland-application/src/models/getRegulationOptionList.input.ts
+++ b/libs/api/domains/official-journal-of-iceland-application/src/models/getRegulationOptionList.input.ts
@@ -1,0 +1,7 @@
+import { Field, InputType } from '@nestjs/graphql'
+
+@InputType()
+export class OJOIAGetRegulationOptionListInput {
+  @Field(() => [String])
+  names!: string[]
+}

--- a/libs/application/templates/official-journal-of-iceland/src/graphql/queries.ts
+++ b/libs/application/templates/official-journal-of-iceland/src/graphql/queries.ts
@@ -445,6 +445,22 @@ export const REGULATION_OPTION_SEARCH_QUERY = gql`
   }
 `
 
+export const REGULATION_OPTION_LIST_QUERY = gql`
+  query OJOIAGetRegulationOptionList(
+    $input: OJOIAGetRegulationOptionListInput!
+  ) {
+    OJOIAGetRegulationOptionList(input: $input) {
+      regulations {
+        name
+        title
+        type
+        migrated
+        repealed
+      }
+    }
+  }
+`
+
 export const REGULATION_FROM_API_QUERY = gql`
   query OJOIAGetRegulationFromApi($input: OJOIAGetRegulationFromApiInput!) {
     OJOIAGetRegulationFromApi(input: $input)

--- a/libs/application/templates/official-journal-of-iceland/src/hooks/useMentionedRegulations.ts
+++ b/libs/application/templates/official-journal-of-iceland/src/hooks/useMentionedRegulations.ts
@@ -43,8 +43,7 @@ export const useMentionedRegulations = (
       return []
     }
 
-    const regulations =
-      data?.OJOIAGetRegulationOptionList?.regulations ?? []
+    const regulations = data?.OJOIAGetRegulationOptionList?.regulations ?? []
 
     return mentionedNames.map((name): SelRegOption => {
       const reg = regulations.find((r) => r.name === String(name))

--- a/libs/application/templates/official-journal-of-iceland/src/hooks/useMentionedRegulations.ts
+++ b/libs/application/templates/official-journal-of-iceland/src/hooks/useMentionedRegulations.ts
@@ -2,18 +2,26 @@
  * Validates mentioned regulation names (parsed from draft text) against the API.
  * Returns enriched options with "not found" / "repealed" labels, matching
  * the regulations-admin `useAffectedRegulations` + `formatSelRegOptions` behavior.
+ *
+ * Uses a single batch query (`getRegulationOptionList`) instead of N individual
+ * search queries, fixing both performance and correctness issues.
  */
-import { useEffect, useMemo, useState } from 'react'
-import { useApolloClient } from '@apollo/client'
+import { useMemo } from 'react'
+import { useQuery } from '@apollo/client'
 import { prettyName, type RegName } from '@island.is/regulations'
-import { REGULATION_OPTION_SEARCH_QUERY } from '../graphql/queries'
+import { REGULATION_OPTION_LIST_QUERY } from '../graphql/queries'
 import type { SelRegOption } from '../components/regulations/ImpactBaseSelection'
 
-type RegulationInfo = {
-  title: string
-  type: string
-  repealed: boolean
-  migrated: boolean
+type RegulationOptionListResponse = {
+  OJOIAGetRegulationOptionList: {
+    regulations: Array<{
+      name: string
+      title: string
+      type: string
+      migrated: boolean
+      repealed?: boolean
+    }>
+  } | null
 }
 
 export const useMentionedRegulations = (
@@ -21,81 +29,25 @@ export const useMentionedRegulations = (
   notFoundText: string,
   repealedText: string,
 ) => {
-  const client = useApolloClient()
-  const [regulationMap, setRegulationMap] = useState<
-    Map<string, RegulationInfo | null>
-  >(new Map())
-  const [loading, setLoading] = useState(false)
-
-  // Stable key for dependency tracking
-  const namesKey = mentionedNames.join(',')
-
-  useEffect(() => {
-    if (mentionedNames.length === 0) {
-      setRegulationMap(new Map())
-      return
-    }
-
-    let cancelled = false
-    setLoading(true)
-
-    const fetchAll = async () => {
-      const map = new Map<string, RegulationInfo | null>()
-
-      await Promise.all(
-        mentionedNames.map(async (name) => {
-          try {
-            const { data } = await client.query({
-              query: REGULATION_OPTION_SEARCH_QUERY,
-              variables: { input: { rn: String(name), iR: true } },
-              fetchPolicy: 'network-only',
-            })
-            const regulations =
-              data?.OJOIAGetRegulationsOptionSearch?.regulations ?? []
-            const match = regulations.find(
-              (r: { name: string }) => r.name === String(name),
-            )
-            map.set(
-              String(name),
-              match
-                ? {
-                    title: match.title,
-                    type: match.type,
-                    repealed: !!match.repealed,
-                    migrated: !!match.migrated,
-                  }
-                : null,
-            )
-          } catch {
-            map.set(String(name), null)
-          }
-        }),
-      )
-
-      if (!cancelled) {
-        setRegulationMap(map)
-        setLoading(false)
-      }
-    }
-
-    fetchAll()
-    return () => {
-      cancelled = true
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [namesKey, client])
+  const { data, loading } = useQuery<RegulationOptionListResponse>(
+    REGULATION_OPTION_LIST_QUERY,
+    {
+      variables: { input: { names: mentionedNames.map(String) } },
+      skip: mentionedNames.length === 0,
+      fetchPolicy: 'network-only',
+    },
+  )
 
   const options: SelRegOption[] = useMemo(() => {
-    if (regulationMap.size === 0 && mentionedNames.length > 0) {
-      // Still loading — return simple name-only options
-      return mentionedNames.map((name) => ({
-        value: String(name),
-        label: String(name),
-      }))
+    if (mentionedNames.length === 0) {
+      return []
     }
 
+    const regulations =
+      data?.OJOIAGetRegulationOptionList?.regulations ?? []
+
     return mentionedNames.map((name): SelRegOption => {
-      const reg = regulationMap.get(String(name))
+      const reg = regulations.find((r) => r.name === String(name))
       if (reg) {
         return {
           value: String(name),
@@ -105,7 +57,7 @@ export const useMentionedRegulations = (
             reg.title +
             (reg.repealed ? ` (${repealedText})` : ''),
           type: reg.type,
-          disabled: reg.repealed,
+          disabled: !!reg.repealed,
           migrated: reg.migrated,
         }
       }
@@ -115,7 +67,7 @@ export const useMentionedRegulations = (
         disabled: true,
       }
     })
-  }, [mentionedNames, regulationMap, notFoundText, repealedText])
+  }, [mentionedNames, data, notFoundText, repealedText])
 
   return { options, loading }
 }

--- a/libs/application/templates/official-journal-of-iceland/src/screens/TypeSelectionScreen.tsx
+++ b/libs/application/templates/official-journal-of-iceland/src/screens/TypeSelectionScreen.tsx
@@ -56,6 +56,15 @@ export const TypeSelectionScreen = ({
     }
   }, [currentType, setValue, updateApplicationV2])
 
+  // Sync local state with persisted answers when the application prop updates
+  // (e.g. navigating back to this screen after the answers have loaded).
+  useEffect(() => {
+    if (currentType) {
+      setSelected(currentType)
+      setValue('applicationType', currentType)
+    }
+  }, [currentType, setValue])
+
   const { departments } = useDepartments()
 
   const [fetchMainTypes] = useLazyQuery<{


### PR DESCRIPTION
## What

Persist current type for selection

## Why

If type is selected, it should stay selected, even if navigating back to the selection screen.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server endpoint to fetch regulation options by name.
  * Client-side batched lookup to retrieve multiple mentioned regulations at once, improving performance and reliability.
* **Bug Fixes**
  * Form-state syncing ensures the selected application type is preserved and displayed correctly when navigating back.
  * Repealed regulations are consistently marked as disabled in lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->