### PR TITLE
fix(web): restore footer bottom bar defaults

### DIFF
--- a/apps/air-discount-scheme/web/components/AppLayout/AppLayout.tsx
+++ b/apps/air-discount-scheme/web/components/AppLayout/AppLayout.tsx
@@ -19,7 +19,6 @@ import {
   QueryGetMenuArgs,
   QueryGetNamespaceArgs,
 } from '@island.is/api/schema'
-import { useI18n } from '../../i18n'
 
 interface AppLayoutProps {
   children?: React.ReactNode
@@ -49,12 +48,6 @@ export const AppLayout: NextComponentType<
   localeKey,
 }) => {
   const [user, setUser] = useState(null)
-  const { toRoute, activeLocale, switchLanguage } = useI18n()
-  const nextLanguage = activeLocale === 'is' ? 'en' : 'is'
-  const languageRoute: FooterLinkProps = {
-    title: nextLanguage === 'en' ? 'English' : 'Íslenska',
-    href: toRoute(routeKey, nextLanguage),
-  }
 
   const islandHref = 'https://island.is'
   const noEmptyOrHash = ({ href }) => href && href !== '#'
@@ -122,15 +115,10 @@ export const AppLayout: NextComponentType<
       </Box>
       <Footer
         topLinks={footerUpperMenuFiltered}
-        topLinksContact={[]}
-        bottomLinks={footerLowerMenuFiltered}
         middleLinks={footerMiddleMenuFiltered}
         middleLinksTitle={namespace.footerMiddleLabel}
         showMiddleLinks={footerMiddleMenuFiltered.length > 0}
-        languageSwitchLink={languageRoute}
-        languageSwitchOnClick={() => {
-          switchLanguage(null, nextLanguage)
-        }}
+        bottomBarLinks={footerLowerMenuFiltered}
       />
       <style jsx global>{`
         @font-face {

--- a/apps/skilavottord/web/components/Footer/Footer.tsx
+++ b/apps/skilavottord/web/components/Footer/Footer.tsx
@@ -4,8 +4,40 @@ import { useI18n } from '@island.is/skilavottord-web/i18n'
 
 export const Footer: FC<React.PropsWithChildren<unknown>> = () => {
   const {
+    activeLocale,
     t: { footer: t },
   } = useI18n()
+
+  const bottomBarLinks =
+    activeLocale === 'en'
+      ? [
+          {
+            title: 'Can we assist?',
+            href: 'https://island.is/en/help/digital-iceland/contact-us',
+          },
+          {
+            title: 'Privacy policy',
+            href: 'https://island.is/en/privacy-policy',
+          },
+          {
+            title: 'Terms of use',
+            href: 'https://island.is/en/terms-of-use',
+          },
+        ]
+      : [
+          {
+            title: 'Getum við aðstoðað?',
+            href: 'https://island.is/s/stafraent-island/hafa-samband',
+          },
+          {
+            title: 'Persónuverndarstefna',
+            href: 'https://island.is/personuverndarstefna-stafraent-islands',
+          },
+          {
+            title: 'Notendaskilmálar',
+            href: 'https://island.is/skilmalar-island-is',
+          },
+        ]
 
   return (
     <IslandUIFooter
@@ -13,6 +45,7 @@ export const Footer: FC<React.PropsWithChildren<unknown>> = () => {
       middleLinksTitle={t.bottomLinksTitle}
       middleLinks={t.bottomLinks}
       showMiddleLinks
+      bottomBarLinks={bottomBarLinks}
     />
   )
 }

--- a/apps/skilavottord/web/components/Footer/Footer.tsx
+++ b/apps/skilavottord/web/components/Footer/Footer.tsx
@@ -10,10 +10,9 @@ export const Footer: FC<React.PropsWithChildren<unknown>> = () => {
   return (
     <IslandUIFooter
       topLinks={t.topLinksInfo}
-      topLinksContact={t.topLinksContact}
-      bottomLinksTitle={t.bottomLinksTitle}
-      bottomLinks={t.bottomLinks}
-      hideLanguageSwitch={true}
+      middleLinksTitle={t.bottomLinksTitle}
+      middleLinks={t.bottomLinks}
+      showMiddleLinks
     />
   )
 }

--- a/libs/island-ui/core/src/lib/Footer/Footer.tsx
+++ b/libs/island-ui/core/src/lib/Footer/Footer.tsx
@@ -35,7 +35,7 @@ interface FooterProps {
   /**
    * Bottom bar links with hardcoded icons.
    */
-  bottomBarLinks: FooterLinkProps[]
+  bottomBarLinks?: FooterLinkProps[]
 }
 
 const bottomBarIcons = ['informationCircle', 'person', 'document'] as const
@@ -48,7 +48,7 @@ export const Footer = ({
   tagLinks = [],
   tagLinksTitle = 'Flýtileiðir',
   showTagLinks = false,
-  bottomBarLinks,
+  bottomBarLinks = defaultBottomBarLinks,
 }: FooterProps) => {
   return (
     <footer>
@@ -235,6 +235,21 @@ const defaultTopLinksInfo = [
   {
     title: 'Lífsviðburðir',
     href: '/lifsvidburdir',
+  },
+]
+
+const defaultBottomBarLinks = [
+  {
+    title: 'Getum við aðstoðað?',
+    href: '/s/stafraent-island/hafa-samband',
+  },
+  {
+    title: 'Persónuverndarstefna',
+    href: '/personuverndarstefna-stafraent-islands',
+  },
+  {
+    title: 'Notendaskilmálar',
+    href: '/skilmalar-island-is',
   },
 ]
 


### PR DESCRIPTION
# Fix Skilavottord footer crash

[Slack thread](https://islandis.slack.com/archives/C01J3ANCF55/p1777545601223899)

## What

Restore a default value for the island-ui `Footer` `bottomBarLinks` prop and make it optional again.

## Why

Skilavottord web still renders the shared `Footer` with the previous prop contract and does not pass `bottomBarLinks`. After the latest Footer changes, PROD started throwing `Cannot read properties of undefined (reading 'map')` during server-side rendering because `bottomBarLinks` was undefined.