### PR TITLE
fix(web): Place dot between keywords in verdict details

### DIFF
--- a/apps/web/screens/Verdicts/VerdictDetails.tsx
+++ b/apps/web/screens/Verdicts/VerdictDetails.tsx
@@ -324,7 +324,7 @@ const HtmlView = ({ item }: VerdictDetailsProps) => {
                       <Text variant="h4" as="h3">
                         {formatMessage(m.verdictPage.keywords)}
                       </Text>
-                      <Text>{item.keywords.join(', ')}</Text>
+                      <Text>{item.keywords.join('. ')}</Text>
                     </Box>
                   )}
                   {Boolean(item.presentings) && (


### PR DESCRIPTION
# Place dot between keywords in verdict details
