### PR TITLE
fix: Fix crashing xroad collector

### DIFF
--- a/libs/api-catalogue/services/src/lib/api-catalogue-services.module.ts
+++ b/libs/api-catalogue/services/src/lib/api-catalogue-services.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common'
-import fetch from 'isomorphic-fetch'
+import { createEnhancedFetch } from '@island.is/clients/middlewares'
 import { ProviderService } from './provider.service'
 import { RestMetadataService } from './restmetadata.service'
 import { Configuration, MetaservicesApi } from '../../gen/fetch/xrd'
@@ -19,7 +19,7 @@ const XROAD_CLIENT = process.env.XROAD_CLIENT_ID ?? ''
       useFactory: () =>
         new MetaservicesApi(
           new Configuration({
-            fetchApi: fetch,
+            fetchApi: createEnhancedFetch({ name: 'clients-xroad-metaservices' }),
             basePath: XROAD_BASE_PATH,
             headers: {
               Accept: 'application/json',
@@ -32,7 +32,9 @@ const XROAD_CLIENT = process.env.XROAD_CLIENT_ID ?? ''
       useFactory: () =>
         new RestMetaservicesApi(
           new RestConfiguration({
-            fetchApi: fetch,
+            fetchApi: createEnhancedFetch({
+              name: 'clients-xroad-rest-metaservices',
+            }),
             basePath: XROAD_BASE_PATH + '/r1',
             headers: {
               Accept: 'application/json',

--- a/libs/api-catalogue/services/src/lib/api-catalogue-services.module.ts
+++ b/libs/api-catalogue/services/src/lib/api-catalogue-services.module.ts
@@ -19,7 +19,9 @@ const XROAD_CLIENT = process.env.XROAD_CLIENT_ID ?? ''
       useFactory: () =>
         new MetaservicesApi(
           new Configuration({
-            fetchApi: createEnhancedFetch({ name: 'clients-xroad-metaservices' }),
+            fetchApi: createEnhancedFetch({
+              name: 'clients-xroad-metaservices',
+            }),
             basePath: XROAD_BASE_PATH,
             headers: {
               Accept: 'application/json',

--- a/libs/api-catalogue/services/src/lib/restmetadata.service.ts
+++ b/libs/api-catalogue/services/src/lib/restmetadata.service.ts
@@ -105,7 +105,7 @@ export class RestMetadataService {
             })
           }
         } else {
-          logger.error(
+          logger.warn(
             `OpenAPI not found or is invalid for service code ${sorted[i].memberCode}/${sorted[i].subsystemCode}/${sorted[i].serviceCode}`,
           )
         }
@@ -210,7 +210,7 @@ export class RestMetadataService {
 
   private validateSpec(spec: OpenApi): boolean {
     if (!spec.info.title) {
-      logger.error('OpenApi Specification is missing info.title')
+      logger.warn('OpenApi Specification is missing info.title')
       return false
     }
 
@@ -221,7 +221,7 @@ export class RestMetadataService {
       // required and contains only valid values
       for (const item of spec.info['x-category']) {
         if (!Object.values(DataCategory).includes(item as DataCategory)) {
-          logger.error(`${item} is not valid value for DataCategory`)
+          logger.warn(`${item} is not valid value for DataCategory`)
           return false
         }
       }
@@ -234,7 +234,7 @@ export class RestMetadataService {
       // required and contains only valid values
       for (const item of spec.info['x-pricing']) {
         if (!Object.values(PricingCategory).includes(item as PricingCategory)) {
-          logger.error(`${item} is not valid value for PricingCategory`)
+          logger.warn(`${item} is not valid value for PricingCategory`)
           return false
         }
       }

--- a/libs/api-catalogue/services/src/lib/utils.ts
+++ b/libs/api-catalogue/services/src/lib/utils.ts
@@ -1,4 +1,5 @@
 import { logger } from '@island.is/logging'
+import { FetchError } from '@island.is/clients/middlewares'
 import { ServiceId } from '../../gen/fetch/xrd-rest'
 
 const SEPERATOR = '-'
@@ -99,17 +100,14 @@ export const parseServiceCode = (serviceCode: string) => {
   return serviceCode
 }
 
-/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-export const exceptionHandler = async (err: any) => {
-  if (err instanceof Response) {
+export const exceptionHandler = (err: unknown) => {
+  if (err instanceof FetchError) {
     // Error from X-Road calling getOpenApi
-    logger.error(
-      `Error calling X-Road Service.\nReturned HTTP status ${err.status} ${
-        err.statusText
-      }\nMessage: ${await err.text()}`,
+    logger.warn(
+      `Error calling X-Road Service.\nReturned HTTP status ${err.status} ${err.statusText}`,
+      { body: err.body, problem: err.problem },
     )
   } else {
-    logger.error(err)
-    throw err
+    logger.error('Unexpected error calling X-Road Service', err)
   }
 }


### PR DESCRIPTION
It started crashing after we enabled native fetch support in NodeJS. The XRoad collector was still using isomorphic-fetch (node-fetch), but when it was handling 404 response errors, the global Response type (from NodeJS) didn't match the node-fetch Response type anymore.

Also switch to enhanced fetch, and use warning logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error resilience: missing or invalid OpenAPI specifications are now logged as warnings instead of errors, improving overall service continuity.

* **Refactor**
  * Improved error handling and logging infrastructure with structured diagnostic information for better system observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->