### PR TITLE
feat(delegations): Added redirects for old routes if feature flag is on

### DIFF
--- a/libs/portals/my-pages/consent/src/module.tsx
+++ b/libs/portals/my-pages/consent/src/module.tsx
@@ -4,6 +4,7 @@ import { ApiScope } from '@island.is/auth/scopes'
 import { PortalModule } from '@island.is/portals/core'
 import { Features } from '@island.is/react/feature-flags'
 import { m } from '@island.is/portals/my-pages/core'
+import { Navigate } from 'react-router-dom'
 
 import { ConsentPaths } from './lib/paths'
 
@@ -24,11 +25,34 @@ export const consentModule: PortalModule = {
         attributes: {},
       },
     )
+
+    const hasAccess = userInfo.scopes.includes(ApiScope.internal)
+
+    if (useNewRoute) {
+      return [
+        {
+          name: m.consent,
+          path: ConsentPaths.ConsentNew,
+          enabled: hasAccess,
+          notAvailableForActors: true,
+          element: <Consent />,
+        },
+        {
+          name: m.consent,
+          path: ConsentPaths.Consent,
+          enabled: hasAccess,
+          navHide: true,
+          notAvailableForActors: true,
+          element: <Navigate to={ConsentPaths.ConsentNew} replace />,
+        },
+      ]
+    }
+
     return [
       {
         name: m.consent,
-        path: useNewRoute ? ConsentPaths.ConsentNew : ConsentPaths.Consent,
-        enabled: userInfo.scopes.includes(ApiScope.internal),
+        path: ConsentPaths.Consent,
+        enabled: hasAccess,
         notAvailableForActors: true,
         element: <Consent />,
       },

--- a/libs/portals/my-pages/restrictions/src/module.tsx
+++ b/libs/portals/my-pages/restrictions/src/module.tsx
@@ -3,6 +3,7 @@ import { lazy } from 'react'
 import { ApiScope } from '@island.is/auth/scopes'
 import { Features } from '@island.is/react/feature-flags'
 import { PortalModule } from '@island.is/portals/core'
+import { Navigate } from 'react-router-dom'
 
 import { m } from './lib/messages'
 import { Paths } from './lib/paths'
@@ -29,10 +30,29 @@ export const restrictionsModule: PortalModule = {
         attributes: {},
       },
     )
+
+    if (useNewRoute) {
+      return [
+        {
+          name: m.restrictions,
+          path: Paths.RestrictionsNew,
+          loader: restrictionsLoader(args),
+          action: restrictionsAction(args),
+          element: <Restrictions />,
+        },
+        {
+          name: m.restrictions,
+          path: Paths.Restrictions,
+          navHide: true,
+          element: <Navigate to={Paths.RestrictionsNew} replace />,
+        },
+      ]
+    }
+
     return [
       {
         name: m.restrictions,
-        path: useNewRoute ? Paths.RestrictionsNew : Paths.Restrictions,
+        path: Paths.Restrictions,
         loader: restrictionsLoader(args),
         action: restrictionsAction(args),
         element: <Restrictions />,

--- a/libs/portals/my-pages/sessions/src/module.tsx
+++ b/libs/portals/my-pages/sessions/src/module.tsx
@@ -6,6 +6,7 @@ import { m } from '@island.is/portals/my-pages/core'
 
 import { SessionsPaths } from './lib/paths'
 import { Features } from '@island.is/react/feature-flags'
+import { Navigate } from 'react-router-dom'
 
 const allowedScopes: string[] = [ApiScope.internal, ApiScope.internalProcuring]
 
@@ -26,11 +27,35 @@ export const sessionsModule: PortalModule = {
       },
     )
 
+    const hasAccess = userInfo.scopes.some((scope) =>
+      allowedScopes.includes(scope),
+    )
+
+    if (useNewRoute) {
+      return [
+        {
+          name: m.sessions,
+          path: SessionsPaths.SessionsNew,
+          enabled: hasAccess,
+          notAvailableForActors: true,
+          element: <Sessions />,
+        },
+        {
+          name: m.sessions,
+          path: SessionsPaths.Sessions,
+          enabled: hasAccess,
+          navHide: true,
+          notAvailableForActors: true,
+          element: <Navigate to={SessionsPaths.SessionsNew} replace />,
+        },
+      ]
+    }
+
     return [
       {
         name: m.sessions,
-        path: useNewRoute ? SessionsPaths.SessionsNew : SessionsPaths.Sessions,
-        enabled: userInfo.scopes.some((scope) => allowedScopes.includes(scope)),
+        path: SessionsPaths.Sessions,
+        enabled: hasAccess,
         notAvailableForActors: true,
         element: <Sessions />,
       },

--- a/libs/portals/shared-modules/delegations/src/module.tsx
+++ b/libs/portals/shared-modules/delegations/src/module.tsx
@@ -10,6 +10,7 @@ import { m } from './lib/messages'
 import { Features } from '@island.is/react/feature-flags'
 import EditAccess from './screens/EditAccess.tsx/EditAccess'
 import { CategoryDetails } from './screens/CategoryDetails/CategoryDetails'
+import { Navigate } from 'react-router-dom'
 
 const AccessControl = lazy(() => import('./screens/AccessControl'))
 const AccessControlNew = lazy(() =>
@@ -54,7 +55,11 @@ export const delegationsModule: PortalModule = {
       name: coreMessages.accessControlDelegations,
       navHide: !hasAccess,
       enabled: hasAccess,
-      element: <AccessControl />,
+      element: useNewRoutes ? (
+        <Navigate to={DelegationPaths.DelegationsNew} replace />
+      ) : (
+        <AccessControl />
+      ),
     }
 
     const newRoutes: PortalRoute[] = [
@@ -122,15 +127,23 @@ export const delegationsModule: PortalModule = {
       {
         name: coreMessages.accessControlGrant,
         path: DelegationPaths.DelegationsGrant,
-        element: <GrantAccess />,
+        element: useNewRoutes ? (
+          <Navigate to={DelegationPaths.DelegationsGrantNew} replace />
+        ) : (
+          <GrantAccess />
+        ),
       },
       {
         name: coreMessages.accessControlAccess,
         path: DelegationPaths.DelegationAccess,
-        element: <AccessOutgoing />,
+        element: useNewRoutes ? (
+          <Navigate to={DelegationPaths.DelegationsNew} replace />
+        ) : (
+          <AccessOutgoing />
+        ),
       },
     ]
 
-    return useNewRoutes ? newRoutes : oldRoutes
+    return useNewRoutes ? [...newRoutes, ...oldRoutes] : oldRoutes
   },
 }


### PR DESCRIPTION

## What
If feature flag for new delegation system is on, the old routes need to be redirected to the new ones, so external links to the delegations system don't break

- Added support for new routing paths in consent, restrictions, and sessions modules, redirecting to new routes when applicable.
- Updated delegations module to conditionally render Navigate for access control based on route configuration.
- Enhanced access control logic to ensure proper user permissions are checked before rendering components.

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced routing updates for consent, restrictions, sessions, and delegations management with feature-flag controlled access.
  * Implemented automatic redirects from legacy pages to new interfaces, enabling seamless user navigation during transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->