### PR TITLE
feat(verdicts): expose lawCitations on verdict detail endpoint

### DIFF
--- a/libs/api/domains/verdicts/src/lib/dto/verdicts.response.ts
+++ b/libs/api/domains/verdicts/src/lib/dto/verdicts.response.ts
@@ -80,6 +80,9 @@ class VerdictByIdItem {
   @Field(() => String)
   presentings!: string
 
+  @CacheField(() => [String], { nullable: true })
+  lawCitations?: string[]
+
   @Field(() => String, { nullable: true })
   resolutionLink?: string | null
 }

--- a/libs/clients/verdicts/src/lib/verdicts-client.service.ts
+++ b/libs/clients/verdicts/src/lib/verdicts-client.service.ts
@@ -61,6 +61,7 @@ type VerdictByIdResponse =
         caseNumber: string
         keywords: string[]
         presentings: string
+        lawCitations: string[]
       }
     }
   | {
@@ -73,6 +74,7 @@ type VerdictByIdResponse =
         keywords: string[]
         presentings: string
         resolutionLink: string
+        lawCitations: string[]
       }
     }
 
@@ -341,6 +343,8 @@ export class VerdictsClientService {
             caseNumber: response.item.caseNumber ?? '',
             keywords: response.item.keywords ?? [],
             presentings: response.item.presentings ?? '',
+            lawCitations:
+              response.item.lawCitations?.map((c) => c.citation ?? '') ?? [],
           },
         }
     } else if (id.startsWith(SUPREME_COURT_ID_PREFIX)) {
@@ -366,6 +370,7 @@ export class VerdictsClientService {
               response.item.resolutionLink.toLowerCase().startsWith('http')
                 ? response.item.resolutionLink
                 : '',
+            lawCitations: response.item.lawCitations ?? [],
           },
         }
     }


### PR DESCRIPTION
## Summary

Both upstream court APIs (GoPro/Foris for HD/LR and `umsysla.haestirettur.is` for HR) return a `lawCitations` array on each verdict — structured references to the laws cited in the ruling. This data is already fetched by the `VerdictsClientService` but is dropped before reaching the GraphQL schema.

This PR adds `lawCitations` as an optional `[String]` field on the `webVerdictById` response.

- **GoPro** returns `{ position: number, citation: string }[]` — we extract the `citation` string
- **Hæstiréttur** returns `string[]` — passed through directly
- Both normalized to `string[]` in the GraphQL response

## Motivation

The `laws` filter on `webVerdicts` already searches against `lawCitations` server-side, confirming the data is available upstream. However, consumers of `webVerdictById` cannot access the actual citation list — forcing them to regex-parse verdict text to extract law references.

Exposing this field enables downstream tools (legal search engines, verdict analysis platforms) to access authoritative, court-curated law citation data without fragile text parsing.

## What changed

**2 files, 8 lines added.** No changes needed in the resolver or domain service — both pass through the client response directly.

| File | Change |
|------|--------|
| `libs/clients/verdicts/src/lib/verdicts-client.service.ts` | Add `lawCitations` to `VerdictByIdResponse` type and both mapping branches in `getSingleVerdictById()` |
| `libs/api/domains/verdicts/src/lib/dto/verdicts.response.ts` | Add `lawCitations` field to `WebVerdictByIdItem` GraphQL type |

## Example response

```graphql
query {
  webVerdictById(input: { id: "g-..." }) {
    item {
      title
      caseNumber
      lawCitations
    }
  }
}
```

```json
{
  "item": {
    "title": "...",
    "caseNumber": "E-735/2023",
    "lawCitations": [
      "130. gr. laga nr. 91/1991",
      "1. mgr. 72. gr. stjórnarskrárinnar nr. 33/1944",
      "26. gr. laga nr. 50/2016"
    ]
  }
}
```

## Checklist

- [x] No breaking changes — field is nullable/optional
- [x] No new dependencies
- [x] No new environment variables
- [x] Cache behavior unchanged (uses existing `@CacheControl`)
- [x] Both GoPro and Supreme Court sources handled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Verdict details now include associated law citations, providing additional legal reference information for both regular and Supreme Court verdicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->