### PR TITLE
fix(web): Organization footer is now at bottom of landing page

### DIFF
--- a/apps/web/screens/Organization/Home/Home.tsx
+++ b/apps/web/screens/Organization/Home/Home.tsx
@@ -16,6 +16,7 @@ import {
   DigitalIcelandLatestNewsSlice,
   getThemeConfig,
   IconTitleCard,
+  OrganizationFooter,
   OrganizationWrapper,
   SliceMachine,
 } from '@island.is/web/components'
@@ -271,12 +272,22 @@ const Home: Screen<HomeProps, HomeScreenContext> = ({
     !organizationPage && !!organization && organization?.hasALandingPage
   if (isLandingPage)
     return (
-      <LandingPage
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore make web strict
-        namespace={namespace}
-        organization={organization}
-      />
+      <Box
+        display="flex"
+        flexDirection="column"
+        justifyContent="spaceBetween"
+        height="full"
+        rowGap={12}
+      >
+        <div>
+          <LandingPage namespace={namespace} organization={organization} />
+        </div>
+        {organization && (
+          <div>
+            <OrganizationFooter organizations={[organization]} force={true} />
+          </div>
+        )}
+      </Box>
     )
   return (
     <OrganizationHomePage

--- a/apps/web/screens/Organization/Home/LandingPage/LandingPage.tsx
+++ b/apps/web/screens/Organization/Home/LandingPage/LandingPage.tsx
@@ -16,7 +16,6 @@ import {
   FeaturedArticlesSlice,
   HeadWithSocialSharing,
   IconTitleCard,
-  OrganizationFooter,
 } from '@island.is/web/components'
 import {
   Article,
@@ -203,9 +202,6 @@ const LandingPage = ({ organization, namespace }: LandingPageProps) => {
             </GridColumn>
           </GridRow>
         </GridContainer>
-        {organization && (
-          <OrganizationFooter organizations={[organization]} force={true} />
-        )}
       </Stack>
     </>
   )


### PR DESCRIPTION
# Organization footer is now at bottom of landing page

## Before

<img width="1407" height="1301" alt="Screenshot 2026-05-04 at 15 56 26" src="https://github.com/user-attachments/assets/63f29d92-73e0-4210-8fa1-0f166036dd4e" />

## After

<img width="1395" height="1297" alt="Screenshot 2026-05-04 at 15 57 00" src="https://github.com/user-attachments/assets/b298c58e-36f0-4d21-8341-6caa2d616373" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured organization footer layout for improved spacing and consistency on the home page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->