### PR TITLE
fix(ojoi): Prevent submit of amending regulation if no impact

### DIFF
--- a/libs/application/templates/official-journal-of-iceland/src/components/regulations/ImpactAmendingSelection.tsx
+++ b/libs/application/templates/official-journal-of-iceland/src/components/regulations/ImpactAmendingSelection.tsx
@@ -84,7 +84,16 @@ export const ImpactAmendingSelection = ({
       : searchResults ?? []
 
   return (
-    <div className={s.amendingSelectionOption}>
+    <div
+      className={s.amendingSelectionOption}
+      onKeyDown={(e) => {
+        // Prevent Enter from bubbling to the surrounding <form>, which would
+        // otherwise advance the application to the next step.
+        if (e.key === 'Enter') {
+          e.preventDefault()
+        }
+      }}
+    >
       <Text variant="eyebrow" color="blue400" marginBottom={1}>
         Reglugerð sem breytist
       </Text>
@@ -92,7 +101,14 @@ export const ImpactAmendingSelection = ({
         placeholder="Sláðu inn númer stofnreglugerðar (Dæmi: 438/2022)"
         onInputValueChange={(newValue) => updateValue(newValue)}
         loading={loading || isSearching}
-        onSubmit={(newValue) => {
+        onSubmit={(newValue, selectedOption) => {
+          if (
+            selectedOption &&
+            !('disabled' in selectedOption && selectedOption.disabled)
+          ) {
+            onSelect(selectedOption as SelRegOption)
+            return
+          }
           updateValue(newValue)
         }}
         options={options}

--- a/libs/application/templates/official-journal-of-iceland/src/lib/messages/regulation.ts
+++ b/libs/application/templates/official-journal-of-iceland/src/lib/messages/regulation.ts
@@ -226,6 +226,13 @@ export const regulation = {
         defaultMessage: 'Fella hana brott',
         description: 'Button label for revoking a regulation',
       },
+      requireImpact: {
+        id: 'ojoi.application:regulation.impacts.alerts.requireImpact',
+        defaultMessage:
+          'Til að halda áfram þarf að skrá a.m.k. eina breytingu eða brottfellingu.',
+        description:
+          'Helper shown above the Next button when an amending regulation has no impacts yet',
+      },
     }),
     labels: defineMessages({
       amendment: {

--- a/libs/application/templates/official-journal-of-iceland/src/screens/RegulationImpactsScreen.tsx
+++ b/libs/application/templates/official-journal-of-iceland/src/screens/RegulationImpactsScreen.tsx
@@ -45,7 +45,7 @@ import { Routes } from '../lib/constants'
 
 export const RegulationImpactsScreen = (props: OJOIFieldBaseProps) => {
   const { formatMessage: f } = useLocale()
-  const { application } = props
+  const { application, setSubmitButtonDisabled } = props
   const applicationType = application.answers?.applicationType
   const isAmending = applicationType === 'amending_regulation'
 
@@ -131,6 +131,25 @@ export const RegulationImpactsScreen = (props: OJOIFieldBaseProps) => {
   const [chooseType, setChooseType] = useState<
     'cancel' | 'change' | undefined
   >()
+
+  // Gate the "Next" button: amending regulations must have at least one
+  // impact before the user can advance. Base regulations pass through.
+  const nextDisabledReason =
+    isAmending && impactsLoaded && impacts.length === 0
+  useEffect(() => {
+    if (!setSubmitButtonDisabled) return
+    setSubmitButtonDisabled(
+      isAmending && (!impactsLoaded || impacts.length === 0),
+    )
+  }, [setSubmitButtonDisabled, isAmending, impactsLoaded, impacts.length])
+
+  // Reset on unmount so the next screen starts with Next enabled.
+  useEffect(() => {
+    return () => {
+      setSubmitButtonDisabled && setSubmitButtonDisabled(false)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   // Escape key handler
   const escClick = useCallback((e: KeyboardEvent) => {
@@ -511,6 +530,12 @@ export const RegulationImpactsScreen = (props: OJOIFieldBaseProps) => {
             onSaveImpact={handleSaveExistingImpact}
             onDeleteImpact={handleDeleteImpact}
           />
+        )}
+
+        {nextDisabledReason && (
+          <Text variant="small" color="red600">
+            {f(regulation.impacts.alerts.requireImpact)}
+          </Text>
         )}
       </Stack>
     </FormScreen>

--- a/libs/application/templates/official-journal-of-iceland/src/screens/RegulationImpactsScreen.tsx
+++ b/libs/application/templates/official-journal-of-iceland/src/screens/RegulationImpactsScreen.tsx
@@ -134,8 +134,7 @@ export const RegulationImpactsScreen = (props: OJOIFieldBaseProps) => {
 
   // Gate the "Next" button: amending regulations must have at least one
   // impact before the user can advance. Base regulations pass through.
-  const nextDisabledReason =
-    isAmending && impactsLoaded && impacts.length === 0
+  const nextDisabledReason = isAmending && impactsLoaded && impacts.length === 0
   useEffect(() => {
     if (!setSubmitButtonDisabled) return
     setSubmitButtonDisabled(


### PR DESCRIPTION
## What

- Prevent submit of amending regulation if no impact
- Select impact from list on pressing `Enter`

## Why

Bugfixing

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added validation requiring impacts when amending regulations, with a clear warning message displayed when impacts are missing.
  * The "Next" button now intelligently disables when impacts are required but not provided.

* **Bug Fixes**
  * Improved keyboard handling to prevent unintended form submission when selecting impacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->