### PR TITLE
feat(cms-importer): Remove or edit duplicate assets between contentful environments

### DIFF
--- a/apps/services/cms-importer/README.md
+++ b/apps/services/cms-importer/README.md
@@ -40,12 +40,21 @@ Generates a sitemap.xml file in S3 (that gets forwarded to https://island.is/sit
 yarn nx run services-cms-importer:web-sitemap
 ```
 
+### CMS Cleanup
+
+Runs CMS cleanup tasks. Initial scaffold is intended for cleanup jobs like deleting duplicate assets in other Contentful environments.
+
+```bash
+yarn nx run services-cms-importer:cms-cleanup
+```
+
 ## Architecture
 
 - **main.ts** - Entry point that handles job routing based on command-line arguments
 - **app/grant-import/** - Grant import module with service and worker logic
 - **app/energy-fund-import/** - Energy fund import module
 - **app/fsre-buildings-import/** - FSRE buildings import module
+- **app/cms-cleanup/** - CMS cleanup module
 - **app/repositories/** - Data access layer for CMS, grants, and energy grants
 
 ## Building
@@ -64,6 +73,7 @@ Each job can be run individually using the corresponding Nx target:
 nx grant-import services-cms-importer
 nx energy-fund-import services-cms-importer
 nx fsre-buildings-import services-cms-importer
+nx cms-cleanup services-cms-importer
 ```
 
 Or run the built application directly with job arguments:

--- a/apps/services/cms-importer/infra/cms-importer-worker.ts
+++ b/apps/services/cms-importer/infra/cms-importer-worker.ts
@@ -87,19 +87,18 @@ export const webSitemapImportSetup =
         prod: { schedule: '0 */3 * * *' },
       })
 
-export const cmsCleanupSetup =
-  (): ServiceBuilder<'cms-importer-cms-cleanup'> =>
-    service('cms-importer-cms-cleanup')
-      .image('services-cms-importer')
-      .namespace('cms-importer')
-      .secrets({
-        CONTENTFUL_MANAGEMENT_ACCESS_TOKEN:
-          '/k8s/contentful-entry-tagger/CONTENTFUL_MANAGEMENT_ACCESS_TOKEN',
-      })
-      .command('node')
-      .args('main.cjs', '--job', 'cms-cleanup')
-      .extraAttributes({
-        dev: { schedule: '0 0 * * 0' },
-        staging: { schedule: '0 0 * * 0' },
-        prod: { schedule: '0 0 * * 0' },
-      })
+export const cmsCleanupSetup = (): ServiceBuilder<'cms-importer-cms-cleanup'> =>
+  service('cms-importer-cms-cleanup')
+    .image('services-cms-importer')
+    .namespace('cms-importer')
+    .secrets({
+      CONTENTFUL_MANAGEMENT_ACCESS_TOKEN:
+        '/k8s/contentful-entry-tagger/CONTENTFUL_MANAGEMENT_ACCESS_TOKEN',
+    })
+    .command('node')
+    .args('main.cjs', '--job', 'cms-cleanup')
+    .extraAttributes({
+      dev: { schedule: '0 0 * * 0' },
+      staging: { schedule: '0 0 * * 0' },
+      prod: { schedule: '0 0 * * 0' },
+    })

--- a/apps/services/cms-importer/infra/cms-importer-worker.ts
+++ b/apps/services/cms-importer/infra/cms-importer-worker.ts
@@ -86,3 +86,20 @@ export const webSitemapImportSetup =
         staging: { schedule: '0 0 * * 0' },
         prod: { schedule: '0 */3 * * *' },
       })
+
+export const cmsCleanupSetup =
+  (): ServiceBuilder<'cms-importer-cms-cleanup'> =>
+    service('cms-importer-cms-cleanup')
+      .image('services-cms-importer')
+      .namespace('cms-importer')
+      .secrets({
+        CONTENTFUL_MANAGEMENT_ACCESS_TOKEN:
+          '/k8s/contentful-entry-tagger/CONTENTFUL_MANAGEMENT_ACCESS_TOKEN',
+      })
+      .command('node')
+      .args('main.cjs', '--job', 'cms-cleanup')
+      .extraAttributes({
+        dev: { schedule: '0 0 * * 0' },
+        staging: { schedule: '0 0 * * 0' },
+        prod: { schedule: '0 0 * * 0' },
+      })

--- a/apps/services/cms-importer/project.json
+++ b/apps/services/cms-importer/project.json
@@ -65,6 +65,16 @@
         "args": ["--job", "web-sitemap"]
       }
     },
+    "cms-cleanup": {
+      "executor": "@nx/js:node",
+      "options": {
+        "buildTarget": "services-cms-importer:build",
+        "buildTargetOptions": {
+          "outputPath": "dist/apps/services/cms-importer"
+        },
+        "args": ["--job", "cms-cleanup"]
+      }
+    },
     "lint": {
       "executor": "@nx/eslint:lint"
     },

--- a/apps/services/cms-importer/src/app/cms-cleanup/cms-cleanup-worker.ts
+++ b/apps/services/cms-importer/src/app/cms-cleanup/cms-cleanup-worker.ts
@@ -1,0 +1,19 @@
+import { logger } from '@island.is/logging'
+import { NestFactory } from '@nestjs/core'
+import { CmsCleanupModule } from './cms-cleanup.module'
+import { CmsCleanupService } from './cms-cleanup.service'
+
+export const cmsCleanupWorker = async () => {
+  try {
+    logger.info('CMS cleanup worker job initiating...')
+    const app = await NestFactory.createApplicationContext(CmsCleanupModule)
+    app.enableShutdownHooks()
+    await app.get(CmsCleanupService).run()
+    await app.close()
+    logger.info('CMS cleanup worker finished successfully.')
+    process.exit(0)
+  } catch (error) {
+    logger.error('CMS cleanup worker encountered an error:', error)
+    process.exit(1)
+  }
+}

--- a/apps/services/cms-importer/src/app/cms-cleanup/cms-cleanup.module.ts
+++ b/apps/services/cms-importer/src/app/cms-cleanup/cms-cleanup.module.ts
@@ -1,0 +1,19 @@
+import { LoggingModule } from '@island.is/logging'
+import { ConfigModule } from '@island.is/nest/config'
+import { Module } from '@nestjs/common'
+import { CmsRepositoryModule } from '../repositories/cms/cms.module'
+import { ManagementClientConfig } from '../repositories/cms/managementClient/managementClient.config'
+import { CmsCleanupService } from './cms-cleanup.service'
+
+@Module({
+  imports: [
+    LoggingModule,
+    CmsRepositoryModule,
+    ConfigModule.forRoot({
+      isGlobal: true,
+      load: [ManagementClientConfig],
+    }),
+  ],
+  providers: [CmsCleanupService],
+})
+export class CmsCleanupModule {}

--- a/apps/services/cms-importer/src/app/cms-cleanup/cms-cleanup.service.ts
+++ b/apps/services/cms-importer/src/app/cms-cleanup/cms-cleanup.service.ts
@@ -13,7 +13,8 @@ export class CmsCleanupService {
   public async run() {
     logger.info('CMS cleanup worker starting...')
 
-    const allMasterAssets = await this.getAllAssets(ENVIRONMENT)
+    logger.info(`Fetching all assets in ${ENVIRONMENT} environment...`)
+    const allMasterAssets = await this.getAllAssets(ENVIRONMENT, true)
     logger.info(
       `Found ${allMasterAssets.length} assets in ${ENVIRONMENT} environment`,
     )
@@ -130,10 +131,10 @@ export class CmsCleanupService {
     logger.info('CMS cleanup worker finished.')
   }
 
-  private async getAllAssets(environment: string) {
+  private async getAllAssets(environment: string, logProgress = false) {
     let skip = 0
     let total = Infinity
-    const limit = 100
+    const limit = 500
     const assets: Asset[] = []
 
     while (skip < total) {
@@ -147,6 +148,9 @@ export class CmsCleanupService {
       if (!response.ok) throw response.error
       skip += limit
       total = response.data.total
+      if (logProgress)
+        logger.info(`Fetched ${skip < total ? skip : total}/${total} assets...`)
+
       assets.push(...response.data.items)
     }
 

--- a/apps/services/cms-importer/src/app/cms-cleanup/cms-cleanup.service.ts
+++ b/apps/services/cms-importer/src/app/cms-cleanup/cms-cleanup.service.ts
@@ -1,0 +1,155 @@
+import { Injectable } from '@nestjs/common'
+import { Asset } from 'contentful-management'
+import { logger } from '@island.is/logging'
+import { ManagementClientService } from '../repositories/cms/managementClient/managementClient.service'
+import { ENVIRONMENT, LOCALE } from '../constants'
+
+@Injectable()
+export class CmsCleanupService {
+  constructor(
+    private readonly managementClientService: ManagementClientService,
+  ) {}
+
+  public async run() {
+    logger.info('CMS cleanup worker starting...')
+
+    const allMasterAssets = await this.getAllAssets(ENVIRONMENT)
+    logger.info(
+      `Found ${allMasterAssets.length} assets in ${ENVIRONMENT} environment`,
+    )
+
+    const environments = await this.managementClientService.getEnvironments()
+    if (!environments.ok) throw environments.error
+
+    for (const environment of environments.data.items) {
+      if (environment.sys.id === ENVIRONMENT) continue
+
+      logger.info(`Checking ${environment.sys.id} environment...`)
+
+      let skip = 0
+      let total = Infinity
+      const limit = 100
+
+      let archiveCount = 0
+      let countMatchWithMaster = 0
+      let deleteCount = 0
+      let updateCount = 0
+
+      while (skip < total) {
+        const assets = await this.managementClientService.getAssets(
+          {
+            limit,
+            skip,
+          },
+          environment.sys.id,
+        )
+        if (!assets.ok) throw assets.error
+
+        skip += limit
+        total = assets.data.total
+
+        // If master asset is archived, let's archive it also in other environments
+        for (let asset of assets.data.items) {
+          if (
+            allMasterAssets.some(
+              (masterAsset) =>
+                masterAsset.sys.id === asset.sys.id &&
+                masterAsset.isArchived() &&
+                !asset.isArchived(),
+            )
+          ) {
+            if (asset.isPublished() || asset.isUpdated())
+              asset = await asset.unpublish()
+            await asset.archive()
+            logger.info(
+              `Archived asset ${asset.sys.id} in ${environment.sys.id} environment`,
+            )
+            archiveCount++
+          }
+
+          // If assets in other environments are not in master, let's delete them
+          if (
+            allMasterAssets.some(
+              (masterAsset) => masterAsset.sys.id === asset.sys.id,
+            )
+          )
+            countMatchWithMaster++
+          else {
+            if (asset.isPublished() || asset.isUpdated())
+              asset = await asset.unpublish()
+            else if (asset.isDraft() && !asset.isArchived())
+              asset = await asset.archive()
+            await asset.delete()
+            logger.info(
+              `Deleted asset ${asset.sys.id} in ${environment.sys.id} environment`,
+            )
+            deleteCount++
+          }
+
+          // If assets in other environments are in master, let's update them if the file url is different
+          for (const masterAsset of allMasterAssets) {
+            if (masterAsset.sys.id === asset.sys.id) {
+              if (masterAsset.isArchived()) continue
+              const masterFileUrl = masterAsset.fields.file?.[LOCALE]?.url
+              if (masterFileUrl) {
+                let needsUpdate = false
+                const assetFileUrl = asset.fields.file?.[LOCALE]?.url
+                if (!assetFileUrl) needsUpdate = true
+                else if (assetFileUrl !== masterFileUrl) needsUpdate = true
+
+                if (needsUpdate) {
+                  const wasPublished = asset.isPublished()
+                  asset.fields.file = masterAsset.fields.file
+                  asset = await asset.update()
+                  if (wasPublished) await asset.publish()
+                  logger.info(
+                    `Asset ${asset.sys.id} updated in ${environment.sys.id} environment`,
+                  )
+                  updateCount++
+                }
+              }
+            }
+          }
+        }
+      }
+
+      logger.info(
+        `${countMatchWithMaster} assets in master environment matched with ${environment.sys.id} environment`,
+      )
+      logger.info(
+        `${environment.sys.id} environment archived: ${archiveCount} assets`,
+      )
+      logger.info(
+        `${environment.sys.id} environment deleted: ${deleteCount} assets`,
+      )
+      logger.info(
+        `${environment.sys.id} environment updated: ${updateCount} assets`,
+      )
+    }
+
+    logger.info('CMS cleanup worker finished.')
+  }
+
+  private async getAllAssets(environment: string) {
+    let skip = 0
+    let total = Infinity
+    const limit = 100
+    const assets: Asset[] = []
+
+    while (skip < total) {
+      const response = await this.managementClientService.getAssets(
+        {
+          limit,
+          skip,
+        },
+        environment,
+      )
+      if (!response.ok) throw response.error
+      skip += limit
+      total = response.data.total
+      assets.push(...response.data.items)
+    }
+
+    return assets
+  }
+}

--- a/apps/services/cms-importer/src/app/repositories/cms/managementClient/managementClient.service.ts
+++ b/apps/services/cms-importer/src/app/repositories/cms/managementClient/managementClient.service.ts
@@ -1,5 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common'
 import {
+  Asset,
+  AssetProps,
   ClientAPI,
   Collection,
   ContentType,
@@ -30,6 +32,23 @@ export class ManagementClientService {
       .then((space) => space.getEnvironment(ENVIRONMENT))
       .then((environment) => environment.getEntries(queryWithLimit))
       .then((entries) => ({ ok: true as const, data: entries }))
+      .catch((e) => ({
+        ok: false as const,
+        error: e,
+      }))
+  }
+
+  getAssets = async (
+    query?: QueryOptions,
+    environment?: string,
+  ): Promise<ContentfulFetchResponse<Collection<Asset, AssetProps>>> => {
+    const queryWithLimit = { limit: 1000, ...query }
+
+    return this.client
+      .getSpace(SPACE_ID)
+      .then((space) => space.getEnvironment(environment ?? ENVIRONMENT))
+      .then((environment) => environment.getAssets(queryWithLimit))
+      .then((assets) => ({ ok: true as const, data: assets }))
       .catch((e) => ({
         ok: false as const,
         error: e,
@@ -70,6 +89,16 @@ export class ManagementClientService {
       .then((space) => space.getEnvironment(ENVIRONMENT))
       .then((env) => env.getContentType(contentType))
       .then((contentType) => ({ ok: true as const, data: contentType }))
+      .catch((e) => ({
+        ok: false as const,
+        error: e,
+      }))
+
+  getEnvironments = async () =>
+    this.client
+      .getSpace(SPACE_ID)
+      .then((space) => space.getEnvironments())
+      .then((environments) => ({ ok: true as const, data: environments }))
       .catch((e) => ({
         ok: false as const,
         error: e,

--- a/apps/services/cms-importer/src/app/utils.ts
+++ b/apps/services/cms-importer/src/app/utils.ts
@@ -20,6 +20,7 @@ export const processJob = () =>
         'grant-import',
         'fsre-buildings-import',
         'web-sitemap',
+        'cms-cleanup',
       ] as const,
       description: 'Indicate what import application should run',
     })

--- a/apps/services/cms-importer/src/main.ts
+++ b/apps/services/cms-importer/src/main.ts
@@ -48,6 +48,17 @@ switch (job) {
       })
     break
   }
+  case 'cms-cleanup': {
+    import('./app/cms-cleanup/cms-cleanup-worker')
+      .then((app) => app.cmsCleanupWorker())
+      .catch((error) => {
+        console.error(
+          'Failed to import or execute the cms cleanup worker:',
+          error,
+        )
+      })
+    break
+  }
   default: {
     console.debug('No argument provided, nothing executed')
   }

--- a/charts/islandis/values.dev.yaml
+++ b/charts/islandis/values.dev.yaml
@@ -1195,6 +1195,62 @@ application-system-form:
       eks.amazonaws.com/role-arn: 'arn:aws:iam::013313053092:role/application-system-form'
     create: true
     name: 'application-system-form'
+cms-importer-cms-cleanup:
+  args:
+    - 'main.cjs'
+    - '--job'
+    - 'cms-cleanup'
+  command:
+    - 'node'
+  enabled: true
+  env:
+    LOG_LEVEL: 'info'
+    NODE_OPTIONS: '--max-old-space-size=230 --enable-source-maps -r dd-trace/init'
+    SERVERSIDE_FEATURES_ON: ''
+  grantNamespaces: []
+  grantNamespacesEnabled: false
+  healthCheck:
+    liveness:
+      initialDelaySeconds: 3
+      path: '/'
+      timeoutSeconds: 3
+    readiness:
+      initialDelaySeconds: 3
+      path: '/'
+      timeoutSeconds: 3
+  hpa:
+    scaling:
+      metric:
+        cpuAverageUtilization: 90
+        nginxRequestsIrate: 5
+      replicas:
+        max: 3
+        min: 1
+  image:
+    repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/services-cms-importer'
+  namespace: 'cms-importer'
+  podDisruptionBudget:
+    minAvailable: '50%'
+    unhealthyPodEvictionPolicy: 'IfHealthyBudget'
+  pvcs: []
+  replicaCount:
+    default: 1
+    max: 3
+    min: 1
+  resources:
+    limits:
+      cpu: '200m'
+      memory: '256Mi'
+    requests:
+      cpu: '100m'
+      memory: '128Mi'
+  schedule: '0 0 * * 0'
+  secrets:
+    CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
+    CONTENTFUL_MANAGEMENT_ACCESS_TOKEN: '/k8s/contentful-entry-tagger/CONTENTFUL_MANAGEMENT_ACCESS_TOKEN'
+  securityContext:
+    allowPrivilegeEscalation: false
+    privileged: false
 cms-importer-energy-fund-import:
   args:
     - 'main.cjs'

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -1183,6 +1183,62 @@ application-system-form:
       eks.amazonaws.com/role-arn: 'arn:aws:iam::251502586493:role/application-system-form'
     create: true
     name: 'application-system-form'
+cms-importer-cms-cleanup:
+  args:
+    - 'main.cjs'
+    - '--job'
+    - 'cms-cleanup'
+  command:
+    - 'node'
+  enabled: true
+  env:
+    LOG_LEVEL: 'info'
+    NODE_OPTIONS: '--max-old-space-size=230 --enable-source-maps -r dd-trace/init'
+    SERVERSIDE_FEATURES_ON: 'driving-license-use-v1-endpoint-for-v2-comms'
+  grantNamespaces: []
+  grantNamespacesEnabled: false
+  healthCheck:
+    liveness:
+      initialDelaySeconds: 3
+      path: '/'
+      timeoutSeconds: 3
+    readiness:
+      initialDelaySeconds: 3
+      path: '/'
+      timeoutSeconds: 3
+  hpa:
+    scaling:
+      metric:
+        cpuAverageUtilization: 90
+        nginxRequestsIrate: 5
+      replicas:
+        max: 10
+        min: 3
+  image:
+    repository: '821090935708.dkr.ecr.eu-west-1.amazonaws.com/services-cms-importer'
+  namespace: 'cms-importer'
+  podDisruptionBudget:
+    minAvailable: '50%'
+    unhealthyPodEvictionPolicy: 'IfHealthyBudget'
+  pvcs: []
+  replicaCount:
+    default: 3
+    max: 10
+    min: 3
+  resources:
+    limits:
+      cpu: '200m'
+      memory: '256Mi'
+    requests:
+      cpu: '100m'
+      memory: '128Mi'
+  schedule: '0 0 * * 0'
+  secrets:
+    CONFIGCAT_SDK_KEY: '/k8s/configcat/CONFIGCAT_SDK_KEY'
+    CONTENTFUL_MANAGEMENT_ACCESS_TOKEN: '/k8s/contentful-entry-tagger/CONTENTFUL_MANAGEMENT_ACCESS_TOKEN'
+  securityContext:
+    allowPrivilegeEscalation: false
+    privileged: false
 cms-importer-energy-fund-import:
   args:
     - 'main.cjs'

--- a/infra/src/uber-charts/islandis.ts
+++ b/infra/src/uber-charts/islandis.ts
@@ -30,6 +30,7 @@ import { serviceSetup as xroadCollectorSetup } from '../../../apps/services/xroa
 import { serviceSetup as licenseApiSetup } from '../../../apps/services/license-api/infra/license-api'
 import {
   workerSetup as cmsImporterSetup,
+  cmsCleanupSetup as cmsImporterCmsCleanupSetup,
   energyFundImportSetup as cmsImporterEnergyFundImportSetup,
   fsreBuildingsImportSetup as cmsImporterFsreBuildingsImportSetup,
   webSitemapImportSetup as cmsImporterWebSitemapImportSetup,
@@ -172,6 +173,7 @@ const cmsImporter = cmsImporterSetup()
 const cmsImporterEnergyGrantImport = cmsImporterEnergyFundImportSetup()
 const cmsImporterFsreBuildingsImport = cmsImporterFsreBuildingsImportSetup()
 const cmsImporterWebSitemapImport = cmsImporterWebSitemapImportSetup()
+const cmsImporterCmsCleanup = cmsImporterCmsCleanupSetup()
 
 const storybook = storybookSetup({})
 
@@ -222,6 +224,7 @@ export const Services: EnvironmentServices = {
     cmsImporterEnergyGrantImport,
     cmsImporterFsreBuildingsImport,
     cmsImporterWebSitemapImport,
+    cmsImporterCmsCleanup,
     sessionsService,
     sessionsWorker,
     sessionsCleanupWorker,
@@ -319,6 +322,7 @@ export const Services: EnvironmentServices = {
     cmsImporterEnergyGrantImport,
     cmsImporterFsreBuildingsImport,
     cmsImporterWebSitemapImport,
+    cmsImporterCmsCleanup,
     licenseApi,
     sessionsService,
     sessionsWorker,
@@ -353,4 +357,5 @@ export const ExcludedFeatureDeploymentServices: ServiceBuilder<any>[] = [
   cmsImporterEnergyGrantImport,
   cmsImporterFsreBuildingsImport,
   cmsImporterWebSitemapImport,
+  cmsImporterCmsCleanup,
 ]


### PR DESCRIPTION
# Remove or edit duplicate assets between contentful environments

When assets get deleted or archived, their file urls are still active because they might still be in duplicated in other contentful environments.

This PR introduces a cleanup script that simply checks if that is the case and does something about it

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
