### PR TITLE
feat(delegations): add 'select all' checkbox to ScopesTable 

### DIFF
--- a/libs/portals/shared-modules/delegations/src/components/GrantAccessSteps/AccessScopes.tsx
+++ b/libs/portals/shared-modules/delegations/src/components/GrantAccessSteps/AccessScopes.tsx
@@ -164,7 +164,13 @@ export const AccessScopes = () => {
         {formatMessage(m.choosePermissionsTitle)}
       </Text>
       <RecipientsTag />
-      <Box display="flex" columnGap={[0, 2]} marginBottom={2}>
+      <Box
+        display="flex"
+        columnGap={[0, 2]}
+        justifyContent={['spaceBetween', 'spaceBetween', 'flexStart']}
+        marginBottom={2}
+        width="full"
+      >
         <div className={styles.input}>
           <Input
             name="search"
@@ -213,6 +219,7 @@ export const AccessScopes = () => {
         <ScopesTable
           scopes={filteredScopes}
           showCheckbox
+          showSelectAll
           onSelectScope={onSelectScope}
         />
       ) : (

--- a/libs/portals/shared-modules/delegations/src/components/ScopesTable/ScopesTable.tsx
+++ b/libs/portals/shared-modules/delegations/src/components/ScopesTable/ScopesTable.tsx
@@ -11,6 +11,7 @@ import {
 } from '@island.is/island-ui/core'
 import { useLocale } from '@island.is/localization'
 import { m as coreMessages } from '@island.is/portals/core'
+import add from 'date-fns/add'
 import format from 'date-fns/format'
 import {
   useDelegationForm,
@@ -21,6 +22,7 @@ import { m } from '../../lib/messages'
 type ScopesTableProps = {
   scopes?: AuthApiScope[]
   showCheckbox?: boolean
+  showSelectAll?: boolean
   onSelectScope?: (scope: AuthApiScope) => void
   showDate?: boolean
   editableDates?: boolean
@@ -29,6 +31,7 @@ type ScopesTableProps = {
 export const ScopesTable = ({
   scopes: scopesProp,
   showCheckbox,
+  showSelectAll,
   onSelectScope,
   showDate,
   editableDates = true,
@@ -47,9 +50,40 @@ export const ScopesTable = ({
     )
   }
 
+  const allSelected =
+    scopes.length > 0 &&
+    scopes.every((s) => selectedScopes?.some((sel) => sel.name === s.name))
+
+  const onSelectAll = () => {
+    if (allSelected) {
+      const scopeNames = new Set(scopes.map((s) => s.name))
+      setSelectedScopes(selectedScopes.filter((s) => !scopeNames.has(s.name)))
+    } else {
+      const alreadySelected = new Set(selectedScopes.map((s) => s.name))
+      const newScopes = scopes
+        .filter((s) => !alreadySelected.has(s.name))
+        .map((s) => ({ ...s, validTo: add(new Date(), { years: 1 }) }))
+      setSelectedScopes([...selectedScopes, ...newScopes])
+    }
+  }
+
   if (!md) {
     return (
       <Box display="flex" flexDirection="column">
+        {showCheckbox && showSelectAll && (
+          <>
+            <Box paddingY={2}>
+              <Checkbox
+                name="select-all-scopes-mobile"
+                label={formatMessage(m.selectAll)}
+                checked={allSelected}
+                onChange={onSelectAll}
+                disabled={scopes.length === 0}
+              />
+            </Box>
+            <Divider />
+          </>
+        )}
         {scopes.map((scope, index) => {
           const permissionType = scope.allowsWrite
             ? formatMessage(m.readAndWrite)
@@ -171,7 +205,6 @@ export const ScopesTable = ({
   }
 
   const headers: string[] = [
-    ...(showCheckbox ? [''] : []),
     formatMessage(m.headerScopeName),
     formatMessage(m.headerDescription),
     ...(showDate ? [formatMessage(m.headerValidityPeriod)] : []),
@@ -184,6 +217,18 @@ export const ScopesTable = ({
     >
       <T.Head>
         <T.Row>
+          {showCheckbox && (
+            <T.HeadData style={{ paddingLeft: 16, paddingRight: 0 }}>
+              {showSelectAll && (
+                <Checkbox
+                  name="select-all-scopes"
+                  checked={allSelected}
+                  onChange={onSelectAll}
+                  disabled={scopes.length === 0}
+                />
+              )}
+            </T.HeadData>
+          )}
           {headers.map((item) => (
             <T.HeadData style={{ paddingInline: 16 }} key={item}>
               <Text variant="medium" fontWeight="semiBold">

--- a/libs/portals/shared-modules/delegations/src/components/ScopesTable/ScopesTable.tsx
+++ b/libs/portals/shared-modules/delegations/src/components/ScopesTable/ScopesTable.tsx
@@ -225,6 +225,7 @@ export const ScopesTable = ({
                   checked={allSelected}
                   onChange={onSelectAll}
                   disabled={scopes.length === 0}
+                  ariaLabel={formatMessage(m.selectAll)}
                 />
               )}
             </T.HeadData>

--- a/libs/portals/shared-modules/delegations/src/lib/messages.ts
+++ b/libs/portals/shared-modules/delegations/src/lib/messages.ts
@@ -616,6 +616,10 @@ export const m = defineMessages({
     id: 'sp.access-control-delegations:header-permission-type',
     defaultMessage: 'Tegund réttinda',
   },
+  selectAll: {
+    id: 'sp.access-control-delegations:select-all',
+    defaultMessage: 'Velja allt',
+  },
   noDelegationsFound: {
     id: 'sp.access-control-delegations:no-delegations-found',
     defaultMessage: 'Engin rafræn umboð fundust',

--- a/libs/portals/shared-modules/delegations/src/screens/CategoryDetails/CategoryDetails.tsx
+++ b/libs/portals/shared-modules/delegations/src/screens/CategoryDetails/CategoryDetails.tsx
@@ -121,6 +121,7 @@ export const CategoryDetails = () => {
               <ScopesTable
                 scopes={data?.scopes as AuthApiScope[]}
                 showCheckbox
+                showSelectAll
                 onSelectScope={onSelectScope}
               />
               {loading && (


### PR DESCRIPTION


## What

- Implemented 'select all' checkbox in ScopesTable for easier selection of scopes.
- Updated AccessScopes component layout for improved responsiveness and added full width to the Box component.
- Added localization message for 'select all' functionality.

## Why

Specify why you need to achieve this

## Screenshots / Gifs

<img width="1025" height="464" alt="image" src="https://github.com/user-attachments/assets/aecbdb68-bc98-49b8-843c-04437137d669" />

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "select all" control in the access scopes selection interface. Users can now select or deselect all scopes at once, with newly selected scopes automatically assigned a one-year expiration date.
  * Improved responsive layout for search and filter controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->