### PR TITLE
fix(j-s): hide breadcrumbs for defence users in page layout

### DIFF
--- a/apps/judicial-system/web/src/components/PageLayout/PageLayout.tsx
+++ b/apps/judicial-system/web/src/components/PageLayout/PageLayout.tsx
@@ -242,14 +242,17 @@ const PageLayout: FC<PropsWithChildren<PageProps>> = ({
         <GridContainer className={styles.container}>
           <GridRow direction={['columnReverse', 'columnReverse', 'row']}>
             <GridColumn span={['12/12', '12/12', '8/12', '8/12']}>
-              <Box marginY={3} marginX={[3, 3, 0, 0]}>
-                <BreadCrumbs />
-              </Box>
+              {!isDefenceUser(user) && (
+                <Box marginY={3} marginX={[3, 3, 0, 0]}>
+                  <BreadCrumbs />
+                </Box>
+              )}
               <Box
                 background="white"
                 borderColor="white"
                 paddingTop={[3, 3, 10, 10]}
                 className={styles.processContent}
+                marginTop={isDefenceUser(user) ? 10 : 0}
               >
                 {children}
               </Box>


### PR DESCRIPTION
## What

Hide the `BreadCrumbs` component in `PageLayout` when the current user is a defence user. Add a compensating `marginTop` so the page content remains visually balanced without the breadcrumb bar.

## Why

Defence users navigate the judicial system in a restricted, read-only context and do not follow the same case workflow as prosecutors, judges, or court staff. Showing breadcrumbs to defence users is confusing and irrelevant — the navigation trail does not reflect their flow.

## Screenshots / Gifs


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page layout for defence users by hiding breadcrumbs and adjusting vertical spacing accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->