### PR TITLE
feat(admin-portal): prevent UUID errors when filtering

### DIFF
--- a/libs/api/domains/application/src/lib/application-admin/application-adminV2.service.ts
+++ b/libs/api/domains/application/src/lib/application-admin/application-adminV2.service.ts
@@ -56,7 +56,9 @@ export class ApplicationAdminV2Service {
 
     const appSystemPromise = skipAppSystem
       ? null
-      : this.appSystemApplicationApiWithAuth(user).adminControllerFindAllSuperAdmin({
+      : this.appSystemApplicationApiWithAuth(
+          user,
+        ).adminControllerFindAllSuperAdmin({
           count: fetchCount,
           page: 1,
           applicantNationalId: filters.applicantNationalId,
@@ -71,17 +73,19 @@ export class ApplicationAdminV2Service {
 
     const formSystemPromise = skipFormSystem
       ? null
-      : this.formSystemAdminApiWithAuth(user).adminControllerGetOverviewForSuperAdmin({
-            count: fetchCount,
-            page: 1,
-            applicantNationalId: filters.applicantNationalId,
-            locale,
-            from: filters.from,
-            to: filters.to,
-            formId: filters.typeIdValue,
-            searchStr: filters.searchStr,
-            institutionNationalId: filters.institutionNationalId,
-          })
+      : this.formSystemAdminApiWithAuth(
+          user,
+        ).adminControllerGetOverviewForSuperAdmin({
+          count: fetchCount,
+          page: 1,
+          applicantNationalId: filters.applicantNationalId,
+          locale,
+          from: filters.from,
+          to: filters.to,
+          formId: filters.typeIdValue,
+          searchStr: filters.searchStr,
+          institutionNationalId: filters.institutionNationalId,
+        })
 
     const [appSystemSettled, formSystemSettled] = await Promise.allSettled([
       appSystemPromise ?? Promise.resolve(null),
@@ -137,7 +141,9 @@ export class ApplicationAdminV2Service {
 
     const appSystemPromise = skipAppSystem
       ? null
-      : this.appSystemApplicationApiWithAuth(user).adminControllerFindAllInstitutionAdmin({
+      : this.appSystemApplicationApiWithAuth(
+          user,
+        ).adminControllerFindAllInstitutionAdmin({
           count: fetchCount,
           page: 1,
           applicantNationalId: filters.applicantNationalId,
@@ -151,16 +157,18 @@ export class ApplicationAdminV2Service {
 
     const formSystemPromise = skipFormSystem
       ? null
-      : this.formSystemAdminApiWithAuth(user).adminControllerGetOverviewForInstitutionAdmin({
-            count: fetchCount,
-            page: 1,
-            applicantNationalId: filters.applicantNationalId,
-            locale,
-            from: filters.from,
-            to: filters.to,
-            formId: filters.typeIdValue,
-            searchStr: filters.searchStr,
-          })
+      : this.formSystemAdminApiWithAuth(
+          user,
+        ).adminControllerGetOverviewForInstitutionAdmin({
+          count: fetchCount,
+          page: 1,
+          applicantNationalId: filters.applicantNationalId,
+          locale,
+          from: filters.from,
+          to: filters.to,
+          formId: filters.typeIdValue,
+          searchStr: filters.searchStr,
+        })
 
     const [appSystemSettled, formSystemSettled] = await Promise.allSettled([
       appSystemPromise ?? Promise.resolve(null),

--- a/libs/api/domains/application/src/lib/application-admin/application-adminV2.service.ts
+++ b/libs/api/domains/application/src/lib/application-admin/application-adminV2.service.ts
@@ -1,5 +1,6 @@
 import { ApplicationsApi, ApplicationTypeAdmin } from '../../../gen/fetch'
 import { Inject, Injectable, Logger } from '@nestjs/common'
+import { isUUID } from 'class-validator'
 import { Locale } from '@island.is/shared/types'
 import { Auth, AuthMiddleware, User } from '@island.is/auth-nest-tools'
 import { AdminApi as FormSystemAdminApi } from '@island.is/clients/form-system'
@@ -47,61 +48,64 @@ export class ApplicationAdminV2Service {
     locale: Locale,
     filters: ApplicationsSuperAdminFilters,
   ): Promise<ApplicationAdminPaginatedResponse> {
+    // If the user is filtering by a typeId from the opposite system we should skip the call to the other system
+    const skipAppSystem = !!filters.typeIdValue && isUUID(filters.typeIdValue)
+    const skipFormSystem = !!filters.typeIdValue && !isUUID(filters.typeIdValue)
     // Fetch enough items from each source to cover the requested page
     const fetchCount = filters.page * filters.count
 
-    const appSystemPromise = this.appSystemApplicationApiWithAuth(
-      user,
-    ).adminControllerFindAllSuperAdmin({
-      count: fetchCount,
-      page: 1,
-      applicantNationalId: filters.applicantNationalId,
-      locale,
-      status: filters.status?.join(','),
-      from: filters.from,
-      to: filters.to,
-      typeIdValue: filters.typeIdValue,
-      searchStr: filters.searchStr,
-      institutionNationalId: filters.institutionNationalId,
-    })
+    const appSystemPromise = skipAppSystem
+      ? null
+      : this.appSystemApplicationApiWithAuth(user).adminControllerFindAllSuperAdmin({
+          count: fetchCount,
+          page: 1,
+          applicantNationalId: filters.applicantNationalId,
+          locale,
+          status: filters.status?.join(','),
+          from: filters.from,
+          to: filters.to,
+          typeIdValue: filters.typeIdValue,
+          searchStr: filters.searchStr,
+          institutionNationalId: filters.institutionNationalId,
+        })
 
-    const formSystemPromise = this.formSystemAdminApiWithAuth(
-      user,
-    ).adminControllerGetOverviewForSuperAdmin({
-      count: fetchCount,
-      page: 1,
-      applicantNationalId: filters.applicantNationalId,
-      locale,
-      from: filters.from,
-      to: filters.to,
-      formId: filters.typeIdValue,
-      searchStr: filters.searchStr,
-      institutionNationalId: filters.institutionNationalId,
-    })
+    const formSystemPromise = skipFormSystem
+      ? null
+      : this.formSystemAdminApiWithAuth(user).adminControllerGetOverviewForSuperAdmin({
+            count: fetchCount,
+            page: 1,
+            applicantNationalId: filters.applicantNationalId,
+            locale,
+            from: filters.from,
+            to: filters.to,
+            formId: filters.typeIdValue,
+            searchStr: filters.searchStr,
+            institutionNationalId: filters.institutionNationalId,
+          })
 
     const [appSystemSettled, formSystemSettled] = await Promise.allSettled([
-      appSystemPromise,
-      formSystemPromise,
+      appSystemPromise ?? Promise.resolve(null),
+      formSystemPromise ?? Promise.resolve(null),
     ])
 
     let appSystemRows: ApplicationAdmin[] = []
     let formSystemRows: ApplicationAdmin[] = []
     let totalCount = 0
-    if (appSystemSettled.status === 'fulfilled') {
+    if (appSystemSettled.status === 'fulfilled' && appSystemSettled.value) {
       appSystemRows = appSystemSettled.value.rows
       totalCount += appSystemSettled.value.count
-    } else {
+    } else if (appSystemSettled.status === 'rejected') {
       this.logger.error(
         'Error getting application system applications for super-admin',
         appSystemSettled.reason,
       )
     }
-    if (formSystemSettled.status === 'fulfilled') {
+    if (formSystemSettled.status === 'fulfilled' && formSystemSettled.value) {
       formSystemRows = (formSystemSettled.value.rows ?? []).map(
         mapFormSystemApplicationAdmin,
       )
       totalCount += formSystemSettled.value.count
-    } else {
+    } else if (formSystemSettled.status === 'rejected') {
       this.logger.error(
         'Error getting form system applications for super-admin',
         formSystemSettled.reason,
@@ -125,59 +129,62 @@ export class ApplicationAdminV2Service {
     locale: Locale,
     filters: ApplicationsAdminFilters,
   ): Promise<ApplicationAdminPaginatedResponse> {
+    // If the user is filtering by a typeId from the opposite system we should skip the call to the other system
+    const skipAppSystem = !!filters.typeIdValue && isUUID(filters.typeIdValue)
+    const skipFormSystem = !!filters.typeIdValue && !isUUID(filters.typeIdValue)
     // Fetch enough items from each source to cover the requested page
     const fetchCount = filters.page * filters.count
 
-    const appSystemPromise = this.appSystemApplicationApiWithAuth(
-      user,
-    ).adminControllerFindAllInstitutionAdmin({
-      count: fetchCount,
-      page: 1,
-      applicantNationalId: filters.applicantNationalId,
-      locale,
-      status: filters.status?.join(','),
-      from: filters.from,
-      to: filters.to,
-      typeIdValue: filters.typeIdValue,
-      searchStr: filters.searchStr,
-    })
+    const appSystemPromise = skipAppSystem
+      ? null
+      : this.appSystemApplicationApiWithAuth(user).adminControllerFindAllInstitutionAdmin({
+          count: fetchCount,
+          page: 1,
+          applicantNationalId: filters.applicantNationalId,
+          locale,
+          status: filters.status?.join(','),
+          from: filters.from,
+          to: filters.to,
+          typeIdValue: filters.typeIdValue,
+          searchStr: filters.searchStr,
+        })
 
-    const formSystemPromise = this.formSystemAdminApiWithAuth(
-      user,
-    ).adminControllerGetOverviewForInstitutionAdmin({
-      count: fetchCount,
-      page: 1,
-      applicantNationalId: filters.applicantNationalId,
-      locale,
-      from: filters.from,
-      to: filters.to,
-      formId: filters.typeIdValue,
-      searchStr: filters.searchStr,
-    })
+    const formSystemPromise = skipFormSystem
+      ? null
+      : this.formSystemAdminApiWithAuth(user).adminControllerGetOverviewForInstitutionAdmin({
+            count: fetchCount,
+            page: 1,
+            applicantNationalId: filters.applicantNationalId,
+            locale,
+            from: filters.from,
+            to: filters.to,
+            formId: filters.typeIdValue,
+            searchStr: filters.searchStr,
+          })
 
     const [appSystemSettled, formSystemSettled] = await Promise.allSettled([
-      appSystemPromise,
-      formSystemPromise,
+      appSystemPromise ?? Promise.resolve(null),
+      formSystemPromise ?? Promise.resolve(null),
     ])
 
     let appSystemRows: ApplicationAdmin[] = []
     let formSystemRows: ApplicationAdmin[] = []
     let totalCount = 0
-    if (appSystemSettled.status === 'fulfilled') {
+    if (appSystemSettled.status === 'fulfilled' && appSystemSettled.value) {
       appSystemRows = appSystemSettled.value.rows
       totalCount += appSystemSettled.value.count
-    } else {
+    } else if (appSystemSettled.status === 'rejected') {
       this.logger.error(
         'Error getting application system applications for institution admin',
         appSystemSettled.reason,
       )
     }
-    if (formSystemSettled.status === 'fulfilled') {
+    if (formSystemSettled.status === 'fulfilled' && formSystemSettled.value) {
       formSystemRows = (formSystemSettled.value.rows ?? []).map(
         mapFormSystemApplicationAdmin,
       )
       totalCount += formSystemSettled.value.count
-    } else {
+    } else if (formSystemSettled.status === 'rejected') {
       this.logger.error(
         'Error getting form system applications for institution admin',
         formSystemSettled.reason,


### PR DESCRIPTION
# ...

Filtering by a typeId from the application-system would cause the form-system to throw an error. This change checks if a type Id has been selected, if so the call to the opposite system is blocked.

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of application filtering and data retrieval by enhancing validation logic.
  * Better error handling when fetching application information across different system types.

* **Chores**
  * Optimized internal data processing to prevent unnecessary API calls based on system type validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->