### PR TITLE
fix(j-s): fix crash when opening active case as defense lawyer

### DIFF
--- a/apps/judicial-system/web/src/components/FormProvider/limitedAccessCase.graphql
+++ b/apps/judicial-system/web/src/components/FormProvider/limitedAccessCase.graphql
@@ -98,6 +98,10 @@ query LimitedAccessCase($input: CaseQueryInput!) {
       isAlternativeService
       alternativeServiceDescription
       indictmentReviewDecision
+      indictmentCancelledOrDismissedState {
+        type
+        time
+      }
       subpoenas {
         id
         created

--- a/apps/judicial-system/web/src/components/InfoCard/useInfoCardItems.tsx
+++ b/apps/judicial-system/web/src/components/InfoCard/useInfoCardItems.tsx
@@ -28,6 +28,7 @@ import {
 
 import { isNonEmptyArray } from '../../utils/arrayHelpers'
 import { sortByIcelandicAlphabet } from '../../utils/sortHelper'
+import { getDefaultDefendantGender } from '../../utils/utils'
 import { FormContext } from '../FormProvider/FormProvider'
 import { LinkComponent } from '../MarkdownWrapper/MarkdownWrapper'
 import { UserContext } from '../UserProvider/UserProvider'
@@ -65,7 +66,7 @@ const useInfoCardItems = () => {
     const defendants = workingCase.defendants?.filter((defendant) =>
       isDefenceUser(user) && isCompletedCase(workingCase.state)
         ? true
-        : defendant.indictmentCancelledOrDismissedState === null,
+        : !defendant.indictmentCancelledOrDismissedState,
     )
     const isMultipleDefendants = defendants && defendants.length > 1
 
@@ -81,7 +82,7 @@ const useInfoCardItems = () => {
               : isMultipleDefendants
               ? formatMessage(core.indictmentDefendants)
               : formatMessage(core.indictmentDefendant, {
-                  gender: defendants?.[0].gender,
+                  gender: getDefaultDefendantGender(defendants),
                 }),
           )}
         </Text>


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1199153462262248/task/1214235261513332?focus=true)

## What

limitedAccessCase.graphql
Request indictmentCancelledOrDismissedState { type time } for defendants (same as case.graphql), so limited-access responses match full case semantics.

useInfoCardItems.tsx

Filter with !defendant.indictmentCancelledOrDismissedState so both null and undefined mean “still active” (and missing query data cannot empty the list).
Use getDefaultDefendantGender(defendants) for the indictment heading so an empty list cannot crash the title.
## Why

So we don't crash when opening a case as defense lawyer

## Screenshots / Gifs

