### PR TITLE
fix(delegations): duplicate legalGuardian entries

### DIFF
--- a/libs/portals/shared-modules/delegations/src/screens/AccessControlNew/AccessControlNew.tsx
+++ b/libs/portals/shared-modules/delegations/src/screens/AccessControlNew/AccessControlNew.tsx
@@ -141,10 +141,19 @@ const AccessControlNew = () => {
 
   const incomingCustomDelegations = incomingDelegationGroups.Custom
 
-  const legalGuardianDelegations = [
-    ...(incomingDelegationGroups.LegalGuardian || []),
-    ...(incomingDelegationGroups.LegalGuardianMinor || []),
-  ]
+  const legalGuardianDelegations = useMemo(() => {
+    const guardianMinor = incomingDelegationGroups.LegalGuardianMinor || []
+    const guardian = incomingDelegationGroups.LegalGuardian || []
+    const minorNationalIds = new Set(guardianMinor.map((d) => d.nationalId))
+    // Filter out LegalGuardian entries for people who already appear as LegalGuardianMinor
+    const filteredGuardian = guardian.filter(
+      (d) => !minorNationalIds.has(d.nationalId),
+    )
+    return [...guardianMinor, ...filteredGuardian]
+  }, [
+    incomingDelegationGroups.LegalGuardian,
+    incomingDelegationGroups.LegalGuardianMinor,
+  ])
 
   const procuringHolderDelegations = incomingDelegationGroups.ProcurationHolder
 


### PR DESCRIPTION


## What

Refactor the way legal guardian delegations are constructed by using useMemo to filter out entries for individuals already represented as LegalGuardianMinor. This improves performance and clarity in the delegation handling process.

## Why

Children under 15 are appearing twice under custody delegations because if they are under 15 they have both the legalGuardina and legalGuardianMinor scopes

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where duplicate legal guardian delegation entries could appear in the access control list. Delegations now display correctly without redundant entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->