### PR TITLE
fix(j-s): strip defenderNationalId from update unless full defender removal

### DIFF
--- a/apps/judicial-system/backend/src/app/modules/defendant/defendant.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/defendant.service.ts
@@ -44,25 +44,6 @@ export class DefendantService {
     @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
   ) {}
 
-  private validateDefenderInfoRemoval(
-    defendant: Defendant,
-    update: Pick<
-      UpdateDefendantDto | InternalUpdateDefendantDto,
-      'defenderNationalId' | 'defenderName'
-    >,
-  ): void {
-    if (
-      defendant.defenderName &&
-      'defenderNationalId' in update &&
-      update.defenderNationalId === null &&
-      update.defenderName !== null
-    ) {
-      throw new BadRequestException(
-        'DefenderNationalId can only be set to null when defenderName is also set to null.',
-      )
-    }
-  }
-
   private addMessagesForSendDefendantsNotUpdatedAtCourtNotificationToQueue(
     theCase: Case,
     user: User,
@@ -378,7 +359,10 @@ export class DefendantService {
     user: User,
     transaction: Transaction,
   ): Promise<Defendant> {
-    this.validateDefenderInfoRemoval(defendant, update)
+    if (update.defenderChoice === DefenderChoice.DELAY && update.defenderNationalId === null) {
+      const { defenderNationalId: _, ...rest } = update
+      update = rest
+    }
 
     if (isIndictmentCase(theCase.type)) {
       return this.updateIndictmentCaseDefendant(
@@ -409,7 +393,10 @@ export class DefendantService {
     // are initiated by outside API's which should not be able to edit other fields directly
     // Defendant updates originating from the judicial system should use the UpdateDefendantDto
     // and go through the update method above using the defendantId.
-    this.validateDefenderInfoRemoval(defendant, update)
+    if (update.defenderChoice === DefenderChoice.DELAY && update.defenderNationalId === null) {
+      const { defenderNationalId: _, ...rest } = update
+      update = rest
+    }
 
     // If there is a change in the defender choice after the judge has confirmed the choice,
     // we need to set the isDefenderChoiceConfirmed to false

--- a/apps/judicial-system/backend/src/app/modules/defendant/defendant.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/defendant.service.ts
@@ -359,7 +359,10 @@ export class DefendantService {
     user: User,
     transaction: Transaction,
   ): Promise<Defendant> {
-    if (update.defenderChoice === DefenderChoice.DELAY && update.defenderNationalId === null) {
+    if (
+      update.defenderChoice === DefenderChoice.DELAY &&
+      update.defenderNationalId === null
+    ) {
       const { defenderNationalId: _, ...rest } = update
       update = rest
     }
@@ -393,7 +396,10 @@ export class DefendantService {
     // are initiated by outside API's which should not be able to edit other fields directly
     // Defendant updates originating from the judicial system should use the UpdateDefendantDto
     // and go through the update method above using the defendantId.
-    if (update.defenderChoice === DefenderChoice.DELAY && update.defenderNationalId === null) {
+    if (
+      update.defenderChoice === DefenderChoice.DELAY &&
+      update.defenderNationalId === null
+    ) {
       const { defenderNationalId: _, ...rest } = update
       update = rest
     }

--- a/apps/judicial-system/backend/src/app/modules/defendant/defendant.service.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/defendant.service.ts
@@ -1,6 +1,6 @@
 import { literal, Op, Transaction } from 'sequelize'
 
-import { BadRequestException, Inject, Injectable } from '@nestjs/common'
+import { Inject, Injectable } from '@nestjs/common'
 
 import type { Logger } from '@island.is/logging'
 import { LOGGER_PROVIDER } from '@island.is/logging'
@@ -359,7 +359,14 @@ export class DefendantService {
     user: User,
     transaction: Transaction,
   ): Promise<Defendant> {
-    if (update.defenderChoice === DefenderChoice.DELAY && update.defenderNationalId === null) {
+    if (
+      update.defenderNationalId === null &&
+      !(
+        update.defenderEmail === null &&
+        update.defenderName === null &&
+        update.defenderPhoneNumber === null
+      )
+    ) {
       const { defenderNationalId: _, ...rest } = update
       update = rest
     }
@@ -393,7 +400,14 @@ export class DefendantService {
     // are initiated by outside API's which should not be able to edit other fields directly
     // Defendant updates originating from the judicial system should use the UpdateDefendantDto
     // and go through the update method above using the defendantId.
-    if (update.defenderChoice === DefenderChoice.DELAY && update.defenderNationalId === null) {
+    if (
+      update.defenderNationalId === null &&
+      !(
+        update.defenderEmail === null &&
+        update.defenderName === null &&
+        update.defenderPhoneNumber === null
+      )
+    ) {
       const { defenderNationalId: _, ...rest } = update
       update = rest
     }

--- a/apps/judicial-system/backend/src/app/modules/defendant/test/defendantService/update.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/test/defendantService/update.spec.ts
@@ -1,8 +1,6 @@
 import { Transaction } from 'sequelize'
 
-import { BadRequestException } from '@nestjs/common'
-
-import { CaseType, User } from '@island.is/judicial-system/types'
+import { CaseType, DefenderChoice, User } from '@island.is/judicial-system/types'
 
 import { createTestingDefendantModule } from '../createTestingDefendantModule'
 
@@ -64,33 +62,39 @@ describe('DefendantService - update', () => {
     }
   })
 
-  describe('when defenderName is set and defenderNationalId is set to null without also setting defenderName to null', () => {
-    let then: Then
+  describe('when defenderChoice is DELAY and defenderNationalId is null', () => {
+    const defendant = {
+      id: 'defendant-id',
+      caseId: theCase.id,
+      defenderNationalId: '0101302399',
+      defenderName: 'Defender Name',
+    } as Defendant
     const update = {
+      defenderChoice: DefenderChoice.DELAY,
       defenderNationalId: null,
     } as unknown as UpdateDefendantDto
+    const updatedDefendant = {
+      ...defendant,
+      defenderChoice: DefenderChoice.DELAY,
+    } as unknown as Defendant
+    let then: Then
 
     beforeEach(async () => {
-      then = await givenWhenThen(
-        {
-          id: 'defendant-id',
-          caseId: theCase.id,
-          defenderNationalId: '0101302399',
-          defenderName: 'Defender Name',
-          defenderEmail: 'defender@example.com',
-          defenderPhoneNumber: '5551234',
-        } as Defendant,
-        update,
-      )
+      ;(
+        mockDefendantRepositoryService.update as jest.Mock
+      ).mockResolvedValueOnce(updatedDefendant)
+
+      then = await givenWhenThen(defendant, update)
     })
 
-    it('should throw a bad request exception', () => {
-      expect(then.error).toBeInstanceOf(BadRequestException)
-      expect(then.error).toHaveProperty(
-        'message',
-        'DefenderNationalId can only be set to null when defenderName is also set to null.',
+    it('should update the defendant without defenderNationalId', () => {
+      expect(mockDefendantRepositoryService.update).toHaveBeenCalledWith(
+        theCase.id,
+        defendant.id,
+        { defenderChoice: DefenderChoice.DELAY },
+        { transaction },
       )
-      expect(mockDefendantRepositoryService.update).not.toHaveBeenCalled()
+      expect(then.result).toEqual(updatedDefendant)
     })
   })
 

--- a/apps/judicial-system/backend/src/app/modules/defendant/test/defendantService/update.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/test/defendantService/update.spec.ts
@@ -1,6 +1,10 @@
 import { Transaction } from 'sequelize'
 
-import { CaseType, DefenderChoice, User } from '@island.is/judicial-system/types'
+import {
+  CaseType,
+  DefenderChoice,
+  User,
+} from '@island.is/judicial-system/types'
 
 import { createTestingDefendantModule } from '../createTestingDefendantModule'
 

--- a/apps/judicial-system/backend/src/app/modules/defendant/test/defendantService/update.spec.ts
+++ b/apps/judicial-system/backend/src/app/modules/defendant/test/defendantService/update.spec.ts
@@ -1,6 +1,6 @@
 import { Transaction } from 'sequelize'
 
-import { CaseType, DefenderChoice, User } from '@island.is/judicial-system/types'
+import { CaseType, User } from '@island.is/judicial-system/types'
 
 import { createTestingDefendantModule } from '../createTestingDefendantModule'
 
@@ -20,11 +20,6 @@ type GivenWhenThen = (
   defendant: Defendant,
   update: UpdateDefendantDto,
 ) => Promise<Then>
-
-type DefenderNullUpdate = {
-  defenderNationalId: null
-  defenderName?: null
-}
 
 describe('DefendantService - update', () => {
   const theCase = { id: 'case-id', type: CaseType.CUSTODY } as Case
@@ -62,7 +57,7 @@ describe('DefendantService - update', () => {
     }
   })
 
-  describe('when defenderChoice is DELAY and defenderNationalId is null', () => {
+  describe('when defenderNationalId is null', () => {
     const defendant = {
       id: 'defendant-id',
       caseId: theCase.id,
@@ -70,13 +65,9 @@ describe('DefendantService - update', () => {
       defenderName: 'Defender Name',
     } as Defendant
     const update = {
-      defenderChoice: DefenderChoice.DELAY,
       defenderNationalId: null,
     } as unknown as UpdateDefendantDto
-    const updatedDefendant = {
-      ...defendant,
-      defenderChoice: DefenderChoice.DELAY,
-    } as unknown as Defendant
+    const updatedDefendant = { ...defendant } as unknown as Defendant
     let then: Then
 
     beforeEach(async () => {
@@ -87,18 +78,18 @@ describe('DefendantService - update', () => {
       then = await givenWhenThen(defendant, update)
     })
 
-    it('should update the defendant without defenderNationalId', () => {
+    it('should strip defenderNationalId from the update', () => {
       expect(mockDefendantRepositoryService.update).toHaveBeenCalledWith(
         theCase.id,
         defendant.id,
-        { defenderChoice: DefenderChoice.DELAY },
+        {},
         { transaction },
       )
       expect(then.result).toEqual(updatedDefendant)
     })
   })
 
-  describe('when defenderName is set and defenderNationalId and defenderName are both set to null', () => {
+  describe('when defenderNationalId and defenderName are both set to null', () => {
     const defendant = {
       id: 'defendant-id',
       caseId: theCase.id,
@@ -107,45 +98,13 @@ describe('DefendantService - update', () => {
       defenderEmail: 'defender@example.com',
       defenderPhoneNumber: '5551234',
     } as Defendant
-    const update: DefenderNullUpdate = {
-      defenderNationalId: null,
-      defenderName: null,
-    }
-    const defendantUpdate = update as unknown as UpdateDefendantDto
-    const updatedDefendant = { ...defendant, ...update } as unknown as Defendant
-    let then: Then
-
-    beforeEach(async () => {
-      ;(
-        mockDefendantRepositoryService.update as jest.Mock
-      ).mockResolvedValueOnce(updatedDefendant)
-
-      then = await givenWhenThen(defendant, defendantUpdate)
-    })
-
-    it('should update the defendant', () => {
-      expect(mockDefendantRepositoryService.update).toHaveBeenCalledWith(
-        theCase.id,
-        defendant.id,
-        defendantUpdate,
-        { transaction },
-      )
-      expect(then.result).toEqual(updatedDefendant)
-    })
-  })
-
-  describe('when defenderName is not set and defenderNationalId is set to null', () => {
-    const defendant = {
-      id: 'defendant-id',
-      caseId: theCase.id,
-      defenderNationalId: '0101302399',
-    } as Defendant
     const update = {
       defenderNationalId: null,
+      defenderName: null,
     } as unknown as UpdateDefendantDto
     const updatedDefendant = {
       ...defendant,
-      defenderNationalId: null,
+      defenderName: null,
     } as unknown as Defendant
     let then: Then
 
@@ -157,7 +116,44 @@ describe('DefendantService - update', () => {
       then = await givenWhenThen(defendant, update)
     })
 
-    it('should update the defendant', () => {
+    it('should strip defenderNationalId but preserve defenderName', () => {
+      expect(mockDefendantRepositoryService.update).toHaveBeenCalledWith(
+        theCase.id,
+        defendant.id,
+        { defenderName: null },
+        { transaction },
+      )
+      expect(then.result).toEqual(updatedDefendant)
+    })
+  })
+
+  describe('when all defender fields are set to null', () => {
+    const defendant = {
+      id: 'defendant-id',
+      caseId: theCase.id,
+      defenderNationalId: '0101302399',
+      defenderName: 'Defender Name',
+      defenderEmail: 'defender@example.com',
+      defenderPhoneNumber: '5551234',
+    } as Defendant
+    const update = {
+      defenderNationalId: null,
+      defenderName: null,
+      defenderEmail: null,
+      defenderPhoneNumber: null,
+    } as unknown as UpdateDefendantDto
+    const updatedDefendant = { ...defendant, ...update } as unknown as Defendant
+    let then: Then
+
+    beforeEach(async () => {
+      ;(
+        mockDefendantRepositoryService.update as jest.Mock
+      ).mockResolvedValueOnce(updatedDefendant)
+
+      then = await givenWhenThen(defendant, update)
+    })
+
+    it('should not strip defenderNationalId', () => {
       expect(mockDefendantRepositoryService.update).toHaveBeenCalledWith(
         theCase.id,
         defendant.id,


### PR DESCRIPTION
## What

Replaces the old `validateDefenderInfoRemoval` helper (which threw a `BadRequestException`) with inline sanitization in both `update` and `updateRestricted`.

When an update contains `defenderNationalId: null`, the field is stripped from the payload before it reaches the database — **unless** the update is a full defender removal, i.e. `defenderEmail`, `defenderName`, and `defenderPhoneNumber` are also all `null`. In that case the full payload passes through unchanged.

## Why

Setting `defenderChoice` to `DELAY` (or similar flows) sends `defenderNationalId: null` as a side-effect of the UI, not as an intentional data change. Persisting that null would silently clear the existing national ID. The full-removal exception ensures that explicit defender clearing still works correctly.

## Screenshots / Gifs


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review