### PR TITLE
feat(web): Court agenda cards - Show closed hearing text in a tag

### DIFF
--- a/apps/web/screens/CourtAgendas/components/AgendaCard.tsx
+++ b/apps/web/screens/CourtAgendas/components/AgendaCard.tsx
@@ -58,12 +58,6 @@ export const AgendaCard = ({
     })
   }
 
-  if (closedHearingText) {
-    detailLines.push({
-      text: closedHearingText,
-    })
-  }
-
   const renderDetails = () => {
     return (
       <Stack space={1}>
@@ -102,11 +96,18 @@ export const AgendaCard = ({
                 <Text variant="h5" as="h2">
                   {caseNumber}
                 </Text>
-                {Boolean(type) && (
-                  <Tag variant="blue" disabled>
-                    {type}
-                  </Tag>
-                )}
+                <Inline space={2} alignY="center">
+                  {Boolean(type) && (
+                    <Tag variant="blue" outlined={true} disabled>
+                      {type}
+                    </Tag>
+                  )}
+                  {Boolean(closedHearingText) && (
+                    <Tag variant="red" outlined={true} disabled>
+                      {closedHearingText}
+                    </Tag>
+                  )}
+                </Inline>
               </Inline>
               <Text variant="medium" color="purple400" fontWeight="semiBold">
                 {date}
@@ -141,11 +142,18 @@ export const AgendaCard = ({
                 <Text variant="h5" as="h2">
                   {caseNumber}
                 </Text>
-                {Boolean(type) && (
-                  <Tag variant="blue" disabled>
-                    {type}
-                  </Tag>
-                )}
+                <Inline space={2} alignY="center">
+                  {Boolean(type) && (
+                    <Tag variant="blue" outlined={true} disabled>
+                      {type}
+                    </Tag>
+                  )}
+                  {Boolean(closedHearingText) && (
+                    <Tag variant="red" outlined={true} disabled>
+                      {closedHearingText}
+                    </Tag>
+                  )}
+                </Inline>
               </Inline>
               <Text variant="medium" color="purple400" fontWeight="semiBold">
                 {date}


### PR DESCRIPTION
# Court agenda cards - Show closed hearing text in a tag

<img width="254" height="54" alt="Screenshot 2026-04-15 at 15 32 08" src="https://github.com/user-attachments/assets/b07e3c72-5c3a-4c84-98d0-0b60c1d01b9f" />

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated court agenda card layouts to display closed hearing status as a visual tag indicator instead of a details list item.
  * Reorganized hearing information tags to appear inline together with improved visual hierarchy.
  * Applied outlined styling to hearing type indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->