### PR TITLE
fix(web): Adjust margin top for h3 below h2 in VerdictDetails

### DIFF
--- a/apps/web/screens/Verdicts/VerdictDetails.css.ts
+++ b/apps/web/screens/Verdicts/VerdictDetails.css.ts
@@ -31,6 +31,10 @@ globalStyle(`${richText} p`, {
   textAlign: 'justify',
 })
 
+globalStyle(`${richText} h2 + h3`, {
+  marginTop: '8px',
+})
+
 export const verdictHtmlTitleContainer = style({
   maxWidth: '774px',
   textAlign: 'center',


### PR DESCRIPTION
# Adjust margin top for h3 below h2 in VerdictDetails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing between heading levels in rich text content for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->