### PR TITLE
fix(web): Chat bubble styles overriden after client side routing

### DIFF
--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -253,7 +253,7 @@ import {
   LandspitaliModule,
   LandspitaliApiModuleConfig,
 } from '@island.is/api/domains/landspitali'
-
+// TODO: remove this comment
 const environment = getConfig
 
 @Module({

--- a/apps/web/components/ChatPanel/ChatBubble/ChatBubble.tsx
+++ b/apps/web/components/ChatPanel/ChatBubble/ChatBubble.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useRef, useState } from 'react'
 import cn from 'classnames'
 
 import { Box, FocusableBox, LoadingDots, Text } from '@island.is/island-ui/core'
+import { blue200, blue400 } from '@island.is/island-ui/theme'
 
 import {
   EmbedDisclaimer,
@@ -42,6 +43,15 @@ const DefaultVariant = ({
         data-testid="chatbot"
         tabIndex={0}
         className={cn(styles.message, pushUp && styles.messagePushUp)}
+        style={{
+          // Keep critical visuals even if class-based CSS is delayed on route changes.
+          appearance: 'none',
+          WebkitAppearance: 'none',
+          background: blue400,
+          backgroundColor: blue400,
+          border: `1px solid ${blue200}`,
+          color: 'white',
+        }}
         onClick={handleClick}
       >
         <Box position="relative">


### PR DESCRIPTION
# Chat bubble styles overriden after client side routing

Attach a link to issue if relevant

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
