### PR TITLE
fix(application-system-api): Reducing application-system-api startup time locally

### DIFF
--- a/apps/application-system/api/project.json
+++ b/apps/application-system/api/project.json
@@ -120,7 +120,10 @@
     "serve": {
       "executor": "@nx/js:node",
       "options": {
-        "buildTarget": "application-system-api:build"
+        "buildTarget": "application-system-api:build",
+        "buildTargetOptions": {
+          "skipTypeCheck": true
+        }
       }
     },
     "lint": {


### PR DESCRIPTION
## What

This 1 line changes the start time from ~90s to around ~15s.
Skip type checks on local builds only to improve startup time and change detection timings locally

## Why

Helps a lot with developer experience

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for improved serve performance by adjusting type-checking behavior during development builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->