### PR TITLE
fix(j-s): Error toast in civil claimain field 

### DIFF
--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Processing/CivilClaimantFields.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Processing/CivilClaimantFields.tsx
@@ -83,30 +83,50 @@ export const CivilClaimantFields = ({
     updateCivilClaimant({ name, civilClaimantId, caseId })
   }
 
-  const handleCivilClaimantNationalIdBlur = (
-    nationalId: string,
-    noNationalId?: boolean | null,
-    civilClaimantId?: string | null,
+  const applyNationalIdLookupFromInput = (
+    value: string,
+    civilClaimantId: string,
   ) => {
+    const cleanNationalId = value ? value.replace('-', '') : ''
+    setLookupNationalId(cleanNationalId || null)
+
+    if (cleanNationalId.length === 10) {
+      setCivilClaimantNationalIdUpdate({
+        nationalId: cleanNationalId || null,
+        civilClaimantId,
+      })
+    }
+  }
+
+  const handleInputNationalIdChange = (value: string) => {
+    const civilClaimantId = civilClaimant.id
     if (!civilClaimantId) {
       return
     }
 
-    if (noNationalId) {
-      handleSetAndSendCivilClaimantToServer({
+    if (civilClaimant.noNationalId) {
+      handleUpdateCivilClaimantState({
         civilClaimantId,
-        nationalId: nationalId || null,
+        nationalId: value || null,
       })
     } else {
-      const cleanNationalId = nationalId ? nationalId.replace('-', '') : ''
-      setLookupNationalId(cleanNationalId || null)
+      applyNationalIdLookupFromInput(value, civilClaimantId)
+    }
+  }
 
-      if (cleanNationalId.length === 10) {
-        setCivilClaimantNationalIdUpdate({
-          nationalId: cleanNationalId || null,
-          civilClaimantId,
-        })
-      }
+  const handleInputNationalIdBlur = (value: string) => {
+    const civilClaimantId = civilClaimant.id
+    if (!civilClaimantId) {
+      return
+    }
+
+    if (civilClaimant.noNationalId) {
+      handleSetAndSendCivilClaimantToServer({
+        civilClaimantId,
+        nationalId: value || null,
+      })
+    } else {
+      applyNationalIdLookupFromInput(value, civilClaimantId)
     }
   }
 
@@ -178,20 +198,8 @@ export const CivilClaimantFields = ({
           isDateOfBirth={Boolean(civilClaimant.noNationalId)}
           value={civilClaimant.nationalId ?? undefined}
           required={Boolean(!civilClaimant.noNationalId)}
-          onChange={(val) => {
-            handleCivilClaimantNationalIdBlur(
-              val,
-              civilClaimant.noNationalId,
-              civilClaimant.id,
-            )
-          }}
-          onBlur={(val) =>
-            handleCivilClaimantNationalIdBlur(
-              val,
-              civilClaimant.noNationalId,
-              civilClaimant.id,
-            )
-          }
+          onChange={handleInputNationalIdChange}
+          onBlur={handleInputNationalIdBlur}
         />
         {notFound && (
           <Text color="red600" variant="eyebrow" marginTop={1}>

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Processing/CivilClaimantFields.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Processing/CivilClaimantFields.tsx
@@ -87,12 +87,12 @@ export const CivilClaimantFields = ({
     value: string,
     civilClaimantId: string,
   ) => {
-    const cleanNationalId = value ? value.replace('-', '') : ''
+    const cleanNationalId = value.replace('-', '')
     setLookupNationalId(cleanNationalId || null)
 
     if (cleanNationalId.length === 10) {
       setCivilClaimantNationalIdUpdate({
-        nationalId: cleanNationalId || null,
+        nationalId: cleanNationalId,
         civilClaimantId,
       })
     }
@@ -107,7 +107,7 @@ export const CivilClaimantFields = ({
     if (civilClaimant.noNationalId) {
       handleUpdateCivilClaimantState({
         civilClaimantId,
-        nationalId: value || null,
+        nationalId: value,
       })
     } else {
       applyNationalIdLookupFromInput(value, civilClaimantId)
@@ -123,7 +123,7 @@ export const CivilClaimantFields = ({
     if (civilClaimant.noNationalId) {
       handleSetAndSendCivilClaimantToServer({
         civilClaimantId,
-        nationalId: value || null,
+        nationalId: value,
       })
     } else {
       applyNationalIdLookupFromInput(value, civilClaimantId)


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1214051587709419?focus=true)

## What

When civil claimant had no national id, we sent updates to the server on every keystroke, and the server validation errored every time (except the final one, if the birth date was valid)

Changed it so we only update local state in onChange, and persist to the server in onBlur

## Why

So the users don't see errors when typing in a date of birth

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved national ID input handling in the indictment processing workflow for enhanced reliability and consistency when managing civil claimant information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->