### PR TITLE
chore(native-app): bump version to 1.43.1

### DIFF
--- a/apps/native/app/app.json
+++ b/apps/native/app/app.json
@@ -3,7 +3,7 @@
     "name": "IslandApp",
     "displayName": "Ísland.is",
     "slug": "island-app",
-    "version": "1.41.2",
+    "version": "1.43.1",
     "orientation": "portrait",
     "icon": "./assets/images/island_is/icon.png",
     "scheme": "is.island.app",


### PR DESCRIPTION
## What

- Bump native app version in `apps/native/app/app.json` from `1.41.2` to `1.43.1`

## Why

- Align the app version with the upcoming release

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Application version updated to 1.43.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->