### PR TITLE
feat(application-system-form): Add fallbackThirdLanguage to Secondary school form

### DIFF
--- a/libs/application/template-api-modules/src/lib/modules/templates/secondary-school/utils.ts
+++ b/libs/application/template-api-modules/src/lib/modules/templates/secondary-school/utils.ts
@@ -144,6 +144,8 @@ export const getCleanSchoolSelection = (
           },
         ].filter((x) => !!x.programId),
         thirdLanguageCode: selectionItem.thirdLanguage?.code || undefined,
+        fallbackThirdLanguageCode:
+          selectionItem.fallbackThirdLanguage?.code || undefined,
         nordicLanguageCode: selectionItem.nordicLanguage?.code || undefined,
         requestDormitory: selectionItem.requestDormitory?.includes(YES),
       })

--- a/libs/application/templates/secondary-school/src/fields/overview/SchoolSelectionOverview.tsx
+++ b/libs/application/templates/secondary-school/src/fields/overview/SchoolSelectionOverview.tsx
@@ -66,6 +66,12 @@ export const SchoolSelectionOverview: FC<FieldBaseProps> = ({
                 {selection?.[0]?.thirdLanguage?.name}
               </Text>
             )}
+            {!!selection?.[0]?.fallbackThirdLanguage?.code && (
+              <Text>
+                {formatMessage(overview.selection.fallbackThirdLanguageLabel)}:{' '}
+                {selection?.[0]?.fallbackThirdLanguage?.name}
+              </Text>
+            )}{' '}
             {!!selection?.[0]?.nordicLanguage?.code && (
               <Text>
                 {formatMessage(overview.selection.nordicLanguageLabel)}:{' '}
@@ -101,6 +107,12 @@ export const SchoolSelectionOverview: FC<FieldBaseProps> = ({
                 <Text>
                   {formatMessage(overview.selection.thirdLanguageLabel)}:{' '}
                   {selection?.[1]?.thirdLanguage?.name}
+                </Text>
+              )}{' '}
+              {!!selection?.[1]?.fallbackThirdLanguage?.code && (
+                <Text>
+                  {formatMessage(overview.selection.fallbackThirdLanguageLabel)}
+                  : {selection?.[1]?.fallbackThirdLanguage?.name}
                 </Text>
               )}{' '}
               {!!selection?.[1]?.nordicLanguage?.code && (

--- a/libs/application/templates/secondary-school/src/fields/overview/SchoolSelectionOverview.tsx
+++ b/libs/application/templates/secondary-school/src/fields/overview/SchoolSelectionOverview.tsx
@@ -154,6 +154,14 @@ export const SchoolSelectionOverview: FC<FieldBaseProps> = ({
                     {selection?.[2]?.thirdLanguage?.name}
                   </Text>
                 )}
+                {!!selection?.[2]?.fallbackThirdLanguage?.code && (
+                  <Text>
+                    {formatMessage(
+                      overview.selection.fallbackThirdLanguageLabel,
+                    )}
+                    : {selection?.[2]?.fallbackThirdLanguage?.name}
+                  </Text>
+                )}{' '}
                 {!!selection?.[2]?.nordicLanguage?.code && (
                   <Text>
                     {formatMessage(overview.selection.nordicLanguageLabel)}:{' '}

--- a/libs/application/templates/secondary-school/src/forms/secondarySchoolForm/schoolSection/index.ts
+++ b/libs/application/templates/secondary-school/src/forms/secondarySchoolForm/schoolSection/index.ts
@@ -13,6 +13,8 @@ import {
   getAlertMessageConditionAddThirdSelection,
   getAlertMessageConditionSpecialNeedsProgram,
   getAlertMessageSpecialNeedsProgram,
+  getFallbackThirdLanguageOptions,
+  getConditionFallbackThirdLanguage,
   getConditionNordicLanguage,
   getConditionProgramApplicationMessage,
   getConditionRequestDormitory,
@@ -23,6 +25,7 @@ import {
   getNordicLanguageOptions,
   getProgramApplicationMessage,
   getRequestDormitoryOptions,
+  getRequireFallbackThirdLanguage,
   getRequireSecondProgram,
   getRequireThirdLanguage,
   getRowsLimitCount,
@@ -31,6 +34,7 @@ import {
   getUpdateOnSelectFirstProgram,
   getUpdateOnSelectSecondProgram,
   loadProgramOptions,
+  setOnChangeFallbackThirdLanguage,
   setOnChangeFirstProgram,
   setOnChangeNordicLanguage,
   setOnChangeSchool,
@@ -177,6 +181,24 @@ export const schoolSection = buildSection({
                 getThirdLanguageOptions(application, activeField),
               setOnChange: async (option, application, index, activeField) =>
                 setOnChangeThirdLanguage(
+                  option,
+                  application,
+                  index,
+                  activeField,
+                ),
+            },
+            'fallbackThirdLanguage.code': {
+              component: 'select',
+              label: school.selection.fallbackThirdLanguageLabel,
+              required: (_, activeField) =>
+                getRequireFallbackThirdLanguage(activeField),
+              isClearable: true,
+              condition: (application, activeField) =>
+                getConditionFallbackThirdLanguage(application, activeField),
+              options: (application, activeField) =>
+                getFallbackThirdLanguageOptions(application, activeField),
+              setOnChange: async (option, application, index, activeField) =>
+                setOnChangeFallbackThirdLanguage(
                   option,
                   application,
                   index,

--- a/libs/application/templates/secondary-school/src/forms/secondarySchoolForm/schoolSection/utils.ts
+++ b/libs/application/templates/secondary-school/src/forms/secondarySchoolForm/schoolSection/utils.ts
@@ -172,6 +172,10 @@ export const setOnChangeSchool = (
       value: undefined,
     },
     {
+      key: `selection[${index}].fallbackThirdLanguage`,
+      value: undefined,
+    },
+    {
       key: `selection[${index}].nordicLanguage`,
       value: undefined,
     },
@@ -182,6 +186,10 @@ export const setOnChangeSchool = (
     {
       key: `selection[${index}].thirdLanguageRequire`,
       value: selectedSchool?.requireThirdLanguage,
+    },
+    {
+      key: `selection[${index}].fallbackThirdLanguageRequire`,
+      value: selectedSchool?.requireFallbackThirdLanguage,
     },
     { key: `selection[${index}].requestDormitory`, value: [] }, // clear answer
   ]
@@ -409,6 +417,57 @@ export const setOnChangeThirdLanguage = (
   return [
     {
       key: `selection[${index}].thirdLanguage.name`,
+      value: languageInfo?.name,
+    },
+  ]
+}
+
+export const getRequireFallbackThirdLanguage = (
+  activeField?: Record<string, string>,
+): boolean => {
+  const fallbackThirdLanguageRequire =
+    (activeField &&
+      getValueViaPath<boolean>(activeField, 'fallbackThirdLanguageRequire')) ||
+    false
+  return fallbackThirdLanguageRequire
+}
+
+export const getConditionFallbackThirdLanguage = (
+  application: Application,
+  activeField?: Record<string, string>,
+): boolean => {
+  return (
+    getRequireFallbackThirdLanguage(activeField) &&
+    !!getFallbackThirdLanguageOptions(application, activeField).length
+  )
+}
+
+export const getFallbackThirdLanguageOptions = (
+  application: Application,
+  activeField?: Record<string, string>,
+): RepeaterOption[] => {
+  const schoolInfo = getSchoolInfo(application.externalData, activeField)
+  return (schoolInfo?.thirdLanguages || []).map((language) => {
+    return {
+      label: language.name,
+      value: language.code,
+    }
+  })
+}
+
+export const setOnChangeFallbackThirdLanguage = (
+  optionValue: RepeaterOptionValue,
+  application: Application,
+  index: number,
+  activeField?: Record<string, string>,
+) => {
+  const schoolInfo = getSchoolInfo(application.externalData, activeField)
+  const languageInfo = schoolInfo?.thirdLanguages?.find(
+    (x) => x.code === getStringFromOptionValue(optionValue),
+  )
+  return [
+    {
+      key: `selection[${index}].fallbackThirdLanguage.name`,
       value: languageInfo?.name,
     },
   ]

--- a/libs/application/templates/secondary-school/src/lib/dataSchema.ts
+++ b/libs/application/templates/secondary-school/src/lib/dataSchema.ts
@@ -136,6 +136,13 @@ const SelectionSchema = z
         name: z.string().optional(),
       })
       .optional(),
+    fallbackThirdLanguageRequire: z.boolean().optional(),
+    fallbackThirdLanguage: z
+      .object({
+        code: z.string().optional().nullable(),
+        name: z.string().optional(),
+      })
+      .optional(),
     nordicLanguage: z
       .object({
         code: z.string().optional().nullable(),
@@ -179,6 +186,13 @@ const SelectionSchema = z
       return !!thirdLanguage?.code
     },
     { path: ['thirdLanguage', 'code'] },
+  )
+  .refine(
+    ({ fallbackThirdLanguageRequire, fallbackThirdLanguage }) => {
+      if (!fallbackThirdLanguageRequire) return true
+      return !!fallbackThirdLanguage?.code
+    },
+    { path: ['fallbackThirdLanguage', 'code'] },
   )
 
 export const SecondarySchoolSchema = z.object({

--- a/libs/application/templates/secondary-school/src/lib/messages/overview.ts
+++ b/libs/application/templates/secondary-school/src/lib/messages/overview.ts
@@ -106,6 +106,11 @@ export const overview = {
       defaultMessage: 'Þriðja tungumál',
       description: 'Selection third language label',
     },
+    fallbackThirdLanguageLabel: {
+      id: 'ss.application:overview.selection.fallbackThirdLanguageLabel',
+      defaultMessage: 'Þriðja tungumál til vara ef við á',
+      description: 'Selection fallback third language label',
+    },
     nordicLanguageLabel: {
       id: 'ss.application:overview.selection.nordicLanguageLabel',
       defaultMessage: 'Norðurlandamál',

--- a/libs/application/templates/secondary-school/src/lib/messages/school.ts
+++ b/libs/application/templates/secondary-school/src/lib/messages/school.ts
@@ -40,6 +40,11 @@ export const school = {
       defaultMessage: 'Þriðja tungumál ef við á',
       description: 'Third language select label',
     },
+    fallbackThirdLanguageLabel: {
+      id: 'ss.application:school.selection.fallbackThirdLanguageLabel',
+      defaultMessage: 'Þriðja tungumál til vara ef við á',
+      description: 'Fallback third language select label',
+    },
     nordicLanguageLabel: {
       id: 'ss.application:school.selection.nordicLanguageLabel',
       defaultMessage:

--- a/libs/application/templates/secondary-school/src/utils/types/index.ts
+++ b/libs/application/templates/secondary-school/src/utils/types/index.ts
@@ -22,6 +22,7 @@ export type SecondarySchool = {
   nordicLanguages: Language[]
   allowRequestDormitory: boolean
   requireThirdLanguage: boolean
+  requireFallbackThirdLanguage: boolean
   isOpenForAdmissionGeneral: boolean
   isOpenForAdmissionFreshman: boolean
 }

--- a/libs/clients/secondary-school/src/clientConfig.json
+++ b/libs/clients/secondary-school/src/clientConfig.json
@@ -1471,6 +1471,7 @@
             "description": "Third language chosen by the applicant\r\ne.g. en = English \r\nFollows the ISO 639-1 standard\r\nhttps://en.wikipedia.org/wiki/List_of_ISO_639_language_codes",
             "nullable": true
           },
+          "fallbackThirdLanguage": { "type": "string", "nullable": true },
           "northernLanguage": {
             "type": "string",
             "description": "Northern langauge chosen by the applicant\r\ne.g. da = Danish \r\nFollows the ISO 639-1 standard\r\nhttps://en.wikipedia.org/wiki/List_of_ISO_639_language_codes",
@@ -1507,6 +1508,9 @@
             "nullable": true
           },
           "thirdLanguage": { "$ref": "#/components/schemas/LanguageDto" },
+          "fallbackThirdLanguage": {
+            "$ref": "#/components/schemas/LanguageDto"
+          },
           "northernLanguage": { "$ref": "#/components/schemas/LanguageDto" },
           "requestDormitory": {
             "type": "boolean",
@@ -1530,6 +1534,12 @@
           "isManuallyAccepted": { "type": "boolean" },
           "allocatedProgramme": {
             "$ref": "#/components/schemas/ProgrammeSimpleDto"
+          },
+          "statusUpdatedDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "readOnly": true
           }
         },
         "additionalProperties": false
@@ -1614,18 +1624,23 @@
           "thirdLanguages": {
             "type": "array",
             "items": { "$ref": "#/components/schemas/LanguageDto" },
-            "description": "Third languageges tought in school",
+            "description": "Third languages taught in school",
             "nullable": true
           },
           "nordicLanguages": {
             "type": "array",
             "items": { "$ref": "#/components/schemas/LanguageDto" },
-            "description": "Nordic languageges tought in school",
+            "description": "Nordic languages taught in school",
             "nullable": true
           },
           "requireThirdLanguage": {
             "type": "boolean",
             "description": "Whether third language is required",
+            "nullable": true
+          },
+          "requireFallbackThirdLanguage": {
+            "type": "boolean",
+            "description": "Whether fallback third language is required",
             "nullable": true
           }
         },

--- a/libs/clients/secondary-school/src/lib/secondarySchoolClient.service.ts
+++ b/libs/clients/secondary-school/src/lib/secondarySchoolClient.service.ts
@@ -75,6 +75,8 @@ export class SecondarySchoolClient {
         })) || [],
       allowRequestDormitory: school.availableDormitory || false,
       requireThirdLanguage: school.requireThirdLanguage || false,
+      requireFallbackThirdLanguage:
+        school.requireFallbackThirdLanguage || false,
       isOpenForAdmissionGeneral: school.anyOpenForAdmissionGeneral || false,
       isOpenForAdmissionFreshman: school.anyOpenForAdmissionFreshman || false,
     }))
@@ -167,6 +169,7 @@ export class SecondarySchoolClient {
           programmeId: program.programId,
         })),
         thirdLanguage: school.thirdLanguageCode,
+        fallbackThirdLanguage: school.fallbackThirdLanguageCode,
         northernLanguage: school.nordicLanguageCode,
         requestDormitory: school.requestDormitory,
       })),

--- a/libs/clients/secondary-school/src/lib/secondarySchoolClient.types.ts
+++ b/libs/clients/secondary-school/src/lib/secondarySchoolClient.types.ts
@@ -24,6 +24,7 @@ export interface SecondarySchool {
   nordicLanguages: Language[]
   allowRequestDormitory: boolean
   requireThirdLanguage: boolean
+  requireFallbackThirdLanguage: boolean
   isOpenForAdmissionGeneral: boolean
   isOpenForAdmissionFreshman: boolean
 }
@@ -56,6 +57,7 @@ export interface ApplicationSelectionSchool {
   schoolId: string
   programs: ApplicationSelectionSchoolProgram[]
   thirdLanguageCode?: string
+  fallbackThirdLanguageCode?: string
   nordicLanguageCode?: string
   requestDormitory?: boolean
 }


### PR DESCRIPTION
- requireFallbackThirdLanguage added to schools fetch
- fallbackThirdLanguage added to submit
- fallbackThirdLanguage field only shows in form if requireFallbackThirdLanguage is true.
- For testing, Borgarholtsskóli has requireFallbackThirdLanguage = true

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added fallback third language selection field to secondary school applications
  * Schools can now require a fallback third language option based on their specific requirements
  * Fallback third language selection is now displayed in the application overview
  * Implemented conditional validation to ensure fallback third language is provided when required by the selected school

<!-- end of auto-generated comment: release notes by coderabbit.ai -->