### PR TITLE
feat(web): Add english fallback for verdicts and court agendas

### DIFF
--- a/apps/web/screens/CourtAgendas/CourtAgendas.tsx
+++ b/apps/web/screens/CourtAgendas/CourtAgendas.tsx
@@ -1392,6 +1392,10 @@ CourtAgendas.getProps = async ({ apolloClient, customPageData, query }) => {
     lawyers: lawyersResponse.data.webVerdictLawyers?.lawyers ?? [],
     scheduleTypes: scheduleTypesResponse.data.webCourtScheduleTypes,
     caseTypes: caseTypesResponse.data.webVerdictCaseFilterOptionsPerCourt,
+    languageToggleHrefOverride: {
+      is: '/dagskra-domstola',
+      en: customPageData?.configJson?.englishFallbackUrl ?? '',
+    },
   }
 }
 

--- a/apps/web/screens/Verdicts/VerdictDetails.tsx
+++ b/apps/web/screens/Verdicts/VerdictDetails.tsx
@@ -410,6 +410,10 @@ VerdictDetails.getProps = async ({ apolloClient, query, customPageData }) => {
 
   return {
     item,
+    languageToggleHrefOverride: {
+      is: `/domar/${query.id}`,
+      en: customPageData?.configJson?.englishFallbackUrl ?? '',
+    },
   }
 }
 

--- a/apps/web/screens/Verdicts/VerdictsList.tsx
+++ b/apps/web/screens/Verdicts/VerdictsList.tsx
@@ -1673,6 +1673,10 @@ VerdictsList.getProps = async ({ apolloClient, query, customPageData }) => {
       caseFilterOptionsPerCourtResponse.data
         .webVerdictCaseFilterOptionsPerCourt,
     keywords: keywordsResponse.data.webVerdictKeywords.keywords,
+    languageToggleHrefOverride: {
+      is: '/domar',
+      en: customPageData?.configJson?.englishFallbackUrl ?? '',
+    },
   }
 }
 


### PR DESCRIPTION
# Add english fallback for verdicts and court agendas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced language toggle support across court agendas, verdict details, and verdict lists with improved URL routing and fallback handling. Users can now seamlessly switch between Icelandic and English versions, with language preferences consistently maintained across all court-related pages and sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->