### PR TITLE
fix(delegations): missing logos in delegations tables

### DIFF
--- a/libs/api/domains/auth/src/lib/resolvers/domain.resolver.ts
+++ b/libs/api/domains/auth/src/lib/resolvers/domain.resolver.ts
@@ -7,8 +7,11 @@ import { CurrentUser, IdsUserGuard } from '@island.is/auth-nest-tools'
 import { Domain } from '../models/domain.model'
 import { DomainService } from '../services/domain.service'
 import { DomainsInput } from '../dto/domains.input'
-import { OrganizationLogoByTitleLoader } from '@island.is/cms'
-import type { LogoUrl, OrganizationLogoByTitleDataLoader } from '@island.is/cms'
+import { OrganizationLogoByNationalIdLoader } from '@island.is/cms'
+import type {
+  LogoUrl,
+  OrganizationLogoByNationalIdDataLoader,
+} from '@island.is/cms'
 import { Loader } from '@island.is/nest/dataloader'
 
 @UseGuards(IdsUserGuard)
@@ -28,13 +31,13 @@ export class DomainResolver {
 
   @ResolveField('organisationLogoUrl', () => String, { nullable: true })
   async resolveOrganisationLogoUrl(
-    @Loader(OrganizationLogoByTitleLoader)
-    organizationLogoLoader: OrganizationLogoByTitleDataLoader,
+    @Loader(OrganizationLogoByNationalIdLoader)
+    organizationLogoLoader: OrganizationLogoByNationalIdDataLoader,
     @Parent() domain: Domain,
   ): Promise<LogoUrl> {
-    if (!domain.organisationLogoKey) {
+    if (!domain.nationalId) {
       return null
     }
-    return organizationLogoLoader.load(domain.organisationLogoKey)
+    return organizationLogoLoader.load(domain.nationalId)
   }
 }


### PR DESCRIPTION
## What

- Adjusted logic to load organization logo from contentful using national ID intead of organizationLogoKey.

## Why

Specify why you need to achieve this

## Screenshots / Gifs

Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the internal logo resolution mechanism to improve reliability and consistency in how organization logos are retrieved and displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->