### PR TITLE
fix(annual-report): content error for createNavigation() and breadcrumbs for eng

### DIFF
--- a/apps/web/screens/Organization/AnnualReports/AnnualReportChapter.tsx
+++ b/apps/web/screens/Organization/AnnualReports/AnnualReportChapter.tsx
@@ -160,7 +160,7 @@ const AnnualReportChapter: Screen<
                       paddingBottom={2}
                     >
                       <AnchorNavigation
-                        title={'Á þessari síðu'}
+                        title={activeLocale === 'is' ? 'Á þessari síðu' : 'On this page'}
                         navigation={navigation}
                         position="right"
                       />

--- a/apps/web/screens/Organization/AnnualReports/AnnualReportChapter.tsx
+++ b/apps/web/screens/Organization/AnnualReports/AnnualReportChapter.tsx
@@ -190,7 +190,7 @@ const AnnualReportChapter: Screen<
                     >
                       <Sticky>
                         <AnchorNavigation
-                          title={'Á þessari síðu'}
+                        title={activeLocale === 'is' ? 'Á þessari síðu' : 'On this page'}
                           navigation={navigation}
                           position="right"
                         />

--- a/apps/web/screens/Organization/AnnualReports/AnnualReportChapter.tsx
+++ b/apps/web/screens/Organization/AnnualReports/AnnualReportChapter.tsx
@@ -46,7 +46,9 @@ export type AnnualReportChapterType = NonNullable<
   GetAnnualReportQuery['getAnnualReport']
 >['chapters'][number]
 
-export type AnnualReportType = NonNullable<GetAnnualReportQuery['getAnnualReport']>
+export type AnnualReportType = NonNullable<
+  GetAnnualReportQuery['getAnnualReport']
+>
 
 export interface AnnualReportChapterProps {
   organizationPage: OrganizationPage
@@ -103,16 +105,19 @@ const AnnualReportChapter: Screen<
                     },
                     {
                       title: organizationPage?.title ?? '',
-                      href: linkResolver('organizationpage', [
-                        organizationPage?.slug ?? '',
-                      ], activeLocale).href,
+                      href: linkResolver(
+                        'organizationpage',
+                        [organizationPage?.slug ?? ''],
+                        activeLocale,
+                      ).href,
                     },
                     {
                       title: annualReport?.title ?? '',
-                      href: linkResolver('annualreport', [
-                        organizationPage?.slug ?? '',
-                        annualReport.slug,
-                      ], activeLocale).href,
+                      href: linkResolver(
+                        'annualreport',
+                        [organizationPage?.slug ?? '', annualReport.slug],
+                        activeLocale,
+                      ).href,
                     },
                   ]}
                 />

--- a/apps/web/screens/Organization/AnnualReports/AnnualReportChapter.tsx
+++ b/apps/web/screens/Organization/AnnualReports/AnnualReportChapter.tsx
@@ -20,9 +20,8 @@ import {
   Webreader,
 } from '@island.is/web/components'
 import {
-  AnnualReport,
-  AnnualReportChapter as AnnualReportChapterSchema,
   ContentLanguage,
+  GetAnnualReportQuery,
   OrganizationPage,
   Query,
   QueryGetAnnualReportArgs,
@@ -43,10 +42,16 @@ import {
   GET_ORGANIZATION_PAGE_QUERY,
 } from '../../queries'
 
+export type AnnualReportChapterType = NonNullable<
+  GetAnnualReportQuery['getAnnualReport']
+>['chapters'][number]
+
+export type AnnualReportType = NonNullable<GetAnnualReportQuery['getAnnualReport']>
+
 export interface AnnualReportChapterProps {
   organizationPage: OrganizationPage
-  annualReport: AnnualReport
-  annualReportChapter: AnnualReportChapterSchema
+  annualReport: AnnualReportType
+  annualReportChapter: AnnualReportChapterType
 }
 
 type AnnualReportChapterScreenContext = ScreenContext & {
@@ -94,20 +99,20 @@ const AnnualReportChapter: Screen<
                   items={[
                     {
                       title: 'Ísland.is',
-                      href: linkResolver('homepage').href,
+                      href: linkResolver('homepage', [], activeLocale).href,
                     },
                     {
                       title: organizationPage?.title ?? '',
                       href: linkResolver('organizationpage', [
                         organizationPage?.slug ?? '',
-                      ]).href,
+                      ], activeLocale).href,
                     },
                     {
-                      title: 'Ársskýrslur',
+                      title: annualReport?.title ?? '',
                       href: linkResolver('annualreport', [
                         organizationPage?.slug ?? '',
                         annualReport.slug,
-                      ]).href,
+                      ], activeLocale).href,
                     },
                   ]}
                 />
@@ -242,7 +247,7 @@ AnnualReportChapter.getProps = async ({
           },
         })
       : { data: { getOrganizationPage: organizationPage } },
-    apolloClient.query<Query, QueryGetAnnualReportArgs>({
+    apolloClient.query<GetAnnualReportQuery, QueryGetAnnualReportArgs>({
       query: GET_ANNUAL_REPORT_QUERY,
       variables: {
         input: {

--- a/apps/web/screens/Organization/AnnualReports/AnnualReports.tsx
+++ b/apps/web/screens/Organization/AnnualReports/AnnualReports.tsx
@@ -151,7 +151,11 @@ const AnnualReports: Screen<AnnualReportsProps, AnnualReportsScreenContext> = ({
                       span={['12/12', '12/12', '6/12', '6/12', '5/12']}
                     >
                       <Select
-                        label={activeLocale === 'is' ? 'Veldu ársskýrslu' : 'Select annual report'}
+                        label={
+                          activeLocale === 'is'
+                            ? 'Veldu ársskýrslu'
+                            : 'Select annual report'
+                        }
                         name="select-annual-report"
                         size="sm"
                         // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/apps/web/screens/Organization/AnnualReports/AnnualReports.tsx
+++ b/apps/web/screens/Organization/AnnualReports/AnnualReports.tsx
@@ -65,7 +65,7 @@ const AnnualReports: Screen<AnnualReportsProps, AnnualReportsScreenContext> = ({
 
   const [selectedId, setSelectedId] = useState<string>('')
 
-  const pageTitle = 'Ársskýrslur'
+  const pageTitle = activeLocale === 'is' ? 'Ársskýrslur' : 'Annual Reports'
 
   const dropdownOptions = useMemo(() => {
     return annualReports.map((report) => ({
@@ -151,7 +151,7 @@ const AnnualReports: Screen<AnnualReportsProps, AnnualReportsScreenContext> = ({
                       span={['12/12', '12/12', '6/12', '6/12', '5/12']}
                     >
                       <Select
-                        label="Veldu ársskýrslu"
+                        label={activeLocale === 'is' ? 'Veldu ársskýrslu' : 'Select annual report'}
                         name="select-annual-report"
                         size="sm"
                         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -213,6 +213,7 @@ const AnnualReports: Screen<AnnualReportsProps, AnnualReportsScreenContext> = ({
                                     selectedReport.slug,
                                     chapter.slug,
                                   ],
+                                  activeLocale,
                                 ).href
 
                                 return (


### PR DESCRIPTION
## What

There was an error regarding content type for createNavigation. 
Page title, select label and annual report title both in is and en. 
Added activeLocale to linkResolver so URL work for english translation.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review
