### PR TITLE
fix(web): prevent double encoded sharing image urls (#22410)

### DIFF
--- a/apps/web/components/HeadWithSocialSharing/HeadWithSocialSharing.tsx
+++ b/apps/web/components/HeadWithSocialSharing/HeadWithSocialSharing.tsx
@@ -13,6 +13,18 @@ interface HeadWithSocialSharingProps {
 
 const usableContentTypes = ['image/jpeg', 'image/gif', 'image/png', undefined]
 
+const normalizeImageUrl = (imageUrl: string) => {
+  const imageUrlWithProtocol = `${
+    imageUrl.startsWith('//') ? 'https:' : ''
+  }${imageUrl}`
+
+  try {
+    return encodeURI(decodeURI(imageUrlWithProtocol))
+  } catch {
+    return encodeURI(imageUrlWithProtocol)
+  }
+}
+
 export const HeadWithSocialSharing: FC<
   React.PropsWithChildren<HeadWithSocialSharingProps>
 > = ({
@@ -30,9 +42,7 @@ export const HeadWithSocialSharing: FC<
     : false
   const isUsableImage = !isSvg && usableContentTypes.includes(imageContentType)
 
-  const encodedImageUrl = !imageUrl
-    ? ''
-    : encodeURI(`${imageUrl.startsWith('//') ? 'https:' : ''}${imageUrl}`)
+  const encodedImageUrl = !imageUrl ? '' : normalizeImageUrl(imageUrl)
 
   return (
     <Head>


### PR DESCRIPTION
hotfix