### PR TITLE
fix(contentful-apps): Adjust how we check if subpage is already linked

### DIFF
--- a/apps/contentful-apps/pages/fields/organization-parent-subpage-pages-field.tsx
+++ b/apps/contentful-apps/pages/fields/organization-parent-subpage-pages-field.tsx
@@ -74,11 +74,32 @@ const OrganizationParentSubpagePagesField = () => {
             })
             entries = Array.isArray(entries) ? entries : [entries]
             entries = entries.filter((entry) => entry?.sys?.id) // Make sure the entries are non-empty
-            if (entries[0]?.fields?.organizationParentSubpage) {
-              sdk.notifier.warning(
-                'Subpage could not be linked since it is already linked to a parent page',
-              )
-            } else if (entries.length > 0) {
+
+            const parentId =
+              entries[0]?.fields?.organizationParentSubpage?.[DEFAULT_LOCALE]
+                ?.sys?.id
+
+            if (parentId) {
+              const parentExists = await cma.entry
+                .get({
+                  entryId: parentId,
+                })
+                .catch((error) => {
+                  if (!error?.message?.includes('not be found')) {
+                    sdk.notifier.warning(error.message)
+                    throw error
+                  }
+                })
+
+              if (parentExists) {
+                sdk.notifier.warning(
+                  'Subpage could not be linked since it is already linked to a parent page',
+                )
+                return
+              }
+            }
+
+            if (entries.length > 0) {
               const selectedEntry = entries[0]
               const entry = await cma.entry.get({
                 entryId: selectedEntry.sys.id,


### PR DESCRIPTION
# Adjust how we check if subpage is already linked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced parent entry validation when linking existing pages to confirm that referenced parent entries still exist and can be successfully accessed before completing the link operation.
  * Improved error handling for parent entry lookups to properly distinguish between cases where entries cannot be found and other types of retrieval errors occurring during the validation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->