### PR TITLE
fix(admin-portal): use order-insensitive comparison for env sync check

### DIFF
--- a/libs/portals/admin/ids-admin/src/utils/checkEnvironmentsSync.spec.ts
+++ b/libs/portals/admin/ids-admin/src/utils/checkEnvironmentsSync.spec.ts
@@ -26,9 +26,7 @@ describe('checkEnvironmentsSync', () => {
       makeEnv({ environment: 'Production' }),
     ]
 
-    expect(checkEnvironmentsSync(envs, ['boolField', 'stringField'])).toBe(
-      true,
-    )
+    expect(checkEnvironmentsSync(envs, ['boolField', 'stringField'])).toBe(true)
   })
 
   it('should return false when a scalar field differs', () => {

--- a/libs/portals/admin/ids-admin/src/utils/checkEnvironmentsSync.spec.ts
+++ b/libs/portals/admin/ids-admin/src/utils/checkEnvironmentsSync.spec.ts
@@ -1,0 +1,85 @@
+import { checkEnvironmentsSync } from './checkEnvironmentsSync'
+
+interface TestEnvironment {
+  environment: string
+  name: string
+  boolField: boolean
+  stringField: string
+  arrayField: string[]
+}
+
+const makeEnv = (
+  overrides: Partial<TestEnvironment> & { environment: string },
+): TestEnvironment => ({
+  name: 'test',
+  boolField: true,
+  stringField: 'value',
+  arrayField: ['a', 'b', 'c'],
+  ...overrides,
+})
+
+describe('checkEnvironmentsSync', () => {
+  it('should return true when all environments match', () => {
+    const envs = [
+      makeEnv({ environment: 'Development' }),
+      makeEnv({ environment: 'Staging' }),
+      makeEnv({ environment: 'Production' }),
+    ]
+
+    expect(checkEnvironmentsSync(envs, ['boolField', 'stringField'])).toBe(
+      true,
+    )
+  })
+
+  it('should return false when a scalar field differs', () => {
+    const envs = [
+      makeEnv({ environment: 'Development', boolField: true }),
+      makeEnv({ environment: 'Staging', boolField: false }),
+    ]
+
+    expect(checkEnvironmentsSync(envs, ['boolField'])).toBe(false)
+  })
+
+  it('should return true when arrays have the same values in different order', () => {
+    const envs = [
+      makeEnv({
+        environment: 'Development',
+        arrayField: ['Custom', 'GeneralMandate', 'ProcurationHolder'],
+      }),
+      makeEnv({
+        environment: 'Staging',
+        arrayField: ['Custom', 'ProcurationHolder', 'GeneralMandate'],
+      }),
+      makeEnv({
+        environment: 'Production',
+        arrayField: ['Custom', 'GeneralMandate', 'ProcurationHolder'],
+      }),
+    ]
+
+    expect(checkEnvironmentsSync(envs, ['arrayField'])).toBe(true)
+  })
+
+  it('should return false when arrays have different values', () => {
+    const envs = [
+      makeEnv({
+        environment: 'Development',
+        arrayField: ['Custom', 'GeneralMandate'],
+      }),
+      makeEnv({
+        environment: 'Staging',
+        arrayField: ['Custom', 'ProcurationHolder'],
+      }),
+    ]
+
+    expect(checkEnvironmentsSync(envs, ['arrayField'])).toBe(false)
+  })
+
+  it('should only check specified variables', () => {
+    const envs = [
+      makeEnv({ environment: 'Development', boolField: true }),
+      makeEnv({ environment: 'Staging', boolField: false }),
+    ]
+
+    expect(checkEnvironmentsSync(envs, ['stringField'])).toBe(true)
+  })
+})

--- a/libs/portals/admin/ids-admin/src/utils/checkEnvironmentsSync.ts
+++ b/libs/portals/admin/ids-admin/src/utils/checkEnvironmentsSync.ts
@@ -22,10 +22,7 @@ export const checkEnvironmentsSync = <T extends DynamicEnvironmentResult<T>>(
 
       if (
         Array.isArray(referenceValue) && Array.isArray(currentValue)
-          ? !isEqual(
-              [...referenceValue].sort(),
-              [...currentValue].sort(),
-            )
+          ? !isEqual([...referenceValue].sort(), [...currentValue].sort())
           : !isEqual(currentValue, referenceValue)
       ) {
         return false

--- a/libs/portals/admin/ids-admin/src/utils/checkEnvironmentsSync.ts
+++ b/libs/portals/admin/ids-admin/src/utils/checkEnvironmentsSync.ts
@@ -20,7 +20,14 @@ export const checkEnvironmentsSync = <T extends DynamicEnvironmentResult<T>>(
       const currentEnvironment = environments[i]
       const currentValue = currentEnvironment[variableName]
 
-      if (!isEqual(currentValue, referenceValue)) {
+      if (
+        Array.isArray(referenceValue) && Array.isArray(currentValue)
+          ? !isEqual(
+              [...referenceValue].sort(),
+              [...currentValue].sort(),
+            )
+          : !isEqual(currentValue, referenceValue)
+      ) {
         return false
       }
     }


### PR DESCRIPTION
# fix(admin-portal): use order-insensitive comparison for env sync check

## What

- Fixed `checkEnvironmentsSync` to sort array values before comparing, making the comparison order-insensitive
- Added unit tests for `checkEnvironmentsSync`

## Why

- Array fields like `supportedDelegationTypes` can be returned in different order across environments (e.g. `["Custom", "GeneralMandate", "ProcurationHolder"]` vs `["Custom", "ProcurationHolder", "GeneralMandate"]`), causing the UI to incorrectly show delegation settings as "out of sync" even when they are identical

## Screenshots / Gifs

N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review