### PR TITLE
feat(j-s): Gives court of appeals access to police digital case files

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/file/file.controller.ts
+++ b/apps/judicial-system/backend/src/app/modules/file/file.controller.ts
@@ -439,6 +439,9 @@ export class FileController {
     districtCourtJudgeRule,
     districtCourtRegistrarRule,
     districtCourtAssistantRule,
+    courtOfAppealsJudgeRule,
+    courtOfAppealsRegistrarRule,
+    courtOfAppealsAssistantRule,
   )
   @Get('policeDigitalCaseFiles')
   @ApiOkResponse({
@@ -470,6 +473,9 @@ export class FileController {
     districtCourtJudgeRule,
     districtCourtRegistrarRule,
     districtCourtAssistantRule,
+    courtOfAppealsJudgeRule,
+    courtOfAppealsRegistrarRule,
+    courtOfAppealsAssistantRule,
   )
   @Get('policeDigitalCaseFileTokenUrl')
   @ApiOkResponse({

--- a/apps/judicial-system/web/src/components/IndictmentCaseFilesList/IndictmentCaseFilesList.tsx
+++ b/apps/judicial-system/web/src/components/IndictmentCaseFilesList/IndictmentCaseFilesList.tsx
@@ -7,6 +7,7 @@ import { formatDate } from '@island.is/judicial-system/formatters'
 import {
   hasGeneratedCourtRecordPdf,
   isCompletedCase,
+  isCourtOfAppealsUser,
   isDefenceUser,
   isDistrictCourtUser,
   isPrisonAdminUser,
@@ -291,7 +292,8 @@ const IndictmentCaseFilesList: FC<Props> = ({
     usePoliceDigitalCaseFile(workingCase.id, workingCase.origin)
 
   const showPoliceDigitalCaseFiles =
-    (digitalCaseFiles?.length ?? 0) > 0 && isDistrictCourtUser(user)
+    (digitalCaseFiles?.length ?? 0) > 0 &&
+    (isDistrictCourtUser(user) || isCourtOfAppealsUser(user))
 
   return (
     <>


### PR DESCRIPTION
# Gives court of appeals access to police digital case files

[Landsréttur hafi aðgang að rafrænum gögnum í máli](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1213985081689156?focus=true)

## What

- Gives the court of appeals access to police digital case files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Court of appeals judges, registrars, and assistants can now access and download police digital case files. This extends file access permissions to the appellate level, providing the same case file access capabilities that were previously available to district court users only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->