### PR TITLE
fix(application-system): Medical rehabilitation inactive payments for too long message

### DIFF
--- a/libs/application/templates/social-insurance-administration/medical-and-rehabilitation-payments/src/lib/messages.ts
+++ b/libs/application/templates/social-insurance-administration/medical-and-rehabilitation-payments/src/lib/messages.ts
@@ -238,7 +238,7 @@ export const medicalAndRehabilitationPaymentsFormMessage: MessageDir = {
       defaultMessage:
         'Ástæðan fyrir því er eftirfarandi:\n* Þú ert ekki með gilt vottorð um sjúkra- og endurhæfingargreiðslur (má vera mest 6 mánaða gamalt).\n\nEf hlé hefur orðið á greiðslum frá Tryggingastofnun í meira en 6 mánuði, vegna vanda sem orsakar skerta starfsgetu, þá þarf að fá nýtt vottorð til þess að geta sótt aftur um sjúkra- og endurhæfingargreiðslur',
       description:
-        'The reason for this is the following:\n* You do not have a valid certificate for sickness and rehabilitation (issued within the last 6 months).\n\nYou need a new certificate for medical and rehabilitation payments in order to apply for medical and rehabilitation payments.',
+        'The reason for this is the following:\n* You do not have a valid certificate for sickness and rehabilitation (issued within the last 6 months).\n\nYou need a new certificate in order to apply for medical and rehabilitation payments.',
     },
     baseCertNotFoundDescription: {
       id: 'marp.application:not.eligible.base.cert.not.found.description#markdown',

--- a/libs/application/templates/social-insurance-administration/medical-and-rehabilitation-payments/src/lib/messages.ts
+++ b/libs/application/templates/social-insurance-administration/medical-and-rehabilitation-payments/src/lib/messages.ts
@@ -233,6 +233,13 @@ export const medicalAndRehabilitationPaymentsFormMessage: MessageDir = {
       description:
         'The reason for this is the following:\n* You are already receiving payments from the Social Insurance Administration.\n\nYou can apply for a continuation of payments when there are 3 months or less left on approved payments.\n\nIf you do not think the above applies to you, please contact the Social Insurance Administration at [endurhaefing@tr.is](mailto:endurhaefing@tr.is)',
     },
+    inactivePaymentsForTooLongDescription: {
+      id: 'marp.application:not.eligible.inactive.payments.for.too.long.description#markdown',
+      defaultMessage:
+        'Ástæðan fyrir því er eftirfarandi:\n* Þú er ekki með gilt vottorð um sjúkra- og endurhæfingargreiðslur (má vera mest 6 mánaða gamalt).\n\nEf hlé hefur orðið á greiðslum frá Tryggingastofnun í meira en 6 mánuði, vegna vanda sem orsakar skerta starfsgetu, þá þarf að fá nýtt vottorð til þess að geta sótt aftur um sjúkra- og endurhæfingargreiðslur',
+      description:
+        'The reason for this is the following:\n* You do not have a valid certificate for sickness and rehabilitation (issued within the last 6 months).\n\nYou need a new certificate for medical and rehabilitation payments in order to be apply for medical and rehabilitation payments.',
+    },
     baseCertNotFoundDescription: {
       id: 'marp.application:not.eligible.base.cert.not.found.description#markdown',
       defaultMessage:

--- a/libs/application/templates/social-insurance-administration/medical-and-rehabilitation-payments/src/lib/messages.ts
+++ b/libs/application/templates/social-insurance-administration/medical-and-rehabilitation-payments/src/lib/messages.ts
@@ -236,9 +236,9 @@ export const medicalAndRehabilitationPaymentsFormMessage: MessageDir = {
     inactivePaymentsForTooLongDescription: {
       id: 'marp.application:not.eligible.inactive.payments.for.too.long.description#markdown',
       defaultMessage:
-        'Ástæðan fyrir því er eftirfarandi:\n* Þú er ekki með gilt vottorð um sjúkra- og endurhæfingargreiðslur (má vera mest 6 mánaða gamalt).\n\nEf hlé hefur orðið á greiðslum frá Tryggingastofnun í meira en 6 mánuði, vegna vanda sem orsakar skerta starfsgetu, þá þarf að fá nýtt vottorð til þess að geta sótt aftur um sjúkra- og endurhæfingargreiðslur',
+        'Ástæðan fyrir því er eftirfarandi:\n* Þú ert ekki með gilt vottorð um sjúkra- og endurhæfingargreiðslur (má vera mest 6 mánaða gamalt).\n\nEf hlé hefur orðið á greiðslum frá Tryggingastofnun í meira en 6 mánuði, vegna vanda sem orsakar skerta starfsgetu, þá þarf að fá nýtt vottorð til þess að geta sótt aftur um sjúkra- og endurhæfingargreiðslur',
       description:
-        'The reason for this is the following:\n* You do not have a valid certificate for sickness and rehabilitation (issued within the last 6 months).\n\nYou need a new certificate for medical and rehabilitation payments in order to be apply for medical and rehabilitation payments.',
+        'The reason for this is the following:\n* You do not have a valid certificate for sickness and rehabilitation (issued within the last 6 months).\n\nYou need a new certificate for medical and rehabilitation payments in order to apply for medical and rehabilitation payments.',
     },
     baseCertNotFoundDescription: {
       id: 'marp.application:not.eligible.base.cert.not.found.description#markdown',

--- a/libs/application/templates/social-insurance-administration/medical-and-rehabilitation-payments/src/utils/medicalAndRehabilitationPaymentsUtils.ts
+++ b/libs/application/templates/social-insurance-administration/medical-and-rehabilitation-payments/src/utils/medicalAndRehabilitationPaymentsUtils.ts
@@ -531,7 +531,7 @@ export const eligibleText = (externalData: ExternalData) => {
         .hasActivePaymentsDescription
     case EligibleReasonCodes.INACTIVE_PAYMENTS_FOR_TOO_LONG:
       return medicalAndRehabilitationPaymentsFormMessage.notEligible
-        .baseCertOlderThanSevenYearsDescription
+        .inactivePaymentsForTooLongDescription
     case EligibleReasonCodes.BASE_CERT_NOT_FOUND:
       return medicalAndRehabilitationPaymentsFormMessage.notEligible
         .baseCertNotFoundDescription


### PR DESCRIPTION
## What

Updating inactive payments for too long string for medical rehabilitation application eligibility code

## Why

Currently 2 different eligibility codes are using the same message and the owners want separate messages for the inactive payments for too long code. Requested via [batman](https://digitaliceland.zendesk.com/agent/tickets/460333)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved eligibility messaging for medical and rehabilitation payments applications. Users now see a more specific message when payments have been paused for over 6 months, clearly indicating that renewal and a new medical certificate are required to restore eligibility and continue receiving benefits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->