### PR TITLE
fix(my-pages): action card heading size

### DIFF
--- a/libs/portals/my-pages/air-discount/src/screens/AirDiscountOverview/AirDiscountOverview.tsx
+++ b/libs/portals/my-pages/air-discount/src/screens/AirDiscountOverview/AirDiscountOverview.tsx
@@ -259,6 +259,7 @@ export const AirDiscountOverview = () => {
                   <ActionCard
                     key={`loftbru-item-connection-code-${codeIndex}`}
                     heading={item.user.name}
+                    headingVariant="h4"
                     text={formatMessage(m.flight) + ': ' + code.flightDesc}
                     subText={code.code}
                     tag={{

--- a/libs/portals/my-pages/assets/src/screens/IntellectualPropertiesOverview/IntellectualPropertiesOverview.tsx
+++ b/libs/portals/my-pages/assets/src/screens/IntellectualPropertiesOverview/IntellectualPropertiesOverview.tsx
@@ -31,6 +31,7 @@ const IntellectualPropertiesOverview = () => {
       <ActionCard
         text={`${ipId}${description ? ' - ' + description : ''}`}
         heading={heading ?? ''}
+        headingVariant="h4"
         cta={{
           label: formatMessage(m.view),
           variant: 'text',

--- a/libs/portals/my-pages/assets/src/screens/Ships/Overview/ShipsOverview.tsx
+++ b/libs/portals/my-pages/assets/src/screens/Ships/Overview/ShipsOverview.tsx
@@ -40,6 +40,7 @@ export const ShipsOverview = () => {
             <ActionCard
               key={ship.registrationNumber}
               heading={ship.name}
+              headingVariant="h4"
               text={
                 ship.regionAcronym
                   ? `${ship.registrationNumber}, ${ship.regionAcronym}`

--- a/libs/portals/my-pages/assets/src/screens/WorkMachinesOverview/WorkMachinesOverview.tsx
+++ b/libs/portals/my-pages/assets/src/screens/WorkMachinesOverview/WorkMachinesOverview.tsx
@@ -237,6 +237,7 @@ const WorkMachinesOverview = () => {
                     : formatMessage(messages.noInspection)
                 }`}
                 heading={wm?.type ? `${wm.type} ${wm.model}`.trim() : ''}
+                headingVariant="h4"
                 cta={{
                   label: formatMessage(m.seeDetails),
                   variant: 'text',

--- a/libs/portals/my-pages/education-career/src/screens/EducationCareer/components/CareerCards/CareerCards.tsx
+++ b/libs/portals/my-pages/education-career/src/screens/EducationCareer/components/CareerCards/CareerCards.tsx
@@ -88,6 +88,7 @@ const CareerCards = () => {
               outlined: false,
             }}
             heading={member.organizationName}
+            headingVariant="h4"
             text={member.yearInterval}
           />
         </Box>

--- a/libs/portals/my-pages/education/src/screens/SecondarySchool/SecondarySchoolGraduationOverview/SecondarySchoolGraduationOverview.tsx
+++ b/libs/portals/my-pages/education/src/screens/SecondarySchool/SecondarySchoolGraduationOverview/SecondarySchoolGraduationOverview.tsx
@@ -51,6 +51,7 @@ export const EducationGraduationDetail = () => {
             <Box key={i} marginBottom={3}>
               <ActionCard
                 heading={item.organisation ?? ''}
+                headingVariant="h4"
                 text={item.diplomaName ?? ''}
                 key={item.diplomaId}
                 cta={{

--- a/libs/portals/my-pages/health/src/components/PatientDataPermit/InvalidatePermitModal.tsx
+++ b/libs/portals/my-pages/health/src/components/PatientDataPermit/InvalidatePermitModal.tsx
@@ -34,6 +34,7 @@ export const InvalidatePermitModal: React.FC<InvalidatePermitModalProps> = ({
           eyebrow={formatMessage(messages.healthDirectorate)}
           eyebrowColor="purple400"
           heading={formatMessage(messages.patientDataPermit)}
+          headingVariant="h4"
           text={formatMessage(messages.validToFrom, {
             fromDate: validFrom,
             toDate: validTo,

--- a/libs/portals/my-pages/health/src/screens/Medicine/MedicineLicense.tsx
+++ b/libs/portals/my-pages/health/src/screens/Medicine/MedicineLicense.tsx
@@ -51,6 +51,7 @@ export const MedicineLicense = () => {
                   <ActionCard
                     key={i}
                     heading={certificate.drugName ?? undefined}
+                    headingVariant="h4"
                     tag={{
                       label: formatMessage(
                         certificate.processed === false

--- a/libs/portals/my-pages/health/src/screens/MedicineDelegation/NewMedicineDelegation.tsx
+++ b/libs/portals/my-pages/health/src/screens/MedicineDelegation/NewMedicineDelegation.tsx
@@ -133,6 +133,7 @@ const NewMedicineDelegation = () => {
                 toDate: formState?.dateTo?.toLocaleDateString(),
               })}
               heading={formState?.name}
+              headingVariant="h4"
               text={
                 formState?.lookup
                   ? formatMessage(messages.pickupMedicineAndLookup)

--- a/libs/portals/my-pages/health/src/screens/OrganDonation/OrganDonation.tsx
+++ b/libs/portals/my-pages/health/src/screens/OrganDonation/OrganDonation.tsx
@@ -86,6 +86,7 @@ const OrganDonation = () => {
             </Text>
             <ActionCard
               heading={texts.heading}
+              headingVariant="h4"
               text={texts.cardText}
               cta={{
                 onClick: () =>

--- a/libs/portals/my-pages/health/src/screens/PatientDataPermits/Permits.tsx
+++ b/libs/portals/my-pages/health/src/screens/PatientDataPermits/Permits.tsx
@@ -96,6 +96,7 @@ const PatientDataPermits: FC = () => {
               eyebrow={formatMessage(messages.healthDirectorate)}
               eyebrowColor="purple400"
               heading={formatMessage(messages.patientDataPermit)}
+              headingVariant="h4"
               text={formatMessage(messages.patientDataSharedDescription)}
               tag={permitTagSelector(permit.status, formatMessage)}
               cta={{

--- a/libs/portals/my-pages/information/src/screens/UserContracts/UserContractsOverview/UserContractsOverview.tsx
+++ b/libs/portals/my-pages/information/src/screens/UserContracts/UserContractsOverview/UserContractsOverview.tsx
@@ -122,7 +122,7 @@ const UserContractsOverview = () => {
                   <ActionCard
                     key={id}
                     heading={address}
-                    headingVariant="h3"
+                    headingVariant="h4"
                     cta={{
                       label: formatMessage(cm.seeInfo),
                       onClick: () =>

--- a/libs/portals/my-pages/law-and-order/src/screens/CourtCases/CourtCases.tsx
+++ b/libs/portals/my-pages/law-and-order/src/screens/CourtCases/CourtCases.tsx
@@ -47,6 +47,7 @@ const CourtCases = () => {
           <Box marginTop={2}>
             <ActionCard
               heading={x.caseNumberTitle ?? ''}
+              headingVariant="h4"
               text={x.type ?? ''}
               tag={{
                 label: x.state?.label ?? '',

--- a/libs/portals/my-pages/law-and-order/src/screens/PoliceCases/PoliceCases.tsx
+++ b/libs/portals/my-pages/law-and-order/src/screens/PoliceCases/PoliceCases.tsx
@@ -64,6 +64,7 @@ const PoliceCases = () => {
               heading={formatMessage(messages.policeCaseCardTitle, {
                 arg: c.number,
               })}
+              headingVariant="h4"
               text={
                 c.modified
                   ? formatMessage(messages.policeCaseCardText, {

--- a/libs/portals/my-pages/signature-collection/src/screens/Municipal/OwnerView/index.tsx
+++ b/libs/portals/my-pages/signature-collection/src/screens/Municipal/OwnerView/index.tsx
@@ -47,6 +47,7 @@ const OwnerView = ({
                 key={list.id}
                 backgroundColor="white"
                 heading={list.candidate.name ?? ''}
+                headingVariant="h4"
                 progressMeter={{
                   currentProgress: list.numberOfSignatures || 0,
                   maxProgress: list.area?.max || 0,

--- a/libs/portals/my-pages/signature-collection/src/screens/Parliamentary/OwnerView/index.tsx
+++ b/libs/portals/my-pages/signature-collection/src/screens/Parliamentary/OwnerView/index.tsx
@@ -63,6 +63,7 @@ const OwnerView = ({
                 key={list.id}
                 backgroundColor="white"
                 heading={list.area?.name}
+                headingVariant="h4"
                 progressMeter={{
                   currentProgress: list.numberOfSignatures || 0,
                   maxProgress: list.area?.max || 0,

--- a/libs/portals/my-pages/signature-collection/src/screens/Presidential/OwnerView/index.tsx
+++ b/libs/portals/my-pages/signature-collection/src/screens/Presidential/OwnerView/index.tsx
@@ -46,6 +46,7 @@ const OwnerView = ({
                 key={list.id}
                 backgroundColor="white"
                 heading={list.title}
+                headingVariant="h4"
                 eyebrow={`${formatMessage(m.endTime)} ${format(
                   new Date(list.endTime),
                   'dd.MM.yyyy',

--- a/libs/portals/my-pages/signature-collection/src/screens/shared/SignedLists/index.tsx
+++ b/libs/portals/my-pages/signature-collection/src/screens/shared/SignedLists/index.tsx
@@ -81,6 +81,7 @@ const SignedLists = ({
                   ? list.candidate.name
                   : list.title.split(' - ')[0]
               }
+              headingVariant="h4"
               eyebrow={`${formatMessage(m.endTime)} ${format(
                 new Date(list.endTime),
                 'dd.MM.yyyy',

--- a/libs/portals/my-pages/signature-collection/src/screens/shared/SigneeView/index.tsx
+++ b/libs/portals/my-pages/signature-collection/src/screens/shared/SigneeView/index.tsx
@@ -59,6 +59,7 @@ const SigneeView = ({
                   <ActionCard
                     key={list.id}
                     backgroundColor="white"
+                    headingVariant="h4"
                     eyebrow={`${formatMessage(m.endTime)} ${format(
                       new Date(list.endTime),
                       'dd.MM.yyyy',


### PR DESCRIPTION
# My pages - Action card heading sizes

## What

Change all action card heading sizes to H4 instead of default H3 to ensure consistency across pages and match design.

After 

<img width="1090" height="763" alt="Screenshot 2026-04-16 at 14 56 31" src="https://github.com/user-attachments/assets/8bd0c009-62eb-4012-ab40-b51fdf844f66" />

Before

<img width="1059" height="678" alt="Screenshot 2026-04-16 at 14 56 49" src="https://github.com/user-attachments/assets/a5602c93-172b-4e44-a3af-7c031a8af3b7" />

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
