### PR TITLE
chore(j-s): Hide Indictment Appeal

### DIFF
--- a/apps/judicial-system/api/infra/judicial-system-api.ts
+++ b/apps/judicial-system/api/infra/judicial-system-api.ts
@@ -52,8 +52,8 @@ export const serviceSetup = (services: {
       },
       HIDDEN_FEATURES: {
         dev: '',
-        staging: '',
-        prod: '',
+        staging: 'INDICTMENT_APPEAL_RULING',
+        prod: 'INDICTMENT_APPEAL_RULING',
       },
       REDIS_NODES: {
         dev: json([

--- a/apps/judicial-system/web/src/utils/hooks/useAppealCase/index.tsx
+++ b/apps/judicial-system/web/src/utils/hooks/useAppealCase/index.tsx
@@ -11,13 +11,16 @@ import {
 } from '@island.is/judicial-system/consts'
 import { formatDate } from '@island.is/judicial-system/formatters'
 import {
+  Feature,
   isDefenceUser,
   isDistrictCourtUser,
+  isIndictmentCase,
   isProsecutionUser,
 } from '@island.is/judicial-system/types'
 import { appealRuling } from '@island.is/judicial-system-web/messages'
 import {
   AlertBanner,
+  FeatureContext,
   FormContext,
   Modal,
   UserContext,
@@ -317,8 +320,13 @@ const useAppealCase = () => {
     </>
   )
 
+  const { features } = useContext(FeatureContext)
+
   const appealBanner =
-    isLoadingWorkingCase || (!title && !description) ? null : (
+    isLoadingWorkingCase ||
+    (!title && !description) ||
+    (isIndictmentCase(workingCase.type) &&
+      !features.includes(Feature.INDICTMENT_APPEAL_RULING)) ? null : (
       <AlertBanner variant="warning" title={title} description={description}>
         {child}
       </AlertBanner>

--- a/charts/judicial-system-services/judicial-system-api/values.prod.yaml
+++ b/charts/judicial-system-services/judicial-system-api/values.prod.yaml
@@ -30,7 +30,7 @@ env:
   BACKEND_URL: 'http://web-judicial-system-backend'
   CONTENTFUL_ENVIRONMENT: 'master'
   CONTENTFUL_HOST: 'cdn.contentful.com'
-  HIDDEN_FEATURES: ''
+  HIDDEN_FEATURES: 'INDICTMENT_APPEAL_RULING'
   IDENTITY_SERVER_ISSUER_URL: 'https://innskra.island.is'
   LOG_LEVEL: 'info'
   NODE_OPTIONS: '--max-old-space-size=460 --enable-source-maps -r dd-trace/init'

--- a/charts/judicial-system-services/judicial-system-api/values.staging.yaml
+++ b/charts/judicial-system-services/judicial-system-api/values.staging.yaml
@@ -30,7 +30,7 @@ env:
   BACKEND_URL: 'http://web-judicial-system-backend'
   CONTENTFUL_ENVIRONMENT: 'test'
   CONTENTFUL_HOST: 'cdn.contentful.com'
-  HIDDEN_FEATURES: ''
+  HIDDEN_FEATURES: 'INDICTMENT_APPEAL_RULING'
   IDENTITY_SERVER_ISSUER_URL: 'https://identity-server.staging01.devland.is'
   LOG_LEVEL: 'info'
   NODE_OPTIONS: '--max-old-space-size=460 --enable-source-maps -r dd-trace/init'

--- a/charts/judicial-system/values.prod.yaml
+++ b/charts/judicial-system/values.prod.yaml
@@ -30,7 +30,7 @@ judicial-system-api:
     BACKEND_URL: 'http://web-judicial-system-backend'
     CONTENTFUL_ENVIRONMENT: 'master'
     CONTENTFUL_HOST: 'cdn.contentful.com'
-    HIDDEN_FEATURES: ''
+    HIDDEN_FEATURES: 'INDICTMENT_APPEAL_RULING'
     IDENTITY_SERVER_ISSUER_URL: 'https://innskra.island.is'
     LOG_LEVEL: 'info'
     NODE_OPTIONS: '--max-old-space-size=460 --enable-source-maps -r dd-trace/init'

--- a/charts/judicial-system/values.staging.yaml
+++ b/charts/judicial-system/values.staging.yaml
@@ -30,7 +30,7 @@ judicial-system-api:
     BACKEND_URL: 'http://web-judicial-system-backend'
     CONTENTFUL_ENVIRONMENT: 'test'
     CONTENTFUL_HOST: 'cdn.contentful.com'
-    HIDDEN_FEATURES: ''
+    HIDDEN_FEATURES: 'INDICTMENT_APPEAL_RULING'
     IDENTITY_SERVER_ISSUER_URL: 'https://identity-server.staging01.devland.is'
     LOG_LEVEL: 'info'
     NODE_OPTIONS: '--max-old-space-size=460 --enable-source-maps -r dd-trace/init'

--- a/libs/judicial-system/types/src/lib/feature.ts
+++ b/libs/judicial-system/types/src/lib/feature.ts
@@ -1,3 +1,4 @@
 export enum Feature {
   NONE = 'NONE', // must be at least one
+  INDICTMENT_APPEAL_RULING = 'INDICTMENT_APPEAL_RULING',
 }


### PR DESCRIPTION
# Hide Indictment Appeal

[Kærur í sakamálum - featur hiding](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1214067034411502)

## What

- Hides indictment appeal banner.

-------------------------------------

This pull request enables the "INDICTMENT_APPEAL_RULING" feature flag in staging and production environments for the judicial system, and updates the frontend logic to conditionally display the appeal banner based on this feature flag. It also introduces the new feature flag to the shared types.

Feature flag enablement:

* Added `INDICTMENT_APPEAL_RULING` to the `Feature` enum in `feature.ts`, making it available for use throughout the codebase.
* Set the `HIDDEN_FEATURES` environment variable to `'INDICTMENT_APPEAL_RULING'` in both staging and production Kubernetes chart values and infrastructure configuration, enabling the feature in those environments. [[1]](diffhunk://#diff-9b16f5811bd35cc3efd2f423fb45321f902bd591588d734e41e98f334dbc3863L33-R33) [[2]](diffhunk://#diff-bdd7e378d3827cd696bc225e1ce67b808cce44fb3b2024658e0ff59a167315dbL33-R33) [[3]](diffhunk://#diff-aa5ebfd61edbae1f0a56366efb41a4cf8f89da6d62a29a87e4007c39811185c7L33-R33) [[4]](diffhunk://#diff-f4262299f0600e63686fc9dd4a64002105e60b66753a7815f822c2b33cdc7f55L33-R33) [[5]](diffhunk://#diff-c13d4f1d7980a975c2e5d5d65b999084ce39b3f03432d6cf3031efc5de051cc7L55-R56)

Frontend logic updates:

* Updated the `useAppealCase` hook to import the new `Feature` enum and use the `FeatureContext` to check if `INDICTMENT_APPEAL_RULING` is enabled. The appeal banner is now only shown for indictment cases if the feature is enabled. [[1]](diffhunk://#diff-d26a5a82b99f749fc7d99e8de1c4b11e16bc9ccfd985e1246ba0ba414759b053R14-R23) [[2]](diffhunk://#diff-d26a5a82b99f749fc7d99e8de1c4b11e16bc9ccfd985e1246ba0ba414759b053R323-R329)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the INDICTMENT_APPEAL_RULING feature flag, now enabled in staging and production environments. Appeal case warning displays for indictment cases have been updated to respect feature flag settings, enabling more flexible control over notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->