### PR TITLE
feat(web): Render text in hyperlinks if url is missing

### DIFF
--- a/libs/island-ui/contentful/src/lib/RichTextRC/defaultRenderNode.tsx
+++ b/libs/island-ui/contentful/src/lib/RichTextRC/defaultRenderNode.tsx
@@ -9,6 +9,7 @@ import {
   ResponsiveSpace,
   Box,
   Table as T,
+  Text,
 } from '@island.is/island-ui/core'
 import { getOrganizationPageUrlPrefix } from '@island.is/shared/utils'
 import Hyperlink from '../Hyperlink/Hyperlink'
@@ -240,11 +241,18 @@ export const defaultRenderNodeObject: RenderNode = {
     } else {
       url = ''
     }
-    return url ? <Hyperlink href={url}>{children}</Hyperlink> : null
+    return url ? (
+      <Hyperlink href={url}>{children}</Hyperlink>
+    ) : (
+      <Text as="span">{children}</Text>
+    )
   },
   [INLINES.ENTRY_HYPERLINK]: (node, children) => {
     const entry = node.data.target
     const type = entry?.sys?.contentType?.sys?.id
+
+    if (!type) return <Text as="span">{children}</Text>
+
     switch (type) {
       case 'article':
         return entry?.fields?.slug ? (


### PR DESCRIPTION
# Render text in hyperlinks if url is missing

This was requested by Digital Iceland, when a hyperlinked asset or entry gets archived or deleted we want to keep the text (otherwise it would dissapear).

## Before
<img width="185" height="57" alt="Screenshot 2026-04-15 at 13 00 48" src="https://github.com/user-attachments/assets/7cbf9bba-fe44-49bb-8b5b-1461e7e048e9" />

## After
<img width="291" height="73" alt="Screenshot 2026-04-15 at 13 00 23" src="https://github.com/user-attachments/assets/20e51910-0353-4cf9-924b-54160c05db10" />


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of broken or missing hyperlinks in rich text content with graceful fallback rendering
  * Enhanced display stability when hyperlink references are unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->