### PR TITLE
feat(judicial-system): allow editing verdict checkboxes when correcting

### DIFF
--- a/apps/judicial-system/web/src/routes/Court/Indictments/Conclusion/Conclusion.tsx
+++ b/apps/judicial-system/web/src/routes/Court/Indictments/Conclusion/Conclusion.tsx
@@ -849,7 +849,6 @@ const Conclusion: FC = () => {
                             setWorkingCase,
                           )
                         }
-                        disabled={workingCase.state === CaseState.CORRECTING}
                         backgroundColor="white"
                         large
                         filled
@@ -869,7 +868,6 @@ const Conclusion: FC = () => {
                           setWorkingCase,
                         )
                       }
-                      disabled={workingCase.state === CaseState.CORRECTING}
                       backgroundColor="white"
                       large
                       filled


### PR DESCRIPTION
## Summary
- When an indictment case is in the CORRECTING state, the \"Útivistardómur\" (default judgement) and \"Svipting ökuréttar\" (driving licence suspension) checkboxes were disabled
- Removed the `disabled={workingCase.state === CaseState.CORRECTING}` prop from both checkboxes so users can update them while correcting

## Test plan
- Open an indictment case in CORRECTING state
- Navigate to the Conclusion page and select "Completing" with ruling decision "Ruling" or "Fine"
- Verify the "Útivistardómur" and "Svipting ökuréttar" checkboxes are now interactive (not greyed out)
- Toggle the checkboxes and confirm the values are saved correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new page for police digital file access with error handling
  * Implemented error notifications for failed file operations

* **Improvements**
  * Enhanced user experience with animated loading states for digital case files

* **Bug Fixes**
  * Fixed checkbox availability during case correction workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->