### PR TITLE
fix(web): Chat bubble styles are overriden after client side routing

### DIFF
--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -253,7 +253,7 @@ import {
   LandspitaliModule,
   LandspitaliApiModuleConfig,
 } from '@island.is/api/domains/landspitali'
-
+// TODO: remove this comment
 const environment = getConfig
 
 @Module({

--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -253,7 +253,6 @@ import {
   LandspitaliModule,
   LandspitaliApiModuleConfig,
 } from '@island.is/api/domains/landspitali'
-// TODO: remove this comment
 const environment = getConfig
 
 @Module({

--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -253,6 +253,7 @@ import {
   LandspitaliModule,
   LandspitaliApiModuleConfig,
 } from '@island.is/api/domains/landspitali'
+
 const environment = getConfig
 
 @Module({

--- a/apps/web/components/ChatPanel/ChatBubble/ChatBubble.css.ts
+++ b/apps/web/components/ChatPanel/ChatBubble/ChatBubble.css.ts
@@ -54,8 +54,8 @@ export const message = style({
   textAlign: 'center',
   transition: 'bottom 0.3s ease, transform 0.3s ease',
   transform: 'translateY(0)',
-  ':focus': {
-    outline: 0,
+  ':focus-visible': {
+    outline: `4px solid ${theme.color.mint400}`,
     transform: 'translateY(-10px)',
   },
 })
@@ -81,7 +81,7 @@ export const messageArrow = style({
   borderTop: `10px solid ${blue200}`,
   transition: 'all 150ms ease',
   selectors: {
-    [`${message}:focus &`]: {
+    [`${message}:focus-visible &`]: {
       bottom: -13,
       right: 41,
       borderLeft: '13px solid transparent',

--- a/apps/web/components/ChatPanel/ChatBubble/ChatBubble.tsx
+++ b/apps/web/components/ChatPanel/ChatBubble/ChatBubble.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useRef, useState } from 'react'
 import cn from 'classnames'
 
-import { Box, FocusableBox, LoadingDots, Text } from '@island.is/island-ui/core'
+import { Box, LoadingDots, Text } from '@island.is/island-ui/core'
 
 import {
   EmbedDisclaimer,

--- a/apps/web/components/ChatPanel/ChatBubble/ChatBubble.tsx
+++ b/apps/web/components/ChatPanel/ChatBubble/ChatBubble.tsx
@@ -37,8 +37,7 @@ const DefaultVariant = ({
 }: DefaultVariantProps) => {
   return (
     <div className={cn(styles.root, { [styles.hidden]: !isVisible })}>
-      <FocusableBox
-        component="button"
+      <button
         data-testid="chatbot"
         tabIndex={0}
         className={cn(styles.message, pushUp && styles.messagePushUp)}
@@ -60,7 +59,7 @@ const DefaultVariant = ({
         </Box>
         <div className={styles.messageArrow} />
         <div className={styles.messageArrowBorder} />
-      </FocusableBox>
+      </button>
     </div>
   )
 }


### PR DESCRIPTION
# Chat bubble styles are overriden after client side routing

## Before

https://github.com/user-attachments/assets/e23b390e-89cb-48f3-9ba3-54162d01090a

## After

https://github.com/user-attachments/assets/44a56655-5d58-4ab2-b146-3fcf4c38dbd7



## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
