### PR TITLE
feat(web): LatestNews, always show the same component regardless of news.length

### DIFF
--- a/apps/web/screens/Organization/Home/Home.tsx
+++ b/apps/web/screens/Organization/Home/Home.tsx
@@ -207,10 +207,7 @@ const OrganizationHomePage = ({
         }
       >
         {organizationPage?.bottomSlices.map((slice, index) => {
-          if (
-            slice.__typename === 'LatestNewsSlice' &&
-            slice.news.length >= 3
-          ) {
+          if (slice.__typename === 'LatestNewsSlice') {
             return (
               <Box
                 paddingTop={[5, 5, 8]}

--- a/apps/web/screens/Project/Project.tsx
+++ b/apps/web/screens/Project/Project.tsx
@@ -313,11 +313,7 @@ const ProjectPage: Screen<PageProps> = ({
               </Box>
             )
           }
-          if (
-            slice.__typename === 'LatestNewsSlice' &&
-            slice.news.length >= 3 &&
-            projectPage?.slug
-          ) {
+          if (slice.__typename === 'LatestNewsSlice' && projectPage?.slug) {
             return (
               <Box paddingBottom={[2, 2, 5]} key={slice.id}>
                 <DigitalIcelandLatestNewsSlice


### PR DESCRIPTION
# LatestNews, always show the same component regardless of news.length

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Latest news sections now display consistently across organization and project pages, regardless of the number of available news items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->