### PR TITLE
feat(hh-courses-application): Gather applicant and participant workplace and job title for professional courses

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/hh/courses/courses.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/hh/courses/courses.service.ts
@@ -84,7 +84,7 @@ export class CoursesService extends BaseTemplateApiService {
           'participantList',
         ) ?? []
 
-      const { name, email, phone, healthcenter, nationalId } =
+      const { name, email, phone, healthcenter, nationalId, education, jobTitle } =
         await this.extractApplicantInfo(application)
 
       if (!name || !email || !phone || !nationalId)
@@ -109,6 +109,8 @@ export class CoursesService extends BaseTemplateApiService {
         email,
         phone,
         healthcenter,
+        education,
+        jobTitle,
       )
 
       const success = await this.zendeskService.submitTicket({
@@ -427,6 +429,14 @@ export class CoursesService extends BaseTemplateApiService {
       application.answers,
       'userInformation.healthcenter',
     )
+    const education = getValueViaPath<string>(
+      application.answers,
+      'education',
+    )
+    const jobTitle = getValueViaPath<string>(
+      application.answers,
+      'jobTitle',
+    )
 
     return {
       nationalId,
@@ -434,6 +444,8 @@ export class CoursesService extends BaseTemplateApiService {
       email,
       phone,
       healthcenter,
+      education,
+      jobTitle,
     }
   }
 
@@ -469,6 +481,8 @@ export class CoursesService extends BaseTemplateApiService {
     email: string,
     phone: string,
     healthcenter?: string,
+    education?: string,
+    jobTitle?: string,
   ): Promise<string> {
     const courseHasChargeItemCode = Boolean(courseInstance.chargeItemCode)
     const userIsPayingAsIndividual = getValueViaPath<YesOrNoEnum>(
@@ -505,6 +519,8 @@ export class CoursesService extends BaseTemplateApiService {
     message += `Netfang umsækjanda: ${email}\n`
     message += `Símanúmer umsækjanda: ${phone}\n`
     message += `Heilsugæslustöð umsækjanda: ${healthcenter ?? ''}\n`
+    if (education) message += `Menntun umsækjanda: ${education}\n`
+    if (jobTitle) message += `Starfsheiti umsækjanda: ${jobTitle}\n`
 
     if (courseHasChargeItemCode) {
       const payer =

--- a/libs/application/template-api-modules/src/lib/modules/templates/hh/courses/courses.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/hh/courses/courses.service.ts
@@ -84,8 +84,15 @@ export class CoursesService extends BaseTemplateApiService {
           'participantList',
         ) ?? []
 
-      const { name, email, phone, healthcenter, nationalId, education, jobTitle } =
-        await this.extractApplicantInfo(application)
+      const {
+        name,
+        email,
+        phone,
+        healthcenter,
+        nationalId,
+        education,
+        jobTitle,
+      } = await this.extractApplicantInfo(application)
 
       if (!name || !email || !phone || !nationalId)
         throw new TemplateApiError(
@@ -429,14 +436,8 @@ export class CoursesService extends BaseTemplateApiService {
       application.answers,
       'userInformation.healthcenter',
     )
-    const education = getValueViaPath<string>(
-      application.answers,
-      'education',
-    )
-    const jobTitle = getValueViaPath<string>(
-      application.answers,
-      'jobTitle',
-    )
+    const education = getValueViaPath<string>(application.answers, 'education')
+    const jobTitle = getValueViaPath<string>(application.answers, 'jobTitle')
 
     return {
       nationalId,

--- a/libs/application/template-api-modules/src/lib/modules/templates/hh/courses/courses.service.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/hh/courses/courses.service.ts
@@ -90,7 +90,7 @@ export class CoursesService extends BaseTemplateApiService {
         phone,
         healthcenter,
         nationalId,
-        education,
+        workplace,
         jobTitle,
       } = await this.extractApplicantInfo(application)
 
@@ -116,7 +116,7 @@ export class CoursesService extends BaseTemplateApiService {
         email,
         phone,
         healthcenter,
-        education,
+        workplace,
         jobTitle,
       )
 
@@ -436,7 +436,7 @@ export class CoursesService extends BaseTemplateApiService {
       application.answers,
       'userInformation.healthcenter',
     )
-    const education = getValueViaPath<string>(application.answers, 'education')
+    const workplace = getValueViaPath<string>(application.answers, 'workplace')
     const jobTitle = getValueViaPath<string>(application.answers, 'jobTitle')
 
     return {
@@ -445,7 +445,7 @@ export class CoursesService extends BaseTemplateApiService {
       email,
       phone,
       healthcenter,
-      education,
+      workplace,
       jobTitle,
     }
   }
@@ -482,7 +482,7 @@ export class CoursesService extends BaseTemplateApiService {
     email: string,
     phone: string,
     healthcenter?: string,
-    education?: string,
+    workplace?: string,
     jobTitle?: string,
   ): Promise<string> {
     const courseHasChargeItemCode = Boolean(courseInstance.chargeItemCode)
@@ -520,7 +520,7 @@ export class CoursesService extends BaseTemplateApiService {
     message += `Netfang umsækjanda: ${email}\n`
     message += `Símanúmer umsækjanda: ${phone}\n`
     message += `Heilsugæslustöð umsækjanda: ${healthcenter ?? ''}\n`
-    if (education) message += `Menntun umsækjanda: ${education}\n`
+    if (workplace) message += `Vinnustaður umsækjanda: ${workplace}\n`
     if (jobTitle) message += `Starfsheiti umsækjanda: ${jobTitle}\n`
 
     if (courseHasChargeItemCode) {
@@ -542,6 +542,14 @@ export class CoursesService extends BaseTemplateApiService {
       message += `Kennitala þátttakanda ${index + 1}: ${p.nationalId}\n`
       message += `Netfang þátttakanda ${index + 1}: ${p.email}\n`
       message += `Símanúmer þátttakanda ${index + 1}: ${p.phone}\n`
+      if (participant.workplace)
+        message += `Vinnustaður þátttakanda ${index + 1}: ${
+          participant.workplace
+        }\n`
+      if (participant.jobTitle)
+        message += `Starfsheiti þátttakanda ${index + 1}: ${
+          participant.jobTitle
+        }\n`
     })
 
     return message

--- a/libs/application/template-api-modules/src/lib/modules/templates/hh/courses/types.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/hh/courses/types.ts
@@ -27,4 +27,6 @@ export type ApplicationAnswers = {
   courseSelect: string
   dateSelect: string
   courseHasChargeItemCode?: boolean
+  education?: string
+  jobTitle?: string
 }

--- a/libs/application/template-api-modules/src/lib/modules/templates/hh/courses/types.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/hh/courses/types.ts
@@ -16,6 +16,8 @@ export type ApplicationAnswers = {
   }
   participantList: Array<{
     nationalIdWithName: NationalIdWithName
+    workplace?: string
+    jobTitle?: string
   }>
   userInformation: {
     name: string
@@ -27,6 +29,6 @@ export type ApplicationAnswers = {
   courseSelect: string
   dateSelect: string
   courseHasChargeItemCode?: boolean
-  education?: string
+  workplace?: string
   jobTitle?: string
 }

--- a/libs/application/templates/hh/courses/src/forms/mainForm/overview.ts
+++ b/libs/application/templates/hh/courses/src/forms/mainForm/overview.ts
@@ -10,7 +10,6 @@ import { type Application, DefaultEvents } from '@island.is/application/types'
 import {
   getPayerOverviewItems,
   getParticipantOverviewTableData,
-  getEducationAndJobTitleOverviewItems,
 } from '../../utils/getOverviewItems'
 import { m } from '../../lib/messages'
 import { doesCourseInstanceHaveChargeItemCode } from '../../utils/loadOptions'
@@ -40,17 +39,6 @@ export const overviewSection = buildSection({
           bottomLine: false,
           title: m.overview.participantHeading,
           tableData: getParticipantOverviewTableData,
-        }),
-        buildOverviewField({
-          condition: (answers) =>
-            !!(
-              getValueViaPath<string>(answers, 'education') ||
-              getValueViaPath<string>(answers, 'jobTitle')
-            ),
-          id: 'educationAndJobTitleOverview',
-          bottomLine: false,
-          title: m.overview.educationAndJobTitleHeading,
-          items: getEducationAndJobTitleOverviewItems,
         }),
         buildOverviewField({
           condition: (answers) => {

--- a/libs/application/templates/hh/courses/src/forms/mainForm/overview.ts
+++ b/libs/application/templates/hh/courses/src/forms/mainForm/overview.ts
@@ -10,6 +10,7 @@ import { type Application, DefaultEvents } from '@island.is/application/types'
 import {
   getPayerOverviewItems,
   getParticipantOverviewTableData,
+  getEducationAndJobTitleOverviewItems,
 } from '../../utils/getOverviewItems'
 import { m } from '../../lib/messages'
 import { doesCourseInstanceHaveChargeItemCode } from '../../utils/loadOptions'
@@ -39,6 +40,17 @@ export const overviewSection = buildSection({
           bottomLine: false,
           title: m.overview.participantHeading,
           tableData: getParticipantOverviewTableData,
+        }),
+        buildOverviewField({
+          condition: (answers) =>
+            !!(
+              getValueViaPath<string>(answers, 'education') ||
+              getValueViaPath<string>(answers, 'jobTitle')
+            ),
+          id: 'educationAndJobTitleOverview',
+          bottomLine: false,
+          title: m.overview.educationAndJobTitleHeading,
+          items: getEducationAndJobTitleOverviewItems,
         }),
         buildOverviewField({
           condition: (answers) => {

--- a/libs/application/templates/hh/courses/src/forms/mainForm/participantSection.ts
+++ b/libs/application/templates/hh/courses/src/forms/mainForm/participantSection.ts
@@ -6,6 +6,7 @@ import {
 } from '@island.is/application/core'
 import type { Application } from '@island.is/application/types'
 import { m } from '../../lib/messages'
+import { isCourseForProfessionals } from '../../utils/isCourseForProfessionals'
 
 export const participantSection = buildSection({
   id: 'participantSection',
@@ -39,6 +40,11 @@ export const participantSection = buildSection({
               return undefined
             }
 
+            const workplace =
+              getValueViaPath<string>(application.answers, 'workplace') ?? ''
+            const jobTitle =
+              getValueViaPath<string>(application.answers, 'jobTitle') ?? ''
+
             return [
               {
                 nationalIdWithName: {
@@ -47,6 +53,8 @@ export const participantSection = buildSection({
                   email,
                   phone,
                 },
+                workplace,
+                jobTitle,
               },
             ]
           },
@@ -69,6 +77,26 @@ export const participantSection = buildSection({
               showPhoneField: true,
               phoneRequired: true,
               emailRequired: true,
+            },
+            workplace: {
+              component: 'input',
+              label: m.participant.participantWorkplace,
+              width: 'half',
+              displayInTable: false,
+              condition: (application: Application) =>
+                isCourseForProfessionals(application.answers),
+              defaultValue: (application: Application) =>
+                getValueViaPath<string>(application.answers, 'workplace') ?? '',
+            },
+            jobTitle: {
+              component: 'input',
+              label: m.participant.participantJobTitle,
+              width: 'half',
+              displayInTable: false,
+              condition: (application: Application) =>
+                isCourseForProfessionals(application.answers),
+              defaultValue: (application: Application) =>
+                getValueViaPath<string>(application.answers, 'jobTitle') ?? '',
             },
           },
         }),

--- a/libs/application/templates/hh/courses/src/forms/mainForm/userInformation.ts
+++ b/libs/application/templates/hh/courses/src/forms/mainForm/userInformation.ts
@@ -8,17 +8,7 @@ import {
 } from '@island.is/application/core'
 import { m } from '../../lib/messages'
 import { Application } from '@island.is/application/types'
-import { getCachedCourseListPageId } from '../../utils/loadOptions'
-
-const COURSE_LIST_PAGE_ID_FOR_PROFESSIONALS = '147YftiWFQsBcbUFFe2rj1'
-
-const isCourseForProfessionals = (answers: Record<string, unknown>) => {
-  const courseId = getValueViaPath<string>(answers, 'courseSelect', '')
-  return (
-    getCachedCourseListPageId(courseId) ===
-    COURSE_LIST_PAGE_ID_FOR_PROFESSIONALS
-  )
-}
+import { isCourseForProfessionals } from '../../utils/isCourseForProfessionals'
 
 export const userInformation = buildSection({
   id: 'userInformation',
@@ -97,8 +87,8 @@ export const userInformation = buildSection({
             ),
         }),
         buildTextField({
-          id: 'education',
-          title: m.userInformation.education,
+          id: 'workplace',
+          title: m.userInformation.workplace,
           width: 'half',
           condition: (answers) => isCourseForProfessionals(answers),
         }),

--- a/libs/application/templates/hh/courses/src/forms/mainForm/userInformation.ts
+++ b/libs/application/templates/hh/courses/src/forms/mainForm/userInformation.ts
@@ -8,6 +8,17 @@ import {
 } from '@island.is/application/core'
 import { m } from '../../lib/messages'
 import { Application } from '@island.is/application/types'
+import { getCachedCourseListPageId } from '../../utils/loadOptions'
+
+const COURSE_LIST_PAGE_ID_FOR_PROFESSIONALS = '147YftiWFQsBcbUFFe2rj1'
+
+const isCourseForProfessionals = (answers: Record<string, unknown>) => {
+  const courseId = getValueViaPath<string>(answers, 'courseSelect', '')
+  return (
+    getCachedCourseListPageId(courseId) ===
+    COURSE_LIST_PAGE_ID_FOR_PROFESSIONALS
+  )
+}
 
 export const userInformation = buildSection({
   id: 'userInformation',
@@ -84,6 +95,18 @@ export const userInformation = buildSection({
               externalData,
               'currentHealthcenter.data.healthCenter',
             ),
+        }),
+        buildTextField({
+          id: 'education',
+          title: m.userInformation.education,
+          width: 'half',
+          condition: (answers) => isCourseForProfessionals(answers),
+        }),
+        buildTextField({
+          id: 'jobTitle',
+          title: m.userInformation.jobTitle,
+          width: 'half',
+          condition: (answers) => isCourseForProfessionals(answers),
         }),
       ],
     }),

--- a/libs/application/templates/hh/courses/src/graphql/index.ts
+++ b/libs/application/templates/hh/courses/src/graphql/index.ts
@@ -15,6 +15,7 @@ export const GET_COURSE_BY_ID_QUERY = gql`
   query GetCourseById($input: GetCourseByIdInput!) {
     getCourseById(input: $input) {
       course {
+        courseListPageId
         instances {
           id
           startDate

--- a/libs/application/templates/hh/courses/src/lib/dataSchema.ts
+++ b/libs/application/templates/hh/courses/src/lib/dataSchema.ts
@@ -53,6 +53,8 @@ const nationalIdWithNameSchema = z.object({
 
 const participantSchema = z.object({
   nationalIdWithName: nationalIdWithNameSchema,
+  workplace: z.string().optional(),
+  jobTitle: z.string().optional(),
 })
 
 const userInformationSchema = z.object({
@@ -73,7 +75,7 @@ export const dataSchema = z.object({
   dateSelect: z.string().min(1),
   payment: paymentSchema.optional(),
   userInformation: userInformationSchema,
-  education: z.string().optional(),
+  workplace: z.string().optional(),
   jobTitle: z.string().optional(),
 })
 

--- a/libs/application/templates/hh/courses/src/lib/dataSchema.ts
+++ b/libs/application/templates/hh/courses/src/lib/dataSchema.ts
@@ -73,6 +73,8 @@ export const dataSchema = z.object({
   dateSelect: z.string().min(1),
   payment: paymentSchema.optional(),
   userInformation: userInformationSchema,
+  education: z.string().optional(),
+  jobTitle: z.string().optional(),
 })
 
 export type ApplicationAnswers = z.TypeOf<typeof dataSchema>

--- a/libs/application/templates/hh/courses/src/lib/messages.ts
+++ b/libs/application/templates/hh/courses/src/lib/messages.ts
@@ -83,10 +83,10 @@ export const m = {
       defaultMessage: 'Engin heilsugæslustöð fannst skráð á þig',
       description: 'Message shown when no health center is found',
     },
-    education: {
-      id: 'hh.courses.application:userInformation.education',
-      defaultMessage: 'Menntun',
-      description: 'Title of education field',
+    workplace: {
+      id: 'hh.courses.application:userInformation.workplace',
+      defaultMessage: 'Vinnustaður',
+      description: 'Title of workplace field',
     },
     jobTitle: {
       id: 'hh.courses.application:userInformation.jobTitle',
@@ -175,6 +175,16 @@ export const m = {
       id: 'hh.courses.application:participant.participantPhone',
       defaultMessage: 'Símanúmer',
       description: 'Title of participant phone field',
+    },
+    participantWorkplace: {
+      id: 'hh.courses.application:participant.participantWorkplace',
+      defaultMessage: 'Vinnustaður',
+      description: 'Title of participant workplace field',
+    },
+    participantJobTitle: {
+      id: 'hh.courses.application:participant.participantJobTitle',
+      defaultMessage: 'Starfsheiti',
+      description: 'Title of participant job title field',
     },
   }),
   payer: defineMessages({
@@ -292,15 +302,10 @@ export const m = {
       defaultMessage: 'Staðfesta skráningu',
       description: 'Title of submit button in overview section without payment',
     },
-    educationAndJobTitleHeading: {
-      id: 'hh.courses.application:overview.educationAndJobTitleHeading',
-      defaultMessage: 'Menntun og starfsheiti',
-      description: 'Heading for education and job title in overview section',
-    },
-    education: {
-      id: 'hh.courses.application:overview.education',
-      defaultMessage: 'Menntun',
-      description: 'Heading for education in overview section',
+    workplace: {
+      id: 'hh.courses.application:overview.workplace',
+      defaultMessage: 'Vinnustaður',
+      description: 'Heading for workplace in overview section',
     },
     jobTitle: {
       id: 'hh.courses.application:overview.jobTitle',

--- a/libs/application/templates/hh/courses/src/lib/messages.ts
+++ b/libs/application/templates/hh/courses/src/lib/messages.ts
@@ -83,6 +83,16 @@ export const m = {
       defaultMessage: 'Engin heilsugæslustöð fannst skráð á þig',
       description: 'Message shown when no health center is found',
     },
+    education: {
+      id: 'hh.courses.application:userInformation.education',
+      defaultMessage: 'Menntun',
+      description: 'Title of education field',
+    },
+    jobTitle: {
+      id: 'hh.courses.application:userInformation.jobTitle',
+      defaultMessage: 'Starfsheiti',
+      description: 'Title of job title field',
+    },
   }),
   prerequisites: defineMessages({
     nationalRegistryTitle: {
@@ -281,6 +291,21 @@ export const m = {
       id: 'hh.courses.application:overview.submitRegistrationTitle',
       defaultMessage: 'Staðfesta skráningu',
       description: 'Title of submit button in overview section without payment',
+    },
+    educationAndJobTitleHeading: {
+      id: 'hh.courses.application:overview.educationAndJobTitleHeading',
+      defaultMessage: 'Menntun og starfsheiti',
+      description: 'Heading for education and job title in overview section',
+    },
+    education: {
+      id: 'hh.courses.application:overview.education',
+      defaultMessage: 'Menntun',
+      description: 'Heading for education in overview section',
+    },
+    jobTitle: {
+      id: 'hh.courses.application:overview.jobTitle',
+      defaultMessage: 'Starfsheiti',
+      description: 'Heading for job title in overview section',
     },
   }),
   completedForm: defineMessages({

--- a/libs/application/templates/hh/courses/src/utils/getOverviewItems.ts
+++ b/libs/application/templates/hh/courses/src/utils/getOverviewItems.ts
@@ -88,4 +88,3 @@ export const getPayerOverviewItems = (
 
   return items
 }
-

--- a/libs/application/templates/hh/courses/src/utils/getOverviewItems.ts
+++ b/libs/application/templates/hh/courses/src/utils/getOverviewItems.ts
@@ -16,34 +16,37 @@ export const getParticipantOverviewTableData = (
   answers: FormValue,
   _externalData: ExternalData,
 ): TableData => {
-  const tableData: TableData = {
-    header: [
-      m.overview.participantName,
-      m.overview.participantNationalId,
-      m.overview.participantEmail,
-      m.overview.participantPhone,
-    ],
-    rows: [],
-  }
-
   const participantList =
     getValueViaPath<z.infer<typeof dataSchema.shape.participantList>>(
       answers,
       'participantList',
     ) ?? []
 
-  if (participantList.length > 0) {
-    for (const participant of participantList) {
-      tableData.rows.push([
-        participant.nationalIdWithName.name,
-        participant.nationalIdWithName.nationalId,
-        participant.nationalIdWithName.email,
-        formatPhoneNumber(participant.nationalIdWithName.phone),
-      ])
-    }
-  }
+  const hasWorkplaceOrJobTitle = participantList.some(
+    (p) => p.workplace || p.jobTitle,
+  )
 
-  return tableData
+  const header = [
+    m.overview.participantName,
+    m.overview.participantNationalId,
+    m.overview.participantEmail,
+    m.overview.participantPhone,
+    ...(hasWorkplaceOrJobTitle
+      ? [m.overview.workplace, m.overview.jobTitle]
+      : []),
+  ]
+
+  const rows = participantList.map((participant) => [
+    participant.nationalIdWithName.name,
+    participant.nationalIdWithName.nationalId,
+    participant.nationalIdWithName.email,
+    formatPhoneNumber(participant.nationalIdWithName.phone),
+    ...(hasWorkplaceOrJobTitle
+      ? [participant.workplace ?? '', participant.jobTitle ?? '']
+      : []),
+  ])
+
+  return { header, rows }
 }
 
 export const getPayerOverviewItems = (
@@ -86,30 +89,3 @@ export const getPayerOverviewItems = (
   return items
 }
 
-export const getEducationAndJobTitleOverviewItems = (
-  answers: FormValue,
-  _externalData: ExternalData,
-): Array<KeyValueItem> => {
-  const items: Array<KeyValueItem> = []
-
-  const education = getValueViaPath<string>(answers, 'education')
-  const jobTitle = getValueViaPath<string>(answers, 'jobTitle')
-
-  if (education) {
-    items.push({
-      width: 'half',
-      keyText: m.overview.education,
-      valueText: education,
-    })
-  }
-
-  if (jobTitle) {
-    items.push({
-      width: 'half',
-      keyText: m.overview.jobTitle,
-      valueText: jobTitle,
-    })
-  }
-
-  return items
-}

--- a/libs/application/templates/hh/courses/src/utils/getOverviewItems.ts
+++ b/libs/application/templates/hh/courses/src/utils/getOverviewItems.ts
@@ -85,3 +85,31 @@ export const getPayerOverviewItems = (
 
   return items
 }
+
+export const getEducationAndJobTitleOverviewItems = (
+  answers: FormValue,
+  _externalData: ExternalData,
+): Array<KeyValueItem> => {
+  const items: Array<KeyValueItem> = []
+
+  const education = getValueViaPath<string>(answers, 'education')
+  const jobTitle = getValueViaPath<string>(answers, 'jobTitle')
+
+  if (education) {
+    items.push({
+      width: 'half',
+      keyText: m.overview.education,
+      valueText: education,
+    })
+  }
+
+  if (jobTitle) {
+    items.push({
+      width: 'half',
+      keyText: m.overview.jobTitle,
+      valueText: jobTitle,
+    })
+  }
+
+  return items
+}

--- a/libs/application/templates/hh/courses/src/utils/isCourseForProfessionals.ts
+++ b/libs/application/templates/hh/courses/src/utils/isCourseForProfessionals.ts
@@ -1,0 +1,14 @@
+import { getValueViaPath } from '@island.is/application/core'
+import { getCachedCourseListPageId } from './loadOptions'
+
+const COURSE_LIST_PAGE_ID_FOR_PROFESSIONALS = '147YftiWFQsBcbUFFe2rj1'
+
+export const isCourseForProfessionals = (
+  answers: Record<string, unknown>,
+): boolean => {
+  const courseId = getValueViaPath<string>(answers, 'courseSelect', '')
+  return (
+    getCachedCourseListPageId(courseId) ===
+    COURSE_LIST_PAGE_ID_FOR_PROFESSIONALS
+  )
+}

--- a/libs/application/templates/hh/courses/src/utils/loadOptions.ts
+++ b/libs/application/templates/hh/courses/src/utils/loadOptions.ts
@@ -18,8 +18,11 @@ import {
 
 const cache = storageFactory(() => localStorage)
 
-const createCacheKey = (instanceId: string): string =>
+const creatChargeItemCodeCacheKey = (instanceId: string): string =>
   `hhCourseInstanceChargeItemCode:${instanceId}`
+
+const createCourseListPageIdCacheKey = (courseId: string): string =>
+  `hhCourseListPageId:${courseId}`
 
 /**
  * Checks if the course instance has a charge item code.
@@ -30,7 +33,7 @@ export const doesCourseInstanceHaveChargeItemCode = (
   instanceId: string | undefined | null,
 ): boolean => {
   if (!instanceId) return true
-  const cachedValue = cache.getItem(createCacheKey(instanceId))
+  const cachedValue = cache.getItem(creatChargeItemCodeCacheKey(instanceId))
   if (cachedValue === 'true') return true
   if (cachedValue === 'false') return false
   return true
@@ -58,6 +61,13 @@ export const loadCourseSelectOptions = async ({
   }))
 }
 
+export const getCachedCourseListPageId = (
+  courseId: string | undefined | null,
+): string | null => {
+  if (!courseId) return null
+  return cache.getItem(createCourseListPageIdCacheKey(courseId)) ?? null
+}
+
 export const loadDateSelectOptions = async ({
   apolloClient,
   selectedValues,
@@ -76,9 +86,16 @@ export const loadDateSelectOptions = async ({
   })
   if (!data?.getCourseById?.course) return []
 
+  if (data.getCourseById.course.courseListPageId) {
+    cache.setItem(
+      createCourseListPageIdCacheKey(courseId),
+      data.getCourseById.course.courseListPageId,
+    )
+  }
+
   for (const instance of data.getCourseById.course.instances)
     cache.setItem(
-      createCacheKey(instance.id),
+      creatChargeItemCodeCacheKey(instance.id),
       String(Boolean(instance.chargeItemCode)),
     )
 


### PR DESCRIPTION
# Gather applicant and participant workplace and job title for professional courses

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional workplace and job title fields for applicants and participants.
  * These fields appear in forms only for professional-designated courses.
  * Application overview and participant tables now show workplace/job title columns when provided.
  * Submitted application summaries include workplace and job title details when present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->