### PR TITLE
fix(web): Increase category card description text size to 18px

### DIFF
--- a/apps/web/components/CategoryItems/CategoryItems.tsx
+++ b/apps/web/components/CategoryItems/CategoryItems.tsx
@@ -101,7 +101,7 @@ export const CategoryItems = ({
                   {title}
                 </Text>
                 {description && (
-                  <Text paddingTop={2} variant="medium" fontWeight="light">
+                  <Text paddingTop={2} variant="default" fontWeight="light">
                     {description}
                   </Text>
                 )}

--- a/apps/web/screens/Category/Categories/Categories.tsx
+++ b/apps/web/screens/Category/Categories/Categories.tsx
@@ -132,7 +132,7 @@ const Categories: Screen<CategoriesProps> = ({ categories, namespace }) => {
                           {description && (
                             <Text
                               paddingTop={2}
-                              variant="medium"
+                              variant="default"
                               fontWeight="light"
                             >
                               {description}


### PR DESCRIPTION
Bumps the category card description text from 16px to 18px on desktop by switching the `Text` variant from `medium` to `default`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style

* Updated the visual styling of category item descriptions for improved consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->