### PR TITLE
chore(j-s): Digital case files show explainer text if status 425

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/file/file.controller.ts
+++ b/apps/judicial-system/backend/src/app/modules/file/file.controller.ts
@@ -17,7 +17,12 @@ import {
   UseGuards,
 } from '@nestjs/common'
 import { InjectConnection } from '@nestjs/sequelize'
-import { ApiCreatedResponse, ApiOkResponse, ApiTags } from '@nestjs/swagger'
+import {
+  ApiCreatedResponse,
+  ApiOkResponse,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger'
 
 import type { Logger } from '@island.is/logging'
 import { LOGGER_PROVIDER } from '@island.is/logging'
@@ -481,6 +486,11 @@ export class FileController {
   @ApiOkResponse({
     type: SignedUrl,
     description: 'Gets a token URL for a police digital case file',
+  })
+  @ApiResponse({
+    status: 425,
+    description:
+      'Police digital case file is not published yet (secure area still processing)',
   })
   getPoliceDigitalCaseFileTokenUrl(
     @Param('caseId') caseId: string,

--- a/apps/judicial-system/backend/src/app/modules/police/police.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/police/police.service.ts
@@ -7,6 +7,7 @@ import { z } from 'zod'
 import {
   BadGatewayException,
   forwardRef,
+  HttpException,
   Inject,
   Injectable,
   NotFoundException,
@@ -554,6 +555,7 @@ export class PoliceService {
       rafraennGagnId: policeDigitalFileId,
     }).toString()
     const url = `${this.xRoadPath}/V4/GetTokenUrl?${query}`
+    const httpStatusTooEarly = 425
 
     try {
       const res = await this.fetchPoliceDocumentApi(url)
@@ -570,6 +572,17 @@ export class PoliceService {
         })
       }
 
+      if (res.status === httpStatusTooEarly) {
+        throw new HttpException(
+          {
+            error: 'PoliceDigitalFileNotPublished',
+            message:
+              'The police secure digital case file area is not ready yet. Please try again later.',
+          },
+          httpStatusTooEarly,
+        )
+      }
+
       const reason = await res.text()
 
       throw new NotFoundException({
@@ -578,6 +591,13 @@ export class PoliceService {
       })
     } catch (reason) {
       if (reason instanceof NotFoundException) {
+        throw reason
+      }
+
+      if (
+        reason instanceof HttpException &&
+        reason.getStatus() === httpStatusTooEarly
+      ) {
         throw reason
       }
 

--- a/apps/judicial-system/web/src/routes/Shared/PoliceDigitalFileRedirect/PoliceDigitalFileRedirect.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/PoliceDigitalFileRedirect/PoliceDigitalFileRedirect.tsx
@@ -1,9 +1,20 @@
 import { useCallback } from 'react'
 import { useRouter } from 'next/router'
+import type { ApolloError } from '@apollo/client'
 
 import { usePoliceDigitalCaseFileTokenUrlLazyQuery } from '@island.is/judicial-system-web/src/utils/hooks/usePoliceDigitalCaseFile/policeDigitalCaseFileTokenUrl.generated'
+import { findProblemInApolloError } from '@island.is/shared/problem'
 
-import RouteHandler from '../RouteHandler/RouteHandler'
+import RouteHandler, {
+  policeDigitalCaseFileNotPublishedResult,
+} from '../RouteHandler/RouteHandler'
+
+const HTTP_STATUS_TOO_EARLY = 425
+
+const isTooEarlyProblem = (error: ApolloError | undefined) => {
+  const problem = findProblemInApolloError(error)
+  return problem?.status === HTTP_STATUS_TOO_EARLY
+}
 
 const PoliceDigitalFileRedirect = () => {
   const router = useRouter()
@@ -26,6 +37,13 @@ const PoliceDigitalFileRedirect = () => {
     const result = await getTokenUrl({
       variables: { input: { caseId, policeDigitalFileId: fileId } },
     })
+
+    if (result.error) {
+      if (isTooEarlyProblem(result.error)) {
+        return policeDigitalCaseFileNotPublishedResult
+      }
+      return null
+    }
 
     return result.data?.policeDigitalCaseFileTokenUrl ?? null
   }, [router.isReady, caseId, fileId, getTokenUrl])

--- a/apps/judicial-system/web/src/routes/Shared/RouteHandler/RouteHandler.tsx
+++ b/apps/judicial-system/web/src/routes/Shared/RouteHandler/RouteHandler.tsx
@@ -1,7 +1,7 @@
 import { FC, useCallback, useContext, useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/router'
 
-import { Box, LoadingDots } from '@island.is/island-ui/core'
+import { Box, LoadingDots, Text } from '@island.is/island-ui/core'
 import {
   CLOSED_INDICTMENT_OVERVIEW_ROUTE,
   INDICTMENTS_COMPLETED_ROUTE,
@@ -94,8 +94,29 @@ const getRoute = (caseToOpen: Case, user: User): string => {
   return route ? `${route}/${caseToOpen.id}` : '/'
 }
 
+export const policeDigitalCaseFileNotPublishedResult = Object.freeze({
+  kind: 'police_digital_case_file_not_published' as const,
+})
+
+export type PoliceDigitalCaseFileNotPublishedResult =
+  typeof policeDigitalCaseFileNotPublishedResult
+
+export type RouteHandlerResolveResult =
+  | string
+  | null
+  | undefined
+  | PoliceDigitalCaseFileNotPublishedResult
+
+const isPoliceDigitalCaseFileNotPublishedResult = (
+  value: RouteHandlerResolveResult,
+): value is PoliceDigitalCaseFileNotPublishedResult =>
+  typeof value === 'object' &&
+  value !== null &&
+  'kind' in value &&
+  value.kind === 'police_digital_case_file_not_published'
+
 interface Props {
-  resolve?: () => Promise<string | null | undefined>
+  resolve?: () => Promise<RouteHandlerResolveResult>
 }
 
 const RouteHandler: FC<Props> = ({ resolve }) => {
@@ -103,7 +124,12 @@ const RouteHandler: FC<Props> = ({ resolve }) => {
   const { user } = useContext(UserContext)
   const { getCase } = useContext(FormContext)
   const [caseToOpen, setCaseToOpen] = useState<Case>()
+  const [resolveView, setResolveView] = useState<'loading' | 'notPublished'>(
+    'loading',
+  )
   const resolveRef = useRef(resolve)
+
+  resolveRef.current = resolve
 
   const handleGetCase = useCallback(
     (caseId?: string) => {
@@ -125,17 +151,22 @@ const RouteHandler: FC<Props> = ({ resolve }) => {
 
   useEffect(() => {
     if (!resolveRef.current) return
-    resolveRef.current().then((url) => {
-      if (url === undefined) {
+    resolveRef.current().then((result) => {
+      if (result === undefined) {
         return
-      } else if (url) {
-        window.location.href = url
-      } else {
-        new BroadcastChannel('police-digital-file-redirect').postMessage({
-          type: 'error',
-        })
-        window.close()
       }
+      if (isPoliceDigitalCaseFileNotPublishedResult(result)) {
+        setResolveView('notPublished')
+        return
+      }
+      if (typeof result === 'string' && result) {
+        window.location.href = result
+        return
+      }
+      new BroadcastChannel('police-digital-file-redirect').postMessage({
+        type: 'error',
+      })
+      window.close()
     })
   }, [router])
 
@@ -151,7 +182,13 @@ const RouteHandler: FC<Props> = ({ resolve }) => {
 
   return (
     <Box className={styles.loadingContainer}>
-      <LoadingDots />
+      {resolveView === 'notPublished' ? (
+        <Text>
+          Tenging við öruggt gagnasvæði í vinnslu. Reynið aftur síðar.
+        </Text>
+      ) : (
+        <LoadingDots />
+      )}
     </Box>
   )
 }


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1212657017130395/task/1214130719757001?focus=true)

## What

When the token url endpoint returns a 425 (too early) status, we render copy to explain to the user they should try again shortly.

## Why

So it doesn't just go the same generic error path and the user thinks something is broken, when in fact the url is being prepared

## Screenshots / Gifs

<img width="3456" height="1750" alt="image" src="https://github.com/user-attachments/assets/3b97f42d-e232-458c-98e8-fb60f08d110f" />

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of police digital case files that are not yet published so users no longer see generic errors when the secure area is still processing.
* **New Features**
  * Frontend now shows a clear, localized message and avoids unwanted redirects while the police digital case file is pending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->