### PR TITLE
fix(j-s): Redirect to correct view after selecting sign later

### DIFF
--- a/apps/judicial-system/web/src/components/Modals/SignatureConfirmationModal/SignatureConfirmationModal.tsx
+++ b/apps/judicial-system/web/src/components/Modals/SignatureConfirmationModal/SignatureConfirmationModal.tsx
@@ -31,6 +31,7 @@ interface SignatureConfirmationModalProps {
   signatureType: SignatureType
   isAudkenni: boolean
   onClose: () => void
+  onErrorOrCanceledClose?: () => void
   navigateOnClose?: boolean
   onRetry?: () => void
 }
@@ -78,6 +79,7 @@ export const SignatureConfirmationModal: FC<
   signatureType,
   isAudkenni,
   onClose,
+  onErrorOrCanceledClose,
   navigateOnClose = true,
   onRetry,
 }) => {
@@ -190,6 +192,12 @@ export const SignatureConfirmationModal: FC<
       router.push(
         `${constants.SIGNED_VERDICT_OVERVIEW_ROUTE}/${workingCase.id}`,
       )
+    } else if (
+      (signingProgress === 'error' || signingProgress === 'canceled') &&
+      onErrorOrCanceledClose
+    ) {
+      onErrorOrCanceledClose()
+      return
     }
     onClose()
   }

--- a/apps/judicial-system/web/src/routes/Court/RestrictionCase/Confirmation/Confirmation.tsx
+++ b/apps/judicial-system/web/src/routes/Court/RestrictionCase/Confirmation/Confirmation.tsx
@@ -267,6 +267,11 @@ const Confirmation: FC = () => {
             setIsRulingSignatureAudkenni(false)
             setModalVisible('none')
           }}
+          onErrorOrCanceledClose={() =>
+            router.replace(
+              `${constants.SIGNED_VERDICT_OVERVIEW_ROUTE}/${workingCase.id}`,
+            )
+          }
           onRetry={() => {
             setRulingSignatureResponse(undefined)
             setIsRulingSignatureAudkenni(false)


### PR DESCRIPTION
[Asana](https://app.asana.com/1/203394141643832/project/1212657017130395/task/1214305495506128?focus=true)

## What

When signing failed and the user selected "Undirrita seinna", the user would still see the same view as he was on before, where the case looks incomplete.

Now, we correctly route to the signed verdict overview route, where the user can sign the verdict from the case files list



## Screenshots / Gifs

<img width="1446" height="1310" alt="image" src="https://github.com/user-attachments/assets/18c02e80-a41d-4b77-afac-27970092f1d1" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced signature confirmation flow with improved handling of signing errors and cancellations.
  * Users are now automatically redirected to the verdict overview when a signature confirmation fails or is canceled, streamlining the recovery process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->