### PR TITLE
fix(web): Display hearing time on agenda card

### DIFF
--- a/apps/web/screens/CourtAgendas/CourtAgendas.tsx
+++ b/apps/web/screens/CourtAgendas/CourtAgendas.tsx
@@ -1314,6 +1314,13 @@ const CourtAgendas: CustomScreen<CourtAgendasProps> = (props) => {
                         : ''
                     }
                     time={time}
+                    hearingTime={
+                      agenda.hearingTime
+                        ? formatMessage(m.listPage.hearingTime, {
+                            hearingTime: agenda.hearingTime,
+                          })
+                        : undefined
+                    }
                     court={agenda.court}
                     courtRoom={agenda.courtRoom}
                     addToCalendarButton={

--- a/apps/web/screens/CourtAgendas/components/AgendaCard.tsx
+++ b/apps/web/screens/CourtAgendas/components/AgendaCard.tsx
@@ -18,6 +18,7 @@ type AgendaCardProps = {
   title: string
   date: string
   time: string
+  hearingTime?: string | null
   court: string
   courtRoom: string
   addToCalendarButton: React.ReactNode
@@ -32,6 +33,7 @@ export const AgendaCard = ({
   judgesString,
   date,
   time,
+  hearingTime,
   court,
   courtRoom,
   closedHearingText,
@@ -129,6 +131,9 @@ export const AgendaCard = ({
                       <Text className={styles.preLine}>{title}</Text>
                     </Box>
                   )}
+                  {Boolean(hearingTime) && (
+                    <Text variant="small">{hearingTime}</Text>
+                  )}
                 </Stack>
               </GridColumn>
               <GridColumn span="4/12">{renderDetails()}</GridColumn>
@@ -164,6 +169,9 @@ export const AgendaCard = ({
               <Box flexGrow={1} marginTop={1}>
                 <Text className={styles.preLine}>{title}</Text>
               </Box>
+            )}
+            {Boolean(hearingTime) && (
+              <Text variant="small">{`Málflutningstími: ${hearingTime}`}</Text>
             )}
             {renderDetails()}
           </Stack>

--- a/apps/web/screens/CourtAgendas/translations.strings.ts
+++ b/apps/web/screens/CourtAgendas/translations.strings.ts
@@ -2,6 +2,11 @@ import { defineMessages } from 'react-intl'
 
 export const m = {
   listPage: defineMessages({
+    hearingTime: {
+      id: 'web.courtAgendas:listPage.hearingTime',
+      defaultMessage: 'Málflutningstími: {hearingTime}',
+      description: 'Málflutningstími',
+    },
     caseTypeAccordionLabel: {
       id: 'web.courtAgendas:listPage.caseTypeAccordionLabel',
       defaultMessage: 'Málategundir',

--- a/apps/web/screens/queries/CourtAgendas.ts
+++ b/apps/web/screens/queries/CourtAgendas.ts
@@ -17,6 +17,7 @@ export const GET_COURT_AGENDAS_QUERY = gql`
           name
         }
         court
+        hearingTime
       }
       total
       input {

--- a/libs/api/domains/verdicts/src/lib/dto/courtAgendas.response.ts
+++ b/libs/api/domains/verdicts/src/lib/dto/courtAgendas.response.ts
@@ -75,6 +75,9 @@ class CourtAgenda {
 
   @Field(() => String, { nullable: true })
   caseSubType?: string
+
+  @Field(() => String, { nullable: true })
+  hearingTime?: string | null
 }
 
 @ObjectType('WebCourtAgendasResponse')

--- a/libs/clients/verdicts/src/lib/verdicts-client.service.ts
+++ b/libs/clients/verdicts/src/lib/verdicts-client.service.ts
@@ -606,6 +606,7 @@ export class VerdictsClientService {
           type: agenda.bookingType ?? '',
           title: agenda.caseTitle?.raw ? agenda.caseTitle.raw : '',
           caseSubType: agenda.caseSubType ?? '',
+          hearingTime: agenda.length ?? '',
         })
       }
     } else {

--- a/libs/clients/verdicts/src/lib/verdicts-client.service.ts
+++ b/libs/clients/verdicts/src/lib/verdicts-client.service.ts
@@ -581,6 +581,7 @@ export class VerdictsClientService {
           court: SUPREME_COURT,
           type: '',
           title: agenda.title ?? '',
+          hearingTime: agenda.hearingTime ?? '',
         })
       }
     } else {


### PR DESCRIPTION
# Display hearing time on agenda card

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Court agenda cards now display hearing time information when available, with responsive formatting optimized for both desktop and mobile layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->