### PR TITLE
feat(j-s): use grid recipe for spacing in indictments overview

### DIFF
--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Overview/Overview.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Overview/Overview.tsx
@@ -39,6 +39,7 @@ import {
   IndictmentDecision,
 } from '@island.is/judicial-system-web/src/graphql/schema'
 import { useCase } from '@island.is/judicial-system-web/src/utils/hooks'
+import { grid } from '@island.is/judicial-system-web/src/utils/styles/recipes.css'
 
 import DenyIndictmentCaseModal from './DenyIndictmentCaseModal/DenyIndictmentCaseModal'
 import { overview as strings } from './Overview.strings'
@@ -224,63 +225,67 @@ const Overview: FC = () => {
               />
             </Box>
           )}
-        <Box component="section" marginBottom={5}>
-          <InfoCardActiveIndictment
-            displayVerdictViewDate
-            onProsecutorClick={() => {
-              setModal('editProsecutor')
-            }}
-          />
-        </Box>
-        <AllIndictmentCaseFiles />
-        {userCanAddDocuments && (
-          <Box display="flex" justifyContent="flexEnd" marginBottom={5}>
-            <Button
-              size="small"
-              icon="add"
-              onClick={() =>
-                router.push(
-                  `${constants.INDICTMENTS_ADD_FILES_ROUTE}/${workingCase.id}`,
-                )
-              }
-            >
-              {formatMessage(strings.addDocumentsButtonText)}
-            </Button>
-          </Box>
-        )}
-        {userCanSendIndictmentToCourt && (
-          <Box marginBottom={5}>
-            <SectionHeading
-              title={formatMessage(strings.indictmentConfirmationTitle)}
-              required
+        <div className={grid({ gap: 5, marginBottom: 10 })}>
+          <Box component="section">
+            <InfoCardActiveIndictment
+              displayVerdictViewDate
+              onProsecutorClick={() => {
+                setModal('editProsecutor')
+              }}
             />
-            <BlueBox>
-              <div className={styles.gridRowEqual}>
-                <RadioButton
-                  large
-                  name="indictmentConfirmationRequest"
-                  id="denyIndictment"
-                  backgroundColor="white"
-                  label={formatMessage(strings.denyIndictment)}
-                  checked={indictmentConfirmationDecision === 'deny'}
-                  onChange={() => setIndictmentConfirmationDecision('deny')}
-                />
-                <RadioButton
-                  large
-                  name="indictmentConfirmationRequest"
-                  id="confirmIndictment"
-                  backgroundColor="white"
-                  label={formatMessage(strings.confirmIndictment)}
-                  checked={indictmentConfirmationDecision === 'confirm'}
-                  onChange={() => setIndictmentConfirmationDecision('confirm')}
-                />
-              </div>
-            </BlueBox>
           </Box>
-        )}
-        <Box component="section" marginBottom={10}>
-          <InputPenalties />
-        </Box>
+          <AllIndictmentCaseFiles />
+          {userCanAddDocuments && (
+            <Box display="flex" justifyContent="flexEnd">
+              <Button
+                size="small"
+                icon="add"
+                onClick={() =>
+                  router.push(
+                    `${constants.INDICTMENTS_ADD_FILES_ROUTE}/${workingCase.id}`,
+                  )
+                }
+              >
+                {formatMessage(strings.addDocumentsButtonText)}
+              </Button>
+            </Box>
+          )}
+          {userCanSendIndictmentToCourt && (
+            <>
+              <SectionHeading
+                title={formatMessage(strings.indictmentConfirmationTitle)}
+                required
+              />
+              <BlueBox>
+                <div className={styles.gridRowEqual}>
+                  <RadioButton
+                    large
+                    name="indictmentConfirmationRequest"
+                    id="denyIndictment"
+                    backgroundColor="white"
+                    label={formatMessage(strings.denyIndictment)}
+                    checked={indictmentConfirmationDecision === 'deny'}
+                    onChange={() => setIndictmentConfirmationDecision('deny')}
+                  />
+                  <RadioButton
+                    large
+                    name="indictmentConfirmationRequest"
+                    id="confirmIndictment"
+                    backgroundColor="white"
+                    label={formatMessage(strings.confirmIndictment)}
+                    checked={indictmentConfirmationDecision === 'confirm'}
+                    onChange={() =>
+                      setIndictmentConfirmationDecision('confirm')
+                    }
+                  />
+                </div>
+              </BlueBox>
+            </>
+          )}
+          <Box component="section">
+            <InputPenalties />
+          </Box>
+        </div>
       </FormContentContainer>
       <FormContentContainer isFooter>
         <FormFooter


### PR DESCRIPTION
## What

Replace individual `Box` components with `marginBottom` props with a single `div` using the shared `grid` recipe in the prosecutor indictments overview page.

## Why

Consolidates spacing management into a single grid container rather than scattered `marginBottom` on each section, making the layout more consistent and easier to maintain.

## Screenshots / Gifs


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review