### PR TITLE
fix(web): Dot between keywords in determinations

### DIFF
--- a/apps/web/screens/SupremeCourt/Determinations/DeterminationDetails.tsx
+++ b/apps/web/screens/SupremeCourt/Determinations/DeterminationDetails.tsx
@@ -105,7 +105,7 @@ const HtmlView = ({ item }: HtmlViewProps) => {
                   <Text variant="h4" as="h3">
                     {formatMessage(m.detailsPage.keywords)}
                   </Text>
-                  <Text>{item.keywords.join(', ')}</Text>
+                  <Text>{item.keywords.join('. ')}</Text>
                 </Box>
               )}
               {item.presentings && (

--- a/apps/web/screens/SupremeCourt/Determinations/DeterminationList.tsx
+++ b/apps/web/screens/SupremeCourt/Determinations/DeterminationList.tsx
@@ -168,7 +168,7 @@ const Determinations: CustomScreen<DeterminationsProps> = ({
                         label: '',
                       },
                       title: item.caseNumber,
-                      subDescription: item.keywords.join(', '),
+                      subDescription: item.keywords.join('. '),
                       borderColor: 'blue200',
                       detailLines: [],
                     }


### PR DESCRIPTION
# Dot between keywords in determinations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated keyword separator formatting in Supreme Court determination displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->