### PR TITLE
fix(core): Allow www.island.is redirect urls in bff

### DIFF
--- a/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/emailWorker.service.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/emailWorker.service.ts
@@ -142,7 +142,7 @@ export class EmailWorkerService {
           context: {
             small: true,
             preText: isEnglish ? 'In settings on ' : 'Í stillingum á ',
-            linkHref: 'https://www.island.is/minarsidur/min-gogn/stillingar/',
+            linkHref: 'https://island.is/minarsidur/min-gogn/stillingar/',
             linkLabel: 'Ísland.is',
             postText: isEnglish
               ? ', you can decide if you want to be notified or not.'

--- a/charts/islandis-services/services-bff-portals-admin/values.prod.yaml
+++ b/charts/islandis-services/services-bff-portals-admin/values.prod.yaml
@@ -20,7 +20,7 @@ name: 'services-bff-portals-admin'
 enabled: true
 env:
   BFF_ALLOWED_EXTERNAL_API_URLS: '["https://api.island.is"]'
-  BFF_ALLOWED_REDIRECT_URIS: '["https://island.is/stjornbord"]'
+  BFF_ALLOWED_REDIRECT_URIS: '["https://island.is/stjornbord","https://www.island.is/stjornbord"]'
   BFF_CACHE_USER_PROFILE_TTL_MS: '3595000'
   BFF_CALLBACKS_BASE_PATH: 'https://island.is/stjornbord/bff/callbacks'
   BFF_CLIENT_BASE_PATH: '/stjornbord'

--- a/charts/islandis-services/services-bff-portals-my-pages/values.prod.yaml
+++ b/charts/islandis-services/services-bff-portals-my-pages/values.prod.yaml
@@ -20,7 +20,7 @@ name: 'services-bff-portals-my-pages'
 enabled: true
 env:
   BFF_ALLOWED_EXTERNAL_API_URLS: '["https://api.island.is"]'
-  BFF_ALLOWED_REDIRECT_URIS: '["https://island.is/minarsidur","https://island.is/umsoknir","https://island.is/form"]'
+  BFF_ALLOWED_REDIRECT_URIS: '["https://island.is/minarsidur","https://island.is/umsoknir","https://island.is/form","https://www.island.is/minarsidur","https://www.island.is/umsoknir","https://www.island.is/form"]'
   BFF_CACHE_USER_PROFILE_TTL_MS: '3595000'
   BFF_CALLBACKS_BASE_PATH: 'https://island.is/bff/callbacks'
   BFF_CLIENT_BASE_PATH: '/minarsidur'

--- a/charts/islandis/values.prod.yaml
+++ b/charts/islandis/values.prod.yaml
@@ -3053,7 +3053,7 @@ services-bff-portals-admin:
   enabled: true
   env:
     BFF_ALLOWED_EXTERNAL_API_URLS: '["https://api.island.is"]'
-    BFF_ALLOWED_REDIRECT_URIS: '["https://island.is/stjornbord"]'
+    BFF_ALLOWED_REDIRECT_URIS: '["https://island.is/stjornbord","https://www.island.is/stjornbord"]'
     BFF_CACHE_USER_PROFILE_TTL_MS: '3595000'
     BFF_CALLBACKS_BASE_PATH: 'https://island.is/stjornbord/bff/callbacks'
     BFF_CLIENT_BASE_PATH: '/stjornbord'
@@ -3155,7 +3155,7 @@ services-bff-portals-my-pages:
   enabled: true
   env:
     BFF_ALLOWED_EXTERNAL_API_URLS: '["https://api.island.is"]'
-    BFF_ALLOWED_REDIRECT_URIS: '["https://island.is/minarsidur","https://island.is/umsoknir","https://island.is/form"]'
+    BFF_ALLOWED_REDIRECT_URIS: '["https://island.is/minarsidur","https://island.is/umsoknir","https://island.is/form","https://www.island.is/minarsidur","https://www.island.is/umsoknir","https://www.island.is/form"]'
     BFF_CACHE_USER_PROFILE_TTL_MS: '3595000'
     BFF_CALLBACKS_BASE_PATH: 'https://island.is/bff/callbacks'
     BFF_CLIENT_BASE_PATH: '/minarsidur'

--- a/infra/src/dsl/bff.ts
+++ b/infra/src/dsl/bff.ts
@@ -97,7 +97,10 @@ export const bffConfig = ({
         ]),
         dev: ref((ctx) => json(getRedirectUris(getBaseUrl(ctx), key))),
         staging: ref((ctx) => json(getRedirectUris(getBaseUrl(ctx), key))),
-        prod: json(getRedirectUris('https://island.is', key)),
+        prod: json([
+          ...getRedirectUris('https://island.is', key),
+          ...getRedirectUris('https://www.island.is', key),
+        ]),
       },
       BFF_LOGOUT_REDIRECT_URI: {
         local: `http://localhost:4200/${key}`,


### PR DESCRIPTION
## What

Update BFF so it allows redirecting to minarsidur on www.island.is

Also update URL in notification email.

## Why

The hnipp email has a link to www.island.is/minarsidur/min-gogn/stillingar. This link breaks because BFF only allowed redirecting to island.is for security reasons.

Currently island.is can be navigated with and without www. I have started a discussion to consolidate to one version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated email notification settings link to use the correct hostname.
  * Expanded allowed authentication redirect URIs to support both domain variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->