### PR TITLE
fix(contentful): Adding Internal Title property value when running extract-strings

### DIFF
--- a/libs/localization/scripts/extract.ts
+++ b/libs/localization/scripts/extract.ts
@@ -68,11 +68,13 @@ const createNamespace = (id: string, messages: MessageDict, locales: Locales) =>
     .then((space) => space.getEnvironment(environmentId))
     .then(async (environment) => {
       const namespace = { [DEFAULT_LOCALE]: id }
+      const internalTitle = namespace
       const defaults = { [DEFAULT_LOCALE]: createDefaultsObject(messages) }
       const strings = createStringsObject(locales, messages)
 
       const entry = await environment.createEntryWithId('namespace', id, {
         fields: {
+          internalTitle,
           namespace,
           defaults,
           strings,
@@ -92,6 +94,10 @@ export const updateNamespace = async (
   messages: MessageDict,
   locales: Locales,
 ) => {
+  namespace.fields.internalTitle = {
+    [DEFAULT_LOCALE]: namespace.fields.namespace[DEFAULT_LOCALE],
+  }
+
   namespace.fields.defaults[DEFAULT_LOCALE] = updateDefaultsObject(
     namespace,
     messages,


### PR DESCRIPTION
## What

Adding value to Internal Title property when running extract strings

## Why

So we dont get a bunch of warnings and this existing property actually has the right value.

## Screenshots / Gifs

<img width="1271" height="296" alt="image" src="https://github.com/user-attachments/assets/341c8e91-6657-4b00-8a1f-e911b5511469" />


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review
