### PR TITLE
fix(clients-statistics): Fix date filtering for Charts

### DIFF
--- a/libs/clients/statistics/src/lib/statistics.utils.ts
+++ b/libs/clients/statistics/src/lib/statistics.utils.ts
@@ -253,7 +253,7 @@ export const getStatistics = ({
     return []
   }
 
-  const isDateHeader = _tryToGetDate(allSourceDataForKey[0]?.header) !== null
+  const isDateHeader = !Number.isNaN(Number(allSourceDataForKey[0]?.header))
 
   const mapped = allSourceDataForKey.map((item) => ({
     ...item,
@@ -261,7 +261,7 @@ export const getStatistics = ({
   }))
 
   const dropLeft = (item: StatisticSourceValue) => {
-    if (isDateHeader && dateFrom && new Date(item.header) < dateFrom) {
+    if (isDateHeader && dateFrom && new Date(Number(item.header)) < dateFrom) {
       return true
     }
 
@@ -273,7 +273,7 @@ export const getStatistics = ({
   }
 
   const dropRight = (item: StatisticSourceValue) => {
-    if (isDateHeader && dateTo && new Date(item.header) > dateTo) {
+    if (isDateHeader && dateTo && new Date(Number(item.header)) > dateTo) {
       return true
     }
 
@@ -372,7 +372,7 @@ export const getMultipleStatistics = async (
   } else if (dateFrom) {
     // If we have only date from, get the X number of data points from that date
     return filterByInterval(
-      trimmedResult.slice(numberOfDataPointsToUse),
+      trimmedResult.slice(0, numberOfDataPointsToUse),
       interval,
     )
   } else if (dateTo) {


### PR DESCRIPTION
## What

Fixed date filtering for Charts

## Why

So that we can filter data by `Date From`/`Date To`

## Screenshots / Gifs

<img width="914" height="465" alt="image" src="https://github.com/user-attachments/assets/de5dd627-f203-4958-a219-94cba924081e" />

### Before:
<img width="840" height="650" alt="image" src="https://github.com/user-attachments/assets/067c760f-3945-46f1-a0e0-ab181ffc5afe" />

### After:
<img width="838" height="647" alt="image" src="https://github.com/user-attachments/assets/9a4396d7-2ef7-4f40-8ccd-0909366f8e1f" />


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed statistics filtering behavior when only a start date is specified, ensuring the correct date range is selected.
  * Improved date parsing validation for more reliable date-header detection in statistics data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->