### PR TITLE
feat(native-app): change medicine label to 'Lyf' / 'Medicine'

### DIFF
--- a/apps/native/app/src/messages/en.ts
+++ b/apps/native/app/src/messages/en.ts
@@ -763,7 +763,7 @@ export const en: TranslatedMessages = {
   'health.overview.dentist': 'Dentist',
   'health.overview.noDentistRegistered': 'No dentist registered',
   'health.overview.prescriptions': 'Prescriptions',
-  'health.overview.medicine': 'My medicine',
+  'health.overview.medicine': 'Medicine',
   'health.overview.seeAllCategories': 'See all categories',
 
   // health: categories
@@ -925,7 +925,7 @@ export const en: TranslatedMessages = {
   'health.medicineDelegation.form.xMonths': '{months} months',
 
   // health - prescriptions & drug certificates
-  'health.prescriptionsAndCertificates.screenTitle': 'My medicine',
+  'health.prescriptionsAndCertificates.screenTitle': 'Medicine',
   'health.prescriptionsAndCertificates.validTo': 'Valid to: {date}',
   'health.prescriptionsAndCertificates.expired': 'Expired',
   'health.prescriptionsAndCertificates.rejected': 'Rejected',

--- a/apps/native/app/src/messages/is.ts
+++ b/apps/native/app/src/messages/is.ts
@@ -761,7 +761,7 @@ export const is = {
   'health.overview.noBloodTypeRegistered': 'Ekki verið flokkaður',
   'health.overview.dentist': 'Tannlæknir',
   'health.overview.noDentistRegistered': 'Enginn tannlæknir skráður',
-  'health.overview.medicine': 'Lyfin mín',
+  'health.overview.medicine': 'Lyf',
   'health.overview.seeAllCategories': 'Sjá alla flokka',
 
   // health: categories
@@ -920,7 +920,7 @@ export const is = {
   'health.medicineDelegation.form.xMonths': '{months} mán',
 
   // health - prescriptions & drug certificates
-  'health.prescriptionsAndCertificates.screenTitle': 'Lyfin mín',
+  'health.prescriptionsAndCertificates.screenTitle': 'Lyf',
   'health.prescriptionsAndCertificates.validTo': 'Gildir til: {date}',
   'health.prescriptionsAndCertificates.expired': 'Útrunnið',
   'health.prescriptionsAndCertificates.rejected': 'Hafnað',


### PR DESCRIPTION
## What

- Rename `health.overview.medicine` from "Lyfin mín" / "My medicine" to "Lyf" / "Medicine"
- Rename `health.prescriptionsAndCertificates.screenTitle` from "Lyfin mín" / "My medicine" to "Lyf" / "Medicine"

## Why

- Shorter, neutral label aligns with the rest of the overview/category labels and removes the first-person framing

## Screenshots / Gifs

N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Formatting passes locally with my changes
- [ ] I have rebased against main before asking for a review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated English translations for health-related medication sections and prescriptions screens
  * Updated Icelandic translations for health-related medication sections and prescriptions screens
  * Simplified terminology used in health feature labels for improved clarity and consistency
  * Enhanced UI text presentation across medicine overview and prescriptions features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->