### PR TITLE
fix(my-pages): Health routes

### DIFF
--- a/libs/portals/my-pages/health/src/lib/messages.ts
+++ b/libs/portals/my-pages/health/src/lib/messages.ts
@@ -48,6 +48,14 @@ export const messages = defineMessages({
     defaultMessage: 'Öll lyf',
     id: 'sp.health:all-medicine',
   },
+  myMedicine: {
+    defaultMessage: 'Lyfin mín',
+    id: 'sp.health:my-medicine',
+  },
+  therapiesAndAids: {
+    defaultMessage: 'Þjálfun og hjálpartæki',
+    id: 'sp.health:therapies-and-aids',
+  },
   ALM: {
     defaultMessage: 'Almennur sjúklingur',
     id: 'sp.health:alm',

--- a/libs/portals/my-pages/health/src/lib/navigation.ts
+++ b/libs/portals/my-pages/health/src/lib/navigation.ts
@@ -25,12 +25,6 @@ export const healthNavigation: PortalNavigationItem = {
       path: HealthPaths.HealthOverview,
     },
     {
-      name: messages.myHealthOverview,
-      searchHide: true,
-      navHide: true,
-      path: HealthPaths.HealthBasicOld,
-    },
-    {
       name: messages.myMedicine,
       path: HealthPaths.HealthMedicine,
       children: [

--- a/libs/portals/my-pages/health/src/lib/navigation.ts
+++ b/libs/portals/my-pages/health/src/lib/navigation.ts
@@ -31,6 +31,79 @@ export const healthNavigation: PortalNavigationItem = {
       path: HealthPaths.HealthBasicOld,
     },
     {
+      name: messages.myMedicine,
+      path: HealthPaths.HealthMedicine,
+      children: [
+        {
+          name: m.medicinePrescriptions,
+          description: m.medicinePrescriptionsIntro,
+          path: HealthPaths.HealthMedicinePrescription,
+        },
+
+        {
+          name: m.medicineDelegation,
+          path: HealthPaths.HealthMedicineDelegation,
+          searchTags: [s.medicineDelegationOther],
+          children: [
+            {
+              name: m.medicineDelegation,
+              path: HealthPaths.HealthMedicineDelegationDetail,
+              navHide: true,
+              breadcrumbHide: true,
+              searchHide: true,
+            },
+            {
+              name: messages.addDelegation,
+              path: HealthPaths.HealthMedicineDelegationAdd,
+              navHide: true,
+              breadcrumbHide: true,
+              searchTags: [
+                s.medicineDelegationOther,
+                s.medicineDelegationOtherNew,
+              ],
+            },
+          ],
+        },
+        {
+          name: m.medicinePaymentParticipation,
+          description: m.medicinePaymentParticipationIntro,
+          path: HealthPaths.HealthMedicinePaymentParticipation,
+          children: [
+            {
+              name: m.medicinePurchaseTitle,
+              path: HealthPaths.HealthMedicinePurchase,
+              activeIfExact: true,
+              navHide: true,
+            },
+            {
+              name: m.medicineCalculatorTitle,
+              path: HealthPaths.HealthMedicineCalculator,
+              activeIfExact: true,
+              navHide: true,
+            },
+          ],
+        },
+        {
+          name: m.medicineLicenseTitle,
+          description: m.medicineLicenseIntro,
+          path: HealthPaths.HealthMedicineCertificates,
+          children: [
+            {
+              name: m.medicineLicenseTitle,
+              path: HealthPaths.HealthMedicineCertificate,
+              navHide: true,
+              breadcrumbHide: true,
+            },
+          ],
+        },
+        {
+          name: m.medicinePrescriptionHistory,
+          description: m.medicinePrescriptionHistoryIntro,
+          path: HealthPaths.HealthMedicinePrescriptionHistory,
+        },
+      ],
+    },
+    {
       name: messages.appointments,
       searchHide: false,
       path: HealthPaths.HealthAppointments,
@@ -105,155 +178,34 @@ export const healthNavigation: PortalNavigationItem = {
       ],
     },
     {
-      name: m.medicine,
-      path: HealthPaths.HealthMedicine,
-      children: [
-        {
-          name: m.medicinePrescriptions,
-          description: m.medicinePrescriptionsIntro,
-          path: HealthPaths.HealthMedicinePrescription,
-        },
-
-        {
-          name: m.medicineDelegation,
-          path: HealthPaths.HealthMedicineDelegation,
-          searchTags: [s.medicineDelegationOther],
-          children: [
-            {
-              name: m.medicineDelegation,
-              path: HealthPaths.HealthMedicineDelegationDetail,
-              navHide: true,
-              breadcrumbHide: true,
-              searchHide: true,
-            },
-            {
-              name: messages.addDelegation,
-              path: HealthPaths.HealthMedicineDelegationAdd,
-              navHide: true,
-              breadcrumbHide: true,
-              searchTags: [
-                s.medicineDelegationOther,
-                s.medicineDelegationOtherNew,
-              ],
-            },
-          ],
-        },
-        {
-          name: m.medicinePaymentParticipation,
-          description: m.medicinePaymentParticipationIntro,
-          path: HealthPaths.HealthMedicinePaymentParticipation,
-          children: [
-            {
-              name: m.medicinePurchaseTitle,
-              path: HealthPaths.HealthMedicinePurchase,
-              activeIfExact: true,
-              navHide: true,
-            },
-            {
-              name: m.medicineCalculatorTitle,
-              path: HealthPaths.HealthMedicineCalculator,
-              activeIfExact: true,
-              navHide: true,
-            },
-          ],
-        },
-        {
-          name: m.medicineLicenseTitle,
-          description: m.medicineLicenseIntro,
-          path: HealthPaths.HealthMedicineCertificates,
-          children: [
-            {
-              name: m.medicineLicenseTitle,
-              path: HealthPaths.HealthMedicineCertificate,
-              navHide: true,
-              breadcrumbHide: true,
-            },
-          ],
-        },
-        {
-          name: m.medicinePrescriptionHistory,
-          description: m.medicinePrescriptionHistoryIntro,
-          path: HealthPaths.HealthMedicinePrescriptionHistory,
-        },
-      ],
-    },
-    {
-      name: m.aidsAndNutrition,
-      description: m.aidsAndNutritionIntro,
-      path: HealthPaths.HealthAidsAndNutrition,
-    },
-    {
-      name: m.therapies,
+      name: messages.therapiesAndAids,
       path: HealthPaths.HealthTherapies,
       children: [
         {
-          name: messages.physicalTherapy,
-          path: HealthPaths.HealthTherapiesPhysical,
-          navHide: true,
-        },
-        {
-          name: messages.speechTherapy,
-          path: HealthPaths.HealthTherapiesSpeech,
-          navHide: true,
-        },
-        {
-          name: messages.occupationalTherapy,
-          path: HealthPaths.HealthTherapiesOccupational,
-          navHide: true,
-        },
-      ],
-    },
-    {
-      name: m.vaccinations,
-      description: m.vaccinationsIntro,
-      path: HealthPaths.HealthVaccinations,
-      children: [
-        {
-          name: messages.generalVaccinations,
-          path: HealthPaths.HealthVaccinationsGeneral,
-          navHide: true,
-        },
-        {
-          name: messages.otherVaccinations,
-          path: HealthPaths.HealthVaccinationsOther,
-          navHide: true,
-        },
-      ],
-    },
-    {
-      name: messages.waitlists,
-      path: HealthPaths.HealthWaitlists,
-      searchTags: [s.healthWaiting],
-      children: [
-        {
-          name: messages.singleWaitlist,
-          path: HealthPaths.HealthWaitlistsDetail,
-          navHide: true,
-        },
-      ],
-    },
-    {
-      name: messages.questionnaires,
-      path: HealthPaths.HealthQuestionnaires,
-      searchTags: [],
-      children: [
-        {
-          name: messages.questionnaire,
-          path: HealthPaths.HealthQuestionnairesDetail,
-          navHide: true,
+          name: m.therapies,
+          path: HealthPaths.HealthTherapies,
           children: [
             {
-              name: messages.questionnaire,
-              path: HealthPaths.HealthQuestionnairesAnswer,
+              name: messages.physicalTherapy,
+              path: HealthPaths.HealthTherapiesPhysical,
               navHide: true,
-              breadcrumbHide: true,
             },
             {
-              name: messages.answers,
-              path: HealthPaths.HealthQuestionnairesAnswered,
+              name: messages.speechTherapy,
+              path: HealthPaths.HealthTherapiesSpeech,
+              navHide: true,
+            },
+            {
+              name: messages.occupationalTherapy,
+              path: HealthPaths.HealthTherapiesOccupational,
               navHide: true,
             },
           ],
+        },
+        {
+          name: m.aidsAndNutrition,
+          description: m.aidsAndNutritionIntro,
+          path: HealthPaths.HealthAidsAndNutrition,
         },
       ],
     },
@@ -262,6 +214,60 @@ export const healthNavigation: PortalNavigationItem = {
       path: HealthPaths.HealthPatientData,
       searchTags: [s.healthPatientData],
       children: [
+        {
+          name: messages.waitlists,
+          path: HealthPaths.HealthWaitlists,
+          searchTags: [s.healthWaiting],
+          children: [
+            {
+              name: messages.singleWaitlist,
+              path: HealthPaths.HealthWaitlistsDetail,
+              navHide: true,
+            },
+          ],
+        },
+        {
+          name: m.vaccinations,
+          description: m.vaccinationsIntro,
+          path: HealthPaths.HealthVaccinations,
+          children: [
+            {
+              name: messages.generalVaccinations,
+              path: HealthPaths.HealthVaccinationsGeneral,
+              navHide: true,
+            },
+            {
+              name: messages.otherVaccinations,
+              path: HealthPaths.HealthVaccinationsOther,
+              navHide: true,
+            },
+          ],
+        },
+        {
+          name: messages.questionnaires,
+          path: HealthPaths.HealthQuestionnaires,
+          searchTags: [],
+          children: [
+            {
+              name: messages.questionnaire,
+              path: HealthPaths.HealthQuestionnairesDetail,
+              navHide: true,
+              children: [
+                {
+                  name: messages.questionnaire,
+                  path: HealthPaths.HealthQuestionnairesAnswer,
+                  navHide: true,
+                  breadcrumbHide: true,
+                },
+                {
+                  name: messages.answers,
+                  path: HealthPaths.HealthQuestionnairesAnswered,
+                  navHide: true,
+                },
+              ],
+            },
+          ],
+        },
         {
           name: messages.patientDataPermit,
           path: HealthPaths.HealthPatientDataPermits,

--- a/libs/portals/my-pages/health/src/lib/navigation.ts
+++ b/libs/portals/my-pages/health/src/lib/navigation.ts
@@ -179,7 +179,7 @@ export const healthNavigation: PortalNavigationItem = {
     },
     {
       name: messages.therapiesAndAids,
-      path: HealthPaths.HealthTherapies,
+      path: HealthPaths.HealthTherapiesAndAids,
       children: [
         {
           name: m.therapies,

--- a/libs/portals/my-pages/health/src/lib/paths.ts
+++ b/libs/portals/my-pages/health/src/lib/paths.ts
@@ -1,82 +1,92 @@
 // ATTENTION -> When adding or changing paths, please always make sure to redirect old paths. The app is using links to navigate
 const basicInformation = '/heilsa/grunnupplysingar'
+const therapiesAndAids = '/heilsa/thjalfun-og-hjalpartaeki'
+const medicine = '/heilsa/lyf'
+const patientData = '/heilsa/sjukraskra'
+const payments = '/heilsa/greidslur'
 export enum HealthPaths {
   HealthRoot = '/heilsa',
 
-  HealthBasicOld = '/heilsa/yfirlit',
   HealthBasicInformation = `${basicInformation}`,
   HealthOverview = `${basicInformation}/yfirlit`,
-
   HealthDentists = `${basicInformation}/tannlaeknar`,
   HealthDentistRegistration = `${basicInformation}/tannlaeknar/skraning`,
-
   HealthOrganDonation = `${basicInformation}/liffaeragjof`,
   HealthOrganDonationRegistration = `${basicInformation}/liffaeragjof/skraning`,
-
   HealthInsurance = `${basicInformation}/sjukratryggingar`,
-
   HealthCenter = `${basicInformation}/heilsugaesla`,
   HealthCenterRegistration = `${basicInformation}/heilsugaesla/skraning`,
+  HealthBloodtype = `${basicInformation}/blodflokkur`,
 
-  HealthDentistsOld = '/heilsa/tannlaeknar',
-  HealthDentistRegistrationOld = '/heilsa/tannlaeknar/skraning',
+  HealthTherapiesAndAids = `${therapiesAndAids}`,
+  HealthTherapies = `${therapiesAndAids}/thjalfun`,
+  HealthTherapiesPhysical = `${therapiesAndAids}/thjalfun/sjukrathjalfun`,
+  HealthTherapiesSpeech = `${therapiesAndAids}/thjalfun/talthjalfun`,
+  HealthTherapiesOccupational = `${therapiesAndAids}/thjalfun/idjuthjalfun`,
+  HealthAidsAndNutrition = `${therapiesAndAids}/hjalpartaeki-og-naering`,
 
-  HealthOrganDonationOld = '/heilsa/liffaeragjof',
-  HealthOrganDonationRegistrationOld = '/heilsa/liffaeragjof/skraning',
+  HealthPayments = `${payments}`,
+  HealthPaymentParticipation = `${payments}/greidsluthatttaka`,
+  HealthPaymentOverview = `${payments}/greidsluyfirlit`,
+  HealthPaymentOverviewInvoices = `${payments}/greidsluyfirlit/reikningar`,
+  HealthPaymentOverviewTotals = `${payments}/greidsluyfirlit/timabil`,
+  HealthPaymentRights = `${payments}/rettindi`,
 
-  HealthCenterOld = '/heilsa/heilsugaesla',
-  HealthCenterRegistrationOld = '/heilsa/heilsugaesla/skraning',
+  HealthMedicine = `${medicine}`,
+  HealthMedicinePaymentParticipation = `${medicine}/greidsluthatttaka`,
+  HealthMedicinePurchase = `${medicine}/greidsluthatttaka/lyfjakaup`,
+  HealthMedicineCalculator = `${medicine}/greidsluthatttaka/lyfjareiknivel`,
+  HealthMedicineCertificates = `${medicine}/lyfjaskirteini`,
+  HealthMedicineCertificate = `${medicine}/lyfjaskirteini/:name/:id`,
+  HealthMedicinePrescription = `${medicine}/lyfjaavisanir`,
+  HealthMedicinePrescriptionOverview = `${medicine}/lyfjaavisanir/yfirlit`,
+  HealthMedicinePrescriptionHistory = `${medicine}/lyfjasaga`,
+  HealthMedicineDelegation = `${medicine}/lyfjaumbod`,
+  HealthMedicineDelegationDetail = `${medicine}/lyfjaumbod/:id`,
+  HealthMedicineDelegationAdd = `${medicine}/lyfjaumbod/nytt-lyfjaumbod`,
 
-  HealthTherapies = '/heilsa/thjalfun',
-  HealthTherapiesPhysical = '/heilsa/thjalfun/sjukrathjalfun',
-  HealthTherapiesSpeech = '/heilsa/thjalfun/talthjalfun',
-  HealthTherapiesOccupational = '/heilsa/thjalfun/idjuthjalfun',
-
-  HealthPayments = '/heilsa/greidslur',
-  HealthPaymentParticipation = '/heilsa/greidslur/greidsluthatttaka',
-  HealthPaymentOverview = '/heilsa/greidslur/greidsluyfirlit',
-  HealthPaymentOverviewInvoices = '/heilsa/greidslur/greidsluyfirlit/reikningar',
-  HealthPaymentOverviewTotals = '/heilsa/greidslur/greidsluyfirlit/timabil',
-  HealthPaymentRights = '/heilsa/greidslur/rettindi',
-
-  HealthAidsAndNutrition = '/heilsa/hjalpartaeki-og-naering',
-
-  HealthMedicine = '/heilsa/lyf',
-  HealthMedicinePaymentParticipation = '/heilsa/lyf/greidsluthatttaka',
-  HealthMedicinePurchase = '/heilsa/lyf/greidsluthatttaka/lyfjakaup',
-  HealthMedicineCalculator = '/heilsa/lyf/greidsluthatttaka/lyfjareiknivel',
-  HealthMedicineCertificates = '/heilsa/lyf/lyfjaskirteini',
-  HealthMedicineCertificate = '/heilsa/lyf/lyfjaskirteini/:name/:id',
-  HealthMedicinePrescription = '/heilsa/lyf/lyfjaavisanir',
-  HealthMedicinePrescriptionOverview = '/heilsa/lyf/lyfjaavisanir/yfirlit',
-  HealthMedicinePrescriptionHistory = '/heilsa/lyf/lyfjasaga',
-  HealthMedicineDelegation = '/heilsa/lyf/lyfjaumbod',
-  HealthMedicineDelegationDetail = '/heilsa/lyf/lyfjaumbod/:id',
-  HealthMedicineDelegationAdd = '/heilsa/lyf/lyfjaumbod/nytt-lyfjaumbod',
-
-  HealthVaccinations = '/heilsa/bolusetningar',
-  HealthVaccinationsGeneral = '/heilsa/bolusetningar/almennar',
-  HealthVaccinationsOther = '/heilsa/bolusetningar/adrar',
-
-  HealthBloodtype = '/heilsa/blodflokkur',
+  HealthVaccinations = `${patientData}/bolusetningar`,
+  HealthVaccinationsGeneral = `${patientData}/bolusetningar/almennar`,
+  HealthVaccinationsOther = `${patientData}/bolusetningar/adrar`,
+  HealthWaitlists = `${patientData}/bidlistar`,
+  HealthWaitlistsDetail = `${patientData}/bidlistar/:id`,
+  HealthQuestionnaires = `${patientData}/spurningalistar`,
+  HealthQuestionnairesDetail = `${patientData}/spurningalistar/:org/:id`,
+  HealthQuestionnairesAnswer = `${patientData}/spurningalistar/:org/:id/svara`,
+  HealthQuestionnairesAnswered = `${patientData}/spurningalistar/:org/:id/skoda-svor/:submissionId`,
+  HealthPatientData = `${patientData}`,
+  HealthPatientDataOverview = `${patientData}/yfirlit`,
+  HealthPatientDataPermits = `${patientData}/heimildir`,
+  HealthPatientDataPermitsDetail = `${patientData}/heimildir/heimild`,
+  HealthPatientDataPermitsAdd = `${patientData}/heimildir/ny-heimild`,
 
   HealthReferrals = '/heilsa/tilvisanir',
   HealthReferralsDetail = '/heilsa/tilvisanir/:id',
 
-  HealthWaitlists = '/heilsa/bidlistar',
-  HealthWaitlistsDetail = '/heilsa/bidlistar/:id',
-
-  HealthQuestionnaires = '/heilsa/spurningalistar',
-  HealthQuestionnairesDetail = '/heilsa/spurningalistar/:org/:id',
-  HealthQuestionnairesAnswer = '/heilsa/spurningalistar/:org/:id/svara',
-  HealthQuestionnairesAnswered = '/heilsa/spurningalistar/:org/:id/skoda-svor/:submissionId',
-
-  HealthPatientData = '/heilsa/sjukraskra',
-  HealthPatientDataOverview = '/heilsa/sjukraskra/yfirlit',
-  HealthPatientDataPermits = '/heilsa/sjukraskra/heimildir',
-  HealthPatientDataPermitsDetail = '/heilsa/sjukraskra/heimildir/heimild',
-  HealthPatientDataPermitsAdd = '/heilsa/sjukraskra/heimildir/ny-heimild',
-
   HealthAppointments = '/heilsa/timabokanir',
   HealthAppointmentDetail = '/heilsa/timabokanir/:id',
+
+  // Deprecated paths - kept for redirects
+  HealthBasicOld = '/heilsa/yfirlit',
+  HealthBloodtypeOld = '/heilsa/blodflokkur',
+  HealthDentistsOld = '/heilsa/tannlaeknar',
+  HealthDentistRegistrationOld = '/heilsa/tannlaeknar/skraning',
+  HealthOrganDonationOld = '/heilsa/liffaeragjof',
+  HealthOrganDonationRegistrationOld = '/heilsa/liffaeragjof/skraning',
+  HealthCenterOld = '/heilsa/heilsugaesla',
+  HealthCenterRegistrationOld = '/heilsa/heilsugaesla/skraning',
+  HealthTherapiesAndAidsOld = '/heilsa/thjalfun',
+  HealthTherapiesPhysicalOld = '/heilsa/thjalfun/sjukrathjalfun',
+  HealthTherapiesSpeechOld = '/heilsa/thjalfun/talthjalfun',
+  HealthTherapiesOccupationalOld = '/heilsa/thjalfun/idjuthjalfun',
+  HealthAidsAndNutritionOld = '/heilsa/hjalpartaeki-og-naering',
+  HealthVaccinationsOld = '/heilsa/bolusetningar',
+  HealthVaccinationsGeneralOld = '/heilsa/bolusetningar/almennar',
+  HealthVaccinationsOtherOld = '/heilsa/bolusetningar/adrar',
+  HealthWaitlistsOld = '/heilsa/bidlistar',
+  HealthWaitlistsDetailOld = '/heilsa/bidlistar/:id',
+  HealthQuestionnairesOld = '/heilsa/spurningalistar',
+  HealthQuestionnairesDetailOld = '/heilsa/spurningalistar/:org/:id',
+  HealthQuestionnairesAnswerOld = '/heilsa/spurningalistar/:org/:id/svara',
+  HealthQuestionnairesAnsweredOld = '/heilsa/spurningalistar/:org/:id/skoda-svor/:submissionId',
 }

--- a/libs/portals/my-pages/health/src/lib/paths.ts
+++ b/libs/portals/my-pages/health/src/lib/paths.ts
@@ -8,7 +8,7 @@ export enum HealthPaths {
   HealthRoot = '/heilsa',
 
   HealthBasicInformation = `${basicInformation}`,
-  HealthOverview = `${basicInformation}/yfirlit`,
+  HealthOverview = '/heilsa/yfirlit',
   HealthDentists = `${basicInformation}/tannlaeknar`,
   HealthDentistRegistration = `${basicInformation}/tannlaeknar/skraning`,
   HealthOrganDonation = `${basicInformation}/liffaeragjof`,
@@ -67,7 +67,7 @@ export enum HealthPaths {
   HealthAppointmentDetail = '/heilsa/timabokanir/:id',
 
   // Deprecated paths - kept for redirects
-  HealthBasicOld = '/heilsa/yfirlit',
+  HealthOverviewOld = `${basicInformation}/yfirlit`,
   HealthBloodtypeOld = '/heilsa/blodflokkur',
   HealthDentistsOld = '/heilsa/tannlaeknar',
   HealthDentistRegistrationOld = '/heilsa/tannlaeknar/skraning',

--- a/libs/portals/my-pages/health/src/module.tsx
+++ b/libs/portals/my-pages/health/src/module.tsx
@@ -175,6 +175,17 @@ export const healthModule: PortalModule = {
       element: <HealthOverview />,
     },
     {
+      name: hm.therapiesAndAids,
+      path: HealthPaths.HealthTherapiesAndAids,
+      enabled: userInfo.scopes.includes(ApiScope.healthTherapies),
+      element: <Navigate to={HealthPaths.HealthTherapies} replace />,
+    },
+    {
+      name: hm.therapiesAndAids,
+      path: HealthPaths.HealthTherapiesAndAidsOld,
+      element: <Navigate to={HealthPaths.HealthTherapiesAndAids} replace />,
+    },
+    {
       name: hm.therapyTitle,
       path: HealthPaths.HealthTherapies,
       enabled: userInfo.scopes.includes(ApiScope.healthTherapies),
@@ -187,10 +198,20 @@ export const healthModule: PortalModule = {
       element: <TherapiesPhysical />,
     },
     {
+      name: hm.physicalTherapy,
+      path: HealthPaths.HealthTherapiesPhysicalOld,
+      element: <Navigate to={HealthPaths.HealthTherapiesPhysical} replace />,
+    },
+    {
       name: hm.speechTherapy,
       path: HealthPaths.HealthTherapiesSpeech,
       enabled: userInfo.scopes.includes(ApiScope.healthTherapies),
       element: <TherapiesSpeech />,
+    },
+    {
+      name: hm.speechTherapy,
+      path: HealthPaths.HealthTherapiesSpeechOld,
+      element: <Navigate to={HealthPaths.HealthTherapiesSpeech} replace />,
     },
     {
       name: hm.occupationalTherapy,
@@ -199,10 +220,20 @@ export const healthModule: PortalModule = {
       element: <TherapiesOccupational />,
     },
     {
+      name: hm.occupationalTherapy,
+      path: HealthPaths.HealthTherapiesOccupationalOld,
+      element: <Navigate to={HealthPaths.HealthTherapiesOccupational} replace />,
+    },
+    {
       name: hm.aidsAndNutritionTitle,
       path: HealthPaths.HealthAidsAndNutrition,
       enabled: userInfo.scopes.includes(ApiScope.healthAssistiveAndNutrition),
       element: <AidsAndNutrition />,
+    },
+    {
+      name: hm.aidsAndNutritionTitle,
+      path: HealthPaths.HealthAidsAndNutritionOld,
+      element: <Navigate to={HealthPaths.HealthAidsAndNutrition} replace />,
     },
     {
       name: hm.payments,
@@ -241,6 +272,11 @@ export const healthModule: PortalModule = {
       path: HealthPaths.HealthPaymentRights,
       enabled: userInfo.scopes.includes(ApiScope.healthPayments),
       element: <Rights />,
+    },
+    {
+      name: hm.basicInformation,
+      path: HealthPaths.HealthBasicInformation,
+      element: <Navigate to={HealthPaths.HealthCenter} replace />,
     },
     {
       name: hm.dentistsTitle,
@@ -407,6 +443,11 @@ export const healthModule: PortalModule = {
       element: <Bloodtype />,
     },
     {
+      name: hm.bloodtype,
+      path: HealthPaths.HealthBloodtypeOld,
+      element: <Navigate to={HealthPaths.HealthBloodtype} replace />,
+    },
+    {
       name: hm.referrals,
       path: HealthPaths.HealthReferrals,
       key: 'Referrals',
@@ -435,6 +476,11 @@ export const healthModule: PortalModule = {
       element: <WaitlistDetail />,
     },
     {
+      name: hm.waitlists,
+      path: HealthPaths.HealthWaitlistsDetailOld,
+      element: <Navigate to={HealthPaths.HealthWaitlists} replace />,
+    },
+    {
       name: hm.questionnaires,
       path: HealthPaths.HealthQuestionnaires,
       key: 'HealthQuestionnaires',
@@ -449,6 +495,11 @@ export const healthModule: PortalModule = {
       element: <QuestionnairesDetail />,
     },
     {
+      name: hm.questionnaires,
+      path: HealthPaths.HealthQuestionnairesDetailOld,
+      element: <Navigate to={HealthPaths.HealthQuestionnaires} replace />,
+    },
+    {
       name: hm.questionnaire,
       path: HealthPaths.HealthQuestionnairesAnswer,
       key: 'HealthQuestionnaires',
@@ -457,10 +508,20 @@ export const healthModule: PortalModule = {
     },
     {
       name: hm.questionnaire,
+      path: HealthPaths.HealthQuestionnairesAnswerOld,
+      element: <Navigate to={HealthPaths.HealthQuestionnaires} replace />,
+    },
+    {
+      name: hm.questionnaire,
       path: HealthPaths.HealthQuestionnairesAnswered,
       key: 'HealthQuestionnaires',
       enabled: userInfo.scopes.includes(ApiScope.health),
       element: <QuestionnairesAnswered />,
+    },
+    {
+      name: hm.questionnaire,
+      path: HealthPaths.HealthQuestionnairesAnsweredOld,
+      element: <Navigate to={HealthPaths.HealthQuestionnaires} replace />,
     },
     {
       name: hm.patientData,

--- a/libs/portals/my-pages/health/src/module.tsx
+++ b/libs/portals/my-pages/health/src/module.tsx
@@ -222,7 +222,9 @@ export const healthModule: PortalModule = {
     {
       name: hm.occupationalTherapy,
       path: HealthPaths.HealthTherapiesOccupationalOld,
-      element: <Navigate to={HealthPaths.HealthTherapiesOccupational} replace />,
+      element: (
+        <Navigate to={HealthPaths.HealthTherapiesOccupational} replace />
+      ),
     },
     {
       name: hm.aidsAndNutritionTitle,

--- a/libs/portals/my-pages/health/src/module.tsx
+++ b/libs/portals/my-pages/health/src/module.tsx
@@ -164,8 +164,8 @@ export const healthModule: PortalModule = {
       element: <Navigate to={HealthPaths.HealthOverview} replace />,
     },
     {
-      name: hm.basicInformation,
-      path: HealthPaths.HealthBasicOld,
+      name: hm.overviewTitle,
+      path: HealthPaths.HealthOverviewOld,
       element: <Navigate to={HealthPaths.HealthOverview} replace />,
     },
     {
@@ -177,8 +177,14 @@ export const healthModule: PortalModule = {
     {
       name: hm.therapiesAndAids,
       path: HealthPaths.HealthTherapiesAndAids,
-      enabled: userInfo.scopes.includes(ApiScope.healthTherapies),
-      element: <Navigate to={HealthPaths.HealthTherapies} replace />,
+      enabled:
+        userInfo.scopes.includes(ApiScope.healthTherapies) ||
+        userInfo.scopes.includes(ApiScope.healthAssistiveAndNutrition),
+      element: userInfo.scopes.includes(ApiScope.healthTherapies) ? (
+        <Navigate to={HealthPaths.HealthTherapies} replace />
+      ) : (
+        <Navigate to={HealthPaths.HealthAidsAndNutrition} replace />
+      ),
     },
     {
       name: hm.therapiesAndAids,
@@ -437,6 +443,21 @@ export const healthModule: PortalModule = {
       enabled: userInfo.scopes.includes(ApiScope.healthVaccinations),
       element: <Vaccinations />,
     },
+    {
+      name: hm.vaccinations,
+      path: HealthPaths.HealthVaccinationsOld,
+      element: <Navigate to={HealthPaths.HealthVaccinations} replace />,
+    },
+    {
+      name: hm.vaccinations,
+      path: HealthPaths.HealthVaccinationsGeneralOld,
+      element: <Navigate to={HealthPaths.HealthVaccinationsGeneral} replace />,
+    },
+    {
+      name: hm.vaccinations,
+      path: HealthPaths.HealthVaccinationsOtherOld,
+      element: <Navigate to={HealthPaths.HealthVaccinationsOther} replace />,
+    },
 
     {
       name: hm.bloodtype,
@@ -479,6 +500,11 @@ export const healthModule: PortalModule = {
     },
     {
       name: hm.waitlists,
+      path: HealthPaths.HealthWaitlistsOld,
+      element: <Navigate to={HealthPaths.HealthWaitlists} replace />,
+    },
+    {
+      name: hm.waitlists,
       path: HealthPaths.HealthWaitlistsDetailOld,
       element: <Navigate to={HealthPaths.HealthWaitlists} replace />,
     },
@@ -488,6 +514,11 @@ export const healthModule: PortalModule = {
       key: 'HealthQuestionnaires',
       enabled: userInfo.scopes.includes(ApiScope.health),
       element: <Questionnaires />,
+    },
+    {
+      name: hm.questionnaires,
+      path: HealthPaths.HealthQuestionnairesOld,
+      element: <Navigate to={HealthPaths.HealthQuestionnaires} replace />,
     },
     {
       name: hm.questionnaires,

--- a/libs/portals/my-pages/health/src/screens/Medicine/wrapper/MedicinePaymentParticipationWrapper.tsx
+++ b/libs/portals/my-pages/health/src/screens/Medicine/wrapper/MedicinePaymentParticipationWrapper.tsx
@@ -6,8 +6,8 @@ import {
   TabNavigation,
 } from '@island.is/portals/my-pages/core'
 import { messages as m } from '../../../lib/messages'
-import { m as coreMessages } from '@island.is/portals/my-pages/core'
 import { healthNavigation } from '../../../lib/navigation'
+import { HealthPaths } from '../../../lib/paths'
 import { SECTION_GAP } from '../../../utils/constants'
 
 export const MedicinePaymentParticipationWrapper = ({
@@ -20,12 +20,12 @@ export const MedicinePaymentParticipationWrapper = ({
   const { formatMessage } = useLocale()
 
   const medicineChildren = healthNavigation.children?.find(
-    (itm) => itm.name === coreMessages.medicine,
+    (itm) => itm.path === HealthPaths.HealthMedicine,
   )
 
   const paymentParticipationChildren =
     medicineChildren?.children?.find(
-      (item) => item.name === coreMessages.medicinePaymentParticipation,
+      (item) => item.path === HealthPaths.HealthMedicinePaymentParticipation,
     )?.children ?? []
 
   return (

--- a/libs/portals/my-pages/health/src/screens/Therapies/wrapper/TherapiesWrapper.tsx
+++ b/libs/portals/my-pages/health/src/screens/Therapies/wrapper/TherapiesWrapper.tsx
@@ -6,11 +6,11 @@ import {
   IntroWrapper,
   SJUKRATRYGGINGAR_SLUG,
   TabNavigation,
-  m,
 } from '@island.is/portals/my-pages/core'
 import { Problem } from '@island.is/react-spa/shared'
 import { messages } from '../../../lib/messages'
 import { healthNavigation } from '../../../lib/navigation'
+import { HealthPaths } from '../../../lib/paths'
 import { useHealthPlausibleSwap } from '../../../utils/useHealthPlausibleSwap'
 
 type Props = {
@@ -42,7 +42,9 @@ export const TherapiesWrapper = ({
         label={formatMessage(messages.therapyType)}
         pathname={pathname}
         items={
-          healthNavigation.children?.find((itm) => itm.name === m.therapies)
+          healthNavigation.children
+            ?.find((itm) => itm.path === HealthPaths.HealthTherapiesAndAids)
+            ?.children?.find((itm) => itm.path === HealthPaths.HealthTherapies)
             ?.children ?? []
         }
       />


### PR DESCRIPTION
## What

Reordering of health navigation in the menu. Correcting missing routing for parent paths. 

## Why

We want a different order and when parents are missing paths the UI doesn't highlight the parent in the side menu correctly. 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Combined "Therapies and Aids" into a single menu section.
  * Added visible labels for "My medicine" and "Therapies and aids".
  * Reorganized health navigation: appointments, referrals, payments and several patient-data items moved for clearer hierarchy.
  * Added canonical routes and automatic redirects for legacy health pages.
  * Questionnaires answer pages now hide breadcrumb entries for a cleaner trail.

* **Chores**
  * Navigation lookups updated to use stable route identifiers for more reliable resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->