### PR TITLE
fix(j-s): right align appeal case file metadata:

### DIFF
--- a/apps/judicial-system/web/src/components/AppealCaseFilesOverview/AppealCaseFilesOverview.css.ts
+++ b/apps/judicial-system/web/src/components/AppealCaseFilesOverview/AppealCaseFilesOverview.css.ts
@@ -1,15 +1,18 @@
 import { style } from '@vanilla-extract/css'
 
-import { theme } from '@island.is/island-ui/theme'
+export const metadataRow = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'flex-end',
+  flex: 1,
+  minWidth: 0,
+})
 
 export const childContainer = style({
   display: 'flex',
   flexDirection: 'column',
-  alignSelf: 'start',
-
-  '@media': {
-    [`screen and (min-width: ${theme.breakpoints.md}px)`]: {
-      alignSelf: 'center',
-    },
-  },
+  alignItems: 'flex-end',
+  textAlign: 'right',
+  minWidth: 0,
+  maxWidth: '100%',
 })

--- a/apps/judicial-system/web/src/components/AppealCaseFilesOverview/AppealCaseFilesOverview.tsx
+++ b/apps/judicial-system/web/src/components/AppealCaseFilesOverview/AppealCaseFilesOverview.tsx
@@ -192,11 +192,7 @@ const AppealCaseFilesOverview = () => {
                 disabled={isDisabled}
                 handleClick={() => onOpen(file.id)}
               >
-                <Box
-                  display="flex"
-                  alignItems={['flexEnd', 'flexEnd', 'center']}
-                  justifyContent={['spaceBetween', 'spaceBetween', 'center']}
-                >
+                <Box className={styles.metadataRow}>
                   <Box className={styles.childContainer}>
                     <Text whiteSpace="nowrap">
                       {`${formatDate(file.created, 'dd.MM.y')} kl. ${formatDate(


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1214106082183228?focus=true)
## What

Fix this: 
<img width="1400" height="700" alt="image" src="https://github.com/user-attachments/assets/757938fb-c7d7-4acb-b76e-e6b6734613ff" />


So it instead looks like this:
<img width="1768" height="520" alt="image" src="https://github.com/user-attachments/assets/2157085c-53fe-438b-9e4a-5e05ce243d10" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the layout styling for metadata rows in the Appeal Case Files Overview component to use consistent right-alignment with width constraints instead of responsive breakpoint-based centering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->