### PR TITLE
feat(web): Adjust search results to display top level and then links on card for levels below

### DIFF
--- a/apps/web/components/Card/Card.css.ts
+++ b/apps/web/components/Card/Card.css.ts
@@ -7,7 +7,6 @@ export const card = style({
   height: '100%',
   width: '100%',
   flexDirection: 'column',
-  cursor: 'pointer',
   boxSizing: 'border-box',
   minHeight: 146,
   textDecoration: 'none',

--- a/apps/web/components/Card/Card.tsx
+++ b/apps/web/components/Card/Card.tsx
@@ -8,6 +8,7 @@ import {
   FocusableBox,
   Hyphen,
   Inline,
+  LinkV2,
   Stack,
   Tag,
   TagProps,
@@ -42,6 +43,7 @@ export interface CardProps {
   linkProps?: LinkProps
   link?: LinkResolverResponse
   highlightedResults?: boolean
+  childLinks?: Array<{ label: string; href: string }>
 }
 
 export const Card = ({
@@ -53,6 +55,7 @@ export const Card = ({
   link,
   dataTestId,
   highlightedResults = false,
+  childLinks = [],
 }: CardProps & TestSupport) => {
   const { colorScheme } = useContext(ColorSchemeContext)
   const [ref, { width }] = useMeasure()
@@ -88,6 +91,13 @@ export const Card = ({
 
   const visibleTags = tags.filter((t) => t.title)
 
+  const TitleWrapper =
+    childLinks.length > 0 && !!link?.href
+      ? ({ children }: { children: ReactNode }) => (
+          <LinkV2 href={link?.href}>{children}</LinkV2>
+        )
+      : Box
+
   const items = (
     <Box
       ref={ref}
@@ -115,25 +125,27 @@ export const Card = ({
           )}
           <Box display="flex" flexDirection="row" alignItems="center">
             <Box display="inlineFlex" flexGrow={1}>
-              {highlightedResults ? (
-                <Text
-                  as="h3"
-                  variant="h3"
-                  color={titleColor}
-                  fontWeight="medium"
-                >
-                  <span dangerouslySetInnerHTML={{ __html: title }}></span>
-                </Text>
-              ) : (
-                <Text
-                  as="h3"
-                  variant="h3"
-                  color={titleColor}
-                  fontWeight="medium"
-                >
-                  <Hyphen>{title}</Hyphen>
-                </Text>
-              )}
+              <TitleWrapper>
+                {highlightedResults ? (
+                  <Text
+                    as="h3"
+                    variant="h3"
+                    color={titleColor}
+                    fontWeight="medium"
+                  >
+                    <span dangerouslySetInnerHTML={{ __html: title }}></span>
+                  </Text>
+                ) : (
+                  <Text
+                    as="h3"
+                    variant="h3"
+                    color={titleColor}
+                    fontWeight="medium"
+                  >
+                    <Hyphen>{title}</Hyphen>
+                  </Text>
+                )}
+              </TitleWrapper>
             </Box>
           </Box>
           {description && highlightedResults ? (
@@ -144,7 +156,27 @@ export const Card = ({
             <Text>{description}</Text>
           )}
 
-          {visibleTags.length > 0 && highlightedResults && (
+          {childLinks.length > 0 && (
+            <Box paddingTop={2} flexGrow={0} position="relative">
+              <Stack space={1}>
+                {childLinks.map(({ label, href }) => (
+                  <Box key={`${label}-${href}`} display="flex">
+                    <LinkV2 href={href}>
+                      <Text
+                        variant="small"
+                        fontWeight="semiBold"
+                        color={titleColor}
+                      >
+                        {label}
+                      </Text>
+                    </LinkV2>
+                  </Box>
+                ))}
+              </Stack>
+            </Box>
+          )}
+
+          {visibleTags.length > 0 && (
             <Box paddingTop={3} flexGrow={0} position="relative">
               <Inline space={1}>
                 {visibleTags.map(
@@ -188,10 +220,11 @@ export const Card = ({
     </Box>
   )
 
-  if (link?.href) {
+  if (link?.href && !childLinks.length) {
     return (
       <FocusableBox
         href={link.href}
+        cursor="pointer"
         borderRadius="large"
         flexDirection="column"
         height="full"
@@ -206,7 +239,21 @@ export const Card = ({
       </FocusableBox>
     )
   }
-  return <Frame>{items}</Frame>
+  return (
+    <Box
+      borderRadius="large"
+      flexDirection="column"
+      height="full"
+      width="full"
+      data-testid={dataTestId}
+      flexGrow={1}
+      background="white"
+      borderColor={borderColor}
+      borderWidth="standard"
+    >
+      <Frame>{items}</Frame>
+    </Box>
+  )
 }
 
 export const Frame = ({ children }: { children: ReactNode }) => {

--- a/apps/web/components/SearchInput/SearchInput.tsx
+++ b/apps/web/components/SearchInput/SearchInput.tsx
@@ -127,7 +127,6 @@ const useSearch = (
                 types: [
                   // RÁ suggestions has only been searching particular types for some time - SYNC SUGGESTIONS SCOPE WITH DEFAULT - keep it in sync
                   SearchableContentTypes['WebArticle'],
-                  SearchableContentTypes['WebSubArticle'],
                   SearchableContentTypes['WebProjectPage'],
                   SearchableContentTypes['WebOrganizationPage'],
                   SearchableContentTypes['WebOrganizationSubpage'],

--- a/apps/web/screens/Search/Search.tsx
+++ b/apps/web/screens/Search/Search.tsx
@@ -91,7 +91,6 @@ const ALL_TYPES: `${SearchableContentTypes}`[] = [
   'webLifeEventPage',
   'webDigitalIcelandService',
   'webDigitalIcelandCommunityPage',
-  'webSubArticle',
   'webLink',
   'webNews',
   'webOrganizationSubpage',
@@ -145,7 +144,6 @@ const connectedTypes: Partial<
 > = {
   webArticle: [
     'WebArticle',
-    'WebSubArticle',
     'WebOrganizationSubpage',
     'webOrganizationPage',
     'WebProjectPage',
@@ -208,10 +206,6 @@ const Search: Screen<CategoryProps> = ({
 
       total +=
         (countResults?.typesCount ?? []).find((x) => x.key === 'webArticle')
-          ?.count ?? 0
-
-      total +=
-        (countResults?.typesCount ?? []).find((x) => x.key === 'webSubArticle')
           ?.count ?? 0
 
       total +=
@@ -297,7 +291,6 @@ const Search: Screen<CategoryProps> = ({
     | Record<string, string> = useMemo(
     () => ({
       webArticle: n('webArticle', 'Greinar'),
-      webSubArticle: n('webSubArticle', 'Undirgreinar'),
       webLink: n('webLink', 'Tenglar'),
       webNews: n('webNews', 'Fréttir og tilkynningar'),
       webQNA: n('webQNA', 'Spurt og svarað'),

--- a/apps/web/screens/Search/Search.tsx
+++ b/apps/web/screens/Search/Search.tsx
@@ -383,6 +383,27 @@ const Search: Screen<CategoryProps> = ({
     }
   }
 
+  const getChildLinks = (
+    item: SearchEntryType,
+  ): { label: string; href: string }[] => {
+    if (item.__typename === 'Article' && item.subArticles?.length) {
+      return item.subArticles.map((sub) => ({
+        label: sub.title,
+        href: linkResolver('subarticle', sub.slug.split('/')).href,
+      }))
+    }
+    if (
+      item.__typename === 'OrganizationParentSubpage' &&
+      item.childLinks?.length
+    ) {
+      return item.childLinks.map((link) => ({
+        label: link.label,
+        href: link.href,
+      }))
+    }
+    return []
+  }
+
   const searchResultsItems = (
     searchResults.items as Array<SearchEntryType>
   ).map((item) => ({
@@ -399,6 +420,7 @@ const Search: Screen<CategoryProps> = ({
     group: item.group,
     ...getItemImages(item),
     labels: getLabels(item),
+    childLinks: getChildLinks(item),
   }))
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore make web strict
@@ -785,6 +807,7 @@ const Search: Screen<CategoryProps> = ({
                       thumbnail,
                       labels,
                       parentTitle,
+                      childLinks,
                       link: linkHref,
                       ...rest
                     },
@@ -810,6 +833,7 @@ const Search: Screen<CategoryProps> = ({
                         subTitle={parentTitle}
                         highlightedResults={false}
                         link={{ href: linkHref }}
+                        childLinks={childLinks}
                         {...rest}
                       />
                     )

--- a/apps/web/screens/queries/Search.tsx
+++ b/apps/web/screens/queries/Search.tsx
@@ -276,6 +276,10 @@ export const GET_SEARCH_RESULTS_QUERY_DETAILED = gql`
           href
           organizationPageTitle
           intro
+          childLinks {
+            label
+            href
+          }
         }
         ... on ProjectPage {
           id

--- a/libs/shared/types/src/lib/searchable-content-types.ts
+++ b/libs/shared/types/src/lib/searchable-content-types.ts
@@ -1,6 +1,5 @@
 export enum SearchableContentTypes {
   webArticle = 'webArticle',
-  webSubArticle = 'webSubArticle',
   webLifeEventPage = 'webLifeEventPage',
   webDigitalIcelandService = 'webDigitalIcelandService',
   webDigitalIcelandCommunityPage = 'webDigitalIcelandCommunityPage',


### PR DESCRIPTION
# Adjust search results to display top level and then links on card for levels below

Article

<img width="931" height="461" alt="Screenshot 2026-04-14 at 15 21 24" src="https://github.com/user-attachments/assets/d7399579-ec53-4bd7-a649-fcdca7742d3b" />



Organization parent subpage

<img width="933" height="413" alt="Screenshot 2026-04-14 at 15 20 38" src="https://github.com/user-attachments/assets/51775004-fa31-4ce2-ab80-4142802475a8" />

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
