### PR TITLE
feat(contentful-apps): Project subpage preview link

### DIFF
--- a/apps/contentful-apps/pages/sidebars/preview-link.tsx
+++ b/apps/contentful-apps/pages/sidebars/preview-link.tsx
@@ -42,7 +42,8 @@ const PreviewLinkSidebar = () => {
 
             const url = await previewLinkHandler[contentTypeId](entry, cma)
 
-            window.open(`${url}${queryParams}`, '_blank')
+            if (url) window.open(`${url}${queryParams}`, '_blank')
+            else sdk.notifier.warning('No preview link available')
           }
         }}
       >

--- a/apps/contentful-apps/utils/index.ts
+++ b/apps/contentful-apps/utils/index.ts
@@ -100,6 +100,20 @@ export const previewLinkHandler = {
   projectPage: (entry: EntryProps<KeyValueMap>) => {
     return `${DEV_WEB_BASE_URL}/v/${entry.fields.slug[DEFAULT_LOCALE]}`
   },
+  projectSubpage: async (entry: EntryProps<KeyValueMap>, cma: CMAClient) => {
+    const projectPageResponse = await cma.entry.getMany({
+      query: {
+        content_type: 'projectPage',
+        links_to_entry: entry.sys.id,
+        limit: 1,
+        'sys.archivedVersion[exists]': false,
+      },
+    })
+    const projectPageSlug =
+      projectPageResponse?.items?.[0]?.fields?.slug?.[DEFAULT_LOCALE]
+    if (!projectPageSlug) return ''
+    return `${DEV_WEB_BASE_URL}/v/${projectPageSlug}/${entry.fields.slug[DEFAULT_LOCALE]}`
+  },
   organizationSubpage: async (
     entry: EntryProps<KeyValueMap>,
     cma: CMAClient,


### PR DESCRIPTION
# Project subpage preview link

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where preview link clicks with missing URLs would fail silently. A warning notification is now displayed when a preview link is unavailable.

* **New Features**
  * Added preview link support for project subpage entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->