### PR TITLE
fix(my-pages): Hide medicine strength if not provided

### DIFF
--- a/libs/portals/my-pages/health/src/screens/MedicinePrescriptions/components/PrescriptionsTable.tsx
+++ b/libs/portals/my-pages/health/src/screens/MedicinePrescriptions/components/PrescriptionsTable.tsx
@@ -118,7 +118,7 @@ const PrescriptionsTable: React.FC<Props> = ({ data, loading }) => {
 
             return {
               id: item.id,
-              medicine: item?.name + ' ' + item?.strength,
+              medicine: [item?.name, item?.strength].filter(Boolean).join(' '),
               usedFor: item?.indication ?? '',
               process: item?.amountRemaining ?? '',
               validTo: isExpired ? (
@@ -196,10 +196,16 @@ const PrescriptionsTable: React.FC<Props> = ({ data, loading }) => {
                             href: item?.url ?? '',
                             type: 'link',
                           },
-                          {
-                            title: formatMessage(messages.medicineStrength),
-                            value: item?.strength ?? '',
-                          },
+                          ...(item?.strength
+                            ? [
+                                {
+                                  title: formatMessage(
+                                    messages.medicineStrength,
+                                  ),
+                                  value: item?.strength ?? '',
+                                },
+                              ]
+                            : []),
                           {
                             title: formatMessage(messages.usedFor),
                             value: item?.indication ?? '',


### PR DESCRIPTION
## What

Hide medicine strength if not provided

## Why

Sometimes the strength is not returned and we want to skip showing an empty line or null in string form

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved the display of medicine information in prescriptions by refining how medication names and strength are formatted, removing unnecessary spacing from incomplete entries, and conditionally showing strength details only when available for a cleaner user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->