### PR TITLE
feat(j-s): add includeCounter to public prosecution office indictment table groups

### DIFF
--- a/libs/judicial-system/types/src/lib/tables/tableGroups/publicProsecutionOffice.ts
+++ b/libs/judicial-system/types/src/lib/tables/tableGroups/publicProsecutionOffice.ts
@@ -22,6 +22,7 @@ const publicProsecutionOfficeIndictmentsTableGroup = {
       route: 'yfirlesin-sakamal',
       title: 'Yfirlesin mál',
       description: 'Mál sem hafa verið lesin yfir og eru óbirt eða á fresti.',
+      includeCounter: true,
     },
     {
       type: CaseTableType.PUBLIC_PROSECUTION_OFFICE_INDICTMENTS_APPEAL_PERIOD_EXPIRED,
@@ -48,12 +49,14 @@ const publicProsecutionOfficeIndictmentsTableGroup = {
       route: 'syknudomar',
       title: 'Sýknudómar',
       description: 'Yfirlesnir sýknudómar.',
+      includeCounter: true,
     },
     {
       type: CaseTableType.PUBLIC_PROSECUTION_OFFICE_INDICTMENTS_REQUESTED_APPEAL,
       route: 'afryjunarleyfi',
       title: 'Áfrýjunarleyfi',
       description: 'Yfirlesnir dómar með beiðni um áfrýjunarleyfi.',
+      includeCounter: true,
     },
   ],
 }


### PR DESCRIPTION
## What
Added `includeCounter: true` to three public prosecution office indictment table group entries: reviewed cases (yfirlesin-sakamal), acquittals (syknudomar), and requested appeal (afryjunarleyfi).

## Why
These table groups were missing the `includeCounter` flag, which is needed to display a count badge on the table tab.

## Screenshots / Gifs
Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review