### PR TITLE
feat(j-s): add migration to update verdict service data for 3 cases

### DIFF
--- a/apps/judicial-system/backend/migrations/20260420000000-update-verdict.js
+++ b/apps/judicial-system/backend/migrations/20260420000000-update-verdict.js
@@ -4,19 +4,19 @@ const verdictUpdates = [
   {
     caseId: 'af89ac94-683d-40c6-bc75-b4d87c34b5f7',
     externalPoliceDocumentId: 'c7eee886-9275-4eff-b283-e2ec871976fa',
-    serviceDate: '2026-04-07 21:51:58',
+    serviceDate: '2026-04-07 21:51:58.000000+00',
     serviceStatus: 'ELECTRONICALLY',
   },
   {
     caseId: 'f10923d5-3bee-4c47-bb86-965d334e357d',
     externalPoliceDocumentId: '2eb16579-ca88-4ccd-afaa-34af45cdb203',
-    serviceDate: '2026-04-06 21:07:27',
+    serviceDate: '2026-04-06 21:07:27.000000+00',
     serviceStatus: 'ELECTRONICALLY',
   },
   {
     caseId: 'ab0c4372-c662-4e22-bf18-95a21e1ce03a',
     externalPoliceDocumentId: 'c3286794-b613-4090-99df-de8d072cedeb',
-    serviceDate: '2026-04-09 19:35:38',
+    serviceDate: '2026-04-09 19:35:38.000000+00',
     serviceStatus: 'ELECTRONICALLY',
   },
 ]

--- a/apps/judicial-system/backend/migrations/20260420000000-update-verdict.js
+++ b/apps/judicial-system/backend/migrations/20260420000000-update-verdict.js
@@ -1,0 +1,82 @@
+'use strict'
+
+const verdictUpdates = [
+  {
+    caseId: 'af89ac94-683d-40c6-bc75-b4d87c34b5f7',
+    externalPoliceDocumentId: 'c7eee886-9275-4eff-b283-e2ec871976fa',
+    serviceDate: '2026-04-07 21:51:58',
+    serviceStatus: 'ELECTRONICALLY',
+  },
+  {
+    caseId: 'f10923d5-3bee-4c47-bb86-965d334e357d',
+    externalPoliceDocumentId: '2eb16579-ca88-4ccd-afaa-34af45cdb203',
+    serviceDate: '2026-04-06 21:07:27',
+    serviceStatus: 'ELECTRONICALLY',
+  },
+  {
+    caseId: 'ab0c4372-c662-4e22-bf18-95a21e1ce03a',
+    externalPoliceDocumentId: 'c3286794-b613-4090-99df-de8d072cedeb',
+    serviceDate: '2026-04-09 19:35:38',
+    serviceStatus: 'ELECTRONICALLY',
+  },
+]
+
+module.exports = {
+  async up(queryInterface) {
+    return queryInterface.sequelize.transaction((transaction) =>
+      Promise.all(
+        verdictUpdates.map(
+          ({ caseId, externalPoliceDocumentId, serviceDate, serviceStatus }) =>
+            queryInterface.sequelize.query(
+              `UPDATE verdict
+             SET external_police_document_id = :externalPoliceDocumentId,
+                 service_date = :serviceDate,
+                 service_status = :serviceStatus
+             WHERE id = (
+               SELECT id FROM verdict
+               WHERE case_id = :caseId
+               ORDER BY created DESC
+               LIMIT 1
+             )`,
+              {
+                replacements: {
+                  caseId,
+                  externalPoliceDocumentId,
+                  serviceDate,
+                  serviceStatus,
+                },
+                transaction,
+              },
+            ),
+        ),
+      ),
+    )
+  },
+
+  async down(queryInterface) {
+    return queryInterface.sequelize.transaction((transaction) =>
+      Promise.all(
+        verdictUpdates.map(
+          ({ caseId, externalPoliceDocumentId, serviceDate, serviceStatus }) =>
+            queryInterface.sequelize.query(
+              `UPDATE verdict
+             SET external_police_document_id = NULL,
+                 service_date = NULL,
+                 service_status = NULL
+             WHERE case_id = :caseId
+             AND external_police_document_id = :externalPoliceDocumentId`,
+              {
+                replacements: {
+                  caseId,
+                  externalPoliceDocumentId,
+                  serviceDate,
+                  serviceStatus,
+                },
+                transaction,
+              },
+            ),
+        ),
+      ),
+    )
+  },
+}


### PR DESCRIPTION
## What

Adds a database migration that updates the `verdict` table for 3 specific cases, setting `external_police_document_id`, `service_date`, and `service_status` fields.

## Why

Data correction for 3 cases where verdict service information was missing or incorrect.

## Screenshots / Gifs


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review