### PR TITLE
feat(web): Court agenda hearing time - render html directly

### DIFF
--- a/apps/web/screens/CourtAgendas/CourtAgendas.tsx
+++ b/apps/web/screens/CourtAgendas/CourtAgendas.tsx
@@ -1559,11 +1559,16 @@ const CourtAgendas: CustomScreen<CourtAgendasProps> = (props) => {
                     }
                     time={time}
                     hearingTime={
-                      agenda.hearingTime
-                        ? formatMessage(m.listPage.hearingTime, {
-                            hearingTime: agenda.hearingTime,
-                          })
-                        : undefined
+                      agenda.hearingTime ? (
+                        <Text variant="small">
+                          {formatMessage(m.listPage.hearingTimePrefix)}
+                          <span
+                            dangerouslySetInnerHTML={{
+                              __html: agenda.hearingTime,
+                            }}
+                          />
+                        </Text>
+                      ) : undefined
                     }
                     court={agenda.court}
                     courtRoom={agenda.courtRoom}

--- a/apps/web/screens/CourtAgendas/components/AgendaCard.tsx
+++ b/apps/web/screens/CourtAgendas/components/AgendaCard.tsx
@@ -1,3 +1,5 @@
+import { isValidElement, type ReactNode } from 'react'
+
 import {
   Box,
   GridColumn,
@@ -18,7 +20,7 @@ type AgendaCardProps = {
   title: string
   date: string
   time: string
-  hearingTime?: string | null
+  hearingTime?: ReactNode | string | null
   court: string
   courtRoom: string
   addToCalendarButton: React.ReactNode
@@ -131,9 +133,12 @@ export const AgendaCard = ({
                       <Text className={styles.preLine}>{title}</Text>
                     </Box>
                   )}
-                  {Boolean(hearingTime) && (
-                    <Text variant="small">{hearingTime}</Text>
-                  )}
+                  {Boolean(hearingTime) &&
+                    (isValidElement(hearingTime) ? (
+                      hearingTime
+                    ) : (
+                      <Text variant="small">{hearingTime}</Text>
+                    ))}
                 </Stack>
               </GridColumn>
               <GridColumn span="4/12">{renderDetails()}</GridColumn>

--- a/apps/web/screens/CourtAgendas/translations.strings.ts
+++ b/apps/web/screens/CourtAgendas/translations.strings.ts
@@ -2,10 +2,10 @@ import { defineMessages } from 'react-intl'
 
 export const m = {
   listPage: defineMessages({
-    hearingTime: {
-      id: 'web.courtAgendas:listPage.hearingTime',
-      defaultMessage: 'Málflutningstími: {hearingTime}',
-      description: 'Málflutningstími',
+    hearingTimePrefix: {
+      id: 'web.courtAgendas:listPage.hearingTimePrefix',
+      defaultMessage: 'Málflutningstími: ',
+      description: 'Málflutningstími: ',
     },
     caseTypeAccordionLabel: {
       id: 'web.courtAgendas:listPage.caseTypeAccordionLabel',

--- a/libs/clients/verdicts/src/lib/verdicts-client.service.ts
+++ b/libs/clients/verdicts/src/lib/verdicts-client.service.ts
@@ -629,7 +629,7 @@ export class VerdictsClientService {
           court: SUPREME_COURT,
           type: '',
           title: agenda.title ?? '',
-          hearingTime: agenda.hearingTime ?? '',
+          hearingTime: sanitizeHtml(agenda.hearingTime ?? ''),
         })
       }
     } else {
@@ -654,7 +654,7 @@ export class VerdictsClientService {
           type: agenda.bookingType ?? '',
           title: agenda.caseTitle?.raw ? agenda.caseTitle.raw : '',
           caseSubType: agenda.caseSubType ?? '',
-          hearingTime: agenda.length ?? '',
+          hearingTime: sanitizeHtml(agenda.length ?? ''),
         })
       }
     } else {


### PR DESCRIPTION
#  Court agenda hearing time - render html directly

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated hearing time display in court agendas to allow richer formatting and improved presentation across layouts, including a localized prefix label.
* **Bug Fixes / Security**
  * Sanitized hearing time content to ensure unsafe HTML is not rendered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->