### PR TITLE
feat(ids-admin): require category selection for custom delegations

### DIFF
--- a/libs/portals/admin/ids-admin/src/lib/messages.ts
+++ b/libs/portals/admin/ids-admin/src/lib/messages.ts
@@ -865,6 +865,10 @@ export const m = defineMessages({
     defaultMessage:
       'Select which tags this permission is relevant for. This helps users understand when they might need this permission.',
   },
+  categoryRequired: {
+    id: 'ap.ids-admin:category-required',
+    defaultMessage: 'At least one category must be selected',
+  },
   noCategories: {
     id: 'ap.ids-admin:no-categories',
     defaultMessage: 'No categories available',

--- a/libs/portals/admin/ids-admin/src/screens/Permission/components/PermissionDelegations.tsx
+++ b/libs/portals/admin/ids-admin/src/screens/Permission/components/PermissionDelegations.tsx
@@ -156,6 +156,12 @@ export const PermissionDelegations = ({
     ],
   )
 
+  const categoryRequired =
+    showCategoriesAndTags &&
+    !categoriesLoading &&
+    categories.length > 0 &&
+    selectedCategories.length === 0
+
   const loadingCategoriesAndTags = categoriesLoading || tagsLoading
 
   const toggleDelegationType = (field: string, checked: boolean) => {
@@ -215,22 +221,18 @@ export const PermissionDelegations = ({
     }
   }
 
-  const supportsCustomDelegation =
-    selectedPermission.supportedDelegationTypes?.includes(
-      AuthDelegationType.Custom,
-    ) ?? false
-
   return (
     <FormCard
       title={formatMessage(m.delegations)}
       intent={PermissionFormTypes.DELEGATIONS}
       inSync={checkEnvironmentsSync(permission.environments, [
         'supportedDelegationTypes',
-        ...(supportsCustomDelegation
+        ...(showCategoriesAndTags
           ? (['categoryIds', 'tagIds'] as const)
           : []),
       ])}
       customValidation={customValidation}
+      submitDisabled={categoryRequired}
     >
       <Stack space={4}>
         {providers.map((provider) =>
@@ -319,6 +321,10 @@ export const PermissionDelegations = ({
                                     }}
                                     placeholder={formatMessage(
                                       m.selectCategoriesPlaceholder,
+                                    )}
+                                    hasError={categoryRequired}
+                                    errorMessage={formatMessage(
+                                      m.categoryRequired,
                                     )}
                                     isMulti
                                     size="sm"

--- a/libs/portals/admin/ids-admin/src/screens/Permission/components/PermissionDelegations.tsx
+++ b/libs/portals/admin/ids-admin/src/screens/Permission/components/PermissionDelegations.tsx
@@ -227,9 +227,7 @@ export const PermissionDelegations = ({
       intent={PermissionFormTypes.DELEGATIONS}
       inSync={checkEnvironmentsSync(permission.environments, [
         'supportedDelegationTypes',
-        ...(showCategoriesAndTags
-          ? (['categoryIds', 'tagIds'] as const)
-          : []),
+        ...(showCategoriesAndTags ? (['categoryIds', 'tagIds'] as const) : []),
       ])}
       customValidation={customValidation}
       submitDisabled={categoryRequired}


### PR DESCRIPTION
# feat(ids-admin): require category selection for custom delegations

## What

- Added `hasError` prop to `FormCard` component to disable save button when validation fails
- Added category required validation in `PermissionDelegations` when Custom delegations is checked (behind feature flag)
- Shows inline error message on the categories Select when no category is selected
- Fixed `inSync` check to use current UI state instead of persisted server state

## Why

- Custom delegations should always have at least one category selected, but the data model cannot enforce this due to backwards compatibility
- Frontend validation ensures all new and edited scopes with custom delegations have a category
- The `inSync` fix ensures the environment sync indicator is accurate when Custom is toggled on for the first time

## Screenshots / Gifs
<img width="942" height="604" alt="Screenshot 2026-04-14 at 14 05 56" src="https://github.com/user-attachments/assets/c8b4918c-167f-4ce0-b79d-7871330a31e4" />

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Permission delegation form now enforces mandatory category selection when applicable
  * Category field displays validation error messages to guide users when categories are required
<!-- end of auto-generated comment: release notes by coderabbit.ai -->