### PR TITLE
fix(web): Escape html in verdict and court agenda rss feeds

### DIFF
--- a/apps/web/pages/api/dagskra-domstola/rss/index.ts
+++ b/apps/web/pages/api/dagskra-domstola/rss/index.ts
@@ -20,7 +20,6 @@ interface Item {
 const generateItemString = (item: Item) => {
   return `<item>
   <title>${escape(item.title)}</title>
-  <link>${escape(item.fullUrl)}</link>
   ${
     item.description
       ? `<description>${escape(item.description)}</description>`

--- a/apps/web/pages/api/dagskra-domstola/rss/index.ts
+++ b/apps/web/pages/api/dagskra-domstola/rss/index.ts
@@ -1,3 +1,4 @@
+import escape from 'escape-html'
 import type { NextApiRequest, NextApiResponse } from 'next'
 
 import initApollo from '@island.is/web/graphql/client'
@@ -18,11 +19,15 @@ interface Item {
 
 const generateItemString = (item: Item) => {
   return `<item>
-  <title>${item.title}</title>
-  <link>${item.fullUrl}</link>
-  ${item.description ? `<description>${item.description}</description>` : ''}
-  <guid isPermaLink="false">${item.id}</guid>
-  ${item.date ? ` <pubDate>${item.date}</pubDate>` : ''}
+  <title>${escape(item.title)}</title>
+  <link>${escape(item.fullUrl)}</link>
+  ${
+    item.description
+      ? `<description>${escape(item.description)}</description>`
+      : ''
+  }
+  <guid isPermaLink="false">${escape(item.id)}</guid>
+  ${item.date ? ` <pubDate>${escape(item.date)}</pubDate>` : ''}
   </item>`
 }
 
@@ -71,7 +76,7 @@ export default async function handler(
   <rss version="2.0">
   <channel>
   <title>Dagskrá dómstóla á Ísland.is</title>
-  <link>${baseUrl}</link>
+  <link>${escape(baseUrl)}</link>
   ${itemString}
   </channel>
   </rss>`

--- a/apps/web/pages/api/domar/rss/index.ts
+++ b/apps/web/pages/api/domar/rss/index.ts
@@ -1,3 +1,4 @@
+import escape from 'escape-html'
 import type { NextApiRequest, NextApiResponse } from 'next'
 
 import initApollo from '@island.is/web/graphql/client'
@@ -18,11 +19,15 @@ interface Item {
 
 const generateItemString = (item: Item) => {
   return `<item>
-  <title>${item.title}</title>
-  <link>${item.fullUrl}</link>
-  ${item.description ? `<description>${item.description}</description>` : ''}
-  <guid isPermaLink="false">${item.id}</guid>
-  ${item.date ? ` <pubDate>${item.date}</pubDate>` : ''}
+  <title>${escape(item.title)}</title>
+  <link>${escape(item.fullUrl)}</link>
+  ${
+    item.description
+      ? `<description>${escape(item.description)}</description>`
+      : ''
+  }
+  <guid isPermaLink="false">${escape(item.id)}</guid>
+  ${item.date ? ` <pubDate>${escape(item.date)}</pubDate>` : ''}
   </item>`
 }
 
@@ -68,7 +73,7 @@ export default async function handler(
   <rss version="2.0">
   <channel>
   <title>Dómar og úrskurðir á Ísland.is</title>
-  <link>${baseUrl}</link>
+  <link>${escape(baseUrl)}</link>
   ${itemString}
   </channel>
   </rss>`


### PR DESCRIPTION
# Escape html in verdict and court agenda rss feeds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Improved RSS feed generation to correctly handle special characters and markup in feed content, ensuring feeds render properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->