### PR TITLE
feat(auth): Virtual scope categories, municipality-based tag grouping, and showAsCard support

### DIFF
--- a/libs/api/domains/auth-admin/src/lib/scope/scope.resolver.ts
+++ b/libs/api/domains/auth-admin/src/lib/scope/scope.resolver.ts
@@ -135,8 +135,9 @@ export class ScopeResolver {
     lang?: string,
   ): Promise<ScopeCategory[]> {
     const language = lang ?? 'is'
-    const cmsCategories =
-      await this.cmsContentfulService.getArticleCategories(language)
+    const cmsCategories = await this.cmsContentfulService.getArticleCategories(
+      language,
+    )
 
     return [
       ...cmsCategories,

--- a/libs/api/domains/auth-admin/src/lib/scope/scope.resolver.ts
+++ b/libs/api/domains/auth-admin/src/lib/scope/scope.resolver.ts
@@ -11,6 +11,7 @@ import {
 import type { User } from '@island.is/auth-nest-tools'
 import { CurrentUser, IdsUserGuard } from '@island.is/auth-nest-tools'
 import { Environment } from '@island.is/shared/types'
+import { ISLAND_IS_CATEGORY } from '@island.is/auth-api-lib'
 import { CmsContentfulService } from '@island.is/cms'
 
 import { Scope } from './models/scope.model'
@@ -133,7 +134,20 @@ export class ScopeResolver {
     @Args('lang', { type: () => String, nullable: true, defaultValue: 'is' })
     lang?: string,
   ): Promise<ScopeCategory[]> {
-    return this.cmsContentfulService.getArticleCategories(lang ?? 'is')
+    const language = lang ?? 'is'
+    const cmsCategories =
+      await this.cmsContentfulService.getArticleCategories(language)
+
+    return [
+      ...cmsCategories,
+      {
+        id: ISLAND_IS_CATEGORY.id,
+        title: ISLAND_IS_CATEGORY.title[language === 'en' ? 'en' : 'is'],
+        slug: ISLAND_IS_CATEGORY.slug,
+        description:
+          ISLAND_IS_CATEGORY.description[language === 'en' ? 'en' : 'is'],
+      },
+    ]
   }
 
   @Query(() => [ScopeTag], {

--- a/libs/api/domains/auth/src/lib/models/scopeTag.model.ts
+++ b/libs/api/domains/auth/src/lib/models/scopeTag.model.ts
@@ -15,6 +15,9 @@ export class ScopeTag {
   @Field(() => String)
   slug!: string
 
+  @Field(() => Boolean, { nullable: true })
+  showAsCard?: boolean
+
   @Field(() => [ApiScope])
   scopes!: ApiScope[]
 

--- a/libs/auth-api-lib/src/lib/resources/dto/scope-category.dto.ts
+++ b/libs/auth-api-lib/src/lib/resources/dto/scope-category.dto.ts
@@ -61,7 +61,8 @@ export class ScopeTagDTO {
   slug!: string
 
   @ApiProperty({
-    description: 'Whether this tag should be displayed as a card on the service categories page',
+    description:
+      'Whether this tag should be displayed as a card on the service categories page',
     required: false,
   })
   showAsCard?: boolean

--- a/libs/auth-api-lib/src/lib/resources/dto/scope-category.dto.ts
+++ b/libs/auth-api-lib/src/lib/resources/dto/scope-category.dto.ts
@@ -61,6 +61,12 @@ export class ScopeTagDTO {
   slug!: string
 
   @ApiProperty({
+    description: 'Whether this tag should be displayed as a card on the service categories page',
+    required: false,
+  })
+  showAsCard?: boolean
+
+  @ApiProperty({
     description: 'List of scopes tagged with this life event',
     type: [ScopeDTO],
   })

--- a/libs/auth-api-lib/src/lib/resources/resources.module.ts
+++ b/libs/auth-api-lib/src/lib/resources/resources.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common'
 import { SequelizeModule } from '@nestjs/sequelize'
 
+import { NationalRegistryV3ClientModule } from '@island.is/clients/national-registry-v3'
 import { CmsModule } from '@island.is/cms'
 import { DelegationScope } from '../delegations/models/delegation-scope.model'
 import { Delegation } from '../delegations/models/delegation.model'
@@ -34,6 +35,7 @@ import { ApiScopeDelegationType } from './models/api-scope-delegation-type.model
 @Module({
   imports: [
     CmsModule,
+    NationalRegistryV3ClientModule,
     TranslationModule,
     SequelizeModule.forFeature([
       Domain,

--- a/libs/auth-api-lib/src/lib/resources/scope.service.spec.ts
+++ b/libs/auth-api-lib/src/lib/resources/scope.service.spec.ts
@@ -1,0 +1,317 @@
+import { Test } from '@nestjs/testing'
+import { getModelToken } from '@nestjs/sequelize'
+
+import { CmsContentfulService } from '@island.is/cms'
+import { NationalRegistryV3ClientService } from '@island.is/clients/national-registry-v3'
+
+import { ScopeService, ISLAND_IS_CATEGORY } from './scope.service'
+import { ResourceTranslationService } from './resource-translation.service'
+import { DelegationResourcesService } from './delegation-resources.service'
+import { ApiScope } from './models/api-scope.model'
+import { IdentityResource } from './models/identity-resource.model'
+import { Domain } from './models/domain.model'
+
+const mockUser = {
+  nationalId: '0101302399',
+  scope: ['@island.is/auth/delegations:write'],
+  authorization: '',
+  client: '',
+} as any
+
+function makeScope(
+  name: string,
+  domainName: string,
+  overrides?: Partial<{ displayName: string; description: string }>,
+) {
+  return {
+    name,
+    displayName: overrides?.displayName ?? name,
+    description: overrides?.description ?? '',
+    domainName,
+    order: 0,
+    allowsWrite: false,
+  }
+}
+
+describe('ScopeService', () => {
+  let service: ScopeService
+  let mockCms: { getArticleCategories: jest.Mock; getDelegationScopeTags: jest.Mock }
+  let mockDelegationResources: { findScopesInternal: jest.Mock }
+  let mockNationalRegistry: { getAddress: jest.Mock }
+  let mockDomainModel: { findOne: jest.Mock }
+
+  beforeEach(async () => {
+    mockCms = {
+      getArticleCategories: jest.fn().mockResolvedValue([]),
+      getDelegationScopeTags: jest.fn().mockResolvedValue([]),
+    }
+    mockDelegationResources = {
+      findScopesInternal: jest.fn().mockResolvedValue([]),
+    }
+    mockNationalRegistry = {
+      getAddress: jest.fn().mockResolvedValue(null),
+    }
+    mockDomainModel = {
+      findOne: jest.fn().mockResolvedValue(null),
+    }
+
+    const module = await Test.createTestingModule({
+      providers: [
+        ScopeService,
+        { provide: getModelToken(ApiScope), useValue: { findAll: jest.fn() } },
+        { provide: getModelToken(IdentityResource), useValue: { findAll: jest.fn() } },
+        { provide: getModelToken(Domain), useValue: mockDomainModel },
+        { provide: ResourceTranslationService, useValue: { translateApiScopes: jest.fn(), translateIdentityResources: jest.fn() } },
+        { provide: CmsContentfulService, useValue: mockCms },
+        { provide: DelegationResourcesService, useValue: mockDelegationResources },
+        { provide: NationalRegistryV3ClientService, useValue: mockNationalRegistry },
+      ],
+    }).compile()
+
+    service = module.get(ScopeService)
+  })
+
+  describe('findScopeCategories', () => {
+    it('should map CMS categories to scopes', async () => {
+      mockCms.getArticleCategories.mockResolvedValue([
+        { id: 'cat-1', title: 'Fjármál', slug: 'fjarmal', description: 'desc' },
+      ])
+      mockDelegationResources.findScopesInternal.mockResolvedValue([
+        { ...makeScope('@island.is/finance:overview', '@island.is'), categories: [{ categoryId: 'cat-1' }] },
+      ])
+
+      const result = await service.findScopeCategories(mockUser, 'is')
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('cat-1')
+      expect(result[0].scopes).toHaveLength(1)
+      expect(result[0].scopes[0].name).toBe('@island.is/finance:overview')
+    })
+
+    it('should build virtual "Þjónusta ísland.is" category from DB-assigned scopes', async () => {
+      mockCms.getArticleCategories.mockResolvedValue([
+        { id: 'cat-1', title: 'Fjármál', slug: 'fjarmal', description: '' },
+      ])
+      mockDelegationResources.findScopesInternal.mockResolvedValue([
+        { ...makeScope('@island.is/finance:overview', '@island.is'), categories: [{ categoryId: 'cat-1' }] },
+        { ...makeScope('@island.is/documents', '@island.is'), categories: [{ categoryId: ISLAND_IS_CATEGORY.id }] },
+      ])
+
+      const result = await service.findScopeCategories(mockUser, 'is')
+
+      const virtualCat = result.find((c) => c.id === ISLAND_IS_CATEGORY.id)
+      expect(virtualCat).toBeDefined()
+      expect(virtualCat!.title).toBe('Þjónusta ísland.is')
+      expect(virtualCat!.description).toBe(ISLAND_IS_CATEGORY.description.is)
+      expect(virtualCat!.scopes).toHaveLength(1)
+      expect(virtualCat!.scopes[0].name).toBe('@island.is/documents')
+    })
+
+    it('should return english title for virtual category when lang is en', async () => {
+      mockCms.getArticleCategories.mockResolvedValue([])
+      mockDelegationResources.findScopesInternal.mockResolvedValue([
+        { ...makeScope('@island.is/documents', '@island.is'), categories: [{ categoryId: ISLAND_IS_CATEGORY.id }] },
+      ])
+
+      const result = await service.findScopeCategories(mockUser, 'en')
+
+      expect(result[0].title).toBe('island.is services')
+    })
+
+    it('should not create virtual category when no scopes are assigned to it', async () => {
+      mockCms.getArticleCategories.mockResolvedValue([
+        { id: 'cat-1', title: 'Fjármál', slug: 'fjarmal', description: '' },
+      ])
+      mockDelegationResources.findScopesInternal.mockResolvedValue([
+        { ...makeScope('@island.is/finance:overview', '@island.is'), categories: [{ categoryId: 'cat-1' }] },
+      ])
+
+      const result = await service.findScopeCategories(mockUser, 'is')
+
+      expect(result.find((c) => c.id === ISLAND_IS_CATEGORY.id)).toBeUndefined()
+    })
+
+    it('should not put virtual category scopes into orphaned/uncategorized', async () => {
+      mockCms.getArticleCategories.mockResolvedValue([])
+      mockDelegationResources.findScopesInternal.mockResolvedValue([
+        { ...makeScope('@island.is/documents', '@island.is'), categories: [{ categoryId: ISLAND_IS_CATEGORY.id }] },
+      ])
+
+      const result = await service.findScopeCategories(mockUser, 'is')
+
+      const uncategorized = result.find((c) => c.id === '__uncategorized__')
+      expect(uncategorized).toBeUndefined()
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe(ISLAND_IS_CATEGORY.id)
+    })
+
+    it('should put truly orphaned scopes into uncategorized', async () => {
+      mockCms.getArticleCategories.mockResolvedValue([])
+      mockDelegationResources.findScopesInternal.mockResolvedValue([
+        { ...makeScope('@island.is/something', '@island.is'), categories: [{ categoryId: 'deleted-cms-id' }] },
+      ])
+
+      const result = await service.findScopeCategories(mockUser, 'is')
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('__uncategorized__')
+      expect(result[0].scopes[0].name).toBe('@island.is/something')
+    })
+  })
+
+  describe('findScopeTags', () => {
+    it('should map CMS tags to scopes', async () => {
+      mockCms.getDelegationScopeTags.mockResolvedValue([
+        { id: 'tag-1', title: 'Eignir', slug: 'eignir', description: 'desc' },
+      ])
+      mockDelegationResources.findScopesInternal.mockResolvedValue([
+        { ...makeScope('@island.is/assets', '@island.is'), tags: [{ tagId: 'tag-1' }] },
+      ])
+
+      const result = await service.findScopeTags(mockUser, 'is')
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('tag-1')
+      expect(result[0].scopes[0].name).toBe('@island.is/assets')
+    })
+
+    it('should create "Mitt sveitarfélag" tag when user municipality matches a domain', async () => {
+      mockNationalRegistry.getAddress.mockResolvedValue({ sveitarfelag: 'Kópavogur' })
+      mockDomainModel.findOne.mockResolvedValue({ name: '@kopavogur.is' })
+
+      mockCms.getDelegationScopeTags.mockResolvedValue([
+        { id: 'tag-sv', title: 'Sveitarfélag', slug: 'sveitarfelog', description: '' },
+      ])
+      mockDelegationResources.findScopesInternal.mockResolvedValue([
+        { ...makeScope('@kopavogur.is/service', '@kopavogur.is'), tags: [{ tagId: 'tag-sv' }] },
+        { ...makeScope('@arborg.is/service', '@arborg.is'), tags: [{ tagId: 'tag-sv' }] },
+      ])
+
+      const result = await service.findScopeTags(mockUser, 'is')
+
+      const mittTag = result.find((t) => t.id === 'virtual-mitt-sveitarfelag')
+      expect(mittTag).toBeDefined()
+      expect(mittTag!.title).toBe('Mitt sveitarfélag')
+      expect(mittTag!.scopes).toHaveLength(1)
+      expect(mittTag!.scopes[0].name).toBe('@kopavogur.is/service')
+    })
+
+    it('should keep scopes in original "Sveitarfélag" tag when creating "Mitt sveitarfélag"', async () => {
+      mockNationalRegistry.getAddress.mockResolvedValue({ sveitarfelag: 'Kópavogur' })
+      mockDomainModel.findOne.mockResolvedValue({ name: '@kopavogur.is' })
+
+      mockCms.getDelegationScopeTags.mockResolvedValue([
+        { id: 'tag-sv', title: 'Sveitarfélag', slug: 'sveitarfelog', description: '' },
+      ])
+      mockDelegationResources.findScopesInternal.mockResolvedValue([
+        { ...makeScope('@kopavogur.is/service', '@kopavogur.is'), tags: [{ tagId: 'tag-sv' }] },
+      ])
+
+      const result = await service.findScopeTags(mockUser, 'is')
+
+      const svTag = result.find((t) => t.slug === 'sveitarfelog')
+      expect(svTag).toBeDefined()
+      expect(svTag!.scopes).toHaveLength(1)
+      expect(svTag!.scopes[0].name).toBe('@kopavogur.is/service')
+    })
+
+    it('should pin "Mitt sveitarfélag" to the top of the list', async () => {
+      mockNationalRegistry.getAddress.mockResolvedValue({ sveitarfelag: 'Kópavogur' })
+      mockDomainModel.findOne.mockResolvedValue({ name: '@kopavogur.is' })
+
+      mockCms.getDelegationScopeTags.mockResolvedValue([
+        { id: 'tag-sv', title: 'Sveitarfélag', slug: 'sveitarfelog', description: '' },
+        { id: 'tag-other', title: 'Annað', slug: 'annad', description: '' },
+      ])
+      mockDelegationResources.findScopesInternal.mockResolvedValue([
+        { ...makeScope('@kopavogur.is/service', '@kopavogur.is'), tags: [{ tagId: 'tag-sv' }] },
+        { ...makeScope('@island.is/something', '@island.is'), tags: [{ tagId: 'tag-other' }] },
+      ])
+
+      const result = await service.findScopeTags(mockUser, 'is')
+
+      expect(result[0].id).toBe('virtual-mitt-sveitarfelag')
+    })
+
+    it('should not create "Mitt sveitarfélag" when NatReg fails', async () => {
+      mockNationalRegistry.getAddress.mockRejectedValue(new Error('NatReg down'))
+
+      mockCms.getDelegationScopeTags.mockResolvedValue([
+        { id: 'tag-sv', title: 'Sveitarfélag', slug: 'sveitarfelog', description: '' },
+      ])
+      mockDelegationResources.findScopesInternal.mockResolvedValue([
+        { ...makeScope('@kopavogur.is/service', '@kopavogur.is'), tags: [{ tagId: 'tag-sv' }] },
+      ])
+
+      const result = await service.findScopeTags(mockUser, 'is')
+
+      expect(result.find((t) => t.id === 'virtual-mitt-sveitarfelag')).toBeUndefined()
+      expect(result).toHaveLength(1)
+      expect(result[0].slug).toBe('sveitarfelog')
+    })
+
+    it('should not create "Mitt sveitarfélag" when no domain matches municipality', async () => {
+      mockNationalRegistry.getAddress.mockResolvedValue({ sveitarfelag: 'Dalvík' })
+      mockDomainModel.findOne.mockResolvedValue(null)
+
+      mockCms.getDelegationScopeTags.mockResolvedValue([
+        { id: 'tag-sv', title: 'Sveitarfélag', slug: 'sveitarfelog', description: '' },
+      ])
+      mockDelegationResources.findScopesInternal.mockResolvedValue([
+        { ...makeScope('@kopavogur.is/service', '@kopavogur.is'), tags: [{ tagId: 'tag-sv' }] },
+      ])
+
+      const result = await service.findScopeTags(mockUser, 'is')
+
+      expect(result.find((t) => t.id === 'virtual-mitt-sveitarfelag')).toBeUndefined()
+    })
+
+    it('should not create "Mitt sveitarfélag" when no "Sveitarfélag" tag exists', async () => {
+      mockNationalRegistry.getAddress.mockResolvedValue({ sveitarfelag: 'Kópavogur' })
+      mockDomainModel.findOne.mockResolvedValue({ name: '@kopavogur.is' })
+
+      mockCms.getDelegationScopeTags.mockResolvedValue([
+        { id: 'tag-other', title: 'Eignir', slug: 'eignir', description: '' },
+      ])
+      mockDelegationResources.findScopesInternal.mockResolvedValue([
+        { ...makeScope('@island.is/assets', '@island.is'), tags: [{ tagId: 'tag-other' }] },
+      ])
+
+      const result = await service.findScopeTags(mockUser, 'is')
+
+      expect(result.find((t) => t.id === 'virtual-mitt-sveitarfelag')).toBeUndefined()
+    })
+
+    it('should not create "Mitt sveitarfélag" when user has no municipal scopes in the tag', async () => {
+      mockNationalRegistry.getAddress.mockResolvedValue({ sveitarfelag: 'Kópavogur' })
+      mockDomainModel.findOne.mockResolvedValue({ name: '@kopavogur.is' })
+
+      mockCms.getDelegationScopeTags.mockResolvedValue([
+        { id: 'tag-sv', title: 'Sveitarfélag', slug: 'sveitarfelog', description: '' },
+      ])
+      mockDelegationResources.findScopesInternal.mockResolvedValue([
+        { ...makeScope('@arborg.is/service', '@arborg.is'), tags: [{ tagId: 'tag-sv' }] },
+      ])
+
+      const result = await service.findScopeTags(mockUser, 'is')
+
+      expect(result.find((t) => t.id === 'virtual-mitt-sveitarfelag')).toBeUndefined()
+      expect(result).toHaveLength(1)
+    })
+
+    it('should not create "Mitt sveitarfélag" when address has no sveitarfelag', async () => {
+      mockNationalRegistry.getAddress.mockResolvedValue({ sveitarfelag: null })
+
+      mockCms.getDelegationScopeTags.mockResolvedValue([
+        { id: 'tag-sv', title: 'Sveitarfélag', slug: 'sveitarfelog', description: '' },
+      ])
+      mockDelegationResources.findScopesInternal.mockResolvedValue([
+        { ...makeScope('@kopavogur.is/service', '@kopavogur.is'), tags: [{ tagId: 'tag-sv' }] },
+      ])
+
+      const result = await service.findScopeTags(mockUser, 'is')
+
+      expect(result.find((t) => t.id === 'virtual-mitt-sveitarfelag')).toBeUndefined()
+    })
+  })
+})

--- a/libs/auth-api-lib/src/lib/resources/scope.service.spec.ts
+++ b/libs/auth-api-lib/src/lib/resources/scope.service.spec.ts
@@ -35,7 +35,10 @@ function makeScope(
 
 describe('ScopeService', () => {
   let service: ScopeService
-  let mockCms: { getArticleCategories: jest.Mock; getDelegationScopeTags: jest.Mock }
+  let mockCms: {
+    getArticleCategories: jest.Mock
+    getDelegationScopeTags: jest.Mock
+  }
   let mockDelegationResources: { findScopesInternal: jest.Mock }
   let mockNationalRegistry: { getAddress: jest.Mock }
   let mockDomainModel: { findOne: jest.Mock }
@@ -59,12 +62,27 @@ describe('ScopeService', () => {
       providers: [
         ScopeService,
         { provide: getModelToken(ApiScope), useValue: { findAll: jest.fn() } },
-        { provide: getModelToken(IdentityResource), useValue: { findAll: jest.fn() } },
+        {
+          provide: getModelToken(IdentityResource),
+          useValue: { findAll: jest.fn() },
+        },
         { provide: getModelToken(Domain), useValue: mockDomainModel },
-        { provide: ResourceTranslationService, useValue: { translateApiScopes: jest.fn(), translateIdentityResources: jest.fn() } },
+        {
+          provide: ResourceTranslationService,
+          useValue: {
+            translateApiScopes: jest.fn(),
+            translateIdentityResources: jest.fn(),
+          },
+        },
         { provide: CmsContentfulService, useValue: mockCms },
-        { provide: DelegationResourcesService, useValue: mockDelegationResources },
-        { provide: NationalRegistryV3ClientService, useValue: mockNationalRegistry },
+        {
+          provide: DelegationResourcesService,
+          useValue: mockDelegationResources,
+        },
+        {
+          provide: NationalRegistryV3ClientService,
+          useValue: mockNationalRegistry,
+        },
       ],
     }).compile()
 
@@ -77,7 +95,10 @@ describe('ScopeService', () => {
         { id: 'cat-1', title: 'Fjármál', slug: 'fjarmal', description: 'desc' },
       ])
       mockDelegationResources.findScopesInternal.mockResolvedValue([
-        { ...makeScope('@island.is/finance:overview', '@island.is'), categories: [{ categoryId: 'cat-1' }] },
+        {
+          ...makeScope('@island.is/finance:overview', '@island.is'),
+          categories: [{ categoryId: 'cat-1' }],
+        },
       ])
 
       const result = await service.findScopeCategories(mockUser, 'is')
@@ -93,8 +114,14 @@ describe('ScopeService', () => {
         { id: 'cat-1', title: 'Fjármál', slug: 'fjarmal', description: '' },
       ])
       mockDelegationResources.findScopesInternal.mockResolvedValue([
-        { ...makeScope('@island.is/finance:overview', '@island.is'), categories: [{ categoryId: 'cat-1' }] },
-        { ...makeScope('@island.is/documents', '@island.is'), categories: [{ categoryId: ISLAND_IS_CATEGORY.id }] },
+        {
+          ...makeScope('@island.is/finance:overview', '@island.is'),
+          categories: [{ categoryId: 'cat-1' }],
+        },
+        {
+          ...makeScope('@island.is/documents', '@island.is'),
+          categories: [{ categoryId: ISLAND_IS_CATEGORY.id }],
+        },
       ])
 
       const result = await service.findScopeCategories(mockUser, 'is')
@@ -110,7 +137,10 @@ describe('ScopeService', () => {
     it('should return english title for virtual category when lang is en', async () => {
       mockCms.getArticleCategories.mockResolvedValue([])
       mockDelegationResources.findScopesInternal.mockResolvedValue([
-        { ...makeScope('@island.is/documents', '@island.is'), categories: [{ categoryId: ISLAND_IS_CATEGORY.id }] },
+        {
+          ...makeScope('@island.is/documents', '@island.is'),
+          categories: [{ categoryId: ISLAND_IS_CATEGORY.id }],
+        },
       ])
 
       const result = await service.findScopeCategories(mockUser, 'en')
@@ -123,7 +153,10 @@ describe('ScopeService', () => {
         { id: 'cat-1', title: 'Fjármál', slug: 'fjarmal', description: '' },
       ])
       mockDelegationResources.findScopesInternal.mockResolvedValue([
-        { ...makeScope('@island.is/finance:overview', '@island.is'), categories: [{ categoryId: 'cat-1' }] },
+        {
+          ...makeScope('@island.is/finance:overview', '@island.is'),
+          categories: [{ categoryId: 'cat-1' }],
+        },
       ])
 
       const result = await service.findScopeCategories(mockUser, 'is')
@@ -134,7 +167,10 @@ describe('ScopeService', () => {
     it('should not put virtual category scopes into orphaned/uncategorized', async () => {
       mockCms.getArticleCategories.mockResolvedValue([])
       mockDelegationResources.findScopesInternal.mockResolvedValue([
-        { ...makeScope('@island.is/documents', '@island.is'), categories: [{ categoryId: ISLAND_IS_CATEGORY.id }] },
+        {
+          ...makeScope('@island.is/documents', '@island.is'),
+          categories: [{ categoryId: ISLAND_IS_CATEGORY.id }],
+        },
       ])
 
       const result = await service.findScopeCategories(mockUser, 'is')
@@ -148,7 +184,10 @@ describe('ScopeService', () => {
     it('should put truly orphaned scopes into uncategorized', async () => {
       mockCms.getArticleCategories.mockResolvedValue([])
       mockDelegationResources.findScopesInternal.mockResolvedValue([
-        { ...makeScope('@island.is/something', '@island.is'), categories: [{ categoryId: 'deleted-cms-id' }] },
+        {
+          ...makeScope('@island.is/something', '@island.is'),
+          categories: [{ categoryId: 'deleted-cms-id' }],
+        },
       ])
 
       const result = await service.findScopeCategories(mockUser, 'is')
@@ -165,7 +204,10 @@ describe('ScopeService', () => {
         { id: 'tag-1', title: 'Eignir', slug: 'eignir', description: 'desc' },
       ])
       mockDelegationResources.findScopesInternal.mockResolvedValue([
-        { ...makeScope('@island.is/assets', '@island.is'), tags: [{ tagId: 'tag-1' }] },
+        {
+          ...makeScope('@island.is/assets', '@island.is'),
+          tags: [{ tagId: 'tag-1' }],
+        },
       ])
 
       const result = await service.findScopeTags(mockUser, 'is')
@@ -176,15 +218,28 @@ describe('ScopeService', () => {
     })
 
     it('should create "Mitt sveitarfélag" tag when user municipality matches a domain', async () => {
-      mockNationalRegistry.getAddress.mockResolvedValue({ sveitarfelag: 'Kópavogur' })
+      mockNationalRegistry.getAddress.mockResolvedValue({
+        sveitarfelag: 'Kópavogur',
+      })
       mockDomainModel.findOne.mockResolvedValue({ name: '@kopavogur.is' })
 
       mockCms.getDelegationScopeTags.mockResolvedValue([
-        { id: 'tag-sv', title: 'Sveitarfélag', slug: 'sveitarfelog', description: '' },
+        {
+          id: 'tag-sv',
+          title: 'Sveitarfélag',
+          slug: 'sveitarfelog',
+          description: '',
+        },
       ])
       mockDelegationResources.findScopesInternal.mockResolvedValue([
-        { ...makeScope('@kopavogur.is/service', '@kopavogur.is'), tags: [{ tagId: 'tag-sv' }] },
-        { ...makeScope('@arborg.is/service', '@arborg.is'), tags: [{ tagId: 'tag-sv' }] },
+        {
+          ...makeScope('@kopavogur.is/service', '@kopavogur.is'),
+          tags: [{ tagId: 'tag-sv' }],
+        },
+        {
+          ...makeScope('@arborg.is/service', '@arborg.is'),
+          tags: [{ tagId: 'tag-sv' }],
+        },
       ])
 
       const result = await service.findScopeTags(mockUser, 'is')
@@ -197,14 +252,24 @@ describe('ScopeService', () => {
     })
 
     it('should keep scopes in original "Sveitarfélag" tag when creating "Mitt sveitarfélag"', async () => {
-      mockNationalRegistry.getAddress.mockResolvedValue({ sveitarfelag: 'Kópavogur' })
+      mockNationalRegistry.getAddress.mockResolvedValue({
+        sveitarfelag: 'Kópavogur',
+      })
       mockDomainModel.findOne.mockResolvedValue({ name: '@kopavogur.is' })
 
       mockCms.getDelegationScopeTags.mockResolvedValue([
-        { id: 'tag-sv', title: 'Sveitarfélag', slug: 'sveitarfelog', description: '' },
+        {
+          id: 'tag-sv',
+          title: 'Sveitarfélag',
+          slug: 'sveitarfelog',
+          description: '',
+        },
       ])
       mockDelegationResources.findScopesInternal.mockResolvedValue([
-        { ...makeScope('@kopavogur.is/service', '@kopavogur.is'), tags: [{ tagId: 'tag-sv' }] },
+        {
+          ...makeScope('@kopavogur.is/service', '@kopavogur.is'),
+          tags: [{ tagId: 'tag-sv' }],
+        },
       ])
 
       const result = await service.findScopeTags(mockUser, 'is')
@@ -216,16 +281,29 @@ describe('ScopeService', () => {
     })
 
     it('should pin "Mitt sveitarfélag" to the top of the list', async () => {
-      mockNationalRegistry.getAddress.mockResolvedValue({ sveitarfelag: 'Kópavogur' })
+      mockNationalRegistry.getAddress.mockResolvedValue({
+        sveitarfelag: 'Kópavogur',
+      })
       mockDomainModel.findOne.mockResolvedValue({ name: '@kopavogur.is' })
 
       mockCms.getDelegationScopeTags.mockResolvedValue([
-        { id: 'tag-sv', title: 'Sveitarfélag', slug: 'sveitarfelog', description: '' },
+        {
+          id: 'tag-sv',
+          title: 'Sveitarfélag',
+          slug: 'sveitarfelog',
+          description: '',
+        },
         { id: 'tag-other', title: 'Annað', slug: 'annad', description: '' },
       ])
       mockDelegationResources.findScopesInternal.mockResolvedValue([
-        { ...makeScope('@kopavogur.is/service', '@kopavogur.is'), tags: [{ tagId: 'tag-sv' }] },
-        { ...makeScope('@island.is/something', '@island.is'), tags: [{ tagId: 'tag-other' }] },
+        {
+          ...makeScope('@kopavogur.is/service', '@kopavogur.is'),
+          tags: [{ tagId: 'tag-sv' }],
+        },
+        {
+          ...makeScope('@island.is/something', '@island.is'),
+          tags: [{ tagId: 'tag-other' }],
+        },
       ])
 
       const result = await service.findScopeTags(mockUser, 'is')
@@ -234,68 +312,111 @@ describe('ScopeService', () => {
     })
 
     it('should not create "Mitt sveitarfélag" when NatReg fails', async () => {
-      mockNationalRegistry.getAddress.mockRejectedValue(new Error('NatReg down'))
+      mockNationalRegistry.getAddress.mockRejectedValue(
+        new Error('NatReg down'),
+      )
 
       mockCms.getDelegationScopeTags.mockResolvedValue([
-        { id: 'tag-sv', title: 'Sveitarfélag', slug: 'sveitarfelog', description: '' },
+        {
+          id: 'tag-sv',
+          title: 'Sveitarfélag',
+          slug: 'sveitarfelog',
+          description: '',
+        },
       ])
       mockDelegationResources.findScopesInternal.mockResolvedValue([
-        { ...makeScope('@kopavogur.is/service', '@kopavogur.is'), tags: [{ tagId: 'tag-sv' }] },
+        {
+          ...makeScope('@kopavogur.is/service', '@kopavogur.is'),
+          tags: [{ tagId: 'tag-sv' }],
+        },
       ])
 
       const result = await service.findScopeTags(mockUser, 'is')
 
-      expect(result.find((t) => t.id === 'virtual-mitt-sveitarfelag')).toBeUndefined()
+      expect(
+        result.find((t) => t.id === 'virtual-mitt-sveitarfelag'),
+      ).toBeUndefined()
       expect(result).toHaveLength(1)
       expect(result[0].slug).toBe('sveitarfelog')
     })
 
     it('should not create "Mitt sveitarfélag" when no domain matches municipality', async () => {
-      mockNationalRegistry.getAddress.mockResolvedValue({ sveitarfelag: 'Dalvík' })
+      mockNationalRegistry.getAddress.mockResolvedValue({
+        sveitarfelag: 'Dalvík',
+      })
       mockDomainModel.findOne.mockResolvedValue(null)
 
       mockCms.getDelegationScopeTags.mockResolvedValue([
-        { id: 'tag-sv', title: 'Sveitarfélag', slug: 'sveitarfelog', description: '' },
+        {
+          id: 'tag-sv',
+          title: 'Sveitarfélag',
+          slug: 'sveitarfelog',
+          description: '',
+        },
       ])
       mockDelegationResources.findScopesInternal.mockResolvedValue([
-        { ...makeScope('@kopavogur.is/service', '@kopavogur.is'), tags: [{ tagId: 'tag-sv' }] },
+        {
+          ...makeScope('@kopavogur.is/service', '@kopavogur.is'),
+          tags: [{ tagId: 'tag-sv' }],
+        },
       ])
 
       const result = await service.findScopeTags(mockUser, 'is')
 
-      expect(result.find((t) => t.id === 'virtual-mitt-sveitarfelag')).toBeUndefined()
+      expect(
+        result.find((t) => t.id === 'virtual-mitt-sveitarfelag'),
+      ).toBeUndefined()
     })
 
     it('should not create "Mitt sveitarfélag" when no "Sveitarfélag" tag exists', async () => {
-      mockNationalRegistry.getAddress.mockResolvedValue({ sveitarfelag: 'Kópavogur' })
+      mockNationalRegistry.getAddress.mockResolvedValue({
+        sveitarfelag: 'Kópavogur',
+      })
       mockDomainModel.findOne.mockResolvedValue({ name: '@kopavogur.is' })
 
       mockCms.getDelegationScopeTags.mockResolvedValue([
         { id: 'tag-other', title: 'Eignir', slug: 'eignir', description: '' },
       ])
       mockDelegationResources.findScopesInternal.mockResolvedValue([
-        { ...makeScope('@island.is/assets', '@island.is'), tags: [{ tagId: 'tag-other' }] },
+        {
+          ...makeScope('@island.is/assets', '@island.is'),
+          tags: [{ tagId: 'tag-other' }],
+        },
       ])
 
       const result = await service.findScopeTags(mockUser, 'is')
 
-      expect(result.find((t) => t.id === 'virtual-mitt-sveitarfelag')).toBeUndefined()
+      expect(
+        result.find((t) => t.id === 'virtual-mitt-sveitarfelag'),
+      ).toBeUndefined()
     })
 
     it('should not create "Mitt sveitarfélag" when user has no municipal scopes in the tag', async () => {
-      mockNationalRegistry.getAddress.mockResolvedValue({ sveitarfelag: 'Kópavogur' })
+      mockNationalRegistry.getAddress.mockResolvedValue({
+        sveitarfelag: 'Kópavogur',
+      })
       mockDomainModel.findOne.mockResolvedValue({ name: '@kopavogur.is' })
 
       mockCms.getDelegationScopeTags.mockResolvedValue([
-        { id: 'tag-sv', title: 'Sveitarfélag', slug: 'sveitarfelog', description: '' },
+        {
+          id: 'tag-sv',
+          title: 'Sveitarfélag',
+          slug: 'sveitarfelog',
+          description: '',
+        },
       ])
       mockDelegationResources.findScopesInternal.mockResolvedValue([
-        { ...makeScope('@arborg.is/service', '@arborg.is'), tags: [{ tagId: 'tag-sv' }] },
+        {
+          ...makeScope('@arborg.is/service', '@arborg.is'),
+          tags: [{ tagId: 'tag-sv' }],
+        },
       ])
 
       const result = await service.findScopeTags(mockUser, 'is')
 
-      expect(result.find((t) => t.id === 'virtual-mitt-sveitarfelag')).toBeUndefined()
+      expect(
+        result.find((t) => t.id === 'virtual-mitt-sveitarfelag'),
+      ).toBeUndefined()
       expect(result).toHaveLength(1)
     })
 
@@ -303,15 +424,25 @@ describe('ScopeService', () => {
       mockNationalRegistry.getAddress.mockResolvedValue({ sveitarfelag: null })
 
       mockCms.getDelegationScopeTags.mockResolvedValue([
-        { id: 'tag-sv', title: 'Sveitarfélag', slug: 'sveitarfelog', description: '' },
+        {
+          id: 'tag-sv',
+          title: 'Sveitarfélag',
+          slug: 'sveitarfelog',
+          description: '',
+        },
       ])
       mockDelegationResources.findScopesInternal.mockResolvedValue([
-        { ...makeScope('@kopavogur.is/service', '@kopavogur.is'), tags: [{ tagId: 'tag-sv' }] },
+        {
+          ...makeScope('@kopavogur.is/service', '@kopavogur.is'),
+          tags: [{ tagId: 'tag-sv' }],
+        },
       ])
 
       const result = await service.findScopeTags(mockUser, 'is')
 
-      expect(result.find((t) => t.id === 'virtual-mitt-sveitarfelag')).toBeUndefined()
+      expect(
+        result.find((t) => t.id === 'virtual-mitt-sveitarfelag'),
+      ).toBeUndefined()
     })
   })
 })

--- a/libs/auth-api-lib/src/lib/resources/scope.service.ts
+++ b/libs/auth-api-lib/src/lib/resources/scope.service.ts
@@ -163,6 +163,7 @@ export class ScopeService {
     }
 
     // Map CMS categories to DTO with their scopes
+    const resolvedCategoryIds = new Set(cmsCategories.map((c) => c.id))
     const result = cmsCategories
       .map((cmsCategory) => {
         const scopes = categoryMap.get(cmsCategory.id) ?? []
@@ -176,6 +177,26 @@ export class ScopeService {
       })
       .filter((category) => category.scopes.length > 0) // Only return categories that have scopes
       .sort((a, b) => a.title.localeCompare(b.title))
+
+    // Collect orphaned scopes whose categoryId no longer exists in CMS
+    const orphanedScopes = new Map<string, ScopeDTO>()
+    for (const [categoryId, catScopes] of categoryMap.entries()) {
+      if (!resolvedCategoryIds.has(categoryId)) {
+        for (const scope of catScopes) {
+          orphanedScopes.set(scope.name, scope)
+        }
+      }
+    }
+
+    if (orphanedScopes.size > 0) {
+      result.push({
+        id: '__uncategorized__',
+        title: lang === 'is' ? 'Annað' : 'Other',
+        description: '',
+        slug: 'uncategorized-category',
+        scopes: Array.from(orphanedScopes.values()),
+      })
+    }
 
     return result
   }
@@ -231,7 +252,8 @@ export class ScopeService {
       }
     }
     // Map CMS life events to DTO with their scopes
-    return cmsTags
+    const resolvedTagIds = new Set(cmsTags.map((t) => t.id))
+    const result = cmsTags
       .map((tag) => {
         const scopes = tagMap.get(tag.id) ?? []
         return {
@@ -244,5 +266,27 @@ export class ScopeService {
       })
       .filter((tag) => tag.scopes.length > 0) // Only return tags that have scopes
       .sort((a, b) => a.title.localeCompare(b.title))
+
+    // Collect orphaned scopes whose tagId no longer exists in CMS
+    const orphanedScopes = new Map<string, ScopeDTO>()
+    for (const [tagId, tagScopes] of tagMap.entries()) {
+      if (!resolvedTagIds.has(tagId)) {
+        for (const scope of tagScopes) {
+          orphanedScopes.set(scope.name, scope)
+        }
+      }
+    }
+
+    if (orphanedScopes.size > 0) {
+      result.push({
+        id: '__uncategorized__',
+        title: lang === 'is' ? 'Annað' : 'Other',
+        description: '',
+        slug: 'uncategorized-tag',
+        scopes: Array.from(orphanedScopes.values()),
+      })
+    }
+
+    return result
   }
 }

--- a/libs/auth-api-lib/src/lib/resources/scope.service.ts
+++ b/libs/auth-api-lib/src/lib/resources/scope.service.ts
@@ -23,6 +23,8 @@ import { mapToScopeTree } from './utils/scope-tree.mapper'
 
 const VIRTUAL_MUNICIPALITY_TAG_ID = 'virtual-mitt-sveitarfelag'
 const VIRTUAL_MUNICIPALITY_TAG_SLUG = 'mitt-sveitarfelag'
+// Must match the Contentful delegation scope tag slug for "Sveitarfélag"
+const SVEITARFELOG_CMS_SLUG = 'sveitarfelog'
 
 // Virtual categories not backed by CMS. Scopes are assigned via
 // api_scope_category using these IDs, visible to superadmins in the admin portal.
@@ -361,7 +363,9 @@ export class ScopeService {
     // "Sveitarfélag" tag into a virtual "Mitt sveitarfélag" tag.
     // Scopes remain in their original tag as well.
     if (municipalDomainName) {
-      const sveitarfelagTag = result.find((tag) => tag.slug === 'sveitarfelog')
+      const sveitarfelagTag = result.find(
+        (tag) => tag.slug === SVEITARFELOG_CMS_SLUG,
+      )
 
       if (sveitarfelagTag) {
         const municipalScopes = sveitarfelagTag.scopes.filter(

--- a/libs/auth-api-lib/src/lib/resources/scope.service.ts
+++ b/libs/auth-api-lib/src/lib/resources/scope.service.ts
@@ -213,7 +213,7 @@ export class ScopeService {
 
     // Map CMS categories to DTO with their scopes
     const resolvedCategoryIds = new Set(cmsCategories.map((c) => c.id))
-    let result = cmsCategories
+    const result = cmsCategories
       .map((cmsCategory) => {
         const scopes = categoryMap.get(cmsCategory.id) ?? []
         return {

--- a/libs/auth-api-lib/src/lib/resources/scope.service.ts
+++ b/libs/auth-api-lib/src/lib/resources/scope.service.ts
@@ -73,9 +73,7 @@ export class ScopeService {
       return domain?.name ?? null
     } catch (error) {
       this.logger.warn(
-        `Failed to fetch municipality for user (${
-          (error as Error)?.name ?? 'unknown'
-        }), falling back to normal categories`,
+        'Failed to fetch municipality, falling back to normal categories',
       )
       return null
     }

--- a/libs/auth-api-lib/src/lib/resources/scope.service.ts
+++ b/libs/auth-api-lib/src/lib/resources/scope.service.ts
@@ -1,8 +1,9 @@
-import { Injectable } from '@nestjs/common'
+import { Injectable, Logger } from '@nestjs/common'
 import { InjectModel } from '@nestjs/sequelize'
 import { Op } from 'sequelize'
 
 import { User } from '@island.is/auth-nest-tools'
+import { NationalRegistryV3ClientService } from '@island.is/clients/national-registry-v3'
 import { CmsContentfulService } from '@island.is/cms'
 
 import { DEFAULT_DOMAIN } from '../types'
@@ -20,17 +21,65 @@ import { ResourceTranslationService } from './resource-translation.service'
 import { DelegationResourcesService } from './delegation-resources.service'
 import { mapToScopeTree } from './utils/scope-tree.mapper'
 
+const VIRTUAL_MUNICIPALITY_TAG_ID = 'virtual-mitt-sveitarfelag'
+const VIRTUAL_MUNICIPALITY_TAG_SLUG = 'mitt-sveitarfelag'
+
+// Virtual categories not backed by CMS. Scopes are assigned via
+// api_scope_category using these IDs, visible to superadmins in the admin portal.
+export const ISLAND_IS_CATEGORY = {
+  id: 'virtual-thjonusta-island-is',
+  slug: 'thjonusta-island-is',
+  title: { is: 'Þjónusta ísland.is', en: 'island.is services' },
+  description: {
+    is: 'Ráðgjöf, vörur og þjónusta sem Stafrænt Ísland veitir fyrirtækjum og stofnunum',
+    en: 'Consulting, products and services provided by Digital Iceland to companies and institutions',
+  },
+} as const
+
 @Injectable()
 export class ScopeService {
+  private readonly logger = new Logger(ScopeService.name)
+
   constructor(
     @InjectModel(ApiScope)
     private apiScopeModel: typeof ApiScope,
     @InjectModel(IdentityResource)
     private identityResourceModel: typeof IdentityResource,
+    @InjectModel(Domain)
+    private domainModel: typeof Domain,
     private resourceTranslationService: ResourceTranslationService,
     private cmsContentfulService: CmsContentfulService,
     private delegationResourcesService: DelegationResourcesService,
+    private nationalRegistryService: NationalRegistryV3ClientService,
   ) {}
+
+  /**
+   * Looks up the user's municipality from the National Registry and finds
+   * a matching domain by comparing against Domain.displayName.
+   */
+  private async getUserMunicipalDomain(user: User): Promise<string | null> {
+    try {
+      const address = await this.nationalRegistryService.getAddress(
+        user.nationalId,
+      )
+      const sveitarfelag = address?.sveitarfelag?.trim()
+      if (!sveitarfelag) return null
+
+      const domain = await this.domainModel.findOne({
+        attributes: ['name'],
+        where: { displayName: sveitarfelag },
+      })
+
+      return domain?.name ?? null
+    } catch (error) {
+      this.logger.warn(
+        `Failed to fetch municipality for user (${
+          (error as Error)?.name ?? 'unknown'
+        }), falling back to normal categories`,
+      )
+      return null
+    }
+  }
 
   async findScopeTree(
     requestedScopes: string[],
@@ -164,7 +213,7 @@ export class ScopeService {
 
     // Map CMS categories to DTO with their scopes
     const resolvedCategoryIds = new Set(cmsCategories.map((c) => c.id))
-    const result = cmsCategories
+    let result = cmsCategories
       .map((cmsCategory) => {
         const scopes = categoryMap.get(cmsCategory.id) ?? []
         return {
@@ -175,13 +224,15 @@ export class ScopeService {
           scopes,
         }
       })
-      .filter((category) => category.scopes.length > 0) // Only return categories that have scopes
+      .filter((category) => category.scopes.length > 0)
       .sort((a, b) => a.title.localeCompare(b.title))
 
     // Collect orphaned scopes whose categoryId no longer exists in CMS
+    // (excluding virtual categories which are handled separately)
+    const virtualCategoryIds = new Set<string>([ISLAND_IS_CATEGORY.id])
     const orphanedScopes = new Map<string, ScopeDTO>()
     for (const [categoryId, catScopes] of categoryMap.entries()) {
-      if (!resolvedCategoryIds.has(categoryId)) {
+      if (!resolvedCategoryIds.has(categoryId) && !virtualCategoryIds.has(categoryId)) {
         for (const scope of catScopes) {
           orphanedScopes.set(scope.name, scope)
         }
@@ -198,6 +249,20 @@ export class ScopeService {
       })
     }
 
+    // Virtual "Þjónusta ísland.is" category — scopes assigned to this
+    // category ID in the DB won't match a CMS category, so build it here.
+    const islandIsScopes = categoryMap.get(ISLAND_IS_CATEGORY.id)
+    if (islandIsScopes && islandIsScopes.length > 0) {
+      result.push({
+        id: ISLAND_IS_CATEGORY.id,
+        title: ISLAND_IS_CATEGORY.title[lang === 'en' ? 'en' : 'is'],
+        description:
+          ISLAND_IS_CATEGORY.description[lang === 'en' ? 'en' : 'is'],
+        slug: ISLAND_IS_CATEGORY.slug,
+        scopes: islandIsScopes,
+      })
+    }
+
     return result
   }
 
@@ -206,30 +271,32 @@ export class ScopeService {
     lang: string,
     direction?: DelegationDirection,
   ): Promise<ScopeTagDTO[]> {
-    // Fetch tags from CMS
-    const cmsTags = await this.cmsContentfulService.getDelegationScopeTags(lang)
-
-    const scopes = await this.delegationResourcesService.findScopesInternal({
-      user,
-      language: lang,
-      direction,
-      attributes: [
-        'name',
-        'displayName',
-        'description',
-        'domainName',
-        'order',
-        'allowsWrite',
-      ],
-      additionalIncludes: [
-        {
-          model: ApiScopeTag,
-          as: 'tags',
-          attributes: ['tagId'],
-          required: true,
-        },
-      ],
-    })
+    // Fetch tags, scopes, and user municipality in parallel
+    const [cmsTags, scopes, municipalDomainName] = await Promise.all([
+      this.cmsContentfulService.getDelegationScopeTags(lang),
+      this.delegationResourcesService.findScopesInternal({
+        user,
+        language: lang,
+        direction,
+        attributes: [
+          'name',
+          'displayName',
+          'description',
+          'domainName',
+          'order',
+          'allowsWrite',
+        ],
+        additionalIncludes: [
+          {
+            model: ApiScopeTag,
+            as: 'tags',
+            attributes: ['tagId'],
+            required: true,
+          },
+        ],
+      }),
+      this.getUserMunicipalDomain(user),
+    ])
 
     // Group scopes by tag
     const tagMap = new Map<string, ScopeDTO[]>()
@@ -253,7 +320,7 @@ export class ScopeService {
     }
     // Map CMS life events to DTO with their scopes
     const resolvedTagIds = new Set(cmsTags.map((t) => t.id))
-    const result = cmsTags
+    let result = cmsTags
       .map((tag) => {
         const scopes = tagMap.get(tag.id) ?? []
         return {
@@ -285,6 +352,38 @@ export class ScopeService {
         slug: 'uncategorized-tag',
         scopes: Array.from(orphanedScopes.values()),
       })
+    }
+
+    // If the user has a municipal domain, extract matching scopes from the
+    // "Sveitarfélag" tag into a virtual "Mitt sveitarfélag" tag.
+    // Scopes remain in their original tag as well.
+    if (municipalDomainName) {
+      const sveitarfelagTag = result.find(
+        (tag) => tag.slug === 'sveitarfelog',
+      )
+
+      if (sveitarfelagTag) {
+        const municipalScopes = sveitarfelagTag.scopes.filter(
+          (scope) => scope.domainName === municipalDomainName,
+        )
+
+        if (municipalScopes.length > 0) {
+          result = [
+            {
+              id: VIRTUAL_MUNICIPALITY_TAG_ID,
+              title:
+                lang === 'en' ? 'My municipality' : 'Mitt sveitarfélag',
+              description:
+                lang === 'en'
+                  ? 'Services from your municipality'
+                  : 'Þjónusta frá þínu sveitarfélagi',
+              slug: VIRTUAL_MUNICIPALITY_TAG_SLUG,
+              scopes: municipalScopes,
+            },
+            ...result,
+          ]
+        }
+      }
     }
 
     return result

--- a/libs/auth-api-lib/src/lib/resources/scope.service.ts
+++ b/libs/auth-api-lib/src/lib/resources/scope.service.ts
@@ -328,6 +328,7 @@ export class ScopeService {
           title: tag.title,
           description: tag.description ?? '',
           slug: tag.slug,
+          showAsCard: tag.showAsCard,
           scopes,
         }
       })
@@ -350,6 +351,7 @@ export class ScopeService {
         title: lang === 'is' ? 'Annað' : 'Other',
         description: '',
         slug: 'uncategorized-tag',
+        showAsCard: true,
         scopes: Array.from(orphanedScopes.values()),
       })
     }
@@ -378,6 +380,7 @@ export class ScopeService {
                   ? 'Services from your municipality'
                   : 'Þjónusta frá þínu sveitarfélagi',
               slug: VIRTUAL_MUNICIPALITY_TAG_SLUG,
+              showAsCard: true,
               scopes: municipalScopes,
             },
             ...result,

--- a/libs/auth-api-lib/src/lib/resources/scope.service.ts
+++ b/libs/auth-api-lib/src/lib/resources/scope.service.ts
@@ -60,25 +60,28 @@ export class ScopeService {
    * a matching domain by comparing against Domain.displayName.
    */
   private async getUserMunicipalDomain(user: User): Promise<string | null> {
+    let sveitarfelag: string | undefined
+
     try {
       const address = await this.nationalRegistryService.getAddress(
         user.nationalId,
       )
-      const sveitarfelag = address?.sveitarfelag?.trim()
-      if (!sveitarfelag) return null
-
-      const domain = await this.domainModel.findOne({
-        attributes: ['name'],
-        where: { displayName: sveitarfelag },
-      })
-
-      return domain?.name ?? null
-    } catch (error) {
+      sveitarfelag = address?.sveitarfelag?.trim()
+    } catch {
       this.logger.warn(
         'Failed to fetch municipality, falling back to normal categories',
       )
       return null
     }
+
+    if (!sveitarfelag) return null
+
+    const domain = await this.domainModel.findOne({
+      attributes: ['name'],
+      where: { displayName: sveitarfelag },
+    })
+
+    return domain?.name ?? null
   }
 
   async findScopeTree(
@@ -274,8 +277,8 @@ export class ScopeService {
     lang: string,
     direction?: DelegationDirection,
   ): Promise<ScopeTagDTO[]> {
-    // Fetch tags, scopes, and user municipality in parallel
-    const [cmsTags, scopes, municipalDomainName] = await Promise.all([
+    // Fetch tags and scopes in parallel
+    const [cmsTags, scopes] = await Promise.all([
       this.cmsContentfulService.getDelegationScopeTags(lang),
       this.delegationResourcesService.findScopesInternal({
         user,
@@ -298,7 +301,6 @@ export class ScopeService {
           },
         ],
       }),
-      this.getUserMunicipalDomain(user),
     ])
 
     // Group scopes by tag
@@ -359,15 +361,17 @@ export class ScopeService {
       })
     }
 
-    // If the user has a municipal domain, extract matching scopes from the
-    // "Sveitarfélag" tag into a virtual "Mitt sveitarfélag" tag.
+    // If the "Sveitarfélag" tag exists with scopes, look up the user's
+    // municipality and extract matching scopes into a virtual tag.
     // Scopes remain in their original tag as well.
-    if (municipalDomainName) {
-      const sveitarfelagTag = result.find(
-        (tag) => tag.slug === SVEITARFELOG_CMS_SLUG,
-      )
+    const sveitarfelagTag = result.find(
+      (tag) => tag.slug === SVEITARFELOG_CMS_SLUG,
+    )
 
-      if (sveitarfelagTag) {
+    if (sveitarfelagTag && sveitarfelagTag.scopes.length > 0) {
+      const municipalDomainName = await this.getUserMunicipalDomain(user)
+
+      if (municipalDomainName) {
         const municipalScopes = sveitarfelagTag.scopes.filter(
           (scope) => scope.domainName === municipalDomainName,
         )

--- a/libs/auth-api-lib/src/lib/resources/scope.service.ts
+++ b/libs/auth-api-lib/src/lib/resources/scope.service.ts
@@ -232,7 +232,10 @@ export class ScopeService {
     const virtualCategoryIds = new Set<string>([ISLAND_IS_CATEGORY.id])
     const orphanedScopes = new Map<string, ScopeDTO>()
     for (const [categoryId, catScopes] of categoryMap.entries()) {
-      if (!resolvedCategoryIds.has(categoryId) && !virtualCategoryIds.has(categoryId)) {
+      if (
+        !resolvedCategoryIds.has(categoryId) &&
+        !virtualCategoryIds.has(categoryId)
+      ) {
         for (const scope of catScopes) {
           orphanedScopes.set(scope.name, scope)
         }
@@ -360,9 +363,7 @@ export class ScopeService {
     // "Sveitarfélag" tag into a virtual "Mitt sveitarfélag" tag.
     // Scopes remain in their original tag as well.
     if (municipalDomainName) {
-      const sveitarfelagTag = result.find(
-        (tag) => tag.slug === 'sveitarfelog',
-      )
+      const sveitarfelagTag = result.find((tag) => tag.slug === 'sveitarfelog')
 
       if (sveitarfelagTag) {
         const municipalScopes = sveitarfelagTag.scopes.filter(
@@ -373,8 +374,7 @@ export class ScopeService {
           result = [
             {
               id: VIRTUAL_MUNICIPALITY_TAG_ID,
-              title:
-                lang === 'en' ? 'My municipality' : 'Mitt sveitarfélag',
+              title: lang === 'en' ? 'My municipality' : 'Mitt sveitarfélag',
               description:
                 lang === 'en'
                   ? 'Services from your municipality'

--- a/libs/cms/src/lib/generated/contentfulTypes.d.ts
+++ b/libs/cms/src/lib/generated/contentfulTypes.d.ts
@@ -1087,6 +1087,9 @@ export interface IDelegationScopeTagFields {
 
   /** Slug */
   slug: string
+
+  /** Show as card */
+  showAsCard?: boolean | undefined
 }
 
 /** Tags that can be used to filter available delegations */

--- a/libs/cms/src/lib/models/delegationScopeTag.model.ts
+++ b/libs/cms/src/lib/models/delegationScopeTag.model.ts
@@ -14,6 +14,9 @@ export class DelegationScopeTag {
 
   @Field()
   slug!: string
+
+  @Field({ nullable: true })
+  showAsCard?: boolean
 }
 
 export const mapDelegationScopeTag = ({
@@ -24,4 +27,5 @@ export const mapDelegationScopeTag = ({
   title: fields.title ?? '',
   description: fields.description ?? '',
   slug: fields.slug ?? '',
+  showAsCard: fields.showAsCard ?? false,
 })

--- a/libs/portals/admin/ids-admin/src/lib/messages.ts
+++ b/libs/portals/admin/ids-admin/src/lib/messages.ts
@@ -1161,4 +1161,20 @@ export const m = defineMessages({
     defaultMessage:
       'Should legal representative automatically get this permission for their clients.',
   },
+  deletedCategory: {
+    id: 'ap.ids-admin:deleted-category',
+    defaultMessage: 'Þessum flokki hefur verið eytt ({id})',
+  },
+  deletedCategoryDescription: {
+    id: 'ap.ids-admin:deleted-category-description',
+    defaultMessage: 'Þessi flokkur er ekki lengur til í Contentful',
+  },
+  deletedTag: {
+    id: 'ap.ids-admin:deleted-tag',
+    defaultMessage: 'Þessu merki hefur verið eytt ({id})',
+  },
+  deletedTagDescription: {
+    id: 'ap.ids-admin:deleted-tag-description',
+    defaultMessage: 'Þetta merki er ekki lengur til í Contentful',
+  },
 })

--- a/libs/portals/admin/ids-admin/src/screens/Permission/components/PermissionDelegations.tsx
+++ b/libs/portals/admin/ids-admin/src/screens/Permission/components/PermissionDelegations.tsx
@@ -124,23 +124,29 @@ export const PermissionDelegations = ({
     useEnvironmentState(false)
 
   useEffect(() => {
-    if (
-      !showCategoriesAndTags ||
-      (tags.length === 0 && categories.length === 0)
-    )
-      return
+    if (!showCategoriesAndTags || categoriesLoading || tagsLoading) return
     setSelectedCategories(
-      (selectedPermission.categoryIds ?? [])
-        .map((id) => categories.find((c) => c.value === id))
-        .filter((c): c is Option => c !== undefined),
+      (selectedPermission.categoryIds ?? []).map(
+        (id) =>
+          categories.find((c) => c.value === id) ?? {
+            label: `Eytt flokkur (${id})`,
+            value: id,
+            description: 'Þessi flokkur er ekki lengur til í Contentful',
+          },
+      ),
     )
     setSelectedTags(
-      (selectedPermission.tagIds ?? [])
-        .map((id) => tags.find((t) => t.value === id))
-        .filter((t): t is Option => t !== undefined),
+      (selectedPermission.tagIds ?? []).map(
+        (id) =>
+          tags.find((t) => t.value === id) ?? {
+            label: `Eytt merki (${id})`,
+            value: id,
+            description: 'Þetta merki er ekki lengur til í Contentful',
+          },
+      ),
     )
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [showCategoriesAndTags, tags, categories])
+  }, [showCategoriesAndTags, tags, categories, categoriesLoading, tagsLoading])
 
   const customValidation = useCallback(
     (_newFormData: FormData, _prevFormData: FormData) => {

--- a/libs/portals/admin/ids-admin/src/screens/Permission/components/PermissionDelegations.tsx
+++ b/libs/portals/admin/ids-admin/src/screens/Permission/components/PermissionDelegations.tsx
@@ -45,7 +45,7 @@ export const PermissionDelegations = ({
   isNewPermissionsOptionsEnabled?: boolean
 } = {}) => {
   const { formatMessage, lang } = useLocale()
-  const { selectedPermission, permission } = usePermission()
+  const { selectedPermission, permission, actionData } = usePermission()
   const { isSuperAdmin } = useSuperAdmin()
   const {
     isAccessControlled,
@@ -123,6 +123,14 @@ export const PermissionDelegations = ({
   const [categoriesTagsDirty, setCategoriesTagsDirty] =
     useEnvironmentState(false)
 
+  // Baseline IDs only reset on env change, not after saves — keeps sync diffs accurate
+  const [baselineCategoryIds] = useEnvironmentState<string[]>(
+    selectedPermission.categoryIds ?? [],
+  )
+  const [baselineTagIds] = useEnvironmentState<string[]>(
+    selectedPermission.tagIds ?? [],
+  )
+
   useEffect(() => {
     if (
       !showCategoriesAndTags ||
@@ -140,7 +148,17 @@ export const PermissionDelegations = ({
         .filter((t): t is Option => t !== undefined),
     )
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [showCategoriesAndTags, tags, categories])
+  }, [showCategoriesAndTags, tags, categories, selectedPermission.environment])
+
+  useEffect(() => {
+    if (
+      actionData?.intent === PermissionFormTypes.DELEGATIONS &&
+      actionData?.data
+    ) {
+      setCategoriesTagsDirty(false)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [actionData])
 
   const customValidation = useCallback(
     (_newFormData: FormData, _prevFormData: FormData) => {
@@ -293,7 +311,7 @@ export const PermissionDelegations = ({
                                     type="hidden"
                                     name="originalCategoryIds"
                                     value={JSON.stringify(
-                                      selectedPermission.categoryIds ?? [],
+                                      baselineCategoryIds,
                                     )}
                                   />
                                   <Select
@@ -354,7 +372,7 @@ export const PermissionDelegations = ({
                                     type="hidden"
                                     name="originalTagIds"
                                     value={JSON.stringify(
-                                      selectedPermission.tagIds ?? [],
+                                      baselineTagIds,
                                     )}
                                   />
                                   <Select

--- a/libs/portals/admin/ids-admin/src/screens/Permission/components/PermissionDelegations.tsx
+++ b/libs/portals/admin/ids-admin/src/screens/Permission/components/PermissionDelegations.tsx
@@ -97,12 +97,17 @@ export const PermissionDelegations = ({
 
   const categories: Option[] = useMemo(
     () =>
-      categoriesData?.authAdminScopeCategories.map((cat: Category) => ({
-        label: cat.title,
-        value: cat.id,
-        description: cat.description ?? '',
-      })) ?? [],
-    [categoriesData?.authAdminScopeCategories],
+      categoriesData?.authAdminScopeCategories
+        .filter(
+          (cat: Category) =>
+            isSuperAdmin || !cat.id.startsWith('virtual-'),
+        )
+        .map((cat: Category) => ({
+          label: cat.title,
+          value: cat.id,
+          description: cat.description ?? '',
+        })) ?? [],
+    [categoriesData?.authAdminScopeCategories, isSuperAdmin],
   )
   const tags: Option[] = useMemo(
     () =>

--- a/libs/portals/admin/ids-admin/src/screens/Permission/components/PermissionDelegations.tsx
+++ b/libs/portals/admin/ids-admin/src/screens/Permission/components/PermissionDelegations.tsx
@@ -95,18 +95,22 @@ export const PermissionDelegations = ({
     },
   )
 
+  const allCategories: Option[] = useMemo(
+    () =>
+      categoriesData?.authAdminScopeCategories.map((cat: Category) => ({
+        label: cat.title,
+        value: cat.id,
+        description: cat.description ?? '',
+      })) ?? [],
+    [categoriesData?.authAdminScopeCategories],
+  )
+
   const categories: Option[] = useMemo(
     () =>
-      categoriesData?.authAdminScopeCategories
-        .filter(
-          (cat: Category) => isSuperAdmin || !cat.id.startsWith('virtual-'),
-        )
-        .map((cat: Category) => ({
-          label: cat.title,
-          value: cat.id,
-          description: cat.description ?? '',
-        })) ?? [],
-    [categoriesData?.authAdminScopeCategories, isSuperAdmin],
+      allCategories.filter(
+        (cat) => isSuperAdmin || !cat.value.startsWith('virtual-'),
+      ),
+    [allCategories, isSuperAdmin],
   )
   const tags: Option[] = useMemo(
     () =>
@@ -140,10 +144,10 @@ export const PermissionDelegations = ({
     setSelectedCategories(
       (selectedPermission.categoryIds ?? []).map(
         (id) =>
-          categories.find((c) => c.value === id) ?? {
-            label: `Eytt flokkur (${id})`,
+          allCategories.find((c) => c.value === id) ?? {
+            label: formatMessage(m.deletedCategory, { id }),
             value: id,
-            description: 'Þessi flokkur er ekki lengur til í Contentful',
+            description: formatMessage(m.deletedCategoryDescription),
           },
       ),
     )
@@ -151,9 +155,9 @@ export const PermissionDelegations = ({
       (selectedPermission.tagIds ?? []).map(
         (id) =>
           tags.find((t) => t.value === id) ?? {
-            label: `Eytt merki (${id})`,
+            label: formatMessage(m.deletedTag, { id }),
             value: id,
-            description: 'Þetta merki er ekki lengur til í Contentful',
+            description: formatMessage(m.deletedTagDescription),
           },
       ),
     )

--- a/libs/portals/admin/ids-admin/src/screens/Permission/components/PermissionDelegations.tsx
+++ b/libs/portals/admin/ids-admin/src/screens/Permission/components/PermissionDelegations.tsx
@@ -99,8 +99,7 @@ export const PermissionDelegations = ({
     () =>
       categoriesData?.authAdminScopeCategories
         .filter(
-          (cat: Category) =>
-            isSuperAdmin || !cat.id.startsWith('virtual-'),
+          (cat: Category) => isSuperAdmin || !cat.id.startsWith('virtual-'),
         )
         .map((cat: Category) => ({
           label: cat.title,
@@ -159,7 +158,14 @@ export const PermissionDelegations = ({
       ),
     )
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [showCategoriesAndTags, tags, categories, categoriesLoading, tagsLoading, selectedPermission.environment])
+  }, [
+    showCategoriesAndTags,
+    tags,
+    categories,
+    categoriesLoading,
+    tagsLoading,
+    selectedPermission.environment,
+  ])
 
   useEffect(() => {
     if (
@@ -321,9 +327,7 @@ export const PermissionDelegations = ({
                                   <input
                                     type="hidden"
                                     name="originalCategoryIds"
-                                    value={JSON.stringify(
-                                      baselineCategoryIds,
-                                    )}
+                                    value={JSON.stringify(baselineCategoryIds)}
                                   />
                                   <Select
                                     value={selectedCategories}
@@ -382,9 +386,7 @@ export const PermissionDelegations = ({
                                   <input
                                     type="hidden"
                                     name="originalTagIds"
-                                    value={JSON.stringify(
-                                      baselineTagIds,
-                                    )}
+                                    value={JSON.stringify(baselineTagIds)}
                                   />
                                   <Select
                                     value={selectedTags}

--- a/libs/portals/shared-modules/delegations/src/components/GrantAccessSteps/AccessScopes.tsx
+++ b/libs/portals/shared-modules/delegations/src/components/GrantAccessSteps/AccessScopes.tsx
@@ -127,9 +127,19 @@ export const AccessScopes = () => {
         })
     }
 
+    // Include virtual municipality tag scopes so they remain searchable/filterable
+    const virtualTagScopes =
+      tagsData?.authScopeTags
+        ?.filter((t) => t.id === VIRTUAL_MUNICIPALITY_TAG_ID)
+        .flatMap((t) => t.scopes) ?? []
+
     const seen = new Set<string>()
-    return (categoriesData?.authScopeCategories
-      ?.flatMap((category) => category.scopes)
+    return ([
+      ...virtualTagScopes,
+      ...(categoriesData?.authScopeCategories?.flatMap(
+        (category) => category.scopes,
+      ) ?? []),
+    ]
       .filter((scope) => {
         if (seen.has(scope.name)) return false
 
@@ -156,7 +166,7 @@ export const AccessScopes = () => {
         const matches = matchesSearch && matchesTags && matchesDomains
         if (matches) seen.add(scope.name)
         return matches
-      }) || []) as AuthApiScope[]
+      })) as AuthApiScope[]
   }, [categoriesData, searchQuery, filter, tagsData])
 
   return (

--- a/libs/portals/shared-modules/delegations/src/components/GrantAccessSteps/AccessScopes.tsx
+++ b/libs/portals/shared-modules/delegations/src/components/GrantAccessSteps/AccessScopes.tsx
@@ -1,3 +1,4 @@
+import { VIRTUAL_MUNICIPALITY_TAG_ID } from '../../constants/domain'
 import { useQuery } from '@apollo/client'
 import {
   AuthScopeCategoriesDocument,
@@ -219,7 +220,12 @@ export const AccessScopes = () => {
         <ScopesCategoriesList
           loading={categoriesLoading}
           error={!!categoriesError}
-          categories={categoriesData?.authScopeCategories || []}
+          categories={[
+            ...(tagsData?.authScopeTags
+              ?.filter((t) => t.id === VIRTUAL_MUNICIPALITY_TAG_ID)
+              .map(({ __typename, showAsCard, ...tag }) => tag) ?? []),
+            ...(categoriesData?.authScopeCategories || []),
+          ]}
           onSelectScope={onSelectScope}
           selectedScopes={selectedScopes}
           onSelectCategory={onSelectCategory}

--- a/libs/portals/shared-modules/delegations/src/components/GrantAccessSteps/AccessScopes.tsx
+++ b/libs/portals/shared-modules/delegations/src/components/GrantAccessSteps/AccessScopes.tsx
@@ -134,39 +134,38 @@ export const AccessScopes = () => {
         .flatMap((t) => t.scopes) ?? []
 
     const seen = new Set<string>()
-    return ([
+    return [
       ...virtualTagScopes,
       ...(categoriesData?.authScopeCategories?.flatMap(
         (category) => category.scopes,
       ) ?? []),
-    ]
-      .filter((scope) => {
-        if (seen.has(scope.name)) return false
+    ].filter((scope) => {
+      if (seen.has(scope.name)) return false
 
-        // Search query filter
-        const displayName = scope.displayName.toLowerCase()
-        const description = scope.description?.toLowerCase()
-        const name = scope.name.toLowerCase()
-        const domain = scope.domain?.displayName?.toLowerCase()
-        const matchesSearch =
-          displayName.includes(searchQueryLower) ||
-          description?.includes(searchQueryLower) ||
-          name.includes(searchQueryLower) ||
-          domain?.includes(searchQueryLower)
+      // Search query filter
+      const displayName = scope.displayName.toLowerCase()
+      const description = scope.description?.toLowerCase()
+      const name = scope.name.toLowerCase()
+      const domain = scope.domain?.displayName?.toLowerCase()
+      const matchesSearch =
+        displayName.includes(searchQueryLower) ||
+        description?.includes(searchQueryLower) ||
+        name.includes(searchQueryLower) ||
+        domain?.includes(searchQueryLower)
 
-        // Tags filter - check if scope name is in selected tags
-        const matchesTags =
-          filter.tags.length === 0 || scopeNamesInSelectedTags.has(scope.name)
+      // Tags filter - check if scope name is in selected tags
+      const matchesTags =
+        filter.tags.length === 0 || scopeNamesInSelectedTags.has(scope.name)
 
-        // Domains filter
-        const matchesDomains =
-          filter.domains.length === 0 ||
-          (scope.domain?.name && filter.domains.includes(scope.domain.name))
+      // Domains filter
+      const matchesDomains =
+        filter.domains.length === 0 ||
+        (scope.domain?.name && filter.domains.includes(scope.domain.name))
 
-        const matches = matchesSearch && matchesTags && matchesDomains
-        if (matches) seen.add(scope.name)
-        return matches
-      })) as AuthApiScope[]
+      const matches = matchesSearch && matchesTags && matchesDomains
+      if (matches) seen.add(scope.name)
+      return matches
+    }) as AuthApiScope[]
   }, [categoriesData, searchQuery, filter, tagsData])
 
   return (

--- a/libs/portals/shared-modules/delegations/src/constants/domain.ts
+++ b/libs/portals/shared-modules/delegations/src/constants/domain.ts
@@ -3,3 +3,4 @@
 export const ISLAND_DOMAIN = '@island.is'
 export const ADMIN_ISLAND_DOMAIN = '@admin.island.is'
 export const ALL_DOMAINS = '*'
+export const VIRTUAL_MUNICIPALITY_TAG_ID = 'virtual-mitt-sveitarfelag'

--- a/libs/portals/shared-modules/delegations/src/screens/ServiceCategories/ServiceCategories.graphql
+++ b/libs/portals/shared-modules/delegations/src/screens/ServiceCategories/ServiceCategories.graphql
@@ -24,6 +24,7 @@ query AuthScopeTags($lang: String!, $direction: AuthDelegationDirection) {
     title
     description
     slug
+    showAsCard
     scopes {
       name
       displayName

--- a/libs/portals/shared-modules/delegations/src/screens/ServiceCategories/ServiceCategories.tsx
+++ b/libs/portals/shared-modules/delegations/src/screens/ServiceCategories/ServiceCategories.tsx
@@ -42,8 +42,7 @@ export const ServiceCategories = () => {
     variables: { lang },
   })
 
-  // const categories = data?.authScopeCategories || []
-  const tags = tagsData?.authScopeTags || []
+  const tags = (tagsData?.authScopeTags || []).filter((tag) => tag.showAsCard)
   const categories = categoriesData?.authScopeCategories || []
 
   const loading = categoriesLoading || tagsLoading


### PR DESCRIPTION
# feat(auth): Virtual scope categories, municipality-based tag grouping, and showAsCard support

## What

- Add virtual "Þjónusta ísland.is" scope category backed by `api_scope_category` with a virtual ID, not CMS. Superadmins can assign scopes to it in the admin portal.
- Add virtual "Mitt sveitarfélag" tag that groups municipal scopes from the "Sveitarfélag" tag based on the user's municipality from the National Registry, matched against `Domain.displayName`.
- Add `showAsCard` boolean field to delegation scope tags (Contentful) to control visibility on the þjónustuflokkar grid page.
- Prepend "Mitt sveitarfélag" to the AccessScopes accordion in the delegation grant flow.
- Handle orphaned scopes whose CMS category/tag has been deleted — show under "Annað".
- Fix category/tag baseline sync after saving delegations in the admin portal.
- Add unit tests for `findScopeCategories` and `findScopeTags` (15 test cases).

## Why

- Municipal scopes need personalized grouping so users see services from their own municipality prominently.
- Some scopes (e.g. `@island.is/documents`) don't fit any existing CMS category and need a non-CMS category that admins can manage.
- Tags like "Sveitarfélag" should only be used for filtering, not displayed as cards — `showAsCard` controls this.
- Orphaned scopes were silently hidden when their CMS category was deleted.
- The admin portal had a sync bug where baseline IDs reset after each save, causing incorrect dirty-state diffs.

## Screenshots / Gifs

N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Virtual "Island.is" service category appears alongside CMS categories.
  * Personalized "My municipality" scope tag shown when applicable.
  * Tags can be marked to display as cards and are used in card-style category views.

* **Improvements**
  * Virtual categories hidden for regular admins; deleted/missing categories and tags show fallback/placeholder messages.
  * Municipal scopes included in search, filtering and category lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->