### PR TITLE
feat(j-s): sort indictment counts by crime scene date

### DIFF
--- a/apps/judicial-system/backend/src/app/formatters/indictmentPdf.ts
+++ b/apps/judicial-system/backend/src/app/formatters/indictmentPdf.ts
@@ -107,7 +107,8 @@ export const createIndictment = async (
   const hasManyCounts =
     theCase.indictmentCounts && theCase.indictmentCounts.length > 1
   theCase.indictmentCounts
-    ?.sort(getIndictmentCountCompare(theCase.policeCaseNumbers))
+    ?.slice()
+    .sort(getIndictmentCountCompare(theCase.crimeScenes))
     .forEach((count, index) => {
       addEmptyLines(doc)
 

--- a/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Indictment.tsx
+++ b/apps/judicial-system/web/src/routes/Prosecutor/Indictments/Indictment/Indictment.tsx
@@ -479,9 +479,9 @@ const Indictment = () => {
 
     // We don't want to mutate the original array, so we create a copy
     return [...indictmentCounts].sort(
-      getIndictmentCountCompare(workingCase.policeCaseNumbers),
+      getIndictmentCountCompare(workingCase.crimeScenes),
     )
-  }, [workingCase.indictmentCounts, workingCase.policeCaseNumbers])
+  }, [workingCase.indictmentCounts, workingCase.crimeScenes])
 
   return (
     <PageLayout

--- a/libs/judicial-system/types/src/lib/indictmentCount.ts
+++ b/libs/judicial-system/types/src/lib/indictmentCount.ts
@@ -1,4 +1,4 @@
-import { IndictmentSubtype } from './case'
+import { CrimeSceneMap, IndictmentSubtype } from './case'
 import {
   ILLEGAL_DRUGS_AND_PRESCRIPTION_DRUGS_DRIVING,
   Substance,
@@ -49,44 +49,30 @@ interface IndictmentCount {
 }
 
 export const getIndictmentCountCompare =
-  (policeCaseNumbers: string[] | undefined | null) =>
+  (crimeScenes: CrimeSceneMap | undefined | null) =>
   (a: IndictmentCount, b: IndictmentCount): number => {
-    if (!policeCaseNumbers) {
-      // This should never happen
-      return 0
+    const getDateMs = (
+      date: Date | string | undefined | null,
+    ): number | undefined => {
+      if (!date) return undefined
+      if (typeof date === 'string') return new Date(date).getTime()
+      return date.getTime()
     }
 
-    const aCreated =
-      typeof a.created === 'string'
-        ? new Date(a.created).getTime()
-        : a.created?.getTime() ?? 0
-    const aPoliceCaseNumber = a.policeCaseNumber ?? ''
-    const aIndex = policeCaseNumbers.findIndex((n) => n === aPoliceCaseNumber)
-    const bCreated =
-      typeof b.created === 'string'
-        ? new Date(b.created).getTime()
-        : b.created?.getTime() ?? 0
-    const bPoliceCaseNumber = b.policeCaseNumber ?? ''
-    const bIndex = policeCaseNumbers.findIndex((n) => n === bPoliceCaseNumber)
+    const aDate = getDateMs(
+      a.policeCaseNumber ? crimeScenes?.[a.policeCaseNumber]?.date : undefined,
+    )
+    const bDate = getDateMs(
+      b.policeCaseNumber ? crimeScenes?.[b.policeCaseNumber]?.date : undefined,
+    )
 
-    let result: number
-
-    // We want incictment counts with missing police case numbers
-    // to be at the end of the list
-    if (aIndex < 0) {
-      result = bIndex < 0 ? 0 : 1
-    } else if (bIndex < 0) {
-      result = -1
-    } else {
-      result = aIndex !== bIndex ? (aIndex < bIndex ? -1 : 1) : 0
+    if (aDate === undefined || aDate === null) {
+      return bDate === undefined || bDate === null ? 0 : 1
     }
 
-    return result === 0
-      ? // When the police case numbers are equal we order by creation date
-        aCreated !== bCreated
-        ? aCreated < bCreated
-          ? -1
-          : 1
-        : 0
-      : result
+    if (bDate === undefined || bDate === null) {
+      return -1
+    }
+
+    return aDate !== bDate ? (aDate < bDate ? -1 : 1) : 0
   }


### PR DESCRIPTION
## What
- `getIndictmentCountCompare` now sorts indictment counts by crime scene date (ascending, missing dates last), replacing the previous sort by police case number index
- Updated call sites in `Indictment.tsx` and `indictmentPdf.ts` to pass `crimeScenes` instead of `policeCaseNumbers`
- Fixed `indictmentPdf.ts` mutating `indictmentCounts` in place — added `.slice()` to sort a copy

## Why
Indictment counts should appear in the same order as the police cases they belong to, which are ordered by crime scene date.

## Screenshots / Gifs
Attach Screenshots / Gifs to help reviewers understand the scope of the pull request

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Formatting passes locally with my changes
- [x] I have rebased against main before asking for a review