### PR TITLE
fix(j-s): restore indictmentCancelledOrDismissedState to case.graphql

### DIFF
--- a/apps/judicial-system/web/src/components/FormProvider/case.graphql
+++ b/apps/judicial-system/web/src/components/FormProvider/case.graphql
@@ -83,6 +83,10 @@ query Case($input: CaseQueryInput!) {
       indictmentReviewDecision
       isDrivingLicenseSuspended
       appealStatementDate
+      indictmentCancelledOrDismissedState {
+        type
+        time
+      }
       subpoenas {
         id
         created


### PR DESCRIPTION
## What

Restores `indictmentCancelledOrDismissedState` to the `defendants` selection in `case.graphql`.

## Why

The field was accidentally removed in #22297 when `appealStatementDate` was added — it should have been an addition, not a swap. Court routes (`Conclusion.tsx`, `DefendantInfo.tsx`, `useInfoCardItems.tsx`) depend on this field being present in the query. The app only continued to work because `case.generated.ts` was stale and still contained the old query with the field. Regenerating types would have broken those views.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced system to retrieve and track indictment cancellation and dismissal state information, including timestamps, at both case and individual defendant levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->