### PR TITLE
fix(j-s): Indictment Header for Court of Appeals

### DIFF
--- a/apps/judicial-system/web/src/utils/titleForCase/titleForCase.ts
+++ b/apps/judicial-system/web/src/utils/titleForCase/titleForCase.ts
@@ -1,6 +1,9 @@
 import { IntlShape } from 'react-intl'
 
-import { isInvestigationCase } from '@island.is/judicial-system/types'
+import {
+  isIndictmentCase,
+  isInvestigationCase,
+} from '@island.is/judicial-system/types'
 import {
   Case,
   CaseDecision,
@@ -14,6 +17,10 @@ export const titleForCase = (
   formatMessage: IntlShape['formatMessage'],
   theCase: Case,
 ) => {
+  if (isIndictmentCase(theCase.type)) {
+    return 'Máli lokið'
+  }
+
   if (theCase.state === CaseState.REJECTED) {
     return isInvestigationCase(theCase.type)
       ? formatMessage(strings.investigationCaseRejectedTitle)


### PR DESCRIPTION
<img width="376" height="194" alt="image" src="https://github.com/user-attachments/assets/8b769d85-e5aa-4e79-9952-5a343f4fe5c3" />

This pull request updates the `titleForCase` utility to improve how case titles are determined, specifically adding support for indictment cases. The main change is that indictment cases now return a fixed title.

Enhancement to case title logic:

* Added a check in `titleForCase` to return the fixed title 'Máli lokið' for indictment cases by using the `isIndictmentCase` helper.
* Imported the `isIndictmentCase` function from `@island.is/judicial-system/types` to enable the new logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed case title display for indictment cases to ensure accurate and consistent status information is shown throughout the system interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->