### PR TITLE
feat(application-system): Add Prune Hnipp to applications with approval process

### DIFF
--- a/libs/application/core/src/lib/constants.ts
+++ b/libs/application/core/src/lib/constants.ts
@@ -24,8 +24,22 @@ export const defaultLifecycleWithPruneMessage = (
   message:
     | PruningNotification
     | ((application: PruningApplication) => PruningNotification),
-) => ({
-  ...DefaultStateLifeCycle,
+): StateLifeCycle => ({
+  shouldBeListed: true,
+  shouldBePruned: true,
+  whenToPrune: 30 * 24 * 3600 * 1000,
+  pruneMessage: message,
+})
+
+export const pruneAfterDaysWithMessage = (
+  days: number,
+  message:
+    | PruningNotification
+    | ((application: PruningApplication) => PruningNotification),
+): StateLifeCycle => ({
+  shouldBeListed: true,
+  shouldBePruned: true,
+  whenToPrune: days * 24 * 3600 * 1000,
   pruneMessage: message,
 })
 

--- a/libs/application/templates/aosh/transfer-of-machine-ownership/src/lib/TransferOfMachineOwnershipTemplate.ts
+++ b/libs/application/templates/aosh/transfer-of-machine-ownership/src/lib/TransferOfMachineOwnershipTemplate.ts
@@ -9,6 +9,8 @@ import {
   DefaultEvents,
   defineTemplateApi,
   InstitutionNationalIds,
+  NotificationType,
+  NotificationConfig,
 } from '@island.is/application/types'
 import {
   EphemeralStateLifeCycle,
@@ -253,6 +255,20 @@ const template: ApplicationTemplate<
             whenToPrune: (application: Application) =>
               pruneInDaysAtMidnight(application, 7),
             shouldDeleteChargeIfPaymentFulfilled: true,
+            pruneMessage: (application) => {
+              const regNumber = getValueViaPath(
+                application.answers,
+                'machine.regNumber',
+                undefined,
+              ) as string | undefined
+              return {
+                notificationTemplateId:
+                  NotificationConfig[
+                    NotificationType.TransferOfMachineOwnershipPruned
+                  ].templateId,
+                internalBody: regNumber ?? '',
+              }
+            },
           },
           roles: [
             {

--- a/libs/application/templates/aosh/transfer-of-machine-ownership/src/lib/TransferOfMachineOwnershipTemplate.ts
+++ b/libs/application/templates/aosh/transfer-of-machine-ownership/src/lib/TransferOfMachineOwnershipTemplate.ts
@@ -256,11 +256,11 @@ const template: ApplicationTemplate<
               pruneInDaysAtMidnight(application, 7),
             shouldDeleteChargeIfPaymentFulfilled: true,
             pruneMessage: (application) => {
-              const regNumber = getValueViaPath(
+              const regNumber = getValueViaPath<string | undefined>(
                 application.answers,
                 'machine.regNumber',
                 undefined,
-              ) as string | undefined
+              )
               return {
                 notificationTemplateId:
                   NotificationConfig[

--- a/libs/application/templates/family-matters/children-residence-change-v2/src/lib/ChildrenResidenceChangeTemplate.ts
+++ b/libs/application/templates/family-matters/children-residence-change-v2/src/lib/ChildrenResidenceChangeTemplate.ts
@@ -10,6 +10,8 @@ import {
   defineTemplateApi,
   InstitutionNationalIds,
   ApplicationConfigurations,
+  NotificationConfig,
+  NotificationType,
 } from '@island.is/application/types'
 import { getSelectedChildrenFromExternalData } from '@island.is/application/templates/family-matters-core/utils'
 import { dataSchema } from './dataSchema'
@@ -24,8 +26,10 @@ import {
 import {
   coreHistoryMessages,
   coreMessages,
+  defaultLifecycleWithPruneMessage,
   EphemeralStateLifeCycle,
   DefaultStateLifeCycle,
+  getValueViaPath,
 } from '@island.is/application/core'
 import set from 'lodash/set'
 import { Features } from '@island.is/feature-flags'
@@ -201,7 +205,20 @@ const ChildrenResidenceChangeTemplate: ApplicationTemplate<
                     content: history.actions.waitingForCounterpartyDescription,
                   },
           },
-          lifecycle: DefaultStateLifeCycle,
+          lifecycle: defaultLifecycleWithPruneMessage((application) => {
+            const children = getValueViaPath<string[]>(
+              application.answers,
+              'selectedChildren',
+            )
+            const internalBody = children?.join(',')
+            return {
+              notificationTemplateId:
+                NotificationConfig[
+                  NotificationType.ChildrenResidenceChangePruned
+                ].templateId,
+              ...(internalBody && { internalBody }),
+            }
+          }),
           onEntry: defineTemplateApi({
             action: TemplateApiActions.sendNotificationToCounterParty,
           }),

--- a/libs/application/templates/financial-aid/src/lib/FinancialAidTemplate.ts
+++ b/libs/application/templates/financial-aid/src/lib/FinancialAidTemplate.ts
@@ -6,7 +6,10 @@ import {
   ApplicationStateSchema,
   DefaultEvents,
   Application,
+  NotificationConfig,
+  NotificationType,
 } from '@island.is/application/types'
+import { pruneAfterDaysWithMessage } from '@island.is/application/core'
 
 import { assign } from 'xstate'
 
@@ -180,7 +183,11 @@ const FinancialAidTemplate: ApplicationTemplate<
         meta: {
           name: application.name.defaultMessage,
           status: 'inprogress',
-          lifecycle: oneMonthLifeCycle,
+          lifecycle: pruneAfterDaysWithMessage(31, () => ({
+            notificationTemplateId:
+              NotificationConfig[NotificationType.FinancialAidPruned]
+                .templateId,
+          })),
           actionCard: {
             description: stateDescriptions.spouse,
             historyLogs: [

--- a/libs/application/templates/hms/rental-agreement/src/lib/RentalAgreementTemplate.ts
+++ b/libs/application/templates/hms/rental-agreement/src/lib/RentalAgreementTemplate.ts
@@ -3,7 +3,8 @@ import { assign } from 'xstate'
 import {
   DefaultStateLifeCycle,
   EphemeralStateLifeCycle,
-  pruneAfterDays,
+  getValueViaPath,
+  pruneAfterDaysWithMessage,
 } from '@island.is/application/core'
 import { AuthDelegationType } from '@island.is/shared/types'
 import { CodeOwners } from '@island.is/shared/constants'
@@ -20,6 +21,8 @@ import {
   defineTemplateApi,
   InstitutionNationalIds,
   IdentityApi,
+  NotificationConfig,
+  NotificationType,
 } from '@island.is/application/types'
 import { Events } from '../utils/types'
 import { States, Roles } from '../utils/enums'
@@ -177,7 +180,18 @@ const RentalAgreementTemplate: ApplicationTemplate<
         meta: {
           name: States.INREVIEW,
           status: 'inprogress',
-          lifecycle: pruneAfterDays(10),
+          lifecycle: pruneAfterDaysWithMessage(10, (application) => {
+            const address = getValueViaPath<string>(
+              application.answers,
+              'registerProperty.searchresults.address',
+            )
+            return {
+              notificationTemplateId:
+                NotificationConfig[NotificationType.RentalAgreementPruned]
+                  .templateId,
+              ...(address && { internalBody: address }),
+            }
+          }),
           onEntry: defineTemplateApi({
             action: TemplateApiActions.sendDraft,
           }),
@@ -245,7 +259,18 @@ const RentalAgreementTemplate: ApplicationTemplate<
         meta: {
           name: States.SIGNING,
           status: 'inprogress',
-          lifecycle: pruneAfterDays(31),
+          lifecycle: pruneAfterDaysWithMessage(31, (application) => {
+            const address = getValueViaPath<string>(
+              application.answers,
+              'registerProperty.searchresults.address',
+            )
+            return {
+              notificationTemplateId:
+                NotificationConfig[NotificationType.RentalAgreementPruned]
+                  .templateId,
+              ...(address && { internalBody: address }),
+            }
+          }),
           onEntry: defineTemplateApi({
             action: TemplateApiActions.submitApplicationToHmsRentalService,
           }),

--- a/libs/application/templates/iceland-health/accident-notification/src/lib/AccidentNotificationTemplate.ts
+++ b/libs/application/templates/iceland-health/accident-notification/src/lib/AccidentNotificationTemplate.ts
@@ -337,9 +337,8 @@ const AccidentNotificationTemplate: ApplicationTemplate<
             )
             return {
               notificationTemplateId:
-                NotificationConfig[
-                  NotificationType.AccidentNotificationPruned
-                ].templateId,
+                NotificationConfig[NotificationType.AccidentNotificationPruned]
+                  .templateId,
               ...(nationalId && { internalBody: nationalId }),
             }
           }),

--- a/libs/application/templates/iceland-health/accident-notification/src/lib/AccidentNotificationTemplate.ts
+++ b/libs/application/templates/iceland-health/accident-notification/src/lib/AccidentNotificationTemplate.ts
@@ -1,5 +1,6 @@
 import {
   coreHistoryMessages,
+  defaultLifecycleWithPruneMessage,
   DefaultStateLifeCycle,
   getValueViaPath,
 } from '@island.is/application/core'
@@ -14,6 +15,8 @@ import {
   DefaultEvents,
   defineTemplateApi,
   FormModes,
+  NotificationConfig,
+  NotificationType,
 } from '@island.is/application/types'
 import set from 'lodash/set'
 import { assign } from 'xstate'
@@ -327,7 +330,19 @@ const AccidentNotificationTemplate: ApplicationTemplate<
           status: 'completed',
           name: States.IN_FINAL_REVIEW,
           progress: 1,
-          lifecycle: DefaultStateLifeCycle,
+          lifecycle: defaultLifecycleWithPruneMessage((application) => {
+            const nationalId = getValueViaPath<string>(
+              application.answers,
+              'injuredPersonInformation.nationalId',
+            )
+            return {
+              notificationTemplateId:
+                NotificationConfig[
+                  NotificationType.AccidentNotificationPruned
+                ].templateId,
+              ...(nationalId && { internalBody: nationalId }),
+            }
+          }),
           onEntry: defineTemplateApi({
             action: ApiActions.reviewApplication,
           }),

--- a/libs/application/templates/id-card/src/lib/IdCardTemplate.ts
+++ b/libs/application/templates/id-card/src/lib/IdCardTemplate.ts
@@ -4,6 +4,7 @@ import {
   EphemeralStateLifeCycle,
   getValueViaPath,
   pruneAfterDays,
+  pruneAfterDaysWithMessage,
 } from '@island.is/application/core'
 import {
   Application,
@@ -17,6 +18,8 @@ import {
   defineTemplateApi,
   DistrictsApi,
   InstitutionNationalIds,
+  NotificationConfig,
+  NotificationType,
   PassportsApi,
   StaticText,
 } from '@island.is/application/types'
@@ -168,7 +171,17 @@ const IdCardTemplate: ApplicationTemplate<
         meta: {
           name: 'ParentB',
           status: 'inprogress',
-          lifecycle: pruneAfterDays(7),
+          lifecycle: pruneAfterDaysWithMessage(7, (application) => {
+            const nationalId = getValueViaPath<string>(
+              application.answers,
+              'applicantInformation.nationalId',
+            )
+            return {
+              notificationTemplateId:
+                NotificationConfig[NotificationType.IdCardPruned].templateId,
+              ...(nationalId && { internalBody: nationalId }),
+            }
+          }),
           onEntry: defineTemplateApi({
             action: ApiActions.assignParentB,
           }),

--- a/libs/application/templates/marriage-conditions/src/lib/MarriageConditionsTemplate.ts
+++ b/libs/application/templates/marriage-conditions/src/lib/MarriageConditionsTemplate.ts
@@ -12,11 +12,14 @@ import {
   DefaultEvents,
   defineTemplateApi,
   NationalRegistryV3UserApi,
+  NotificationConfig,
+  NotificationType,
   UserProfileApi,
   DistrictsApi,
   InstitutionNationalIds,
   ApplicationConfigurations,
 } from '@island.is/application/types'
+import { pruneAfterDaysWithMessage } from '@island.is/application/core'
 import { assign } from 'xstate'
 import { FeatureFlagClient } from '@island.is/feature-flags'
 import {
@@ -124,7 +127,12 @@ const MarriageConditionsTemplate: ApplicationTemplate<
           name: 'Done',
           status: 'inprogress',
           progress: 1,
-          lifecycle: pruneAfter(sixtyDays),
+          lifecycle: pruneAfterDaysWithMessage(60, () => ({
+            notificationTemplateId:
+              NotificationConfig[
+                NotificationType.MarriageConditionsPruned
+              ].templateId,
+          })),
           onEntry: defineTemplateApi({
             action: ApiActions.assignSpouse,
           }),

--- a/libs/application/templates/marriage-conditions/src/lib/MarriageConditionsTemplate.ts
+++ b/libs/application/templates/marriage-conditions/src/lib/MarriageConditionsTemplate.ts
@@ -129,9 +129,8 @@ const MarriageConditionsTemplate: ApplicationTemplate<
           progress: 1,
           lifecycle: pruneAfterDaysWithMessage(60, () => ({
             notificationTemplateId:
-              NotificationConfig[
-                NotificationType.MarriageConditionsPruned
-              ].templateId,
+              NotificationConfig[NotificationType.MarriageConditionsPruned]
+                .templateId,
           })),
           onEntry: defineTemplateApi({
             action: ApiActions.assignSpouse,

--- a/libs/application/templates/new-primary-school/src/lib/NewPrimarySchoolTemplate.ts
+++ b/libs/application/templates/new-primary-school/src/lib/NewPrimarySchoolTemplate.ts
@@ -262,9 +262,8 @@ const NewPrimarySchoolTemplate: ApplicationTemplate<
             )
             return {
               notificationTemplateId:
-                NotificationConfig[
-                  NotificationType.NewPrimarySchoolPruned
-                ].templateId,
+                NotificationConfig[NotificationType.NewPrimarySchoolPruned]
+                  .templateId,
               ...(nationalId && { internalBody: nationalId }),
             }
           }),
@@ -390,9 +389,8 @@ const NewPrimarySchoolTemplate: ApplicationTemplate<
             )
             return {
               notificationTemplateId:
-                NotificationConfig[
-                  NotificationType.NewPrimarySchoolPruned
-                ].templateId,
+                NotificationConfig[NotificationType.NewPrimarySchoolPruned]
+                  .templateId,
               ...(nationalId && { internalBody: nationalId }),
             }
           }),

--- a/libs/application/templates/new-primary-school/src/lib/NewPrimarySchoolTemplate.ts
+++ b/libs/application/templates/new-primary-school/src/lib/NewPrimarySchoolTemplate.ts
@@ -1,9 +1,11 @@
 import {
   DefaultStateLifeCycle,
+  defaultLifecycleWithPruneMessage,
   EphemeralStateLifeCycle,
   YES,
   coreHistoryMessages,
   corePendingActionMessages,
+  getValueViaPath,
 } from '@island.is/application/core'
 import {
   Application,
@@ -17,6 +19,8 @@ import {
   FormModes,
   InstitutionNationalIds,
   NationalRegistryV3UserApi,
+  NotificationConfig,
+  NotificationType,
   UserProfileApi,
   defineTemplateApi,
 } from '@island.is/application/types'
@@ -251,7 +255,19 @@ const NewPrimarySchoolTemplate: ApplicationTemplate<
         meta: {
           name: States.OTHER_GUARDIAN_APPROVAL,
           status: FormModes.IN_PROGRESS,
-          lifecycle: DefaultStateLifeCycle,
+          lifecycle: defaultLifecycleWithPruneMessage((application) => {
+            const nationalId = getValueViaPath<string>(
+              application.answers,
+              'childNationalId',
+            )
+            return {
+              notificationTemplateId:
+                NotificationConfig[
+                  NotificationType.NewPrimarySchoolPruned
+                ].templateId,
+              ...(nationalId && { internalBody: nationalId }),
+            }
+          }),
           actionCard: {
             pendingAction: otherGuardianApprovalStatePendingAction,
             historyLogs: [
@@ -367,7 +383,19 @@ const NewPrimarySchoolTemplate: ApplicationTemplate<
         meta: {
           name: States.PAYER_APPROVAL,
           status: FormModes.IN_PROGRESS,
-          lifecycle: DefaultStateLifeCycle,
+          lifecycle: defaultLifecycleWithPruneMessage((application) => {
+            const nationalId = getValueViaPath<string>(
+              application.answers,
+              'childNationalId',
+            )
+            return {
+              notificationTemplateId:
+                NotificationConfig[
+                  NotificationType.NewPrimarySchoolPruned
+                ].templateId,
+              ...(nationalId && { internalBody: nationalId }),
+            }
+          }),
           actionCard: {
             pendingAction: payerApprovalStatePendingAction,
             historyLogs: [

--- a/libs/application/templates/passport/src/lib/PassportTemplate.ts
+++ b/libs/application/templates/passport/src/lib/PassportTemplate.ts
@@ -15,6 +15,8 @@ import {
   defineTemplateApi,
   InstitutionNationalIds,
   MockablePaymentCatalogApi,
+  NotificationConfig,
+  NotificationType,
   PassportsApi,
 } from '@island.is/application/types'
 import { Features } from '@island.is/feature-flags'
@@ -152,8 +154,22 @@ const PassportTemplate: ApplicationTemplate<
           name: 'ParentB',
           status: 'inprogress',
           lifecycle: {
-            ...pruneAfter(sevenDays),
+            shouldBeListed: true,
+            shouldBePruned: true,
+            whenToPrune: sevenDays,
             shouldDeleteChargeIfPaymentFulfilled: true,
+            pruneMessage: (application) => {
+              const nationalId = getValueViaPath<string>(
+                application.answers,
+                'childsPersonalInfo.nationalId',
+              )
+              return {
+                notificationTemplateId:
+                  NotificationConfig[NotificationType.PassportPruned]
+                    .templateId,
+                ...(nationalId && { internalBody: nationalId }),
+              }
+            },
           },
           onEntry: defineTemplateApi({
             action: ApiActions.assignParentB,

--- a/libs/application/types/src/lib/NotificationTypes.ts
+++ b/libs/application/types/src/lib/NotificationTypes.ts
@@ -21,6 +21,15 @@ export enum NotificationType {
   TransferOfVehicleOwnershipPruned = 'TransferOfVehicleOwnershipPrunedNotification',
   ChangeCoOwnerOfVehiclePruned = 'ChangeCoOwnerOfVehiclePrunedNotification',
   ChangeOperatorOfVehiclePruned = 'ChangeOperatorOfVehiclePrunedNotification',
+  TransferOfMachineOwnershipPruned = 'TransferOfMachineOwnershipPrunedNotification',
+  AccidentNotificationPruned = 'AccidentNotificationPrunedNotification',
+  PassportPruned = 'PassportPrunedNotification',
+  IdCardPruned = 'IdCardPrunedNotification',
+  NewPrimarySchoolPruned = 'NewPrimarySchoolPrunedNotification',
+  ChildrenResidenceChangePruned = 'ChildrenResidenceChangePrunedNotification',
+  MarriageConditionsPruned = 'MarriageConditionsPrunedNotification',
+  FinancialAidPruned = 'FinancialAidPrunedNotification',
+  RentalAgreementPruned = 'RentalAgreementPrunedNotification',
 }
 
 interface NotificationKeysMap {
@@ -148,6 +157,33 @@ export const NotificationConfig = defineNotificationConfig({
   },
   [NotificationType.ChangeOperatorOfVehiclePruned]: {
     templateId: 'HNIPP.AS.TA.COV.PRUNED',
+  },
+  [NotificationType.TransferOfMachineOwnershipPruned]: {
+    templateId: 'HNIPP.AS.VER.TOMO.PRUNED',
+  },
+  [NotificationType.AccidentNotificationPruned]: {
+    templateId: 'HNIPP.AS.AN.PRUNED',
+  },
+  [NotificationType.PassportPruned]: {
+    templateId: 'HNIPP.AS.PA.PRUNED',
+  },
+  [NotificationType.IdCardPruned]: {
+    templateId: 'HNIPP.AS.ID.PRUNED',
+  },
+  [NotificationType.NewPrimarySchoolPruned]: {
+    templateId: 'HNIPP.AS.NPS.PRUNED',
+  },
+  [NotificationType.ChildrenResidenceChangePruned]: {
+    templateId: 'HNIPP.AS.CRC.V2.PRUNED',
+  },
+  [NotificationType.MarriageConditionsPruned]: {
+    templateId: 'HNIPP.AS.MAC.PRUNED',
+  },
+  [NotificationType.FinancialAidPruned]: {
+    templateId: 'HNIPP.AS.FA.PRUNED',
+  },
+  [NotificationType.RentalAgreementPruned]: {
+    templateId: 'HNIPP.AS.HMS.RA.PRUNED',
   },
 } as const)
 


### PR DESCRIPTION
# ...

Some application states require 3rd party approval to progress to the next state. This PR adds a pruneMessage to those states, informing the applicant if the application gets pruned before the 3rd party approved.

## What

Specify what you're trying to achieve

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pruning notifications: applications removed for inactivity now send configured notifications.

* **Enhancements**
  * Prune notifications extended to financial aid, ID card, passport, rental agreements, machine ownership transfer, accident reports, children's residence changes, marriage conditions, and primary school templates.
  * Notification payloads now include relevant application context (IDs, addresses, selected children) when available.
  * Prune timing and messages can be configured per state for tailored notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->