### PR TITLE
fix: remote API only accepts 4 mb files, lowering limit

### DIFF
--- a/libs/application/templates/driving-license/src/forms/draft/subSectionHealthDeclaration.ts
+++ b/libs/application/templates/driving-license/src/forms/draft/subSectionHealthDeclaration.ts
@@ -299,7 +299,7 @@ export const subSectionHealthDeclaration = buildSubSection({
           uploadHeader: m.healthCertificateUploadHeader,
           uploadDescription: m.healthCertificateUploadDescription,
           uploadButtonLabel: m.healthCertificateUploadButtonLabel,
-          maxSize: 10000000,
+          maxSize: 4000000,
           uploadAccept: '.pdf, .jpg, .jpeg, .png',
           condition: needsHealthCertificateCondition(YES),
         }),


### PR DESCRIPTION
## What

Lower the maxSize on the healthCertificate file upload in the driving-license application from 10 MB to 4 MB so the file is rejected client-side with a clear error before the user reaches submission.

  - libs/application/templates/driving-license/src/forms/draft/subSectionHealthDeclaration.ts: maxSize: 10000000 → maxSize: 4000000

## Why

  A user submitting an Eftirvagn BE application got a 400 from RLS's applyfor/be endpoint:

  ContentList[0].Content: "File must not exceed 4 MB."

  The driving-license template was allowing 10 MB uploads while RLS enforces a 4 MB cap on the health certificate (the only file forwarded for BE — see driving-license-submission.service.ts:378-394). That mismatch let users upload files the
  API would later reject, with no useful in-form feedback.

  By aligning the field's maxSize with the API limit, the existing FileUploadController rejection path now surfaces the standard core message ("Skráin er of stór. Hægt er að hlaða inn skrám sem eru 4MB eða minni.") inline, before any S3
  upload or RLS call.

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the maximum file size limit for health certificate uploads to 4MB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->