### PR TITLE
fix(user-notification): skip notifications to inactive companies

### DIFF
--- a/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/helpers.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/helpers.ts
@@ -3,3 +3,6 @@ export const wait = async (seconds = 2) => {
 }
 
 export const DECEASED_STATUS = 'LÉST' as const
+
+// TODO: Confirm exact RSK stada values for inactive companies
+export const INACTIVE_COMPANY_STATUSES = ['Inactive'] as const

--- a/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/helpers.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/helpers.ts
@@ -4,5 +4,4 @@ export const wait = async (seconds = 2) => {
 
 export const DECEASED_STATUS = 'LÉST' as const
 
-// TODO: Confirm exact RSK stada values for inactive companies
-export const INACTIVE_COMPANY_STATUSES = ['Inactive'] as const
+export const INACTIVE_COMPANY_STATUS = 'Afskráð' as const

--- a/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/mocks.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/mocks.ts
@@ -10,7 +10,7 @@ import { createNationalId } from '@island.is/testing/fixtures'
 
 import { UserNotificationsConfig } from '../../../../config'
 import { HnippTemplate } from '../dto/hnippTemplate.response'
-import { DECEASED_STATUS, INACTIVE_COMPANY_STATUSES } from './helpers'
+import { DECEASED_STATUS, INACTIVE_COMPANY_STATUS } from './helpers'
 
 import type { User } from '@island.is/auth-nest-tools'
 import type { ConfigType } from '@island.is/nest/config'
@@ -139,7 +139,7 @@ export const inactiveCompanyUser: MockUserProfileDto = {
   smsNotifications: true,
 }
 
-export const inactiveCompanyStatus = INACTIVE_COMPANY_STATUSES[0]
+export const inactiveCompanyStatus = INACTIVE_COMPANY_STATUS
 
 export const companyUser: MockUserProfileDto = {
   name: 'companyUser',

--- a/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/mocks.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/mocks.ts
@@ -10,7 +10,7 @@ import { createNationalId } from '@island.is/testing/fixtures'
 
 import { UserNotificationsConfig } from '../../../../config'
 import { HnippTemplate } from '../dto/hnippTemplate.response'
-import { DECEASED_STATUS } from './helpers'
+import { DECEASED_STATUS, INACTIVE_COMPANY_STATUSES } from './helpers'
 
 import type { User } from '@island.is/auth-nest-tools'
 import type { ConfigType } from '@island.is/nest/config'
@@ -126,6 +126,21 @@ export const userWithSendToDelegationsFeatureFlagDisabled: MockUserProfileDto =
     smsNotifications: true,
   }
 
+export const inactiveCompanyUser: MockUserProfileDto = {
+  name: 'inactiveCompanyUser',
+  nationalId: createNationalId('company'),
+  mobilePhoneNumber: '1234567',
+  email: 'email@inactivecompany.com',
+  emailVerified: true,
+  mobilePhoneNumberVerified: true,
+  documentNotifications: true,
+  emailNotifications: true,
+  isRestricted: false,
+  smsNotifications: true,
+}
+
+export const inactiveCompanyStatus = INACTIVE_COMPANY_STATUSES[0]
+
 export const companyUser: MockUserProfileDto = {
   name: 'companyUser',
   nationalId: createNationalId('company'),
@@ -186,6 +201,7 @@ export const userProfiles = [
   userWithSendToDelegationsFeatureFlagDisabled,
   userWithNoEmail,
   companyUser,
+  inactiveCompanyUser,
   deceasedUser,
 ]
 

--- a/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/notificationsWorker.service.spec.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/notificationsWorker.service.spec.ts
@@ -454,6 +454,14 @@ describe('NotificationsWorkerService', () => {
     expect(notificationDispatch.sendPushNotification).not.toHaveBeenCalled()
   })
 
+  it('should not send email or push notification if recipient is deceased', async () => {
+    await addToQueue(deceasedUser.nationalId)
+
+    expect(notificationsWorkerService.createEmail).not.toHaveBeenCalled()
+    expect(emailService.sendEmail).not.toHaveBeenCalled()
+    expect(notificationDispatch.sendPushNotification).not.toHaveBeenCalled()
+  })
+
   it('should not send email if feature flag is turned off', async () => {
     await addToQueue(userWithFeatureFlagDisabled.nationalId)
 

--- a/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/notificationsWorker.service.spec.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/notificationsWorker.service.spec.ts
@@ -448,13 +448,6 @@ describe('NotificationsWorkerService', () => {
     expect(notificationDispatch.sendPushNotification).not.toHaveBeenCalled()
   })
 
-  it('should not send email or push notification if recipient is deceased', async () => {
-    await addToQueue(deceasedUser.nationalId)
-
-    expect(emailService.sendEmail).not.toHaveBeenCalled()
-    expect(notificationDispatch.sendPushNotification).not.toHaveBeenCalled()
-  })
-
   it('should not send notification if company is inactive', async () => {
     jest.spyOn(companyRegistryService, 'getCompany').mockReturnValue(
       Promise.resolve<CompanyExtendedInfo>({

--- a/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/notificationsWorker.service.spec.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/notificationsWorker.service.spec.ts
@@ -50,6 +50,8 @@ import {
   deceasedUser,
   delegationSubjectId,
   getMockHnippTemplate,
+  inactiveCompanyStatus,
+  inactiveCompanyUser,
   mockTemplateId,
   userProfiles,
   userWithDelegations,
@@ -449,7 +451,25 @@ describe('NotificationsWorkerService', () => {
   it('should not send email or push notification if recipient is deceased', async () => {
     await addToQueue(deceasedUser.nationalId)
 
-    expect(notificationsWorkerService.createEmail).not.toHaveBeenCalled()
+    expect(emailService.sendEmail).not.toHaveBeenCalled()
+    expect(notificationDispatch.sendPushNotification).not.toHaveBeenCalled()
+  })
+
+  it('should not send notification if company is inactive', async () => {
+    jest.spyOn(companyRegistryService, 'getCompany').mockReturnValue(
+      Promise.resolve<CompanyExtendedInfo>({
+        nationalId: inactiveCompanyUser.nationalId,
+        name: 'Inactive Company',
+        formOfOperation: [],
+        addresses: [],
+        relatedParty: [],
+        vat: [],
+        status: inactiveCompanyStatus,
+      }),
+    )
+
+    await addToQueue(inactiveCompanyUser.nationalId)
+
     expect(emailService.sendEmail).not.toHaveBeenCalled()
     expect(notificationDispatch.sendPushNotification).not.toHaveBeenCalled()
   })

--- a/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/notificationsWorker.service.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/notificationsWorker.service.ts
@@ -38,7 +38,7 @@ import { mapToLocale, SmsDelivery } from '../utils'
 import { EmailQueueMessage } from './emailWorker.service'
 import { SmsQueueMessage } from './smsWorker.service'
 import { PushQueueMessage } from './pushWorker.service'
-import { DECEASED_STATUS, INACTIVE_COMPANY_STATUSES } from './helpers'
+import { DECEASED_STATUS, INACTIVE_COMPANY_STATUS } from './helpers'
 
 const getOnBehalfOfLabel = (
   onBehalfOf: string,
@@ -767,7 +767,7 @@ export class NotificationsWorkerService {
       const company = await this.companyRegistryService.getCompany(nationalId)
       return (
         company !== null &&
-        (INACTIVE_COMPANY_STATUSES as readonly string[]).includes(company.status)
+        company.status === INACTIVE_COMPANY_STATUS
       )
     } catch (error) {
       this.logger.warn(

--- a/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/notificationsWorker.service.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/notificationsWorker.service.ts
@@ -751,10 +751,7 @@ export class NotificationsWorkerService {
   ): Promise<boolean> {
     try {
       const company = await this.companyRegistryService.getCompany(nationalId)
-      return (
-        company !== null &&
-        company.status === INACTIVE_COMPANY_STATUS
-      )
+      return company !== null && company.status === INACTIVE_COMPANY_STATUS
     } catch (error) {
       this.logger.warn(
         'Failed to check company status from company registry, proceeding with notification',

--- a/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/notificationsWorker.service.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/notificationsWorker.service.ts
@@ -154,6 +154,13 @@ export class NotificationsWorkerService {
       return
     }
 
+    if (await this.isRecipientDeceased(args.recipient, args.messageId)) {
+      this.logger.info('Actor recipient is deceased, skipping notification', {
+        messageId: args.messageId,
+      })
+      return
+    }
+
     const locale: Locale = actorProfile.locale
       ? mapToLocale(actorProfile.locale)
       : 'is'
@@ -335,6 +342,13 @@ export class NotificationsWorkerService {
 
       if (!userProfile) {
         this.logger.info('No user profile found for user', { messageId })
+        return
+      }
+
+      if (await this.isRecipientDeceased(message.recipient, messageId)) {
+        this.logger.info('Recipient is deceased, skipping notification', {
+          messageId,
+        })
         return
       }
 

--- a/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/notificationsWorker.service.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/notificationsWorker.service.ts
@@ -154,13 +154,6 @@ export class NotificationsWorkerService {
       return
     }
 
-    if (await this.isRecipientDeceased(args.recipient, args.messageId)) {
-      this.logger.info('Actor recipient is deceased, skipping notification', {
-        messageId: args.messageId,
-      })
-      return
-    }
-
     const locale: Locale = actorProfile.locale
       ? mapToLocale(actorProfile.locale)
       : 'is'
@@ -342,13 +335,6 @@ export class NotificationsWorkerService {
 
       if (!userProfile) {
         this.logger.info('No user profile found for user', { messageId })
-        return
-      }
-
-      if (await this.isRecipientDeceased(message.recipient, messageId)) {
-        this.logger.info('Recipient is deceased, skipping notification', {
-          messageId,
-        })
         return
       }
 

--- a/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/notificationsWorker.service.ts
+++ b/apps/services/user-notification/src/app/modules/notifications/notificationsWorker/notificationsWorker.service.ts
@@ -38,7 +38,7 @@ import { mapToLocale, SmsDelivery } from '../utils'
 import { EmailQueueMessage } from './emailWorker.service'
 import { SmsQueueMessage } from './smsWorker.service'
 import { PushQueueMessage } from './pushWorker.service'
-import { DECEASED_STATUS } from './helpers'
+import { DECEASED_STATUS, INACTIVE_COMPANY_STATUSES } from './helpers'
 
 const getOnBehalfOfLabel = (
   onBehalfOf: string,
@@ -361,6 +361,13 @@ export class NotificationsWorkerService {
 
       locale = userProfile.locale ? mapToLocale(userProfile.locale) : 'is'
     } else {
+      if (await this.isCompanyInactive(nationalId, messageId)) {
+        this.logger.info('Company is inactive, skipping notification', {
+          messageId,
+        })
+        return
+      }
+
       const allowCompanyEmails = await this.featureFlagService.getValue(
         Features.shouldSendEmailNotificationsToCompanyUserProfiles,
         false,
@@ -747,6 +754,25 @@ export class NotificationsWorkerService {
       this.logger.warn(
         'Failed to check deceased status from national registry, proceeding with notification',
         { messageId },
+      )
+      return false
+    }
+  }
+
+  private async isCompanyInactive(
+    nationalId: string,
+    messageId: string,
+  ): Promise<boolean> {
+    try {
+      const company = await this.companyRegistryService.getCompany(nationalId)
+      return (
+        company !== null &&
+        (INACTIVE_COMPANY_STATUSES as readonly string[]).includes(company.status)
+      )
+    } catch (error) {
+      this.logger.warn(
+        'Failed to check company status from company registry, proceeding with notification',
+        { messageId, error },
       )
       return false
     }


### PR DESCRIPTION
Skip notifications to inactive companies

## What

- Add `isCompanyInactive` check using the company registry before sending notifications to company recipients
- Add `INACTIVE_COMPANY_STATUS` constant for the `Afskráð` status
- Add tests for inactive company notification skipping

## Why

- Notifications were being sent to companies that are no longer active (deregistered), which is unnecessary and potentially confusing
- The check uses the company registry to verify the company status before proceeding with notification delivery

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review