### PR TITLE
fix(OpenData): add alert banner to open data page

### DIFF
--- a/apps/web/screens/OpenData/Home/Index.tsx
+++ b/apps/web/screens/OpenData/Home/Index.tsx
@@ -220,62 +220,61 @@ const OpenDataPage: Screen<OpenDataProps> = ({ namespace }) => {
   return (
     <Box>
       <HeroSection n={n} />
-        <SidebarLayout
-          paddingTop={[2, 2, 9]}
-          paddingBottom={[4, 4, 4]}
-          isSticky={false}
-          fullWidthContent={true}
-          sidebarContent={
-            <FilterSidebar
-              filterOptions={filterOptions}
-              filters={filters}
-              isOpen={isOpen}
-              onFilterChange={handleFilters}
-              onClearFilterType={clearFilterType}
-              onClearAllFilters={clearAllFilters}
-              onToggleIsOpen={toggleIsOpen}
-              onToggleOpenAll={toggleOpenAll}
-              onToggleCloseAll={toggleCloseAll}
-              areAnyFiltersOpen={areAnyFiltersOpen}
-              n={n}
-            />
-          }
-        >
-          <Box minWidth={0} className={styles.mainContentWrapper}>
-            <SearchSection
-              query={query}
-              onQueryChange={setQuery}
-              filters={filters}
-              filterOptions={filterOptions}
-              onRemoveTag={handleRemoveTag}
-              onClearAllFilters={clearAllFilters}
-              onFilterTypeChange={handleFilterType}
-              onClearFilterType={clearFilterType}
-              totalCount={totalCount}
-              n={n}
-              titleRef={titleRef}
-            />
+      <SidebarLayout
+        paddingTop={[2, 2, 9]}
+        paddingBottom={[4, 4, 4]}
+        isSticky={false}
+        fullWidthContent={true}
+        sidebarContent={
+          <FilterSidebar
+            filterOptions={filterOptions}
+            filters={filters}
+            isOpen={isOpen}
+            onFilterChange={handleFilters}
+            onClearFilterType={clearFilterType}
+            onClearAllFilters={clearAllFilters}
+            onToggleIsOpen={toggleIsOpen}
+            onToggleOpenAll={toggleOpenAll}
+            onToggleCloseAll={toggleCloseAll}
+            areAnyFiltersOpen={areAnyFiltersOpen}
+            n={n}
+          />
+        }
+      >
+        <Box minWidth={0} className={styles.mainContentWrapper}>
+          <SearchSection
+            query={query}
+            onQueryChange={setQuery}
+            filters={filters}
+            filterOptions={filterOptions}
+            onRemoveTag={handleRemoveTag}
+            onClearAllFilters={clearAllFilters}
+            onFilterTypeChange={handleFilterType}
+            onClearFilterType={clearFilterType}
+            totalCount={totalCount}
+            n={n}
+            titleRef={titleRef}
+          />
 
-            <DatasetList
-              datasets={datasets}
-              loading={loading}
-              error={error}
-              totalCount={totalCount}
-              totalPages={totalPages}
-              selectedPage={selectedPage}
-              onPageChange={setSelectedPage}
-              gridView={gridView}
-              onToggleView={() => setGridView(!gridView)}
-              formatDate={formatDate}
-              n={n}
-              isMobileScreenWidth={isMobileScreenWidth}
-              isTabletScreenWidth={isTabletScreenWidth}
-              titleRef={titleRef}
-              itemsPerPage={ITEMS_PER_PAGE}
-            />
-          </Box>
-        </SidebarLayout>
-      
+          <DatasetList
+            datasets={datasets}
+            loading={loading}
+            error={error}
+            totalCount={totalCount}
+            totalPages={totalPages}
+            selectedPage={selectedPage}
+            onPageChange={setSelectedPage}
+            gridView={gridView}
+            onToggleView={() => setGridView(!gridView)}
+            formatDate={formatDate}
+            n={n}
+            isMobileScreenWidth={isMobileScreenWidth}
+            isTabletScreenWidth={isTabletScreenWidth}
+            titleRef={titleRef}
+            itemsPerPage={ITEMS_PER_PAGE}
+          />
+        </Box>
+      </SidebarLayout>
     </Box>
   )
 }

--- a/apps/web/screens/OpenData/Home/Index.tsx
+++ b/apps/web/screens/OpenData/Home/Index.tsx
@@ -220,8 +220,6 @@ const OpenDataPage: Screen<OpenDataProps> = ({ namespace }) => {
   return (
     <Box>
       <HeroSection n={n} />
-
-      <GridContainer>
         <SidebarLayout
           paddingTop={[2, 2, 9]}
           paddingBottom={[4, 4, 4]}
@@ -277,7 +275,7 @@ const OpenDataPage: Screen<OpenDataProps> = ({ namespace }) => {
             />
           </Box>
         </SidebarLayout>
-      </GridContainer>
+      
     </Box>
   )
 }
@@ -302,6 +300,16 @@ OpenDataPage.getProps = async ({ apolloClient, locale }) => {
 
   return {
     namespace,
+    customAlertBanner: {
+      showAlertBanner: true,
+      bannerVariant: 'info',
+      title: namespace.alertTitle || 'Opin gögn í vinnslu',
+      description:
+        namespace.alertMessage ||
+        'Þessi síða er í vinnslu. Gögn og virkni geta breyst.',
+      isDismissable: true,
+      dismissedForDays: 7,
+    },
   }
 }
 

--- a/apps/web/screens/OpenData/Home/components/HeroSection.tsx
+++ b/apps/web/screens/OpenData/Home/components/HeroSection.tsx
@@ -24,7 +24,7 @@ export const HeroSection: React.FC<HeroSectionProps> = ({ n }) => {
         >
           <Box style={{ flex: '1 1 65%', paddingRight: '2rem' }}>
             <Text variant="h1" as="h1" marginBottom={2}>
-              {n('heroTitle', 'Opin Gögn')}
+              {n('heroTitle', 'Opin gögn')}
             </Text>
             <Text marginBottom={2}>
               {n(


### PR DESCRIPTION
# ...

Attach a link to issue if relevant

## What
Added banner alert on top of page to show that the page is in development

## Why

Alert the user that the page is being worked on

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a customizable, dismissable informational banner on the Open Data home page, with localization fallbacks and a 7-day dismissal.

* **UI & Style**
  * Simplified page layout to improve rendering and structure.
  * Adjusted hero heading text capitalization for refined presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->