### PR TITLE
fix(matomo): exclude localhost from referrer tracking cookie

### DIFF
--- a/libs/matomo/src/lib/MatomoTracker.tsx
+++ b/libs/matomo/src/lib/MatomoTracker.tsx
@@ -42,6 +42,8 @@ export const MatomoTracker = ({
     window._paq = window._paq || []
     window._paq.push(['setTrackerUrl', `${normalizedDomain.current}matomo.php`])
     window._paq.push(['setSiteId', `${matomoSiteId}`])
+    window._paq.push(['setExcludedReferrers', ['localhost', '*.localhost']])
+    window._paq.push(['setReferralCookieTimeout', 2592000])
     window._paq.push(['enableLinkTracking'])
     const handleRouteChange = (url: string) => {
       window._paq?.push(['setCustomUrl', url])


### PR DESCRIPTION
## Problem

A returning user on island.is can get a **403 ERROR from CloudFront** when the `_pk_ref.2.0662` Matomo referrer cookie contains `localhost`. This happens when developers navigate from their local dev server (`localhost:4200`) to island.is — Matomo records that as the referrer, and a WAF rule blocks subsequent requests because it sees `localhost` in the Cookie header.

See bug report: `island-is-403-bug-report.pdf` (CloudFront Request ID: `nfDJlP5lc3aEQFRe6hO20UyxmF--rTsuZKUx8FPSIGlo0hHRghCyvg==`)

## Fix

- **`setExcludedReferrers(['localhost', '*.localhost'])`** — prevents the Matomo JS tracker from ever storing a localhost referrer in the `_pk_ref` cookie. This is a Matomo 4.12+ API.
- **`setReferralCookieTimeout(2592000)`** — reduces the referral cookie lifetime from 6 months to 30 days, so any existing bad cookies expire sooner.

Both calls are placed before `enableLinkTracking` and before any `trackPageView`, as required by the Matomo API.

## What this does NOT fix

Users who already have the bad `_pk_ref` cookie will still be blocked until:
1. The cookie expires (now 30 days instead of 6 months), or
2. They visit from a new external referrer (overwrites the cookie), or
3. They manually clear cookies

A complementary WAF rule change (scoping the localhost pattern match away from Cookie headers) would provide immediate relief but is out of scope for this PR.

## Testing

1. Clear cookies for island.is
2. Set `_pk_ref.2.0662` to the encoded localhost value from the bug report
3. Verify the 403 still occurs (pre-fix behavior)
4. Deploy this change
5. Visit island.is from `localhost:4200` — the `_pk_ref` cookie should no longer contain localhost
6. Confirm no 403 error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated analytics configuration to exclude local development environments from tracking metrics.
  * Adjusted referral cookie timeout settings to improve analytics accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->