### PR TITLE
fix(cms): Exclude sitemap import service for feature deployments

### DIFF
--- a/infra/src/uber-charts/islandis.ts
+++ b/infra/src/uber-charts/islandis.ts
@@ -352,4 +352,5 @@ export const ExcludedFeatureDeploymentServices: ServiceBuilder<any>[] = [
   cmsImporter,
   cmsImporterEnergyGrantImport,
   cmsImporterFsreBuildingsImport,
+  cmsImporterWebSitemapImport,
 ]


### PR DESCRIPTION
# Exclude sitemap import service for feature deployments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified feature deployment configuration to exclude the web sitemap importer from feature deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->