### PR TITLE
feat(web): Fixed Annual Report Chapter Sticky Navigation

### DIFF
--- a/apps/web/screens/Organization/AnnualReports/AnnualReportChapter.tsx
+++ b/apps/web/screens/Organization/AnnualReports/AnnualReportChapter.tsx
@@ -201,7 +201,7 @@ const AnnualReportChapter: Screen<
                       marginTop={10}
                       paddingLeft={4}
                     >
-                      <Sticky>
+                      <Sticky constantSticky>
                         <AnchorNavigation
                           title={
                             activeLocale === 'is'


### PR DESCRIPTION
## What

Fixed so the `AnchorNavigation` is always `Sticky` in Annual Report Chapter

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sticky behavior for anchor navigation in annual reports, ensuring it remains properly positioned while scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->